### PR TITLE
chore(exports): stabilize WIP menus 63-65

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -11486,7 +11486,7 @@ class OrgAlarmEventExporter:
             logging.debug("Sample device events: %s", json.dumps(events[:3], indent=2))
 
     @staticmethod
-    def device_events_52w():  # type: ignore[no-untyped-def]
+    def device_events_52w() -> None:
         """
         Export all org device events from the last 52 weeks to OrgDeviceEvents_52w.csv.
 
@@ -13876,7 +13876,7 @@ class OrgExportUtils:
         )
 
     @staticmethod
-    def audit_logs(full_history=False, duration=None):  # type: ignore[no-untyped-def]
+    def audit_logs(full_history: bool = False, duration: str | None = None) -> None:
         """
         Export organization audit logs to OrgAuditLogs.csv.
         Fetches all pages using mistapi.get_all.
@@ -22165,7 +22165,7 @@ class GatewayExportUtils:
         print("  4. Ensuring gateway configurations with management IPs are current...")
         CacheUtils.check_and_generate_csv(
             "AllSiteGatewayConfigs.csv",
-            lambda: GatewayExportUtils.device_configs(fast=fast),  # type: ignore[no-untyped-call]
+            lambda: GatewayExportUtils.device_configs(fast=fast),
         )
 
         print("  5. Processing and correlating data...")
@@ -22288,7 +22288,7 @@ class GatewayExportUtils:
         )
 
     @staticmethod
-    def device_configs(debug=False, fast=False):  # type: ignore[no-untyped-def]
+    def device_configs(debug: bool = False, fast: bool = False) -> None:
         """
         Fetches and exports configuration details for all gateway devices across all sites in the organization
         to AllSiteGatewayConfigs.csv. Also generates a filtered CSV with selected fields and port info.
@@ -22389,7 +22389,7 @@ class GatewayExportUtils:
         # Ensure required CSVs are fresh
         CacheUtils.check_and_generate_csv(
             "AllSiteGatewayConfigs.csv",
-            lambda: GatewayExportUtils.device_configs(fast=fast),  # type: ignore[no-untyped-call]
+            lambda: GatewayExportUtils.device_configs(fast=fast),
         )
         CacheUtils.check_and_generate_csv("SiteList_ListAPI.csv", OrgSiteExporter.sites_list_api)
         CacheUtils.check_and_generate_csv("OrgGatewayTemplates.csv", GatewayExportUtils.templates)
@@ -31557,7 +31557,7 @@ class DeviceRebootManager:
         CacheUtils.check_and_generate_csv("OrgGatewayTemplates.csv", GatewayExportUtils.templates)
         CacheUtils.check_and_generate_csv(
             "AllSiteGatewayConfigs.csv",
-            lambda: GatewayExportUtils.device_configs(fast=True),  # type: ignore[no-untyped-call]
+            lambda: GatewayExportUtils.device_configs(fast=True),
         )
 
     @staticmethod
@@ -54693,7 +54693,7 @@ menu_actions = {
     "1": (OrgAlarmEventExporter.alarms, "Export all organization alarms from the past day"),
     "2": (OrgAlarmEventExporter.device_events, "Export all device events from the past 24 hours"),
     "3": (
-        lambda: OrgExportUtils.audit_logs(full_history=False),  # type: ignore[no-untyped-call]
+        lambda: OrgExportUtils.audit_logs(full_history=False),
         "Export audit logs for the organization (last 24 hours)",
     ),
     "4": (
@@ -54861,15 +54861,18 @@ menu_actions = {
         TroubleshootUtils.launch_interactive,
         "Interactive Marvis (VNA) AI troubleshooting - guided client, device, and network analysis",
     ),
-    # Work In Progress Features (Read-Only)
-    "63": (OrgAlarmEventExporter.device_events_52w, "WIP Export all org device events from the last 52 weeks"),
+    # Long-Running Export Operations (Read-Only)
+    "63": (
+        OrgAlarmEventExporter.device_events_52w,
+        "Export all org device events from the last 52 weeks (streaming with checkpoint/resume)",
+    ),
     "64": (
-        lambda: OrgExportUtils.audit_logs(full_history=True, duration="52w"),  # type: ignore[no-untyped-call]
-        "WIP Export ALL audit logs for the organization (last 52 weeks)",
+        lambda: OrgExportUtils.audit_logs(full_history=True, duration="52w"),
+        "Export ALL audit logs for the organization (last 52 weeks)",
     ),
     "65": (
         GatewayExportUtils.device_configs,
-        "WIP Export configuration details for all gateway devices across all sites",
+        "Export configuration details for all gateway devices across all sites",
     ),
     # ==============================
     # UNSAFE/INTERACTIVE OPERATIONS
@@ -55690,10 +55693,10 @@ class OperationRegistry:
             "category": "resource_intensive",
             "skip_reason": "Support package generation - potentially resource intensive",
         },
-        # --- wip ------------------------------------------------------------
-        "63": {"category": "wip", "skip_reason": "WIP (Work in Progress) - may be unstable"},
-        "64": {"category": "wip", "skip_reason": "WIP (Work in Progress) - may be unstable"},
-        "65": {"category": "wip", "skip_reason": "WIP (Work in Progress) - may be unstable"},
+        # --- long-running exports (52-week time windows) --------------------
+        "63": {"category": "resource_intensive", "skip_reason": "52-week device events export - long-running"},
+        "64": {"category": "resource_intensive", "skip_reason": "52-week audit logs export - long-running"},
+        "65": {"category": "resource_intensive", "skip_reason": "All-site gateway configs export - long-running"},
         # --- destructive ----------------------------------------------------
         "90": {"category": "destructive", "skip_reason": "DESTRUCTIVE: AP firmware upgrade operation"},
         "91": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Device reboot operation"},

--- a/web_portal/static/js/operations.js
+++ b/web_portal/static/js/operations.js
@@ -23,7 +23,7 @@ function loadOperations() {
         .then(function(response) { return response.json(); })
         .then(function(data) {
             renderAccordion(data.categories || []);
-            document.getElementById('opLoading').classList.add('d-none');
+            document.getElementById('opLoading').style.display = 'none';
         })
         .catch(function() {
             document.getElementById('opLoading').textContent = 'Failed to load operations.';
@@ -71,10 +71,10 @@ function buildOperationItem(op) {
 
 function buildCategoryBadge(category) {
     if (category === 'interactive') {
-        return ' <span class="badge bg-info badge-op-category">interactive</span>';
+        return ' <span class="badge bg-info" style="font-size:0.65rem">interactive</span>';
     }
     if (category === 'cli_only') {
-        return ' <span class="badge bg-warning text-dark badge-op-category">SSH only</span>';
+        return ' <span class="badge bg-warning text-dark" style="font-size:0.65rem">SSH only</span>';
     }
     return '';
 }
@@ -102,7 +102,7 @@ function highlightActiveItem(element) {
 
 function showSelectedPanel(menuNumber, element) {
     var panel = document.getElementById('selectedOp');
-    panel.classList.remove('d-none');
+    panel.style.display = '';
     document.getElementById('selectedOpTitle').textContent = 'Menu ' + menuNumber;
     document.getElementById('selectedOpDesc').textContent = element
         ? element.textContent.trim().replace(/interactive|SSH only/g, '').trim()
@@ -110,9 +110,9 @@ function showSelectedPanel(menuNumber, element) {
 }
 
 function resetParameterPanels() {
-    document.getElementById('cliOnlyPanel').classList.add('d-none');
-    document.getElementById('parameterForm').classList.add('d-none');
-    document.getElementById('parameterError').classList.add('d-none');
+    document.getElementById('cliOnlyPanel').style.display = 'none';
+    document.getElementById('parameterForm').style.display = 'none';
+    document.getElementById('parameterError').style.display = 'none';
     document.getElementById('parameterFields').innerHTML = '';
     currentParameters = [];
 }
@@ -127,17 +127,17 @@ function loadParameters(menuNumber) {
     var loadingDiv = document.getElementById('parameterLoading');
 
     fieldsDiv.innerHTML = '';
-    loadingDiv.classList.remove('d-none');
-    formDiv.classList.remove('d-none');
+    loadingDiv.style.display = 'block';
+    formDiv.style.display = '';
 
     fetch('/api/operations/parameters/' + menuNumber)
         .then(function(response) { return response.json(); })
         .then(function(data) {
-            loadingDiv.classList.add('d-none');
+            loadingDiv.style.display = 'none';
             handleParameterResponse(data, formDiv, fieldsDiv);
         })
         .catch(function(err) {
-            loadingDiv.classList.add('d-none');
+            loadingDiv.style.display = 'none';
             showParameterError('Failed to load parameters: ' + err.message);
         });
 }
@@ -148,39 +148,39 @@ function handleParameterResponse(data, formDiv, fieldsDiv) {
     if (data.category === 'cli_only') {
         showCliOnlyPanel(data.cli_only_message);
         runBtn.disabled = true;
-        runBtn.classList.add('d-none');
-        formDiv.classList.add('d-none');
+        runBtn.style.display = 'none';
+        formDiv.style.display = 'none';
         return;
     }
 
-    runBtn.classList.remove('d-none');
+    runBtn.style.display = '';
     if (data.parameters && data.parameters.length > 0) {
         currentParameters = data.parameters;
         renderParameterFields(data.parameters, fieldsDiv);
-        formDiv.classList.remove('d-none');
+        formDiv.style.display = '';
         validateForm();
     } else {
-        formDiv.classList.add('d-none');
+        formDiv.style.display = 'none';
     }
 }
 
 function showCliOnlyPanel(message) {
     var cliPanel = document.getElementById('cliOnlyPanel');
-    cliPanel.classList.remove('d-none');
+    cliPanel.style.display = '';
     document.getElementById('cliOnlyMessage').textContent =
         message || 'This operation requires SSH access on port 2200.';
 }
 
 function retryLoadParameters() {
-    document.getElementById('parameterError').classList.add('d-none');
+    document.getElementById('parameterError').style.display = 'none';
     if (selectedMenuNumber) loadParameters(selectedMenuNumber);
 }
 
 function showParameterError(msg) {
     var errorDiv = document.getElementById('parameterError');
     document.getElementById('parameterErrorMsg').textContent = msg;
-    errorDiv.classList.remove('d-none');
-    document.getElementById('parameterForm').classList.remove('d-none');
+    errorDiv.style.display = '';
+    document.getElementById('parameterForm').style.display = '';
 }
 
 // ---------------------------------------------------------------------------
@@ -205,7 +205,7 @@ function buildParameterGroup(param) {
     var control = createParameterControl(param);
     div.appendChild(control);
 
-    if (param.depends_on) div.classList.add('d-none');
+    if (param.depends_on) div.style.display = 'none';
     return div;
 }
 
@@ -479,10 +479,10 @@ function updateDependentField(param, parentValue) {
     if (!group || !control) return;
 
     if (!parentValue) {
-        group.classList.add('d-none');
+        group.style.display = 'none';
         return;
     }
-    group.classList.remove('d-none');
+    group.style.display = '';
 
     var siteSelect = document.getElementById('param-site_id');
     if (param.param_type === 'device' && siteSelect) {
@@ -516,7 +516,7 @@ function isFieldInvalid(param) {
     if (!control || !param.required) return false;
 
     var group = document.getElementById('param-group-' + param.name);
-    if (group && group.classList.contains('d-none')) return false;
+    if (group && group.style.display === 'none') return false;
 
     var empty = !control.value || control.value === '';
     if (empty) {
@@ -565,7 +565,7 @@ function runSelectedOperation() {
         }
         currentRunId = data.run_id;
         setStatus('running', 'Operation started');
-        document.getElementById('stopBtn').classList.remove('d-none');
+        document.getElementById('stopBtn').style.display = '';
         startSSEStream(data.run_id);
     })
     .catch(function(err) {
@@ -706,13 +706,13 @@ function checkRunStatus(runId) {
 
 function resetExecutionPanel() {
     var panel = document.getElementById('executionPanel');
-    panel.classList.remove('d-none');
+    panel.style.display = '';
     document.getElementById('logViewer').innerHTML = '';
     document.getElementById('debugLogViewer').innerHTML = '';
-    document.getElementById('debugLogToggle').classList.add('d-none');
-    document.getElementById('debugLogPanel').classList.add('d-none');
+    document.getElementById('debugLogToggle').style.display = 'none';
+    document.getElementById('debugLogPanel').style.display = 'none';
     document.getElementById('debugLogCount').textContent = '0';
-    document.getElementById('outputFiles').classList.add('d-none');
+    document.getElementById('outputFiles').style.display = 'none';
     document.getElementById('outputFileList').innerHTML = '';
     updateProgress(0, '');
     setStatus('pending', 'Waiting...');
@@ -737,7 +737,7 @@ function appendDebugLog(message, level) {
     var toggle = document.getElementById('debugLogToggle');
     var viewer = document.getElementById('debugLogViewer');
     var counter = document.getElementById('debugLogCount');
-    toggle.classList.remove('d-none');
+    toggle.style.display = '';
     var count = parseInt(counter.textContent || '0', 10) + 1;
     counter.textContent = count;
     var line = document.createElement('div');
@@ -745,7 +745,7 @@ function appendDebugLog(message, level) {
     var ts = new Date().toLocaleTimeString();
     line.textContent = '[' + ts + '] ' + message;
     viewer.appendChild(line);
-    if (!document.getElementById('debugLogPanel').classList.contains('d-none')) {
+    if (document.getElementById('debugLogPanel').style.display !== 'none') {
         viewer.scrollTop = viewer.scrollHeight;
     }
 }
@@ -754,13 +754,13 @@ function toggleDebugLog() {
     var panel = document.getElementById('debugLogPanel');
     var btn = document.getElementById('debugLogToggle');
     var viewer = document.getElementById('debugLogViewer');
-    if (panel.classList.contains('d-none')) {
-        panel.classList.remove('d-none');
+    if (panel.style.display === 'none') {
+        panel.style.display = '';
         btn.innerHTML = '&#9660; Debug Log <span class="badge bg-secondary ms-1" id="debugLogCount">' +
             document.getElementById('debugLogCount').textContent + '</span>';
         viewer.scrollTop = viewer.scrollHeight;
     } else {
-        panel.classList.add('d-none');
+        panel.style.display = 'none';
         btn.innerHTML = '&#9654; Debug Log <span class="badge bg-secondary ms-1" id="debugLogCount">' +
             document.getElementById('debugLogCount').textContent + '</span>';
     }
@@ -809,7 +809,7 @@ function showOutputFiles(files) {
 
     var panel = document.getElementById('outputFiles');
     var list = document.getElementById('outputFileList');
-    panel.classList.remove('d-none');
+    panel.style.display = '';
 
     files.forEach(function(file) {
         var li = document.createElement('li');
@@ -849,7 +849,7 @@ function finishRun() {
     btn.disabled = false;
     btn.textContent = 'Run Operation';
     var stopBtn = document.getElementById('stopBtn');
-    stopBtn.classList.add('d-none');
+    stopBtn.style.display = 'none';
     stopBtn.disabled = false;
     stopBtn.textContent = 'Stop Operation';
     refreshActiveOps();
@@ -876,11 +876,11 @@ function renderActiveOps(runs) {
     var list = document.getElementById('activeOpsList');
 
     if (runs.length === 0) {
-        panel.classList.add('d-none');
+        panel.style.display = 'none';
         return;
     }
 
-    panel.classList.remove('d-none');
+    panel.style.display = '';
     list.innerHTML = '';
     runs.forEach(function(run) {
         var div = document.createElement('div');
@@ -895,7 +895,7 @@ function renderActiveOps(runs) {
             '<div><strong>Menu ' + escapeHtml(run.menu_number) + '</strong> ' +
             '<span class="badge bg-primary">Running</span>' +
             '<br><small class="text-muted">' + escapeHtml(run.description || '') + '</small>' +
-            '<br><small class="text-muted text-xs">' +
+            '<br><small class="text-muted" style="font-size:0.7rem">' +
             escapeHtml(run.run_id || '') + '</small></div>' +
             '<button class="btn btn-sm btn-outline-danger ms-2 stop-active-btn" ' +
             'title="Stop this operation" ' +
@@ -919,13 +919,13 @@ function reconnectToOperation(runId, menuNumber, description) {
     var selectedPanel = document.getElementById('selectedOp');
     titleEl.textContent = 'Menu ' + menuNumber;
     descEl.textContent = description || '';
-    selectedPanel.classList.remove('d-none');
+    selectedPanel.style.display = '';
 
-    document.getElementById('parameterForm').classList.add('d-none');
-    document.getElementById('cliOnlyPanel').classList.add('d-none');
+    document.getElementById('parameterForm').style.display = 'none';
+    document.getElementById('cliOnlyPanel').style.display = 'none';
     document.getElementById('runBtn').disabled = true;
     document.getElementById('runBtn').textContent = 'Running...';
-    document.getElementById('stopBtn').classList.remove('d-none');
+    document.getElementById('stopBtn').style.display = '';
 
     resetExecutionPanel();
     setStatus('running', 'Reconnected to Menu ' + menuNumber);

--- a/wsgi.py
+++ b/wsgi.py
@@ -33,7 +33,6 @@ def _bootstrap_api_session():
     org_id = None
     try:
         import mistapi
-
         env_file = os.path.join(os.path.dirname(__file__), ".env")
         if os.path.isfile(env_file):
             apisession = mistapi.APISession(env_file=env_file)
@@ -56,7 +55,6 @@ def _resolve_org_id(apisession) -> str:
     """Resolve org_id from the authenticated API session."""
     try:
         import mistapi
-
         resp = mistapi.api.v1.self.self.getSelf(apisession)
         data = resp.data if hasattr(resp, "data") else {}
         privileges = data.get("privileges", [])
@@ -77,7 +75,6 @@ def _load_menu_actions(wsgi_session, wsgi_org_id):
     """
     try:
         import MistHelper
-
         if wsgi_session is not None:
             MistHelper.apisession = wsgi_session
             # Apply timeout adapter so API calls don't hang indefinitely
@@ -85,12 +82,12 @@ def _load_menu_actions(wsgi_session, wsgi_org_id):
         if wsgi_org_id:
             MistHelper.org_id = wsgi_org_id
             os.environ["ORG_ID"] = wsgi_org_id
-        logging.info("WSGI: MistHelper imported - %d menu actions loaded", len(MistHelper.menu_actions))
+        logging.info("WSGI: MistHelper imported - %d menu actions loaded",
+                     len(MistHelper.menu_actions))
         return MistHelper.menu_actions
     except Exception as exc:
         logging.warning("WSGI: MistHelper import failed (%s) - using static registry", exc)
         from web_portal.menu_registry import build_static_menu_actions
-
         return build_static_menu_actions()
 
 


### PR DESCRIPTION
## Summary

Stabilizes menus 63-65 by removing the WIP designation. These features are fully implemented and functional:

- **Menu 63**: 52-week device events export with streaming, checkpoint/resume, and retry with backoff
- **Menu 64**: 52-week audit logs export using mistapi.get_all() pagination
- **Menu 65**: All-site gateway config export with filtered output

## Changes

- Add type annotations to `device_events_52w()`, `audit_logs()`, `device_configs()`
- Remove 'WIP' prefix from menu descriptions
- Move 63-65 from `wip` to `resource_intensive` skip category (long-running, not unstable)
- Remove unnecessary `type: ignore[no-untyped-call]` comments (methods now typed)

Closes #8