### PR TITLE
fix(macs): use correct API body for clear_learned_macs

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -20127,9 +20127,6 @@ class DeviceUtilityCommands:
     @staticmethod
     def clear_learned_macs() -> None:
         """Menu 152: Clear learned MACs from switch port (typed 'CLEAR')."""
-        # TODO: Returns 400 on Morrison-Switch EX4100 with port ge-0/0/0.
-        #   Investigate API body format - may need different key than port_id,
-        #   or port name format may differ from what if_stat returns.
         logging.info("Menu #152: Clear Learned MACs")
         selection = DeviceUtilityCommands._select_site_and_device("clear_macs", "switch")
         if not selection:
@@ -20139,17 +20136,18 @@ class DeviceUtilityCommands:
         if not port_id:
             print("! Port selection is required for clearing learned MACs.")
             return
+        port_with_unit = port_id if "." in port_id else f"{port_id}.0"
         if not DeviceUtilityCommands._confirm_destructive(
-            f"Type 'CLEAR' to clear learned MACs on port {port_id}: ", "CLEAR", "clear_macs"
+            f"Type 'CLEAR' to clear learned MACs on port {port_with_unit}: ", "CLEAR", "clear_macs"
         ):
             return
-        body: dict[str, Any] = {"port_id": port_id}
+        body: dict[str, Any] = {"ports": [port_with_unit]}
         try:
             response = mistapi.api.v1.sites.devices.clearAllLearnedMacsFromPortOnSwitch(
                 apisession, site_id, device_id, body
             )
             DeviceUtilityCommands._print_api_result(
-                response, f"Learned MACs cleared from port {port_id}.", "Clear learned MACs failed"
+                response, f"Learned MACs cleared from port {port_with_unit}.", "Clear learned MACs failed"
             )
         except Exception as error:
             logging.error(f"Clear learned MACs failed: {error}", exc_info=True)


### PR DESCRIPTION
## Summary

Fixes the 400 error when calling Menu #152 (Clear Learned MACs) on EX4100 switches.

### Root Cause
Three bugs in the API body construction:
1. Wrong key: `port_id` (string) but API expects `ports` (array) per OpenAPI `utils_clear_macs` schema
2. Wrong type: single string value but API expects array of strings
3. Missing logical unit: `ge-0/0/0` but API requires `ge-0/0/0.0` (with unit number)

### Changes
- Changed body from `{"port_id": "ge-0/0/0"}` to `{"ports": ["ge-0/0/0.0"]}`
- Auto-appends `.0` logical unit when not present in port name
- Shows port with unit in confirmation prompt and success message
- Removed TODO comment (root cause identified and fixed)

Closes #6