### PR TITLE
fix(security): remove api_key from log output entirely

### DIFF
--- a/scripts/mist_ideas_analyzer.py
+++ b/scripts/mist_ideas_analyzer.py
@@ -385,12 +385,7 @@ class AiBackendDetector:
             "https://api.openai.com/v1",
         )
         model = os.environ.get("AI_MODEL", "gpt-4o-mini")
-        redacted = redact_key(api_key)
-        logger.info(
-            "Backend: Generic OpenAI (model=%s, key=%s)",
-            model,
-            redacted,
-        )
+        logger.info("Backend: Generic OpenAI (model=%s)", model)
         return {
             "backend": "generic",
             "base_url": base_url,


### PR DESCRIPTION
CodeQL flagged clear-text logging of sensitive information at scripts/mist_ideas_analyzer.py:391. Remove the key parameter from the logger.info call entirely rather than attempting to redact it.

Closes #131