### PR TITLE
fix(MistHelper): restrict remote prefilter to exact-match operators only

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -15412,9 +15412,6 @@ class FilterOperatorEngine:
     REMOTE_PREFILTER_OPERATORS: frozenset[str] = frozenset(
         {
             "is",
-            "contains",
-            "starts with",
-            "ends with",
         }
     )
 


### PR DESCRIPTION
## Problem

Menu 161 (Global Wired Client Report) returned 0 records when filtering by Manufacturer **starts with** 'Brother', despite Brother devices existing in the org (confirmed via previous unfiltered CSV export showing 'Brother industries, LTD.').

## Root Cause

\FilterOperatorEngine.REMOTE_PREFILTER_OPERATORS\ included 'contains', 'starts with', and 'ends with'. When any of these operators were selected, \_build_remote_params()\ sent the filter value directly to the Mist API's \searchOrgWiredClients\ endpoint (e.g., \manufacture=Brother\). However, the API's \manufacture\ parameter only supports **exact matching** -- so \manufacture=Brother\ returned 0 results because the actual value is \Brother industries, LTD.\.

Since \_fetch_clients()\ returned an empty list, the early-return guard (\if not records: return\) triggered before \_apply_filters()\ could apply local filtering.

## Fix

Restrict \REMOTE_PREFILTER_OPERATORS\ to only \is\ -- the one operator that correctly maps to the API's exact-match behavior. All other operators (contains, starts with, ends with) will now:
1. Fetch **all** records from the API (no remote prefilter)
2. Apply the operator **locally** via \_record_matches()\ and \valuate_operator()\

Closes #128