### PR TITLE
feat(ci): auto-close quality-gate issues when gate passes on main

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -671,6 +671,11 @@ All tools run in `.github/workflows/ci.yml` as a parallel matrix. A PR cannot au
 
 **Pre-commit hooks** (`.pre-commit-config.yaml`) run Ruff, mypy, and Bandit locally to catch issues before push.
 
+**Automated issue lifecycle** (main branch only):
+- Gate fails on `main` → GitHub issue auto-created with `quality-gate` label
+- Gate passes on `main` → matching open issue auto-closed
+- PR branch failures are visible in PR checks only (no issues created)
+
 ### Security Findings: Fix Over Suppress
 
 Security tool findings (bandit, pip-audit, CodeQL) must be **resolved**, not suppressed:

--- a/.github/quality-gates-portable.yml
+++ b/.github/quality-gates-portable.yml
@@ -247,7 +247,7 @@ jobs:
       - vulture
       - pydocstyle
       - interrogate
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -306,5 +306,58 @@ jobs:
                 --label "bug,ci,quality-gate" \
                 --body "$BODY"
               echo "Created issue for failed gate: ${gate}"
+            fi
+          done
+
+  # ── SUCCESS → AUTO-CLOSE resolved quality-gate issues ─────────
+  close_resolved_issues:
+    name: "Close resolved quality-gate issues"
+    needs:
+      - ruff
+      - black
+      - mypy
+      - pytest
+      - bandit
+      - pip_audit
+      - pylint
+      - radon
+      - vulture
+      - pydocstyle
+      - interrogate
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Close issues for passing gates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          declare -A RESULTS
+          RESULTS[ruff]="${{ needs.ruff.result }}"
+          RESULTS[black]="${{ needs.black.result }}"
+          RESULTS[mypy]="${{ needs.mypy.result }}"
+          RESULTS[pytest]="${{ needs.pytest.result }}"
+          RESULTS[bandit]="${{ needs.bandit.result }}"
+          RESULTS[pip_audit]="${{ needs.pip_audit.result }}"
+          RESULTS[pylint]="${{ needs.pylint.result }}"
+          RESULTS[radon]="${{ needs.radon.result }}"
+          RESULTS[vulture]="${{ needs.vulture.result }}"
+          RESULTS[pydocstyle]="${{ needs.pydocstyle.result }}"
+          RESULTS[interrogate]="${{ needs.interrogate.result }}"
+
+          for gate in "${!RESULTS[@]}"; do
+            result="${RESULTS[$gate]}"
+            if [ "$result" = "success" ]; then
+              SEARCH="CI: quality-gate ${gate} failed"
+              ISSUES=$(gh issue list --state open --label "quality-gate" --search "$SEARCH" --json number --jq '.[].number')
+              for issue_number in $ISSUES; do
+                gh issue close "$issue_number" \
+                  --reason completed \
+                  --comment "Auto-closed: \`${gate}\` gate now passing on \`${{ github.ref_name }}\` (commit \`${{ github.sha }}\`)."
+                echo "Closed issue #${issue_number} (gate: ${gate})"
+              done
             fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
       - vulture
       - pydocstyle
       - interrogate
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -475,5 +475,62 @@ jobs:
                 --label "bug,ci,quality-gate" \
                 --body "$BODY"
               echo "Created issue for failed gate: ${gate}"
+            fi
+          done
+
+  # ──────────────────────────────────────────────────────────────
+  # SUCCESS → AUTO-CLOSE resolved quality-gate issues
+  # ──────────────────────────────────────────────────────────────
+  close_resolved_issues:
+    name: "Close resolved quality-gate issues"
+    needs:
+      - ruff
+      - black
+      - mypy
+      - pytest
+      - bandit
+      - pip_audit
+      - pylint
+      - radon
+      - vulture
+      - pydocstyle
+      - interrogate
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Close issues for passing gates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          declare -A RESULTS
+          RESULTS[ruff]="${{ needs.ruff.result }}"
+          RESULTS[black]="${{ needs.black.result }}"
+          RESULTS[mypy]="${{ needs.mypy.result }}"
+          RESULTS[pytest]="${{ needs.pytest.result }}"
+          RESULTS[bandit]="${{ needs.bandit.result }}"
+          RESULTS[pip_audit]="${{ needs.pip_audit.result }}"
+          RESULTS[pylint]="${{ needs.pylint.result }}"
+          RESULTS[radon]="${{ needs.radon.result }}"
+          RESULTS[vulture]="${{ needs.vulture.result }}"
+          RESULTS[pydocstyle]="${{ needs.pydocstyle.result }}"
+          RESULTS[interrogate]="${{ needs.interrogate.result }}"
+
+          for gate in "${!RESULTS[@]}"; do
+            result="${RESULTS[$gate]}"
+            if [ "$result" = "success" ]; then
+              SEARCH="CI: quality-gate ${gate} failed"
+              ISSUES=$(gh issue list --state open --label "quality-gate" --search "$SEARCH" --json number --jq '.[].number')
+              for issue_number in $ISSUES; do
+                gh issue close "$issue_number" \
+                  --reason completed \
+                  --comment "Auto-closed: \`${gate}\` gate now passing on \`${{ github.ref_name }}\` (commit \`${{ github.sha }}\`)."
+                echo "Closed issue #${issue_number} (gate: ${gate})"
+              done
             fi
           done

--- a/agents.md
+++ b/agents.md
@@ -555,6 +555,11 @@ All tools run in `.github/workflows/ci.yml` as a parallel matrix. A PR cannot au
 
 **Pre-commit hooks** (`.pre-commit-config.yaml`) run Ruff, mypy, and Bandit locally to catch issues before push.
 
+**Automated issue lifecycle** (main branch only):
+- Gate fails on `main` → GitHub issue auto-created with `quality-gate` label
+- Gate passes on `main` → matching open issue auto-closed
+- PR branch failures are visible in PR checks only (no issues created)
+
 ### Security Findings: Fix Over Suppress
 
 Security tool findings (bandit, pip-audit, CodeQL) must be **resolved**, not suppressed:


### PR DESCRIPTION
## Summary

Quality-gate issues are auto-created when CI fails on main, but nothing auto-closes them when the fix lands. This was discovered during PR #139 where issues #140 and #141 had to be manually closed.

## Changes

### CI Workflows (\.github/workflows/ci.yml\ + \.github/quality-gates-portable.yml\)

1. **New \close_resolved_issues\ job**: For each gate that passes, searches for open issues with the \quality-gate\ label matching that gate and auto-closes them with a comment linking the fixing commit.

2. **Main-only scoping**: Both \create_failure_issues\ and \close_resolved_issues\ jobs now require \github.ref == 'refs/heads/main'\. PR branch failures stay in the PR checks UI only — no cross-branch issue races.

### Documentation (\.github/copilot-instructions.md\ + \gents.md\)

3. **Automated issue lifecycle** note added under Quality Gates section documenting the create/close behavior.

Closes #143