### PR TITLE
fix(MistHelper): alphabetize manufacturer list in Menu 162

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -15764,12 +15764,12 @@ class WiredClientManufacturerReportGenerator:
 
     @staticmethod
     def _build_manufacturer_summary(records: list[dict[str, Any]]) -> list[tuple[str, int]]:
-        """Extract unique manufacturers with client counts, sorted by count descending."""
+        """Extract unique manufacturers with client counts, sorted alphabetically."""
         manufacturer_counts: dict[str, int] = {}
         for record in records:
             manufacturer = str(record.get("manufacture", "Unknown") or "Unknown").strip()
             manufacturer_counts[manufacturer] = manufacturer_counts.get(manufacturer, 0) + 1
-        sorted_manufacturers = sorted(manufacturer_counts.items(), key=lambda item: item[1], reverse=True)
+        sorted_manufacturers = sorted(manufacturer_counts.items(), key=lambda item: item[0].lower())
         return sorted_manufacturers
 
     @staticmethod


### PR DESCRIPTION
## Summary

Menu 162's manufacturer selection list was sorted by client count (descending). This makes it hard to find a specific manufacturer when the list is long.

## Changes

Changed \_build_manufacturer_summary()\ sort key from \item[1]\ (count, descending) to \item[0].lower()\ (name, case-insensitive ascending).

**Before**: Manufacturers sorted by count (most clients first)
**After**: Manufacturers sorted alphabetically (A-Z, case-insensitive)

Closes #145