### PR TITLE
ci(workflows): auto-close linked issues on PR merge

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,0 +1,39 @@
+name: Close linked issues on merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced in PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Extract issue numbers from Closes/Fixes/Resolves keywords (case-insensitive)
+          ISSUES=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | grep -oE '[0-9]+' | sort -u)
+          if [ -z "$ISSUES" ]; then
+            echo "No linked issues found in PR body."
+            exit 0
+          fi
+          for ISSUE in $ISSUES; do
+            STATE=$(gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')
+            if [ "$STATE" = "OPEN" ]; then
+              gh issue close "$ISSUE" --repo "$GITHUB_REPOSITORY" --reason completed \
+                --comment "Automatically closed by PR #${PR_NUMBER} merge."
+              echo "Closed issue #${ISSUE}"
+            else
+              echo "Issue #${ISSUE} is already ${STATE}, skipping."
+            fi
+          done


### PR DESCRIPTION
## Problem

When PRs are squash-merged via the auto-merge workflow (using `peter-evans/enable-pull-request-automerge` with `GITHUB_TOKEN`), GitHub does not process `Closes #N` keywords in the PR body. This is a known limitation: events triggered by `GITHUB_TOKEN` don't trigger downstream automations like issue auto-close.

Observed twice:
- PR #144 did not auto-close issue #143
- PR #146 did not auto-close issue #145

## Fix

Added `.github/workflows/close-linked-issues.yml` which triggers on `pull_request: closed` (merged only). It:
1. Parses the PR body for `Closes/Fixes/Resolves #N` keywords
2. Checks if each referenced issue is still open
3. Closes it with a comment linking back to the PR

Closes #147