### PR TITLE
feat(db): polyglot data routing - raw data to backends, Redis JSON dual-write

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -50,6 +50,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-03
 - JSON files in `data/mist_ideas_cache/` (per-idea cache + `api_index.json`); output to `data/mist_ideas_analysis.{md,json,csv}` (183-mist-ideas-analyzer)
 - Python 3.13+ + `mistapi>=0.61.4`, existing MistHelper utilities (`ConfigUtils`, `InputUtils`, `DataExporter`, `DataProcessingUtils`) (001-wired-client-global-report)
 - `data/` CSV exports and `data/mist_data.db` SQLite output via existing exporter flow (001-wired-client-global-report)
+- Python 3.13+ + `mistapi>=0.61.4`, `python-arango>=8.3.2`, `redis>=7.4.0` (with hiredis) (184-polyglot-db-migration)
+- ArangoDB 3.12 (documents + graph), Redis Stack (TimeSeries module), CSV files (always) (184-polyglot-db-migration)
 
 - Python 3.13+ + mistapi>=0.59.0, python-dotenv>=1.0.0 (001-radius-wlan-config)
 
@@ -69,11 +71,9 @@ cd src; pytest; ruff check .
 Python 3.13+: Follow standard conventions
 
 ## Recent Changes
+- 184-polyglot-db-migration: Added Python 3.13+ + `mistapi>=0.61.4`, `python-arango>=8.3.2`, `redis>=7.4.0` (with hiredis)
 - 001-wired-client-global-report: Added Python 3.13+ + `mistapi>=0.61.4`, existing MistHelper utilities (`ConfigUtils`, `InputUtils`, `DataExporter`, `DataProcessingUtils`)
 - 183-mist-ideas-analyzer: Added Python 3.13+ + `openai>=1.0` (AI API client, OpenAI-compatible surface for all 3 backends), `python-dotenv` (credential loading), `argparse` (stdlib, CLI flags)
-- 001-mistapi-sdk-audit: Added Python 3.13 + `mistapi` (target floor `>=0.61.4`), `websocket-client` (target floor `>=1.8.0`), `requests`, `python-dotenv`
-- feat/73-audit-menu-12-org-inventory: Added Python 3.13+ + mistapi 0.59+, pytest, sqlite3 (stdlib), csv (stdlib)
-- feat/018-ssid-template-consolidation: Added [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION] + [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -66,6 +66,19 @@ if TYPE_CHECKING:
     from prettytable import PrettyTable
 
 # ============================================================================
+# POLYGLOT DATABASE LAYER (OPTIONAL)
+# ============================================================================
+# Conditional import for ArangoDB + Redis TimeSeries backends.
+# Falls back gracefully in standalone mode (no python-arango/redis installed).
+try:
+    from src.db import DatabaseConfig, configure_db_logging
+    from src.db.router import DatabaseRouter
+
+    DB_LAYER_AVAILABLE = True
+except ImportError:
+    DB_LAYER_AVAILABLE = False
+
+# ============================================================================
 # EARLY LOGGING SETUP
 # ============================================================================
 # Configure logging IMMEDIATELY after imports to prevent Python from creating
@@ -3398,49 +3411,61 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "System events with composite key for uniqueness",
     },
-    # Type 3: Composite key for statistics and metrics APIs
-    # These APIs return aggregated data that benefits from composite keys
+    # Type 3: TimeSeries metrics -- pure-numeric endpoints routed to Redis TimeSeries
+    # These APIs return time-series data with explicit numeric and label fields
     "listOrgDevicesStats": {
-        "type": "composite_pk",
+        "type": "timeseries_pk",
         "primary_key": ["device_id", "timestamp"],
         "indexes": ["device_id", "timestamp", "org_id", "site_id", "type"],
         "unique_constraints": [],
-        "description": "Organization device statistics with composite key for metrics",
+        "description": "Organization device statistics routed to Redis TimeSeries",
+        "ts_value_fields": ["cpu_util", "mem_util", "uptime", "num_clients"],
+        "ts_label_fields": ["hostname", "model", "type", "site_id"],
     },
     "listSiteDevicesStats": {
-        "type": "composite_pk",
+        "type": "timeseries_pk",
         "primary_key": ["device_id", "timestamp"],
         "indexes": ["device_id", "timestamp", "site_id", "type"],
         "unique_constraints": [],
-        "description": "Site device statistics with composite key for metrics",
+        "description": "Site device statistics routed to Redis TimeSeries",
+        "ts_value_fields": ["cpu_util", "mem_util", "uptime", "num_clients"],
+        "ts_label_fields": ["hostname", "model", "type"],
     },
     "listSiteWirelessClientsStats": {
-        "type": "composite_pk",
+        "type": "timeseries_pk",
         "primary_key": ["client_mac", "timestamp"],
         "indexes": ["client_mac", "timestamp", "site_id", "device_id"],
         "unique_constraints": [],
-        "description": "Site wireless client statistics with composite key for metrics",
+        "description": "Wireless client statistics routed to Redis TimeSeries",
+        "ts_value_fields": ["rssi", "snr", "rx_rate", "tx_rate"],
+        "ts_label_fields": ["ssid", "hostname", "device_id"],
     },
     "searchOrgSwOrGwPorts": {
-        "type": "composite_pk",
+        "type": "timeseries_pk",
         "primary_key": ["device_id", "port_id", "timestamp"],
         "indexes": ["device_id", "port_id", "timestamp", "org_id"],
         "unique_constraints": [],
-        "description": "Switch/gateway port statistics with composite key",
+        "description": "Switch/gateway port statistics routed to Redis TimeSeries",
+        "ts_value_fields": ["rx_bytes", "tx_bytes", "rx_errors", "tx_errors"],
+        "ts_label_fields": ["port_id", "device_id", "org_id"],
     },
     "searchSiteSwOrGwPorts": {
-        "type": "composite_pk",
+        "type": "timeseries_pk",
         "primary_key": ["device_id", "port_id", "timestamp"],
         "indexes": ["device_id", "port_id", "timestamp", "site_id"],
         "unique_constraints": [],
-        "description": "Site switch/gateway port statistics with composite key",
+        "description": "Site port statistics routed to Redis TimeSeries",
+        "ts_value_fields": ["rx_bytes", "tx_bytes", "rx_errors", "tx_errors"],
+        "ts_label_fields": ["port_id", "device_id", "site_id"],
     },
     "searchOrgPeerPathStats": {
-        "type": "composite_pk",
+        "type": "timeseries_pk",
         "primary_key": ["from_device", "to_device", "timestamp"],
         "indexes": ["from_device", "to_device", "timestamp", "org_id"],
         "unique_constraints": [],
-        "description": "Peer path statistics with composite key",
+        "description": "Peer path statistics routed to Redis TimeSeries",
+        "ts_value_fields": ["latency", "jitter", "loss"],
+        "ts_label_fields": ["from_device", "to_device", "org_id"],
     },
     # Map-related endpoints
     "listSiteMaps": {
@@ -3493,6 +3518,13 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "indexes": ["org_id", "sku", "type"],
         "unique_constraints": [],
         "description": "License summary data (aggregated, no stable primary key)",
+    },
+    "listOrgLicenses": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "sku", "type"],
+        "unique_constraints": [],
+        "description": "License records from canonical list endpoint",
     },
     # Site Inventory Health Analysis reports
     "sitesMissingInfrastructure": {
@@ -9405,12 +9437,38 @@ class DataExporter:
     Uses static methods to avoid unnecessary object instantiation.
     """
 
+    _router: "DatabaseRouter | None" = None  # type: ignore[name-defined]
+    _router_initialized: bool = False
+    _last_snapshot_times: dict[str, float] = {}
+
+    @classmethod
+    def _init_router(cls) -> None:
+        """Initialize polyglot DatabaseRouter once (lazy, idempotent)."""
+        if cls._router_initialized:
+            return
+        cls._router_initialized = True
+        if not DB_LAYER_AVAILABLE:
+            logging.debug("Polyglot DB layer not installed - CSV/SQLite only")
+            return
+        try:
+            configure_db_logging()
+            config = DatabaseConfig.from_env()
+            cls._router = DatabaseRouter(
+                config,
+                strategies=ENDPOINT_PRIMARY_KEY_STRATEGIES,
+            )
+            logging.info("Polyglot DatabaseRouter initialized")
+        except Exception as error:
+            logging.warning(f"DatabaseRouter init failed, CSV/SQLite only: {error}")
+            cls._router = None
+
     @staticmethod
     def write_with_format_selection(
         data: list[dict[str, Any]],
         filename_or_table: str,
         format_override: str | None = None,
         api_function_name: str | None = None,
+        raw_data: list[dict[str, Any]] | None = None,
     ) -> bool:
         """
         Writes data to either CSV or SQLite database based on global OUTPUT_FORMAT or override.
@@ -9420,6 +9478,7 @@ class DataExporter:
             filename_or_table: CSV filename or database table name
             format_override: Optional override for output format ("csv" or "sqlite")
             api_function_name: Name of the API function for SQLite strategy selection
+            raw_data: Unflattened API response for polyglot backends (if None, uses data)
 
         Returns:
             bool: True if successful, False otherwise
@@ -9434,12 +9493,56 @@ class DataExporter:
 
         try:
             if output_format == "csv":
-                return DataExporter._write_csv_format(data, filename_or_table)
+                csv_ok = DataExporter._write_csv_format(data, filename_or_table)
             else:
-                return DataExporter._write_sqlite_format(data, filename_or_table, api_function_name)
+                csv_ok = DataExporter._write_sqlite_format(data, filename_or_table, api_function_name)
         except Exception as error:
             logging.error(f"Failed to write data to {filename_or_table} in {output_format} format: {error}")
             return False
+
+        DataExporter._route_to_polyglot(data, api_function_name, raw_data=raw_data)
+        return csv_ok
+
+    @staticmethod
+    def _route_to_polyglot(
+        data: list[dict[str, Any]],
+        api_function_name: str | None,
+        raw_data: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Send data to polyglot backends (ArangoDB/Redis) if available."""
+        if not api_function_name or not DB_LAYER_AVAILABLE:
+            return
+        DataExporter._init_router()
+        if DataExporter._router is None:
+            return
+        try:
+            polyglot_data = raw_data or data
+            result = DataExporter._router.write(polyglot_data, api_function_name)
+            logging.info(
+                f"Polyglot write: backend={result.backend}, "
+                f"written={result.records_written}, "
+                f"failed={result.records_failed}"
+            )
+        except Exception as error:
+            logging.warning(f"Polyglot write failed (CSV preserved): {error}")
+
+    @classmethod
+    def _check_periodic_snapshot(
+        cls,
+        api_function_name: str,
+        threshold_seconds: float = 3600.0,
+    ) -> bool:
+        """Check if enough time elapsed since last snapshot for this API.
+
+        Returns True if a snapshot should be taken (threshold exceeded).
+        Updates the timestamp when returning True.
+        """
+        now = time.time()
+        last_time = cls._last_snapshot_times.get(api_function_name, 0.0)
+        if (now - last_time) < threshold_seconds:
+            return False
+        cls._last_snapshot_times[api_function_name] = now
+        return True
 
     @staticmethod
     def _validate_write_inputs(data: list[dict[str, Any]], filename_or_table: str, output_format: str) -> bool:
@@ -9566,19 +9669,24 @@ class DataExporter:
             return 0
 
         # Filter to dict entries only (defensive)
-        processed_data = [entry for entry in data if isinstance(entry, dict)]
+        raw_data = [entry for entry in data if isinstance(entry, dict)]
 
         # Sort if requested
         if sort_key:
-            processed_data = sorted(processed_data, key=lambda x: x.get(sort_key, ""))
+            raw_data = sorted(raw_data, key=lambda x: x.get(sort_key, ""))
             logging.debug(f"Data sorted by key: {sort_key}")
 
-        # Apply standard processing
-        processed_data = DataProcessingUtils.flatten_nested_fields(processed_data)
+        # Apply standard processing for CSV/SQLite (flatten + escape)
+        processed_data = DataProcessingUtils.flatten_nested_fields(raw_data)
         processed_data = DataProcessingUtils.escape_multiline(processed_data)  # type: ignore[no-untyped-call]
 
-        # Save the processed data
-        success = DataExporter.save_data_to_output(processed_data, filename, api_function_name)  # type: ignore[no-untyped-call]
+        # Save flattened data to CSV/SQLite, pass raw to polyglot
+        success = DataExporter.write_with_format_selection(
+            processed_data,
+            filename,
+            api_function_name=api_function_name,
+            raw_data=raw_data,
+        )
 
         if success:
             logging.info(f"Exported {len(processed_data)} records to {filename}")
@@ -15901,11 +16009,11 @@ class OrgAdminExporter:
                 raw_items = [raw_items]
             if not raw_items:
                 logging.info("No license records returned from canonical endpoint; writing empty OrgLicenses.csv")
-                DataExporter.save_data_to_output([], filename)  # type: ignore[no-untyped-call]
+                DataExporter.save_data_to_output([], filename, api_function_name="listOrgLicenses")  # type: ignore[no-untyped-call]
                 return
             processed = DataProcessingUtils.flatten_nested_fields(raw_items)
             processed = DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
-            DataExporter.save_data_to_output(processed, filename)  # type: ignore[no-untyped-call]
+            DataExporter.save_data_to_output(processed, filename, api_function_name="listOrgLicenses")  # type: ignore[no-untyped-call]
             logging.info(f"Exported {len(processed)} license records to {filename}.")
         except Exception as e:
             logging.error(f"Failed to export licenses: {e}")
@@ -62107,7 +62215,16 @@ def main():  # type: ignore[no-untyped-def]  # noqa: C901, PLR0912, PLR0915
         action="store_true",
         help="Launch the web portal interface on port 8055 (or WEB_PORT env var) instead of the CLI menu",
     )
+    parser.add_argument(
+        "--standalone",
+        action="store_true",
+        help="Force standalone/CSV-only mode, disabling ArangoDB and Redis connections",
+    )
     args = parser.parse_args()
+
+    # Apply --standalone CLI flag to environment
+    if args.standalone:
+        os.environ["MISTHELPER_STANDALONE"] = "true"
 
     # Store args globally for menu functions to access CLI flags
     globals()["args"] = args

--- a/documentation/diagrams/core/data-persistence-routing.md
+++ b/documentation/diagrams/core/data-persistence-routing.md
@@ -1,0 +1,75 @@
+# Data Persistence Routing
+
+## Decision Tree
+
+How MistHelper routes data to the appropriate storage backend based on
+the primary key strategy defined in `ENDPOINT_PRIMARY_KEY_STRATEGIES`.
+
+```mermaid
+flowchart TD
+    A["Menu Operation<br/>(e.g. Menu 11, 13, 45)"] --> B["API Call<br/>mistapi SDK"]
+    B --> C["Flatten / Normalize<br/>JSON Response"]
+    C --> D["save_data_to_output()"]
+
+    D --> E["CSV / SQLite<br/>write_with_format_selection()"]
+    D --> F{"api_function_name<br/>provided?"}
+
+    F -->|No| G["Skip polyglot<br/>(CSV only)"]
+    F -->|Yes| H["_route_to_polyglot()"]
+
+    H --> I["DatabaseRouter.write()"]
+
+    I --> J{"Standalone mode?<br/>(no DB env vars)"}
+    J -->|Yes| K["Return csv_only<br/>(graceful degrade)"]
+
+    J -->|No| L{"Look up<br/>ENDPOINT_PRIMARY_KEY_STRATEGIES"}
+
+    L --> M{"Strategy Type?"}
+
+    M -->|natural_pk| N["ArangoDB Writer"]
+    M -->|auto_increment_with_unique| N
+    M -->|composite_pk| O["Redis TimeSeries Writer"]
+
+    N --> P{"ArangoDB<br/>available?"}
+    P -->|No| Q["Fallback: csv_only"]
+    P -->|Yes| R["import_bulk()<br/>batches of 5,000<br/>on_duplicate=replace"]
+
+    R --> S{"Config entity?<br/>(sites, WLANs, templates...)"}
+    S -->|Yes| T["Config Snapshot<br/>SHA-256 hash tracking"]
+    S -->|No| U["Done"]
+    T --> U
+
+    O --> V{"Redis<br/>available?"}
+    V -->|No| W["Fallback: csv_only"]
+    V -->|Yes| X["Extract numeric fields<br/>ThreadPoolExecutor<br/>(8 workers)"]
+
+    X --> Y["Pipeline TS.CREATE<br/>batches of 500<br/>DUPLICATE_POLICY LAST"]
+    Y --> Z["Pipeline TS.ADD<br/>batches of 10,000"]
+    Z --> AA["Auto-compaction rules<br/>hourly + daily rollups"]
+    AA --> U
+
+    style N fill:#4a9,stroke:#333,color:#fff
+    style O fill:#e74,stroke:#333,color:#fff
+    style Q fill:#888,stroke:#333,color:#fff
+    style W fill:#888,stroke:#333,color:#fff
+    style K fill:#888,stroke:#333,color:#fff
+    style G fill:#888,stroke:#333,color:#fff
+```
+
+## Strategy Routing Summary
+
+| Strategy Type | Backend | Use Case | Examples |
+| - | - | - | - |
+| `natural_pk` | ArangoDB | Entities with stable UUIDs | Sites, Inventory, Templates |
+| `auto_increment_with_unique` | ArangoDB | Aggregated data without stable keys | Licenses summary |
+| `composite_pk` | Redis TimeSeries | Time-series metrics | Device stats, Alarms, Events |
+
+## Key Files
+
+| File | Role |
+| - | - |
+| `MistHelper.py` | `ENDPOINT_PRIMARY_KEY_STRATEGIES` dict, `_route_to_polyglot()` |
+| `src/db/router.py` | `DatabaseRouter` — strategy lookup and backend dispatch |
+| `src/db/arango_writer.py` | `ArangoDBWriter` — batch `import_bulk()`, snapshots, graph edges |
+| `src/db/redis_writer.py` | `RedisTimeSeriesWriter` — pipelined TS.CREATE/TS.ADD, compaction |
+| `src/db/__init__.py` | `DatabaseConfig`, `WriteResult`, shared logger |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ dependencies = [
     # Address parsing and fuzzy matching
     "usaddress-scourgify>=0.6.0",
     "rapidfuzz>=3.8.0",
+
+    # Polyglot database backends (ArangoDB + Redis TimeSeries)
+    "python-arango>=8.3.2",
+    "redis[hiredis]>=7.4.0",
+
+    # Structured logging for database modules
+    "structlog",
 ]
 
 [project.optional-dependencies]
@@ -117,6 +124,7 @@ warn_return_any = true
 ignore_missing_imports = true
 warn_unused_configs = true
 warn_unused_ignores = false
+explicit_package_bases = true
 exclude = ["mist-ops-platform", "ops-portal", "web_portal", "maps_manager", "scripts", "specs", "tests"]
 
 [[tool.mypy.overrides]]
@@ -133,6 +141,14 @@ follow_imports = "skip"
 # Others: third-party or legacy code not under active development
 module = ["maps_manager", "maps_manager.*", "mist-ops-platform.*", "ops-portal.*", "web_portal.*", "scripts.*", "specs.*"]
 follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+# src.db: polyglot database modules use python-arango and redis SDKs which have
+# untyped methods and return union types. Relax strict checks here; tighten in Phase 2.
+module = ["src.db", "src.db.*"]
+disallow_untyped_calls = false
+disallow_any_generics = false
+warn_return_any = false
 
 [[tool.mypy.overrides]]
 # Tests: relax strict mode — test functions rarely benefit from full type annotations.

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,13 @@ matplotlib
 pillow
 kaleido
 
+# Polyglot database backends (ArangoDB + Redis TimeSeries)
+python-arango>=8.3.2
+redis[hiredis]>=7.4.0
+
+# Structured logging for database modules
+structlog
+
 # Pygments: CVE-2026-4539 has no fix available yet - ignored in CI pip-audit
 Pygments>=2.19.2
 

--- a/scripts/migrate_sqlite_to_polyglot.py
+++ b/scripts/migrate_sqlite_to_polyglot.py
@@ -1,0 +1,271 @@
+"""One-time migration utility: SQLite -> polyglot backends.
+
+Reads the existing data/mist_data.db, classifies tables by primary key
+strategy from ENDPOINT_PRIMARY_KEY_STRATEGIES, and exports:
+  - natural_pk / auto_increment_with_unique -> ArangoDB
+  - composite_pk -> Redis TimeSeries
+
+Usage:
+    python scripts/migrate_sqlite_to_polyglot.py [--dry-run] [--db-path data/mist_data.db]
+
+Requires ArangoDB and Redis Stack to be running (use compose.yml).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger("migrate_sqlite_to_polyglot")
+
+
+class MigrationConfig:
+    """Configuration for the migration run."""
+
+    def __init__(self, db_path: str, dry_run: bool = False):
+        self.db_path = db_path
+        self.dry_run = dry_run
+
+
+class StrategyLoader:
+    """Load ENDPOINT_PRIMARY_KEY_STRATEGIES from MistHelper.py."""
+
+    @staticmethod
+    def load_strategies() -> dict:
+        """Import strategies dict from MistHelper module."""
+        try:
+            import MistHelper
+
+            strategies = getattr(MistHelper, "ENDPOINT_PRIMARY_KEY_STRATEGIES", {})
+            logger.info(
+                "Loaded %d endpoint strategies from MistHelper",
+                len(strategies),
+            )
+            return strategies
+        except ImportError:
+            logger.error("Cannot import MistHelper.py -- run from project root")
+            sys.exit(1)
+
+
+class TableClassifier:
+    """Classify SQLite tables by their PK strategy type."""
+
+    ARANGO_TYPES = {"natural_pk", "auto_increment_with_unique"}
+    REDIS_TYPES = {"composite_pk"}
+
+    def __init__(self, strategies: dict):
+        self._strategies = strategies
+        self._reverse_map = self._build_reverse_map()
+
+    def _build_reverse_map(self) -> dict:
+        """Map table names to their strategy config."""
+        reverse = {}
+        for api_name, strategy in self._strategies.items():
+            table_name = api_name
+            reverse[table_name] = strategy
+        return reverse
+
+    def classify(self, table_name: str) -> str | None:
+        """Return 'arango', 'redis', or None for unknown tables."""
+        strategy = self._reverse_map.get(table_name)
+        if not strategy:
+            return None
+        pk_type = strategy.get("type", "")
+        if pk_type in self.ARANGO_TYPES:
+            return "arango"
+        if pk_type in self.REDIS_TYPES:
+            return "redis"
+        return None
+
+
+class SqliteReader:
+    """Read data from SQLite database."""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._connection: sqlite3.Connection | None = None
+
+    def connect(self) -> None:
+        """Open read-only connection to SQLite."""
+        if not os.path.exists(self.db_path):
+            logger.error("Database not found: %s", self.db_path)
+            sys.exit(1)
+        uri = f"file:{self.db_path}?mode=ro"
+        self._connection = sqlite3.connect(uri, uri=True)
+        self._connection.row_factory = sqlite3.Row
+        logger.info("Connected to SQLite: %s", self.db_path)
+
+    def list_tables(self) -> list[str]:
+        """Return list of user table names."""
+        cursor = self._connection.cursor()
+        cursor.execute("SELECT name FROM sqlite_master " "WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+        return [row[0] for row in cursor.fetchall()]
+
+    def read_table(self, table_name: str) -> list[dict]:
+        """Read all rows from a table as list of dicts."""
+        cursor = self._connection.cursor()
+        cursor.execute(f'SELECT * FROM "{table_name}"')  # noqa: S608
+        columns = [desc[0] for desc in cursor.description]
+        rows = []
+        for row in cursor.fetchall():
+            rows.append(dict(zip(columns, row, strict=True)))
+        return rows
+
+    def close(self) -> None:
+        """Close the SQLite connection."""
+        if self._connection:
+            self._connection.close()
+
+
+class MigrationRunner:
+    """Orchestrate the full migration pipeline."""
+
+    def __init__(self, config: MigrationConfig):
+        self._config = config
+        self._strategies: dict = {}
+        self._classifier: TableClassifier | None = None
+        self._reader: SqliteReader | None = None
+
+    def run(self) -> None:
+        """Execute the migration end-to-end."""
+        self._strategies = StrategyLoader.load_strategies()
+        self._classifier = TableClassifier(self._strategies)
+        self._reader = SqliteReader(self._config.db_path)
+        self._reader.connect()
+
+        try:
+            self._execute_migration()
+        finally:
+            self._reader.close()
+
+    def _execute_migration(self) -> None:
+        """Classify tables and export to appropriate backends."""
+        tables = self._reader.list_tables()
+        logger.info("Found %d tables in SQLite", len(tables))
+
+        classification = self._classify_all(tables)
+        self._print_summary(classification)
+
+        if self._config.dry_run:
+            logger.info("DRY RUN -- no data written to backends")
+            return
+
+        self._export_arango(classification.get("arango", []))
+        self._export_redis(classification.get("redis", []))
+        logger.info("Migration complete")
+
+    def _classify_all(self, tables: list[str]) -> dict:
+        """Group tables by target backend."""
+        result: dict[str, list[str]] = {
+            "arango": [],
+            "redis": [],
+            "unknown": [],
+        }
+        for table in tables:
+            target = self._classifier.classify(table)
+            if target:
+                result[target].append(table)
+            else:
+                result["unknown"].append(table)
+        return result
+
+    def _print_summary(self, classification: dict) -> None:
+        """Log migration plan summary."""
+        logger.info("--- Migration Plan ---")
+        logger.info("ArangoDB targets: %d tables", len(classification["arango"]))
+        for table in classification["arango"]:
+            logger.info("  -> %s", table)
+        logger.info("Redis TS targets: %d tables", len(classification["redis"]))
+        for table in classification["redis"]:
+            logger.info("  -> %s", table)
+        logger.info("Unclassified: %d tables", len(classification["unknown"]))
+        for table in classification["unknown"]:
+            logger.info("  ?? %s (skipped)", table)
+
+    def _export_arango(self, tables: list[str]) -> None:
+        """Export document tables to ArangoDB."""
+        from src.db import DatabaseConfig
+        from src.db.arango_writer import ArangoDBWriter
+
+        config = DatabaseConfig.from_env()
+        writer = ArangoDBWriter(config)
+        try:
+            for table in tables:
+                rows = self._reader.read_table(table)
+                if not rows:
+                    logger.info("Skipping empty table: %s", table)
+                    continue
+                strategy = self._strategies.get(table, {})
+                result = writer.write(rows, table, strategy)
+                logger.info(
+                    "ArangoDB <- %s: %d written, %d failed",
+                    table,
+                    result.records_written,
+                    result.records_failed,
+                )
+        finally:
+            writer.close()
+
+    def _export_redis(self, tables: list[str]) -> None:
+        """Export time-series tables to Redis."""
+        from src.db import DatabaseConfig
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        config = DatabaseConfig.from_env()
+        writer = RedisTimeSeriesWriter(config)
+        try:
+            for table in tables:
+                rows = self._reader.read_table(table)
+                if not rows:
+                    logger.info("Skipping empty table: %s", table)
+                    continue
+                strategy = self._strategies.get(table, {})
+                result = writer.write(rows, table, strategy)
+                logger.info(
+                    "Redis TS <- %s: %d written, %d failed",
+                    table,
+                    result.records_written,
+                    result.records_failed,
+                )
+        finally:
+            writer.close()
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Migrate SQLite data to polyglot backends")
+    parser.add_argument(
+        "--db-path",
+        default="data/mist_data.db",
+        help="Path to SQLite database (default: data/mist_data.db)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show migration plan without writing data",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for the migration utility."""
+    args = parse_args()
+    config = MigrationConfig(db_path=args.db_path, dry_run=args.dry_run)
+    runner = MigrationRunner(config)
+    runner.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/184-polyglot-db-migration/checklists/requirements.md
+++ b/specs/184-polyglot-db-migration/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Polyglot Database Migration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-20  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- ArangoDB and Redis are named explicitly because the user specified them as target technologies. The spec focuses on WHAT data goes where and WHY, not HOW to implement the connectors.
+- All validation items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/184-polyglot-db-migration/contracts/database-router.md
+++ b/specs/184-polyglot-db-migration/contracts/database-router.md
@@ -1,0 +1,171 @@
+# Contract: DatabaseRouter
+
+**Feature**: 184-polyglot-db-migration | **Date**: 2026-04-20
+
+## Overview
+
+`DatabaseRouter` is the central dispatch class that replaces direct `SQLiteDatabaseWriter` calls in `DataExporter`. It reads the `ENDPOINT_PRIMARY_KEY_STRATEGIES` dictionary, determines the backend for each dataset, and delegates to the appropriate writer class.
+
+## Public Interface
+
+### `DatabaseRouter.__init__(self, config: DatabaseConfig)`
+
+Initialize the router with connection configuration.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+| - | - | - | - |
+| `config` | `DatabaseConfig` | Yes | Dataclass with connection settings (from `.env`) |
+
+**Behavior**:
+- Attempts connection to ArangoDB and Redis on init
+- Logs connection status at Info level
+- Sets internal `_arango_available` and `_redis_available` flags
+- Does NOT raise on connection failure (degraded mode)
+- In standalone mode (no containers), sets both flags to False without attempting connections
+
+### `DatabaseRouter.write(self, data: list[dict], api_function_name: str)`
+
+Route and write data to the appropriate backend.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+| - | - | - | - |
+| `data` | `list[dict]` | Yes | Flattened records from API response |
+| `api_function_name` | `str` | Yes | Key into `ENDPOINT_PRIMARY_KEY_STRATEGIES` |
+
+**Behavior**:
+1. Look up `api_function_name` in `ENDPOINT_PRIMARY_KEY_STRATEGIES`
+2. Determine backend from strategy `type`:
+   - `natural_pk` or `auto_increment_with_unique` → ArangoDB
+   - `composite_pk` → Redis TimeSeries
+3. If target backend is unavailable, log warning and skip (CSV already written by caller)
+4. Call appropriate writer's `write()` method
+5. Return `WriteResult` with success/failure status
+
+**Returns**: `WriteResult` dataclass
+
+**Error handling**:
+- Connection errors: log error, set backend unavailable, return `WriteResult(success=False)`
+- Data validation errors: log error per-record, continue with remaining records
+- Never raises exceptions to caller
+
+### `DatabaseRouter.health_check(self) -> dict[str, bool]`
+
+Check connectivity to all backends.
+
+**Returns**:
+
+```python
+{
+    "arangodb": True,   # or False
+    "redis": True,      # or False
+    "standalone": False  # True if running without containers
+}
+```
+
+### `DatabaseRouter.close(self)`
+
+Close all database connections gracefully.
+
+## Supporting Types
+
+### `DatabaseConfig` (dataclass)
+
+```python
+@dataclass
+class DatabaseConfig:
+    arango_host: str = "http://arangodb:8529"
+    arango_database: str = "misthelper"
+    arango_username: str = "root"
+    arango_password: str = ""  # from ARANGO_ROOT_PASSWORD env
+    redis_host: str = "redis-stack"
+    redis_port: int = 6379
+    redis_password: str = ""  # from REDIS_PASSWORD env
+    standalone_mode: bool = False  # True = skip all backend connections
+```
+
+### `WriteResult` (dataclass)
+
+```python
+@dataclass
+class WriteResult:
+    success: bool
+    backend: str  # "arangodb", "redis", "csv_only"
+    records_written: int
+    records_failed: int
+    error_message: str = ""
+```
+
+## Integration Point: DataExporter
+
+The existing `DataExporter.write_with_format_selection()` method (line ~9410 in MistHelper.py) is modified to:
+
+1. **Always write CSV** (existing behavior, unchanged)
+2. **If not standalone mode**: call `DatabaseRouter.write(data, api_function_name)`
+3. **Log WriteResult** at Info level
+
+```python
+# Pseudocode for modified DataExporter
+class DataExporter:
+    def __init__(self):
+        config = DatabaseConfig.from_env()
+        self.router = DatabaseRouter(config)
+
+    def write_with_format_selection(self, data, filename, api_function_name=None):
+        # Step 1: Always write CSV (existing code)
+        self._write_csv(data, filename)
+
+        # Step 2: Route to polyglot backend (new code)
+        if api_function_name and not self.router.config.standalone_mode:
+            result = self.router.write(data, api_function_name)
+            if not result.success:
+                logging.warning(f"Backend write failed: {result.error_message}")
+```
+
+## ArangoDBWriter Contract
+
+### `ArangoDBWriter.write(self, data: list[dict], collection_name: str, strategy: dict)`
+
+Upsert documents into ArangoDB.
+
+- Uses `collection.insert(doc, overwrite=True, overwrite_mode="replace")`
+- Sets `_key` from strategy's `primary_key[0]` field value
+- Adds `_misthelper_updated_at` with current epoch
+- Manages edge collections for known graph relationships
+- Creates collection on first write if it doesn't exist
+
+### `ArangoDBWriter.snapshot(self, entity_type: str, entity_id: str, config_body: dict)`
+
+Create a configuration snapshot if content has changed.
+
+- Computes `config_hash` (SHA-256 of sorted JSON)
+- Skips if hash matches latest snapshot for this entity
+- Stores in `config_snapshots` collection
+
+## RedisTimeSeriesWriter Contract
+
+### `RedisTimeSeriesWriter.write(self, data: list[dict], api_function_name: str, strategy: dict)`
+
+Write time-series data to Redis.
+
+- Converts each record to one or more TS.ADD commands
+- Extracts numeric values from flattened records
+- Key pattern: `{api_function_name}:{entity_id}:{field_name}`
+- Creates TS key with labels + retention on first write
+- Creates compaction rules (hourly, daily) on first write per key
+- Uses pipeline for batch writes (performance)
+
+## Error Contracts
+
+| Scenario | Behavior | Log Level |
+| - | - | - |
+| ArangoDB unreachable on init | Set `_arango_available = False` | Warning |
+| Redis unreachable on init | Set `_redis_available = False` | Warning |
+| ArangoDB connection lost mid-write | Set unavailable, return failed result | Error |
+| Redis connection lost mid-write | Set unavailable, return failed result | Error |
+| Unknown api_function_name | Skip routing, CSV-only | Debug |
+| Invalid document (missing _key field) | Skip record, continue others | Error |
+| Redis key creation failure | Skip key, continue others | Error |

--- a/specs/184-polyglot-db-migration/data-model.md
+++ b/specs/184-polyglot-db-migration/data-model.md
@@ -1,0 +1,194 @@
+# Data Model: Polyglot Database Migration
+
+**Feature**: 184-polyglot-db-migration | **Date**: 2026-04-20
+
+## ArangoDB Collections (Document)
+
+### Sites
+
+| Field | Type | Source | Notes |
+| - | - | - | - |
+| `_key` | string | Mist API `id` (UUID) | Natural PK |
+| `org_id` | string | API | Indexed |
+| `name` | string | API | Indexed |
+| `country_code` | string | API | Indexed |
+| `timezone` | string | API | |
+| `address` | string | API | |
+| `latlng` | object | API | `{lat, lng}` |
+| `_misthelper_updated_at` | integer | System | Unix epoch of last upsert |
+| `_misthelper_deleted_at` | integer | System | Null if active; epoch if soft-deleted |
+
+**Validation**: `_key` must be a valid UUID (max 254 bytes). `org_id` required.
+
+### Devices
+
+| Field | Type | Source | Notes |
+| - | - | - | - |
+| `_key` | string | Mist API `id` (UUID) | Natural PK |
+| `org_id` | string | API | Indexed |
+| `site_id` | string | API | Indexed, foreign ref to Sites |
+| `name` | string | API | Indexed |
+| `mac` | string | API | Indexed |
+| `serial` | string | API | |
+| `model` | string | API | |
+| `type` | string | API | `ap`, `switch`, `gateway` |
+| `version` | string | API | Firmware version |
+| `_misthelper_updated_at` | integer | System | Unix epoch |
+| `_misthelper_deleted_at` | integer | System | Soft-delete timestamp |
+
+**Validation**: `_key` must be valid UUID. `site_id` must reference existing Sites collection.
+
+### Templates
+
+Covers AP templates, network templates, RF templates, gateway templates, device profiles.
+
+| Field | Type | Source | Notes |
+| - | - | - | - |
+| `_key` | string | Mist API `id` (UUID) | Natural PK |
+| `org_id` | string | API | Indexed |
+| `name` | string | API | Indexed |
+| `template_type` | string | System | `ap`, `network`, `rf`, `gateway`, `device_profile` |
+| `body` | object | API | Full template configuration (flattened) |
+| `_misthelper_updated_at` | integer | System | |
+| `_misthelper_deleted_at` | integer | System | |
+
+### ConfigSnapshots
+
+Versioned configuration snapshots stored on change and periodically.
+
+| Field | Type | Source | Notes |
+| - | - | - | - |
+| `_key` | string | System | Auto-generated (UUID or hash) |
+| `entity_type` | string | System | `site`, `wlan`, `template`, etc. |
+| `entity_id` | string | System | Reference to source entity `_key` |
+| `org_id` | string | API | Indexed |
+| `timestamp` | integer | System | Unix epoch when snapshot was taken |
+| `config_hash` | string | System | SHA-256 of config body (dedup) |
+| `config_body` | object | System | Full config at snapshot time |
+| `trigger` | string | System | `webhook`, `periodic`, `manual` |
+| `_misthelper_updated_at` | integer | System | |
+
+**Validation**: `config_hash` used to skip duplicate snapshots. `entity_id` must exist in the referenced entity collection.
+
+### Generic Document Collections
+
+All other `natural_pk` and `auto_increment_with_unique` entities follow this pattern:
+
+| Field | Type | Source | Notes |
+| - | - | - | - |
+| `_key` | string | Mist API `id` or auto-generated | PK |
+| `org_id` | string | API | Indexed |
+| All API fields | varies | API | Flattened via `DataProcessingUtils.flatten_dict()` |
+| `_misthelper_updated_at` | integer | System | |
+| `_misthelper_deleted_at` | integer | System | |
+
+Applies to: WLANs, PSKs, Networks, Services, Webhooks, Admins, API Tokens, Licenses, Alarms, Events, Audit Logs.
+
+## ArangoDB Collections (Edge)
+
+### OrgContainsSite
+
+| Field | Type | Notes |
+| - | - | - |
+| `_from` | string | `orgs/<org_id>` |
+| `_to` | string | `sites/<site_id>` |
+
+### SiteContainsDevice
+
+| Field | Type | Notes |
+| - | - | - |
+| `_from` | string | `sites/<site_id>` |
+| `_to` | string | `devices/<device_id>` |
+
+### TemplateAssignedToSite
+
+| Field | Type | Notes |
+| - | - | - |
+| `_from` | string | `templates/<template_id>` |
+| `_to` | string | `sites/<site_id>` |
+
+### DeviceHasPort
+
+| Field | Type | Notes |
+| - | - | - |
+| `_from` | string | `devices/<device_id>` |
+| `_to` | string | `ports/<port_id>` |
+
+### Graph Definition
+
+```
+Graph: "mist_network_topology"
+Vertex Collections: orgs, sites, devices, templates, ports
+Edge Definitions:
+  - OrgContainsSite: orgs → sites
+  - SiteContainsDevice: sites → devices
+  - TemplateAssignedToSite: templates → sites
+  - DeviceHasPort: devices → ports
+```
+
+## Redis TimeSeries Keys
+
+### Key Naming Convention
+
+```
+{metric_category}:{entity_id}:{metric_name}
+```
+
+Examples:
+- `device_stats:ap-uuid-123:cpu_usage`
+- `device_stats:ap-uuid-123:memory_usage`
+- `port_stats:switch-uuid:ge-0/0/1:traffic_in`
+- `sle:site-uuid-456:successful_connect`
+- `client_stats:site-uuid:client_count`
+
+### Labels (applied to every key)
+
+| Label | Source | Purpose |
+| - | - | - |
+| `org_id` | API | Organization filter |
+| `site_id` | API | Site filter |
+| `device_id` | API | Device filter (if applicable) |
+| `metric_name` | System | Metric type filter |
+| `metric_category` | System | Category filter (`device_stats`, `port_stats`, `sle`, `client_stats`) |
+
+### Downsampling Tiers
+
+| Tier | Granularity | Retention | Aggregation | Destination Key Suffix |
+| - | - | - | - | - |
+| Raw | As ingested | 7 days | N/A | (source key) |
+| Hourly | 1 hour | 90 days | `avg` | `:avg_1h` |
+| Daily | 1 day | 365 days | `avg` | `:avg_1d` |
+
+Compaction rules are created automatically when a new TimeSeries key is created.
+
+### Retention Policy Config
+
+| Setting | Source | Default |
+| - | - | - |
+| `REDIS_RAW_RETENTION_DAYS` | `.env` | `7` |
+| `REDIS_HOURLY_RETENTION_DAYS` | `.env` | `90` |
+| `REDIS_DAILY_RETENTION_DAYS` | `.env` | `365` |
+| `ARANGO_MAX_STORAGE_GB` | `.env` | `50` |
+| `RETENTION_CHECK_INTERVAL_HOURS` | `.env` | `6` |
+
+## State Transitions
+
+### Entity Lifecycle
+
+```
+[Not Exists] → INSERT → [Active]
+[Active] → UPSERT (data changed) → [Active] (updated_at refreshed)
+[Active] → Removed from Mist API → [Soft-Deleted] (deleted_at set)
+[Soft-Deleted] → Re-appears in Mist API → [Active] (deleted_at cleared)
+[Soft-Deleted] → Retention rollover → [Purged] (document removed)
+```
+
+### Backend Availability States
+
+```
+[All Backends Up] → Normal operation (ArangoDB + Redis + CSV)
+[ArangoDB Down] → Degraded mode (Redis + CSV only, log warning)
+[Redis Down] → Degraded mode (ArangoDB + CSV only, log warning)
+[Both Down] → CSV-only mode (log error, no crash)
+[Standalone Mode] → CSV-only (no connection attempts)
+```

--- a/specs/184-polyglot-db-migration/plan.md
+++ b/specs/184-polyglot-db-migration/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Polyglot Database Migration
+
+**Branch**: `184-polyglot-db-migration` | **Date**: 2026-04-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/184-polyglot-db-migration/spec.md`
+
+## Summary
+
+Replace SQLite with ArangoDB (graph/document store) and Redis TimeSeries (metrics/stats) for containerized MistHelper deployments. The existing `ENDPOINT_PRIMARY_KEY_STRATEGIES` dictionary (~53 entries) drives automatic routing: `natural_pk` and `auto_increment_with_unique` types route to ArangoDB, `composite_pk` types route to Redis TimeSeries. CSV output is preserved for all modes. Standalone mode (no containers) continues with CSV-only output. New `python-arango` and `redis` dependencies provide the Python client libraries. ArangoDB and Redis Stack services are added to `compose.yml` alongside the existing MistHelper and Ollama services.
+
+## Technical Context
+
+**Language/Version**: Python 3.13+
+**Primary Dependencies**: `mistapi>=0.61.4`, `python-arango>=8.3.2`, `redis>=7.4.0` (with hiredis)
+**Storage**: ArangoDB 3.12 (documents + graph), Redis Stack (TimeSeries module), CSV files (always)
+**Testing**: `pytest` + `pytest-cov`, `hypothesis` (property-based), `MistHelper.py --test`
+**Target Platform**: Linux containers (Podman/Docker), Windows 11 standalone
+**Project Type**: CLI tool with containerized multi-service deployment
+**Performance Goals**: Data ingestion at least equivalent to current SQLite throughput (SC-003); time-series queries <1s for 100K data points (SC-004)
+**Constraints**: Single-node only (no clustering); ArangoDB Community Edition 100GB dataset limit; all outputs to `data/` directory; non-root container user
+**Scale/Scope**: 160+ menu operations, ~53 endpoint strategies, single-org deployments
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| - | - | - |
+| I. Five-Item Rule | PASS | New classes (`ArangoDBWriter`, `RedisTimeSeriesWriter`, `DatabaseRouter`, `RetentionManager`, `SnapshotManager`) each under 5 public methods. `src/db/` package has max 5 modules. |
+| II. Class-Based Architecture | PASS | All DB backends are classes (no wrapper functions). `DatabaseRouter` replaces direct SQLite calls. |
+| III. Safety-First | PASS | No destructive operations added. DB credentials via `.env` only, never logged. Connection failures degrade gracefully to CSV. |
+| IV. Full Deployment Pipeline | PASS | compose.yml updated; container build triggers on push to main. |
+| V. Observability & Logging | PASS | New DB modules use `structlog` for structured, ASCII-only logging. Connection events logged at Info, queries at Debug. |
+| Tech: Dual Output | PASS | CSV output preserved for all 160+ operations regardless of backend availability (FR-002). |
+| Tech: Natural Business Keys | PASS | Mist API UUIDs used as ArangoDB `_key` values. No artificial IDs introduced. |
+| Tech: ENDPOINT_PRIMARY_KEY_STRATEGIES | PASS | Existing dictionary drives routing logic. No strategy entries are removed or renamed. |
+| Tech: File Paths | PASS | All new outputs use `os.path.join()` / `pathlib.Path()`. ArangoDB and Redis data stored under `data/` volume mount. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/184-polyglot-db-migration/
+├── plan.md              # This file
+├── research.md          # Phase 0: technology decisions
+├── data-model.md        # Phase 1: entity/collection design
+├── quickstart.md        # Phase 1: developer setup guide
+├── contracts/           # Phase 1: interface contracts
+│   └── database-router.md
+└── tasks.md             # Phase 2 output (speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── db/
+    ├── __init__.py          # Package init, public exports
+    ├── router.py            # DatabaseRouter: routes data by PK strategy type
+    ├── arango_writer.py     # ArangoDBWriter: document/graph operations
+    ├── redis_writer.py      # RedisTimeSeriesWriter: time-series operations
+    └── retention.py         # RetentionManager: storage-aware rollover
+
+MistHelper.py                # Modified: DataExporter delegates to DatabaseRouter
+compose.yml                  # Modified: add arangodb + redis-stack services
+requirements.txt             # Modified: add python-arango, redis[hiredis]
+deploy/.env.example          # Modified: add DB connection vars
+
+tests/
+├── unit/
+│   ├── test_router.py       # DatabaseRouter routing logic
+│   ├── test_arango_writer.py # ArangoDB upsert/graph operations (mocked)
+│   └── test_redis_writer.py  # Redis TimeSeries operations (mocked)
+└── integration/
+    └── test_compose_deploy.py # Container deployment validation
+```
+
+**Structure Decision**: New database code lives in `src/db/` package (4 modules + `__init__.py` = 5 files, satisfying Five-Item Rule). This isolates the polyglot logic from the monolithic `MistHelper.py` while the `DataExporter` class remains the entry point, delegating to `DatabaseRouter` when backends are available.
+
+## Complexity Tracking
+
+> No constitution violations detected. All five principles pass.

--- a/specs/184-polyglot-db-migration/quickstart.md
+++ b/specs/184-polyglot-db-migration/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: Polyglot Database Migration Development
+
+**Feature**: 184-polyglot-db-migration | **Date**: 2026-04-20
+
+## Prerequisites
+
+- Python 3.13+
+- Podman or Docker (for container mode)
+- Git + `gh` CLI
+
+## 1. Clone and Setup
+
+```powershell
+git checkout 184-polyglot-db-migration
+cd "C:\Users\jmorrison\OneDrive - Juniper Networks, Inc\Code\MistHelper"
+.venv\Scripts\Activate.ps1
+pip install python-arango redis[hiredis] structlog
+```
+
+## 2. Start Services (Container Mode)
+
+```powershell
+# Create .env with required variables (copy from deploy/.env.example)
+# Ensure these are set:
+#   ARANGO_ROOT_PASSWORD=<secure-password>
+#   REDIS_PASSWORD=<secure-password>
+
+# Start all services
+podman compose up -d
+
+# Verify health
+podman compose ps
+# All 4 services (misthelper, ollama, arangodb, redis-stack) should show "healthy"
+```
+
+## 3. Verify Connections
+
+```python
+# Quick ArangoDB check
+from arango import ArangoClient
+client = ArangoClient(hosts="http://localhost:8529")
+db = client.db("misthelper", username="root", password="<password>")
+print(db.version())  # Should print ArangoDB version
+
+# Quick Redis check
+import redis
+r = redis.Redis(host="localhost", port=6379, password="<password>")
+print(r.ping())  # Should print True
+print(r.module_list())  # Should include "timeseries"
+```
+
+## 4. Run Tests
+
+```powershell
+# Unit tests (mocked, no services needed)
+pytest tests/unit/test_router.py -v
+pytest tests/unit/test_arango_writer.py -v
+pytest tests/unit/test_redis_writer.py -v
+
+# Integration tests (requires running services)
+pytest tests/integration/test_compose_deploy.py -v
+
+# Full quality gates
+python -m py_compile MistHelper.py
+python -m ruff check MistHelper.py
+python -m black --check MistHelper.py
+```
+
+## 5. Key Files to Edit
+
+| File | What to Change |
+| - | - |
+| `src/db/router.py` | DatabaseRouter class (new) |
+| `src/db/arango_writer.py` | ArangoDBWriter class (new) |
+| `src/db/redis_writer.py` | RedisTimeSeriesWriter class (new) |
+| `src/db/retention.py` | RetentionManager class (new) |
+| `MistHelper.py` line ~9401 | DataExporter: add DatabaseRouter delegation |
+| `compose.yml` | Add arangodb + redis-stack services |
+| `requirements.txt` | Add python-arango, redis[hiredis], structlog |
+| `deploy/.env.example` | Add ARANGO_ROOT_PASSWORD, REDIS_PASSWORD, retention vars |
+
+## 6. Environment Variables
+
+| Variable | Default | Purpose |
+| - | - | - |
+| `ARANGO_ROOT_PASSWORD` | (required) | ArangoDB root password |
+| `REDIS_PASSWORD` | (required) | Redis requirepass |
+| `ARANGO_HOST` | `http://arangodb:8529` | ArangoDB connection URL |
+| `REDIS_HOST` | `redis-stack` | Redis hostname |
+| `REDIS_PORT` | `6379` | Redis port |
+| `REDIS_RAW_RETENTION_DAYS` | `7` | Raw metric retention |
+| `REDIS_HOURLY_RETENTION_DAYS` | `90` | Hourly aggregate retention |
+| `REDIS_DAILY_RETENTION_DAYS` | `365` | Daily aggregate retention |
+| `ARANGO_MAX_STORAGE_GB` | `50` | Max ArangoDB storage |
+| `RETENTION_CHECK_INTERVAL_HOURS` | `6` | Retention sweep interval |
+| `MISTHELPER_STANDALONE` | `false` | Set `true` to disable DB backends |
+
+## 7. Architecture Overview
+
+```text
+MistHelper.py
+  └── DataExporter.write_with_format_selection()
+        ├── _write_csv()           # Always (unchanged)
+        └── DatabaseRouter.write() # New: routes by PK strategy type
+              ├── ArangoDBWriter   # natural_pk, auto_increment_with_unique
+              └── RedisTimeSeriesWriter  # composite_pk
+```

--- a/specs/184-polyglot-db-migration/research.md
+++ b/specs/184-polyglot-db-migration/research.md
@@ -1,0 +1,139 @@
+# Research: Polyglot Database Migration
+
+**Feature**: 184-polyglot-db-migration | **Date**: 2026-04-20
+
+## 1. ArangoDB Python Driver
+
+**Decision**: Use `python-arango` 8.3.2 (official driver by ArangoDB Inc)
+**Rationale**: Only official, actively maintained Python driver. Supports Python 3.9+ (compatible with 3.13). Provides both low-level collection operations and high-level graph APIs.
+**Alternatives considered**:
+- Direct HTTP via `requests`: Rejected — reinvents driver functionality, no connection pooling, no type safety
+- `aioarango`: Rejected — async-only, MistHelper is synchronous
+- `python-arango-async`: Considered for future — separate package, not needed now
+
+### Key patterns
+
+- **Upsert**: `collection.insert(doc, overwrite=True, overwrite_mode="replace")` — equivalent to SQLite's `INSERT OR REPLACE`
+- **Graph creation**: `db.create_graph("network_topology")` with vertex/edge definitions
+- **Edge insertion**: Edge collection with `_from`/`_to` referencing `collection/key`
+- **Connection**: `ArangoClient(hosts="http://arangodb:8529").db("misthelper", username="root", password=<from_env>)`
+
+## 2. Redis TimeSeries Client
+
+**Decision**: Use `redis` (redis-py) 7.4.0 with `hiredis` C extension for performance
+**Rationale**: Official Redis client with built-in TimeSeries namespace (`r.ts()`). No separate package needed. `hiredis` gives 10x parsing speedup.
+**Alternatives considered**:
+- `redistimeseries`: Rejected — deprecated in favor of built-in `redis.ts()` namespace
+- `aioredis`: Rejected — merged into `redis` package, synchronous API sufficient
+
+### Key patterns
+
+- **Create**: `ts.create("metric:device_id", retention_msecs=N, labels={"device_id": "...", "metric": "cpu"})`
+- **Add**: `ts.add("metric:device_id", "*", value)` — auto-timestamp from server
+- **Query**: `ts.range(key, from_ts, to_ts)` returns `[(timestamp, value), ...]`
+- **Compaction**: `ts.createrule(src_key, dest_key, aggregation_type="avg", bucket_size_msec=3600000)`
+- **Cross-series**: `ts.mrange(from, to, filters=["metric=cpu"])` with label matching
+
+## 3. ArangoDB Container
+
+**Decision**: Use `arangodb:3.12` (Docker Hub official image)
+**Rationale**: Latest stable LTS. Official image supports amd64 + arm64. Community Edition sufficient (Apache 2.0 license).
+**Alternatives considered**:
+- ArangoDB 3.11: Rejected — older, fewer features, 3.12 is current stable
+
+### Configuration
+
+| Setting | Value |
+| - | - |
+| Image | `arangodb:3.12` |
+| Port | `8529` |
+| Auth env | `ARANGO_ROOT_PASSWORD` |
+| Data volume | `/var/lib/arangodb3` |
+| Health check | `curl -f http://localhost:8529/_api/version` |
+| Dataset limit | 100 GB (Community Edition 3.12+) |
+| Max document key | 254 bytes |
+
+## 4. Redis Stack Container
+
+**Decision**: Use `redis/redis-stack-server:latest` (includes TimeSeries module)
+**Rationale**: Official Redis image with all modules pre-loaded (TimeSeries, Search, JSON, Graph, Bloom). Server-only variant (no RedisInsight UI) is lighter.
+**Alternatives considered**:
+- `redis/redis-stack`: Rejected — includes RedisInsight web UI (unnecessary overhead)
+- `redis:latest` + manual module loading: Rejected — complex, fragile
+- `valkey`: Considered for future — Redis fork, but TimeSeries module availability uncertain
+
+### Configuration
+
+| Setting | Value |
+| - | - |
+| Image | `redis/redis-stack-server:latest` |
+| Port | `6379` |
+| Auth | `REDIS_ARGS="--requirepass ${REDIS_PASSWORD}"` |
+| Memory limit | `REDIS_ARGS="--maxmemory 2gb --maxmemory-policy allkeys-lru"` |
+| Data volume | `/data` |
+| Health check | `redis-cli -a ${REDIS_PASSWORD} ping` |
+
+## 5. Data Routing Strategy
+
+**Decision**: Route by `ENDPOINT_PRIMARY_KEY_STRATEGIES` type field
+**Rationale**: The existing dictionary already classifies all 53 endpoints by data pattern. No new metadata needed — the `type` field directly maps to backend.
+**Alternatives considered**:
+- Explicit backend field per endpoint: Rejected — redundant with type field, increases maintenance
+- Configuration file mapping: Rejected — adds external dependency when routing is deterministic from type
+
+### Routing rules
+
+| PK Strategy Type | Count | Backend | Collection/Key Pattern |
+| - | - | - | - |
+| `natural_pk` | ~17 | ArangoDB document | Collection per API function, `_key` = entity UUID |
+| `composite_pk` | ~34 | Redis TimeSeries | Key = `metric:entity_id`, labels from PK fields |
+| `auto_increment_with_unique` | ~2 | ArangoDB document | Collection per API function, auto-generated `_key` |
+
+## 6. Compose Integration
+
+**Decision**: Add `arangodb` and `redis-stack` services to existing `compose.yml`
+**Rationale**: compose.yml already exists with `misthelper` and `ollama` services on `misthelper-network`. Adding services to the same network enables container DNS resolution.
+**Alternatives considered**:
+- Separate compose file: Rejected — adds operational complexity, requires network linking
+- Kubernetes/Podman pods: Rejected — out of scope, single-node deployment
+
+### Health check + depends_on pattern
+
+```yaml
+arangodb:
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:8529/_api/version"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+
+redis-stack:
+  healthcheck:
+    test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+
+misthelper:
+  depends_on:
+    arangodb:
+      condition: service_healthy
+    redis-stack:
+      condition: service_healthy
+```
+
+## 7. Soft-Delete Pattern
+
+**Decision**: Mark entities inactive with `_misthelper_deleted_at` timestamp field
+**Rationale**: Preserves history for snapshots and graph edge integrity. Hard-delete would orphan edges and lose config snapshot history.
+**Alternatives considered**:
+- Hard delete with cascade: Rejected — loses history, complex edge cleanup
+- TTL-based expiry: Rejected — unpredictable timing, no human control
+
+## 8. Structured Logging
+
+**Decision**: Use `structlog` for all new `src/db/` modules
+**Rationale**: Constitution Principle V requires structured, machine-parseable logging for new modules. `structlog` integrates with stdlib `logging` and produces JSON-formatted entries compatible with monitoring tools.
+**Alternatives considered**:
+- stdlib `logging` only: Rejected — not structured, harder to parse programmatically
+- `loguru`: Rejected — not in existing deps, `structlog` is more widely adopted for structured output

--- a/specs/184-polyglot-db-migration/spec.md
+++ b/specs/184-polyglot-db-migration/spec.md
@@ -5,6 +5,24 @@
 **Status**: Draft  
 **Input**: User description: "Replace SQL everywhere we can in this project when running as a container, with Redis and ArangoDB containers bundled together. Minimize or eliminate the use of SQLite and other SQL variants. Snapshot frequency: on-change, and periodic when load is lite. Retention policy: as much as storage can hold, then rollover the oldest."
 
+## Clarifications
+
+### Session 2026-04-20
+
+- Q: Should ArangoDB and Redis require authentication credentials when deployed as containers? → A: Yes, require auth via credentials in `.env` (root password for ArangoDB, `requirepass` for Redis).
+- Q: How should entity deletion be handled when an entity is removed from the Mist API? → A: Soft-delete (mark inactive with timestamp, retain history for snapshots and graph integrity).
+- Q: What is the scalability scope — single-node only or multi-node clustering? → A: Single-node only; matches the existing single-container deployment model.
+- Q: What is explicitly out of scope for this feature? → A: No query UI, no multi-org federation, no real-time streaming dashboard, no ArangoDB/Redis clustering.
+- Q: How should Redis TimeSeries downsampling be triggered? → A: Automatically on ingestion via Redis compaction rules (not batch jobs).
+
+### Out of Scope
+
+- Query UI or data exploration dashboard (future feature)
+- Multi-org federation or cross-org data sharing
+- Real-time streaming dashboard (WebSocket-based live views)
+- ArangoDB or Redis clustering / high-availability configurations
+- Custom AQL query interface for end users
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Container Deployment with Multi-DB Backend (Priority: P1)
@@ -125,6 +143,7 @@ As a user running MistHelper directly on a host (not in a container), I want the
 - What happens when Redis TimeSeries runs out of memory? The retention policy should prevent OOM by proactively trimming, and Redis should be configured with a max-memory eviction policy as a safety net.
 - What happens when network connectivity between containers is interrupted mid-write? Writes should be atomic per entity with retry logic, and partial writes should not corrupt data.
 - What happens when migrating from an existing SQLite deployment to polyglot? A one-time migration tool should export existing SQLite data into ArangoDB/Redis.
+- What happens when an entity is deleted from the Mist API? Documents are soft-deleted (marked inactive with a timestamp) rather than hard-deleted, preserving history for snapshots and graph edge integrity.
 
 ## Requirements *(mandatory)*
 
@@ -144,6 +163,9 @@ As a user running MistHelper directly on a host (not in a container), I want the
 - **FR-012**: System MUST support configuring database connection parameters via environment variables in `.env`.
 - **FR-013**: System MUST upsert documents in ArangoDB (insert or update based on document key) to prevent duplicates, matching current SQLite `INSERT OR REPLACE` behavior.
 - **FR-014**: System MUST operate in degraded mode when only one of the two backends (ArangoDB or Redis) is available, routing data to the available backend plus CSV.
+- **FR-015**: System MUST require authentication for both ArangoDB (root password) and Redis (`requirepass`), with credentials configured via `.env` environment variables.
+- **FR-016**: System MUST soft-delete entities removed from the Mist API by marking them inactive with a timestamp, preserving history for snapshots and graph integrity.
+- **FR-017**: System MUST apply Redis TimeSeries compaction rules automatically on ingestion (not via batch jobs) for downsampling.
 
 ### Key Entities
 
@@ -174,3 +196,6 @@ As a user running MistHelper directly on a host (not in a container), I want the
 - Mist webhook integration for on-change snapshots uses the existing webhook infrastructure already present in MistHelper.
 - Network connectivity between containers on the same compose network is reliable and low-latency.
 - The `data/` volume mount pattern continues to be used for ArangoDB and Redis persistent storage.
+- Deployment is single-node only; no ArangoDB or Redis clustering is required.
+- Both ArangoDB and Redis containers require authentication; credentials are managed via `.env`.
+- Entity deletion from Mist API uses soft-delete (mark inactive) rather than hard-delete.

--- a/specs/184-polyglot-db-migration/spec.md
+++ b/specs/184-polyglot-db-migration/spec.md
@@ -1,0 +1,176 @@
+# Feature Specification: Polyglot Database Migration
+
+**Feature Branch**: `184-polyglot-db-migration`  
+**Created**: 2026-04-20  
+**Status**: Draft  
+**Input**: User description: "Replace SQL everywhere we can in this project when running as a container, with Redis and ArangoDB containers bundled together. Minimize or eliminate the use of SQLite and other SQL variants. Snapshot frequency: on-change, and periodic when load is lite. Retention policy: as much as storage can hold, then rollover the oldest."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Container Deployment with Multi-DB Backend (Priority: P1)
+
+As a NOC engineer deploying MistHelper in a container, I want the system to automatically use ArangoDB and Redis instead of SQLite so that I get richer data storage with graph relationships and time-series capabilities without any manual database setup.
+
+**Why this priority**: This is the foundational change. Without multi-DB container deployment, no other features in this spec work. Every menu operation that currently writes to SQLite must route to the correct backend database.
+
+**Independent Test**: Deploy using `podman-compose up` and run Menu 11 (org sites export). Verify data is stored in ArangoDB (not SQLite) and CSV output still works identically.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh `podman-compose up` deployment, **When** the containers start, **Then** MistHelper, ArangoDB, and Redis containers are all running and connected on the same network.
+2. **Given** a running multi-container deployment, **When** a user runs any data extraction menu operation (1-86), **Then** data is persisted to ArangoDB or Redis (based on data type) AND CSV output is produced identically to the current behavior.
+3. **Given** a running deployment, **When** the ArangoDB or Redis container is temporarily unavailable, **Then** MistHelper logs a clear error message and continues operating with CSV-only output without crashing.
+
+---
+
+### User Story 2 - Natural Key Entities Stored in ArangoDB (Priority: P1)
+
+As a NOC engineer, I want all configuration and inventory data (sites, devices, templates, WLANs, PSKs, networks) stored in ArangoDB as documents so that I can later query relationships between entities and view historical snapshots.
+
+**Why this priority**: Configuration/inventory data is the largest category of menu operations. This covers all `natural_pk` entities in the current `ENDPOINT_PRIMARY_KEY_STRATEGIES` dictionary.
+
+**Independent Test**: Run Menu 12 (org inventory), then query ArangoDB to verify device documents exist with correct fields and natural primary keys preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a device inventory pull via Menu 12, **When** data is ingested, **Then** each device is stored as a document in an ArangoDB collection with its Mist API UUID as the document key.
+2. **Given** an existing device document in ArangoDB, **When** the same device is pulled again with updated fields, **Then** the document is upserted (updated in place, not duplicated).
+3. **Given** multiple entity types (sites, devices, templates), **When** they are stored, **Then** graph edges are created representing relationships (site contains device, template assigned to site).
+
+---
+
+### User Story 3 - Time-Series Metrics Stored in Redis TimeSeries (Priority: P1)
+
+As a NOC engineer, I want all statistical and performance data (device stats, port stats, SLE metrics, client counts) stored in Redis TimeSeries so that I get efficient time-range queries and automatic downsampling.
+
+**Why this priority**: Time-series data is the second largest category. Redis TimeSeries is purpose-built for this access pattern and enables future "time voyager" visualizations.
+
+**Independent Test**: Run Menu 13 (org device stats), then query Redis to verify time-series keys exist with correct labels and data points.
+
+**Acceptance Scenarios**:
+
+1. **Given** a device stats pull via Menu 13, **When** data is ingested, **Then** each metric (CPU, memory, throughput, etc.) is stored as a Redis TimeSeries key with appropriate labels (device_id, site_id, metric_name).
+2. **Given** existing time-series data, **When** new data points arrive for the same metric, **Then** they are appended to the existing time-series (not overwritten).
+3. **Given** a Redis TimeSeries key, **When** storage capacity is reached, **Then** the oldest data points are automatically trimmed per the retention policy.
+
+---
+
+### User Story 4 - Automatic Data Routing by Endpoint Type (Priority: P2)
+
+As a developer maintaining MistHelper, I want data to be automatically routed to the correct backend (ArangoDB vs Redis) based on the existing `ENDPOINT_PRIMARY_KEY_STRATEGIES` configuration so that adding new menu operations requires minimal changes.
+
+**Why this priority**: This is the internal architecture that makes the system maintainable. Without automatic routing, every new menu operation requires manual backend selection.
+
+**Independent Test**: Add a new test endpoint to `ENDPOINT_PRIMARY_KEY_STRATEGIES` with type `natural_pk` and verify it automatically routes to ArangoDB without any additional code.
+
+**Acceptance Scenarios**:
+
+1. **Given** an endpoint configured with `type: natural_pk`, **When** data is written, **Then** it is routed to ArangoDB as a document collection.
+2. **Given** an endpoint configured with `type: composite_pk`, **When** data is written, **Then** it is routed to Redis TimeSeries with composite labels.
+3. **Given** an endpoint configured with `type: auto_increment_with_unique`, **When** data is written, **Then** it is routed to ArangoDB with auto-generated keys.
+
+---
+
+### User Story 5 - Config Snapshot on Change with Periodic Fallback (Priority: P2)
+
+As a NOC engineer, I want MistHelper to capture configuration snapshots whenever a change is detected and periodically during low-load periods so that I have a complete history of my network configuration.
+
+**Why this priority**: Snapshots enable the future "time voyager" feature. On-change capture ensures no configuration change is missed; periodic capture fills gaps when webhooks are unavailable.
+
+**Independent Test**: Modify a WLAN configuration via the Mist dashboard, then verify MistHelper captured a new snapshot document in ArangoDB with a timestamp and diff from the previous version.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running MistHelper with webhook integration, **When** a configuration change event is received from Mist, **Then** a new snapshot document is stored in ArangoDB with the full config and a timestamp.
+2. **Given** no configuration changes for a configurable idle period, **When** the periodic timer fires, **Then** MistHelper polls the current config and stores a snapshot if it differs from the last stored version.
+3. **Given** a config snapshot, **When** a user requests the history, **Then** the system returns an ordered list of snapshots with timestamps and can produce a diff between any two snapshots.
+
+---
+
+### User Story 6 - Storage-Aware Retention with Oldest-First Rollover (Priority: P3)
+
+As a system administrator, I want MistHelper to automatically manage data retention by using all available storage and rolling over the oldest data first so that I never need to manually clean up databases.
+
+**Why this priority**: Without retention management, storage will eventually fill up and cause failures. This is important but can ship after the core migration.
+
+**Independent Test**: Configure a small storage limit in a test environment, ingest enough data to exceed it, and verify the oldest records are automatically removed while newest data is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configurable maximum storage threshold per database, **When** storage usage exceeds the threshold, **Then** the oldest data is automatically purged until usage drops below the threshold.
+2. **Given** a Redis TimeSeries key, **When** the retention policy triggers, **Then** data older than the calculated cutoff is trimmed while downsampled aggregates are preserved.
+3. **Given** ArangoDB document collections, **When** the retention policy triggers, **Then** the oldest snapshot versions are removed while at least one snapshot per entity is always retained.
+
+---
+
+### User Story 7 - Standalone Mode Backward Compatibility (Priority: P3)
+
+As a user running MistHelper directly on a host (not in a container), I want the tool to continue working with CSV output even when ArangoDB and Redis are not available so that standalone mode is not broken by this migration.
+
+**Why this priority**: Standalone mode must not regress. Container mode is the target for polyglot DB, but standalone users should not be forced to install ArangoDB and Redis.
+
+**Independent Test**: Run `python MistHelper.py --menu 11` on a host without ArangoDB or Redis installed. Verify CSV output is produced and no errors are thrown.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper running in standalone mode without ArangoDB/Redis, **When** a menu operation is executed, **Then** data is exported to CSV only and no database connection errors occur.
+2. **Given** MistHelper running in standalone mode, **When** ArangoDB and Redis are available on configurable host/port, **Then** MistHelper connects and uses them as backends in addition to CSV.
+
+---
+
+### Edge Cases
+
+- What happens when ArangoDB is available but Redis is not (or vice versa)? The system should operate in degraded mode, routing data only to the available backend plus CSV.
+- What happens when a document exceeds ArangoDB's maximum document size? Large API responses (e.g., full org inventory) should be split into individual documents per entity, not stored as a single blob.
+- What happens when Redis TimeSeries runs out of memory? The retention policy should prevent OOM by proactively trimming, and Redis should be configured with a max-memory eviction policy as a safety net.
+- What happens when network connectivity between containers is interrupted mid-write? Writes should be atomic per entity with retry logic, and partial writes should not corrupt data.
+- What happens when migrating from an existing SQLite deployment to polyglot? A one-time migration tool should export existing SQLite data into ArangoDB/Redis.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST route data to ArangoDB or Redis TimeSeries based on the endpoint's primary key strategy type when running in container mode.
+- **FR-002**: System MUST maintain CSV output for all menu operations regardless of backend database availability.
+- **FR-003**: System MUST store `natural_pk` and `auto_increment_with_unique` entities as ArangoDB documents with Mist API UUIDs as document keys where available.
+- **FR-004**: System MUST store `composite_pk` time-series data as Redis TimeSeries keys with labels for device_id, site_id, and metric_name.
+- **FR-005**: System MUST create ArangoDB graph edges representing relationships between entities (org→site, site→device, template→site, device→port).
+- **FR-006**: System MUST capture configuration snapshots on-change (via Mist webhooks) and periodically when the system is idle.
+- **FR-007**: System MUST implement storage-aware retention that rolls over the oldest data first when storage thresholds are reached.
+- **FR-008**: System MUST support Redis TimeSeries downsampling rules (e.g., 1-minute granularity for 7 days, 1-hour granularity for 90 days, 1-day granularity beyond 90 days).
+- **FR-009**: System MUST add ArangoDB and Redis services to `compose.yml` with appropriate volume mounts, network configuration, and health checks.
+- **FR-010**: System MUST fall back to CSV-only output when running in standalone mode without ArangoDB/Redis available.
+- **FR-011**: System MUST provide a one-time migration utility to export existing SQLite data into ArangoDB and Redis.
+- **FR-012**: System MUST support configuring database connection parameters via environment variables in `.env`.
+- **FR-013**: System MUST upsert documents in ArangoDB (insert or update based on document key) to prevent duplicates, matching current SQLite `INSERT OR REPLACE` behavior.
+- **FR-014**: System MUST operate in degraded mode when only one of the two backends (ArangoDB or Redis) is available, routing data to the available backend plus CSV.
+
+### Key Entities
+
+- **ArangoDB Collections (Documents)**: Sites, Devices, Templates (AP/Switch/Gateway/RF/Network), WLANs, PSKs, Networks, Services, Webhooks, Admins, API Tokens, Licenses, Alarms, Events, Audit Logs, Config Snapshots.
+- **ArangoDB Collections (Edges)**: OrgContainsSite, SiteContainsDevice, TemplateAssignedToSite, DeviceHasPort, ClientConnectedToDevice.
+- **Redis TimeSeries Keys**: Device stats (CPU, memory, throughput per device), Port stats (traffic, errors per port), SLE metrics (per site/AP), Client metrics (count, signal, throughput), License usage over time.
+- **Config Snapshots**: Versioned documents in ArangoDB with timestamp, config hash, full config body, and diff from previous version.
+- **Retention Policy Config**: Per-collection/per-key retention rules defining max age, max storage, and downsampling tiers.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All 160+ menu operations produce identical CSV output compared to the current implementation (zero regression in data content or format).
+- **SC-002**: Container deployment via `podman-compose up` starts all three services (MistHelper, ArangoDB, Redis) within 60 seconds on a standard machine.
+- **SC-003**: Data ingestion throughput is at least equivalent to current performance (no perceptible slowdown for the user).
+- **SC-004**: Time-series queries return results for any time range within retained data in under 1 second for up to 100,000 data points.
+- **SC-005**: Configuration snapshots capture 100% of changes detected via webhooks with zero data loss during normal operation.
+- **SC-006**: Storage retention rollover operates without manual intervention and maintains at least the most recent snapshot for every entity.
+- **SC-007**: Standalone mode (no containers) continues to work with CSV output with zero breaking changes to existing user workflows.
+- **SC-008**: The migration from an existing deployment preserves all historical data with field-level accuracy.
+
+## Assumptions
+
+- ArangoDB Community Edition (Apache 2.0 license) is sufficient; Enterprise features are not required.
+- Redis Stack (which includes the TimeSeries module) is available as a container image.
+- The existing `ENDPOINT_PRIMARY_KEY_STRATEGIES` dictionary provides sufficient metadata to automatically route data to the correct backend.
+- Mist webhook integration for on-change snapshots uses the existing webhook infrastructure already present in MistHelper.
+- Network connectivity between containers on the same compose network is reliable and low-latency.
+- The `data/` volume mount pattern continues to be used for ArangoDB and Redis persistent storage.

--- a/specs/184-polyglot-db-migration/tasks.md
+++ b/specs/184-polyglot-db-migration/tasks.md
@@ -1,0 +1,305 @@
+# Tasks: Polyglot Database Migration
+
+**Input**: Design documents from `/specs/184-polyglot-db-migration/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/database-router.md, quickstart.md
+
+**Tests**: Included — plan.md defines test files (tests/unit/test_router.py, test_arango_writer.py, test_redis_writer.py, tests/integration/test_compose_deploy.py) and CI requires >=70% coverage.
+
+**Organization**: Tasks are grouped by user story. Implementation order differs from priority labels due to dependencies: US2 and US3 (backend writers) must exist before US4 (routing), and US4 must exist before US1 (end-to-end integration) can be validated.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1–US7)
+- Exact file paths included in every task description
+
+---
+
+## Phase 1: Setup (Project Initialization)
+
+**Purpose**: Create package structure and declare new dependencies
+
+- [ ] T001 Create `src/db/` package directory with empty `src/db/__init__.py`
+- [ ] T002 [P] Add `python-arango>=8.3.2`, `redis[hiredis]>=7.4.0`, `structlog` to `requirements.txt` and `pyproject.toml` dependencies
+- [ ] T003 [P] Add database environment variables (`ARANGO_ROOT_PASSWORD`, `REDIS_PASSWORD`, `ARANGO_HOST`, `REDIS_HOST`, `REDIS_PORT`, retention vars, `MISTHELPER_STANDALONE`) to `deploy/.env.example`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core types, container services, and router skeleton that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Implement `DatabaseConfig` dataclass (from_env class method, 8 fields per contract) and `WriteResult` dataclass (5 fields) in `src/db/__init__.py`
+- [ ] T005 [P] Configure `structlog` logging for `src/db/` modules: JSON output, ASCII-only, stdlib integration, bound loggers per class in `src/db/__init__.py`
+- [ ] T006 [P] Add `arangodb` service to `compose.yml` — image `arangodb:3.12`, port `8529`, volume `arangodb-data:/var/lib/arangodb3`, health check `curl -f http://localhost:8529/_api/version`, env `ARANGO_ROOT_PASSWORD`
+- [ ] T007 [P] Add `redis-stack` service to `compose.yml` — image `redis/redis-stack-server:latest`, port `6379`, volume `redis-data:/data`, health check `redis-cli -a ${REDIS_PASSWORD} ping`, env `REDIS_ARGS="--requirepass ${REDIS_PASSWORD} --maxmemory 2gb --maxmemory-policy allkeys-lru"`
+- [ ] T008 Implement `DatabaseRouter` skeleton in `src/db/router.py` — `__init__(config)` with connection attempts and availability flags, `health_check()` returning backend status dict, `close()` for graceful shutdown (leave `write()` as stub for US4)
+
+**Checkpoint**: Package exists, types defined, compose services configured, router skeleton ready — user story implementation can begin
+
+---
+
+## Phase 3: User Story 2 — Natural Key Entities in ArangoDB (Priority: P1)
+
+**Goal**: All configuration and inventory data (sites, devices, templates, WLANs, PSKs) stored as ArangoDB documents with graph edges representing relationships
+
+**Independent Test**: Run Menu 12 (org inventory), then query ArangoDB to verify device documents exist with correct fields and Mist API UUID as `_key`
+
+### Tests for User Story 2
+
+- [ ] T009 [P] [US2] Write unit tests for `ArangoDBWriter` in `tests/unit/test_arango_writer.py` — mock `python-arango` client; test upsert with overwrite, collection auto-creation, `_key` from natural PK, `_misthelper_updated_at` timestamp, graph edge creation, soft-delete marking
+
+### Implementation for User Story 2
+
+- [ ] T010 [US2] Implement `ArangoDBWriter.__init__()` in `src/db/arango_writer.py` — connect using `ArangoClient`, authenticate, ensure `misthelper` database exists, bind structured logger
+- [ ] T011 [US2] Implement `ArangoDBWriter.write()` in `src/db/arango_writer.py` — auto-create collection on first write, upsert via `collection.insert(doc, overwrite=True, overwrite_mode="replace")`, set `_key` from strategy `primary_key[0]`, add `_misthelper_updated_at` epoch, handle `auto_increment_with_unique` with auto-generated keys
+- [ ] T012 [US2] Implement graph creation and edge management in `ArangoDBWriter` in `src/db/arango_writer.py` — create `mist_network_topology` graph with vertex collections (orgs, sites, devices, templates, ports) and 4 edge definitions (`OrgContainsSite`, `SiteContainsDevice`, `TemplateAssignedToSite`, `DeviceHasPort`); insert edges during write when relationship fields detected
+- [ ] T013 [US2] Implement soft-delete logic in `ArangoDBWriter` in `src/db/arango_writer.py` — set `_misthelper_deleted_at` epoch when entity absent from API pull, clear on re-appearance, lifecycle: Active → Soft-Deleted → Purged (by retention)
+
+**Checkpoint**: ArangoDB writer can upsert documents with natural keys, create graph edges, and handle soft-deletes — testable independently via direct `ArangoDBWriter` calls
+
+---
+
+## Phase 4: User Story 3 — Time-Series Metrics in Redis TimeSeries (Priority: P1)
+
+**Goal**: All statistical and performance data (device stats, port stats, SLE metrics, client counts) stored as Redis TimeSeries keys with labels and automatic downsampling
+
+**Independent Test**: Run Menu 13 (org device stats), then query Redis to verify time-series keys exist with correct labels and data points
+
+**Note**: Phase 4 can proceed in parallel with Phase 3 (different files, no shared dependencies)
+
+### Tests for User Story 3
+
+- [ ] T014 [P] [US3] Write unit tests for `RedisTimeSeriesWriter` in `tests/unit/test_redis_writer.py` — mock `redis` client; test TS.CREATE with labels and retention, TS.ADD with pipeline batching, compaction rule creation, key naming convention, numeric value extraction from flattened records
+
+### Implementation for User Story 3
+
+- [ ] T015 [US3] Implement `RedisTimeSeriesWriter.__init__()` in `src/db/redis_writer.py` — connect using `redis.Redis`, verify TimeSeries module available via `module_list()`, bind structured logger
+- [ ] T016 [US3] Implement `RedisTimeSeriesWriter.write()` in `src/db/redis_writer.py` — extract numeric values from flattened records, create TS key per metric (`{api_function_name}:{entity_id}:{field_name}`), apply labels (org_id, site_id, device_id, metric_name, metric_category), use `TS.ADD` with auto-timestamp, batch via pipeline
+- [ ] T017 [US3] Implement automatic compaction rules in `RedisTimeSeriesWriter` in `src/db/redis_writer.py` — on first key creation, add `TS.CREATERULE` for hourly avg (`:avg_1h`, 90d retention) and daily avg (`:avg_1d`, 365d retention); raw key retention from `REDIS_RAW_RETENTION_DAYS` (default 7d); track created keys to avoid duplicate rules
+
+**Checkpoint**: Redis TimeSeries writer can store metrics with labels, append data points, and auto-create downsampling compaction rules — testable independently
+
+---
+
+## Phase 5: User Story 4 — Automatic Data Routing by Endpoint Type (Priority: P2)
+
+**Goal**: `DatabaseRouter.write()` automatically routes data to ArangoDB or Redis based on `ENDPOINT_PRIMARY_KEY_STRATEGIES` type field — no per-endpoint code changes needed for new operations
+
+**Independent Test**: Add a test endpoint to `ENDPOINT_PRIMARY_KEY_STRATEGIES` with type `natural_pk` and verify it routes to ArangoDB without additional code
+
+### Tests for User Story 4
+
+- [ ] T018 [P] [US4] Write unit tests for `DatabaseRouter.write()` routing logic in `tests/unit/test_router.py` — test `natural_pk` → ArangoDB, `composite_pk` → Redis, `auto_increment_with_unique` → ArangoDB, unknown `api_function_name` → skip with Debug log, both backends down → CSV-only with Error log, single backend down → degraded mode
+
+### Implementation for User Story 4
+
+- [ ] T019 [US4] Implement `DatabaseRouter.write()` routing logic in `src/db/router.py` — look up `api_function_name` in `ENDPOINT_PRIMARY_KEY_STRATEGIES`, route `natural_pk`/`auto_increment_with_unique` to `ArangoDBWriter.write()`, route `composite_pk` to `RedisTimeSeriesWriter.write()`, return `WriteResult` with success/failure status
+- [ ] T020 [US4] Implement degraded mode handling in `DatabaseRouter.write()` in `src/db/router.py` — if target backend unavailable, log warning and return `WriteResult(success=False, backend="csv_only")`; if both backends down, log error; auto-detect recovery when backend becomes available again (reconnect on next write attempt)
+
+**Checkpoint**: Router correctly dispatches data to backends by strategy type; degraded mode gracefully falls back — testable with mock writers
+
+---
+
+## Phase 6: User Story 1 — Container Deployment with Multi-DB Backend (Priority: P1) — MVP
+
+**Goal**: `podman-compose up` starts MistHelper, ArangoDB, and Redis; any data extraction menu operation persists data to the correct backend AND produces CSV output identically to current behavior
+
+**Independent Test**: Deploy using `podman-compose up` and run Menu 11 (org sites export). Verify data is stored in ArangoDB (not SQLite) and CSV output still works identically.
+
+### Tests for User Story 1
+
+- [ ] T021 [P] [US1] Write integration test for container deployment in `tests/integration/test_compose_deploy.py` — verify all 3 services start healthy within 60s, verify MistHelper can reach ArangoDB and Redis, verify health_check endpoint returns all green, verify CSV output unchanged
+
+### Implementation for User Story 1
+
+- [ ] T022 [US1] Add `DatabaseRouter` initialization in `DataExporter.__init__()` in `MistHelper.py` (line ~9401) — create `DatabaseConfig.from_env()`, instantiate `DatabaseRouter`, handle init failure gracefully (log warning, set router to None)
+- [ ] T023 [US1] Modify `DataExporter.write_with_format_selection()` in `MistHelper.py` (line ~9410) — after existing CSV write, if `api_function_name` provided and router available: call `self.router.write(data, api_function_name)`, log `WriteResult` at Info level, never raise to caller
+- [ ] T024 [US1] Add `depends_on` with `condition: service_healthy` for both `arangodb` and `redis-stack` on the `misthelper` service in `compose.yml`
+- [ ] T025 [US1] Import `src.db` package in `MistHelper.py` — add conditional import with `ImportError` fallback for standalone mode (no python-arango/redis installed)
+
+**Checkpoint**: MVP complete — full end-to-end data flow from menu operation through router to backends with CSV always produced. Deploy and validate with `podman-compose up`
+
+---
+
+## Phase 7: User Story 5 — Config Snapshot on Change with Periodic Fallback (Priority: P2)
+
+**Goal**: Configuration snapshots captured whenever a change is detected and periodically during idle periods, stored as versioned documents in ArangoDB with hash-based deduplication
+
+**Independent Test**: Modify a WLAN configuration, then verify a new snapshot document appears in ArangoDB `config_snapshots` collection with timestamp, config hash, and diff from previous version
+
+### Implementation for User Story 5
+
+- [ ] T026 [US5] Implement `ArangoDBWriter.snapshot()` in `src/db/arango_writer.py` — compute SHA-256 hash of sorted JSON config body, query latest snapshot for entity, skip if hash matches, store in `config_snapshots` collection with entity_type, entity_id, timestamp, config_hash, config_body, trigger field
+- [ ] T027 [US5] Implement on-change snapshot detection in `DatabaseRouter.write()` in `src/db/router.py` — for config entity types (sites, wlans, templates, networks, services), call `ArangoDBWriter.snapshot()` after successful document upsert, set trigger="api_pull"
+- [ ] T028 [US5] Add periodic snapshot check to `DataExporter` in `MistHelper.py` — track last snapshot time per entity type, poll current config when idle period exceeds configurable threshold, snapshot if changed, set trigger="periodic"
+
+**Checkpoint**: Config snapshots are captured on API data pulls and periodically — dedup prevents duplicate snapshots
+
+---
+
+## Phase 8: User Story 6 — Storage-Aware Retention with Oldest-First Rollover (Priority: P3)
+
+**Goal**: Automatic data retention management that uses all available storage and rolls over oldest data first, no manual cleanup needed
+
+**Independent Test**: Configure small storage limit, ingest enough data to exceed it, verify oldest records removed while newest preserved
+
+### Implementation for User Story 6
+
+- [ ] T029 [US6] Implement `RetentionManager.__init__()` in `src/db/retention.py` — accept ArangoDBWriter and RedisTimeSeriesWriter references, load retention config from env (thresholds, intervals), bind structured logger
+- [ ] T030 [US6] Implement ArangoDB retention in `RetentionManager` in `src/db/retention.py` — check `ARANGO_MAX_STORAGE_GB` threshold, purge oldest soft-deleted entities first, then oldest snapshot versions, always preserve at least one snapshot per entity (SC-006)
+- [ ] T031 [US6] Implement Redis retention validation in `RetentionManager` in `src/db/retention.py` — verify compaction rules exist on all TS keys, validate per-tier retention (raw 7d, hourly 90d, daily 365d), trim keys exceeding retention via `TS.DEL`
+- [ ] T032 [US6] Add periodic retention sweep timer in `RetentionManager` in `src/db/retention.py` — configurable interval from `RETENTION_CHECK_INTERVAL_HOURS` (default 6h), run in background thread, log sweep results at Info level
+
+**Checkpoint**: Storage is self-managing — oldest data purged automatically when thresholds reached
+
+---
+
+## Phase 9: User Story 7 — Standalone Mode Backward Compatibility (Priority: P3)
+
+**Goal**: MistHelper running directly on a host (not in a container) continues working with CSV-only output — no errors, no DB connection attempts
+
+**Independent Test**: Run `python MistHelper.py --menu 11` on a host without ArangoDB or Redis installed. Verify CSV output produced and no errors thrown.
+
+### Implementation for User Story 7
+
+- [ ] T033 [US7] Implement standalone mode detection in `DatabaseRouter.__init__()` in `src/db/router.py` — check `MISTHELPER_STANDALONE` env var and `is_running_in_container()` function; if standalone, set `config.standalone_mode = True`, skip all connection attempts, log at Info "Running in standalone mode — CSV-only output"
+- [ ] T034 [US7] Verify conditional import path in `MistHelper.py` — when `python-arango` or `redis` not installed (standalone host), `ImportError` fallback sets `DatabaseRouter` to `None`, DataExporter skips routing silently
+- [ ] T035 [US7] Validate optional backend connectivity in `DatabaseRouter` in `src/db/router.py` — when running standalone but `ARANGO_HOST`/`REDIS_HOST` explicitly configured, attempt connection (user has opted in); log result at Info level
+
+**Checkpoint**: Standalone users experience zero regressions — CSV output identical, no new error messages, no new dependencies required
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, migration utility, and final quality validation
+
+- [ ] T036 [P] Update `README.md` with polyglot database architecture section — new environment variables table, compose service diagram, storage backend descriptions
+- [ ] T037 [P] Update `CHANGELOG.md` with version entry for polyglot DB migration feature (Keep a Changelog format, `version YY.MM.DD.HH.MM`)
+- [ ] T038 Implement SQLite-to-polyglot one-time migration utility in `scripts/migrate_sqlite_to_polyglot.py` (FR-011) — read existing `data/mist_data.db`, classify tables by PK strategy, export documents to ArangoDB and time-series to Redis, preserve all historical data (SC-008)
+- [ ] T039 Run full quality gates: `python -m py_compile MistHelper.py`, `python -m ruff check MistHelper.py`, `python -m black --check MistHelper.py`, `pytest tests/ -v --cov`
+- [ ] T040 [P] Run `quickstart.md` validation steps end-to-end — verify developer setup, service connections, test execution
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **US2 (Phase 3)**: Depends on Foundational — ArangoDB writer (can parallel with Phase 4)
+- **US3 (Phase 4)**: Depends on Foundational — Redis writer (can parallel with Phase 3)
+- **US4 (Phase 5)**: Depends on US2 + US3 — routing connects the writers
+- **US1 (Phase 6)**: Depends on US4 — end-to-end integration (MVP checkpoint)
+- **US5 (Phase 7)**: Depends on US2 — uses ArangoDBWriter.snapshot()
+- **US6 (Phase 8)**: Depends on US2 + US3 — manages retention across both backends
+- **US7 (Phase 9)**: Depends on US4 — validates graceful fallback in router
+- **Polish (Phase 10)**: Depends on all desired user stories being complete
+
+### Priority vs Implementation Order
+
+US1 is P1 (highest priority) but depends on US2 + US3 + US4. The implementation order resolves this: build the backends first (US2, US3), wire the routing (US4), then validate end-to-end (US1). All P1 stories complete together at the Phase 6 checkpoint.
+
+### User Story Dependencies
+
+```text
+US2 (ArangoDB Writer) ──┐
+                        ├──→ US4 (Routing) ──→ US1 (Integration) ──→ MVP
+US3 (Redis Writer) ─────┘         │
+                                  ├──→ US5 (Snapshots)
+                                  ├──→ US7 (Standalone)
+US2 + US3 ────────────────────────┴──→ US6 (Retention)
+```
+
+### Within Each User Story
+
+1. Tests written first (should fail before implementation)
+2. Core class and connection before business logic
+3. Primary operations before edge cases (soft-delete, compaction rules)
+4. Story complete before moving to next phase
+
+---
+
+## Parallel Opportunities
+
+### Phase 3 + Phase 4 (Full Parallel)
+
+```text
+Agent A: T009 → T010 → T011 → T012 → T013   (ArangoDB writer)
+Agent B: T014 → T015 → T016 → T017           (Redis writer)
+```
+
+### Within Foundational Phase
+
+```text
+Parallel: T005 (structlog), T006 (ArangoDB compose), T007 (Redis compose)
+After T004: T008 (router skeleton imports DatabaseConfig)
+```
+
+### Within US1 Phase
+
+```text
+Parallel: T021 (integration test), T025 (import setup)
+Sequential: T022 → T023 → T024 (DataExporter changes + compose depends_on)
+```
+
+### Polish Phase
+
+```text
+Parallel: T036 (README), T037 (CHANGELOG), T040 (quickstart validation)
+Sequential: T038 (migration utility) → T039 (quality gates)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Through Phase 6)
+
+1. Complete Phase 1: Setup (3 tasks)
+2. Complete Phase 2: Foundational (5 tasks, blocks everything)
+3. Complete Phase 3 + 4 in parallel: US2 + US3 backend writers (9 tasks)
+4. Complete Phase 5: US4 routing logic (3 tasks)
+5. Complete Phase 6: US1 integration (5 tasks)
+6. **STOP AND VALIDATE**: `podman-compose up`, run Menu 11, verify ArangoDB + Redis + CSV output
+7. This is the **MVP** — all P1 stories complete, system is functional end-to-end
+
+### Incremental Delivery After MVP
+
+1. Add US5 (P2): Config snapshots → Deploy/validate
+2. Add US6 (P3): Retention management → Deploy/validate
+3. Add US7 (P3): Standalone verification → Deploy/validate
+4. Polish: Docs, migration tool, quality gates → Final release
+
+### Total Task Summary
+
+| Phase | Story | Tasks | Parallel |
+| - | - | - | - |
+| 1 Setup | — | 3 | 2 |
+| 2 Foundational | — | 5 | 3 |
+| 3 US2 | ArangoDB Writer | 5 | 1 |
+| 4 US3 | Redis Writer | 4 | 1 |
+| 5 US4 | Auto-Routing | 3 | 1 |
+| 6 US1 | Container Integration | 5 | 2 |
+| 7 US5 | Config Snapshots | 3 | 0 |
+| 8 US6 | Retention | 4 | 0 |
+| 9 US7 | Standalone Mode | 3 | 0 |
+| 10 Polish | Cross-Cutting | 5 | 3 |
+| **Total** | | **40** | **13** |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps tasks to user stories for traceability
+- Each user story is independently testable at its checkpoint
+- Commit after each task or logical group
+- Stop at Phase 6 checkpoint to validate MVP before proceeding
+- All new code in `src/db/` uses `structlog` (research decision #8)
+- Migration utility (T038) in `scripts/` to keep `src/db/` at 5 files (Five-Item Rule)
+- `ENDPOINT_PRIMARY_KEY_STRATEGIES` dictionary is read-only for this feature — no entries changed

--- a/specs/185-polyglot-data-routing/.spec-context.json
+++ b/specs/185-polyglot-data-routing/.spec-context.json
@@ -1,0 +1,10 @@
+{
+  "workflow": "speckit",
+  "specName": "185-polyglot-data-routing",
+  "branch": "185-polyglot-data-routing",
+  "selectedAt": "2026-04-22T16:40:16.769Z",
+  "currentStep": "specify",
+  "status": "draft",
+  "stepHistory": {},
+  "transitions": []
+}

--- a/specs/185-polyglot-data-routing/checklists/requirements.md
+++ b/specs/185-polyglot-data-routing/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Polyglot Data Routing Refactor
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- SC-001 and SC-002 reference specific database field paths for verification -- these describe *observable outcomes*, not implementation choices. The spec deliberately names the storage backends (ArangoDB, Redis) because they are pre-existing infrastructure constraints, not design choices being made in this feature.
+- SC-006 references quality gate tools (py_compile, ruff, black) -- these are project-mandated quality standards, not feature-specific implementation choices.
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/185-polyglot-data-routing/contracts/internal-interfaces.md
+++ b/specs/185-polyglot-data-routing/contracts/internal-interfaces.md
@@ -1,0 +1,104 @@
+# Contracts: Polyglot Data Routing Refactor
+
+**Feature**: 185-polyglot-data-routing | **Date**: 2026-04-22
+
+## Internal Python Interfaces
+
+These are internal module contracts -- not external APIs. They define the signatures that implementation tasks must conform to.
+
+### 1. DataExporter.write_with_format_selection (updated)
+
+```python
+@staticmethod
+def write_with_format_selection(
+    data: list[dict[str, Any]],
+    filename_or_table: str,
+    format_override: str | None = None,
+    api_function_name: str | None = None,
+    raw_data: list[dict[str, Any]] | None = None,  # NEW
+) -> bool:
+    """
+    Writes data to CSV/SQLite and routes to polyglot backends.
+
+    Args:
+        data: Flattened data for CSV/SQLite output.
+        filename_or_table: Target filename or table name.
+        format_override: Optional output format override.
+        api_function_name: Endpoint name for strategy lookup.
+        raw_data: Unflattened API response for polyglot backends.
+                  If None, falls back to `data` (backward compatible).
+
+    Returns:
+        True if CSV/SQLite write succeeded.
+    """
+```
+
+**Contract**: CSV/SQLite always receives `data` (flattened). Polyglot backends receive `raw_data` if provided, otherwise `data`.
+
+### 2. DataExporter._route_to_polyglot (updated)
+
+```python
+@staticmethod
+def _route_to_polyglot(
+    data: list[dict[str, Any]],
+    api_function_name: str | None,
+    raw_data: list[dict[str, Any]] | None = None,
+) -> None:
+    """Route data to polyglot backends, preferring raw_data."""
+```
+
+**Contract**: Passes `raw_data or data` to `DatabaseRouter.write()`.
+
+### 3. DatabaseRouter.write (updated)
+
+```python
+def write(
+    self,
+    data: list[dict[str, Any]],
+    api_function_name: str,
+) -> WriteResult:
+    """
+    Route data to backends based on endpoint strategy type.
+
+    Routing:
+    - natural_pk → ArangoDB (raw documents)
+    - composite_pk → Redis JSON + ArangoDB (dual-write)
+    - timeseries_pk → Redis TimeSeries
+    - auto_increment_with_unique → ArangoDB
+    """
+```
+
+**Contract**: Signature unchanged. The `data` parameter now receives raw (unflattened) data from the updated caller chain.
+
+### 4. RedisJSONWriter (new class)
+
+```python
+class RedisJSONWriter:
+    """Writes composite_pk data as Redis JSON documents."""
+
+    def __init__(self, config: DatabaseConfig) -> None: ...
+
+    def write(
+        self,
+        data: list[dict[str, Any]],
+        api_function_name: str,
+        strategy: dict[str, Any],
+    ) -> WriteResult: ...
+```
+
+**Contract**:
+- Upserts documents using `JSON.SET` with key pattern `{endpoint}:{pk_values}`
+- Preserves all fields from raw API response (zero field loss)
+- Applies TTL via `EXPIRE` (configurable via `REDIS_JSON_TTL_DAYS`)
+- Uses pipelined batch writes for performance
+- Returns `WriteResult` with `backend="redis_json"`
+
+### 5. DatabaseRouter routing constants (updated)
+
+```python
+ARANGO_ONLY_TYPES = {"natural_pk", "auto_increment_with_unique"}
+DUAL_WRITE_TYPES = {"composite_pk"}
+TIMESERIES_TYPES = {"timeseries_pk"}
+```
+
+**Contract**: Router uses these sets to dispatch to the correct writer(s).

--- a/specs/185-polyglot-data-routing/data-model.md
+++ b/specs/185-polyglot-data-routing/data-model.md
@@ -1,0 +1,122 @@
+# Data Model: Polyglot Data Routing Refactor
+
+**Feature**: 185-polyglot-data-routing | **Date**: 2026-04-22
+
+## Entities
+
+### 1. EndpointStrategy (updated)
+
+**Location**: `ENDPOINT_PRIMARY_KEY_STRATEGIES` dict in `MistHelper.py`
+
+```python
+# Existing fields (unchanged)
+{
+    "type": str,              # "natural_pk" | "composite_pk" | "timeseries_pk" | "auto_increment_with_unique"
+    "primary_key": list[str], # Key fields for upsert
+    "indexes": list[str],     # Fields to index
+    "unique_constraints": list[str],
+    "description": str,
+}
+
+# New fields for timeseries_pk only
+{
+    "ts_value_fields": list[str],  # Numeric fields → TS data points
+    "ts_label_fields": list[str],  # Text fields → TS labels
+}
+```
+
+**Routing rules**:
+| Strategy Type | ArangoDB | Redis JSON | Redis TimeSeries |
+|---|---|---|---|
+| `natural_pk` | Raw documents (upsert) | -- | -- |
+| `composite_pk` | Raw documents (archive) | Full documents (recent) | -- |
+| `timeseries_pk` | -- | -- | Numeric values + labels |
+| `auto_increment_with_unique` | Raw documents (upsert) | -- | -- |
+
+### 2. WriteResult (unchanged)
+
+```python
+@dataclass
+class WriteResult:
+    success: bool
+    backend: str      # "arangodb", "redis", "redis_json", "dual", "csv_only"
+    records_written: int
+    records_failed: int
+    error_message: str = ""
+```
+
+**Change**: `backend` field gains new values: `"redis_json"` for JSON-only writes, `"dual"` for composite_pk dual-write results.
+
+### 3. DualWriteResult (new)
+
+```python
+@dataclass
+class DualWriteResult:
+    arango_result: WriteResult
+    redis_result: WriteResult
+
+    @property
+    def combined(self) -> WriteResult:
+        """Merge both results into a single WriteResult for logging."""
+        ...
+```
+
+**Purpose**: Captures independent success/failure of both backends for composite_pk dual-write.
+
+## Routing Constants (updated)
+
+```python
+# Current (router.py)
+ARANGO_PK_TYPES = {"natural_pk", "auto_increment_with_unique"}
+REDIS_PK_TYPES = {"composite_pk"}
+
+# New
+ARANGO_ONLY_TYPES = {"natural_pk", "auto_increment_with_unique"}
+DUAL_WRITE_TYPES = {"composite_pk"}      # Redis JSON + ArangoDB
+TIMESERIES_TYPES = {"timeseries_pk"}      # Redis TimeSeries only
+```
+
+## Redis Key Patterns
+
+### Redis JSON keys (composite_pk)
+```
+Pattern: {endpoint}:{pk_field1_value}:{pk_field2_value}:...
+Example: searchOrgAlarms:alarm-uuid-123:org-uuid-456:1713800000
+TTL:     7 days (configurable via REDIS_JSON_TTL_DAYS env var)
+```
+
+### Redis TimeSeries keys (timeseries_pk, unchanged)
+```
+Pattern: {endpoint}:{entity_id}:{field_name}
+Example: listOrgDevicesStats:device-uuid-123:cpu_util
+```
+
+## Endpoint Reclassification Table
+
+### Moving from composite_pk to timeseries_pk
+| Endpoint | Primary Key | ts_value_fields (examples) | ts_label_fields |
+|---|---|---|---|
+| `listOrgDevicesStats` | `[device_id, timestamp]` | `cpu_util, mem_util, uptime, num_clients` | `hostname, model, type, site_id` |
+| `listSiteDevicesStats` | `[device_id, timestamp]` | `cpu_util, mem_util, uptime, num_clients` | `hostname, model, type` |
+| `listSiteWirelessClientsStats` | `[client_mac, timestamp]` | `rssi, snr, rx_rate, tx_rate` | `ssid, hostname, device_id` |
+| `searchOrgSwOrGwPorts` | `[device_id, port_id, timestamp]` | `rx_bytes, tx_bytes, rx_errors, tx_errors` | `port_id, device_id, org_id` |
+| `searchSiteSwOrGwPorts` | `[device_id, port_id, timestamp]` | `rx_bytes, tx_bytes, rx_errors, tx_errors` | `port_id, device_id, site_id` |
+| `searchOrgPeerPathStats` | `[from_device, to_device, timestamp]` | `latency, jitter, loss` | `from_device, to_device, org_id` |
+
+### Remaining as composite_pk (→ dual-write: Redis JSON + ArangoDB)
+| Endpoint | Reason |
+|---|---|
+| `searchOrgAlarms` | Text-heavy (severity, type, description) |
+| `searchOrgDeviceEvents` | Text-heavy (event type, text, device name) |
+| `searchOrgClientEvents` | Text-heavy (event type, client info) |
+| `searchOrgSystemEvents` | Text-heavy (system messages) |
+| `searchOrgWirelessClients` | Mixed text/numeric client data |
+| `searchOrgWiredClients` | Mixed text/numeric client data |
+| All device utility commands | Text-heavy diagnostic output |
+| All SSID consolidation endpoints | Configuration analysis data |
+
+### Remaining as natural_pk (→ ArangoDB raw documents)
+All entity endpoints unchanged (sites, devices, templates, maps, etc.)
+
+### Remaining as auto_increment_with_unique (→ ArangoDB)
+License summary/list endpoints unchanged.

--- a/specs/185-polyglot-data-routing/plan.md
+++ b/specs/185-polyglot-data-routing/plan.md
@@ -1,0 +1,228 @@
+# Implementation Plan: Polyglot Data Routing Refactor
+
+**Branch**: `185-polyglot-data-routing` | **Date**: 2026-04-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/185-polyglot-data-routing/spec.md`
+
+## Summary
+
+Refactor the MistHelper data pipeline so polyglot backends (ArangoDB, Redis) receive raw unflattened API data before the CSV flatten/escape step. Introduce `timeseries_pk` as a new strategy type for pure-numeric endpoints, route `composite_pk` data to both Redis JSON and ArangoDB (dual-write), and reclassify ~6 endpoints from `composite_pk` to `timeseries_pk`. CSV/SQLite output remains byte-identical to current behavior.
+
+## Technical Context
+
+**Language/Version**: Python 3.13+
+**Primary Dependencies**: `mistapi` 0.59+, `redis-py` (with JSON commands), `python-arango`, `structlog`
+**Storage**: ArangoDB 3.12 (documents/graph), Redis Stack (JSON + TimeSeries), SQLite (local), CSV (export)
+**Testing**: `python MistHelper.py --test` (skip 14, 18, 63-65, 90-100); manual verification via ArangoDB HTTP API and `redis-cli`
+**Target Platform**: Windows 11 (dev), Linux container (production)
+**Project Type**: CLI tool with menu-driven operations
+**Performance Goals**: Dual-write overhead < 2x single-backend write (SC-007)
+**Constraints**: Max 25 lines/function, max 5 params/function (Five-Item Rule)
+**Scale/Scope**: ~28K line single-file main + `src/db/` package (4 modules)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Five-Item Rule | PASS | New `RedisJSONWriter` class stays within limits. `write_with_format_selection` gains 1 param (5 total = at limit). Router methods remain under 25 lines each. |
+| II. Class-Based Architecture | PASS | `RedisJSONWriter` is a new class in `redis_writer.py`. No wrapper functions. |
+| III. Safety-First | PASS | No new user input. Backend failures degrade gracefully to CSV-only with warning logs. |
+| IV. Full Deployment Pipeline | PASS | All modified files pass `py_compile`, `ruff`, `black` before commit. |
+| V. Observability & Logging | PASS | All new writers use `structlog` with ASCII-only output. Backend failures logged at warning level. |
+| Technology Constraints | PASS | Uses `redis-py` JSON commands, `python-arango`. No new dependencies. |
+| Security: Fix Over Suppress | PASS | No new security suppressions needed. |
+
+### Post-Design Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Five-Item Rule | PASS | `write_with_format_selection` has 5 params (at limit, acceptable). `RedisJSONWriter.write` has 4 params. `DatabaseRouter.write` unchanged at 3 params. No function exceeds 25 lines in the design. |
+| II. Class-Based Architecture | PASS | `RedisJSONWriter` class added. `DatabaseRouter` extended with `_write_dual` method. No standalone wrappers. |
+| III. Safety-First | PASS | `raw_data` parameter is optional with `None` default -- backward compatible. All backend failures caught and logged. |
+| IV. Full Deployment Pipeline | PASS | Quality gates defined in quickstart.md. |
+| V. Observability & Logging | PASS | `RedisJSONWriter` uses `structlog` via `get_logger()`. Dual-write logs both backend results. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/185-polyglot-data-routing/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── internal-interfaces.md  # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Pre-existing
+└── spec.md              # Feature specification
+```
+
+### Source Code (repository root)
+
+```text
+src/db/
+├── __init__.py          # MODIFIED: export RedisJSONWriter
+├── arango_writer.py     # UNCHANGED
+├── redis_writer.py      # MODIFIED: add RedisJSONWriter class
+├── retention.py         # UNCHANGED
+└── router.py            # MODIFIED: routing constants, dual-write, timeseries_pk
+
+MistHelper.py            # MODIFIED: raw_data parameter, strategy reclassification
+```
+
+**Structure Decision**: All changes fit within the existing `src/db/` package structure. No new packages or directories needed. `RedisJSONWriter` lives alongside `RedisTimeSeriesWriter` in `redis_writer.py` since both are Redis writers sharing the same connection infrastructure.
+
+## Design Decisions
+
+### D1: raw_data Parameter (Not Separate Pre-Route Call)
+
+The `write_with_format_selection()` method gains an optional `raw_data` parameter. Callers pass both flattened data (for CSV) and raw data (for polyglot). This is preferred over:
+- **Pre-route call before write**: Would require callers to know about polyglot routing (leaks abstraction)
+- **Deep copy inside write**: Wasteful memory for large datasets
+- **Global/class variable**: Thread-safety concerns
+
+### D2: RedisJSONWriter in redis_writer.py (Not Separate File)
+
+Both Redis writers share connection setup, module detection, and pipelining patterns. Keeping them in one file avoids import complexity and stays within the 5-item rule for the `src/db/` directory (5 files currently).
+
+### D3: Independent Dual-Write (Not Transactional)
+
+For `composite_pk` endpoints, Redis JSON and ArangoDB writes are independent. One can fail without blocking the other. This matches the existing pattern where polyglot failure never blocks CSV output. The `DualWriteResult` captures both outcomes.
+
+### D4: TTL on Redis JSON Documents
+
+Redis JSON documents get a configurable TTL (default 7 days via `REDIS_JSON_TTL_DAYS`). This prevents unbounded memory growth. ArangoDB serves as the long-term archive. Redis serves recent-event queries only.
+
+### D5: Endpoint Reclassification is Conservative
+
+Only 6 clearly-numeric endpoints move to `timeseries_pk`. All event, alarm, client, and diagnostic endpoints stay as `composite_pk`. This minimizes risk and can be expanded later.
+
+## Implementation Phases
+
+### Phase 1: Raw Data Pipeline (User Story 1 - P1)
+
+**Goal**: Route unflattened API data to polyglot backends while preserving CSV output.
+
+**Changes**:
+
+1. **`MistHelper.py` - `DataExporter.write_with_format_selection()`**:
+   - Add `raw_data: list[dict[str, Any]] | None = None` parameter
+   - Pass `raw_data` (or `data` fallback) to `_route_to_polyglot()`
+
+2. **`MistHelper.py` - `DataExporter._route_to_polyglot()`**:
+   - Add `raw_data` parameter
+   - Pass `raw_data or data` to `self._router.write()`
+
+3. **`MistHelper.py` - Caller updates (incremental)**:
+   - Update menu operations that flatten before writing to pass both:
+     ```python
+     # Before
+     flattened = DataProcessingUtils.flatten_and_escape_data(raw_results)
+     DataExporter.write_with_format_selection(flattened, filename, api_function_name=name)
+     
+     # After
+     flattened = DataProcessingUtils.flatten_and_escape_data(raw_results)
+     DataExporter.write_with_format_selection(
+         flattened, filename, api_function_name=name, raw_data=raw_results
+     )
+     ```
+   - Start with high-value endpoints: `listOrgSites` (menu 11), `getOrgInventory` (menu 1), `listSiteDevices` (menu 3)
+
+**Verification**: Run menu 11, query ArangoDB for nested fields (e.g., `doc.latlng.lat`).
+
+### Phase 2: Redis JSON Writer + Dual-Write (User Story 2 - P2)
+
+**Goal**: Store `composite_pk` event documents as Redis JSON with dual-write to ArangoDB.
+
+**Changes**:
+
+1. **`src/db/redis_writer.py` - Add `RedisJSONWriter` class**:
+   - `__init__`: Reuse Redis connection, verify `ReJSON` module
+   - `write()`: Pipeline `JSON.SET` + `EXPIRE` for each record
+   - `_build_key()`: Construct key from endpoint name + PK fields
+   - Uses `REDIS_JSON_TTL_DAYS` env var (default 7)
+
+2. **`src/db/router.py` - Update routing**:
+   - Replace `ARANGO_PK_TYPES` / `REDIS_PK_TYPES` with `ARANGO_ONLY_TYPES` / `DUAL_WRITE_TYPES` / `TIMESERIES_TYPES`
+   - Add `_write_dual()` method for `composite_pk`: calls both `_write_redis_json()` and `_write_arango()`
+   - Initialize `RedisJSONWriter` alongside `RedisTimeSeriesWriter`
+
+3. **`src/db/__init__.py`**:
+   - Add `RedisJSONWriter` to `__all__`
+
+**Verification**: Run menu 13 (Device Events), check Redis JSON documents and ArangoDB archive.
+
+### Phase 3: TimeSeries Strategy Type (User Story 3 - P3)
+
+**Goal**: Route pure-numeric endpoints to Redis TimeSeries with explicit field configuration.
+
+**Changes**:
+
+1. **`src/db/router.py`**:
+   - Add `timeseries_pk` to routing dispatch (uses existing `_write_redis()`)
+   - `RedisTimeSeriesWriter.write()` already handles numeric extraction; `ts_value_fields` and `ts_label_fields` are passed through the strategy dict
+
+2. **`src/db/redis_writer.py` - `RedisTimeSeriesWriter`**:
+   - Update `_extract_chunk()` to respect `ts_value_fields` (only extract listed fields) and `ts_label_fields` (use as TS labels instead of dropping)
+   - If `ts_value_fields` not in strategy, fall back to current auto-detect behavior
+
+**Verification**: Run a device stats endpoint, verify Redis TS has labeled data points.
+
+### Phase 4: Endpoint Reclassification (User Story 4 - P2)
+
+**Goal**: Reclassify endpoints in `ENDPOINT_PRIMARY_KEY_STRATEGIES` to correct strategy types.
+
+**Changes**:
+
+1. **`MistHelper.py` - `ENDPOINT_PRIMARY_KEY_STRATEGIES`**:
+   - Change 6 stats/port endpoints from `composite_pk` to `timeseries_pk`
+   - Add `ts_value_fields` and `ts_label_fields` to each reclassified endpoint
+   - All other endpoints remain unchanged
+
+**Endpoints to reclassify**:
+| Endpoint | New Fields |
+|---|---|
+| `listOrgDevicesStats` | `ts_value_fields: [cpu_util, mem_util, ...], ts_label_fields: [hostname, model, ...]` |
+| `listSiteDevicesStats` | Same pattern |
+| `listSiteWirelessClientsStats` | `ts_value_fields: [rssi, snr, ...], ts_label_fields: [ssid, hostname, ...]` |
+| `searchOrgSwOrGwPorts` | `ts_value_fields: [rx_bytes, tx_bytes, ...], ts_label_fields: [port_id, ...]` |
+| `searchSiteSwOrGwPorts` | Same pattern |
+| `searchOrgPeerPathStats` | `ts_value_fields: [latency, jitter, loss], ts_label_fields: [from_device, to_device]` |
+
+**Verification**: Inspect the strategies dict. Run a stats endpoint and confirm Redis TS receives labeled metrics.
+
+## Dependency Graph
+
+```text
+Phase 1 (raw_data pipeline)
+    ↓
+Phase 2 (RedisJSONWriter + dual-write)  ←── Phase 4 (reclassification)
+    ↓
+Phase 3 (timeseries_pk routing)  ←── Phase 4 (reclassification)
+```
+
+- Phase 1 is prerequisite for all others (provides raw data path)
+- Phases 2 and 3 are independent of each other
+- Phase 4 depends on both Phase 2 (composite_pk routing must exist) and Phase 3 (timeseries_pk routing must exist)
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Breaking CSV output | `raw_data` is optional with `None` default; CSV path unchanged |
+| Redis JSON module not loaded | Module check at init; graceful degradation to ArangoDB-only |
+| Memory pressure from raw_data copy | Raw data is a reference, not a copy; Python shares the list until mutation |
+| Large dual-write overhead | Independent writes, pipelined batches, async not needed at current scale |
+| Reclassification breaks existing TS data | Only 6 endpoints move; they already have `composite_pk` which was routing to TS |
+
+## Complexity Tracking
+
+No constitution violations requiring justification. All changes stay within the Five-Item Rule limits:
+- `write_with_format_selection`: 5 params (at limit, all necessary)
+- `RedisJSONWriter`: 3 public methods (write, health_check, __init__)
+- `src/db/` directory: 5 files (at limit after adding nothing new -- `RedisJSONWriter` goes in existing `redis_writer.py`)

--- a/specs/185-polyglot-data-routing/quickstart.md
+++ b/specs/185-polyglot-data-routing/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart: Polyglot Data Routing Refactor
+
+**Feature**: 185-polyglot-data-routing | **Date**: 2026-04-22
+
+## Prerequisites
+
+1. **Infrastructure running** (via `podman compose up -d arangodb redis-stack`)
+2. **Environment variables set**:
+   ```powershell
+   $env:ARANGO_HOST = "http://localhost:8529"
+   $env:ARANGO_ROOT_PASSWORD = "changeme"
+   $env:REDIS_HOST = "localhost"
+   $env:REDIS_PORT = "6379"
+   $env:REDIS_PASSWORD = "changeme"
+   ```
+3. **Python venv activated**: `.venv\Scripts\Activate.ps1`
+
+## Verification Commands
+
+### After each implementation task, verify:
+
+```powershell
+# Quality gates (must all pass)
+python -m py_compile MistHelper.py
+python -m py_compile src/db/router.py
+python -m py_compile src/db/redis_writer.py
+python -m ruff check MistHelper.py src/db/
+python -m black --check MistHelper.py src/db/
+
+# Smoke test (menu 11 = Org Sites → natural_pk → ArangoDB raw)
+python MistHelper.py --menu 11
+
+# Verify ArangoDB has nested documents
+$auth = "Basic $([Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes('root:changeme')))"
+Invoke-RestMethod -Uri "http://localhost:8529/_db/misthelper/_api/cursor" `
+  -Method Post -Headers @{Authorization=$auth} `
+  -ContentType "application/json" `
+  -Body '{"query":"FOR doc IN listOrgSites LIMIT 1 RETURN doc"}'
+
+# Verify Redis JSON (after composite_pk task)
+redis-cli -h localhost -p 6379 -a changeme JSON.GET "searchOrgDeviceEvents:example-key" $
+```
+
+## File Change Map
+
+| File | Changes | Task |
+|---|---|---|
+| `MistHelper.py` | Add `raw_data` param to `write_with_format_selection`, update callers, reclassify strategies | T1, T4 |
+| `src/db/router.py` | Update routing constants, add dual-write dispatch, add `timeseries_pk` routing | T2, T3 |
+| `src/db/redis_writer.py` | Add `RedisJSONWriter` class, keep `RedisTimeSeriesWriter` unchanged | T2 |
+| `src/db/__init__.py` | Export `RedisJSONWriter` | T2 |
+
+## Task Execution Order
+
+```
+T1 (raw_data pipeline) → T2 (RedisJSONWriter + dual-write) → T3 (timeseries_pk routing) → T4 (endpoint reclassification)
+```
+
+Each task is independently testable. T1 must complete before T2-T4 since it provides the raw data path.

--- a/specs/185-polyglot-data-routing/research.md
+++ b/specs/185-polyglot-data-routing/research.md
@@ -1,0 +1,90 @@
+# Research: Polyglot Data Routing Refactor
+
+**Feature**: 185-polyglot-data-routing | **Date**: 2026-04-22
+
+## R1: Where does flattening occur relative to polyglot routing?
+
+**Decision**: The polyglot routing call currently happens **after** the flatten/CSV write step.
+
+**Evidence**: In `MistHelper.py` line ~9489, `_route_to_polyglot(data, api_function_name)` is called at the end of `write_with_format_selection()`, after `_write_csv_format()` or `_write_sqlite_format()` have already consumed and potentially flattened the data. The `data` parameter passed to polyglot is the same list that was already processed by the flatten step.
+
+**Fix approach**: The `write_with_format_selection()` method must accept a `raw_data` parameter containing the unflattened API response. The call sequence becomes:
+1. Store raw copy before flatten
+2. Flatten for CSV/SQLite
+3. Route raw data to polyglot backends
+
+**Alternatives rejected**:
+- Deep-copy before flatten: Wasteful for large datasets (10K+ records)
+- Flatten inside write method: Flattening already happens at callers before `write_with_format_selection()`
+
+**Key finding**: Flattening is done by individual menu operation functions (callers), not inside `write_with_format_selection()`. The callers call `DataProcessingUtils.flatten_and_escape_data()` then pass the flattened result. This means the raw data is available at the caller level before flattening and can be passed alongside.
+
+## R2: RedisJSON best practices for document upsert
+
+**Decision**: Use `JSON.SET` with the key pattern `{endpoint_name}:{pk_value}` and `NX`/`XX` flags not needed (SET is always upsert by default in RedisJSON).
+
+**Rationale**:
+- `JSON.SET key $ document` creates or replaces the document atomically
+- For composite PKs, join fields with `:` separator: `searchOrgAlarms:alarm_id:org_id:1234567890`
+- Key length limit is 512MB (not a practical concern); hash PKs only if composite key exceeds ~200 chars
+- Use pipelining for bulk writes (same pattern as existing TimeSeries writer)
+
+**Alternatives considered**:
+- `JSON.MERGE`: Only available in Redis 7.4+; not universally available in redis-stack images
+- Separate `JSON.GET` then `JSON.SET`: Unnecessary round-trip; SET is idempotent
+
+## R3: Redis module detection for JSON vs TimeSeries
+
+**Decision**: Extend existing `_verify_timeseries_module()` pattern to also check for `ReJSON` module.
+
+**Rationale**: The `RedisTimeSeriesWriter` already has `_verify_timeseries_module()` that calls `self._client.module_list()`. The same approach works for detecting JSON support. Module name is `ReJSON` (case variations handled by lowering).
+
+## R4: Endpoint reclassification strategy
+
+**Decision**: Introduce `timeseries_pk` as a fourth strategy type. Reclassify endpoints based on data shape:
+
+| Current Type | Endpoint Pattern | New Type | Reason |
+|---|---|---|---|
+| `composite_pk` | `*Events`, `*Alarms` | `composite_pk` (unchanged) | Text-heavy documents |
+| `composite_pk` | `*Stats`, `*Ports` | `timeseries_pk` (new) | Numeric metrics with labels |
+| `composite_pk` | `*Clients` (search) | `composite_pk` (unchanged) | Mixed text/numeric documents |
+| `composite_pk` | Device utility commands | `composite_pk` (unchanged) | Text-heavy diagnostic output |
+| `natural_pk` | Entity endpoints | `natural_pk` (unchanged) | Stable UUID entities |
+| `auto_increment_with_unique` | Summary endpoints | `auto_increment_with_unique` (unchanged) | No stable key |
+
+Endpoints moving to `timeseries_pk`:
+- `listOrgDevicesStats`
+- `listSiteDevicesStats`
+- `listSiteWirelessClientsStats`
+- `searchOrgSwOrGwPorts`
+- `searchSiteSwOrGwPorts`
+- `searchOrgPeerPathStats`
+
+New fields for `timeseries_pk` strategy:
+```python
+{
+    "type": "timeseries_pk",
+    "primary_key": ["device_id", "timestamp"],
+    "ts_value_fields": ["cpu_util", "mem_util", "uptime", ...],  # numeric only
+    "ts_label_fields": ["hostname", "model", "type"],  # text metadata
+    ...
+}
+```
+
+## R5: Dual-write architecture for composite_pk
+
+**Decision**: `composite_pk` endpoints write to both Redis JSON (recent/fast access) and ArangoDB (archival/graph). Writes are independent -- one failure does not block the other.
+
+**Rationale**: Events need fast recent-access (Redis JSON with TTL) and long-term archive (ArangoDB). Making writes independent ensures CSV-first reliability is preserved.
+
+**Implementation**: Router dispatches to both writers in sequence. Each returns a `WriteResult`. Combined result reports both backend statuses.
+
+## R6: How callers provide raw data
+
+**Decision**: Add `raw_data` optional parameter to `write_with_format_selection()`. Callers that flatten before calling pass both `data` (flattened) and `raw_data` (original). If `raw_data` is None, fall back to using `data` (backward compatible).
+
+**Rationale**: This is the least disruptive change. Existing callers that don't pass `raw_data` continue working exactly as before. New/updated callers can opt in by passing the raw data.
+
+**Alternatives rejected**:
+- Refactoring all callers at once: Too risky for a ~28K line file; incremental is safer
+- Storing raw data as a class variable: Thread-safety concerns with concurrent operations

--- a/specs/185-polyglot-data-routing/spec.md
+++ b/specs/185-polyglot-data-routing/spec.md
@@ -1,0 +1,154 @@
+# Feature Specification: Polyglot Data Routing Refactor
+
+**Feature Branch**: `185-polyglot-data-routing`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**: Refactor MistHelper data pipeline so polyglot backends (ArangoDB, Redis) receive raw API data before CSV flattening, and Redis is used to its full capabilities (JSON, Search, TimeSeries) instead of TimeSeries-only.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Raw Document Persistence in ArangoDB (Priority: P1)
+
+As a NOC engineer querying ArangoDB, I want device inventories, site configs, and templates stored as rich nested JSON documents so that I can query nested fields (e.g., `device.radio_config.band_24.power`) without data loss from CSV flattening.
+
+**Why this priority**: ArangoDB currently receives flattened data, losing all nested structure. This is the core pipeline fix that all other stories depend on -- moving the polyglot routing call before the flatten step.
+
+**Independent Test**: Run menu 11 (Org Sites) and verify ArangoDB documents contain nested objects (e.g., `latlng`, `rftemplate_id` as nested references) while CSV output remains identical to current behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Mist API returns nested JSON for org sites, **When** menu 11 runs, **Then** ArangoDB stores the raw nested document and CSV output matches the current flattened format exactly.
+2. **Given** a `natural_pk` endpoint executes, **When** data is exported, **Then** ArangoDB receives raw data BEFORE flatten and CSV receives flattened data AFTER flatten.
+3. **Given** ArangoDB is unavailable, **When** an export runs, **Then** CSV/SQLite output succeeds normally and a warning is logged for the ArangoDB failure.
+
+---
+
+### User Story 2 - Event Documents in Redis JSON (Priority: P2)
+
+As a NOC engineer investigating incidents, I want event data (device events, alarms, client events) stored as full JSON documents in Redis so that I can query recent events by type, hostname, SSID, or severity without data loss from numeric-only extraction.
+
+**Why this priority**: Currently, `composite_pk` endpoints route to Redis TimeSeries which silently drops all non-numeric fields (event types, hostnames, error messages). This makes Redis useless for event investigation. Storing events as RedisJSON documents preserves the full record for fast recent-event queries.
+
+**Independent Test**: Run menu 13 (Device Events) and verify Redis contains full JSON documents with all fields (event type, device name, text, timestamp) and ArangoDB also receives the full document for archival.
+
+**Acceptance Scenarios**:
+
+1. **Given** device events are fetched from Mist API, **When** menu 13 runs, **Then** Redis stores each event as a JSON document with all original fields preserved.
+2. **Given** events are stored in Redis JSON, **When** the same endpoint runs again with overlapping events, **Then** existing documents are updated (upsert) rather than duplicated.
+3. **Given** `composite_pk` endpoints execute, **When** data is exported, **Then** both Redis JSON and ArangoDB receive the full raw document (dual-write).
+
+---
+
+### User Story 3 - Numeric Metrics via Redis TimeSeries (Priority: P3)
+
+As a NOC engineer monitoring network health, I want device statistics and port utilization stored in Redis TimeSeries as pure numeric time-series data so that I can chart trends and set threshold alerts on metrics like signal strength, throughput, and port utilization.
+
+**Why this priority**: TimeSeries already works for numeric data. This story introduces the `timeseries_pk` strategy type that explicitly identifies pure-numeric endpoints, replacing the current `composite_pk` classification that incorrectly groups numeric stats with text-heavy events.
+
+**Independent Test**: Run a device stats endpoint and verify Redis TimeSeries receives numeric metrics (CPU, memory, uplink throughput) while non-numeric metadata (hostname, model) is stored as TimeSeries labels rather than dropped.
+
+**Acceptance Scenarios**:
+
+1. **Given** device stats are fetched, **When** a `timeseries_pk` endpoint executes, **Then** numeric fields are stored as TimeSeries data points and text fields are stored as TimeSeries labels.
+2. **Given** a `timeseries_pk` endpoint configuration, **When** it specifies `ts_value_fields` and `ts_label_fields`, **Then** only those fields are used for values and labels respectively.
+3. **Given** a device stats endpoint runs, **When** the same timestamp data is re-imported, **Then** duplicate data points are not created (idempotent upsert).
+
+---
+
+### User Story 4 - Endpoint Strategy Reclassification (Priority: P2)
+
+As a maintainer of MistHelper, I want each API endpoint classified into the correct primary key strategy (`natural_pk`, `composite_pk`, `timeseries_pk`, `auto_increment_with_unique`) so that data routes to the optimal storage backend for its data shape.
+
+**Why this priority**: The reclassification determines which data goes where. Without it, the pipeline changes from Stories 1-3 would route data incorrectly. This must be done alongside Story 2.
+
+**Independent Test**: Inspect the `ENDPOINT_PRIMARY_KEY_STRATEGIES` dictionary and verify that pure-numeric endpoints use `timeseries_pk`, event/alarm endpoints use `composite_pk`, and entity endpoints use `natural_pk`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the strategies dictionary is updated, **When** a stats endpoint (e.g., `listOrgDevicesStats`) is classified, **Then** it uses `timeseries_pk` with defined `ts_value_fields` and `ts_label_fields`.
+2. **Given** the strategies dictionary is updated, **When** an event endpoint (e.g., `searchOrgDeviceEvents`) is classified, **Then** it uses `composite_pk` routing to Redis JSON + ArangoDB.
+3. **Given** existing `natural_pk` and `auto_increment_with_unique` endpoints, **When** the refactor completes, **Then** their classification and behavior remain unchanged.
+
+---
+
+### Edge Cases
+
+- What happens when Redis is unavailable but ArangoDB is up? Data must still persist to ArangoDB and CSV; Redis failure is logged as a warning.
+- What happens when an endpoint has no strategy defined? Falls back to `auto_increment_with_unique` with ArangoDB-only routing (current behavior preserved).
+- What happens when raw API data contains fields that exceed Redis key length limits? Keys are truncated or hashed with a documented maximum length.
+- What happens when a `timeseries_pk` endpoint returns zero numeric fields in a record? The record is skipped for TimeSeries but logged at debug level.
+- What happens when `composite_pk` dual-write partially fails (Redis succeeds, ArangoDB fails)? Each backend write is independent; partial success is logged with the failing backend identified.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST route raw (unflattened) API response data to polyglot backends before the CSV flatten/escape step.
+- **FR-002**: System MUST preserve existing CSV and SQLite output format exactly (backward compatible).
+- **FR-003**: System MUST support a new `timeseries_pk` strategy type that routes pure numeric data to Redis TimeSeries with text metadata as labels.
+- **FR-004**: System MUST route `composite_pk` endpoints to both Redis JSON (for fast recent access) and ArangoDB (for archival and graph queries).
+- **FR-005**: System MUST store `composite_pk` documents in Redis JSON with all original fields preserved (no field dropping).
+- **FR-006**: System MUST continue routing `natural_pk` endpoints to ArangoDB only, with raw nested documents instead of flattened data.
+- **FR-007**: System MUST continue routing `auto_increment_with_unique` endpoints to ArangoDB only (unchanged behavior).
+- **FR-008**: System MUST handle backend unavailability gracefully -- CSV/SQLite always succeeds; polyglot failures are logged as warnings without blocking the user.
+- **FR-009**: System MUST reclassify endpoint strategies in `ENDPOINT_PRIMARY_KEY_STRATEGIES` to correctly separate numeric-only endpoints (`timeseries_pk`) from document endpoints (`composite_pk`).
+- **FR-010**: System MUST support upsert semantics for Redis JSON documents using the endpoint's primary key fields.
+- **FR-011**: Each function in the modified code MUST conform to the 5-item rule (max 5 parameters, max 25 lines, max 5 logical blocks).
+- **FR-012**: All modified files MUST pass quality gates: `py_compile`, `ruff check`, `black --check`.
+
+### Key Entities
+
+- **API Response**: Raw JSON data returned by the Mist API, containing nested objects, arrays, and mixed types. The source of truth for all backends.
+- **Endpoint Strategy**: Configuration entry in `ENDPOINT_PRIMARY_KEY_STRATEGIES` that determines primary key type, key fields, index fields, and routing behavior for each API endpoint.
+- **TimeSeries Metric**: A numeric measurement associated with a timestamp, device identifier, and descriptive labels. Stored in Redis TimeSeries.
+- **Document Record**: A full JSON object representing an event, alarm, client session, or command output. Stored in Redis JSON (recent) and ArangoDB (archive).
+- **Entity Record**: A JSON object representing a stable business entity (site, device, template). Stored in ArangoDB with upsert by natural UUID.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: ArangoDB documents for `natural_pk` endpoints contain nested objects (verified by querying a nested field path like `doc.latlng.lat`) rather than flattened key names.
+- **SC-002**: Redis JSON documents for `composite_pk` endpoints contain 100% of the fields present in the raw API response (zero field loss compared to current TimeSeries approach).
+- **SC-003**: CSV output for any menu operation produces identical content before and after the refactor (byte-level comparison of output files).
+- **SC-004**: `timeseries_pk` endpoints store numeric values as Redis TimeSeries data points with at least device identifier and metric name as labels.
+- **SC-005**: Backend failure (Redis or ArangoDB unavailable) does not prevent CSV/SQLite output from completing successfully.
+- **SC-006**: All modified files pass `py_compile`, `ruff check`, and `black --check` with zero violations.
+- **SC-007**: Dual-write for `composite_pk` endpoints completes within 2x the time of single-backend write (acceptable overhead for data completeness).
+
+## Assumptions
+
+- Redis Stack container is already running with RedisJSON, RediSearch, and RedisTimeSeries modules loaded.
+- ArangoDB 3.12 is running at `localhost:8529` with the `misthelper` database created.
+- The existing `src/db/router.py`, `src/db/redis_writer.py`, and `src/db/arango_writer.py` modules provide the integration points for routing changes.
+- The `_route_to_polyglot()` method signature can accept a `raw_data` parameter without breaking existing callers.
+- Redis JSON key naming will follow the pattern `{endpoint_name}:{primary_key_value}` for document lookup.
+- RediSearch index creation is deferred to a future feature (not part of this refactor).
+
+## Scope Boundaries
+
+### In Scope
+
+- Moving the polyglot routing call to occur before CSV flattening in `MistHelper.py`
+- Adding `timeseries_pk` strategy type to the router and strategies dictionary
+- Adding a Redis JSON writer class to `src/db/redis_writer.py`
+- Reclassifying ~40 endpoint strategies in `ENDPOINT_PRIMARY_KEY_STRATEGIES`
+- Dual-write for `composite_pk` endpoints (Redis JSON + ArangoDB)
+- Passing raw data to ArangoDB for `natural_pk` endpoints
+
+### Out of Scope
+
+- Redis Streams integration for webhook event streaming (future feature)
+- RediSearch secondary index creation and query API
+- Changing CSV or SQLite output format
+- Adding new menu operations
+- Graph edge creation in ArangoDB (already exists)
+- Performance benchmarking or load testing
+- Migration of existing data from old format to new format
+
+## Dependencies
+
+- `redis-stack` container with RedisJSON module (`JSON.SET`, `JSON.GET`, `JSON.MGET` commands)
+- `redis-py` library with JSON command support (`redis.commands.json`)
+- Existing `src/db/` module structure (router, writers, `__init__.py`)
+- Existing `ENDPOINT_PRIMARY_KEY_STRATEGIES` dictionary in `MistHelper.py`

--- a/specs/185-polyglot-data-routing/tasks.md
+++ b/specs/185-polyglot-data-routing/tasks.md
@@ -1,0 +1,210 @@
+# Tasks: Polyglot Data Routing Refactor
+
+**Input**: Design documents from `/specs/185-polyglot-data-routing/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/internal-interfaces.md, quickstart.md
+
+**Tests**: Not explicitly requested in the feature specification. Test tasks are omitted.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Exact file paths included in all descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify prerequisites and prepare the working environment
+
+- [x] T001 Verify infrastructure is running: `podman compose up -d arangodb redis-stack` and confirm both services are healthy
+- [x] T002 Verify environment variables are set per quickstart.md (`ARANGO_HOST`, `ARANGO_ROOT_PASSWORD`, `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`)
+- [x] T003 Create feature branch `feat/185-polyglot-data-routing` from `main`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core data model updates and new classes that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T004 Add `DualWriteResult` dataclass to `src/db/__init__.py` with `arango_result: WriteResult`, `redis_result: WriteResult`, and `combined` property
+- [x] T005 Update `WriteResult.backend` field documentation in `src/db/__init__.py` to include new values: `"redis_json"`, `"dual"`
+- [x] T006 [P] Add `RedisJSONWriter` class to `src/db/redis_writer.py` with `__init__(config: DatabaseConfig)`, `write(data, api_function_name, strategy) -> WriteResult`, and `_build_key(endpoint, record, pk_fields) -> str` methods
+- [x] T007 [P] Update routing constants in `src/db/router.py`: replace `ARANGO_PK_TYPES` and `REDIS_PK_TYPES` with `ARANGO_ONLY_TYPES`, `DUAL_WRITE_TYPES`, and `TIMESERIES_TYPES` sets
+- [x] T008 Export `RedisJSONWriter` and `DualWriteResult` in `src/db/__init__.py` `__all__` list
+- [x] T009 Run quality gates on all modified files: `py_compile`, `ruff check`, `black --check` for `src/db/__init__.py`, `src/db/redis_writer.py`, `src/db/router.py`
+
+**Checkpoint**: Foundation ready -- new writer class exists, routing constants updated, data models in place
+
+---
+
+## Phase 3: User Story 1 - Raw Document Persistence in ArangoDB (Priority: P1) MVP
+
+**Goal**: Route unflattened API data to polyglot backends while preserving CSV output byte-for-byte
+
+**Independent Test**: Run menu 11 (Org Sites), query ArangoDB for nested fields (e.g., `doc.latlng.lat`), verify CSV output is unchanged
+
+### Implementation for User Story 1
+
+- [x] T010 [US1] Add `raw_data: list[dict[str, Any]] | None = None` parameter to `DataExporter.write_with_format_selection()` in `MistHelper.py` per contract in `contracts/internal-interfaces.md`
+- [x] T011 [US1] Update `DataExporter._route_to_polyglot()` in `MistHelper.py` to accept `raw_data` parameter and pass `raw_data or data` to `DatabaseRouter.write()`
+- [x] T012 [US1] Update menu 11 (`listOrgSites`) caller in `MistHelper.py` to pass `raw_data=raw_results` alongside flattened data to `write_with_format_selection()`
+- [x] T013 [P] [US1] Update menu 1 (`getOrgInventory`) caller in `MistHelper.py` to pass `raw_data=raw_results` alongside flattened data
+- [x] T014 [P] [US1] Update menu 3 (`listSiteDevices`) caller in `MistHelper.py` to pass `raw_data=raw_results` alongside flattened data
+- [x] T015 [US1] Run quality gates: `py_compile`, `ruff check`, `black --check` for `MistHelper.py`
+- [x] T016 [US1] Verify: run `python MistHelper.py --menu 11`, query ArangoDB for nested `latlng` field, confirm CSV output is identical to pre-refactor
+
+**Checkpoint**: ArangoDB receives raw nested documents for `natural_pk` endpoints. CSV output unchanged. SC-001, SC-003 verified.
+
+---
+
+## Phase 4: User Story 2 - Event Documents in Redis JSON (Priority: P2)
+
+**Goal**: Store `composite_pk` event documents as Redis JSON with dual-write to ArangoDB
+
+**Independent Test**: Run menu 13 (Device Events), verify Redis contains full JSON documents with all fields, and ArangoDB also has the archive copy
+
+### Implementation for User Story 2
+
+- [x] T017 [US2] Implement `RedisJSONWriter._verify_json_module()` method in `src/db/redis_writer.py` to check for `ReJSON` module availability (mirrors existing `_verify_timeseries_module()` pattern)
+- [x] T018 [US2] Implement `RedisJSONWriter.write()` body in `src/db/redis_writer.py`: pipeline `JSON.SET` + `EXPIRE` for each record using key pattern `{endpoint}:{pk_values}` and TTL from `REDIS_JSON_TTL_DAYS` env var (default 7)
+- [x] T019 [US2] Initialize `RedisJSONWriter` in `DatabaseRouter.__init__()` in `src/db/router.py` alongside existing `RedisTimeSeriesWriter`
+- [x] T020 [US2] Add `_write_dual()` method to `DatabaseRouter` in `src/db/router.py` that calls both `_write_redis_json()` and `_write_arango()` independently, returning `DualWriteResult`
+- [x] T021 [US2] Update `DatabaseRouter.write()` dispatch in `src/db/router.py` to route `composite_pk` (from `DUAL_WRITE_TYPES`) through `_write_dual()`
+- [x] T022 [US2] Add `_write_redis_json()` helper method to `DatabaseRouter` in `src/db/router.py` that delegates to `RedisJSONWriter.write()`
+- [x] T023 [US2] Run quality gates: `py_compile`, `ruff check`, `black --check` for `src/db/router.py`, `src/db/redis_writer.py`
+- [x] T024 [US2] Verify: run a `composite_pk` endpoint (e.g., menu 13 Device Events), confirm Redis JSON documents exist with `redis-cli JSON.GET`, confirm ArangoDB archive has same documents
+
+**Checkpoint**: `composite_pk` endpoints dual-write to Redis JSON + ArangoDB. SC-002, SC-005 verified.
+
+---
+
+## Phase 5: User Story 3 - Numeric Metrics via Redis TimeSeries (Priority: P3)
+
+**Goal**: Route pure-numeric endpoints to Redis TimeSeries with explicit field configuration via `timeseries_pk` strategy
+
+**Independent Test**: Run a device stats endpoint, verify Redis TimeSeries has numeric data points with text metadata stored as labels
+
+### Implementation for User Story 3
+
+- [x] T025 [US3] Add `timeseries_pk` to routing dispatch in `DatabaseRouter.write()` in `src/db/router.py` -- route to existing `_write_redis()` method
+- [x] T026 [US3] Update `RedisTimeSeriesWriter._extract_chunk()` in `src/db/redis_writer.py` to respect `ts_value_fields` (extract only listed fields) when present in the strategy dict
+- [x] T027 [US3] Update `RedisTimeSeriesWriter._extract_chunk()` in `src/db/redis_writer.py` to use `ts_label_fields` as TimeSeries labels when present in the strategy dict
+- [x] T028 [US3] Ensure fallback: if `ts_value_fields` is not in the strategy, `_extract_chunk()` falls back to current auto-detect behavior in `src/db/redis_writer.py`
+- [x] T029 [US3] Run quality gates: `py_compile`, `ruff check`, `black --check` for `src/db/router.py`, `src/db/redis_writer.py`
+- [x] T030 [US3] Verify: confirm `timeseries_pk` dispatching works by temporarily reclassifying one endpoint and running it
+
+**Checkpoint**: `timeseries_pk` strategy routes numeric data to Redis TimeSeries with labels. SC-004 verified.
+
+---
+
+## Phase 6: User Story 4 - Endpoint Strategy Reclassification (Priority: P2)
+
+**Goal**: Reclassify 6 pure-numeric endpoints from `composite_pk` to `timeseries_pk` with explicit field configuration
+
+**Independent Test**: Inspect `ENDPOINT_PRIMARY_KEY_STRATEGIES` dict, verify reclassified endpoints have `timeseries_pk` type with `ts_value_fields` and `ts_label_fields`
+
+### Implementation for User Story 4
+
+- [x] T031 [US4] Reclassify `listOrgDevicesStats` in `ENDPOINT_PRIMARY_KEY_STRATEGIES` in `MistHelper.py` from `composite_pk` to `timeseries_pk` with `ts_value_fields` and `ts_label_fields` per data-model.md
+- [x] T032 [P] [US4] Reclassify `listSiteDevicesStats` in `ENDPOINT_PRIMARY_KEY_STRATEGIES` in `MistHelper.py` with same pattern as `listOrgDevicesStats`
+- [x] T033 [P] [US4] Reclassify `listSiteWirelessClientsStats` in `ENDPOINT_PRIMARY_KEY_STRATEGIES` in `MistHelper.py` with `ts_value_fields: [rssi, snr, rx_rate, tx_rate]` and `ts_label_fields: [ssid, hostname, device_id]`
+- [x] T034 [P] [US4] Reclassify `searchOrgSwOrGwPorts` in `ENDPOINT_PRIMARY_KEY_STRATEGIES` in `MistHelper.py` with `ts_value_fields: [rx_bytes, tx_bytes, rx_errors, tx_errors]` and `ts_label_fields: [port_id, device_id, org_id]`
+- [x] T035 [P] [US4] Reclassify `searchSiteSwOrGwPorts` in `ENDPOINT_PRIMARY_KEY_STRATEGIES` in `MistHelper.py` with same port pattern
+- [x] T036 [P] [US4] Reclassify `searchOrgPeerPathStats` in `ENDPOINT_PRIMARY_KEY_STRATEGIES` in `MistHelper.py` with `ts_value_fields: [latency, jitter, loss]` and `ts_label_fields: [from_device, to_device, org_id]`
+- [x] T037 [US4] Verify all other endpoints (`natural_pk`, `auto_increment_with_unique`, remaining `composite_pk`) are unchanged in `MistHelper.py`
+- [x] T038 [US4] Run quality gates: `py_compile`, `ruff check`, `black --check` for `MistHelper.py`
+- [x] T039 [US4] Verify: run a reclassified stats endpoint, confirm Redis TimeSeries receives labeled numeric data points
+
+**Checkpoint**: All 6 endpoints reclassified. Remaining endpoints verified unchanged. SC-004 verified end-to-end.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, documentation, and quality sweep
+
+- [x] T040 [P] Verify graceful degradation: stop Redis, run menu 11, confirm CSV output succeeds and warning is logged (SC-005)
+- [x] T041 [P] Verify graceful degradation: stop ArangoDB, run a `composite_pk` endpoint, confirm CSV output succeeds and warning is logged (SC-005)
+- [x] T042 Verify dual-write performance: time a `composite_pk` endpoint write and confirm overhead is < 2x single-backend (SC-007)
+- [x] T043 Run full quality gates on all modified files: `py_compile`, `ruff check`, `black --check` for `MistHelper.py`, `src/db/__init__.py`, `src/db/router.py`, `src/db/redis_writer.py`
+- [x] T044 Update `src/db/__init__.py` module docstring to reflect new routing: "Routes API data to ArangoDB (documents), Redis JSON (events), or Redis TimeSeries (metrics)"
+- [x] T045 Run quickstart.md verification commands end-to-end to confirm all acceptance criteria pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```text
+Phase 1 (Setup)
+    |
+    v
+Phase 2 (Foundational) -- BLOCKS all user stories
+    |
+    v
+Phase 3 (US1: Raw Data Pipeline - P1) -- MVP
+    |
+    v
+Phase 4 (US2: Redis JSON + Dual-Write - P2) ----+
+    |                                             |
+Phase 5 (US3: TimeSeries Strategy - P3) ---------+
+    |                                             |
+    v                                             v
+Phase 6 (US4: Endpoint Reclassification - P2) -- requires Phase 4 AND Phase 5
+    |
+    v
+Phase 7 (Polish)
+```
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 2 only. No dependency on other stories. **This is the MVP.**
+- **US2 (P2)**: Depends on Phase 2 and US1 (needs `raw_data` pipeline from US1 to feed dual-write)
+- **US3 (P3)**: Depends on Phase 2 only. Independent of US1 and US2 (routing update only, no data pipeline change needed)
+- **US4 (P2)**: Depends on US2 (dual-write routing must exist) AND US3 (`timeseries_pk` routing must exist). Both must be complete before reclassification.
+
+### Within Each User Story
+
+- Core implementation before integration/verification
+- Quality gates before verification testing
+- Verification confirms acceptance criteria from spec.md
+
+### Parallel Opportunities
+
+**Phase 2**: T006 and T007 can run in parallel (different files: `redis_writer.py` vs `router.py`)
+
+**Phase 3 (US1)**: T013 and T014 can run in parallel (different menu operations in same file, but independent callers)
+
+**Phase 5 (US3) and Phase 4 (US2)**: These two phases can run in parallel after US1 completes, since they modify different files:
+- US2 modifies `src/db/router.py` (dual-write dispatch) and `src/db/redis_writer.py` (JSON writer body)
+- US3 modifies `src/db/router.py` (TS dispatch) and `src/db/redis_writer.py` (extract_chunk)
+- **Caution**: Both touch the same two files, so true parallelism requires careful coordination. Sequential execution (US2 → US3) is safer for a single agent.
+
+**Phase 6 (US4)**: T032-T036 can all run in parallel (independent endpoint entries in the same dictionary)
+
+---
+
+## Implementation Strategy
+
+### MVP Scope
+
+**User Story 1 (Phase 3)** is the MVP. After completing Phases 1-3:
+- ArangoDB receives raw nested documents instead of flattened data
+- CSV output is byte-identical to current behavior
+- The system is strictly better than before with zero regression risk
+
+### Incremental Delivery
+
+1. **Increment 1 (MVP)**: Phases 1-3 → Raw data pipeline working for `natural_pk` endpoints
+2. **Increment 2**: Phase 4 → `composite_pk` events stored in Redis JSON + ArangoDB
+3. **Increment 3**: Phase 5 → `timeseries_pk` routing with explicit field config
+4. **Increment 4**: Phase 6 → Endpoint reclassification (all routing correct)
+5. **Increment 5**: Phase 7 → Polish, degradation testing, performance verification
+
+Each increment is independently deployable and testable.

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,0 +1,117 @@
+"""MistHelper polyglot database package.
+
+Routes API data to ArangoDB (documents), Redis JSON (events),
+or Redis TimeSeries (metrics) based on ENDPOINT_PRIMARY_KEY_STRATEGIES
+configuration.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import structlog
+
+
+def configure_db_logging() -> None:
+    """Configure structlog for the db package: JSON, ASCII-only, stdlib."""
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.UnicodeDecoder(),
+            structlog.processors.JSONRenderer(ensure_ascii=True),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger(name: str) -> structlog.stdlib.BoundLogger:
+    """Return a bound structlog logger for the given module name."""
+    return structlog.get_logger(name)
+
+
+@dataclass
+class DatabaseConfig:
+    """Connection settings for polyglot database backends."""
+
+    arango_host: str = "http://arangodb:8529"
+    arango_database: str = "misthelper"
+    arango_username: str = "root"
+    arango_password: str = ""
+    redis_host: str = "redis-stack"
+    redis_port: int = 6379
+    redis_password: str = ""
+    standalone_mode: bool = False
+    webhook_enabled: bool = True
+    webhook_secret: str = ""
+
+    @classmethod
+    def from_env(cls) -> DatabaseConfig:
+        """Build config from environment variables."""
+        return cls(
+            arango_host=os.environ.get("ARANGO_HOST", "http://arangodb:8529"),
+            arango_database=os.environ.get("ARANGO_DATABASE", "misthelper"),
+            arango_username=os.environ.get("ARANGO_USERNAME", "root"),
+            arango_password=os.environ.get("ARANGO_ROOT_PASSWORD", ""),
+            redis_host=os.environ.get("REDIS_HOST", "redis-stack"),
+            redis_port=int(os.environ.get("REDIS_PORT", "6379")),
+            redis_password=os.environ.get("REDIS_PASSWORD", ""),
+            standalone_mode=os.environ.get("MISTHELPER_STANDALONE", "false").lower() == "true",
+            webhook_enabled=os.environ.get("WEBHOOK_ENABLED", "true").lower() == "true",
+            webhook_secret=os.environ.get("WEBHOOK_SECRET", ""),
+        )
+
+
+@dataclass
+class WriteResult:
+    """Outcome of a database write operation."""
+
+    success: bool
+    backend: str  # "arangodb", "redis", "redis_json", "dual", "csv_only"
+    records_written: int
+    records_failed: int
+    error_message: str = ""
+
+
+@dataclass
+class DualWriteResult:
+    """Captures independent success/failure of both backends for dual-write."""
+
+    arango_result: WriteResult
+    redis_result: WriteResult
+
+    @property
+    def combined(self) -> WriteResult:
+        """Merge both results into a single WriteResult for logging."""
+        total_written = self.arango_result.records_written + self.redis_result.records_written
+        total_failed = self.arango_result.records_failed + self.redis_result.records_failed
+        both_ok = self.arango_result.success and self.redis_result.success
+        errors = []
+        if self.arango_result.error_message:
+            errors.append(f"arango: {self.arango_result.error_message}")
+        if self.redis_result.error_message:
+            errors.append(f"redis: {self.redis_result.error_message}")
+        return WriteResult(
+            success=both_ok,
+            backend="dual",
+            records_written=total_written,
+            records_failed=total_failed,
+            error_message="; ".join(errors),
+        )
+
+
+__all__ = [
+    "DatabaseConfig",
+    "DualWriteResult",
+    "WriteResult",
+    "configure_db_logging",
+    "get_logger",
+]

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -1,0 +1,226 @@
+"""ArangoDBWriter: document store backend for configuration entities.
+
+Handles upserts, graph edge management, soft-deletes, and config snapshots
+for the MistHelper polyglot database layer.  Uses batch import for high
+throughput on bulk API data pulls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from typing import Any
+
+from arango import ArangoClient
+
+from src.db import DatabaseConfig, WriteResult, get_logger
+
+logger = get_logger(__name__)
+
+GRAPH_NAME = "mist_network_topology"
+IMPORT_BATCH_SIZE = 5000
+
+EDGE_DEFINITIONS = [
+    {
+        "edge_collection": "OrgContainsSite",
+        "from_vertex_collections": ["orgs"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "SiteContainsDevice",
+        "from_vertex_collections": ["sites"],
+        "to_vertex_collections": ["devices"],
+    },
+    {
+        "edge_collection": "TemplateAssignedToSite",
+        "from_vertex_collections": ["templates"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "DeviceHasPort",
+        "from_vertex_collections": ["devices"],
+        "to_vertex_collections": ["ports"],
+    },
+    {
+        "edge_collection": "ClientConnectedToDevice",
+        "from_vertex_collections": ["clients"],
+        "to_vertex_collections": ["devices"],
+    },
+]
+
+
+class ArangoDBWriter:
+    """Write documents to ArangoDB with upsert, graph, and snapshot support."""
+
+    def __init__(self, config: DatabaseConfig) -> None:
+        self._client = ArangoClient(hosts=config.arango_host)
+        self._config = config
+        self._ensure_database()
+        self._db = self._client.db(
+            config.arango_database,
+            username=config.arango_username,
+            password=config.arango_password,
+        )
+        self._ensure_graph()
+        logger.info("arango_writer_ready", database=config.arango_database)
+
+    def _ensure_database(self) -> None:
+        """Create the misthelper database if it does not exist."""
+        sys_db = self._client.db(
+            "_system",
+            username=self._config.arango_username,
+            password=self._config.arango_password,
+        )
+        if not sys_db.has_database(self._config.arango_database):
+            sys_db.create_database(self._config.arango_database)
+            logger.info("database_created", name=self._config.arango_database)
+
+    def _ensure_graph(self) -> None:
+        """Create the network topology graph if it does not exist."""
+        if not self._db.has_graph(GRAPH_NAME):
+            self._db.create_graph(GRAPH_NAME, edge_definitions=EDGE_DEFINITIONS)
+            logger.info("graph_created", name=GRAPH_NAME)
+
+    def _ensure_collection(self, name: str) -> Any:
+        """Return collection, creating it if needed."""
+        if not self._db.has_collection(name):
+            self._db.create_collection(name)
+            logger.info("collection_created", name=name)
+        return self._db.collection(name)
+
+    def write(self, data: list[dict], collection_name: str, strategy: dict) -> WriteResult:
+        """Upsert documents using batch import for performance."""
+        collection = self._ensure_collection(collection_name)
+        if not data:
+            return WriteResult(
+                success=True,
+                backend="arangodb",
+                records_written=0,
+                records_failed=0,
+            )
+
+        docs = [self._prepare_document(r, strategy) for r in data]
+        written, failed = self._batch_import(collection, docs)
+
+        return WriteResult(
+            success=(failed == 0),
+            backend="arangodb",
+            records_written=written,
+            records_failed=failed,
+        )
+
+    def _batch_import(
+        self,
+        collection: Any,
+        docs: list[dict],
+    ) -> tuple[int, int]:
+        """Import documents in batches with on_duplicate=replace."""
+        written = 0
+        failed = 0
+        for start in range(0, len(docs), IMPORT_BATCH_SIZE):
+            batch = docs[start : start + IMPORT_BATCH_SIZE]
+            try:
+                result = collection.import_bulk(
+                    batch,
+                    on_duplicate="replace",
+                )
+                written += result.get("created", 0)
+                written += result.get("updated", 0)
+                failed += result.get("errors", 0)
+            except Exception as error:
+                failed += len(batch)
+                logger.warning(
+                    "batch_import_failed",
+                    collection=collection.name,
+                    batch_size=len(batch),
+                    error=str(error),
+                )
+        logger.info(
+            "import_complete",
+            collection=collection.name,
+            written=written,
+            failed=failed,
+        )
+        return written, failed
+
+    def _prepare_document(self, record: dict, strategy: dict) -> dict:
+        """Add _key, timestamps, and clear soft-delete flag."""
+        doc = dict(record)
+        strategy_type = strategy.get("type", "natural_pk")
+        primary_keys = strategy.get("primary_key", ["id"])
+
+        if strategy_type == "auto_increment_with_unique":
+            doc["_key"] = str(uuid.uuid4())
+        else:
+            key_value = doc.get(primary_keys[0], str(uuid.uuid4()))
+            doc["_key"] = str(key_value)
+
+        doc["_misthelper_updated_at"] = int(time.time())
+        doc["_misthelper_deleted_at"] = None
+        return doc
+
+    def mark_absent_as_deleted(self, collection_name: str, current_keys: set[str]) -> None:
+        """Soft-delete documents whose keys are absent from current data."""
+        if not self._db.has_collection(collection_name):
+            return
+
+        collection = self._db.collection(collection_name)
+        now = int(time.time())
+
+        for doc in collection.all():
+            key = doc.get("_key")
+            already_deleted = doc.get("_misthelper_deleted_at")
+            if key not in current_keys and not already_deleted:
+                collection.update({"_key": key, "_misthelper_deleted_at": now})
+                logger.debug("soft_deleted", collection=collection_name, key=key)
+
+    def snapshot(
+        self,
+        entity_type: str,
+        entity_id: str,
+        config_body: dict,
+        config_hash: str | None = None,
+        trigger: str = "api_pull",
+    ) -> bool:
+        """Store a config snapshot, skipping if hash is unchanged."""
+        if config_hash is None:
+            config_hash = hashlib.sha256(json.dumps(config_body, sort_keys=True).encode()).hexdigest()
+
+        collection = self._ensure_collection("config_snapshots")
+
+        cursor = self._db.aql.execute(
+            "FOR doc IN config_snapshots "
+            "FILTER doc.entity_id == @eid "
+            "SORT doc.timestamp DESC LIMIT 1 "
+            "RETURN doc",
+            bind_vars={"eid": entity_id},
+        )
+        for existing in cursor:
+            if existing.get("config_hash") == config_hash:
+                return False
+
+        snapshot_doc = {
+            "_key": str(uuid.uuid4()),
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "timestamp": int(time.time()),
+            "config_hash": config_hash,
+            "config_body": config_body,
+            "trigger": trigger,
+            "_misthelper_updated_at": int(time.time()),
+        }
+        collection.insert(snapshot_doc)
+        logger.info(
+            "snapshot_stored",
+            entity_type=entity_type,
+            entity_id=entity_id,
+            trigger=trigger,
+        )
+        return True
+
+    def close(self) -> None:
+        """Close the ArangoDB client connection."""
+        self._client.close()
+        logger.info("arango_writer_closed")

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -13,9 +13,9 @@ import time
 import uuid
 from typing import Any
 
-from arango import ArangoClient
+from arango import ArangoClient  # type: ignore[attr-defined]
 
-from src.db import DatabaseConfig, WriteResult, get_logger
+from . import DatabaseConfig, WriteResult, get_logger
 
 logger = get_logger(__name__)
 
@@ -55,6 +55,7 @@ class ArangoDBWriter:
     """Write documents to ArangoDB with upsert, graph, and snapshot support."""
 
     def __init__(self, config: DatabaseConfig) -> None:
+        """Initialize ArangoDB connection and ensure database exists."""
         self._client = ArangoClient(hosts=config.arango_host)
         self._config = config
         self._ensure_database()
@@ -169,7 +170,7 @@ class ArangoDBWriter:
         collection = self._db.collection(collection_name)
         now = int(time.time())
 
-        for doc in collection.all():
+        for doc in collection.all():  # type: ignore[union-attr]
             key = doc.get("_key")
             already_deleted = doc.get("_misthelper_deleted_at")
             if key not in current_keys and not already_deleted:
@@ -197,7 +198,7 @@ class ArangoDBWriter:
             "RETURN doc",
             bind_vars={"eid": entity_id},
         )
-        for existing in cursor:
+        for existing in cursor:  # type: ignore[union-attr]
             if existing.get("config_hash") == config_hash:
                 return False
 

--- a/src/db/redis_writer.py
+++ b/src/db/redis_writer.py
@@ -1,0 +1,594 @@
+"""Redis writers for polyglot data routing.
+
+RedisTimeSeriesWriter: Stores numeric metric values as Redis TimeSeries keys
+with automatic compaction rules for hourly and daily aggregation.
+
+RedisJSONWriter: Stores composite_pk event documents as Redis JSON with
+configurable TTL for fast recent-event queries.
+
+Both use pipelined batch operations for high-throughput bulk imports.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import redis
+
+from src.db import DatabaseConfig, WriteResult, get_logger
+
+RAW_RETENTION_MS = int(os.environ.get("REDIS_RAW_RETENTION_DAYS", "7")) * 86_400_000
+HOURLY_RETENTION_MS = 90 * 86_400_000  # 90 days
+DAILY_RETENTION_MS = 365 * 86_400_000  # 365 days
+REDIS_JSON_TTL_SECONDS = int(os.environ.get("REDIS_JSON_TTL_DAYS", "7")) * 86_400
+JSON_PIPELINE_BATCH = 500
+HOURLY_BUCKET_MS = 3_600_000  # 1 hour
+DAILY_BUCKET_MS = 86_400_000  # 1 day
+KEY_CREATION_BATCH = 500
+ADD_PIPELINE_BATCH = 10_000
+
+_TOPIC_KEY_PREFIX: dict[str, str] = {
+    "client-sessions": "client_stats",
+    "device-updowns": "device_events",
+    "device-events": "device_events",
+    "client-latency": "client_latency",
+}
+
+
+class RedisTimeSeriesWriter:
+    """Writes composite_pk data into Redis TimeSeries.
+
+    Performance strategy:
+    - Key creation uses pipelined TS.CREATE + CREATERULE batches
+    - Data writes use pipelined TS.ADD with DUPLICATE_POLICY LAST
+    - Numeric field extraction runs in thread pool across records
+    """
+
+    def __init__(self, config: DatabaseConfig) -> None:
+        self._log = get_logger("redis_writer")
+        self._client = redis.Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password or None,
+            decode_responses=True,
+        )
+        self._verify_timeseries_module()
+        self._ts = self._client.ts()
+        self._created_keys: set[str] = set()
+        self._log.info("redis_connected", host=config.redis_host)
+
+    def _verify_timeseries_module(self) -> None:
+        modules = self._client.module_list()
+        names = [
+            m.get("name", b"").lower() if isinstance(m.get("name"), str) else m.get("name", b"").decode().lower()
+            for m in modules
+        ]
+        if "timeseries" not in names:
+            raise RuntimeError("Redis TimeSeries module not loaded. " "Use redis/redis-stack-server image.")
+
+    def write(
+        self,
+        data: list[dict[str, Any]],
+        api_function_name: str,
+        strategy: dict[str, Any],
+    ) -> WriteResult:
+        """Write numeric fields as TimeSeries data points.
+
+        Three-phase pipeline approach:
+        1. Extract all (key, value) pairs using thread pool
+        2. Batch-create missing keys with compaction rules
+        3. Pipeline all TS.ADD commands
+        """
+        if not data:
+            return WriteResult(
+                success=True,
+                backend="redis",
+                records_written=0,
+                records_failed=0,
+            )
+
+        primary_keys = strategy.get("primary_key", [])
+        entity_key_field = self._pick_entity_field(primary_keys)
+        ts_value_fields = strategy.get("ts_value_fields")
+        ts_label_fields = strategy.get("ts_label_fields")
+
+        adds, key_records = self._extract_all_adds(
+            data,
+            api_function_name,
+            primary_keys,
+            entity_key_field,
+            ts_value_fields,
+        )
+        self._batch_ensure_keys(key_records, api_function_name, ts_label_fields)
+        written, failed = self._execute_pipeline(adds)
+
+        return WriteResult(
+            success=failed == 0,
+            backend="redis",
+            records_written=written,
+            records_failed=failed,
+        )
+
+    def _extract_all_adds(
+        self,
+        data: list[dict[str, Any]],
+        api_function_name: str,
+        primary_keys: list[str],
+        entity_key_field: str,
+        ts_value_fields: list[str] | None = None,
+    ) -> tuple[list[tuple[str, float]], dict[str, dict[str, Any]]]:
+        """Extract (ts_key, value) pairs and first-seen record per key.
+
+        Uses a thread pool to parallelize numeric extraction across
+        record chunks for large datasets (>1000 records).
+        """
+        if len(data) <= 1000:
+            return self._extract_chunk(
+                data,
+                api_function_name,
+                primary_keys,
+                entity_key_field,
+                ts_value_fields,
+            )
+
+        workers = min(8, os.cpu_count() or 4)
+        chunk_size = max(1, len(data) // workers)
+        chunks = [data[i : i + chunk_size] for i in range(0, len(data), chunk_size)]
+
+        all_adds: list[tuple[str, float]] = []
+        key_records: dict[str, dict[str, Any]] = {}
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [
+                pool.submit(
+                    self._extract_chunk,
+                    chunk,
+                    api_function_name,
+                    primary_keys,
+                    entity_key_field,
+                    ts_value_fields,
+                )
+                for chunk in chunks
+            ]
+            for future in futures:
+                chunk_adds, chunk_keys = future.result()
+                all_adds.extend(chunk_adds)
+                key_records.update(chunk_keys)
+
+        self._log.info(
+            "extraction_complete",
+            data_points=len(all_adds),
+            unique_keys=len(key_records),
+            workers=workers,
+        )
+        return all_adds, key_records
+
+    def _extract_chunk(
+        self,
+        records: list[dict[str, Any]],
+        api_function_name: str,
+        primary_keys: list[str],
+        entity_key_field: str,
+        ts_value_fields: list[str] | None = None,
+    ) -> tuple[list[tuple[str, float]], dict[str, dict[str, Any]]]:
+        """Extract adds and key->record map from a chunk of records."""
+        adds: list[tuple[str, float]] = []
+        key_records: dict[str, dict[str, Any]] = {}
+        for record in records:
+            entity_id = str(record.get(entity_key_field, "unknown"))
+            if ts_value_fields:
+                numeric = self._extract_listed_fields(record, ts_value_fields)
+            else:
+                numeric = self._extract_numeric(record, primary_keys)
+            for field_name, value in numeric.items():
+                ts_key = f"{api_function_name}:{entity_id}:{field_name}"
+                adds.append((ts_key, value))
+                if ts_key not in key_records:
+                    key_records[ts_key] = record
+        return adds, key_records
+
+    def _batch_ensure_keys(
+        self,
+        key_records: dict[str, dict[str, Any]],
+        api_function_name: str,
+        ts_label_fields: list[str] | None = None,
+    ) -> None:
+        """Create all missing TS keys and compaction rules via pipeline."""
+        new_keys = {k: v for k, v in key_records.items() if k not in self._created_keys}
+        if not new_keys:
+            return
+
+        keys_list = list(new_keys.items())
+        for start in range(0, len(keys_list), KEY_CREATION_BATCH):
+            batch = keys_list[start : start + KEY_CREATION_BATCH]
+            self._pipeline_create_keys(batch, api_function_name, ts_label_fields)
+
+        self._log.info("keys_created", count=len(new_keys))
+
+    def _pipeline_create_keys(
+        self,
+        batch: list[tuple[str, dict[str, Any]]],
+        api_function_name: str,
+        ts_label_fields: list[str] | None = None,
+    ) -> None:
+        """Pipeline-create a batch of TS keys with compaction."""
+        pipe = self._client.pipeline(transaction=False)
+
+        for ts_key, record in batch:
+            labels = self._build_labels(record, api_function_name, ts_key, ts_label_fields)
+            label_args = []
+            for label_key, label_val in labels.items():
+                label_args.extend([label_key, label_val])
+            pipe.execute_command(
+                "TS.CREATE",
+                ts_key,
+                "RETENTION",
+                RAW_RETENTION_MS,
+                "DUPLICATE_POLICY",
+                "LAST",
+                "LABELS",
+                *label_args,
+            )
+
+        results = pipe.execute(raise_on_error=False)
+        self._pipeline_create_compaction(batch, results)
+
+    def _pipeline_create_compaction(
+        self,
+        batch: list[tuple[str, dict[str, Any]]],
+        create_results: list,
+    ) -> None:
+        """Create compaction keys and rules for successfully created keys."""
+        pipe = self._client.pipeline(transaction=False)
+        pending: list[str] = []
+
+        for idx, (ts_key, _record) in enumerate(batch):
+            result = create_results[idx]
+            is_new = not isinstance(result, Exception)
+            is_exists = isinstance(result, redis.ResponseError) and "already exists" in str(result).lower()
+            if not is_new and not is_exists:
+                continue
+
+            hourly = f"{ts_key}:avg_1h"
+            daily = f"{ts_key}:avg_1d"
+            pipe.execute_command(
+                "TS.CREATE",
+                hourly,
+                "RETENTION",
+                HOURLY_RETENTION_MS,
+            )
+            pipe.execute_command(
+                "TS.CREATE",
+                daily,
+                "RETENTION",
+                DAILY_RETENTION_MS,
+            )
+            pipe.execute_command(
+                "TS.CREATERULE",
+                ts_key,
+                hourly,
+                "AGGREGATION",
+                "avg",
+                HOURLY_BUCKET_MS,
+            )
+            pipe.execute_command(
+                "TS.CREATERULE",
+                ts_key,
+                daily,
+                "AGGREGATION",
+                "avg",
+                DAILY_BUCKET_MS,
+            )
+            pending.append(ts_key)
+
+        if pending:
+            pipe.execute(raise_on_error=False)
+
+        for ts_key in pending:
+            self._created_keys.add(ts_key)
+            self._created_keys.add(f"{ts_key}:avg_1h")
+            self._created_keys.add(f"{ts_key}:avg_1d")
+
+    def _execute_pipeline(
+        self,
+        adds: list[tuple[str, float]],
+    ) -> tuple[int, int]:
+        """Execute TS.ADD commands in batched pipelines."""
+        written = 0
+        failed = 0
+        for start in range(0, len(adds), ADD_PIPELINE_BATCH):
+            batch = adds[start : start + ADD_PIPELINE_BATCH]
+            pipe = self._client.pipeline(transaction=False)
+            for ts_key, value in batch:
+                pipe.execute_command(
+                    "TS.ADD",
+                    ts_key,
+                    "*",
+                    value,
+                    "DUPLICATE_POLICY",
+                    "LAST",
+                )
+            results = pipe.execute(raise_on_error=False)
+            for idx, result in enumerate(results):
+                if isinstance(result, Exception):
+                    failed += 1
+                    self._log.error(
+                        "ts_add_failed",
+                        key=batch[idx][0],
+                        error=str(result),
+                    )
+                else:
+                    written += 1
+        return written, failed
+
+    def _ensure_key_single(
+        self,
+        ts_key: str,
+        record: dict[str, Any],
+        api_function_name: str,
+    ) -> None:
+        """Create a single TimeSeries key (used by webhook path)."""
+        if ts_key in self._created_keys:
+            return
+        labels = self._build_labels(record, api_function_name, ts_key)
+        try:
+            self._ts.create(
+                ts_key,
+                retention_msecs=RAW_RETENTION_MS,
+                labels=labels,
+                duplicate_policy="last",
+            )
+        except redis.ResponseError as error:
+            if "already exists" not in str(error).lower():
+                raise
+        self._ensure_single_compaction(ts_key)
+        self._created_keys.add(ts_key)
+
+    def _ensure_single_compaction(self, source_key: str) -> None:
+        """Create compaction rules for a single key (webhook path)."""
+        hourly_key = f"{source_key}:avg_1h"
+        daily_key = f"{source_key}:avg_1d"
+
+        if hourly_key in self._created_keys:
+            return
+
+        for dest_key, retention, bucket in [
+            (hourly_key, HOURLY_RETENTION_MS, HOURLY_BUCKET_MS),
+            (daily_key, DAILY_RETENTION_MS, DAILY_BUCKET_MS),
+        ]:
+            try:
+                self._ts.create(dest_key, retention_msecs=retention)
+            except redis.ResponseError as error:
+                if "already exists" not in str(error).lower():
+                    raise
+            try:
+                self._ts.createrule(source_key, dest_key, "avg", bucket)
+            except redis.ResponseError as error:
+                if "already exists" not in str(error).lower():
+                    raise
+
+        self._created_keys.add(hourly_key)
+        self._created_keys.add(daily_key)
+
+    def ingest_webhook(
+        self,
+        events: list[dict],
+        topic: str,
+    ) -> int:
+        """Ingest webhook stats events into Redis TimeSeries.
+
+        Returns the count of successfully written data points.
+        """
+        written = 0
+        key_prefix = _TOPIC_KEY_PREFIX.get(topic, topic)
+        pipe = self._client.pipeline(transaction=False)
+        timestamp_ms = int(time.time() * 1000)
+
+        for event in events:
+            entity_id = str(event.get("mac", event.get("device_id", "unknown")))
+            numeric = self._extract_numeric(event, ["mac", "device_id"])
+            for field_name, value in numeric.items():
+                ts_key = f"{key_prefix}:{entity_id}:{field_name}"
+                self._ensure_key_single(
+                    ts_key,
+                    event,
+                    key_prefix,
+                )
+                pipe.execute_command(
+                    "TS.ADD",
+                    ts_key,
+                    timestamp_ms,
+                    value,
+                    "DUPLICATE_POLICY",
+                    "LAST",
+                )
+                written += 1
+
+        if written > 0:
+            pipe.execute()
+            self._log.info(
+                "webhook_ingested",
+                topic=topic,
+                points=written,
+            )
+        return written
+
+    def close(self) -> None:
+        """Close the Redis connection."""
+        self._client.close()
+        self._log.info("redis_disconnected")
+
+    @staticmethod
+    def _pick_entity_field(primary_keys: list[str]) -> str:
+        """Choose the entity identifier from PK fields."""
+        preferred = ["device_id", "site_id", "org_id", "mac", "id"]
+        for field in preferred:
+            if field in primary_keys:
+                return field
+        return primary_keys[0] if primary_keys else "id"
+
+    @staticmethod
+    def _extract_numeric(
+        record: dict[str, Any],
+        exclude_keys: list[str],
+    ) -> dict[str, float]:
+        """Return only numeric (int/float) fields, excluding PKs."""
+        result: dict[str, float] = {}
+        for key, value in record.items():
+            if key in exclude_keys:
+                continue
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                result[key] = float(value)
+        return result
+
+    @staticmethod
+    def _extract_listed_fields(
+        record: dict[str, Any],
+        value_fields: list[str],
+    ) -> dict[str, float]:
+        """Extract only named fields that have numeric values."""
+        result: dict[str, float] = {}
+        for field in value_fields:
+            value = record.get(field)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                result[field] = float(value)
+        return result
+
+    @staticmethod
+    def _build_labels(
+        record: dict[str, Any],
+        api_function_name: str,
+        ts_key: str,
+        ts_label_fields: list[str] | None = None,
+    ) -> dict[str, str]:
+        """Build TimeSeries labels from record metadata."""
+        parts = ts_key.rsplit(":", 1)
+        metric_name = parts[-1] if len(parts) > 1 else ts_key
+        labels: dict[str, str] = {
+            "api_function": api_function_name,
+            "metric_name": metric_name,
+        }
+        if ts_label_fields:
+            for field in ts_label_fields:
+                if field in record:
+                    labels[field] = str(record[field])
+        else:
+            for field in ("org_id", "site_id", "device_id"):
+                if field in record:
+                    labels[field] = str(record[field])
+        return labels
+
+
+class RedisJSONWriter:
+    """Writes composite_pk data as Redis JSON documents with TTL.
+
+    Stores full unflattened API responses as JSON documents for fast
+    recent-event queries. Documents expire after a configurable TTL
+    (default 7 days). ArangoDB serves as the long-term archive.
+    """
+
+    def __init__(self, config: DatabaseConfig) -> None:
+        self._log = get_logger("redis_json_writer")
+        self._client = redis.Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password or None,
+            decode_responses=True,
+        )
+        self._verify_json_module()
+        self._log.info("redis_json_connected", host=config.redis_host)
+
+    def _verify_json_module(self) -> None:
+        """Check that the ReJSON module is loaded."""
+        modules = self._client.module_list()
+        names = [
+            m.get("name", b"").lower() if isinstance(m.get("name"), str) else m.get("name", b"").decode().lower()
+            for m in modules
+        ]
+        if "rejson" not in names and "redisjson" not in names:
+            raise RuntimeError("Redis JSON module not loaded. Use redis/redis-stack-server image.")
+
+    def write(
+        self,
+        data: list[dict[str, Any]],
+        api_function_name: str,
+        strategy: dict[str, Any],
+    ) -> WriteResult:
+        """Write records as JSON documents with TTL via pipeline."""
+        if not data:
+            return WriteResult(
+                success=True,
+                backend="redis_json",
+                records_written=0,
+                records_failed=0,
+            )
+
+        pk_fields = strategy.get("primary_key", [])
+        written = 0
+        failed = 0
+
+        for start in range(0, len(data), JSON_PIPELINE_BATCH):
+            batch = data[start : start + JSON_PIPELINE_BATCH]
+            batch_ok, batch_fail = self._pipeline_write_batch(batch, api_function_name, pk_fields)
+            written += batch_ok
+            failed += batch_fail
+
+        self._log.info(
+            "json_write_complete",
+            endpoint=api_function_name,
+            written=written,
+            failed=failed,
+        )
+        return WriteResult(
+            success=failed == 0,
+            backend="redis_json",
+            records_written=written,
+            records_failed=failed,
+        )
+
+    def _pipeline_write_batch(
+        self,
+        batch: list[dict[str, Any]],
+        api_function_name: str,
+        pk_fields: list[str],
+    ) -> tuple[int, int]:
+        """Pipeline JSON.SET + EXPIRE for a batch of records."""
+        pipe = self._client.pipeline(transaction=False)
+        for record in batch:
+            key = self._build_key(api_function_name, record, pk_fields)
+            pipe.json().set(key, "$", record)
+            pipe.expire(key, REDIS_JSON_TTL_SECONDS)
+
+        results = pipe.execute(raise_on_error=False)
+        written = 0
+        failed = 0
+        for idx in range(0, len(results), 2):
+            if isinstance(results[idx], Exception):
+                failed += 1
+                self._log.error(
+                    "json_set_failed",
+                    error=str(results[idx]),
+                )
+            else:
+                written += 1
+        return written, failed
+
+    @staticmethod
+    def _build_key(
+        endpoint: str,
+        record: dict[str, Any],
+        pk_fields: list[str],
+    ) -> str:
+        """Build Redis key from endpoint name and PK field values."""
+        parts = [endpoint]
+        for field in pk_fields:
+            parts.append(str(record.get(field, "unknown")))
+        return ":".join(parts)
+
+    def close(self) -> None:
+        """Close the Redis connection."""
+        self._client.close()
+        self._log.info("redis_json_disconnected")

--- a/src/db/redis_writer.py
+++ b/src/db/redis_writer.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import redis
 
-from src.db import DatabaseConfig, WriteResult, get_logger
+from . import DatabaseConfig, WriteResult, get_logger
 
 RAW_RETENTION_MS = int(os.environ.get("REDIS_RAW_RETENTION_DAYS", "7")) * 86_400_000
 HOURLY_RETENTION_MS = 90 * 86_400_000  # 90 days
@@ -48,6 +48,7 @@ class RedisTimeSeriesWriter:
     """
 
     def __init__(self, config: DatabaseConfig) -> None:
+        """Initialize Redis TimeSeries connection and verify module."""
         self._log = get_logger("redis_writer")
         self._client = redis.Redis(
             host=config.redis_host,
@@ -61,7 +62,7 @@ class RedisTimeSeriesWriter:
         self._log.info("redis_connected", host=config.redis_host)
 
     def _verify_timeseries_module(self) -> None:
-        modules = self._client.module_list()
+        modules: list[dict[str, Any]] = self._client.module_list()  # type: ignore[assignment]
         names = [
             m.get("name", b"").lower() if isinstance(m.get("name"), str) else m.get("name", b"").decode().lower()
             for m in modules
@@ -491,6 +492,7 @@ class RedisJSONWriter:
     """
 
     def __init__(self, config: DatabaseConfig) -> None:
+        """Initialize Redis JSON connection and verify module."""
         self._log = get_logger("redis_json_writer")
         self._client = redis.Redis(
             host=config.redis_host,
@@ -503,7 +505,7 @@ class RedisJSONWriter:
 
     def _verify_json_module(self) -> None:
         """Check that the ReJSON module is loaded."""
-        modules = self._client.module_list()
+        modules: list[dict[str, Any]] = self._client.module_list()  # type: ignore[assignment]
         names = [
             m.get("name", b"").lower() if isinstance(m.get("name"), str) else m.get("name", b"").decode().lower()
             for m in modules

--- a/src/db/retention.py
+++ b/src/db/retention.py
@@ -11,7 +11,7 @@ import os
 import threading
 from typing import Any
 
-from src.db import get_logger
+from . import get_logger
 
 logger = get_logger(__name__)
 
@@ -28,6 +28,7 @@ class RetentionManager:
         arango_writer: Any,
         redis_writer: Any,
     ) -> None:
+        """Initialize retention manager with backend writers."""
         self._arango = arango_writer
         self._redis = redis_writer
         self._max_storage_gb = int(

--- a/src/db/retention.py
+++ b/src/db/retention.py
@@ -1,0 +1,158 @@
+"""Storage-aware retention manager for polyglot backends.
+
+Monitors ArangoDB and Redis storage usage and purges oldest data
+when configurable thresholds are exceeded. Oldest-first rollover
+ensures newest data is always preserved.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any
+
+from src.db import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_MAX_STORAGE_GB = 100
+DEFAULT_CHECK_INTERVAL_HOURS = 6
+SNAPSHOT_PURGE_BATCH = 500
+
+
+class RetentionManager:
+    """Manage storage retention across ArangoDB and Redis."""
+
+    def __init__(
+        self,
+        arango_writer: Any,
+        redis_writer: Any,
+    ) -> None:
+        self._arango = arango_writer
+        self._redis = redis_writer
+        self._max_storage_gb = int(
+            os.environ.get(
+                "ARANGO_MAX_STORAGE_GB",
+                str(DEFAULT_MAX_STORAGE_GB),
+            )
+        )
+        self._check_interval_hours = int(
+            os.environ.get(
+                "RETENTION_CHECK_INTERVAL_HOURS",
+                str(DEFAULT_CHECK_INTERVAL_HOURS),
+            )
+        )
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def check_arango_retention(self) -> int:
+        """Purge oldest ArangoDB snapshots if over threshold.
+
+        Returns count of documents purged.
+        """
+        usage = self._get_storage_usage_gb()
+        if usage < self._max_storage_gb * 0.9:
+            logger.info(
+                "arango_retention_ok",
+                usage_gb=usage,
+                threshold_gb=self._max_storage_gb,
+            )
+            return 0
+        return self._purge_oldest_snapshots()
+
+    def _get_storage_usage_gb(self) -> float:
+        """Query ArangoDB storage usage in GB."""
+        try:
+            database = getattr(self._arango, "_database", None)
+            if database is None:
+                return 0.0
+            stats = database.statistics()
+            data_size = stats.get("dataSize", 0)
+            return data_size / (1024**3)
+        except Exception as error:
+            logger.warning("storage_check_failed", error=str(error))
+            return 0.0
+
+    def _purge_oldest_snapshots(self) -> int:
+        """Remove oldest config_snapshots, keeping at least one per entity."""
+        database = getattr(self._arango, "_database", None)
+        if database is None:
+            return 0
+        query = """
+            FOR snapshot IN config_snapshots
+                COLLECT entity = snapshot.entity_id
+                INTO snapshots = snapshot
+                LET sorted = (
+                    FOR s IN snapshots
+                        SORT s.timestamp ASC
+                        RETURN s
+                )
+                LET to_remove = SLICE(sorted, 0, LENGTH(sorted) - 1)
+                FOR doc IN to_remove
+                    LIMIT @batch
+                    REMOVE doc IN config_snapshots
+                    RETURN OLD._key
+        """
+        try:
+            cursor = database.aql.execute(
+                query,
+                bind_vars={"batch": SNAPSHOT_PURGE_BATCH},
+            )
+            removed = list(cursor)
+            count = len(removed)
+            logger.info("arango_snapshots_purged", count=count)
+            return count
+        except Exception as error:
+            logger.warning("purge_failed", error=str(error))
+            return 0
+
+    def check_redis_retention(self) -> int:
+        """Verify Redis TS retention rules are properly configured.
+
+        Returns count of keys checked.
+        """
+        client = getattr(self._redis, "_client", None)
+        if client is None:
+            return 0
+        try:
+            keys = client.execute_command("KEYS", "*.avg_1h")
+            logger.info("redis_retention_checked", keys=len(keys))
+            return len(keys)
+        except Exception as error:
+            logger.warning("redis_check_failed", error=str(error))
+            return 0
+
+    def start_periodic(self) -> None:
+        """Start background retention sweep thread."""
+        if self._thread is not None:
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._sweep_loop,
+            daemon=True,
+            name="retention-sweep",
+        )
+        self._thread.start()
+        logger.info(
+            "retention_sweep_started",
+            interval_hours=self._check_interval_hours,
+        )
+
+    def stop(self) -> None:
+        """Stop the background retention sweep thread."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+        logger.info("retention_sweep_stopped")
+
+    def _sweep_loop(self) -> None:
+        """Periodic sweep: check both backends."""
+        interval = self._check_interval_hours * 3600
+        while not self._stop_event.is_set():
+            try:
+                self.check_arango_retention()
+                self.check_redis_retention()
+            except Exception as error:
+                logger.error("retention_sweep_error", error=str(error))
+            self._stop_event.wait(interval)

--- a/src/db/router.py
+++ b/src/db/router.py
@@ -1,0 +1,365 @@
+"""DatabaseRouter: central dispatch for polyglot database writes.
+
+Routes API data to ArangoDB or Redis TimeSeries based on the
+ENDPOINT_PRIMARY_KEY_STRATEGIES configuration in MistHelper.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from src.db import DatabaseConfig, DualWriteResult, WriteResult, get_logger
+from src.db.arango_writer import ArangoDBWriter
+from src.db.redis_writer import RedisJSONWriter, RedisTimeSeriesWriter
+
+logger = get_logger(__name__)
+
+ARANGO_ONLY_TYPES = {"natural_pk", "auto_increment_with_unique"}
+DUAL_WRITE_TYPES = {"composite_pk"}
+TIMESERIES_TYPES = {"timeseries_pk"}
+
+CONFIG_SNAPSHOT_APIS = {
+    "listOrgSites",
+    "listSiteDevices",
+    "getOrgWlans",
+    "listOrgRfTemplates",
+    "listOrgDeviceProfiles",
+    "listOrgNetworkTemplates",
+    "listOrgGatewayTemplates",
+    "listOrgServices",
+    "listOrgServicePolicies",
+}
+
+DEFAULT_STRATEGY: dict[str, Any] = {
+    "type": "auto_increment_with_unique",
+    "primary_key": ["misthelper_internal_id"],
+}
+
+
+class DatabaseRouter:
+    """Route and write data to the appropriate backend."""
+
+    def __init__(
+        self,
+        config: DatabaseConfig,
+        strategies: dict[str, Any] | None = None,
+    ) -> None:
+        self.config = config
+        self._strategies = strategies or {}
+        self._arango_available = False
+        self._redis_available = False
+        self._redis_json_available = False
+        self._arango_writer: ArangoDBWriter | None = None
+        self._redis_writer: RedisTimeSeriesWriter | None = None
+        self._redis_json_writer: RedisJSONWriter | None = None
+
+        if config.standalone_mode:
+            logger.info("standalone_mode", msg="CSV-only output")
+            return
+
+        self._connect_arango()
+        self._connect_redis()
+        self._connect_redis_json()
+
+    def _connect_arango(self) -> None:
+        """Attempt ArangoDB connection; set availability flag."""
+        try:
+            self._arango_writer = ArangoDBWriter(self.config)
+            self._arango_available = True
+        except Exception as error:
+            self._arango_available = False
+            logger.warning("arangodb_unavailable", error=str(error))
+
+    def _connect_redis(self) -> None:
+        """Attempt Redis connection; set availability flag."""
+        try:
+            self._redis_writer = RedisTimeSeriesWriter(self.config)
+            self._redis_available = True
+        except Exception as error:
+            self._redis_available = False
+            logger.warning("redis_unavailable", error=str(error))
+
+    def _connect_redis_json(self) -> None:
+        """Attempt Redis JSON connection; set availability flag."""
+        try:
+            self._redis_json_writer = RedisJSONWriter(self.config)
+            self._redis_json_available = True
+        except Exception as error:
+            self._redis_json_available = False
+            logger.warning("redis_json_unavailable", error=str(error))
+
+    def write(self, data: list[dict], api_function_name: str) -> WriteResult:
+        """Route data to the correct backend based on PK strategy."""
+        if self.config.standalone_mode:
+            return WriteResult(
+                success=True,
+                backend="csv_only",
+                records_written=0,
+                records_failed=0,
+            )
+
+        strategy = self._resolve_strategy(api_function_name)
+        strategy_type = strategy.get("type", "auto_increment_with_unique")
+
+        if strategy_type in TIMESERIES_TYPES:
+            return self._write_redis(data, api_function_name, strategy)
+        if strategy_type in DUAL_WRITE_TYPES:
+            return self._write_dual(data, api_function_name, strategy)
+        return self._write_arango(data, api_function_name, strategy)
+
+    def _write_arango(
+        self,
+        data: list[dict],
+        api_function_name: str,
+        strategy: dict[str, Any],
+    ) -> WriteResult:
+        """Dispatch to ArangoDB; degrade to csv_only if unavailable."""
+        if not self._arango_available or self._arango_writer is None:
+            return self._csv_fallback(api_function_name, "arangodb")
+        try:
+            result = self._arango_writer.write(
+                data,
+                api_function_name,
+                strategy,
+            )
+            if result.success:
+                self._snapshot_if_config(
+                    data,
+                    api_function_name,
+                    strategy,
+                )
+            return result
+        except Exception as error:
+            logger.error("arango_write_error", error=str(error))
+            return WriteResult(
+                success=False,
+                backend="csv_only",
+                records_written=0,
+                records_failed=len(data),
+                error_message=str(error),
+            )
+
+    def _snapshot_if_config(
+        self,
+        data: list[dict],
+        api_function_name: str,
+        strategy: dict[str, Any],
+    ) -> None:
+        """Create config snapshots for configuration entity types."""
+        if api_function_name not in CONFIG_SNAPSHOT_APIS:
+            return
+        if self._arango_writer is None:
+            return
+        pk_field = strategy.get("primary_key", ["id"])[0]
+        for record in data:
+            entity_id = str(record.get(pk_field, ""))
+            if not entity_id:
+                continue
+            body = json.dumps(record, sort_keys=True, default=str)
+            config_hash = hashlib.sha256(body.encode()).hexdigest()
+            try:
+                self._arango_writer.snapshot(
+                    api_function_name,
+                    entity_id,
+                    record,
+                    config_hash,
+                    "api_pull",
+                )
+            except Exception as error:
+                logger.warning(
+                    "snapshot_failed",
+                    entity_id=entity_id,
+                    error=str(error),
+                )
+
+    def _write_redis(
+        self,
+        data: list[dict],
+        api_function_name: str,
+        strategy: dict[str, Any],
+    ) -> WriteResult:
+        """Dispatch to Redis TS; degrade to csv_only if unavailable."""
+        if not self._redis_available or self._redis_writer is None:
+            return self._csv_fallback(api_function_name, "redis")
+        try:
+            return self._redis_writer.write(
+                data,
+                api_function_name,
+                strategy,
+            )
+        except Exception as error:
+            logger.error("redis_write_error", error=str(error))
+            return WriteResult(
+                success=False,
+                backend="csv_only",
+                records_written=0,
+                records_failed=len(data),
+                error_message=str(error),
+            )
+
+    def _write_redis_json(
+        self,
+        data: list[dict],
+        api_function_name: str,
+        strategy: dict[str, Any],
+    ) -> WriteResult:
+        """Dispatch to Redis JSON; degrade to csv_only if unavailable."""
+        if not self._redis_json_available or self._redis_json_writer is None:
+            return self._csv_fallback(api_function_name, "redis_json")
+        try:
+            return self._redis_json_writer.write(
+                data,
+                api_function_name,
+                strategy,
+            )
+        except Exception as error:
+            logger.error("redis_json_write_error", error=str(error))
+            return WriteResult(
+                success=False,
+                backend="csv_only",
+                records_written=0,
+                records_failed=len(data),
+                error_message=str(error),
+            )
+
+    def _write_dual(
+        self,
+        data: list[dict],
+        api_function_name: str,
+        strategy: dict[str, Any],
+    ) -> WriteResult:
+        """Dual-write to Redis JSON + ArangoDB independently."""
+        redis_result = self._write_redis_json(data, api_function_name, strategy)
+        arango_result = self._write_arango(data, api_function_name, strategy)
+        dual = DualWriteResult(
+            arango_result=arango_result,
+            redis_result=redis_result,
+        )
+        return dual.combined
+
+    def _resolve_strategy(self, api_function_name: str) -> dict[str, Any]:
+        """Look up PK strategy; fall back to default."""
+        if api_function_name in self._strategies:
+            return self._strategies[api_function_name]
+        return self._strategies.get("default", DEFAULT_STRATEGY)
+
+    def health_check(self) -> dict[str, bool]:
+        """Check connectivity to all backends."""
+        return {
+            "arangodb": self._arango_available,
+            "redis": self._redis_available,
+            "redis_json": self._redis_json_available,
+            "standalone": self.config.standalone_mode,
+        }
+
+    def handle_webhook_audit(self, payload: dict[str, Any]) -> None:
+        """Snapshot config when an audit webhook payload arrives."""
+        if self._arango_writer is None:
+            return
+        entity_type = payload.get("object_type", "unknown")
+        entity_id = str(payload.get("object_id", ""))
+        if not entity_id:
+            return
+        config_body = payload.get("after", payload)
+        body = json.dumps(config_body, sort_keys=True, default=str)
+        config_hash = hashlib.sha256(body.encode()).hexdigest()
+        try:
+            self._arango_writer.snapshot(
+                entity_type,
+                entity_id,
+                config_body,
+                config_hash,
+                "webhook",
+            )
+        except Exception as error:
+            logger.warning(
+                "webhook_snapshot_failed",
+                entity_id=entity_id,
+                error=str(error),
+            )
+
+    def ingest_stats_batch(
+        self,
+        data: list[dict],
+        api_function_name: str,
+    ) -> WriteResult:
+        """Ingest periodic stats pull data into Redis TimeSeries.
+
+        Called by the periodic stats collector background thread.
+        """
+        if not self._redis_available or self._redis_writer is None:
+            return self._csv_fallback(api_function_name, "redis")
+        strategy = self._resolve_strategy(api_function_name)
+        return self._write_redis(data, api_function_name, strategy)
+
+    def pull_config_history(
+        self,
+        configs: list[dict],
+    ) -> int:
+        """Import device config history into ArangoDB snapshots.
+
+        Called on startup or periodically via
+        searchOrgDeviceLastConfigs / searchSiteDeviceLastConfigs.
+        Returns count of new snapshots stored.
+        """
+        if self._arango_writer is None:
+            return 0
+        stored = 0
+        for config_record in configs:
+            entity_id = str(config_record.get("device_id", config_record.get("mac", "")))
+            if not entity_id:
+                continue
+            body = json.dumps(
+                config_record,
+                sort_keys=True,
+                default=str,
+            )
+            config_hash = hashlib.sha256(body.encode()).hexdigest()
+            try:
+                self._arango_writer.snapshot(
+                    "device_config",
+                    entity_id,
+                    config_record,
+                    config_hash,
+                    "api_pull",
+                )
+                stored += 1
+            except Exception as error:
+                logger.warning(
+                    "config_history_failed",
+                    entity_id=entity_id,
+                    error=str(error),
+                )
+        return stored
+
+    def close(self) -> None:
+        """Close all database connections gracefully."""
+        if self._arango_writer is not None:
+            try:
+                self._arango_writer.close()
+            except Exception as error:
+                logger.warning("arangodb_close_error", error=str(error))
+        if self._redis_writer is not None:
+            try:
+                self._redis_writer.close()
+            except Exception as error:
+                logger.warning("redis_close_error", error=str(error))
+        logger.info("router_closed")
+
+    @staticmethod
+    def _csv_fallback(api_function_name: str, backend: str) -> WriteResult:
+        """Return a csv_only result when the target backend is down."""
+        logger.warning(
+            "degraded_mode",
+            api=api_function_name,
+            backend=backend,
+        )
+        return WriteResult(
+            success=True,
+            backend="csv_only",
+            records_written=0,
+            records_failed=0,
+            error_message=f"{backend} unavailable, CSV only",
+        )

--- a/src/db/router.py
+++ b/src/db/router.py
@@ -10,9 +10,9 @@ import hashlib
 import json
 from typing import Any
 
-from src.db import DatabaseConfig, DualWriteResult, WriteResult, get_logger
-from src.db.arango_writer import ArangoDBWriter
-from src.db.redis_writer import RedisJSONWriter, RedisTimeSeriesWriter
+from . import DatabaseConfig, DualWriteResult, WriteResult, get_logger
+from .arango_writer import ArangoDBWriter
+from .redis_writer import RedisJSONWriter, RedisTimeSeriesWriter
 
 logger = get_logger(__name__)
 
@@ -46,6 +46,7 @@ class DatabaseRouter:
         config: DatabaseConfig,
         strategies: dict[str, Any] | None = None,
     ) -> None:
+        """Initialize database router and connect to available backends."""
         self.config = config
         self._strategies = strategies or {}
         self._arango_available = False

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -1,0 +1,247 @@
+"""Unit tests for ArangoDBWriter.
+
+All python-arango interactions are mocked — no live ArangoDB required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.db import DatabaseConfig, WriteResult
+
+
+@pytest.fixture
+def config() -> DatabaseConfig:
+    return DatabaseConfig(
+        arango_host="http://localhost:8529",
+        arango_password="test",
+    )
+
+
+@pytest.fixture
+def mock_arango_client():
+    """Patch ArangoClient and return mock objects."""
+    with patch("src.db.arango_writer.ArangoClient") as mock_cls:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_sys_db = MagicMock()
+        mock_client.db.return_value = mock_sys_db
+        mock_sys_db.has_database.return_value = True
+        mock_db = MagicMock()
+        mock_client.db.side_effect = lambda name, **kw: (
+            mock_sys_db if name == "_system" else mock_db
+        )
+        yield {
+            "client_cls": mock_cls,
+            "client": mock_client,
+            "sys_db": mock_sys_db,
+            "db": mock_db,
+        }
+
+
+class TestArangoDBWriterInit:
+    """Tests for ArangoDBWriter.__init__."""
+
+    def test_connects_and_ensures_database(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_arango_client["client_cls"].assert_called_once()
+        assert writer._db is not None
+
+    def test_creates_database_if_missing(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        mock_arango_client["sys_db"].has_database.return_value = False
+        writer = ArangoDBWriter(config)
+        mock_arango_client["sys_db"].create_database.assert_called_once_with(
+            "misthelper"
+        )
+
+
+class TestArangoDBWriterWrite:
+    """Tests for ArangoDBWriter.write."""
+
+    def test_upsert_with_natural_pk(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_db = mock_arango_client["db"]
+        mock_collection = MagicMock()
+        mock_db.has_collection.return_value = True
+        mock_db.collection.return_value = mock_collection
+        mock_collection.insert.return_value = {"_key": "uuid-1"}
+
+        strategy = {
+            "type": "natural_pk",
+            "primary_key": ["id"],
+        }
+        data = [{"id": "uuid-1", "name": "Site A", "org_id": "org-1"}]
+        result = writer.write(data, "sites", strategy)
+
+        assert result.success is True
+        assert result.backend == "arangodb"
+        assert result.records_written == 1
+        mock_collection.insert.assert_called_once()
+        call_args = mock_collection.insert.call_args
+        doc = call_args[0][0]
+        assert doc["_key"] == "uuid-1"
+        assert "_misthelper_updated_at" in doc
+
+    def test_auto_creates_collection(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_db = mock_arango_client["db"]
+        mock_db.has_collection.return_value = False
+        mock_collection = MagicMock()
+        mock_db.create_collection.return_value = mock_collection
+        mock_collection.insert.return_value = {"_key": "uuid-1"}
+
+        strategy = {"type": "natural_pk", "primary_key": ["id"]}
+        data = [{"id": "uuid-1", "name": "Test"}]
+        result = writer.write(data, "new_collection", strategy)
+
+        mock_db.create_collection.assert_called_once_with("new_collection")
+        assert result.success is True
+
+    def test_auto_increment_with_unique(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_db = mock_arango_client["db"]
+        mock_collection = MagicMock()
+        mock_db.has_collection.return_value = True
+        mock_db.collection.return_value = mock_collection
+        mock_collection.insert.return_value = {"_key": "auto-1"}
+
+        strategy = {
+            "type": "auto_increment_with_unique",
+            "primary_key": ["misthelper_internal_id"],
+        }
+        data = [{"name": "Summary", "value": 42}]
+        result = writer.write(data, "summaries", strategy)
+
+        assert result.success is True
+        call_doc = mock_collection.insert.call_args[0][0]
+        assert "_key" in call_doc
+
+    def test_handles_insert_error_gracefully(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_db = mock_arango_client["db"]
+        mock_collection = MagicMock()
+        mock_db.has_collection.return_value = True
+        mock_db.collection.return_value = mock_collection
+        mock_collection.insert.side_effect = Exception("Insert failed")
+
+        strategy = {"type": "natural_pk", "primary_key": ["id"]}
+        data = [{"id": "uuid-1"}]
+        result = writer.write(data, "sites", strategy)
+
+        assert result.records_failed == 1
+
+    def test_updated_at_timestamp(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_db = mock_arango_client["db"]
+        mock_collection = MagicMock()
+        mock_db.has_collection.return_value = True
+        mock_db.collection.return_value = mock_collection
+        mock_collection.insert.return_value = {"_key": "uuid-1"}
+
+        strategy = {"type": "natural_pk", "primary_key": ["id"]}
+        data = [{"id": "uuid-1"}]
+        writer.write(data, "sites", strategy)
+
+        call_doc = mock_collection.insert.call_args[0][0]
+        assert isinstance(call_doc["_misthelper_updated_at"], int)
+
+
+class TestArangoDBWriterGraph:
+    """Tests for graph creation and edge management."""
+
+    def test_creates_graph_on_init(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        mock_db = mock_arango_client["db"]
+        mock_db.has_graph.return_value = False
+        writer = ArangoDBWriter(config)
+        mock_db.create_graph.assert_called_once()
+
+
+class TestArangoDBWriterSoftDelete:
+    """Tests for soft-delete logic."""
+
+    def test_marks_absent_entities_deleted(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_db = mock_arango_client["db"]
+        mock_collection = MagicMock()
+        mock_db.has_collection.return_value = True
+        mock_db.collection.return_value = mock_collection
+
+        existing_doc = {
+            "_key": "old-uuid",
+            "_misthelper_deleted_at": None,
+        }
+        mock_collection.all.return_value = [existing_doc]
+
+        writer.mark_absent_as_deleted(
+            "sites", current_keys=set()
+        )
+
+        mock_collection.update.assert_called_once()
+        update_doc = mock_collection.update.call_args[0][0]
+        assert update_doc["_misthelper_deleted_at"] is not None
+
+    def test_clears_deleted_on_reappearance(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_db = mock_arango_client["db"]
+        mock_collection = MagicMock()
+        mock_db.has_collection.return_value = True
+        mock_db.collection.return_value = mock_collection
+        mock_collection.insert.return_value = {"_key": "uuid-1"}
+
+        strategy = {"type": "natural_pk", "primary_key": ["id"]}
+        data = [{"id": "uuid-1", "_misthelper_deleted_at": 1234567890}]
+        writer.write(data, "sites", strategy)
+
+        call_doc = mock_collection.insert.call_args[0][0]
+        assert call_doc.get("_misthelper_deleted_at") is None
+
+
+class TestArangoDBWriterSnapshot:
+    """Tests for config snapshot deduplication."""
+
+    def test_skips_duplicate_snapshot(self, config, mock_arango_client):
+        from src.db.arango_writer import ArangoDBWriter
+
+        writer = ArangoDBWriter(config)
+        mock_db = mock_arango_client["db"]
+        mock_collection = MagicMock()
+        mock_db.has_collection.return_value = True
+        mock_db.collection.return_value = mock_collection
+
+        existing_snapshot = {"config_hash": "abc123"}
+        mock_cursor = MagicMock()
+        mock_cursor.__iter__ = MagicMock(
+            return_value=iter([existing_snapshot])
+        )
+        mock_db.aql.execute.return_value = mock_cursor
+
+        result = writer.snapshot(
+            entity_type="site",
+            entity_id="uuid-1",
+            config_body={"name": "Test"},
+            config_hash="abc123",
+        )
+
+        assert result is False

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.db import DatabaseConfig, WriteResult
+from src.db import DatabaseConfig
 
 
 @pytest.fixture
@@ -30,9 +30,7 @@ def mock_arango_client():
         mock_client.db.return_value = mock_sys_db
         mock_sys_db.has_database.return_value = True
         mock_db = MagicMock()
-        mock_client.db.side_effect = lambda name, **kw: (
-            mock_sys_db if name == "_system" else mock_db
-        )
+        mock_client.db.side_effect = lambda name, **kw: (mock_sys_db if name == "_system" else mock_db)
         yield {
             "client_cls": mock_cls,
             "client": mock_client,
@@ -55,10 +53,8 @@ class TestArangoDBWriterInit:
         from src.db.arango_writer import ArangoDBWriter
 
         mock_arango_client["sys_db"].has_database.return_value = False
-        writer = ArangoDBWriter(config)
-        mock_arango_client["sys_db"].create_database.assert_called_once_with(
-            "misthelper"
-        )
+        ArangoDBWriter(config)
+        mock_arango_client["sys_db"].create_database.assert_called_once_with("misthelper")
 
 
 class TestArangoDBWriterWrite:
@@ -72,7 +68,7 @@ class TestArangoDBWriterWrite:
         mock_collection = MagicMock()
         mock_db.has_collection.return_value = True
         mock_db.collection.return_value = mock_collection
-        mock_collection.insert.return_value = {"_key": "uuid-1"}
+        mock_collection.import_bulk.return_value = {"created": 1, "updated": 0, "errors": 0}
 
         strategy = {
             "type": "natural_pk",
@@ -84,11 +80,10 @@ class TestArangoDBWriterWrite:
         assert result.success is True
         assert result.backend == "arangodb"
         assert result.records_written == 1
-        mock_collection.insert.assert_called_once()
-        call_args = mock_collection.insert.call_args
-        doc = call_args[0][0]
-        assert doc["_key"] == "uuid-1"
-        assert "_misthelper_updated_at" in doc
+        mock_collection.import_bulk.assert_called_once()
+        docs = mock_collection.import_bulk.call_args[0][0]
+        assert docs[0]["_key"] == "uuid-1"
+        assert "_misthelper_updated_at" in docs[0]
 
     def test_auto_creates_collection(self, config, mock_arango_client):
         from src.db.arango_writer import ArangoDBWriter
@@ -98,7 +93,8 @@ class TestArangoDBWriterWrite:
         mock_db.has_collection.return_value = False
         mock_collection = MagicMock()
         mock_db.create_collection.return_value = mock_collection
-        mock_collection.insert.return_value = {"_key": "uuid-1"}
+        mock_db.collection.return_value = mock_collection
+        mock_collection.import_bulk.return_value = {"created": 1, "updated": 0, "errors": 0}
 
         strategy = {"type": "natural_pk", "primary_key": ["id"]}
         data = [{"id": "uuid-1", "name": "Test"}]
@@ -115,7 +111,7 @@ class TestArangoDBWriterWrite:
         mock_collection = MagicMock()
         mock_db.has_collection.return_value = True
         mock_db.collection.return_value = mock_collection
-        mock_collection.insert.return_value = {"_key": "auto-1"}
+        mock_collection.import_bulk.return_value = {"created": 1, "updated": 0, "errors": 0}
 
         strategy = {
             "type": "auto_increment_with_unique",
@@ -125,8 +121,8 @@ class TestArangoDBWriterWrite:
         result = writer.write(data, "summaries", strategy)
 
         assert result.success is True
-        call_doc = mock_collection.insert.call_args[0][0]
-        assert "_key" in call_doc
+        docs = mock_collection.import_bulk.call_args[0][0]
+        assert "_key" in docs[0]
 
     def test_handles_insert_error_gracefully(self, config, mock_arango_client):
         from src.db.arango_writer import ArangoDBWriter
@@ -136,7 +132,7 @@ class TestArangoDBWriterWrite:
         mock_collection = MagicMock()
         mock_db.has_collection.return_value = True
         mock_db.collection.return_value = mock_collection
-        mock_collection.insert.side_effect = Exception("Insert failed")
+        mock_collection.import_bulk.side_effect = Exception("Import failed")
 
         strategy = {"type": "natural_pk", "primary_key": ["id"]}
         data = [{"id": "uuid-1"}]
@@ -152,14 +148,14 @@ class TestArangoDBWriterWrite:
         mock_collection = MagicMock()
         mock_db.has_collection.return_value = True
         mock_db.collection.return_value = mock_collection
-        mock_collection.insert.return_value = {"_key": "uuid-1"}
+        mock_collection.import_bulk.return_value = {"created": 1, "updated": 0, "errors": 0}
 
         strategy = {"type": "natural_pk", "primary_key": ["id"]}
         data = [{"id": "uuid-1"}]
         writer.write(data, "sites", strategy)
 
-        call_doc = mock_collection.insert.call_args[0][0]
-        assert isinstance(call_doc["_misthelper_updated_at"], int)
+        docs = mock_collection.import_bulk.call_args[0][0]
+        assert isinstance(docs[0]["_misthelper_updated_at"], int)
 
 
 class TestArangoDBWriterGraph:
@@ -170,7 +166,7 @@ class TestArangoDBWriterGraph:
 
         mock_db = mock_arango_client["db"]
         mock_db.has_graph.return_value = False
-        writer = ArangoDBWriter(config)
+        ArangoDBWriter(config)
         mock_db.create_graph.assert_called_once()
 
 
@@ -192,9 +188,7 @@ class TestArangoDBWriterSoftDelete:
         }
         mock_collection.all.return_value = [existing_doc]
 
-        writer.mark_absent_as_deleted(
-            "sites", current_keys=set()
-        )
+        writer.mark_absent_as_deleted("sites", current_keys=set())
 
         mock_collection.update.assert_called_once()
         update_doc = mock_collection.update.call_args[0][0]
@@ -208,14 +202,14 @@ class TestArangoDBWriterSoftDelete:
         mock_collection = MagicMock()
         mock_db.has_collection.return_value = True
         mock_db.collection.return_value = mock_collection
-        mock_collection.insert.return_value = {"_key": "uuid-1"}
+        mock_collection.import_bulk.return_value = {"created": 1, "updated": 0, "errors": 0}
 
         strategy = {"type": "natural_pk", "primary_key": ["id"]}
         data = [{"id": "uuid-1", "_misthelper_deleted_at": 1234567890}]
         writer.write(data, "sites", strategy)
 
-        call_doc = mock_collection.insert.call_args[0][0]
-        assert call_doc.get("_misthelper_deleted_at") is None
+        docs = mock_collection.import_bulk.call_args[0][0]
+        assert docs[0].get("_misthelper_deleted_at") is None
 
 
 class TestArangoDBWriterSnapshot:
@@ -232,9 +226,7 @@ class TestArangoDBWriterSnapshot:
 
         existing_snapshot = {"config_hash": "abc123"}
         mock_cursor = MagicMock()
-        mock_cursor.__iter__ = MagicMock(
-            return_value=iter([existing_snapshot])
-        )
+        mock_cursor.__iter__ = MagicMock(return_value=iter([existing_snapshot]))
         mock_db.aql.execute.return_value = mock_cursor
 
         result = writer.snapshot(

--- a/tests/unit/test_redis_json_writer.py
+++ b/tests/unit/test_redis_json_writer.py
@@ -1,0 +1,202 @@
+"""Unit tests for RedisJSONWriter.
+
+All redis interactions are mocked -- no live Redis required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.db import DatabaseConfig
+
+
+@pytest.fixture
+def config() -> DatabaseConfig:
+    return DatabaseConfig(
+        redis_host="localhost",
+        redis_port=6379,
+        redis_password="test",
+    )
+
+
+@pytest.fixture
+def mock_redis():
+    """Patch redis.Redis and return mock objects."""
+    with patch("src.db.redis_writer.redis.Redis") as mock_cls:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.module_list.return_value = [{"name": b"ReJSON", "ver": 20600}]
+        mock_pipeline = MagicMock()
+        mock_client.pipeline.return_value = mock_pipeline
+        mock_pipeline.__enter__ = MagicMock(return_value=mock_pipeline)
+        mock_pipeline.__exit__ = MagicMock(return_value=False)
+        yield {
+            "client_cls": mock_cls,
+            "client": mock_client,
+            "pipeline": mock_pipeline,
+        }
+
+
+class TestRedisJSONWriterInit:
+    """Tests for RedisJSONWriter.__init__."""
+
+    def test_connects_and_verifies_json_module(self, config, mock_redis):
+        from src.db.redis_writer import RedisJSONWriter
+
+        writer = RedisJSONWriter(config)
+        mock_redis["client_cls"].assert_called_once()
+        mock_redis["client"].module_list.assert_called_once()
+        assert writer is not None
+
+    def test_raises_if_json_module_missing(self, config, mock_redis):
+        from src.db.redis_writer import RedisJSONWriter
+
+        mock_redis["client"].module_list.return_value = []
+        with pytest.raises(RuntimeError, match="JSON"):
+            RedisJSONWriter(config)
+
+
+class TestRedisJSONWriterWrite:
+    """Tests for RedisJSONWriter.write."""
+
+    def test_writes_documents_with_ttl(self, config, mock_redis):
+        from src.db.redis_writer import RedisJSONWriter
+
+        writer = RedisJSONWriter(config)
+        # json().set() + expire() per record, pipeline.execute returns pairs
+        mock_redis["pipeline"].execute.return_value = [True, True]
+        strategy = {
+            "type": "composite_pk",
+            "primary_key": ["id", "device_id"],
+        }
+        data = [{"id": "ev-1", "device_id": "d1", "cpu": 42}]
+        result = writer.write(data, "searchOrgDeviceEvents", strategy)
+
+        assert result.success is True
+        assert result.backend == "redis_json"
+        assert result.records_written == 1
+
+    def test_empty_data_returns_success(self, config, mock_redis):
+        from src.db.redis_writer import RedisJSONWriter
+
+        writer = RedisJSONWriter(config)
+        strategy = {"type": "composite_pk", "primary_key": ["id"]}
+        result = writer.write([], "getStats", strategy)
+
+        assert result.success is True
+        assert result.records_written == 0
+
+    def test_handles_write_error(self, config, mock_redis):
+        from src.db.redis_writer import RedisJSONWriter
+
+        writer = RedisJSONWriter(config)
+        mock_redis["pipeline"].execute.return_value = [
+            Exception("Connection lost"),
+            True,
+        ]
+        strategy = {"type": "composite_pk", "primary_key": ["id"]}
+        data = [{"id": "ev-1", "value": 42}]
+        result = writer.write(data, "getStats", strategy)
+
+        assert result.records_failed == 1
+
+    def test_close(self, config, mock_redis):
+        from src.db.redis_writer import RedisJSONWriter
+
+        writer = RedisJSONWriter(config)
+        writer.close()
+        mock_redis["client"].close.assert_called_once()
+
+
+class TestRedisTimeSeriesClose:
+    """Test close method for RedisTimeSeriesWriter."""
+
+    def test_close(self, config):
+        with patch("src.db.redis_writer.redis.Redis") as mock_cls:
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.module_list.return_value = [{"name": b"timeseries", "ver": 11006}]
+            from src.db.redis_writer import RedisTimeSeriesWriter
+
+            writer = RedisTimeSeriesWriter(config)
+            writer.close()
+            mock_client.close.assert_called_once()
+
+
+class TestRedisTimeSeriesWebhookIngestion:
+    """Tests for ingest_webhook method."""
+
+    def test_ingests_numeric_fields(self, config):
+        with patch("src.db.redis_writer.redis.Redis") as mock_cls:
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.module_list.return_value = [{"name": b"timeseries", "ver": 11006}]
+            mock_pipeline = MagicMock()
+            mock_client.pipeline.return_value = mock_pipeline
+            from src.db.redis_writer import RedisTimeSeriesWriter
+
+            writer = RedisTimeSeriesWriter(config)
+            events = [{"mac": "aa:bb:cc:dd:ee:ff", "rssi": -65, "snr": 30}]
+            result = writer.ingest_webhook(events, "client-sessions")
+            assert result == 2  # rssi and snr
+            mock_pipeline.execute.assert_called_once()
+
+    def test_no_numeric_fields_skips_execute(self, config):
+        with patch("src.db.redis_writer.redis.Redis") as mock_cls:
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.module_list.return_value = [{"name": b"timeseries", "ver": 11006}]
+            mock_pipeline = MagicMock()
+            mock_client.pipeline.return_value = mock_pipeline
+            from src.db.redis_writer import RedisTimeSeriesWriter
+
+            writer = RedisTimeSeriesWriter(config)
+            events = [{"mac": "aa:bb:cc:dd:ee:ff", "status": "connected"}]
+            result = writer.ingest_webhook(events, "client-sessions")
+            assert result == 0
+            mock_pipeline.execute.assert_not_called()
+
+
+class TestBuildLabels:
+    """Tests for _build_labels static method."""
+
+    def test_includes_api_function_and_metric(self):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        labels = RedisTimeSeriesWriter._build_labels(
+            {"org_id": "org-1", "site_id": "site-1"},
+            "getDeviceStats",
+            "getDeviceStats:dev-1:cpu",
+        )
+        assert labels["api_function"] == "getDeviceStats"
+        assert labels["metric_name"] == "cpu"
+        assert labels["org_id"] == "org-1"
+
+    def test_custom_label_fields(self):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        labels = RedisTimeSeriesWriter._build_labels(
+            {"custom_field": "val"},
+            "getStats",
+            "getStats:dev-1:mem",
+            ts_label_fields=["custom_field"],
+        )
+        assert labels["custom_field"] == "val"
+        assert "org_id" not in labels
+
+
+class TestExtractListedFields:
+    """Tests for _extract_listed_fields static method."""
+
+    def test_extracts_only_named_numeric(self):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        result = RedisTimeSeriesWriter._extract_listed_fields(
+            {"cpu": 42.0, "mem": 78, "name": "test", "disk": 90.0},
+            ["cpu", "mem", "name"],
+        )
+        assert result == {"cpu": 42.0, "mem": 78.0}
+        assert "name" not in result
+        assert "disk" not in result

--- a/tests/unit/test_redis_writer.py
+++ b/tests/unit/test_redis_writer.py
@@ -5,11 +5,11 @@ All redis interactions are mocked — no live Redis required.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.db import DatabaseConfig, WriteResult
+from src.db import DatabaseConfig
 
 
 @pytest.fixture
@@ -29,9 +29,7 @@ def mock_redis():
         mock_cls.return_value = mock_client
         mock_ts = MagicMock()
         mock_client.ts.return_value = mock_ts
-        mock_client.module_list.return_value = [
-            {"name": b"timeseries", "ver": 11006}
-        ]
+        mock_client.module_list.return_value = [{"name": b"timeseries", "ver": 11006}]
         mock_pipeline = MagicMock()
         mock_client.pipeline.return_value = mock_pipeline
         mock_pipeline.__enter__ = MagicMock(return_value=mock_pipeline)
@@ -70,6 +68,13 @@ class TestRedisTimeSeriesWriterWrite:
         from src.db.redis_writer import RedisTimeSeriesWriter
 
         writer = RedisTimeSeriesWriter(config)
+        # Pipeline called 3 times: key creation, compaction, TS.ADD
+        # 2 numeric fields (cpu_usage, mem_usage) → 2 keys, 8 compaction cmds, 2 adds
+        mock_redis["pipeline"].execute.side_effect = [
+            [True, True],
+            [True] * 8,
+            [True, True],
+        ]
         strategy = {
             "type": "composite_pk",
             "primary_key": ["id", "device_id", "timestamp"],
@@ -88,7 +93,7 @@ class TestRedisTimeSeriesWriterWrite:
 
         assert result.success is True
         assert result.backend == "redis"
-        assert result.records_written > 0
+        assert result.records_written == 2
 
     def test_skips_non_numeric_fields(self, config, mock_redis):
         from src.db.redis_writer import RedisTimeSeriesWriter
@@ -98,9 +103,7 @@ class TestRedisTimeSeriesWriterWrite:
             "type": "composite_pk",
             "primary_key": ["id", "timestamp"],
         }
-        data = [
-            {"id": "evt-1", "timestamp": 1700000000, "status": "active"}
-        ]
+        data = [{"id": "evt-1", "timestamp": 1700000000, "status": "active"}]
         result = writer.write(data, "getEvents", strategy)
 
         assert result.records_written == 0
@@ -113,9 +116,7 @@ class TestRedisTimeSeriesWriterWrite:
             "type": "composite_pk",
             "primary_key": ["id", "device_id", "timestamp"],
         }
-        data = [
-            {"id": "evt-1", "device_id": "dev-1", "timestamp": 1700000000, "cpu": 50.0}
-        ]
+        data = [{"id": "evt-1", "device_id": "dev-1", "timestamp": 1700000000, "cpu": 50.0}]
         writer.write(data, "getDeviceStats", strategy)
 
         # Verify TS.CREATE was called with the correct key pattern
@@ -139,7 +140,12 @@ class TestRedisTimeSeriesWriterWrite:
         from src.db.redis_writer import RedisTimeSeriesWriter
 
         writer = RedisTimeSeriesWriter(config)
-        mock_redis["ts"].add.side_effect = Exception("Connection lost")
+        # 1 numeric field → 1 key creation, 4 compaction cmds, 1 TS.ADD (fails)
+        mock_redis["pipeline"].execute.side_effect = [
+            [True],
+            [True] * 4,
+            [Exception("Connection lost")],
+        ]
         strategy = {
             "type": "composite_pk",
             "primary_key": ["id", "timestamp"],
@@ -157,7 +163,7 @@ class TestRedisTimeSeriesCompaction:
         from src.db.redis_writer import RedisTimeSeriesWriter
 
         writer = RedisTimeSeriesWriter(config)
-        writer._ensure_compaction("test:dev-1:cpu")
+        writer._ensure_single_compaction("test:dev-1:cpu")
 
         create_rule_calls = mock_redis["ts"].createrule.call_args_list
         assert len(create_rule_calls) >= 2
@@ -169,8 +175,8 @@ class TestRedisTimeSeriesCompaction:
         from src.db.redis_writer import RedisTimeSeriesWriter
 
         writer = RedisTimeSeriesWriter(config)
-        writer._ensure_compaction("test:dev-1:cpu")
+        writer._ensure_single_compaction("test:dev-1:cpu")
         initial_calls = len(mock_redis["ts"].createrule.call_args_list)
 
-        writer._ensure_compaction("test:dev-1:cpu")
+        writer._ensure_single_compaction("test:dev-1:cpu")
         assert len(mock_redis["ts"].createrule.call_args_list) == initial_calls

--- a/tests/unit/test_redis_writer.py
+++ b/tests/unit/test_redis_writer.py
@@ -1,0 +1,176 @@
+"""Unit tests for RedisTimeSeriesWriter.
+
+All redis interactions are mocked — no live Redis required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from src.db import DatabaseConfig, WriteResult
+
+
+@pytest.fixture
+def config() -> DatabaseConfig:
+    return DatabaseConfig(
+        redis_host="localhost",
+        redis_port=6379,
+        redis_password="test",
+    )
+
+
+@pytest.fixture
+def mock_redis():
+    """Patch redis.Redis and return mock objects."""
+    with patch("src.db.redis_writer.redis.Redis") as mock_cls:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_ts = MagicMock()
+        mock_client.ts.return_value = mock_ts
+        mock_client.module_list.return_value = [
+            {"name": b"timeseries", "ver": 11006}
+        ]
+        mock_pipeline = MagicMock()
+        mock_client.pipeline.return_value = mock_pipeline
+        mock_pipeline.__enter__ = MagicMock(return_value=mock_pipeline)
+        mock_pipeline.__exit__ = MagicMock(return_value=False)
+        yield {
+            "client_cls": mock_cls,
+            "client": mock_client,
+            "ts": mock_ts,
+            "pipeline": mock_pipeline,
+        }
+
+
+class TestRedisTimeSeriesWriterInit:
+    """Tests for RedisTimeSeriesWriter.__init__."""
+
+    def test_connects_and_verifies_ts_module(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        writer = RedisTimeSeriesWriter(config)
+        mock_redis["client_cls"].assert_called_once()
+        mock_redis["client"].module_list.assert_called_once()
+        assert writer._ts is not None
+
+    def test_raises_if_ts_module_missing(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        mock_redis["client"].module_list.return_value = []
+        with pytest.raises(RuntimeError, match="TimeSeries"):
+            RedisTimeSeriesWriter(config)
+
+
+class TestRedisTimeSeriesWriterWrite:
+    """Tests for RedisTimeSeriesWriter.write."""
+
+    def test_writes_numeric_values_as_timeseries(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        writer = RedisTimeSeriesWriter(config)
+        strategy = {
+            "type": "composite_pk",
+            "primary_key": ["id", "device_id", "timestamp"],
+        }
+        data = [
+            {
+                "id": "evt-1",
+                "device_id": "dev-1",
+                "timestamp": 1700000000,
+                "cpu_usage": 42.5,
+                "mem_usage": 78.2,
+                "name": "not-a-number",
+            }
+        ]
+        result = writer.write(data, "getDeviceStats", strategy)
+
+        assert result.success is True
+        assert result.backend == "redis"
+        assert result.records_written > 0
+
+    def test_skips_non_numeric_fields(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        writer = RedisTimeSeriesWriter(config)
+        strategy = {
+            "type": "composite_pk",
+            "primary_key": ["id", "timestamp"],
+        }
+        data = [
+            {"id": "evt-1", "timestamp": 1700000000, "status": "active"}
+        ]
+        result = writer.write(data, "getEvents", strategy)
+
+        assert result.records_written == 0
+
+    def test_key_naming_convention(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        writer = RedisTimeSeriesWriter(config)
+        strategy = {
+            "type": "composite_pk",
+            "primary_key": ["id", "device_id", "timestamp"],
+        }
+        data = [
+            {"id": "evt-1", "device_id": "dev-1", "timestamp": 1700000000, "cpu": 50.0}
+        ]
+        writer.write(data, "getDeviceStats", strategy)
+
+        # Verify TS.CREATE was called with the correct key pattern
+        create_calls = mock_redis["ts"].create.call_args_list
+        if create_calls:
+            key = create_calls[0][0][0]
+            assert "getDeviceStats" in key
+            assert "cpu" in key
+
+    def test_empty_data_returns_success(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        writer = RedisTimeSeriesWriter(config)
+        strategy = {"type": "composite_pk", "primary_key": ["id"]}
+        result = writer.write([], "getStats", strategy)
+
+        assert result.success is True
+        assert result.records_written == 0
+
+    def test_handles_write_error_gracefully(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        writer = RedisTimeSeriesWriter(config)
+        mock_redis["ts"].add.side_effect = Exception("Connection lost")
+        strategy = {
+            "type": "composite_pk",
+            "primary_key": ["id", "timestamp"],
+        }
+        data = [{"id": "evt-1", "timestamp": 1700000000, "value": 42.0}]
+        result = writer.write(data, "getStats", strategy)
+
+        assert result.records_failed > 0
+
+
+class TestRedisTimeSeriesCompaction:
+    """Tests for compaction rule creation."""
+
+    def test_creates_hourly_and_daily_compaction(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        writer = RedisTimeSeriesWriter(config)
+        writer._ensure_compaction("test:dev-1:cpu")
+
+        create_rule_calls = mock_redis["ts"].createrule.call_args_list
+        assert len(create_rule_calls) >= 2
+        dest_keys = [call[0][1] for call in create_rule_calls]
+        assert any("avg_1h" in k for k in dest_keys)
+        assert any("avg_1d" in k for k in dest_keys)
+
+    def test_skips_duplicate_compaction(self, config, mock_redis):
+        from src.db.redis_writer import RedisTimeSeriesWriter
+
+        writer = RedisTimeSeriesWriter(config)
+        writer._ensure_compaction("test:dev-1:cpu")
+        initial_calls = len(mock_redis["ts"].createrule.call_args_list)
+
+        writer._ensure_compaction("test:dev-1:cpu")
+        assert len(mock_redis["ts"].createrule.call_args_list) == initial_calls

--- a/tests/unit/test_retention.py
+++ b/tests/unit/test_retention.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestRetentionInit:
     """Verify RetentionManager initializes from config."""
@@ -23,10 +21,13 @@ class TestRetentionInit:
     def test_custom_thresholds_from_env(self) -> None:
         from src.db.retention import RetentionManager
 
-        with patch.dict("os.environ", {
-            "ARANGO_MAX_STORAGE_GB": "50",
-            "RETENTION_CHECK_INTERVAL_HOURS": "12",
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "ARANGO_MAX_STORAGE_GB": "50",
+                "RETENTION_CHECK_INTERVAL_HOURS": "12",
+            },
+        ):
             manager = RetentionManager(
                 arango_writer=MagicMock(),
                 redis_writer=MagicMock(),
@@ -43,7 +44,8 @@ class TestArangoRetention:
 
         arango = MagicMock()
         manager = RetentionManager(
-            arango_writer=arango, redis_writer=MagicMock(),
+            arango_writer=arango,
+            redis_writer=MagicMock(),
         )
         manager._get_storage_usage_gb = MagicMock(return_value=5.0)
         manager._max_storage_gb = 100
@@ -56,15 +58,65 @@ class TestArangoRetention:
         arango = MagicMock()
         arango._database = MagicMock()
         arango._database.aql.execute.return_value = [
-            {"_key": "old-1"}, {"_key": "old-2"},
+            {"_key": "old-1"},
+            {"_key": "old-2"},
         ]
         manager = RetentionManager(
-            arango_writer=arango, redis_writer=MagicMock(),
+            arango_writer=arango,
+            redis_writer=MagicMock(),
         )
         manager._get_storage_usage_gb = MagicMock(return_value=95.0)
         manager._max_storage_gb = 100
         result = manager.check_arango_retention()
         assert result >= 0
+
+    def test_storage_usage_with_no_database_attr(self) -> None:
+        from src.db.retention import RetentionManager
+
+        arango = MagicMock(spec=[])  # no _database attribute
+        manager = RetentionManager(
+            arango_writer=arango,
+            redis_writer=MagicMock(),
+        )
+        usage = manager._get_storage_usage_gb()
+        assert usage == 0.0
+
+    def test_storage_usage_on_exception(self) -> None:
+        from src.db.retention import RetentionManager
+
+        arango = MagicMock()
+        arango._database = MagicMock()
+        arango._database.statistics.side_effect = Exception("fail")
+        manager = RetentionManager(
+            arango_writer=arango,
+            redis_writer=MagicMock(),
+        )
+        usage = manager._get_storage_usage_gb()
+        assert usage == 0.0
+
+    def test_purge_with_no_database_returns_zero(self) -> None:
+        from src.db.retention import RetentionManager
+
+        arango = MagicMock(spec=[])
+        manager = RetentionManager(
+            arango_writer=arango,
+            redis_writer=MagicMock(),
+        )
+        result = manager._purge_oldest_snapshots()
+        assert result == 0
+
+    def test_purge_on_aql_error(self) -> None:
+        from src.db.retention import RetentionManager
+
+        arango = MagicMock()
+        arango._database = MagicMock()
+        arango._database.aql.execute.side_effect = Exception("AQL error")
+        manager = RetentionManager(
+            arango_writer=arango,
+            redis_writer=MagicMock(),
+        )
+        result = manager._purge_oldest_snapshots()
+        assert result == 0
 
 
 class TestRedisRetention:
@@ -77,7 +129,72 @@ class TestRedisRetention:
         redis_writer._client = MagicMock()
         redis_writer._client.execute_command.return_value = []
         manager = RetentionManager(
-            arango_writer=MagicMock(), redis_writer=redis_writer,
+            arango_writer=MagicMock(),
+            redis_writer=redis_writer,
         )
         result = manager.check_redis_retention()
         assert isinstance(result, int)
+
+    def test_redis_retention_no_client(self) -> None:
+        from src.db.retention import RetentionManager
+
+        redis_writer = MagicMock(spec=[])
+        manager = RetentionManager(
+            arango_writer=MagicMock(),
+            redis_writer=redis_writer,
+        )
+        result = manager.check_redis_retention()
+        assert result == 0
+
+    def test_redis_retention_on_error(self) -> None:
+        from src.db.retention import RetentionManager
+
+        redis_writer = MagicMock()
+        redis_writer._client = MagicMock()
+        redis_writer._client.execute_command.side_effect = Exception("err")
+        manager = RetentionManager(
+            arango_writer=MagicMock(),
+            redis_writer=redis_writer,
+        )
+        result = manager.check_redis_retention()
+        assert result == 0
+
+
+class TestRetentionPeriodic:
+    """Verify start/stop of background sweep."""
+
+    def test_start_and_stop(self) -> None:
+        from src.db.retention import RetentionManager
+
+        manager = RetentionManager(
+            arango_writer=MagicMock(),
+            redis_writer=MagicMock(),
+        )
+        manager._check_interval_hours = 1
+        manager.start_periodic()
+        assert manager._thread is not None
+        assert manager._thread.is_alive()
+        manager.stop()
+        assert manager._thread is None
+
+    def test_start_idempotent(self) -> None:
+        from src.db.retention import RetentionManager
+
+        manager = RetentionManager(
+            arango_writer=MagicMock(),
+            redis_writer=MagicMock(),
+        )
+        manager.start_periodic()
+        thread1 = manager._thread
+        manager.start_periodic()
+        assert manager._thread is thread1
+        manager.stop()
+
+    def test_stop_without_start(self) -> None:
+        from src.db.retention import RetentionManager
+
+        manager = RetentionManager(
+            arango_writer=MagicMock(),
+            redis_writer=MagicMock(),
+        )
+        manager.stop()  # should not raise

--- a/tests/unit/test_retention.py
+++ b/tests/unit/test_retention.py
@@ -1,0 +1,83 @@
+"""Unit tests for RetentionManager."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRetentionInit:
+    """Verify RetentionManager initializes from config."""
+
+    def test_default_thresholds(self) -> None:
+        from src.db.retention import RetentionManager
+
+        manager = RetentionManager(
+            arango_writer=MagicMock(),
+            redis_writer=MagicMock(),
+        )
+        assert manager._max_storage_gb > 0
+        assert manager._check_interval_hours > 0
+
+    def test_custom_thresholds_from_env(self) -> None:
+        from src.db.retention import RetentionManager
+
+        with patch.dict("os.environ", {
+            "ARANGO_MAX_STORAGE_GB": "50",
+            "RETENTION_CHECK_INTERVAL_HOURS": "12",
+        }):
+            manager = RetentionManager(
+                arango_writer=MagicMock(),
+                redis_writer=MagicMock(),
+            )
+            assert manager._max_storage_gb == 50
+            assert manager._check_interval_hours == 12
+
+
+class TestArangoRetention:
+    """Verify ArangoDB retention purges oldest data first."""
+
+    def test_purge_skips_when_under_threshold(self) -> None:
+        from src.db.retention import RetentionManager
+
+        arango = MagicMock()
+        manager = RetentionManager(
+            arango_writer=arango, redis_writer=MagicMock(),
+        )
+        manager._get_storage_usage_gb = MagicMock(return_value=5.0)
+        manager._max_storage_gb = 100
+        result = manager.check_arango_retention()
+        assert result == 0  # nothing purged
+
+    def test_purge_removes_oldest_snapshots(self) -> None:
+        from src.db.retention import RetentionManager
+
+        arango = MagicMock()
+        arango._database = MagicMock()
+        arango._database.aql.execute.return_value = [
+            {"_key": "old-1"}, {"_key": "old-2"},
+        ]
+        manager = RetentionManager(
+            arango_writer=arango, redis_writer=MagicMock(),
+        )
+        manager._get_storage_usage_gb = MagicMock(return_value=95.0)
+        manager._max_storage_gb = 100
+        result = manager.check_arango_retention()
+        assert result >= 0
+
+
+class TestRedisRetention:
+    """Verify Redis retention rules are validated."""
+
+    def test_verify_compaction_exists(self) -> None:
+        from src.db.retention import RetentionManager
+
+        redis_writer = MagicMock()
+        redis_writer._client = MagicMock()
+        redis_writer._client.execute_command.return_value = []
+        manager = RetentionManager(
+            arango_writer=MagicMock(), redis_writer=redis_writer,
+        )
+        result = manager.check_redis_retention()
+        assert isinstance(result, int)

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -50,20 +50,25 @@ def strategies() -> dict:
 
 @pytest.fixture
 def mock_backends():
-    """Patch both writer constructors so router doesn't need live DBs."""
+    """Patch all writer constructors so router doesn't need live DBs."""
     with (
         patch("src.db.router.ArangoDBWriter") as arango_cls,
         patch("src.db.router.RedisTimeSeriesWriter") as redis_cls,
+        patch("src.db.router.RedisJSONWriter") as redis_json_cls,
     ):
         arango_writer = MagicMock()
         arango_cls.return_value = arango_writer
         redis_writer = MagicMock()
         redis_cls.return_value = redis_writer
+        redis_json_writer = MagicMock()
+        redis_json_cls.return_value = redis_json_writer
         yield {
             "arango_cls": arango_cls,
             "arango_writer": arango_writer,
             "redis_cls": redis_cls,
             "redis_writer": redis_writer,
+            "redis_json_cls": redis_json_cls,
+            "redis_json_writer": redis_json_writer,
         }
 
 
@@ -80,8 +85,10 @@ class TestRouterRouting:
     def test_natural_pk_routes_to_arango(self, config, mock_backends, strategies):
         router = _make_router(config, mock_backends, strategies)
         mock_backends["arango_writer"].write.return_value = WriteResult(
-            success=True, backend="arangodb",
-            records_written=3, records_failed=0,
+            success=True,
+            backend="arangodb",
+            records_written=3,
+            records_failed=0,
         )
         data = [{"id": "site-1", "name": "HQ"}]
         result = router.write(data, "listOrgSites")
@@ -90,23 +97,34 @@ class TestRouterRouting:
         assert result.backend == "arangodb"
         assert result.success is True
 
-    def test_composite_pk_routes_to_redis(self, config, mock_backends, strategies):
+    def test_composite_pk_routes_to_dual(self, config, mock_backends, strategies):
         router = _make_router(config, mock_backends, strategies)
-        mock_backends["redis_writer"].write.return_value = WriteResult(
-            success=True, backend="redis",
-            records_written=5, records_failed=0,
+        mock_backends["redis_json_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="redis_json",
+            records_written=1,
+            records_failed=0,
+        )
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
         )
         data = [{"id": "ev-1", "device_id": "d1", "timestamp": 170000, "cpu": 42}]
         result = router.write(data, "searchOrgDeviceEvents")
 
-        mock_backends["redis_writer"].write.assert_called_once()
-        assert result.backend == "redis"
+        mock_backends["redis_json_writer"].write.assert_called_once()
+        mock_backends["arango_writer"].write.assert_called_once()
+        assert result.backend == "dual"
 
     def test_auto_increment_routes_to_arango(self, config, mock_backends, strategies):
         router = _make_router(config, mock_backends, strategies)
         mock_backends["arango_writer"].write.return_value = WriteResult(
-            success=True, backend="arangodb",
-            records_written=1, records_failed=0,
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
         )
         data = [{"license_type": "SUB-MAN", "quantity": 100}]
         result = router.write(data, "getOrgLicensesSummary")
@@ -117,8 +135,10 @@ class TestRouterRouting:
     def test_unknown_function_uses_default_arango(self, config, mock_backends, strategies):
         router = _make_router(config, mock_backends, strategies)
         mock_backends["arango_writer"].write.return_value = WriteResult(
-            success=True, backend="arangodb",
-            records_written=1, records_failed=0,
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
         )
         result = router.write([{"x": 1}], "unknownEndpoint")
         assert result.backend == "arangodb"
@@ -145,15 +165,24 @@ class TestRouterDegradedMode:
 
         assert result.backend == "csv_only"
 
-    def test_redis_unavailable_returns_csv_only(self, config, mock_backends, strategies):
+    def test_redis_unavailable_degrades_to_arango_only(self, config, mock_backends, strategies):
         mock_backends["redis_cls"].side_effect = Exception("Connection refused")
+        mock_backends["redis_json_cls"].side_effect = Exception("Connection refused")
         from src.db.router import DatabaseRouter
 
         router = DatabaseRouter(config, strategies=strategies)
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
+        )
         data = [{"id": "ev-1", "device_id": "d1", "timestamp": 170000, "cpu": 42}]
         result = router.write(data, "searchOrgDeviceEvents")
 
-        assert result.backend == "csv_only"
+        # Dual write: redis_json falls back, arango still writes
+        assert result.backend == "dual"
+        mock_backends["arango_writer"].write.assert_called_once()
 
     def test_backend_write_failure_returns_error(self, config, mock_backends, strategies):
         router = _make_router(config, mock_backends, strategies)
@@ -162,3 +191,308 @@ class TestRouterDegradedMode:
 
         assert result.success is False
         assert "Write failed" in result.error_message
+
+
+class TestRouterHealthCheck:
+    """Test health_check returns correct status."""
+
+    def test_all_backends_available(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        health = router.health_check()
+        assert health["arangodb"] is True
+        assert health["redis"] is True
+        assert health["redis_json"] is True
+        assert health["standalone"] is False
+
+    def test_standalone_health(self, standalone_config):
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(standalone_config)
+        health = router.health_check()
+        assert health["standalone"] is True
+
+
+class TestRouterSnapshot:
+    """Test config snapshot logic."""
+
+    def test_snapshot_called_for_config_api(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
+        )
+        mock_backends["arango_writer"].snapshot.return_value = True
+        data = [{"id": "site-1", "name": "HQ"}]
+        router.write(data, "listOrgSites")
+        mock_backends["arango_writer"].snapshot.assert_called_once()
+
+    def test_snapshot_error_does_not_fail_write(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
+        )
+        mock_backends["arango_writer"].snapshot.side_effect = Exception("snap err")
+        data = [{"id": "site-1", "name": "HQ"}]
+        result = router.write(data, "listOrgSites")
+        assert result.success is True
+
+
+class TestRouterWebhook:
+    """Test webhook audit handler."""
+
+    def test_handle_webhook_audit(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].snapshot.return_value = True
+        payload = {
+            "object_type": "site",
+            "object_id": "site-1",
+            "after": {"name": "Updated Site"},
+        }
+        router.handle_webhook_audit(payload)
+        mock_backends["arango_writer"].snapshot.assert_called_once()
+
+    def test_webhook_with_no_arango(self, standalone_config):
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(standalone_config)
+        router.handle_webhook_audit({"object_type": "site", "object_id": "s1"})
+        # Should not raise
+
+    def test_webhook_missing_object_id(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        router.handle_webhook_audit({"object_type": "site"})
+        mock_backends["arango_writer"].snapshot.assert_not_called()
+
+    def test_webhook_snapshot_error_handled(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].snapshot.side_effect = Exception("err")
+        payload = {"object_type": "site", "object_id": "s1", "after": {}}
+        router.handle_webhook_audit(payload)  # should not raise
+
+
+class TestRouterTimeseries:
+    """Test timeseries_pk routing."""
+
+    def test_timeseries_routes_to_redis(self, config, mock_backends):
+        strategies = {
+            "getDeviceStats": {
+                "type": "timeseries_pk",
+                "primary_key": ["mac", "timestamp"],
+            },
+        }
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["redis_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="redis",
+            records_written=2,
+            records_failed=0,
+        )
+        data = [{"mac": "aa:bb", "timestamp": 170000, "cpu": 42}]
+        result = router.write(data, "getDeviceStats")
+
+        assert result.backend == "redis"
+        mock_backends["redis_writer"].write.assert_called_once()
+
+    def test_timeseries_redis_unavailable(self, config, mock_backends):
+        strategies = {
+            "getDeviceStats": {
+                "type": "timeseries_pk",
+                "primary_key": ["mac", "timestamp"],
+            },
+        }
+        mock_backends["redis_cls"].side_effect = Exception("down")
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(config, strategies=strategies)
+        data = [{"mac": "aa:bb", "timestamp": 170000, "cpu": 42}]
+        result = router.write(data, "getDeviceStats")
+
+        assert result.backend == "csv_only"
+
+
+class TestRouterIngestStatsBatch:
+    """Test ingest_stats_batch for periodic stats."""
+
+    def test_ingests_with_redis_available(self, config, mock_backends):
+        strategies = {
+            "getDeviceStats": {
+                "type": "timeseries_pk",
+                "primary_key": ["mac", "timestamp"],
+            },
+        }
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["redis_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="redis",
+            records_written=3,
+            records_failed=0,
+        )
+        data = [{"mac": "aa:bb", "timestamp": 170000, "cpu": 42}]
+        result = router.ingest_stats_batch(data, "getDeviceStats")
+
+        assert result.backend == "redis"
+
+    def test_degrades_when_redis_unavailable(self, config, mock_backends):
+        mock_backends["redis_cls"].side_effect = Exception("down")
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(config, strategies={})
+        result = router.ingest_stats_batch([], "getDeviceStats")
+
+        assert result.backend == "csv_only"
+
+
+class TestRouterPullConfigHistory:
+    """Test pull_config_history for device config snapshots."""
+
+    def test_stores_config_snapshots(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].snapshot.return_value = True
+        configs = [
+            {"device_id": "dev-1", "config": {"ntp": "1.2.3.4"}},
+            {"device_id": "dev-2", "config": {"ntp": "5.6.7.8"}},
+        ]
+        count = router.pull_config_history(configs)
+
+        assert count == 2
+        assert mock_backends["arango_writer"].snapshot.call_count == 2
+
+    def test_skips_empty_entity_id(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        configs = [{"config": {"ntp": "1.2.3.4"}}]  # no device_id or mac
+        count = router.pull_config_history(configs)
+
+        assert count == 0
+        mock_backends["arango_writer"].snapshot.assert_not_called()
+
+    def test_handles_snapshot_error(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].snapshot.side_effect = Exception("err")
+        configs = [{"device_id": "dev-1"}]
+        count = router.pull_config_history(configs)
+
+        assert count == 0
+
+    def test_returns_zero_without_arango(self, standalone_config):
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(standalone_config)
+        count = router.pull_config_history([{"device_id": "d1"}])
+
+        assert count == 0
+
+    def test_mac_fallback(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].snapshot.return_value = True
+        configs = [{"mac": "aa:bb:cc:dd:ee:ff"}]
+        count = router.pull_config_history(configs)
+
+        assert count == 1
+
+
+class TestRouterClose:
+    """Test close() cleanup."""
+
+    def test_close_all_backends(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        router.close()
+
+        mock_backends["arango_writer"].close.assert_called_once()
+        mock_backends["redis_writer"].close.assert_called_once()
+
+    def test_close_handles_errors(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].close.side_effect = Exception("err")
+        mock_backends["redis_writer"].close.side_effect = Exception("err")
+        router.close()  # should not raise
+
+    def test_close_standalone(self, standalone_config):
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(standalone_config)
+        router.close()  # should not raise
+
+
+class TestRouterRedisJsonError:
+    """Test _write_redis_json exception handling."""
+
+    def test_redis_json_write_exception(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["redis_json_writer"].write.side_effect = Exception("JSON err")
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
+        )
+        data = [{"id": "ev-1", "device_id": "d1", "timestamp": 170000}]
+        result = router.write(data, "searchOrgDeviceEvents")
+
+        # Dual write: redis_json fails but arango succeeds
+        assert result.backend == "dual"
+
+
+class TestRouterSnapshotEdgeCases:
+    """Test _snapshot_if_config edge cases."""
+
+    def test_snapshot_skips_non_config_api(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
+        )
+        data = [{"id": "lic-1"}]
+        router.write(data, "getOrgLicensesSummary")
+        mock_backends["arango_writer"].snapshot.assert_not_called()
+
+    def test_snapshot_skips_empty_pk(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True,
+            backend="arangodb",
+            records_written=1,
+            records_failed=0,
+        )
+        data = [{"id": "", "name": "Empty ID"}]
+        router.write(data, "listOrgSites")
+        mock_backends["arango_writer"].snapshot.assert_not_called()
+
+    def test_snapshot_skips_when_arango_none(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+
+        def clear_writer(*_args, **_kwargs):
+            router._arango_writer = None
+            return WriteResult(success=True, backend="arangodb", records_written=1, records_failed=0)
+
+        mock_backends["arango_writer"].write.side_effect = clear_writer
+        data = [{"id": "site-1", "name": "HQ"}]
+        result = router.write(data, "listOrgSites")
+        assert result.success is True
+        mock_backends["arango_writer"].snapshot.assert_not_called()
+
+
+class TestRouterRedisWriteError:
+    """Test _write_redis exception handling."""
+
+    def test_redis_write_exception_returns_csv(self, config, mock_backends):
+        strategies = {
+            "getDeviceStats": {
+                "type": "timeseries_pk",
+                "primary_key": ["mac", "timestamp"],
+            },
+        }
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["redis_writer"].write.side_effect = Exception("TS write err")
+        data = [{"mac": "aa:bb", "timestamp": 170000, "cpu": 42}]
+        result = router.write(data, "getDeviceStats")
+
+        assert result.success is False
+        assert result.backend == "csv_only"
+        assert "TS write err" in result.error_message

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -1,0 +1,164 @@
+"""Unit tests for DatabaseRouter write / degraded-mode logic.
+
+All database backends are mocked — no live services required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.db import DatabaseConfig, WriteResult
+
+
+@pytest.fixture
+def config() -> DatabaseConfig:
+    return DatabaseConfig(
+        arango_host="http://localhost:8529",
+        redis_host="localhost",
+    )
+
+
+@pytest.fixture
+def standalone_config() -> DatabaseConfig:
+    return DatabaseConfig(standalone_mode=True)
+
+
+@pytest.fixture
+def strategies() -> dict:
+    """Minimal ENDPOINT_PRIMARY_KEY_STRATEGIES for testing."""
+    return {
+        "listOrgSites": {
+            "type": "natural_pk",
+            "primary_key": ["id"],
+        },
+        "searchOrgDeviceEvents": {
+            "type": "composite_pk",
+            "primary_key": ["id", "device_id", "timestamp"],
+        },
+        "getOrgLicensesSummary": {
+            "type": "auto_increment_with_unique",
+            "primary_key": ["misthelper_internal_id"],
+        },
+        "default": {
+            "type": "auto_increment_with_unique",
+            "primary_key": ["misthelper_internal_id"],
+        },
+    }
+
+
+@pytest.fixture
+def mock_backends():
+    """Patch both writer constructors so router doesn't need live DBs."""
+    with (
+        patch("src.db.router.ArangoDBWriter") as arango_cls,
+        patch("src.db.router.RedisTimeSeriesWriter") as redis_cls,
+    ):
+        arango_writer = MagicMock()
+        arango_cls.return_value = arango_writer
+        redis_writer = MagicMock()
+        redis_cls.return_value = redis_writer
+        yield {
+            "arango_cls": arango_cls,
+            "arango_writer": arango_writer,
+            "redis_cls": redis_cls,
+            "redis_writer": redis_writer,
+        }
+
+
+# Import must happen after patch is active for the constructor path
+def _make_router(config, mock_backends, strategies):
+    from src.db.router import DatabaseRouter
+
+    return DatabaseRouter(config, strategies=strategies)
+
+
+class TestRouterRouting:
+    """Test that write() dispatches to the correct backend."""
+
+    def test_natural_pk_routes_to_arango(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True, backend="arangodb",
+            records_written=3, records_failed=0,
+        )
+        data = [{"id": "site-1", "name": "HQ"}]
+        result = router.write(data, "listOrgSites")
+
+        mock_backends["arango_writer"].write.assert_called_once()
+        assert result.backend == "arangodb"
+        assert result.success is True
+
+    def test_composite_pk_routes_to_redis(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["redis_writer"].write.return_value = WriteResult(
+            success=True, backend="redis",
+            records_written=5, records_failed=0,
+        )
+        data = [{"id": "ev-1", "device_id": "d1", "timestamp": 170000, "cpu": 42}]
+        result = router.write(data, "searchOrgDeviceEvents")
+
+        mock_backends["redis_writer"].write.assert_called_once()
+        assert result.backend == "redis"
+
+    def test_auto_increment_routes_to_arango(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True, backend="arangodb",
+            records_written=1, records_failed=0,
+        )
+        data = [{"license_type": "SUB-MAN", "quantity": 100}]
+        result = router.write(data, "getOrgLicensesSummary")
+
+        mock_backends["arango_writer"].write.assert_called_once()
+        assert result.backend == "arangodb"
+
+    def test_unknown_function_uses_default_arango(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].write.return_value = WriteResult(
+            success=True, backend="arangodb",
+            records_written=1, records_failed=0,
+        )
+        result = router.write([{"x": 1}], "unknownEndpoint")
+        assert result.backend == "arangodb"
+
+
+class TestRouterDegradedMode:
+    """Test graceful degradation when backends are unavailable."""
+
+    def test_standalone_mode_returns_csv_only(self, standalone_config):
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(standalone_config)
+        result = router.write([{"id": "1"}], "listOrgSites")
+
+        assert result.backend == "csv_only"
+        assert result.success is True
+
+    def test_arango_unavailable_returns_csv_only(self, config, mock_backends, strategies):
+        mock_backends["arango_cls"].side_effect = Exception("Connection refused")
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(config, strategies=strategies)
+        result = router.write([{"id": "1", "name": "HQ"}], "listOrgSites")
+
+        assert result.backend == "csv_only"
+
+    def test_redis_unavailable_returns_csv_only(self, config, mock_backends, strategies):
+        mock_backends["redis_cls"].side_effect = Exception("Connection refused")
+        from src.db.router import DatabaseRouter
+
+        router = DatabaseRouter(config, strategies=strategies)
+        data = [{"id": "ev-1", "device_id": "d1", "timestamp": 170000, "cpu": 42}]
+        result = router.write(data, "searchOrgDeviceEvents")
+
+        assert result.backend == "csv_only"
+
+    def test_backend_write_failure_returns_error(self, config, mock_backends, strategies):
+        router = _make_router(config, mock_backends, strategies)
+        mock_backends["arango_writer"].write.side_effect = Exception("Write failed")
+        result = router.write([{"id": "1"}], "listOrgSites")
+
+        assert result.success is False
+        assert "Write failed" in result.error_message


### PR DESCRIPTION
## Summary

Refactors polyglot data routing so raw/unmolested API data goes to polyglot backends BEFORE flatten/escape processing. Adds Redis JSON dual-write capability for composite_pk endpoints and introduces timeseries_pk strategy.

### Changes
- **Raw data pipeline**: Thread \aw_data\ parameter through \xport_with_processing()\ and \write_with_format_selection()\ so polyglot backends receive nested JSON, not flattened CSV data
- **RedisJSONWriter**: New writer class using Redis JSON module for full document storage with pipeline batching and TTL
- **DualWriteResult**: New dataclass combining results from Redis JSON + ArangoDB writes
- **Strategy split**: Reclassify 6 stats endpoints from \composite_pk\ to \	imeseries_pk\ for Redis TimeSeries; composite_pk now dual-writes to Redis JSON + ArangoDB
- **Router updates**: \_write_dual()\ method for independent fallback writes to each backend
- **Unit tests**: Tests for router, redis_writer, arango_writer, retention modules
- **Documentation**: Data persistence routing diagram, migration script, SpecKit artifacts

### Integration Test Results
- Menu 11 (natural_pk): 41 sites -> ArangoDB with nested \latlng: {lat, lng}\ preserved
- Menu 1 (composite_pk): 21 alarms -> dual-write (Redis JSON + ArangoDB), nested arrays preserved
- Quality gates: py_compile, ruff, black all pass

Closes #185