### PR TITLE
feat(165): Bulk org data collection with 137 API operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to MistHelper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
+## [26.04.26.01.53] - 2026-04-26
+
+### Added
+
+- Bulk Org Data Collection (Menu 165): New external module `src/org_data_collector.py` with `OrgDataCollector` class. Executes 137 org-level read API calls (64 list, 36 search, 6 get, 31 count) in a single pass to populate ArangoDB, Redis, and SQLite backends. Covers admins, API tokens, licenses, SSO/SSO roles, device profiles, network templates, RF templates, site templates, AP templates, security policies/profiles (AAMW, AV, IDP, SecIntel), PSKs, webhooks, VPNs, EVPN topologies, WxLAN rules/tags/tunnels, MxEdge/MxEdge clusters/tunnels, NAC portals/rules/tags, assets/asset filters, alarm templates, site groups, services, service policies, certificates, guest authorizations, PSK portals, tickets, dashboards, SDK invites/templates, Marvis client invites, packet captures, JSI data, firmware versions/upgrades, and 31 count endpoints. Includes per-call error handling (skip on failure, continue with remaining), categorized progress display, pagination support for non-paginated APIs, and collection summary.
+- 68 additional ENDPOINT_PRIMARY_KEY_STRATEGIES entries for all new org-level API endpoints (31 count endpoints as auto_increment, entity endpoints as natural_pk, event/search data as composite_pk).
+
+### Fixed
+
+- Fixed `OrgExportUtils.export_data()` to accept optional `limit` parameter (default 1000). When `limit=None`, the limit parameter is omitted from API calls, fixing failures on non-paginated endpoints that reject the `limit` argument.
+- Removed 4 broken/parent-dependent operations from org data collector: `listOrgSsoLatestFailures` (requires sso_id), `listOrgNacPortalSsoLatestFailures` (requires nacportal_id), `searchOrgWebhooksDeliveries` (requires webhook_id), `listOrgJsiPastPurchases` (HTTP 400).
+
 ## [26.04.23.16.39] - 2026-04-23
 
 ### Added

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -78,6 +78,7 @@ try:
 except ImportError:
     DB_LAYER_AVAILABLE = False
 
+from src.org_data_collector import OrgDataCollector
 from src.wan_hub_group_manager import WanHubGroupNumberManager
 from src.wan_vpn_builder import WanVpnBuilder
 
@@ -3695,6 +3696,881 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "indexes": ["old_template_id", "status"],
         "unique_constraints": [],
         "description": "Old SSID disable results for SSID consolidation",
+    },
+    # ========================================================================
+    # ORG DATA COLLECTOR -- bulk collection endpoints (menu 165)
+    # ========================================================================
+    # -- Security Profiles (natural_pk) --------------------------------------
+    "listOrgAAMWProfiles": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization Advanced Anti-Malware profiles",
+    },
+    "listOrgAntivirusProfiles": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization antivirus profiles",
+    },
+    "listOrgIdpProfiles": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization IDP profiles",
+    },
+    # -- Network & VPN (natural_pk) ------------------------------------------
+    "listOrgVpns": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization VPN configurations",
+    },
+    "listOrgEvpnTopologies": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization EVPN topology configurations",
+    },
+    "listOrgWxTunnels": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization WxLAN tunnel configurations",
+    },
+    # -- Wireless Policy (natural_pk) ----------------------------------------
+    "listOrgWxRules": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "order"],
+        "unique_constraints": [],
+        "description": "Organization WxLAN rules",
+    },
+    "listOrgWxTags": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization WxLAN tags",
+    },
+    # -- Edge Infrastructure -------------------------------------------------
+    "listOrgMxEdgeClusters": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization MxEdge cluster configurations",
+    },
+    "listOrgMxEdgeUpgrades": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "mxedge_id", "status"],
+        "unique_constraints": [],
+        "description": "MxEdge firmware upgrade records",
+    },
+    # -- Device Management ---------------------------------------------------
+    "listOrgDeviceUpgrades": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "site_id", "status"],
+        "unique_constraints": [],
+        "description": "Device firmware upgrade records",
+    },
+    "listOrgOtherDevices": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name", "mac", "vendor"],
+        "unique_constraints": [],
+        "description": "Non-Juniper devices tracked by the organization",
+    },
+    # -- Assets & Inventory --------------------------------------------------
+    "listOrgAssets": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name", "mac", "site_id"],
+        "unique_constraints": [],
+        "description": "Organization BLE asset definitions",
+    },
+    "listOrgAssetFilters": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization asset filter rules",
+    },
+    "listOrgAssetsStats": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac", "timestamp"],
+        "indexes": ["org_id", "site_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization BLE asset statistics",
+    },
+    # -- JSI (Juniper Support Insights) --------------------------------------
+    "listOrgJsiDevices": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "serial", "mac"],
+        "unique_constraints": [],
+        "description": "JSI-tracked device inventory",
+    },
+    "listOrgJsiPastPurchases": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "JSI historical purchase records",
+    },
+    # -- Access & Auth -------------------------------------------------------
+    "listOrgCertificates": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization TLS/SSL certificates",
+    },
+    "listOrgSsoRoles": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization SSO role mappings",
+    },
+    "listOrgSsoLatestFailures": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "timestamp"],
+        "unique_constraints": [],
+        "description": "Latest SSO authentication failures",
+    },
+    "listOrgIssuedClientCertificates": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Client certificates issued by the organization",
+    },
+    "listOrgNacPortalSsoLatestFailures": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "timestamp"],
+        "unique_constraints": [],
+        "description": "NAC portal SSO authentication failures",
+    },
+    "listOrgGuestAuthorizations": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "site_id", "mac"],
+        "unique_constraints": [],
+        "description": "Guest network authorization records",
+    },
+    # -- PSK Portals ---------------------------------------------------------
+    "listOrgPskPortals": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization PSK portal configurations",
+    },
+    "listOrgPskPortalLogs": {
+        "type": "composite_pk",
+        "primary_key": ["id", "timestamp"],
+        "indexes": ["org_id", "psk_portal_id"],
+        "unique_constraints": [],
+        "description": "PSK portal access log entries",
+    },
+    # -- SDK & Invites -------------------------------------------------------
+    "listSdkInvites": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "SDK invite records",
+    },
+    "listSdkTemplates": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "SDK template definitions",
+    },
+    "listOrgMarvisClientInvites": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Marvis client invite records",
+    },
+    # -- Alarms & Tickets ----------------------------------------------------
+    "listOrgSuppressedAlarms": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Suppressed alarm rules",
+    },
+    "listOrgTickets": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "status", "type"],
+        "unique_constraints": [],
+        "description": "Organization support tickets",
+    },
+    # -- Dashboards & UI -----------------------------------------------------
+    "listOrgPmaDashboards": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "PMA dashboard configurations",
+    },
+    "listOrgUiSettings": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Organization UI preference settings",
+    },
+    # -- Search Endpoints (composite_pk for time-series/event data) ----------
+    "searchOrgDevices": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id", "site_id", "model", "type", "hostname"],
+        "unique_constraints": [],
+        "description": "Organization device search results",
+    },
+    "searchOrgDeviceLastConfigs": {
+        "type": "composite_pk",
+        "primary_key": ["device_id", "timestamp"],
+        "indexes": ["org_id", "site_id", "name"],
+        "unique_constraints": [],
+        "description": "Last pushed device configurations",
+    },
+    "searchOrgInventory": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id", "site_id", "serial", "model", "type"],
+        "unique_constraints": [],
+        "description": "Organization inventory search results",
+    },
+    "searchOrgWirelessClientEvents": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac", "timestamp"],
+        "indexes": ["org_id", "site_id", "type", "ap"],
+        "unique_constraints": [],
+        "description": "Wireless client event search results",
+    },
+    "searchOrgWirelessClientSessions": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac", "timestamp"],
+        "indexes": ["org_id", "site_id", "ap", "ssid"],
+        "unique_constraints": [],
+        "description": "Wireless client session search results",
+    },
+    "searchOrgWanClientEvents": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac", "timestamp"],
+        "indexes": ["org_id", "site_id", "type"],
+        "unique_constraints": [],
+        "description": "WAN client event search results",
+    },
+    "searchOrgWanClients": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id", "site_id", "hostname"],
+        "unique_constraints": [],
+        "description": "WAN client search results",
+    },
+    "searchOrgMistEdgeEvents": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mxedge_id", "timestamp"],
+        "indexes": ["org_id", "type"],
+        "unique_constraints": [],
+        "description": "MistEdge event search results",
+    },
+    "searchOrgOtherDeviceEvents": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac", "timestamp"],
+        "indexes": ["org_id", "site_id", "type"],
+        "unique_constraints": [],
+        "description": "Other device event search results",
+    },
+    "searchOrgMxEdges": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id", "site_id", "name", "model"],
+        "unique_constraints": [],
+        "description": "MxEdge search results",
+    },
+    "searchOrgSites": {
+        "type": "composite_pk",
+        "primary_key": ["id", "name"],
+        "indexes": ["org_id", "country_code"],
+        "unique_constraints": [],
+        "description": "Organization site search results",
+    },
+    "searchOrgOspfStats": {
+        "type": "composite_pk",
+        "primary_key": ["device_id", "neighbor", "timestamp"],
+        "indexes": ["org_id", "site_id", "state"],
+        "unique_constraints": [],
+        "description": "OSPF neighbor statistics search results",
+    },
+    "searchOrgUserMacs": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Organization user MAC address search results",
+    },
+    "searchOrgPskPortalLogs": {
+        "type": "composite_pk",
+        "primary_key": ["id", "timestamp"],
+        "indexes": ["org_id", "psk_portal_id"],
+        "unique_constraints": [],
+        "description": "PSK portal log search results",
+    },
+    "searchOrgJsiAssetsAndContracts": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "serial"],
+        "unique_constraints": [],
+        "description": "JSI assets and contract search results",
+    },
+    "searchOrgJsiPbn": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "JSI PBN search results",
+    },
+    "searchOrgJsiSirt": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "JSI SIRT search results",
+    },
+    "searchOrgVars": {
+        "type": "composite_pk",
+        "primary_key": ["site_id", "name"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Organization variable search results",
+    },
+    "searchOrgWebhooksDeliveries": {
+        "type": "composite_pk",
+        "primary_key": ["id", "webhook_id", "timestamp"],
+        "indexes": ["org_id", "status_code"],
+        "unique_constraints": [],
+        "description": "Webhook delivery search results",
+    },
+    # -- GET Endpoints (org-level summaries) ---------------------------------
+    "getOrgSettings": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Organization settings snapshot",
+    },
+    "getOrgStats": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Organization-level statistics snapshot",
+    },
+    "getOrgApplicationList": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization application definitions",
+    },
+    # -- Count Endpoints (aggregated counts → auto_increment) ------------------
+    "countOrgAlarms": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Organization alarm count aggregates",
+    },
+    "countOrgAssetsByDistanceField": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Asset count by distance field aggregates",
+    },
+    "countOrgAuditLogs": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Audit log count aggregates",
+    },
+    "countOrgBgpStats": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "BGP statistics count aggregates",
+    },
+    "countOrgDeviceEvents": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Device event count aggregates",
+    },
+    "countOrgDeviceLastConfigs": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Device last config count aggregates",
+    },
+    "countOrgDevices": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Device count aggregates",
+    },
+    "countOrgGuestAuthorizations": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Guest authorization count aggregates",
+    },
+    "countOrgInventory": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Inventory count aggregates",
+    },
+    "countOrgJsiAssetsAndContracts": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "JSI assets and contracts count aggregates",
+    },
+    "countOrgJsiPbn": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "JSI PBN count aggregates",
+    },
+    "countOrgJsiSirt": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "JSI SIRT count aggregates",
+    },
+    "countOrgMxEdges": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "MxEdge count aggregates",
+    },
+    "countOrgNacClientEvents": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "NAC client event count aggregates",
+    },
+    "countOrgNacClients": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "NAC client count aggregates",
+    },
+    "countOrgOspfStats": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "OSPF statistics count aggregates",
+    },
+    "countOrgOtherDeviceEvents": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Other device event count aggregates",
+    },
+    "countOrgPeerPathStats": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Peer path statistics count aggregates",
+    },
+    "countOrgPskPortalLogs": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "PSK portal log count aggregates",
+    },
+    "countOrgSiteMxEdgeEvents": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Site MxEdge event count aggregates",
+    },
+    "countOrgSites": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Site count aggregates",
+    },
+    "countOrgSwOrGwPorts": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Switch/gateway port count aggregates",
+    },
+    "countOrgSystemEvents": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "System event count aggregates",
+    },
+    "countOrgTickets": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Ticket count aggregates",
+    },
+    "countOrgTunnelsStats": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Tunnel statistics count aggregates",
+    },
+    "countOrgUserMacs": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "User MAC address count aggregates",
+    },
+    "countOrgWanClients": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "WAN client count aggregates",
+    },
+    "countOrgWiredClients": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Wired client count aggregates",
+    },
+    "countOrgWirelessClientEvents": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Wireless client event count aggregates",
+    },
+    "countOrgWirelessClients": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Wireless client count aggregates",
+    },
+    "countOrgWirelessClientsSessions": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "distinct"],
+        "unique_constraints": [],
+        "description": "Wireless client session count aggregates",
+    },
+    # -- GET Endpoints (additional org-level data) ---------------------------
+    "getOrg": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization details snapshot",
+    },
+    "getOrgCapturingStatus": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Organization packet capture status",
+    },
+    "getOrgLicensesBySite": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "site_id"],
+        "unique_constraints": [],
+        "description": "License allocation by site",
+    },
+    # -- LIST Endpoints (additional org-level entities) ----------------------
+    "listOrgAdmins": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name", "email"],
+        "unique_constraints": [],
+        "description": "Organization administrator accounts",
+    },
+    "listOrgAlarmTemplates": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization alarm template configurations",
+    },
+    "listOrgApiTokens": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization API token records",
+    },
+    "listOrgApsMacs": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "mac"],
+        "unique_constraints": [],
+        "description": "Organization AP MAC address list",
+    },
+    "listOrgAuditLogs": {
+        "type": "composite_pk",
+        "primary_key": ["id", "timestamp"],
+        "indexes": ["org_id", "admin_name", "message"],
+        "unique_constraints": [],
+        "description": "Organization audit log entries",
+    },
+    "listOrgAvailableDeviceVersions": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "model", "version"],
+        "unique_constraints": [],
+        "description": "Available firmware versions for org devices",
+    },
+    "listOrgAvailableSsrVersions": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "version"],
+        "unique_constraints": [],
+        "description": "Available SSR firmware versions",
+    },
+    "listOrgDeviceProfiles": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name", "type"],
+        "unique_constraints": [],
+        "description": "Organization device profile configurations",
+    },
+    "listOrgDevices": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "site_id", "mac", "serial", "model"],
+        "unique_constraints": [],
+        "description": "Organization devices list",
+    },
+    "listOrgDevicesSummary": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "Organization device summary statistics",
+    },
+    "listOrgMxEdges": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name", "model"],
+        "unique_constraints": [],
+        "description": "Organization MxEdge appliances",
+    },
+    "listOrgMxEdgesStats": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id", "site_id", "name", "model"],
+        "unique_constraints": [],
+        "description": "Organization MxEdge statistics",
+    },
+    "listOrgMxTunnels": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization Mist tunnel configurations",
+    },
+    "listOrgNacPortals": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization NAC portal configurations",
+    },
+    "listOrgNacRules": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name", "order"],
+        "unique_constraints": [],
+        "description": "Organization NAC rules",
+    },
+    "listOrgNacTags": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name", "type"],
+        "unique_constraints": [],
+        "description": "Organization NAC tags",
+    },
+    "listOrgNetworks": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization network definitions",
+    },
+    "listOrgPacketCaptures": {
+        "type": "composite_pk",
+        "primary_key": ["id", "timestamp"],
+        "indexes": ["org_id", "site_id", "type"],
+        "unique_constraints": [],
+        "description": "Organization packet capture records",
+    },
+    "listOrgSecIntelProfiles": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization security intelligence profiles",
+    },
+    "listOrgServicePolicies": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization service policy configurations",
+    },
+    "listOrgServices": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name", "type"],
+        "unique_constraints": [],
+        "description": "Organization service definitions",
+    },
+    "listOrgSiteGroups": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization site group configurations",
+    },
+    "listOrgSiteStats": {
+        "type": "composite_pk",
+        "primary_key": ["id", "name"],
+        "indexes": ["org_id", "country_code"],
+        "unique_constraints": [],
+        "description": "Organization site statistics",
+    },
+    "listOrgSsos": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization SSO configurations",
+    },
+    "listOrgSsrUpgrades": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id", "device_id", "status"],
+        "unique_constraints": [],
+        "description": "SSR firmware upgrade records",
+    },
+    "listOrgTemplates": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization WLAN template configurations",
+    },
+    "listOrgWlans": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["org_id", "ssid"],
+        "unique_constraints": [],
+        "description": "Organization WLAN configurations",
+    },
+    # -- SEARCH Endpoints (additional) --------------------------------------
+    "searchOrgAssets": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id", "site_id", "name"],
+        "unique_constraints": [],
+        "description": "Organization asset search results",
+    },
+    "searchOrgBgpStats": {
+        "type": "composite_pk",
+        "primary_key": ["device_id", "neighbor", "timestamp"],
+        "indexes": ["org_id", "site_id", "state"],
+        "unique_constraints": [],
+        "description": "BGP neighbor statistics search results",
+    },
+    "searchOrgEvents": {
+        "type": "composite_pk",
+        "primary_key": ["id", "timestamp"],
+        "indexes": ["org_id", "site_id", "type"],
+        "unique_constraints": [],
+        "description": "Organization event search results",
+    },
+    "searchOrgGuestAuthorization": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id", "site_id"],
+        "unique_constraints": [],
+        "description": "Guest authorization search results",
+    },
+    "searchOrgNacClientEvents": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac", "timestamp"],
+        "indexes": ["org_id", "site_id", "type"],
+        "unique_constraints": [],
+        "description": "NAC client event search results",
+    },
+    "searchOrgNacClients": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["org_id", "site_id"],
+        "unique_constraints": [],
+        "description": "NAC client search results",
+    },
+    "searchOrgTunnelsStats": {
+        "type": "composite_pk",
+        "primary_key": ["id", "device_id", "timestamp"],
+        "indexes": ["org_id", "site_id"],
+        "unique_constraints": [],
+        "description": "Tunnel statistics search results",
     },
     # Default fallback strategy for unclassified endpoints
     # Uses auto-increment with unique constraint on API id field if present
@@ -7537,7 +8413,7 @@ class SFPTransceiverDataProcessor:
         This logic was previously a standalone function (`process_and_merge_csv_for_sfp_address`).
         It is only invoked by menu option 77 and has no tight coupling with most runtime state.
         Encapsulating it in a class improves hierarchy and opens the door for future extensions
-        (e.g., JSON export, filtering, unit tests) without growing the monolithic global scope.
+        (e.g., JSON export, filtering, unit tests) without growing the legacy global scope.
 
     SECURITY:
         Operates only on locally generated CSV artifacts inside the controlled `data/` directory.
@@ -16206,7 +17082,7 @@ class OrgExportUtils:
     """
 
     @staticmethod
-    def export_data(api_call, data_type, sort_key="name", **api_kwargs):  # type: ignore[no-untyped-def]
+    def export_data(api_call, data_type, sort_key="name", limit=1000, **api_kwargs):  # type: ignore[no-untyped-def]
         """
         Generic function to export organization-specific data to CSV.
 
@@ -16214,6 +17090,7 @@ class OrgExportUtils:
             api_call: The mistapi function to call
             data_type: Description of the data type (e.g., "licenses", "templates")
             sort_key: Field to sort results by
+            limit: Page size for paginated APIs. Pass None to omit (non-paginated APIs).
             **api_kwargs: Additional arguments to pass to the API call
 
         Returns:
@@ -16225,13 +17102,16 @@ class OrgExportUtils:
         safe_data_type = data_type.replace(" ", "").replace("-", "").title()
         filename = f"Org{safe_data_type}.csv"
 
+        fetcher_kwargs = dict(api_kwargs)
+        if limit is not None:
+            fetcher_kwargs["limit"] = limit
+
         APIDataFetcher(
             title=f"Organization {data_type.title()}:",
             api_call=api_call,
             filename=filename,
             sort_key=sort_key,
-            limit=1000,
-            **api_kwargs,
+            **fetcher_kwargs,
         ).execute()
 
     @staticmethod
@@ -58141,6 +59021,13 @@ menu_actions = {
         lambda: WanVpnBuilder.execute(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input),
         "WAN Hub-Spoke VPN Builder",
     ),
+    # > Bulk Data Collection
+    "165": (
+        lambda: OrgDataCollector.execute(
+            OrgExportUtils.export_data, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input
+        ),
+        "Bulk Org Data Collection (populate ArangoDB/Redis/SQLite with all org-level APIs)",
+    ),
 }
 
 
@@ -58887,6 +59774,10 @@ class OperationRegistry:
         "164": {
             "category": "interactive",
             "skip_reason": "Interactive VPN builder with API writes",
+        },
+        "165": {
+            "category": "resource_intensive",
+            "skip_reason": "Bulk org data collection - runs 57 API calls, resource intensive",
         },
     }
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Network Operations & Data Export Tool for Juniper Mist Cloud
 [![Quality Gates](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml)
 [![Container Build](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml)
 
-**Operation Count:** The code currently defines 165 actionable menu entries (0-164) with some gaps for future expansion.
+**Operation Count:** The code currently defines 166 actionable menu entries (0-165) with some gaps for future expansion.
 
 MistHelper is a production-focused Python application that streamlines large-scale Juniper Mist Cloud data extraction, enrichment, transformation, and limited lifecycle operations. It supports both interactive (menu) and fully automated CLI execution, with flexible output to CSV files, a local SQLite database, or a polyglot backend (ArangoDB for documents, Redis for time-series and JSON caching) using natural/composite business keys (no artificial surrogate IDs for core entities). The codebase emphasizes safety, transparency, and predictable behavior-aligned with the included internal Agents Guide and NASA/JPL style defensive programming practices.
 
@@ -104,7 +104,7 @@ flowchart LR
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 mindmap
-  root((MistHelper<br/>165 Operations))
+  root((MistHelper<br/>166 Operations))
     Safe (51)
       Org Sites
       Device Inventory
@@ -133,9 +133,10 @@ mindmap
       SSR Firmware
       AP Reboots
       VC Conversion
-    Resource Intensive (7)
+    Resource Intensive (8)
       Port Stats
       Full Site Config
+      Bulk Org Data
     Continuous (2)
       Monitoring Loops
 ```
@@ -166,7 +167,8 @@ mindmap
 
 | Path | Purpose |
 |------|---------|
-| `MistHelper.py` | Primary monolithic implementation (menu, exports, SSH, persistence) |
+| `MistHelper.py` | Legacy entrypoint -- actively being decomposed into `src/` modules (see Architecture Evolution below) |
+| `src/` | Extracted modules mirroring the Mist API / mistapi hierarchy (db, output, constants, WAN builders) |
 | `data/` | SQLite DB (`mist_data.db`), generated CSV outputs, derived artifacts; polyglot backends run in containers |
 | `CombinedInventory_ByWeek/` | Time-series weekly inventory snapshots |
 | `data/SSH_COMMANDS.CSV` | Fallback SSH command list (legacy root path still supported) |
@@ -177,6 +179,61 @@ mindmap
 | `agents.md` | Internal "Agents Guide" (style, safety, refactor guidance) |
 
 All export CSVs are now written inside `data/` (the code enforces a data directory even if a legacy doc claims root CSV placement).
+
+---
+
+## Architecture Evolution
+
+MistHelper started as a single-file script (`MistHelper.py`) and is being incrementally decomposed into a modular `src/` package. The target structure mirrors both the **Mist Cloud API hierarchy** (from the OpenAPI spec) and **Thomas Munzer's mistapi library** (`tmunzer/mistapi_python`), so that MistHelper's internal organization matches the APIs it consumes.
+
+### Target `src/` Layout
+
+```text
+src/
+├── api/                    # Mirrors mistapi.api.v1 -- operation modules
+│   ├── orgs/               # Org-scoped operations (80 resources in Mist API)
+│   │   ├── devices.py
+│   │   ├── clients.py
+│   │   ├── inventory.py
+│   │   └── ...
+│   ├── sites/              # Site-scoped operations (61 resources in Mist API)
+│   │   ├── devices.py
+│   │   ├── wlans.py
+│   │   ├── stats.py
+│   │   └── ...
+│   └── const/              # Constants and enums (27 resources)
+├── db/                     # Database backends (DONE: arango_writer, redis_writer, retention, router)
+├── output/                 # Output formatting (DONE: writer)
+├── websockets/             # Real-time WebSocket operations
+├── device_utils/           # SSH runner, device diagnostics
+├── auth/                   # Authentication and session management
+├── ui/                     # Web portal components
+├── constants.py            # DONE: Shared constants
+├── wan_hub_group_manager.py  # DONE: WAN hub/group operations
+└── wan_vpn_builder.py      # DONE: WAN VPN builder
+```
+
+### Decomposition Status
+
+| Module | Status | Description |
+|--------|--------|-------------|
+| `src/db/` | **Done** | ArangoDB writer, Redis writer, retention, routing |
+| `src/output/` | **Done** | Output writer |
+| `src/constants.py` | **Done** | Shared constants |
+| `src/wan_*.py` | **Done** | WAN hub group manager, VPN builder |
+| `src/api/orgs/` | Planned | Org-scoped data extraction operations |
+| `src/api/sites/` | Planned | Site-scoped data extraction operations |
+| `src/websockets/` | Planned | WebSocket manager extraction |
+| `src/device_utils/` | Planned | SSH runner, packet capture |
+| `src/auth/` | Planned | Authentication flows |
+| `src/ui/` | Planned | Web portal extraction |
+
+### Guiding Principles
+
+- **New features go in `src/`**, not `MistHelper.py`
+- **One module per API resource** (e.g., `src/api/orgs/devices.py` handles org device operations)
+- **MistHelper.py remains the entrypoint** but delegates to `src/` modules
+- **Incremental migration** -- extract one class/feature at a time, keep tests green
 
 ---
 

--- a/compose.yml
+++ b/compose.yml
@@ -19,14 +19,23 @@ services:
       - .env
     environment:
       # Container-specific environment variables (override .env if needed)
-      - OUTPUT_FORMAT=sqlite
+      - OUTPUT_FORMAT=polyglot
       - DATABASE_PATH=/app/data/mist_data.db
       - PYTHONUNBUFFERED=1
       # Web portal port (must match exposed port)
       - WEB_PORT=8055
+      # Database connection (container names resolve via compose network)
+      - ARANGO_HOST=http://arangodb:8529
+      - REDIS_HOST=redis-stack
+      - REDIS_PORT=6379
       # SSL settings for UV downloads (if needed)
       - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+    depends_on:
+      arangodb:
+        condition: service_healthy
+      redis-stack:
+        condition: service_healthy
     networks:
       - misthelper-network
     restart: unless-stopped
@@ -53,6 +62,46 @@ services:
   #     context: .
   #     dockerfile: Dockerfile  # Docker-compatible version with HEALTHCHECK
   #   # ... same config as above
+
+  arangodb:
+    image: docker.io/arangodb/arangodb:3.12
+    container_name: arangodb
+    ports:
+      - "8529:8529"
+    volumes:
+      - arangodb-data:/var/lib/arangodb3
+    environment:
+      - ARANGO_ROOT_PASSWORD=${ARANGO_ROOT_PASSWORD:-}
+    networks:
+      - misthelper-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "arangosh", "--server.password", "${ARANGO_ROOT_PASSWORD:-}", "--javascript.execute-string", "print(1)"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
+  redis-stack:
+    image: docker.io/redis/redis-stack:latest
+    container_name: redis-stack
+    ports:
+      - "6379:6379"
+      # RedisInsight web UI for browsing data
+      - "8001:8001"
+    volumes:
+      - redis-data:/data
+    environment:
+      - REDIS_ARGS=--requirepass ${REDIS_PASSWORD:-}
+    networks:
+      - misthelper-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   ollama:
     image: docker.io/ollama/ollama
@@ -94,6 +143,10 @@ networks:
 
 volumes:
   misthelper-data:
+    driver: local
+  arangodb-data:
+    driver: local
+  redis-data:
     driver: local
   # Persistent model storage for the local Ollama instance.
   # Models survive container restarts, upgrades, and `podman rm`.

--- a/documentation/diagrams/core/architecture-overview.md
+++ b/documentation/diagrams/core/architecture-overview.md
@@ -23,7 +23,7 @@ flowchart TB
     ci_system(["CI/CD System<br/>GitHub Actions"])
 
     subgraph misthelper["MistHelper"]
-        mh["Python CLI tool<br/>164 operations"]
+        mh["Python CLI tool<br/>166 operations"]
     end
 
     mist_cloud["Juniper Mist Cloud<br/>REST API + WebSocket"]

--- a/documentation/diagrams/operations/metrics-and-analytics.md
+++ b/documentation/diagrams/operations/metrics-and-analytics.md
@@ -6,7 +6,7 @@ Operation distribution, rate limiting behavior, data flow volumes, and version h
 
 ## Operation Category Distribution
 
-How MistHelper's 164 operations break down by safety classification.
+How MistHelper's 166 operations break down by safety classification.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -27,13 +27,13 @@ How MistHelper's 164 operations break down by safety classification.
   'pieTitleTextColor': '#E0E0E0',
   'pieSectionTextColor': '#E0E0E0'
 }, 'pie': {'textPosition': 0.75}}}%%
-pie title Operation Safety Classification (164 total)
+pie title Operation Safety Classification (166 total)
     "Safe (51)" : 51
     "Destructive (32)" : 32
-    "Interactive (26)" : 26
+    "Interactive (27)" : 27
     "WebSocket (22)" : 22
     "Interactive Safe (24)" : 24
-    "Resource Intensive (7)" : 7
+    "Resource Intensive (8)" : 8
     "Continuous (2)" : 2
 ```
 
@@ -177,7 +177,7 @@ timeline
                 : Auto-merge workflow
                 : Web portal (Gunicorn)
     section Current
-        2025 : 164 operations
+        2025 : 166 operations
              : SpecKit integration
              : Mermaid documentation suite
              : Polyglot backends (ArangoDB/Redis)

--- a/src/org_data_collector.py
+++ b/src/org_data_collector.py
@@ -1,5 +1,4 @@
-"""
-Organization Data Collector
+"""Organization Data Collector.
 
 Bulk-collects all org-level read (list/search/get/count) API endpoints to
 populate ArangoDB, Redis TimeSeries, and SQLite backends in a single pass.

--- a/src/org_data_collector.py
+++ b/src/org_data_collector.py
@@ -1,0 +1,1125 @@
+"""
+Organization Data Collector
+
+Bulk-collects all org-level read (list/search/get/count) API endpoints to
+populate ArangoDB, Redis TimeSeries, and SQLite backends in a single pass.
+
+Menu item 165 -- read-only, no destructive operations.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import mistapi.api.v1.orgs.aamwprofiles
+import mistapi.api.v1.orgs.admins
+import mistapi.api.v1.orgs.alarms
+import mistapi.api.v1.orgs.alarmtemplates
+import mistapi.api.v1.orgs.apitokens
+import mistapi.api.v1.orgs.aptemplates
+import mistapi.api.v1.orgs.assetfilters
+import mistapi.api.v1.orgs.assets
+import mistapi.api.v1.orgs.avprofiles
+import mistapi.api.v1.orgs.cert
+import mistapi.api.v1.orgs.clients
+import mistapi.api.v1.orgs.deviceprofiles
+import mistapi.api.v1.orgs.devices
+import mistapi.api.v1.orgs.events
+import mistapi.api.v1.orgs.evpn_topologies
+import mistapi.api.v1.orgs.gatewaytemplates
+import mistapi.api.v1.orgs.guests
+import mistapi.api.v1.orgs.idpprofiles
+import mistapi.api.v1.orgs.inventory
+import mistapi.api.v1.orgs.jsi
+import mistapi.api.v1.orgs.licenses
+import mistapi.api.v1.orgs.logs
+import mistapi.api.v1.orgs.marvisinvites
+import mistapi.api.v1.orgs.mxclusters
+import mistapi.api.v1.orgs.mxedges
+import mistapi.api.v1.orgs.mxtunnels
+import mistapi.api.v1.orgs.nac_clients
+import mistapi.api.v1.orgs.nacportals
+import mistapi.api.v1.orgs.nacrules
+import mistapi.api.v1.orgs.nactags
+import mistapi.api.v1.orgs.networks
+import mistapi.api.v1.orgs.networktemplates
+import mistapi.api.v1.orgs.orgs
+import mistapi.api.v1.orgs.otherdevices
+import mistapi.api.v1.orgs.pcaps
+import mistapi.api.v1.orgs.pma
+import mistapi.api.v1.orgs.pskportals
+import mistapi.api.v1.orgs.psks
+import mistapi.api.v1.orgs.rftemplates
+import mistapi.api.v1.orgs.sdkinvites
+import mistapi.api.v1.orgs.sdktemplates
+import mistapi.api.v1.orgs.secintelprofiles
+import mistapi.api.v1.orgs.secpolicies
+import mistapi.api.v1.orgs.servicepolicies
+import mistapi.api.v1.orgs.services
+import mistapi.api.v1.orgs.setting
+import mistapi.api.v1.orgs.sitegroups
+import mistapi.api.v1.orgs.sites
+import mistapi.api.v1.orgs.sitetemplates
+import mistapi.api.v1.orgs.ssoroles
+import mistapi.api.v1.orgs.ssos
+import mistapi.api.v1.orgs.ssr
+import mistapi.api.v1.orgs.stats
+import mistapi.api.v1.orgs.templates
+import mistapi.api.v1.orgs.tickets
+import mistapi.api.v1.orgs.uisettings
+import mistapi.api.v1.orgs.usermacs
+import mistapi.api.v1.orgs.vars
+import mistapi.api.v1.orgs.vpns
+import mistapi.api.v1.orgs.wan_clients
+import mistapi.api.v1.orgs.webhooks
+import mistapi.api.v1.orgs.wired_clients
+import mistapi.api.v1.orgs.wlans
+import mistapi.api.v1.orgs.wxrules
+import mistapi.api.v1.orgs.wxtags
+import mistapi.api.v1.orgs.wxtunnels
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# ---------------------------------------------------------------------------
+# Collection registry -- each entry maps to one org-level API call
+# ---------------------------------------------------------------------------
+# Fields:
+#   api_call      - mistapi function reference
+#   data_type     - human label (used for filename & logging)
+#   sort_key      - field to sort results by (None = default "name")
+#   category      - grouping for progress display
+#   paginated     - False if API does not accept limit parameter
+#                   (default True when omitted)
+#   api_kwargs    - extra keyword args passed to the API call
+#                   (e.g. {"distinct": "mac"} for count endpoints)
+# ---------------------------------------------------------------------------
+
+_LIST_OPERATIONS: list[dict[str, Any]] = [
+    # -- Organization --------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.admins.listOrgAdmins,
+        "data_type": "admins",
+        "sort_key": "name",
+        "category": "Organization",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.apitokens.listOrgApiTokens,
+        "data_type": "api tokens",
+        "sort_key": "name",
+        "category": "Organization",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.licenses.getOrgLicensesBySite,
+        "data_type": "licenses by site",
+        "sort_key": None,
+        "category": "Organization",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.ssos.listOrgSsos,
+        "data_type": "ssos",
+        "sort_key": "name",
+        "category": "Organization",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.ssoroles.listOrgSsoRoles,
+        "data_type": "sso roles",
+        "sort_key": "name",
+        "category": "Organization",
+    },
+    # -- Sites & Groups ------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.sites.listOrgSites,
+        "data_type": "sites",
+        "sort_key": "name",
+        "category": "Sites & Groups",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.sitegroups.listOrgSiteGroups,
+        "data_type": "site groups",
+        "sort_key": "name",
+        "category": "Sites & Groups",
+    },
+    # -- Templates -----------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.templates.listOrgTemplates,
+        "data_type": "templates",
+        "sort_key": "name",
+        "category": "Templates",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.sitetemplates.listOrgSiteTemplates,
+        "data_type": "site templates",
+        "sort_key": "name",
+        "category": "Templates",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.aptemplates.listOrgAptemplates,
+        "data_type": "ap templates",
+        "sort_key": "name",
+        "category": "Templates",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.gatewaytemplates.listOrgGatewayTemplates,
+        "data_type": "gateway templates",
+        "sort_key": "name",
+        "category": "Templates",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.networktemplates.listOrgNetworkTemplates,
+        "data_type": "network templates",
+        "sort_key": "name",
+        "category": "Templates",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.rftemplates.listOrgRfTemplates,
+        "data_type": "rf templates",
+        "sort_key": "name",
+        "category": "Templates",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.alarmtemplates.listOrgAlarmTemplates,
+        "data_type": "alarm templates",
+        "sort_key": "name",
+        "category": "Templates",
+    },
+    # -- Device Profiles & Configs -------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.deviceprofiles.listOrgDeviceProfiles,
+        "data_type": "device profiles",
+        "sort_key": "name",
+        "category": "Device Profiles",
+    },
+    # -- Devices & Inventory -------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.devices.listOrgDevices,
+        "data_type": "devices",
+        "sort_key": "name",
+        "category": "Devices & Inventory",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.listOrgDevicesSummary,
+        "data_type": "devices summary",
+        "sort_key": None,
+        "category": "Devices & Inventory",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.listOrgApsMacs,
+        "data_type": "aps macs",
+        "sort_key": None,
+        "category": "Devices & Inventory",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.listOrgAvailableDeviceVersions,
+        "data_type": "available device versions",
+        "sort_key": None,
+        "category": "Devices & Inventory",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.listOrgDeviceUpgrades,
+        "data_type": "device upgrades",
+        "sort_key": None,
+        "category": "Devices & Inventory",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.inventory.getOrgInventory,
+        "data_type": "inventory",
+        "sort_key": None,
+        "category": "Devices & Inventory",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.otherdevices.listOrgOtherDevices,
+        "data_type": "other devices",
+        "sort_key": "name",
+        "category": "Devices & Inventory",
+    },
+    # -- Network & VPN -------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.networks.listOrgNetworks,
+        "data_type": "networks",
+        "sort_key": "name",
+        "category": "Network & VPN",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.vpns.listOrgVpns,
+        "data_type": "vpns",
+        "sort_key": "name",
+        "category": "Network & VPN",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.evpn_topologies.listOrgEvpnTopologies,
+        "data_type": "evpn topologies",
+        "sort_key": "name",
+        "category": "Network & VPN",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.services.listOrgServices,
+        "data_type": "services",
+        "sort_key": "name",
+        "category": "Network & VPN",
+    },
+    # -- Wireless Policy -----------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.wlans.listOrgWlans,
+        "data_type": "wlans",
+        "sort_key": "ssid",
+        "category": "Wireless Policy",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wxrules.listOrgWxRules,
+        "data_type": "wx rules",
+        "sort_key": "order",
+        "category": "Wireless Policy",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wxtags.listOrgWxTags,
+        "data_type": "wx tags",
+        "sort_key": "name",
+        "category": "Wireless Policy",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wxtunnels.listOrgWxTunnels,
+        "data_type": "wx tunnels",
+        "sort_key": "name",
+        "category": "Wireless Policy",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.psks.listOrgPsks,
+        "data_type": "psks",
+        "sort_key": "name",
+        "category": "Wireless Policy",
+    },
+    # -- Security Profiles ---------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.aamwprofiles.listOrgAAMWProfiles,
+        "data_type": "aamw profiles",
+        "sort_key": "name",
+        "category": "Security Profiles",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.avprofiles.listOrgAntivirusProfiles,
+        "data_type": "antivirus profiles",
+        "sort_key": "name",
+        "category": "Security Profiles",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.idpprofiles.listOrgIdpProfiles,
+        "data_type": "idp profiles",
+        "sort_key": "name",
+        "category": "Security Profiles",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.secintelprofiles.listOrgSecIntelProfiles,
+        "data_type": "secIntel profiles",
+        "sort_key": "name",
+        "category": "Security Profiles",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.secpolicies.listOrgSecPolicies,
+        "data_type": "sec policies",
+        "sort_key": "name",
+        "category": "Security Profiles",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.servicepolicies.listOrgServicePolicies,
+        "data_type": "service policies",
+        "sort_key": "name",
+        "category": "Security Profiles",
+    },
+    # -- Edge Infrastructure -------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.mxedges.listOrgMxEdges,
+        "data_type": "mxedges",
+        "sort_key": "name",
+        "category": "Edge Infrastructure",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.mxclusters.listOrgMxEdgeClusters,
+        "data_type": "mxedge clusters",
+        "sort_key": "name",
+        "category": "Edge Infrastructure",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.mxedges.listOrgMxEdgeUpgrades,
+        "data_type": "mxedge upgrades",
+        "sort_key": None,
+        "category": "Edge Infrastructure",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.mxtunnels.listOrgMxTunnels,
+        "data_type": "mx tunnels",
+        "sort_key": "name",
+        "category": "Edge Infrastructure",
+    },
+    # -- NAC -----------------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.nacportals.listOrgNacPortals,
+        "data_type": "nac portals",
+        "sort_key": "name",
+        "category": "NAC",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.nacrules.listOrgNacRules,
+        "data_type": "nac rules",
+        "sort_key": "name",
+        "category": "NAC",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.nactags.listOrgNacTags,
+        "data_type": "nac tags",
+        "sort_key": "name",
+        "category": "NAC",
+    },
+    # -- Access & Auth -------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.cert.listOrgCertificates,
+        "data_type": "certificates",
+        "sort_key": None,
+        "category": "Access & Auth",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.setting.listOrgIssuedClientCertificates,
+        "data_type": "issued client certificates",
+        "sort_key": None,
+        "category": "Access & Auth",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.guests.listOrgGuestAuthorizations,
+        "data_type": "guest authorizations",
+        "sort_key": None,
+        "category": "Access & Auth",
+        "paginated": False,
+    },
+    # -- Assets --------------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.assets.listOrgAssets,
+        "data_type": "assets",
+        "sort_key": "name",
+        "category": "Assets",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.assetfilters.listOrgAssetFilters,
+        "data_type": "asset filters",
+        "sort_key": "name",
+        "category": "Assets",
+    },
+    # -- JSI (Juniper Support Insights) --------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.jsi.listOrgJsiDevices,
+        "data_type": "jsi devices",
+        "sort_key": None,
+        "category": "JSI",
+    },
+    # -- PSK Portals ---------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.pskportals.listOrgPskPortals,
+        "data_type": "psk portals",
+        "sort_key": "name",
+        "category": "PSK Portals",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.pskportals.listOrgPskPortalLogs,
+        "data_type": "psk portal logs",
+        "sort_key": None,
+        "category": "PSK Portals",
+    },
+    # -- SDK & Invites -------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.sdkinvites.listSdkInvites,
+        "data_type": "sdk invites",
+        "sort_key": None,
+        "category": "SDK & Invites",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.sdktemplates.listSdkTemplates,
+        "data_type": "sdk templates",
+        "sort_key": "name",
+        "category": "SDK & Invites",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.marvisinvites.listOrgMarvisClientInvites,
+        "data_type": "marvis client invites",
+        "sort_key": None,
+        "category": "SDK & Invites",
+        "paginated": False,
+    },
+    # -- SSR -----------------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.ssr.listOrgAvailableSsrVersions,
+        "data_type": "available ssr versions",
+        "sort_key": None,
+        "category": "SSR",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.ssr.listOrgSsrUpgrades,
+        "data_type": "ssr upgrades",
+        "sort_key": None,
+        "category": "SSR",
+        "paginated": False,
+    },
+    # -- Alarms & Tickets ----------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.alarmtemplates.listOrgSuppressedAlarms,
+        "data_type": "suppressed alarms",
+        "sort_key": None,
+        "category": "Alarms & Tickets",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.tickets.listOrgTickets,
+        "data_type": "tickets",
+        "sort_key": None,
+        "category": "Alarms & Tickets",
+        "paginated": False,
+    },
+    # -- Packet Captures -----------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.pcaps.listOrgPacketCaptures,
+        "data_type": "packet captures",
+        "sort_key": None,
+        "category": "Packet Captures",
+    },
+    # -- Audit Logs ----------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.logs.listOrgAuditLogs,
+        "data_type": "audit logs",
+        "sort_key": None,
+        "category": "Audit Logs",
+    },
+    # -- Webhooks ------------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.webhooks.listOrgWebhooks,
+        "data_type": "webhooks",
+        "sort_key": "name",
+        "category": "Webhooks",
+    },
+    # -- Dashboards & UI -----------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.pma.listOrgPmaDashboards,
+        "data_type": "pma dashboards",
+        "sort_key": None,
+        "category": "Dashboards & UI",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.uisettings.listOrgUiSettings,
+        "data_type": "ui settings",
+        "sort_key": None,
+        "category": "Dashboards & UI",
+        "paginated": False,
+    },
+]
+
+_SEARCH_OPERATIONS: list[dict[str, Any]] = [
+    # -- Device Searches -----------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.devices.searchOrgDevices,
+        "data_type": "devices search",
+        "sort_key": None,
+        "category": "Device Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.searchOrgDeviceEvents,
+        "data_type": "device events",
+        "sort_key": None,
+        "category": "Device Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.searchOrgDeviceLastConfigs,
+        "data_type": "device last configs",
+        "sort_key": None,
+        "category": "Device Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.inventory.searchOrgInventory,
+        "data_type": "inventory search",
+        "sort_key": None,
+        "category": "Device Searches",
+    },
+    # -- Client Searches -----------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.clients.searchOrgWirelessClients,
+        "data_type": "wireless clients",
+        "sort_key": None,
+        "category": "Client Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.clients.searchOrgWirelessClientEvents,
+        "data_type": "wireless client events",
+        "sort_key": None,
+        "category": "Client Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.clients.searchOrgWirelessClientSessions,
+        "data_type": "wireless client sessions",
+        "sort_key": None,
+        "category": "Client Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients,
+        "data_type": "wired clients",
+        "sort_key": None,
+        "category": "Client Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wan_clients.searchOrgWanClients,
+        "data_type": "wan clients",
+        "sort_key": None,
+        "category": "Client Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wan_clients.searchOrgWanClientEvents,
+        "data_type": "wan client events",
+        "sort_key": None,
+        "category": "Client Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.nac_clients.searchOrgNacClients,
+        "data_type": "nac clients",
+        "sort_key": None,
+        "category": "Client Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.nac_clients.searchOrgNacClientEvents,
+        "data_type": "nac client events",
+        "sort_key": None,
+        "category": "Client Searches",
+    },
+    # -- Event Searches ------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.events.searchOrgEvents,
+        "data_type": "org events",
+        "sort_key": None,
+        "category": "Event Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.events.searchOrgSystemEvents,
+        "data_type": "system events",
+        "sort_key": None,
+        "category": "Event Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.mxedges.searchOrgMistEdgeEvents,
+        "data_type": "mist edge events",
+        "sort_key": None,
+        "category": "Event Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.otherdevices.searchOrgOtherDeviceEvents,
+        "data_type": "other device events",
+        "sort_key": None,
+        "category": "Event Searches",
+    },
+    # -- Alarm Searches ------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.alarms.searchOrgAlarms,
+        "data_type": "alarms",
+        "sort_key": None,
+        "category": "Alarm Searches",
+    },
+    # -- Infrastructure Searches ---------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.mxedges.searchOrgMxEdges,
+        "data_type": "mxedges search",
+        "sort_key": None,
+        "category": "Infrastructure Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.sites.searchOrgSites,
+        "data_type": "sites search",
+        "sort_key": None,
+        "category": "Infrastructure Searches",
+    },
+    # -- Stats Searches ------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.stats.searchOrgAssets,
+        "data_type": "assets search",
+        "sort_key": None,
+        "category": "Stats Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.searchOrgBgpStats,
+        "data_type": "bgp stats",
+        "sort_key": None,
+        "category": "Stats Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.searchOrgOspfStats,
+        "data_type": "ospf stats",
+        "sort_key": None,
+        "category": "Stats Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.searchOrgPeerPathStats,
+        "data_type": "peer path stats",
+        "sort_key": None,
+        "category": "Stats Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.searchOrgSwOrGwPorts,
+        "data_type": "switch gateway ports",
+        "sort_key": None,
+        "category": "Stats Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.searchOrgTunnelsStats,
+        "data_type": "tunnels stats",
+        "sort_key": None,
+        "category": "Stats Searches",
+    },
+    # -- Stats List ----------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.stats.listOrgDevicesStats,
+        "data_type": "devices stats",
+        "sort_key": None,
+        "category": "Stats Lists",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.listOrgMxEdgesStats,
+        "data_type": "mxedges stats",
+        "sort_key": None,
+        "category": "Stats Lists",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.listOrgSiteStats,
+        "data_type": "site stats",
+        "sort_key": None,
+        "category": "Stats Lists",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.listOrgAssetsStats,
+        "data_type": "assets stats",
+        "sort_key": None,
+        "category": "Stats Lists",
+    },
+    # -- Access Searches -----------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.usermacs.searchOrgUserMacs,
+        "data_type": "user macs",
+        "sort_key": None,
+        "category": "Access Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.guests.searchOrgGuestAuthorization,
+        "data_type": "guest authorization search",
+        "sort_key": None,
+        "category": "Access Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.pskportals.searchOrgPskPortalLogs,
+        "data_type": "psk portal logs search",
+        "sort_key": None,
+        "category": "Access Searches",
+    },
+    # -- JSI Searches --------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.jsi.searchOrgJsiAssetsAndContracts,
+        "data_type": "jsi assets and contracts",
+        "sort_key": None,
+        "category": "JSI Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.jsi.searchOrgJsiPbn,
+        "data_type": "jsi pbn",
+        "sort_key": None,
+        "category": "JSI Searches",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.jsi.searchOrgJsiSirt,
+        "data_type": "jsi sirt",
+        "sort_key": None,
+        "category": "JSI Searches",
+    },
+    # -- Misc Searches -------------------------------------------------------
+    {
+        "api_call": mistapi.api.v1.orgs.vars.searchOrgVars,
+        "data_type": "org vars",
+        "sort_key": None,
+        "category": "Misc Searches",
+    },
+]
+
+_GET_OPERATIONS: list[dict[str, Any]] = [
+    {
+        "api_call": mistapi.api.v1.orgs.orgs.getOrg,
+        "data_type": "org info",
+        "sort_key": None,
+        "category": "Organization Info",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.licenses.getOrgLicensesSummary,
+        "data_type": "licenses summary",
+        "sort_key": None,
+        "category": "Organization Info",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.setting.getOrgSettings,
+        "data_type": "org settings",
+        "sort_key": None,
+        "category": "Organization Info",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.getOrgStats,
+        "data_type": "org stats",
+        "sort_key": None,
+        "category": "Organization Info",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wxtags.getOrgApplicationList,
+        "data_type": "application list",
+        "sort_key": None,
+        "category": "Organization Info",
+        "paginated": False,
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.pcaps.getOrgCapturingStatus,
+        "data_type": "capturing status",
+        "sort_key": None,
+        "category": "Organization Info",
+        "paginated": False,
+    },
+]
+
+_COUNT_OPERATIONS: list[dict[str, Any]] = [
+    {
+        "api_call": mistapi.api.v1.orgs.alarms.countOrgAlarms,
+        "data_type": "alarms count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.countOrgDevices,
+        "data_type": "devices count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.countOrgDeviceEvents,
+        "data_type": "device events count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.clients.countOrgWirelessClients,
+        "data_type": "wireless clients count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.clients.countOrgWirelessClientEvents,
+        "data_type": "wireless client events count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.clients.countOrgWirelessClientsSessions,
+        "data_type": "wireless client sessions count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wired_clients.countOrgWiredClients,
+        "data_type": "wired clients count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.wan_clients.countOrgWanClients,
+        "data_type": "wan clients count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.nac_clients.countOrgNacClients,
+        "data_type": "nac clients count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.nac_clients.countOrgNacClientEvents,
+        "data_type": "nac client events count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.events.countOrgSystemEvents,
+        "data_type": "system events count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.inventory.countOrgInventory,
+        "data_type": "inventory count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.sites.countOrgSites,
+        "data_type": "sites count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.mxedges.countOrgMxEdges,
+        "data_type": "mxedges count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.mxedges.countOrgSiteMxEdgeEvents,
+        "data_type": "mxedge events count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.otherdevices.countOrgOtherDeviceEvents,
+        "data_type": "other device events count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.guests.countOrgGuestAuthorizations,
+        "data_type": "guest authorizations count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.logs.countOrgAuditLogs,
+        "data_type": "audit logs count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.tickets.countOrgTickets,
+        "data_type": "tickets count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.usermacs.countOrgUserMacs,
+        "data_type": "user macs count",
+        "sort_key": None,
+        "category": "Counts",
+        "api_kwargs": {"distinct": "mac"},
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.pskportals.countOrgPskPortalLogs,
+        "data_type": "psk portal logs count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.devices.countOrgDeviceLastConfigs,
+        "data_type": "device last configs count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.jsi.countOrgJsiAssetsAndContracts,
+        "data_type": "jsi assets contracts count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.jsi.countOrgJsiPbn,
+        "data_type": "jsi pbn count",
+        "sort_key": None,
+        "category": "Counts",
+        "api_kwargs": {"distinct": "mac"},
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.jsi.countOrgJsiSirt,
+        "data_type": "jsi sirt count",
+        "sort_key": None,
+        "category": "Counts",
+        "api_kwargs": {"distinct": "mac"},
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.countOrgBgpStats,
+        "data_type": "bgp stats count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.countOrgOspfStats,
+        "data_type": "ospf stats count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.countOrgPeerPathStats,
+        "data_type": "peer path stats count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.countOrgSwOrGwPorts,
+        "data_type": "switch gateway ports count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.countOrgTunnelsStats,
+        "data_type": "tunnels stats count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+    {
+        "api_call": mistapi.api.v1.orgs.stats.countOrgAssetsByDistanceField,
+        "data_type": "assets by distance count",
+        "sort_key": None,
+        "category": "Counts",
+    },
+]
+
+ALL_OPERATIONS: list[dict[str, Any]] = _LIST_OPERATIONS + _SEARCH_OPERATIONS + _GET_OPERATIONS + _COUNT_OPERATIONS
+
+
+class OrgDataCollector:
+    """Bulk-collect all org-level read APIs for database population.
+
+    Iterates through every registered list/search/get/count endpoint,
+    delegates to the existing ``OrgExportUtils.export_data`` pipeline
+    (which handles pagination, rate-limiting, and multi-backend writes),
+    and logs per-call success/failure without aborting the run.
+    """
+
+    @staticmethod
+    def execute(
+        export_data_fn: Callable[..., None],
+        get_org_id_fn: Callable[[], str],
+        safe_input_fn: Callable[..., str],
+    ) -> None:
+        """Run the full org-level data collection.
+
+        Args:
+            export_data_fn: Reference to ``OrgExportUtils.export_data``.
+            get_org_id_fn:  Reference to ``ConfigUtils.get_cached_or_prompted_org_id``.
+            safe_input_fn:  Reference to ``InputUtils.safe_input``.
+        """
+        org_id = get_org_id_fn()
+        total = len(ALL_OPERATIONS)
+        logging.info(f"Org Data Collector: starting {total} operations for org {org_id}")
+
+        confirmation = safe_input_fn(
+            f"\nThis will run {total} org-level API calls to populate databases.\n" "Continue? (y/N): ",
+            context="org_data_collector",
+        )
+        if confirmation.strip().lower() != "y":
+            logging.info("Org Data Collector: cancelled by user")
+            print("Cancelled.")
+            return
+
+        result = _collect_all(export_data_fn, total)
+        _print_summary(total, *result)
+
+
+def _collect_all(
+    export_data_fn: Callable[..., None],
+    total: int,
+) -> tuple[int, int, int, float]:
+    """Execute every registered operation, return (succeeded, failed, skipped, elapsed)."""
+    succeeded = 0
+    failed = 0
+    skipped = 0
+    start_time = time.time()
+    current_category = ""
+
+    for index, operation in enumerate(ALL_OPERATIONS, 1):
+        category = operation["category"]
+        if category != current_category:
+            current_category = category
+            print(f"\n{'=' * 60}")
+            print(f"  {category}")
+            print(f"{'=' * 60}")
+
+        result = _run_single(export_data_fn, operation, index, total)
+        if result == "ok":
+            succeeded += 1
+        elif result == "failed":
+            failed += 1
+        else:
+            skipped += 1
+
+    elapsed = time.time() - start_time
+    return succeeded, failed, skipped, elapsed
+
+
+def _run_single(
+    export_data_fn: Callable[..., None],
+    operation: dict[str, Any],
+    index: int,
+    total: int,
+) -> str:
+    """Execute one operation, return 'ok', 'failed', or 'skipped'."""
+    api_name = operation["api_call"].__name__
+    data_type = operation["data_type"]
+    sort_key = operation["sort_key"]
+    paginated = operation.get("paginated", True)
+    progress = f"[{index}/{total}]"
+
+    print(f"{progress} {api_name} ({data_type})...", end=" ", flush=True)
+    try:
+        limit_value = 1000 if paginated else None
+        extra_kwargs = operation.get("api_kwargs", {})
+        export_data_fn(
+            api_call=operation["api_call"],
+            data_type=data_type,
+            sort_key=sort_key if sort_key else "name",
+            limit=limit_value,
+            **extra_kwargs,
+        )
+        print("OK")
+        return "ok"
+    except Exception as error:
+        error_name = type(error).__name__
+        print(f"FAILED ({error_name})")
+        logging.error(f"Org Data Collector: {api_name} failed: {error_name}: {error}")
+        return "failed"
+
+
+def _print_summary(
+    total: int,
+    succeeded: int,
+    failed: int,
+    skipped: int,
+    elapsed: float,
+) -> None:
+    """Print collection summary to console and log."""
+    minutes = int(elapsed // 60)
+    seconds = int(elapsed % 60)
+    print(f"\n{'=' * 60}")
+    print("  Org Data Collection Complete")
+    print(f"{'=' * 60}")
+    print(f"  Total:     {total}")
+    print(f"  Succeeded: {succeeded}")
+    print(f"  Failed:    {failed}")
+    print(f"  Skipped:   {skipped}")
+    print(f"  Duration:  {minutes}m {seconds}s")
+    print(f"{'=' * 60}")
+    logging.info(
+        f"Org Data Collector: complete -- "
+        f"{succeeded}/{total} succeeded, {failed} failed, "
+        f"{minutes}m {seconds}s elapsed"
+    )


### PR DESCRIPTION
## Summary

Add Menu 165 'Bulk Org Data Collection' that executes 137 org-level read API calls in a single pass to populate ArangoDB, Redis, and SQLite backends.

### Changes

- **New module**: `src/org_data_collector.py` with `OrgDataCollector` class
  - 64 list, 36 search, 6 get, 31 count org-level API operations
  - Per-call error handling (skip on failure, continue with remaining)
  - Categorized progress display with operation counter
  - Pagination support via `paginated` flag for non-paginated APIs
  - `api_kwargs` support for APIs requiring extra params (e.g. `distinct`)
- **Fix**: `OrgExportUtils.export_data()` now accepts optional `limit` parameter (`None` = omit from API call)
- **68 new** `ENDPOINT_PRIMARY_KEY_STRATEGIES` entries for all new endpoints
- **compose.yml**: Added ArangoDB 3.12 and Redis Stack services with healthchecks
- Updated README, CHANGELOG, architecture diagrams

### Test Results

`137/137 succeeded, 0 failed, 0 skipped` in 2m 23s against production API.

Closes #157