### PR TITLE
feat(arango): site-level guest authorization graph storage

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -3869,6 +3869,13 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "Guest network authorization records",
     },
+    "listSiteAllGuestAuthorizations": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "mac", "wlan_id", "ap_mac"],
+        "unique_constraints": [],
+        "description": "Site-level guest WiFi authorization records",
+    },
     # -- PSK Portals ---------------------------------------------------------
     "listOrgPskPortals": {
         "type": "natural_pk",
@@ -4550,6 +4557,13 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "indexes": ["org_id", "site_id"],
         "unique_constraints": [],
         "description": "Guest authorization search results",
+    },
+    "searchSiteGuestAuthorization": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["site_id", "wlan_id", "ap_mac"],
+        "unique_constraints": [],
+        "description": "Site-level guest authorization search results",
     },
     "searchOrgNacClientEvents": {
         "type": "composite_pk",

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -466,6 +466,11 @@ EDGE_DEFINITIONS = [
         "from_vertex_collections": ["guests"],
         "to_vertex_collections": ["wlans"],
     },
+    {
+        "edge_collection": "GuestConnectedToAP",
+        "from_vertex_collections": ["guests"],
+        "to_vertex_collections": ["devices"],
+    },
     # -- Tier 2: Event/search entity relationships --
     {
         "edge_collection": "ClientEventBelongsToSite",
@@ -765,6 +770,8 @@ ENTITY_TYPE_TO_VERTEX: dict[str, str] = {
     "searchOrgDeviceLastConfigs": "device_configs",
     "listOrgSiteStats": "site_stats",
     "searchOrgGuestAuthorization": "guests",
+    "listSiteAllGuestAuthorizations": "guests",
+    "searchSiteGuestAuthorization": "guests",
     "searchOrgMxEdges": "devices",
     "searchOrgSites": "sites",
     # -- New operations for complete SDK coverage ----------------------------
@@ -1289,6 +1296,63 @@ COLLECTION_VERTEX_MAP: dict[str, dict[str, Any]] = {
                 "from_field": "id",
                 "to_col": "sites",
                 "to_field": "site_id",
+            },
+            {
+                "edge_col": "GuestAuthorizedOnWlan",
+                "from_col": "guests",
+                "from_field": "id",
+                "to_col": "wlans",
+                "to_field": "wlan_id",
+            },
+        ],
+    },
+    # -- Site-level guest authorizations --
+    "listSiteAllGuestAuthorizations": {
+        "vertex": "guests",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "GuestBelongsToSite",
+                "from_col": "guests",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "GuestConnectedToAP",
+                "from_col": "guests",
+                "from_field": "id",
+                "to_col": "devices",
+                "to_field": "ap_mac",
+                "to_key_lookup": "mac",
+            },
+            {
+                "edge_col": "GuestAuthorizedOnWlan",
+                "from_col": "guests",
+                "from_field": "id",
+                "to_col": "wlans",
+                "to_field": "wlan_id",
+            },
+        ],
+    },
+    "searchSiteGuestAuthorization": {
+        "vertex": "guests",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "GuestBelongsToSite",
+                "from_col": "guests",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "GuestConnectedToAP",
+                "from_col": "guests",
+                "from_field": "id",
+                "to_col": "devices",
+                "to_field": "ap_mac",
+                "to_key_lookup": "mac",
             },
             {
                 "edge_col": "GuestAuthorizedOnWlan",

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -888,3 +888,54 @@ class TestArangoDBWriterPopulateGraph:
 
         # Should have attempted to import org vertex + site vertex + edges
         assert mock_collection.import_bulk.called
+
+
+class TestArangoDBWriterSiteGuestGraph:
+    """Tests for site-level guest authorization graph storage (issue #179)."""
+
+    def test_site_guest_list_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteAllGuestAuthorizations" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteAllGuestAuthorizations"]
+        assert mapping["vertex"] == "guests"
+        assert mapping["key_field"] == "id"
+
+    def test_site_guest_search_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteGuestAuthorization" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteGuestAuthorization"]
+        assert mapping["vertex"] == "guests"
+        assert mapping["key_field"] == "id"
+
+    def test_site_guest_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteAllGuestAuthorizations"]
+        edge_cols = [e["edge_col"] for e in mapping["edges"]]
+        assert "GuestBelongsToSite" in edge_cols
+        assert "GuestConnectedToAP" in edge_cols
+        assert "GuestAuthorizedOnWlan" in edge_cols
+
+    def test_guest_ap_edge_uses_mac_lookup(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteAllGuestAuthorizations"]["edges"]
+        ap_edge = next(e for e in edges if e["edge_col"] == "GuestConnectedToAP")
+        assert ap_edge["from_col"] == "guests"
+        assert ap_edge["to_col"] == "devices"
+        assert ap_edge["to_field"] == "ap_mac"
+        assert ap_edge["to_key_lookup"] == "mac"
+
+    def test_guest_edge_definition_registered(self):
+        from src.db.arango_writer import EDGE_DEFINITIONS
+
+        edge_names = [e["edge_collection"] for e in EDGE_DEFINITIONS]
+        assert "GuestConnectedToAP" in edge_names
+
+    def test_site_guest_entity_type_mapped(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteAllGuestAuthorizations"] == "guests"
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteGuestAuthorization"] == "guests"

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -404,6 +404,7 @@ class TestArangoDBWriterEdgeDefinitions:
             "AuditLogBelongsToSite",
             "GuestBelongsToSite",
             "GuestAuthorizedOnWlan",
+            "GuestConnectedToAP",
             # Tier 2: Event/search entity relationships
             "ClientEventBelongsToSite",
             "ClientEventOnDevice",


### PR DESCRIPTION
Add ArangoDB graph storage for site-level guest authorization endpoints. This is the first site-level endpoint implementation in COLLECTION_VERTEX_MAP.

## Changes

- **MistHelper.py**: PK strategies for `listSiteAllGuestAuthorizations` (natural_pk) and `searchSiteGuestAuthorization` (composite_pk)
- **arango_writer.py**:
  - `ENTITY_TYPE_TO_VERTEX` entries for both endpoints
  - `GuestConnectedToAP` edge definition (new -- links guests to APs via ap_mac with mac-based key lookup)
  - `COLLECTION_VERTEX_MAP` entries with 3 edges each: GuestBelongsToSite, GuestConnectedToAP, GuestAuthorizedOnWlan
- **tests**: 6 new unit tests validating mappings, edge configs, MAC lookup, and entity type registration

Closes #179