### PR TITLE
feat(arango): site-level rogue detection graph storage

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -3876,6 +3876,21 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "Site-level guest WiFi authorization records",
     },
+    # -- Site Rogues (insight-based, no API id field) -------------------------
+    "listSiteRogueAPs": {
+        "type": "composite_pk",
+        "primary_key": ["bssid", "ap_mac"],
+        "indexes": ["site_id", "ssid", "channel"],
+        "unique_constraints": [],
+        "description": "Rogue APs detected at a site via RF scanning",
+    },
+    "listSiteRogueClients": {
+        "type": "composite_pk",
+        "primary_key": ["client_mac", "bssid"],
+        "indexes": ["site_id", "ap_mac", "band"],
+        "unique_constraints": [],
+        "description": "Rogue clients detected at a site via RF scanning",
+    },
     # -- PSK Portals ---------------------------------------------------------
     "listOrgPskPortals": {
         "type": "natural_pk",
@@ -4564,6 +4579,13 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "indexes": ["site_id", "wlan_id", "ap_mac"],
         "unique_constraints": [],
         "description": "Site-level guest authorization search results",
+    },
+    "searchSiteRogueEvents": {
+        "type": "composite_pk",
+        "primary_key": ["bssid", "timestamp"],
+        "indexes": ["site_id", "ap", "ssid"],
+        "unique_constraints": [],
+        "description": "Rogue AP/client event search results",
     },
     "searchOrgNacClientEvents": {
         "type": "composite_pk",

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -471,6 +471,36 @@ EDGE_DEFINITIONS = [
         "from_vertex_collections": ["guests"],
         "to_vertex_collections": ["devices"],
     },
+    {
+        "edge_collection": "RogueAPDetectedBySite",
+        "from_vertex_collections": ["rogue_aps"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "RogueAPDetectedByAP",
+        "from_vertex_collections": ["rogue_aps"],
+        "to_vertex_collections": ["devices"],
+    },
+    {
+        "edge_collection": "RogueClientDetectedByAP",
+        "from_vertex_collections": ["rogue_clients"],
+        "to_vertex_collections": ["devices"],
+    },
+    {
+        "edge_collection": "RogueClientOnBSSID",
+        "from_vertex_collections": ["rogue_clients"],
+        "to_vertex_collections": ["rogue_aps"],
+    },
+    {
+        "edge_collection": "RogueEventBelongsToSite",
+        "from_vertex_collections": ["rogue_events"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "RogueEventOnDevice",
+        "from_vertex_collections": ["rogue_events"],
+        "to_vertex_collections": ["devices"],
+    },
     # -- Tier 2: Event/search entity relationships --
     {
         "edge_collection": "ClientEventBelongsToSite",
@@ -772,6 +802,9 @@ ENTITY_TYPE_TO_VERTEX: dict[str, str] = {
     "searchOrgGuestAuthorization": "guests",
     "listSiteAllGuestAuthorizations": "guests",
     "searchSiteGuestAuthorization": "guests",
+    "listSiteRogueAPs": "rogue_aps",
+    "listSiteRogueClients": "rogue_clients",
+    "searchSiteRogueEvents": "rogue_events",
     "searchOrgMxEdges": "devices",
     "searchOrgSites": "sites",
     # -- New operations for complete SDK coverage ----------------------------
@@ -1360,6 +1393,70 @@ COLLECTION_VERTEX_MAP: dict[str, dict[str, Any]] = {
                 "from_field": "id",
                 "to_col": "wlans",
                 "to_field": "wlan_id",
+            },
+        ],
+    },
+    # -- Site-level rogue detection --
+    "listSiteRogueAPs": {
+        "vertex": "rogue_aps",
+        "key_field": "bssid",
+        "edges": [
+            {
+                "edge_col": "RogueAPDetectedBySite",
+                "from_col": "rogue_aps",
+                "from_field": "bssid",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "RogueAPDetectedByAP",
+                "from_col": "rogue_aps",
+                "from_field": "bssid",
+                "to_col": "devices",
+                "to_field": "ap_mac",
+                "to_key_lookup": "mac",
+            },
+        ],
+    },
+    "listSiteRogueClients": {
+        "vertex": "rogue_clients",
+        "key_field": "client_mac",
+        "edges": [
+            {
+                "edge_col": "RogueClientDetectedByAP",
+                "from_col": "rogue_clients",
+                "from_field": "client_mac",
+                "to_col": "devices",
+                "to_field": "ap_mac",
+                "to_key_lookup": "mac",
+            },
+            {
+                "edge_col": "RogueClientOnBSSID",
+                "from_col": "rogue_clients",
+                "from_field": "client_mac",
+                "to_col": "rogue_aps",
+                "to_field": "bssid",
+            },
+        ],
+    },
+    "searchSiteRogueEvents": {
+        "vertex": "rogue_events",
+        "key_field": "bssid",
+        "edges": [
+            {
+                "edge_col": "RogueEventBelongsToSite",
+                "from_col": "rogue_events",
+                "from_field": "bssid",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "RogueEventOnDevice",
+                "from_col": "rogue_events",
+                "from_field": "bssid",
+                "to_col": "devices",
+                "to_field": "ap",
+                "to_key_lookup": "mac",
             },
         ],
     },

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -457,6 +457,13 @@ class TestArangoDBWriterEdgeDefinitions:
             "DeviceConfigBelongsToSite",
             "DeviceConfigForDevice",
             "SiteStatsBelongsToSite",
+            # Issue #180: Site rogue detection edges
+            "RogueAPDetectedBySite",
+            "RogueAPDetectedByAP",
+            "RogueClientDetectedByAP",
+            "RogueClientOnBSSID",
+            "RogueEventBelongsToSite",
+            "RogueEventOnDevice",
         }
         assert edge_names == expected
 
@@ -940,3 +947,82 @@ class TestArangoDBWriterSiteGuestGraph:
 
         assert ENTITY_TYPE_TO_VERTEX["listSiteAllGuestAuthorizations"] == "guests"
         assert ENTITY_TYPE_TO_VERTEX["searchSiteGuestAuthorization"] == "guests"
+
+
+class TestArangoDBWriterSiteRogueGraph:
+    """Tests for site-level rogue detection graph storage (issue #180)."""
+
+    def test_rogue_ap_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteRogueAPs" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteRogueAPs"]
+        assert mapping["vertex"] == "rogue_aps"
+        assert mapping["key_field"] == "bssid"
+
+    def test_rogue_client_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteRogueClients" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteRogueClients"]
+        assert mapping["vertex"] == "rogue_clients"
+        assert mapping["key_field"] == "client_mac"
+
+    def test_rogue_events_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteRogueEvents" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteRogueEvents"]
+        assert mapping["vertex"] == "rogue_events"
+        assert mapping["key_field"] == "bssid"
+
+    def test_rogue_ap_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteRogueAPs"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "RogueAPDetectedBySite" in edge_cols
+        assert "RogueAPDetectedByAP" in edge_cols
+
+    def test_rogue_ap_edge_uses_mac_lookup(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteRogueAPs"]["edges"]
+        ap_edge = next(e for e in edges if e["edge_col"] == "RogueAPDetectedByAP")
+        assert ap_edge["to_col"] == "devices"
+        assert ap_edge["to_field"] == "ap_mac"
+        assert ap_edge["to_key_lookup"] == "mac"
+
+    def test_rogue_client_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteRogueClients"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "RogueClientDetectedByAP" in edge_cols
+        assert "RogueClientOnBSSID" in edge_cols
+
+    def test_rogue_client_bssid_edge_targets_rogue_aps(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteRogueClients"]["edges"]
+        bssid_edge = next(e for e in edges if e["edge_col"] == "RogueClientOnBSSID")
+        assert bssid_edge["to_col"] == "rogue_aps"
+        assert bssid_edge["to_field"] == "bssid"
+
+    def test_rogue_edge_definitions_registered(self):
+        from src.db.arango_writer import EDGE_DEFINITIONS
+
+        edge_names = {e["edge_collection"] for e in EDGE_DEFINITIONS}
+        assert "RogueAPDetectedBySite" in edge_names
+        assert "RogueAPDetectedByAP" in edge_names
+        assert "RogueClientDetectedByAP" in edge_names
+        assert "RogueClientOnBSSID" in edge_names
+        assert "RogueEventBelongsToSite" in edge_names
+        assert "RogueEventOnDevice" in edge_names
+
+    def test_rogue_entity_types_mapped(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteRogueAPs"] == "rogue_aps"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteRogueClients"] == "rogue_clients"
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteRogueEvents"] == "rogue_events"


### PR DESCRIPTION
## Summary

Add ArangoDB graph storage for site-level rogue detection endpoints.

## Changes

### MistHelper.py
- Add PK strategies for listSiteRogueAPs (composite on bssid+ap_mac), listSiteRogueClients (composite on client_mac+bssid), searchSiteRogueEvents (composite on bssid+timestamp)

### src/db/arango_writer.py
- Add 6 new EDGE_DEFINITIONS: RogueAPDetectedBySite, RogueAPDetectedByAP, RogueClientDetectedByAP, RogueClientOnBSSID, RogueEventBelongsToSite, RogueEventOnDevice
- Add 3 ENTITY_TYPE_TO_VERTEX entries: listSiteRogueAPs -> ogue_aps, listSiteRogueClients -> ogue_clients, searchSiteRogueEvents -> ogue_events
- Add 3 COLLECTION_VERTEX_MAP entries with MAC-based key lookups for AP edges and BSSID-based cross-references for rogue client -> rogue AP relationships

### tests/unit/test_arango_writer.py
- Add TestArangoDBWriterSiteRogueGraph class with 9 tests
- Update 	est_all_edge_definitions expected set with 6 new edges
- All 67 tests pass

Closes #180