### PR TITLE
feat(arango): add site-level MxEdge graph storage

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -4587,6 +4587,28 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "Rogue AP/client event search results",
     },
+    # -- Site MxEdge endpoints (issue #178) --
+    "listSiteMxEdges": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "mac", "mxcluster_id"],
+        "unique_constraints": [],
+        "description": "Site MxEdge appliances",
+    },
+    "listSiteMxEdgesStats": {
+        "type": "composite_pk",
+        "primary_key": ["id", "mac"],
+        "indexes": ["site_id", "name", "status"],
+        "unique_constraints": [],
+        "description": "Site MxEdge statistics",
+    },
+    "searchSiteMistEdgeEvents": {
+        "type": "composite_pk",
+        "primary_key": ["mxedge_id", "timestamp"],
+        "indexes": ["site_id", "mac", "type"],
+        "unique_constraints": [],
+        "description": "Site MxEdge event search results",
+    },
     "searchOrgNacClientEvents": {
         "type": "composite_pk",
         "primary_key": ["id", "mac", "timestamp"],

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -501,6 +501,16 @@ EDGE_DEFINITIONS = [
         "from_vertex_collections": ["rogue_events"],
         "to_vertex_collections": ["devices"],
     },
+    {
+        "edge_collection": "MxEdgeBelongsToSite",
+        "from_vertex_collections": ["devices"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "MxEdgeEventOnDevice",
+        "from_vertex_collections": ["mxedge_events"],
+        "to_vertex_collections": ["devices"],
+    },
     # -- Tier 2: Event/search entity relationships --
     {
         "edge_collection": "ClientEventBelongsToSite",
@@ -806,6 +816,10 @@ ENTITY_TYPE_TO_VERTEX: dict[str, str] = {
     "listSiteRogueClients": "rogue_clients",
     "searchSiteRogueEvents": "rogue_events",
     "searchOrgMxEdges": "devices",
+    # Issue #178: Site MxEdge endpoints
+    "listSiteMxEdges": "devices",
+    "listSiteMxEdgesStats": "mxedge_stats",
+    "searchSiteMistEdgeEvents": "mxedge_events",
     "searchOrgSites": "sites",
     # -- New operations for complete SDK coverage ----------------------------
     "listOrgJsiPastPurchases": "jsi_purchases",
@@ -1457,6 +1471,61 @@ COLLECTION_VERTEX_MAP: dict[str, dict[str, Any]] = {
                 "to_col": "devices",
                 "to_field": "ap",
                 "to_key_lookup": "mac",
+            },
+        ],
+    },
+    # Issue #178: Site MxEdge graph mappings
+    "listSiteMxEdges": {
+        "vertex": "devices",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "MxEdgeBelongsToSite",
+                "from_col": "devices",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "MxEdgeBelongsToCluster",
+                "from_col": "devices",
+                "from_field": "id",
+                "to_col": "mxclusters",
+                "to_field": "mxcluster_id",
+            },
+        ],
+        "ensure_target_vertices": [("mxcluster_id", "mxclusters")],
+    },
+    "listSiteMxEdgesStats": {
+        "vertex": "mxedge_stats",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "MxEdgeStatsBelongsToSite",
+                "from_col": "mxedge_stats",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+    },
+    "searchSiteMistEdgeEvents": {
+        "vertex": "mxedge_events",
+        "key_field": "mxedge_id",
+        "edges": [
+            {
+                "edge_col": "MxEdgeEventBelongsToSite",
+                "from_col": "mxedge_events",
+                "from_field": "mxedge_id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "MxEdgeEventOnDevice",
+                "from_col": "mxedge_events",
+                "from_field": "mxedge_id",
+                "to_col": "devices",
+                "to_field": "mxedge_id",
             },
         ],
     },

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -464,6 +464,9 @@ class TestArangoDBWriterEdgeDefinitions:
             "RogueClientOnBSSID",
             "RogueEventBelongsToSite",
             "RogueEventOnDevice",
+            # Issue #178: Site MxEdge edges
+            "MxEdgeBelongsToSite",
+            "MxEdgeEventOnDevice",
         }
         assert edge_names == expected
 
@@ -1026,3 +1029,76 @@ class TestArangoDBWriterSiteRogueGraph:
         assert ENTITY_TYPE_TO_VERTEX["listSiteRogueAPs"] == "rogue_aps"
         assert ENTITY_TYPE_TO_VERTEX["listSiteRogueClients"] == "rogue_clients"
         assert ENTITY_TYPE_TO_VERTEX["searchSiteRogueEvents"] == "rogue_events"
+
+
+class TestArangoDBWriterSiteMxEdgeGraph:
+    """Tests for site-level MxEdge graph storage (issue #178)."""
+
+    def test_mxedge_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteMxEdges" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteMxEdges"]
+        assert mapping["vertex"] == "devices"
+        assert mapping["key_field"] == "id"
+
+    def test_mxedge_stats_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteMxEdgesStats" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteMxEdgesStats"]
+        assert mapping["vertex"] == "mxedge_stats"
+        assert mapping["key_field"] == "id"
+
+    def test_mxedge_events_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteMistEdgeEvents" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteMistEdgeEvents"]
+        assert mapping["vertex"] == "mxedge_events"
+        assert mapping["key_field"] == "mxedge_id"
+
+    def test_mxedge_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteMxEdges"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "MxEdgeBelongsToSite" in edge_cols
+        assert "MxEdgeBelongsToCluster" in edge_cols
+
+    def test_mxedge_stats_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteMxEdgesStats"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "MxEdgeStatsBelongsToSite" in edge_cols
+
+    def test_mxedge_events_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["searchSiteMistEdgeEvents"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "MxEdgeEventBelongsToSite" in edge_cols
+        assert "MxEdgeEventOnDevice" in edge_cols
+
+    def test_mxedge_edge_definitions_registered(self):
+        from src.db.arango_writer import EDGE_DEFINITIONS
+
+        edge_names = {e["edge_collection"] for e in EDGE_DEFINITIONS}
+        assert "MxEdgeBelongsToSite" in edge_names
+        assert "MxEdgeEventOnDevice" in edge_names
+
+    def test_mxedge_entity_types_mapped(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteMxEdges"] == "devices"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteMxEdgesStats"] == "mxedge_stats"
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteMistEdgeEvents"] == "mxedge_events"
+
+    def test_mxedge_ensure_target_vertices(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteMxEdges"]
+        assert "ensure_target_vertices" in mapping
+        targets = mapping["ensure_target_vertices"]
+        assert ("mxcluster_id", "mxclusters") in targets


### PR DESCRIPTION
Add ArangoDB graph mappings for 3 site-level MxEdge endpoints:
- `listSiteMxEdges` (devices vertex, MxEdgeBelongsToSite + MxEdgeBelongsToCluster edges)
- `listSiteMxEdgesStats` (mxedge_stats vertex, MxEdgeStatsBelongsToSite edge)
- `searchSiteMistEdgeEvents` (mxedge_events vertex, MxEdgeEventBelongsToSite + MxEdgeEventOnDevice edges)

Adds 2 new edge definitions, reuses 3 existing edges. Includes PK strategies and 9 unit tests (76 total passing).

Closes #178