### PR TITLE
feat(arango): add site-level Asset graph storage

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -4609,6 +4609,42 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "Site MxEdge event search results",
     },
+    # -- Site Asset endpoints (issue #176) --
+    "listSiteAssets": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "mac", "map_id", "name"],
+        "unique_constraints": [],
+        "description": "Site BLE asset definitions",
+    },
+    "searchSiteAssets": {
+        "type": "composite_pk",
+        "primary_key": ["mac", "map_id"],
+        "indexes": ["site_id", "name", "device_name"],
+        "unique_constraints": [],
+        "description": "Site asset search results",
+    },
+    "listSiteAssetsStats": {
+        "type": "composite_pk",
+        "primary_key": ["mac", "map_id"],
+        "indexes": ["site_id", "name", "device_name"],
+        "unique_constraints": [],
+        "description": "Site BLE asset statistics",
+    },
+    "listSiteDiscoveredAssets": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "mac", "map_id", "name"],
+        "unique_constraints": [],
+        "description": "Site discovered BLE assets",
+    },
+    "listSiteAssetFilters": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "name", "ap_mac"],
+        "unique_constraints": [],
+        "description": "Site asset filter rules",
+    },
     "searchOrgNacClientEvents": {
         "type": "composite_pk",
         "primary_key": ["id", "mac", "timestamp"],

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -400,6 +400,21 @@ EDGE_DEFINITIONS = [
         "to_vertex_collections": ["maps"],
     },
     {
+        "edge_collection": "AssetFilterBelongsToSite",
+        "from_vertex_collections": ["asset_filters"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "DiscoveredAssetOnMap",
+        "from_vertex_collections": ["discovered_assets"],
+        "to_vertex_collections": ["maps"],
+    },
+    {
+        "edge_collection": "AssetTrackedByAP",
+        "from_vertex_collections": ["assets"],
+        "to_vertex_collections": ["devices"],
+    },
+    {
         "edge_collection": "WebhookBelongsToSite",
         "from_vertex_collections": ["webhooks"],
         "to_vertex_collections": ["sites"],
@@ -820,6 +835,12 @@ ENTITY_TYPE_TO_VERTEX: dict[str, str] = {
     "listSiteMxEdges": "devices",
     "listSiteMxEdgesStats": "mxedge_stats",
     "searchSiteMistEdgeEvents": "mxedge_events",
+    # Issue #176: Site Asset endpoints
+    "listSiteAssets": "assets",
+    "searchSiteAssets": "assets",
+    "listSiteAssetsStats": "assets",
+    "listSiteDiscoveredAssets": "discovered_assets",
+    "listSiteAssetFilters": "asset_filters",
     "searchOrgSites": "sites",
     # -- New operations for complete SDK coverage ----------------------------
     "listOrgJsiPastPurchases": "jsi_purchases",
@@ -1526,6 +1547,83 @@ COLLECTION_VERTEX_MAP: dict[str, dict[str, Any]] = {
                 "from_field": "mxedge_id",
                 "to_col": "devices",
                 "to_field": "mxedge_id",
+            },
+        ],
+    },
+    # Issue #176: Site Asset graph mappings
+    "listSiteAssets": {
+        "vertex": "assets",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "AssetBelongsToSite",
+                "from_col": "assets",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "AssetOnMap",
+                "from_col": "assets",
+                "from_field": "id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps")],
+    },
+    "searchSiteAssets": {
+        "vertex": "assets",
+        "key_field": "mac",
+        "edges": [
+            {
+                "edge_col": "AssetOnMap",
+                "from_col": "assets",
+                "from_field": "mac",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps")],
+    },
+    "listSiteAssetsStats": {
+        "vertex": "assets",
+        "key_field": "mac",
+        "edges": [
+            {
+                "edge_col": "AssetOnMap",
+                "from_col": "assets",
+                "from_field": "mac",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps")],
+    },
+    "listSiteDiscoveredAssets": {
+        "vertex": "discovered_assets",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "DiscoveredAssetOnMap",
+                "from_col": "discovered_assets",
+                "from_field": "id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps")],
+    },
+    "listSiteAssetFilters": {
+        "vertex": "asset_filters",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "AssetFilterBelongsToSite",
+                "from_col": "asset_filters",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
             },
         ],
     },

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -467,6 +467,10 @@ class TestArangoDBWriterEdgeDefinitions:
             # Issue #178: Site MxEdge edges
             "MxEdgeBelongsToSite",
             "MxEdgeEventOnDevice",
+            # Issue #176: Site Asset edges
+            "AssetFilterBelongsToSite",
+            "DiscoveredAssetOnMap",
+            "AssetTrackedByAP",
         }
         assert edge_names == expected
 
@@ -1102,3 +1106,94 @@ class TestArangoDBWriterSiteMxEdgeGraph:
         assert "ensure_target_vertices" in mapping
         targets = mapping["ensure_target_vertices"]
         assert ("mxcluster_id", "mxclusters") in targets
+
+
+class TestArangoDBWriterSiteAssetGraph:
+    """Tests for site-level Asset graph storage (issue #176)."""
+
+    def test_site_assets_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteAssets" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteAssets"]
+        assert mapping["vertex"] == "assets"
+        assert mapping["key_field"] == "id"
+
+    def test_search_assets_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteAssets" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteAssets"]
+        assert mapping["vertex"] == "assets"
+        assert mapping["key_field"] == "mac"
+
+    def test_assets_stats_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteAssetsStats" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteAssetsStats"]
+        assert mapping["vertex"] == "assets"
+        assert mapping["key_field"] == "mac"
+
+    def test_discovered_assets_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteDiscoveredAssets" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteDiscoveredAssets"]
+        assert mapping["vertex"] == "discovered_assets"
+        assert mapping["key_field"] == "id"
+
+    def test_asset_filters_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteAssetFilters" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteAssetFilters"]
+        assert mapping["vertex"] == "asset_filters"
+        assert mapping["key_field"] == "id"
+
+    def test_site_assets_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteAssets"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "AssetBelongsToSite" in edge_cols
+        assert "AssetOnMap" in edge_cols
+
+    def test_discovered_assets_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteDiscoveredAssets"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "DiscoveredAssetOnMap" in edge_cols
+
+    def test_asset_filters_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteAssetFilters"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "AssetFilterBelongsToSite" in edge_cols
+
+    def test_asset_edge_definitions_registered(self):
+        from src.db.arango_writer import EDGE_DEFINITIONS
+
+        edge_names = {e["edge_collection"] for e in EDGE_DEFINITIONS}
+        assert "AssetFilterBelongsToSite" in edge_names
+        assert "DiscoveredAssetOnMap" in edge_names
+        assert "AssetTrackedByAP" in edge_names
+
+    def test_asset_entity_types_mapped(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteAssets"] == "assets"
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteAssets"] == "assets"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteAssetsStats"] == "assets"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteDiscoveredAssets"] == "discovered_assets"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteAssetFilters"] == "asset_filters"
+
+    def test_site_assets_ensure_target_vertices(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteAssets"]
+        assert "ensure_target_vertices" in mapping
+        targets = mapping["ensure_target_vertices"]
+        assert ("map_id", "maps") in targets


### PR DESCRIPTION
Add ArangoDB graph mappings for 5 site-level Asset endpoints:
- \listSiteAssets\ (assets vertex, AssetBelongsToSite + AssetOnMap edges)
- \searchSiteAssets\ (assets vertex, AssetOnMap edge)
- \listSiteAssetsStats\ (assets vertex, AssetOnMap edge)
- \listSiteDiscoveredAssets\ (discovered_assets vertex, DiscoveredAssetOnMap edge)
- \listSiteAssetFilters\ (asset_filters vertex, AssetFilterBelongsToSite edge)

Adds 3 new edge definitions, reuses 2 existing edges. Includes PK strategies and 11 unit tests (87 total passing).

Closes #176