### PR TITLE
feat(arango): add site-level config history & synthetic test graph storage

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -4609,6 +4609,42 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "Site MxEdge event search results",
     },
+    # -- Site Config History & Synthetic Tests (issue #181) --
+    "searchSiteDeviceConfigHistory": {
+        "type": "composite_pk",
+        "primary_key": ["device_mac", "timestamp"],
+        "indexes": ["site_id", "device_id", "admin_id"],
+        "unique_constraints": [],
+        "description": "Device configuration change history",
+    },
+    "searchSiteDeviceLastConfigs": {
+        "type": "composite_pk",
+        "primary_key": ["timestamp", "version"],
+        "indexes": ["channel_24", "channel_5", "secpolicy_violated"],
+        "unique_constraints": [],
+        "description": "Device last known configurations",
+    },
+    "searchSiteSyntheticTest": {
+        "type": "composite_pk",
+        "primary_key": ["mac", "timestamp"],
+        "indexes": ["type", "status", "vlan_id"],
+        "unique_constraints": [],
+        "description": "Synthetic test results",
+    },
+    "searchSiteWebhooksDeliveries": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "webhook_id", "status_code", "topic"],
+        "unique_constraints": [],
+        "description": "Webhook delivery audit records",
+    },
+    "listSitePacketCaptures": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "org_id", "type", "timestamp"],
+        "unique_constraints": [],
+        "description": "Site packet capture metadata",
+    },
     "searchOrgNacClientEvents": {
         "type": "composite_pk",
         "primary_key": ["id", "mac", "timestamp"],

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -613,6 +613,27 @@ EDGE_DEFINITIONS = [
         "from_vertex_collections": ["mxedge_stats"],
         "to_vertex_collections": ["sites"],
     },
+    # -- Issue #181: Config history, synthetic tests, webhooks, packet captures --
+    {
+        "edge_collection": "ConfigHistoryForDevice",
+        "from_vertex_collections": ["config_history"],
+        "to_vertex_collections": ["devices"],
+    },
+    {
+        "edge_collection": "SyntheticTestOnDevice",
+        "from_vertex_collections": ["synthetic_tests"],
+        "to_vertex_collections": ["devices"],
+    },
+    {
+        "edge_collection": "WebhookDeliveryFromWebhook",
+        "from_vertex_collections": ["webhook_deliveries"],
+        "to_vertex_collections": ["webhooks"],
+    },
+    {
+        "edge_collection": "PacketCaptureOnDevice",
+        "from_vertex_collections": ["packet_captures"],
+        "to_vertex_collections": ["devices"],
+    },
     # -- Tier 4: WxLAN policy relationships --
     {
         "edge_collection": "WxRuleBelongsToTemplate",
@@ -820,6 +841,12 @@ ENTITY_TYPE_TO_VERTEX: dict[str, str] = {
     "listSiteMxEdges": "devices",
     "listSiteMxEdgesStats": "mxedge_stats",
     "searchSiteMistEdgeEvents": "mxedge_events",
+    # Issue #181: Config history, synthetic tests, webhooks, packet captures
+    "searchSiteDeviceConfigHistory": "config_history",
+    "searchSiteDeviceLastConfigs": "config_history",
+    "searchSiteSyntheticTest": "synthetic_tests",
+    "searchSiteWebhooksDeliveries": "webhook_deliveries",
+    "listSitePacketCaptures": "packet_captures",
     "searchOrgSites": "sites",
     # -- New operations for complete SDK coverage ----------------------------
     "listOrgJsiPastPurchases": "jsi_purchases",
@@ -1526,6 +1553,66 @@ COLLECTION_VERTEX_MAP: dict[str, dict[str, Any]] = {
                 "from_field": "mxedge_id",
                 "to_col": "devices",
                 "to_field": "mxedge_id",
+            },
+        ],
+    },
+    # -- Issue #181: Config history, synthetic tests, webhooks, pcaps --
+    "searchSiteDeviceConfigHistory": {
+        "vertex": "config_history",
+        "key_field": "device_mac",
+        "edges": [
+            {
+                "edge_col": "ConfigHistoryForDevice",
+                "from_col": "config_history",
+                "from_field": "device_mac",
+                "to_col": "devices",
+                "to_field": "device_mac",
+                "to_key_lookup": "mac",
+            },
+        ],
+    },
+    "searchSiteDeviceLastConfigs": {
+        "vertex": "config_history",
+        "key_field": "timestamp",
+        "edges": [],
+    },
+    "searchSiteSyntheticTest": {
+        "vertex": "synthetic_tests",
+        "key_field": "mac",
+        "edges": [
+            {
+                "edge_col": "SyntheticTestOnDevice",
+                "from_col": "synthetic_tests",
+                "from_field": "mac",
+                "to_col": "devices",
+                "to_field": "mac",
+                "to_key_lookup": "mac",
+            },
+        ],
+    },
+    "searchSiteWebhooksDeliveries": {
+        "vertex": "webhook_deliveries",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "WebhookDeliveryFromWebhook",
+                "from_col": "webhook_deliveries",
+                "from_field": "id",
+                "to_col": "webhooks",
+                "to_field": "webhook_id",
+            },
+        ],
+    },
+    "listSitePacketCaptures": {
+        "vertex": "packet_captures",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "PacketCaptureBelongsToSite",
+                "from_col": "packet_captures",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
             },
         ],
     },

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -467,6 +467,11 @@ class TestArangoDBWriterEdgeDefinitions:
             # Issue #178: Site MxEdge edges
             "MxEdgeBelongsToSite",
             "MxEdgeEventOnDevice",
+            # Issue #181: Config history, synthetic tests, webhooks, pcaps
+            "ConfigHistoryForDevice",
+            "SyntheticTestOnDevice",
+            "WebhookDeliveryFromWebhook",
+            "PacketCaptureOnDevice",
         }
         assert edge_names == expected
 
@@ -1102,3 +1107,99 @@ class TestArangoDBWriterSiteMxEdgeGraph:
         assert "ensure_target_vertices" in mapping
         targets = mapping["ensure_target_vertices"]
         assert ("mxcluster_id", "mxclusters") in targets
+
+
+class TestArangoDBWriterSiteConfigHistoryGraph:
+    """Tests for site-level config history & synthetic test graph (issue #181)."""
+
+    def test_config_history_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteDeviceConfigHistory" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteDeviceConfigHistory"]
+        assert mapping["vertex"] == "config_history"
+        assert mapping["key_field"] == "device_mac"
+
+    def test_last_configs_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteDeviceLastConfigs" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteDeviceLastConfigs"]
+        assert mapping["vertex"] == "config_history"
+        assert mapping["key_field"] == "timestamp"
+
+    def test_synthetic_test_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteSyntheticTest" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteSyntheticTest"]
+        assert mapping["vertex"] == "synthetic_tests"
+        assert mapping["key_field"] == "mac"
+
+    def test_webhook_deliveries_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteWebhooksDeliveries" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteWebhooksDeliveries"]
+        assert mapping["vertex"] == "webhook_deliveries"
+        assert mapping["key_field"] == "id"
+
+    def test_packet_captures_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSitePacketCaptures" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSitePacketCaptures"]
+        assert mapping["vertex"] == "packet_captures"
+        assert mapping["key_field"] == "id"
+
+    def test_config_history_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["searchSiteDeviceConfigHistory"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "ConfigHistoryForDevice" in edge_cols
+
+    def test_last_configs_no_edges(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["searchSiteDeviceLastConfigs"]["edges"]
+        assert edges == []
+
+    def test_synthetic_test_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["searchSiteSyntheticTest"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "SyntheticTestOnDevice" in edge_cols
+
+    def test_webhook_deliveries_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["searchSiteWebhooksDeliveries"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "WebhookDeliveryFromWebhook" in edge_cols
+
+    def test_packet_captures_edges_complete(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSitePacketCaptures"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "PacketCaptureBelongsToSite" in edge_cols
+
+    def test_edge_definitions_registered(self):
+        from src.db.arango_writer import EDGE_DEFINITIONS
+
+        edge_names = {e["edge_collection"] for e in EDGE_DEFINITIONS}
+        assert "ConfigHistoryForDevice" in edge_names
+        assert "SyntheticTestOnDevice" in edge_names
+        assert "WebhookDeliveryFromWebhook" in edge_names
+        assert "PacketCaptureOnDevice" in edge_names
+
+    def test_entity_types_mapped(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteDeviceConfigHistory"] == "config_history"
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteDeviceLastConfigs"] == "config_history"
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteSyntheticTest"] == "synthetic_tests"
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteWebhooksDeliveries"] == "webhook_deliveries"
+        assert ENTITY_TYPE_TO_VERTEX["listSitePacketCaptures"] == "packet_captures"


### PR DESCRIPTION
Add ArangoDB graph mappings for 5 site-level endpoints:
- `searchSiteDeviceConfigHistory` (config_history vertex, ConfigHistoryForDevice edge)
- `searchSiteDeviceLastConfigs` (config_history vertex, no edges - no device identifier field)
- `searchSiteSyntheticTest` (synthetic_tests vertex, SyntheticTestOnDevice edge)
- `searchSiteWebhooksDeliveries` (webhook_deliveries vertex, WebhookDeliveryFromWebhook edge)
- `listSitePacketCaptures` (packet_captures vertex, PacketCaptureBelongsToSite edge)

Adds 4 new edge definitions (ConfigHistoryForDevice, SyntheticTestOnDevice, WebhookDeliveryFromWebhook, PacketCaptureOnDevice), 4 new vertex collections, PK strategies, and 12 unit tests (88 total passing).

Closes #181