### PR TITLE
feat(arango): add graph storage for site maps, zones & location

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -3536,6 +3536,65 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "Individual site map with stable UUID identifier",
     },
+    "listSiteMapStacks": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "name", "created_time", "modified_time"],
+        "unique_constraints": [],
+        "description": "Site map stacks (multi-floor groupings)",
+    },
+    # Zone and RSSI zone endpoints
+    "listSiteZones": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "map_id", "name"],
+        "unique_constraints": [],
+        "description": "Zones defined on site maps",
+    },
+    "listSiteZonesStats": {
+        "type": "composite_pk",
+        "primary_key": ["id", "map_id"],
+        "indexes": ["site_id", "map_id", "name", "num_clients"],
+        "unique_constraints": [],
+        "description": "Zone statistics with client counts",
+    },
+    "listSiteRssiZones": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "name"],
+        "unique_constraints": [],
+        "description": "RSSI-based zones for location analytics",
+    },
+    "listSiteRssiZonesStats": {
+        "type": "composite_pk",
+        "primary_key": ["id", "map_id"],
+        "indexes": ["site_id", "map_id", "name"],
+        "unique_constraints": [],
+        "description": "RSSI zone statistics",
+    },
+    # Beacon endpoints
+    "listSiteBeacons": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "map_id", "name", "type"],
+        "unique_constraints": [],
+        "description": "BLE beacons deployed on site maps",
+    },
+    "listSiteVBeacons": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "map_id", "name"],
+        "unique_constraints": [],
+        "description": "Virtual BLE beacons on site maps",
+    },
+    # Zone session search
+    "searchSiteZoneSessions": {
+        "type": "composite_pk",
+        "primary_key": ["zone_id", "mac", "enter"],
+        "indexes": ["site_id", "map_id", "zone_id", "mac", "enter", "exit"],
+        "unique_constraints": [],
+        "description": "Client zone session events for location analytics",
+    },
     # Type 4: Client search APIs (special handling for large datasets)
     "searchOrgWirelessClients": {
         "type": "composite_pk",

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -711,6 +711,57 @@ EDGE_DEFINITIONS = [
         "from_vertex_collections": ["sle_impacted_entities"],
         "to_vertex_collections": ["sites"],
     },
+    # -- Tier 5: Maps, zones & location --
+    {
+        "edge_collection": "MapBelongsToSite",
+        "from_vertex_collections": ["maps"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "ZoneBelongsToMap",
+        "from_vertex_collections": ["zones"],
+        "to_vertex_collections": ["maps"],
+    },
+    {
+        "edge_collection": "ZoneBelongsToSite",
+        "from_vertex_collections": ["zones"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "RssiZoneBelongsToMap",
+        "from_vertex_collections": ["rssizones"],
+        "to_vertex_collections": ["maps"],
+    },
+    {
+        "edge_collection": "BeaconOnMap",
+        "from_vertex_collections": ["beacons"],
+        "to_vertex_collections": ["maps"],
+    },
+    {
+        "edge_collection": "BeaconBelongsToSite",
+        "from_vertex_collections": ["beacons"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "VBeaconOnMap",
+        "from_vertex_collections": ["vbeacons"],
+        "to_vertex_collections": ["maps"],
+    },
+    {
+        "edge_collection": "DeviceOnMap",
+        "from_vertex_collections": ["devices"],
+        "to_vertex_collections": ["maps"],
+    },
+    {
+        "edge_collection": "ZoneSessionInZone",
+        "from_vertex_collections": ["zone_sessions"],
+        "to_vertex_collections": ["zones"],
+    },
+    {
+        "edge_collection": "ZoneSessionOnMap",
+        "from_vertex_collections": ["zone_sessions"],
+        "to_vertex_collections": ["maps"],
+    },
     # -- Tier 4: WxLAN policy relationships --
     {
         "edge_collection": "WxRuleBelongsToTemplate",
@@ -951,6 +1002,17 @@ ENTITY_TYPE_TO_VERTEX: dict[str, str] = {
     "listSiteDiscoveredSwitchesMetrics": "discovered_switch_metrics",
     "searchSiteDiscoveredSwitchesMetrics": "discovered_switch_metrics",
     "listSiteCurrentRrmNeighbors": "rrm_neighbors",
+    # -- Issue #175: Maps, zones & location --
+    "listSiteMaps": "maps",
+    "getSiteMap": "maps",
+    "listSiteMapStacks": "map_stacks",
+    "listSiteZones": "zones",
+    "listSiteZonesStats": "zone_stats",
+    "listSiteRssiZones": "rssizones",
+    "listSiteRssiZonesStats": "rssizone_stats",
+    "listSiteBeacons": "beacons",
+    "listSiteVBeacons": "vbeacons",
+    "searchSiteZoneSessions": "zone_sessions",
     "searchOrgSites": "sites",
     # -- New operations for complete SDK coverage ----------------------------
     "listOrgJsiPastPurchases": "jsi_purchases",
@@ -2035,6 +2097,157 @@ COLLECTION_VERTEX_MAP: dict[str, dict[str, Any]] = {
                 "to_field": "site_id",
             },
         ],
+    },
+    # -- Issue #175: Maps, zones & location --
+    "listSiteMaps": {
+        "vertex": "maps",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "MapBelongsToSite",
+                "from_col": "maps",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+    },
+    "getSiteMap": {
+        "vertex": "maps",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "MapBelongsToSite",
+                "from_col": "maps",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+    },
+    "listSiteMapStacks": {
+        "vertex": "map_stacks",
+        "key_field": "id",
+        "edges": [],
+    },
+    "listSiteZones": {
+        "vertex": "zones",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "ZoneBelongsToMap",
+                "from_col": "zones",
+                "from_field": "id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+            {
+                "edge_col": "ZoneBelongsToSite",
+                "from_col": "zones",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps")],
+    },
+    "listSiteZonesStats": {
+        "vertex": "zone_stats",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "ZoneBelongsToMap",
+                "from_col": "zones",
+                "from_field": "id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps"), ("id", "zones")],
+    },
+    "listSiteRssiZones": {
+        "vertex": "rssizones",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "RssiZoneBelongsToMap",
+                "from_col": "rssizones",
+                "from_field": "id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps")],
+    },
+    "listSiteRssiZonesStats": {
+        "vertex": "rssizone_stats",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "RssiZoneBelongsToMap",
+                "from_col": "rssizones",
+                "from_field": "id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps"), ("id", "rssizones")],
+    },
+    "listSiteBeacons": {
+        "vertex": "beacons",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "BeaconOnMap",
+                "from_col": "beacons",
+                "from_field": "id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+            {
+                "edge_col": "BeaconBelongsToSite",
+                "from_col": "beacons",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps")],
+    },
+    "listSiteVBeacons": {
+        "vertex": "vbeacons",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "VBeaconOnMap",
+                "from_col": "vbeacons",
+                "from_field": "id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("map_id", "maps")],
+    },
+    "searchSiteZoneSessions": {
+        "vertex": "zone_sessions",
+        "key_field": "zone_id",
+        "edges": [
+            {
+                "edge_col": "ZoneSessionInZone",
+                "from_col": "zone_sessions",
+                "from_field": "zone_id",
+                "to_col": "zones",
+                "to_field": "zone_id",
+            },
+            {
+                "edge_col": "ZoneSessionOnMap",
+                "from_col": "zone_sessions",
+                "from_field": "zone_id",
+                "to_col": "maps",
+                "to_field": "map_id",
+            },
+        ],
+        "ensure_target_vertices": [("zone_id", "zones"), ("map_id", "maps")],
     },
     "listOrgMxTunnels": {
         "vertex": "mx_tunnels",

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -490,6 +490,17 @@ class TestArangoDBWriterEdgeDefinitions:
             "EVPNTopologyContainsSwitch",
             "DiscoveredSwitchBelongsToSite",
             "RrmNeighborBelongsToSite",
+            # Issue #175: Maps, zones & location
+            "MapBelongsToSite",
+            "ZoneBelongsToMap",
+            "ZoneBelongsToSite",
+            "RssiZoneBelongsToMap",
+            "BeaconOnMap",
+            "BeaconBelongsToSite",
+            "VBeaconOnMap",
+            "DeviceOnMap",
+            "ZoneSessionInZone",
+            "ZoneSessionOnMap",
         }
         assert edge_names == expected
 
@@ -1576,3 +1587,154 @@ class TestArangoDBWriterSiteRoutingGraph:
         assert ENTITY_TYPE_TO_VERTEX["listSiteDiscoveredSwitchesMetrics"] == "discovered_switch_metrics"
         assert ENTITY_TYPE_TO_VERTEX["searchSiteDiscoveredSwitchesMetrics"] == "discovered_switch_metrics"
         assert ENTITY_TYPE_TO_VERTEX["listSiteCurrentRrmNeighbors"] == "rrm_neighbors"
+
+
+class TestArangoDBWriterSiteMapsZonesGraph:
+    """Tests for site maps, zones & location graph storage (issue #175)."""
+
+    def test_maps_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteMaps" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteMaps"]
+        assert mapping["vertex"] == "maps"
+        assert mapping["key_field"] == "id"
+
+    def test_get_site_map_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "getSiteMap" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["getSiteMap"]
+        assert mapping["vertex"] == "maps"
+        assert mapping["key_field"] == "id"
+
+    def test_map_stacks_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteMapStacks" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteMapStacks"]
+        assert mapping["vertex"] == "map_stacks"
+        assert mapping["key_field"] == "id"
+
+    def test_zones_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteZones" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteZones"]
+        assert mapping["vertex"] == "zones"
+        assert mapping["key_field"] == "id"
+
+    def test_zone_stats_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteZonesStats" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteZonesStats"]
+        assert mapping["vertex"] == "zone_stats"
+        assert mapping["key_field"] == "id"
+
+    def test_rssi_zones_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteRssiZones" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteRssiZones"]
+        assert mapping["vertex"] == "rssizones"
+        assert mapping["key_field"] == "id"
+
+    def test_rssi_zone_stats_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteRssiZonesStats" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteRssiZonesStats"]
+        assert mapping["vertex"] == "rssizone_stats"
+        assert mapping["key_field"] == "id"
+
+    def test_beacons_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteBeacons" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteBeacons"]
+        assert mapping["vertex"] == "beacons"
+        assert mapping["key_field"] == "id"
+
+    def test_vbeacons_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "listSiteVBeacons" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["listSiteVBeacons"]
+        assert mapping["vertex"] == "vbeacons"
+        assert mapping["key_field"] == "id"
+
+    def test_zone_sessions_mapping_exists(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        assert "searchSiteZoneSessions" in COLLECTION_VERTEX_MAP
+        mapping = COLLECTION_VERTEX_MAP["searchSiteZoneSessions"]
+        assert mapping["vertex"] == "zone_sessions"
+        assert mapping["key_field"] == "zone_id"
+
+    def test_map_edges_include_site(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteMaps"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "MapBelongsToSite" in edge_cols
+
+    def test_zone_edges_include_map_and_site(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteZones"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "ZoneBelongsToMap" in edge_cols
+        assert "ZoneBelongsToSite" in edge_cols
+
+    def test_beacon_edges_include_map_and_site(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteBeacons"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "BeaconOnMap" in edge_cols
+        assert "BeaconBelongsToSite" in edge_cols
+
+    def test_vbeacon_edges_include_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["listSiteVBeacons"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "VBeaconOnMap" in edge_cols
+
+    def test_zone_session_edges_include_zone_and_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        edges = COLLECTION_VERTEX_MAP["searchSiteZoneSessions"]["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "ZoneSessionInZone" in edge_cols
+        assert "ZoneSessionOnMap" in edge_cols
+
+    def test_maps_zones_edge_definitions_registered(self):
+        from src.db.arango_writer import EDGE_DEFINITIONS
+
+        edge_names = {e["edge_collection"] for e in EDGE_DEFINITIONS}
+        assert "MapBelongsToSite" in edge_names
+        assert "ZoneBelongsToMap" in edge_names
+        assert "ZoneBelongsToSite" in edge_names
+        assert "RssiZoneBelongsToMap" in edge_names
+        assert "BeaconOnMap" in edge_names
+        assert "BeaconBelongsToSite" in edge_names
+        assert "VBeaconOnMap" in edge_names
+        assert "DeviceOnMap" in edge_names
+        assert "ZoneSessionInZone" in edge_names
+        assert "ZoneSessionOnMap" in edge_names
+
+    def test_maps_zones_entity_types_mapped(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteMaps"] == "maps"
+        assert ENTITY_TYPE_TO_VERTEX["getSiteMap"] == "maps"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteMapStacks"] == "map_stacks"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteZones"] == "zones"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteZonesStats"] == "zone_stats"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteRssiZones"] == "rssizones"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteRssiZonesStats"] == "rssizone_stats"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteBeacons"] == "beacons"
+        assert ENTITY_TYPE_TO_VERTEX["listSiteVBeacons"] == "vbeacons"
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteZoneSessions"] == "zone_sessions"


### PR DESCRIPTION
Add ArangoDB graph storage for site maps, zones, RSSI zones, beacons, vbeacons, and zone sessions (11 endpoints, 10 edge collections).

## Changes
- **MistHelper.py**: 9 new PK strategies for map stacks, zones, zone stats, RSSI zones, RSSI zone stats, beacons, vbeacons, zone sessions
- **src/db/arango_writer.py**: 10 edge definitions, 11 entity type mappings, 11 collection vertex maps
- **tests/unit/test_arango_writer.py**: 17 new tests (146 total, up from 129)

## New Vertex Collections
maps (enriched), map_stacks, zones, zone_stats, rssizones, rssizone_stats, beacons, vbeacons, zone_sessions

## New Edge Collections
MapBelongsToSite, ZoneBelongsToMap, ZoneBelongsToSite, RssiZoneBelongsToMap, BeaconOnMap, BeaconBelongsToSite, VBeaconOnMap, DeviceOnMap, ZoneSessionInZone, ZoneSessionOnMap

Closes #175