### PR TITLE
feat(arango): add config history & synthetic test graph storage

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -3659,6 +3659,42 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "Site anomaly detection events",
     },
+    # Type 3b: Config history, synthetic tests, webhook deliveries, packet captures
+    "searchSiteDeviceConfigHistory": {
+        "type": "composite_pk",
+        "primary_key": ["timestamp"],
+        "indexes": ["site_id", "version", "channel_24", "channel_5"],
+        "unique_constraints": [],
+        "description": "Site device config change history",
+    },
+    "searchSiteDeviceLastConfigs": {
+        "type": "composite_pk",
+        "primary_key": ["timestamp"],
+        "indexes": ["site_id", "version", "channel_24", "channel_5"],
+        "unique_constraints": [],
+        "description": "Site device last known configurations",
+    },
+    "searchSiteSyntheticTest": {
+        "type": "composite_pk",
+        "primary_key": ["mac", "timestamp"],
+        "indexes": ["site_id", "mac", "type", "status", "port_id"],
+        "unique_constraints": [],
+        "description": "Site synthetic test results",
+    },
+    "searchSiteWebhooksDeliveries": {
+        "type": "composite_pk",
+        "primary_key": ["id", "timestamp"],
+        "indexes": ["site_id", "org_id", "webhook_id", "status", "topic"],
+        "unique_constraints": [],
+        "description": "Site webhook delivery audit records",
+    },
+    "listSitePacketCaptures": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "org_id", "type", "timestamp"],
+        "unique_constraints": [],
+        "description": "Site packet capture metadata",
+    },
     # Type 4: Client search APIs (special handling for large datasets)
     "searchOrgWirelessClients": {
         "type": "composite_pk",

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -808,6 +808,27 @@ EDGE_DEFINITIONS = [
         "from_vertex_collections": ["anomaly_events"],
         "to_vertex_collections": ["sites"],
     },
+    # -- Tier 7: Config history, synthetic tests, webhook deliveries (issue #181) --
+    {
+        "edge_collection": "ConfigHistoryForDevice",
+        "from_vertex_collections": ["config_history"],
+        "to_vertex_collections": ["devices"],
+    },
+    {
+        "edge_collection": "SyntheticTestOnDevice",
+        "from_vertex_collections": ["synthetic_tests"],
+        "to_vertex_collections": ["devices"],
+    },
+    {
+        "edge_collection": "WebhookDeliveryFromWebhook",
+        "from_vertex_collections": ["webhook_deliveries"],
+        "to_vertex_collections": ["webhooks"],
+    },
+    {
+        "edge_collection": "PacketCaptureOnDevice",
+        "from_vertex_collections": ["packet_captures"],
+        "to_vertex_collections": ["devices"],
+    },
     # -- Tier 4: WxLAN policy relationships --
     {
         "edge_collection": "WxRuleBelongsToTemplate",
@@ -1069,6 +1090,12 @@ ENTITY_TYPE_TO_VERTEX: dict[str, str] = {
     "listSiteRoamingEvents": "roaming_events",
     "listSiteRrmEvents": "rrm_events",
     "listSiteAnomalyEvents": "anomaly_events",
+    # -- Issue #181: Config history, synthetic tests, webhook deliveries --
+    "searchSiteDeviceConfigHistory": "config_history",
+    "searchSiteDeviceLastConfigs": "config_history",
+    "searchSiteSyntheticTest": "synthetic_tests",
+    "searchSiteWebhooksDeliveries": "webhook_deliveries",
+    "listSitePacketCaptures": "packet_captures",
     "searchOrgSites": "sites",
     # -- New operations for complete SDK coverage ----------------------------
     "listOrgJsiPastPurchases": "jsi_purchases",
@@ -2904,6 +2931,83 @@ COLLECTION_VERTEX_MAP: dict[str, dict[str, Any]] = {
             {
                 "edge_col": "AssetBelongsToSite",
                 "from_col": "assets",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+    },
+    # -- Issue #181: Config history, synthetic tests, webhook deliveries --
+    "searchSiteDeviceConfigHistory": {
+        "vertex": "config_history",
+        "key_field": "timestamp",
+        "edges": [
+            {
+                "edge_col": "ConfigHistoryForDevice",
+                "from_col": "config_history",
+                "from_field": "timestamp",
+                "to_col": "devices",
+                "to_field": "device_mac",
+                "to_key_lookup": "mac",
+            },
+        ],
+    },
+    "searchSiteDeviceLastConfigs": {
+        "vertex": "config_history",
+        "key_field": "timestamp",
+        "edges": [
+            {
+                "edge_col": "ConfigHistoryForDevice",
+                "from_col": "config_history",
+                "from_field": "timestamp",
+                "to_col": "devices",
+                "to_field": "device_mac",
+                "to_key_lookup": "mac",
+            },
+        ],
+    },
+    "searchSiteSyntheticTest": {
+        "vertex": "synthetic_tests",
+        "key_field": "mac",
+        "edges": [
+            {
+                "edge_col": "SyntheticTestOnDevice",
+                "from_col": "synthetic_tests",
+                "from_field": "mac",
+                "to_col": "devices",
+                "to_field": "mac",
+                "to_key_lookup": "mac",
+            },
+        ],
+    },
+    "searchSiteWebhooksDeliveries": {
+        "vertex": "webhook_deliveries",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "WebhookDeliveryFromWebhook",
+                "from_col": "webhook_deliveries",
+                "from_field": "id",
+                "to_col": "webhooks",
+                "to_field": "webhook_id",
+            },
+        ],
+    },
+    "listSitePacketCaptures": {
+        "vertex": "packet_captures",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "PacketCaptureOnDevice",
+                "from_col": "packet_captures",
+                "from_field": "id",
+                "to_col": "devices",
+                "to_field": "ap_macs",
+                "to_key_lookup": "mac",
+            },
+            {
+                "edge_col": "PacketCaptureBelongsToSite",
+                "from_col": "packet_captures",
                 "from_field": "id",
                 "to_col": "sites",
                 "to_field": "site_id",

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -511,6 +511,11 @@ class TestArangoDBWriterEdgeDefinitions:
             "RrmEventBelongsToSite",
             "RrmEventOnDevice",
             "AnomalyEventBelongsToSite",
+            # Issue #181: Config history, synthetic tests, webhook deliveries
+            "ConfigHistoryForDevice",
+            "SyntheticTestOnDevice",
+            "WebhookDeliveryFromWebhook",
+            "PacketCaptureOnDevice",
         }
         assert edge_names == expected
 
@@ -1913,3 +1918,87 @@ class TestArangoDBWriterSiteEventsAlarmsGraph:
         mapping = COLLECTION_VERTEX_MAP["searchSiteServicePathEvents"]
         targets = mapping.get("ensure_target_vertices", [])
         assert ("vpn_name", "vpns") in targets
+
+
+class TestConfigHistorySyntheticTestGraphStorage:
+    """Issue #181: Config history, synthetic tests, webhook deliveries."""
+
+    def test_config_history_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteDeviceConfigHistory"] == "config_history"
+
+    def test_last_configs_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteDeviceLastConfigs"] == "config_history"
+
+    def test_synthetic_test_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteSyntheticTest"] == "synthetic_tests"
+
+    def test_webhook_deliveries_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["searchSiteWebhooksDeliveries"] == "webhook_deliveries"
+
+    def test_packet_captures_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSitePacketCaptures"] == "packet_captures"
+
+    def test_config_history_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["searchSiteDeviceConfigHistory"]
+        assert mapping["vertex"] == "config_history"
+        edges = mapping["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "ConfigHistoryForDevice" in edge_cols
+
+    def test_last_configs_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["searchSiteDeviceLastConfigs"]
+        assert mapping["vertex"] == "config_history"
+        edges = mapping["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "ConfigHistoryForDevice" in edge_cols
+
+    def test_synthetic_test_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["searchSiteSyntheticTest"]
+        assert mapping["vertex"] == "synthetic_tests"
+        edges = mapping["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "SyntheticTestOnDevice" in edge_cols
+
+    def test_webhook_deliveries_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["searchSiteWebhooksDeliveries"]
+        assert mapping["vertex"] == "webhook_deliveries"
+        edges = mapping["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "WebhookDeliveryFromWebhook" in edge_cols
+
+    def test_packet_captures_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSitePacketCaptures"]
+        assert mapping["vertex"] == "packet_captures"
+        edges = mapping["edges"]
+        edge_cols = [e["edge_col"] for e in edges]
+        assert "PacketCaptureOnDevice" in edge_cols
+        assert "PacketCaptureBelongsToSite" in edge_cols
+
+    def test_edge_definitions_registered(self):
+        from src.db.arango_writer import EDGE_DEFINITIONS
+
+        edge_names = {e["edge_collection"] for e in EDGE_DEFINITIONS}
+        assert "ConfigHistoryForDevice" in edge_names
+        assert "SyntheticTestOnDevice" in edge_names
+        assert "WebhookDeliveryFromWebhook" in edge_names
+        assert "PacketCaptureOnDevice" in edge_names


### PR DESCRIPTION
Adds ArangoDB graph storage for 5 site-level endpoints:

- searchSiteDeviceConfigHistory
- searchSiteDeviceLastConfigs  
- searchSiteSyntheticTest
- searchSiteWebhooksDeliveries
- listSitePacketCaptures

Changes:
- 5 PK strategies in MistHelper.py
- 4 edge definitions (ConfigHistoryForDevice, SyntheticTestOnDevice, WebhookDeliveryFromWebhook, PacketCaptureOnDevice)
- 5 ENTITY_TYPE_TO_VERTEX mappings
- 5 COLLECTION_VERTEX_MAP entries with edge relationships
- 11 new unit tests (176 total passing)

Closes #181