### PR TITLE
feat(arango): add site-level WLANs, PSKs, Webhooks, WxLAN graph storage

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -3695,6 +3695,49 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "Site packet capture metadata",
     },
+    # Issue #173: Site-level WLANs, PSKs, Webhooks, WxLAN policies
+    "listSiteWlans": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "org_id", "ssid", "template_id"],
+        "unique_constraints": [],
+        "description": "Site-level WLAN configurations",
+    },
+    "listSitePsks": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "org_id", "ssid", "name"],
+        "unique_constraints": [],
+        "description": "Site-level pre-shared key configurations",
+    },
+    "listSiteWebhooks": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "org_id", "name", "type"],
+        "unique_constraints": [],
+        "description": "Site-level webhook configurations",
+    },
+    "listSiteWxRules": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "org_id", "order"],
+        "unique_constraints": [],
+        "description": "Site-level WxLAN rules",
+    },
+    "listSiteWxTags": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "org_id", "name", "type"],
+        "unique_constraints": [],
+        "description": "Site-level WxLAN tags",
+    },
+    "listSiteWxTunnels": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "org_id", "name"],
+        "unique_constraints": [],
+        "description": "Site-level WxLAN tunnel configurations",
+    },
     # Type 4: Client search APIs (special handling for large datasets)
     "searchOrgWirelessClients": {
         "type": "composite_pk",

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -829,6 +829,27 @@ EDGE_DEFINITIONS = [
         "from_vertex_collections": ["packet_captures"],
         "to_vertex_collections": ["devices"],
     },
+    # -- Tier 8: Site-level WLANs, PSKs, Webhooks, WxLAN policies (Issue #173) --
+    {
+        "edge_collection": "WxRuleBelongsToSite",
+        "from_vertex_collections": ["wx_rules"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "WxTagBelongsToSite",
+        "from_vertex_collections": ["wx_tags"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "WxTunnelBelongsToSite",
+        "from_vertex_collections": ["mx_tunnels"],
+        "to_vertex_collections": ["sites"],
+    },
+    {
+        "edge_collection": "WlanUsesWxTunnel",
+        "from_vertex_collections": ["wlans"],
+        "to_vertex_collections": ["mx_tunnels"],
+    },
     # -- Tier 4: WxLAN policy relationships --
     {
         "edge_collection": "WxRuleBelongsToTemplate",
@@ -1096,6 +1117,13 @@ ENTITY_TYPE_TO_VERTEX: dict[str, str] = {
     "searchSiteSyntheticTest": "synthetic_tests",
     "searchSiteWebhooksDeliveries": "webhook_deliveries",
     "listSitePacketCaptures": "packet_captures",
+    # -- Issue #173: Site-level WLANs, PSKs, Webhooks, WxLAN policies --
+    "listSiteWlans": "wlans",
+    "listSitePsks": "psks",
+    "listSiteWebhooks": "webhooks",
+    "listSiteWxRules": "wx_rules",
+    "listSiteWxTags": "wx_tags",
+    "listSiteWxTunnels": "mx_tunnels",
     "searchOrgSites": "sites",
     # -- New operations for complete SDK coverage ----------------------------
     "listOrgJsiPastPurchases": "jsi_purchases",
@@ -3008,6 +3036,125 @@ COLLECTION_VERTEX_MAP: dict[str, dict[str, Any]] = {
             {
                 "edge_col": "PacketCaptureBelongsToSite",
                 "from_col": "packet_captures",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+    },
+    # -- Issue #173: Site-level WLANs, PSKs, Webhooks, WxLAN policies --
+    "listSiteWlans": {
+        "vertex": "wlans",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "WlanBelongsToSite",
+                "from_col": "wlans",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "WlanUsesWxTunnel",
+                "from_col": "wlans",
+                "from_field": "id",
+                "to_col": "mx_tunnels",
+                "to_field": "wxtunnel_id",
+            },
+        ],
+    },
+    "listSitePsks": {
+        "vertex": "psks",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "PSKBelongsToSite",
+                "from_col": "psks",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "PSKBelongsToWlan",
+                "from_col": "psks",
+                "from_field": "id",
+                "to_col": "wlans",
+                "to_field": "wlan_id",
+            },
+        ],
+    },
+    "listSiteWebhooks": {
+        "vertex": "webhooks",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "WebhookBelongsToSite",
+                "from_col": "webhooks",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+    },
+    "listSiteWxRules": {
+        "vertex": "wx_rules",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "WxRuleBelongsToSite",
+                "from_col": "wx_rules",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+            {
+                "edge_col": "WxRuleMatchesSrcTag",
+                "from_col": "wx_rules",
+                "from_field": "id",
+                "to_col": "wx_tags",
+                "to_field": "src_wxtags",
+            },
+            {
+                "edge_col": "WxRuleAllowsDstTag",
+                "from_col": "wx_rules",
+                "from_field": "id",
+                "to_col": "wx_tags",
+                "to_field": "dst_allow_wxtags",
+            },
+            {
+                "edge_col": "WxRuleDeniesDstTag",
+                "from_col": "wx_rules",
+                "from_field": "id",
+                "to_col": "wx_tags",
+                "to_field": "dst_deny_wxtags",
+            },
+        ],
+        "ensure_target_vertices": [
+            ("src_wxtags", "wx_tags"),
+            ("dst_allow_wxtags", "wx_tags"),
+            ("dst_deny_wxtags", "wx_tags"),
+        ],
+    },
+    "listSiteWxTags": {
+        "vertex": "wx_tags",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "WxTagBelongsToSite",
+                "from_col": "wx_tags",
+                "from_field": "id",
+                "to_col": "sites",
+                "to_field": "site_id",
+            },
+        ],
+    },
+    "listSiteWxTunnels": {
+        "vertex": "mx_tunnels",
+        "key_field": "id",
+        "edges": [
+            {
+                "edge_col": "WxTunnelBelongsToSite",
+                "from_col": "mx_tunnels",
                 "from_field": "id",
                 "to_col": "sites",
                 "to_field": "site_id",

--- a/tests/unit/test_arango_writer.py
+++ b/tests/unit/test_arango_writer.py
@@ -516,6 +516,11 @@ class TestArangoDBWriterEdgeDefinitions:
             "SyntheticTestOnDevice",
             "WebhookDeliveryFromWebhook",
             "PacketCaptureOnDevice",
+            # Issue #173: Site-level WLANs, PSKs, Webhooks, WxLAN policies
+            "WxRuleBelongsToSite",
+            "WxTagBelongsToSite",
+            "WxTunnelBelongsToSite",
+            "WlanUsesWxTunnel",
         }
         assert edge_names == expected
 
@@ -2002,3 +2007,108 @@ class TestConfigHistorySyntheticTestGraphStorage:
         assert "SyntheticTestOnDevice" in edge_names
         assert "WebhookDeliveryFromWebhook" in edge_names
         assert "PacketCaptureOnDevice" in edge_names
+
+
+class TestSiteWlansPsksWebhooksGraphStorage:
+    """Issue #173: Site-level WLANs, PSKs, Webhooks, WxLAN policies."""
+
+    def test_site_wlans_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteWlans"] == "wlans"
+
+    def test_site_psks_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSitePsks"] == "psks"
+
+    def test_site_webhooks_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteWebhooks"] == "webhooks"
+
+    def test_site_wxrules_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteWxRules"] == "wx_rules"
+
+    def test_site_wxtags_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteWxTags"] == "wx_tags"
+
+    def test_site_wxtunnels_entity_type(self):
+        from src.db.arango_writer import ENTITY_TYPE_TO_VERTEX
+
+        assert ENTITY_TYPE_TO_VERTEX["listSiteWxTunnels"] == "mx_tunnels"
+
+    def test_site_wlans_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteWlans"]
+        assert mapping["vertex"] == "wlans"
+        edge_cols = [e["edge_col"] for e in mapping["edges"]]
+        assert "WlanBelongsToSite" in edge_cols
+        assert "WlanUsesWxTunnel" in edge_cols
+
+    def test_site_psks_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSitePsks"]
+        assert mapping["vertex"] == "psks"
+        edge_cols = [e["edge_col"] for e in mapping["edges"]]
+        assert "PSKBelongsToSite" in edge_cols
+        assert "PSKBelongsToWlan" in edge_cols
+
+    def test_site_webhooks_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteWebhooks"]
+        assert mapping["vertex"] == "webhooks"
+        edge_cols = [e["edge_col"] for e in mapping["edges"]]
+        assert "WebhookBelongsToSite" in edge_cols
+
+    def test_site_wxrules_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteWxRules"]
+        assert mapping["vertex"] == "wx_rules"
+        edge_cols = [e["edge_col"] for e in mapping["edges"]]
+        assert "WxRuleBelongsToSite" in edge_cols
+        assert "WxRuleMatchesSrcTag" in edge_cols
+        assert "WxRuleAllowsDstTag" in edge_cols
+        assert "WxRuleDeniesDstTag" in edge_cols
+
+    def test_site_wxrules_ensure_target_vertices(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteWxRules"]
+        targets = mapping.get("ensure_target_vertices", [])
+        assert ("src_wxtags", "wx_tags") in targets
+        assert ("dst_allow_wxtags", "wx_tags") in targets
+        assert ("dst_deny_wxtags", "wx_tags") in targets
+
+    def test_site_wxtags_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteWxTags"]
+        assert mapping["vertex"] == "wx_tags"
+        edge_cols = [e["edge_col"] for e in mapping["edges"]]
+        assert "WxTagBelongsToSite" in edge_cols
+
+    def test_site_wxtunnels_collection_vertex_map(self):
+        from src.db.arango_writer import COLLECTION_VERTEX_MAP
+
+        mapping = COLLECTION_VERTEX_MAP["listSiteWxTunnels"]
+        assert mapping["vertex"] == "mx_tunnels"
+        edge_cols = [e["edge_col"] for e in mapping["edges"]]
+        assert "WxTunnelBelongsToSite" in edge_cols
+
+    def test_edge_definitions_registered(self):
+        from src.db.arango_writer import EDGE_DEFINITIONS
+
+        edge_names = {e["edge_collection"] for e in EDGE_DEFINITIONS}
+        assert "WxRuleBelongsToSite" in edge_names
+        assert "WxTagBelongsToSite" in edge_names
+        assert "WxTunnelBelongsToSite" in edge_names
+        assert "WlanUsesWxTunnel" in edge_names


### PR DESCRIPTION
Add PK strategies and ArangoDB graph mappings for 6 site-level config endpoints: listSiteWlans, listSitePsks, listSiteWebhooks, listSiteWxRules, listSiteWxTags, listSiteWxTunnels.

New edges: WxRuleBelongsToSite, WxTagBelongsToSite, WxTunnelBelongsToSite, WlanUsesWxTunnel. Reuses existing edges for site/WLAN/PSK relationships.

14 new tests (190 total, all passing).

Closes #173