### PR TITLE
refactor(virtual-chassis): extract VirtualChassisManager to src/device

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -33751,558 +33751,63 @@ class WANProbeDeviceOverrideManager:
 # VIRTUAL CHASSIS MANAGER CLASS
 # ============================================================================
 class VirtualChassisManager:
-    """
-    Manages virtual chassis to virtual MAC conversion operations.
+    """Virtual chassis to virtual MAC conversion operations (Menus 92-94).
 
-    Provides functionality to convert virtual chassis switches to virtual MAC
-    addressing, check conversion status, and perform bulk conversions.
-    All methods are static to avoid unnecessary object instantiation.
+    Implementation extracted to src/device/virtual_chassis.py.
+    This stub delegates to the extracted module while providing
+    access to MistHelper globals (apisession, utility classes).
     """
 
     @staticmethod
     def convert_single(dry_run: bool = False) -> None:
-        """
-        Interactively convert a single virtual chassis switch to virtual MAC.
+        """Convert a single VC switch to virtual MAC (Menu 92)."""
+        from src.device.virtual_chassis import (
+            VirtualChassisManager as _VC,
+        )
 
-        Presents site selection, then shows available switches, and converts
-        the selected device after confirmation.
-        """
-        mode_label = "[DRY RUN] " if dry_run else ""
-        print(f"\n  {mode_label}DESTRUCTIVE: Virtual Chassis to Virtual MAC Conversion")
-        print("=" * 60)
-        if dry_run:
-            print("  DRY RUN MODE: No changes will be made. Showing what would happen.")
-
-        site_id = PromptUtils.select_site()
-        if not site_id:
-            print(" No site selected.")
-            return
-
-        site_name = VirtualChassisManager._get_site_name(site_id)
-        print(f"\n  Selected Site: {site_name} ({site_id})")
-
-        switches = VirtualChassisManager._load_site_switches(site_id)
-        if not switches:
-            print(f"! No virtual chassis switches found at site '{site_name}'.")
-            print(" Virtual chassis switches must have a device ID assigned.")
-            logging.warning(f"No virtual chassis switches found at site {site_id}.")
-            return
-
-        selected = VirtualChassisManager._prompt_switch_selection(switches, site_name)
-        if not selected:
-            return
-
-        device_id = selected.get("id")
-        if not device_id:
-            print(" Missing device_id for selected switch.")
-            logging.warning("Missing device_id for selected switch.")
-            return
-
-        if not VirtualChassisManager._preflight_check(selected):
-            return
-
-        if dry_run:
-            print(f"\n  [DRY RUN] Would convert switch '{selected.get('name', '')}' at site '{site_name}'")
-            print(f"  [DRY RUN] Device ID: {device_id}")
-            print(f"  [DRY RUN] MAC: {selected.get('mac', '')}")
-            print("  [DRY RUN] No API call made. Use without --dry-run to execute.")
-            logging.info(f"DRY RUN: Would convert {device_id} at site {site_id}")
-            return
-
-        if not VirtualChassisManager._confirm_conversion(selected, site_name, device_id):
-            print(" Operation cancelled.")
-            return
-
-        VirtualChassisManager._execute_conversion(site_id, device_id, selected.get("name", ""), site_name)
+        _VC.convert_single(
+            apisession=apisession,
+            select_site_fn=PromptUtils.select_site,
+            safe_input_fn=InputUtils.safe_input,
+            get_csv_path_fn=FilePathUtils.get_csv_path,
+            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
+            inventory_generator=OrgInventoryExporter.inventory,
+            dry_run=dry_run,
+        )
 
     @staticmethod
     def convert_by_site_list() -> None:
-        """
-        Bulk convert virtual chassis switches from sites listed in VCConvert.CSV.
-
-        Reads site names from CSV file, finds all VC switches in those sites,
-        displays them for confirmation, and converts all if confirmed.
-        """
-        logging.info("Starting bulk virtual chassis to virtual MAC conversion by site list...")
-
-        site_names = VirtualChassisManager._load_site_names_from_csv()
-        if not site_names:
-            return
-
-        print(f"! Loaded {len(site_names)} site names from VCConvert.CSV:")
-        for idx, site_name in enumerate(site_names):
-            print(f"  [{idx + 1}] {site_name}")
-
-        CacheUtils.check_and_generate_csv("OrgInventory.csv", OrgInventoryExporter.inventory)
-        CacheUtils.check_and_generate_csv("SiteList.csv", OrgSiteExporter.sites)
-
-        site_name_to_id = VirtualChassisManager._load_site_name_mapping()
-        if not site_name_to_id:
-            return
-
-        target_site_ids, missing_sites = VirtualChassisManager._resolve_site_ids(site_names, site_name_to_id)
-
-        if missing_sites:
-            print("! Warning: The following sites were not found in the organization:")
-            for site in missing_sites:
-                print(f"   - {site}")
-
-        if not target_site_ids:
-            print(" No valid sites found. Exiting.")
-            logging.error("No valid sites found for VC conversion.")
-            return
-
-        switches_to_convert = VirtualChassisManager._load_switches_for_sites(target_site_ids, site_name_to_id)
-        if not switches_to_convert:
-            print(" No virtual chassis switches found in the specified sites.")
-            logging.warning("No virtual chassis switches found in target sites.")
-            return
-
-        VirtualChassisManager._display_switches_for_conversion(switches_to_convert)
-
-        confirm = InputUtils.safe_input(
-            "\nType 'CONVERT' to proceed with bulk conversion or anything else to cancel: ",
-            context="vc_bulk_conversion",
+        """Bulk convert VC switches from site list CSV (Menu 93)."""
+        from src.device.virtual_chassis import (
+            VirtualChassisManager as _VC,
         )
-        if confirm != "CONVERT":
-            print(" Conversion cancelled by user.")
-            logging.info("Virtual chassis conversion cancelled by user.")
-            return
 
-        VirtualChassisManager._execute_bulk_conversion(switches_to_convert)
+        _VC.convert_by_site_list(
+            apisession=apisession,
+            safe_input_fn=InputUtils.safe_input,
+            get_csv_path_fn=FilePathUtils.get_csv_path,
+            create_csv_template_fn=FilePathUtils.create_csv_template,
+            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
+            inventory_generator=OrgInventoryExporter.inventory,
+            sites_generator=OrgSiteExporter.sites,
+        )
 
     @staticmethod
     def check_status() -> None:
-        """
-        Check conversion status of all virtual chassis switches in organization.
-
-        Analyzes vc_mac prefixes to determine which switches have been converted
-        (prefix '020003') vs not converted. Exports results to CSV.
-        """
-        print("\n  Virtual Chassis to Virtual MAC Conversion Status Check")
-        print("=" * 70)
-        print(" Checking all switches for virtual chassis conversion status...")
-        print(" Converted switches have vc_mac starting with '020003'")
-
-        logging.info("Starting virtual chassis conversion status check...")
-
-        CacheUtils.check_and_generate_csv("OrgInventory.csv", OrgInventoryExporter.inventory)
-
-        switches_with_vc_mac = VirtualChassisManager._load_vc_switches()
-        if not switches_with_vc_mac:
-            print(" No switches with vc_mac found in the organization.")
-            print(" Only virtual chassis switches have vc_mac assigned.")
-            logging.warning("No switches with vc_mac found.")
-            return
-
-        site_id_to_name = VirtualChassisManager._load_site_id_mapping()
-        converted, not_converted = VirtualChassisManager._analyze_conversion_status(
-            switches_with_vc_mac, site_id_to_name
+        """Check conversion status of all VC switches (Menu 94)."""
+        from src.device.virtual_chassis import (
+            VirtualChassisManager as _VC,
         )
 
-        VirtualChassisManager._display_status_summary(converted, not_converted)
-        VirtualChassisManager._export_status_results(converted + not_converted)
-
-        print("\n  Usage Notes:")
-        print("   !? Use option 92 to convert individual switches")
-        print("   !? Use option 93 for bulk conversion by site list")
-        print("   !? Virtual chassis switches without '020003' vc_mac prefix can be converted")
-
-    # ========================================================================
-    # HELPER METHODS
-    # ========================================================================
-
-    @staticmethod
-    def _get_site_name(site_id: str) -> str:
-        """Get site name from API."""
-        try:
-            response = mistapi.api.v1.sites.getSite(apisession, site_id)
-            if response.data:
-                return response.data.get("name", site_id)  # type: ignore[no-any-return]
-        except Exception as exception:
-            logging.warning(f"Could not fetch site name for {site_id}: {exception}")
-        return "Unknown Site"
-
-    @staticmethod
-    def _load_site_switches(site_id: str) -> list[dict]:  # type: ignore[type-arg]
-        """Load switches at a specific site from cached inventory."""
-        CacheUtils.check_and_generate_csv("OrgInventory.csv", OrgInventoryExporter.inventory)
-        inventory_path = FilePathUtils.get_csv_path("OrgInventory.csv")
-
-        with open(inventory_path, encoding="utf-8") as csvfile:
-            reader = list(csv.DictReader(csvfile))
-            return [
-                row
-                for row in reader
-                if (row.get("type") == "switch" and row.get("id", "").strip() and row.get("site_id") == site_id)
-            ]
-
-    @staticmethod
-    def _prompt_switch_selection(switches: list[dict], site_name: str) -> dict | None:  # type: ignore[type-arg]
-        """Display switches and prompt user for selection."""
-        print(f"\n  Available Virtual Chassis Switches at '{site_name}':")
-        print("-" * 80)
-
-        index_to_device = {}
-        name_to_device = {}
-        for idx, switch in enumerate(switches):
-            print(
-                f"[{idx}] {switch.get('name', ''):20} MAC: {switch.get('mac', ''):17} "
-                f"Model: {switch.get('model', ''):10} Serial: {switch.get('serial', ''):15} ID: {switch.get('id', '')}"
-            )
-            index_to_device[idx] = switch
-            name_to_device[switch.get("name", "")] = switch
-
-        user_input = InputUtils.safe_input(
-            f"\nEnter the index or switch name to convert to virtual MAC [0-{len(switches) - 1}]: ",
-            context="vc_switch_selection",
-        ).strip()
-
-        if user_input.isdigit():
-            return index_to_device.get(int(user_input))
-        return name_to_device.get(user_input)
-
-    @staticmethod
-    def _preflight_check(switch: dict) -> bool:  # type: ignore[type-arg]
-        """Validate switch is eligible for VC-to-virtual-MAC conversion."""
-        device_type = switch.get("type", "")
-        if device_type != "switch":
-            print(f"! Preflight FAILED: Device type is '{device_type}', expected 'switch'.")
-            logging.error(f"Preflight: wrong device type '{device_type}' for VC conversion")
-            return False
-
-        device_id = switch.get("id", "").strip()
-        if not device_id:
-            print("! Preflight FAILED: Device has no assigned device ID.")
-            logging.error("Preflight: missing device_id for VC conversion")
-            return False
-
-        vc_mac = switch.get("vc_mac", "").strip()
-        if vc_mac and vc_mac.startswith("020003"):
-            print(f"! Preflight WARNING: Switch '{switch.get('name', '')}' appears already converted.")
-            print(f"   vc_mac '{vc_mac}' starts with '020003' (virtual MAC prefix).")
-            proceed = (
-                InputUtils.safe_input("   Continue anyway? (y/n): ", context="vc_preflight_already_converted")
-                .strip()
-                .lower()
-            )
-            if proceed not in ["y", "yes"]:
-                return False
-
-        logging.info(f"Preflight passed for switch '{switch.get('name', '')}' (id={device_id})")
-        return True
-
-    @staticmethod
-    def _confirm_conversion(switch: dict, site_name: str, device_id: str) -> bool:  # type: ignore[type-arg]
-        """Display warning and get confirmation for destructive operation."""
-        print("\n   DESTRUCTIVE OPERATION WARNING ")
-        print(f"You are about to convert switch '{switch.get('name', '')}' to virtual MAC.")
-        print(f"Site: {site_name}")
-        print(f"Device ID: {device_id}")
-        print(f"MAC: {switch.get('mac', '')}")
-        print("This operation cannot be undone!")
-
-        confirm = InputUtils.safe_input(
-            "\nType 'CONVERT' to proceed or anything else to cancel: ", "", True, "virtual MAC conversion confirmation"
+        _VC.check_status(
+            get_csv_path_fn=FilePathUtils.get_csv_path,
+            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
+            inventory_generator=OrgInventoryExporter.inventory,
+            sites_generator=OrgSiteExporter.sites,
+            flatten_fields_fn=DataProcessingUtils.flatten_nested_fields,
+            escape_multiline_fn=DataProcessingUtils.escape_multiline,
+            save_data_fn=DataExporter.save_data_to_output,
         )
-        return confirm == "CONVERT"
-
-    @staticmethod
-    def _execute_conversion(site_id: str, device_id: str, switch_name: str, site_name: str) -> None:
-        """Execute the API call to convert a switch to virtual MAC."""
-        print(f"! Converting switch '{switch_name}' (device_id: {device_id}) at site '{site_name}' to virtual MAC...")
-        try:
-            response = mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac(
-                apisession, site_id, device_id
-            )
-
-            if hasattr(response, "status_code") and response.status_code >= 400:
-                print(f"! Conversion failed (HTTP {response.status_code}): {getattr(response, 'data', '')}")
-                logging.error(
-                    f"Conversion to virtual MAC failed for device {device_id} at site {site_id}. Response: {getattr(response, 'data', '')}"  # noqa: E501
-                )
-            elif isinstance(getattr(response, "data", None), dict) and "detail" in response.data:
-                print(f"! Conversion failed: {response.data['detail']}")
-                logging.error(
-                    f"Conversion to virtual MAC failed for device {device_id} at site_id {site_id}. Detail: {response.data['detail']}"  # noqa: E501
-                )
-            else:
-                print(" Conversion to virtual MAC triggered successfully!")
-                print(" Check the device status in the Mist UI to monitor progress.")
-                print("\n  Rollback Guidance:")
-                print("   If the conversion causes issues, contact Juniper TAC.")
-                print("   The device may need a factory reset and re-adoption to revert.")
-                print("   Use Menu 94 to verify conversion status after the device reboots.")
-                logging.info(
-                    f"Conversion to virtual MAC triggered for device {device_id} at site {site_id}. Response: {getattr(response, 'data', '')}"  # noqa: E501
-                )
-        except Exception as exception:
-            print(f"! Failed to convert to virtual MAC: {exception}")
-            logging.error(f"Failed to convert to virtual MAC: {exception}")
-
-    @staticmethod
-    def _load_site_names_from_csv() -> list[str]:
-        """Load site names from VCConvert.CSV file."""
-        csv_file_path = FilePathUtils.get_csv_path("VCConvert.CSV")
-        if not os.path.exists(csv_file_path):
-            print("! File 'VCConvert.CSV' not found.")
-            print(f"   Please create this file at: {csv_file_path}")
-            print("   This file should contain site names (one per line, no header).")
-
-            user_input = (
-                InputUtils.safe_input(
-                    "   Would you like to create an empty file to get started? (y/n): ",
-                    context="vc_csv_create",
-                )
-                .strip()
-                .lower()
-            )
-            if user_input in ["y", "yes"]:
-                try:
-                    template_path = FilePathUtils.create_csv_template("VCConvert.CSV")
-                    print(f"! Empty file created at: {template_path}")
-                    print("   Please edit the file to add your site names and run the script again.")
-                except Exception as exception:
-                    print(f"! Failed to create file: {exception}")
-
-            logging.error("VCConvert.CSV file not found.")
-            return []
-
-        try:
-            site_names = []
-            with open(csv_file_path, encoding="utf-8") as csvfile:
-                reader = csv.reader(csvfile)
-                for row in reader:
-                    if row and row[0].strip():
-                        site_names.append(row[0].strip())
-            return site_names
-        except Exception as exception:
-            print(f"! Error reading VCConvert.CSV: {exception}")
-            logging.error(f"Error reading VCConvert.CSV: {exception}")
-            return []
-
-    @staticmethod
-    def _load_site_name_mapping() -> dict[str, str]:
-        """Load site name to ID mapping from cached CSV."""
-        try:
-            site_list_path = FilePathUtils.get_csv_path("SiteList.csv")
-            with open(site_list_path, encoding="utf-8") as csvfile:
-                reader = csv.DictReader(csvfile)
-                return {row.get("name", ""): row.get("id", "") for row in reader}
-        except Exception as exception:
-            print(f"! Error reading SiteList.csv: {exception}")
-            logging.error(f"Error reading SiteList.csv: {exception}")
-            return {}
-
-    @staticmethod
-    def _resolve_site_ids(site_names: list[str], site_name_to_id: dict[str, str]) -> tuple[list[str], list[str]]:
-        """Resolve site names to IDs, returning valid IDs and missing names."""
-        target_site_ids = []
-        missing_sites = []
-        for site_name in site_names:
-            site_id = site_name_to_id.get(site_name)
-            if site_id:
-                target_site_ids.append(site_id)
-            else:
-                missing_sites.append(site_name)
-        return target_site_ids, missing_sites
-
-    @staticmethod
-    def _load_switches_for_sites(target_site_ids: list[str], site_name_to_id: dict[str, str]) -> list[dict]:  # type: ignore[type-arg]
-        """Load switches from inventory for specific sites."""
-        try:
-            inventory_path = FilePathUtils.get_csv_path("OrgInventory.csv")
-            switches = []
-            with open(inventory_path, encoding="utf-8") as csvfile:
-                reader = csv.DictReader(csvfile)
-                for row in reader:
-                    if (
-                        row.get("type") == "switch"
-                        and row.get("site_id") in target_site_ids
-                        and row.get("id", "").strip()
-                    ):
-                        site_name = next(
-                            (name for name, id_ in site_name_to_id.items() if id_ == row.get("site_id")), "Unknown Site"
-                        )
-                        row["site_name"] = site_name
-                        switches.append(row)
-            return switches
-        except Exception as exception:
-            print(f"! Error reading OrgInventory.csv: {exception}")
-            logging.error(f"Error reading OrgInventory.csv: {exception}")
-            return []
-
-    @staticmethod
-    def _display_switches_for_conversion(switches: list[dict]) -> None:  # type: ignore[type-arg]
-        """Display switches that will be converted."""
-        print(f"\n  Found {len(switches)} virtual chassis switches to convert:")
-        print("=" * 100)
-        for idx, switch in enumerate(switches):
-            print(
-                f"[{idx + 1:2}] Site: {switch.get('site_name', ''):25} | "
-                f"Name: {switch.get('name', ''):20} | "
-                f"MAC: {switch.get('mac', ''):17} | "
-                f"Model: {switch.get('model', ''):12} | "
-                f"Serial: {switch.get('serial', '')}"
-            )
-
-        print(f"\n  This will convert {len(switches)} virtual chassis switches to virtual MAC.")
-        print(" This operation cannot be undone easily.")
-
-    @staticmethod
-    def _execute_bulk_conversion(switches: list[dict]) -> None:  # type: ignore[type-arg]
-        """Execute conversion for multiple switches."""
-        print(f"\n  Starting conversion of {len(switches)} switches...")
-        successful_conversions = 0
-        failed_conversions = 0
-
-        for idx, switch in enumerate(switches):
-            site_id = switch.get("site_id")
-            device_id = switch.get("id")
-            switch_name = switch.get("name", "")
-            site_name = switch.get("site_name", "")
-
-            print(f"\n[{idx + 1}/{len(switches)}] Converting '{switch_name}' at site '{site_name}'...")
-
-            try:
-                response = mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac(
-                    apisession, site_id, device_id
-                )
-
-                if hasattr(response, "status_code") and response.status_code >= 400:
-                    print(f"! Conversion failed (HTTP {response.status_code}): {getattr(response, 'data', '')}")
-                    logging.error(f"Conversion failed for {switch_name} at {site_name}. HTTP {response.status_code}")
-                    failed_conversions += 1
-                elif isinstance(getattr(response, "data", None), dict) and "detail" in response.data:
-                    print(f"! Conversion failed: {response.data['detail']}")
-                    logging.error(
-                        f"Conversion failed for {switch_name} at {site_name}. Detail: {response.data['detail']}"
-                    )
-                    failed_conversions += 1
-                else:
-                    print("! Conversion triggered successfully.")
-                    logging.info(f"Conversion triggered for {switch_name} at {site_name}.")
-                    successful_conversions += 1
-
-            except Exception as exception:
-                print(f"! Exception during conversion: {exception}")
-                logging.error(f"Exception during conversion of {switch_name} at {site_name}: {exception}")
-                failed_conversions += 1
-
-        print("\n  Conversion Summary:")
-        print(f"   Successful conversions: {successful_conversions}")
-        print(f"   Failed conversions: {failed_conversions}")
-        print(f"   Total switches processed: {len(switches)}")
-
-        if successful_conversions > 0:
-            print("\n  Note: Successful conversions may take a few minutes to complete.")
-            print("   Monitor the devices in the Mist portal to confirm the conversion status.")
-
-        logging.info(f"Bulk VC conversion completed: {successful_conversions} successful, {failed_conversions} failed")
-
-    @staticmethod
-    def _load_vc_switches() -> list[dict]:  # type: ignore[type-arg]
-        """Load all switches with vc_mac from inventory."""
-        try:
-            inventory_path = FilePathUtils.get_csv_path("OrgInventory.csv")
-            switches = []
-            with open(inventory_path, encoding="utf-8") as csvfile:
-                reader = csv.DictReader(csvfile)
-                for row in reader:
-                    if row.get("type") == "switch" and row.get("vc_mac", "").strip():
-                        switches.append(row)
-            return switches
-        except Exception as exception:
-            print(f"! Error reading OrgInventory.csv: {exception}")
-            logging.error(f"Error reading OrgInventory.csv: {exception}")
-            return []
-
-    @staticmethod
-    def _load_site_id_mapping() -> dict[str, str]:
-        """Load site ID to name mapping from cached CSV."""
-        try:
-            CacheUtils.check_and_generate_csv("SiteList.csv", OrgSiteExporter.sites)
-            site_list_path = FilePathUtils.get_csv_path("SiteList.csv")
-            with open(site_list_path, encoding="utf-8") as csvfile:
-                reader = csv.DictReader(csvfile)
-                return {row.get("id", ""): row.get("name", "Unknown Site") for row in reader}
-        except Exception as exception:
-            logging.warning(f"Could not load site names: {exception}")
-            return {}
-
-    @staticmethod
-    def _analyze_conversion_status(
-        switches: list[dict],  # type: ignore[type-arg]
-        site_id_to_name: dict[str, str],
-    ) -> tuple[list[dict], list[dict]]:  # type: ignore[type-arg]
-        """Analyze switches to determine conversion status."""
-        converted = []
-        not_converted = []
-
-        for switch in switches:
-            vc_mac = switch.get("vc_mac", "")
-            site_id = switch.get("site_id", "")
-
-            enhanced_switch = switch.copy()
-            enhanced_switch["site_name"] = site_id_to_name.get(site_id, "Unknown Site")
-
-            if vc_mac.startswith("020003"):
-                enhanced_switch["conversion_status"] = "CONVERTED"
-                enhanced_switch["conversion_notes"] = "vc_mac starts with 020003 - converted to virtual MAC"
-                converted.append(enhanced_switch)
-            else:
-                enhanced_switch["conversion_status"] = "NOT_CONVERTED"
-                enhanced_switch["conversion_notes"] = f"vc_mac starts with {vc_mac[:6]} - not converted to virtual MAC"
-                not_converted.append(enhanced_switch)
-
-        return converted, not_converted
-
-    @staticmethod
-    def _display_status_summary(converted: list[dict], not_converted: list[dict]) -> None:  # type: ignore[type-arg]
-        """Display conversion status summary."""
-        total = len(converted) + len(not_converted)
-
-        print("\n  Virtual Chassis Conversion Status Summary:")
-        print(f"   Total virtual chassis switches: {total}")
-        print(f"   Converted to virtual MAC: {len(converted)}")
-        print(f"   Not converted: {len(not_converted)}")
-
-        if converted:
-            print("\n Converted Switches (vc_mac starts with '020003'):")
-            for switch in converted[:10]:
-                print(
-                    f"   !? {switch.get('name', 'Unnamed'):20} | Site: {switch.get('site_name', ''):25} | vc_mac: {switch.get('vc_mac', '')[:8]}..."  # noqa: E501
-                )
-            if len(converted) > 10:
-                print(f"   ... and {len(converted) - 10} more")
-
-        if not_converted:
-            print("\n Not Converted Switches (vc_mac does NOT start with '020003'):")
-            for switch in not_converted[:10]:
-                print(
-                    f"   !? {switch.get('name', 'Unnamed'):20} | Site: {switch.get('site_name', ''):25} | vc_mac: {switch.get('vc_mac', '')[:8]}..."  # noqa: E501
-                )
-            if len(not_converted) > 10:
-                print(f"   ... and {len(not_converted) - 10} more")
-
-    @staticmethod
-    def _export_status_results(all_switches: list[dict]) -> None:  # type: ignore[type-arg]
-        """Export conversion status results to CSV."""
-        try:
-            flattened = DataProcessingUtils.flatten_nested_fields(all_switches)
-            sanitized = DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
-
-            filename = "VirtualChassisConversionStatus.csv"
-            DataExporter.save_data_to_output(sanitized, filename)  # type: ignore[no-untyped-call]
-
-            print(f"\n  Results exported to: {filename}")
-            print(f"   Location: {FilePathUtils.get_csv_path(filename)}")
-
-            logging.info(f"Virtual chassis conversion status exported to {filename}")
-
-        except Exception as exception:
-            print(f"! Error exporting results: {exception}")
-            logging.error(f"Error exporting conversion status results: {exception}")
 
 
 # ============================================================================

--- a/src/device/__init__.py
+++ b/src/device/__init__.py
@@ -1,0 +1,1 @@
+"""Device management modules for MistHelper."""

--- a/src/device/virtual_chassis.py
+++ b/src/device/virtual_chassis.py
@@ -1,0 +1,794 @@
+"""Virtual chassis to virtual MAC conversion operations.
+
+Extracted from MistHelper.py (Issue #213). Provides functionality to convert
+virtual chassis switches to virtual MAC addressing, check conversion status,
+and perform bulk conversions via CSV site lists.
+
+Menu operations: 92 (single convert), 93 (bulk by site list), 94 (status check).
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+from collections.abc import Callable
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Type aliases for dependency injection
+# ---------------------------------------------------------------------------
+SafeInputFn = Callable[..., str]
+SelectSiteFn = Callable[[], str | None]
+GetCsvPathFn = Callable[[str], str]
+CreateCsvTemplateFn = Callable[[str], str]
+CheckAndGenerateCsvFn = Callable[[str, Any], None]
+FlattenFieldsFn = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
+EscapeMultilineFn = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
+SaveDataFn = Callable[[list[dict[str, Any]], str], None]
+
+# Converted prefix for virtual MAC
+_CONVERTED_PREFIX = "020003"
+
+
+class VirtualChassisManager:
+    """Manage virtual chassis to virtual MAC conversion operations.
+
+    All methods are static. External dependencies are injected as explicit
+    function parameters so the module can be tested and run independently
+    of MistHelper globals.
+    """
+
+    # ------------------------------------------------------------------
+    # Public entry-points (menus 92, 93, 94)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def convert_single(
+        *,
+        apisession: Any,
+        select_site_fn: SelectSiteFn,
+        safe_input_fn: SafeInputFn,
+        get_csv_path_fn: GetCsvPathFn,
+        check_and_generate_csv_fn: CheckAndGenerateCsvFn,
+        inventory_generator: Any,
+        dry_run: bool = False,
+    ) -> None:
+        """Interactively convert a single VC switch to virtual MAC (Menu 92).
+
+        Args:
+            apisession: Authenticated Mist API session.
+            select_site_fn: Callback that prompts user and returns a site_id.
+            safe_input_fn: Callback for safe user input with EOF handling.
+            get_csv_path_fn: Resolves a filename to its full data-directory path.
+            check_and_generate_csv_fn: Ensures a cached CSV exists.
+            inventory_generator: Callable passed to check_and_generate_csv_fn.
+            dry_run: If True, show what would happen without making API calls.
+        """
+        mode_label = "[DRY RUN] " if dry_run else ""
+        print(f"\n  {mode_label}DESTRUCTIVE: Virtual Chassis to Virtual MAC Conversion")
+        print("=" * 60)
+        if dry_run:
+            print("  DRY RUN MODE: No changes will be made. Showing what would happen.")
+
+        site_id = select_site_fn()
+        if not site_id:
+            print(" No site selected.")
+            return
+
+        site_name = VirtualChassisManager._get_site_name(apisession, site_id)
+        print(f"\n  Selected Site: {site_name} ({site_id})")
+
+        switches = VirtualChassisManager._load_site_switches(
+            site_id, get_csv_path_fn, check_and_generate_csv_fn, inventory_generator
+        )
+        if not switches:
+            print(f"! No virtual chassis switches found at site '{site_name}'.")
+            print(" Virtual chassis switches must have a device ID assigned.")
+            logging.warning("No virtual chassis switches found at site %s.", site_id)
+            return
+
+        selected = VirtualChassisManager._prompt_switch_selection(switches, site_name, safe_input_fn)
+        if not selected:
+            return
+
+        device_id = selected.get("id")
+        if not device_id:
+            print(" Missing device_id for selected switch.")
+            logging.warning("Missing device_id for selected switch.")
+            return
+
+        if not VirtualChassisManager._preflight_check(selected, safe_input_fn):
+            return
+
+        if dry_run:
+            VirtualChassisManager._print_dry_run(selected, site_name, device_id, site_id)
+            return
+
+        if not VirtualChassisManager._confirm_conversion(selected, site_name, device_id, safe_input_fn):
+            print(" Operation cancelled.")
+            return
+
+        VirtualChassisManager._execute_conversion(apisession, site_id, device_id, selected.get("name", ""), site_name)
+
+    @staticmethod
+    def convert_by_site_list(
+        *,
+        apisession: Any,
+        safe_input_fn: SafeInputFn,
+        get_csv_path_fn: GetCsvPathFn,
+        create_csv_template_fn: CreateCsvTemplateFn,
+        check_and_generate_csv_fn: CheckAndGenerateCsvFn,
+        inventory_generator: Any,
+        sites_generator: Any,
+    ) -> None:
+        """Bulk convert VC switches from sites in VCConvert.CSV (Menu 93).
+
+        Args:
+            apisession: Authenticated Mist API session.
+            safe_input_fn: Callback for safe user input with EOF handling.
+            get_csv_path_fn: Resolves a filename to its full data-directory path.
+            create_csv_template_fn: Creates an empty CSV template file.
+            check_and_generate_csv_fn: Ensures a cached CSV exists.
+            inventory_generator: Callable for OrgInventory generation.
+            sites_generator: Callable for SiteList generation.
+        """
+        logging.info("Starting bulk VC to virtual MAC conversion by site list...")
+
+        site_names = VirtualChassisManager._load_site_names_from_csv(
+            get_csv_path_fn, create_csv_template_fn, safe_input_fn
+        )
+        if not site_names:
+            return
+
+        print(f"! Loaded {len(site_names)} site names from VCConvert.CSV:")
+        for idx, name in enumerate(site_names):
+            print(f"  [{idx + 1}] {name}")
+
+        check_and_generate_csv_fn("OrgInventory.csv", inventory_generator)
+        check_and_generate_csv_fn("SiteList.csv", sites_generator)
+
+        site_name_to_id = VirtualChassisManager._load_site_name_mapping(get_csv_path_fn)
+        if not site_name_to_id:
+            return
+
+        target_ids, missing = VirtualChassisManager._resolve_site_ids(site_names, site_name_to_id)
+
+        if missing:
+            print("! Warning: The following sites were not found in the organization:")
+            for site in missing:
+                print(f"   - {site}")
+
+        if not target_ids:
+            print(" No valid sites found. Exiting.")
+            logging.error("No valid sites found for VC conversion.")
+            return
+
+        switches = VirtualChassisManager._load_switches_for_sites(target_ids, site_name_to_id, get_csv_path_fn)
+        if not switches:
+            print(" No virtual chassis switches found in the specified sites.")
+            logging.warning("No virtual chassis switches found in target sites.")
+            return
+
+        VirtualChassisManager._display_switches_for_conversion(switches)
+
+        confirm = safe_input_fn(
+            "\nType 'CONVERT' to proceed with bulk conversion or anything else to cancel: ",
+            context="vc_bulk_conversion",
+        )
+        if confirm != "CONVERT":
+            print(" Conversion cancelled by user.")
+            logging.info("Virtual chassis conversion cancelled by user.")
+            return
+
+        VirtualChassisManager._execute_bulk_conversion(apisession, switches)
+
+    @staticmethod
+    def check_status(
+        *,
+        get_csv_path_fn: GetCsvPathFn,
+        check_and_generate_csv_fn: CheckAndGenerateCsvFn,
+        inventory_generator: Any,
+        sites_generator: Any,
+        flatten_fields_fn: FlattenFieldsFn,
+        escape_multiline_fn: EscapeMultilineFn,
+        save_data_fn: SaveDataFn,
+    ) -> None:
+        """Check conversion status of all VC switches in the org (Menu 94).
+
+        Args:
+            get_csv_path_fn: Resolves a filename to its full data-directory path.
+            check_and_generate_csv_fn: Ensures a cached CSV exists.
+            inventory_generator: Callable for OrgInventory generation.
+            sites_generator: Callable for SiteList generation.
+            flatten_fields_fn: Flattens nested dict fields.
+            escape_multiline_fn: Escapes multiline strings for CSV.
+            save_data_fn: Writes data list to output file.
+        """
+        print("\n  Virtual Chassis to Virtual MAC Conversion Status Check")
+        print("=" * 70)
+        print(" Checking all switches for virtual chassis conversion status...")
+        print(f" Converted switches have vc_mac starting with '{_CONVERTED_PREFIX}'")
+
+        logging.info("Starting virtual chassis conversion status check...")
+
+        check_and_generate_csv_fn("OrgInventory.csv", inventory_generator)
+
+        vc_switches = VirtualChassisManager._load_vc_switches(get_csv_path_fn)
+        if not vc_switches:
+            print(" No switches with vc_mac found in the organization.")
+            print(" Only virtual chassis switches have vc_mac assigned.")
+            logging.warning("No switches with vc_mac found.")
+            return
+
+        site_id_to_name = VirtualChassisManager._load_site_id_mapping(
+            get_csv_path_fn, check_and_generate_csv_fn, sites_generator
+        )
+        converted, not_converted = VirtualChassisManager._analyze_conversion_status(vc_switches, site_id_to_name)
+
+        VirtualChassisManager._display_status_summary(converted, not_converted)
+        VirtualChassisManager._export_status_results(
+            converted + not_converted,
+            flatten_fields_fn,
+            escape_multiline_fn,
+            save_data_fn,
+            get_csv_path_fn,
+        )
+
+        print("\n  Usage Notes:")
+        print("   !? Use option 92 to convert individual switches")
+        print("   !? Use option 93 for bulk conversion by site list")
+        print(f"   !? Virtual chassis switches without '{_CONVERTED_PREFIX}' " "vc_mac prefix can be converted")
+
+    # ------------------------------------------------------------------
+    # API helpers (require apisession)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_site_name(apisession: Any, site_id: str) -> str:
+        """Fetch site name from API."""
+        import mistapi
+
+        try:
+            response = mistapi.api.v1.sites.getSite(apisession, site_id)
+            if response.data:
+                return str(response.data.get("name", site_id))
+        except Exception as exc:
+            logging.warning("Could not fetch site name for %s: %s", site_id, exc)
+        return "Unknown Site"
+
+    @staticmethod
+    def _execute_conversion(
+        apisession: Any,
+        site_id: str,
+        device_id: str,
+        switch_name: str,
+        site_name: str,
+    ) -> None:
+        """Execute API call to convert one switch to virtual MAC."""
+        import mistapi
+
+        print(
+            f"! Converting switch '{switch_name}' (device_id: {device_id}) " f"at site '{site_name}' to virtual MAC..."
+        )
+        try:
+            response = mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac(
+                apisession, site_id, device_id
+            )
+            VirtualChassisManager._handle_conversion_response(response, device_id, site_id, site_name, switch_name)
+        except Exception as exc:
+            print(f"! Failed to convert to virtual MAC: {exc}")
+            logging.error("Failed to convert to virtual MAC: %s", exc)
+
+    @staticmethod
+    def _handle_conversion_response(
+        response: Any,
+        device_id: str,
+        site_id: str,
+        site_name: str,
+        switch_name: str,
+    ) -> None:
+        """Process API response from a conversion call."""
+        if hasattr(response, "status_code") and response.status_code >= 400:
+            data = getattr(response, "data", "")
+            print(f"! Conversion failed (HTTP {response.status_code}): {data}")
+            logging.error(
+                "Conversion failed for %s at %s. HTTP %s",
+                switch_name,
+                site_name,
+                response.status_code,
+            )
+            return
+
+        resp_data = getattr(response, "data", None)
+        if isinstance(resp_data, dict) and "detail" in resp_data:
+            print(f"! Conversion failed: {resp_data['detail']}")
+            logging.error(
+                "Conversion failed for %s at %s. Detail: %s",
+                switch_name,
+                site_name,
+                resp_data["detail"],
+            )
+            return
+
+        print(" Conversion to virtual MAC triggered successfully!")
+        print(" Check the device status in the Mist UI to monitor progress.")
+        print("\n  Rollback Guidance:")
+        print("   If the conversion causes issues, contact Juniper TAC.")
+        print("   The device may need a factory reset and re-adoption to revert.")
+        print("   Use Menu 94 to verify conversion status after the device reboots.")
+        logging.info(
+            "Conversion triggered for device %s at site %s. Response: %s",
+            device_id,
+            site_id,
+            getattr(response, "data", ""),
+        )
+
+    @staticmethod
+    def _execute_bulk_conversion(apisession: Any, switches: list[dict[str, Any]]) -> None:
+        """Execute conversion for multiple switches."""
+        import mistapi
+
+        print(f"\n  Starting conversion of {len(switches)} switches...")
+        successful = 0
+        failed = 0
+
+        for idx, switch in enumerate(switches):
+            site_id = switch.get("site_id", "")
+            device_id = switch.get("id", "")
+            switch_name = switch.get("name", "")
+            site_name = switch.get("site_name", "")
+
+            print(f"\n[{idx + 1}/{len(switches)}] " f"Converting '{switch_name}' at site '{site_name}'...")
+
+            try:
+                response = mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac(
+                    apisession, site_id, device_id
+                )
+                if VirtualChassisManager._is_conversion_error(response):
+                    failed += 1
+                else:
+                    print("! Conversion triggered successfully.")
+                    logging.info("Conversion triggered for %s at %s.", switch_name, site_name)
+                    successful += 1
+            except Exception as exc:
+                print(f"! Exception during conversion: {exc}")
+                logging.error(
+                    "Exception during conversion of %s at %s: %s",
+                    switch_name,
+                    site_name,
+                    exc,
+                )
+                failed += 1
+
+        VirtualChassisManager._print_bulk_summary(successful, failed, len(switches))
+
+    # ------------------------------------------------------------------
+    # CSV / file helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load_site_switches(
+        site_id: str,
+        get_csv_path_fn: GetCsvPathFn,
+        check_and_generate_csv_fn: CheckAndGenerateCsvFn,
+        inventory_generator: Any,
+    ) -> list[dict[str, Any]]:
+        """Load switches at a specific site from cached inventory."""
+        check_and_generate_csv_fn("OrgInventory.csv", inventory_generator)
+        path = get_csv_path_fn("OrgInventory.csv")
+
+        with open(path, encoding="utf-8") as csvfile:
+            reader = list(csv.DictReader(csvfile))
+            return [
+                row
+                for row in reader
+                if (row.get("type") == "switch" and row.get("id", "").strip() and row.get("site_id") == site_id)
+            ]
+
+    @staticmethod
+    def _load_site_names_from_csv(
+        get_csv_path_fn: GetCsvPathFn,
+        create_csv_template_fn: CreateCsvTemplateFn,
+        safe_input_fn: SafeInputFn,
+    ) -> list[str]:
+        """Load site names from VCConvert.CSV file."""
+        csv_path = get_csv_path_fn("VCConvert.CSV")
+        if not os.path.exists(csv_path):
+            VirtualChassisManager._handle_missing_csv(csv_path, create_csv_template_fn, safe_input_fn)
+            return []
+
+        try:
+            site_names: list[str] = []
+            with open(csv_path, encoding="utf-8") as csvfile:
+                for row in csv.reader(csvfile):
+                    if row and row[0].strip():
+                        site_names.append(row[0].strip())
+            return site_names
+        except Exception as exc:
+            print(f"! Error reading VCConvert.CSV: {exc}")
+            logging.error("Error reading VCConvert.CSV: %s", exc)
+            return []
+
+    @staticmethod
+    def _handle_missing_csv(
+        csv_path: str,
+        create_csv_template_fn: CreateCsvTemplateFn,
+        safe_input_fn: SafeInputFn,
+    ) -> None:
+        """Prompt user when VCConvert.CSV is not found."""
+        print("! File 'VCConvert.CSV' not found.")
+        print(f"   Please create this file at: {csv_path}")
+        print("   This file should contain site names (one per line, no header).")
+
+        answer = (
+            safe_input_fn(
+                "   Would you like to create an empty file to get started? (y/n): ",
+                context="vc_csv_create",
+            )
+            .strip()
+            .lower()
+        )
+
+        if answer in ("y", "yes"):
+            try:
+                path = create_csv_template_fn("VCConvert.CSV")
+                print(f"! Empty file created at: {path}")
+                print("   Please edit the file to add your site names " "and run the script again.")
+            except Exception as exc:
+                print(f"! Failed to create file: {exc}")
+
+        logging.error("VCConvert.CSV file not found.")
+
+    @staticmethod
+    def _load_site_name_mapping(
+        get_csv_path_fn: GetCsvPathFn,
+    ) -> dict[str, str]:
+        """Load site name-to-ID mapping from cached SiteList.csv."""
+        try:
+            path = get_csv_path_fn("SiteList.csv")
+            with open(path, encoding="utf-8") as csvfile:
+                reader = csv.DictReader(csvfile)
+                return {row.get("name", ""): row.get("id", "") for row in reader}
+        except Exception as exc:
+            print(f"! Error reading SiteList.csv: {exc}")
+            logging.error("Error reading SiteList.csv: %s", exc)
+            return {}
+
+    @staticmethod
+    def _load_switches_for_sites(
+        target_site_ids: list[str],
+        site_name_to_id: dict[str, str],
+        get_csv_path_fn: GetCsvPathFn,
+    ) -> list[dict[str, Any]]:
+        """Load switches from inventory for specific sites."""
+        try:
+            path = get_csv_path_fn("OrgInventory.csv")
+            switches: list[dict[str, Any]] = []
+            with open(path, encoding="utf-8") as csvfile:
+                for row in csv.DictReader(csvfile):
+                    if not VirtualChassisManager._is_target_switch(row, target_site_ids):
+                        continue
+                    site_name = VirtualChassisManager._reverse_lookup(row.get("site_id", ""), site_name_to_id)
+                    row["site_name"] = site_name
+                    switches.append(row)
+            return switches
+        except Exception as exc:
+            print(f"! Error reading OrgInventory.csv: {exc}")
+            logging.error("Error reading OrgInventory.csv: %s", exc)
+            return []
+
+    @staticmethod
+    def _load_vc_switches(
+        get_csv_path_fn: GetCsvPathFn,
+    ) -> list[dict[str, Any]]:
+        """Load all switches with vc_mac from inventory."""
+        try:
+            path = get_csv_path_fn("OrgInventory.csv")
+            switches: list[dict[str, Any]] = []
+            with open(path, encoding="utf-8") as csvfile:
+                for row in csv.DictReader(csvfile):
+                    if row.get("type") == "switch" and row.get("vc_mac", "").strip():
+                        switches.append(row)
+            return switches
+        except Exception as exc:
+            print(f"! Error reading OrgInventory.csv: {exc}")
+            logging.error("Error reading OrgInventory.csv: %s", exc)
+            return []
+
+    @staticmethod
+    def _load_site_id_mapping(
+        get_csv_path_fn: GetCsvPathFn,
+        check_and_generate_csv_fn: CheckAndGenerateCsvFn,
+        sites_generator: Any,
+    ) -> dict[str, str]:
+        """Load site ID-to-name mapping from cached CSV."""
+        try:
+            check_and_generate_csv_fn("SiteList.csv", sites_generator)
+            path = get_csv_path_fn("SiteList.csv")
+            with open(path, encoding="utf-8") as csvfile:
+                reader = csv.DictReader(csvfile)
+                return {row.get("id", ""): row.get("name", "Unknown Site") for row in reader}
+        except Exception as exc:
+            logging.warning("Could not load site names: %s", exc)
+            return {}
+
+    # ------------------------------------------------------------------
+    # User-interaction helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _prompt_switch_selection(
+        switches: list[dict[str, Any]],
+        site_name: str,
+        safe_input_fn: SafeInputFn,
+    ) -> dict[str, Any] | None:
+        """Display switches and prompt user for selection."""
+        print(f"\n  Available Virtual Chassis Switches at '{site_name}':")
+        print("-" * 80)
+
+        index_map: dict[int, dict[str, Any]] = {}
+        name_map: dict[str, dict[str, Any]] = {}
+        for idx, switch in enumerate(switches):
+            print(
+                f"[{idx}] {switch.get('name', ''):20} "
+                f"MAC: {switch.get('mac', ''):17} "
+                f"Model: {switch.get('model', ''):10} "
+                f"Serial: {switch.get('serial', ''):15} "
+                f"ID: {switch.get('id', '')}"
+            )
+            index_map[idx] = switch
+            name_map[switch.get("name", "")] = switch
+
+        user_input = safe_input_fn(
+            f"\nEnter the index or switch name to convert " f"to virtual MAC [0-{len(switches) - 1}]: ",
+            context="vc_switch_selection",
+        ).strip()
+
+        if user_input.isdigit():
+            return index_map.get(int(user_input))
+        return name_map.get(user_input)
+
+    @staticmethod
+    def _preflight_check(switch: dict[str, Any], safe_input_fn: SafeInputFn) -> bool:
+        """Validate switch is eligible for VC-to-virtual-MAC conversion."""
+        device_type = switch.get("type", "")
+        if device_type != "switch":
+            print(f"! Preflight FAILED: Device type is '{device_type}', " "expected 'switch'.")
+            logging.error("Preflight: wrong device type '%s' for VC conversion", device_type)
+            return False
+
+        device_id = switch.get("id", "").strip()
+        if not device_id:
+            print("! Preflight FAILED: Device has no assigned device ID.")
+            logging.error("Preflight: missing device_id for VC conversion")
+            return False
+
+        vc_mac = switch.get("vc_mac", "").strip()
+        if vc_mac and vc_mac.startswith(_CONVERTED_PREFIX):
+            print(f"! Preflight WARNING: Switch '{switch.get('name', '')}' " "appears already converted.")
+            print(f"   vc_mac '{vc_mac}' starts with '{_CONVERTED_PREFIX}' " "(virtual MAC prefix).")
+            proceed = (
+                safe_input_fn(
+                    "   Continue anyway? (y/n): ",
+                    context="vc_preflight_already_converted",
+                )
+                .strip()
+                .lower()
+            )
+            if proceed not in ("y", "yes"):
+                return False
+
+        logging.info(
+            "Preflight passed for switch '%s' (id=%s)",
+            switch.get("name", ""),
+            device_id,
+        )
+        return True
+
+    @staticmethod
+    def _confirm_conversion(
+        switch: dict[str, Any],
+        site_name: str,
+        device_id: str,
+        safe_input_fn: SafeInputFn,
+    ) -> bool:
+        """Display warning and get confirmation for destructive operation."""
+        print("\n   DESTRUCTIVE OPERATION WARNING ")
+        print(f"You are about to convert switch " f"'{switch.get('name', '')}' to virtual MAC.")
+        print(f"Site: {site_name}")
+        print(f"Device ID: {device_id}")
+        print(f"MAC: {switch.get('mac', '')}")
+        print("This operation cannot be undone!")
+
+        confirm = safe_input_fn(
+            "\nType 'CONVERT' to proceed or anything else to cancel: ",
+            "",
+            True,
+            "virtual MAC conversion confirmation",
+        )
+        return confirm == "CONVERT"
+
+    # ------------------------------------------------------------------
+    # Pure logic helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_site_ids(site_names: list[str], site_name_to_id: dict[str, str]) -> tuple[list[str], list[str]]:
+        """Resolve site names to IDs, returning valid IDs and missing names."""
+        target_ids: list[str] = []
+        missing: list[str] = []
+        for name in site_names:
+            site_id = site_name_to_id.get(name)
+            if site_id:
+                target_ids.append(site_id)
+            else:
+                missing.append(name)
+        return target_ids, missing
+
+    @staticmethod
+    def _analyze_conversion_status(
+        switches: list[dict[str, Any]], site_id_to_name: dict[str, str]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Classify switches as converted or not based on vc_mac prefix."""
+        converted: list[dict[str, Any]] = []
+        not_converted: list[dict[str, Any]] = []
+
+        for switch in switches:
+            vc_mac = switch.get("vc_mac", "")
+            site_id = switch.get("site_id", "")
+            enhanced = switch.copy()
+            enhanced["site_name"] = site_id_to_name.get(site_id, "Unknown Site")
+
+            if vc_mac.startswith(_CONVERTED_PREFIX):
+                enhanced["conversion_status"] = "CONVERTED"
+                enhanced["conversion_notes"] = f"vc_mac starts with {_CONVERTED_PREFIX} - converted to virtual MAC"
+                converted.append(enhanced)
+            else:
+                enhanced["conversion_status"] = "NOT_CONVERTED"
+                enhanced["conversion_notes"] = f"vc_mac starts with {vc_mac[:6]} - not converted to virtual MAC"
+                not_converted.append(enhanced)
+
+        return converted, not_converted
+
+    @staticmethod
+    def _is_target_switch(row: dict[str, Any], target_site_ids: list[str]) -> bool:
+        """Check if an inventory row is a switch in one of the target sites."""
+        return (
+            row.get("type") == "switch"
+            and row.get("site_id", "") in target_site_ids
+            and bool(row.get("id", "").strip())
+        )
+
+    @staticmethod
+    def _reverse_lookup(site_id: str, name_to_id: dict[str, str]) -> str:
+        """Find the site name for a given site_id from a name->id map."""
+        return next(
+            (name for name, sid in name_to_id.items() if sid == site_id),
+            "Unknown Site",
+        )
+
+    @staticmethod
+    def _is_conversion_error(response: Any) -> bool:
+        """Return True if the response indicates a conversion failure."""
+        if hasattr(response, "status_code") and response.status_code >= 400:
+            data = getattr(response, "data", "")
+            print(f"! Conversion failed (HTTP {response.status_code}): {data}")
+            logging.error("Conversion failed. HTTP %s", response.status_code)
+            return True
+
+        resp_data = getattr(response, "data", None)
+        if isinstance(resp_data, dict) and "detail" in resp_data:
+            print(f"! Conversion failed: {resp_data['detail']}")
+            logging.error("Conversion failed. Detail: %s", resp_data["detail"])
+            return True
+
+        return False
+
+    # ------------------------------------------------------------------
+    # Display helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _print_dry_run(selected: dict[str, Any], site_name: str, device_id: str, site_id: str) -> None:
+        """Print dry-run output for a single conversion."""
+        print(f"\n  [DRY RUN] Would convert switch " f"'{selected.get('name', '')}' at site '{site_name}'")
+        print(f"  [DRY RUN] Device ID: {device_id}")
+        print(f"  [DRY RUN] MAC: {selected.get('mac', '')}")
+        print("  [DRY RUN] No API call made. Use without --dry-run to execute.")
+        logging.info("DRY RUN: Would convert %s at site %s", device_id, site_id)
+
+    @staticmethod
+    def _display_switches_for_conversion(
+        switches: list[dict[str, Any]],
+    ) -> None:
+        """Display switches that will be converted."""
+        print(f"\n  Found {len(switches)} virtual chassis switches to convert:")
+        print("=" * 100)
+        for idx, switch in enumerate(switches):
+            print(
+                f"[{idx + 1:2}] "
+                f"Site: {switch.get('site_name', ''):25} | "
+                f"Name: {switch.get('name', ''):20} | "
+                f"MAC: {switch.get('mac', ''):17} | "
+                f"Model: {switch.get('model', ''):12} | "
+                f"Serial: {switch.get('serial', '')}"
+            )
+        print(f"\n  This will convert {len(switches)} " "virtual chassis switches to virtual MAC.")
+        print(" This operation cannot be undone easily.")
+
+    @staticmethod
+    def _display_status_summary(
+        converted: list[dict[str, Any]],
+        not_converted: list[dict[str, Any]],
+    ) -> None:
+        """Display conversion status summary."""
+        total = len(converted) + len(not_converted)
+        print("\n  Virtual Chassis Conversion Status Summary:")
+        print(f"   Total virtual chassis switches: {total}")
+        print(f"   Converted to virtual MAC: {len(converted)}")
+        print(f"   Not converted: {len(not_converted)}")
+
+        VirtualChassisManager._print_status_list(converted, "Converted", f"vc_mac starts with '{_CONVERTED_PREFIX}'")
+        VirtualChassisManager._print_status_list(
+            not_converted,
+            "Not Converted",
+            f"vc_mac does NOT start with '{_CONVERTED_PREFIX}'",
+        )
+
+    @staticmethod
+    def _print_status_list(switches: list[dict[str, Any]], label: str, description: str) -> None:
+        """Print up to 10 switches from a status list."""
+        if not switches:
+            return
+        print(f"\n {label} Switches ({description}):")
+        for switch in switches[:10]:
+            vc_mac_display = switch.get("vc_mac", "")[:8]
+            print(
+                f"   !? {switch.get('name', 'Unnamed'):20} | "
+                f"Site: {switch.get('site_name', ''):25} | "
+                f"vc_mac: {vc_mac_display}..."
+            )
+        if len(switches) > 10:
+            print(f"   ... and {len(switches) - 10} more")
+
+    @staticmethod
+    def _print_bulk_summary(successful: int, failed: int, total: int) -> None:
+        """Print summary after bulk conversion."""
+        print("\n  Conversion Summary:")
+        print(f"   Successful conversions: {successful}")
+        print(f"   Failed conversions: {failed}")
+        print(f"   Total switches processed: {total}")
+
+        if successful > 0:
+            print("\n  Note: Successful conversions may take " "a few minutes to complete.")
+            print("   Monitor the devices in the Mist portal " "to confirm the conversion status.")
+
+        logging.info(
+            "Bulk VC conversion completed: %d successful, %d failed",
+            successful,
+            failed,
+        )
+
+    @staticmethod
+    def _export_status_results(
+        all_switches: list[dict[str, Any]],
+        flatten_fields_fn: FlattenFieldsFn,
+        escape_multiline_fn: EscapeMultilineFn,
+        save_data_fn: SaveDataFn,
+        get_csv_path_fn: GetCsvPathFn,
+    ) -> None:
+        """Export conversion status results to CSV."""
+        try:
+            flattened = flatten_fields_fn(all_switches)
+            sanitized = escape_multiline_fn(flattened)
+
+            filename = "VirtualChassisConversionStatus.csv"
+            save_data_fn(sanitized, filename)
+
+            print(f"\n  Results exported to: {filename}")
+            print(f"   Location: {get_csv_path_fn(filename)}")
+            logging.info("Virtual chassis conversion status exported to %s", filename)
+        except Exception as exc:
+            print(f"! Error exporting results: {exc}")
+            logging.error("Error exporting conversion status results: %s", exc)

--- a/tests/unit/test_virtual_chassis.py
+++ b/tests/unit/test_virtual_chassis.py
@@ -1,0 +1,1001 @@
+"""Tests for src.device.virtual_chassis -- VirtualChassisManager.
+
+Covers all static methods: public entry-points (convert_single,
+convert_by_site_list, check_status) and private helpers.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# We need to mock mistapi before importing the module under test because
+# the module uses lazy ``import mistapi`` inside certain methods.
+# ---------------------------------------------------------------------------
+_mock_mistapi = MagicMock()
+with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+    from src.device.virtual_chassis import VirtualChassisManager
+
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+@pytest.fixture(autouse=True)
+def _clean(tmp_path, monkeypatch):
+    """Run every test in a temp dir with a data/ subdirectory."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+
+
+@pytest.fixture()
+def deps():
+    """Return a dict of common mock dependencies."""
+    return {
+        "apisession": MagicMock(),
+        "safe_input_fn": MagicMock(return_value=""),
+        "select_site_fn": MagicMock(return_value="site-1"),
+        "get_csv_path_fn": MagicMock(side_effect=lambda f: os.path.join("data", f)),
+        "create_csv_template_fn": MagicMock(return_value="data/VCConvert.CSV"),
+        "check_and_generate_csv_fn": MagicMock(),
+        "inventory_generator": MagicMock(),
+        "sites_generator": MagicMock(),
+        "flatten_fields_fn": MagicMock(side_effect=lambda x: x),
+        "escape_multiline_fn": MagicMock(side_effect=lambda x: x),
+        "save_data_fn": MagicMock(),
+    }
+
+
+def _write_inventory_csv(path, rows):
+    """Helper: write an OrgInventory.csv at *path*."""
+    fieldnames = ["type", "id", "site_id", "name", "mac", "model", "serial", "vc_mac"]
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            full = {k: "" for k in fieldnames}
+            full.update(row)
+            writer.writerow(full)
+
+
+def _write_site_list_csv(path, rows):
+    """Helper: write a SiteList.csv at *path*."""
+    fieldnames = ["id", "name"]
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _write_vc_csv(path, site_names):
+    """Helper: write a VCConvert.CSV."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        for name in site_names:
+            fh.write(name + "\n")
+
+
+# ===================================================================
+# _resolve_site_ids
+# ===================================================================
+
+
+class TestResolveSiteIds:
+    """Tests for _resolve_site_ids."""
+
+    def test_all_found(self):
+        mapping = {"SiteA": "id-a", "SiteB": "id-b"}
+        ids, missing = VirtualChassisManager._resolve_site_ids(["SiteA", "SiteB"], mapping)
+        assert ids == ["id-a", "id-b"]
+        assert missing == []
+
+    def test_some_missing(self):
+        mapping = {"SiteA": "id-a"}
+        ids, missing = VirtualChassisManager._resolve_site_ids(["SiteA", "SiteX"], mapping)
+        assert ids == ["id-a"]
+        assert missing == ["SiteX"]
+
+    def test_empty_input(self):
+        ids, missing = VirtualChassisManager._resolve_site_ids([], {"A": "1"})
+        assert ids == []
+        assert missing == []
+
+
+# ===================================================================
+# _analyze_conversion_status
+# ===================================================================
+
+
+class TestAnalyzeConversionStatus:
+    """Tests for _analyze_conversion_status."""
+
+    def test_converted(self):
+        switches = [{"vc_mac": "020003aabbcc", "site_id": "s1", "name": "sw1"}]
+        site_map = {"s1": "Site One"}
+        conv, not_conv = VirtualChassisManager._analyze_conversion_status(switches, site_map)
+        assert len(conv) == 1
+        assert conv[0]["conversion_status"] == "CONVERTED"
+        assert conv[0]["site_name"] == "Site One"
+        assert not_conv == []
+
+    def test_not_converted(self):
+        switches = [{"vc_mac": "aabbccddeeff", "site_id": "s2", "name": "sw2"}]
+        site_map = {"s2": "Site Two"}
+        conv, not_conv = VirtualChassisManager._analyze_conversion_status(switches, site_map)
+        assert conv == []
+        assert len(not_conv) == 1
+        assert not_conv[0]["conversion_status"] == "NOT_CONVERTED"
+
+    def test_unknown_site(self):
+        switches = [{"vc_mac": "020003112233", "site_id": "s-unknown"}]
+        conv, _ = VirtualChassisManager._analyze_conversion_status(switches, {})
+        assert conv[0]["site_name"] == "Unknown Site"
+
+    def test_empty(self):
+        conv, not_conv = VirtualChassisManager._analyze_conversion_status([], {})
+        assert conv == []
+        assert not_conv == []
+
+    def test_mixed(self):
+        switches = [
+            {"vc_mac": "020003aabb", "site_id": "s1"},
+            {"vc_mac": "ffeedd112233", "site_id": "s1"},
+        ]
+        conv, not_conv = VirtualChassisManager._analyze_conversion_status(switches, {"s1": "S"})
+        assert len(conv) == 1
+        assert len(not_conv) == 1
+
+
+# ===================================================================
+# _is_target_switch
+# ===================================================================
+
+
+class TestIsTargetSwitch:
+    """Tests for _is_target_switch."""
+
+    def test_valid_target(self):
+        row = {"type": "switch", "site_id": "s1", "id": "dev-1"}
+        assert VirtualChassisManager._is_target_switch(row, ["s1"]) is True
+
+    def test_wrong_type(self):
+        row = {"type": "ap", "site_id": "s1", "id": "dev-1"}
+        assert VirtualChassisManager._is_target_switch(row, ["s1"]) is False
+
+    def test_wrong_site(self):
+        row = {"type": "switch", "site_id": "s2", "id": "dev-1"}
+        assert VirtualChassisManager._is_target_switch(row, ["s1"]) is False
+
+    def test_empty_id(self):
+        row = {"type": "switch", "site_id": "s1", "id": "  "}
+        assert VirtualChassisManager._is_target_switch(row, ["s1"]) is False
+
+    def test_missing_id(self):
+        row = {"type": "switch", "site_id": "s1"}
+        assert VirtualChassisManager._is_target_switch(row, ["s1"]) is False
+
+
+# ===================================================================
+# _reverse_lookup
+# ===================================================================
+
+
+class TestReverseLookup:
+    """Tests for _reverse_lookup."""
+
+    def test_found(self):
+        name_to_id = {"SiteA": "id-a", "SiteB": "id-b"}
+        assert VirtualChassisManager._reverse_lookup("id-b", name_to_id) == "SiteB"
+
+    def test_not_found(self):
+        assert VirtualChassisManager._reverse_lookup("x", {}) == "Unknown Site"
+
+
+# ===================================================================
+# _is_conversion_error
+# ===================================================================
+
+
+class TestIsConversionError:
+    """Tests for _is_conversion_error."""
+
+    def test_http_error(self, capsys):
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.data = "server error"
+        assert VirtualChassisManager._is_conversion_error(resp) is True
+        assert "500" in capsys.readouterr().out
+
+    def test_detail_error(self, capsys):
+        resp = MagicMock(spec=[])
+        resp.data = {"detail": "device not found"}
+        assert VirtualChassisManager._is_conversion_error(resp) is True
+        assert "device not found" in capsys.readouterr().out
+
+    def test_success(self):
+        resp = MagicMock(spec=[])
+        resp.data = {"id": "ok"}
+        assert VirtualChassisManager._is_conversion_error(resp) is False
+
+
+# ===================================================================
+# _preflight_check
+# ===================================================================
+
+
+class TestPreflightCheck:
+    """Tests for _preflight_check."""
+
+    def test_valid_switch(self):
+        switch = {"type": "switch", "id": "dev-1", "name": "sw1"}
+        assert VirtualChassisManager._preflight_check(switch, MagicMock()) is True
+
+    def test_wrong_type(self, capsys):
+        switch = {"type": "ap", "id": "dev-1"}
+        assert VirtualChassisManager._preflight_check(switch, MagicMock()) is False
+        assert "Preflight FAILED" in capsys.readouterr().out
+
+    def test_missing_device_id(self, capsys):
+        switch = {"type": "switch", "id": ""}
+        assert VirtualChassisManager._preflight_check(switch, MagicMock()) is False
+        assert "Preflight FAILED" in capsys.readouterr().out
+
+    def test_already_converted_user_cancels(self):
+        switch = {"type": "switch", "id": "dev-1", "vc_mac": "020003aabb", "name": "s"}
+        safe_fn = MagicMock(return_value="n")
+        assert VirtualChassisManager._preflight_check(switch, safe_fn) is False
+
+    def test_already_converted_user_continues(self):
+        switch = {"type": "switch", "id": "dev-1", "vc_mac": "020003aabb", "name": "s"}
+        safe_fn = MagicMock(return_value="y")
+        assert VirtualChassisManager._preflight_check(switch, safe_fn) is True
+
+
+# ===================================================================
+# _confirm_conversion
+# ===================================================================
+
+
+class TestConfirmConversion:
+    """Tests for _confirm_conversion."""
+
+    def test_confirmed(self):
+        safe_fn = MagicMock(return_value="CONVERT")
+        result = VirtualChassisManager._confirm_conversion({"name": "sw1", "mac": "aa:bb"}, "Site1", "dev-1", safe_fn)
+        assert result is True
+
+    def test_cancelled(self):
+        safe_fn = MagicMock(return_value="no")
+        result = VirtualChassisManager._confirm_conversion({"name": "sw1"}, "Site1", "dev-1", safe_fn)
+        assert result is False
+
+
+# ===================================================================
+# _prompt_switch_selection
+# ===================================================================
+
+
+class TestPromptSwitchSelection:
+    """Tests for _prompt_switch_selection."""
+
+    def test_select_by_index(self):
+        switches = [
+            {"name": "sw-a", "mac": "aa", "model": "EX", "serial": "S1", "id": "d1"},
+            {"name": "sw-b", "mac": "bb", "model": "EX", "serial": "S2", "id": "d2"},
+        ]
+        safe_fn = MagicMock(return_value="1")
+        result = VirtualChassisManager._prompt_switch_selection(switches, "TestSite", safe_fn)
+        assert result is not None
+        assert result["name"] == "sw-b"
+
+    def test_select_by_name(self):
+        switches = [
+            {"name": "sw-a", "mac": "aa", "model": "EX", "serial": "S1", "id": "d1"},
+        ]
+        safe_fn = MagicMock(return_value="sw-a")
+        result = VirtualChassisManager._prompt_switch_selection(switches, "TestSite", safe_fn)
+        assert result is not None
+        assert result["id"] == "d1"
+
+    def test_invalid_selection(self):
+        switches = [
+            {"name": "sw-a", "mac": "aa", "model": "EX", "serial": "S1", "id": "d1"},
+        ]
+        safe_fn = MagicMock(return_value="nonexistent")
+        result = VirtualChassisManager._prompt_switch_selection(switches, "TestSite", safe_fn)
+        assert result is None
+
+
+# ===================================================================
+# _get_site_name
+# ===================================================================
+
+
+class TestGetSiteName:
+    """Tests for _get_site_name."""
+
+    def test_success(self):
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            session = MagicMock()
+            resp = MagicMock()
+            resp.data = {"name": "MySite"}
+            _mock_mistapi.api.v1.sites.getSite.return_value = resp
+            name = VirtualChassisManager._get_site_name(session, "s1")
+            assert name == "MySite"
+
+    def test_exception(self):
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            _mock_mistapi.api.v1.sites.getSite.side_effect = RuntimeError("err")
+            name = VirtualChassisManager._get_site_name(MagicMock(), "s1")
+            assert name == "Unknown Site"
+            _mock_mistapi.api.v1.sites.getSite.side_effect = None
+
+    def test_no_data(self):
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            resp = MagicMock()
+            resp.data = None
+            _mock_mistapi.api.v1.sites.getSite.return_value = resp
+            name = VirtualChassisManager._get_site_name(MagicMock(), "s1")
+            assert name == "Unknown Site"
+
+
+# ===================================================================
+# _load_site_switches
+# ===================================================================
+
+
+class TestLoadSiteSwitches:
+    """Tests for _load_site_switches."""
+
+    def test_filters_by_site_and_type(self, tmp_path):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(
+            inv_path,
+            [
+                {"type": "switch", "id": "d1", "site_id": "s1", "name": "sw1"},
+                {"type": "ap", "id": "d2", "site_id": "s1", "name": "ap1"},
+                {"type": "switch", "id": "d3", "site_id": "s2", "name": "sw2"},
+                {"type": "switch", "id": "", "site_id": "s1", "name": "sw3"},
+            ],
+        )
+        get_fn = MagicMock(return_value=inv_path)
+        check_fn = MagicMock()
+        result = VirtualChassisManager._load_site_switches("s1", get_fn, check_fn, MagicMock())
+        assert len(result) == 1
+        assert result[0]["name"] == "sw1"
+
+
+# ===================================================================
+# _load_site_names_from_csv
+# ===================================================================
+
+
+class TestLoadSiteNamesFromCsv:
+    """Tests for _load_site_names_from_csv."""
+
+    def test_reads_names(self, tmp_path):
+        csv_path = str(tmp_path / "data" / "VCConvert.CSV")
+        _write_vc_csv(csv_path, ["SiteA", "SiteB"])
+        get_fn = MagicMock(return_value=csv_path)
+        result = VirtualChassisManager._load_site_names_from_csv(get_fn, MagicMock(), MagicMock())
+        assert result == ["SiteA", "SiteB"]
+
+    def test_missing_file(self, tmp_path):
+        csv_path = str(tmp_path / "data" / "VCConvert.CSV")
+        get_fn = MagicMock(return_value=csv_path)
+        safe_fn = MagicMock(return_value="n")
+        result = VirtualChassisManager._load_site_names_from_csv(get_fn, MagicMock(), safe_fn)
+        assert result == []
+
+    def test_missing_file_creates_template(self, tmp_path):
+        csv_path = str(tmp_path / "data" / "VCConvert.CSV")
+        get_fn = MagicMock(return_value=csv_path)
+        safe_fn = MagicMock(return_value="y")
+        create_fn = MagicMock(return_value=csv_path)
+        result = VirtualChassisManager._load_site_names_from_csv(get_fn, create_fn, safe_fn)
+        assert result == []
+        create_fn.assert_called_once_with("VCConvert.CSV")
+
+    def test_empty_lines_skipped(self, tmp_path):
+        csv_path = str(tmp_path / "data" / "VCConvert.CSV")
+        _write_vc_csv(csv_path, ["SiteA", "", "  ", "SiteB"])
+        get_fn = MagicMock(return_value=csv_path)
+        result = VirtualChassisManager._load_site_names_from_csv(get_fn, MagicMock(), MagicMock())
+        assert result == ["SiteA", "SiteB"]
+
+
+# ===================================================================
+# _load_site_name_mapping
+# ===================================================================
+
+
+class TestLoadSiteNameMapping:
+    """Tests for _load_site_name_mapping."""
+
+    def test_reads_mapping(self, tmp_path):
+        csv_path = str(tmp_path / "data" / "SiteList.csv")
+        _write_site_list_csv(csv_path, [{"id": "id-a", "name": "SiteA"}])
+        get_fn = MagicMock(return_value=csv_path)
+        result = VirtualChassisManager._load_site_name_mapping(get_fn)
+        assert result == {"SiteA": "id-a"}
+
+    def test_file_error(self, tmp_path):
+        get_fn = MagicMock(return_value=str(tmp_path / "nope.csv"))
+        result = VirtualChassisManager._load_site_name_mapping(get_fn)
+        assert result == {}
+
+
+# ===================================================================
+# _load_switches_for_sites
+# ===================================================================
+
+
+class TestLoadSwitchesForSites:
+    """Tests for _load_switches_for_sites."""
+
+    def test_loads_target_switches(self, tmp_path):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(
+            inv_path,
+            [
+                {"type": "switch", "id": "d1", "site_id": "s1", "name": "sw1"},
+                {"type": "switch", "id": "d2", "site_id": "s2", "name": "sw2"},
+            ],
+        )
+        get_fn = MagicMock(return_value=inv_path)
+        name_map = {"SiteA": "s1", "SiteB": "s2"}
+        result = VirtualChassisManager._load_switches_for_sites(["s1"], name_map, get_fn)
+        assert len(result) == 1
+        assert result[0]["site_name"] == "SiteA"
+
+    def test_file_error(self, tmp_path):
+        get_fn = MagicMock(return_value=str(tmp_path / "nope.csv"))
+        result = VirtualChassisManager._load_switches_for_sites(["s1"], {}, get_fn)
+        assert result == []
+
+
+# ===================================================================
+# _load_vc_switches
+# ===================================================================
+
+
+class TestLoadVcSwitches:
+    """Tests for _load_vc_switches."""
+
+    def test_filters_by_vc_mac(self, tmp_path):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(
+            inv_path,
+            [
+                {"type": "switch", "vc_mac": "020003aa", "name": "sw1"},
+                {"type": "switch", "vc_mac": "", "name": "sw2"},
+                {"type": "ap", "vc_mac": "020003bb", "name": "ap1"},
+            ],
+        )
+        get_fn = MagicMock(return_value=inv_path)
+        result = VirtualChassisManager._load_vc_switches(get_fn)
+        assert len(result) == 1
+        assert result[0]["name"] == "sw1"
+
+    def test_file_error(self, tmp_path):
+        get_fn = MagicMock(return_value=str(tmp_path / "nope.csv"))
+        result = VirtualChassisManager._load_vc_switches(get_fn)
+        assert result == []
+
+
+# ===================================================================
+# _load_site_id_mapping
+# ===================================================================
+
+
+class TestLoadSiteIdMapping:
+    """Tests for _load_site_id_mapping."""
+
+    def test_reads_mapping(self, tmp_path):
+        csv_path = str(tmp_path / "data" / "SiteList.csv")
+        _write_site_list_csv(csv_path, [{"id": "id-a", "name": "SiteA"}])
+        get_fn = MagicMock(return_value=csv_path)
+        check_fn = MagicMock()
+        result = VirtualChassisManager._load_site_id_mapping(get_fn, check_fn, MagicMock())
+        assert result == {"id-a": "SiteA"}
+
+    def test_exception(self, tmp_path):
+        get_fn = MagicMock(return_value=str(tmp_path / "nope.csv"))
+        result = VirtualChassisManager._load_site_id_mapping(get_fn, MagicMock(), MagicMock())
+        assert result == {}
+
+
+# ===================================================================
+# Display helpers (smoke tests -- verify no exceptions)
+# ===================================================================
+
+
+class TestDisplayHelpers:
+    """Smoke tests for display/print helpers."""
+
+    def test_print_dry_run(self, capsys):
+        VirtualChassisManager._print_dry_run({"name": "sw1", "mac": "aa:bb"}, "Site1", "dev-1", "s1")
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "sw1" in out
+
+    def test_display_switches_for_conversion(self, capsys):
+        switches = [
+            {
+                "site_name": "S",
+                "name": "sw",
+                "mac": "aa",
+                "model": "EX",
+                "serial": "123",
+            }
+        ]
+        VirtualChassisManager._display_switches_for_conversion(switches)
+        out = capsys.readouterr().out
+        assert "1" in out
+
+    def test_display_status_summary_empty(self, capsys):
+        VirtualChassisManager._display_status_summary([], [])
+        out = capsys.readouterr().out
+        assert "Total virtual chassis switches: 0" in out
+
+    def test_display_status_summary_with_data(self, capsys):
+        conv = [{"name": "sw1", "site_name": "S1", "vc_mac": "020003aabb"}]
+        not_conv = [{"name": "sw2", "site_name": "S2", "vc_mac": "ffeeddccbb"}]
+        VirtualChassisManager._display_status_summary(conv, not_conv)
+        out = capsys.readouterr().out
+        assert "Converted to virtual MAC: 1" in out
+        assert "Not converted: 1" in out
+
+    def test_print_bulk_summary(self, capsys):
+        VirtualChassisManager._print_bulk_summary(3, 1, 4)
+        out = capsys.readouterr().out
+        assert "Successful conversions: 3" in out
+        assert "Failed conversions: 1" in out
+
+    def test_print_status_list_truncates(self, capsys):
+        switches = [{"name": f"sw{i}", "site_name": "S", "vc_mac": "aabb"} for i in range(15)]
+        VirtualChassisManager._print_status_list(switches, "Test", "desc")
+        out = capsys.readouterr().out
+        assert "... and 5 more" in out
+
+    def test_print_status_list_empty(self, capsys):
+        VirtualChassisManager._print_status_list([], "Test", "desc")
+        assert capsys.readouterr().out == ""
+
+
+# ===================================================================
+# _export_status_results
+# ===================================================================
+
+
+class TestExportStatusResults:
+    """Tests for _export_status_results."""
+
+    def test_success(self):
+        flatten_fn = MagicMock(side_effect=lambda x: x)
+        escape_fn = MagicMock(side_effect=lambda x: x)
+        save_fn = MagicMock()
+        get_fn = MagicMock(return_value="data/out.csv")
+        data = [{"name": "sw1"}]
+        VirtualChassisManager._export_status_results(data, flatten_fn, escape_fn, save_fn, get_fn)
+        save_fn.assert_called_once()
+
+    def test_exception(self, capsys):
+        flatten_fn = MagicMock(side_effect=RuntimeError("boom"))
+        VirtualChassisManager._export_status_results([], flatten_fn, MagicMock(), MagicMock(), MagicMock())
+        assert "Error exporting" in capsys.readouterr().out
+
+
+# ===================================================================
+# _handle_conversion_response
+# ===================================================================
+
+
+class TestHandleConversionResponse:
+    """Tests for _handle_conversion_response."""
+
+    def test_http_error(self, capsys):
+        resp = MagicMock()
+        resp.status_code = 403
+        resp.data = "forbidden"
+        VirtualChassisManager._handle_conversion_response(resp, "d1", "s1", "Site1", "sw1")
+        assert "403" in capsys.readouterr().out
+
+    def test_detail_error(self, capsys):
+        resp = MagicMock(spec=[])
+        resp.data = {"detail": "bad device"}
+        VirtualChassisManager._handle_conversion_response(resp, "d1", "s1", "Site1", "sw1")
+        assert "bad device" in capsys.readouterr().out
+
+    def test_success(self, capsys):
+        resp = MagicMock(spec=[])
+        resp.data = {"ok": True}
+        VirtualChassisManager._handle_conversion_response(resp, "d1", "s1", "Site1", "sw1")
+        out = capsys.readouterr().out
+        assert "successfully" in out
+
+
+# ===================================================================
+# _execute_conversion
+# ===================================================================
+
+
+class TestExecuteConversion:
+    """Tests for _execute_conversion."""
+
+    def test_calls_api(self):
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            session = MagicMock()
+            resp = MagicMock(spec=[])
+            resp.data = {"ok": True}
+            _mock_mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac.return_value = resp
+            VirtualChassisManager._execute_conversion(session, "s1", "d1", "sw1", "Site1")
+            _mock_mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac.assert_called_once()
+
+    def test_exception(self, capsys):
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            _mock_mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac.side_effect = RuntimeError("fail")
+            VirtualChassisManager._execute_conversion(MagicMock(), "s1", "d1", "sw1", "Site1")
+            assert "Failed" in capsys.readouterr().out
+            _mock_mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac.side_effect = None
+
+
+# ===================================================================
+# _execute_bulk_conversion
+# ===================================================================
+
+
+class TestExecuteBulkConversion:
+    """Tests for _execute_bulk_conversion."""
+
+    def test_mixed_results(self, capsys):
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            ok_resp = MagicMock(spec=[])
+            ok_resp.data = {"ok": True}
+            fail_resp = MagicMock()
+            fail_resp.status_code = 500
+            fail_resp.data = "err"
+            _mock_mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac.side_effect = [
+                ok_resp,
+                fail_resp,
+            ]
+            switches = [
+                {"site_id": "s1", "id": "d1", "name": "sw1", "site_name": "S1"},
+                {"site_id": "s2", "id": "d2", "name": "sw2", "site_name": "S2"},
+            ]
+            VirtualChassisManager._execute_bulk_conversion(MagicMock(), switches)
+            out = capsys.readouterr().out
+            assert "Successful conversions: 1" in out
+            assert "Failed conversions: 1" in out
+            _mock_mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac.side_effect = None
+
+    def test_exception_during_conversion(self, capsys):
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            _mock_mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac.side_effect = RuntimeError("boom")
+            switches = [
+                {"site_id": "s1", "id": "d1", "name": "sw1", "site_name": "S1"},
+            ]
+            VirtualChassisManager._execute_bulk_conversion(MagicMock(), switches)
+            out = capsys.readouterr().out
+            assert "Exception" in out
+            _mock_mistapi.api.v1.sites.devices.convertSiteVirtualChassisToVirtualMac.side_effect = None
+
+
+# ===================================================================
+# convert_single (integration-style)
+# ===================================================================
+
+
+class TestConvertSingle:
+    """Tests for the convert_single public entry-point."""
+
+    def test_no_site_selected(self, deps, capsys):
+        deps["select_site_fn"].return_value = None
+        VirtualChassisManager.convert_single(
+            apisession=deps["apisession"],
+            select_site_fn=deps["select_site_fn"],
+            safe_input_fn=deps["safe_input_fn"],
+            get_csv_path_fn=deps["get_csv_path_fn"],
+            check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+            inventory_generator=deps["inventory_generator"],
+        )
+        assert "No site selected" in capsys.readouterr().out
+
+    def test_no_switches_found(self, deps, tmp_path, capsys):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(inv_path, [])
+        deps["get_csv_path_fn"].side_effect = lambda f: inv_path
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            resp = MagicMock()
+            resp.data = {"name": "TestSite"}
+            _mock_mistapi.api.v1.sites.getSite.return_value = resp
+            VirtualChassisManager.convert_single(
+                apisession=deps["apisession"],
+                select_site_fn=deps["select_site_fn"],
+                safe_input_fn=deps["safe_input_fn"],
+                get_csv_path_fn=deps["get_csv_path_fn"],
+                check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+                inventory_generator=deps["inventory_generator"],
+            )
+        assert "No virtual chassis switches" in capsys.readouterr().out
+
+    def test_dry_run(self, deps, tmp_path, capsys):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(
+            inv_path,
+            [{"type": "switch", "id": "d1", "site_id": "site-1", "name": "sw1"}],
+        )
+        deps["get_csv_path_fn"].side_effect = lambda f: inv_path
+        deps["safe_input_fn"].return_value = "0"
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            resp = MagicMock()
+            resp.data = {"name": "TestSite"}
+            _mock_mistapi.api.v1.sites.getSite.return_value = resp
+            VirtualChassisManager.convert_single(
+                apisession=deps["apisession"],
+                select_site_fn=deps["select_site_fn"],
+                safe_input_fn=deps["safe_input_fn"],
+                get_csv_path_fn=deps["get_csv_path_fn"],
+                check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+                inventory_generator=deps["inventory_generator"],
+                dry_run=True,
+            )
+        assert "DRY RUN" in capsys.readouterr().out
+
+    def test_user_cancels_conversion(self, deps, tmp_path, capsys):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(
+            inv_path,
+            [{"type": "switch", "id": "d1", "site_id": "site-1", "name": "sw1"}],
+        )
+        deps["get_csv_path_fn"].side_effect = lambda f: inv_path
+        # First call selects switch "0", second call cancels "NOPE"
+        deps["safe_input_fn"].side_effect = ["0", "NOPE"]
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            resp = MagicMock()
+            resp.data = {"name": "TestSite"}
+            _mock_mistapi.api.v1.sites.getSite.return_value = resp
+            VirtualChassisManager.convert_single(
+                apisession=deps["apisession"],
+                select_site_fn=deps["select_site_fn"],
+                safe_input_fn=deps["safe_input_fn"],
+                get_csv_path_fn=deps["get_csv_path_fn"],
+                check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+                inventory_generator=deps["inventory_generator"],
+            )
+        assert "cancelled" in capsys.readouterr().out
+
+    def test_no_switch_selected(self, deps, tmp_path, capsys):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(
+            inv_path,
+            [{"type": "switch", "id": "d1", "site_id": "site-1", "name": "sw1"}],
+        )
+        deps["get_csv_path_fn"].side_effect = lambda f: inv_path
+        deps["safe_input_fn"].return_value = "nonexistent"
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            resp = MagicMock()
+            resp.data = {"name": "TestSite"}
+            _mock_mistapi.api.v1.sites.getSite.return_value = resp
+            VirtualChassisManager.convert_single(
+                apisession=deps["apisession"],
+                select_site_fn=deps["select_site_fn"],
+                safe_input_fn=deps["safe_input_fn"],
+                get_csv_path_fn=deps["get_csv_path_fn"],
+                check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+                inventory_generator=deps["inventory_generator"],
+            )
+        # Should return silently with no crash
+        out = capsys.readouterr().out
+        assert "DESTRUCTIVE" in out
+
+    def test_missing_device_id(self, deps, tmp_path, capsys):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        # Write a switch with a non-empty id so it passes the filter,
+        # but we'll mock the selection to return one without id
+        _write_inventory_csv(
+            inv_path,
+            [{"type": "switch", "id": "d1", "site_id": "site-1", "name": "sw1"}],
+        )
+        deps["get_csv_path_fn"].side_effect = lambda f: inv_path
+        deps["safe_input_fn"].return_value = "0"
+        with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
+            resp = MagicMock()
+            resp.data = {"name": "TestSite"}
+            _mock_mistapi.api.v1.sites.getSite.return_value = resp
+            # Patch _prompt_switch_selection to return a switch with empty id
+            with patch.object(
+                VirtualChassisManager,
+                "_prompt_switch_selection",
+                return_value={"name": "sw1", "id": ""},
+            ):
+                VirtualChassisManager.convert_single(
+                    apisession=deps["apisession"],
+                    select_site_fn=deps["select_site_fn"],
+                    safe_input_fn=deps["safe_input_fn"],
+                    get_csv_path_fn=deps["get_csv_path_fn"],
+                    check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+                    inventory_generator=deps["inventory_generator"],
+                )
+        assert "Missing device_id" in capsys.readouterr().out
+
+
+# ===================================================================
+# convert_by_site_list (integration-style)
+# ===================================================================
+
+
+class TestConvertBySiteList:
+    """Tests for the convert_by_site_list public entry-point."""
+
+    def test_no_sites_in_csv(self, deps, tmp_path):
+        csv_path = str(tmp_path / "data" / "VCConvert.CSV")
+        _write_vc_csv(csv_path, [])
+        deps["get_csv_path_fn"].side_effect = lambda f: str(tmp_path / "data" / f)
+        VirtualChassisManager.convert_by_site_list(
+            apisession=deps["apisession"],
+            safe_input_fn=deps["safe_input_fn"],
+            get_csv_path_fn=deps["get_csv_path_fn"],
+            create_csv_template_fn=deps["create_csv_template_fn"],
+            check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+            inventory_generator=deps["inventory_generator"],
+            sites_generator=deps["sites_generator"],
+        )
+        # Empty CSV returns empty list, function returns early before printing
+        deps["check_and_generate_csv_fn"].assert_not_called()
+
+    def test_no_valid_sites(self, deps, tmp_path, capsys):
+        csv_path = str(tmp_path / "data" / "VCConvert.CSV")
+        _write_vc_csv(csv_path, ["NonexistentSite"])
+        site_list_path = str(tmp_path / "data" / "SiteList.csv")
+        _write_site_list_csv(site_list_path, [{"id": "s1", "name": "RealSite"}])
+
+        def path_fn(f):
+            return str(tmp_path / "data" / f)
+
+        deps["get_csv_path_fn"].side_effect = path_fn
+        VirtualChassisManager.convert_by_site_list(
+            apisession=deps["apisession"],
+            safe_input_fn=deps["safe_input_fn"],
+            get_csv_path_fn=deps["get_csv_path_fn"],
+            create_csv_template_fn=deps["create_csv_template_fn"],
+            check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+            inventory_generator=deps["inventory_generator"],
+            sites_generator=deps["sites_generator"],
+        )
+        out = capsys.readouterr().out
+        assert "No valid sites found" in out
+
+    def test_user_cancels(self, deps, tmp_path, capsys):
+        csv_path = str(tmp_path / "data" / "VCConvert.CSV")
+        _write_vc_csv(csv_path, ["SiteA"])
+        site_list_path = str(tmp_path / "data" / "SiteList.csv")
+        _write_site_list_csv(site_list_path, [{"id": "s1", "name": "SiteA"}])
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(
+            inv_path,
+            [{"type": "switch", "id": "d1", "site_id": "s1", "name": "sw1"}],
+        )
+
+        def path_fn(f):
+            return str(tmp_path / "data" / f)
+
+        deps["get_csv_path_fn"].side_effect = path_fn
+        deps["safe_input_fn"].return_value = "no"
+        VirtualChassisManager.convert_by_site_list(
+            apisession=deps["apisession"],
+            safe_input_fn=deps["safe_input_fn"],
+            get_csv_path_fn=deps["get_csv_path_fn"],
+            create_csv_template_fn=deps["create_csv_template_fn"],
+            check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+            inventory_generator=deps["inventory_generator"],
+            sites_generator=deps["sites_generator"],
+        )
+        out = capsys.readouterr().out
+        assert "cancelled" in out
+
+
+# ===================================================================
+# check_status (integration-style)
+# ===================================================================
+
+
+class TestCheckStatus:
+    """Tests for the check_status public entry-point."""
+
+    def test_no_vc_switches(self, deps, tmp_path, capsys):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(inv_path, [{"type": "ap", "vc_mac": ""}])
+
+        def path_fn(f):
+            return str(tmp_path / "data" / f)
+
+        deps["get_csv_path_fn"].side_effect = path_fn
+        VirtualChassisManager.check_status(
+            get_csv_path_fn=deps["get_csv_path_fn"],
+            check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+            inventory_generator=deps["inventory_generator"],
+            sites_generator=deps["sites_generator"],
+            flatten_fields_fn=deps["flatten_fields_fn"],
+            escape_multiline_fn=deps["escape_multiline_fn"],
+            save_data_fn=deps["save_data_fn"],
+        )
+        out = capsys.readouterr().out
+        assert "No switches with vc_mac" in out
+
+    def test_with_vc_switches(self, deps, tmp_path, capsys):
+        inv_path = str(tmp_path / "data" / "OrgInventory.csv")
+        _write_inventory_csv(
+            inv_path,
+            [
+                {
+                    "type": "switch",
+                    "vc_mac": "020003aabbcc",
+                    "site_id": "s1",
+                    "name": "sw1",
+                },
+                {
+                    "type": "switch",
+                    "vc_mac": "ffeeddaabbcc",
+                    "site_id": "s1",
+                    "name": "sw2",
+                },
+            ],
+        )
+        site_path = str(tmp_path / "data" / "SiteList.csv")
+        _write_site_list_csv(site_path, [{"id": "s1", "name": "SiteA"}])
+
+        def path_fn(f):
+            return str(tmp_path / "data" / f)
+
+        deps["get_csv_path_fn"].side_effect = path_fn
+        VirtualChassisManager.check_status(
+            get_csv_path_fn=deps["get_csv_path_fn"],
+            check_and_generate_csv_fn=deps["check_and_generate_csv_fn"],
+            inventory_generator=deps["inventory_generator"],
+            sites_generator=deps["sites_generator"],
+            flatten_fields_fn=deps["flatten_fields_fn"],
+            escape_multiline_fn=deps["escape_multiline_fn"],
+            save_data_fn=deps["save_data_fn"],
+        )
+        out = capsys.readouterr().out
+        assert "Converted to virtual MAC: 1" in out
+        assert "Not converted: 1" in out
+        deps["save_data_fn"].assert_called_once()
+
+
+# ===================================================================
+# _handle_missing_csv
+# ===================================================================
+
+
+class TestHandleMissingCsv:
+    """Tests for _handle_missing_csv."""
+
+    def test_user_declines(self, capsys):
+        safe_fn = MagicMock(return_value="n")
+        create_fn = MagicMock()
+        VirtualChassisManager._handle_missing_csv("path.csv", create_fn, safe_fn)
+        create_fn.assert_not_called()
+        assert "not found" in capsys.readouterr().out
+
+    def test_user_accepts(self, capsys):
+        safe_fn = MagicMock(return_value="y")
+        create_fn = MagicMock(return_value="/data/VCConvert.CSV")
+        VirtualChassisManager._handle_missing_csv("path.csv", create_fn, safe_fn)
+        create_fn.assert_called_once_with("VCConvert.CSV")
+
+    def test_create_fails(self, capsys):
+        safe_fn = MagicMock(return_value="yes")
+        create_fn = MagicMock(side_effect=OSError("denied"))
+        VirtualChassisManager._handle_missing_csv("path.csv", create_fn, safe_fn)
+        assert "Failed to create" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Extract VirtualChassisManager class (~558 lines) from MistHelper.py into a standalone module at src/device/virtual_chassis.py. The original class is replaced with a thin delegation stub that wires MistHelper globals via dependency injection.

## Changes

- **src/device/virtual_chassis.py**: Extracted module with 3 public static methods (convert_single, convert_by_site_list, check_status) and all private helpers
- **src/device/__init__.py**: Package init
- **tests/unit/test_virtual_chassis.py**: 74 unit tests, 97% coverage
- **MistHelper.py**: Original ~558-line class replaced with ~65-line delegation stub

## Design

- All dependencies injected as explicit parameters (no globals in extracted module)
- Lazy \import mistapi\ inside methods that call the API
- Menu dispatch (operations 92-94) unchanged - stub methods are API-compatible

Closes #213