### PR TITLE
fix(ci): install requirements.txt in container-build test job

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -9,6 +9,7 @@ on:
       - 'Containerfile'
       - 'Dockerfile'
       - '__init__.py'
+      - 'src/**'
       - 'web_portal/**'
       - 'tests/**'
   workflow_dispatch:
@@ -84,6 +85,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install pytest hypothesis
 
       - name: Run unit tests


### PR DESCRIPTION
The test step only installed pytest+hypothesis but not requirements.txt, causing \ModuleNotFoundError: No module named 'mistapi'\ when conftest.py loads MistHelper.py.

Also adds \src/**\ to path triggers so extracted modules trigger container rebuilds.

Closes #246