### PR TITLE
feat(MistHelper.py): mistapi 0.57.2->0.62.0 alignment -- fix breaks, add new endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to MistHelper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
+## [26.05.07.16.34] - 2026-05-07
+
+### Fixed
+
+- FR-001: Renamed `searchOrgBgpPeers` → `searchOrgBgpStats` (mistapi 0.62.0 function rename; line ~16191)
+- FR-002: Renamed `searchOrgTunnels` → `searchOrgTunnelsStats` (mistapi 0.62.0 function rename; line ~16198)
+- FR-003: Renamed `listOrgSitesStats` → `listOrgSiteStats` (mistapi 0.62.0 function rename; line ~16205)
+- All three were confirmed `AttributeError` runtime crashes. No such function names exist in mistapi 0.62.0.
+
+### Security
+
+- FR-004: Attached `LogSanitizer` (mistapi `__logger`) to root logger at startup. Automatically redacts API tokens, passwords, and sensitive field values from all log output. Wrapped in `try/except ImportError` for backward compatibility with pre-0.59.3 mistapi.
+
+### Added
+
+- FR-005: Updated `requirements.txt` to `mistapi>=0.62.0` (was `>=0.61.4`)
+- FR-006: New menu 166 — Export E911 Report (`getOrgE911Report`): exports organization E911 data to CSV
+- FR-007: New menu 167 — Export JSI PBN Data (`searchOrgJsiPbn`): exports JSI Product Bulletin Notifications
+- FR-008: New menu 168 — Export JSI SIRT Advisories (`searchOrgJsiSirt`): exports JSI Security Incident Response Team advisories
+- FR-009: New menu 169 — Export Org OSPF Stats (`searchOrgOspfStats`): org-level OSPF adjacency statistics
+- New menu 170 — Export Site OSPF Stats (`searchSiteOspfStats`): site-level OSPF adjacency statistics
+- FR-010: New menu 171 — Export MxEdge Upgrade Status (`listSiteMxEdgeUpgrades`): site-level MxEdge firmware upgrade records
+- FR-011: New menu 172 — Export Auto-Map Assignment Status (`getSiteAutoMapAssignmentStatus`): site auto-map assignment state
+- Added `ENDPOINT_PRIMARY_KEY_STRATEGIES` entries for all 5 new API endpoints: `getOrgE911Report`, `listSiteMxEdgeUpgrades`, `getSiteAutoMapAssignmentStatus` (new); `searchOrgOspfStats`, `searchSiteOspfStats` (already present, verified)
+
 ## [26.04.26.01.53] - 2026-04-26
 
 ### Added

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -205,6 +205,14 @@ logging.basicConfig(
     force=True,
 )
 
+# Attach LogSanitizer to redact sensitive fields (API tokens, passwords, MACs) from logs
+try:
+    from mistapi.__logger import LogSanitizer
+
+    logging.getLogger().addFilter(LogSanitizer())
+except ImportError:
+    pass  # mistapi pre-0.59.3 does not have LogSanitizer; safe to skip
+
 # Log Python version warning if below minimum requirement
 if sys.version_info < MINIMUM_PYTHON_VERSION:
     version_str = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
@@ -5337,6 +5345,27 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "indexes": [],  # Will be determined at runtime based on available fields
         "unique_constraints": [],  # Will be applied if 'id' field exists in data
         "description": "Fallback strategy with auto-increment primary key and unique constraint on API id",
+    },
+    "getOrgE911Report": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["org_id"],
+        "unique_constraints": [],
+        "description": "E911 report data for the organization",
+    },
+    "listSiteMxEdgeUpgrades": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "status"],
+        "unique_constraints": [],
+        "description": "MxEdge upgrade status records for a site",
+    },
+    "getSiteAutoMapAssignmentStatus": {
+        "type": "auto_increment_with_unique",
+        "primary_key": ["misthelper_internal_id"],
+        "indexes": ["site_id"],
+        "unique_constraints": [],
+        "description": "Auto-map assignment status for a site",
     },
 }
 
@@ -16182,21 +16211,21 @@ class OrgExportUtils:
     def _bgp_peers():  # type: ignore[no-untyped-def]
         """Export BGP peer data to OrgBgpPeers.csv."""
         OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
-            api_call=mistapi.api.v1.orgs.stats.searchOrgBgpPeers, data_type="bgp peers", sort_key="peer_ip"
+            api_call=mistapi.api.v1.orgs.stats.searchOrgBgpStats, data_type="bgp peers", sort_key="peer_ip"
         )
 
     @staticmethod
     def _tunnel_stats():  # type: ignore[no-untyped-def]
         """Export tunnel statistics to OrgTunnelStats.csv."""
         OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
-            api_call=mistapi.api.v1.orgs.stats.searchOrgTunnels, data_type="tunnel stats", sort_key="name"
+            api_call=mistapi.api.v1.orgs.stats.searchOrgTunnelsStats, data_type="tunnel stats", sort_key="name"
         )
 
     @staticmethod
     def _site_stats():  # type: ignore[no-untyped-def]
         """Export site statistics to OrgSiteStats.csv."""
         OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
-            api_call=mistapi.api.v1.orgs.stats.listOrgSitesStats, data_type="site stats", sort_key="name"
+            api_call=mistapi.api.v1.orgs.stats.listOrgSiteStats, data_type="site stats", sort_key="name"
         )
 
     @staticmethod
@@ -16204,6 +16233,42 @@ class OrgExportUtils:
         """Export MX Edge statistics to OrgMxedgeStats.csv."""
         OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
             api_call=mistapi.api.v1.orgs.stats.listOrgMxEdgesStats, data_type="mx edge stats", sort_key="name"
+        )
+
+    @staticmethod
+    def e911_report():  # type: ignore[no-untyped-def]
+        """Export E911 report for the organization to OrgE911Report.csv."""
+        OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.orgs.exports.getOrgE911Report,
+            data_type="e911 report",
+            sort_key="name",
+        )
+
+    @staticmethod
+    def jsi_pbn():  # type: ignore[no-untyped-def]
+        """Export JSI PBN (Product Bulletin Notifications) data to OrgJsiPbn.csv."""
+        OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.orgs.jsi.searchOrgJsiPbn,
+            data_type="jsi pbn",
+            sort_key="id",
+        )
+
+    @staticmethod
+    def jsi_sirt():  # type: ignore[no-untyped-def]
+        """Export JSI SIRT (Security Incident Response Team) advisories to OrgJsiSirt.csv."""
+        OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.orgs.jsi.searchOrgJsiSirt,
+            data_type="jsi sirt",
+            sort_key="id",
+        )
+
+    @staticmethod
+    def ospf_stats():  # type: ignore[no-untyped-def]
+        """Export OSPF adjacency statistics for the organization to OrgOspfStats.csv."""
+        OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.orgs.stats.searchOrgOspfStats,
+            data_type="ospf stats",
+            sort_key="mac",
         )
 
     @staticmethod
@@ -17834,6 +17899,33 @@ class SiteExportUtils:
             data_type="fast roam events",
             sort_key="timestamp",
             duration=f"{hours}h",
+        )
+
+    @staticmethod
+    def ospf_stats():  # type: ignore[no-untyped-def]
+        """Export OSPF adjacency statistics for a selected site to SiteOspfStats.csv."""
+        SiteExportUtils._export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.sites.stats.searchSiteOspfStats,
+            data_type="ospf stats",
+            sort_key="mac",
+        )
+
+    @staticmethod
+    def mxedge_upgrade_status():  # type: ignore[no-untyped-def]
+        """Export MxEdge upgrade status for a selected site to SiteMxEdgeUpgrades.csv."""
+        SiteExportUtils._export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.sites.mxedges.listSiteMxEdgeUpgrades,
+            data_type="mxedge upgrade status",
+            sort_key="id",
+        )
+
+    @staticmethod
+    def auto_map_assignment_status():  # type: ignore[no-untyped-def]
+        """Export auto-map assignment status for a selected site to SiteAutoMapAssignmentStatus.csv."""
+        SiteExportUtils._export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.sites.auto_map_assignment.getSiteAutoMapAssignmentStatus,
+            data_type="auto map assignment status",
+            sort_key="id",
         )
 
 
@@ -35284,6 +35376,16 @@ menu_actions = {
         ),
         "Bulk Org Data Collection (populate ArangoDB/Redis/SQLite with all org-level APIs)",
     ),
+    # ==============================
+    # MISTAPI 0.62.0 NEW ENDPOINTS
+    # ==============================
+    "166": (OrgExportUtils.e911_report, "Export E911 report for the organization"),
+    "167": (OrgExportUtils.jsi_pbn, "Export JSI PBN (Product Bulletin Notifications) data"),
+    "168": (OrgExportUtils.jsi_sirt, "Export JSI SIRT (Security Incident Response) advisories"),
+    "169": (OrgExportUtils.ospf_stats, "Export OSPF adjacency statistics for the organization"),
+    "170": (SiteExportUtils.ospf_stats, "Export OSPF adjacency statistics for a selected site"),
+    "171": (SiteExportUtils.mxedge_upgrade_status, "Export MxEdge upgrade status for a selected site"),
+    "172": (SiteExportUtils.auto_map_assignment_status, "Export auto-map assignment status for a selected site"),
 }
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Network Operations & Data Export Tool for Juniper Mist Cloud
 [![Quality Gates](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml)
 [![Container Build](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml)
 
-**Operation Count:** The code currently defines 166 actionable menu entries (0-165) with some gaps for future expansion.
+**Operation Count:** The code currently defines 173 actionable menu entries (0-165) with some gaps for future expansion.
 
 MistHelper is a production-focused Python application that streamlines large-scale Juniper Mist Cloud data extraction, enrichment, transformation, and limited lifecycle operations. It supports both interactive (menu) and fully automated CLI execution, with flexible output to CSV files, a local SQLite database, or a polyglot backend (ArangoDB for documents, Redis for time-series and JSON caching) using natural/composite business keys (no artificial surrogate IDs for core entities). The codebase emphasizes safety, transparency, and predictable behavior-aligned with the included internal Agents Guide and NASA/JPL style defensive programming practices.
 
@@ -104,7 +104,7 @@ flowchart LR
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 mindmap
-  root((MistHelper<br/>166 Operations))
+  root((MistHelper<br/>173 Operations))
     Safe (51)
       Org Sites
       Device Inventory

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Requires Python 3.13 or newer
 
 # Core API and networking
-mistapi>=0.61.4
+mistapi>=0.62.0
 requests
 websocket-client>=1.8.0
 urllib3


### PR DESCRIPTION
Closes #260

## Summary
Full alignment with mistapi 0.62.0 based on complete code audit.

### Fixed -- P0 Runtime Breaks (AttributeError crashes)
- searchOrgBgpPeers -> searchOrgBgpStats
- searchOrgTunnels -> searchOrgTunnelsStats
- listOrgSitesStats -> listOrgSiteStats

### Security
- LogSanitizer attached to root logger

### Added -- New Export Menus 166-172
- 166: E911 Report
- 167: JSI PBN
- 168: JSI SIRT
- 169: Org OSPF Stats
- 170: Site OSPF Stats
- 171: MxEdge Upgrade Status (site)
- 172: Auto-Map Assignment Status (site)

- requirements.txt updated to mistapi>=0.62.0
- README operations 166->173