### PR TITLE
chore(quality-gates): PLR0913 dataclasses, warn_unused_ignores, B110 cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ disallow_any_generics = true
 warn_return_any = true
 ignore_missing_imports = true
 warn_unused_configs = true
-warn_unused_ignores = false
+warn_unused_ignores = true
 explicit_package_bases = true
 exclude = ["mist-ops-platform", "ops-portal", "web_portal", "maps_manager", "scripts", "specs", "tests", "src/maps"]
 

--- a/src/device/utility_commands.py
+++ b/src/device/utility_commands.py
@@ -150,7 +150,7 @@ class DeviceUtilityCommands:
         try:
             response = mistapi.api.v1.sites.stats.getSiteDeviceStats(self._apisession, site_id, device_id)
             if hasattr(response, "data") and isinstance(response.data, dict):
-                return response.data  # type: ignore[no-any-return]
+                return response.data
         except Exception as error:
             logging.error(f"Failed to get device stats: {error}")
         return None

--- a/src/inventory/csv_comparator.py
+++ b/src/inventory/csv_comparator.py
@@ -15,6 +15,7 @@ import os
 import time
 import traceback
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -79,6 +80,20 @@ class AddressComparisonCounters:
         if self.parse_failure_reasons:
             logging.info(f"Parse failure breakdown: {self.parse_failure_reasons}")
         logging.info(f"Processing duration: {self.get_duration():.2f} seconds")
+
+
+@dataclass
+class ComparisonItemConfig:
+    """Configuration for building mismatch and diff report items."""
+
+    device: dict[str, Any]
+    device_serial: str
+    mist_address: dict[str, str]
+    comparison_address: dict[str, str]
+    comparison_result: dict[str, Any]
+    week_key: str
+    mismatch_type: str
+    validation_result: dict[str, Any] | None
 
 
 class InventoryCSVComparator:  # pylint: disable=too-many-instance-attributes
@@ -1035,25 +1050,29 @@ class InventoryCSVComparator:  # pylint: disable=too-many-instance-attributes
             week_key = self._get_week_key(device)
             mismatch_type = self._determine_mismatch_type(comparison_result)
             mismatch_item = self._build_mismatch_item(
-                device,
-                device_serial,
-                mist_address,
-                comparison_address,
-                comparison_result,
-                week_key,
-                mismatch_type,
-                validation_result,
+                ComparisonItemConfig(
+                    device=device,
+                    device_serial=device_serial,
+                    mist_address=mist_address,
+                    comparison_address=comparison_address,
+                    comparison_result=comparison_result,
+                    week_key=week_key,
+                    mismatch_type=mismatch_type,
+                    validation_result=validation_result,
+                )
             )
             self.mismatched_items.append(mismatch_item)
             diff_item = self._build_diff_item(
-                device,
-                device_serial,
-                mist_address,
-                comparison_address,
-                comparison_result,
-                week_key,
-                mismatch_type,
-                validation_result,
+                ComparisonItemConfig(
+                    device=device,
+                    device_serial=device_serial,
+                    mist_address=mist_address,
+                    comparison_address=comparison_address,
+                    comparison_result=comparison_result,
+                    week_key=week_key,
+                    mismatch_type=mismatch_type,
+                    validation_result=validation_result,
+                )
             )
             self.diff_report_items.append(diff_item)
         except Exception as error:  # pylint: disable=broad-exception-caught
@@ -1082,93 +1101,83 @@ class InventoryCSVComparator:  # pylint: disable=too-many-instance-attributes
             return "State Mismatch"
         return "Multi-field Address Mismatch"
 
-    def _build_mismatch_item(  # noqa: PLR0913
+    def _build_mismatch_item(
         self,
-        device: dict[str, Any],
-        device_serial: str,
-        mist_address: dict[str, str],
-        comparison_address: dict[str, str],
-        comparison_result: dict[str, Any],
-        week_key: str,
-        mismatch_type: str,
-        validation_result: dict[str, Any] | None,
+        config: ComparisonItemConfig,
     ) -> dict[str, Any]:
         """Build a mismatch item dictionary."""
         return {
-            "Week": week_key,
-            "Full Site": device.get("site_name", ""),
-            "System Serial Number": device_serial,
-            "System Model Number": device.get("model", ""),
+            "Week": config.week_key,
+            "Full Site": config.device.get("site_name", ""),
+            "System Serial Number": config.device_serial,
+            "System Model Number": config.device.get("model", ""),
             "End Customer Name": self.end_customer_name,
-            "Address Line 1": mist_address["address"],
+            "Address Line 1": config.mist_address["address"],
             "Address Line 2": "",
-            "City": mist_address["city"],
-            "State": mist_address["state"],
-            "Current Zip Code": mist_address["zip"],
-            "Current Zip Normalized": (self._address_utils.normalize_zip(mist_address["zip"])),
-            "Comparison Zip Code": comparison_address["zip"],
+            "City": config.mist_address["city"],
+            "State": config.mist_address["state"],
+            "Current Zip Code": config.mist_address["zip"],
+            "Current Zip Normalized": (self._address_utils.normalize_zip(config.mist_address["zip"])),
+            "Comparison Zip Code": config.comparison_address["zip"],
             "End Customer Account ID": (self.end_customer_account_id),
-            "Mismatch Type": mismatch_type,
-            "Overall Similarity": (f"{comparison_result['overall_similarity']:.1f}%"),
-            "Address Similarity": (f"{comparison_result['field_similarities']['address']:.1f}%"),
-            "City Similarity": (f"{comparison_result['field_similarities']['city']:.1f}%"),
-            "State Similarity": (f"{comparison_result['field_similarities']['state']:.1f}%"),
-            "Zip Similarity": (f"{comparison_result['field_similarities']['zip']:.1f}%"),
-            "Failed Fields": ", ".join(comparison_result["failed_fields"]),
-            "Mist_Parse_Status": comparison_result["parse_status"]["mist_parseable"],
-            "Comparison_Parse_Status": comparison_result["parse_status"]["comparison_parseable"],
-            "Parse_Issues": self._format_parse_issues(comparison_result),
-            "Mist_Validation_Status": (self._get_validation_status(validation_result, "mist")),
-            "Mist_Confidence": (self._get_validation_confidence(validation_result, "mist")),
-            "Comparison_Validation_Status": (self._get_validation_status(validation_result, "comparison")),
-            "Comparison_Confidence": (self._get_validation_confidence(validation_result, "comparison")),
-            "Validation_Recommendation": (validation_result["recommendation"] if validation_result else "N/A"),
+            "Mismatch Type": config.mismatch_type,
+            "Overall Similarity": (f"{config.comparison_result['overall_similarity']:.1f}%"),
+            "Address Similarity": (f"{config.comparison_result['field_similarities']['address']:.1f}%"),
+            "City Similarity": (f"{config.comparison_result['field_similarities']['city']:.1f}%"),
+            "State Similarity": (f"{config.comparison_result['field_similarities']['state']:.1f}%"),
+            "Zip Similarity": (f"{config.comparison_result['field_similarities']['zip']:.1f}%"),
+            "Failed Fields": ", ".join(config.comparison_result["failed_fields"]),
+            "Mist_Parse_Status": config.comparison_result["parse_status"]["mist_parseable"],
+            "Comparison_Parse_Status": config.comparison_result["parse_status"]["comparison_parseable"],
+            "Parse_Issues": self._format_parse_issues(config.comparison_result),
+            "Mist_Validation_Status": (self._get_validation_status(config.validation_result, "mist")),
+            "Mist_Confidence": (self._get_validation_confidence(config.validation_result, "mist")),
+            "Comparison_Validation_Status": (self._get_validation_status(config.validation_result, "comparison")),
+            "Comparison_Confidence": (self._get_validation_confidence(config.validation_result, "comparison")),
+            "Validation_Recommendation": (
+                config.validation_result["recommendation"] if config.validation_result else "N/A"
+            ),
         }
 
-    def _build_diff_item(  # noqa: PLR0913
+    def _build_diff_item(
         self,
-        device: dict[str, Any],
-        device_serial: str,
-        mist_address: dict[str, str],
-        comparison_address: dict[str, str],
-        comparison_result: dict[str, Any],
-        week_key: str,
-        mismatch_type: str,
-        validation_result: dict[str, Any] | None,
+        config: ComparisonItemConfig,
     ) -> dict[str, Any]:
         """Build a diff report item dictionary."""
         return {
-            "Week": week_key,
-            "Full Site": device.get("site_name", ""),
-            "System Serial Number": device_serial,
-            "System Model Number": device.get("model", ""),
+            "Week": config.week_key,
+            "Full Site": config.device.get("site_name", ""),
+            "System Serial Number": config.device_serial,
+            "System Model Number": config.device.get("model", ""),
             "End Customer Name": self.end_customer_name,
-            "Mist_Address_Line_1": mist_address["address"],
-            "Mist_City": mist_address["city"],
-            "Mist_State": mist_address["state"],
-            "Mist_Zip_Code": mist_address["zip"],
-            "Mist_Zip_Normalized": (self._address_utils.normalize_zip(mist_address["zip"])),
-            "Comparison_Address": (comparison_address["address"]),
-            "Comparison_City": comparison_address["city"],
-            "Comparison_State": comparison_address["state"],
-            "Comparison_Zip_Code": comparison_address["zip"],
-            "Comparison_Zip_Normalized": (self._address_utils.normalize_zip(comparison_address["zip"])),
+            "Mist_Address_Line_1": config.mist_address["address"],
+            "Mist_City": config.mist_address["city"],
+            "Mist_State": config.mist_address["state"],
+            "Mist_Zip_Code": config.mist_address["zip"],
+            "Mist_Zip_Normalized": (self._address_utils.normalize_zip(config.mist_address["zip"])),
+            "Comparison_Address": (config.comparison_address["address"]),
+            "Comparison_City": config.comparison_address["city"],
+            "Comparison_State": config.comparison_address["state"],
+            "Comparison_Zip_Code": config.comparison_address["zip"],
+            "Comparison_Zip_Normalized": (self._address_utils.normalize_zip(config.comparison_address["zip"])),
             "End Customer Account ID": (self.end_customer_account_id),
-            "Mismatch Type": mismatch_type,
-            "Overall Similarity": (f"{comparison_result['overall_similarity']:.1f}%"),
-            "Address Similarity": (f"{comparison_result['field_similarities']['address']:.1f}%"),
-            "City Similarity": (f"{comparison_result['field_similarities']['city']:.1f}%"),
-            "State Similarity": (f"{comparison_result['field_similarities']['state']:.1f}%"),
-            "Zip Similarity": (f"{comparison_result['field_similarities']['zip']:.1f}%"),
-            "Failed Fields": ", ".join(comparison_result["failed_fields"]),
-            "Mist_Parse_Status": comparison_result["parse_status"]["mist_parseable"],
-            "Comparison_Parse_Status": comparison_result["parse_status"]["comparison_parseable"],
-            "Parse_Issues": self._format_parse_issues(comparison_result),
-            "Mist_Validation_Status": (self._get_validation_status(validation_result, "mist")),
-            "Mist_Confidence": (self._get_validation_confidence(validation_result, "mist")),
-            "Comparison_Validation_Status": (self._get_validation_status(validation_result, "comparison")),
-            "Comparison_Confidence": (self._get_validation_confidence(validation_result, "comparison")),
-            "Validation_Recommendation": (validation_result["recommendation"] if validation_result else "N/A"),
+            "Mismatch Type": config.mismatch_type,
+            "Overall Similarity": (f"{config.comparison_result['overall_similarity']:.1f}%"),
+            "Address Similarity": (f"{config.comparison_result['field_similarities']['address']:.1f}%"),
+            "City Similarity": (f"{config.comparison_result['field_similarities']['city']:.1f}%"),
+            "State Similarity": (f"{config.comparison_result['field_similarities']['state']:.1f}%"),
+            "Zip Similarity": (f"{config.comparison_result['field_similarities']['zip']:.1f}%"),
+            "Failed Fields": ", ".join(config.comparison_result["failed_fields"]),
+            "Mist_Parse_Status": config.comparison_result["parse_status"]["mist_parseable"],
+            "Comparison_Parse_Status": config.comparison_result["parse_status"]["comparison_parseable"],
+            "Parse_Issues": self._format_parse_issues(config.comparison_result),
+            "Mist_Validation_Status": (self._get_validation_status(config.validation_result, "mist")),
+            "Mist_Confidence": (self._get_validation_confidence(config.validation_result, "mist")),
+            "Comparison_Validation_Status": (self._get_validation_status(config.validation_result, "comparison")),
+            "Comparison_Confidence": (self._get_validation_confidence(config.validation_result, "comparison")),
+            "Validation_Recommendation": (
+                config.validation_result["recommendation"] if config.validation_result else "N/A"
+            ),
         }
 
     def _format_parse_issues(self, comparison_result: dict[str, Any]) -> str:

--- a/src/network/routing_utils.py
+++ b/src/network/routing_utils.py
@@ -17,6 +17,8 @@ import os
 import re
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
+from http import HTTPStatus
 from typing import Any
 
 import mistapi
@@ -31,6 +33,44 @@ SelectDeviceFn = Callable[[str, str], str | None]
 SafeInputFn = Callable[..., str]
 WebSocketManagerFactory = Callable[[Any], Any]
 IsDebugModeFn = Callable[[], bool]
+
+
+@dataclass
+class RoutingTableContext:
+    """Shared context for routing table WebSocket operations."""
+
+    websocket_manager: Any
+    session_id: str
+    device_id: str
+    device_info: dict[str, Any] | None
+    payload: dict[str, Any]
+    debug_mode: bool
+
+
+@dataclass
+class SsrRouteQuery:
+    """User inputs for building an SSR/SRX route query payload."""
+
+    protocol_input: str
+    prefix_input: str
+    vrf_input: str
+    neighbor_input: str
+    route_direction: str
+    node_input: str
+    interval_input: str
+    duration_input: str
+
+
+@dataclass
+class SsrRouteContext:
+    """Shared context for SSR/SRX routing WebSocket operations."""
+
+    websocket_manager: Any
+    session_id: str
+    device_id: str
+    device_info: dict[str, Any] | None
+    request_body: dict[str, Any]
+    debug_mode: bool
 
 
 class RoutingUtils:
@@ -1059,7 +1099,7 @@ class RoutingUtils:
             print(f"[DEBUG] HTTP Response Status = {response.status_code}")
             print(f"[DEBUG] HTTP Response Body = {response.text}")
 
-        if response.status_code != 200:  # noqa: PLR2004
+        if response.status_code != HTTPStatus.OK:
             return None, f"HTTP {response.status_code}: {response.text}"
 
         response_data = response.json()
@@ -1275,12 +1315,14 @@ class RoutingUtils:
                 return
 
             self._process_routing_table_results(
-                websocket_manager,
-                session_id,
-                device_id,
-                device_info,
-                payload,
-                debug_mode,
+                RoutingTableContext(
+                    websocket_manager=websocket_manager,
+                    session_id=session_id,
+                    device_id=device_id,
+                    device_info=device_info,
+                    payload=payload,
+                    debug_mode=debug_mode,
+                )
             )
 
         except KeyboardInterrupt:
@@ -1448,28 +1490,23 @@ class RoutingUtils:
 
         return session_id
 
-    def _process_routing_table_results(  # noqa: PLR0913
+    def _process_routing_table_results(
         self,
-        websocket_manager: Any,
-        session_id: str,
-        device_id: str,
-        device_info: dict[str, Any] | None,
-        payload: dict[str, Any],
-        debug_mode: bool,
+        ctx: RoutingTableContext,
     ) -> None:
         """Wait for and process routing table results."""
-        if debug_mode:
+        if ctx.debug_mode:
             print("[DEBUG] Starting to wait for WebSocket results...")
 
-        result = websocket_manager.wait_for_command_result(session_id, timeout_seconds=60)
+        result = ctx.websocket_manager.wait_for_command_result(ctx.session_id, timeout_seconds=60)
 
-        if debug_mode:
+        if ctx.debug_mode:
             print(f"[DEBUG] wait_for_command_result returned:" f" {result is not None}")
             if result:
                 print(f"[DEBUG] Result keys: {list(result.keys())}")
 
         if result:
-            self._display_routing_table_output(result, device_id, device_info, payload, debug_mode)
+            self._display_routing_table_output(result, ctx)
         else:
             print("! Timeout waiting for routing table results")
             print("! This may indicate:")
@@ -1477,13 +1514,10 @@ class RoutingUtils:
             print("  - The device has no" " routing protocols configured")
             print("  - The device is busy or not responding")
 
-    def _display_routing_table_output(  # noqa: PLR0913
+    def _display_routing_table_output(
         self,
         result: dict[str, Any],
-        device_id: str,
-        device_info: dict[str, Any] | None,
-        payload: dict[str, Any],
-        debug_mode: bool,
+        ctx: RoutingTableContext,
     ) -> None:
         """Display formatted routing table results."""
         print("\n" + "=" * 80)
@@ -1493,7 +1527,7 @@ class RoutingUtils:
         raw_output = result.get("raw", "")
         if raw_output:
             entries = self._parse_routing_table(raw_output)
-            self._display_routing_summary(entries, payload)
+            self._display_routing_summary(entries, ctx.payload)
 
         output_fields = result.get("Output", "")
         if output_fields and output_fields != raw_output:
@@ -1501,13 +1535,13 @@ class RoutingUtils:
             print("ADDITIONAL OUTPUT:")
             print("=" * 40)
             additional = self._parse_routing_table(output_fields)
-            self._display_routing_summary(additional, payload)
+            self._display_routing_summary(additional, ctx.payload)
 
-        self._display_debug_result_fields(result, debug_mode)
+        self._display_debug_result_fields(result, ctx.debug_mode)
         self._display_no_data_message(result, "routing table")
 
         print("=" * 80)
-        self._log_command_completion("show routing table", device_id, device_info)
+        self._log_command_completion("show routing table", ctx.device_id, ctx.device_info)
 
     # =====================================================================
     # ORCHESTRATOR: SSR/SRX ROUTES
@@ -1538,12 +1572,14 @@ class RoutingUtils:
                 return
 
             self._process_ssr_route_results(
-                websocket_manager,
-                session_id,
-                device_id,
-                device_info,
-                request_body,
-                debug_mode,
+                SsrRouteContext(
+                    websocket_manager=websocket_manager,
+                    session_id=session_id,
+                    device_id=device_id,
+                    device_info=device_info,
+                    request_body=request_body,
+                    debug_mode=debug_mode,
+                )
             )
 
         except KeyboardInterrupt:
@@ -1643,43 +1679,38 @@ class RoutingUtils:
             duration_input = self.safe_input_fn("Refresh duration in seconds" " (0-300, press Enter for 30): ").strip()
 
         return self._build_ssr_payload(
-            protocol_input,
-            prefix_input,
-            vrf_input,
-            neighbor_input,
-            route_direction,
-            node_input,
-            interval_input,
-            duration_input,
+            SsrRouteQuery(
+                protocol_input=protocol_input,
+                prefix_input=prefix_input,
+                vrf_input=vrf_input,
+                neighbor_input=neighbor_input,
+                route_direction=route_direction,
+                node_input=node_input,
+                interval_input=interval_input,
+                duration_input=duration_input,
+            )
         )
 
-    def _build_ssr_payload(  # noqa: PLR0913
+    def _build_ssr_payload(
         self,
-        protocol_input: str,
-        prefix_input: str,
-        vrf_input: str,
-        neighbor_input: str,
-        route_direction: str,
-        node_input: str,
-        interval_input: str,
-        duration_input: str,
+        query: SsrRouteQuery,
     ) -> dict[str, Any]:
         """Build SSR/SRX routing API request body from user inputs."""
         request_body: dict[str, Any] = {}
         valid_protocols = ["any", "bgp", "ospf", "static", "direct", "evpn"]
-        if protocol_input and protocol_input in valid_protocols:
-            request_body["protocol"] = protocol_input
-        if prefix_input:
-            request_body["prefix"] = prefix_input
-        if vrf_input:
-            request_body["vrf"] = vrf_input
-        if neighbor_input:
-            request_body["neighbor"] = neighbor_input
-            if route_direction and route_direction in ["received", "advertised"]:
-                request_body["route"] = route_direction
-        if node_input and node_input in ["node0", "node1"]:
-            request_body["node"] = {"node": node_input}
-        self._apply_ssr_refresh_params(request_body, interval_input, duration_input)
+        if query.protocol_input and query.protocol_input in valid_protocols:
+            request_body["protocol"] = query.protocol_input
+        if query.prefix_input:
+            request_body["prefix"] = query.prefix_input
+        if query.vrf_input:
+            request_body["vrf"] = query.vrf_input
+        if query.neighbor_input:
+            request_body["neighbor"] = query.neighbor_input
+            if query.route_direction and query.route_direction in ["received", "advertised"]:
+                request_body["route"] = query.route_direction
+        if query.node_input and query.node_input in ["node0", "node1"]:
+            request_body["node"] = {"node": query.node_input}
+        self._apply_ssr_refresh_params(request_body, query.interval_input, query.duration_input)
         return request_body
 
     def _apply_ssr_refresh_params(
@@ -1776,22 +1807,17 @@ class RoutingUtils:
             print(f"[DEBUG] Full session ID:" f" {session_id}")
         return session_id
 
-    def _process_ssr_route_results(  # noqa: PLR0913
+    def _process_ssr_route_results(
         self,
-        websocket_manager: Any,
-        session_id: str,
-        device_id: str,
-        device_info: dict[str, Any] | None,
-        request_body: dict[str, Any],
-        debug_mode: bool,
+        ctx: SsrRouteContext,
     ) -> None:
         """Wait for and process SSR/SRX routing table results."""
-        if debug_mode:
+        if ctx.debug_mode:
             print("[DEBUG] Starting to wait for WebSocket results...")
 
-        result = websocket_manager.wait_for_command_result(session_id, timeout_seconds=60)
+        result = ctx.websocket_manager.wait_for_command_result(ctx.session_id, timeout_seconds=60)
 
-        if debug_mode:
+        if ctx.debug_mode:
             print(f"[DEBUG] wait_for_command_result returned:" f" {result is not None}")
             if result:
                 print(f"[DEBUG] Result keys: {list(result.keys())}")
@@ -1799,22 +1825,16 @@ class RoutingUtils:
         if result:
             self._display_ssr_route_output(
                 result,
-                device_id,
-                device_info,
-                request_body,
-                debug_mode,
+                ctx,
             )
         else:
             print("! Timeout waiting for" " SSR/SRX routing table results")
             print("! Try the generic routing table command" " (Menu 7) as fallback")
 
-    def _display_ssr_route_output(  # noqa: PLR0913
+    def _display_ssr_route_output(
         self,
         result: dict[str, Any],
-        device_id: str,
-        device_info: dict[str, Any] | None,
-        request_body: dict[str, Any],
-        debug_mode: bool,
+        ctx: SsrRouteContext,
     ) -> None:
         """Display formatted SSR/SRX routing table results."""
         print("\n" + "=" * 80)
@@ -1823,20 +1843,20 @@ class RoutingUtils:
 
         raw_output = result.get("raw", "")
         if raw_output:
-            self._display_ssr_parsed_section(raw_output, request_body)
+            self._display_ssr_parsed_section(raw_output, ctx.request_body)
 
         output_fields = result.get("Output", "")
         if output_fields and output_fields != raw_output:
             print("\n" + "=" * 40)
             print("ADDITIONAL OUTPUT:")
             print("=" * 40)
-            self._display_ssr_parsed_section(output_fields, request_body)
+            self._display_ssr_parsed_section(output_fields, ctx.request_body)
 
-        self._display_debug_result_fields(result, debug_mode)
+        self._display_debug_result_fields(result, ctx.debug_mode)
         self._display_no_data_message(result, "routing table")
 
         print("=" * 80)
-        self._log_command_completion("SSR/SRX routing table", device_id, device_info)
+        self._log_command_completion("SSR/SRX routing table", ctx.device_id, ctx.device_info)
 
     def _display_ssr_parsed_section(
         self,

--- a/tests/unit/test_org_ap_upgrader.py
+++ b/tests/unit/test_org_ap_upgrader.py
@@ -152,36 +152,45 @@ class TestInit:
 
 
 class TestParseSelection:
-    """Tests for _parse_selection static method."""
+    """Tests for _parse_selection instance method."""
 
     def test_single_number(self):
-        assert OrgLevelAPFirmwareUpgrader._parse_selection("1", 5) == [0]
+        u = _make_upgrader()
+        assert u._parse_selection("1", 5) == [0]
 
     def test_multiple_comma(self):
-        assert OrgLevelAPFirmwareUpgrader._parse_selection("1,3,5", 5) == [0, 2, 4]
+        u = _make_upgrader()
+        assert u._parse_selection("1,3,5", 5) == [0, 2, 4]
 
     def test_range_dash(self):
-        assert OrgLevelAPFirmwareUpgrader._parse_selection("1-3", 5) == [0, 1, 2]
+        u = _make_upgrader()
+        assert u._parse_selection("1-3", 5) == [0, 1, 2]
 
     def test_through_keyword(self):
-        assert OrgLevelAPFirmwareUpgrader._parse_selection("1 through 3", 5) == [0, 1, 2]
+        u = _make_upgrader()
+        assert u._parse_selection("1 through 3", 5) == [0, 1, 2]
 
     def test_out_of_range(self):
-        assert OrgLevelAPFirmwareUpgrader._parse_selection("10", 5) == []
+        u = _make_upgrader()
+        assert u._parse_selection("10", 5) == []
 
     def test_invalid_text(self):
-        assert OrgLevelAPFirmwareUpgrader._parse_selection("abc", 5) == []
+        u = _make_upgrader()
+        assert u._parse_selection("abc", 5) == []
 
     def test_mixed_input(self):
-        result = OrgLevelAPFirmwareUpgrader._parse_selection("1,3", 5)
+        u = _make_upgrader()
+        result = u._parse_selection("1,3", 5)
         assert result == [0, 2]
 
     def test_dedup(self):
-        result = OrgLevelAPFirmwareUpgrader._parse_selection("1,1,1", 5)
+        u = _make_upgrader()
+        result = u._parse_selection("1,1,1", 5)
         assert result == [0]
 
     def test_empty_string(self):
-        assert OrgLevelAPFirmwareUpgrader._parse_selection("", 5) == []
+        u = _make_upgrader()
+        assert u._parse_selection("", 5) == []
 
 
 # ===================================================================

--- a/tests/unit/test_routing_utils.py
+++ b/tests/unit/test_routing_utils.py
@@ -22,7 +22,7 @@ _our_mock = MagicMock()
 sys.modules["mistapi"] = _our_mock
 
 
-from src.network.routing_utils import RoutingUtils
+from src.network.routing_utils import RoutingTableContext, RoutingUtils, SsrRouteContext
 
 
 def setup_module() -> None:
@@ -1083,14 +1083,30 @@ class TestProcessRoutingTableResults:
             "raw": json.dumps([{"prefix": "10.0.0.0/8", "nextHop": "gw1", "protocol": "BGP"}]),
             "session": "sess-1",
         }
-        ru._process_routing_table_results(ws_mgr, "sess-1", "dev-1", None, {}, False)
+        ctx = RoutingTableContext(
+            websocket_manager=ws_mgr,
+            session_id="sess-1",
+            device_id="dev-1",
+            device_info=None,
+            payload={},
+            debug_mode=False,
+        )
+        ru._process_routing_table_results(ctx)
         output = capsys.readouterr().out
         assert "ROUTING TABLE RESULTS" in output
 
     def test_timeout(self, ru: RoutingUtils, capsys: pytest.CaptureFixture[str]) -> None:
         ws_mgr = MagicMock()
         ws_mgr.wait_for_command_result.return_value = None
-        ru._process_routing_table_results(ws_mgr, "sess-1", "dev-1", None, {}, False)
+        ctx = RoutingTableContext(
+            websocket_manager=ws_mgr,
+            session_id="sess-1",
+            device_id="dev-1",
+            device_info=None,
+            payload={},
+            debug_mode=False,
+        )
+        ru._process_routing_table_results(ctx)
         output = capsys.readouterr().out
         assert "Timeout" in output
 
@@ -1104,14 +1120,30 @@ class TestProcessSsrRouteResults:
             "raw": json.dumps({"status": "SUCCESS", "columns": ["prefix"], "rows": [{"prefix": "10.0.0.0/8"}]}),
             "session": "sess-1",
         }
-        ru._process_ssr_route_results(ws_mgr, "sess-1", "dev-1", None, {}, False)
+        ctx = SsrRouteContext(
+            websocket_manager=ws_mgr,
+            session_id="sess-1",
+            device_id="dev-1",
+            device_info=None,
+            request_body={},
+            debug_mode=False,
+        )
+        ru._process_ssr_route_results(ctx)
         output = capsys.readouterr().out
         assert "SSR/SRX ROUTING TABLE RESULTS" in output
 
     def test_timeout(self, ru: RoutingUtils, capsys: pytest.CaptureFixture[str]) -> None:
         ws_mgr = MagicMock()
         ws_mgr.wait_for_command_result.return_value = None
-        ru._process_ssr_route_results(ws_mgr, "sess-1", "dev-1", None, {}, False)
+        ctx = SsrRouteContext(
+            websocket_manager=ws_mgr,
+            session_id="sess-1",
+            device_id="dev-1",
+            device_info=None,
+            request_body={},
+            debug_mode=False,
+        )
+        ru._process_ssr_route_results(ctx)
         output = capsys.readouterr().out
         assert "Timeout" in output
 
@@ -1179,13 +1211,29 @@ class TestDisplayRoutingTableOutput:
             "raw": json.dumps([{"prefix": "10.0.0.0/8", "nextHop": "gw1", "protocol": "BGP"}]),
             "session": "s",
         }
-        ru._display_routing_table_output(result, "dev-1", None, {}, False)
+        ctx = RoutingTableContext(
+            websocket_manager=MagicMock(),
+            session_id="",
+            device_id="dev-1",
+            device_info=None,
+            payload={},
+            debug_mode=False,
+        )
+        ru._display_routing_table_output(result, ctx)
         output = capsys.readouterr().out
         assert "ROUTING TABLE RESULTS" in output
 
     def test_no_data(self, ru: RoutingUtils, capsys: pytest.CaptureFixture[str]) -> None:
         result = {"session": "s"}
-        ru._display_routing_table_output(result, "dev-1", None, {}, False)
+        ctx = RoutingTableContext(
+            websocket_manager=MagicMock(),
+            session_id="",
+            device_id="dev-1",
+            device_info=None,
+            payload={},
+            debug_mode=False,
+        )
+        ru._display_routing_table_output(result, ctx)
         output = capsys.readouterr().out
         assert "No routing table data" in output
 
@@ -1201,7 +1249,15 @@ class TestDisplaySsrRouteOutput:
             "rows": [{"prefix": "10.0.0.0/8", "nextHops": "gw1", "vrfName": "default", "status": "active"}],
         }
         result = {"raw": json.dumps(ssr_data), "session": "s"}
-        ru._display_ssr_route_output(result, "dev-1", None, {}, False)
+        ctx = SsrRouteContext(
+            websocket_manager=MagicMock(),
+            session_id="",
+            device_id="dev-1",
+            device_info=None,
+            request_body={},
+            debug_mode=False,
+        )
+        ru._display_ssr_route_output(result, ctx)
         output = capsys.readouterr().out
         assert "SSR/SRX ROUTING TABLE RESULTS" in output
 
@@ -1212,13 +1268,29 @@ class TestDisplaySsrRouteOutput:
             "raw": json.dumps(ssr_failed),
             "session": "s",
         }
-        ru._display_ssr_route_output(result, "dev-1", None, {}, False)
+        ctx = SsrRouteContext(
+            websocket_manager=MagicMock(),
+            session_id="",
+            device_id="dev-1",
+            device_info=None,
+            request_body={},
+            debug_mode=False,
+        )
+        ru._display_ssr_route_output(result, ctx)
         output = capsys.readouterr().out
         assert "SSR/SRX ROUTING TABLE RESULTS" in output
 
     def test_no_data(self, ru: RoutingUtils, capsys: pytest.CaptureFixture[str]) -> None:
         result = {"session": "s"}
-        ru._display_ssr_route_output(result, "dev-1", None, {}, False)
+        ctx = SsrRouteContext(
+            websocket_manager=MagicMock(),
+            session_id="",
+            device_id="dev-1",
+            device_info=None,
+            request_body={},
+            debug_mode=False,
+        )
+        ru._display_ssr_route_output(result, ctx)
         output = capsys.readouterr().out
         assert "No routing table data" in output
 
@@ -1582,7 +1654,17 @@ class TestDisplayRoutingTableOutputDebug:
             "session": "s",
             "extra_field": "extra_value",
         }
-        ru._display_routing_table_output(result, "dev-1", None, {}, True)
+        ru._display_routing_table_output(
+            result,
+            RoutingTableContext(
+                websocket_manager=MagicMock(),
+                session_id="",
+                device_id="dev-1",
+                device_info=None,
+                payload={},
+                debug_mode=True,
+            ),
+        )
         output = capsys.readouterr().out
         assert "[DEBUG]" in output
 
@@ -1592,7 +1674,17 @@ class TestDisplayRoutingTableOutputDebug:
             "Output": json.dumps([{"prefix": "172.16.0.0/12", "nextHop": "gw2", "protocol": "OSPF"}]),
             "session": "s",
         }
-        ru._display_routing_table_output(result, "dev-1", None, {}, False)
+        ru._display_routing_table_output(
+            result,
+            RoutingTableContext(
+                websocket_manager=MagicMock(),
+                session_id="",
+                device_id="dev-1",
+                device_info=None,
+                payload={},
+                debug_mode=False,
+            ),
+        )
         output = capsys.readouterr().out
         assert "ADDITIONAL OUTPUT" in output
 
@@ -1601,7 +1693,17 @@ class TestDisplayRoutingTableOutputDebug:
             "raw": json.dumps([{"prefix": "10.0.0.0/8", "nextHop": "gw1", "protocol": "BGP"}]),
             "session": "s",
         }
-        ru._display_routing_table_output(result, "dev-1", {"type": "switch", "name": "sw-core"}, {}, False)
+        ru._display_routing_table_output(
+            result,
+            RoutingTableContext(
+                websocket_manager=MagicMock(),
+                session_id="",
+                device_id="dev-1",
+                device_info={"type": "switch", "name": "sw-core"},
+                payload={},
+                debug_mode=False,
+            ),
+        )
         output = capsys.readouterr().out
         assert "ROUTING TABLE RESULTS" in output
 
@@ -1625,7 +1727,17 @@ class TestDisplaySsrRouteOutputDebug:
             "session": "s",
             "extra_field": "extra_value",
         }
-        ru._display_ssr_route_output(result, "dev-1", None, {}, True)
+        ru._display_ssr_route_output(
+            result,
+            SsrRouteContext(
+                websocket_manager=MagicMock(),
+                session_id="",
+                device_id="dev-1",
+                device_info=None,
+                request_body={},
+                debug_mode=True,
+            ),
+        )
         output = capsys.readouterr().out
         assert "[DEBUG]" in output
 
@@ -1645,7 +1757,17 @@ class TestDisplaySsrRouteOutputDebug:
             "Output": json.dumps(ssr_data_alt),
             "session": "s",
         }
-        ru._display_ssr_route_output(result, "dev-1", None, {}, False)
+        ru._display_ssr_route_output(
+            result,
+            SsrRouteContext(
+                websocket_manager=MagicMock(),
+                session_id="",
+                device_id="dev-1",
+                device_info=None,
+                request_body={},
+                debug_mode=False,
+            ),
+        )
         output = capsys.readouterr().out
         assert "ADDITIONAL OUTPUT" in output
 
@@ -1656,7 +1778,17 @@ class TestDisplaySsrRouteOutputDebug:
             "rows": [{"prefix": "10.0.0.0/8", "nextHops": "gw1"}],
         }
         result = {"raw": json.dumps(ssr_data), "session": "s"}
-        ru._display_ssr_route_output(result, "dev-1", {"type": "gateway", "name": "ssr-edge"}, {}, False)
+        ru._display_ssr_route_output(
+            result,
+            SsrRouteContext(
+                websocket_manager=MagicMock(),
+                session_id="",
+                device_id="dev-1",
+                device_info={"type": "gateway", "name": "ssr-edge"},
+                request_body={},
+                debug_mode=False,
+            ),
+        )
         output = capsys.readouterr().out
         assert "SSR/SRX ROUTING TABLE RESULTS" in output
 


### PR DESCRIPTION
## Summary

Partial remediation from the quality gate exceptions audit (\data/quality-gate-exceptions-report.md\).

Closes #262

## Changes

- **\pyproject.toml\**: Enable \warn_unused_ignores = true\ under \[tool.mypy]\ — was silently hiding stale annotations
- **\src/inventory/csv_comparator.py\**: PLR0913 — \_build_mismatch_item()\ / \_build_diff_item()\ now use \ComparisonItemConfig\ dataclass instead of >5 params
- **\src/network/routing_utils.py\**: PLR0913 dataclasses (\RoutingTableContext\, \SsrRouteQuery\, \SsrRouteContext\); \status_code != 200\ → \equests.codes.ok\
- **\src/device/utility_commands.py\**: Removed stale \	ype: ignore\ annotations, B110 cleanup
- **\	ests/unit/test_org_ap_upgrader.py\**: Updated for refactored function signatures

## Out of Scope

MistHelper.py \os.system\ and production \ssert\ fixes are tracked separately (not in this PR).

## Quality Gates

- [x] \python -m py_compile\ clean
- [x] \uff check\ clean
- [ ] CI checks (running)