### PR TITLE
chore: ignore starlink-api-reference upstream clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,6 @@ configs/
 *.deb
 *.rpm
 interrogate_badge.svg
+
+# SpaceX Enterprise API reference (upstream clone, not MistHelper code)
+starlink-api-reference/


### PR DESCRIPTION
Adds starlink-api-reference/ to .gitignore. It is a SpaceX upstream API reference clone, not MistHelper code.