### PR TITLE
fix(MistHelper.py): pass limit=None to e911_report and register option 170 as interactive_safe

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -16242,6 +16242,7 @@ class OrgExportUtils:
             api_call=mistapi.api.v1.orgs.exports.getOrgE911Report,
             data_type="e911 report",
             sort_key="name",
+            limit=None,  # getOrgE911Report only accepts (mist_session, org_id) - no limit param
         )
 
     @staticmethod
@@ -36137,6 +36138,7 @@ class OperationRegistry:
             "category": "resource_intensive",
             "skip_reason": "Bulk org data collection - runs 57 API calls, resource intensive",
         },
+        "170": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
     }
 
     # Categories that are safe for --test (fully automated, no user input)


### PR DESCRIPTION
## Summary

Fixes two issues found during systematic \--test\ run:
- Option 166 failed with \TypeError: getOrgE911Report() got an unexpected keyword argument 'limit'\
- Option 170 hung indefinitely waiting for stdin (site selection prompt)

## Changes

1. **\911_report()\**: Pass \limit=None\ to \xport_data()\. \getOrgE911Report\ only accepts \(mist_session, org_id)\ with no \limit\ parameter. \xport_data()\ already handles \limit=None\ correctly via its \if limit is not None\ guard.

2. **\OperationRegistry\**: Register option \170\ as \interactive_safe\. \SiteExportUtils.ospf_stats\ requires interactive site selection via \input()\. Without registration it defaulted to \safe\ (fully automated), blocked on stdin during \--test\, and had to be killed.

## Test Results

Before: 1 failure (option 166), 1 hang (option 170)
After: 0 failures expected, option 170 properly moved to \--testinteractive\

Closes #277