### PR TITLE
fix(container): remove stale maps_manager.py from Containerfile COPY instruction

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -75,7 +75,7 @@ RUN pip install --no-cache-dir -r requirements.txt \
         --trusted-host files.pythonhosted.org
 
 # Copy application files
-COPY MistHelper.py __init__.py maps_manager.py wsgi.py ./
+COPY MistHelper.py __init__.py wsgi.py ./
 COPY src/ ./src/
 COPY web_portal/ ./web_portal/
 


### PR DESCRIPTION
Closes #279

## Summary
Removes the stale reference to \maps_manager.py\ from the Containerfile COPY instruction. This file no longer exists at the project root, causing \podman build\ to fail with a file-not-found error.