### PR TITLE
fix(MistHelper.py): register options 171 and 172 as interactive_safe

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -36139,6 +36139,8 @@ class OperationRegistry:
             "skip_reason": "Bulk org data collection - runs 57 API calls, resource intensive",
         },
         "170": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
+        "171": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
+        "172": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
     }
 
     # Categories that are safe for --test (fully automated, no user input)


### PR DESCRIPTION
## Summary

Options 171 (MxEdge upgrade status for a selected site) and 172 (auto-map assignment status for a selected site) present interactive site-selection prompts that block --test mode waiting for stdin. Registers them as interactive_safe so they are skipped during automated testing.

Closes #281