### PR TITLE
security(maps): replace str(e) in Dash UI callback with generic message

### DIFF
--- a/src/maps/maps_manager.py
+++ b/src/maps/maps_manager.py
@@ -7958,7 +7958,11 @@ class MapsManager:
 
             except Exception as e:
                 logging.error(f"Clone operation failed: {e}", exc_info=True)
-                return html.Span(f"! Clone failed: {str(e)}", style={"color": "#ff4444"}), no_update
+                error_span = html.Span(
+                    "! Clone operation failed. Check server logs for details.",
+                    style={"color": "#ff4444"},
+                )
+                return error_span, no_update
 
         # Callback to refresh map dropdown after clone/delete operations or page load (cache bust)
         @app.callback(


### PR DESCRIPTION
## Summary

The clone map Dash callback returned the raw exception message in an html.Span component, exposing internal server details in the browser UI. Replaced with a generic user-facing message while keeping the full exception logged at ERROR level server-side.

Closes #268