### PR TITLE
chore(293): Phase 2 - Extract PlotlyMapDataSerializer and integrate stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 - Reduced `interactive_map_viewer` CC from 43 to 8 in `src/maps/maps_manager.py` (#295)
   - Extracted `_install_visualization_packages` (CC=5), `_check_visualization_packages` (CC=4), `_fetch_map_details` (CC=3), `_fetch_devices_on_map` (CC=3), `_fetch_zones_on_map` (CC=3), `_filter_clients_for_map` (CC=5), `_fetch_clients_on_map` (CC=8), `_handle_coverage_exception` (CC=3), `_fetch_map_coverage` (CC=6)
 - Reduced `launch_viewer_standalone` CC from 30 to 3 in `src/maps/maps_manager.py` (#296)
+- Extracted `PlotlyMapDataSerializer` into `src/maps/plotly_map_serializer.py` and integrated `_launch_plotly_viewer` store/dropdown payload construction through serializer helpers (#293, Phase 2)
+  - Replaced inline `dcc.Store` payload dict/list construction for map config, available maps/sites, selected zone, refresh times, and cache bust
+  - Replaced repeated dropdown/store map list serialization in site-switch and map-refresh callbacks
+  - Added serializer unit tests in `tests/maps/test_plotly_map_serializer.py` (5 tests)
 
 ### Refactored
 

--- a/src/maps/maps_manager.py
+++ b/src/maps/maps_manager.py
@@ -32,6 +32,7 @@ import sys
 from datetime import datetime
 from typing import Any
 
+from src.maps.plotly_map_serializer import PlotlyMapDataSerializer
 from src.maps.plotly_map_templates import DashTemplateManager
 
 # Optional visualization imports — use find_spec for availability checks
@@ -3073,6 +3074,7 @@ class MapsManager:
 
         # Initialize template manager for CSS/HTML/metadata
         template_mgr = DashTemplateManager(org_id=self.org_id)
+        serializer = PlotlyMapDataSerializer()
         app_meta = template_mgr.get_app_meta()
 
         app = Dash(
@@ -5060,32 +5062,32 @@ class MapsManager:
                 # Hidden stores for state management
                 dcc.Store(
                     id="map-config-store",
-                    data={
-                        "site_id": site_id,
-                        "site_name": site_name,
-                        "map_id": map_id,
-                        "map_name": map_data.get("name", "Unknown"),
-                        "ppm": ppm,
-                        "map_width": map_width,
-                        "map_height": map_height,
-                    },
+                    data=serializer.build_map_config(
+                        site_id=site_id,
+                        site_name=site_name,
+                        map_id=map_id,
+                        map_name=map_data.get("name", "Unknown"),
+                        ppm=ppm,
+                        map_width=map_width,
+                        map_height=map_height,
+                    ),
                 ),
                 # Store for available maps list (for dropdown)
                 dcc.Store(
                     id="available-maps-store",
-                    data=[{"id": m.get("id"), "name": m.get("name", "Unnamed")} for m in all_maps],
+                    data=serializer.build_named_items(all_maps, default_name="Unnamed"),
                 ),
                 # Store for available sites list (for dropdown)
                 dcc.Store(
                     id="available-sites-store",
-                    data=[{"id": s.get("id"), "name": s.get("name", "Unnamed Site")} for s in all_sites],
+                    data=serializer.build_named_items(all_sites, default_name="Unnamed Site"),
                 ),
                 # Store for tracking selected zone ID
-                dcc.Store(id="selected-zone-store", data={"zone_id": None, "zone_name": None}),
+                dcc.Store(id="selected-zone-store", data=serializer.build_selected_zone_store()),
                 # Store for tracking last refresh times
-                dcc.Store(id="refresh-times-store", data={"client_last_refresh": 0, "coverage_last_refresh": 0}),
+                dcc.Store(id="refresh-times-store", data=serializer.build_refresh_times_store()),
                 # Store to trigger map list refresh (cache bust) after clone/delete operations
-                dcc.Store(id="cache-bust-store", data={"trigger": 0}),
+                dcc.Store(id="cache-bust-store", data=serializer.build_cache_bust_store()),
                 # Interval components for live refresh (enabled by default since auto-refresh is on)
                 dcc.Interval(
                     id="client-refresh-interval",
@@ -5267,8 +5269,8 @@ class MapsManager:
                     return [], None, [], updated_config, empty_fig
 
                 # Build new dropdown options
-                new_map_options = [{"label": m.get("name", "Unnamed"), "value": m.get("id")} for m in new_maps]
-                new_maps_store = [{"id": m.get("id"), "name": m.get("name", "Unnamed")} for m in new_maps]
+                new_map_options = serializer.build_dropdown_options(new_maps, default_name="Unnamed")
+                new_maps_store = serializer.build_named_items(new_maps, default_name="Unnamed")
                 print(f"[DEBUG] Built {len(new_map_options)} dropdown options")
 
                 # Select first map
@@ -7668,9 +7670,9 @@ class MapsManager:
                 logging.info(f"Map dropdown refreshed: {len(fresh_maps)} maps found")
 
                 # Build new dropdown options
-                new_options = [{"label": m.get("name", "Unnamed"), "value": m.get("id")} for m in fresh_maps]
+                new_options = serializer.build_dropdown_options(fresh_maps, default_name="Unnamed")
                 # Build new available maps store data
-                new_store_data = [{"id": m.get("id"), "name": m.get("name", "Unnamed")} for m in fresh_maps]
+                new_store_data = serializer.build_named_items(fresh_maps, default_name="Unnamed")
 
                 return new_options, new_store_data
 

--- a/src/maps/plotly_map_serializer.py
+++ b/src/maps/plotly_map_serializer.py
@@ -1,0 +1,61 @@
+"""Serialization helpers for Plotly/Dash map viewer state stores."""
+
+from __future__ import annotations
+
+
+class PlotlyMapDataSerializer:
+    """Build normalized payloads for Dash dcc.Store and dropdown options."""
+
+    @staticmethod
+    def build_map_config(
+        site_id: str,
+        site_name: str,
+        map_id: str,
+        map_name: str,
+        ppm: float,
+        map_width: int,
+        map_height: int,
+    ) -> dict:
+        """Create canonical map-config-store payload."""
+        return {
+            "site_id": site_id,
+            "site_name": site_name,
+            "map_id": map_id,
+            "map_name": map_name,
+            "ppm": ppm,
+            "map_width": map_width,
+            "map_height": map_height,
+        }
+
+    @staticmethod
+    def build_named_items(items: list | None, default_name: str) -> list[dict]:
+        """Build [{id,name}] list from API records with safe defaults."""
+        records = items or []
+        return [{"id": item.get("id"), "name": item.get("name", default_name)} for item in records]
+
+    @staticmethod
+    def build_dropdown_options(items: list | None, default_name: str) -> list[dict]:
+        """Build [{label,value}] dropdown options from API records."""
+        records = items or []
+        return [{"label": item.get("name", default_name), "value": item.get("id")} for item in records]
+
+    @staticmethod
+    def build_selected_zone_store(zone_id: str | None = None, zone_name: str | None = None) -> dict:
+        """Create selected-zone-store payload."""
+        return {"zone_id": zone_id, "zone_name": zone_name}
+
+    @staticmethod
+    def build_refresh_times_store(client_last_refresh: int = 0, coverage_last_refresh: int = 0) -> dict:
+        """Create refresh-times-store payload."""
+        return {"client_last_refresh": client_last_refresh, "coverage_last_refresh": coverage_last_refresh}
+
+    @staticmethod
+    def build_cache_bust_store(trigger: int = 0) -> dict:
+        """Create cache-bust-store payload."""
+        return {"trigger": trigger}
+
+    @staticmethod
+    def increment_cache_bust(data: dict | None) -> dict:
+        """Increment cache-bust trigger payload safely."""
+        current = data.get("trigger", 0) if data else 0
+        return {"trigger": current + 1}

--- a/tests/maps/test_plotly_map_serializer.py
+++ b/tests/maps/test_plotly_map_serializer.py
@@ -1,0 +1,56 @@
+"""Unit tests for PlotlyMapDataSerializer."""
+
+from src.maps.plotly_map_serializer import PlotlyMapDataSerializer
+
+
+def test_build_map_config() -> None:
+    """Map config payload contains expected keys and values."""
+    payload = PlotlyMapDataSerializer.build_map_config(
+        site_id="s1",
+        site_name="Site A",
+        map_id="m1",
+        map_name="Floor 1",
+        ppm=12.5,
+        map_width=1000,
+        map_height=600,
+    )
+
+    assert payload == {
+        "site_id": "s1",
+        "site_name": "Site A",
+        "map_id": "m1",
+        "map_name": "Floor 1",
+        "ppm": 12.5,
+        "map_width": 1000,
+        "map_height": 600,
+    }
+
+
+def test_build_named_items_defaults() -> None:
+    """Named item serialization applies default names when missing."""
+    items = [{"id": "a", "name": "Alpha"}, {"id": "b"}]
+    payload = PlotlyMapDataSerializer.build_named_items(items, default_name="Unnamed")
+    assert payload == [{"id": "a", "name": "Alpha"}, {"id": "b", "name": "Unnamed"}]
+
+
+def test_build_dropdown_options_defaults() -> None:
+    """Dropdown option serialization applies labels and values correctly."""
+    items = [{"id": "a", "name": "Alpha"}, {"id": "b"}]
+    payload = PlotlyMapDataSerializer.build_dropdown_options(items, default_name="Unnamed")
+    assert payload == [{"label": "Alpha", "value": "a"}, {"label": "Unnamed", "value": "b"}]
+
+
+def test_store_builders() -> None:
+    """Simple store builders return expected defaults."""
+    assert PlotlyMapDataSerializer.build_selected_zone_store() == {"zone_id": None, "zone_name": None}
+    assert PlotlyMapDataSerializer.build_refresh_times_store() == {
+        "client_last_refresh": 0,
+        "coverage_last_refresh": 0,
+    }
+    assert PlotlyMapDataSerializer.build_cache_bust_store() == {"trigger": 0}
+
+
+def test_increment_cache_bust() -> None:
+    """Cache bust counter increments safely with or without input."""
+    assert PlotlyMapDataSerializer.increment_cache_bust(None) == {"trigger": 1}
+    assert PlotlyMapDataSerializer.increment_cache_bust({"trigger": 7}) == {"trigger": 8}


### PR DESCRIPTION
Part of #293\n\n## Phase 2: PlotlyMapDataSerializer Extraction\n\n### Completed\n- Added src/maps/plotly_map_serializer.py with PlotlyMapDataSerializer\n- Integrated serializer into _launch_plotly_viewer for:\n  - map-config-store payload\n  - vailable-maps-store payload\n  - vailable-sites-store payload\n  - selected-zone-store, efresh-times-store, cache-bust-store defaults\n  - site-switch callback map option/store construction\n  - map-dropdown refresh callback option/store construction\n- Added unit tests in 	ests/maps/test_plotly_map_serializer.py (5 tests)\n\n### Validation\n- py_compile passed\n- uff passed\n- lack passed\n- pydocstyle passed on new serializer module/tests\n- Focused pytest suites passed (49 tests):\n  - 	ests/maps/test_plotly_map_serializer.py\n  - 	ests/maps/test_plotly_map_templates.py\n  - 	ests/maps/test_phase1_integration.py\n\n### Complexity\nsrc/maps/plotly_map_serializer.py methods all A-grade (max CC=3).\n