### PR TITLE
chore(293): Phase 3 - Extract PlotlyCoverageHeatmapRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   - Replaced inline `dcc.Store` payload dict/list construction for map config, available maps/sites, selected zone, refresh times, and cache bust
   - Replaced repeated dropdown/store map list serialization in site-switch and map-refresh callbacks
   - Added serializer unit tests in `tests/maps/test_plotly_map_serializer.py` (5 tests)
+- Extracted `PlotlyCoverageHeatmapRenderer` into `src/maps/plotly_heatmap_renderer.py` and delegated RF heatmap trace construction from `_launch_plotly_viewer` (#293, Phase 3)
+  - Replaced large inline coverage parsing/rendering block with `build_heatmap_trace(...)`
+  - Added heatmap renderer unit tests in `tests/maps/test_plotly_heatmap_renderer.py` (5 tests)
 
 ### Refactored
 

--- a/src/maps/maps_manager.py
+++ b/src/maps/maps_manager.py
@@ -32,6 +32,7 @@ import sys
 from datetime import datetime
 from typing import Any
 
+from src.maps.plotly_heatmap_renderer import PlotlyCoverageHeatmapRenderer
 from src.maps.plotly_map_serializer import PlotlyMapDataSerializer
 from src.maps.plotly_map_templates import DashTemplateManager
 
@@ -3074,6 +3075,7 @@ class MapsManager:
 
         # Initialize template manager for CSS/HTML/metadata
         template_mgr = DashTemplateManager(org_id=self.org_id)
+        heatmap_renderer = PlotlyCoverageHeatmapRenderer(logger=logging.getLogger(__name__))
         serializer = PlotlyMapDataSerializer()
         app_meta = template_mgr.get_app_meta()
 
@@ -3869,131 +3871,14 @@ class MapsManager:
             logging.info("No BLE beacons found on this map")
 
         # Add RF Coverage Heatmap from Mist API data
-        if coverage_data and "results" in coverage_data and len(coverage_data.get("results", [])) > 0:
-            logging.info(f"Processing RF coverage data - {len(coverage_data.get('results', []))} grid points")
-
-            # API returns coordinates in METERS - must convert to pixels using PPM
-            result_def = coverage_data.get("result_def", [])
-            results = coverage_data.get("results", [])
-            gridsize_meters = coverage_data.get("gridsize", 1)
-
-            logging.debug(f"Coverage result_def: {result_def}")
-            logging.debug(f"Coverage gridsize: {gridsize_meters} meters, PPM: {ppm}")
-
-            # Find indices for data fields
-            try:
-                x_idx = result_def.index("x")
-                y_idx = result_def.index("y")
-                max_rssi_idx = result_def.index("max_rssi")
-                avg_rssi_idx = result_def.index("avg_rssi")
-            except ValueError as e:
-                logging.error(f"Coverage data missing expected fields: {e}")
-                x_idx, y_idx, max_rssi_idx, avg_rssi_idx = 0, 1, 4, 5
-
-            # Build grid data structure for heatmap
-            grid_data = {}
-            for result in results:
-                if len(result) <= max(x_idx, y_idx, max_rssi_idx, avg_rssi_idx):
-                    continue
-
-                x_meters = result[x_idx]
-                y_meters = result[y_idx]
-                pixel_x = x_meters * ppm
-                pixel_y = y_meters * ppm
-                max_rssi = result[max_rssi_idx]
-
-                grid_data[(pixel_x, pixel_y)] = max_rssi
-
-            if grid_data:
-                # Auto-scale color range based on actual data
-                all_rssi_values = [v for v in grid_data.values() if v is not None]
-                if all_rssi_values:
-                    min_rssi = min(all_rssi_values)  # Most negative (weakest)
-                    max_rssi = max(all_rssi_values)  # Closest to zero (strongest)
-                    logging.info(f"RF Coverage RSSI range: {min_rssi} dBm (weakest) to {max_rssi} dBm (strongest)")
-                else:
-                    min_rssi = -100
-                    max_rssi = -40
-
-                # Convert to regular grid for Heatmap trace
-                unique_x = sorted(set(x for x, y in grid_data.keys()))
-                unique_y = sorted(set(y for x, y in grid_data.keys()))
-
-                # Diagnostic logging for coordinate alignment debugging
-                logging.info(f"HEATMAP DEBUG - Map dimensions: {map_width}x{map_height} pixels, PPM: {ppm}")
-                logging.info(
-                    f"HEATMAP DEBUG - Coverage X range: {min(unique_x):.1f} to {max(unique_x):.1f} pixels "
-                    f"(from {min(unique_x) / ppm:.1f}m to {max(unique_x) / ppm:.1f}m)"
-                )
-                logging.info(
-                    f"HEATMAP DEBUG - Coverage Y range: {min(unique_y):.1f} to {max(unique_y):.1f} pixels "
-                    f"(from {min(unique_y) / ppm:.1f}m to {max(unique_y) / ppm:.1f}m)"
-                )
-                logging.info(
-                    f"HEATMAP DEBUG - Grid size: {len(unique_x)} x {len(unique_y)} = {len(grid_data)} data points"
-                )
-
-                # Create Z matrix for heatmap - use None for missing data points
-                # This prevents artificial values from being interpolated
-                z_matrix = []
-                for y_val in unique_y:
-                    row = []
-                    for x_val in unique_x:
-                        rssi = grid_data.get((x_val, y_val), None)  # None for missing - no fake data
-                        row.append(rssi)
-                    z_matrix.append(row)
-
-                # Custom colorscale: red (strongest/closest to 0) -> blue (weakest/most negative)
-                colorscale = [
-                    [0.0, "rgb(0, 0, 255)"],  # Blue (weakest/most negative)
-                    [0.33, "rgb(0, 255, 0)"],  # Green
-                    [0.50, "rgb(255, 255, 0)"],  # Yellow
-                    [0.67, "rgb(255, 165, 0)"],  # Orange
-                    [1.0, "rgb(255, 0, 0)"],  # Red (strongest/closest to 0)
-                ]
-
-                fig.add_trace(
-                    go.Heatmap(
-                        x=unique_x,
-                        y=unique_y,
-                        z=z_matrix,
-                        colorscale=colorscale,
-                        zmin=min_rssi,  # Auto-scale to actual data range
-                        zmax=max_rssi,
-                        opacity=0.5,
-                        name="RF Coverage",
-                        hovertemplate="X: %{x}<br>Y: %{y}<br>RSSI: %{z} dBm<extra></extra>",
-                        visible=False,
-                        showscale=True,  # Show color scale legend
-                        colorbar=dict(
-                            title=dict(text="RSSI (dBm)", side="right", font=dict(size=12, color="white")),
-                            thickness=20,
-                            len=0.5,
-                            y=0.95,
-                            yanchor="top",
-                            x=1.02,
-                            tickfont=dict(size=10, color="white"),
-                            tickmode="linear",
-                            tick0=min_rssi,
-                            dtick=(max_rssi - min_rssi) / 5,  # Show 6 tick marks
-                            outlinewidth=1,
-                            outlinecolor="white",
-                        ),
-                        connectgaps=True,  # Interpolate across gaps for smooth coverage
-                        zsmooth="best",  # Smooth interpolation between data points
-                    )
-                )
-
-                logging.info(
-                    f"Added RF Coverage heatmap: {len(grid_data)} cells "
-                    f"({gridsize_meters}m grid) with auto-scaled colors ({min_rssi} to {max_rssi} dBm)"
-                )
-            else:
-                logging.warning("No valid coverage grid data to visualize")
-        elif coverage_data:
-            logging.warning("Coverage data received but no results")
-        else:
-            logging.info("No RF coverage data available")
+        heatmap_trace = heatmap_renderer.build_heatmap_trace(
+            coverage_data=coverage_data,
+            ppm=ppm,
+            map_width=map_width,
+            map_height=map_height,
+        )
+        if heatmap_trace is not None:
+            fig.add_trace(heatmap_trace)
 
         # Add map origin marker (coordinate reference point)
         origin = map_data.get("origin", {}) or {}

--- a/src/maps/plotly_heatmap_renderer.py
+++ b/src/maps/plotly_heatmap_renderer.py
@@ -1,0 +1,184 @@
+"""RF coverage heatmap rendering helpers for Plotly map viewer."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import plotly.graph_objects as go
+
+
+class PlotlyCoverageHeatmapRenderer:
+    """Render Mist RF coverage API payloads into Plotly heatmap traces."""
+
+    def __init__(self, logger: logging.Logger | None = None):
+        """Initialize renderer with optional logger."""
+        self.logger = logger or logging.getLogger(__name__)
+
+    def build_heatmap_trace(
+        self,
+        coverage_data: dict[str, Any] | None,
+        ppm: float,
+        map_width: int,
+        map_height: int,
+    ) -> go.Heatmap | None:
+        """Create RF coverage heatmap trace from Mist coverage payload."""
+        if not coverage_data:
+            self.logger.info("No RF coverage data available")
+            return None
+
+        results = coverage_data.get("results", [])
+        if not results:
+            self.logger.warning("Coverage data received but no results")
+            return None
+
+        self.logger.info("Processing RF coverage data - %s grid points", len(results))
+        result_def = coverage_data.get("result_def", [])
+        gridsize_meters = coverage_data.get("gridsize", 1)
+        self.logger.debug("Coverage result_def: %s", result_def)
+        self.logger.debug("Coverage gridsize: %s meters, PPM: %s", gridsize_meters, ppm)
+
+        x_idx, y_idx, max_rssi_idx, avg_rssi_idx = self._resolve_indices(result_def)
+        grid_data = self._build_grid_data(results, x_idx, y_idx, max_rssi_idx, avg_rssi_idx, ppm)
+
+        if not grid_data:
+            self.logger.warning("No valid coverage grid data to visualize")
+            return None
+
+        all_rssi_values = [value for value in grid_data.values() if value is not None]
+        min_rssi = min(all_rssi_values) if all_rssi_values else -100
+        max_rssi = max(all_rssi_values) if all_rssi_values else -40
+
+        unique_x = sorted({x for x, _ in grid_data.keys()})
+        unique_y = sorted({y for _, y in grid_data.keys()})
+
+        self._log_alignment(map_width, map_height, ppm, unique_x, unique_y, grid_data)
+        z_matrix = self._build_z_matrix(unique_x, unique_y, grid_data)
+
+        trace = go.Heatmap(
+            x=unique_x,
+            y=unique_y,
+            z=z_matrix,
+            colorscale=self._colorscale(),
+            zmin=min_rssi,
+            zmax=max_rssi,
+            opacity=0.5,
+            name="RF Coverage",
+            hovertemplate="X: %{x}<br>Y: %{y}<br>RSSI: %{z} dBm<extra></extra>",
+            visible=False,
+            showscale=True,
+            colorbar=dict(
+                title=dict(text="RSSI (dBm)", side="right", font=dict(size=12, color="white")),
+                thickness=20,
+                len=0.5,
+                y=0.95,
+                yanchor="top",
+                x=1.02,
+                tickfont=dict(size=10, color="white"),
+                tickmode="linear",
+                tick0=min_rssi,
+                dtick=(max_rssi - min_rssi) / 5,
+                outlinewidth=1,
+                outlinecolor="white",
+            ),
+            connectgaps=True,
+            zsmooth="best",
+        )
+
+        self.logger.info(
+            "Added RF Coverage heatmap: %s cells (%sm grid) with auto-scaled colors (%s to %s dBm)",
+            len(grid_data),
+            gridsize_meters,
+            min_rssi,
+            max_rssi,
+        )
+        return trace
+
+    def _resolve_indices(self, result_def: list[str]) -> tuple[int, int, int, int]:
+        """Resolve coverage field indices with safe fallback."""
+        try:
+            return (
+                result_def.index("x"),
+                result_def.index("y"),
+                result_def.index("max_rssi"),
+                result_def.index("avg_rssi"),
+            )
+        except ValueError as error:
+            self.logger.error("Coverage data missing expected fields: %s", error)
+            return 0, 1, 4, 5
+
+    def _build_grid_data(
+        self,
+        results: list[list[Any]],
+        x_idx: int,
+        y_idx: int,
+        max_rssi_idx: int,
+        avg_rssi_idx: int,
+        ppm: float,
+    ) -> dict[tuple[float, float], Any]:
+        """Convert API meter-coordinate points to pixel-coordinate grid map."""
+        grid_data: dict[tuple[float, float], Any] = {}
+        for result in results:
+            if len(result) <= max(x_idx, y_idx, max_rssi_idx, avg_rssi_idx):
+                continue
+            pixel_x = result[x_idx] * ppm
+            pixel_y = result[y_idx] * ppm
+            grid_data[(pixel_x, pixel_y)] = result[max_rssi_idx]
+        return grid_data
+
+    def _build_z_matrix(
+        self,
+        unique_x: list[float],
+        unique_y: list[float],
+        grid_data: dict[tuple[float, float], Any],
+    ) -> list[list[Any]]:
+        """Build z matrix with None for missing points to avoid fake interpolation values."""
+        matrix: list[list[Any]] = []
+        for y_value in unique_y:
+            row: list[Any] = []
+            for x_value in unique_x:
+                row.append(grid_data.get((x_value, y_value), None))
+            matrix.append(row)
+        return matrix
+
+    def _log_alignment(
+        self,
+        map_width: int,
+        map_height: int,
+        ppm: float,
+        unique_x: list[float],
+        unique_y: list[float],
+        grid_data: dict[tuple[float, float], Any],
+    ) -> None:
+        """Log coordinate alignment diagnostics for debugging coverage placement."""
+        self.logger.info("HEATMAP DEBUG - Map dimensions: %sx%s pixels, PPM: %s", map_width, map_height, ppm)
+        self.logger.info(
+            "HEATMAP DEBUG - Coverage X range: %.1f to %.1f pixels (from %.1fm to %.1fm)",
+            min(unique_x),
+            max(unique_x),
+            min(unique_x) / ppm,
+            max(unique_x) / ppm,
+        )
+        self.logger.info(
+            "HEATMAP DEBUG - Coverage Y range: %.1f to %.1f pixels (from %.1fm to %.1fm)",
+            min(unique_y),
+            max(unique_y),
+            min(unique_y) / ppm,
+            max(unique_y) / ppm,
+        )
+        self.logger.info(
+            "HEATMAP DEBUG - Grid size: %s x %s = %s data points",
+            len(unique_x),
+            len(unique_y),
+            len(grid_data),
+        )
+
+    def _colorscale(self) -> list[list[Any]]:
+        """Return RF color scale (red strongest to blue weakest)."""
+        return [
+            [0.0, "rgb(0, 0, 255)"],
+            [0.33, "rgb(0, 255, 0)"],
+            [0.50, "rgb(255, 255, 0)"],
+            [0.67, "rgb(255, 165, 0)"],
+            [1.0, "rgb(255, 0, 0)"],
+        ]

--- a/tests/maps/test_plotly_heatmap_renderer.py
+++ b/tests/maps/test_plotly_heatmap_renderer.py
@@ -1,0 +1,68 @@
+"""Unit tests for PlotlyCoverageHeatmapRenderer."""
+
+import logging
+
+import plotly.graph_objects as go
+
+from src.maps.plotly_heatmap_renderer import PlotlyCoverageHeatmapRenderer
+
+
+def _sample_coverage() -> dict:
+    """Create minimal valid coverage payload."""
+    return {
+        "result_def": ["x", "y", "channel", "snr", "max_rssi", "avg_rssi"],
+        "results": [
+            [0.0, 0.0, 36, 25, -45, -50],
+            [1.0, 0.0, 36, 20, -60, -65],
+            [0.0, 1.0, 36, 18, -70, -72],
+            [1.0, 1.0, 36, 16, -80, -82],
+        ],
+        "gridsize": 1,
+    }
+
+
+def test_build_heatmap_trace_none_data() -> None:
+    """Renderer returns None when no coverage payload is provided."""
+    renderer = PlotlyCoverageHeatmapRenderer(logger=logging.getLogger("test"))
+    assert renderer.build_heatmap_trace(None, ppm=10, map_width=1000, map_height=500) is None
+
+
+def test_build_heatmap_trace_empty_results() -> None:
+    """Renderer returns None for empty coverage results."""
+    renderer = PlotlyCoverageHeatmapRenderer(logger=logging.getLogger("test"))
+    payload = {"result_def": ["x", "y"], "results": []}
+    assert renderer.build_heatmap_trace(payload, ppm=10, map_width=1000, map_height=500) is None
+
+
+def test_build_heatmap_trace_valid_payload() -> None:
+    """Renderer returns a Plotly heatmap trace for valid payloads."""
+    renderer = PlotlyCoverageHeatmapRenderer(logger=logging.getLogger("test"))
+    trace = renderer.build_heatmap_trace(_sample_coverage(), ppm=10, map_width=1000, map_height=500)
+
+    assert trace is not None
+    assert isinstance(trace, go.Heatmap)
+    assert trace.name == "RF Coverage"
+    assert trace.visible is False
+
+
+def test_build_heatmap_trace_value_ranges() -> None:
+    """Rendered heatmap keeps expected RSSI range bounds from payload."""
+    renderer = PlotlyCoverageHeatmapRenderer(logger=logging.getLogger("test"))
+    trace = renderer.build_heatmap_trace(_sample_coverage(), ppm=10, map_width=1000, map_height=500)
+
+    assert trace is not None
+    assert trace.zmin == -80
+    assert trace.zmax == -45
+
+
+def test_build_heatmap_trace_fallback_indices() -> None:
+    """Renderer tolerates missing expected fields by using fallback index mapping."""
+    renderer = PlotlyCoverageHeatmapRenderer(logger=logging.getLogger("test"))
+    payload = {
+        "result_def": ["foo", "bar"],
+        "results": [[0.0, 0.0, 36, 20, -55, -60]],
+        "gridsize": 1,
+    }
+
+    trace = renderer.build_heatmap_trace(payload, ppm=10, map_width=1000, map_height=500)
+    assert trace is not None


### PR DESCRIPTION
Part of #293\n\n## Phase 3: Heatmap Extraction\n\n### Completed\n- Added src/maps/plotly_heatmap_renderer.py with PlotlyCoverageHeatmapRenderer\n- Delegated RF coverage parsing and go.Heatmap construction from _launch_plotly_viewer to uild_heatmap_trace(...)\n- Preserved existing behavior/logging for:\n  - missing coverage data\n  - empty results\n  - index fallback handling\n  - grid diagnostics and color scaling\n- Added unit tests in 	ests/maps/test_plotly_heatmap_renderer.py (5 tests)\n\n### Validation\n- py_compile passed\n- uff passed\n- lack passed\n- pydocstyle passed for new renderer and tests\n- Focused pytest suites passed (54 tests)\n\n### Complexity\nsrc/maps/plotly_heatmap_renderer.py methods are all <=10 (max B(10)).\n