### PR TITLE
chore(docs): update README operation count to 185 entries (1-186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+## [26.05.20.16.29]
+
+### Changed
+
+- README: Update operation count from 184 to 185 entries and range from (1-185) to (1-186), reflecting Menu 186 added in PR #339
+
 ### Added
 
 - Menu 178: Export site aggregate health & capacity statistics (`getSiteStats`)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Network Operations & Data Export Tool for Juniper Mist Cloud
 [![Quality Gates](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml)
 [![Container Build](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml)
 
-**Operation Count:** The code currently defines 184 actionable menu entries (1-185) with some gaps for future expansion.
+**Operation Count:** The code currently defines 185 actionable menu entries (1-186) with some gaps for future expansion.
 
 MistHelper is a production-focused Python application that streamlines large-scale Juniper Mist Cloud data extraction, enrichment, transformation, and limited lifecycle operations. It supports both interactive (menu) and fully automated CLI execution, with flexible output to CSV files, a local SQLite database, or a polyglot backend (ArangoDB for documents, Redis for time-series and JSON caching) using natural/composite business keys (no artificial surrogate IDs for core entities). The codebase emphasizes safety, transparency, and predictable behavior-aligned with the included internal Agents Guide and NASA/JPL style defensive programming practices.
 
@@ -104,7 +104,7 @@ flowchart LR
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 mindmap
-   root((MistHelper<br/>185 Operations))
+   root((MistHelper<br/>186 Operations))
     Safe (52)
       Org Sites
       Device Inventory


### PR DESCRIPTION
## Summary

README.md still referenced 184 entries (1-185) after PR #339 added Menu 186 (HA gateway cluster info).

## Changes

- README.md line 7: 184 -> 185 entries, (1-185) -> (1-186)
- README.md line 107: mindmap node 'MistHelper 185 Operations' -> '186 Operations'
- CHANGELOG.md: version entry 26.05.20.16.29

Closes #349