### PR TITLE
chore(docs): configure markdownlint to allow duplicate headings in CHANGELOG

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,10 +2,12 @@
   "MD004": false,
   "MD013": false,
   "MD022": false,
+  "MD024": { "siblings_only": true },
   "MD031": false,
   "MD032": false,
   "MD034": false,
   "MD036": false,
+  "MD037": false,
   "MD058": false,
   "MD060": false
 }


### PR DESCRIPTION
## Summary

Configure .markdownlint.json to stop flagging Keep a Changelog's intentional duplicate section headings.

## Changes

- MD024 set to { siblings_only: true } — only flags duplicate headings within the same parent section. Keep a Changelog legitimately repeats ### Added, ### Changed, ### Refactored, etc. under each ## [version] block; siblings_only ignores cross-version duplicates.
- MD037 disabled — suppresses false-positive emphasis warnings on API method names (e.g. adio_stat) in changelog bullet text.

## Before / After

| Before | After |
| - | - |
| 144 markdownlint errors in CHANGELOG.md | 0 errors |

Closes #356