### PR TITLE
fix(ci): replace maps_manager.py with src/ in release bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,9 @@ jobs:
           cp pyproject.toml "${BUNDLE_DIR}/"
           cp README.md "${BUNDLE_DIR}/"
           cp LICENSE "${BUNDLE_DIR}/"
-          cp maps_manager.py "${BUNDLE_DIR}/"
           cp wsgi.py "${BUNDLE_DIR}/"
           cp __init__.py "${BUNDLE_DIR}/"
+          cp -r src/ "${BUNDLE_DIR}/src/"
           cp -r web_portal/ "${BUNDLE_DIR}/web_portal/"
           zip -r "misthelper-${VERSION}.zip" "${BUNDLE_DIR}/"
 


### PR DESCRIPTION
## Problem

Release workflow bundles \maps_manager.py\ from the repo root. This file was moved to \src/maps/maps_manager.py\ during the monolith decomposition. Every release since then fails with:

\\\
cp: cannot stat 'maps_manager.py': No such file or directory
\\\

## Fix

Replace \cp maps_manager.py\ with \cp -r src/\ so the entire src package is included.

Closes #362