### PR TITLE
chore(docs): update diagram suite for 187-op count and new destructive range

### DIFF
--- a/documentation/diagrams/core/architecture-overview.md
+++ b/documentation/diagrams/core/architecture-overview.md
@@ -23,7 +23,7 @@ flowchart TB
     ci_system(["CI/CD System<br/>GitHub Actions"])
 
     subgraph misthelper["MistHelper"]
-        mh["Python CLI tool<br/>166 operations"]
+        mh["Python CLI tool<br/>187 operations"]
     end
 
     mist_cloud["Juniper Mist Cloud<br/>REST API + WebSocket"]

--- a/documentation/diagrams/core/database-strategy.md
+++ b/documentation/diagrams/core/database-strategy.md
@@ -6,7 +6,7 @@ Hybrid primary key system and PK strategy decision flowchart for MistHelper's SQ
 
 ## Entity Relationship Diagram
 
-Representative tables showing the three PK strategies used across MistHelper's 159 operations.
+Representative tables showing the three PK strategies used across MistHelper's 187 operations.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {

--- a/documentation/diagrams/operations/metrics-and-analytics.md
+++ b/documentation/diagrams/operations/metrics-and-analytics.md
@@ -6,7 +6,7 @@ Operation distribution, rate limiting behavior, data flow volumes, and version h
 
 ## Operation Category Distribution
 
-How MistHelper's 166 operations break down by safety classification.
+How MistHelper's 187 operations break down by safety classification.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -27,12 +27,12 @@ How MistHelper's 166 operations break down by safety classification.
   'pieTitleTextColor': '#E0E0E0',
   'pieSectionTextColor': '#E0E0E0'
 }, 'pie': {'textPosition': 0.75}}}%%
-pie title Operation Safety Classification (166 total)
-    "Safe (51)" : 51
-    "Destructive (32)" : 32
+pie title Operation Safety Classification (187 total)
+    "Safe (57)" : 57
+    "Destructive (34)" : 34
+    "Interactive Safe (37)" : 37
     "Interactive (27)" : 27
     "WebSocket (22)" : 22
-    "Interactive Safe (24)" : 24
     "Resource Intensive (8)" : 8
     "Continuous (2)" : 2
 ```
@@ -177,7 +177,8 @@ timeline
                 : Auto-merge workflow
                 : Web portal (Gunicorn)
     section Current
-        2025 : 166 operations
+        2026 : 187 operations
+             : 30-group menu reorg (issue #368)
              : SpecKit integration
              : Mermaid documentation suite
              : Polyglot backends (ArangoDB/Redis)

--- a/documentation/diagrams/operations/operations-reference.md
+++ b/documentation/diagrams/operations/operations-reference.md
@@ -84,7 +84,7 @@ journey
 
 ## Destructive Operation Safety Requirements
 
-Requirements that MUST be met before any destructive operation (Menu 90-100) executes.
+Requirements that MUST be met before any destructive operation (Menu 154-187) executes.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -97,7 +97,7 @@ Requirements that MUST be met before any destructive operation (Menu 90-100) exe
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 flowchart TB
-    subgraph requirements["Safety Requirements - Menu 90-100"]
+    subgraph requirements["Safety Requirements - Menu 154-187"]
         SAF001["SAF-001: Explicit Confirmation<br/>Type exact word to proceed<br/>Risk: HIGH | Verify: test"]
         SAF002["SAF-002: EOF Handling<br/>All input calls handle EOFError<br/>Risk: HIGH | Verify: inspection"]
         SAF003["SAF-003: No Blind Automation<br/>--menu flag requires confirmation<br/>Risk: HIGH | Verify: test"]


### PR DESCRIPTION
Updates four diagram files left stale after the menu regrouping (#368/#369).

Closes #370