### PR TITLE
fix(tickets): remove unsupported limit param from listOrgTickets

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -11959,7 +11959,6 @@ class OrgTicketManager:
                 api_call=mistapi.api.v1.orgs.tickets.listOrgTickets,  # SDK function for ticket listing
                 filename="OrgTickets.csv",  # Output filename in data/ directory
                 sort_key="created_at",  # Sort tickets by creation timestamp
-                limit=1000,  # Page size for API pagination
             ).execute()  # Run the full fetch-flatten-export workflow
             logging.info("Completed org ticket list export")  # Log success
             logging.debug("EXIT: OrgTicketManager.list_tickets - success")  # Debug trace


### PR DESCRIPTION
## Fix
Menu 188 (List Org Tickets) threw TypeError: `listOrgTickets() got an unexpected keyword argument 'limit'`\n
## Root Cause
The `listOrgTickets` SDK function signature is `(mist_session, org_id, start, end, duration)` -- it does not accept a `limit` parameter. `APIDataFetcher` passes `**kwargs` directly to the SDK call, so `limit=1000` was forwarded and rejected.

## Fix
Removed `limit=1000` from the `APIDataFetcher` constructor call in `OrgTicketManager.list_tickets()`. Pagination is handled internally by `APIDataFetcher` via `mistapi.get_all()`.