### PR TITLE
docs: update operation counts and menu categories to 193

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ When refactoring code, avoid using wrappers; actually restructure into classes a
 ---
 
 ## Project Overview
-MistHelper is a production-grade Python tool (~28K lines) for Juniper Mist Cloud network operations. It provides 100+ menu-driven operations for data extraction, device management, and firmware upgrades with multi-backend output (CSV, SQLite, or polyglot ArangoDB/Redis) and containerized SSH access.
+MistHelper is a production-grade Python tool (~28K lines) for Juniper Mist Cloud network operations. It provides 193 menu-driven operations for data extraction, device management, and firmware upgrades with multi-backend output (CSV, SQLite, or polyglot ArangoDB/Redis) and containerized SSH access.
 
 **Target Audience**: Junior NOC engineers. Use clear, professional language without jargon. Think Fred Rogers meets NASA/JPL safety standards.
 
@@ -327,34 +327,57 @@ is_running_in_container()  # Checks /.dockerenv, /run/.containerenv
 
 ## Menu System & Operations
 
-### Menu Categories (Full Range: 1-100)
-**Data Extraction (1-50)**:
-- 1-4: Core organization/site operations
-- 5-8: WebSocket real-time commands (wireless devices, switches, gateways)
-- 9-10: Packet captures (site-level, org-level with switch support)
-- 11-50: Device inventory, events, stats, licenses, templates, etc.
+### Menu Categories (Full Range: 1-193)
+**Safe Org Exports (1-59)**:
+- 1-7: Sites and analysis
+- 8-14: Device inventory
+- 15-19: Device stats
+- 20-26: Events and logs
+- 27-30: Client stats
+- 31-36: Gateway operations
+- 37-41: Templates
+- 42-50: Config and admin
+- 51-55: SLE and insights
+- 56-59: Misc exports
 
-**Advanced Operations (51-89)**:
-- 51-62: Maps, webhooks, SLE metrics, alarms
-- 63-65: WIP features (skip in tests)
-- 66-86: Client data, WLAN configs, RF templates, API tokens
-- 87-89: Additional WebSocket commands
+**Interactive Safe (60-96)**:
+- 60-72: Site devices
+- 73-79: Site insights
+- 80-91: Site stats
+- 92-96: Viewers
 
-**Destructive Operations (90-100)** - NEVER automate without explicit user confirmation:
-- 90: AP Firmware (Site or Template-based)
-- 91-93: AP Reboots (various strategies)
-- 94-96: VC Conversion (virtual chassis operations)
-- 97-98: SSH Runner (device command execution)
-- 99-100: Switch/SSR Firmware (advanced upgrade modes)
+**Resource Intensive (97-101, 153)**:
+- 97-101: Long-running operations
+- 153: Bulk operations
+
+**WebSocket (102-123)**:
+- 102-115: Show commands (wireless, switches, gateways)
+- 116-123: Diagnostics
+
+**Interactive (124-150)**:
+- 124-127: Device diagnostics
+- 128-133: Device management
+- 134-135: Packet captures (site-level, org-level with switch support)
+- 136-147: Tools
+- 148-150: Config management
+
+**Continuous (151-152)**:
+- 151-152: Continuous monitoring loops
+
+**Destructive Operations (154-193)** - NEVER automate without explicit user confirmation:
+- 154-157: Firmware upgrades
+- 158-160: AP reboots
+- 161-162: VC conversion (virtual chassis operations)
+- 163-167: Template operations
+- 168-170: Site config operations
+- 171-174: Test data operations
+- 175-176: SSH runners (device command execution)
+- 177-187: Clear/reset operations
+- 188-193: Support ticket operations
 
 ### Interactive vs Direct Invocation
 - **Interactive**: No args = menu-driven selection with safe navigation
 - **Direct**: `--menu 11` for automation
-- **Packet Captures** (Menu 9-10): 
-  - Site captures (Menu 9): Wireless client, wired client, gateway, **switch**, new association, scan radio
-  - Org captures (Menu 10): Similar capabilities at org level
-  - **Switch captures**: Full support for port-specific captures with tcpdump filtering
-- **WebSocket Commands** (Menu 5-8, 87-89): Real-time device commands with connection management
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ flowchart LR
 }}}%%
 mindmap
    root((MistHelper<br/>193 Operations))
-    Safe Org Exports (57)
+    Safe Org Exports (59)
       Sites and Analysis 1-7
       Device Inventory 8-14
       Device Stats 15-19
@@ -135,7 +135,7 @@ mindmap
       Config Mgmt 148-150
     Continuous (2)
       Loops 151-152
-    Destructive (36)
+    Destructive (40)
       ::icon(fa fa-warning)
       Firmware 154-157
       Reboot 158-160

--- a/documentation/diagrams/core/architecture-overview.md
+++ b/documentation/diagrams/core/architecture-overview.md
@@ -23,7 +23,7 @@ flowchart TB
     ci_system(["CI/CD System<br/>GitHub Actions"])
 
     subgraph misthelper["MistHelper"]
-        mh["Python CLI tool<br/>187 operations"]
+        mh["Python CLI tool<br/>193 operations"]
     end
 
     mist_cloud["Juniper Mist Cloud<br/>REST API + WebSocket"]
@@ -98,7 +98,7 @@ flowchart LR
 
 | Subsystem | Primary Classes | Purpose |
 |-----------|----------------|---------|
-| Menu System | `OperationRegistry`, `MistHelperTUI` | 164-operation interactive/CLI menu |
+| Menu System | `OperationRegistry`, `MistHelperTUI` | 193-operation interactive/CLI menu |
 | API Layer | `APIFetchUtils`, `RateLimitingUtils` | Paginated API calls with adaptive rate limiting |
 | Data Exporters | `DataExporter`, `SQLiteDatabaseWriter`, `DatabaseRouter` | Multi-backend output (CSV/SQLite/ArangoDB/Redis) with business keys |
 | WebSocket | `WebSocketManager`, `WebSocketCommands` | Real-time device commands |

--- a/documentation/diagrams/core/database-strategy.md
+++ b/documentation/diagrams/core/database-strategy.md
@@ -6,7 +6,7 @@ Hybrid primary key system and PK strategy decision flowchart for MistHelper's SQ
 
 ## Entity Relationship Diagram
 
-Representative tables showing the three PK strategies used across MistHelper's 187 operations.
+Representative tables showing the three PK strategies used across MistHelper's 193 operations.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {

--- a/documentation/diagrams/operations/metrics-and-analytics.md
+++ b/documentation/diagrams/operations/metrics-and-analytics.md
@@ -6,7 +6,7 @@ Operation distribution, rate limiting behavior, data flow volumes, and version h
 
 ## Operation Category Distribution
 
-How MistHelper's 187 operations break down by safety classification.
+How MistHelper's 193 operations break down by safety classification.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -27,13 +27,13 @@ How MistHelper's 187 operations break down by safety classification.
   'pieTitleTextColor': '#E0E0E0',
   'pieSectionTextColor': '#E0E0E0'
 }, 'pie': {'textPosition': 0.75}}}%%
-pie title Operation Safety Classification (187 total)
-    "Safe (57)" : 57
-    "Destructive (34)" : 34
+pie title Operation Safety Classification (193 total)
+    "Safe (59)" : 59
+    "Destructive (40)" : 40
     "Interactive Safe (37)" : 37
     "Interactive (27)" : 27
     "WebSocket (22)" : 22
-    "Resource Intensive (8)" : 8
+    "Resource Intensive (6)" : 6
     "Continuous (2)" : 2
 ```
 
@@ -177,7 +177,7 @@ timeline
                 : Auto-merge workflow
                 : Web portal (Gunicorn)
     section Current
-        2026 : 187 operations
+        2026 : 193 operations
              : 30-group menu reorg (issue #368)
              : SpecKit integration
              : Mermaid documentation suite

--- a/documentation/diagrams/operations/operations-reference.md
+++ b/documentation/diagrams/operations/operations-reference.md
@@ -84,7 +84,7 @@ journey
 
 ## Destructive Operation Safety Requirements
 
-Requirements that MUST be met before any destructive operation (Menu 154-187) executes.
+Requirements that MUST be met before any destructive operation (Menu 154-193) executes.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -97,7 +97,7 @@ Requirements that MUST be met before any destructive operation (Menu 154-187) ex
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 flowchart TB
-    subgraph requirements["Safety Requirements - Menu 154-187"]
+    subgraph requirements["Safety Requirements - Menu 154-193"]
         SAF001["SAF-001: Explicit Confirmation<br/>Type exact word to proceed<br/>Risk: HIGH | Verify: test"]
         SAF002["SAF-002: EOF Handling<br/>All input calls handle EOFError<br/>Risk: HIGH | Verify: inspection"]
         SAF003["SAF-003: No Blind Automation<br/>--menu flag requires confirmation<br/>Risk: HIGH | Verify: test"]


### PR DESCRIPTION
Updates all stale documentation references after Menu 192-193 additions.

## Changes
- **README.md**: Fix mindmap Safe (57->59), Destructive (36->40)
- **architecture-overview.md**: 187->193 operations
- **database-strategy.md**: 187->193 operations
- **metrics-and-analytics.md**: Pie chart total 187->193, Destructive 34->40, Safe 57->59, Resource Intensive 8->6, timeline 187->193
- **operations-reference.md**: Destructive range 154-187->154-193
- **copilot-instructions.md**: 100+->193, rewrite Menu Categories from stale 1-100 to current 1-193 layout

Docs-only, no code changes.