### PR TITLE
docs(wiki): update operation counts from 164 to 193

### DIFF
--- a/documentation/wiki/History.md
+++ b/documentation/wiki/History.md
@@ -2,7 +2,7 @@
 
 The previous README was partially outdated compared to the current codebase. Key discrepancies that were corrected:
 
-1. **Operation Count**: MistHelper now has 164 actionable menu entries (0-163), with some gaps reserved for future expansion
+1. **Operation Count**: MistHelper now has 193 actionable menu entries (1-193)
 2. **File Naming**: Actual output files use names like `OrgApiTokens.csv`, `OrgPsks.csv`, etc. Weekly inventory is stored in `CombinedInventory_ByWeek/`
 3. **SSH Command Runner**: The Enhanced SSH Runner (option 97) uses a fallback CSV located at `data/SSH_COMMANDS.CSV`, not the root directory
 4. **Heavy Operations**: Options 14 (port stats for all sites) and 18 (site settings for all sites) are excluded from `--test` mode due to multi-hour runtime

--- a/documentation/wiki/Home.md
+++ b/documentation/wiki/Home.md
@@ -1,10 +1,10 @@
 # MistHelper Wiki
 
-Welcome to the MistHelper documentation wiki. MistHelper is a production-focused Python application for Juniper Mist Cloud network operations, providing 164 menu-driven operations for data extraction, device management, and firmware upgrades.
+Welcome to the MistHelper documentation wiki. MistHelper is a production-focused Python application for Juniper Mist Cloud network operations, providing 193 menu-driven operations for data extraction, device management, and firmware upgrades.
 
 ## Quick Links
 
-- [Menu Reference](Menu-Reference) - Complete list of all 164 menu operations
+- [Menu Reference](Menu-Reference) - Complete list of all 193 menu operations
 - [Data Model](Data-Model) - CSV, SQLite, and polyglot output details
 - [Testing](Testing) - Systematic test mode and CI pipeline
 - [Troubleshooting](Troubleshooting) - Common issues and solutions

--- a/documentation/wiki/Menu-Reference.md
+++ b/documentation/wiki/Menu-Reference.md
@@ -1,6 +1,6 @@
 # Menu Reference
 
-Operation Count: MistHelper currently defines 164 actionable menu entries (0-163) with some gaps for future expansion.
+Operation Count: MistHelper currently defines 193 actionable menu entries (1-193).
 
 Below is the authoritative list derived directly from `menu_actions` in code. WIP = unstable schema, DESTRUCTIVE = requires explicit user confirmation.
 


### PR DESCRIPTION
Updates in-repo wiki pages with current operation count after Menu 188-193 additions.

## Changes
- **Home.md**: 164->193 in description and quick links
- **Menu-Reference.md**: 164->193 in operation count header  
- **History.md**: 164->193 in operation count entry

Docs-only, no code changes.