### PR TITLE
docs: sync operation count 193->194 across READMEs, diagrams, wiki

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ When refactoring code, avoid using wrappers; actually restructure into classes a
 ---
 
 ## Project Overview
-MistHelper is a production-grade Python tool (~28K lines) for Juniper Mist Cloud network operations. It provides 193 menu-driven operations for data extraction, device management, and firmware upgrades with multi-backend output (CSV, SQLite, or polyglot ArangoDB/Redis) and containerized SSH access.
+MistHelper is a production-grade Python tool (~28K lines) for Juniper Mist Cloud network operations. It provides 194 menu-driven operations for data extraction, device management, and firmware upgrades with multi-backend output (CSV, SQLite, or polyglot ArangoDB/Redis) and containerized SSH access.
 
 **Target Audience**: Junior NOC engineers. Use clear, professional language without jargon. Think Fred Rogers meets NASA/JPL safety standards.
 
@@ -243,7 +243,7 @@ is_running_in_container()  # Checks /.dockerenv, /run/.containerenv
 
 ## Menu System & Operations
 
-### Menu Categories (Full Range: 1-193)
+### Menu Categories (Full Range: 1-194)
 
 | Range | Category | Notes |
 | - | - | - |
@@ -253,7 +253,7 @@ is_running_in_container()  # Checks /.dockerenv, /run/.containerenv
 | 102-123 | WebSocket | Show commands (102-115), Diagnostics (116-123) |
 | 124-150 | Interactive | Diagnostics (124-127), Management (128-133), Packet captures (134-135), Tools (136-147), Config (148-150) |
 | 151-152 | Continuous | Monitoring loops |
-| 154-193 | **Destructive** | Firmware (154-157), Reboots (158-160), VC (161-162), Templates (163-167), Site config (168-170), Test data (171-174), SSH runners (175-176), Clear/reset (177-187), Support tickets (188-193). **NEVER automate without explicit user confirmation.** |
+| 154-194 | **Destructive** | Firmware (154-157), Reboots (158-160), VC (161-162), Templates (163-167), Site config (168-170), Test data (171-174), SSH runners (175-176), Clear/reset (177-187), Support tickets (188-193), Clone device config to gateway template (194). **NEVER automate without explicit user confirmation.** |
 
 ### Interactive vs Direct Invocation
 - **Interactive**: No args = menu-driven selection with safe navigation

--- a/documentation/diagrams/core/architecture-overview.md
+++ b/documentation/diagrams/core/architecture-overview.md
@@ -23,7 +23,7 @@ flowchart TB
     ci_system(["CI/CD System<br/>GitHub Actions"])
 
     subgraph misthelper["MistHelper"]
-        mh["Python CLI tool<br/>193 operations"]
+        mh["Python CLI tool<br/>194 operations"]
     end
 
     mist_cloud["Juniper Mist Cloud<br/>REST API + WebSocket"]

--- a/documentation/diagrams/core/database-strategy.md
+++ b/documentation/diagrams/core/database-strategy.md
@@ -6,7 +6,7 @@ Hybrid primary key system and PK strategy decision flowchart for MistHelper's SQ
 
 ## Entity Relationship Diagram
 
-Representative tables showing the three PK strategies used across MistHelper's 193 operations.
+Representative tables showing the three PK strategies used across MistHelper's 194 operations.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {

--- a/documentation/diagrams/operations/metrics-and-analytics.md
+++ b/documentation/diagrams/operations/metrics-and-analytics.md
@@ -6,7 +6,7 @@ Operation distribution, rate limiting behavior, data flow volumes, and version h
 
 ## Operation Category Distribution
 
-How MistHelper's 193 operations break down by safety classification.
+How MistHelper's 194 operations break down by safety classification.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -177,7 +177,7 @@ timeline
                 : Auto-merge workflow
                 : Web portal (Gunicorn)
     section Current
-        2026 : 193 operations
+        2026 : 194 operations
              : 30-group menu reorg (issue #368)
              : SpecKit integration
              : Mermaid documentation suite

--- a/documentation/diagrams/operations/operations-reference.md
+++ b/documentation/diagrams/operations/operations-reference.md
@@ -84,7 +84,7 @@ journey
 
 ## Destructive Operation Safety Requirements
 
-Requirements that MUST be met before any destructive operation (Menu 154-193) executes.
+Requirements that MUST be met before any destructive operation (Menu 154-194) executes.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -97,7 +97,7 @@ Requirements that MUST be met before any destructive operation (Menu 154-193) ex
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 flowchart TB
-    subgraph requirements["Safety Requirements - Menu 154-193"]
+    subgraph requirements["Safety Requirements - Menu 154-194"]
         SAF001["SAF-001: Explicit Confirmation<br/>Type exact word to proceed<br/>Risk: HIGH | Verify: test"]
         SAF002["SAF-002: EOF Handling<br/>All input calls handle EOFError<br/>Risk: HIGH | Verify: inspection"]
         SAF003["SAF-003: No Blind Automation<br/>--menu flag requires confirmation<br/>Risk: HIGH | Verify: test"]

--- a/documentation/wiki/History.md
+++ b/documentation/wiki/History.md
@@ -2,7 +2,7 @@
 
 The previous README was partially outdated compared to the current codebase. Key discrepancies that were corrected:
 
-1. **Operation Count**: MistHelper now has 193 actionable menu entries (1-193)
+1. **Operation Count**: MistHelper now has 194 actionable menu entries (1-194)
 2. **File Naming**: Actual output files use names like `OrgApiTokens.csv`, `OrgPsks.csv`, etc. Weekly inventory is stored in `CombinedInventory_ByWeek/`
 3. **SSH Command Runner**: The Enhanced SSH Runner (option 97) uses a fallback CSV located at `data/SSH_COMMANDS.CSV`, not the root directory
 4. **Heavy Operations**: Options 14 (port stats for all sites) and 18 (site settings for all sites) are excluded from `--test` mode due to multi-hour runtime

--- a/documentation/wiki/Home.md
+++ b/documentation/wiki/Home.md
@@ -1,10 +1,10 @@
 # MistHelper Wiki
 
-Welcome to the MistHelper documentation wiki. MistHelper is a production-focused Python application for Juniper Mist Cloud network operations, providing 193 menu-driven operations for data extraction, device management, and firmware upgrades.
+Welcome to the MistHelper documentation wiki. MistHelper is a production-focused Python application for Juniper Mist Cloud network operations, providing 194 menu-driven operations for data extraction, device management, and firmware upgrades.
 
 ## Quick Links
 
-- [Menu Reference](Menu-Reference) - Complete list of all 193 menu operations
+- [Menu Reference](Menu-Reference) - Complete list of all 194 menu operations
 - [Data Model](Data-Model) - CSV, SQLite, and polyglot output details
 - [Testing](Testing) - Systematic test mode and CI pipeline
 - [Troubleshooting](Troubleshooting) - Common issues and solutions

--- a/documentation/wiki/Menu-Reference.md
+++ b/documentation/wiki/Menu-Reference.md
@@ -1,6 +1,6 @@
 # Menu Reference
 
-Operation Count: MistHelper currently defines 193 actionable menu entries (1-193).
+Operation Count: MistHelper currently defines 194 actionable menu entries (1-194).
 
 Below is the authoritative list derived directly from `menu_actions` in code. WIP = unstable schema, DESTRUCTIVE = requires explicit user confirmation.
 


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #394

Closes #394

## Summary

Pure documentation sync. After PR #393 added Menu 194 (Clone Device Config to
Gateway Template), several files still referenced the old operation count (193)
and menu range (1-193, 154-193). This PR updates all of them in a single pass.

## Files changed

| File | Change |
| - | - |
| `.github/copilot-instructions.md` | Op count, full range, destructive table row description |
| `documentation/diagrams/core/architecture-overview.md` | Mermaid node label |
| `documentation/diagrams/core/database-strategy.md` | Prose op count |
| `documentation/diagrams/operations/metrics-and-analytics.md` | Prose op count + timeline entry |
| `documentation/diagrams/operations/operations-reference.md` | Two destructive-range references |
| `documentation/wiki/History.md` | Op count entry |
| `documentation/wiki/Home.md` | Welcome blurb + menu reference link |
| `documentation/wiki/Menu-Reference.md` | Op count header |

Total: 13 line edits across 8 files. No code change.

## Acceptance Criteria
- [x] Every doc reference to operation count reads `194`
- [x] Every doc reference to destructive menu range reads `154-194`
- [x] Destructive table mentions clone-device-config (Menu 194)
- [x] No code change

## Quality
- [x] No `.py` files touched — Ruff/mypy/Bandit/pytest unaffected
- [x] Mermaid diagrams parse (existing structure preserved; only text inside labels changed)
- [x] Wiki mirror in `documentation/wiki/` is updated; will sync to GitHub wiki after merge

## Security
- [x] No code change; security scanners (Bandit, pip-audit, CodeQL) unchanged

## Deployment
- [x] No `.env` change
- [x] No container image change

## Documentation
- [x] This IS the documentation update
- [ ] CHANGELOG entry — not added (pure doc sync, no functional change)

## Notes for reviewer

Wiki sync (separate `MistHelper.wiki.git` repo on GitHub) will follow this PR's
merge as a separate step. The `documentation/wiki/` folder is the source of
truth and gets mirrored to the wiki repo.
