### PR TITLE
chore: sync agent tooling (caveman skills, rtk hook, .agents gitignore)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -602,3 +602,31 @@ For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
 at specs/168-clone-gateway-template/plan.md
 <!-- SPECKIT END -->
+
+<!-- rtk-instructions v2 -->
+# RTK — Token-Optimized CLI
+
+**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
+
+## Rule
+
+Always prefix shell commands with `rtk`:
+
+```bash
+# Instead of:              Use:
+git status                 rtk git status
+git log -10                rtk git log -10
+cargo test                 rtk cargo test
+docker ps                  rtk docker ps
+kubectl get pods           rtk kubectl pods
+```
+
+## Meta commands (use directly)
+
+```bash
+rtk gain              # Token savings dashboard
+rtk gain --history    # Per-command savings history
+rtk discover          # Find missed rtk opportunities
+rtk proxy <cmd>       # Run raw (no filtering) but track usage
+```
+<!-- /rtk-instructions -->

--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "rtk hook copilot",
+        "cwd": ".",
+        "timeout": 5
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "rtk hook copilot",
+        "powershell": "rtk hook copilot",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.github/instructions/caveman.instructions.md
+++ b/.github/instructions/caveman.instructions.md
@@ -1,0 +1,51 @@
+---
+description: "Use when: any conversational output in this repo. Caveman compression — drop fluff, keep substance. Source: https://github.com/JuliusBrussee/caveman"
+applyTo: "**"
+---
+
+# Caveman Mode (Repo)
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Rules
+
+- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging.
+- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+- Pattern: `[thing] [action] [reason]. [next step].`
+- Not: "Sure! I'd be happy to help you with that."
+- Yes: "Bug in auth middleware. Fix:"
+
+## Levels
+
+User say `/caveman lite|full|ultra|wenyan` -> switch level. Default: `full`.
+
+- **lite**: drop filler only.
+- **full**: caveman default (this file).
+- **ultra**: telegraphic, max compression.
+- **wenyan**: classical Chinese style, shortest.
+
+Stop: "stop caveman" or "normal mode". Resume on next request unless user say off.
+
+## Auto-Clarity (override caveman)
+
+Drop caveman for:
+- Security warnings.
+- Irreversible / destructive actions (rm -rf, force-push, drop table, prod deploy).
+- User confused -- clarify in full sentence.
+
+Resume caveman after.
+
+## Boundaries (NOT compressed)
+
+- **Code**: written normal. Inline comments, docstrings, logging stay per project rules.
+- **Commit messages**: Conventional Commits, full grammar.
+- **PR descriptions**: full prose for reviewers.
+- **Error messages / log output**: verbatim, no edit.
+- **File paths, URLs, identifiers**: byte-preserved.
+
+## Interaction with Repo Instructions
+
+Repo-level `.github/copilot-instructions.md` and project `agents.md` take precedence
+for **code artifacts** (inline comments, action logging, 5-Item Rule, etc.).
+Caveman only compresses **chat prose** -- explanations, status updates, summaries
+between tool calls. All NON-NEGOTIABLE code conventions remain in full.

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ dmypy.json
 .DS_Store?
 ._*
 .Spotlight-V100
+
+# Caveman installer artifacts (universal skills format, unused by VS Code Copilot)
+.agents/
 .Trashes
 ehthumbs.db
 Thumbs.db

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "skills": {
+    "cavecrew": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/cavecrew/SKILL.md",
+      "computedHash": "326e2f95ddfa1d2aca1c33cbcc2c7352561e4e9a1d26b7c9e84f938590063c9f"
+    },
+    "caveman": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman/SKILL.md",
+      "computedHash": "7935e83f9c6a8b7cbb5404d144b0d19e3ba93583f4388301c3dada37cd25adf8"
+    },
+    "caveman-commit": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-commit/SKILL.md",
+      "computedHash": "1dd642480aee47934d6c202fd471e41922c7dc312e92a6e38059442b39bb0795"
+    },
+    "caveman-compress": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-compress/SKILL.md",
+      "computedHash": "6a1722a4381909febe8c8b23e87e3396e3688c05c302f625143e194b447f5bd2"
+    },
+    "caveman-help": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-help/SKILL.md",
+      "computedHash": "7a667161d6a0644fa175b0cb4a043b76108a603af70cf25f62afd788191a3fa8"
+    },
+    "caveman-review": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-review/SKILL.md",
+      "computedHash": "b9091dbc51de0f3710ea818fd4d638539f8c1784f8fda931eb159c44861e702e"
+    },
+    "caveman-stats": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-stats/SKILL.md",
+      "computedHash": "331f720e2fa97b68cacdae44384878071e8cac6013479edea68f4c8eca308852"
+    }
+  }
+}


### PR DESCRIPTION
Closes #396

## Files
- `.gitignore`: ignore `.agents/` (caveman installer artifacts that appear post-install)
- `.github/copilot-instructions.md`: rtk CLI prefix block
- `.github/instructions/caveman.instructions.md`: caveman skill instructions
- `.github/hooks/rtk-rewrite.json`: rtk hook config
- `skills-lock.json`: lock JuliusBrussee/caveman skill versions

Tooling-only \u2014 no production code touched. Quality gates will skip (no Python changes).