### PR TITLE
fix(tests): re-export E911BSSIDReportGenerator for module-level access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+## [26.06.09.22.10] - Fix E911BSSIDReportGenerator module-level access
+
+### Fixed
+
+- **Tests**: `tests/integration/test_mistapi_sdk_compatibility.py::test_maps_and_wlan_helpers_are_covered` and `test_e911_report_runs_with_stubbed_maps_and_wlans` no longer fail with `AttributeError: module 'MistHelper' has no attribute 'E911BSSIDReportGenerator'`. Moved `E911BSSIDReportGenerator` import from function-local (aliased as `_E911`) to module-level so tests can access it via `MistHelper.E911BSSIDReportGenerator`. Closes #364.
+
 ## [26.06.08] - Menu 194 Clone Device Config to Gateway Template
 
 ### Added

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -133,6 +133,7 @@ from src.gateway.gateway_export_utils import (
     configure_gateway_export_utils_dependencies,
 )  # Import gateway export utility configuration
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
+from src.reports.e911_bssid import E911BSSIDReportGenerator  # Module-level for tests
 from src.ssh.ssh_runner import EnhancedSSHRunner  # Import SSH command execution and result parsing
 from src.ssh.ssh_runner_manager import (
     SSHRunnerManager as ExtractedSSHRunnerManager,
@@ -15784,9 +15785,7 @@ class OrgExportUtils:
         if not current_org_id:
             print("! No organization selected. Exiting.")
             return
-        from src.reports.e911_bssid import E911BSSIDReportGenerator as _E911  # noqa: PLC0415
-
-        _E911.execute(
+        E911BSSIDReportGenerator.execute(
             apisession=apisession,
             page_limit=DEFAULT_API_PAGE_LIMIT,
             org_id=current_org_id,


### PR DESCRIPTION
Closes #364

## Summary

Fixes 2 failing integration tests that error with:

```nAttributeError: module 'MistHelper' has no attribute 'E911BSSIDReportGenerator'`

## Failing tests now passing/skipping cleanly

- 	ests/integration/test_mistapi_sdk_compatibility.py::test_maps_and_wlan_helpers_are_covered`n- 	ests/integration/test_mistapi_sdk_compatibility.py::test_e911_report_runs_with_stubbed_maps_and_wlans`n
## Change

Moves E911BSSIDReportGenerator import from function-local (aliased as _E911) to module level. Tests access it via MistHelper.E911BSSIDReportGenerator attribute lookup, which only works when imported at module scope.

- Added module-level import at MistHelper.py top imports block
- Removed redundant function-local import and _E911 alias
- Call site now references E911BSSIDReportGenerator.execute(...) directly

## Quality gates

- python -m py_compile MistHelper.py clean
- python -m ruff check MistHelper.py All checks passed!
- python -m black --check MistHelper.py clean
- Failing tests now SKIP (require live API) instead of failing with AttributeError