### PR TITLE
Fix menu 13 undercount: include unassigned AP/switch inventory (#415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Menu 13 undercounted devices (unassigned AP/switch inventory excluded)** (#415): The Org Device Inventory Summary counted APs via `countOrgDevices` and switches via `searchOrgDevices`, both of which return only devices **assigned to a site**. Unassigned APs and switches sitting in org inventory were therefore omitted from the model-count, firmware-summary, and version-per-model reports, understating totals and leaving the reports internally inconsistent (gateways already used `getOrgInventory`, which includes unassigned stock). A supplemental `getOrgInventory(type="ap,switch")` fetch now pulls claimed-but-unassigned APs and switches (filtered client-side on a missing `site_id`), merges them into the model counts, and surfaces them under a dedicated `unassigned` firmware column in the firmware summary and version-per-model pivot (single-org and MSP combined). The `unassigned` bucket is kept distinct from `unknown` (an assigned device that never reported firmware). Assigned-but-offline/disconnected devices were already counted (the assigned-device APIs do not filter on connection state), so no change was needed there. Gateways are intentionally excluded from the supplemental fetch to avoid double counting.
+
 ## [26.06.09.22.10] - Fix E911BSSIDReportGenerator module-level access
 
 ### Fixed

--- a/src/inventory/inventory_summary/version_per_model_fetcher.py
+++ b/src/inventory/inventory_summary/version_per_model_fetcher.py
@@ -11,7 +11,7 @@ class VersionPerModelFetcher:
     """Decomposed replacement for the original `_fetch_versions_per_model` helper."""
 
     @staticmethod
-    def fetch(target_org_id: str, model_rows: list[dict]) -> list[dict]:
+    def fetch(target_org_id: str, model_rows: list[dict], unassigned_records: list[dict] | None = None) -> list[dict]:
         """Return per-model version count rows across AP / switch / gateway types."""
         logging.info(
             "Fetching version distribution per model, org=%s", target_org_id
@@ -33,6 +33,9 @@ class VersionPerModelFetcher:
                 )
             )
             all_rows.extend(rows)  # Append helper output verbatim; helper returns [] on skip
+        all_rows.extend(  # Add unassigned AP/switch stock so the pivot gains an "unassigned" version column
+            VersionPerModelFetcher._unassigned_rows(target_org_id, unassigned_records)
+        )
         all_rows.sort(  # Stable order for human-readable output: type, then model, then count desc
             key=lambda row: (row.get("device_type", ""), row.get("model", ""), -int(row.get("count", 0)))
         )
@@ -40,6 +43,28 @@ class VersionPerModelFetcher:
             "Total version-per-model rows after fetch and sort: %d", len(all_rows)
         )  # Record final row count for diagnostics
         return all_rows
+
+    @staticmethod
+    def _unassigned_rows(target_org_id: str, unassigned_records: list[dict] | None) -> list[dict]:
+        """Build per-model rows for unassigned AP/switch stock, bucketed under version 'unassigned'."""
+        # These devices are claimed but not assigned to a site, so the assigned-only count/search
+        # APIs never return them. We surface them under a dedicated "unassigned" version so the
+        # pivot renderer emits a clearly labelled column instead of silently undercounting.
+        if unassigned_records is None:  # Direct/test callers may omit the shared fetch; pull it ourselves
+            unassigned_records = _parent.OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
+        logging.info("Building unassigned version-per-model rows from %d records", len(unassigned_records))
+        counts: dict[tuple[str, str], int] = {}  # Running total per (device_type, model)
+        for record in unassigned_records:  # Walk each unassigned inventory record once
+            device_type = record.get("type") or "unknown"  # Inventory record carries its own ap/switch type
+            model_name = record.get("model") or "unknown"  # Keep real model so it lines up with assigned rows
+            key = (device_type, model_name)  # Compose grouping key
+            counts[key] = counts.get(key, 0) + 1  # Each unassigned record is one physical device
+        rows = [  # Materialize into standard rows with the synthetic "unassigned" version bucket
+            {"device_type": device_type, "model": model_name, "version": "unassigned", "count": count}
+            for (device_type, model_name), count in counts.items()
+        ]
+        logging.debug("Unassigned version-per-model produced %d rows", len(rows))  # Record outcome
+        return rows
 
     @staticmethod
     def _prefetch_switches(target_org_id: str, model_rows: list[dict]) -> list[dict]:

--- a/src/inventory/org_device_inventory_summary.py
+++ b/src/inventory/org_device_inventory_summary.py
@@ -251,16 +251,26 @@ class OrgDeviceInventorySummaryCore:
                     error,
                     exc_info=True,
                 )
-        if unassigned_records is None:  # Direct/test callers may omit the shared fetch; pull it ourselves
-            unassigned_records = OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
-        try:  # Fold unassigned AP/switch stock into the counts so totals are not understated
-            unassigned_rows = OrgDeviceInventorySummaryCore._aggregate_unassigned_counts(unassigned_records, distinct)
-            all_rows = OrgDeviceInventorySummaryCore._merge_counts(all_rows, unassigned_rows, distinct)
-        except Exception as error:  # Supplemental counting must never break the primary report
-            logging.error("Unassigned %s supplemental count failed: %s", distinct, error, exc_info=True)
+        all_rows = OrgDeviceInventorySummaryCore._with_unassigned(all_rows, target_org_id, distinct, unassigned_records)
         all_rows.sort(key=lambda row: (row.get("device_type", ""), -int(row.get("count", 0))))
         logging.info("Total %s count rows after fetch and sort: %d", distinct, len(all_rows))
         return all_rows
+
+    @staticmethod
+    def _with_unassigned(
+        all_rows: list[dict], target_org_id: str, distinct: str, unassigned_records: list[dict] | None
+    ) -> list[dict]:
+        """Merge unassigned AP/switch stock into assigned counts so totals are not understated."""
+        # Kept as its own method so the primary counting loop stays within the complexity budget.
+        if unassigned_records is None:  # Direct/test callers may omit the shared fetch; pull it ourselves
+            unassigned_records = OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
+        try:  # Supplemental counting must never break the primary report
+            unassigned_rows = OrgDeviceInventorySummaryCore._aggregate_unassigned_counts(unassigned_records, distinct)
+            merged = OrgDeviceInventorySummaryCore._merge_counts(all_rows, unassigned_rows, distinct)
+            return merged  # Combined assigned + unassigned rows
+        except Exception as error:  # Fall back to assigned-only rows on any aggregation/merge failure
+            logging.error("Unassigned %s supplemental count failed: %s", distinct, error, exc_info=True)
+            return all_rows  # Degrade gracefully to the assigned-only counts
 
     @staticmethod
     def _display_and_export(rows: list[dict], distinct: str, filename: str, api_func: str) -> None:

--- a/src/inventory/org_device_inventory_summary.py
+++ b/src/inventory/org_device_inventory_summary.py
@@ -131,7 +131,78 @@ class OrgDeviceInventorySummaryCore:
         return rows
 
     @staticmethod
-    def _fetch_all_counts(target_org_id: str, distinct: str) -> list[dict]:
+    def _fetch_unassigned_inventory(target_org_id: str) -> list[dict]:
+        """Fetch AP/switch inventory that is claimed but not assigned to any site."""
+        # Unassigned AP/switch are invisible to searchOrgDevices/countOrgDevices (assigned-only),
+        # so pull the full org inventory and keep only records that lack a site_id.
+        logging.info("Fetching unassigned AP/switch inventory via getOrgInventory, org=%s", target_org_id)
+        try:
+            response = mistapi.api.v1.orgs.inventory.getOrgInventory(  # Inventory API returns claimed stock
+                apisession,
+                target_org_id,
+                type="ap,switch",  # Gateways excluded: gateway path already counts unassigned via getOrgInventory
+                limit=1000,  # Large page size minimizes round trips for big inventories
+            )
+            all_records: list[dict] = mistapi.get_all(response=response, mist_session=apisession)  # Auto-paginate
+        except Exception as error:  # Inventory fetch errors must not abort the larger summary run
+            logging.error("getOrgInventory unassigned AP/switch failed: %s", error, exc_info=True)  # Traceback for ops
+            all_records = []  # Degrade gracefully so callers simply see no unassigned rows
+        unassigned = [record for record in all_records if not record.get("site_id")]  # site_id empty/None => unassigned
+        logging.debug(
+            "Unassigned AP/switch inventory: %d of %d records have no site_id",  # Show filter selectivity
+            len(unassigned),
+            len(all_records),
+        )
+        return unassigned
+
+    @staticmethod
+    def _aggregate_unassigned_counts(unassigned_records: list[dict], distinct: str) -> list[dict]:
+        """Aggregate unassigned device counts; firmware rows bucket under an 'unassigned' label."""
+        # For the version report we surface unassigned stock as its own bucket (distinct from
+        # "unknown", which means an assigned device that never reported firmware). For the model
+        # report we keep the real model so per-model totals stay accurate.
+        logging.info("Aggregating %d unassigned records by %s", len(unassigned_records), distinct)
+        counts: dict[tuple[str, str], int] = {}  # Key on (device_type, bucket) to keep types separate
+        for record in unassigned_records:  # Walk each unassigned inventory record once
+            device_type = record.get("type") or "unknown"  # Inventory record carries its own ap/switch type
+            if distinct == "version":  # Firmware report: collapse all unassigned stock into one column
+                value = "unassigned"  # New column the operator can see at a glance
+            else:  # Model report: preserve real model so totals merge correctly with assigned counts
+                value = record.get(distinct) or "unknown"  # Fall back to "unknown" only if model missing
+            key = (device_type, value)  # Compose the grouping key
+            counts[key] = counts.get(key, 0) + 1  # Each unassigned record is one physical device (no VC in stock)
+        rows = [  # Materialize accumulator into standard row dicts
+            {"device_type": device_type, distinct: value, "count": count}
+            for (device_type, value), count in counts.items()
+        ]
+        logging.debug("Unassigned %s aggregation produced %d rows", distinct, len(rows))  # Record outcome
+        return rows
+
+    @staticmethod
+    def _merge_counts(base_rows: list[dict], extra_rows: list[dict], distinct: str) -> list[dict]:
+        """Merge supplemental rows into base rows, summing counts by (device_type, value)."""
+        # Used to fold unassigned counts into the assigned-device rows so a model present in both
+        # assigned and unassigned states reports one combined total instead of duplicate rows.
+        logging.info("Merging %d base and %d supplemental %s rows", len(base_rows), len(extra_rows), distinct)
+        combined: dict[tuple[str, str], int] = {}  # Running total per (device_type, value)
+        order: list[tuple[str, str]] = []  # Preserve first-seen order for deterministic output
+        for row in [*base_rows, *extra_rows]:  # Iterate assigned rows first, then unassigned supplements
+            key = (row.get("device_type", ""), row.get(distinct, ""))  # Same grouping key both reports use
+            if key not in combined:  # First time we see this key
+                combined[key] = 0  # Initialize the bucket
+                order.append(key)  # Remember insertion order
+            combined[key] += int(row.get("count", 0) or 0)  # Accumulate this row's count
+        merged = [  # Rebuild rows from the merged totals in first-seen order
+            {"device_type": device_type, distinct: value, "count": combined[(device_type, value)]}
+            for (device_type, value) in order
+        ]
+        logging.debug("Merge produced %d combined %s rows", len(merged), distinct)  # Record outcome
+        return merged
+
+    @staticmethod
+    def _fetch_all_counts(
+        target_org_id: str, distinct: str, unassigned_records: list[dict] | None = None
+    ) -> list[dict]:
         """Fetch grouped counts for AP/switch/gateway by model or version."""
         logging.info("Fetching device %s counts for all types, org=%s", distinct, target_org_id)
         all_rows: list[dict] = []
@@ -180,6 +251,13 @@ class OrgDeviceInventorySummaryCore:
                     error,
                     exc_info=True,
                 )
+        if unassigned_records is None:  # Direct/test callers may omit the shared fetch; pull it ourselves
+            unassigned_records = OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
+        try:  # Fold unassigned AP/switch stock into the counts so totals are not understated
+            unassigned_rows = OrgDeviceInventorySummaryCore._aggregate_unassigned_counts(unassigned_records, distinct)
+            all_rows = OrgDeviceInventorySummaryCore._merge_counts(all_rows, unassigned_rows, distinct)
+        except Exception as error:  # Supplemental counting must never break the primary report
+            logging.error("Unassigned %s supplemental count failed: %s", distinct, error, exc_info=True)
         all_rows.sort(key=lambda row: (row.get("device_type", ""), -int(row.get("count", 0))))
         logging.info("Total %s count rows after fetch and sort: %d", distinct, len(all_rows))
         return all_rows
@@ -238,7 +316,11 @@ class OrgDeviceInventorySummaryCore:
         start_time = time.time()
         safe_org = OrgDeviceInventorySummaryCore._resolve_safe_org_name(target_org_id)
 
-        model_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(target_org_id, "model")
+        # Fetch unassigned AP/switch inventory once and share it across every report below so the
+        # supplemental getOrgInventory call is not repeated three times per organization.
+        unassigned_records = OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
+
+        model_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(target_org_id, "model", unassigned_records)
         OrgDeviceInventorySummaryCore._display_and_export(
             model_rows,
             "model",
@@ -246,7 +328,7 @@ class OrgDeviceInventorySummaryCore:
             "orgDeviceModelSummary",
         )
 
-        version_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(target_org_id, "version")
+        version_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(target_org_id, "version", unassigned_records)
         OrgDeviceInventorySummaryCore._display_and_export(
             version_rows,
             "version",
@@ -255,7 +337,7 @@ class OrgDeviceInventorySummaryCore:
         )
 
         ver_per_model = VersionPerModelFetcher.fetch(
-            target_org_id, model_rows
+            target_org_id, model_rows, unassigned_records
         )  # Decomposed: per-type version expansion lives in collaborator
         PivotRenderer.render(
             ver_per_model, f"{safe_org}_OrgDeviceVersionPerModel"

--- a/tests/unit/inventory/test_org_device_inventory_summary.py
+++ b/tests/unit/inventory/test_org_device_inventory_summary.py
@@ -78,6 +78,68 @@ def test_aggregate_gateway_counts_counts_physical_records() -> None:
     assert rows[1]["count"] == 1
 
 
+def test_fetch_unassigned_inventory_filters_assigned_devices() -> None:
+    """Only inventory records without a site_id should be treated as unassigned."""
+    _configure_dependencies()
+    from src.inventory import org_device_inventory_summary as _mod
+
+    # get_all returns a mix of assigned (site_id present) and unassigned (site_id missing/empty) records.
+    _mod.mistapi.get_all = MagicMock(
+        return_value=[
+            {"type": "ap", "model": "AP43", "site_id": "site-1"},
+            {"type": "ap", "model": "AP43"},
+            {"type": "switch", "model": "EX2300", "site_id": ""},
+        ]
+    )
+    unassigned = OrgDeviceInventorySummaryCore._fetch_unassigned_inventory("org-1")
+    assert len(unassigned) == 2
+    assert all(not record.get("site_id") for record in unassigned)
+
+
+def test_aggregate_unassigned_counts_version_uses_unassigned_bucket() -> None:
+    """Version aggregation should collapse unassigned stock into an 'unassigned' bucket."""
+    _configure_dependencies()
+    rows = OrgDeviceInventorySummaryCore._aggregate_unassigned_counts(
+        [
+            {"type": "ap", "model": "AP43", "version": "0.1"},
+            {"type": "ap", "model": "AP43"},
+            {"type": "switch", "model": "EX2300"},
+        ],
+        "version",
+    )
+    by_type = {(row["device_type"], row["version"]): row["count"] for row in rows}
+    assert by_type[("ap", "unassigned")] == 2
+    assert by_type[("switch", "unassigned")] == 1
+
+
+def test_aggregate_unassigned_counts_model_keeps_real_model() -> None:
+    """Model aggregation should keep the real model so totals merge with assigned counts."""
+    _configure_dependencies()
+    rows = OrgDeviceInventorySummaryCore._aggregate_unassigned_counts(
+        [
+            {"type": "ap", "model": "AP43"},
+            {"type": "ap", "model": "AP43"},
+        ],
+        "model",
+    )
+    assert rows == [{"device_type": "ap", "model": "AP43", "count": 2}]
+
+
+def test_merge_counts_sums_overlapping_keys() -> None:
+    """Merging should sum counts for matching (device_type, value) keys without duplicates."""
+    _configure_dependencies()
+    base = [{"device_type": "ap", "model": "AP43", "count": 10}]
+    extra = [
+        {"device_type": "ap", "model": "AP43", "count": 3},
+        {"device_type": "switch", "model": "EX2300", "count": 1},
+    ]
+    merged = OrgDeviceInventorySummaryCore._merge_counts(base, extra, "model")
+    by_key = {(row["device_type"], row["model"]): row["count"] for row in merged}
+    assert by_key[("ap", "AP43")] == 13
+    assert by_key[("switch", "EX2300")] == 1
+    assert len(merged) == 2
+
+
 def test_run_for_org_calls_all_export_steps(monkeypatch) -> None:
     """run_for_org should execute model, version, and pivot export flows."""
     _configure_dependencies()
@@ -89,7 +151,9 @@ def test_run_for_org_calls_all_export_steps(monkeypatch) -> None:
     monkeypatch.setattr(
         OrgDeviceInventorySummaryCore,
         "_fetch_all_counts",
-        staticmethod(lambda target_org_id, distinct: [{"device_type": "ap", distinct: "v", "count": 1}]),
+        staticmethod(
+            lambda target_org_id, distinct, unassigned_records=None: [{"device_type": "ap", distinct: "v", "count": 1}]
+        ),
     )
     from src.inventory.inventory_summary import pivot_renderer as _pivot_mod
     from src.inventory.inventory_summary import version_per_model_fetcher as _vpm_mod
@@ -98,7 +162,9 @@ def test_run_for_org_calls_all_export_steps(monkeypatch) -> None:
         _vpm_mod.VersionPerModelFetcher,
         "fetch",
         staticmethod(
-            lambda target_org_id, model_rows: [{"device_type": "ap", "model": "A", "version": "1", "count": 1}]
+            lambda target_org_id, model_rows, unassigned_records=None: [
+                {"device_type": "ap", "model": "A", "version": "1", "count": 1}
+            ]
         ),
     )
     display_mock = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #415 -- Menu 13 (Org Device Inventory Summary) undercounted devices because **unassigned AP/switch inventory was excluded**.

## Root cause

The three device types were counted from inconsistent, partly assigned-only sources:

| Device type | Source | Coverage |
| - | - | - |
| AP | `countOrgDevices` | Assigned only |
| Switch | `searchOrgDevices` | Assigned only |
| Gateway | `getOrgInventory` | All claimed (assigned + unassigned) |

Unassigned APs and switches (claimed but not yet assigned to a site) were never counted, understating totals and making the reports internally inconsistent with the gateway path.

## Fix

- Added `getOrgInventory(type="ap,switch")` supplemental fetch, filtered client-side to records with no `site_id`, shared once per org across all three reports.
- Unassigned devices merge into the model counts and appear under a dedicated **`unassigned`** firmware column in the firmware summary and the version-per-model pivot (single-org and MSP combined).
- `unassigned` is kept distinct from `unknown` (an assigned device that never reported firmware).
- Gateways excluded from the supplemental fetch (already counted via `getOrgInventory`) -- no double counting.
- Assigned-but-offline devices were already counted; verified and documented (assigned-device APIs do not filter on connection state).

## Tests

- 4 new unit tests: unassigned filter, version bucket labelling, model-preserving aggregation, count merge.
- `tests/unit/inventory/` 11/11 pass; runtime-coupling integration test passes.
- ruff, black (line-length 120), py_compile all clean.

## Conformance

- [x] Linked to issue #415
- [x] Unit tests added and passing
- [x] No secrets introduced
- [x] CHANGELOG updated