### PR TITLE
fix: clear 18 Pylance type-safety diagnostics + latent Menu #87 crash (#444)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -55,7 +55,7 @@ from concurrent.futures import (
 )  # Import thread pool executors for parallel API calls with rate limiting
 from dataclasses import dataclass, field  # Import dataclass decorators for configuration objects and entity classes
 from datetime import datetime  # Import datetime for timestamping logs and events
-from typing import TYPE_CHECKING, Any, Literal  # Import type hints for static analysis without runtime overhead
+from typing import TYPE_CHECKING, Any, Literal, cast  # Import type hints for static analysis without runtime overhead
 
 # Type stubs for dynamically imported modules
 # These allow type checking while the actual imports happen at runtime via GlobalImportManager
@@ -80,6 +80,9 @@ try:  # Attempt to import polyglot database layer for ArangoDB/Redis export back
 
     DB_LAYER_AVAILABLE = True  # Set flag indicating database backends are available for export operations
 except ImportError:  # If database dependencies (python-arango, redis) not installed, gracefully disable
+    DatabaseConfig = None  # type: ignore[assignment, misc]  # None lets runtime guards detect DB-layer absence
+    configure_db_logging = None  # type: ignore[assignment]  # None lets runtime guards detect DB-layer absence
+    DatabaseRouter = None  # type: ignore[assignment, misc]  # None lets runtime guards detect DB-layer absence
     DB_LAYER_AVAILABLE = False  # Set flag to disable database output formats (CSV/SQLite only)
 
 from src.analytics.site_analytics_configurator import (  # Import site analytics configuration tools
@@ -6412,6 +6415,12 @@ class APICoreFetchUtils:  # Low-level Mist API fetch helpers.
         )  # vc=True includes all physical VC member devices
         return mistapi.get_all(response=response, mist_session=apisession)  # type: ignore[no-any-return]
 
+    @staticmethod
+    def get_api_response_data(response: Any) -> Any:
+        """Return a mistapi response's .data payload, or the response itself when .data is absent."""
+        logging.debug("Unwrapping API response payload (type=%s)", type(response).__name__)  # Trace unwrap calls
+        return getattr(response, "data", response)  # mistapi carries parsed JSON on .data; fall back to the raw object
+
 
 # APITenantFetchUtils extracted to src/api/tenant_fetch.py (issue #331).
 # Dependency injection is used so the module has no circular import with MistHelper.
@@ -7348,7 +7357,8 @@ class DataExporter:  # Multi-backend export facade.
         if cls._router_initialized:  # Skip all work when a prior call already attempted initialization.
             return  # Idempotent early-out keeps repeated export calls cheap.
         cls._router_initialized = True  # Latch the guard before fallible work so a failure does not retry endlessly.
-        if not DB_LAYER_AVAILABLE:  # Optional polyglot dependency stack is not installed in this environment.
+        # Treat the layer as unavailable unless the flag is set AND all three names imported (not None).
+        if not DB_LAYER_AVAILABLE or DatabaseConfig is None or configure_db_logging is None or DatabaseRouter is None:
             logging.debug("Polyglot DB layer not installed - CSV/SQLite only")  # Record the CSV/SQLite-only fallback.
             return  # Nothing more to wire up without the polyglot DB layer present.
         try:  # Router construction reads env and opens connections, so guard against any startup failure.
@@ -10916,11 +10926,11 @@ class OfflineDeviceReporter:
         all_devices: list[dict[str, Any]],
         site_lookup: dict[str, str],
         threshold_hours: int,
-    ) -> list[dict[str, str]]:
+    ) -> list[dict[str, Any]]:
         """Filter offline devices beyond threshold, enrich with site names."""
         now = time.time()
         threshold_seconds = threshold_hours * 3600
-        offline_records: list[dict[str, str]] = []
+        offline_records: list[dict[str, Any]] = []  # Values include API Any fields, not strictly str
 
         for device in all_devices:
             if device.get("status") == "connected":
@@ -11096,7 +11106,7 @@ class OrgDeviceInventorySummary:  # Org device inventory summary.
             apisession_dependency=apisession,
             mistapi_dependency=mistapi,
             data_exporter=DataExporter,
-            org_id_value=org_id,
+            org_id_value=cast(str, org_id),  # Global org_id is set before this runs; assert str for the checker
         )
         return OrgDeviceInventorySummaryCore  # Return the core class.
 
@@ -11610,7 +11620,7 @@ class GlobalWiredClientReportGenerator:  # Global wired client report.
         GlobalWiredClientReportGenerator._write_outputs(matched, metadata)  # Write the outputs.
 
     @staticmethod
-    def _prompt_filter_criteria() -> dict[str, str] | None | bool:  # Prompt filter criteria.
+    def _prompt_filter_criteria() -> dict[str, str] | Literal[False] | None:  # False = user cancelled, never True
         """Collect optional MAC and manufacturer filter criteria from user."""
         print("\n--- Global Wired Client Report ---")  # Header.
         print("Optional filters (press Enter to skip):\n")  # Explain skipping.
@@ -11717,8 +11727,7 @@ class GlobalWiredClientReportGenerator:  # Global wired client report.
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Apply local authoritative filtering with AND logic. Returns matched records and metadata."""
         total_retrieved = len(records)  # How many records the API returned before local filtering
-        has_filters = criteria is not None and bool(criteria)  # Whether any filter criteria were supplied
-        if not has_filters:  # No criteria -- every record passes
+        if not criteria:  # No criteria (None/empty) -- every record passes; narrows criteria to dict[str,str] after
             metadata = GlobalWiredClientReportGenerator._build_metadata(  # Build metadata noting no filtering occurred
                 total_retrieved,
                 total_retrieved,
@@ -12615,7 +12624,7 @@ class OrgExportUtils:  # Generic org export helpers.
             api_call=mistapi.api.v1.orgs.exports.getOrgE911Report,
             data_type="e911 report",
             sort_key="name",
-            limit=None,  # getOrgE911Report only accepts (mist_session, org_id) - no limit param
+            limit=None,  # pyright: ignore[reportArgumentType] - getOrgE911Report takes no limit param
         )
 
     @staticmethod
@@ -13776,7 +13785,8 @@ class GatewayHaExporter:  # Gateway HA exporter.
         logging.info("Starting Gateway HA Cluster Info export (Menu #87)")  # Log entry point
         try:
             org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Retrieve or prompt for org ID
-            site_id = PromptUtils.select_site(org_id)  # Prompt user to pick a site from the list
+            logging.debug("Gateway HA export resolved org %s", org_id)  # Record resolved org; keeps value referenced
+            site_id = PromptUtils.select_site()  # Pick a site; select_site() is org-independent (reads SiteList.csv)
             if not site_id:  # User cancelled or no sites available
                 logging.warning("No site selected -- aborting HA cluster export")  # Log cancellation
                 return  # Exit without exporting

--- a/src/device/utility_commands.py
+++ b/src/device/utility_commands.py
@@ -25,7 +25,7 @@ import mistapi
 SelectSiteFn = Callable[[], str | None]
 SelectDeviceFn = Callable[[str, str], str | None]
 SafeInputFn = Callable[..., str]
-WriteExportFn = Callable[[list[dict[str, Any]], str, str], None]
+WriteExportFn = Callable[[list[dict[str, Any]], str, str], bool]  # Exporter returns a success bool, not None
 WebSocketManagerFactory = Callable[[Any], Any]
 
 

--- a/src/device/virtual_chassis.py
+++ b/src/device/virtual_chassis.py
@@ -22,10 +22,10 @@ SafeInputFn = Callable[..., str]
 SelectSiteFn = Callable[[], str | None]
 GetCsvPathFn = Callable[[str], str]
 CreateCsvTemplateFn = Callable[[str], str]
-CheckAndGenerateCsvFn = Callable[[str, Any], None]
+CheckAndGenerateCsvFn = Callable[[str, Any], bool]  # CSV cache check returns a success bool
 FlattenFieldsFn = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
 EscapeMultilineFn = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
-SaveDataFn = Callable[[list[dict[str, Any]], str], None]
+SaveDataFn = Callable[[list[dict[str, Any]], str], bool]  # Exporter returns a success bool, not None
 
 # Converted prefix for virtual MAC
 _CONVERTED_PREFIX = "020003"

--- a/src/reports/e911_bssid.py
+++ b/src/reports/e911_bssid.py
@@ -685,7 +685,7 @@ class E911BSSIDReportGenerator:
         page_limit: int,
         org_id: str,
         safe_input_fn: Callable[..., str],
-        write_data_fn: Callable[..., None],
+        write_data_fn: Callable[..., bool],  # DataExporter.write_with_format_selection returns a success bool
     ) -> None:
         """Generate E911 BSSID compliance report (Menu 160).
 
@@ -754,7 +754,7 @@ class E911BSSIDReportGenerator:
         org_data: dict[str, Any],
         radio_macs_data: list[dict[str, Any]],
         site_state: dict[str, Any],
-        write_data_fn: Callable[..., None],
+        write_data_fn: Callable[..., bool],  # Matches execute(): exporter returns a success bool
         start_time: float,
     ) -> None:
         """Build rows, write CSV, display summary, and clean up."""


### PR DESCRIPTION
Closes #444

## Summary
Clears all 18 Pylance diagnostics on `MistHelper.py` (3 `reportPossiblyUnbound`,
11 `reportArgumentType`, 2 `reportAttributeAccessIssue`, 1 `reportCallIssue`).
13 are also real mypy strict errors: `mypy MistHelper.py` goes **491 -> 478** (13 fixed, 0 new).

### Real bug fixed (not just typing)
`APICoreFetchUtils.get_api_response_data` did not exist, yet `GatewayHaExporter` (Menu #87)
called it twice -- a latent `AttributeError` at runtime. Method implemented.

### MistHelper.py
- `_init_router`: bind DB-layer names in the `except ImportError` block + widen the guard
  (`... or DatabaseConfig is None or ...`) so Pyright narrows them (fixes possibly-unbound)
- `APICoreFetchUtils.get_api_response_data`: new unwrap helper (fixes 2 attr-access + Menu #87 crash)
- `OfflineDeviceReporter._process_devices`: widen return/local to `list[dict[str, Any]]`
- `OrgDeviceInventorySummary`: `cast(str, org_id)`
- `GlobalWiredClientReportGenerator`: `_prompt_filter_criteria -> dict[str, str] | Literal[False] | None`;
  narrow `criteria` via `if not criteria:` so `_record_matches` receives a `dict`
- `GatewayHaExporter`: drop dead positional arg to `PromptUtils.select_site()` (keeps org side-effect + adds debug log)
- E911 export: targeted `# pyright: ignore[reportArgumentType]` (getOrgE911Report has no limit param)

### src/ callback type aliases (`-> None` -> `-> bool`)
- `device/utility_commands.WriteExportFn`
- `device/virtual_chassis.CheckAndGenerateCsvFn`, `SaveDataFn`
- `reports/e911_bssid` `execute` + `_build_and_write` `write_data_fn`

## Conformance
- [x] Linked to spec issue (#444)
- [x] Acceptance criteria met
- [x] py_compile / ruff / black clean on all 4 files
- [x] mypy strict: net -13, zero new errors (validated by grouped-message diff vs origin/main)
- [x] No secrets; no behavior change except the Menu #87 crash fix
- [x] Rebased onto current main (post #442); #442 inline comments preserved on edited lines

## Notes
- Coordinated with #442 (inline-comment sweep) on the hot file: waited for #442 to merge,
  then rebased; conflicts were comment-vs-code on 2 lines, resolved keeping both the fix and the comment.
- No CHANGELOG entry yet to avoid a second hot-file collision; can add on request.