### PR TITLE
fix(MistHelper): bytearray->bytes for WebSocket send_binary (#446)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -16115,7 +16115,7 @@ class CLIShellManager:  # CLI shell over WebSocket.
                     return  # Issue #431: removed obsolete stop_listening() call (was a no-op stub)
                 mapped_key = keymap.get(key, key)  # Map the key.
                 data = f"\00{mapped_key}"  # Frame the data.
-                data_byte = bytearray(map(ord, data))  # Encode to bytes.
+                data_byte = bytes(map(ord, data))  # Immutable bytes: send_binary(payload: bytes) requires bytes.
                 if debug:  # Debug mode.
                     print(f"[DEBUG] Sending: {repr(data)}")  # Trace the send.
                 try:
@@ -16129,7 +16129,7 @@ class CLIShellManager:  # CLI shell over WebSocket.
 
         # Wake up Juniper SSR prompt
         time.sleep(1)  # Wait for connect.
-        ws.send_binary(bytearray(map(ord, "\00\n\n")))  # Send a wakeup.
+        ws.send_binary(bytes(map(ord, "\00\n\n")))  # Send a wakeup; bytes (not bytearray) matches send_binary.
         if debug:  # Debug mode.
             print("[DEBUG] Sent wakeup sequence to Juniper SSRs")  # Trace the wakeup.
 


### PR DESCRIPTION
## Summary

Closes #446. Clears the **2 remaining real Pyright `reportArgumentType` errors** on
`MistHelper.py` (not part of the #444/#445 batch -- a separate detection).

`websocket.WebSocket.send_binary(self, payload: bytes) -> int` requires `bytes`, but
`CLIShellManager._run_interactive` passed `bytearray(map(ord, ...))`. Switched both call
sites to `bytes(map(ord, ...))` -- an immutable `bytes` object, exactly what `send_binary`
wants. **Runtime-identical** (the same bytes are sent); no `# type: ignore`/suppression.

## Verification

- `pyright --pythonpath .venv\Scripts\python.exe MistHelper.py`: **2 errors -> 0**.
- `ruff check` clean, `black --check` clean, `py_compile` OK, `import MistHelper` OK.
- 2-line diff, no behavior change.

## Context

The 18 Pylance diagnostics originally reported were already resolved by #444/#445 (merged
`5fd72de`); the IDE was showing stale pre-merge state. These 2 `bytearray` errors are the
only genuinely-remaining type errors and are fixed here.

Part of #433.
