### PR TITLE
feat(codemod): detect dynamic logging.getLogger(...).level() pattern (#439)

### DIFF
--- a/tests/test_issue_439_codemod_dynamic_getlogger.py
+++ b/tests/test_issue_439_codemod_dynamic_getlogger.py
@@ -1,0 +1,66 @@
+"""Issue #439: the logging codemod must rewrite dynamic ``getLogger(...)`` receivers.
+
+The #429 codemod recognized loggers only by name (``logging``/``logger``/``self.logger``).
+It silently skipped the dynamic form ``logging.getLogger(__name__).info(f"...")`` -- which
+forced a manual hand-conversion during the #433 Phase A sweep. These tests drive the codemod
+CLI as a subprocess (public surface) and assert the dynamic receivers are now rewritten to
+lazy ``%s`` form, while genuinely-unrelated calls are left untouched.
+"""
+
+from __future__ import annotations  # PEP 604 union syntax for Python 3.13.
+
+import subprocess  # Drive the codemod CLI as a subprocess so we exercise the public surface.
+import sys  # Path to the active interpreter for the subprocess call.
+from pathlib import Path  # Portable filesystem handling on Windows + POSIX.
+
+REPO_ROOT = Path(__file__).resolve().parent.parent  # tests/ -> repo root.
+CODEMOD = REPO_ROOT / "tools" / "codemod_logging_lazy.py"  # The CLI under test.
+
+
+def _run_codemod(target: Path) -> None:
+    """Invoke the codemod on ``target`` (writing in place) and assert a clean exit."""
+    cmd = [sys.executable, str(CODEMOD), str(target)]  # Always pass python explicitly.
+    result = subprocess.run(  # nosec B603 - args are trusted repo paths only.
+        cmd,
+        capture_output=True,  # Capture stderr so failures are debuggable.
+        text=True,  # Decode streams as text.
+        check=False,  # Assert below so the captured stderr is surfaced.
+    )
+    assert result.returncode == 0, f"codemod exited {result.returncode}\nSTDERR:\n{result.stderr}"  # Clean exit.
+
+
+def test_module_qualified_getlogger_is_rewritten(tmp_path: Path) -> None:
+    """``logging.getLogger(__name__).info(f"x={x}")`` becomes the lazy ``%s`` form."""
+    target = tmp_path / "dyn_mod.py"  # Per-test temp file so runs do not interfere.
+    target.write_text(  # Seed the dynamic module-qualified pattern.
+        "import logging\n" "x = 1\n" 'logging.getLogger(__name__).info(f"x={x}")\n',
+        encoding="utf-8",
+    )
+    _run_codemod(target)  # Apply the codemod in place.
+    out = target.read_text(encoding="utf-8")  # Read the rewritten source back.
+    assert 'logging.getLogger(__name__).info("x=%s", x)' in out, out  # Lazy form emitted.
+    assert 'f"x={x}"' not in out, out  # The eager f-string is gone.
+
+
+def test_from_import_getlogger_is_rewritten(tmp_path: Path) -> None:
+    """``getLogger(__name__).warning(f"y={y}")`` (from-import form) is rewritten too."""
+    target = tmp_path / "dyn_bare.py"  # Per-test temp file.
+    target.write_text(  # Seed the from-import dynamic pattern.
+        "from logging import getLogger\n" "y = 2\n" 'getLogger(__name__).warning(f"y={y}")\n',
+        encoding="utf-8",
+    )
+    _run_codemod(target)  # Apply the codemod in place.
+    out = target.read_text(encoding="utf-8")  # Read the rewritten source back.
+    assert 'getLogger(__name__).warning("y=%s", y)' in out, out  # Lazy form emitted.
+
+
+def test_non_logger_factory_call_is_untouched(tmp_path: Path) -> None:
+    """A same-shaped call on a non-getLogger factory must NOT be rewritten."""
+    target = tmp_path / "decoy.py"  # Per-test temp file.
+    original = (  # ``build().info(...)`` looks structurally similar but is not a logger.
+        "def build():\n" "    return object()\n" "z = 3\n" 'build().info(f"z={z}")\n'
+    )
+    target.write_text(original, encoding="utf-8")  # Seed the decoy.
+    _run_codemod(target)  # Apply the codemod in place.
+    out = target.read_text(encoding="utf-8")  # Read the (expected unchanged) source back.
+    assert out == original, out  # Non-getLogger receiver left untouched.

--- a/tools/codemod_logging_lazy.py
+++ b/tools/codemod_logging_lazy.py
@@ -17,6 +17,13 @@ Supported rewrites:
 * **G201 (logging-exc-info)** -- inside an ``except`` block,
   ``logging.error(msg, exc_info=True)`` becomes ``logging.exception(msg)``.
 
+Recognized logger receivers (any of these on the left of ``.<level>(...)``):
+
+* a known logger name -- ``logging``, ``logger``, ``log``, ``self.logger`` (see
+  ``LOGGER_NAMES``);
+* a **dynamic** ``getLogger(...)`` call -- ``logging.getLogger(__name__).info(...)``
+  or ``getLogger(__name__).info(...)`` (issue #439).
+
 CLI flags (all optional):
 
 * ``--dry-run`` -- write nothing; report what would change.
@@ -56,6 +63,7 @@ LOGGER_NAMES: frozenset[str] = frozenset(  # Names the codemod recognizes as a l
 LEVEL_METHODS: frozenset[str] = frozenset(  # Method names that take a message + args.
     {"debug", "info", "warning", "warn", "error", "critical", "exception", "log"}
 )
+GET_LOGGER_NAME: str = "getLogger"  # The stdlib factory whose result is a Logger we can rewrite against.
 
 
 @dataclass
@@ -253,7 +261,21 @@ class LoggingLazyCodemod(cst.CSTTransformer):
                 return True  # Direct match against known logger names.
             if isinstance(value, cst.Attribute) and value.attr.value in LOGGER_NAMES:  # self.logger.info(...)
                 return True  # Matches attribute-chain access to a logger.
+            if isinstance(value, cst.Call) and self._is_get_logger_call(value):  # logging.getLogger(__name__).info(...)
+                return True  # Issue #439: dynamic logger obtained inline from a getLogger(...) call.
         return False  # Anything else is not a logging call we touch.
+
+    @staticmethod
+    def _is_get_logger_call(expr: cst.BaseExpression) -> bool:
+        """Return True if ``expr`` is a ``getLogger(...)`` call (issue #439 dynamic-logger receiver)."""
+        if not isinstance(expr, cst.Call):  # Dynamic loggers come from a call expression, not a bare name.
+            return False  # Not a call -> not a getLogger receiver.
+        get_logger_func = expr.func  # The callable producing the Logger (the getLogger part).
+        if isinstance(get_logger_func, cst.Attribute) and get_logger_func.attr.value == GET_LOGGER_NAME:
+            return True  # Module-qualified form: logging.getLogger(...).
+        if isinstance(get_logger_func, cst.Name) and get_logger_func.value == GET_LOGGER_NAME:
+            return True  # From-import form: getLogger(...) after `from logging import getLogger`.
+        return False  # Some other call expression -> not a logger factory.
 
     def _line_of(self, node: cst.CSTNode) -> int:
         """Look up the 1-based source line for a node via libcst metadata."""


### PR DESCRIPTION
## Summary

Closes #439. Teaches the #429 logging codemod (`tools/codemod_logging_lazy.py`) to recognize the
**dynamic logger receiver** `logging.getLogger(__name__).info(f"...")`, which it previously skipped
silently -- forcing a manual hand-conversion in `src/firmware/firmware_manager.py` during the #433
Phase A sweep.

## What changed

- **`_is_logging_call`**: added a branch that matches when the method's receiver (`func.value`) is a
  `cst.Call` recognized as a `getLogger(...)` factory call.
- **`_is_get_logger_call`** (new static helper): matches both module-qualified
  `logging.getLogger(...)` and from-import `getLogger(...)` forms.
- The existing G004/G003/G201 rewrite logic operates on the call's message arg / method name and is
  **receiver-agnostic**, so no transform changes were needed -- only detection was extended.
- Docstring "Supported rewrites" section updated to document recognized receivers.

## Tests (`tests/test_issue_439_codemod_dynamic_getlogger.py`)

- `logging.getLogger(__name__).info(f"x={x}")` -> `... .info("x=%s", x)` ✅
- `getLogger(__name__).warning(f"y={y}")` (from-import) -> lazy form ✅
- `build().info(f"z={z}")` (same shape, non-getLogger factory) -> **untouched** ✅
- Existing #429 idempotency test still passes.

## Verification

- 4 codemod tests pass; `ruff check`, `black --check`, `py_compile` clean on both changed files.
- No behavior change to already-supported patterns (detection-only extension).

Part of #433.
