### PR TITLE
fix(analyzer): exclude generated/vendored trees from compliance scan (#451)

### DIFF
--- a/tests/unit/test_compliance_analyzer.py
+++ b/tests/unit/test_compliance_analyzer.py
@@ -138,3 +138,25 @@ def test_scorer_grades_and_minimums() -> None:
     assert scorer.grade(59.0) == "F"  # A failing score is an F grade.
     assert scorer.meets_minimum("B", "C")  # A B grade satisfies a C minimum.
     assert not scorer.meets_minimum("D", "C")  # A D grade fails a C minimum.
+
+
+def test_generated_and_vendored_paths_are_excluded(tmp_path: Path) -> None:
+    """Generated/vendored trees are skipped by default so they do not inflate counts (issue #451)."""
+    sample = "x = 1  # trivial module body.\n"  # Minimal valid Python for each throwaway file.
+    # Files that MUST be excluded by default: generated protobuf + vendored skill scripts.
+    excluded_rel = [
+        "starlink-api-reference/device-api/device_pb2_grpc.py",  # Generated gRPC stub.
+        ".agents/skills/caveman/scripts/compress.py",  # Vendored skill script.
+        "data/skills/caveman/scripts/validate.py",  # Mirror of the vendored skill script.
+    ]
+    # A normal source file that MUST still be collected.
+    included_rel = "src/example_module.py"  # Ordinary project source under src/.
+    for rel in [*excluded_rel, included_rel]:  # Materialize every sample on disk.
+        path = tmp_path / rel  # Resolve under the throwaway temp root.
+        path.parent.mkdir(parents=True, exist_ok=True)  # Create intermediate dirs.
+        path.write_text(sample, encoding="utf-8")  # Write the minimal module.
+    reports = ComplianceAnalyzer().analyze_targets([str(tmp_path)], recursive=True)  # Scan the tree.
+    collected = {Path(r.path).as_posix() for r in reports}  # Normalize collected paths for matching.
+    assert any(included_rel in p for p in collected)  # The ordinary src/ file is analyzed.
+    for rel in excluded_rel:  # None of the generated/vendored files may appear.
+        assert not any(rel in p for p in collected), f"{rel} should have been excluded"  # Assert exclusion.

--- a/tools/compliance_analyzer/engine.py
+++ b/tools/compliance_analyzer/engine.py
@@ -86,8 +86,9 @@ class ComplianceAnalyzer:
     """Read Python files, run the analyzers, and score each file."""
 
     # Path fragments that are always skipped during directory scans.
-    # Both POSIX and Windows separators are listed for tests/fixtures so the analyzer
-    # ignores intentionally-broken codemod input corpora regardless of host OS.
+    # Matching is performed against the POSIX form of each path (see _is_excluded), so the
+    # tokens below use forward slashes. The Windows "tests\\fixtures" form is kept only for
+    # backward compatibility with callers that pass pre-normalized Windows fragments.
     _DEFAULT_EXCLUDES = (
         ".venv",
         "site-packages",
@@ -96,6 +97,9 @@ class ComplianceAnalyzer:
         "node_modules",
         "tests/fixtures",
         "tests\\fixtures",
+        "starlink-api-reference",  # Third-party reference + generated gRPC protobuf (device_pb2*.py).
+        ".agents/skills",  # Vendored Copilot skill scripts -- not project source.
+        "data/skills",  # Mirror of the vendored skill scripts under the runtime data dir.
     )
 
     def __init__(


### PR DESCRIPTION
Closes #451. Adds `starlink-api-reference` (generated gRPC protobuf), `.agents/skills`, and `data/skills` (vendored skill scripts) to `ComplianceAnalyzer._DEFAULT_EXCLUDES`. These are not project source and were inflating violation counts (high-severity 611 -> 584 after exclusion). New unit test asserts exclusion while ordinary src/ files are still collected. Gates: ruff/black/py_compile clean; 8 analyzer unit tests pass. Part of #433.