### PR TITLE
fix(analyzer): CONV-PATH must not flag regex escapes as drive paths (#453)

### DIFF
--- a/tests/unit/test_compliance_analyzer.py
+++ b/tests/unit/test_compliance_analyzer.py
@@ -111,6 +111,22 @@ def test_class_level_delegator_still_flagged(tmp_path: Path) -> None:
     assert delegations[0].symbol == "fetch"  # The forwarding method is the one reported.
 
 
+def test_conv_path_distinguishes_drive_paths_from_regex(tmp_path: Path) -> None:
+    """CONV-PATH flags real drive paths but not regex escapes like `:\\d` (issue #453)."""
+    sample = (
+        "import re\n"
+        'real = "C:\\\\Users\\\\j\\\\data"\n'  # Genuine hardcoded Windows drive path -> must flag.
+        'prompt = re.compile(r"{master:\\\\d+}")\n'  # Juniper prompt regex -> must NOT flag.
+        'doc = re.compile(r"API doc:\\\\s*(https?://\\\\S+)")\n'  # Doc-link regex -> must NOT flag.
+    )
+    target = tmp_path / "paths.py"  # Throwaway sample file.
+    target.write_text(sample, encoding="utf-8")  # Write the mixed sample.
+    report = ComplianceAnalyzer().analyze_file(target)  # Analyze it.
+    path_hits = [v for v in report.violations if v.rule_id == "CONV-PATH"]  # Collect CONV-PATH findings.
+    assert len(path_hits) == 1, [v.line for v in path_hits]  # Only the genuine drive path is flagged.
+    assert path_hits[0].line == 2  # Specifically the real "C:\\Users..." literal on line 2.
+
+
 def test_clean_file_scores_well(tmp_path: Path) -> None:
     """A compliant file earns a high score and grade."""
     target = tmp_path / "clean.py"  # Path for the throwaway clean sample.

--- a/tools/compliance_analyzer/analyzers.py
+++ b/tools/compliance_analyzer/analyzers.py
@@ -717,9 +717,11 @@ class ConventionAnalyzer:
         """Flag string literals that hardcode Windows drive path separators.
 
         Heuristic: requires the literal to LOOK like a real drive path -- a
-        letter immediately before the colon, followed by colon + backslash.
-        This avoids flagging regex character classes (e.g. `r"[:\\-.]"`) that
-        happen to contain `:\\` for unrelated reasons.
+        single letter immediately before the colon, followed by colon + backslash,
+        with a token boundary (string start or non-alphanumeric) before that letter.
+        This avoids flagging regex character classes (e.g. `r"[:\\-.]"`) and regex
+        escapes embedded in longer words (e.g. `r"{master:\\d+}"`, `r"doc:\\s*"`)
+        that happen to contain `:\\` for unrelated reasons.
         """
         if not isinstance(node, ast.Constant) or not isinstance(node.value, str):  # Only string literals.
             return None  # Not a string literal.
@@ -733,6 +735,8 @@ class ConventionAnalyzer:
         preceding = text[index - 1]  # Look at the char immediately before the colon.
         if not preceding.isalpha():  # Real drive paths look like `C:\` (letter, colon, backslash).
             return None  # Not a drive-letter pattern -- skip regex char classes etc.
+        if index >= 2 and text[index - 2].isalnum():  # The "letter" is part of a longer word, not a lone drive.
+            return None  # Skip regex escapes like `master:\d+` or `doc:\s*` (multi-char word before `:\`).
         return Violation(
             rule_id="CONV-PATH",  # Stable rule identifier.
             category="Conventions",  # Report grouping.


### PR DESCRIPTION
fix(analyzer): CONV-PATH must not flag regex escapes as drive paths

Closes #453. The CONV-PATH heuristic flagged any word:\char sequence as a
hardcoded Windows drive path, producing false positives on regex literals such
as the Juniper prompt pattern and the doc-link pattern (both contain a colon
followed by a backslash-escape).

A real drive letter is a SINGLE letter at a token boundary, so additionally
require the character before the drive letter to be a string start or
non-alphanumeric. Genuine paths still flag; the two false positives in
src/ssh/shell_execution/shell_executor.py and scripts/generate_api_docs.py are
cleared without touching that source.

New regression test asserts the discrimination. CONV-PATH repo-wide: 2 to 0.

Part of #433.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
