### PR TITLE
feat(menu122): persist pulled RADIUS WLAN settings to an examinable snapshot

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -20431,6 +20431,32 @@ class BulkRadiusWLANConfigManager:
 
     CANCEL_KEYWORDS = {"q", "quit", "cancel", "back"}
 
+    # Stable column order for the per-scan WLAN snapshot (see _export_scan_snapshot).
+    # The *_present flags reveal whether a value is real (key was in the API record)
+    # or merely the default the compliance check assumes when the key is absent.
+    _SNAPSHOT_FIELDS = [
+        "scan_timestamp",
+        "org_id",
+        "ssid",
+        "wlan_id",
+        "compliance_status",
+        "inheritance_level",
+        "inheritance_source",
+        "auth_type",
+        "num_auth_servers",
+        "radsec_enabled",
+        "auth_servers_timeout",
+        "auth_servers_timeout_present",
+        "auth_servers_retries",
+        "auth_servers_retries_present",
+        "fast_dot1x_timers",
+        "fast_dot1x_timers_present",
+        "target_timeout",
+        "target_retries",
+        "target_fast_dot1x",
+        "enabled",
+    ]
+
     def __init__(self) -> None:
         """Initialize manager and load configuration from .env."""
         self.org_id: str = ""
@@ -20759,6 +20785,55 @@ class BulkRadiusWLANConfigManager:
         }
         self.change_records.append(record)  # Append to the audit trail for later CSV export
 
+    def _export_scan_snapshot(self) -> None:
+        """Persist every pulled RADIUS WLAN's settings to disk so they can be examined after the run."""
+        all_radius = self.radius_wlans + self.compliant_wlans  # Every RADIUS WLAN discovered this scan
+        if not all_radius:  # Nothing was pulled -> nothing to snapshot
+            logging.debug("No RADIUS WLANs to snapshot; skipping scan export")  # Trace the empty case
+            return  # No snapshot to write
+        logging.info("Exporting scan snapshot for %s RADIUS WLAN(s)", len(all_radius))  # Before-action log
+        scan_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")  # Human-readable scan time stamped on each row
+        rows = [self._build_snapshot_row(wlan, scan_timestamp) for wlan in all_radius]  # Flatten each WLAN to a row
+        file_stamp = datetime.now().strftime("%Y%m%d_%H%M%S")  # Compact stamp for a unique, non-overwriting filename
+        filename = f"RadiusWLANScanSnapshot_{file_stamp}.csv"  # Snapshot filename (DataExporter drops .csv for SQLite)
+        ok = DataExporter.write_with_format_selection(  # Multi-backend write: CSV by default, SQLite if configured
+            rows,
+            filename,
+            fieldnames=self._SNAPSHOT_FIELDS,
+        )
+        if ok:  # The export succeeded
+            print(f"[+] Scan snapshot of {len(rows)} RADIUS WLAN(s) saved to data/{filename}")  # Show the location
+            logging.info("Scan snapshot written to data/%s (%s rows)", filename, len(rows))  # After-action log
+        else:  # The export failed (permissions, disk, or backend error)
+            print("[!] Failed to save scan snapshot (see log for details)")  # Inform the operator of the failure
+            logging.error("Failed to write RADIUS WLAN scan snapshot to %s", filename)  # Log the failure
+
+    def _build_snapshot_row(self, wlan: dict[str, Any], scan_timestamp: str) -> dict[str, Any]:
+        """Flatten one RADIUS WLAN into an examinable snapshot row with value-presence flags."""
+        radsec, auth = wlan.get("radsec", {}), wlan.get("auth", {})  # Sub-configs (each may be missing/non-dict)
+        return {  # One flat, examinable row per RADIUS WLAN
+            "scan_timestamp": scan_timestamp,  # When this scan ran (identical for every row in the run)
+            "org_id": self.org_id,  # Organization the WLANs were pulled from
+            "ssid": wlan.get("ssid", ""),  # Human-readable network name
+            "wlan_id": wlan.get("id", ""),  # Stable WLAN UUID
+            "compliance_status": wlan.get("_compliance_status", ""),  # COMPLIANT/NEEDS_UPDATE from the filter step
+            "inheritance_level": wlan.get("_inheritance_level", ""),  # template vs org (from _add_inheritance_metadata)
+            "inheritance_source": wlan.get("_inheritance_source", ""),  # Where the WLAN is defined
+            "auth_type": auth.get("type", "") if isinstance(auth, dict) else "",  # eap/eap192/psk/etc.
+            "num_auth_servers": len(wlan.get("auth_servers", []) or []),  # How many RADIUS servers are configured
+            "radsec_enabled": radsec.get("enabled", False) if isinstance(radsec, dict) else False,  # RadSec on/off
+            "auth_servers_timeout": wlan.get("auth_servers_timeout", 5),  # Actual value (5 = the check's own default)
+            "auth_servers_timeout_present": "auth_servers_timeout" in wlan,  # True => real value; False => defaulted
+            "auth_servers_retries": wlan.get("auth_servers_retries", 2),  # Actual value (2 = the check's own default)
+            "auth_servers_retries_present": "auth_servers_retries" in wlan,  # True => real value; False => defaulted
+            "fast_dot1x_timers": wlan.get("fast_dot1x_timers", False),  # Actual value (False = the check's own default)
+            "fast_dot1x_timers_present": "fast_dot1x_timers" in wlan,  # True => real value; False => defaulted
+            "target_timeout": self.target_timeout,  # Target timeout this run compared against
+            "target_retries": self.target_retries,  # Target retries this run compared against
+            "target_fast_dot1x": self.target_fast_dot1x,  # Target fast-timer flag this run compared against
+            "enabled": wlan.get("enabled", ""),  # Whether the WLAN itself is enabled
+        }
+
     def _export_audit_trail(self) -> None:
         """Export change records to CSV in data/ directory."""
         if not self.change_records:  # No changes were recorded this run
@@ -20815,6 +20890,8 @@ class BulkRadiusWLANConfigManager:
             return  # Cannot proceed without WLAN data
 
         self._filter_radius_wlans()  # Split WLANs into selectable vs already-compliant buckets
+
+        self._export_scan_snapshot()  # Persist the pulled settings so they can be examined after the run
 
         total_radius = len(self.radius_wlans) + len(self.compliant_wlans)  # Total RADIUS WLANs discovered
         if total_radius == 0:  # No RADIUS WLANs exist in the org

--- a/tests/unit/test_bulk_radius_wlan_snapshot.py
+++ b/tests/unit/test_bulk_radius_wlan_snapshot.py
@@ -1,0 +1,102 @@
+"""Unit tests for the Menu 122 RADIUS WLAN scan-snapshot export.
+
+Covers BulkRadiusWLANConfigManager._build_snapshot_row (per-WLAN flattening
+with value-presence flags) and _export_scan_snapshot (combines compliant +
+non-compliant WLANs and writes via DataExporter). The presence flags are the
+key feature: they reveal whether a value is real (key present in the API
+record) or merely the default the compliance check assumes when absent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import MistHelper  # Preloaded as the actual script by tests/conftest.py
+
+
+def _make_manager() -> Any:
+    """Build a manager with deterministic target settings (timeout=3, retries=2, fast=True)."""
+    manager = MistHelper.BulkRadiusWLANConfigManager()  # __init__ only loads env config (no network)
+    manager.org_id = "org-123"  # Stable org id for assertions
+    manager.target_timeout = 3  # Force the target values regardless of the host .env
+    manager.target_retries = 2  # Force the target retries
+    manager.target_fast_dot1x = True  # Force the target fast-timer flag
+    return manager  # Ready-to-use manager
+
+
+def test_snapshot_row_marks_present_values() -> None:
+    """A WLAN with all keys present reports present=True and passes the real values through."""
+    manager = _make_manager()  # Deterministic manager
+    wlan = {  # Fully-specified compliant WLAN record
+        "id": "wlan-1",
+        "ssid": "Corp",
+        "auth": {"type": "eap"},
+        "auth_servers": [{"host": "a"}, {"host": "b"}],
+        "radsec": {"enabled": False},
+        "auth_servers_timeout": 3,
+        "auth_servers_retries": 2,
+        "fast_dot1x_timers": True,
+        "enabled": True,
+        "_compliance_status": "COMPLIANT",
+        "_inheritance_level": "template",
+        "_inheritance_source": "Template ID: abcd1234...",
+    }
+    row = manager._build_snapshot_row(wlan, "2026-06-25 12:00:00")  # Flatten to a snapshot row
+    assert row["wlan_id"] == "wlan-1"  # Identity carried through
+    assert row["auth_type"] == "eap"  # Nested auth.type extracted
+    assert row["num_auth_servers"] == 2  # Auth-server count derived
+    assert row["auth_servers_timeout"] == 3 and row["auth_servers_timeout_present"] is True  # Real value flagged
+    assert row["auth_servers_retries"] == 2 and row["auth_servers_retries_present"] is True  # Real value flagged
+    assert row["fast_dot1x_timers"] is True and row["fast_dot1x_timers_present"] is True  # Real value flagged
+    assert row["compliance_status"] == "COMPLIANT"  # Status carried from the filter step
+    assert row["target_timeout"] == 3  # Target snapshotted for comparison
+
+
+def test_snapshot_row_flags_defaulted_values() -> None:
+    """A WLAN missing the timer keys reports present=False with the check's own defaults (5/2/False)."""
+    manager = _make_manager()  # Deterministic manager
+    wlan = {"id": "wlan-2", "ssid": "Guest", "auth_servers": [{"host": "x"}]}  # No timer keys at all
+    row = manager._build_snapshot_row(wlan, "2026-06-25 12:00:00")  # Flatten to a snapshot row
+    assert row["auth_servers_timeout"] == 5 and row["auth_servers_timeout_present"] is False  # Defaulted, flagged
+    assert row["auth_servers_retries"] == 2 and row["auth_servers_retries_present"] is False  # Defaulted, flagged
+    assert row["fast_dot1x_timers"] is False and row["fast_dot1x_timers_present"] is False  # Defaulted, flagged
+    assert row["auth_type"] == ""  # Missing auth sub-config -> empty type
+    assert row["radsec_enabled"] is False  # Missing radsec -> disabled
+
+
+def test_snapshot_row_tolerates_non_dict_subconfigs() -> None:
+    """Non-dict auth/radsec sub-configs do not raise and degrade to safe empty/False values."""
+    manager = _make_manager()  # Deterministic manager
+    wlan = {"id": "wlan-3", "ssid": "Odd", "auth": "not-a-dict", "radsec": "nope", "auth_servers": None}  # Malformed
+    row = manager._build_snapshot_row(wlan, "2026-06-25 12:00:00")  # Must not raise
+    assert row["auth_type"] == ""  # Non-dict auth -> empty type
+    assert row["radsec_enabled"] is False  # Non-dict radsec -> disabled
+    assert row["num_auth_servers"] == 0  # None auth_servers -> zero count
+
+
+def test_export_scan_snapshot_combines_and_writes() -> None:
+    """_export_scan_snapshot writes one row per RADIUS WLAN (compliant + non-compliant) with stable fields."""
+    manager = _make_manager()  # Deterministic manager
+    manager.radius_wlans = [{"id": "n-1", "ssid": "NeedsUpdate", "_compliance_status": "NEEDS_UPDATE"}]  # 1 needing
+    manager.compliant_wlans = [{"id": "c-1", "ssid": "OK", "_compliance_status": "COMPLIANT"}]  # 1 compliant
+    with patch.object(MistHelper.DataExporter, "write_with_format_selection", return_value=True) as mock_write:
+        manager._export_scan_snapshot()  # Trigger the export
+    mock_write.assert_called_once()  # Exactly one write
+    rows = mock_write.call_args.args[0]  # First positional arg is the row list
+    filename = mock_write.call_args.args[1]  # Second positional arg is the filename
+    assert len(rows) == 2  # Both compliant and non-compliant WLANs included
+    assert filename.startswith("RadiusWLANScanSnapshot_") and filename.endswith(".csv")  # Timestamped CSV name
+    assert mock_write.call_args.kwargs["fieldnames"] == manager._SNAPSHOT_FIELDS  # Stable column order passed
+    statuses = {r["compliance_status"] for r in rows}  # Collect the statuses present
+    assert statuses == {"NEEDS_UPDATE", "COMPLIANT"}  # Both buckets represented
+
+
+def test_export_scan_snapshot_skips_when_empty() -> None:
+    """With no RADIUS WLANs discovered, the export is skipped entirely (no write attempted)."""
+    manager = _make_manager()  # Deterministic manager
+    manager.radius_wlans = []  # Nothing needing update
+    manager.compliant_wlans = []  # Nothing compliant either
+    with patch.object(MistHelper.DataExporter, "write_with_format_selection", return_value=True) as mock_write:
+        manager._export_scan_snapshot()  # Should no-op
+    mock_write.assert_not_called()  # No snapshot written when there is no data


### PR DESCRIPTION
## Summary

Menu 122 (Bulk RADIUS WLAN Configuration) previously kept the scanned WLAN
settings only in memory, so they were discarded when the run finished. That
made it hard to verify a result like *"0 needing configuration, 161 already
compliant"* -- there was nothing on disk to inspect afterward.

This adds **`_export_scan_snapshot()`**, called right after the scan/filter
step so it runs on **every** path -- including the *all-compliant, no-changes*
early return. It writes one row per RADIUS WLAN via `DataExporter` (CSV by
default, SQLite if `--output-format sqlite`) to a timestamped
`data/RadiusWLANScanSnapshot_<ts>.csv` that never overwrites prior runs.

### Why this answers the trust question
Each row records the **actual** `auth_servers_timeout` /
`auth_servers_retries` / `fast_dot1x_timers` **plus a `*_present` flag**
per field:
- `present=True` -> the value is real (the key was in the API record).
- `present=False` -> the compliance check is assuming its default (5 / 2 / False).

So you can confirm at a glance whether "compliant" reflects real per-WLAN
values or defaulted assumptions. Rows also carry `compliance_status`,
inheritance level/source, `auth_type`, auth-server count, RadSec state, the
run's target values, and org/ssid/id for identification.

## Verification
- New unit tests (5) cover: present-value flagging, defaulted-value flagging,
  non-dict `auth`/`radsec` tolerance, combined compliant+non-compliant
  export with stable fieldnames, and the empty no-op. **All pass.**
- Read-only live check against the org: scanned WLANs and wrote a correct
  27-row snapshot; every RADIUS WLAN showed `*_present=True` with 3/2/True.
- `py_compile`, `ruff`, `black` clean; no new STRUCT violations in the
  two added methods.

## Conformance
- [x] Inline why-comment on every touched line; ASCII-only; <= 120 chars.
- [x] Action logging before/after the export.
- [x] No wrappers; output under `data/`; multi-backend via `DataExporter`.
- [x] No behavior change to the existing scan/compare/apply logic.
