### PR TITLE
refactor(phase-high): wave 5 -- bundle TelemetryEmitter event params (High 74->71)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -115,6 +115,10 @@ from src.capture.packet_capture import (
 from src.dataclasses.batch_worker import (
     BatchWorkerConfig,
 )  # Issue #431: groups thread-pool batch config to keep _pool_process_batch_wait_loop within the 5-Item Rule.
+from src.dataclasses.progress_event import (
+    ProgressContext,
+    TestSummary,
+)  # Issue #470: groups TelemetryEmitter event fields to keep emit_* signatures within the 5-Item Rule.
 from src.export.device_events_52w_exporter import DeviceEvents52wExporter  # Import 52-week device events export handler
 from src.export.site_export_utils import (
     configure_site_export_utils_dependencies,
@@ -9584,7 +9588,7 @@ class OrgSiteExporter:  # Org site exporters.
         output_desc = "SQLite table" if OUTPUT_FORMAT == "sqlite" else "CSV file"  # Describe output backend.
         logging.info("Completed site list export and wrote results to %s.", output_desc)  # Log site export success.
         if emitter:  # Branch: emitter present.
-            emitter.emit_progress_complete("11", "sites", 1, 1, False, time.time() - op_start)
+            emitter.emit_progress_complete(ProgressContext("11", "sites", 1), 1, False, time.time() - op_start)
 
     @staticmethod
     def sites_list_api():  # Export sites via list API.
@@ -9716,7 +9720,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
         ).execute()
         logging.info("Completed organization inventory export and wrote results to OrgInventory.csv.")
         if emitter:  # Branch: emitter present.
-            emitter.emit_progress_complete("12", "inventory", 1, 1, False, time.time() - op_start)
+            emitter.emit_progress_complete(ProgressContext("12", "inventory", 1), 1, False, time.time() - op_start)
 
     @staticmethod
     def devices():  # Export all org devices.
@@ -9737,7 +9741,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
         ).execute()
         logging.info("Completed organization devices export and wrote results to OrgDevices.csv.")
         if emitter:  # Branch: emitter present.
-            emitter.emit_progress_complete("17", "devices", 1, 1, False, time.time() - op_start)
+            emitter.emit_progress_complete(ProgressContext("17", "devices", 1), 1, False, time.time() - op_start)
 
     @staticmethod
     def _resolve_combined_inventory_org_name(current_org_id: str | None, fallback_org_name: str | None) -> str:
@@ -10412,7 +10416,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
             limit=1000,
         ).execute()
         if emitter:  # Branch: emitter present.
-            emitter.emit_progress_complete("13", "device_stats", 1, 1, False, time.time() - op_start)
+            emitter.emit_progress_complete(ProgressContext("13", "device_stats", 1), 1, False, time.time() - op_start)
 
     @staticmethod
     def _port_stats_cache_hit(output_file: str, fast: bool) -> bool:  # Check port-stats cache hit.
@@ -10775,7 +10779,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
             limit=1000,
         ).execute()
         if emitter:
-            emitter.emit_progress_complete("15", "vpn_peer_stats", 1, 1, False, time.time() - op_start)
+            emitter.emit_progress_complete(ProgressContext("15", "vpn_peer_stats", 1), 1, False, time.time() - op_start)
 
     @staticmethod
     def switch_vc_stats():
@@ -12276,7 +12280,10 @@ class OrgExportUtils:  # Generic org export helpers.
                 items_done += 1  # Count this item.
                 if emitter:  # Emitter present.
                     emitter.emit_progress_tick(  # Tick progress.
-                        "67", "sites_sle_summary", len(sle_types), sle_type, items_done, len(sle_types) - items_done
+                        ProgressContext("67", "sites_sle_summary", len(sle_types)),
+                        sle_type,
+                        items_done,
+                        len(sle_types) - items_done,
                     )
 
         if all_sites_sle_data:  # Have data.
@@ -12291,7 +12298,7 @@ class OrgExportUtils:  # Generic org export helpers.
             DataExporter.write_with_format_selection([], "OrgSitesSLESummary.csv")  # type: ignore[no-untyped-call]
         if emitter:  # Emitter present.
             emitter.emit_progress_complete(  # Signal progress complete.
-                "67", "sites_sle_summary", len(sle_types), items_done, False, time.time() - op_start
+                ProgressContext("67", "sites_sle_summary", len(sle_types)), items_done, False, time.time() - op_start
             )
 
     @staticmethod
@@ -12922,7 +12929,7 @@ class SiteDeviceExporter:  # Site device exporters.
             api_call=mistapi.api.v1.sites.stats.searchSiteSwOrGwPorts, data_type="port stats", sort_key="mac"
         )
         if emitter:  # Emitter present.
-            emitter.emit_progress_complete("29", "port_stats", 1, 1, False, time.time() - op_start)
+            emitter.emit_progress_complete(ProgressContext("29", "port_stats", 1), 1, False, time.time() - op_start)
 
     @staticmethod
     def device_virtual_chassis():  # Export device virtual chassis.
@@ -15774,9 +15781,7 @@ class GatewayTestExporter:  # Gateway synthetic test exporter.
             print("! No synthetic test results found. CSV not created.")  # Tell the user.
         if emitter:  # Emitter present.
             emitter.emit_progress_complete(  # Signal progress complete.
-                "16",
-                "synthetic_tests",
-                len(gateway_devices) if gateway_devices else 0,
+                ProgressContext("16", "synthetic_tests", len(gateway_devices) if gateway_devices else 0),
                 len(all_stats),
                 False,
                 time.time() - op_start,
@@ -22119,23 +22124,21 @@ class TelemetryEmitter:
             }
         )
 
-    def emit_test_summary(
-        self, total: int, passed: int, failed: int, skipped: int, elapsed: float, test_mode: str
-    ) -> None:  # noqa: PLR0913
-        """Emit a test_summary event."""
-        overall = "pass" if failed == 0 else "fail"
+    def emit_test_summary(self, summary: TestSummary) -> None:
+        """Emit a test_summary event from a bundled TestSummary (issue #470: was 6 positional params)."""
+        overall = "pass" if summary.failed == 0 else "fail"  # Overall verdict is pass only when nothing failed.
         self.emit(
             {
                 "event_type": "test_summary",
                 "timestamp": datetime.now(UTC).isoformat(),
                 "menu_option": "0",
                 "status": overall,
-                "total_operations": total,
-                "pass_count": passed,
-                "fail_count": failed,
-                "skip_count": skipped,
-                "total_elapsed_seconds": round(elapsed, 3),
-                "test_mode": test_mode,
+                "total_operations": summary.total,  # Total operations exercised (issue #470: from dataclass).
+                "pass_count": summary.passed,  # Passed count (issue #470: from dataclass).
+                "fail_count": summary.failed,  # Failed count (issue #470: from dataclass).
+                "skip_count": summary.skipped,  # Skipped count (issue #470: from dataclass).
+                "total_elapsed_seconds": round(summary.elapsed, 3),  # Elapsed wall-clock seconds (issue #470).
+                "test_mode": summary.test_mode,  # Test mode label (issue #470: from dataclass).
             }
         )
 
@@ -22153,43 +22156,39 @@ class TelemetryEmitter:
             }
         )
 
-    def emit_progress_tick(
-        self, menu_option: str | int, operation_name: str, total: int, current: object, completed: int, remaining: int
-    ) -> None:  # noqa: PLR0913
-        """Emit a progress_tick event."""
+    def emit_progress_tick(self, ctx: ProgressContext, current: object, completed: int, remaining: int) -> None:
+        """Emit a progress_tick event from a ProgressContext (issue #470: identity bundled into ctx)."""
         self.emit(
             {
                 "event_type": "progress_tick",
                 "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "operation_name": operation_name,
-                "total_items": total,
-                "current_item": str(current),
-                "items_completed": completed,
-                "items_remaining": remaining,
+                "menu_option": str(ctx.menu_option),  # Menu option from the bundled context (issue #470).
+                "operation_name": ctx.operation_name,  # Operation label from the bundled context (issue #470).
+                "total_items": ctx.total,  # Total item count from the bundled context (issue #470).
+                "current_item": str(current),  # The item currently being processed.
+                "items_completed": completed,  # Count of items finished so far.
+                "items_remaining": remaining,  # Count of items still pending.
             }
         )
 
     def emit_progress_complete(
         self,
-        menu_option: str | int,
-        operation_name: str,
-        total: int,
+        ctx: ProgressContext,
         processed: int,
         was_stopped: bool,
         duration: float,
-    ) -> None:  # noqa: PLR0913
-        """Emit a progress_complete event."""
+    ) -> None:
+        """Emit a progress_complete event from a ProgressContext (issue #470: identity bundled into ctx)."""
         self.emit(
             {
                 "event_type": "progress_complete",
                 "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "operation_name": operation_name,
-                "total_items": total,
-                "items_processed": processed,
-                "was_stopped": was_stopped,
-                "duration_seconds": round(duration, 3),
+                "menu_option": str(ctx.menu_option),  # Menu option from the bundled context (issue #470).
+                "operation_name": ctx.operation_name,  # Operation label from the bundled context (issue #470).
+                "total_items": ctx.total,  # Total item count from the bundled context (issue #470).
+                "items_processed": processed,  # Count of items actually processed before completion.
+                "was_stopped": was_stopped,  # True when the operation was interrupted by the user.
+                "duration_seconds": round(duration, 3),  # Wall-clock seconds the operation took.
             }
         )
 
@@ -22887,7 +22886,7 @@ def run_systematic_test():  # noqa: C901, PLR0912, PLR0915
     total_time = time.time() - start_time  # Total elapsed time includes setup, option execution, and delays.
     total_ops = len(all_options)  # Use total option count (including skipped) as denominator for coverage %.
     emitter.emit_test_summary(
-        total_ops, success_count, error_count, skip_count, total_time, "systematic"
+        TestSummary(total_ops, success_count, error_count, skip_count, total_time, "systematic")
     )  # Emit aggregate telemetry summary.
     emitter.close()  # Flush and close telemetry file before printing summary.
     emitter.enforce_retention()  # Clean up old telemetry files per configured retention policy.

--- a/src/dataclasses/progress_event.py
+++ b/src/dataclasses/progress_event.py
@@ -1,0 +1,41 @@
+"""Frozen dataclasses that group TelemetryEmitter event fields.
+
+Several ``TelemetryEmitter`` methods in ``MistHelper.py`` exceeded the 5-Item
+Rule's max-5-parameter limit. These frozen dataclasses bundle the related event
+fields so the ``emit_*`` method signatures stay within the limit:
+
+- ``ProgressContext`` groups the operation identity (menu option, operation
+  name, total item count) that identifies a progress event. It is shared by the
+  ``progress_tick`` and ``progress_complete`` events.
+- ``TestSummary`` groups the six aggregate statistics emitted once at the end of
+  a ``--test`` run.
+
+Issue: https://github.com/jmorrison-juniper/MistHelper/issues/470
+"""
+
+from __future__ import annotations  # Enable PEP 604 union syntax (str | int) on older runtimes.
+
+from dataclasses import dataclass  # The standard library dataclass decorator.
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressContext:
+    """Operation identity shared across a single operation's progress events."""
+
+    menu_option: str | int  # Menu option the progress event belongs to (accepts str or int form).
+    operation_name: str  # Human-readable operation label (e.g. "sites", "inventory").
+    total: int  # Total number of items the operation will process (the progress denominator).
+
+
+@dataclass(frozen=True, slots=True)
+class TestSummary:
+    """The six aggregate statistics emitted once at the end of a --test run."""
+
+    __test__ = False  # Tell pytest this is NOT a test class (it is Test-prefixed but a data carrier).
+
+    total: int  # Total number of operations exercised in the test run.
+    passed: int  # Count of operations that passed.
+    failed: int  # Count of operations that failed.
+    skipped: int  # Count of operations skipped (heavy / destructive / WIP).
+    elapsed: float  # Wall-clock seconds the whole test run took.
+    test_mode: str  # Test mode label (e.g. "systematic", "quick").

--- a/src/refactors/serial_cc/security_events.py
+++ b/src/refactors/serial_cc/security_events.py
@@ -9,6 +9,8 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
+from src.dataclasses.progress_event import ProgressContext  # Issue #470: bundle progress identity for emit_progress_*.
+
 
 def _resolve_runtime_dependencies() -> SimpleNamespace:
     """Resolve MistHelper runtime dependencies without static src imports."""
@@ -79,7 +81,9 @@ class SecurityEventsService:
         print("Security data export completed (3 files generated)")
         logging.info("Completed security policies, intelligence profiles, and rogue data export aggregate.")
         if emitter:
-            emitter.emit_progress_complete("42", "security_events", 3, 3, False, time.time() - op_start)
+            emitter.emit_progress_complete(  # Issue #470: operation identity bundled into a ProgressContext.
+                ProgressContext("42", "security_events", 3), 3, False, time.time() - op_start
+            )
 
     @staticmethod
     def _all_outputs_fresh(deps: SimpleNamespace, output_files: list[str]) -> bool:

--- a/src/refactors/serial_cc/sle_metrics.py
+++ b/src/refactors/serial_cc/sle_metrics.py
@@ -6,6 +6,8 @@ import time
 from types import SimpleNamespace
 from typing import Any
 
+from src.dataclasses.progress_event import ProgressContext  # Issue #470: bundle progress identity for emit_progress_*.
+
 
 def _resolve_runtime_dependencies() -> SimpleNamespace:
     """Resolve MistHelper runtime dependencies without static src imports."""
@@ -40,15 +42,15 @@ class _SleProgressTracker:
         self._done += 1  # One more metric/category finished (success or failure)
         if self._emitter:  # Only emit when progress tracking is active
             self._emitter.emit_progress_tick(
-                "66", "sle_metrics", self._total, label, self._done, self._total - self._done
-            )  # Report current label and remaining count
+                ProgressContext("66", "sle_metrics", self._total), label, self._done, self._total - self._done
+            )  # Report current label and remaining count (issue #470: identity bundled into ProgressContext)
 
     def complete(self) -> None:
         """Emit the progress-complete event with elapsed duration."""
         if self._emitter:  # Only emit when progress tracking is active
             self._emitter.emit_progress_complete(
-                "66", "sle_metrics", self._total, self._done, False, time.time() - self._start
-            )  # Final event with elapsed seconds
+                ProgressContext("66", "sle_metrics", self._total), self._done, False, time.time() - self._start
+            )  # Final event with elapsed seconds (issue #470: identity bundled into ProgressContext)
 
 
 class SLEMetricsService:

--- a/src/ssh/ssh_runner_manager.py
+++ b/src/ssh/ssh_runner_manager.py
@@ -9,6 +9,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from src.dataclasses.progress_event import ProgressContext  # Issue #470: bundle progress identity for emit_progress_*.
 from src.ssh.batch.multi_host_runner import MultiHostRunner  # T013c: extracted multi-host orchestrator
 from src.ssh.config.csv_loader import CommandCsvLoader  # T013a: extracted CSV loader
 from src.ssh.config.env_loader import EnvSshConfigLoader  # T013a: extracted .env loader
@@ -86,8 +87,8 @@ class SSHRunnerManager:
         if not emitter:  # No emitter → silent no-op
             return
         emitter.emit_progress_complete(  # Fire completion event with derived duration
-            "97", "ssh_runner", 0, 0, cancelled, time.time() - op_start
-        )
+            ProgressContext("97", "ssh_runner", 0), 0, cancelled, time.time() - op_start
+        )  # Issue #470: operation identity bundled into a ProgressContext.
 
     @staticmethod
     def by_gateway_template(deps: SSHRunnerManagerDeps, fast: bool = False) -> None:

--- a/src/troubleshooting/interactive_test_runner.py
+++ b/src/troubleshooting/interactive_test_runner.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+from src.dataclasses.progress_event import TestSummary  # Issue #470: bundle test-summary stats for emit_test_summary.
+
 
 @dataclass
 class InteractiveTestRunner:
@@ -263,8 +265,8 @@ class InteractiveTestRunner:
         """Emit summary event, close emitter, and enforce retention policy."""
         logging.info("Emitting telemetry summary for interactive test suite")  # Log before summary emission.
         emitter.emit_test_summary(
-            total_ops, success_count, error_count, skip_count, total_time, "interactive"
-        )  # Emit aggregate metrics.
+            TestSummary(total_ops, success_count, error_count, skip_count, total_time, "interactive")
+        )  # Emit aggregate metrics (issue #470: stats bundled into a TestSummary dataclass).
         logging.debug("Telemetry summary event emitted successfully")  # Log summary completion.
         logging.info("Closing telemetry emitter after interactive suite completion")  # Log before close.
         emitter.close()  # Flush pending events.

--- a/tests/unit/test_menu_12_inventory.py
+++ b/tests/unit/test_menu_12_inventory.py
@@ -97,12 +97,12 @@ class TestInventoryProgressEmitter:
         mock_emitter.emit_progress_start.assert_called_once_with("12", "inventory", 1)
         mock_emitter.emit_progress_complete.assert_called_once()
         call_args = mock_emitter.emit_progress_complete.call_args
-        assert call_args[0][0] == "12"
-        assert call_args[0][1] == "inventory"
-        assert call_args[0][2] == 1
-        assert call_args[0][3] == 1
-        assert call_args[0][4] is False
-        assert isinstance(call_args[0][5], float)
+        assert call_args[0][0].menu_option == "12"  # Issue #470: identity now bundled in ProgressContext.
+        assert call_args[0][0].operation_name == "inventory"  # ProgressContext.operation_name.
+        assert call_args[0][0].total == 1  # ProgressContext.total.
+        assert call_args[0][1] == 1  # processed count (now second positional arg).
+        assert call_args[0][2] is False  # was_stopped flag (now third positional arg).
+        assert isinstance(call_args[0][3], float)  # duration seconds (now fourth positional arg).
 
     def test_handles_no_emitter_gracefully(self, monkeypatch):
         """US4 Scenario 3: No exception when PROGRESS_EMITTER is None."""

--- a/tests/unit/test_menu_13_device_stats.py
+++ b/tests/unit/test_menu_13_device_stats.py
@@ -142,12 +142,12 @@ class TestDeviceStatsProgressEmitter:
         mock_emitter.emit_progress_start.assert_called_once_with("13", "device_stats", 1)
         mock_emitter.emit_progress_complete.assert_called_once()
         call_args = mock_emitter.emit_progress_complete.call_args
-        assert call_args[0][0] == "13"
-        assert call_args[0][1] == "device_stats"
-        assert call_args[0][2] == 1
-        assert call_args[0][3] == 1
-        assert call_args[0][4] is False
-        assert isinstance(call_args[0][5], float)
+        assert call_args[0][0].menu_option == "13"  # Issue #470: identity now bundled in ProgressContext.
+        assert call_args[0][0].operation_name == "device_stats"  # ProgressContext.operation_name.
+        assert call_args[0][0].total == 1  # ProgressContext.total.
+        assert call_args[0][1] == 1  # processed count (now second positional arg).
+        assert call_args[0][2] is False  # was_stopped flag (now third positional arg).
+        assert isinstance(call_args[0][3], float)  # duration seconds (now fourth positional arg).
 
     def test_handles_no_emitter_gracefully(self, monkeypatch):
         """US4 Scenario 3: No exception when PROGRESS_EMITTER is None."""

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -9,6 +9,8 @@ import json
 import os
 from datetime import UTC, datetime
 
+from src.dataclasses.progress_event import ProgressContext, TestSummary  # Issue #470: bundled event-field dataclasses.
+
 
 # ---------------------------------------------------------------------------
 # Duplicated class (R1: avoid MistHelper.py import side effects)
@@ -107,20 +109,20 @@ class TelemetryEmitter:
             }
         )
 
-    def emit_test_summary(self, total, passed, failed, skipped, elapsed, test_mode):
-        overall = "pass" if failed == 0 else "fail"
+    def emit_test_summary(self, summary):
+        overall = "pass" if summary.failed == 0 else "fail"
         self.emit(
             {
                 "event_type": "test_summary",
                 "timestamp": datetime.now(UTC).isoformat(),
                 "menu_option": "0",
                 "status": overall,
-                "total_operations": total,
-                "pass_count": passed,
-                "fail_count": failed,
-                "skip_count": skipped,
-                "total_elapsed_seconds": round(elapsed, 3),
-                "test_mode": test_mode,
+                "total_operations": summary.total,
+                "pass_count": summary.passed,
+                "fail_count": summary.failed,
+                "skip_count": summary.skipped,
+                "total_elapsed_seconds": round(summary.elapsed, 3),
+                "test_mode": summary.test_mode,
             }
         )
 
@@ -135,28 +137,28 @@ class TelemetryEmitter:
             }
         )
 
-    def emit_progress_tick(self, menu_option, operation_name, total, current, completed, remaining):
+    def emit_progress_tick(self, ctx, current, completed, remaining):
         self.emit(
             {
                 "event_type": "progress_tick",
                 "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "operation_name": operation_name,
-                "total_items": total,
+                "menu_option": str(ctx.menu_option),
+                "operation_name": ctx.operation_name,
+                "total_items": ctx.total,
                 "current_item": str(current),
                 "items_completed": completed,
                 "items_remaining": remaining,
             }
         )
 
-    def emit_progress_complete(self, menu_option, operation_name, total, processed, was_stopped, duration):
+    def emit_progress_complete(self, ctx, processed, was_stopped, duration):
         self.emit(
             {
                 "event_type": "progress_complete",
                 "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "operation_name": operation_name,
-                "total_items": total,
+                "menu_option": str(ctx.menu_option),
+                "operation_name": ctx.operation_name,
+                "total_items": ctx.total,
                 "items_processed": processed,
                 "was_stopped": was_stopped,
                 "duration_seconds": round(duration, 3),
@@ -290,7 +292,7 @@ class TestTelemetryEmitterTestEvents:
     def test_emit_test_summary_pass(self, tmp_path):
         path = str(tmp_path / "events.jsonl")
         with TelemetryEmitter(path) as emitter:
-            emitter.emit_test_summary(100, 80, 0, 20, 120.5, "systematic")
+            emitter.emit_test_summary(TestSummary(100, 80, 0, 20, 120.5, "systematic"))
         event = read_events(path)[0]
         assert event["event_type"] == "test_summary"
         assert event["status"] == "pass"
@@ -302,7 +304,7 @@ class TestTelemetryEmitterTestEvents:
     def test_emit_test_summary_fail(self, tmp_path):
         path = str(tmp_path / "events.jsonl")
         with TelemetryEmitter(path) as emitter:
-            emitter.emit_test_summary(100, 70, 10, 20, 120.5, "systematic")
+            emitter.emit_test_summary(TestSummary(100, 70, 10, 20, 120.5, "systematic"))
         event = read_events(path)[0]
         assert event["status"] == "fail"
 
@@ -324,7 +326,7 @@ class TestTelemetryEmitterProgressEvents:
     def test_emit_progress_tick(self, tmp_path):
         path = str(tmp_path / "events.jsonl")
         with TelemetryEmitter(path) as emitter:
-            emitter.emit_progress_tick("11", "List Sites", 50, "site_abc", 10, 40)
+            emitter.emit_progress_tick(ProgressContext("11", "List Sites", 50), "site_abc", 10, 40)
         event = read_events(path)[0]
         assert event["event_type"] == "progress_tick"
         assert event["items_completed"] == 10
@@ -333,7 +335,7 @@ class TestTelemetryEmitterProgressEvents:
     def test_emit_progress_complete(self, tmp_path):
         path = str(tmp_path / "events.jsonl")
         with TelemetryEmitter(path) as emitter:
-            emitter.emit_progress_complete("11", "List Sites", 50, 50, False, 30.5)
+            emitter.emit_progress_complete(ProgressContext("11", "List Sites", 50), 50, False, 30.5)
         event = read_events(path)[0]
         assert event["event_type"] == "progress_complete"
         assert event["items_processed"] == 50
@@ -344,8 +346,8 @@ class TestTelemetryEmitterProgressEvents:
         with TelemetryEmitter(path) as emitter:
             emitter.emit_progress_start("11", "List Sites", 3)
             for i in range(3):
-                emitter.emit_progress_tick("11", "List Sites", 3, f"site_{i}", i + 1, 2 - i)
-            emitter.emit_progress_complete("11", "List Sites", 3, 3, False, 5.0)
+                emitter.emit_progress_tick(ProgressContext("11", "List Sites", 3), f"site_{i}", i + 1, 2 - i)
+            emitter.emit_progress_complete(ProgressContext("11", "List Sites", 3), 3, False, 5.0)
         events = read_events(path)
         assert len(events) == 5
         assert events[0]["event_type"] == "progress_start"


### PR DESCRIPTION
Part of #470 (High-severity STRUCT decomposition), umbrella #433. Overlaps #431 (STRUCT-PARAMS).

## What
Wave 5 of the High phase. Clears **3 High STRUCT-PARAMS** violations on the `TelemetryEmitter` event helpers by bundling related fields into two frozen dataclasses (new `src/dataclasses/progress_event.py`), following the established #431 `BatchWorkerConfig` pattern:

- **`ProgressContext`** (menu_option, operation_name, total) -- shared operation identity:
  - `emit_progress_tick` 6 -> 4 params
  - `emit_progress_complete` 6 -> 4 params
- **`TestSummary`** (total, passed, failed, skipped, elapsed, test_mode):
  - `emit_test_summary` 6 -> 1 param
  - marked `__test__ = False` so pytest does not try to collect the Test-prefixed data class.

`emit_progress_start` (3 params, not flagged) intentionally left unchanged to keep the blast radius minimal; its `total` legitimately differs from `complete`'s in some callers.

## Atomic caller update
A signature change is only safe if every caller moves together. Updated **all** real callers in one commit:
- MistHelper.py: 11 call sites (sites/inventory/devices/device_stats/vpn/sle_summary/port_stats/synthetic_tests + the systematic-test summary)
- `src/ssh/ssh_runner_manager.py`, `src/troubleshooting/interactive_test_runner.py`, `src/refactors/serial_cc/{security_events,sle_metrics}.py`
- `tests/unit/test_telemetry.py` (R1 duplicate class + calls), `test_menu_12_inventory.py` / `test_menu_13_device_stats.py` (call_args assertions now read `ProgressContext` attrs)

## Result
- Analyzer High **74 -> 71**. No new Medium/Low violations.

## Verification
- `ruff` / `black` / `mypy` (strict) all green on every changed module.
- Emitter NDJSON parity harness: test_summary (pass+fail verdict), progress_tick, progress_complete (incl. was_stopped=True) all emit byte-identical schema/values.
- 49 affected unit/integration tests pass (telemetry, menu_12/13, serial_cc sle/security, ssh_runner_manager).

## Conformance
- [x] Real param-bundling dataclasses, no wrappers (ARCH-DELEGATE clean)
- [x] Inline comments + action logging on touched lines
- [x] No secrets; event schema unchanged (no behavior change)
- [x] 5-Item Rule respected (all refactored signatures now <=5 params)