### PR TITLE
refactor(phase-high): wave 6 -- bundle params for 3 single-caller fns (High 71->68)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -115,10 +115,19 @@ from src.capture.packet_capture import (
 from src.dataclasses.batch_worker import (
     BatchWorkerConfig,
 )  # Issue #431: groups thread-pool batch config to keep _pool_process_batch_wait_loop within the 5-Item Rule.
+from src.dataclasses.msp_org_context import (
+    MspOrgContext,
+)  # Issue #470: groups MSP/Org identity to keep _enrich_device_context within the 5-Item Rule.
 from src.dataclasses.progress_event import (
     ProgressContext,
     TestSummary,
 )  # Issue #470: groups TelemetryEmitter event fields to keep emit_* signatures within the 5-Item Rule.
+from src.dataclasses.systematic_test_option import (
+    SystematicTestOption,
+)  # Issue #470: groups menu-option identity to keep _systematic_test_run_option within the 5-Item Rule.
+from src.dataclasses.websocket_stream_target import (
+    WebSocketStreamTarget,
+)  # Issue #470: groups WS connection identity to keep _listen_for_output within the 5-Item Rule.
 from src.export.device_events_52w_exporter import DeviceEvents52wExporter  # Import 52-week device events export handler
 from src.export.site_export_utils import (
     configure_site_export_utils_dependencies,
@@ -16319,7 +16328,9 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         session_id = ARPCommandManager._trigger_command(mist_host, mist_apitoken, site_id, device_id)  # type: ignore[no-untyped-call]
         if session_id:  # Have a session.
             ARPCommandManager._listen_for_output(  # type: ignore[no-untyped-call]
-                mist_host.replace("api.", "api-ws."), mist_apitoken, site_id, device_id, session_id
+                WebSocketStreamTarget(  # Issue #470: bundle WS connection identity into one target.
+                    mist_host.replace("api.", "api-ws."), mist_apitoken, site_id, device_id, session_id
+                )
             )
 
     @staticmethod
@@ -16339,16 +16350,16 @@ class ARPCommandManager:  # ARP WebSocket command manager.
             return None  # Return None.
 
     @staticmethod
-    def _listen_for_output(  # noqa: PLR0913
-        mist_host, mist_apitoken, site_id, device_id, session_id, timeout=30, idle_timeout=3, debug=False
-    ):
-        """Listen for WebSocket command output from a device."""
+    def _listen_for_output(target: WebSocketStreamTarget, timeout=30, idle_timeout=3, debug=False):
+        """Listen for WebSocket command output from a device (issue #470: connection identity in target)."""
         if debug:  # Debug mode.
             websocket.enableTrace(True)  # Trace the WebSocket.
 
-        ws_url = f"wss://{mist_host}/api-ws/v1/stream"  # Stream URL.
-        headers = [f"Authorization: Token {mist_apitoken}"]  # Auth header.
-        subscribe_msg = {"subscribe": f"/sites/{site_id}/devices/{device_id}/cmd"}  # Subscribe message.
+        ws_url = f"wss://{target.mist_host}/api-ws/v1/stream"  # Stream URL from the bundled target (issue #470).
+        headers = [f"Authorization: Token {target.mist_apitoken}"]  # Auth header from the bundled target (issue #470).
+        subscribe_msg = {
+            "subscribe": f"/sites/{target.site_id}/devices/{target.device_id}/cmd"
+        }  # Subscribe message built from the bundled target identity (issue #470).
 
         output_lines: list[str] = []  # Collect output lines.
         buffer = ""  # Reassembly buffer.
@@ -16357,7 +16368,7 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         def on_message(ws, message):  # Handle a message.
             nonlocal last_message_time, buffer, output_lines  # Share outer state.
             last_message_time, buffer = ARPCommandManager._handle_message(  # type: ignore[no-untyped-call]
-                message, session_id, buffer, output_lines, debug
+                message, target.session_id, buffer, output_lines, debug
             )
 
         def on_close(ws, *args):  # Handle close.
@@ -19479,20 +19490,17 @@ class MSPInventoryExporter:
             return devices_data  # Use it as-is
         return [devices_data] if devices_data else []  # Wrap a single record, or empty when falsy
 
-    def _enrich_device_context(  # noqa: PLR0913
+    def _enrich_device_context(
         self,
         device: dict,  # type: ignore[type-arg]
-        msp_id: str,
-        msp_name: str,
-        org_id: str,
-        org_name: str,
+        context: MspOrgContext,
         site_lookup: dict,  # type: ignore[type-arg]
     ) -> None:
-        """Add MSP/Org/Site context to a device record."""
-        device["_msp_id"] = msp_id
-        device["_msp_name"] = msp_name
-        device["_org_id"] = org_id
-        device["_org_name"] = org_name
+        """Add MSP/Org/Site context to a device record (issue #470: MSP/Org identity bundled into context)."""
+        device["_msp_id"] = context.msp_id  # Stamp MSP id from the bundled context (issue #470).
+        device["_msp_name"] = context.msp_name  # Stamp MSP name from the bundled context (issue #470).
+        device["_org_id"] = context.org_id  # Stamp org id from the bundled context (issue #470).
+        device["_org_name"] = context.org_name  # Stamp org name from the bundled context (issue #470).
         site_id = device.get("site_id")
         device["_site_name"] = site_lookup.get(site_id, "Unknown Site") if site_id else "Unassigned"
 
@@ -19524,8 +19532,9 @@ class MSPInventoryExporter:
                 return
 
             site_lookup = self._build_site_lookup(org_id)
+            device_context = MspOrgContext(msp_id, msp_name, org_id, org_name)  # Bundle MSP/Org identity (issue #470).
             for device in devices_data:
-                self._enrich_device_context(device, msp_id, msp_name, org_id, org_name, site_lookup)
+                self._enrich_device_context(device, device_context, site_lookup)
                 self.all_devices.append(device)
 
             self.device_count += len(devices_data)
@@ -22727,14 +22736,13 @@ def _systematic_test_emit_skips(emitter: Any, unsafe_list: list[str]) -> int:
 
 def _systematic_test_run_option(
     emitter: Any,
-    option: str,
-    func: Any,
-    description: str,
+    case: SystematicTestOption,
     i: int,
     total_safe: int,
     fast_enabled: bool,
 ) -> tuple[bool, float]:
     """Run one menu option in the systematic test harness and return (success, duration)."""
+    option, func, description = case.option, case.func, case.description  # Unpack the option identity (issue #470).
     print(
         f"   [{i:2}/{total_safe}] Testing option {option:>3}: {description[:60]}..."
     )  # Show current progress position before invoking.
@@ -22874,8 +22882,8 @@ def run_systematic_test():  # noqa: C901, PLR0912, PLR0915
     for i, option in enumerate(safe_options, 1):  # Iterate options in optimized order, 1-indexed for display.
         func, description = menu_actions[option]  # Unpack the callable and display name for this option.
         success, _duration = _systematic_test_run_option(
-            emitter, option, func, description, i, len(safe_options), fast_enabled
-        )  # Execute option with telemetry and return result.
+            emitter, SystematicTestOption(option, func, description), i, len(safe_options), fast_enabled
+        )  # Execute option with telemetry and return result (issue #470: option identity bundled).
         if success:  # Count success and failure separately for the final summary.
             success_count += 1  # Increment on successful option execution.
         else:  # Non-success means the option raised or returned an error.

--- a/src/dataclasses/msp_org_context.py
+++ b/src/dataclasses/msp_org_context.py
@@ -1,0 +1,23 @@
+"""Frozen dataclass that groups MSP / organization identity for device enrichment.
+
+``_enrich_device_context`` in ``MistHelper.py`` took 6 parameters, exceeding the
+5-Item Rule's max-5 limit. The four MSP/Org identity values that get stamped onto
+each device record are grouped here so the method keeps only its per-call
+arguments (the device record and the site lookup) and drops to 3 parameters.
+
+Issue: https://github.com/jmorrison-juniper/MistHelper/issues/470
+"""
+
+from __future__ import annotations  # Enable PEP 604 union syntax on older runtimes.
+
+from dataclasses import dataclass  # The standard library dataclass decorator.
+
+
+@dataclass(frozen=True, slots=True)
+class MspOrgContext:
+    """MSP and organization identity stamped onto each enriched device record."""
+
+    msp_id: str  # MSP (managed service provider) UUID the org belongs to.
+    msp_name: str  # Human-readable MSP name.
+    org_id: str  # Organization UUID the device belongs to.
+    org_name: str  # Human-readable organization name.

--- a/src/dataclasses/systematic_test_option.py
+++ b/src/dataclasses/systematic_test_option.py
@@ -1,0 +1,28 @@
+"""Frozen dataclass that groups one systematic-test menu option's identity.
+
+``_systematic_test_run_option`` in ``MistHelper.py`` took 7 parameters, exceeding
+the 5-Item Rule's max-5 limit. The three values that describe the menu option
+under test (its number, its callable, and its display description) are grouped
+here so the function keeps its per-run arguments (emitter, position index, total
+count, fast flag) and drops to 5 parameters.
+
+The class name is deliberately NOT ``Test``-prefixed so pytest does not try to
+collect it as a test case.
+
+Issue: https://github.com/jmorrison-juniper/MistHelper/issues/470
+"""
+
+from __future__ import annotations  # Enable PEP 604 union syntax on older runtimes.
+
+from collections.abc import Callable  # Modern home for the Callable type alias.
+from dataclasses import dataclass  # The standard library dataclass decorator.
+from typing import Any  # The menu callable returns Any and takes arbitrary kwargs.
+
+
+@dataclass(frozen=True, slots=True)
+class SystematicTestOption:
+    """Identity of a single menu option exercised by the systematic test harness."""
+
+    option: str  # Menu option number being tested (e.g. "11").
+    func: Callable[..., Any]  # The menu action callable invoked for this option.
+    description: str  # Human-readable option description shown in progress output.

--- a/src/dataclasses/websocket_stream_target.py
+++ b/src/dataclasses/websocket_stream_target.py
@@ -1,0 +1,25 @@
+"""Frozen dataclass that groups the WebSocket stream connection-target fields.
+
+``ARPCommandManager._listen_for_output`` in ``MistHelper.py`` took 8 parameters,
+which exceeded the 5-Item Rule's max-5 limit. The five connection-identity
+values (host, API token, site, device, session) that locate the device stream
+are grouped here so the method's option parameters (timeout, idle_timeout,
+debug) stay as direct arguments and the signature drops to 4 parameters.
+
+Issue: https://github.com/jmorrison-juniper/MistHelper/issues/470
+"""
+
+from __future__ import annotations  # Enable PEP 604 union syntax on older runtimes.
+
+from dataclasses import dataclass  # The standard library dataclass decorator.
+
+
+@dataclass(frozen=True, slots=True)
+class WebSocketStreamTarget:
+    """Connection identity that locates one device's WebSocket command stream."""
+
+    mist_host: str  # Mist API-WS host the stream connects to (e.g. api-ws.mist.com).
+    mist_apitoken: str  # API token used in the WebSocket Authorization header.
+    site_id: str  # Site UUID the target device belongs to.
+    device_id: str  # Device UUID whose command output is being streamed.
+    session_id: str  # Command session id used to match inbound stream messages.


### PR DESCRIPTION
Part of #470 (High-severity STRUCT decomposition), umbrella #433. Overlaps #431 (STRUCT-PARAMS).

## What
Wave 6 of the High phase. Clears **3 High STRUCT-PARAMS** violations by bundling each function's identity fields into a small frozen dataclass (new modules under `src/dataclasses/`, following the #431 `BatchWorkerConfig` pattern). Each target has exactly **one caller**, updated in the same commit:

| Function | Before | After | Dataclass |
|---|---|---|---|
| `ARPCommandManager._listen_for_output` | 8 | 4 | `WebSocketStreamTarget` (host, token, site, device, session) |
| `MSPInventoryExporter._enrich_device_context` | 6 | 3 | `MspOrgContext` (msp_id, msp_name, org_id, org_name) |
| `_systematic_test_run_option` | 7 | 5 | `SystematicTestOption` (option, func, description) |

Notes:
- `_enrich_device_context` caller now builds the `MspOrgContext` **once** outside the per-device loop (small efficiency win).
- `SystematicTestOption` is deliberately **not** `Test`-prefixed so pytest won't try to collect it.
- `_listen_for_output` drops its `# noqa: PLR0913`; the websocket logic is unchanged.

## Result
- Analyzer High **71 -> 68**. No new Medium/Low violations.
- Remaining High PARAMS (3): two `__init__` constructors and `write_with_format_selection` (83 call sites) -- deferred to dedicated waves.

## Verification
- `ruff` / `black` / `mypy` (strict) green on every changed module.
- Behavior-parity harness, all pass:
  - enrich: site-lookup hit / miss (Unknown Site) / no-site (Unassigned), all four MSP/Org stamps.
  - systematic: success -> (True, dur) + emit_test_pass(option, desc); exception -> (False, dur) + emit_test_fail; fast-mode flag propagated only when func supports it.
  - listen: ws_url, Authorization header, and subscribe path all rebuilt from the `WebSocketStreamTarget` fields.

## Conformance
- [x] Real param-bundling dataclasses, no wrappers (ARCH-DELEGATE clean)
- [x] Inline comments + action logging on touched lines
- [x] No secrets; no behavior change
- [x] 5-Item Rule respected (all three signatures now <=5 params)