### PR TITLE
refactor(phase-high): wave 7 -- DeviceDataFetcher ctor takes DeviceFetchConfig (High 68->67)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -5719,38 +5719,18 @@ class DeviceDataFetcher:
     SECURITY: Uses authenticated API session for all device queries.
 
     Usage:
-        DeviceDataFetcher(fetch_function, filename, description).fetch()
-        DeviceDataFetcher(fetch_function, filename, description, device_type="gateway").fetch()
+        DeviceDataFetcher(DeviceFetchConfig(fetch_function, filename, description)).fetch()
+        DeviceDataFetcher(DeviceFetchConfig(fetch_function, filename, description, device_type="gateway")).fetch()
     """
 
-    def __init__(  # noqa: PLR0913
-        self,
-        fetch_function: Callable,  # type: ignore[type-arg]
-        filename: str,
-        description: str,
-        device_type: str = "all",
-        site_id: str | None = None,
-        device_id: str | None = None,
-    ):
-        """Initialize fetcher with required parameters."""
-        self.fetch_function = fetch_function
-        self.filename = filename
-        self.description = description
-        self.device_type = device_type
-        self.site_id = site_id
-        self.device_id = device_id
-
-    @classmethod
-    def from_config(cls, config: "DeviceFetchConfig") -> "DeviceDataFetcher":
-        """Create fetcher from DeviceFetchConfig object."""
-        return cls(
-            fetch_function=config.fetch_function,
-            filename=config.filename,
-            description=config.description,
-            device_type=config.device_type,
-            site_id=config.site_id,
-            device_id=config.device_id,
-        )
+    def __init__(self, config: DeviceFetchConfig):
+        """Initialize fetcher from a DeviceFetchConfig (issue #470: 6 params bundled into one per 5-Item Rule)."""
+        self.fetch_function = config.fetch_function  # Callable that performs the actual API fetch.
+        self.filename = config.filename  # Output filename for the exported data.
+        self.description = config.description  # Human-readable description shown during the fetch.
+        self.device_type = config.device_type  # Device type filter (all/ap/switch/gateway).
+        self.site_id = config.site_id  # Optional site scope (None means an org-wide fetch).
+        self.device_id = config.device_id  # Optional single-device scope (None means all matching devices).
 
     def fetch(self) -> None:
         """Main entry point - orchestrates the device data fetch workflow."""
@@ -15549,11 +15529,13 @@ class InteractiveDisplayUtils:  # Interactive display utils.
         """
         logging.info("Prompting user to select a device for detailed statistics view...")  # Log the prompt.
         DeviceDataFetcher(  # Fetch and display.
-            fetch_function=mistapi.api.v1.sites.stats.getSiteDeviceStats,
-            filename="DeviceStats.csv",
-            description="Fetching detailed stats",
-            site_id=site_id,
-            device_id=device_id,
+            DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+                fetch_function=mistapi.api.v1.sites.stats.getSiteDeviceStats,
+                filename="DeviceStats.csv",
+                description="Fetching detailed stats",
+                site_id=site_id,
+                device_id=device_id,
+            )
         ).fetch()
         logging.info("Completed device_stats execution.")  # Log completion.
 
@@ -15564,10 +15546,12 @@ class InteractiveDisplayUtils:  # Interactive display utils.
         """
         logging.info("Prompting user to select a gateway device for synthetic test stats view...")  # Log the prompt.
         DeviceDataFetcher(  # Fetch and display.
-            fetch_function=mistapi.api.v1.sites.devices.getSiteDeviceSyntheticTest,
-            filename="DeviceTestResults.csv",
-            description="Fetching synthetic test stats",
-            device_type="gateway",
+            DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+                fetch_function=mistapi.api.v1.sites.devices.getSiteDeviceSyntheticTest,
+                filename="DeviceTestResults.csv",
+                description="Fetching synthetic test stats",
+                device_type="gateway",
+            )
         ).fetch()
         logging.info("Completed device_tests execution.")  # Log completion.
 
@@ -15578,9 +15562,11 @@ class InteractiveDisplayUtils:  # Interactive display utils.
         """
         logging.info("Prompting user to select a device for configuration details view...")  # Log the prompt.
         DeviceDataFetcher(  # Fetch and display.
-            fetch_function=mistapi.api.v1.sites.devices.getSiteDevice,
-            filename="DeviceConfig.csv",
-            description="Fetching device configuration",
+            DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+                fetch_function=mistapi.api.v1.sites.devices.getSiteDevice,
+                filename="DeviceConfig.csv",
+                description="Fetching device configuration",
+            )
         ).fetch()
         logging.info("Completed device_config execution.")  # Log completion.
 


### PR DESCRIPTION
Part of #470 (High-severity STRUCT decomposition), umbrella #433. Overlaps #431.

## What
Wave 7 completes a **dormant #431 migration**. `DeviceFetchConfig` was defined but had **zero instantiations**, and `DeviceDataFetcher.from_config()` was **never called** -- callers still used the 6-parameter positional `__init__`.

This wave:
- Changes `DeviceDataFetcher.__init__` to take the existing `DeviceFetchConfig` dataclass (**6 params -> 1**), unpacking it into `self.*`.
- **Removes** the now-redundant `from_config` classmethod -- with `__init__(config)` it would collapse to a pure `cls(config)` delegate (ARCH-DELEGATE).
- Updates all **3 real callers** (`device_stats` / `device_tests` / `device_config`) and the class docstring usage examples to build a `DeviceFetchConfig`.

## Result
- Analyzer High **68 -> 67**. No new Medium/Low. `DeviceFetchConfig` is now actually used (clears latent dead-code).
- Remaining High PARAMS (2): `APIDataFetcher.__init__` (15 callers, uses **kwargs) and `write_with_format_selection` (83 callers) -- each its own dedicated wave next.

## Note on the namesake
`src/gateway/overrides/device_data_fetcher.py` defines a **separate** `DeviceDataFetcher` (static-method API, no `__init__(config)`). It is package-local, not imported into MistHelper.py, and is **untouched** by this change.

## Verification
- `ruff` / `black` green; analyzer confirms the drop.
- Constructor parity harness: full config (all 6 fields mapped), defaults path (device_type='all', site_id/device_id=None), and `from_config` confirmed removed.

## Conformance
- [x] Real param-bundling via existing dataclass, no wrappers (delegate removed, not added)
- [x] Inline comments + action logging on touched lines
- [x] No secrets; no behavior change
- [x] 5-Item Rule: __init__ now 1 param