### PR TITLE
refactor(phase-high): wave 8 -- drop dead display_fields param from APIDataFetcher (High 67->66)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -7579,7 +7579,6 @@ class APIDataFetcher:  # Fetch, export, display a result.
         api_call: Any,
         filename: str,
         sort_key: str | None = None,
-        display_fields: list[str] | None = None,
         **kwargs,
     ):
         """
@@ -7590,14 +7589,12 @@ class APIDataFetcher:  # Fetch, export, display a result.
             api_call: Mist API function to call
             filename: Output filename (without extension)
             sort_key: Optional field to sort results by
-            display_fields: Optional list of fields for table display
             **kwargs: Additional arguments passed to the API call
         """
         self.title = title  # Human-readable title.
         self.api_call = api_call  # Callable that fetches data.
         self.filename = filename  # Output filename.
         self.sort_key = sort_key  # Optional sort key.
-        self.display_fields = display_fields  # Columns to display.
         self.kwargs = kwargs  # Extra API arguments.
 
         self.org_id = ""  # Resolved org id.
@@ -7901,7 +7898,7 @@ class APIDataFetcher:  # Fetch, export, display a result.
     def _build_pretty_table(self, data: list[dict[str, Any]], fields: list[str]) -> Any:  # Build a PrettyTable.
         """Build PrettyTable from processed data."""
         table = PrettyTable()  # New table.
-        table.field_names = self.display_fields if self.display_fields else fields  # Choose columns.
+        table.field_names = fields  # Use the auto-derived field list as the table columns.
         table.valign = "t"  # Top-align cells.
 
         for item in tqdm(data, desc="Processing", unit="record"):  # type: ignore[no-untyped-call]


### PR DESCRIPTION
Part of #470 (High-severity STRUCT decomposition), umbrella #433. Overlaps #431.

## What
Wave 8 clears the `APIDataFetcher.__init__` High STRUCT-PARAMS violation (**6 -> 5 params**) by **removing the dead `display_fields` parameter**.

### Why removal (not a config bundle)
- `display_fields` has **zero callers** -- all 15 `APIDataFetcher(...)` sites omit it, and no `src/` or test code passes it.
- Because it was always `None`, the only read site (`_build_pretty_table`) --
  `table.field_names = self.display_fields if self.display_fields else fields` --
  **always evaluated to `fields`**. Removing it is therefore behavior-identical.
- Alternatives were worse: a `kwargs.pop('display_fields')` demotion would be analyzer-gaming (violates fix-over-suppress); a full `APIFetchConfig` bundle would churn **19 files** (15 prod callers + 4 mock-based test files: test_menu_12/13/19, test_mistapi_sdk_compatibility) for a feature nobody uses.

This is honest dead-code elimination -- exactly the param bloat the 5-Item Rule targets.

## Result
- Analyzer High **67 -> 66**. No new Medium/Low.
- **High STRUCT-PARAMS is now down to a single function**: `write_with_format_selection` (83 callers) -- its own dedicated wave next.

## Verification
- `ruff` / `black` green; analyzer confirms the drop.
- Parity harness: `__init__` still sets title/api_call/filename/sort_key and forwards extra kwargs (limit, duration) to `self.kwargs`; `_build_pretty_table` returns the auto-derived field list; minimal construction defaults intact; `display_fields` attribute gone.
- 19 APIDataFetcher wiring tests pass (test_menu_12/13/19, sdk_compatibility), 7 skipped.

## Conformance
- [x] Honest dead-code removal, not suppression
- [x] Inline comments + action logging on touched lines
- [x] No secrets; behavior-identical
- [x] 5-Item Rule: __init__ now 5 params