### PR TITLE
refactor(phase-high): wave 9 -- bundle backend overrides (High PARAMS -> 0)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -115,6 +115,9 @@ from src.capture.packet_capture import (
 from src.dataclasses.batch_worker import (
     BatchWorkerConfig,
 )  # Issue #431: groups thread-pool batch config to keep _pool_process_batch_wait_loop within the 5-Item Rule.
+from src.dataclasses.export_backend_options import (
+    ExportBackendOptions,
+)  # Issue #470: groups output-backend overrides to keep write_with_format_selection within the 5-Item Rule.
 from src.dataclasses.msp_org_context import (
     MspOrgContext,
 )  # Issue #470: groups MSP/Org identity to keep _enrich_device_context within the 5-Item Rule.
@@ -7297,10 +7300,9 @@ class DataExporter:  # Multi-backend export facade.
     def write_with_format_selection(  # Public export entry point.
         data: list[dict[str, Any]],
         filename_or_table: str,
-        format_override: str | None = None,
         api_function_name: str | None = None,
-        raw_data: list[dict[str, Any]] | None = None,
         fieldnames: list[str] | None = None,
+        backend_options: "ExportBackendOptions | None" = None,
     ) -> bool:
         """
         Writes data to either CSV or SQLite database based on global OUTPUT_FORMAT or override.
@@ -7308,16 +7310,19 @@ class DataExporter:  # Multi-backend export facade.
         Args:
             data: List of dictionaries containing the data to write
             filename_or_table: CSV filename or database table name
-            format_override: Optional override for output format ("csv" or "sqlite")
             api_function_name: Name of the API function for SQLite strategy selection
-            raw_data: Unflattened API response for polyglot backends (if None, uses data)
             fieldnames: Optional explicit column order for CSV output.  When provided the
                 columns are written in exactly this order instead of being sorted alphabetically.
+            backend_options: Optional output-backend overrides (format_override, raw_data).
+                Issue #470: bundled into one ExportBackendOptions so the signature stays <=5 params.
 
         Returns:
             bool: True if successful, False otherwise
         """
-        output_format = format_override if format_override else OUTPUT_FORMAT  # Override or global format.
+        opts = (
+            backend_options if backend_options is not None else ExportBackendOptions()
+        )  # Resolve to defaults when no overrides were supplied (avoids a mutable default arg).
+        output_format = opts.format_override if opts.format_override else OUTPUT_FORMAT  # Override or global format.
         logging.debug(  # Trace the write request.
             "DataExporter.write_with_format_selection: rows=%s, target=%s, format=%s, api_func=%s",
             len(data) if data else 0,
@@ -7338,7 +7343,9 @@ class DataExporter:  # Multi-backend export facade.
             logging.error("Failed to write data to %s in %s format: %s", filename_or_table, output_format, error)
             return False  # Write failed.
 
-        DataExporter._route_to_polyglot(data, api_function_name, raw_data=raw_data)  # Mirror to polyglot DB.
+        DataExporter._route_to_polyglot(
+            data, api_function_name, raw_data=opts.raw_data
+        )  # Mirror to polyglot DB (issue #470: raw_data from bundled backend options).
         return csv_ok  # Return the primary result.
 
     _standalone_logged = False  # One-shot standalone log guard.
@@ -7535,7 +7542,7 @@ class DataExporter:  # Multi-backend export facade.
             processed_data,
             filename,
             api_function_name=api_function_name,
-            raw_data=raw_data,
+            backend_options=ExportBackendOptions(raw_data=raw_data),  # Issue #470: raw_data bundled.
         )
 
         return DataExporter._finalize_export(success, len(processed_data), filename)  # Log outcome, return count

--- a/src/dataclasses/export_backend_options.py
+++ b/src/dataclasses/export_backend_options.py
@@ -1,0 +1,29 @@
+"""Frozen dataclass that groups the rarely-used output-backend override options.
+
+``DataExporter.write_with_format_selection`` in ``MistHelper.py`` took 6 parameters,
+exceeding the 5-Item Rule's max-5 limit. The two least-used optional parameters --
+both of which control the *output backend* rather than the data content or CSV
+display -- are grouped here so the public signature drops to 5 parameters while
+the common ``(data, filename)`` and ``api_function_name`` / ``fieldnames`` call
+shapes are unaffected:
+
+- ``format_override`` selects the backend ("csv" or "sqlite") instead of the
+  global ``OUTPUT_FORMAT``.
+- ``raw_data`` supplies the unflattened API rows for the polyglot (ArangoDB/Redis)
+  backend.
+
+Issue: https://github.com/jmorrison-juniper/MistHelper/issues/470
+"""
+
+from __future__ import annotations  # Enable PEP 604 union syntax on older runtimes.
+
+from dataclasses import dataclass  # The standard library dataclass decorator.
+from typing import Any  # Element type for the raw_data row list.
+
+
+@dataclass(frozen=True, slots=True)
+class ExportBackendOptions:
+    """Optional output-backend overrides for DataExporter.write_with_format_selection."""
+
+    format_override: str | None = None  # Force "csv" or "sqlite" instead of the global OUTPUT_FORMAT.
+    raw_data: list[dict[str, Any]] | None = None  # Unflattened API rows for the polyglot backend (None -> use data).

--- a/src/export/device_events_52w_exporter.py
+++ b/src/export/device_events_52w_exporter.py
@@ -8,6 +8,10 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from src.dataclasses.export_backend_options import (
+    ExportBackendOptions,
+)  # Issue #470: backend overrides for write_with_format_selection.
+
 
 @dataclass
 class DeviceEvents52wExporter:
@@ -160,8 +164,8 @@ class DeviceEvents52wExporter:
             self.data_exporter.write_with_format_selection(
                 rows,
                 "OrgDeviceEvents_52w",
-                format_override="sqlite",
                 api_function_name="searchOrgDeviceEvents",
+                backend_options=ExportBackendOptions(format_override="sqlite"),  # Issue #470: backend override bundled.
             )
             return
         with open(csv_file, "w", newline="", encoding="utf-8") as handle:
@@ -176,8 +180,8 @@ class DeviceEvents52wExporter:
             self.data_exporter.write_with_format_selection(
                 rows,
                 "OrgDeviceEvents_52w",
-                format_override="sqlite",
                 api_function_name="searchOrgDeviceEvents",
+                backend_options=ExportBackendOptions(format_override="sqlite"),  # Issue #470: backend override bundled.
             )
             return
         with open(csv_file, "a", newline="", encoding="utf-8") as handle:


### PR DESCRIPTION
Part of #470 (High-severity STRUCT decomposition), umbrella #433. Overlaps #431.

## What
Wave 9 clears the **last** High STRUCT-PARAMS violation -- **High STRUCT-PARAMS is now 0**.

`DataExporter.write_with_format_selection` is the primary export entry point (**162 call sites**). It goes **6 params -> 5** by bundling the two least-used optionals into a single coherent dataclass:

`ExportBackendOptions(format_override, raw_data)` -- both are *output-backend* overrides (format_override picks csv/sqlite vs the global OUTPUT_FORMAT; raw_data supplies unflattened rows for the polyglot ArangoDB/Redis backend).

### Why this design (minimal, safe)
- Only **3 of 162** call sites pass these two optionals (MistHelper.py x1 `raw_data`; `device_events_52w_exporter` x2 `format_override`). The **115** `(data, filename)`-only callers and the many `api_function_name=` / `fieldnames=` callers are **untouched** -- those stay direct params.
- Verified (AST-style scan) that **no caller passes any optional positionally**, so reordering the remaining params is safe.
- Used `backend_options: ExportBackendOptions | None = None` with an internal `opts = backend_options or ExportBackendOptions()` resolve -- no mutable default (no ruff B008), no analyzer-gaming.
- Chose this over bundling the high-traffic optionals (api_function_name=76, fieldnames=38 sites) which would have churned 40+ sites incl. critical SQLite-upsert tests.

## Result
- Analyzer High **66 -> 65**. **High STRUCT-PARAMS: 1 -> 0.** Remaining High = COMPLEXITY (36) + LENGTH (29).

## Verification
- `ruff` / `black` / `mypy` (strict) green on all changed modules.
- Export-path parity harness (helpers stubbed), 4 cases: CSV default (fieldnames forwarded, raw_data None), format_override='sqlite' routes to SQLite, raw_data forwarded to polyglot, global-sqlite + `(data, table)`-only.
- 12 integration tests pass: `test_menu_12_sqlite_upsert` (5), `test_menu_13_sqlite_upsert` (6), `test_device_events_52w_exporter` (1).

## Conformance
- [x] Real param-bundling dataclass, no wrappers/suppression
- [x] Inline comments + action logging on touched lines
- [x] No secrets; behavior-identical (verified on the critical export path)
- [x] 5-Item Rule: signature now 5 params