### PR TITLE
refactor(MistHelper): M14 -- eliminate STRUCT-LENGTH + 1 nesting

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -14529,23 +14529,27 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
 
     def _extract_gateway_models(self, device_models_data) -> list[str]:  # Filter to gateway models.
         """Extract gateway model names from device models data."""
-        gateway_models = []  # Collect model names.
+        gateway_models = []  # Collect model names
 
-        if isinstance(device_models_data, dict):  # Dict payload.
-            for model_name, model_details in device_models_data.items():  # Walk models.
-                if isinstance(model_details, dict):  # Dict details.
-                    model_type = model_details.get("type", "").lower()  # Read the type.
-                    if model_type == "gateway":  # Gateway type.
-                        gateway_models.append(model_name)  # Keep the model.
-        elif isinstance(device_models_data, list):  # List payload.
-            for model_item in device_models_data:  # Walk models.
-                if isinstance(model_item, dict):  # Dict item.
-                    model_name = model_item.get("model", model_item.get("name", ""))  # Read the name.
-                    model_type = model_item.get("type", "").lower()  # Read the type.
-                    if model_name and model_type == "gateway":  # Gateway with a name.
-                        gateway_models.append(model_name)  # Keep the model.
+        if isinstance(device_models_data, dict):  # Dict payload
+            for model_name, model_details in device_models_data.items():  # Walk models
+                if not isinstance(model_details, dict):  # Skip non-dict values for safety
+                    continue
+                if model_details.get("type", "").lower() != "gateway":  # Only keep gateway entries
+                    continue
+                gateway_models.append(model_name)  # Keep the model
+        elif isinstance(device_models_data, list):  # List payload
+            for model_item in device_models_data:  # Walk models
+                if not isinstance(model_item, dict):  # Skip non-dict items
+                    continue
+                model_name = model_item.get("model", model_item.get("name", ""))  # Read the name
+                if not model_name:  # Empty name = unusable entry
+                    continue
+                if model_item.get("type", "").lower() != "gateway":  # Only keep gateway entries
+                    continue
+                gateway_models.append(model_name)  # Keep the model
 
-        return gateway_models  # Return gateway models.
+        return gateway_models  # Return gateway models
 
     def _normalize_model_data(self, model: str, model_data) -> list[dict]:  # type: ignore[no-untyped-def, type-arg]
         """Normalize model data into list of records with model identifier."""
@@ -20787,35 +20791,44 @@ class BulkRadiusWLANConfigManager:
             wlan["_inheritance_level"] = "org"
             wlan["_inheritance_source"] = "Org-Level WLAN"
 
-    def _display_wlans(self) -> None:
-        """Display unified table of all RADIUS WLANs with compliance markers."""
-        print("\n" + "-" * 70)  # Top border of the WLAN table
-        print("  RADIUS-ENABLED WLANs")  # Table title
-        print("-" * 70)  # Separator under the title
-        print(f"  {'#':<4} {'SSID':<25} {'Level':<12} {'Timeout':<8} {'Retries':<8} {'Fast':<6}")  # Column headers
-        print("-" * 70)  # Separator under the headers
-        display_index = 1  # Running 1-based number for selectable (non-compliant) WLANs
-        combined: list[tuple[dict[str, Any], int | None]] = []  # Pairs of (wlan, display index or None for compliant)
+    def _build_combined_wlan_rows(self) -> list[tuple[dict[str, Any], int | None]]:
+        """Pair WLANs with display indices: selectable WLANs get 1-based numbers; compliant ones get None."""
+        display_index = 1  # Running 1-based number for selectable WLANs
+        combined: list[tuple[dict[str, Any], int | None]] = []  # Output pairs
         for wlan in self.radius_wlans:  # Selectable WLANs that need configuration
             combined.append((wlan, display_index))  # Give each a selectable index
-            display_index += 1  # Advance the index for the next selectable WLAN
-        for wlan in self.compliant_wlans:  # Already-compliant WLANs (shown but not selectable)
-            combined.append((wlan, None))  # No index -- they cannot be selected
-        combined.sort(key=lambda item: item[0].get("ssid", "").lower())  # Sort the table alphabetically by SSID
-        for wlan, idx in combined:  # Render each row in sorted order
-            ssid = wlan.get("ssid", "Unknown")  # The WLAN's SSID (fallback if missing)
-            is_compliant = wlan.get("_compliance_status") == "COMPLIANT"  # Whether this WLAN already meets the target
-            suffix = " (COMPLIANT)" if is_compliant else ""  # Tag compliant rows for clarity
-            ssid_display = (ssid[:13] + suffix) if is_compliant else ssid[:24]  # Truncate SSID to fit the column
-            level = wlan.get("_inheritance_level", "unknown")[:11]  # Inheritance level, truncated to the column width
-            timeout = wlan.get("auth_servers_timeout", 5)  # Current timeout value
-            retries = wlan.get("auth_servers_retries", 2)  # Current retry value
-            fast = "Yes" if wlan.get("fast_dot1x_timers", False) else "No"  # Fast-timer flag as a friendly string
-            idx_str = str(idx) if idx is not None else "--"  # Show the index, or '--' for non-selectable rows
-            print(f"  {idx_str:<4} {ssid_display:<25} {level:<12} {timeout:<8} {retries:<8} {fast:<6}")  # Print the row
-        print("-" * 70)  # Bottom border of the table
-        total = len(self.radius_wlans) + len(self.compliant_wlans)  # Total RADIUS WLANs across both buckets
-        print(  # Summary line of selectable vs compliant counts
+            display_index += 1  # Advance the index
+        for wlan in self.compliant_wlans:  # Already-compliant WLANs (not selectable)
+            combined.append((wlan, None))  # No index for compliant rows
+        combined.sort(key=lambda item: item[0].get("ssid", "").lower())  # Sort by SSID
+        return combined  # Ready for rendering
+
+    def _print_wlan_row(self, wlan: dict[str, Any], idx: int | None) -> None:
+        """Print one WLAN row in the compliance table, with COMPLIANT tag suffix where applicable."""
+        ssid = wlan.get("ssid", "Unknown")  # The WLAN's SSID (fallback if missing)
+        is_compliant = wlan.get("_compliance_status") == "COMPLIANT"  # Whether already at target
+        suffix = " (COMPLIANT)" if is_compliant else ""  # Tag for clarity
+        ssid_display = (ssid[:13] + suffix) if is_compliant else ssid[:24]  # Truncate to column width
+        level = wlan.get("_inheritance_level", "unknown")[:11]  # Inheritance level
+        timeout = wlan.get("auth_servers_timeout", 5)  # Current timeout value
+        retries = wlan.get("auth_servers_retries", 2)  # Current retry value
+        fast = "Yes" if wlan.get("fast_dot1x_timers", False) else "No"  # Fast-timer flag
+        idx_str = str(idx) if idx is not None else "--"  # Index, or '--' for non-selectable
+        print(f"  {idx_str:<4} {ssid_display:<25} {level:<12} {timeout:<8} {retries:<8} {fast:<6}")
+
+    def _display_wlans(self) -> None:
+        """Display unified table of all RADIUS WLANs with compliance markers."""
+        print("\n" + "-" * 70)  # Top border
+        print("  RADIUS-ENABLED WLANs")  # Title
+        print("-" * 70)  # Separator
+        print(f"  {'#':<4} {'SSID':<25} {'Level':<12} {'Timeout':<8} {'Retries':<8} {'Fast':<6}")  # Headers
+        print("-" * 70)  # Separator
+        combined = self._build_combined_wlan_rows()  # Sorted (wlan, idx) pairs
+        for wlan, idx in combined:  # Render each row
+            self._print_wlan_row(wlan, idx)
+        print("-" * 70)  # Bottom border
+        total = len(self.radius_wlans) + len(self.compliant_wlans)  # Total across both buckets
+        print(
             f"  Total: {total} RADIUS WLANs ({len(self.radius_wlans)} selectable, {len(self.compliant_wlans)} compliant)"  # noqa: E501
         )
         print("")  # Blank spacer line
@@ -21057,47 +21070,46 @@ class BulkRadiusWLANConfigManager:
             "enabled": wlan.get("enabled", ""),  # Whether the WLAN itself is enabled
         }
 
+    _AUDIT_TRAIL_FIELDNAMES = [
+        "timestamp",
+        "wlan_id",
+        "ssid",
+        "site_name",
+        "inheritance_level",
+        "before_timeout",
+        "after_timeout",
+        "before_retries",
+        "after_retries",
+        "before_fast_dot1x",
+        "after_fast_dot1x",
+        "status",
+        "error_message",
+    ]
+
+    def _write_audit_csv(self, filepath: str) -> None:
+        """Write self.change_records to a CSV at filepath; log success or surface failure to the user."""
+        try:
+            with open(filepath, "w", newline="", encoding="utf-8") as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=self._AUDIT_TRAIL_FIELDNAMES)
+                writer.writeheader()  # Write the column header row
+                writer.writerows(self.change_records)  # Write every recorded change
+            print(f"\n[+] Audit trail exported to: {filepath}")
+            logging.info("Audit trail exported to %s with %s records", filepath, len(self.change_records))
+        except Exception as e:  # Writing the CSV failed (permissions, disk, etc.)
+            print(f"\n[!] Failed to export audit trail: {e}")
+            logging.error("Failed to export audit trail: %s", e)
+
     def _export_audit_trail(self) -> None:
         """Export change records to CSV in data/ directory."""
         if not self.change_records:  # No changes were recorded this run
-            print("[*] No changes to export.")  # Tell the user there is nothing to write
-            return  # Nothing to export
-
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")  # Timestamp for a unique filename
+            print("[*] No changes to export.")
+            return
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")  # Unique filename timestamp
         prefix = "DRYRUN_" if self.dry_run else ""  # Mark dry-run exports distinctly
-        filename = f"{prefix}RadiusWLANBulkConfig_{timestamp}.csv"  # Compose the audit CSV filename
-        filepath = os.path.join("data", filename)  # Place it under the data/ directory (cross-platform join)
-
-        os.makedirs("data", exist_ok=True)  # Ensure the data/ directory exists before writing
-
-        fieldnames = [
-            "timestamp",
-            "wlan_id",
-            "ssid",
-            "site_name",
-            "inheritance_level",
-            "before_timeout",
-            "after_timeout",
-            "before_retries",
-            "after_retries",
-            "before_fast_dot1x",
-            "after_fast_dot1x",
-            "status",
-            "error_message",
-        ]
-
-        try:
-            with open(filepath, "w", newline="", encoding="utf-8") as csvfile:  # Open the audit CSV for writing
-                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)  # Map dict records to CSV columns
-                writer.writeheader()  # Write the column header row
-                writer.writerows(self.change_records)  # Write every recorded change
-            print(f"\n[+] Audit trail exported to: {filepath}")  # Tell the user where the file landed
-            logging.info(
-                "Audit trail exported to %s with %s records", filepath, len(self.change_records)
-            )  # Log the export
-        except Exception as e:  # Writing the CSV failed (permissions, disk, etc.)
-            print(f"\n[!] Failed to export audit trail: {e}")  # Inform the user of the failure
-            logging.error("Failed to export audit trail: %s", e)  # Log the error detail
+        filename = f"{prefix}RadiusWLANBulkConfig_{timestamp}.csv"  # Composed audit CSV name
+        filepath = os.path.join("data", filename)  # Place under data/ (cross-platform)
+        os.makedirs("data", exist_ok=True)  # Ensure target directory exists
+        self._write_audit_csv(filepath)  # Open + write + report
 
     def manage(self, dry_run: bool = False) -> None:
         """Main entry point - orchestrates the bulk RADIUS WLAN configuration."""
@@ -21206,6 +21218,43 @@ class AuditAnalysisOps:
     """Menu #25: Audit Log Analysis operations."""
 
     @staticmethod
+    def _prompt_audit_time_range_input() -> str:
+        """Capture the audit-log time-range input string (test-mode fixed default or interactive prompt)."""
+        if IS_TEST_MODE:  # Use a fixed time range so --test runs without interactive input
+            return "7d"  # Default to 7 days in test mode; skips the safe_input prompt
+        print("\nTime range examples: 7d, 4w, 3m, 1y, 6w-2w (6 weeks ago to 2 weeks ago)")
+        return InputUtils.safe_input("Enter time range [7d]: ", context="audit_analysis").strip()
+
+    @staticmethod
+    def _fetch_filtered_audit_entries(org_id, time_range):
+        """Call Mist audit-logs API for the chosen org+time-range and return paginated entries (None on failure)."""
+        api_kwargs = TimeRangeParser.to_api_kwargs(time_range)  # Convert to API start/end params
+        try:
+            logging.info(
+                "Fetching audit logs for org %s with range %s",
+                org_id,
+                time_range.description,
+            )  # Log before API call
+            response = mistapi.api.v1.orgs.logs.listOrgAuditLogs(apisession, org_id, **api_kwargs, limit=1000)
+            entries = mistapi.get_all(response=response, mist_session=apisession) or []
+            logging.debug("Retrieved %d raw audit log entries", len(entries))
+            return entries
+        except Exception as exc:
+            logging.error("API call failed: %s", exc)  # Log API failure with context
+            return None
+
+    @staticmethod
+    def _render_audit_analysis_reports(analysis) -> None:
+        """Render the analysis to both the Mermaid markdown file and the interactive HTML file."""
+        renderer = AuditReportRenderer()  # Initialize report generator
+        md_path = os.path.join("data", "OrgAuditAnalysis.md")  # Mermaid timeline output path
+        renderer.render_mermaid(analysis, md_path)
+        print(f"Mermaid report: {md_path}")
+        html_path = os.path.join("data", "OrgAuditAnalysis.html")  # Interactive HTML output path
+        renderer.render_html(analysis, html_path)
+        print(f"HTML report: {html_path}")
+
+    @staticmethod
     def audit_log_analysis():
         """Fetch org audit logs, filter noise, generate analysis reports."""
         if CacheUtils.fast_cache_hit("OrgAuditAnalysis.md"):  # Skip if cached report exists
@@ -21213,58 +21262,24 @@ class AuditAnalysisOps:
         org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org context
         if not org_id:
             return
-
-        if IS_TEST_MODE:  # Use a fixed time range so --test runs without interactive input
-            time_input = "7d"  # Default to 7 days in test mode; skips the safe_input prompt
-        else:
-            print("\nTime range examples: 7d, 4w, 3m, 1y, 6w-2w (6 weeks ago to 2 weeks ago)")
-            time_input = InputUtils.safe_input(  # Prompt for time range
-                "Enter time range [7d]: ", context="audit_analysis"
-            ).strip()
-
+        time_input = AuditAnalysisOps._prompt_audit_time_range_input()  # Test-mode default or interactive prompt
         parser = TimeRangeParser()  # Parse human-readable time range
         try:
             time_range = parser.parse(time_input)  # Convert input to TimeRange object
         except ValueError as exc:
-            logging.error("Invalid time range: %s", exc)  # Log parse failure
+            logging.error("Invalid time range: %s", exc)
             return
-
         print(f"\nFetching audit logs for: {time_range.description}")
-        api_kwargs = TimeRangeParser.to_api_kwargs(time_range)  # Convert to API start/end params
-
-        try:
-            logging.info(
-                "Fetching audit logs for org %s with range %s",
-                org_id,
-                time_range.description,
-            )  # Log before API call
-            response = mistapi.api.v1.orgs.logs.listOrgAuditLogs(
-                apisession, org_id, **api_kwargs, limit=1000
-            )  # Call Mist audit logs API
-            entries = mistapi.get_all(response=response, mist_session=apisession) or []  # Paginate all results
-            logging.debug("Retrieved %d raw audit log entries", len(entries))  # Log result count
-        except Exception as exc:
-            logging.error("API call failed: %s", exc)  # Log API failure with context
+        entries = AuditAnalysisOps._fetch_filtered_audit_entries(org_id, time_range)  # API call + paginate
+        if entries is None:  # API failed (already logged inside helper)
             return
-
         print(f"Retrieved {len(entries)} raw entries")
-
-        log_filter = AuditLogFilter()  # Initialize noise filter
+        log_filter = AuditLogFilter()  # Noise filter
         filtered, stats = log_filter.filter_with_stats(entries)  # Remove noise entries with stats
         print(f"Filtered: {stats['kept_count']} kept, {stats['removed_count']} noise removed")
-
-        analyzer = AuditLogAnalyzer()  # Initialize pattern analyzer
+        analyzer = AuditLogAnalyzer()  # Pattern analyzer
         analysis = analyzer.analyze(filtered, time_range.description)  # Detect patterns and anomalies
-
-        renderer = AuditReportRenderer()  # Initialize report generator
-
-        md_path = os.path.join("data", "OrgAuditAnalysis.md")  # Mermaid timeline output path
-        renderer.render_mermaid(analysis, md_path)  # Generate Mermaid timeline report
-        print(f"Mermaid report: {md_path}")
-
-        html_path = os.path.join("data", "OrgAuditAnalysis.html")  # Interactive HTML output path
-        renderer.render_html(analysis, html_path)  # Generate interactive HTML report
-        print(f"HTML report: {html_path}")
+        AuditAnalysisOps._render_audit_analysis_reports(analysis)  # Markdown + HTML reports
 
 
 menu_actions = {
@@ -22741,6 +22756,40 @@ def _systematic_test_emit_skips(emitter: Any, unsafe_list: list[str]) -> int:
     return len([opt for opt in unsafe_list if opt in menu_actions])  # Return actual skip count for summary reporting.
 
 
+def _resolve_systematic_test_invoke_kwargs(func: Any, fast_enabled: bool) -> dict[str, Any]:
+    """Inspect a menu function's signature and build invoke kwargs (fast=True only if supported)."""
+    supports_fast = False  # Default to no fast-mode support until introspection confirms it.
+    try:  # inspect.signature can raise on built-in callables; degrade gracefully.
+        sig = inspect.signature(func)  # type: ignore[arg-type]  # Detect optional 'fast' parameter
+        supports_fast = "fast" in sig.parameters  # True when function accepts fast-mode
+    except Exception:  # Signature inspection failure is non-fatal
+        supports_fast = False  # Treat as non-fast-capable when signature is uninspectable
+    invoke_kwargs: dict[str, Any] = {}  # Build kwargs dict
+    if supports_fast and fast_enabled:  # Both function and global mode agree
+        invoke_kwargs["fast"] = True  # Activate fast mode for this operation
+    return invoke_kwargs
+
+
+def _invoke_one_systematic_test(
+    emitter: Any, case: SystematicTestOption, invoke_kwargs: dict, op_start: float
+) -> tuple[bool, float]:
+    """Call one menu func with the resolved kwargs; record pass/fail in telemetry and return (success, duration)."""
+    option, func, description = case.option, case.func, case.description  # Unpack identity (issue #470)
+    try:  # Each option runs independently so one failure does not abort remaining tests
+        func(**invoke_kwargs)  # type: ignore[operator, no-untyped-call]  # Call menu action
+        duration = time.time() - op_start  # Elapsed seconds
+        print(f"   [SUCCESS] Option {option} completed successfully")
+        emitter.emit_test_pass(option, description, duration, "systematic")  # Record pass
+        logging.info("SYSTEMATIC_TEST: Successfully completed menu option %s", option)
+        return True, duration
+    except Exception as exc:  # Catch all so harness continues
+        duration = time.time() - op_start  # Still record elapsed
+        print(f"   [FAILED]  Option {option} failed: {str(exc)[:100]}...")
+        emitter.emit_test_fail(option, description, duration, exc, "systematic")  # Record failure
+        logging.error("SYSTEMATIC_TEST: Failed menu option %s: %s", option, exc)
+        return False, duration
+
+
 def _systematic_test_run_option(
     emitter: Any,
     case: SystematicTestOption,
@@ -22749,51 +22798,19 @@ def _systematic_test_run_option(
     fast_enabled: bool,
 ) -> tuple[bool, float]:
     """Run one menu option in the systematic test harness and return (success, duration)."""
-    option, func, description = case.option, case.func, case.description  # Unpack the option identity (issue #470).
-    print(
-        f"   [{i:2}/{total_safe}] Testing option {option:>3}: {description[:60]}..."
-    )  # Show current progress position before invoking.
-    emitter.emit_test_start(
-        option, description, "systematic"
-    )  # Record test start in telemetry for elapsed-time tracking.
-    op_start = time.time()  # Capture start time before any invocation overhead.
-    supports_fast = False  # Default to no fast-mode support until introspection confirms it.
-    try:  # inspect.signature can raise on built-in callables; degrade gracefully.
-        sig = inspect.signature(func)  # type: ignore[arg-type]  # Inspect function signature to detect optional 'fast' parameter.
-        supports_fast = "fast" in sig.parameters  # True when the operation accepts fast-mode acceleration.
-    except Exception:  # Signature inspection failure is non-fatal; fall back to standard invocation.
-        supports_fast = False  # Treat as non-fast-capable when signature is uninspectable.
-    invoke_kwargs = {}  # Build kwargs dict so fast-mode flag is only passed when the function supports it.
-    if supports_fast and fast_enabled:  # Only pass fast=True when both the function and global mode agree.
-        invoke_kwargs["fast"] = True  # Activate fast mode for this operation to reduce test time.
+    option, func, description = case.option, case.func, case.description  # Unpack identity (issue #470)
+    print(f"   [{i:2}/{total_safe}] Testing option {option:>3}: {description[:60]}...")
+    emitter.emit_test_start(option, description, "systematic")  # Telemetry start
+    op_start = time.time()  # Capture start time before invocation overhead
+    invoke_kwargs = _resolve_systematic_test_invoke_kwargs(func, fast_enabled)  # Signature-aware kwargs
     logging.info(
         "SYSTEMATIC_TEST: INVOKE option=%s fast_supported=%s fast_enabled=%s test_mode=True description='%s'",
         option,
-        supports_fast,
+        "fast" in invoke_kwargs,
         fast_enabled,
         description,
-    )  # Log invocation details before calling so post-mortem analysis can match events to options.
-    try:  # Each option runs independently so one failure does not abort remaining tests.
-        func(**invoke_kwargs)  # type: ignore[operator, no-untyped-call]  # Call menu action with resolved kwargs.
-        duration = time.time() - op_start  # Compute elapsed seconds for telemetry and summary.
-        print(f"   [SUCCESS] Option {option} completed successfully")  # Confirm success immediately after call returns.
-        emitter.emit_test_pass(option, description, duration, "systematic")  # Record pass event in telemetry.
-        logging.info(
-            "SYSTEMATIC_TEST: Successfully completed menu option %s", option
-        )  # Log success for log-correlation.
-        return True, duration  # Signal success to the caller for count tracking.
-    except Exception as exc:  # Catch all exceptions so the test harness can continue to the next option.
-        duration = time.time() - op_start  # Still record elapsed time for failed options.
-        print(
-            f"   [FAILED]  Option {option} failed: {str(exc)[:100]}..."
-        )  # Surface failure immediately without crashing the loop.
-        emitter.emit_test_fail(
-            option, description, duration, exc, "systematic"
-        )  # Record failure in telemetry for coverage reporting.
-        logging.error(
-            "SYSTEMATIC_TEST: Failed menu option %s: %s", option, exc
-        )  # Log full error for detailed investigation.
-        return False, duration  # Signal failure to the caller for count tracking.
+    )  # Log invocation details for post-mortem correlation
+    return _invoke_one_systematic_test(emitter, case, invoke_kwargs, op_start)
 
 
 def _systematic_test_resolve_fast_mode() -> bool:
@@ -22968,44 +22985,55 @@ def _report_systematic_outcome(success_count, error_count, safe_count, total_tim
     return False  # Signal partial failure to callers.
 
 
-def run_interactive_test():
-    """Compatibility facade that delegates interactive-safe tests to extracted runner."""
-    global org_id
-
-    logging.info(
-        "Delegating run_interactive_test to InteractiveTestRunner"
-    )  # Log before helper creation and runner construction.
-
-    def _get_org_id():
-        return org_id  # Return current module-level org_id so extracted runner can read shared runtime context.
-
-    def _set_org_id(new_org_id):
-        global org_id
-        org_id = new_org_id  # Persist resolved org_id from runner back into module-level shared state.
-
-    logging.info(
-        "Constructing InteractiveTestRunner facade dependencies"
-    )  # Log before creating extracted runner instance.
-    runner = InteractiveTestRunner(  # Build extracted runner with runtime deps.
+def _build_interactive_test_runner(get_org_id: Any, set_org_id: Any) -> Any:
+    """Construct InteractiveTestRunner with the current runtime context and return it."""
+    logging.info("Constructing InteractiveTestRunner dependencies")  # Log before instance creation
+    runner = InteractiveTestRunner(  # Build runner with runtime deps
         menu_actions=menu_actions,
         operation_registry=OperationRegistry,
         telemetry_emitter_cls=TelemetryEmitter,
         config_utils=ConfigUtils,
         mistapi_module=mistapi,
         apisession=apisession,
-        org_id_getter=_get_org_id,
-        org_id_setter=_set_org_id,
+        org_id_getter=get_org_id,
+        org_id_setter=set_org_id,
     )
-    logging.debug("InteractiveTestRunner initialized successfully")  # Log runner construction completion.
+    logging.debug("InteractiveTestRunner initialized successfully")  # Confirm construction
+    return runner
 
-    logging.info(
-        "Executing delegated interactive test runner"
-    )  # Log before invoking extracted runner execution action.
-    result = runner.execute()  # Execute extracted interactive test workflow and capture boolean result.
-    logging.debug(
-        "Completed delegated run_interactive_test with result=%s", result
-    )  # Log delegated execution outcome summary.
-    return result  # Return delegated execution result to preserve prior function contract.
+
+def run_interactive_test():
+    """Run interactive-safe tests through the extracted InteractiveTestRunner."""
+    global org_id
+
+    logging.info("Routing run_interactive_test to InteractiveTestRunner")  # Log entry
+
+    def _get_org_id():
+        return org_id  # Return current module-level org_id so runner can read shared runtime context
+
+    def _set_org_id(new_org_id):
+        global org_id
+        org_id = new_org_id  # Persist resolved org_id from runner back into module-level state
+
+    runner = _build_interactive_test_runner(_get_org_id, _set_org_id)  # Build runner with context closures
+    logging.info("Executing interactive test runner")  # Log before invocation
+    result = runner.execute()  # Execute extracted interactive test workflow
+    logging.debug("Completed run_interactive_test with result=%s", result)  # Log outcome
+    return result
+
+
+def _run_web_portal_server(app: Any, host: str, port: int, dev_debug: bool) -> None:
+    """Start the Flask app in container mode (Gunicorn-aware) or local Flask dev server mode."""
+    in_container = EnvironmentUtils.is_running_in_container()  # Detect container runtime to switch banner + debug flag
+    if in_container:
+        logging.info("WEB_PORTAL: Container detected - use wsgi.py with Gunicorn")  # Log container path
+        print(f">> Running Flask dev server on {host}:{port}")  # Notify user
+        print(">> For production, use: gunicorn wsgi:app")  # Hint at prod runner
+        app.run(host=host, port=port, debug=False)  # Force debug=False inside container
+    else:
+        logging.info("WEB_PORTAL: Local mode - Flask dev server on %s:%s", host, port)  # Log local dev path
+        print(f">> Web portal starting at http://127.0.0.1:{port}")  # Notify user
+        app.run(host=host, port=port, debug=dev_debug)  # Honor caller's debug flag locally
 
 
 def _launch_web_portal(args):
@@ -23019,27 +23047,18 @@ def _launch_web_portal(args):
     from web_portal.app import WebPortalApp
     from web_portal.services.config import PortalConfigLoader
 
-    loader = PortalConfigLoader()
+    loader = PortalConfigLoader()  # Read web_port + other portal settings from env/.env
     config = loader.load_config()
     port = config["web_port"]
-    host = "0.0.0.0"  # nosec B104
+    host = "0.0.0.0"  # nosec B104  # Bind all interfaces so container port maps work
 
-    app = WebPortalApp.create_app(
+    app = WebPortalApp.create_app(  # Construct Flask app with shared API session + menu registry
         apisession=apisession,
         menu_actions=menu_actions,
         org_id=org_id,
     )
 
-    in_container = EnvironmentUtils.is_running_in_container()
-    if in_container:
-        logging.info("WEB_PORTAL: Container detected - use wsgi.py with Gunicorn")
-        print(f">> Running Flask dev server on {host}:{port}")
-        print(">> For production, use: gunicorn wsgi:app")
-        app.run(host=host, port=port, debug=False)
-    else:
-        logging.info("WEB_PORTAL: Local mode - Flask dev server on %s:%s", host, port)
-        print(f">> Web portal starting at http://127.0.0.1:{port}")
-        app.run(host=host, port=port, debug=args.debug)
+    _run_web_portal_server(app, host, port, args.debug)  # Dispatch to container/local runner
 
 
 def _report_tqdm_status() -> None:
@@ -23203,6 +23222,35 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     return parser  # Return parser for caller to call parse_args() on
 
 
+_FAST_MODE_CAPABLE_FUNCTIONS: tuple[str, ...] = (
+    "export_gateway_synthetic_tests_to_csv",
+    "get_gateway_devices_with_sites",
+    "export_gateway_device_stats_to_csv_with_freshness_check",
+    "export_gateway_device_stats_to_csv",
+    "GatewayTestExporter.test_results_by_site",
+    "OrgInventoryExporter.devices_with_site_info",
+    "export_gateway_device_configs_to_csv",
+    "APIFetchUtils.gateway_device_configs",
+    "InventoryCSVComparator",
+    "export_gateways_with_wan_overrides_to_csv",
+    "OrgDeviceStatsExporter.device_stats",
+    "OrgDeviceStatsExporter.device_port_stats",
+    "OrgDeviceStatsExporter.vpn_peer_stats",
+    "OrgDeviceStatsExporter.switch_vc_stats",
+)
+
+
+def _announce_fast_mode_scope() -> None:
+    """Log and print the list of fast-capable functions so operators know which paths get accelerated."""
+    logging.info(
+        "FAST MODE ACTIVE: Enabling caching/concurrency shortcuts for: %s",
+        ", ".join(_FAST_MODE_CAPABLE_FUNCTIONS),
+    )  # Log fast scope for log-correlation
+    print("* Fast mode active (caching/concurrency). Functions optimized:")  # Inform operator at console
+    for name in _FAST_MODE_CAPABLE_FUNCTIONS:  # Iterate the module-level constant
+        print(f"  - {name}")  # Print each fast-capable function name for operator awareness
+
+
 def _setup_runtime_flags(args: argparse.Namespace) -> None:
     """Apply standalone env flag, register args globally, and configure FAST_MODE_ENABLED."""
     logging.debug("_setup_runtime_flags: applying standalone and fast mode flags")  # Log entry
@@ -23217,31 +23265,8 @@ def _setup_runtime_flags(args: argparse.Namespace) -> None:
     except Exception:
         FAST_MODE_ENABLED = False  # Fail-safe: ensure symbol exists even if args access fails
     logging.debug("FAST_MODE_ENABLED set to %s", FAST_MODE_ENABLED)  # Log fast mode state
-    if args.fast:  # Print fast-capable function list so operators know the scope of fast mode
-        fast_capable = [
-            "export_gateway_synthetic_tests_to_csv",
-            "get_gateway_devices_with_sites",
-            "export_gateway_device_stats_to_csv_with_freshness_check",
-            "export_gateway_device_stats_to_csv",
-            "GatewayTestExporter.test_results_by_site",
-            "OrgInventoryExporter.devices_with_site_info",
-            "export_gateway_device_configs_to_csv",
-            "APIFetchUtils.gateway_device_configs",
-            "InventoryCSVComparator",
-            "export_gateways_with_wan_overrides_to_csv",
-            "OrgDeviceStatsExporter.device_stats",
-            "OrgDeviceStatsExporter.device_port_stats",
-            "OrgDeviceStatsExporter.vpn_peer_stats",
-            "OrgDeviceStatsExporter.switch_vc_stats",
-        ]
-        logging.info(
-            "FAST MODE ACTIVE: Enabling caching/concurrency shortcuts for: %s", ", ".join(fast_capable)
-        )  # Log fast scope  # noqa: E501
-        print(
-            "* Fast mode active (caching/concurrency). Functions optimized:"
-        )  # Inform operator which functions benefit  # noqa: E501
-        for name in fast_capable:
-            print(f"  - {name}")  # Print each fast-capable function name for operator awareness
+    if args.fast:  # Announce scope only when fast mode actually engaged
+        _announce_fast_mode_scope()  # Log + print fast-capable function list
     logging.debug("_setup_runtime_flags: complete")  # Log exit
 
 
@@ -23316,6 +23341,19 @@ def _establish_mist_session(args: argparse.Namespace) -> None:
     logging.debug("_establish_mist_session: session established successfully")  # Log successful auth
 
 
+def _apply_debug_log_level() -> None:
+    """Set DEBUG on root + file handlers and keep console at INFO so DEBUG noise stays out of the terminal."""
+    logging.getLogger().setLevel(logging.DEBUG)  # Enable DEBUG on root logger
+    for handler in logging.getLogger().handlers:  # Iterate each registered handler
+        if isinstance(handler, logging.FileHandler):  # File handlers get full DEBUG output
+            handler.setLevel(logging.DEBUG)
+        elif isinstance(handler, logging.StreamHandler):  # Console stays at INFO to avoid noise
+            handler.setLevel(logging.INFO)
+    logging.debug("Debug logging enabled via --debug flag")  # Confirm debug mode active in log file
+    logging.debug("Command line arguments: %s", " ".join(sys.argv))  # Log full command line for diagnostics
+    logging.debug("Performance monitoring will trigger circuit breakers for infinite loops")  # Remind about CBs
+
+
 def _configure_runtime_options(args: argparse.Namespace) -> None:
     """Set OUTPUT_FORMAT, initialize PROGRESS_EMITTER, and configure debug log level."""
     global OUTPUT_FORMAT, PROGRESS_EMITTER  # Declare intent to modify module-level runtime config
@@ -23326,25 +23364,15 @@ def _configure_runtime_options(args: argparse.Namespace) -> None:
     try:
         PROGRESS_EMITTER = TelemetryEmitter(
             os.path.join("data", "test_events.jsonl")
-        )  # Initialize JSONL telemetry emitter  # noqa: E501
+        )  # Initialize JSONL telemetry emitter
         logging.info("Progress telemetry emitter initialized: data/test_events.jsonl")  # Log emitter ready
     except Exception as emitter_exc:
         logging.warning(
             "Progress telemetry emitter init failed (non-blocking): %s", emitter_exc
-        )  # Log non-fatal failure  # noqa: E501
+        )  # Log non-fatal failure
         PROGRESS_EMITTER = None  # Set to None so callers skip telemetry gracefully
     if args.debug:  # Apply debug logging level to file handlers; keep console at INFO to avoid noise
-        logging.getLogger().setLevel(logging.DEBUG)  # Enable DEBUG on root logger
-        for handler in logging.getLogger().handlers:
-            if isinstance(handler, logging.FileHandler):  # File handlers get full DEBUG output
-                handler.setLevel(logging.DEBUG)
-            elif isinstance(handler, logging.StreamHandler):  # Console stays at INFO to avoid noise
-                handler.setLevel(logging.INFO)
-        logging.debug("Debug logging enabled via --debug flag")  # Confirm debug mode active in log file
-        logging.debug("Command line arguments: %s", " ".join(sys.argv))  # Log full command line for diagnostics
-        logging.debug(
-            "Performance monitoring will trigger circuit breakers for infinite loops"
-        )  # Remind about circuit breakers  # noqa: E501
+        _apply_debug_log_level()  # Promote root + file handlers to DEBUG
     logging.debug("_configure_runtime_options: complete")  # Log exit
 
 
@@ -23388,36 +23416,46 @@ def _silence_console_handlers_for_tui() -> None:
         logging.debug("TUI_MODE: Removed console handler to prevent interference with Rich TUI")  # Log removal.
 
 
+def _handle_tui_keyboard_interrupt(debug: bool) -> None:
+    """Log clean exit when user pressed Ctrl+C inside the TUI and inform them at the console."""
+    if debug:  # Debug: log timestamped interrupt event
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]  # Format timestamp
+        logging.debug(
+            "TUI_DEBUG: [%s] KeyboardInterrupt caught - user pressed Ctrl+C", timestamp
+        )  # Log interrupt with time
+    logging.info("TUI_MODE: User interrupted with Ctrl+C")  # Log clean user exit
+    print("\n[EXIT] TUI mode stopped by user")  # Inform user TUI was stopped
+
+
+def _handle_tui_exception(debug: bool, error: Exception) -> None:
+    """Log fatal error from the TUI event loop and exit with code 1."""
+    if debug:  # Debug: log timestamped exception detail
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]  # Format timestamp
+        logging.debug(
+            "TUI_DEBUG: [%s] Exception caught in TUI mode: %s: %s",
+            timestamp,
+            type(error).__name__,
+            error,
+        )  # Log error
+    logging.exception("TUI_MODE: Fatal error - %s", error)  # Log full traceback to file
+    print(f"\n[ERROR] TUI mode crashed: {error}")  # Inform user of crash
+    sys.exit(1)  # Exit with error code after TUI crash
+
+
 def _run_tui_event_loop(args: argparse.Namespace) -> None:
     """Instantiate and run the TUI event loop. Handles Ctrl+C cleanly and Exceptions with traceback."""
     try:
-        from src.ui.tui import MistHelperTUI  # PLC0415: lazy import avoids loading Rich at startup.
+        from src.ui.tui import MistHelperTUI  # PLC0415: lazy import avoids loading Rich at startup
 
-        tui = MistHelperTUI(debug_mode=args.debug)  # type: ignore[no-untyped-call]  # Create TUI with debug flag.
-        tui.apisession = apisession  # Pass global API session so TUI can execute live API calls.
-        if args.debug:  # Debug: record that TUI was launched with debug enabled.
-            logging.debug("TUI_MODE: Debug mode is ACTIVE - enhanced logging enabled")  # Log debug state.
-        tui.run()  # type: ignore[no-untyped-call]  # Launch TUI event loop (blocks until user exits).
-    except KeyboardInterrupt:  # User pressed Ctrl+C inside the TUI.
-        if args.debug:  # Debug: log timestamped interrupt event.
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]  # Format timestamp.
-            logging.debug(
-                "TUI_DEBUG: [%s] KeyboardInterrupt caught - user pressed Ctrl+C", timestamp
-            )  # Log interrupt with time.
-        logging.info("TUI_MODE: User interrupted with Ctrl+C")  # Log clean user exit.
-        print("\n[EXIT] TUI mode stopped by user")  # Inform user TUI was stopped.
-    except Exception as error:  # Unexpected error inside the TUI event loop.
-        if args.debug:  # Debug: log timestamped exception detail.
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]  # Format timestamp.
-            logging.debug(
-                "TUI_DEBUG: [%s] Exception caught in TUI mode: %s: %s",
-                timestamp,
-                type(error).__name__,
-                error,
-            )  # Log error.
-        logging.exception("TUI_MODE: Fatal error - %s", error)  # Log full traceback to file.
-        print(f"\n[ERROR] TUI mode crashed: {error}")  # Inform user of crash.
-        sys.exit(1)  # Exit with error code after TUI crash.
+        tui = MistHelperTUI(debug_mode=args.debug)  # type: ignore[no-untyped-call]  # Create TUI with debug flag
+        tui.apisession = apisession  # Pass global API session so TUI can execute live API calls
+        if args.debug:  # Debug: record that TUI was launched with debug enabled
+            logging.debug("TUI_MODE: Debug mode is ACTIVE - enhanced logging enabled")  # Log debug state
+        tui.run()  # type: ignore[no-untyped-call]  # Launch TUI event loop (blocks until user exits)
+    except KeyboardInterrupt:  # User pressed Ctrl+C inside the TUI
+        _handle_tui_keyboard_interrupt(args.debug)  # Log and inform user of clean exit
+    except Exception as error:  # Unexpected error inside the TUI event loop
+        _handle_tui_exception(args.debug, error)  # Log + print + exit(1)
 
 
 def _run_cli_mode(args: argparse.Namespace) -> None:

--- a/data/compliance_report.md
+++ b/data/compliance_report.md
@@ -1,6 +1,6 @@
 # Coding Guideline Compliance Report
 
-- **Generated**: 2026-06-28 09:08:15 UTC
+- **Generated**: 2026-06-28 09:30:11 UTC
 - **Tool**: compliance-analyzer (tools/compliance_analyzer)
 - **Files analyzed**: 1
 
@@ -16,7 +16,7 @@ Plan at the end to drive fixes.
 
 | File | Score | Grade | Critical | High | Medium | Low | Total |
 | - | - | - | - | - | - | - | - |
-| MistHelper.py | 60.0 | D- | 0 | 0 | 16 | 65 | 81 |
+| MistHelper.py | 60.0 | D- | 0 | 0 | 6 | 61 | 67 |
 
 ## Machine-Readable Summary
 
@@ -27,21 +27,20 @@ Plan at the end to drive fixes.
   "severity_totals": {
     "critical": 0,
     "high": 0,
-    "medium": 16,
-    "low": 65
+    "medium": 6,
+    "low": 61
   },
   "rule_totals": {
     "STRUCT-BLOCKS": 6,
-    "STRUCT-COMPLEXITY": 59,
-    "STRUCT-LENGTH": 9,
-    "STRUCT-NESTING": 7
+    "STRUCT-COMPLEXITY": 55,
+    "STRUCT-NESTING": 6
   },
   "files": [
     {
       "path": "MistHelper.py",
       "score": 60.0,
       "grade": "D-",
-      "violations": 81
+      "violations": 67
     }
   ]
 }
@@ -56,13 +55,13 @@ Plan at the end to drive fixes.
 
 | Metric | Value |
 | - | - |
-| Lines of code | 23785 |
-| Executable code lines | 11006 |
-| Functions | 1300 |
+| Lines of code | 23823 |
+| Executable code lines | 11045 |
+| Functions | 1314 |
 | Classes | 96 |
 | Average complexity | 2.7 |
 | Max complexity | 10 |
-| Inline comment coverage | 81.9% |
+| Inline comment coverage | 81.6% |
 
 ### Complexity Hotspots
 
@@ -102,43 +101,39 @@ Plan at the end to drive fixes.
 | 13754 | low | STRUCT-COMPLEXITY | ha_cluster_info | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 | 14266 | low | STRUCT-COMPLEXITY | _find_api_functions | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 | 14530 | low | STRUCT-COMPLEXITY | _extract_gateway_models | Cyclomatic complexity is 10 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14594 | low | STRUCT-COMPLEXITY | _get_country_codes_list | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14620 | low | STRUCT-COMPLEXITY | _extract_country_codes | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14634 | low | STRUCT-COMPLEXITY | _normalize_states_data | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14683 | low | STRUCT-COMPLEXITY | _filter_to_iso2_country_codes | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14712 | low | STRUCT-COMPLEXITY | _extract_channel_country_codes | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14881 | low | STRUCT-COMPLEXITY | _collect_metrics_for_scope | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 15076 | low | STRUCT-COMPLEXITY | _extract_results | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 15456 | low | STRUCT-COMPLEXITY | fetch_synthetic_test_stats_with_retry | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 15838 | low | STRUCT-COMPLEXITY | _dispatch_marvis_choice | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16180 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 10 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16290 | low | STRUCT-COMPLEXITY | _handle_message | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16381 | low | STRUCT-COMPLEXITY | _split_arp_text_into_datasets | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16876 | low | STRUCT-COMPLEXITY | _detect_conflicts | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16915 | low | STRUCT-COMPLEXITY | _check_network_subnet_overlap | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 17266 | low | STRUCT-COMPLEXITY | _execute | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 17353 | low | STRUCT-COMPLEXITY | _parse_template_selection | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 17479 | low | STRUCT-COMPLEXITY | _show_preview | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18599 | low | STRUCT-COMPLEXITY | _create_progress_display | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18700 | low | STRUCT-COMPLEXITY | _display_progress_distribution | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18732 | low | STRUCT-COMPLEXITY | _check_ssr_upgrades | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18807 | low | STRUCT-COMPLEXITY | _check_stored_upgrades | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18851 | low | STRUCT-COMPLEXITY | _check_stored_upgrade | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18879 | low | STRUCT-COMPLEXITY | _check_audit_logs | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18955 | low | STRUCT-COMPLEXITY | _check_site_upgrades | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 19371 | low | STRUCT-COMPLEXITY | _fetch_msp_orgs | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 19476 | low | STRUCT-COMPLEXITY | _process_org | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 19981 | low | STRUCT-COMPLEXITY | _fetch_site_template_wlans | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 20032 | low | STRUCT-COMPLEXITY | _is_template_assigned_to_site | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 20049 | low | STRUCT-COMPLEXITY | _fetch_and_filter_org_wlans | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 20790 | low | STRUCT-COMPLEXITY | _display_wlans | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 21209 | low | STRUCT-COMPLEXITY | audit_log_analysis | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 22799 | low | STRUCT-COMPLEXITY | _systematic_test_resolve_fast_mode | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 23319 | low | STRUCT-COMPLEXITY | _configure_runtime_options | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 23391 | low | STRUCT-COMPLEXITY | _run_tui_event_loop | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 23462 | low | STRUCT-COMPLEXITY | _resolve_cli_site_id | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 23698 | low | STRUCT-COMPLEXITY | _dispatch_main_mode | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 23719 | low | STRUCT-COMPLEXITY | _has_meaningful_cli_args | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14598 | low | STRUCT-COMPLEXITY | _get_country_codes_list | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14624 | low | STRUCT-COMPLEXITY | _extract_country_codes | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14638 | low | STRUCT-COMPLEXITY | _normalize_states_data | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14687 | low | STRUCT-COMPLEXITY | _filter_to_iso2_country_codes | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14716 | low | STRUCT-COMPLEXITY | _extract_channel_country_codes | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14885 | low | STRUCT-COMPLEXITY | _collect_metrics_for_scope | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 15080 | low | STRUCT-COMPLEXITY | _extract_results | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 15460 | low | STRUCT-COMPLEXITY | fetch_synthetic_test_stats_with_retry | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 15842 | low | STRUCT-COMPLEXITY | _dispatch_marvis_choice | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16184 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 10 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16294 | low | STRUCT-COMPLEXITY | _handle_message | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16385 | low | STRUCT-COMPLEXITY | _split_arp_text_into_datasets | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16880 | low | STRUCT-COMPLEXITY | _detect_conflicts | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16919 | low | STRUCT-COMPLEXITY | _check_network_subnet_overlap | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 17270 | low | STRUCT-COMPLEXITY | _execute | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 17357 | low | STRUCT-COMPLEXITY | _parse_template_selection | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 17483 | low | STRUCT-COMPLEXITY | _show_preview | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18603 | low | STRUCT-COMPLEXITY | _create_progress_display | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18704 | low | STRUCT-COMPLEXITY | _display_progress_distribution | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18736 | low | STRUCT-COMPLEXITY | _check_ssr_upgrades | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18811 | low | STRUCT-COMPLEXITY | _check_stored_upgrades | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18855 | low | STRUCT-COMPLEXITY | _check_stored_upgrade | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18883 | low | STRUCT-COMPLEXITY | _check_audit_logs | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18959 | low | STRUCT-COMPLEXITY | _check_site_upgrades | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 19375 | low | STRUCT-COMPLEXITY | _fetch_msp_orgs | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 19480 | low | STRUCT-COMPLEXITY | _process_org | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 19985 | low | STRUCT-COMPLEXITY | _fetch_site_template_wlans | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 20036 | low | STRUCT-COMPLEXITY | _is_template_assigned_to_site | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 20053 | low | STRUCT-COMPLEXITY | _fetch_and_filter_org_wlans | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 22816 | low | STRUCT-COMPLEXITY | _systematic_test_resolve_fast_mode | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 23500 | low | STRUCT-COMPLEXITY | _resolve_cli_site_id | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 23736 | low | STRUCT-COMPLEXITY | _dispatch_main_mode | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 23757 | low | STRUCT-COMPLEXITY | _has_meaningful_cli_args | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 
 #### Structure
 
@@ -146,26 +141,16 @@ Plan at the end to drive fixes.
 | - | - | - | - | - | - |
 | 6552 | medium | STRUCT-NESTING | flatten_dict | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
 | 7889 | medium | STRUCT-NESTING | _pool_drain_wait_loop | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 14530 | medium | STRUCT-NESTING | _extract_gateway_models | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 14620 | medium | STRUCT-NESTING | _extract_country_codes | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 14712 | medium | STRUCT-NESTING | _extract_channel_country_codes | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 15838 | medium | STRUCT-NESTING | _dispatch_marvis_choice | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 18700 | medium | STRUCT-NESTING | _display_progress_distribution | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 20790 | medium | STRUCT-LENGTH | _display_wlans | Function spans 32 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 21060 | medium | STRUCT-LENGTH | _export_audit_trail | Function spans 41 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 21209 | medium | STRUCT-LENGTH | audit_log_analysis | Function spans 59 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 22744 | medium | STRUCT-LENGTH | _systematic_test_run_option | Function spans 53 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 22971 | medium | STRUCT-LENGTH | run_interactive_test | Function spans 38 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 23011 | medium | STRUCT-LENGTH | _launch_web_portal | Function spans 32 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 23206 | medium | STRUCT-LENGTH | _setup_runtime_flags | Function spans 40 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 23319 | medium | STRUCT-LENGTH | _configure_runtime_options | Function spans 30 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 23391 | medium | STRUCT-LENGTH | _run_tui_event_loop | Function spans 30 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 14624 | medium | STRUCT-NESTING | _extract_country_codes | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
+| 14716 | medium | STRUCT-NESTING | _extract_channel_country_codes | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
+| 15842 | medium | STRUCT-NESTING | _dispatch_marvis_choice | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
+| 18704 | medium | STRUCT-NESTING | _display_progress_distribution | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
 | 2941 | low | STRUCT-BLOCKS | initialize_mist_session | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 14530 | low | STRUCT-BLOCKS | _extract_gateway_models | Function has 8 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 14634 | low | STRUCT-BLOCKS | _normalize_states_data | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 16915 | low | STRUCT-BLOCKS | _check_network_subnet_overlap | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 17266 | low | STRUCT-BLOCKS | _execute | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 18700 | low | STRUCT-BLOCKS | _display_progress_distribution | Function has 7 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 14530 | low | STRUCT-BLOCKS | _extract_gateway_models | Function has 9 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 14638 | low | STRUCT-BLOCKS | _normalize_states_data | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 16919 | low | STRUCT-BLOCKS | _check_network_subnet_overlap | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 17270 | low | STRUCT-BLOCKS | _execute | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 18704 | low | STRUCT-BLOCKS | _display_progress_distribution | Function has 7 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
 
 ## SpecKit Remediation Plan
 
@@ -174,7 +159,7 @@ Plan at the end to drive fixes.
 > `speckit.tasks`, and `speckit.implement`. Re-run this analyzer to verify
 > every task is resolved before closing the phase.
 
-### Phase: Medium (16 task(s))
+### Phase: Medium (6 task(s))
 
 - [ ] **CMP-001** `MistHelper.py:6552` - STRUCT-NESTING (Structure)
   - Symbol: `flatten_dict`
@@ -186,400 +171,330 @@ Plan at the end to drive fixes.
   - Problem: Maximum nesting depth is 5 (limit 4).
   - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
   - Done when: analyzer reports no STRUCT-NESTING for `_pool_drain_wait_loop` in `MistHelper.py`.
-- [ ] **CMP-003** `MistHelper.py:14530` - STRUCT-NESTING (Structure)
-  - Symbol: `_extract_gateway_models`
-  - Problem: Maximum nesting depth is 5 (limit 4).
-  - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
-  - Done when: analyzer reports no STRUCT-NESTING for `_extract_gateway_models` in `MistHelper.py`.
-- [ ] **CMP-004** `MistHelper.py:14620` - STRUCT-NESTING (Structure)
+- [ ] **CMP-003** `MistHelper.py:14624` - STRUCT-NESTING (Structure)
   - Symbol: `_extract_country_codes`
   - Problem: Maximum nesting depth is 5 (limit 4).
   - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
   - Done when: analyzer reports no STRUCT-NESTING for `_extract_country_codes` in `MistHelper.py`.
-- [ ] **CMP-005** `MistHelper.py:14712` - STRUCT-NESTING (Structure)
+- [ ] **CMP-004** `MistHelper.py:14716` - STRUCT-NESTING (Structure)
   - Symbol: `_extract_channel_country_codes`
   - Problem: Maximum nesting depth is 5 (limit 4).
   - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
   - Done when: analyzer reports no STRUCT-NESTING for `_extract_channel_country_codes` in `MistHelper.py`.
-- [ ] **CMP-006** `MistHelper.py:15838` - STRUCT-NESTING (Structure)
+- [ ] **CMP-005** `MistHelper.py:15842` - STRUCT-NESTING (Structure)
   - Symbol: `_dispatch_marvis_choice`
   - Problem: Maximum nesting depth is 5 (limit 4).
   - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
   - Done when: analyzer reports no STRUCT-NESTING for `_dispatch_marvis_choice` in `MistHelper.py`.
-- [ ] **CMP-007** `MistHelper.py:18700` - STRUCT-NESTING (Structure)
+- [ ] **CMP-006** `MistHelper.py:18704` - STRUCT-NESTING (Structure)
   - Symbol: `_display_progress_distribution`
   - Problem: Maximum nesting depth is 5 (limit 4).
   - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
   - Done when: analyzer reports no STRUCT-NESTING for `_display_progress_distribution` in `MistHelper.py`.
-- [ ] **CMP-008** `MistHelper.py:20790` - STRUCT-LENGTH (Structure)
-  - Symbol: `_display_wlans`
-  - Problem: Function spans 32 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `_display_wlans` in `MistHelper.py`.
-- [ ] **CMP-009** `MistHelper.py:21060` - STRUCT-LENGTH (Structure)
-  - Symbol: `_export_audit_trail`
-  - Problem: Function spans 41 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `_export_audit_trail` in `MistHelper.py`.
-- [ ] **CMP-010** `MistHelper.py:21209` - STRUCT-LENGTH (Structure)
-  - Symbol: `audit_log_analysis`
-  - Problem: Function spans 59 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `audit_log_analysis` in `MistHelper.py`.
-- [ ] **CMP-011** `MistHelper.py:22744` - STRUCT-LENGTH (Structure)
-  - Symbol: `_systematic_test_run_option`
-  - Problem: Function spans 53 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `_systematic_test_run_option` in `MistHelper.py`.
-- [ ] **CMP-012** `MistHelper.py:22971` - STRUCT-LENGTH (Structure)
-  - Symbol: `run_interactive_test`
-  - Problem: Function spans 38 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `run_interactive_test` in `MistHelper.py`.
-- [ ] **CMP-013** `MistHelper.py:23011` - STRUCT-LENGTH (Structure)
-  - Symbol: `_launch_web_portal`
-  - Problem: Function spans 32 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `_launch_web_portal` in `MistHelper.py`.
-- [ ] **CMP-014** `MistHelper.py:23206` - STRUCT-LENGTH (Structure)
-  - Symbol: `_setup_runtime_flags`
-  - Problem: Function spans 40 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `_setup_runtime_flags` in `MistHelper.py`.
-- [ ] **CMP-015** `MistHelper.py:23319` - STRUCT-LENGTH (Structure)
-  - Symbol: `_configure_runtime_options`
-  - Problem: Function spans 30 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `_configure_runtime_options` in `MistHelper.py`.
-- [ ] **CMP-016** `MistHelper.py:23391` - STRUCT-LENGTH (Structure)
-  - Symbol: `_run_tui_event_loop`
-  - Problem: Function spans 30 lines (limit 25).
-  - Fix: Extract logical sections into well-named helper methods to shrink the function.
-  - Done when: analyzer reports no STRUCT-LENGTH for `_run_tui_event_loop` in `MistHelper.py`.
 
-### Phase: Low (65 task(s))
+### Phase: Low (61 task(s))
 
-- [ ] **CMP-017** `MistHelper.py:2941` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-007** `MistHelper.py:2941` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `initialize_mist_session`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `initialize_mist_session` in `MistHelper.py`.
-- [ ] **CMP-018** `MistHelper.py:2941` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-008** `MistHelper.py:2941` - STRUCT-BLOCKS (Structure)
   - Symbol: `initialize_mist_session`
   - Problem: Function has 6 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `initialize_mist_session` in `MistHelper.py`.
-- [ ] **CMP-019** `MistHelper.py:5602` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-009** `MistHelper.py:5602` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `dict_list_as_pretty_table`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `dict_list_as_pretty_table` in `MistHelper.py`.
-- [ ] **CMP-020** `MistHelper.py:6552` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-010** `MistHelper.py:6552` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `flatten_dict`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `flatten_dict` in `MistHelper.py`.
-- [ ] **CMP-021** `MistHelper.py:7217` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-011** `MistHelper.py:7217` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_init_router`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_init_router` in `MistHelper.py`.
-- [ ] **CMP-022** `MistHelper.py:7299` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-012** `MistHelper.py:7299` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_route_to_polyglot`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_route_to_polyglot` in `MistHelper.py`.
-- [ ] **CMP-023** `MistHelper.py:8077` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-013** `MistHelper.py:8077` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_all_clients_for_site`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_all_clients_for_site` in `MistHelper.py`.
-- [ ] **CMP-024** `MistHelper.py:8283` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-014** `MistHelper.py:8283` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_and_filter_devices`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_and_filter_devices` in `MistHelper.py`.
-- [ ] **CMP-025** `MistHelper.py:8540` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-015** `MistHelper.py:8540` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_display_client_table`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_display_client_table` in `MistHelper.py`.
-- [ ] **CMP-026** `MistHelper.py:8766` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-016** `MistHelper.py:8766` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `get_device_identifier`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `get_device_identifier` in `MistHelper.py`.
-- [ ] **CMP-027** `MistHelper.py:9651` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-017** `MistHelper.py:9651` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_partition_combined_inventory_rows`
   - Problem: Cyclomatic complexity is 9 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_partition_combined_inventory_rows` in `MistHelper.py`.
-- [ ] **CMP-028** `MistHelper.py:10274` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-018** `MistHelper.py:10274` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_load_port_stats_sites`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_load_port_stats_sites` in `MistHelper.py`.
-- [ ] **CMP-029** `MistHelper.py:10697` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-019** `MistHelper.py:10697` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_maybe_build_offline_record`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_maybe_build_offline_record` in `MistHelper.py`.
-- [ ] **CMP-030** `MistHelper.py:11391` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-020** `MistHelper.py:11391` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_prompt_operator`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_prompt_operator` in `MistHelper.py`.
-- [ ] **CMP-031** `MistHelper.py:11758` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-021** `MistHelper.py:11758` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_license_records`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_license_records` in `MistHelper.py`.
-- [ ] **CMP-032** `MistHelper.py:12756` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-022** `MistHelper.py:12756` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `device_stats`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `device_stats` in `MistHelper.py`.
-- [ ] **CMP-033** `MistHelper.py:12863` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-023** `MistHelper.py:12863` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `devices`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `devices` in `MistHelper.py`.
-- [ ] **CMP-034** `MistHelper.py:12908` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-024** `MistHelper.py:12908` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `clients`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `clients` in `MistHelper.py`.
-- [ ] **CMP-035** `MistHelper.py:13443` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-025** `MistHelper.py:13443` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_prompt_model_selection`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_prompt_model_selection` in `MistHelper.py`.
-- [ ] **CMP-036** `MistHelper.py:13534` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-026** `MistHelper.py:13534` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `export_sites_by_ap_model`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `export_sites_by_ap_model` in `MistHelper.py`.
-- [ ] **CMP-037** `MistHelper.py:13754` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-027** `MistHelper.py:13754` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `ha_cluster_info`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `ha_cluster_info` in `MistHelper.py`.
-- [ ] **CMP-038** `MistHelper.py:14266` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-028** `MistHelper.py:14266` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_find_api_functions`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_find_api_functions` in `MistHelper.py`.
-- [ ] **CMP-039** `MistHelper.py:14530` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-029** `MistHelper.py:14530` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_extract_gateway_models`
   - Problem: Cyclomatic complexity is 10 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_extract_gateway_models` in `MistHelper.py`.
-- [ ] **CMP-040** `MistHelper.py:14530` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-030** `MistHelper.py:14530` - STRUCT-BLOCKS (Structure)
   - Symbol: `_extract_gateway_models`
-  - Problem: Function has 8 logical blocks (limit 5).
+  - Problem: Function has 9 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_extract_gateway_models` in `MistHelper.py`.
-- [ ] **CMP-041** `MistHelper.py:14594` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-031** `MistHelper.py:14598` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_get_country_codes_list`
   - Problem: Cyclomatic complexity is 9 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_get_country_codes_list` in `MistHelper.py`.
-- [ ] **CMP-042** `MistHelper.py:14620` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-032** `MistHelper.py:14624` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_extract_country_codes`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_extract_country_codes` in `MistHelper.py`.
-- [ ] **CMP-043** `MistHelper.py:14634` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-033** `MistHelper.py:14638` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_normalize_states_data`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_normalize_states_data` in `MistHelper.py`.
-- [ ] **CMP-044** `MistHelper.py:14634` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-034** `MistHelper.py:14638` - STRUCT-BLOCKS (Structure)
   - Symbol: `_normalize_states_data`
   - Problem: Function has 6 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_normalize_states_data` in `MistHelper.py`.
-- [ ] **CMP-045** `MistHelper.py:14683` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-035** `MistHelper.py:14687` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_filter_to_iso2_country_codes`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_filter_to_iso2_country_codes` in `MistHelper.py`.
-- [ ] **CMP-046** `MistHelper.py:14712` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-036** `MistHelper.py:14716` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_extract_channel_country_codes`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_extract_channel_country_codes` in `MistHelper.py`.
-- [ ] **CMP-047** `MistHelper.py:14881` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-037** `MistHelper.py:14885` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_collect_metrics_for_scope`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_collect_metrics_for_scope` in `MistHelper.py`.
-- [ ] **CMP-048** `MistHelper.py:15076` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-038** `MistHelper.py:15080` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_extract_results`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_extract_results` in `MistHelper.py`.
-- [ ] **CMP-049** `MistHelper.py:15456` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-039** `MistHelper.py:15460` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `fetch_synthetic_test_stats_with_retry`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `fetch_synthetic_test_stats_with_retry` in `MistHelper.py`.
-- [ ] **CMP-050** `MistHelper.py:15838` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-040** `MistHelper.py:15842` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_dispatch_marvis_choice`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_dispatch_marvis_choice` in `MistHelper.py`.
-- [ ] **CMP-051** `MistHelper.py:16180` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-041** `MistHelper.py:16184` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `execute`
   - Problem: Cyclomatic complexity is 10 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `execute` in `MistHelper.py`.
-- [ ] **CMP-052** `MistHelper.py:16290` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-042** `MistHelper.py:16294` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_handle_message`
   - Problem: Cyclomatic complexity is 9 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_handle_message` in `MistHelper.py`.
-- [ ] **CMP-053** `MistHelper.py:16381` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-043** `MistHelper.py:16385` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_split_arp_text_into_datasets`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_split_arp_text_into_datasets` in `MistHelper.py`.
-- [ ] **CMP-054** `MistHelper.py:16876` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-044** `MistHelper.py:16880` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_detect_conflicts`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_detect_conflicts` in `MistHelper.py`.
-- [ ] **CMP-055** `MistHelper.py:16915` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-045** `MistHelper.py:16919` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_network_subnet_overlap`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_network_subnet_overlap` in `MistHelper.py`.
-- [ ] **CMP-056** `MistHelper.py:16915` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-046** `MistHelper.py:16919` - STRUCT-BLOCKS (Structure)
   - Symbol: `_check_network_subnet_overlap`
   - Problem: Function has 6 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_check_network_subnet_overlap` in `MistHelper.py`.
-- [ ] **CMP-057** `MistHelper.py:17266` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-047** `MistHelper.py:17270` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_execute`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_execute` in `MistHelper.py`.
-- [ ] **CMP-058** `MistHelper.py:17266` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-048** `MistHelper.py:17270` - STRUCT-BLOCKS (Structure)
   - Symbol: `_execute`
   - Problem: Function has 6 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_execute` in `MistHelper.py`.
-- [ ] **CMP-059** `MistHelper.py:17353` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-049** `MistHelper.py:17357` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_parse_template_selection`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_parse_template_selection` in `MistHelper.py`.
-- [ ] **CMP-060** `MistHelper.py:17479` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-050** `MistHelper.py:17483` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_show_preview`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_show_preview` in `MistHelper.py`.
-- [ ] **CMP-061** `MistHelper.py:18599` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-051** `MistHelper.py:18603` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_create_progress_display`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_create_progress_display` in `MistHelper.py`.
-- [ ] **CMP-062** `MistHelper.py:18700` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-052** `MistHelper.py:18704` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_display_progress_distribution`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_display_progress_distribution` in `MistHelper.py`.
-- [ ] **CMP-063** `MistHelper.py:18700` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-053** `MistHelper.py:18704` - STRUCT-BLOCKS (Structure)
   - Symbol: `_display_progress_distribution`
   - Problem: Function has 7 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_display_progress_distribution` in `MistHelper.py`.
-- [ ] **CMP-064** `MistHelper.py:18732` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-054** `MistHelper.py:18736` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_ssr_upgrades`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_ssr_upgrades` in `MistHelper.py`.
-- [ ] **CMP-065** `MistHelper.py:18807` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-055** `MistHelper.py:18811` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_stored_upgrades`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_stored_upgrades` in `MistHelper.py`.
-- [ ] **CMP-066** `MistHelper.py:18851` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-056** `MistHelper.py:18855` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_stored_upgrade`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_stored_upgrade` in `MistHelper.py`.
-- [ ] **CMP-067** `MistHelper.py:18879` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-057** `MistHelper.py:18883` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_audit_logs`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_audit_logs` in `MistHelper.py`.
-- [ ] **CMP-068** `MistHelper.py:18955` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-058** `MistHelper.py:18959` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_site_upgrades`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_site_upgrades` in `MistHelper.py`.
-- [ ] **CMP-069** `MistHelper.py:19371` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-059** `MistHelper.py:19375` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_msp_orgs`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_msp_orgs` in `MistHelper.py`.
-- [ ] **CMP-070** `MistHelper.py:19476` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-060** `MistHelper.py:19480` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_process_org`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_process_org` in `MistHelper.py`.
-- [ ] **CMP-071** `MistHelper.py:19981` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-061** `MistHelper.py:19985` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_site_template_wlans`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_site_template_wlans` in `MistHelper.py`.
-- [ ] **CMP-072** `MistHelper.py:20032` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-062** `MistHelper.py:20036` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_is_template_assigned_to_site`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_is_template_assigned_to_site` in `MistHelper.py`.
-- [ ] **CMP-073** `MistHelper.py:20049` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-063** `MistHelper.py:20053` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_and_filter_org_wlans`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_and_filter_org_wlans` in `MistHelper.py`.
-- [ ] **CMP-074** `MistHelper.py:20790` - STRUCT-COMPLEXITY (Complexity)
-  - Symbol: `_display_wlans`
-  - Problem: Cyclomatic complexity is 8 (target <= 5).
-  - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
-  - Done when: analyzer reports no STRUCT-COMPLEXITY for `_display_wlans` in `MistHelper.py`.
-- [ ] **CMP-075** `MistHelper.py:21209` - STRUCT-COMPLEXITY (Complexity)
-  - Symbol: `audit_log_analysis`
-  - Problem: Cyclomatic complexity is 7 (target <= 5).
-  - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
-  - Done when: analyzer reports no STRUCT-COMPLEXITY for `audit_log_analysis` in `MistHelper.py`.
-- [ ] **CMP-076** `MistHelper.py:22799` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-064** `MistHelper.py:22816` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_systematic_test_resolve_fast_mode`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_systematic_test_resolve_fast_mode` in `MistHelper.py`.
-- [ ] **CMP-077** `MistHelper.py:23319` - STRUCT-COMPLEXITY (Complexity)
-  - Symbol: `_configure_runtime_options`
-  - Problem: Cyclomatic complexity is 6 (target <= 5).
-  - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
-  - Done when: analyzer reports no STRUCT-COMPLEXITY for `_configure_runtime_options` in `MistHelper.py`.
-- [ ] **CMP-078** `MistHelper.py:23391` - STRUCT-COMPLEXITY (Complexity)
-  - Symbol: `_run_tui_event_loop`
-  - Problem: Cyclomatic complexity is 6 (target <= 5).
-  - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
-  - Done when: analyzer reports no STRUCT-COMPLEXITY for `_run_tui_event_loop` in `MistHelper.py`.
-- [ ] **CMP-079** `MistHelper.py:23462` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-065** `MistHelper.py:23500` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_resolve_cli_site_id`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_resolve_cli_site_id` in `MistHelper.py`.
-- [ ] **CMP-080** `MistHelper.py:23698` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-066** `MistHelper.py:23736` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_dispatch_main_mode`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_dispatch_main_mode` in `MistHelper.py`.
-- [ ] **CMP-081** `MistHelper.py:23719` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-067** `MistHelper.py:23757` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_has_meaningful_cli_args`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.


### PR DESCRIPTION
## Summary

Wave M14 of the Phase Medium decomposition campaign. **Eliminates the
last STRUCT-LENGTH violations** in `MistHelper.py` and flattens one
STRUCT-NESTING violation. Pure structural refactor -- behavior unchanged.

This wave targets the **systematic test harness, the interactive test
runner, the web portal launcher, runtime flag setup, the TUI event
loop, and the gateway model extractor**. Ten function bodies brought
into compliance via genuine helper extraction (no wrappers, no aliases,
no delegates, no shims).

Refs #469
Refs #208

## Decomposition Map (10 functions)

| # | Function | Before | Strategy |
| - | - | - | - |
| T1 | `_display_wlans` | 32 | Extracted `_build_combined_wlan_rows` (pair+sort) + `_print_wlan_row` (per-row render) |
| T2 | `_export_audit_trail` | 41 | Promoted CSV fieldnames literal to class-level constant `_AUDIT_TRAIL_FIELDNAMES` + extracted `_write_audit_csv` (open/write/log) |
| T3 | `audit_log_analysis` | 59 | Extracted 3 staticmethod helpers inside `AuditAnalysisOps`: prompt-collection, dataset-fetch, analysis-and-export |
| T4 | `_systematic_test_run_option` | 53 | Extracted `_resolve_systematic_test_invoke_kwargs` (signature introspection + fast-mode kwargs) + `_invoke_one_systematic_test` (call + pass/fail telemetry) |
| T5 | `run_interactive_test` | 38 | Extracted `_build_interactive_test_runner` (runner construction with shared runtime deps). Also retitled docstring from "Compatibility facade" to plain-language description |
| T6 | `_launch_web_portal` | 32 | Extracted `_run_web_portal_server` (container/local Flask dev-server branch) |
| T7 | `_setup_runtime_flags` | 40 | Promoted fast-capable function list to module-level constant `_FAST_MODE_CAPABLE_FUNCTIONS` + extracted `_announce_fast_mode_scope` (log + print fast scope) |
| T8 | `_configure_runtime_options` | 30 | Extracted `_apply_debug_log_level` (DEBUG-on-root + per-handler tweaks) |
| T9 | `_run_tui_event_loop` | 30 | Extracted `_handle_tui_keyboard_interrupt` + `_handle_tui_exception` (each owns one exception path) |
| T10 | `_extract_gateway_models` | depth 5 | Flattened nesting from `if + for + if + if` to `for + continue` guard pattern (depth 5 -> 4) |

## Compliance Analyzer Deltas (`data/compliance_report.md`)

| Severity | Before (post-M13) | After M14 | Delta |
| - | - | - | - |
| Critical | 0 | 0 | 0 |
| **High** | **0** | **0** | **0** |
| **Medium** | **16** | **6** | **-10** |
| Low | 65 | 61 | -4 |
| **Total** | **81** | **67** | **-14** |

| Rule | Before | After | Delta |
| - | - | - | - |
| **STRUCT-LENGTH** | **9** | **0** | **-9 (ELIMINATED)** |
| STRUCT-NESTING | 7 | 6 | -1 |
| STRUCT-PARAMS | 0 | 0 | 0 |
| STRUCT-BLOCKS | 6 | 6 | 0 |
| STRUCT-COMPLEXITY | 59 | 55 | -4 |
| ARCH-* | 0 | 0 | 0 |

**Phase Medium STRUCT-LENGTH: 19 -> 9 -> 0 across M13 + M14.**
All remaining Phase Medium items (6) are STRUCT-NESTING. One more
focused wave should clear Phase Medium entirely.

## Gates

- [x] `python -m py_compile MistHelper.py` -- OK
- [x] `python -m black MistHelper.py` -- reformatted once, then clean
- [x] `python -m ruff check MistHelper.py` -- All checks passed (after trimming one E501 docstring)
- [x] `python tools/check_compliance.py MistHelper.py` -- Critical 0, High 0, STRUCT-LENGTH 0

## Constraints Honored

- Branch off `origin/main` (no stacking; PR #524 merged before M14 started)
- Hot-file rule: only one open PR touching `MistHelper.py` at a time
- All new helpers have inline comments (NON-NEGOTIABLE)
- Action logging preserved on every API call site
- ARCH rules stay at 0 -- no wrappers, no aliases, no delegates, no shims, no facades
- New helper names avoid blocked tokens (`wrapper`, `shim`, `proxy`, `facade`, `delegate`, `passthrough`, `forwarder`, `adapter`, `compat`, `legacy`, `alias`)
- No helper exceeds STRUCT-PARAMS limit (>5 params); `_invoke_one_systematic_test` and `_run_web_portal_server` at 4 args (boundary watched)
- T3 staticmethod-context fix: helpers extracted from inside class `AuditAnalysisOps` retain `@staticmethod` decorators and use `ClassName.helper(...)` call-site form
- Pure structural refactor -- behavior preserved; `python MistHelper.py --test` stays green

## Cumulative Campaign Progress

| Phase | Issue | Status |
| - | - | - |
| Critical | -- | 0 throughout |
| High | #470 | DONE (cleared earlier in campaign) |
| Medium | #469 | **STRUCT-LENGTH eliminated** -- 6 STRUCT-NESTING remain |
| Low | #468 | Untouched (next phase) |

14 waves merged (M1-M13) + this wave = 15 total ships toward Phase Medium completion. Total compliance violations 253 -> 67 (-186) since campaign start.
