### PR TITLE
refactor(MistHelper): M15 -- eliminate Phase Medium STRUCT-NESTING (Phase Medium COMPLETE)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -6549,23 +6549,31 @@ class DataProcessingUtils:  # JSON flattening/normalization.
     """
 
     @staticmethod
+    def _flatten_list_value(new_key: str, sep: str, v: list) -> list[tuple[str, Any]]:
+        """Flatten a list value: list-of-dicts gets index keys; scalar lists join as CSV. Returns pairs to extend."""
+        out: list[tuple[str, Any]] = []  # Accumulator for produced pairs
+        if all(isinstance(i, dict) for i in v):  # List of dicts: index each
+            for idx, item in enumerate(v):  # Walk list items
+                out.extend(DataProcessingUtils.flatten_dict(item, f"{new_key}{sep}{idx}", sep=sep).items())
+            return out
+        out.append((new_key, ",".join(map(str, v))))  # Join scalar list as CSV
+        return out
+
+    @staticmethod
     def flatten_dict(d: dict[str, Any], parent_key: str = "", sep: str = "_") -> dict[str, Any]:  # Flatten nested dict.
         """Recursively flatten nested dict for CSV/JSON; lists-of-dicts get index keys, scalar lists join as CSV."""
-        items: list[tuple[str, Any]] = []  # Accumulate flattened pairs.
-        for k, v in d.items():  # Walk each key/value.
-            k_str = str(k)  # Stringify the key.
-            new_key = f"{parent_key}{sep}{k_str}" if parent_key else k_str  # Compose the dotted key.
-            if isinstance(v, dict):  # Recurse into nested dicts.
-                items.extend(DataProcessingUtils.flatten_dict(v, new_key, sep=sep).items())  # Merge nested results.
-            elif isinstance(v, list):  # Lists need index expansion.
-                if all(isinstance(i, dict) for i in v):  # List of dicts: index each.
-                    for idx, item in enumerate(v):  # Walk list items.
-                        items.extend(DataProcessingUtils.flatten_dict(item, f"{new_key}{sep}{idx}", sep=sep).items())
-                else:
-                    items.append((new_key, ",".join(map(str, v))))  # Join scalar list as CSV.
-            else:
-                items.append((new_key, v))  # Keep scalar value as-is.
-        return dict(items)  # Return the flat dict.
+        items: list[tuple[str, Any]] = []  # Accumulate flattened pairs
+        for k, v in d.items():  # Walk each key/value
+            k_str = str(k)  # Stringify the key
+            new_key = f"{parent_key}{sep}{k_str}" if parent_key else k_str  # Compose the dotted key
+            if isinstance(v, dict):  # Recurse into nested dicts
+                items.extend(DataProcessingUtils.flatten_dict(v, new_key, sep=sep).items())
+                continue
+            if isinstance(v, list):  # Lists need index expansion
+                items.extend(DataProcessingUtils._flatten_list_value(new_key, sep, v))
+                continue
+            items.append((new_key, v))  # Keep scalar value as-is
+        return dict(items)  # Return the flat dict
 
     @staticmethod
     def flatten_nested_fields(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -7886,28 +7894,31 @@ def _pool_advance_progress_bar(pbar: Any) -> None:
         logging.error("! Progress bar update failed: %s", upd_err)  # Log progress bar failure for debugging.
 
 
+def _record_future_outcome(future: Any, item: Any, config: "BatchWorkerConfig", accumulator: dict) -> None:
+    """Inspect one completed future and update accumulator with the success/failure outcome."""
+    outcome, payload = _pool_collect_future_result(future, item, config)  # Resolve future to (status, payload)
+    if outcome == "success":  # Worker returned usable data
+        accumulator["successful"].append(payload)  # Collect successful result
+        if not accumulator["first_logged"]:  # First-result one-shot debug log
+            logging.debug("! First future result type: %s", type(payload))  # One-shot shape debug log
+            accumulator["first_logged"] = True  # Prevent repeated debug log
+        return
+    accumulator["failed"].append(payload)  # Empty result or worker exception — track for retry
+
+
 def _pool_drain_wait_loop(future_to_item: dict, batch_desc: str, config: "BatchWorkerConfig") -> tuple[list, list]:
     """Wait on the futures, collecting successful results and failed items until all have resolved."""
-    batch_successful: list[Any] = []  # Accumulate successful worker results for this batch.
-    batch_failed: list[Any] = []  # Accumulate items whose futures raised or returned empty for this batch.
-    first_result_logged = False  # Track whether the first-result debug log has fired to avoid repeated noise.
-    pending = set(future_to_item.keys())  # Track in-flight futures so the wait loop can detect completion.
-    with tqdm(  # Show per-batch progress to the operator (issue #431: batch_description from config).
+    accumulator: dict[str, Any] = {"successful": [], "failed": [], "first_logged": False}  # Mutable batch state
+    pending = set(future_to_item.keys())  # Track in-flight futures so the wait loop can detect completion
+    with tqdm(  # Show per-batch progress to the operator (issue #431: batch_description from config)
         total=len(pending), desc=batch_desc, unit=config.batch_description.rstrip("s")
     ) as pbar:  # type: ignore[call-arg, no-untyped-call]
-        while pending:  # Keep collecting futures until all have resolved.
-            done, pending = wait(pending, return_when=FIRST_COMPLETED)  # Wake up as soon as any future finishes.
-            for future in done:  # Inspect each completed future before moving on.
-                outcome, payload = _pool_collect_future_result(future, future_to_item[future], config)  # Resolve it
-                if outcome == "success":  # Worker returned usable data.
-                    batch_successful.append(payload)  # Collect successful result for the caller's output list.
-                    if not first_result_logged:  # Log the first result's type once to help debug worker outputs.
-                        logging.debug("! First future result type: %s", type(payload))  # One-shot shape debug log.
-                        first_result_logged = True  # Prevent repeated debug log on subsequent results.
-                else:  # Empty result or worker exception.
-                    batch_failed.append(payload)  # Track the failed item for potential retry.
-                _pool_advance_progress_bar(pbar)  # Advance progress regardless of success or failure.
-    return batch_successful, batch_failed  # Return batch-level results so caller can accumulate them.
+        while pending:  # Keep collecting futures until all have resolved
+            done, pending = wait(pending, return_when=FIRST_COMPLETED)  # Wake on any future finish
+            for future in done:  # Inspect each completed future before moving on
+                _record_future_outcome(future, future_to_item[future], config, accumulator)  # Resolve + record
+                _pool_advance_progress_bar(pbar)  # Advance progress regardless of success or failure
+    return accumulator["successful"], accumulator["failed"]  # Return batch-level results for caller
 
 
 def _pool_process_batch_wait_loop(  # Submit one batch to a thread pool.
@@ -14623,17 +14634,19 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
 
     def _extract_country_codes(self, countries_data) -> list[str]:  # Extract country codes.
         """Extract country codes from countries data."""
-        if isinstance(countries_data, dict):  # Dict payload.
-            return list(countries_data.keys())  # Return the keys.
-        elif isinstance(countries_data, list):  # List payload.
-            codes = []  # Collect codes.
-            for item in countries_data:  # Walk items.
-                if isinstance(item, dict):  # Dict item.
-                    code = item.get("code") or item.get("alpha2") or item.get("name", "")[:2].upper()  # Resolve a code.
-                    if code:  # Have a code.
-                        codes.append(code)  # Keep it.
-            return codes  # Return the codes.
-        return []  # Unknown shape.
+        if isinstance(countries_data, dict):  # Dict payload
+            return list(countries_data.keys())  # Return the keys
+        if not isinstance(countries_data, list):  # Unknown shape — return empty
+            return []
+        codes = []  # Collect codes
+        for item in countries_data:  # Walk items
+            if not isinstance(item, dict):  # Skip non-dict items
+                continue
+            code = item.get("code") or item.get("alpha2") or item.get("name", "")[:2].upper()  # Resolve a code
+            if not code:  # Empty code = skip
+                continue
+            codes.append(code)  # Keep it
+        return codes  # Return the codes
 
     def _normalize_states_data(self, country_code: str, country_data) -> list[dict]:  # type: ignore[no-untyped-def, type-arg]
         """Normalize states data into list of records with country identifier."""
@@ -14715,17 +14728,19 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
 
     def _extract_channel_country_codes(self, countries_data) -> list[str]:  # Extract channel countries.
         """Extract country codes from countries data for channel lookup."""
-        if isinstance(countries_data, dict):  # Dict payload.
-            return list(countries_data.keys())  # Return the keys.
-        elif isinstance(countries_data, list):  # List payload.
-            codes = []  # Collect codes.
-            for item in countries_data:  # Walk items.
-                if isinstance(item, dict):  # Dict item.
-                    code = item.get("alpha2") or item.get("code")  # Resolve a code.
-                    if code:  # Have a code.
-                        codes.append(code)  # Keep it.
-            return codes  # Return the codes.
-        return []  # Unknown shape.
+        if isinstance(countries_data, dict):  # Dict payload
+            return list(countries_data.keys())  # Return the keys
+        if not isinstance(countries_data, list):  # Unknown shape — return empty
+            return []
+        codes = []  # Collect codes
+        for item in countries_data:  # Walk items
+            if not isinstance(item, dict):  # Skip non-dict items
+                continue
+            code = item.get("alpha2") or item.get("code")  # Resolve a code
+            if not code:  # Empty code = skip
+                continue
+            codes.append(code)  # Keep it
+        return codes  # Return the codes
 
     def _normalize_channels_data(self, country_code: str, country_data) -> list[dict]:  # type: ignore[no-untyped-def, type-arg]
         """Normalize channels data into list of records with country identifier."""
@@ -15839,27 +15854,57 @@ class TroubleshootUtils:  # Marvis troubleshoot delegators.
         print()  # Spacer.
 
     @staticmethod
+    def _handle_marvis_invalid_choice(choice: str) -> None:
+        """Handle an out-of-range Marvis menu selection (warn + log)."""
+        print(" Invalid option selected.")  # User-facing notice
+        logging.warning("MARVIS DEBUG: Invalid troubleshooting option selected: %s", choice)  # Audit trail
+        logging.debug("MARVIS DEBUG: Exiting launch_interactive() due to invalid choice")  # Trace exit reason
+
+    @staticmethod
+    def _handle_marvis_exit() -> None:
+        """Handle the Marvis exit menu pick."""
+        logging.debug("MARVIS DEBUG: User chose to exit")  # Trace the exit
+        print("Exiting Marvis troubleshooting.")  # Tell the user
+
+    @staticmethod
+    def _invoke_marvis_client_connectivity() -> None:
+        """Run the client-connectivity troubleshooter."""
+        logging.debug("MARVIS DEBUG: Calling TroubleshootUtils.client_connectivity()")  # Trace the call
+        TroubleshootUtils.client_connectivity()  # type: ignore[no-untyped-call]
+
+    @staticmethod
+    def _invoke_marvis_device_performance() -> None:
+        """Run the device-performance troubleshooter."""
+        logging.debug("MARVIS DEBUG: Calling TroubleshootUtils.device_performance()")  # Trace the call
+        TroubleshootUtils.device_performance()  # type: ignore[no-untyped-call]
+
+    @staticmethod
+    def _invoke_marvis_network_connectivity() -> None:
+        """Run the network-connectivity troubleshooter."""
+        logging.debug("MARVIS DEBUG: Calling TroubleshootUtils.network_connectivity()")  # Trace the call
+        TroubleshootUtils.network_connectivity()  # type: ignore[no-untyped-call]
+
+    @staticmethod
+    def _invoke_marvis_view_insights() -> None:
+        """Run the insights viewer."""
+        logging.debug("MARVIS DEBUG: Calling TroubleshootUtils.view_insights()")  # Trace the call
+        TroubleshootUtils.view_insights()  # Show the insights
+
+    @staticmethod
     def _dispatch_marvis_choice(choice: str) -> None:
         """Dispatch the user's menu pick to the matching TroubleshootUtils entrypoint."""
-        if choice == "1":  # Client connectivity.
-            logging.debug("MARVIS DEBUG: Calling TroubleshootUtils.client_connectivity()")  # Trace the call.
-            TroubleshootUtils.client_connectivity()  # type: ignore[no-untyped-call]
-        elif choice == "2":  # Device performance.
-            logging.debug("MARVIS DEBUG: Calling TroubleshootUtils.device_performance()")  # Trace the call.
-            TroubleshootUtils.device_performance()  # type: ignore[no-untyped-call]
-        elif choice == "3":  # Network connectivity.
-            logging.debug("MARVIS DEBUG: Calling TroubleshootUtils.network_connectivity()")  # Trace the call.
-            TroubleshootUtils.network_connectivity()  # type: ignore[no-untyped-call]
-        elif choice == "4":  # View insights.
-            logging.debug("MARVIS DEBUG: Calling TroubleshootUtils.view_insights()")  # Trace the call.
-            TroubleshootUtils.view_insights()  # Show the insights.
-        elif choice == "5":  # Exit option.
-            logging.debug("MARVIS DEBUG: User chose to exit")  # Trace the exit.
-            print("Exiting Marvis troubleshooting.")  # Tell the user.
-        else:
-            print(" Invalid option selected.")  # Tell the user invalid.
-            logging.warning("MARVIS DEBUG: Invalid troubleshooting option selected: %s", choice)  # %s not f-string
-            logging.debug("MARVIS DEBUG: Exiting launch_interactive() due to invalid choice")  # Trace the exit.
+        handlers = {  # Map menu pick → handler (eliminates if/elif chain)
+            "1": TroubleshootUtils._invoke_marvis_client_connectivity,  # Client connectivity
+            "2": TroubleshootUtils._invoke_marvis_device_performance,  # Device performance
+            "3": TroubleshootUtils._invoke_marvis_network_connectivity,  # Network connectivity
+            "4": TroubleshootUtils._invoke_marvis_view_insights,  # View insights
+            "5": TroubleshootUtils._handle_marvis_exit,  # Exit option
+        }
+        handler = handlers.get(choice)  # Lookup the picked handler
+        if handler is None:  # Unknown pick = invalid path
+            TroubleshootUtils._handle_marvis_invalid_choice(choice)  # Warn + log
+            return  # Early return to keep depth flat
+        handler()  # Invoke the matched handler
 
     @staticmethod
     def launch_interactive() -> None:  # Launch interactive Marvis.
@@ -18701,26 +18746,28 @@ class FirmwareUpgradeStatusChecker:
         progress_bar = DisplayUtils.create_progress_bar(device["progress"], bar_length=15)
         print(f"  {name:<35} {dtype:<8} {site:<35} {progress_bar}")
 
+    @staticmethod
+    def _classify_progress_bucket(progress: int) -> str:
+        """Return the histogram bucket label for one device progress value."""
+        if progress <= 25:  # First quartile
+            return "0-25%"
+        if progress <= 50:  # Second quartile
+            return "26-50%"
+        if progress <= 75:  # Third quartile
+            return "51-75%"
+        if progress < 100:  # Pre-completion bucket
+            return "76-99%"
+        return "100%"  # Fully complete
+
     def _display_progress_distribution(self, sorted_upgrading: list[dict[str, Any]]) -> None:
         """Display progress distribution for upgrading devices."""
-        ranges = {"0-25%": 0, "26-50%": 0, "51-75%": 0, "76-99%": 0, "100%": 0}
-
-        for device in sorted_upgrading:
-            progress = device["progress"]
-            if progress <= 25:
-                ranges["0-25%"] += 1
-            elif progress <= 50:
-                ranges["26-50%"] += 1
-            elif progress <= 75:
-                ranges["51-75%"] += 1
-            elif progress < 100:
-                ranges["76-99%"] += 1
-            else:
-                ranges["100%"] += 1
-
-        print("\n  Progress Distribution:")
-        for range_label, count in ranges.items():
-            if count > 0:
+        ranges = {"0-25%": 0, "26-50%": 0, "51-75%": 0, "76-99%": 0, "100%": 0}  # Histogram buckets
+        for device in sorted_upgrading:  # Count each device into its bucket
+            bucket = self._classify_progress_bucket(device["progress"])  # Resolve the bucket
+            ranges[bucket] += 1  # Increment that bucket
+        print("\n  Progress Distribution:")  # Section header
+        for range_label, count in ranges.items():  # Print each non-empty bucket
+            if count > 0:  # Skip zero buckets to keep output compact
                 print(f"   X  {range_label}: {count} device(s)")
 
     def _check_active_operations(self) -> None:

--- a/data/compliance_report.md
+++ b/data/compliance_report.md
@@ -1,6 +1,6 @@
 # Coding Guideline Compliance Report
 
-- **Generated**: 2026-06-28 09:30:11 UTC
+- **Generated**: 2026-06-28 09:48:30 UTC
 - **Tool**: compliance-analyzer (tools/compliance_analyzer)
 - **Files analyzed**: 1
 
@@ -11,36 +11,35 @@ Plan at the end to drive fixes.
 
 ## Summary
 
-- **Overall score**: 60.0 / 100
-- **Overall grade**: D-
+- **Overall score**: 75.0 / 100
+- **Overall grade**: C
 
 | File | Score | Grade | Critical | High | Medium | Low | Total |
 | - | - | - | - | - | - | - | - |
-| MistHelper.py | 60.0 | D- | 0 | 0 | 6 | 61 | 67 |
+| MistHelper.py | 75.0 | C | 0 | 0 | 0 | 57 | 57 |
 
 ## Machine-Readable Summary
 
 ```json
 {
-  "overall_score": 60.0,
-  "overall_grade": "D-",
+  "overall_score": 75.0,
+  "overall_grade": "C",
   "severity_totals": {
     "critical": 0,
     "high": 0,
-    "medium": 6,
-    "low": 61
+    "medium": 0,
+    "low": 57
   },
   "rule_totals": {
-    "STRUCT-BLOCKS": 6,
-    "STRUCT-COMPLEXITY": 55,
-    "STRUCT-NESTING": 6
+    "STRUCT-BLOCKS": 5,
+    "STRUCT-COMPLEXITY": 52
   },
   "files": [
     {
       "path": "MistHelper.py",
-      "score": 60.0,
-      "grade": "D-",
-      "violations": 67
+      "score": 75.0,
+      "grade": "C",
+      "violations": 57
     }
   ]
 }
@@ -48,20 +47,20 @@ Plan at the end to drive fixes.
 
 ## File: MistHelper.py
 
-- **Score**: 60.0 / 100
-- **Grade**: D-
+- **Score**: 75.0 / 100
+- **Grade**: C
 
 ### Metrics
 
 | Metric | Value |
 | - | - |
-| Lines of code | 23823 |
-| Executable code lines | 11045 |
-| Functions | 1314 |
+| Lines of code | 23870 |
+| Executable code lines | 11065 |
+| Functions | 1323 |
 | Classes | 96 |
-| Average complexity | 2.7 |
+| Average complexity | 2.6 |
 | Max complexity | 10 |
-| Inline comment coverage | 81.6% |
+| Inline comment coverage | 81.5% |
 
 ### Complexity Hotspots
 
@@ -81,76 +80,66 @@ Plan at the end to drive fixes.
 | - | - | - | - | - | - |
 | 2941 | low | STRUCT-COMPLEXITY | initialize_mist_session | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 | 5602 | low | STRUCT-COMPLEXITY | dict_list_as_pretty_table | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 6552 | low | STRUCT-COMPLEXITY | flatten_dict | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 7217 | low | STRUCT-COMPLEXITY | _init_router | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 7299 | low | STRUCT-COMPLEXITY | _route_to_polyglot | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 8077 | low | STRUCT-COMPLEXITY | _fetch_all_clients_for_site | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 8283 | low | STRUCT-COMPLEXITY | _fetch_and_filter_devices | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 8540 | low | STRUCT-COMPLEXITY | _display_client_table | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 8766 | low | STRUCT-COMPLEXITY | get_device_identifier | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 9651 | low | STRUCT-COMPLEXITY | _partition_combined_inventory_rows | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 10274 | low | STRUCT-COMPLEXITY | _load_port_stats_sites | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 10697 | low | STRUCT-COMPLEXITY | _maybe_build_offline_record | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 11391 | low | STRUCT-COMPLEXITY | _prompt_operator | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 11758 | low | STRUCT-COMPLEXITY | _fetch_license_records | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 12756 | low | STRUCT-COMPLEXITY | device_stats | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 12863 | low | STRUCT-COMPLEXITY | devices | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 12908 | low | STRUCT-COMPLEXITY | clients | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 13443 | low | STRUCT-COMPLEXITY | _prompt_model_selection | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 13534 | low | STRUCT-COMPLEXITY | export_sites_by_ap_model | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 13754 | low | STRUCT-COMPLEXITY | ha_cluster_info | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14266 | low | STRUCT-COMPLEXITY | _find_api_functions | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14530 | low | STRUCT-COMPLEXITY | _extract_gateway_models | Cyclomatic complexity is 10 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14598 | low | STRUCT-COMPLEXITY | _get_country_codes_list | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14624 | low | STRUCT-COMPLEXITY | _extract_country_codes | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14638 | low | STRUCT-COMPLEXITY | _normalize_states_data | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14687 | low | STRUCT-COMPLEXITY | _filter_to_iso2_country_codes | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14716 | low | STRUCT-COMPLEXITY | _extract_channel_country_codes | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 14885 | low | STRUCT-COMPLEXITY | _collect_metrics_for_scope | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 15080 | low | STRUCT-COMPLEXITY | _extract_results | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 15460 | low | STRUCT-COMPLEXITY | fetch_synthetic_test_stats_with_retry | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 15842 | low | STRUCT-COMPLEXITY | _dispatch_marvis_choice | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16184 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 10 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16294 | low | STRUCT-COMPLEXITY | _handle_message | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16385 | low | STRUCT-COMPLEXITY | _split_arp_text_into_datasets | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16880 | low | STRUCT-COMPLEXITY | _detect_conflicts | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 16919 | low | STRUCT-COMPLEXITY | _check_network_subnet_overlap | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 17270 | low | STRUCT-COMPLEXITY | _execute | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 17357 | low | STRUCT-COMPLEXITY | _parse_template_selection | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 17483 | low | STRUCT-COMPLEXITY | _show_preview | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18603 | low | STRUCT-COMPLEXITY | _create_progress_display | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18704 | low | STRUCT-COMPLEXITY | _display_progress_distribution | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18736 | low | STRUCT-COMPLEXITY | _check_ssr_upgrades | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18811 | low | STRUCT-COMPLEXITY | _check_stored_upgrades | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18855 | low | STRUCT-COMPLEXITY | _check_stored_upgrade | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18883 | low | STRUCT-COMPLEXITY | _check_audit_logs | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 18959 | low | STRUCT-COMPLEXITY | _check_site_upgrades | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 19375 | low | STRUCT-COMPLEXITY | _fetch_msp_orgs | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 19480 | low | STRUCT-COMPLEXITY | _process_org | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 19985 | low | STRUCT-COMPLEXITY | _fetch_site_template_wlans | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 20036 | low | STRUCT-COMPLEXITY | _is_template_assigned_to_site | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 20053 | low | STRUCT-COMPLEXITY | _fetch_and_filter_org_wlans | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 22816 | low | STRUCT-COMPLEXITY | _systematic_test_resolve_fast_mode | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 23500 | low | STRUCT-COMPLEXITY | _resolve_cli_site_id | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 23736 | low | STRUCT-COMPLEXITY | _dispatch_main_mode | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
-| 23757 | low | STRUCT-COMPLEXITY | _has_meaningful_cli_args | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 7225 | low | STRUCT-COMPLEXITY | _init_router | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 7307 | low | STRUCT-COMPLEXITY | _route_to_polyglot | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 8088 | low | STRUCT-COMPLEXITY | _fetch_all_clients_for_site | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 8294 | low | STRUCT-COMPLEXITY | _fetch_and_filter_devices | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 8551 | low | STRUCT-COMPLEXITY | _display_client_table | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 8777 | low | STRUCT-COMPLEXITY | get_device_identifier | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 9662 | low | STRUCT-COMPLEXITY | _partition_combined_inventory_rows | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 10285 | low | STRUCT-COMPLEXITY | _load_port_stats_sites | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 10708 | low | STRUCT-COMPLEXITY | _maybe_build_offline_record | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 11402 | low | STRUCT-COMPLEXITY | _prompt_operator | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 11769 | low | STRUCT-COMPLEXITY | _fetch_license_records | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 12767 | low | STRUCT-COMPLEXITY | device_stats | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 12874 | low | STRUCT-COMPLEXITY | devices | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 12919 | low | STRUCT-COMPLEXITY | clients | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 13454 | low | STRUCT-COMPLEXITY | _prompt_model_selection | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 13545 | low | STRUCT-COMPLEXITY | export_sites_by_ap_model | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 13765 | low | STRUCT-COMPLEXITY | ha_cluster_info | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14277 | low | STRUCT-COMPLEXITY | _find_api_functions | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14541 | low | STRUCT-COMPLEXITY | _extract_gateway_models | Cyclomatic complexity is 10 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14609 | low | STRUCT-COMPLEXITY | _get_country_codes_list | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14635 | low | STRUCT-COMPLEXITY | _extract_country_codes | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14651 | low | STRUCT-COMPLEXITY | _normalize_states_data | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14700 | low | STRUCT-COMPLEXITY | _filter_to_iso2_country_codes | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14729 | low | STRUCT-COMPLEXITY | _extract_channel_country_codes | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 14900 | low | STRUCT-COMPLEXITY | _collect_metrics_for_scope | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 15095 | low | STRUCT-COMPLEXITY | _extract_results | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 15475 | low | STRUCT-COMPLEXITY | fetch_synthetic_test_stats_with_retry | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16229 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 10 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16339 | low | STRUCT-COMPLEXITY | _handle_message | Cyclomatic complexity is 9 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16430 | low | STRUCT-COMPLEXITY | _split_arp_text_into_datasets | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16925 | low | STRUCT-COMPLEXITY | _detect_conflicts | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16964 | low | STRUCT-COMPLEXITY | _check_network_subnet_overlap | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 17315 | low | STRUCT-COMPLEXITY | _execute | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 17402 | low | STRUCT-COMPLEXITY | _parse_template_selection | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 17528 | low | STRUCT-COMPLEXITY | _show_preview | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18648 | low | STRUCT-COMPLEXITY | _create_progress_display | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18783 | low | STRUCT-COMPLEXITY | _check_ssr_upgrades | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18858 | low | STRUCT-COMPLEXITY | _check_stored_upgrades | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18902 | low | STRUCT-COMPLEXITY | _check_stored_upgrade | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 18930 | low | STRUCT-COMPLEXITY | _check_audit_logs | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 19006 | low | STRUCT-COMPLEXITY | _check_site_upgrades | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 19422 | low | STRUCT-COMPLEXITY | _fetch_msp_orgs | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 19527 | low | STRUCT-COMPLEXITY | _process_org | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 20032 | low | STRUCT-COMPLEXITY | _fetch_site_template_wlans | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 20083 | low | STRUCT-COMPLEXITY | _is_template_assigned_to_site | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 20100 | low | STRUCT-COMPLEXITY | _fetch_and_filter_org_wlans | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 22863 | low | STRUCT-COMPLEXITY | _systematic_test_resolve_fast_mode | Cyclomatic complexity is 7 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 23547 | low | STRUCT-COMPLEXITY | _resolve_cli_site_id | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 23783 | low | STRUCT-COMPLEXITY | _dispatch_main_mode | Cyclomatic complexity is 8 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 23804 | low | STRUCT-COMPLEXITY | _has_meaningful_cli_args | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 
 #### Structure
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 6552 | medium | STRUCT-NESTING | flatten_dict | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 7889 | medium | STRUCT-NESTING | _pool_drain_wait_loop | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 14624 | medium | STRUCT-NESTING | _extract_country_codes | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 14716 | medium | STRUCT-NESTING | _extract_channel_country_codes | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 15842 | medium | STRUCT-NESTING | _dispatch_marvis_choice | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
-| 18704 | medium | STRUCT-NESTING | _display_progress_distribution | Maximum nesting depth is 5 (limit 4). | Flatten nesting with early returns, guard clauses, or extracted helper methods. |
 | 2941 | low | STRUCT-BLOCKS | initialize_mist_session | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 14530 | low | STRUCT-BLOCKS | _extract_gateway_models | Function has 9 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 14638 | low | STRUCT-BLOCKS | _normalize_states_data | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 16919 | low | STRUCT-BLOCKS | _check_network_subnet_overlap | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 17270 | low | STRUCT-BLOCKS | _execute | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
-| 18704 | low | STRUCT-BLOCKS | _display_progress_distribution | Function has 7 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 14541 | low | STRUCT-BLOCKS | _extract_gateway_models | Function has 9 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 14651 | low | STRUCT-BLOCKS | _normalize_states_data | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 16964 | low | STRUCT-BLOCKS | _check_network_subnet_overlap | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
+| 17315 | low | STRUCT-BLOCKS | _execute | Function has 6 logical blocks (limit 5). | Split the function so each helper owns a single cohesive block of logic. |
 
 ## SpecKit Remediation Plan
 
@@ -159,342 +148,289 @@ Plan at the end to drive fixes.
 > `speckit.tasks`, and `speckit.implement`. Re-run this analyzer to verify
 > every task is resolved before closing the phase.
 
-### Phase: Medium (6 task(s))
+### Phase: Low (57 task(s))
 
-- [ ] **CMP-001** `MistHelper.py:6552` - STRUCT-NESTING (Structure)
-  - Symbol: `flatten_dict`
-  - Problem: Maximum nesting depth is 5 (limit 4).
-  - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
-  - Done when: analyzer reports no STRUCT-NESTING for `flatten_dict` in `MistHelper.py`.
-- [ ] **CMP-002** `MistHelper.py:7889` - STRUCT-NESTING (Structure)
-  - Symbol: `_pool_drain_wait_loop`
-  - Problem: Maximum nesting depth is 5 (limit 4).
-  - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
-  - Done when: analyzer reports no STRUCT-NESTING for `_pool_drain_wait_loop` in `MistHelper.py`.
-- [ ] **CMP-003** `MistHelper.py:14624` - STRUCT-NESTING (Structure)
-  - Symbol: `_extract_country_codes`
-  - Problem: Maximum nesting depth is 5 (limit 4).
-  - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
-  - Done when: analyzer reports no STRUCT-NESTING for `_extract_country_codes` in `MistHelper.py`.
-- [ ] **CMP-004** `MistHelper.py:14716` - STRUCT-NESTING (Structure)
-  - Symbol: `_extract_channel_country_codes`
-  - Problem: Maximum nesting depth is 5 (limit 4).
-  - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
-  - Done when: analyzer reports no STRUCT-NESTING for `_extract_channel_country_codes` in `MistHelper.py`.
-- [ ] **CMP-005** `MistHelper.py:15842` - STRUCT-NESTING (Structure)
-  - Symbol: `_dispatch_marvis_choice`
-  - Problem: Maximum nesting depth is 5 (limit 4).
-  - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
-  - Done when: analyzer reports no STRUCT-NESTING for `_dispatch_marvis_choice` in `MistHelper.py`.
-- [ ] **CMP-006** `MistHelper.py:18704` - STRUCT-NESTING (Structure)
-  - Symbol: `_display_progress_distribution`
-  - Problem: Maximum nesting depth is 5 (limit 4).
-  - Fix: Flatten nesting with early returns, guard clauses, or extracted helper methods.
-  - Done when: analyzer reports no STRUCT-NESTING for `_display_progress_distribution` in `MistHelper.py`.
-
-### Phase: Low (61 task(s))
-
-- [ ] **CMP-007** `MistHelper.py:2941` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-001** `MistHelper.py:2941` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `initialize_mist_session`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `initialize_mist_session` in `MistHelper.py`.
-- [ ] **CMP-008** `MistHelper.py:2941` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-002** `MistHelper.py:2941` - STRUCT-BLOCKS (Structure)
   - Symbol: `initialize_mist_session`
   - Problem: Function has 6 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `initialize_mist_session` in `MistHelper.py`.
-- [ ] **CMP-009** `MistHelper.py:5602` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-003** `MistHelper.py:5602` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `dict_list_as_pretty_table`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `dict_list_as_pretty_table` in `MistHelper.py`.
-- [ ] **CMP-010** `MistHelper.py:6552` - STRUCT-COMPLEXITY (Complexity)
-  - Symbol: `flatten_dict`
-  - Problem: Cyclomatic complexity is 8 (target <= 5).
-  - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
-  - Done when: analyzer reports no STRUCT-COMPLEXITY for `flatten_dict` in `MistHelper.py`.
-- [ ] **CMP-011** `MistHelper.py:7217` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-004** `MistHelper.py:7225` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_init_router`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_init_router` in `MistHelper.py`.
-- [ ] **CMP-012** `MistHelper.py:7299` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-005** `MistHelper.py:7307` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_route_to_polyglot`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_route_to_polyglot` in `MistHelper.py`.
-- [ ] **CMP-013** `MistHelper.py:8077` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-006** `MistHelper.py:8088` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_all_clients_for_site`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_all_clients_for_site` in `MistHelper.py`.
-- [ ] **CMP-014** `MistHelper.py:8283` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-007** `MistHelper.py:8294` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_and_filter_devices`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_and_filter_devices` in `MistHelper.py`.
-- [ ] **CMP-015** `MistHelper.py:8540` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-008** `MistHelper.py:8551` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_display_client_table`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_display_client_table` in `MistHelper.py`.
-- [ ] **CMP-016** `MistHelper.py:8766` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-009** `MistHelper.py:8777` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `get_device_identifier`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `get_device_identifier` in `MistHelper.py`.
-- [ ] **CMP-017** `MistHelper.py:9651` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-010** `MistHelper.py:9662` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_partition_combined_inventory_rows`
   - Problem: Cyclomatic complexity is 9 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_partition_combined_inventory_rows` in `MistHelper.py`.
-- [ ] **CMP-018** `MistHelper.py:10274` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-011** `MistHelper.py:10285` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_load_port_stats_sites`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_load_port_stats_sites` in `MistHelper.py`.
-- [ ] **CMP-019** `MistHelper.py:10697` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-012** `MistHelper.py:10708` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_maybe_build_offline_record`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_maybe_build_offline_record` in `MistHelper.py`.
-- [ ] **CMP-020** `MistHelper.py:11391` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-013** `MistHelper.py:11402` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_prompt_operator`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_prompt_operator` in `MistHelper.py`.
-- [ ] **CMP-021** `MistHelper.py:11758` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-014** `MistHelper.py:11769` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_license_records`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_license_records` in `MistHelper.py`.
-- [ ] **CMP-022** `MistHelper.py:12756` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-015** `MistHelper.py:12767` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `device_stats`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `device_stats` in `MistHelper.py`.
-- [ ] **CMP-023** `MistHelper.py:12863` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-016** `MistHelper.py:12874` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `devices`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `devices` in `MistHelper.py`.
-- [ ] **CMP-024** `MistHelper.py:12908` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-017** `MistHelper.py:12919` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `clients`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `clients` in `MistHelper.py`.
-- [ ] **CMP-025** `MistHelper.py:13443` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-018** `MistHelper.py:13454` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_prompt_model_selection`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_prompt_model_selection` in `MistHelper.py`.
-- [ ] **CMP-026** `MistHelper.py:13534` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-019** `MistHelper.py:13545` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `export_sites_by_ap_model`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `export_sites_by_ap_model` in `MistHelper.py`.
-- [ ] **CMP-027** `MistHelper.py:13754` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-020** `MistHelper.py:13765` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `ha_cluster_info`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `ha_cluster_info` in `MistHelper.py`.
-- [ ] **CMP-028** `MistHelper.py:14266` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-021** `MistHelper.py:14277` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_find_api_functions`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_find_api_functions` in `MistHelper.py`.
-- [ ] **CMP-029** `MistHelper.py:14530` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-022** `MistHelper.py:14541` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_extract_gateway_models`
   - Problem: Cyclomatic complexity is 10 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_extract_gateway_models` in `MistHelper.py`.
-- [ ] **CMP-030** `MistHelper.py:14530` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-023** `MistHelper.py:14541` - STRUCT-BLOCKS (Structure)
   - Symbol: `_extract_gateway_models`
   - Problem: Function has 9 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_extract_gateway_models` in `MistHelper.py`.
-- [ ] **CMP-031** `MistHelper.py:14598` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-024** `MistHelper.py:14609` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_get_country_codes_list`
   - Problem: Cyclomatic complexity is 9 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_get_country_codes_list` in `MistHelper.py`.
-- [ ] **CMP-032** `MistHelper.py:14624` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-025** `MistHelper.py:14635` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_extract_country_codes`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_extract_country_codes` in `MistHelper.py`.
-- [ ] **CMP-033** `MistHelper.py:14638` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-026** `MistHelper.py:14651` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_normalize_states_data`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_normalize_states_data` in `MistHelper.py`.
-- [ ] **CMP-034** `MistHelper.py:14638` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-027** `MistHelper.py:14651` - STRUCT-BLOCKS (Structure)
   - Symbol: `_normalize_states_data`
   - Problem: Function has 6 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_normalize_states_data` in `MistHelper.py`.
-- [ ] **CMP-035** `MistHelper.py:14687` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-028** `MistHelper.py:14700` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_filter_to_iso2_country_codes`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_filter_to_iso2_country_codes` in `MistHelper.py`.
-- [ ] **CMP-036** `MistHelper.py:14716` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-029** `MistHelper.py:14729` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_extract_channel_country_codes`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_extract_channel_country_codes` in `MistHelper.py`.
-- [ ] **CMP-037** `MistHelper.py:14885` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-030** `MistHelper.py:14900` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_collect_metrics_for_scope`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_collect_metrics_for_scope` in `MistHelper.py`.
-- [ ] **CMP-038** `MistHelper.py:15080` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-031** `MistHelper.py:15095` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_extract_results`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_extract_results` in `MistHelper.py`.
-- [ ] **CMP-039** `MistHelper.py:15460` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-032** `MistHelper.py:15475` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `fetch_synthetic_test_stats_with_retry`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `fetch_synthetic_test_stats_with_retry` in `MistHelper.py`.
-- [ ] **CMP-040** `MistHelper.py:15842` - STRUCT-COMPLEXITY (Complexity)
-  - Symbol: `_dispatch_marvis_choice`
-  - Problem: Cyclomatic complexity is 6 (target <= 5).
-  - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
-  - Done when: analyzer reports no STRUCT-COMPLEXITY for `_dispatch_marvis_choice` in `MistHelper.py`.
-- [ ] **CMP-041** `MistHelper.py:16184` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-033** `MistHelper.py:16229` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `execute`
   - Problem: Cyclomatic complexity is 10 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `execute` in `MistHelper.py`.
-- [ ] **CMP-042** `MistHelper.py:16294` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-034** `MistHelper.py:16339` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_handle_message`
   - Problem: Cyclomatic complexity is 9 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_handle_message` in `MistHelper.py`.
-- [ ] **CMP-043** `MistHelper.py:16385` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-035** `MistHelper.py:16430` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_split_arp_text_into_datasets`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_split_arp_text_into_datasets` in `MistHelper.py`.
-- [ ] **CMP-044** `MistHelper.py:16880` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-036** `MistHelper.py:16925` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_detect_conflicts`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_detect_conflicts` in `MistHelper.py`.
-- [ ] **CMP-045** `MistHelper.py:16919` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-037** `MistHelper.py:16964` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_network_subnet_overlap`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_network_subnet_overlap` in `MistHelper.py`.
-- [ ] **CMP-046** `MistHelper.py:16919` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-038** `MistHelper.py:16964` - STRUCT-BLOCKS (Structure)
   - Symbol: `_check_network_subnet_overlap`
   - Problem: Function has 6 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_check_network_subnet_overlap` in `MistHelper.py`.
-- [ ] **CMP-047** `MistHelper.py:17270` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-039** `MistHelper.py:17315` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_execute`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_execute` in `MistHelper.py`.
-- [ ] **CMP-048** `MistHelper.py:17270` - STRUCT-BLOCKS (Structure)
+- [ ] **CMP-040** `MistHelper.py:17315` - STRUCT-BLOCKS (Structure)
   - Symbol: `_execute`
   - Problem: Function has 6 logical blocks (limit 5).
   - Fix: Split the function so each helper owns a single cohesive block of logic.
   - Done when: analyzer reports no STRUCT-BLOCKS for `_execute` in `MistHelper.py`.
-- [ ] **CMP-049** `MistHelper.py:17357` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-041** `MistHelper.py:17402` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_parse_template_selection`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_parse_template_selection` in `MistHelper.py`.
-- [ ] **CMP-050** `MistHelper.py:17483` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-042** `MistHelper.py:17528` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_show_preview`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_show_preview` in `MistHelper.py`.
-- [ ] **CMP-051** `MistHelper.py:18603` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-043** `MistHelper.py:18648` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_create_progress_display`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_create_progress_display` in `MistHelper.py`.
-- [ ] **CMP-052** `MistHelper.py:18704` - STRUCT-COMPLEXITY (Complexity)
-  - Symbol: `_display_progress_distribution`
-  - Problem: Cyclomatic complexity is 8 (target <= 5).
-  - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
-  - Done when: analyzer reports no STRUCT-COMPLEXITY for `_display_progress_distribution` in `MistHelper.py`.
-- [ ] **CMP-053** `MistHelper.py:18704` - STRUCT-BLOCKS (Structure)
-  - Symbol: `_display_progress_distribution`
-  - Problem: Function has 7 logical blocks (limit 5).
-  - Fix: Split the function so each helper owns a single cohesive block of logic.
-  - Done when: analyzer reports no STRUCT-BLOCKS for `_display_progress_distribution` in `MistHelper.py`.
-- [ ] **CMP-054** `MistHelper.py:18736` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-044** `MistHelper.py:18783` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_ssr_upgrades`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_ssr_upgrades` in `MistHelper.py`.
-- [ ] **CMP-055** `MistHelper.py:18811` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-045** `MistHelper.py:18858` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_stored_upgrades`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_stored_upgrades` in `MistHelper.py`.
-- [ ] **CMP-056** `MistHelper.py:18855` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-046** `MistHelper.py:18902` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_stored_upgrade`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_stored_upgrade` in `MistHelper.py`.
-- [ ] **CMP-057** `MistHelper.py:18883` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-047** `MistHelper.py:18930` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_audit_logs`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_audit_logs` in `MistHelper.py`.
-- [ ] **CMP-058** `MistHelper.py:18959` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-048** `MistHelper.py:19006` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_check_site_upgrades`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_check_site_upgrades` in `MistHelper.py`.
-- [ ] **CMP-059** `MistHelper.py:19375` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-049** `MistHelper.py:19422` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_msp_orgs`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_msp_orgs` in `MistHelper.py`.
-- [ ] **CMP-060** `MistHelper.py:19480` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-050** `MistHelper.py:19527` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_process_org`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_process_org` in `MistHelper.py`.
-- [ ] **CMP-061** `MistHelper.py:19985` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-051** `MistHelper.py:20032` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_site_template_wlans`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_site_template_wlans` in `MistHelper.py`.
-- [ ] **CMP-062** `MistHelper.py:20036` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-052** `MistHelper.py:20083` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_is_template_assigned_to_site`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_is_template_assigned_to_site` in `MistHelper.py`.
-- [ ] **CMP-063** `MistHelper.py:20053` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-053** `MistHelper.py:20100` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_fetch_and_filter_org_wlans`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_fetch_and_filter_org_wlans` in `MistHelper.py`.
-- [ ] **CMP-064** `MistHelper.py:22816` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-054** `MistHelper.py:22863` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_systematic_test_resolve_fast_mode`
   - Problem: Cyclomatic complexity is 7 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_systematic_test_resolve_fast_mode` in `MistHelper.py`.
-- [ ] **CMP-065** `MistHelper.py:23500` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-055** `MistHelper.py:23547` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_resolve_cli_site_id`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_resolve_cli_site_id` in `MistHelper.py`.
-- [ ] **CMP-066** `MistHelper.py:23736` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-056** `MistHelper.py:23783` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_dispatch_main_mode`
   - Problem: Cyclomatic complexity is 8 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.
   - Done when: analyzer reports no STRUCT-COMPLEXITY for `_dispatch_main_mode` in `MistHelper.py`.
-- [ ] **CMP-067** `MistHelper.py:23757` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-057** `MistHelper.py:23804` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `_has_meaningful_cli_args`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.


### PR DESCRIPTION
## Summary

Wave M15 of the Phase Medium decomposition campaign. **Eliminates every
remaining STRUCT-NESTING violation** in `MistHelper.py` -- **Phase Medium
is now COMPLETE (Medium = 0).** Pure structural refactor -- behavior
unchanged.

This wave targets six depth-5 hotspots: two list/dict flattener helpers
(`flatten_dict`, `_pool_drain_wait_loop`), two country-code extractors,
the Marvis menu dispatcher, and the firmware progress histogram.
Each function is brought to depth <=4 via genuine helper extraction
or guard-clause/dispatch-table conversion (no wrappers, no aliases,
no delegates, no shims).

Refs #469
Refs #208

## Decomposition Map (6 functions)

| # | Function | Strategy |
| - | - | - |
| T1 | `flatten_dict` | Extracted `_flatten_list_value` staticmethod for list-branch handling + converted nested `if`s to `continue`-guard pattern (depth 5 -> 4) |
| T2 | `_pool_drain_wait_loop` | Extracted `_record_future_outcome` taking `accumulator: dict` (bundles `successful`/`failed`/`first_logged` into one param to stay <=5) and reformed the main loop to a flat 4-depth body |
| T3 | `_extract_country_codes` | Converted nested `isinstance + for + if + if` chain to a sequence of early-return + `continue` guards (depth 5 -> 4) |
| T4 | `_extract_channel_country_codes` | Same pattern as T3 -- early-return + `continue` guards on the list branch (depth 5 -> 4) |
| T5 | `_dispatch_marvis_choice` | Replaced six-branch `if/elif/else` chain with a `handlers` dispatch dict + five per-choice invocation helpers (depth 5 -> 1). Also extracted `_handle_marvis_invalid_choice` and `_handle_marvis_exit` for the non-handler branches |
| T6 | `_display_progress_distribution` | Extracted `_classify_progress_bucket` staticmethod (returns histogram bucket label) so the main loop becomes a flat `for + lookup + increment` (depth 5 -> 2) |

## Compliance Analyzer Deltas (`data/compliance_report.md`)

| Severity | Before (post-M14) | After M15 | Delta |
| - | - | - | - |
| Critical | 0 | 0 | 0 |
| High | 0 | 0 | 0 |
| **Medium** | **6** | **0** | **-6 (PHASE MEDIUM COMPLETE)** |
| Low | 61 | 57 | -4 |
| **Total** | **67** | **57** | **-10** |

| Rule | Before | After | Delta |
| - | - | - | - |
| STRUCT-LENGTH | 0 | 0 | 0 |
| **STRUCT-NESTING** | **6** | **0** | **-6 (ELIMINATED)** |
| STRUCT-PARAMS | 0 | 0 | 0 |
| STRUCT-BLOCKS | 6 | 5 | -1 |
| STRUCT-COMPLEXITY | 55 | 52 | -3 |
| ARCH-* | 0 | 0 | 0 |

**Score: 67.0 -> 75.0 (D+ -> C).**

## Campaign Tally (15 waves merged)

| Phase | Issue | Wave Range | Status |
| - | - | - | - |
| High | #470 | M1-M11 | DONE |
| Medium | #469 | M12-M15 | **COMPLETE WITH THIS PR** |
| Low | #468 | M16+ | PENDING |

Cumulative violations 253 -> 57 (-196 across 15 waves).
After M15 merges: re-read agents.md + .github/copilot-instructions.md
per user directive, then start Phase Low (#468) workflow on the 57
remaining Low items (52 STRUCT-COMPLEXITY + 5 STRUCT-BLOCKS).

## Quality Gates

- `python -m py_compile MistHelper.py` -- clean
- `python -m black MistHelper.py` -- no changes needed (formatter happy)
- `python -m ruff check MistHelper.py` -- all checks passed
- `python tools/check_compliance.py MistHelper.py` -- Medium = 0, STRUCT-NESTING = 0, score 75.0 (C)
- CI gates pending in this PR (CodeQL, mypy, pytest)

## Hot-File Serialization

Branched off `origin/main` after PR #525 merged. Only one PR touching
`MistHelper.py` open at a time per repo guidelines.

## Constraints Honored

- 5-Item Rule (max 5 params, max 25 lines per body, max depth 4)
- Inline comments on every new line explaining *why*
- Action logging preserved on every helper that originally had it
  (`_dispatch_marvis_choice` per-choice helpers each carry the original
  `MARVIS DEBUG: Calling ...` traces)
- No wrappers/delegates/aliases/shims/facades/passthroughs/forwarders
- No new ARCH-* violations introduced (count remains 0)
- ARCH-NAMING blocked token scan: no `wrapper`/`facade`/`delegate` etc. in any new identifier or docstring

## What's Not in This PR

- No behavior changes -- this is pure structural refactor
- No test changes -- existing `python MistHelper.py --test` suite remains the contract
- Low-severity STRUCT-COMPLEXITY (52) and STRUCT-BLOCKS (5) remain for Phase Low (#468) M16+

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
