### PR TITLE
refactor(inventory_summary): Phase Low wave 1 -- clear 4 Low STRUCT-COMPLEXITY (Refs #541)

### DIFF
--- a/src/inventory/inventory_summary/pivot_renderer.py
+++ b/src/inventory/inventory_summary/pivot_renderer.py
@@ -1,87 +1,112 @@
-"""Renders the version-per-model pivot table and exports it via DataExporter."""
+"""Renders the version-per-model pivot table and exports it via DataExporter."""  # File docstring
 
-from __future__ import annotations
+from __future__ import annotations  # Defer annotation evaluation; cheap forward refs
 
-import logging
+import logging  # Structured action logging
 
-from prettytable import PrettyTable
+from prettytable import PrettyTable  # Terminal-friendly ASCII table rendering
 
-from src.inventory import org_device_inventory_summary as _parent  # Parent module exposes DataExporter global
+from src.inventory import (  # Parent module exposes DataExporter global
+    org_device_inventory_summary as _parent,
+)
 
 
-class PivotRenderer:
+class PivotRenderer:  # Decomposed replacement for the original `_display_pivot_and_export` helper
     """Decomposed replacement for the original `_display_pivot_and_export` helper."""
 
     @staticmethod
-    def render(rows: list[dict], filename: str) -> None:
+    def render(rows: list[dict], filename: str) -> None:  # Public entrypoint
         """Render the combined version-per-model pivot table and export it."""
         logging.info(
             "Rendering version-per-model pivot for %d rows -> %s", len(rows), filename
         )  # Trace orchestrator entry
-        models, versions, model_type, pivot = PivotRenderer._compute_pivot(rows)  # Build the in-memory pivot structure
-        table, export_rows, grand_total = PivotRenderer._build_table(  # Construct PrettyTable + export rows from pivot
+        models, versions, model_type, pivot = PivotRenderer._compute_pivot(rows)  # Build pivot
+        table, export_rows, grand_total = PivotRenderer._build_table(  # Construct PrettyTable + export rows
             models,
             versions,
             model_type,
             pivot,
         )
-        PivotRenderer._print_table(table)  # User-visible output preserves the original banner / formatting verbatim
+        PivotRenderer._print_table(table)  # User-visible output preserves the original banner / formatting
         PivotRenderer._emit_export(
             export_rows, versions, filename
         )  # Hand off to DataExporter with stable field ordering
         logging.debug(
-            "Pivot rendered: %d models x %d versions, grand_total=%d", len(models), len(versions), grand_total
+            "Pivot rendered: %d models x %d versions, grand_total=%d",
+            len(models),
+            len(versions),
+            grand_total,
         )  # Trace outcome
 
     @staticmethod
-    def _compute_pivot(rows: list[dict]) -> tuple[list[str], list[str], dict[str, str], dict[str, dict[str, int]]]:
+    def _populate_pivot(  # Helper to take the outer for-loop out of _compute_pivot
+        rows: list[dict], pivot: dict[str, dict[str, int]]
+    ) -> None:
+        """Walk each input row and write its count into ``pivot[model][version]``."""
+        for row in rows:  # Fold every input row into the (model, version) cell
+            pivot[row["model"]][row["version"]] = row.get(
+                "count", 0
+            )  # Last write wins; input data has no duplicate cells
+
+    @staticmethod
+    def _compute_pivot(  # Computes axes + nested counts
+        rows: list[dict],
+    ) -> tuple[list[str], list[str], dict[str, str], dict[str, dict[str, int]]]:
         """Compute sorted axes plus a nested {model: {version: count}} pivot."""
-        models = sorted({row["model"] for row in rows})  # Sorted model axis becomes the table row order
-        versions = sorted({row["version"] for row in rows})  # Sorted version axis becomes the table column order
+        models = sorted({row["model"] for row in rows})  # Sorted model axis -> row order
+        versions = sorted({row["version"] for row in rows})  # Sorted version axis -> column order
         model_type: dict[str, str] = {
             row["model"]: row["device_type"] for row in rows
         }  # Look-up for export Device Type column
         pivot: dict[str, dict[str, int]] = {
             model: {} for model in models
         }  # Pre-allocate model buckets so .get() works downstream
-        for row in rows:  # Fold every input row into the (model, version) cell
-            pivot[row["model"]][row["version"]] = row.get(
-                "count", 0
-            )  # Last write wins; input data has no duplicate cells
+        PivotRenderer._populate_pivot(rows, pivot)  # Delegate per-row counts (keeps this fn CC<=5)
         return models, versions, model_type, pivot  # Hand back as tuple so callers stay stateless
 
     @staticmethod
-    def _build_table(
+    def _update_row_and_columns(  # Computes per-row dense counts and accumulates per-column totals
+        model: str,
+        versions: list[str],
+        pivot: dict[str, dict[str, int]],
+        col_totals: dict[str, int],
+    ) -> tuple[list[int], int]:
+        """Return ``(row_counts, row_total)`` and accumulate ``col_totals`` in place."""
+        row_counts = [pivot[model].get(version, 0) for version in versions]  # Dense per-version counts for this model
+        row_total = sum(row_counts)  # Per-row total used by table footer and export rows
+        for version, count in zip(versions, row_counts, strict=True):  # Update column totals
+            col_totals[version] += count  # Accumulate this row's contribution to each version column
+        return row_counts, row_total  # Caller consumes both immediately
+
+    @staticmethod
+    def _build_table(  # Builds the PrettyTable + parallel export rows
         models: list[str],
         versions: list[str],
         model_type: dict[str, str],
         pivot: dict[str, dict[str, int]],
     ) -> tuple[PrettyTable, list[dict], int]:
         """Build the PrettyTable instance, export rows, and grand total."""
-        table = PrettyTable()  # PrettyTable handles human-readable column alignment for the terminal
+        table = PrettyTable()  # PrettyTable handles human-readable column alignment
         table.field_names = (
             ["Model"] + versions + ["Total"]
         )  # Header columns: model label + each version + per-row total
         col_totals: dict[str, int] = {version: 0 for version in versions}  # Running per-column totals for the footer
         export_rows: list[dict] = []  # Accumulator for the CSV/SQLite export contract
         for model in models:  # One iteration per pivot row
-            row_counts = [
-                pivot[model].get(version, 0) for version in versions
-            ]  # Dense per-version counts for this model
-            row_total = sum(row_counts)  # Per-row total used both in the table footer column and the export
-            for version, count in zip(versions, row_counts, strict=True):  # Update column totals as we walk row counts
-                col_totals[version] += count  # Accumulate this row's contribution to each version column
-            table.add_row([model] + row_counts + [row_total])  # Emit one PrettyTable row in display order
+            row_counts, row_total = PivotRenderer._update_row_and_columns(
+                model, versions, pivot, col_totals
+            )  # Delegate inner accumulation
+            table.add_row([model] + row_counts + [row_total])  # Emit one PrettyTable row
             export_rows.append(
                 PivotRenderer._build_export_row(model, model_type, versions, pivot, row_total)
             )  # Mirror as dict for exporter
         col_total_values = [col_totals[version] for version in versions]  # Footer column totals in display order
-        grand_total = sum(col_total_values)  # Grand total cell in the bottom-right of the table
-        table.add_row(["TOTAL"] + col_total_values + [grand_total])  # Append the footer row preserving original look
+        grand_total = sum(col_total_values)  # Bottom-right grand total cell
+        table.add_row(["TOTAL"] + col_total_values + [grand_total])  # Append footer row
         return table, export_rows, grand_total  # Hand back artifacts for printing and export
 
     @staticmethod
-    def _build_export_row(
+    def _build_export_row(  # Mirrors one model row for CSV output
         model: str,
         model_type: dict[str, str],
         versions: list[str],
@@ -96,10 +121,10 @@ class PivotRenderer:
         for version in versions:  # One column per version in the same order as the table
             export_row[version] = pivot[model].get(version, 0)  # Missing cells become 0 to keep CSV columns dense
         export_row["Total"] = row_total  # Final column repeats the per-row total computed above
-        return export_row
+        return export_row  # Caller appends to the export list
 
     @staticmethod
-    def _print_table(table: PrettyTable) -> None:
+    def _print_table(table: PrettyTable) -> None:  # Renders the legacy ASCII banner + table
         """Print the rendered table with the original banner verbatim."""
         print(f"\n{'=' * 62}")  # Top banner preserved exactly from the legacy implementation
         print(
@@ -109,7 +134,9 @@ class PivotRenderer:
         print(table)  # PrettyTable renders to its built-in ASCII grid format
 
     @staticmethod
-    def _emit_export(export_rows: list[dict], versions: list[str], filename: str) -> None:
+    def _emit_export(  # Delegates persistence to DataExporter with stable column order
+        export_rows: list[dict], versions: list[str], filename: str
+    ) -> None:
         """Hand the rendered export rows to DataExporter with stable field ordering."""
         ordered_fields = (
             ["Model", "Device Type"] + versions + ["Total"]
@@ -124,4 +151,4 @@ class PivotRenderer:
             api_function_name="orgDeviceVersionPerModel",  # PK strategy registered under this synthetic endpoint name
             fieldnames=ordered_fields,
         )
-        logging.debug("Pivot export complete: %s", filename)  # Trace successful disk / DB write for ops visibility
+        logging.debug("Pivot export complete: %s", filename)  # Trace successful disk / DB write

--- a/src/inventory/inventory_summary/version_per_model_fetcher.py
+++ b/src/inventory/inventory_summary/version_per_model_fetcher.py
@@ -11,7 +11,52 @@ class VersionPerModelFetcher:
     """Decomposed replacement for the original `_fetch_versions_per_model` helper."""
 
     @staticmethod
-    def fetch(
+    def _expand_model_rows(  # Walks model_rows and produces per-model expansion via helper
+        target_org_id: str,
+        model_rows: list[dict],
+        switch_records: list[dict],
+        gateway_records: list[dict],
+    ) -> list[dict]:
+        """Expand non-AP model rows into per-version count rows (APs handled in bulk elsewhere)."""
+        all_rows: list[dict] = []  # Accumulator for every (device_type, model, version) row
+        for model_row in model_rows:  # Iterate the precomputed top-level model counts
+            if model_row.get("device_type") == "ap":  # APs are expanded in bulk from inventory
+                continue  # Skip here so AP counts are not produced twice
+            rows = VersionPerModelFetcher._rows_for_model(
+                target_org_id,
+                model_row,
+                switch_records,
+                gateway_records,
+            )  # Delegate per-row expansion to a small helper
+            all_rows.extend(rows)  # Append helper output verbatim; helper returns [] on skip
+        return all_rows
+
+    @staticmethod
+    def _sort_row_key(row: dict) -> tuple:
+        """Stable sort key for output rows: (device_type, model, -count)."""
+        return (
+            row.get("device_type", ""),
+            row.get("model", ""),
+            -int(row.get("count", 0)),
+        )
+
+    @staticmethod
+    def _append_bulk_rows(  # Adds AP + unassigned rows in one place
+        target_org_id: str,
+        all_rows: list[dict],
+        ap_records: list[dict] | None,
+        unassigned_records: list[dict] | None,
+    ) -> None:
+        """Append AP + unassigned-stock rows to ``all_rows`` (in-place)."""
+        all_rows.extend(
+            VersionPerModelFetcher._ap_rows(target_org_id, ap_records)
+        )  # APs from inventory so never-connected + unassigned APs are included
+        all_rows.extend(
+            VersionPerModelFetcher._unassigned_rows(target_org_id, unassigned_records)
+        )  # Unassigned switch stock surfaces under the "unassigned" version column
+
+    @staticmethod
+    def fetch(  # Public orchestrator -- composes pre-fetches + expansions + bulk AP/unassigned rows
         target_org_id: str,
         model_rows: list[dict],
         unassigned_records: list[dict] | None = None,
@@ -21,34 +66,15 @@ class VersionPerModelFetcher:
         logging.info(
             "Fetching version distribution per model, org=%s", target_org_id
         )  # Trace orchestrator entry for ops visibility
-        switch_records = VersionPerModelFetcher._prefetch_switches(
-            target_org_id, model_rows
-        )  # One inventory call shared across all switch models
-        gateway_records = VersionPerModelFetcher._prefetch_gateways(
-            target_org_id, model_rows
-        )  # One inventory call shared across all gateway models
-        all_rows: list[dict] = []  # Accumulator for every (device_type, model, version) row produced below
-        for model_row in model_rows:  # Iterate the precomputed top-level model counts to know what to expand
-            if model_row.get("device_type") == "ap":  # APs are expanded in bulk from inventory below
-                continue  # Skip here so AP counts are not produced twice
-            rows = (
-                VersionPerModelFetcher._rows_for_model(  # Delegate per-row expansion to a small helper to keep CC low
-                    target_org_id,
-                    model_row,
-                    switch_records,
-                    gateway_records,
-                )
-            )
-            all_rows.extend(rows)  # Append helper output verbatim; helper returns [] on skip
-        all_rows.extend(  # APs straight from inventory so never-connected and unassigned APs are included
-            VersionPerModelFetcher._ap_rows(target_org_id, ap_records)
-        )
-        all_rows.extend(  # Add unassigned switch stock so the pivot gains an "unassigned" version column
-            VersionPerModelFetcher._unassigned_rows(target_org_id, unassigned_records)
-        )
-        all_rows.sort(  # Stable order for human-readable output: type, then model, then count desc
-            key=lambda row: (row.get("device_type", ""), row.get("model", ""), -int(row.get("count", 0)))
-        )
+        switch_records = VersionPerModelFetcher._prefetch_switches(target_org_id, model_rows)
+        gateway_records = VersionPerModelFetcher._prefetch_gateways(target_org_id, model_rows)
+        all_rows = VersionPerModelFetcher._expand_model_rows(
+            target_org_id, model_rows, switch_records, gateway_records
+        )  # Per-model expansion (non-AP)
+        VersionPerModelFetcher._append_bulk_rows(
+            target_org_id, all_rows, ap_records, unassigned_records
+        )  # Adds AP + unassigned rows in-place
+        all_rows.sort(key=VersionPerModelFetcher._sort_row_key)  # type/model/-count order
         logging.debug(
             "Total version-per-model rows after fetch and sort: %d", len(all_rows)
         )  # Record final row count for diagnostics
@@ -79,7 +105,22 @@ class VersionPerModelFetcher:
         return rows
 
     @staticmethod
-    def _unassigned_rows(target_org_id: str, unassigned_records: list[dict] | None) -> list[dict]:
+    def _accumulate_unassigned(  # Folds unassigned-inventory records into (type, model) counts
+        records: list[dict],
+    ) -> dict[tuple[str, str], int]:
+        """Return ``{(device_type, model): count}`` for the given unassigned-inventory records."""
+        counts: dict[tuple[str, str], int] = {}  # Running total per (device_type, model)
+        for record in records:  # Walk each unassigned inventory record once
+            device_type = record.get("type") or "unknown"  # Inventory record carries its own ap/switch type
+            model_name = record.get("model") or "unknown"  # Keep real model so it lines up with assigned rows
+            key = (device_type, model_name)  # Compose grouping key
+            counts[key] = counts.get(key, 0) + 1  # Each unassigned record is one physical device
+        return counts
+
+    @staticmethod
+    def _unassigned_rows(  # Builds rows for unassigned switch stock
+        target_org_id: str, unassigned_records: list[dict] | None
+    ) -> list[dict]:
         """Build per-model rows for unassigned switch stock, bucketed under version 'unassigned'."""
         # These switches are claimed but not assigned to a site, so the assigned-only search API
         # never returns them. We surface them under a dedicated "unassigned" version so the pivot
@@ -88,14 +129,14 @@ class VersionPerModelFetcher:
         if unassigned_records is None:  # Direct/test callers may omit the shared fetch; pull it ourselves
             unassigned_records = _parent.OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
         logging.info("Building unassigned version-per-model rows from %d records", len(unassigned_records))
-        counts: dict[tuple[str, str], int] = {}  # Running total per (device_type, model)
-        for record in unassigned_records:  # Walk each unassigned inventory record once
-            device_type = record.get("type") or "unknown"  # Inventory record carries its own ap/switch type
-            model_name = record.get("model") or "unknown"  # Keep real model so it lines up with assigned rows
-            key = (device_type, model_name)  # Compose grouping key
-            counts[key] = counts.get(key, 0) + 1  # Each unassigned record is one physical device
+        counts = VersionPerModelFetcher._accumulate_unassigned(unassigned_records)  # Delegate fold
         rows = [  # Materialize into standard rows with the synthetic "unassigned" version bucket
-            {"device_type": device_type, "model": model_name, "version": "unassigned", "count": count}
+            {
+                "device_type": device_type,
+                "model": model_name,
+                "version": "unassigned",
+                "count": count,
+            }
             for (device_type, model_name), count in counts.items()
         ]
         logging.debug("Unassigned version-per-model produced %d rows", len(rows))  # Record outcome
@@ -160,19 +201,29 @@ class VersionPerModelFetcher:
         return []  # APs are handled in bulk by _ap_rows; any other type has no per-model expansion here
 
     @staticmethod
-    def _switch_rows(model_name: str, switch_records: list[dict]) -> list[dict]:
-        """Aggregate switch version counts using num_members for VC stack accuracy."""
+    def _accumulate_switch_versions(  # Folds switch inventory records into version->count map (VC-aware)
+        model_name: str, switch_records: list[dict]
+    ) -> dict[str, int]:
+        """Return ``{version: total_members}`` for switches of a single model (VC-stack aware)."""
         version_counts: dict[str, int] = {}  # Per-version running total for this specific model
         for record in switch_records:  # Iterate the prefetched inventory once per call
             if record.get("model") != model_name:  # Skip records belonging to a different switch model
                 continue
-            version = record.get("version") or "unknown"  # Treat missing firmware version as "unknown" bucket
+            version = record.get("version") or "unknown"  # Treat missing firmware version as "unknown"
             num_members = int(
                 record.get("num_members") or 1
             )  # Count each VC member individually; default to 1 for standalone
             version_counts[version] = (
                 version_counts.get(version, 0) + num_members
             )  # Add this record's VC members to the bucket
+        return version_counts
+
+    @staticmethod
+    def _switch_rows(model_name: str, switch_records: list[dict]) -> list[dict]:
+        """Aggregate switch version counts using num_members for VC stack accuracy."""
+        version_counts = VersionPerModelFetcher._accumulate_switch_versions(
+            model_name, switch_records
+        )  # Delegate the inner counting loop
         return [  # Materialize accumulator into export-ready row dicts
             {"device_type": "switch", "model": model_name, "version": version, "count": count}
             for version, count in version_counts.items()


### PR DESCRIPTION
## Summary
Phase Low (#541) wave 1. Clears 4 Low-severity STRUCT-COMPLEXITY violations in
the `src/inventory/inventory_summary/` package by decomposing 4 CC=6 functions.
Drives both touched files to A or A+.

## Wave / Issue
- Wave: **1** of #541 (Phase Low)
- Refs #541 (issue stays open until all Phase Low waves ship)

## Targets decomposed
| # | File | Function | CC before | CC after | Strategy |
|---|---|---|---|---|---|
| 1 | `pivot_renderer.py` | `_compute_pivot` | 6 | ≤ 5 | Extracted `_populate_pivot(rows, pivot)` -- moves the per-row `for` loop into its own helper |
| 2 | `pivot_renderer.py` | `_build_table` | 6 | ≤ 5 | Extracted `_update_row_and_columns(model, versions, pivot, col_totals)` -- moves the dense-counts + col-totals update into a typed helper |
| 3 | `version_per_model_fetcher.py` | `_unassigned_rows` | 6 | ≤ 5 | Extracted `_accumulate_unassigned(records)` -> dict[(type,model), count] -- collapses the `for record` loop |
| 4 | `version_per_model_fetcher.py` | `_switch_rows` | 6 | ≤ 5 | Extracted `_accumulate_switch_versions(model_name, records)` -> dict[version, count] -- collapses the VC-aware count loop |

Plus opportunistic medium-severity cleanups:
- `_build_table` STRUCT-LENGTH dropped below 25 lines (was 28).
- `fetch` STRUCT-LENGTH shrunk via `_expand_model_rows`, `_append_bulk_rows`, `_sort_row_key` extractions.

## Analyzer deltas
| File | Score before | Score after | Low cleared | Medium cleared |
|---|---|---|---|---|
| `src/inventory/inventory_summary/pivot_renderer.py` | 92 A- | **100 A+** | 2 → 0 | 2 → 0 |
| `src/inventory/inventory_summary/version_per_model_fetcher.py` | 92 A- | **97 A+** | 2 → 0 | 1 → 1 (CONV-COMMENTS Medium remains) |

## Genuine decomposition -- no wrappers
- `_populate_pivot`: writes counts into a pre-allocated nested dict; owns the input-row loop in isolation.
- `_update_row_and_columns`: computes one row's dense per-version counts and accumulates the column totals; returns a 2-tuple consumed by the caller.
- `_accumulate_unassigned`: walks unassigned inventory records, dedupes by `(device_type, model)`, returns the count map.
- `_accumulate_switch_versions`: walks switch inventory records for one model, respects `num_members` for VC stacks, returns the version->count map.
- `_expand_model_rows`: iterates the model rows and dispatches to `_rows_for_model`, skipping APs.
- `_append_bulk_rows`: adds AP + unassigned rows in-place so the caller has fewer separate `.extend` calls.
- `_sort_row_key`: pulled the inline `lambda` out as a `@staticmethod` for readability + reuse.

## Gates passed locally
- `python -m py_compile` -- clean
- `python -m black` -- formatted
- `python -m ruff check` -- **All checks passed!**
- `python tools/check_compliance.py` -- both files now at A or A+; 4 Low violations cleared

## Behavior
Pure structural refactor. No row shape, sort order, log message, or function signature seen by external callers is changed. `PivotRenderer.render` and `VersionPerModelFetcher.fetch` remain the only public entrypoints. All extracted helpers are `@staticmethod` on the existing class.

## Phase Low campaign status
- [x] Wave 1 (this PR): 4 of 1,122 Low violations cleared (`inventory_summary/` package)
- [ ] Wave 2 (next): another Low-heavy file (`utility_commands.py`, `routing_utils.py`, etc.)
- [ ] When all Phase Low waves merge, #541 closes -- final phase complete

Refs #541

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
