### PR TITLE
fix: auto-detect CSV delimiter in address audit (menu 195 skipped comma-delimited files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Address audit CSV delimiter (menu 195)**: The CSV ingester assumed tab
+  delimiters and silently skipped every row of a comma-delimited file (the Excel
+  default `.csv`), reporting "No valid rows parsed". The delimiter is now
+  **auto-detected** per file (tab / comma / semicolon / pipe), an Excel BOM is
+  stripped, blank lines no longer count as parse failures, and addresses that
+  contain the delimiter (e.g. "6670 US Highway 129, Suite 1") are reconstructed
+  by parsing on the fixed serial/model + city/state/zip anchors. Verified against
+  a real 44-row customer export (44 parsed, 0 skipped).
+
 ### Added
 
 - **Site Address Audit from CSV (menu 195, read-only)**: New `src/site/address_audit/`

--- a/src/site/address_audit/csv_ingester.py
+++ b/src/site/address_audit/csv_ingester.py
@@ -1,27 +1,33 @@
 """CSV ingestion for the address-audit feature (1003-site-address-audit).
 
-Parses the customer-provided, tab-delimited, header-less CSV into ``AddressRow``
-objects. The columns (positional) are: serial, model, address, city, state, zip.
-Addresses frequently contain embedded newlines/whitespace from the source
-export, so each is sanitized. Rows whose serial is empty or non-numeric after
-stripping are skipped and counted (never emitted), since the serial is the
-golden key for site matching.
+Parses the customer-provided, header-less CSV into ``AddressRow`` objects. The
+six positional columns are: serial, model, address, city, state, zip.
+
+Real customer exports vary: a file saved as ``.csv`` from Excel is comma-
+delimited, while a ``.tsv`` (or a tab-pasted file) is tab-delimited. The
+delimiter is therefore **auto-detected** per file rather than assumed. Addresses
+themselves may contain the delimiter (e.g. a comma in "Mall, Suite 330"), so the
+row is parsed by its fixed structure -- the first two fields are serial/model,
+the last three are city/state/zip, and everything in between is rejoined as the
+address. Rows whose serial is empty or non-numeric after stripping are skipped
+and counted (never emitted), since the serial is the golden key for matching.
 """
 
 from __future__ import annotations  # PEP 604 union syntax on Python 3.13.
 
-import csv  # Standard-library tab-delimited parsing.
+import csv  # Standard-library delimited-file parsing.
 import logging  # Action logging before/after every operation (project NON-NEGOTIABLE).
 import os  # File-existence checks and path handling.
 import re  # Whitespace-collapsing in address sanitization.
 
 from src.site.address_audit.models import AddressRow  # Parsed-row dataclass.
 
-_EXPECTED_COLUMNS = 6  # serial, model, address, city, state, zip.
+_MIN_COLUMNS = 6  # serial, model, address, city, state, zip (address may span >1 physical field).
+_CANDIDATE_DELIMITERS = ("\t", ",", ";", "|")  # Delimiters to probe, in priority order.
 
 
 class CSVAddressIngester:
-    """Read and sanitize the customer tab-delimited address CSV."""
+    """Read and sanitize the customer address CSV (delimiter auto-detected)."""
 
     def load(self, path: str) -> tuple[list[AddressRow], int]:
         """Parse ``path`` into ``AddressRow`` objects plus a parse-failure count."""
@@ -29,44 +35,78 @@ class CSVAddressIngester:
         if not os.path.isfile(path):  # Guard: a missing file is a controlled error, not a crash.
             logging.error("CSV file not found: %s", path)  # Log the missing-file condition.
             raise FileNotFoundError(f"CSV file not found: {path}")  # Controlled, caller-catchable error.
-        rows: list[AddressRow] = []  # Accumulator for valid parsed rows.
-        failures = 0  # Counter for skipped (invalid-serial) rows.
-        with open(path, encoding="utf-8", newline="") as handle:  # UTF-8 per the data contract.
-            reader = csv.reader(handle, delimiter="\t")  # Tab-delimited, no header row.
-            for raw_fields in reader:  # Walk every physical CSV record.
-                parsed = self._parse_row(raw_fields)  # Convert fields to an AddressRow or None.
-                if parsed is None:  # None signals an invalid/empty-serial row.
-                    failures += 1  # Count the skip for the run summary.
-                    continue  # Skip without emitting.
-                rows.append(parsed)  # Keep the valid row.
+        with open(path, encoding="utf-8-sig", newline="") as handle:  # utf-8-sig strips an Excel BOM.
+            sample = self._read_sample_line(handle)  # First non-blank line, for delimiter detection.
+            handle.seek(0)  # Rewind so the csv.reader sees the whole file (quoted newlines intact).
+            delimiter = self._detect_delimiter(sample)  # Pick tab/comma/etc. from the data itself.
+            logging.debug("Detected delimiter %r for %s", delimiter, path)  # Trace the chosen delimiter.
+            reader = csv.reader(handle, delimiter=delimiter)  # Reader honors quoted multi-line fields.
+            rows, failures = self._parse_reader(reader)  # Parse every record.
         logging.debug("Ingested %d rows, %d parse failures", len(rows), failures)  # Action-log totals.
         return rows, failures  # Hand both back to the orchestrator.
 
+    @staticmethod
+    def _read_sample_line(handle: object) -> str:
+        """Return the first non-blank physical line from an open handle, or ''."""
+        for line in handle:  # type: ignore[attr-defined]  # Iterate the file lazily.
+            if line.strip():  # First line with visible content.
+                return line  # Use it for delimiter detection.
+        return ""  # Empty file -> no sample line.
+
+    def _parse_reader(self, reader: object) -> tuple[list[AddressRow], int]:
+        """Consume a csv.reader into parsed rows + a parse-failure count."""
+        rows: list[AddressRow] = []  # Accumulator for valid parsed rows.
+        failures = 0  # Counter for skipped (invalid-serial) rows.
+        for raw_fields in reader:  # type: ignore[attr-defined]  # Walk every record.
+            if not any(field.strip() for field in raw_fields):  # Entirely blank line.
+                continue  # Silent skip -- blank lines are not parse failures.
+            parsed = self._parse_row(raw_fields)  # Convert fields to an AddressRow or None.
+            if parsed is None:  # None signals an invalid/empty-serial row.
+                failures += 1  # Count the skip for the run summary.
+                continue  # Skip without emitting.
+            rows.append(parsed)  # Keep the valid row.
+        return rows, failures  # Return both to the caller.
+
+    def _detect_delimiter(self, sample: str) -> str:
+        """Choose the delimiter that best splits the first data line into >=6 fields."""
+        if not sample.strip():  # Empty file -> any delimiter works (no rows to parse).
+            return ","  # Harmless default.
+        best_delimiter = ","  # Fallback when nothing yields enough columns.
+        best_count = -1  # Highest field count seen so far.
+        for candidate in _CANDIDATE_DELIMITERS:  # Probe each candidate delimiter.
+            count = len(sample.split(candidate))  # Field count this delimiter would produce.
+            if count >= _MIN_COLUMNS and candidate == "\t":  # A tab that yields >=6 wins outright.
+                return candidate  # Tab is the documented format; prefer it when it fits.
+            if count > best_count:  # Otherwise track the delimiter giving the most fields.
+                best_count = count  # Remember the new best field count.
+                best_delimiter = candidate  # Remember the delimiter that produced it.
+        return best_delimiter  # Most-splitting delimiter (comma for Excel exports).
+
     def _parse_row(self, raw_fields: list[str]) -> AddressRow | None:
         """Build an ``AddressRow`` from raw fields, or ``None`` if the serial is invalid."""
-        if not raw_fields:  # Entirely blank line.
-            return None  # Treat as a parse failure.
-        fields = self._pad_fields(raw_fields)  # Normalize to the expected column count.
-        serial = fields[0].strip()  # Serial is the golden key; trim surrounding whitespace.
-        if not serial or not serial.isdigit():  # Empty or non-numeric serial cannot match a device.
-            logging.debug("Skipping row with invalid serial: %r", fields[0])  # Trace the skip.
+        cleaned = [field.strip() for field in raw_fields]  # Trim every field up front.
+        if len(cleaned) < _MIN_COLUMNS:  # Too few columns to be a valid 6-field record.
+            if any(cleaned):  # Only log non-blank short rows (blank lines are silent skips).
+                logging.debug("Skipping short row (%d fields): %r", len(cleaned), raw_fields)  # Trace.
+            return None  # Signal a parse failure.
+        serial = cleaned[0]  # Serial is the golden key (already trimmed).
+        if not serial.isdigit():  # Non-numeric serial cannot match a device (also rejects headers).
+            logging.debug("Skipping row with non-numeric serial: %r", cleaned[0])  # Trace the skip.
             return None  # Signal a parse failure to the caller.
-        return AddressRow(  # Assemble the sanitized row.
-            serial=serial,  # Validated numeric serial.
-            model=fields[1].strip(),  # Device model (display only).
-            address=self.sanitize_address(fields[2]),  # Clean the messy address field.
-            city=fields[3].strip(),  # City name.
-            state=fields[4].strip(),  # 2-letter state code.
-            zip_code=fields[5].strip(),  # 5-digit ZIP.
-        )
+        return self._build_row(cleaned)  # Assemble the AddressRow by fixed structure.
 
-    @staticmethod
-    def _pad_fields(raw_fields: list[str]) -> list[str]:
-        """Pad/truncate a raw record to exactly the expected column count."""
-        padded = list(raw_fields)  # Copy so we never mutate the reader's list.
-        while len(padded) < _EXPECTED_COLUMNS:  # Short rows get empty trailing fields.
-            padded.append("")  # Append blanks until the column count matches.
-        return padded[:_EXPECTED_COLUMNS]  # Drop any extra trailing columns.
+    def _build_row(self, cleaned: list[str]) -> AddressRow:
+        """Assemble an ``AddressRow`` using first-2 / last-3 anchors, address in the middle."""
+        address_parts = cleaned[2:-3]  # Everything between model and city is the address (>=1 field).
+        joined_address = ", ".join(part for part in address_parts if part)  # Rejoin any comma-split address.
+        return AddressRow(  # Build the sanitized row.
+            serial=cleaned[0],  # Validated numeric serial.
+            model=cleaned[1],  # Device model (display only).
+            address=self.sanitize_address(joined_address),  # Clean the (possibly rejoined) address.
+            city=cleaned[-3],  # Third-from-last field is the city.
+            state=cleaned[-2],  # Second-from-last is the state code.
+            zip_code=cleaned[-1],  # Last field is the ZIP.
+        )
 
     @staticmethod
     def sanitize_address(raw: str) -> str:

--- a/tests/unit/site/address_audit/test_csv_ingester.py
+++ b/tests/unit/site/address_audit/test_csv_ingester.py
@@ -32,13 +32,15 @@ class TestLoad:
         assert rows[0].serial == "2012233588"
         assert rows[0].city == "Boca Raton"
 
-    def test_embedded_newline_sanitized(self, tmp_path):
-        """An address with an embedded newline is flattened to a single line."""
-        text = "2012233588\tSSR130\t5550 N Military Trail\n Unit 200\tBoca Raton\tFL\t33431\n"
-        # The embedded newline splits the record; the ingester reads the serial-bearing line.
-        rows, _ = CSVAddressIngester().load(_write(tmp_path, text))
+    def test_embedded_newline_in_quoted_field_flattened(self, tmp_path):
+        """A quoted address with an embedded newline is read as one field and flattened."""
+        text = '2012233588\tSSR130\t"5550 N Military Trail\n Unit 200"\tBoca Raton\tFL\t33431\n'
+        rows, failures = CSVAddressIngester().load(_write(tmp_path, text))
+        assert failures == 0
         assert rows[0].serial == "2012233588"
         assert "\n" not in rows[0].address
+        assert rows[0].address == "5550 N Military Trail Unit 200"
+        assert rows[0].city == "Boca Raton"
 
     def test_empty_serial_skipped(self, tmp_path):
         """A row with an empty serial is skipped and counted as a failure."""
@@ -66,6 +68,56 @@ class TestLoad:
         """A missing file raises a controlled FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
             CSVAddressIngester().load("does_not_exist_12345.tsv")
+
+
+class TestDelimiterDetection:
+    """Auto-detection of comma vs tab delimiters (the Book1.csv bug)."""
+
+    def _write_csv(self, tmp_path, text):
+        """Write to a .csv file and return its path."""
+        path = tmp_path / "Book1.csv"
+        path.write_text(text, encoding="utf-8")
+        return str(path)
+
+    def test_comma_delimited_excel_export(self, tmp_path):
+        """A comma-delimited .csv (Excel default) parses all rows -- regression for Book1.csv."""
+        text = (
+            "2012233588,SSR130,5550 N Military Trail Unit 200,Boca Raton,FL,33431\n"
+            "2012234081,SSR130,6000 Glades Rd Suite 1019A,Boca Raton,FL,33431\n"
+            "2017233102,SSR130,4103 14th St W Suite 101,Bradenton,FL,34205\n"
+        )
+        rows, failures = CSVAddressIngester().load(self._write_csv(tmp_path, text))
+        assert failures == 0
+        assert len(rows) == 3
+        assert rows[0].serial == "2012233588"
+        assert rows[0].address == "5550 N Military Trail Unit 200"
+        assert rows[0].city == "Boca Raton"
+        assert rows[0].zip_code == "33431"
+
+    def test_comma_in_address_reconstructed(self, tmp_path):
+        """An unquoted address containing a comma is rejoined; city/state/zip stay correct."""
+        text = "2017233783,SSR130,6670 US Highway 129, Suite 1,Live Oak,FL,32060\n"
+        rows, failures = CSVAddressIngester().load(self._write_csv(tmp_path, text))
+        assert failures == 0
+        assert len(rows) == 1
+        assert rows[0].address == "6670 US Highway 129, Suite 1"
+        assert rows[0].city == "Live Oak"
+        assert rows[0].state == "FL"
+        assert rows[0].zip_code == "32060"
+
+    def test_bom_stripped(self, tmp_path):
+        """A UTF-8 BOM on the first serial does not break numeric detection."""
+        text = "\ufeff2012233588,SSR130,1 A St,Town,FL,33000\n"
+        rows, failures = CSVAddressIngester().load(self._write_csv(tmp_path, text))
+        assert failures == 0
+        assert rows[0].serial == "2012233588"
+
+    def test_blank_lines_skipped_silently(self, tmp_path):
+        """Trailing blank lines are skipped and do not inflate the failure count."""
+        text = "2012233588,SSR130,1 A St,Town,FL,33000\n\n\n"
+        rows, failures = CSVAddressIngester().load(self._write_csv(tmp_path, text))
+        assert len(rows) == 1
+        assert failures == 0
 
 
 class TestSanitize:


### PR DESCRIPTION
## Problem

Running menu 195 against a real customer CSV (`data/Book1.csv`) skipped **all 44 rows**:
```
Select file number: 18
No valid rows parsed from data\Book1.csv (44 skipped).
```

Root cause: the CSV ingester hardcoded a **tab** delimiter, but the file was **comma**-delimited (the Excel default when you "Save As .csv"). Every line landed in column 0 as one string, so the numeric-serial check rejected every row.

## Fix

`CSVAddressIngester` now:
- **Auto-detects the delimiter** per file (tab → comma → semicolon → pipe). It reads the first non-blank line to choose, then parses via the file handle so **quoted multi-line fields are preserved**.
- **Strips an Excel UTF-8 BOM** (`utf-8-sig`).
- **Parses by fixed structure** — first two fields are serial/model, last three are city/state/zip, and everything in between is rejoined as the address — so an **unquoted address containing the delimiter** (e.g. `6670 US Highway 129, Suite 1`) is reconstructed correctly instead of shifting the columns.
- **Stops counting blank lines as parse failures.**

## Verification

Against the real 44-row export: **44 parsed, 0 skipped** (was 0 / 44). The one address with an embedded comma reconstructs correctly (`6670 US Highway 129, Suite 1`, Live Oak FL 32060).

Tests: added comma-delimited / BOM / comma-in-address / blank-line cases and replaced the (unrealistic) unquoted-embedded-newline test with a **quoted** multi-line test that the handle-based reader now handles properly. **67 tests pass**; `py_compile` + `ruff` + `black` + `vulture@90` all clean.

---

# Spec Conformance Checklist

**Linked Spec Issue**: #551 (bugfix to the feature delivered in #552)

## Acceptance Criteria
- [x] Reads a real comma-delimited customer CSV from `data/` without skipping valid rows
- [x] Verified against the actual failing file (44/44 rows)

## Quality
- [x] Tests added for the regression (comma, BOM, comma-in-address, blank lines)
- [x] No new Ruff lint violations
- [x] Code formatted (`black --check`)
- [x] Vulture (dead code) clean at confidence 90
- [ ] mypy / coverage — deferred to CI

## Security
- [x] No secrets; read-only file parsing; no new dependencies

## Documentation
- [x] Changelog `### Fixed` entry added