### PR TITLE
fix: make OpenStreetMap validation work behind Zscaler (menu 195 Source never showed Nominatim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
+- **Address audit external validation via OpenStreetMap (menu 195)**: Nominatim
+  (Tier 2) silently failed for every site because the resolver verified TLS
+  certificates, which Zscaler SSL inspection breaks -- so the audit only ever
+  used internal CSV/SNMP comparison and the "Source" column never showed external
+  validation. The resolver now skips TLS verification for the public Nominatim
+  call by default (override with `MIST_SKIP_SSL_VERIFY=false`), strips the
+  suite/unit before geocoding (OpenStreetMap has no US retail suites) so the base
+  street can match, validates the street on **every** row, and records a
+  `street_validated` flag surfaced as `Internal+OSM` / `Nominatim` in the Source
+  column. The Nominatim step now logs visibly (INFO on hit, WARNING on miss).
+  Verified live: real streets validate (confidence ~0.88), nonsense streets do
+  not. NOTE: OpenStreetMap validates the street only; business-name + suite
+  confirmation still requires the optional `--ui-geocode` Google-Places tier.
+
 - **Address audit CSV delimiter (menu 195)**: The CSV ingester assumed tab
   delimiters and silently skipped every row of a comma-delimited file (the Excel
   default `.csv`), reporting "No valid rows parsed". The delimiter is now

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -68,22 +68,34 @@ class AddressResolver:
         return result  # Hand the result back to the engine.
 
     def _resolve_uncached(self, candidates: ResolveCandidates, query: str) -> ResolverResult:
-        """Run Tier 1 -> Tier 2 -> Tier 3 with a fail-soft envelope (FR-013)."""
+        """Run Tier 1 (internal) + Tier 2 (OSM street validation) + optional Tier 3, fail-soft."""
         try:
-            internal = self._compare_internal(candidates)  # Tier 1: no network.
-            if internal is not None:  # Internal signal already answers the question.
-                internal.query = query  # Stamp the query for cache consistency.
-                return internal  # Return the internal suggestion.
-            nominatim = self._validate_nominatim(candidates, query)  # Tier 2: free OSM validation.
-            if nominatim is not None:  # Nominatim produced a usable result.
-                return nominatim  # Return the validated address.
-            ui_result = self._maybe_ui(candidates, query)  # Tier 3: optional, flagged.
-            if ui_result is not None:  # UI tier captured a suggestion.
-                return ui_result  # Return the UI-sourced address.
-            return ResolverResult(query=query, canonical_address=None, source="internal", confidence=0.0)
+            internal = self._compare_internal(candidates)  # Tier 1: internal suite candidate (no network).
+            osm = self._validate_nominatim(candidates, query)  # Tier 2: OpenStreetMap street validation.
+            return self._combine(internal, osm, candidates, query)  # Merge the tiers into one result.
         except Exception as exc:  # noqa: BLE001 -- one row must never abort the audit.
             logging.warning("Resolve failed for key derived from '%s': %s", query, exc)  # Log and continue.
             return ResolverResult(query=query, canonical_address=None, source="internal", confidence=0.0)
+
+    def _combine(
+        self,
+        internal: ResolverResult | None,
+        osm: ResolverResult | None,
+        candidates: ResolveCandidates,
+        query: str,
+    ) -> ResolverResult:
+        """Merge internal + OSM (+ optional UI) results, recording external validation."""
+        if internal is not None:  # Internal supplied the suite-corrected suggestion.
+            internal.query = query  # Stamp the query for cache consistency.
+            internal.street_validated = osm is not None  # OSM confirmed the base street exists.
+            return internal  # Suite from internal source, street externally cross-checked.
+        if osm is not None:  # No internal suite, but OSM validated the street.
+            osm.street_validated = True  # OSM itself is the external validator here.
+            return osm  # Return the OSM-canonical result.
+        ui_result = self._maybe_ui(candidates, query)  # Tier 3: optional, flagged.
+        if ui_result is not None:  # UI tier captured a suggestion.
+            return ui_result  # Return the UI-sourced address.
+        return ResolverResult(query=query, canonical_address=None, source="internal", confidence=0.0)
 
     def _compare_internal(self, candidates: ResolveCandidates) -> ResolverResult | None:
         """Tier 1: suggest a CSV/SNMP candidate that adds a suite the Mist address lacks."""
@@ -100,14 +112,18 @@ class AddressResolver:
         """Tier 2: validate the base street via the reused ``NominatimValidator``."""
         self._respect_rate_limit()  # Enforce <=1 req/sec before calling out.
         self.external_calls += 1  # Count this external call for the run summary.
+        mist_street = self._strip_suite_from_dict(candidates.mist_address)  # OSM has no suites -> validate street.
+        csv_street = self._strip_suite_from_dict(candidates.csv_address)  # Strip suite so the street can match.
+        logging.info("Validating street via OpenStreetMap/Nominatim: %s", csv_street.get("address", query))
         validator = NominatimValidator(self._nominatim_config)  # Build the reused validator.
-        outcome = validator.validate(candidates.mist_address, candidates.csv_address)  # Geocode both addresses.
+        outcome = validator.validate(mist_street, csv_street)  # Geocode both suite-stripped streets.
         comparison = outcome.get("comparison_validation", {})  # The CSV-side geocode result.
         if not comparison.get("valid"):  # Nominatim could not validate the candidate street.
-            logging.debug("Nominatim returned no valid comparison result")  # Trace the miss.
+            logging.warning("Nominatim returned no result for %s (check network/SSL)", query)  # Visible miss.
             return None  # Defer to Tier 3 / NO_RESULT.
         confidence = float(comparison.get("confidence", 0.0))  # OSM importance-derived confidence.
         canonical = comparison.get("display_name") or self._format_address(candidates.csv_address)  # Canonical.
+        logging.info("Nominatim validated street: %s (confidence=%.2f)", canonical, confidence)  # Visible hit.
         return ResolverResult(  # Build the Tier-2 result.
             query=query,  # Echo the query for caching.
             canonical_address=canonical,  # OSM-canonicalized address.
@@ -163,6 +179,19 @@ class AddressResolver:
         return " ".join(part for part in parts if part).strip()  # Skip blanks; trim.
 
     @staticmethod
+    def _strip_suite_from_dict(address: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of an address dict with any suite/unit token removed from the street.
+
+        OpenStreetMap does not carry US retail suite numbers, so the suite is
+        stripped before geocoding to let the base street match.
+        """
+        cleaned = dict(address)  # Shallow copy so the caller's dict is untouched.
+        street = cleaned.get("address", "")  # Original street line (may carry a suite).
+        without_suite = re.sub(_SUITE_PATTERN, "", street, flags=re.IGNORECASE)  # Drop the suite token.
+        cleaned["address"] = re.sub(r"[,\s]+$", "", without_suite).strip()  # Trim trailing comma/space.
+        return cleaned  # Suite-free address dict for OSM geocoding.
+
+    @staticmethod
     def _adds_suite(base: str, candidate: str) -> bool:
         """Return True when ``candidate`` contains a suite/unit marker ``base`` lacks."""
         candidate_has = re.search(_SUITE_PATTERN, candidate.lower()) is not None  # Candidate carries a suite.
@@ -200,12 +229,14 @@ class AddressResolver:
             return None  # Caller resolves live.
         self.cache_hits += 1  # Count the hit for the run summary.
         logging.debug("cache hit for %s", key)  # Action-log the hit.
+        raw = self._loads_json(row[3])  # Restore the raw payload (carries street-validation flag).
         return ResolverResult(  # Reconstruct the result from the cached row.
             query=key,  # Use the key as the query echo.
             canonical_address=row[0],  # Cached canonical address (may be None => NO_RESULT).
             source="cache",  # Mark the source as the cache.
             confidence=float(row[2] or 0.0),  # Cached confidence.
-            raw_response=self._loads_json(row[3]),  # Restore the raw payload.
+            raw_response=raw,  # Restore the raw payload.
+            street_validated=bool(raw.get("_street_validated", False)),  # Restore OSM confirmation flag.
         )
 
     def _to_cache(self, key: str, result: ResolverResult) -> None:
@@ -222,7 +253,7 @@ class AddressResolver:
                         result.canonical_address,
                         result.source,
                         result.confidence,
-                        json.dumps(result.raw_response),
+                        json.dumps({**result.raw_response, "_street_validated": result.street_validated}),
                         datetime.now(UTC).isoformat(),
                     ),
                 )

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -188,7 +188,19 @@ class AddressAuditEngine:
         ui_geocoder = None  # Default: Tier 3 disabled.
         if ui_geocode:  # Operator opted into UI geocoding.
             ui_geocoder = self._make_ui_geocoder()  # Build and connect the browser geocoder.
-        return AddressResolver(ui_geocoder=ui_geocoder)  # Resolver with optional Tier 3.
+        skip_ssl = self._skip_ssl_verify()  # Skip cert checks behind corporate SSL inspection (Zscaler).
+        return AddressResolver(skip_ssl_verify=skip_ssl, ui_geocoder=ui_geocoder)  # Resolver with optional Tier 3.
+
+    @staticmethod
+    def _skip_ssl_verify() -> bool:
+        """Return whether to skip TLS verification for the public Nominatim call.
+
+        Defaults to True because the deployment environment sits behind Zscaler
+        SSL inspection, whose MITM cert otherwise breaks the OpenStreetMap call.
+        Set ``MIST_SKIP_SSL_VERIFY=false`` to enforce verification (non-Zscaler hosts).
+        """
+        raw = os.environ.get("MIST_SKIP_SSL_VERIFY", "true").strip().lower()  # Env override; default on.
+        return raw not in ("false", "0", "no", "off")  # Any falsey token re-enables verification.
 
     @staticmethod
     def _make_ui_geocoder() -> Any:
@@ -373,7 +385,10 @@ class AddressAuditEngine:
         }
         if resolver_result is None or resolver_result.canonical_address is None:  # No suggestion.
             return "-"  # Placeholder when nothing was resolved.
-        return labels.get(resolver_result.source, "-")  # Mapped label or placeholder.
+        base = labels.get(resolver_result.source, "-")  # Tier label for the resolved source.
+        if resolver_result.source == "internal" and getattr(resolver_result, "street_validated", False):
+            return "Internal+OSM"  # Internal suite, street externally confirmed by OpenStreetMap.
+        return base  # Mapped label or placeholder.
 
     def _finish(self, results: list[AuditResult]) -> None:
         """Run the post-table prompt and save the CSV when the operator chooses to."""

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -57,6 +57,7 @@ class ResolverResult:
     confidence: float = 0.0  # Heuristic 0.0-1.0 confidence in the result.
     raw_response: dict[str, Any] = field(default_factory=dict)  # Raw tier payload (cached as raw_json).
     ambiguous: bool = False  # True when multiple plausible results (mall) -> drives AMBIGUOUS.
+    street_validated: bool = False  # True when OpenStreetMap/Nominatim confirmed the base street exists.
 
 
 @dataclass

--- a/tests/unit/site/address_audit/test_address_resolver.py
+++ b/tests/unit/site/address_audit/test_address_resolver.py
@@ -37,15 +37,30 @@ def _db(tmp_path):
 class TestTier1Internal:
     """Tier 1 internal comparison (no network)."""
 
-    def test_internal_suite_no_network(self, tmp_path, monkeypatch):
-        """CSV carrying a suite Mist lacks resolves internally with zero network."""
-        # Any attempt to construct the validator would be a network path -> fail the test.
-        monkeypatch.setattr(resolver_mod, "NominatimValidator", MagicMock(side_effect=AssertionError("no net")))
+    def test_internal_suite_with_osm_street_validation(self, tmp_path, monkeypatch):
+        """CSV suite resolves internally; OSM additionally confirms the street."""
+        _FakeValidator.count = 0
+        _FakeValidator.valid = True  # OSM validates the street successfully.
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
+        monkeypatch.setattr(resolver_mod.time, "sleep", lambda *_: None)  # Skip rate-limit sleeps.
+        resolver = AddressResolver(db_path=_db(tmp_path))
+        candidates = ResolveCandidates(mist_address=_NO_SUITE, csv_address=_WITH_SUITE)
+        result = resolver.resolve(candidates)
+        assert result.source == "internal"  # Suite came from the internal CSV candidate.
+        assert "Suite 5" in result.canonical_address
+        assert result.street_validated is True  # OSM externally confirmed the base street.
+
+    def test_internal_suite_osm_unconfirmed(self, tmp_path, monkeypatch):
+        """When OSM cannot confirm the street, the internal suite still resolves, unflagged."""
+        _FakeValidator.count = 0
+        _FakeValidator.valid = False  # OSM returns nothing.
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
+        monkeypatch.setattr(resolver_mod.time, "sleep", lambda *_: None)
         resolver = AddressResolver(db_path=_db(tmp_path))
         candidates = ResolveCandidates(mist_address=_NO_SUITE, csv_address=_WITH_SUITE)
         result = resolver.resolve(candidates)
         assert result.source == "internal"
-        assert "Suite 5" in result.canonical_address
+        assert result.street_validated is False  # OSM did not confirm the street.
 
 
 class TestTier2Nominatim:

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -117,3 +117,37 @@ class TestEnvConfig:
         assert config.dashboard_url == "https://manage.eu.mist.com/"
         assert config.per_lookup_timeout_s == 30.0
         assert config.max_lookups == 10
+
+    def test_skip_ssl_verify_defaults_true(self, monkeypatch):
+        """SSL verification is skipped by default (corporate Zscaler environment)."""
+        monkeypatch.delenv("MIST_SKIP_SSL_VERIFY", raising=False)
+        assert AddressAuditEngine._skip_ssl_verify() is True
+
+    def test_skip_ssl_verify_env_disable(self, monkeypatch):
+        """Setting MIST_SKIP_SSL_VERIFY=false re-enables certificate verification."""
+        monkeypatch.setenv("MIST_SKIP_SSL_VERIFY", "false")
+        assert AddressAuditEngine._skip_ssl_verify() is False
+
+
+class TestSourceLabel:
+    """Source-column labelling, including OSM street-validation."""
+
+    def test_internal_with_osm_confirmation(self):
+        """An internal suite whose street OSM confirmed is labelled Internal+OSM."""
+        rr = ResolverResult(query="q", canonical_address="X Suite 5", source="internal", street_validated=True)
+        assert AddressAuditEngine._source_label(rr) == "Internal+OSM"
+
+    def test_internal_without_osm(self):
+        """An internal suite OSM could not confirm is labelled plain Internal."""
+        rr = ResolverResult(query="q", canonical_address="X Suite 5", source="internal", street_validated=False)
+        assert AddressAuditEngine._source_label(rr) == "Internal"
+
+    def test_nominatim_label(self):
+        """A Nominatim-sourced result is labelled Nominatim."""
+        rr = ResolverResult(query="q", canonical_address="X", source="nominatim")
+        assert AddressAuditEngine._source_label(rr) == "Nominatim"
+
+    def test_no_result_label(self):
+        """A result with no canonical address is labelled '-'."""
+        rr = ResolverResult(query="q", canonical_address=None, source="internal")
+        assert AddressAuditEngine._source_label(rr) == "-"


### PR DESCRIPTION
## Problem

When running menu 195, the saved CSV's **Source** column only ever showed `Internal` (26 rows) or `-` (18 rows) — **never `Nominatim`**. The audit was silently *not* validating against any external website, even though OpenStreetMap/Nominatim (Tier 2) is wired in.

Root cause: the resolver verified TLS certificates on the Nominatim call, and **Zscaler SSL inspection breaks that handshake**. Confirmed by direct test:
- `verify=True` → `SSLError`
- `verify=False` → `HTTP 200`, real result: `5550, North Military Trail, Boca Raton, Palm Beach County, Florida`

The validator swallowed the SSL error (debug-only logging), so every external call failed invisibly and rows fell through to internal-only / NO_RESULT.

## Fix

- **Skip TLS verification for the public Nominatim call by default** (override with `MIST_SKIP_SSL_VERIFY=false`), wired from the engine — consistent with the existing `InventoryCSVComparator`. Nominatim returns only public address data; no secrets are sent.
- **Strip the suite/unit before geocoding** — OpenStreetMap has no US retail suite numbers, so `6000 Glades Rd Suite 1019A` never matched; now the base street `6000 Glades Rd` is validated.
- **Validate the street on every row** and record a `street_validated` flag, surfaced in the Source column as **`Internal+OSM`** (suite from your CSV/SNMP, street externally confirmed by OSM) or **`Nominatim`**.
- **Visible logging**: INFO on a successful OSM validation, WARNING on a miss (so SSL/network problems are no longer silent). The `street_validated` flag round-trips through the SQLite cache.

## Verification (live, against nominatim.openstreetmap.org)

| Case | Result |
|------|--------|
| Real street, no suite | `Nominatim`, `street_validated=True`, confidence ~0.88 |
| CSV adds a suite | `Internal`, `street_validated=True` (base street confirmed) |
| Nonsense street | `Internal`, `street_validated=False` (correctly rejected) |

74 unit tests pass; `py_compile` + `ruff` + `black` + `vulture@90` clean.

> **Scope note**: OpenStreetMap validates the **street** only. Business-name + suite-level confirmation (the "type the business name into Google" workflow) is the optional Tier-3 `--ui-geocode` path, which drives the Mist dashboard's Google-Places field.

---

# Spec Conformance Checklist

**Linked Spec Issue**: #551 (bugfix/enhancement to #552)

## Acceptance Criteria
- [x] External validation (OpenStreetMap) actually runs and is visible in the Source column
- [x] Verified live against real Nominatim

## Quality
- [x] Tests added (SSL-skip env, source label, suite-stripped OSM validation)
- [x] Ruff / Black / Vulture clean
- [ ] mypy / coverage — deferred to CI

## Security
- [x] TLS-skip limited to the public Nominatim call; opt-out via `MIST_SKIP_SSL_VERIFY=false`; no secrets transmitted

## Documentation
- [x] Changelog `### Fixed` entry added