### PR TITLE
fix(address-audit): clean suggested address, strip SAP prefix, flag-free Tier-3 geocoding (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Changed
+
+- **Address audit Tier-3 web geocoding is now flag-free (menu 195)**: The
+  Tier-3 browser geocoder no longer requires the `--ui-geocode` CLI flag (the
+  flag has been removed). It is treated as the natural extension of the
+  "everything is a hint" model: the Mist site address, the SNMP location
+  variable, and the customer CSV are all *hints*, fused into one best-guess
+  query and verified against the web to deduce the true, shippable address.
+  Tier-3 now auto-engages whenever a debuggable browser is reachable and
+  degrades quietly to the internal + OpenStreetMap baseline otherwise, so
+  routine runs are never disrupted. A new `ADDRESS_AUDIT_GEOCODE=off` env knob
+  skips the attempt; the "no browser attached" message dropped from WARNING to
+  an informational note with enablement guidance.
+
 ### Fixed
 
 - **Address audit suggested-address cleanup (menu 195)**: Suggested addresses
@@ -33,7 +47,8 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   column. The Nominatim step now logs visibly (INFO on hit, WARNING on miss).
   Verified live: real streets validate (confidence ~0.88), nonsense streets do
   not. NOTE: OpenStreetMap validates the street only; business-name + suite
-  confirmation still requires the optional `--ui-geocode` Google-Places tier.
+  confirmation still requires the optional Tier-3 Google-Places browser tier
+  (auto-engaged when a debuggable browser is available).
 
 - **Address audit CSV delimiter (menu 195)**: The CSV ingester assumed tab
   delimiters and silently skipped every row of a comma-delimited file (the Excel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
+- **Address audit suggested-address cleanup (menu 195)**: Suggested addresses
+  were polluted with the customer's SAP internal store-code prefix
+  (e.g. `S2SJB - `, `08806 - `) and sometimes carried the SNMP field's stale ZIP.
+  The SNMP enricher now strips the leading SAP store code (it is not part of the
+  postal address), and Tier-1 rebuilds a clean suggestion from Mist's own
+  street/city/state/ZIP plus the discovered suite -- preferring the customer CSV
+  suite over the SNMP one. The suite detector was broadened to catch `#3`,
+  `Space P239`, `Spc`, `Rm`, `Lot`, and `Apartment` in addition to
+  Suite/Ste/Unit/Apt/Bldg. Result: `S2SJB - 5550 N Military Trl Unit 200 ... FL
+  33496` now renders as the clean, shippable `5550 N Military Trl Unit 200,
+  Boca Raton, FL 33431`.
+
 - **Address audit external validation via OpenStreetMap (menu 195)**: Nominatim
   (Tier 2) silently failed for every site because the resolver verified TLS
   certificates, which Zscaler SSL inspection breaks -- so the audit only ever

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -21699,10 +21699,8 @@ menu_actions = {
     # SITE ADDRESS AUDIT (read-only)
     # ==============================
     "195": (
-        lambda ui_geocode=False: AddressAuditEngine().run(  # type: ignore[misc]
-            apisession, ConfigUtils.get_cached_or_prompted_org_id(), ui_geocode=ui_geocode
-        ),
-        "Audit site addresses from CSV (data/) - compare Mist vs. customer CSV vs. web; READ-ONLY, saves report. Optional --ui-geocode enables Tier-3 browser lookup",  # noqa: E501
+        lambda: AddressAuditEngine().run(apisession, ConfigUtils.get_cached_or_prompted_org_id()),  # type: ignore[misc]
+        "Audit site addresses from CSV (data/) - fuse Mist + SNMP + CSV hints, verify vs. web; READ-ONLY, saves report. Tier-3 browser geocoding auto-engages when available (ADDRESS_AUDIT_GEOCODE=off to skip)",  # noqa: E501
     ),
     # ==============================
     # READ-ONLY OPERATIONS
@@ -23598,11 +23596,6 @@ def _add_safety_arguments(parser: argparse.ArgumentParser) -> None:
         help="Enable external address validation using Nominatim API for address comparison operations",  # Nominatim toggle  # noqa: E501
     )
     parser.add_argument(
-        "--ui-geocode",
-        action="store_true",
-        help="Enable Tier-3 browser-based address lookup (menu 195) by driving/taking over the Mist dashboard address screen",  # noqa: E501
-    )
-    parser.add_argument(
         "--skip-ssl-verify",
         action="store_true",
         help="Skip SSL certificate verification for external API calls (use with caution - for corporate networks only)",  # noqa: E501
@@ -24004,7 +23997,6 @@ def _build_cli_func_kwargs(args: argparse.Namespace, site_id: str | None, device
         "fast": args.fast,  # Pass fast mode flag to enable concurrency.
         "dry_run": args.dry_run,  # Pass dry-run flag to skip destructive actions.
         "address_check": args.address_check,  # Pass address validation toggle.
-        "ui_geocode": args.ui_geocode,  # Pass Tier-3 UI geocoding toggle (menu 195).
         "skip_ssl_verify": args.skip_ssl_verify,  # Pass SSL verification bypass flag.
     }
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -75,15 +75,24 @@ MIST_ORG_ID=your_org_id_here
 # the audit prompts once at runtime (press Enter to skip for private addresses).
 # BUSINESS_NAME=T-Mobile
 
+# Mist site address, SNMP location, and the customer CSV are all treated as
+# *hints*; the audit fuses them into one best-guess query and verifies against
+# the web to deduce the true, shippable address.
+
 # rapidfuzz score cutoff (0-100) for the address fuzzy-match fallback used
 # when a device serial is not found in inventory (default: 85).
 # FUZZY_MATCH_THRESHOLD=85
 
-# Mist dashboard base URL used by the optional Tier-3 browser geocoder
-# (--ui-geocode). Override for non-global clouds (e.g. https://manage.eu.mist.com/).
+# Tier-3 browser geocoding switch (no CLI flag). Default "auto": engages
+# automatically when a debuggable browser is reachable and degrades silently
+# to internal + OpenStreetMap otherwise. Set to "off" to skip the attempt.
+# ADDRESS_AUDIT_GEOCODE=auto
+
+# Mist dashboard base URL used by the Tier-3 browser geocoder. Override for
+# non-global clouds (e.g. https://manage.eu.mist.com/).
 # MIST_DASHBOARD_URL=https://manage.mist.com/
 
-# Tier-3 UI geocoder bounds (only used with --ui-geocode).
+# Tier-3 browser geocoder bounds (used when Tier-3 is active).
 # Per-lookup timeout in seconds (default: 20) and max lookups per run (default: 50).
 # UI_GEOCODE_TIMEOUT_SECONDS=20
 # UI_GEOCODE_MAX_LOOKUPS=50

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -34,7 +34,9 @@ from src.utils.address_utils import AddressValidationConfig, NominatimValidator 
 
 _DB_RELATIVE_PATH = os.path.join("data", "mist_data.db")  # Constitution-fixed cache location.
 _NOMINATIM_MIN_INTERVAL = 1.1  # Seconds between Nominatim calls (>=1 req/sec ToS).
-_SUITE_PATTERN = r"\b(?:ste|suite|unit|apt|bldg|building)\.?\s+#?\s*[\w-]+"  # Suite/unit markers (state-safe).
+_SUITE_PATTERN = (  # Suite/unit markers (state-safe: explicit keywords or "#NNN", never bare "FL").
+    r"\b(?:ste|suite|unit|apt|apartment|bldg|building|space|spc|rm|room|lot)\b\.?\s*#?\s*[\w-]+" r"|#\s*\d[\w-]*"
+)
 
 
 class AddressResolver:
@@ -98,15 +100,45 @@ class AddressResolver:
         return ResolverResult(query=query, canonical_address=None, source="internal", confidence=0.0)
 
     def _compare_internal(self, candidates: ResolveCandidates) -> ResolverResult | None:
-        """Tier 1: suggest a CSV/SNMP candidate that adds a suite the Mist address lacks."""
-        mist_text = self._format_address(candidates.mist_address)  # Current Mist address as text.
-        candidate_text = candidates.snmp_location or self._format_address(candidates.csv_address)  # Best internal.
-        if not candidate_text:  # Nothing internal to compare against.
-            return None  # Defer to Tier 2.
-        if self._adds_suite(mist_text, candidate_text):  # Candidate carries a suite Mist is missing.
-            logging.debug("Tier 1 internal suggestion: %s", candidate_text)  # Trace the internal hit.
-            return ResolverResult(query="", canonical_address=candidate_text, source="internal", confidence=0.7)
-        return None  # No clear internal discrepancy -> let Tier 2 validate.
+        """Tier 1: build a clean Mist-base + suite suggestion when Mist is missing a suite.
+
+        The suite is taken preferentially from the customer CSV (their authoritative
+        corrected data), then the SNMP location. The suggestion is rebuilt from
+        Mist's own clean street/city/state/zip so SNMP store-number prefixes and
+        stale ZIPs never leak into the output.
+        """
+        mist_street = candidates.mist_address.get("address", "")  # Mist street line (the clean base).
+        if re.search(_SUITE_PATTERN, mist_street, flags=re.IGNORECASE):  # Mist already carries a suite.
+            return None  # No discrepancy to surface; defer to Tier 2.
+        csv_suite = self._extract_suite(candidates.csv_address.get("address", ""))  # CSV suite (authoritative).
+        snmp_suite = self._extract_suite(candidates.snmp_location or "")  # SNMP suite (fallback).
+        suite = csv_suite or snmp_suite  # Prefer the CSV's suite over the SNMP one.
+        if not suite:  # Neither internal source supplies a suite Mist lacks.
+            return None  # Nothing to add; defer to Tier 2.
+        clean = self._build_clean_suggestion(candidates.mist_address, suite)  # Mist base + suite, no pollution.
+        logging.debug("Tier 1 internal suggestion (suite=%s): %s", suite, clean)  # Trace the internal hit.
+        return ResolverResult(query="", canonical_address=clean, source="internal", confidence=0.7)
+
+    @staticmethod
+    def _extract_suite(text: str) -> str:
+        """Return the normalized suite/unit token from an address string, or ''."""
+        match = re.search(_SUITE_PATTERN, text, flags=re.IGNORECASE)  # First suite token in the string.
+        if not match:  # No suite present.
+            return ""  # Signal absence.
+        return " ".join(match.group(0).split()).strip()  # Collapse whitespace in the matched token.
+
+    def _build_clean_suggestion(self, mist_address: dict[str, Any], suite: str) -> str:
+        """Compose a clean suggested address from Mist's own fields plus the suite."""
+        base = mist_address.get("address", "").strip()  # Mist's street line.
+        base = re.sub(_SUITE_PATTERN, "", base, flags=re.IGNORECASE).strip().rstrip(",").strip()  # De-dupe suite.
+        street = f"{base} {suite}".strip() if suite else base  # Append the discovered suite.
+        locality = " ".join(  # "STATE ZIP" tail built from Mist's own fields.
+            part
+            for part in (mist_address.get("state", ""), str(mist_address.get("zip", mist_address.get("zipcode", ""))))
+            if part
+        ).strip()
+        parts = [street, mist_address.get("city", ""), locality]  # Ordered output components.
+        return ", ".join(part for part in parts if part).strip()  # Clean "street, city, ST ZIP".
 
     def _validate_nominatim(self, candidates: ResolveCandidates, query: str) -> ResolverResult | None:
         """Tier 2: validate the base street via the reused ``NominatimValidator``."""
@@ -190,13 +222,6 @@ class AddressResolver:
         without_suite = re.sub(_SUITE_PATTERN, "", street, flags=re.IGNORECASE)  # Drop the suite token.
         cleaned["address"] = re.sub(r"[,\s]+$", "", without_suite).strip()  # Trim trailing comma/space.
         return cleaned  # Suite-free address dict for OSM geocoding.
-
-    @staticmethod
-    def _adds_suite(base: str, candidate: str) -> bool:
-        """Return True when ``candidate`` contains a suite/unit marker ``base`` lacks."""
-        candidate_has = re.search(_SUITE_PATTERN, candidate.lower()) is not None  # Candidate carries a suite.
-        base_has = re.search(_SUITE_PATTERN, base.lower()) is not None  # Base already has a suite.
-        return candidate_has and not base_has  # Discrepancy only when candidate adds one.
 
     def _ensure_db_dir(self) -> None:
         """Create the cache DB's parent directory if it does not yet exist."""

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -64,9 +64,17 @@ class AddressAuditEngine:
         self._renderer = renderer or ComparisonTableRenderer()  # Table + prompt.
         self._reporter = reporter or AddressAuditReporter()  # CSV report writer.
 
-    def run(self, apisession: Any, org_id: str, ui_geocode: bool = False) -> None:
-        """Menu entry point: drive the full read-only audit pipeline end-to-end."""
-        logging.info("Starting site address audit (ui_geocode=%s)", ui_geocode)  # Action-log start.
+    def run(self, apisession: Any, org_id: str) -> None:
+        """Menu entry point: drive the full read-only audit pipeline end-to-end.
+
+        The Mist site address, the SNMP location variable, and the customer CSV
+        are all treated as *hints* -- none is authoritative. The resolver fuses
+        them into one best-guess query and prefers an external verifier
+        (OpenStreetMap, plus Tier-3 browser geocoding when a debuggable browser
+        is reachable) to deduce the true, shippable address.
+        """
+        ui_geocode = self._ui_geocode_enabled()  # Tier-3 web geocoding: env-gated, default auto, no CLI flag.
+        logging.info("Starting site address audit (tier3_geocode=%s)", ui_geocode)  # Action-log start.
         csv_path = self._select_csv_file()  # Pick the customer CSV from data/.
         if csv_path is None:  # No CSV present -> nothing to audit.
             print("No CSV/TSV files found in data/. Drop your address file there and retry.")  # Inform.
@@ -188,10 +196,21 @@ class AddressAuditEngine:
     def _build_resolver(self, ui_geocode: bool) -> AddressResolver:
         """Construct the tiered resolver, wiring the Tier-3 UI geocoder when enabled."""
         ui_geocoder = None  # Default: Tier 3 disabled.
-        if ui_geocode:  # Operator opted into UI geocoding.
-            ui_geocoder = self._make_ui_geocoder()  # Build and connect the browser geocoder.
+        if ui_geocode:  # Tier 3 permitted (env default auto) -> try to attach a browser.
+            ui_geocoder = self._make_ui_geocoder()  # Build and connect the browser geocoder (fail-soft).
         skip_ssl = self._skip_ssl_verify()  # Skip cert checks behind corporate SSL inspection (Zscaler).
         return AddressResolver(skip_ssl_verify=skip_ssl, ui_geocoder=ui_geocoder)  # Resolver with optional Tier 3.
+
+    @staticmethod
+    def _ui_geocode_enabled() -> bool:
+        """Return whether Tier-3 web geocoding may run (env-gated, default on, no CLI flag).
+
+        Tier 3 engages automatically when a debuggable browser is reachable and
+        degrades silently to Tier 1/2 otherwise, so routine runs are never
+        disrupted. Set ``ADDRESS_AUDIT_GEOCODE=off`` to skip the attempt.
+        """
+        raw = os.environ.get("ADDRESS_AUDIT_GEOCODE", "auto").strip().lower()  # Env override; default auto/on.
+        return raw not in ("off", "0", "no", "false", "none", "disabled")  # Any disable token turns it off.
 
     @staticmethod
     def _skip_ssl_verify() -> bool:
@@ -211,7 +230,11 @@ class AddressAuditEngine:
 
         geocoder = MistUIGeocoder(AddressAuditEngine._ui_config())  # Env-driven attach/launch config.
         if not geocoder.connect():  # Establish the browser session (fail-soft).
-            logging.warning("Tier-3 UI geocoder unavailable; continuing with Tier 1/2 only")  # Inform.
+            logging.info(  # No debuggable browser is the normal case; degrade quietly to Tier 1/2.
+                "Tier-3 web geocoder not attached (no debuggable browser found); "
+                "using internal + OpenStreetMap hints only. Open Edge with "
+                "--remote-debugging-port=9222 to enable, or set ADDRESS_AUDIT_GEOCODE=off to skip."
+            )
             return None  # Disable Tier 3 for this run.
         return geocoder  # Connected geocoder ready for selective lookups.
 

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -43,7 +43,9 @@ except ImportError:  # pragma: no cover -- exercised only when tqdm is absent.
     tqdm = None  # type: ignore[assignment]  # Sentinel; _progress degrades to a plain iterator.
 
 _DATA_DIR = "data"  # Directory scanned for the customer CSV.
-_SUITE_PATTERN = r"\b(?:ste|suite|unit|apt|bldg|building)\.?\s+#?\s*([\w-]+)"  # Suite token (state-safe).
+_SUITE_PATTERN = (  # Suite token with a capture group for the unit id (state-safe).
+    r"\b(?:ste|suite|unit|apt|apartment|bldg|building|space|spc|rm|room|lot)\b\.?\s*#?\s*([\w-]+)" r"|#\s*(\d[\w-]*)"
+)
 
 
 class AddressAuditEngine:
@@ -366,7 +368,9 @@ class AddressAuditEngine:
     def _suite(text: str) -> str:
         """Extract a normalized suite/unit identifier from an address, or ''."""
         match = re.search(_SUITE_PATTERN, text.lower())  # Find the first suite token.
-        return match.group(1).strip() if match else ""  # The unit identifier (e.g. "200").
+        if not match:  # No suite token present.
+            return ""  # Signal absence.
+        return (match.group(1) or match.group(2) or "").strip()  # Unit id from whichever alt matched.
 
     @staticmethod
     def _normalize(text: str) -> str:

--- a/src/site/address_audit/snmp_enricher.py
+++ b/src/site/address_audit/snmp_enricher.py
@@ -6,12 +6,24 @@ variable and the standard ``snmp_config.location`` setting. This enricher pulls
 both for a site and returns the more authoritative non-empty value as an extra
 matching/validation signal. It never raises on absence -- a site with neither
 field simply yields ``None``.
+
+The customer prefixes these values with their own SAP internal store code
+(e.g. ``"S2SJB - 5550 N Military Trl ..."`` or ``"08806 - 2525 Howell Branch
+Rd ..."``). That code is not part of the postal address, so it is stripped
+before the value is returned -- the audit must never treat the store number as
+part of the street.
 """
 
 from __future__ import annotations  # PEP 604 union syntax on Python 3.13.
 
 import logging  # Action logging before/after every operation (project NON-NEGOTIABLE).
+import re  # Strip the leading SAP store-code prefix.
 from typing import Any  # Loose typing for the Mist site record dict.
+
+# Leading SAP store code: 3-7 alphanumerics followed by a hyphen separator, anchored at start.
+# Matches "S2SJB - ", "08806 - ", "0542E - ", "T000I - "; never strips a real street number
+# because a bare house number is not followed by " - " in these records.
+_SAP_PREFIX = re.compile(r"^\s*[A-Za-z0-9]{3,7}\s*-\s*")
 
 
 class SNMPLocationEnricher:
@@ -21,16 +33,26 @@ class SNMPLocationEnricher:
         """Return the authoritative SNMP location for a site, or ``None`` if absent.
 
         ``snmp_config.location`` (set by the NOC) wins over the ``snmp_location``
-        site variable (often set at provisioning) when both are present.
+        site variable (often set at provisioning) when both are present. The
+        customer's SAP store-code prefix is stripped from whichever value wins.
         """
         site_id = site_record.get("id", "unknown")  # For log context only.
         logging.info("Enriching SNMP location for site %s", site_id)  # Action-log start.
         var_value = self._read_var_location(site_record)  # Read the snmp_location site variable.
         config_value = self._read_config_location(site_record)  # Read snmp_config.location.
         chosen = config_value or var_value  # Prefer the authoritative config value when present.
+        cleaned = self._strip_store_prefix(chosen)  # Drop the SAP store code (not part of the address).
         source = self._describe_source(config_value, var_value)  # Which field won (for the log line).
-        logging.debug("SNMP location for site %s resolved from %s", site_id, source)  # Action-log result.
-        return chosen  # May be None when neither field is populated.
+        logging.debug("SNMP location for site %s resolved from %s (store-code stripped)", site_id, source)
+        return cleaned  # De-prefixed location, or None when neither field is populated.
+
+    @staticmethod
+    def _strip_store_prefix(value: str | None) -> str | None:
+        """Remove the customer's leading SAP store-code prefix (e.g. ``08806 - ``)."""
+        if not value:  # Nothing to strip.
+            return None  # Preserve the absent sentinel.
+        stripped = _SAP_PREFIX.sub("", value).strip()  # Drop the anchored store-code prefix.
+        return stripped or None  # Normalize an empty remainder back to None.
 
     @staticmethod
     def _read_var_location(site_record: dict[str, Any]) -> str | None:

--- a/tests/unit/site/address_audit/test_address_resolver.py
+++ b/tests/unit/site/address_audit/test_address_resolver.py
@@ -34,6 +34,64 @@ def _db(tmp_path):
     return str(tmp_path / "mist_data.db")
 
 
+class TestCleanSuggestion:
+    """Tier 1 builds a clean Mist-base + suite suggestion, free of SAP/zip pollution."""
+
+    def test_suggestion_uses_mist_base_and_zip(self):
+        """Suggestion = Mist street + CSV suite + Mist city/state/zip (not the SNMP zip)."""
+        res = AddressResolver()
+        mist = {"address": "5550 N Military Trl", "city": "Boca Raton", "state": "FL", "zip": "33431"}
+        csv = {"address": "5550 N Military Trail Unit 200", "city": "Boca Raton", "state": "FL", "zip": "33431"}
+        # SNMP carries a different (wrong) zip; it must not leak into the suggestion.
+        cand = ResolveCandidates(
+            mist_address=mist, csv_address=csv, snmp_location="5550 N Military Trl Unit 200 FL 33496"
+        )
+        result = res._compare_internal(cand)
+        assert result is not None
+        assert result.canonical_address == "5550 N Military Trl Unit 200, Boca Raton, FL 33431"
+
+    def test_hash_suite_detected(self):
+        """A bare '#3' suite is detected and appended cleanly."""
+        res = AddressResolver()
+        mist = {"address": "940 S Military Trail", "city": "West Palm Beach", "state": "FL", "zip": "33415"}
+        csv = {"address": "940 S Military Trail #3", "city": "West Palm Beach", "state": "FL", "zip": "33415"}
+        result = res._compare_internal(ResolveCandidates(mist_address=mist, csv_address=csv))
+        assert result.canonical_address == "940 S Military Trail #3, West Palm Beach, FL 33415"
+
+    def test_space_suite_detected(self):
+        """A 'Space P239' suite is detected (broadened keyword set)."""
+        res = AddressResolver()
+        mist = {"address": "3101 PGA Boulevard", "city": "Palm Beach Gardens", "state": "FL", "zip": "33410"}
+        csv = {"address": "3101 PGA Boulevard Space P239", "city": "Palm Beach Gardens", "state": "FL", "zip": "33410"}
+        result = res._compare_internal(ResolveCandidates(mist_address=mist, csv_address=csv))
+        assert result.canonical_address == "3101 PGA Boulevard Space P239, Palm Beach Gardens, FL 33410"
+
+    def test_prefers_csv_suite_over_bad_snmp(self):
+        """When SNMP holds a different (stale) address, the CSV suite is used on the Mist base."""
+        res = AddressResolver()
+        mist = {"address": "3101 PGA Boulevard", "city": "Palm Beach Gardens", "state": "FL", "zip": "33410"}
+        csv = {"address": "3101 PGA Boulevard Space P239", "city": "Palm Beach Gardens", "state": "FL", "zip": "33410"}
+        cand = ResolveCandidates(
+            mist_address=mist, csv_address=csv, snmp_location="1520 Route 38 Bldg 4 Hainesport NJ 08060"
+        )
+        result = res._compare_internal(cand)
+        assert result.canonical_address == "3101 PGA Boulevard Space P239, Palm Beach Gardens, FL 33410"
+
+    def test_no_suite_anywhere_defers(self):
+        """With no suite in CSV or SNMP, Tier 1 returns None (defers to OSM)."""
+        res = AddressResolver()
+        mist = {"address": "100 Main St", "city": "Town", "state": "FL", "zip": "33000"}
+        csv = {"address": "100 Main St", "city": "Town", "state": "FL", "zip": "33000"}
+        assert res._compare_internal(ResolveCandidates(mist_address=mist, csv_address=csv)) is None
+
+    def test_mist_already_has_suite_defers(self):
+        """If Mist already carries a suite, Tier 1 does not flag MISSING_SUITE."""
+        res = AddressResolver()
+        mist = {"address": "100 Main St Suite 9", "city": "Town", "state": "FL", "zip": "33000"}
+        csv = {"address": "100 Main St Suite 5", "city": "Town", "state": "FL", "zip": "33000"}
+        assert res._compare_internal(ResolveCandidates(mist_address=mist, csv_address=csv)) is None
+
+
 class TestTier1Internal:
     """Tier 1 internal comparison (no network)."""
 

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -128,6 +128,21 @@ class TestEnvConfig:
         monkeypatch.setenv("MIST_SKIP_SSL_VERIFY", "false")
         assert AddressAuditEngine._skip_ssl_verify() is False
 
+    def test_ui_geocode_enabled_defaults_true(self, monkeypatch):
+        """Tier-3 web geocoding is permitted by default (no CLI flag required)."""
+        monkeypatch.delenv("ADDRESS_AUDIT_GEOCODE", raising=False)
+        assert AddressAuditEngine._ui_geocode_enabled() is True
+
+    def test_ui_geocode_enabled_env_off(self, monkeypatch):
+        """Setting ADDRESS_AUDIT_GEOCODE=off disables the Tier-3 attempt."""
+        monkeypatch.setenv("ADDRESS_AUDIT_GEOCODE", "off")
+        assert AddressAuditEngine._ui_geocode_enabled() is False
+
+    def test_ui_geocode_enabled_env_auto(self, monkeypatch):
+        """An explicit 'auto' value keeps Tier-3 enabled."""
+        monkeypatch.setenv("ADDRESS_AUDIT_GEOCODE", "auto")
+        assert AddressAuditEngine._ui_geocode_enabled() is True
+
 
 class TestSourceLabel:
     """Source-column labelling, including OSM street-validation."""

--- a/tests/unit/site/address_audit/test_snmp_enricher.py
+++ b/tests/unit/site/address_audit/test_snmp_enricher.py
@@ -16,9 +16,9 @@ class TestEnrich:
         assert SNMPLocationEnricher().enrich(record) == "Authoritative NOC Location"
 
     def test_falls_back_to_var(self):
-        """With only the site variable present, that value is returned."""
+        """With only the site variable present, that value is returned (SAP prefix stripped)."""
         record = {"id": "s1", "vars": {"snmp_location": "08095 - 29728 Urgent Care Dr"}}
-        assert SNMPLocationEnricher().enrich(record) == "08095 - 29728 Urgent Care Dr"
+        assert SNMPLocationEnricher().enrich(record) == "29728 Urgent Care Dr"
 
     def test_returns_none_when_absent(self):
         """A record with neither field yields None (no exception)."""
@@ -32,4 +32,28 @@ class TestEnrich:
     def test_missing_containers_do_not_raise(self):
         """None-valued vars/snmp_config containers are handled gracefully."""
         record = {"vars": None, "snmp_config": None}
+        assert SNMPLocationEnricher().enrich(record) is None
+
+
+class TestStorePrefixStripping:
+    """The customer's SAP store-code prefix is removed from SNMP location."""
+
+    def test_alpha_store_code_stripped(self):
+        """An alphanumeric store code like 'S2SJB - ' is removed."""
+        record = {"snmp_config": {"location": "S2SJB - 5550 N Military Trl Unit 200 Boca Raton FL 33496"}}
+        assert SNMPLocationEnricher().enrich(record) == "5550 N Military Trl Unit 200 Boca Raton FL 33496"
+
+    def test_numeric_store_code_stripped(self):
+        """A numeric store code like '08806 - ' is removed."""
+        record = {"vars": {"snmp_location": "08806 - 2525 Howell Branch Rd Suite 1001 Casselberry FL 32707"}}
+        assert SNMPLocationEnricher().enrich(record) == "2525 Howell Branch Rd Suite 1001 Casselberry FL 32707"
+
+    def test_no_prefix_left_intact(self):
+        """A value with no store-code prefix is returned unchanged."""
+        record = {"snmp_config": {"location": "5550 N Military Trl Boca Raton FL 33431"}}
+        assert SNMPLocationEnricher().enrich(record) == "5550 N Military Trl Boca Raton FL 33431"
+
+    def test_prefix_only_becomes_none(self):
+        """A value that is only a store code collapses to None."""
+        record = {"snmp_config": {"location": "08806 -"}}
         assert SNMPLocationEnricher().enrich(record) is None


### PR DESCRIPTION
## Summary
Refines the **menu 195 site-address audit** so all three internal signals -- the Mist site address, the SNMP location variable, and the customer CSV -- are treated as **hints**, fused into one best-guess query and verified against the web to deduce the true, shippable address. Closes the loop on two operator-reported gaps: SAP-prefixed/garbled suggestions, and the Tier-3 web geocoder being gated behind a CLI flag.

Linked issue: #551

## Changes
**Clean suggested address + SAP prefix strip (\c73888\)**
- \snmp_enricher.py\: strip the customer's leading SAP internal store code (e.g. \S2SJB - \, \