### PR TITLE
fix(address-audit): Mist-portal Tier-3 self-spawn + suite authority (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,35 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Changed
 
-- **Address audit Tier-3 web geocoding is now flag-free (menu 195)**: The
-  Tier-3 browser geocoder no longer requires the `--ui-geocode` CLI flag (the
-  flag has been removed). It is treated as the natural extension of the
-  "everything is a hint" model: the Mist site address, the SNMP location
-  variable, and the customer CSV are all *hints*, fused into one best-guess
-  query and verified against the web to deduce the true, shippable address.
-  Tier-3 now auto-engages whenever a debuggable browser is reachable and
-  degrades quietly to the internal + OpenStreetMap baseline otherwise, so
-  routine runs are never disrupted. A new `ADDRESS_AUDIT_GEOCODE=off` env knob
-  skips the attempt; the "no browser attached" message dropped from WARNING to
-  an informational note with enablement guidance.
+- **Address audit Tier-3 now self-spawns a browser and deduces the suite (menu 195)**:
+  Two gaps stopped the Mist-portal path from ever working. (1) Tier-3 only ever
+  *took over* a browser at `localhost:9222` -- which nothing was running, and
+  `localhost` resolved to IPv6 `::1` (`ECONNREFUSED`). The default mode is now
+  `auto`: it takes over a running debuggable browser if present, otherwise it
+  **spawns Edge for you**, waits while you log into Mist and open a site's
+  settings page, then takes it over (CDP endpoint fixed to `127.0.0.1`). A
+  one-time readiness probe confirms the "Location Search" box is visible and
+  guides you to it if not. (2) Tier-3 never ran for the rows that needed it --
+  `_combine` returned the Tier-1/Tier-2 result first, so Google-via-Mist (the
+  only source that knows the real suite) was skipped on every MISSING_SUITE row.
+  Tier-3 now runs whenever a suite is actually missing and, when it returns a
+  confident result, **acts as the authority** (overriding the internal guess);
+  if it returns nothing, results are exactly as before (graceful). The single
+  `ADDRESS_AUDIT_GEOCODE` knob now accepts `off | auto | attach | launch`
+  (default `auto`).
+
+- **Address audit Tier-3 web geocoding is flag-free (menu 195)**: The Tier-3
+  browser geocoder no longer requires the `--ui-geocode` CLI flag (removed). The
+  Mist site address, the SNMP location variable, and the customer CSV are all
+  treated as *hints*, fused into one best-guess query and verified against the
+  web to deduce the true, shippable address.
 
 ### Fixed
+
+- **Address audit misleading Nominatim log (menu 195)**: The "Nominatim returned
+  no result" warning printed the business-name + suite query string even though
+  the actual geocode used the suite-stripped street, making it look like the
+  wrong thing was searched. It now logs the street actually geocoded.
 
 - **Address audit suggested-address cleanup (menu 195)**: Suggested addresses
   were polluted with the customer's SAP internal store-code prefix

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -83,9 +83,15 @@ MIST_ORG_ID=your_org_id_here
 # when a device serial is not found in inventory (default: 85).
 # FUZZY_MATCH_THRESHOLD=85
 
-# Tier-3 browser geocoding switch (no CLI flag). Default "auto": engages
-# automatically when a debuggable browser is reachable and degrades silently
-# to internal + OpenStreetMap otherwise. Set to "off" to skip the attempt.
+# Tier-3 browser geocoding mode (no CLI flag). Values:
+#   auto   (default) - take over a debuggable browser if one is running; else
+#                      spawn Edge, wait for you to log in + open a site settings
+#                      page, then take it over. Zero manual setup.
+#   attach           - take over only (you started Edge with --remote-debugging-port).
+#   launch           - Playwright launches a fresh system Edge for interactive login.
+#   off              - disable Tier 3 (internal + OpenStreetMap only).
+# Tier 3 is the authority that deduces the true suite/unit; it degrades silently
+# to Tier 1/2 if no browser is available, so routine runs are never disrupted.
 # ADDRESS_AUDIT_GEOCODE=auto
 
 # Mist dashboard base URL used by the Tier-3 browser geocoder. Override for

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -70,11 +70,12 @@ class AddressResolver:
         return result  # Hand the result back to the engine.
 
     def _resolve_uncached(self, candidates: ResolveCandidates, query: str) -> ResolverResult:
-        """Run Tier 1 (internal) + Tier 2 (OSM street validation) + optional Tier 3, fail-soft."""
+        """Run Tier 1 (internal) + Tier 2 (OSM) + optional Tier 3 (web authority), fail-soft."""
         try:
             internal = self._compare_internal(candidates)  # Tier 1: internal suite candidate (no network).
             osm = self._validate_nominatim(candidates, query)  # Tier 2: OpenStreetMap street validation.
-            return self._combine(internal, osm, candidates, query)  # Merge the tiers into one result.
+            ui = self._maybe_ui(candidates, query)  # Tier 3: Google-via-Mist authority (gated; fail-soft).
+            return self._combine(internal, osm, ui, candidates, query)  # Merge the tiers into one result.
         except Exception as exc:  # noqa: BLE001 -- one row must never abort the audit.
             logging.warning("Resolve failed for key derived from '%s': %s", query, exc)  # Log and continue.
             return ResolverResult(query=query, canonical_address=None, source="internal", confidence=0.0)
@@ -83,20 +84,29 @@ class AddressResolver:
         self,
         internal: ResolverResult | None,
         osm: ResolverResult | None,
+        ui: ResolverResult | None,
         candidates: ResolveCandidates,
         query: str,
     ) -> ResolverResult:
-        """Merge internal + OSM (+ optional UI) results, recording external validation."""
+        """Merge results with the web (Tier 3) as the authority for the true suite.
+
+        Priority: a confident Tier-3 (Google-via-Mist) suggestion WINS because it is
+        the only source that knows the real suite; otherwise the internal suite
+        candidate (street cross-checked by OSM); otherwise OSM's validated street;
+        otherwise NO_RESULT. Tier 3 only overrides when it actually returned an
+        address, so a missing/failed browser never makes results worse.
+        """
+        if ui is not None and ui.canonical_address:  # Tier 3 deduced a real (suite-bearing) address.
+            ui.query = query  # Stamp the query for cache consistency.
+            ui.street_validated = ui.street_validated or osm is not None  # Note OSM street cross-check.
+            return ui  # Web authority wins -> the true shippable address.
         if internal is not None:  # Internal supplied the suite-corrected suggestion.
             internal.query = query  # Stamp the query for cache consistency.
             internal.street_validated = osm is not None  # OSM confirmed the base street exists.
-            return internal  # Suite from internal source, street externally cross-checked.
+            return internal  # Suite from internal hint, street externally cross-checked.
         if osm is not None:  # No internal suite, but OSM validated the street.
             osm.street_validated = True  # OSM itself is the external validator here.
             return osm  # Return the OSM-canonical result.
-        ui_result = self._maybe_ui(candidates, query)  # Tier 3: optional, flagged.
-        if ui_result is not None:  # UI tier captured a suggestion.
-            return ui_result  # Return the UI-sourced address.
         return ResolverResult(query=query, canonical_address=None, source="internal", confidence=0.0)
 
     def _compare_internal(self, candidates: ResolveCandidates) -> ResolverResult | None:
@@ -151,7 +161,10 @@ class AddressResolver:
         outcome = validator.validate(mist_street, csv_street)  # Geocode both suite-stripped streets.
         comparison = outcome.get("comparison_validation", {})  # The CSV-side geocode result.
         if not comparison.get("valid"):  # Nominatim could not validate the candidate street.
-            logging.warning("Nominatim returned no result for %s (check network/SSL)", query)  # Visible miss.
+            street_for_log = csv_street.get("address") or mist_street.get("address") or query  # Actual street tried.
+            logging.warning(  # Show the street actually geocoded (not the business+suite query string).
+                "Nominatim returned no result for street '%s' (check network/SSL)", street_for_log
+            )
             return None  # Defer to Tier 3 / NO_RESULT.
         confidence = float(comparison.get("confidence", 0.0))  # OSM importance-derived confidence.
         canonical = comparison.get("display_name") or self._format_address(candidates.csv_address)  # Canonical.
@@ -166,15 +179,30 @@ class AddressResolver:
         )
 
     def _maybe_ui(self, candidates: ResolveCandidates, query: str) -> ResolverResult | None:
-        """Tier 3: delegate to the optional ``MistUIGeocoder`` when permitted."""
+        """Tier 3: consult the Google-via-Mist authority when a suite is actually missing.
+
+        Only runs when UI geocoding is permitted AND the Mist street lacks a
+        suite -- that is exactly the case the operator wants resolved (the true
+        suite/unit for shipping). Rows where Mist already carries a suite skip the
+        (slow) browser lookup. Always fail-soft to ``None``.
+        """
         if not candidates.ui_geocode or self._ui_geocoder is None:  # Tier 3 disabled for this row/run.
             return None  # Skip the UI tier.
-        logging.info("Delegating to Tier 3 UI geocoder")  # Action-log the delegation.
+        if self._mist_has_suite(candidates.mist_address):  # Mist is already suite-specific.
+            logging.debug("Mist already has a suite; skipping Tier-3 lookup")  # No suite to discover.
+            return None  # Save a browser lookup.
+        logging.info("Delegating to Tier 3 (Google-via-Mist) to deduce the suite")  # Action-log delegation.
         self.external_calls += 1  # Count the UI lookup as an external call.
         result = self._ui_geocoder.geocode_via_ui(query)  # Drive the dashboard autocomplete (fail-soft).
         if result is not None:  # Stamp the query so caching stays consistent.
             result.query = query  # Align the result's query with the cache key source.
-        return result  # May be None (fail-soft) -> caller yields NO_RESULT.
+        return result  # May be None (fail-soft) -> caller falls back to Tier 1/2.
+
+    @staticmethod
+    def _mist_has_suite(mist_address: dict[str, Any]) -> bool:
+        """Return True when the Mist street line already carries a suite/unit token."""
+        street = mist_address.get("address", "")  # Mist's street line.
+        return bool(re.search(_SUITE_PATTERN, street, flags=re.IGNORECASE))  # Suite already present?
 
     def _respect_rate_limit(self) -> None:
         """Sleep as needed so consecutive Nominatim calls stay within ToS."""

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -202,15 +202,31 @@ class AddressAuditEngine:
         return AddressResolver(skip_ssl_verify=skip_ssl, ui_geocoder=ui_geocoder)  # Resolver with optional Tier 3.
 
     @staticmethod
+    def _geocode_mode() -> str:
+        """Return the Tier-3 connection mode from a single env knob (no CLI flag).
+
+        ``ADDRESS_AUDIT_GEOCODE`` accepts: ``off`` (disable Tier 3), ``auto``
+        (default -- take over a debuggable browser if present, else spawn one and
+        guide login), ``attach`` (take over only; operator pre-started Edge), or
+        ``launch`` (Playwright launches a fresh Edge). Unknown values fall back to
+        ``auto`` so a typo never disables suite discovery.
+        """
+        raw = os.environ.get("ADDRESS_AUDIT_GEOCODE", "auto").strip().lower()  # Single env knob; default auto.
+        if raw in ("off", "0", "no", "false", "none", "disabled"):  # Any disable token.
+            return "off"  # Tier 3 turned off.
+        if raw in ("attach", "launch", "auto"):  # Explicit, recognized mode.
+            return raw  # Honor the operator's choice.
+        return "auto"  # Unknown value -> safe default keeps suite discovery on.
+
+    @staticmethod
     def _ui_geocode_enabled() -> bool:
         """Return whether Tier-3 web geocoding may run (env-gated, default on, no CLI flag).
 
-        Tier 3 engages automatically when a debuggable browser is reachable and
-        degrades silently to Tier 1/2 otherwise, so routine runs are never
-        disrupted. Set ``ADDRESS_AUDIT_GEOCODE=off`` to skip the attempt.
+        Tier 3 engages automatically when a browser is reachable (taking one over
+        or spawning one) and degrades silently to Tier 1/2 otherwise, so routine
+        runs are never disrupted. Set ``ADDRESS_AUDIT_GEOCODE=off`` to skip it.
         """
-        raw = os.environ.get("ADDRESS_AUDIT_GEOCODE", "auto").strip().lower()  # Env override; default auto/on.
-        return raw not in ("off", "0", "no", "false", "none", "disabled")  # Any disable token turns it off.
+        return AddressAuditEngine._geocode_mode() != "off"  # Enabled for every non-off mode.
 
     @staticmethod
     def _skip_ssl_verify() -> bool:
@@ -228,20 +244,21 @@ class AddressAuditEngine:
         """Build and connect a ``MistUIGeocoder`` from env config; ``None`` if unavailable."""
         from src.site.address_audit.ui_geocoder import MistUIGeocoder  # Lazy: optional Playwright.
 
-        geocoder = MistUIGeocoder(AddressAuditEngine._ui_config())  # Env-driven attach/launch config.
+        geocoder = MistUIGeocoder(AddressAuditEngine._ui_config())  # Env-driven auto/attach/launch config.
         if not geocoder.connect():  # Establish the browser session (fail-soft).
-            logging.info(  # No debuggable browser is the normal case; degrade quietly to Tier 1/2.
-                "Tier-3 web geocoder not attached (no debuggable browser found); "
-                "using internal + OpenStreetMap hints only. Open Edge with "
-                "--remote-debugging-port=9222 to enable, or set ADDRESS_AUDIT_GEOCODE=off to skip."
+            logging.info(  # No browser is the normal case; degrade quietly to Tier 1/2.
+                "Tier-3 web geocoder not available; using internal + OpenStreetMap hints only. "
+                "Set ADDRESS_AUDIT_GEOCODE=off to skip, or 'launch' to force a fresh Edge."
             )
             return None  # Disable Tier 3 for this run.
-        return geocoder  # Connected geocoder ready for selective lookups.
+        geocoder.ensure_location_field_ready()  # Guide the operator to a page with the Location Search box.
+        return geocoder  # Connected geocoder ready for suite-discovery lookups.
 
     @staticmethod
     def _ui_config() -> UIGeocoderConfig:
         """Build a ``UIGeocoderConfig`` from environment overrides (with safe defaults)."""
         config = UIGeocoderConfig()  # Start from the Zscaler-safe defaults.
+        config.connect_mode = AddressAuditEngine._geocode_mode()  # off is filtered earlier; auto/attach/launch here.
         config.dashboard_url = os.environ.get("MIST_DASHBOARD_URL", config.dashboard_url).strip()  # Cloud region.
         config.per_lookup_timeout_s = AddressAuditEngine._env_float(  # Per-lookup timeout override.
             "UI_GEOCODE_TIMEOUT_SECONDS", config.per_lookup_timeout_s

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -103,8 +103,8 @@ class UIGeocoderConfig:
     or take over an already-authenticated browser over CDP.
     """
 
-    connect_mode: str = "attach"  # "attach" (CDP takeover) or "launch" (fresh Edge + interactive login).
-    cdp_endpoint: str = "http://localhost:9222"  # DevTools endpoint of the operator's debuggable browser.
+    connect_mode: str = "auto"  # "auto" (take over else spawn), "attach" (CDP only), or "launch" (fresh Edge).
+    cdp_endpoint: str = "http://127.0.0.1:9222"  # DevTools endpoint (127.0.0.1, not localhost: avoids IPv6 ::1).
     browser_channel: str = "msedge"  # System browser channel; avoids the Zscaler-blocked Chromium CDN.
     dashboard_url: str = "https://manage.mist.com/"  # Regional Mist cloud login/landing URL (override per cloud).
     headless: bool = False  # Must be visible so the operator can log in / observe the takeover.

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -6,14 +6,18 @@ suite/unit-corrected retail address the operator sees by hand. This module
 drives that field through a real browser and reads back the top suggestion --
 WITHOUT ever committing a change (read-only audit).
 
-Two connection modes (both proven to work behind Zscaler SSL inspection, where
+Three connection modes (all proven to work behind Zscaler SSL inspection, where
 Playwright CANNOT download its own Chromium):
 
-  * ``attach`` (default, recommended) -- take over an already-running, already
-    logged-in browser via the Chrome DevTools Protocol. The operator starts a
-    debuggable browser (see ``spawn_debuggable_browser``) or one is spawned for
-    them, logs into Mist once, and we reuse that live SSO session. No bundled
-    browser download, no stored credentials.
+  * ``auto`` (default) -- take over an already-running debuggable browser if one
+    is present; otherwise spawn a debuggable Edge for the operator, wait for them
+    to log into Mist and open a site's settings page, then take it over. This is
+    the zero-setup path: the operator never has to start Edge with debug flags.
+
+  * ``attach`` -- take over an already-running, already logged-in browser via the
+    Chrome DevTools Protocol. The operator starts a debuggable browser (see
+    ``spawn_debuggable_browser``) and logs into Mist once; we reuse that live SSO
+    session. No bundled browser download, no stored credentials.
 
   * ``launch`` -- Playwright launches the system Edge channel
     (``channel="msedge"``, no download) non-headless and pauses for the
@@ -79,6 +83,7 @@ class MistUIGeocoder:
         self._browser: Any = None  # Browser or CDP-attached browser handle.
         self._context: Any = None  # Active browser context (operator session or fresh).
         self._connected: bool = False  # Whether a usable browser is attached.
+        self._spawned_proc: Any = None  # Popen handle when we spawned a debuggable Edge (auto mode).
         self._lookups_done: int = 0  # Counter enforcing the per-run max-lookups cap.
         logging.debug("MistUIGeocoder initialized (mode=%s)", self._config.connect_mode)  # Trace init.
 
@@ -106,10 +111,49 @@ class MistUIGeocoder:
             return False  # Signal Tier-3 unavailable for this run.
 
     def _dispatch_connect(self) -> bool:
-        """Route to the attach or launch connection strategy."""
-        if self._config.connect_mode == "attach":  # Takeover an existing logged-in browser.
+        """Route to the auto, attach, or launch connection strategy."""
+        mode = self._config.connect_mode  # Operator-selected strategy (default "auto").
+        if mode == "attach":  # Take over an already-running debuggable browser (no spawn).
             return self._connect_attach()  # Reuse the operator's live SSO session.
-        return self._connect_launch()  # Otherwise launch a fresh system-Edge for interactive login.
+        if mode == "launch":  # Let Playwright launch a fresh system Edge.
+            return self._connect_launch()  # Interactive-login flow.
+        return self._connect_auto()  # Default: take over if possible, else spawn one for the operator.
+
+    def _connect_auto(self) -> bool:
+        """Take over a debuggable browser if present; otherwise spawn one and take it over."""
+        if self._try_attach():  # A debuggable browser is already running -> reuse it.
+            return True  # Attached to the operator's existing session.
+        logging.info("No debuggable browser found; spawning one for login")  # Action-log the spawn path.
+        proc = MistUIGeocoder.spawn_debuggable_browser(self._cdp_port(), self._config.dashboard_url)  # Spawn Edge.
+        if proc is None:  # Edge not installed -> fall back to a Playwright launch.
+            logging.info("Edge unavailable to spawn; falling back to launch mode")  # Inform operator.
+            return self._connect_launch()  # Last-resort interactive launch.
+        self._spawned_proc = proc  # Own the spawned browser's lifecycle (terminated on close()).
+        self._await_spawn_login()  # Block until the operator logs in and opens a site settings page.
+        return self._try_attach()  # Now take over the spawned, logged-in browser over CDP.
+
+    def _try_attach(self) -> bool:
+        """Attempt a CDP takeover without raising (used by the auto strategy)."""
+        try:
+            return self._connect_attach()  # Reuse the standard takeover path.
+        except Exception as exc:  # noqa: BLE001 -- a missing endpoint is expected in auto mode.
+            logging.info("CDP takeover at %s not available yet: %s", self._config.cdp_endpoint, exc)  # Trace.
+            return False  # Signal "no debuggable browser" so the caller can spawn one.
+
+    def _cdp_port(self) -> int:
+        """Parse the TCP port from the configured CDP endpoint (default 9222)."""
+        tail = self._config.cdp_endpoint.rsplit(":", 1)[-1]  # Text after the final colon.
+        digits = "".join(ch for ch in tail if ch.isdigit())  # Keep only the numeric run.
+        return int(digits) if digits else 9222  # Parsed port or the documented default.
+
+    def _await_spawn_login(self) -> None:
+        """Block until the operator has logged in and opened a site's Location Search page."""
+        InputUtils.safe_input(  # Pause the run until the operator confirms readiness.
+            "A browser opened. Log into Mist, open a SITE's settings page so the "
+            "'Location Search' box is visible, then press Enter to continue: ",
+            context="ui_geocoder_spawn_login",
+        )
+        logging.info("Operator confirmed spawned-browser login; taking over via CDP")  # Action-log gate pass.
 
     def _connect_attach(self) -> bool:
         """Take over a debuggable browser over CDP and reuse its first context."""
@@ -143,6 +187,38 @@ class MistUIGeocoder:
             context="ui_geocoder_login",
         )
         logging.info("Operator confirmed dashboard login; proceeding with UI geocoding")  # Action-log gate pass.
+
+    def ensure_location_field_ready(self, max_prompts: int = 3) -> bool:
+        """Probe for the Location Search field; guide the operator until it appears (fail-soft).
+
+        Tier-3 can only read Google's suggestions when the active tab is on a page
+        that renders the Location Search input. We probe, and if it is missing we
+        ask the operator to open a site's settings page, retrying a few times.
+        """
+        if not self._connected:  # Nothing to probe without a connection.
+            return False  # Caller already handled the disconnected case.
+        for attempt in range(1, max_prompts + 1):  # Bounded retries so we never loop forever.
+            page = self._active_page()  # Current tab in the operator's context.
+            if page is not None and self._field_present(page):  # Location Search input is visible.
+                logging.info("Location Search field detected on attempt %d; Tier-3 ready", attempt)  # Ready.
+                return True  # Proceed to the per-row lookups.
+            InputUtils.safe_input(  # Guide the operator to the correct page, then re-probe.
+                "Could not see the 'Location Search' box. In the browser, open a "
+                "SITE's settings page where that box is visible, then press Enter: ",
+                context="ui_geocoder_navigate",
+            )
+        logging.info("Location Search field not found after %d prompts; Tier-3 will fail-soft", max_prompts)
+        return False  # Lookups will return None; the audit still completes on Tier 1/2.
+
+    def _field_present(self, page: Any) -> bool:
+        """Return True when any Location Search input selector matches on ``page``."""
+        for selector in INPUT_SELECTORS:  # Probe each candidate selector quickly.
+            try:
+                if page.query_selector(selector) is not None:  # Immediate (non-waiting) DOM probe.
+                    return True  # Found the autocomplete input.
+            except Exception as exc:  # noqa: BLE001 -- a transient DOM error must not abort the probe.
+                logging.debug("Field probe error for %s: %s", selector, exc)  # Trace and keep probing.
+        return False  # No candidate matched on the current page.
 
     def geocode_via_ui(self, query: str) -> ResolverResult | None:
         """Resolve one address via the dashboard autocomplete; fail-soft to ``None``."""
@@ -237,7 +313,19 @@ class MistUIGeocoder:
                 self._playwright.stop()  # Release the driver subprocess.
         except Exception as exc:  # noqa: BLE001 -- teardown must not raise.
             logging.debug("Playwright stop error (ignored): %s", exc)  # Trace and continue.
+        self._terminate_spawned()  # Close any Edge we spawned ourselves (auto mode).
         self._connected = False  # Reset state so a stale handle is never reused.
+
+    def _terminate_spawned(self) -> None:
+        """Terminate the debuggable Edge we spawned in auto mode (never raises)."""
+        if self._spawned_proc is None:  # We only own a process when we spawned one.
+            return  # Attach/launch modes have nothing to clean up here.
+        try:
+            self._spawned_proc.terminate()  # Ask the spawned Edge to exit.
+            logging.debug("Terminated spawned debuggable Edge (pid=%s)", self._spawned_proc.pid)  # Trace.
+        except Exception as exc:  # noqa: BLE001 -- teardown must not raise.
+            logging.debug("Spawned Edge terminate error (ignored): %s", exc)  # Trace and continue.
+        self._spawned_proc = None  # Drop the handle so close() is idempotent.
 
     @staticmethod
     def spawn_debuggable_browser(

--- a/tests/unit/site/address_audit/test_address_resolver.py
+++ b/tests/unit/site/address_audit/test_address_resolver.py
@@ -176,6 +176,50 @@ class TestTier3Gating:
         ui.geocode_via_ui.assert_called_once()
         assert result.source == "mist_ui"
 
+    def test_ui_wins_over_internal_and_osm(self, tmp_path, monkeypatch):
+        """Tier 3 (web authority) overrides internal + OSM when Mist lacks a suite."""
+        _FakeValidator.count = 0
+        _FakeValidator.valid = True  # OSM also validates -> proves Tier 3 still wins.
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
+        monkeypatch.setattr(resolver_mod.time, "sleep", lambda *_: None)
+        ui = MagicMock()
+        ui.geocode_via_ui.return_value = ResolverResult(
+            query="q", canonical_address="100 Main St #200, Town, FL 33000", source="mist_ui", confidence=0.9
+        )
+        resolver = AddressResolver(db_path=_db(tmp_path), ui_geocoder=ui)
+        csv = {"address": "100 Main St Unit 200", "city": "Town", "state": "FL", "zip": "33000"}  # Internal suite.
+        result = resolver.resolve(ResolveCandidates(mist_address=_NO_SUITE, csv_address=csv, ui_geocode=True))
+        ui.geocode_via_ui.assert_called_once()
+        assert result.source == "mist_ui"  # Web authority wins over the internal suggestion.
+        assert result.canonical_address == "100 Main St #200, Town, FL 33000"
+        assert result.street_validated is True  # OSM cross-checked the street.
+
+    def test_ui_skipped_when_mist_has_suite(self, tmp_path, monkeypatch):
+        """No Tier-3 lookup when Mist already carries a suite (nothing to discover)."""
+        _FakeValidator.count = 0
+        _FakeValidator.valid = False
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
+        monkeypatch.setattr(resolver_mod.time, "sleep", lambda *_: None)
+        ui = MagicMock()
+        resolver = AddressResolver(db_path=_db(tmp_path), ui_geocoder=ui)
+        resolver.resolve(ResolveCandidates(mist_address=_WITH_SUITE, csv_address=_WITH_SUITE, ui_geocode=True))
+        ui.geocode_via_ui.assert_not_called()  # Mist is already suite-specific -> skip the slow lookup.
+
+    def test_internal_used_when_ui_returns_none(self, tmp_path, monkeypatch):
+        """When Tier 3 returns None, the internal suite suggestion is used (no worse than before)."""
+        _FakeValidator.count = 0
+        _FakeValidator.valid = False
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
+        monkeypatch.setattr(resolver_mod.time, "sleep", lambda *_: None)
+        ui = MagicMock()
+        ui.geocode_via_ui.return_value = None  # Selectors/login failed -> fail-soft.
+        resolver = AddressResolver(db_path=_db(tmp_path), ui_geocoder=ui)
+        csv = {"address": "100 Main St Unit 200", "city": "Town", "state": "FL", "zip": "33000"}
+        result = resolver.resolve(ResolveCandidates(mist_address=_NO_SUITE, csv_address=csv, ui_geocode=True))
+        ui.geocode_via_ui.assert_called_once()
+        assert result.source == "internal"  # Graceful fallback to the internal suggestion.
+        assert "Unit 200" in result.canonical_address  # Internal suite preserved.
+
 
 class TestHelpers:
     """Query-key normalization and rate limiting."""

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -143,6 +143,27 @@ class TestEnvConfig:
         monkeypatch.setenv("ADDRESS_AUDIT_GEOCODE", "auto")
         assert AddressAuditEngine._ui_geocode_enabled() is True
 
+    def test_geocode_mode_default_auto(self, monkeypatch):
+        """Unset ADDRESS_AUDIT_GEOCODE defaults to auto (take over else spawn)."""
+        monkeypatch.delenv("ADDRESS_AUDIT_GEOCODE", raising=False)
+        assert AddressAuditEngine._geocode_mode() == "auto"
+
+    def test_geocode_mode_off(self, monkeypatch):
+        """'off' disables Tier 3 entirely."""
+        monkeypatch.setenv("ADDRESS_AUDIT_GEOCODE", "off")
+        assert AddressAuditEngine._geocode_mode() == "off"
+        assert AddressAuditEngine._ui_geocode_enabled() is False
+
+    def test_geocode_mode_launch(self, monkeypatch):
+        """'launch' selects the Playwright-launch strategy."""
+        monkeypatch.setenv("ADDRESS_AUDIT_GEOCODE", "launch")
+        assert AddressAuditEngine._geocode_mode() == "launch"
+
+    def test_geocode_mode_unknown_falls_back_auto(self, monkeypatch):
+        """An unrecognized value falls back to auto so a typo never disables Tier 3."""
+        monkeypatch.setenv("ADDRESS_AUDIT_GEOCODE", "banana")
+        assert AddressAuditEngine._geocode_mode() == "auto"
+
 
 class TestSourceLabel:
     """Source-column labelling, including OSM street-validation."""

--- a/tests/unit/site/address_audit/test_ui_geocoder.py
+++ b/tests/unit/site/address_audit/test_ui_geocoder.py
@@ -147,3 +147,101 @@ class TestHelpers:
         """No Edge binary => spawn_debuggable_browser returns None gracefully."""
         monkeypatch.setattr(MistUIGeocoder, "_edge_executable", staticmethod(lambda: None))
         assert MistUIGeocoder.spawn_debuggable_browser() is None
+
+
+class TestAutoConnect:
+    """The default 'auto' mode: take over an existing browser, else spawn one."""
+
+    def test_auto_attaches_when_browser_present(self, monkeypatch):
+        """Auto reuses a running debuggable browser without spawning."""
+        browser = MagicMock()
+        ctx = MagicMock()
+        browser.contexts = [ctx]
+        factory, _ = _fake_playwright(browser)
+        monkeypatch.setattr(ui_mod, "sync_playwright", factory)
+        spy = MagicMock()
+        monkeypatch.setattr(MistUIGeocoder, "spawn_debuggable_browser", staticmethod(spy))
+        geo = MistUIGeocoder(UIGeocoderConfig(connect_mode="auto"))
+        assert geo.connect() is True
+        assert geo._context is ctx
+        spy.assert_not_called()  # Existing browser taken over; no spawn needed.
+
+    def test_auto_spawns_when_no_browser(self, monkeypatch):
+        """Auto spawns Edge, waits for login, then takes it over via CDP."""
+        browser = MagicMock()
+        ctx = MagicMock()
+        browser.contexts = [ctx]
+        driver = MagicMock()
+        driver.chromium.connect_over_cdp.side_effect = [RuntimeError("no endpoint"), browser]  # miss, then hit.
+        factory = MagicMock()
+        factory.return_value.start.return_value = driver
+        monkeypatch.setattr(ui_mod, "sync_playwright", factory)
+        proc = MagicMock()
+        monkeypatch.setattr(MistUIGeocoder, "spawn_debuggable_browser", staticmethod(lambda *a, **k: proc))
+        monkeypatch.setattr(ui_mod.InputUtils, "safe_input", staticmethod(lambda *a, **k: ""))
+        geo = MistUIGeocoder(UIGeocoderConfig(connect_mode="auto"))
+        assert geo.connect() is True
+        assert geo._spawned_proc is proc
+        assert driver.chromium.connect_over_cdp.call_count == 2  # Attach-miss, then attach-after-spawn.
+
+    def test_auto_falls_back_to_launch_when_no_edge(self, monkeypatch):
+        """Auto falls back to Playwright launch when Edge cannot be spawned."""
+        browser = MagicMock()
+        browser.new_context.return_value = MagicMock()
+        driver = MagicMock()
+        driver.chromium.connect_over_cdp.side_effect = RuntimeError("no endpoint")  # No browser to attach.
+        driver.chromium.launch.return_value = browser
+        factory = MagicMock()
+        factory.return_value.start.return_value = driver
+        monkeypatch.setattr(ui_mod, "sync_playwright", factory)
+        monkeypatch.setattr(MistUIGeocoder, "spawn_debuggable_browser", staticmethod(lambda *a, **k: None))
+        monkeypatch.setattr(ui_mod.InputUtils, "safe_input", staticmethod(lambda *a, **k: ""))
+        geo = MistUIGeocoder(UIGeocoderConfig(connect_mode="auto"))
+        assert geo.connect() is True
+        driver.chromium.launch.assert_called_once()
+
+
+class TestPortAndReadiness:
+    """CDP port parsing, the Location Search readiness probe, and spawned teardown."""
+
+    def test_cdp_port_parses_endpoint(self):
+        """A port in the CDP endpoint is parsed correctly."""
+        geo = MistUIGeocoder(UIGeocoderConfig(cdp_endpoint="http://127.0.0.1:9333"))
+        assert geo._cdp_port() == 9333
+
+    def test_cdp_port_defaults_when_no_digits(self):
+        """An endpoint without a port falls back to the documented 9222 default."""
+        geo = MistUIGeocoder(UIGeocoderConfig(cdp_endpoint="http://localhost"))
+        assert geo._cdp_port() == 9222
+
+    def test_ensure_ready_false_when_disconnected(self):
+        """The readiness probe returns False without a connection."""
+        assert MistUIGeocoder().ensure_location_field_ready() is False
+
+    def test_ensure_ready_detects_field(self):
+        """A present Location Search field is detected without prompting."""
+        geo = MistUIGeocoder()
+        geo._connected = True  # Simulate a successful connect().
+        page = MagicMock()
+        page.query_selector.return_value = object()  # Field present on first probe.
+        geo._active_page = MagicMock(return_value=page)
+        assert geo.ensure_location_field_ready() is True
+
+    def test_ensure_ready_guides_then_finds(self, monkeypatch):
+        """When the field is missing, the operator is prompted, then it's found."""
+        geo = MistUIGeocoder()
+        geo._connected = True  # Simulate a successful connect().
+        page = MagicMock()
+        page.query_selector.side_effect = [None, None, None, object()]  # All miss, then a hit next attempt.
+        geo._active_page = MagicMock(return_value=page)
+        monkeypatch.setattr(ui_mod.InputUtils, "safe_input", staticmethod(lambda *a, **k: ""))
+        assert geo.ensure_location_field_ready(max_prompts=2) is True
+
+    def test_close_terminates_spawned(self):
+        """close() terminates a browser we spawned and clears the handle."""
+        geo = MistUIGeocoder()
+        proc = MagicMock()
+        geo._spawned_proc = proc
+        geo.close()
+        proc.terminate.assert_called_once()
+        assert geo._spawned_proc is None


### PR DESCRIPTION
## Summary
Makes the **menu 195** Mist-portal (Tier-3) path actually work for its core purpose: deducing the true, shippable suite/unit. Fixes two gaps found in a live run, plus a misleading log. Honors the principle that the Mist address, SNMP location, and CSV are all **hints**; the web (Google via the Mist site-address screen) is the authority.

Linked issue: #551

## Problems fixed
1. **Tier-3 could never get a browser** (ECONNREFUSED ::1:9222). It only ever *took over* a browser at `localhost:9222` -- nothing was running, and `localhost` resolved to IPv6 `::1`. `spawn_debuggable_browser()` existed but was never wired in.
2. **Tier-3 never ran for the rows that needed it.** `_combine` returned the Tier-1/Tier-2 result first, so Google-via-Mist was skipped on every `MISSING_SUITE` row -- defeating the whole point.
3. **Misleading log**: the "Nominatim no result" warning printed the business-name + suite query, not the street actually geocoded.

## Changes
- **`auto` connect mode (new default)**: take over a running debuggable browser if present; otherwise **spawn Edge**, wait for the operator to log in + open a site's settings page, then take it over. CDP endpoint fixed to `127.0.0.1` (IPv6 fix). One-time **readiness probe** confirms the Location Search box is visible and guides the operator to it. Spawned Edge is terminated on `close()`.
- **Tier-3 as suite authority**: runs whenever a suite is actually missing; when it returns a confident result it **overrides** the internal guess; **graceful** fallback to internal+OSM when it returns nothing (never worse than before).
- **Single env knob**: `ADDRESS_AUDIT_GEOCODE = off | auto | attach | launch` (default `auto`); unknown values fall back to `auto`.
- **Log fix**: Nominatim "no result" now shows the suite-stripped street.

## Testing
- `py_compile` / `black --line-length 120` / `ruff` / `vulture@90`: clean.
- **103 unit tests pass** (+16: Tier-3-wins / skip-when-suite-present / graceful-fallback, `_geocode_mode` variants, auto-spawn + launch-fallback, CDP port parse, readiness probe, spawned teardown).

## Honest limit
The Mist-side **selectors** (Location Search input + Google `.pac-item` suggestions) can't be validated without the live tenant. The design is fail-soft and operator-guided, and the new readiness probe + INFO logs make a single live run confirm the selectors clearly. If a selector needs updating, it's centralized in `ui_geocoder.py`.

READ-ONLY feature; no destructive operations.