### PR TITLE
fix(address-audit): Tier-3 captured wrong suggestion (one-row autocomplete lag) (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
+- **Address audit Tier-3 captured the WRONG suggestion (one-row lag) (menu 195)**:
+  Google Places leaves the previous query's suggestions in the dropdown until the
+  new request returns, so the geocoder read each address's result one lookup late
+  -- every row was shifted by one and therefore wrong (e.g. the query for
+  `1701 Ohio Ave` captured `7535 North Kendall Drive`). The geocoder now anchors
+  on the query's house number and polls until the TOP suggestion actually
+  contains it, dismissing the stale dropdown first; on timeout it returns
+  NO_RESULT rather than risk a stale, wrong address. It also cleans Google's row
+  text -- stripping the glued business-name prefix (`T-Mobile931 US Highway...`)
+  and trailing `, USA` -- so the suggested value is the clean, shippable street
+  line with its suite preserved (`931 US Highway 331 Ste A2, DeFuniak Springs, FL
+  32435`). NOTE: anyone who ran the audit before this fix should re-run it and
+  discard the prior output; the cached results were shifted.
+
 - **Address audit misleading Nominatim log (menu 195)**: The "Nominatim returned
   no result" warning printed the business-name + suite query string even though
   the actual geocode used the suite-stripped street, making it look like the

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -42,6 +42,7 @@ from __future__ import annotations  # PEP 604 union syntax on Python 3.13.
 
 import logging  # Action logging before/after every operation (project NON-NEGOTIABLE).
 import os  # Filesystem probing for the Edge executable.
+import re  # House-number extraction + suggestion cleanup (defeats the autocomplete lag race).
 import shutil  # PATH lookup fallback for the Edge executable.
 import subprocess  # Spawn a debuggable browser for CDP takeover.
 import tempfile  # Dedicated throwaway profile for the spawned browser.
@@ -252,17 +253,64 @@ class MistUIGeocoder:
         return self._context.new_page()  # Otherwise open a fresh tab (launch mode).
 
     def _perform_lookup(self, page: Any, query: str) -> list[str]:
-        """Type ``query`` into the Location Search field and read suggestion texts."""
+        """Type ``query``, then read ONLY the suggestion list that belongs to it (stale-safe)."""
         timeout_ms = int(self._config.per_lookup_timeout_s * 1000)  # Playwright uses milliseconds.
         field = self._locate_input(page, timeout_ms)  # Find the autocomplete input element.
-        field.click()  # Focus the field so Google binds keystrokes.
-        field.fill("")  # Clear any pre-existing text.
-        field.type(query, delay=30)  # Type slowly so Google fires the autocomplete request.
-        page.wait_for_selector(PAC_ITEM_SELECTOR, timeout=timeout_ms)  # Wait for the suggestion dropdown.
-        items = page.query_selector_all(PAC_ITEM_SELECTOR)  # Collect every suggestion row.
-        texts = [self._item_text(item) for item in items]  # Extract each row's visible text.
-        logging.debug("UI autocomplete returned %d suggestion(s)", len(texts))  # Action-log count.
-        return [text for text in texts if text]  # Drop empties.
+        self._enter_query(page, field, query)  # Focus, clear the stale dropdown, type the new query.
+        expected = self._house_number(query)  # House number anchors the fresh-result wait.
+        texts = self._read_fresh_suggestions(page, expected, timeout_ms)  # Wait for THIS query's suggestions.
+        logging.debug("UI autocomplete returned %d fresh suggestion(s)", len(texts))  # Action-log count.
+        return texts  # May be empty -> NO_RESULT (never a stale, wrong answer).
+
+    def _enter_query(self, page: Any, field: Any, query: str) -> None:
+        """Focus the field, clear any stale value/dropdown, then type the new query."""
+        field.click()  # Focus so Google binds keystrokes.
+        field.fill("")  # Clear any previous text.
+        self._settle(page, 150)  # Let Google tear down the previous dropdown before typing.
+        field.type(query, delay=40)  # Type slowly so Google fires the autocomplete request.
+
+    def _read_fresh_suggestions(self, page: Any, expected: str, timeout_ms: int) -> list[str]:
+        """Poll until the TOP suggestion matches ``expected`` (this query's house number).
+
+        Google leaves the PREVIOUS query's suggestions in the DOM until the new
+        request returns, so reading immediately yields a stale (wrong) answer -- the
+        observed one-row lag. We wait until the top row actually contains this
+        query's house number; on timeout we return [] (NO_RESULT) rather than risk
+        a stale, wrong address. Queries without a house number cannot be anchored,
+        so they read the first stable list (rare for retail addresses).
+        """
+        deadline = time.monotonic() + max(0.0, timeout_ms / 1000.0)  # Absolute wait deadline.
+        while time.monotonic() < deadline:  # Poll until fresh or timed out.
+            texts = self._current_suggestions(page)  # Snapshot the current dropdown rows.
+            if texts and (not expected or self._matches_house_number(texts[0], expected)):  # Fresh top row.
+                return texts  # The top suggestion belongs to THIS query.
+            self._settle(page, 200)  # Brief pause before re-polling.
+        logging.info("No fresh suggestion for house number '%s' within timeout; skipping (stale-guard)", expected)
+        return []  # Fail-soft to NO_RESULT.
+
+    def _current_suggestions(self, page: Any) -> list[str]:
+        """Return the non-empty visible texts of the current suggestion rows."""
+        items = page.query_selector_all(PAC_ITEM_SELECTOR)  # All suggestion rows in the dropdown.
+        return [text for text in (self._item_text(item) for item in items) if text]  # Drop empties.
+
+    @staticmethod
+    def _settle(page: Any, millis: int) -> None:
+        """Pause via Playwright's clock between polls (no-op-safe in tests)."""
+        try:
+            page.wait_for_timeout(millis)  # Cooperative wait that yields to the browser event loop.
+        except Exception as exc:  # noqa: BLE001 -- a timing helper must never abort the lookup.
+            logging.debug("wait_for_timeout ignored: %s", exc)  # Trace and continue.
+
+    @staticmethod
+    def _house_number(text: str) -> str:
+        """Return the first digit-run (the house number); names like 'T-Mobile' have none."""
+        match = re.search(r"\d+", text)  # First run of digits in the query.
+        return match.group(0) if match else ""  # House number or empty when none present.
+
+    @staticmethod
+    def _matches_house_number(text: str, expected: str) -> bool:
+        """Return True when ``expected`` is one of the digit-runs in ``text`` (glue-safe)."""
+        return expected in re.findall(r"\d+", text)  # Compare extracted numbers, not a raw substring.
 
     def _locate_input(self, page: Any, timeout_ms: int) -> Any:
         """Probe candidate selectors and return the first matching input element."""
@@ -284,21 +332,37 @@ class MistUIGeocoder:
             return ""  # Treat as empty so it is filtered out.
 
     def _build_result(self, query: str, suggestions: list[str]) -> ResolverResult:
-        """Turn ranked Google suggestions into a ``ResolverResult``."""
+        """Turn ranked Google suggestions into a ``ResolverResult`` (cleaned address)."""
         if not suggestions:  # No autocomplete suggestions at all.
             logging.debug("No UI suggestions for query: %s", query)  # Trace the empty result.
             return ResolverResult(query=query, canonical_address=None, source="mist_ui", confidence=0.0)
-        top = suggestions[0]  # Google ranks the best match first.
+        top = self._clean_address(suggestions[0])  # Strip the glued business name + trailing country.
         ambiguous = len(suggestions) > 1  # Multiple hits => mall/strip-center ambiguity.
         confidence = 0.6 if ambiguous else 0.9  # Lower confidence when several candidates exist.
         logging.info("UI geocode top suggestion: %s (ambiguous=%s)", top, ambiguous)  # Action-log result.
         return ResolverResult(
             query=query,  # Echo the query for cache keying.
-            canonical_address=top,  # Best suite-corrected address.
+            canonical_address=top,  # Best suite-corrected, shippable address.
             source="mist_ui",  # Mark the originating tier.
             confidence=confidence,  # Heuristic confidence.
             raw_response={"suggestions": suggestions, "ambiguous": ambiguous},  # Full payload for cache.
         )
+
+    @staticmethod
+    def _clean_address(text: str) -> str:
+        """Strip a glued leading place/business name and a trailing country from a suggestion.
+
+        Google's ``.pac-item`` rows glue the establishment name to the address with
+        no separator (e.g. ``T-Mobile931 US Highway 331 Ste A2, ..., USA``). We drop
+        the trailing country and any leading non-digit run that precedes a
+        ``<house-number> <street>`` start, yielding the clean shippable street line.
+        Addresses with no house number are returned as-is (rare for retail).
+        """
+        s = text.strip()  # Normalize surrounding whitespace.
+        s = re.sub(r",?\s*(?:USA|United States)\s*$", "", s, flags=re.IGNORECASE).strip()  # Drop trailing country.
+        match = re.match(r"^\D*?(\d+\s+\D.*)$", s)  # Find "<house-number> <street>..." after any name prefix.
+        cleaned = match.group(1) if match else s  # Use the address tail when a real street start is present.
+        return cleaned.strip().strip(",").strip() or text.strip()  # Never return empty.
 
     def close(self) -> None:
         """Tear down browser and driver handles; never raises."""

--- a/tests/unit/site/address_audit/test_ui_geocoder.py
+++ b/tests/unit/site/address_audit/test_ui_geocoder.py
@@ -149,6 +149,77 @@ class TestHelpers:
         assert MistUIGeocoder.spawn_debuggable_browser() is None
 
 
+class TestStaleGuard:
+    """The autocomplete lag race: never read the previous query's suggestion."""
+
+    def test_house_number_extracts_first_digits(self):
+        """The first digit-run of the query is the house-number anchor."""
+        assert MistUIGeocoder._house_number("T-Mobile 931 US Highway 331") == "931"
+        assert MistUIGeocoder._house_number("No digits here") == ""
+
+    def test_matches_house_number_is_glue_safe(self):
+        """House-number match works even when the name is glued to the number."""
+        assert MistUIGeocoder._matches_house_number("T-Mobile931 US Highway 331", "931") is True
+        assert MistUIGeocoder._matches_house_number("T-Mobile7535 Kendall Dr", "931") is False
+
+    def test_read_fresh_returns_when_top_matches(self):
+        """A top row containing the query's house number is returned immediately."""
+        geo = MistUIGeocoder()
+        page = MagicMock()
+        item = MagicMock()
+        item.inner_text.return_value = "T-Mobile931 US Highway 331 Ste A2, DeFuniak Springs, FL"
+        page.query_selector_all.return_value = [item]
+        out = geo._read_fresh_suggestions(page, "931", 5000)
+        assert out and out[0].startswith("T-Mobile931")
+
+    def test_read_fresh_skips_stale_then_returns(self):
+        """A stale top row (wrong house number) is skipped until the fresh one appears."""
+        geo = MistUIGeocoder()
+        page = MagicMock()
+        stale = MagicMock()
+        stale.inner_text.return_value = "T-Mobile7535 North Kendall Drive #1515b, Miami, FL"
+        fresh = MagicMock()
+        fresh.inner_text.return_value = "T-Mobile1701 Ohio Ave N, Live Oak, FL"
+        page.query_selector_all.side_effect = [[stale], [fresh]]  # First poll stale, second fresh.
+        out = geo._read_fresh_suggestions(page, "1701", 5000)
+        assert out[0].startswith("T-Mobile1701")
+        assert page.query_selector_all.call_count == 2
+
+    def test_read_fresh_times_out_to_empty(self):
+        """Persistent stale (never the right house number) fails soft to [] (NO_RESULT)."""
+        geo = MistUIGeocoder()
+        page = MagicMock()
+        stale = MagicMock()
+        stale.inner_text.return_value = "T-Mobile7535 North Kendall Drive, Miami, FL"
+        page.query_selector_all.return_value = [stale]
+        assert geo._read_fresh_suggestions(page, "9999", 0) == []  # Zero budget -> immediate timeout.
+
+
+class TestCleanAddress:
+    """The captured Google suggestion is reduced to a clean shippable street line."""
+
+    def test_strips_business_prefix_and_country(self):
+        """A glued business name and trailing ', USA' are removed."""
+        raw = "T-Mobile931 US Highway 331 Ste A2, DeFuniak Springs, FL 32435, USA"
+        assert MistUIGeocoder._clean_address(raw) == "931 US Highway 331 Ste A2, DeFuniak Springs, FL 32435"
+
+    def test_keeps_plain_address_unchanged(self):
+        """An already-clean address is returned as-is."""
+        assert MistUIGeocoder._clean_address("123 Main St Suite 4") == "123 Main St Suite 4"
+
+    def test_keeps_numberless_address(self):
+        """A place with no house number is preserved (cannot safely split)."""
+        assert MistUIGeocoder._clean_address("Brandon Town Center Mall, Brandon, FL") == (
+            "Brandon Town Center Mall, Brandon, FL"
+        )
+
+    def test_build_result_cleans_top_suggestion(self):
+        """_build_result returns the cleaned address, not the raw glued text."""
+        raw = "T-Mobile7535 North Kendall Drive #1515b, Miami, FL 33156, USA"
+        result = MistUIGeocoder()._build_result("q", [raw])
+        assert result.canonical_address == "7535 North Kendall Drive #1515b, Miami, FL 33156"
+
+
 class TestAutoConnect:
     """The default 'auto' mode: take over an existing browser, else spawn one."""
 


### PR DESCRIPTION
## Summary
Fixes a **correctness bug** in the menu 195 Tier-3 geocoder found in a live run: results were shifted by one (each address captured the *previous* query's Google suggestion). Also cleans the captured suggestion to a shippable street line.

Linked issue: #551

## The bug (from a live run log)
Google Places leaves the previous query's suggestions in the dropdown until the new request returns. The geocoder waited for *any* `.pac-item` and read it immediately -- so it captured the stale, previous answer:
- query `1701 Ohio Ave` -> captured `7535 North Kendall Drive` (the prior row's answer)
- query `11401 NW 12th St` -> captured `1701 Ohio Ave`
- query `1455 NW 107th Ave` -> captured `11401 NW 12th St`

Every row was off by one and therefore **wrong**.

## Fix
- **Stale-guard**: anchor on the query's **house number** and poll until the TOP suggestion actually contains it (dismissing the stale dropdown first). On timeout, return **NO_RESULT** rather than risk a stale, wrong address. Queries without a house number (rare for retail) read the first stable list.
- **Clean output**: strip Google's glued business-name prefix (`T-Mobile931 US Highway...`) and trailing `, USA` so the suggestion is the clean shippable street with its suite preserved -> `931 US Highway 331 Ste A2, DeFuniak Springs, FL 32435`.

## Testing
- `py_compile` / `black --line-length 120` / `ruff` / `vulture@90`: clean.
- **112 unit tests pass** (+9: house-number anchor, glue-safe match, fresh/stale/timeout polling, address cleaning).
- Verified against the exact strings from the live log: stale answers rejected, fresh accepted, suites preserved.

## Operator note
Anyone who ran the audit before this fix should **re-run and discard the prior output** (it was shifted). The geocoding cache should be cleared so the shifted answers are recomputed.

READ-ONLY feature; no destructive operations.