### PR TITLE
fix(address-audit): consensus query (stops out-of-state SNMP hijack) + business fallback + cleaner (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Changed
 
+- **Address audit query is now built by house-number consensus (menu 195)**: the
+  geocoding query was built SNMP-location-first, so when a site's SNMP location
+  pointed at a different address -- even a different state -- the audit geocoded
+  the wrong place. One real T-Mobile site in Palm Beach Gardens, FL had an SNMP
+  location of `1520 Route 38 ... Hainesport NJ`, and the audit "corrected" the FL
+  store to a **New Jersey** address (a shipping-safety bug). The Mist address, the
+  SNMP location, and the customer CSV are now treated as equal *hints*: the audit
+  votes on the house number across all three and uses the agreed-upon, cleanest,
+  suite-bearing source, so one bad hint can no longer hijack the query. SNMP
+  directional glue (`SFederal` -> `S Federal`, `NMilitary` -> `N Military`) is
+  repaired before voting. Tier 3 also retries once **without** the business-name
+  prefix when the `"<business> <address>"` query returns nothing (a store may not
+  sit at that exact number), which recovers rows that previously hit NO_RESULT.
+
 - **Address audit Tier-3 now self-spawns a browser and deduces the suite (menu 195)**:
   Two gaps stopped the Mist-portal path from ever working. (1) Tier-3 only ever
   *took over* a browser at `localhost:9222` -- which nothing was running, and
@@ -33,6 +47,13 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   web to deduce the true, shippable address.
 
 ### Fixed
+
+- **Address audit suggested-address still showed the business name on number-first
+  streets (menu 195)**: the suggestion cleaner stripped Google's glued business
+  name only when the street name began with a letter, so rows whose street starts
+  with a digit kept the prefix (`T-Mobile4103 14th St W`). It now strips the
+  prefix in that case too (`4103 14th St W, Bradenton, FL 34205`) and splits a
+  directional fused to the city (`...Ave NLive Oak` -> `...Ave N Live Oak`).
 
 - **Address audit Tier-3 captured the WRONG suggestion (one-row lag) (menu 195)**:
   Google Places leaves the previous query's suggestions in the dropdown until the

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -192,11 +192,34 @@ class AddressResolver:
             logging.debug("Mist already has a suite; skipping Tier-3 lookup")  # No suite to discover.
             return None  # Save a browser lookup.
         logging.info("Delegating to Tier 3 (Google-via-Mist) to deduce the suite")  # Action-log delegation.
-        self.external_calls += 1  # Count the UI lookup as an external call.
-        result = self._ui_geocoder.geocode_via_ui(query)  # Drive the dashboard autocomplete (fail-soft).
+        result = self._ui_lookup_with_fallback(candidates, query)  # Business query, then plain on a miss.
         if result is not None:  # Stamp the query so caching stays consistent.
             result.query = query  # Align the result's query with the cache key source.
-        return result  # May be None (fail-soft) -> caller falls back to Tier 1/2.
+        return result  # May be None / empty (fail-soft) -> caller falls back to Tier 1/2.
+
+    def _ui_lookup_with_fallback(self, candidates: ResolveCandidates, query: str) -> ResolverResult | None:
+        """Geocode the business-prefixed query; if it yields nothing, retry the plain address.
+
+        A business-name prefix (``T-Mobile <addr>``) helps Google return the exact
+        store unit, but when no store sits at that number Google returns unrelated
+        stores and the stale-guard rejects them all. Retrying the plain address
+        then resolves the street itself (e.g. ``2315 S Federal Hwy``).
+        """
+        self.external_calls += 1  # Count the primary UI lookup.
+        result = self._ui_geocoder.geocode_via_ui(query)  # Business-prefixed query first.
+        if self._has_address(result) or not candidates.business_name:  # Got an answer, or nothing to strip.
+            return result  # Use the primary result as-is.
+        plain = self._consensus_address(candidates)  # The same address without the business prefix.
+        if not plain:  # No usable plain query to retry with.
+            return result  # Keep the (empty) primary result.
+        logging.info("Tier 3 retrying without business prefix: %s", plain)  # Action-log the fallback.
+        self.external_calls += 1  # Count the fallback lookup.
+        return self._ui_geocoder.geocode_via_ui(plain)  # Plain-address retry (fail-soft).
+
+    @staticmethod
+    def _has_address(result: ResolverResult | None) -> bool:
+        """Return True when a resolver result actually carries a canonical address."""
+        return result is not None and bool(result.canonical_address)  # Non-empty suggestion present.
 
     @staticmethod
     def _mist_has_suite(mist_address: dict[str, Any]) -> bool:
@@ -212,15 +235,77 @@ class AddressResolver:
         self._last_nominatim_ts = time.monotonic()  # Record this call's timestamp.
 
     def _build_query(self, candidates: ResolveCandidates) -> str:
-        """Build the query string: best internal candidate, optionally business-prefixed."""
-        best = (  # First non-empty of SNMP -> CSV -> Mist, in priority order.
-            candidates.snmp_location
-            or self._format_address(candidates.csv_address)
-            or self._format_address(candidates.mist_address)
-        )
-        if candidates.business_name:  # Prepend the business name when configured.
-            return f"{candidates.business_name} {best}".strip()  # Business-qualified query.
-        return best.strip()  # Raw-address query (private/internal addresses).
+        """Build the geocoding query from the consensus hint, optionally business-prefixed."""
+        address = self._consensus_address(candidates)  # Best hint by house-number agreement.
+        if candidates.business_name:  # Prepend the business name (retail store disambiguation).
+            return f"{candidates.business_name} {address}".strip()  # Business-qualified query.
+        return address.strip()  # Raw-address query (private/internal addresses).
+
+    def _consensus_address(self, candidates: ResolveCandidates) -> str:
+        """Pick the hint whose house number the most sources agree on (suite-preferring).
+
+        The Mist address, the SNMP location, and the customer CSV are all hints,
+        and any single one can be wrong -- Mist may lack a house number, the SNMP
+        location may point at a different site (even a different state), and the
+        CSV was rejected by the shipping system. Voting on the house number means
+        one bad hint cannot hijack the geocoding query; the agreed-upon, cleanest,
+        suite-bearing source wins.
+        """
+        hints = self._gather_hints(candidates)  # [(label, text, house_no, has_suite), ...].
+        if not hints:  # No usable hint at all.
+            return ""  # Empty query -> NO_RESULT.
+        winner = self._majority_house_number(hints)  # House number with the most votes.
+        group = [hint for hint in hints if hint[2] == winner] or hints  # Sources matching the winner.
+        return self._prefer_hint(group)[1]  # Suite-bearing first, then CSV > Mist > SNMP.
+
+    def _gather_hints(self, candidates: ResolveCandidates) -> list[tuple[str, str, str, bool]]:
+        """Normalize each hint into (label, text, house_number, has_suite); drop empties."""
+        raw = [  # Source label -> raw text (CSV/Mist first so ties prefer the customer data).
+            ("csv", self._format_address(candidates.csv_address)),
+            ("mist", self._format_address(candidates.mist_address)),
+            ("snmp", candidates.snmp_location or ""),
+        ]
+        hints: list[tuple[str, str, str, bool]] = []  # Accumulate usable hints.
+        for label, text in raw:  # Walk each candidate source.
+            norm = self._normalize_glue(text)  # Repair directional glue (SFederal -> S Federal).
+            if norm:  # Skip empty sources.
+                has_suite = bool(re.search(_SUITE_PATTERN, norm, flags=re.IGNORECASE))  # Suite present?
+                hints.append((label, norm, self._leading_house_number(norm), has_suite))  # Record it.
+        return hints  # One tuple per non-empty source.
+
+    @staticmethod
+    def _normalize_glue(text: str) -> str:
+        """Repair common SNMP glue: split a directional/US prefix fused to a street name."""
+        spaced = re.sub(r"\b(US|NE|NW|SE|SW|N|S|E|W)([A-Z][a-z])", r"\1 \2", text)  # NMilitary -> N Military.
+        no_space_comma = re.sub(r"\s+,", ",", spaced)  # Drop any space before a comma.
+        return re.sub(r"\s{2,}", " ", no_space_comma).strip()  # Collapse repeated whitespace.
+
+    @staticmethod
+    def _leading_house_number(text: str) -> str:
+        """Return the leading 1-6 digit run (the house number), or '' when none leads.
+
+        Anchored at the start so a trailing ZIP is never mistaken for a house
+        number (e.g. ``S Federal Hwy ... 34982`` has no house number).
+        """
+        match = re.match(r"\s*(\d{1,6})\b", text)  # House numbers lead the street line.
+        return match.group(1) if match else ""  # Leading digits or empty.
+
+    @staticmethod
+    def _majority_house_number(hints: list[tuple[str, str, str, bool]]) -> str:
+        """Return the house number shared by the most sources (CSV wins ties via insertion order)."""
+        counts: dict[str, int] = {}  # House number -> vote count.
+        for _, _, number, _ in hints:  # Tally every non-empty house number.
+            if number:  # Ignore sources without a leading house number.
+                counts[number] = counts.get(number, 0) + 1  # One vote.
+        if not counts:  # No house numbers anywhere.
+            return ""  # No consensus possible.
+        return max(counts, key=lambda key: counts[key])  # Most-voted (first-inserted on ties = CSV).
+
+    @staticmethod
+    def _prefer_hint(group: list[tuple[str, str, str, bool]]) -> tuple[str, str, str, bool]:
+        """Pick the best hint in a group: suite-bearing first, then CSV > Mist > SNMP."""
+        rank = {"csv": 0, "mist": 1, "snmp": 2}  # Source preference for ties.
+        return sorted(group, key=lambda hint: (not hint[3], rank.get(hint[0], 9)))[0]  # Suite, then source.
 
     @staticmethod
     def _build_query_key(query: str) -> str:

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -353,14 +353,17 @@ class MistUIGeocoder:
         """Strip a glued leading place/business name and a trailing country from a suggestion.
 
         Google's ``.pac-item`` rows glue the establishment name to the address with
-        no separator (e.g. ``T-Mobile931 US Highway 331 Ste A2, ..., USA``). We drop
-        the trailing country and any leading non-digit run that precedes a
-        ``<house-number> <street>`` start, yielding the clean shippable street line.
-        Addresses with no house number are returned as-is (rare for retail).
+        no separator (e.g. ``T-Mobile931 US Highway 331 Ste A2, ..., USA``) and glue
+        a trailing directional to the city (``...Ave NLive Oak``). We drop the
+        trailing country, split a directional fused to the next word, then drop any
+        leading non-digit run before a ``<house-number> <street>`` start -- yielding
+        the clean shippable street line. Addresses with no house number are returned
+        as-is (rare for retail).
         """
         s = text.strip()  # Normalize surrounding whitespace.
         s = re.sub(r",?\s*(?:USA|United States)\s*$", "", s, flags=re.IGNORECASE).strip()  # Drop trailing country.
-        match = re.match(r"^\D*?(\d+\s+\D.*)$", s)  # Find "<house-number> <street>..." after any name prefix.
+        s = re.sub(r"\b(US|NE|NW|SE|SW|N|S|E|W)([A-Z][a-z])", r"\1 \2", s)  # Split directional glue (NLive).
+        match = re.match(r"^\D*?(\d+\s+\S.*)$", s)  # "<house-number> <street>..." after any name prefix.
         cleaned = match.group(1) if match else s  # Use the address tail when a real street start is present.
         return cleaned.strip().strip(",").strip() or text.strip()  # Never return empty.
 

--- a/tests/unit/site/address_audit/test_address_resolver.py
+++ b/tests/unit/site/address_audit/test_address_resolver.py
@@ -221,6 +221,93 @@ class TestTier3Gating:
         assert "Unit 200" in result.canonical_address  # Internal suite preserved.
 
 
+class TestConsensusQuery:
+    """The geocoding query is built by house-number consensus, not blind SNMP-first."""
+
+    def test_out_of_state_snmp_does_not_hijack(self):
+        """When SNMP points to another state, Mist+CSV consensus wins the query."""
+        res = AddressResolver()
+        mist = {"address": "3101 PGA Boulevard", "city": "Palm Beach Gardens", "state": "FL", "zip": "33410"}
+        csv = {"address": "3101 PGA Boulevard Space P239", "city": "Palm Beach Gardens", "state": "FL", "zip": "33410"}
+        cand = ResolveCandidates(
+            mist_address=mist, csv_address=csv, snmp_location="1520 Route 38 Bldg 4 Hainesport NJ 08060"
+        )
+        query = res._build_query(cand)
+        assert "3101 PGA Boulevard Space P239" in query  # FL consensus address.
+        assert "1520" not in query and "NJ" not in query  # The NJ SNMP outlier is rejected.
+
+    def test_csv_outlier_uses_mist_snmp_consensus(self):
+        """When the CSV house number is the lone outlier, Mist+SNMP consensus wins."""
+        res = AddressResolver()
+        mist = {"address": "1701 Ohio Ave N", "city": "Live Oak", "state": "FL", "zip": "32064"}
+        csv = {"address": "6670 US Highway 129, Suite 1", "city": "Live Oak", "state": "FL", "zip": "32060"}
+        cand = ResolveCandidates(mist_address=mist, csv_address=csv, snmp_location="1701 Ohio Ave N Live Oak FL 32064")
+        query = res._build_query(cand)
+        assert "1701 Ohio Ave N" in query  # Mist+SNMP agree on 1701.
+        assert "6670" not in query  # The CSV outlier is rejected.
+
+    def test_business_name_prefixes_query(self):
+        """A configured business name is prepended to the consensus address."""
+        res = AddressResolver()
+        addr = {"address": "100 Main St", "city": "Town", "state": "FL", "zip": "33000"}
+        query = res._build_query(ResolveCandidates(mist_address=addr, csv_address=addr, business_name="T-Mobile"))
+        assert query.startswith("T-Mobile 100 Main St")
+
+    def test_normalize_glue_splits_directional(self):
+        """Directional/US glue from SNMP is repaired before voting."""
+        assert AddressResolver._normalize_glue("2315 SFederal Hwy") == "2315 S Federal Hwy"
+        assert AddressResolver._normalize_glue("931 USHighway 331") == "931 US Highway 331"
+        assert AddressResolver._normalize_glue("5550 NMilitary Trl") == "5550 N Military Trl"
+
+    def test_leading_house_number_ignores_zip(self):
+        """A street with no leading number yields '' (the trailing ZIP is not a house number)."""
+        assert AddressResolver._leading_house_number("S Federal Hwy Fort Pierce FL 34982") == ""
+        assert AddressResolver._leading_house_number("2315 S Federal Hwy") == "2315"
+
+    def test_consensus_prefers_suite_bearing_source(self):
+        """Within the winning house-number group, a suite-bearing source is preferred."""
+        res = AddressResolver()
+        mist = {"address": "100 Main St", "city": "Town", "state": "FL", "zip": "33000"}
+        csv = {"address": "100 Main St Suite 7", "city": "Town", "state": "FL", "zip": "33000"}
+        assert "Suite 7" in res._consensus_address(ResolveCandidates(mist_address=mist, csv_address=csv))
+
+
+class TestUiBusinessFallback:
+    """Tier 3 retries without the business prefix when the prefixed query finds nothing."""
+
+    def test_retry_plain_when_business_query_empty(self, tmp_path, monkeypatch):
+        """An empty business-prefixed result triggers one plain-address retry."""
+        _FakeValidator.count = 0
+        _FakeValidator.valid = False  # Tier 2 yields nothing so Tier 3 is consulted.
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
+        monkeypatch.setattr(resolver_mod.time, "sleep", lambda *_: None)
+        ui = MagicMock()
+        empty = ResolverResult(query="q", canonical_address=None, source="mist_ui")  # No fresh suggestion.
+        found = ResolverResult(query="q", canonical_address="2315 S Federal Hwy, Fort Pierce, FL", source="mist_ui")
+        ui.geocode_via_ui.side_effect = [empty, found]  # First (business) empty, then (plain) hit.
+        resolver = AddressResolver(db_path=_db(tmp_path), ui_geocoder=ui)
+        mist = {"address": "S Federal Hwy", "city": "Fort Pierce", "state": "FL", "zip": "34982"}
+        csv = {"address": "2315 S Federal Hwy", "city": "Fort Pierce", "state": "FL", "zip": "34982"}
+        result = resolver.resolve(
+            ResolveCandidates(mist_address=mist, csv_address=csv, business_name="T-Mobile", ui_geocode=True)
+        )
+        assert ui.geocode_via_ui.call_count == 2  # Business query, then plain retry.
+        assert "T-Mobile" not in ui.geocode_via_ui.call_args_list[1].args[0]  # Retry had no business prefix.
+        assert result.canonical_address == "2315 S Federal Hwy, Fort Pierce, FL"
+
+    def test_no_retry_without_business_name(self, tmp_path, monkeypatch):
+        """Without a business name there is nothing to strip, so no second lookup."""
+        _FakeValidator.count = 0
+        _FakeValidator.valid = False
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
+        monkeypatch.setattr(resolver_mod.time, "sleep", lambda *_: None)
+        ui = MagicMock()
+        ui.geocode_via_ui.return_value = ResolverResult(query="q", canonical_address=None, source="mist_ui")
+        resolver = AddressResolver(db_path=_db(tmp_path), ui_geocoder=ui)
+        resolver.resolve(ResolveCandidates(mist_address=_NO_SUITE, csv_address=_NO_SUITE, ui_geocode=True))
+        assert ui.geocode_via_ui.call_count == 1  # No business prefix -> no fallback.
+
+
 class TestHelpers:
     """Query-key normalization and rate limiting."""
 

--- a/tests/unit/site/address_audit/test_ui_geocoder.py
+++ b/tests/unit/site/address_audit/test_ui_geocoder.py
@@ -219,6 +219,16 @@ class TestCleanAddress:
         result = MistUIGeocoder()._build_result("q", [raw])
         assert result.canonical_address == "7535 North Kendall Drive #1515b, Miami, FL 33156"
 
+    def test_strips_business_when_street_starts_with_number(self):
+        """The business prefix is stripped even when the street name starts with a digit."""
+        raw = "T-Mobile4103 14th St W, Bradenton, FL 34205, USA"
+        assert MistUIGeocoder._clean_address(raw) == "4103 14th St W, Bradenton, FL 34205"
+
+    def test_splits_directional_glued_to_city(self):
+        """A directional fused to the city is split (NLive Oak -> N Live Oak)."""
+        raw = "1701 Ohio Ave NLive Oak, FL 32064"
+        assert MistUIGeocoder._clean_address(raw) == "1701 Ohio Ave N Live Oak, FL 32064"
+
 
 class TestAutoConnect:
     """The default 'auto' mode: take over an existing browser, else spawn one."""


### PR DESCRIPTION
## Summary
Reviewing a full 44-row menu 195 run surfaced a **shipping-safety bug** plus two data-quality issues. Fixes all three and keeps the "all sources are hints" model.

Linked issue: #551

## 1. Shipping-safety: out-of-state SNMP hijacked the query
The geocoding query was built **SNMP-location-first**. One real T-Mobile site in Palm Beach Gardens, FL had an SNMP location of `1520 Route 38 ... Hainesport NJ`, so the audit "corrected" the FL store to a **New Jersey** address. (Nominatim had even validated the correct FL street at confidence 1.00 -- but the NJ Tier-3 result, driven by the NJ query, won.)

**Fix:** the Mist address, SNMP location, and CSV are now equal hints. The audit **votes on the house number** across all three and uses the agreed-upon, cleanest, suite-bearing source -- so one bad hint cannot hijack the query. Verified:
- PGA: Mist+CSV agree on `3101` (FL) -> query targets FL, NJ rejected.
- A test site where the CSV was the lone outlier -> Mist+SNMP consensus wins (no false WRONG_STREET).
- SNMP directional glue (`SFederal` -> `S Federal`, `NMilitary` -> `N Military`) is repaired before voting.

## 2. NO_RESULT recovery: business-name fallback
A Fort Pierce row hit NO_RESULT because `T-Mobile 2315 S Federal Hwy` returned only unrelated T-Mobile stores (none at 2315), so the stale-guard correctly rejected them all. Tier-3 now **retries once without the business prefix** (plain `2315 S Federal Hwy ...`) to resolve the street itself.

## 3. Cleaner: business name leaked on number-first streets
`T-Mobile4103 14th St W` kept its prefix because the cleaner only stripped it when the street name began with a letter. Now stripped in that case too (`4103 14th St W, Bradenton, FL 34205`), and a directional fused to the city is split (`...Ave NLive Oak` -> `...Ave N Live Oak`).

## Testing
- `py_compile` / `black --line-length 120` / `ruff` / `vulture@90`: clean.
- **122 unit tests pass** (+10: consensus voting, glue repair, leading-house-number vs ZIP, suite-preference, business fallback retry, number-first cleaning).
- Verified all fixes against the exact addresses from the live run.

## Operator note
Re-run the audit and clear the geocoding cache so prior (SNMP-hijacked / dirty) rows are recomputed. READ-ONLY feature; no destructive operations.