### PR TITLE
fix(address-audit): catch wrong-side-of-street + adjudicate suite conflicts (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Changed
 
+- **Address audit now adjudicates suite *conflicts*, not just missing suites (menu
+  195)**: Tier-3 was skipped whenever the Mist address already carried any suite,
+  so when the customer CSV claimed a *different* unit (Mist `#204` vs CSV
+  `Suite H200` at the Mall at Millenia) the audit reported MIST_BETTER without ever
+  checking which unit is real. Tier-3 now also runs when the CSV unit disagrees
+  with Mist's, so the web adjudicates the correct shippable unit. Identical units
+  expressed differently (`Suite 100` vs `Ste 100`) still skip the lookup.
+
 - **Address audit query is now built by house-number consensus (menu 195)**: the
   geocoding query was built SNMP-location-first, so when a site's SNMP location
   pointed at a different address -- even a different state -- the audit geocoded
@@ -48,7 +56,19 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
-- **Address audit suggested-address still showed the business name on number-first
+- **Address audit hid wrong-side-of-street addresses as a MATCH (menu 195)**: the
+  street comparison ignored directionals, so a Mist address of `1606 E Jefferson`
+  was reported as ADDRESS_MATCH against the web-confirmed `1606 West Jefferson` --
+  East vs West are different streets, and shipping to the wrong one is a real risk.
+  The comparison now flags a conflicting *leading* directional (the one right after
+  the house number, so a directional inside a city name like `West Palm Beach` is
+  ignored) as WRONG_STREET, while treating abbreviations as equal (`S` = `South`,
+  `NW` = `Northwest`). The street-name comparison also now includes ordinal names
+  (`107th`, `A1A`), so `1455 NW 107th Ave` reliably matches `1455 Northwest 107th
+  Avenue` regardless of whether Google abbreviates or spells out the directional
+  and street type.
+
+
   streets (menu 195)**: the suggestion cleaner stripped Google's glued business
   name only when the street name began with a letter, so rows whose street starts
   with a digit kept the prefix (`T-Mobile4103 14th St W`). It now strips the

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -179,17 +179,18 @@ class AddressResolver:
         )
 
     def _maybe_ui(self, candidates: ResolveCandidates, query: str) -> ResolverResult | None:
-        """Tier 3: consult the Google-via-Mist authority when a suite is actually missing.
+        """Tier 3: consult the Google-via-Mist authority to find or adjudicate the suite.
 
-        Only runs when UI geocoding is permitted AND the Mist street lacks a
-        suite -- that is exactly the case the operator wants resolved (the true
-        suite/unit for shipping). Rows where Mist already carries a suite skip the
-        (slow) browser lookup. Always fail-soft to ``None``.
+        Runs when UI geocoding is permitted AND either the Mist street lacks a
+        suite (discover the true unit for shipping) or the CSV claims a different
+        unit than Mist (adjudicate the conflict). Rows where Mist already carries a
+        suite that matches the CSV skip the (slow) browser lookup. Fail-soft to
+        ``None``.
         """
         if not candidates.ui_geocode or self._ui_geocoder is None:  # Tier 3 disabled for this row/run.
             return None  # Skip the UI tier.
-        if self._mist_has_suite(candidates.mist_address):  # Mist is already suite-specific.
-            logging.debug("Mist already has a suite; skipping Tier-3 lookup")  # No suite to discover.
+        if not self._should_consult_ui(candidates):  # Mist suite present and consistent with the CSV.
+            logging.debug("Mist suite present and matches CSV; skipping Tier-3 lookup")  # Nothing to discover.
             return None  # Save a browser lookup.
         logging.info("Delegating to Tier 3 (Google-via-Mist) to deduce the suite")  # Action-log delegation.
         result = self._ui_lookup_with_fallback(candidates, query)  # Business query, then plain on a miss.
@@ -221,11 +222,31 @@ class AddressResolver:
         """Return True when a resolver result actually carries a canonical address."""
         return result is not None and bool(result.canonical_address)  # Non-empty suggestion present.
 
+    def _should_consult_ui(self, candidates: ResolveCandidates) -> bool:
+        """Run Tier 3 when Mist lacks a suite, or when the CSV claims a different one.
+
+        The goal is the true shippable unit. Tier 3 runs when Mist has no suite
+        (discover it) or when the CSV's unit disagrees with Mist's (adjudicate the
+        conflict via the web). It is skipped only when Mist already carries a suite
+        that matches the CSV, sparing a browser lookup.
+        """
+        mist_unit = self._suite_unit(candidates.mist_address.get("address", ""))  # Mist's unit id (or '').
+        if not mist_unit:  # Mist has no suite at all.
+            return True  # Discover the missing suite.
+        csv_unit = self._suite_unit(candidates.csv_address.get("address", ""))  # CSV's unit id (or '').
+        if csv_unit and csv_unit != mist_unit:  # CSV claims a different unit.
+            logging.info("Mist unit %r conflicts with CSV unit %r; adjudicating via Tier 3", mist_unit, csv_unit)
+            return True  # Resolve the conflict against the web.
+        return False  # Mist already specific and consistent with the CSV.
+
     @staticmethod
-    def _mist_has_suite(mist_address: dict[str, Any]) -> bool:
-        """Return True when the Mist street line already carries a suite/unit token."""
-        street = mist_address.get("address", "")  # Mist's street line.
-        return bool(re.search(_SUITE_PATTERN, street, flags=re.IGNORECASE))  # Suite already present?
+    def _suite_unit(street: str) -> str:
+        """Extract the bare unit identifier from a street's suite token (e.g. 'h200', '204', '')."""
+        token = AddressResolver._extract_suite(street)  # e.g. 'Suite H200', '#204', 'Space P239'.
+        if not token:  # No suite token present.
+            return ""  # No unit.
+        parts = token.split()  # Split the keyword from the identifier.
+        return parts[-1].lstrip("#").lower() if parts else token.lower()  # Trailing unit id, '#' stripped.
 
     def _respect_rate_limit(self) -> None:
         """Sleep as needed so consecutive Nominatim calls stay within ToS."""

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -46,6 +46,24 @@ _DATA_DIR = "data"  # Directory scanned for the customer CSV.
 _SUITE_PATTERN = (  # Suite token with a capture group for the unit id (state-safe).
     r"\b(?:ste|suite|unit|apt|apartment|bldg|building|space|spc|rm|room|lot)\b\.?\s*#?\s*([\w-]+)" r"|#\s*(\d[\w-]*)"
 )
+_DIRECTIONALS = {  # Street-name directional tokens, normalized to their abbreviation.
+    "n": "N",
+    "s": "S",
+    "e": "E",
+    "w": "W",
+    "ne": "NE",
+    "nw": "NW",
+    "se": "SE",
+    "sw": "SW",
+    "north": "N",
+    "south": "S",
+    "east": "E",
+    "west": "W",
+    "northeast": "NE",
+    "northwest": "NW",
+    "southeast": "SE",
+    "southwest": "SW",
+}
 
 
 class AddressAuditEngine:
@@ -375,22 +393,56 @@ class AddressAuditEngine:
 
         Robust to SNMP/geocoder strings that add a store-number prefix or drop the
         city/ZIP: anchors on the Mist house number plus at least one street-name word.
+        A conflicting leading directional (Mist 'E Jefferson' vs web 'West Jefferson')
+        is treated as a different street so a wrong-side address never reads as a match.
         """
         mist_number = self._house_number(mist_street)  # Mist street's house number.
         if mist_number and mist_number not in self._all_numbers(candidate):  # House number must appear.
             return False  # Different building number -> different street.
+        mist_dir = self._leading_directional(mist_street)  # Directional right after the house number.
+        cand_dir = self._leading_directional(candidate)  # Same for the candidate (city dirs ignored).
+        if mist_dir and cand_dir and mist_dir != cand_dir:  # Opposite directionals (E vs W).
+            return False  # Different side of the street -> different street.
         overlap = self._name_words(mist_street) & self._name_words(candidate)  # Shared street words.
         return bool(overlap)  # Same street when at least one street-name word matches.
+
+    @staticmethod
+    def _leading_directional(street: str) -> str:
+        """Return the directional immediately after the house number, normalized, or ''.
+
+        Only the leading directional (e.g. the ``E`` in ``1606 E Jefferson``) is
+        considered, so a directional inside a later city name (``West Palm Beach``)
+        never triggers a false street mismatch.
+        """
+        tokens = re.sub(r"[^A-Za-z0-9 ]", " ", street).split()  # Punctuation-free tokens.
+        if not tokens:  # Empty street line.
+            return ""  # No directional.
+        index = 1 if tokens[0].isdigit() else 0  # Skip a leading house number.
+        if index >= len(tokens):  # Nothing past the house number.
+            return ""  # No directional.
+        return _DIRECTIONALS.get(tokens[index].lower(), "")  # Normalized directional or ''.
 
     def _has_suite_discrepancy(self, base: str, candidate: str) -> bool:
         """Return True when ``candidate`` carries a suite the ``base`` address lacks."""
         return bool(self._suite(candidate)) and not self._suite(base)  # Candidate-only suite.
 
     def _name_words(self, text: str) -> set[str]:
-        """Return the set of alphabetic street-name words (suite-stripped, len >= 2)."""
+        """Return the comparable street-name tokens (suite-stripped).
+
+        Includes alphabetic words (``jefferson``) AND ordinal/alphanumeric street
+        names (``107th``, ``a1a``) so a numeric-named street still matches when
+        Google spells out ``NW``/``Avenue``; the pure-digit house number is
+        excluded so two different streets at the same number never match on it.
+        """
         without_suite = re.sub(_SUITE_PATTERN, " ", text.lower())  # Drop the suite token.
         normalized = self._normalize(without_suite)  # Lowercase, de-punctuate, collapse.
-        return {token for token in normalized.split() if token.isalpha() and len(token) >= 2}  # Name words.
+        words: set[str] = set()  # Accumulate comparable name tokens.
+        for token in normalized.split():  # Walk every token.
+            if token.isalpha() and len(token) >= 2:  # Street-name words (military, jefferson).
+                words.add(token)  # Keep the word.
+            elif any(ch.isdigit() for ch in token) and any(ch.isalpha() for ch in token):  # Ordinals: 107th, a1a.
+                words.add(token)  # Keep numeric-named streets (pure digits like the house number excluded).
+        return words  # Comparable street-name token set.
 
     @staticmethod
     def _house_number(text: str) -> str:

--- a/tests/unit/site/address_audit/test_address_resolver.py
+++ b/tests/unit/site/address_audit/test_address_resolver.py
@@ -195,7 +195,7 @@ class TestTier3Gating:
         assert result.street_validated is True  # OSM cross-checked the street.
 
     def test_ui_skipped_when_mist_has_suite(self, tmp_path, monkeypatch):
-        """No Tier-3 lookup when Mist already carries a suite (nothing to discover)."""
+        """No Tier-3 lookup when Mist already carries a suite that matches the CSV."""
         _FakeValidator.count = 0
         _FakeValidator.valid = False
         monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
@@ -203,7 +203,43 @@ class TestTier3Gating:
         ui = MagicMock()
         resolver = AddressResolver(db_path=_db(tmp_path), ui_geocoder=ui)
         resolver.resolve(ResolveCandidates(mist_address=_WITH_SUITE, csv_address=_WITH_SUITE, ui_geocode=True))
-        ui.geocode_via_ui.assert_not_called()  # Mist is already suite-specific -> skip the slow lookup.
+        ui.geocode_via_ui.assert_not_called()  # Mist suite matches the CSV -> skip the slow lookup.
+
+    def test_ui_consulted_when_suite_conflicts(self, tmp_path, monkeypatch):
+        """Tier 3 runs to adjudicate when Mist's suite differs from the CSV's."""
+        _FakeValidator.count = 0
+        _FakeValidator.valid = False
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _FakeValidator)
+        monkeypatch.setattr(resolver_mod.time, "sleep", lambda *_: None)
+        ui = MagicMock()
+        ui.geocode_via_ui.return_value = ResolverResult(
+            query="q", canonical_address="4200 Conroy Rd Suite H200, Orlando, FL", source="mist_ui"
+        )
+        resolver = AddressResolver(db_path=_db(tmp_path), ui_geocoder=ui)
+        mist = {"address": "4200 Conroy Rd #204", "city": "Orlando", "state": "FL", "zip": "32839"}
+        csv = {"address": "4200 Conroy Rd Suite H200", "city": "Orlando", "state": "FL", "zip": "32839"}
+        resolver.resolve(ResolveCandidates(mist_address=mist, csv_address=csv, ui_geocode=True))
+        ui.geocode_via_ui.assert_called()  # Conflicting suites -> adjudicate via the web.
+
+    def test_suite_unit_extracts_identifier(self):
+        """The bare unit identifier is extracted for conflict comparison."""
+        assert AddressResolver._suite_unit("4200 Conroy Rd #204") == "204"
+        assert AddressResolver._suite_unit("4200 Conroy Rd Suite H200") == "h200"
+        assert AddressResolver._suite_unit("100 Main St Ste 100") == "100"
+        assert AddressResolver._suite_unit("100 Main St") == ""
+
+    def test_should_consult_ui_matrix(self):
+        """The Tier-3 gate: run on missing or conflicting suites, skip on a match."""
+        res = AddressResolver()
+
+        def gate(mist, csv):
+            cand = ResolveCandidates(mist_address={"address": mist}, csv_address={"address": csv})
+            return res._should_consult_ui(cand)
+
+        assert gate("100 Main St", "100 Main St Suite 5") is True  # Mist missing -> discover.
+        assert gate("100 Main St #204", "100 Main St Suite H200") is True  # Conflict -> adjudicate.
+        assert gate("100 Main St Suite 100", "100 Main St Ste 100") is False  # Same unit -> skip.
+        assert gate("100 Main St #1st", "100 Main St") is False  # CSV claims no unit -> skip.
 
     def test_internal_used_when_ui_returns_none(self, tmp_path, monkeypatch):
         """When Tier 3 returns None, the internal suite suggestion is used (no worse than before)."""

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -62,6 +62,52 @@ class TestClassify:
         rr = _rr("100 Main St Suite 7 Town FL 33000")
         assert self.engine._classify(_MIST_WITH_SUITE, _CSV, None, rr) == "CSV_BETTER"
 
+    def test_directional_conflict_is_wrong_street(self):
+        """Mist 'E Jefferson' vs web 'West Jefferson' is a different street, not a match."""
+        mist = {"address": "1606 E Jefferson St", "city": "Quincy", "state": "FL", "zip": "32351"}
+        rr = _rr("1606 West Jefferson Street, Quincy, FL 32351")
+        assert self.engine._classify(mist, _CSV, None, rr) == "WRONG_STREET"
+
+    def test_abbreviated_directional_still_matches(self):
+        """Mist 'NW 107th Ave' vs web 'Northwest 107th Avenue' is the same street."""
+        mist = {"address": "1455 NW 107th Ave", "city": "Miami", "state": "FL", "zip": "33172"}
+        rr = _rr("1455 Northwest 107th Avenue #410, Miami, FL 33172")
+        assert self.engine._classify(mist, _CSV, None, rr) == "MISSING_SUITE"
+
+    def test_city_directional_does_not_cause_false_mismatch(self):
+        """A directional inside the city (West Palm Beach) does not break the street match."""
+        mist = {"address": "940 S Military Trail", "city": "West Palm Beach", "state": "FL", "zip": "33415"}
+        rr = _rr("940 South Military Trail #3, West Palm Beach, FL 33415")
+        assert self.engine._classify(mist, _CSV, None, rr) == "MISSING_SUITE"
+
+
+class TestSameStreet:
+    """Street-equality helper: directionals, ordinals, and abbreviations."""
+
+    def setup_method(self):
+        """Fresh engine per test."""
+        self.engine = AddressAuditEngine()
+
+    def test_opposite_directionals_differ(self):
+        """East vs West on the same street name are different streets."""
+        assert self.engine._same_street("1606 E Jefferson St", "1606 West Jefferson Street, Quincy, FL") is False
+
+    def test_abbrev_vs_spelled_directional_same(self):
+        """NW and Northwest are the same directional."""
+        assert self.engine._same_street("1455 NW 107th Ave", "1455 Northwest 107th Avenue #410, Miami, FL") is True
+
+    def test_directional_S_vs_South_same(self):
+        """S and South are the same directional (no false mismatch)."""
+        assert self.engine._same_street("1671 US 41 Bypass S", "1671 U.S. 41 Bypass South Unit 100, Venice, FL") is True
+
+    def test_same_house_number_different_street_differs(self):
+        """The same house number on a different street is not a match."""
+        assert self.engine._same_street("100 Main St", "100 Oak Ave, Town, FL") is False
+
+    def test_leading_directional_ignores_city(self):
+        """Only the directional after the house number counts, not one inside the city."""
+        assert self.engine._leading_directional("940 South Military Trail #3, West Palm Beach, FL") == "S"
+
 
 class TestBuildAuditResult:
     """Unmatched rows short-circuit to UNMATCHED without resolution."""


### PR DESCRIPTION
## Summary
Two classification-accuracy fixes found while reviewing the full 44-row menu 195 run. Both affect shipping accuracy.

Linked issue: #551

## 1. Wrong-side-of-street hidden as ADDRESS_MATCH (shipping risk)
The street comparison ignored directionals, so a Mist address of `1606 E Jefferson` was reported **ADDRESS_MATCH** against the web-confirmed `1606 West Jefferson` -- but East and West Jefferson are different streets. Shipping to the wrong one is a real risk.

**Fix:**
- A conflicting **leading** directional (the one right after the house number) -> WRONG_STREET. Anchoring on the leading directional means a directional inside a *city* name (`West Palm Beach`) never causes a false mismatch.
- Abbreviations are treated as equal: `S` = `South`, `NW` = `Northwest`.
- The street-name comparison now includes **ordinal names** (`107th`, `A1A`), so `1455 NW 107th Ave` reliably matches `1455 Northwest 107th Avenue` whether or not Google abbreviates the directional/street-type. (Previously this row's classification was flaky depending on Google's formatting.)

Verified across all 44 rows: only the Quincy row changes (correctly -> WRONG_STREET); zero false positives (`100 Main St` vs `100 Oak Ave` stays WRONG_STREET).

## 2. Suite *conflicts* now adjudicated
Tier-3 was skipped whenever Mist already had a suite, so when the CSV claimed a **different** unit (Mist `#204` vs CSV `Suite H200` at the Mall at Millenia) the audit reported MIST_BETTER without ever verifying which unit is real. Tier-3 now also runs when the CSV unit disagrees with Mist's, so the web adjudicates the correct shippable unit. Identical units in different wording (`Suite 100` vs `Ste 100`) still skip the lookup.

## Testing
- `py_compile` / `black --line-length 120` / `ruff` / `vulture@90`: clean.
- **133 unit tests pass** (+11: directional conflict, abbrev-equality, leading-directional-ignores-city, ordinal matching, same-number-different-street, suite-unit extraction, conflict-gate matrix).
- Verified against the exact addresses from the live run.

## Operator note
Re-run the audit and clear the geocoding cache so prior rows are reclassified. READ-ONLY feature; no destructive operations.