### PR TITLE
fix(address-audit): flag missing house number + de-glue street/city in suggestion (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Changed
 
+- **Address audit now flags incomplete Mist addresses (missing house number)
+  (menu 195)**: a Mist site whose street had no house number (`S Federal Hwy`)
+  was reported ADDRESS_MATCH against the web-resolved `2315 S Federal Hwy` --
+  i.e. "no change needed" -- even though the street *number* was missing, which
+  makes the address unshippable. A new ninth classification state,
+  `MISSING_NUMBER`, now surfaces these so the operator can add the number the web
+  found. Rows where Mist already has a house number are unaffected.
+
 - **Address audit now adjudicates suite *conflicts*, not just missing suites (menu
   195)**: Tier-3 was skipped whenever the Mist address already carried any suite,
   so when the customer CSV claimed a *different* unit (Mist `#204` vs CSV
@@ -56,6 +64,16 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
+- **Address audit suggested address glued the street/suite to the city (menu
+  195)**: Google's autocomplete sometimes returned the street fused to the city
+  with no separator (`2315 S Federal HwyFort Pierce`, `...suite 330Brandon`),
+  leaving an un-shippable suggested address. The cleaner now splits a street-type
+  suffix (`Hwy`, `Blvd`, `Dr`, ...) or a number glued directly to a following
+  capitalized city word, while deliberately preserving legitimately camel-cased
+  cities (`DeFuniak`) and alphanumeric street names (`A1A`) -- only street
+  suffixes and digits trigger a split, never a generic lowercase->uppercase
+  boundary.
+
 - **Address audit hid wrong-side-of-street addresses as a MATCH (menu 195)**: the
   street comparison ignored directionals, so a Mist address of `1606 E Jefferson`
   was reported as ADDRESS_MATCH against the web-confirmed `1606 West Jefferson` --
@@ -68,7 +86,7 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   Avenue` regardless of whether Google abbreviates or spells out the directional
   and street type.
 
-
+- **Address audit suggested-address still showed the business name on number-first
   streets (menu 195)**: the suggestion cleaner stripped Google's glued business
   name only when the street name began with a letter, so rows whose street starts
   with a digit kept the prefix (`T-Mobile4103 14th St W`). It now strips the

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -352,18 +352,32 @@ class AddressAuditEngine:
         snmp_loc: str | None,
         resolver_result: Any,
     ) -> str:
-        """Return exactly one of the eight classification states for a resolved row."""
+        """Return exactly one of the nine classification states for a resolved row."""
         if resolver_result is None or resolver_result.canonical_address is None:  # No external result.
             return self._classify_internal(mist_addr, csv_addr, snmp_loc)  # Fall back to internal signals.
         if resolver_result.ambiguous:  # Multiple plausible candidates (mall scenario).
             return "AMBIGUOUS"  # Needs manual disambiguation.
         mist_street = mist_addr.get("address", "")  # Mist street line is the stable anchor.
         canonical = resolver_result.canonical_address  # Suggested/validated address (may be prefixed/partial).
-        if self._addresses_agree(mist_street, canonical):  # Same street AND same suite.
-            return "ADDRESS_MATCH"  # No change needed.
         if not self._same_street(mist_street, canonical):  # Street number/name does not line up.
             return "WRONG_STREET"  # Beyond a suite-level difference.
+        if self._missing_house_number(mist_street, canonical):  # Mist street lacks the house number we found.
+            return "MISSING_NUMBER"  # Incomplete Mist address -> surface, do not call it a match.
+        if self._addresses_agree(mist_street, canonical):  # Same street AND same suite.
+            return "ADDRESS_MATCH"  # No change needed.
         return self._classify_suite(mist_street, canonical)  # Same street: compare suites.
+
+    @staticmethod
+    def _missing_house_number(mist_street: str, candidate: str) -> bool:
+        """Return True when Mist's street lacks a house number that the candidate supplies.
+
+        A Mist record like ``S Federal Hwy`` with no street number is an
+        incomplete shipping address; surfacing it (instead of calling it a match)
+        lets the operator add the number the web resolved.
+        """
+        mist_has = bool(re.search(r"\d", mist_street))  # Mist street carries any number at all.
+        cand_has = bool(re.match(r"\s*\d", candidate))  # Candidate leads with a house number.
+        return cand_has and not mist_has  # Missing only when Mist has no number but the candidate does.
 
     def _classify_internal(self, mist_addr: dict[str, Any], csv_addr: dict[str, Any], snmp_loc: str | None) -> str:
         """Classify on internal CSV/SNMP signals alone when no external result exists."""

--- a/src/site/address_audit/comparison_display.py
+++ b/src/site/address_audit/comparison_display.py
@@ -23,7 +23,7 @@ _COLUMN_NAMES = [  # The seven table columns, in display order.
     "SNMP Location",  # SNMP-derived location reference (truncated in terminal).
     "Suggested Address",  # Resolver's best correction (truncated in terminal).
     "Source",  # Which tier produced the suggestion.
-    "Issue Type",  # One of the eight classification states.
+    "Issue Type",  # One of the nine classification states.
 ]
 _TRUNCATE_WIDTH = 40  # Max terminal width for the two widest columns.
 

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -67,7 +67,7 @@ class AuditResult:
     address_row: AddressRow  # Original CSV input row.
     matched_site: MatchedSite  # Match outcome (+ SNMP enrichment).
     resolver_result: ResolverResult | None = None  # None for UNMATCHED rows (no resolution attempted).
-    issue_type: str = "UNMATCHED"  # Exactly one of the eight classification states.
+    issue_type: str = "UNMATCHED"  # Exactly one of the nine classification states.
     suggested_address: str = ""  # Best correction to display (full value; truncated only in terminal).
     source: str = "-"  # Display label for the Source column (Internal/Nominatim/Mist UI/Cache/-).
 

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -348,21 +348,31 @@ class MistUIGeocoder:
             raw_response={"suggestions": suggestions, "ambiguous": ambiguous},  # Full payload for cache.
         )
 
+    # Street-type suffixes (abbreviated and spelled out) used to split a street glued to a city.
+    _STREET_SUFFIXES = (
+        r"Hwy|Highway|St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Trl|Trail|Pkwy|Parkway|"
+        r"Ln|Lane|Ct|Court|Cir|Circle|Pl|Place|Ter|Terrace|Sq|Square|Way|Loop|Pike|Plz|Plaza|Walk|Run|Row|Path"
+    )
+
     @staticmethod
     def _clean_address(text: str) -> str:
         """Strip a glued leading place/business name and a trailing country from a suggestion.
 
         Google's ``.pac-item`` rows glue the establishment name to the address with
-        no separator (e.g. ``T-Mobile931 US Highway 331 Ste A2, ..., USA``) and glue
-        a trailing directional to the city (``...Ave NLive Oak``). We drop the
-        trailing country, split a directional fused to the next word, then drop any
-        leading non-digit run before a ``<house-number> <street>`` start -- yielding
-        the clean shippable street line. Addresses with no house number are returned
-        as-is (rare for retail).
+        no separator (e.g. ``T-Mobile931 US Highway 331 Ste A2, ..., USA``), glue a
+        trailing directional to the city (``...Ave NLive Oak``), and sometimes glue
+        the street or a suite number straight to the city (``...HwyFort Pierce``,
+        ``...suite 330Brandon``). We drop the trailing country, repair those glued
+        boundaries, then drop any leading non-digit run before a ``<house-number>
+        <street>`` start -- yielding the clean shippable street line. A real
+        camel-cased city (``DeFuniak``) is preserved because only street suffixes
+        and digits trigger a split, never a generic lowercase->uppercase boundary.
         """
         s = text.strip()  # Normalize surrounding whitespace.
         s = re.sub(r",?\s*(?:USA|United States)\s*$", "", s, flags=re.IGNORECASE).strip()  # Drop trailing country.
         s = re.sub(r"\b(US|NE|NW|SE|SW|N|S|E|W)([A-Z][a-z])", r"\1 \2", s)  # Split directional glue (NLive).
+        s = re.sub(rf"\b({MistUIGeocoder._STREET_SUFFIXES})([A-Z][a-z])", r"\1 \2", s)  # Split street->city (HwyFort).
+        s = re.sub(r"(\d)([A-Z][a-z]{2,})", r"\1 \2", s)  # Split a number glued to a city word (330Brandon).
         match = re.match(r"^\D*?(\d+\s+\S.*)$", s)  # "<house-number> <street>..." after any name prefix.
         cleaned = match.group(1) if match else s  # Use the address tail when a real street start is present.
         return cleaned.strip().strip(",").strip() or text.strip()  # Never return empty.

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -68,6 +68,18 @@ class TestClassify:
         rr = _rr("1606 West Jefferson Street, Quincy, FL 32351")
         assert self.engine._classify(mist, _CSV, None, rr) == "WRONG_STREET"
 
+    def test_missing_house_number_not_match(self):
+        """Mist street with no house number + a numbered suggestion -> MISSING_NUMBER, not ADDRESS_MATCH."""
+        mist = {"address": "S Federal Hwy", "city": "Fort Pierce", "state": "FL", "zip": "34982"}
+        rr = _rr("2315 S Federal Hwy Fort Pierce, FL 34982")
+        assert self.engine._classify(mist, _CSV, None, rr) == "MISSING_NUMBER"
+
+    def test_missing_house_number_helper(self):
+        """The helper fires only when Mist has no number but the candidate leads with one."""
+        assert self.engine._missing_house_number("S Federal Hwy", "2315 S Federal Hwy") is True
+        assert self.engine._missing_house_number("1606 E Jefferson St", "1606 West Jefferson St") is False
+        assert self.engine._missing_house_number("S Federal Hwy", "S Federal Hwy") is False
+
     def test_abbreviated_directional_still_matches(self):
         """Mist 'NW 107th Ave' vs web 'Northwest 107th Avenue' is the same street."""
         mist = {"address": "1455 NW 107th Ave", "city": "Miami", "state": "FL", "zip": "33172"}

--- a/tests/unit/site/address_audit/test_ui_geocoder.py
+++ b/tests/unit/site/address_audit/test_ui_geocoder.py
@@ -229,6 +229,26 @@ class TestCleanAddress:
         raw = "1701 Ohio Ave NLive Oak, FL 32064"
         assert MistUIGeocoder._clean_address(raw) == "1701 Ohio Ave N Live Oak, FL 32064"
 
+    def test_splits_street_suffix_glued_to_city(self):
+        """A street suffix fused to the city is split (HwyFort Pierce -> Hwy Fort Pierce)."""
+        raw = "2315 S Federal HwyFort Pierce, FL 34982"
+        assert MistUIGeocoder._clean_address(raw) == "2315 S Federal Hwy Fort Pierce, FL 34982"
+
+    def test_splits_number_glued_to_city(self):
+        """A suite number fused to the city is split (330Brandon -> 330 Brandon)."""
+        raw = "459 Brandon Town Center Drive suite 330Brandon, FL 33511"
+        assert MistUIGeocoder._clean_address(raw) == "459 Brandon Town Center Drive suite 330 Brandon, FL 33511"
+
+    def test_camelcase_city_is_preserved(self):
+        """A legitimately camel-cased city (DeFuniak) is never split."""
+        raw = "931 US Highway 331 Ste A2, DeFuniak Springs, FL 32435, USA"
+        assert MistUIGeocoder._clean_address(raw) == "931 US Highway 331 Ste A2, DeFuniak Springs, FL 32435"
+
+    def test_alphanumeric_street_name_preserved(self):
+        """An alphanumeric street name (A1A) is not split by the number-glue rule."""
+        raw = "1015 A1A Beach Blvd Unit 4, St. Augustine Beach, FL 32080"
+        assert MistUIGeocoder._clean_address(raw) == "1015 A1A Beach Blvd Unit 4, St. Augustine Beach, FL 32080"
+
 
 class TestAutoConnect:
     """The default 'auto' mode: take over an existing browser, else spawn one."""


### PR DESCRIPTION
## Summary
Reviewing the latest full 44-row menu 195 run (post #558/#559) confirmed those fixes landed -- PGA targets FL, Mall at Millenia adjudicated `H200`, Fort Pierce resolved, Quincy correctly WRONG_STREET. Two new issues remained; this PR fixes both.

Linked issue: #551

## 1. Incomplete Mist address hidden as a MATCH (new `MISSING_NUMBER` state)
One Mist site had **no house number** (`S Federal Hwy`). It was reported **ADDRESS_MATCH** against the web-resolved `2315 S Federal Hwy` -- i.e. "no change needed" -- even though the street *number* was missing, which makes the address unshippable. A new ninth classification state, `MISSING_NUMBER`, now surfaces these so the operator can add the number the web found. Rows where Mist already has a house number are unaffected. (`issue_type` is a free string with dynamic counting, so no enum/renderer changes were needed.)

## 2. Street/suite glued to the city in the suggested address
Google's autocomplete sometimes returned the street fused to the city with no separator (`2315 S Federal HwyFort Pierce`, `...suite 330Brandon`), leaving an un-shippable suggested address. The cleaner now splits a street-type suffix (`Hwy`, `Blvd`, `Dr`, ...) or a number glued to a following capitalized city word -- while **deliberately preserving** legitimately camel-cased cities (`DeFuniak`) and alphanumeric street names (`A1A`). Only street suffixes and digits trigger a split, never a generic lowercase->uppercase boundary (which would wrongly split `DeFuniak`).

## Also
Repairs a CHANGELOG bullet header (the "number-first" Fixed entry) that was lost in a prior squash-merge.

## Testing
- `py_compile` / `black --line-length 120` / `ruff` / `vulture@90`: clean.
- **139 unit tests pass** (+6: MISSING_NUMBER classify + helper, street-suffix de-glue, number-city de-glue, DeFuniak preserved, A1A preserved).
- Verified every fix against the exact addresses from the live run; confirmed no reclassification of the other 43 rows.

## Operator note
Re-run and clear the geocoding cache. The Fort Pierce row will now read `MISSING_NUMBER` and the Fort Pierce / Brandon suggestions will be cleanly spaced. READ-ONLY; no destructive operations.