### PR TITLE
feat(address-audit): push corrected addresses back to Mist (per-site confirm) + MISSING_NUMBER fix (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Added
+
+- **Address audit can now push corrected addresses back to Mist (menu 195)**: the
+  audit was read-only; you reviewed the comparison and fixed addresses by hand.
+  After saving the comparison report you are now offered an **optional write-back**.
+  It is gated twice for safety: a single batch opt-in (`[y/N]`, default No), then a
+  **per-site `[y/N]` confirmation** that shows the site's address BEFORE (current
+  Mist value) and AFTER (the suggested correction) side by side. Only the sites you
+  say yes to are written. The write is minimal and safe -- it fetches the full Mist
+  site record, replaces **only** the `address` field, and PUTs the record back, so
+  `latlng`, `timezone`, `country_code`, sitegroup and template IDs are all
+  preserved. Each write is fail-soft: a read-only token (HTTP 403) or any API error
+  is recorded as a failed outcome and never aborts the batch. Afterwards you are
+  prompted to save a **before/after correction report**
+  (`data/address_corrections_<timestamp>.csv`) listing every reviewed site and
+  whether it was pushed, skipped, or failed. Only correctable rows are offered
+  (MISSING_SUITE, MISSING_NUMBER, WRONG_STREET, CSV_BETTER, AMBIGUOUS); matches and
+  Mist-better rows are never touched.
+
 ### Changed
 
 - **Address audit now flags incomplete Mist addresses (missing house number)
@@ -63,6 +82,17 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   web to deduce the true, shippable address.
 
 ### Fixed
+
+- **Address audit MISSING_NUMBER never fired on real data (menu 195)**: the
+  missing-house-number check (added in the prior release) tested the whole Mist
+  address string for any digit, but Mist stores the address as one formatted
+  string ending in the ZIP (`S Federal Hwy, Fort Pierce, FL 34982, USA`) -- so the
+  ZIP's digits made every address look like it already had a house number, and a
+  number-less street was still reported ADDRESS_MATCH. The check now inspects only
+  the leading street segment (before the first comma) for a leading house number,
+  so `S Federal Hwy, ...` is correctly flagged MISSING_NUMBER against the
+  web-resolved `2315 S Federal Hwy`. (The unit test was strengthened to use full
+  Mist-style strings so it would have caught this.)
 
 - **Address audit suggested address glued the street/suite to the city (menu
   195)**: Google's autocomplete sometimes returned the street fused to the city

--- a/src/site/address_audit/address_corrector.py
+++ b/src/site/address_audit/address_corrector.py
@@ -1,21 +1,133 @@
-"""Deferred address write-back stub (1003-site-address-audit).
+"""Optional site-address write-back for the address-audit feature (1003-site-address-audit).
 
-This release is READ-ONLY: it audits and reports address discrepancies but never
-writes back to a Mist site record. ``AddressCorrector`` documents the future
-write-back surface (OQ-003) and intentionally raises ``NotImplementedError`` on
-every method. It is NOT imported into the menu and performs no Mist writes.
+``AddressCorrector`` is the WRITE surface of menu 195. After the read-only audit
+saves its comparison report, the operator may opt in to push corrected addresses
+back to their Mist sites. Every push is gated twice: a single opt-in for the whole
+batch, then a per-site ``[y/N]`` confirmation showing the BEFORE (current Mist
+address) and AFTER (suggested correction) side by side. Nothing is written without
+that per-site yes.
+
+Write mechanics (safe, minimal): a Mist site stores its address as a single
+formatted string in the ``address`` field (e.g. ``"940 James Bowie Dr, New Boston,
+TX 75570, USA"``) alongside ``latlng``, ``country_code``, ``timezone``, and the
+various template IDs. To change only the address without disturbing anything else,
+we fetch the full current site record, replace ``address``, and PUT the whole
+record back. Every Mist call is fail-soft: a permission error (read-only token) or
+any API failure is recorded as a failed outcome and never aborts the loop.
 """
 
 from __future__ import annotations  # PEP 604 union syntax on Python 3.13.
 
 import logging  # Action logging before/after every operation (project NON-NEGOTIABLE).
-from typing import Any  # Loose typing for the future address payload.
+from typing import Any  # Loose typing for the Mist API session/records.
+
+import mistapi  # Mist API SDK (sole Mist interface; hard dependency of MistHelper).
+
+from src.site.address_audit.models import AuditResult, CorrectionOutcome  # Shared dataclasses.
+from src.utils.input_utils import InputUtils  # EOF-safe operator prompts.
+
+# Issue states whose suggested address represents a correction worth pushing.
+_CORRECTABLE = frozenset({"MISSING_SUITE", "MISSING_NUMBER", "WRONG_STREET", "CSV_BETTER", "AMBIGUOUS"})
+_YES = ("y", "yes")  # Accepted affirmative responses (case-insensitive).
 
 
 class AddressCorrector:
-    """Inert placeholder for the deferred site-address write-back feature."""
+    """Review and push corrected site addresses back to Mist (per-site confirmed)."""
 
-    def apply_correction(self, site_id: str, address: dict[str, Any]) -> None:
-        """Future: push a corrected address to a Mist site. Disabled in this release."""
-        logging.info("apply_correction invoked for site %s (feature disabled)", site_id)  # Action-log attempt.
-        raise NotImplementedError("Address write-back is not enabled in this release.")  # Deferred surface.
+    def __init__(self, apisession: Any) -> None:
+        """Store the authenticated Mist API session used for read + write calls."""
+        self._api = apisession  # Mist session (its token's role governs write success).
+
+    def correctable(self, results: list[AuditResult]) -> list[AuditResult]:
+        """Return the rows whose suggestion is a real, pushable correction."""
+        targets: list[AuditResult] = []  # Accumulate correctable rows.
+        for result in results:  # Walk every audited row.
+            if self._is_correctable(result):  # Has a site, a suggestion, and a correctable state.
+                targets.append(result)  # Keep it for review.
+        logging.debug("Identified %d correctable row(s) of %d", len(targets), len(results))  # Trace count.
+        return targets  # One AuditResult per pushable correction.
+
+    @staticmethod
+    def _is_correctable(result: AuditResult) -> bool:
+        """Return True when a row has a site, a suggestion, and a correctable state that differs."""
+        suggestion = (result.suggested_address or "").strip()  # Suggested correction (may be empty).
+        current = (result.matched_site.mist_address.get("address") or "").strip()  # Current Mist address.
+        if not result.matched_site.site_id or not suggestion:  # Need a target site and a suggestion.
+            return False  # Not pushable.
+        if result.issue_type not in _CORRECTABLE:  # State does not call for a correction.
+            return False  # Skip matches / Mist-better / no-result.
+        return suggestion.lower() != current.lower()  # Only when the suggestion actually differs.
+
+    def review_and_apply(self, results: list[AuditResult]) -> list[CorrectionOutcome]:
+        """Per-site BEFORE/AFTER + ``[y/N]``; push the accepted ones; return all outcomes."""
+        targets = self.correctable(results)  # Rows eligible for write-back.
+        if not targets:  # Nothing to push.
+            print("No correctable addresses to push.")  # Inform the operator.
+            return []  # Empty outcome list.
+        logging.info("Reviewing %d correctable address(es) for write-back", len(targets))  # Action-log start.
+        self._print_intro(len(targets))  # Warn that this writes to Mist.
+        outcomes = [self._review_one(result) for result in targets]  # Review/push each row.
+        self._print_summary(outcomes)  # Show pushed/skipped/failed tally.
+        return outcomes  # Outcomes drive the optional before/after report.
+
+    def _review_one(self, result: AuditResult) -> CorrectionOutcome:
+        """Show one site's BEFORE/AFTER, prompt, and push when the operator accepts."""
+        site = result.matched_site  # Match outcome (site id + current address).
+        before = (site.mist_address.get("address") or "").strip()  # Current Mist address string.
+        after = result.suggested_address.strip()  # Corrected address to write.
+        self._show(site.site_name or "-", before, after)  # Side-by-side display.
+        choice = InputUtils.safe_input("Push this corrected address to Mist? [y/N]: ", context="address_writeback")
+        if choice.strip().lower() not in _YES:  # Operator declined this site.
+            logging.info("Operator skipped write-back for site %s", site.site_id)  # Action-log the skip.
+            return CorrectionOutcome(site.site_name or "-", site.site_id or "", before, after, "skipped")
+        return self._push(site.site_name or "-", site.site_id or "", before, after)  # Accepted -> push.
+
+    def _push(self, name: str, site_id: str, before: str, after: str) -> CorrectionOutcome:
+        """Write the corrected address to one Mist site; never raises."""
+        logging.info("Pushing corrected address to site %s (%s)", site_id, name)  # Action-log the write.
+        try:
+            ok = self._update_site_address(site_id, after)  # Fetch-modify-PUT the site record.
+        except Exception as exc:  # noqa: BLE001 -- one failed write must not abort the batch.
+            logging.warning("Write-back failed for site %s: %s", site_id, exc)  # Surface the cause.
+            print(f"  FAILED: {exc}")  # Inform the operator inline.
+            return CorrectionOutcome(name, site_id, before, after, "failed", str(exc))
+        if ok:  # Mist accepted the update.
+            print("  PUSHED.")  # Confirm inline.
+            return CorrectionOutcome(name, site_id, before, after, "pushed")
+        print("  FAILED: Mist rejected the update (check token permissions).")  # Read-only / rejected.
+        return CorrectionOutcome(name, site_id, before, after, "failed", "update rejected")
+
+    def _update_site_address(self, site_id: str, address: str) -> bool:
+        """Fetch the full site, replace only ``address``, and PUT it back; return success."""
+        logging.debug("Fetching site %s before write-back", site_id)  # Trace the read.
+        current = mistapi.api.v1.sites.sites.getSiteInfo(self._api, site_id)  # Full current site record.
+        site = current.data if isinstance(current.data, dict) else {}  # Guard against list/empty payloads.
+        if not site:  # No usable site record returned.
+            logging.warning("Site %s returned no record; cannot write back", site_id)  # Trace the miss.
+            return False  # Treat as a failed update.
+        site["address"] = address  # Replace ONLY the address; everything else is preserved.
+        updated = mistapi.api.v1.sites.sites.updateSiteInfo(self._api, site_id, site)  # PUT the full record.
+        success = updated.status_code in (200, 201)  # 2xx => Mist accepted the change.
+        logging.debug("Write-back for site %s status=%s", site_id, updated.status_code)  # Trace the result.
+        return success  # True only on a 2xx response.
+
+    @staticmethod
+    def _print_intro(count: int) -> None:
+        """Print a clear banner before any Mist write occurs."""
+        print(f"\n--- Address write-back: {count} site(s) to review ---")  # Section header.
+        print("This WRITES to your Mist sites. Confirm each site with y/N (default No).\n")  # Safety note.
+
+    @staticmethod
+    def _show(name: str, before: str, after: str) -> None:
+        """Display one site's current vs corrected address side by side."""
+        print(f"Site: {name}")  # Which site.
+        print(f"  BEFORE: {before or '(empty)'}")  # Current Mist address.
+        print(f"  AFTER:  {after}")  # Proposed corrected address.
+
+    @staticmethod
+    def _print_summary(outcomes: list[CorrectionOutcome]) -> None:
+        """Print a pushed/skipped/failed tally after the review loop."""
+        pushed = sum(1 for o in outcomes if o.action == "pushed")  # Successful writes.
+        skipped = sum(1 for o in outcomes if o.action == "skipped")  # Operator declines.
+        failed = sum(1 for o in outcomes if o.action == "failed")  # API failures.
+        print(f"\nWrite-back complete: {pushed} pushed, {skipped} skipped, {failed} failed.")  # Tally line.

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -3,8 +3,10 @@
 ``AddressAuditEngine`` is the single menu entry point. It loads the customer CSV,
 matches each row to a Mist site (serial golden key, fuzzy fallback), enriches with
 SNMP location, resolves/validates the address through the free tiers, classifies
-each row into one of eight states, renders the comparison table, and offers to
-save the results to CSV. It is READ-ONLY: no Mist site record is ever written.
+each row into one of nine states, renders the comparison table, and offers to save
+the results to CSV. The audit itself is read-only; afterwards the operator may
+opt in to push corrected addresses back to Mist via ``AddressCorrector``, gated by
+a batch confirmation and a per-site ``[y/N]`` before/after review.
 
 The orchestration is split into small private helpers so every method stays
 within the Five-Item Rule. The classification helpers (``_classify`` and its
@@ -22,6 +24,7 @@ from typing import Any  # Loose typing for Mist API records.
 
 import mistapi  # Mist API SDK (sole Mist interface; hard dependency of MistHelper).
 
+from src.site.address_audit.address_corrector import AddressCorrector  # Optional Mist write-back.
 from src.site.address_audit.address_resolver import AddressResolver  # Tiered resolver.
 from src.site.address_audit.audit_reporter import AddressAuditReporter  # CSV writer.
 from src.site.address_audit.comparison_display import ComparisonTableRenderer  # Table + prompt.
@@ -104,7 +107,7 @@ class AddressAuditEngine:
         business = self._resolve_business_name()  # Business-name prefix (env or prompt).
         results = self._audit_rows(apisession, org_id, rows, business, ui_geocode)  # Core pipeline.
         self._renderer.render(results)  # Render the comparison table.
-        self._finish(results)  # Post-table save/quit prompt.
+        self._finish(results, apisession)  # Post-table save/quit prompt + optional write-back.
 
     def _audit_rows(
         self,
@@ -371,13 +374,15 @@ class AddressAuditEngine:
     def _missing_house_number(mist_street: str, candidate: str) -> bool:
         """Return True when Mist's street lacks a house number that the candidate supplies.
 
-        A Mist record like ``S Federal Hwy`` with no street number is an
-        incomplete shipping address; surfacing it (instead of calling it a match)
-        lets the operator add the number the web resolved.
+        Both inputs are full formatted address strings ("STREET, CITY, ST ZIP"),
+        so we inspect only the leading street segment (before the first comma) and
+        require a *leading* digit there. This avoids mistaking a trailing ZIP for a
+        house number -- e.g. Mist ``S Federal Hwy, Fort Pierce, FL 34982`` has no
+        house number even though the ZIP contains digits.
         """
-        mist_has = bool(re.search(r"\d", mist_street))  # Mist street carries any number at all.
-        cand_has = bool(re.match(r"\s*\d", candidate))  # Candidate leads with a house number.
-        return cand_has and not mist_has  # Missing only when Mist has no number but the candidate does.
+        mist_lead = re.match(r"\s*\d", mist_street.split(",", 1)[0])  # Leading digit of the Mist street.
+        cand_lead = re.match(r"\s*\d", candidate.split(",", 1)[0])  # Leading digit of the candidate street.
+        return bool(cand_lead) and not bool(mist_lead)  # Missing only when the candidate has one and Mist does not.
 
     def _classify_internal(self, mist_addr: dict[str, Any], csv_addr: dict[str, Any], snmp_loc: str | None) -> str:
         """Classify on internal CSV/SNMP signals alone when no external result exists."""
@@ -500,14 +505,52 @@ class AddressAuditEngine:
             return "Internal+OSM"  # Internal suite, street externally confirmed by OpenStreetMap.
         return base  # Mapped label or placeholder.
 
-    def _finish(self, results: list[AuditResult]) -> None:
-        """Run the post-table prompt and save the CSV when the operator chooses to."""
+    def _finish(self, results: list[AuditResult], apisession: Any) -> None:
+        """Save the report (operator's choice), then optionally write corrections back to Mist."""
         action = self._renderer.prompt_post_table(results)  # Ask save vs quit.
-        if action == "save":  # Operator chose to persist the report.
-            path = self._reporter.save(results)  # Write the timestamped CSV.
-            print(f"Saved to {path}")  # Confirm the written path.
+        if action != "save":  # Operator quit without saving.
+            print("No file saved. Exiting address audit.")  # Quit branch confirmation.
+            return  # No write-back when nothing was saved.
+        path = self._reporter.save(results)  # Write the timestamped comparison CSV.
+        print(f"Saved to {path}")  # Confirm the written path.
+        self._offer_write_back(results, apisession)  # Offer to push corrections to Mist.
+
+    def _offer_write_back(self, results: list[AuditResult], apisession: Any) -> None:
+        """Gate, then run, the optional per-site address write-back to Mist."""
+        corrector = self._make_corrector(apisession)  # Build the write-back collaborator.
+        targets = corrector.correctable(results)  # Rows with a pushable correction.
+        if not targets:  # Nothing to correct.
+            logging.debug("No correctable rows; skipping write-back offer")  # Trace the no-op.
+            return  # Audit ends here.
+        prompt = f"\nPush corrected addresses back to Mist for up to {len(targets)} site(s)? [y/N]: "
+        choice = InputUtils.safe_input(prompt, context="address_audit_writeback_gate").strip().lower()
+        if choice not in ("y", "yes"):  # Operator declined the whole batch.
+            print("Skipped write-back. No Mist changes made.")  # Confirm no writes.
+            return  # Audit ends here.
+        outcomes = corrector.review_and_apply(results)  # Per-site review + push.
+        self._maybe_save_corrections(outcomes)  # Offer the before/after report.
+
+    def _maybe_save_corrections(self, outcomes: list[Any]) -> None:
+        """Offer to save a before/after report of the reviewed sites."""
+        if not outcomes:  # No sites were reviewed.
+            return  # Nothing to report.
+        choice = (
+            InputUtils.safe_input(
+                "\nSave a before/after correction report to data/? [y/N]: ", context="address_audit_writeback_report"
+            )
+            .strip()
+            .lower()
+        )
+        if choice not in ("y", "yes"):  # Operator declined the report.
+            print("No correction report saved.")  # Confirm the skip.
             return  # Done.
-        print("No file saved. Exiting address audit.")  # Quit branch confirmation.
+        path = self._reporter.save_corrections(outcomes)  # Write the before/after CSV.
+        print(f"Saved correction report to {path}")  # Confirm the written path.
+
+    @staticmethod
+    def _make_corrector(apisession: Any) -> AddressCorrector:
+        """Construct the write-back collaborator (separated for test injection)."""
+        return AddressCorrector(apisession)  # Real Mist-backed corrector.
 
     def _progress(self, items: list[Any], total: int) -> Any:
         """Wrap an iterable in a tqdm progress bar when interactive and available."""

--- a/src/site/address_audit/audit_reporter.py
+++ b/src/site/address_audit/audit_reporter.py
@@ -13,7 +13,7 @@ import logging  # Action logging before/after every operation (project NON-NEGOT
 import os  # Path construction and directory creation.
 from datetime import UTC, datetime  # Timestamped output filenames.
 
-from src.site.address_audit.models import AuditResult  # Per-row audit record.
+from src.site.address_audit.models import AuditResult, CorrectionOutcome  # Per-row audit + write-back records.
 
 _HEADER = [  # CSV header row -- matches the seven terminal columns.
     "Site Name",  # Mist site name.
@@ -23,6 +23,14 @@ _HEADER = [  # CSV header row -- matches the seven terminal columns.
     "Suggested Address",  # Resolver suggestion (full value).
     "Source",  # Originating tier.
     "Issue Type",  # Classification state.
+]
+_CORRECTION_HEADER = [  # Before/after write-back report columns.
+    "Site Name",  # Mist site name.
+    "Site ID",  # Mist site UUID.
+    "Before Address",  # Address before the (optional) write-back.
+    "After Address",  # Corrected address reviewed by the operator.
+    "Action",  # pushed | skipped | failed.
+    "Error",  # Failure detail when action == failed (else blank).
 ]
 
 
@@ -55,6 +63,22 @@ class AddressAuditReporter:
             result.source,  # Source label.
             result.issue_type,  # Classification state.
         ]
+
+    def save_corrections(self, outcomes: list[CorrectionOutcome], output_dir: str = "data") -> str:
+        """Write the before/after write-back outcomes to a timestamped CSV; return the path."""
+        logging.info("Saving address-correction report (%d outcome rows)", len(outcomes))  # Action-log start.
+        os.makedirs(output_dir, exist_ok=True)  # Ensure the output directory exists.
+        stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")  # UTC timestamp for the filename.
+        path = os.path.join(output_dir, f"address_corrections_{stamp}.csv")  # Full output path.
+        with open(path, "w", encoding="utf-8", newline="") as handle:  # Open for CSV writing.
+            writer = csv.writer(handle)  # Standard CSV writer.
+            writer.writerow(_CORRECTION_HEADER)  # Write the before/after header first.
+            for outcome in outcomes:  # One row per reviewed site.
+                writer.writerow(  # Six cells matching _CORRECTION_HEADER order.
+                    [outcome.site_name, outcome.site_id, outcome.before, outcome.after, outcome.action, outcome.error]
+                )
+        logging.debug("Address-correction report written to %s", path)  # Action-log completion.
+        return path  # Return the written path to the caller.
 
     @staticmethod
     def _format_address(address: dict) -> str:

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -111,3 +111,20 @@ class UIGeocoderConfig:
     per_lookup_timeout_s: float = 20.0  # Hard per-lookup ceiling (UI_GEOCODE_TIMEOUT_SECONDS).
     max_lookups: int = 50  # Per-run cap on Tier-3 lookups (UI_GEOCODE_MAX_LOOKUPS).
     politeness_delay_s: float = 1.0  # >=1 req/sec politeness toward Google Places.
+
+
+@dataclass
+class CorrectionOutcome:
+    """Result of an optional write-back of one corrected address to a Mist site.
+
+    Produced by ``AddressCorrector`` for every site the operator reviewed, whether
+    the corrected address was pushed, skipped, or failed. Drives the optional
+    before/after correction report.
+    """
+
+    site_name: str  # Mist site display name (or "-").
+    site_id: str  # Mist site UUID the correction targets.
+    before: str  # Current Mist address string before the change.
+    after: str  # Corrected address the operator reviewed.
+    action: str  # One of: pushed | skipped | failed.
+    error: str = ""  # Failure detail when action == "failed" (else "").

--- a/tests/unit/site/address_audit/test_address_corrector.py
+++ b/tests/unit/site/address_audit/test_address_corrector.py
@@ -1,0 +1,134 @@
+"""Unit tests for AddressCorrector write-back (1003-site-address-audit).
+
+All Mist calls are mocked -- no live API is touched. Tests cover the correctable
+filter, the per-site review/confirm loop, the fetch-modify-PUT update, and the
+fail-soft behavior on permission/API errors.
+"""
+
+from unittest.mock import MagicMock
+
+from src.site.address_audit import address_corrector as corr_mod
+from src.site.address_audit.address_corrector import AddressCorrector
+from src.site.address_audit.models import AddressRow, AuditResult, MatchedSite
+
+
+def _result(issue="MISSING_SUITE", site_id="s1", mist="100 Main St", suggested="100 Main St Suite 5, Town, FL"):
+    """Build an AuditResult for write-back tests."""
+    row = AddressRow(
+        serial="1", model="SSR130", address="100 Main St Suite 5", city="Town", state="FL", zip_code="33000"
+    )
+    site = MatchedSite(
+        site_id=site_id,
+        site_name="Store 181",
+        mist_address={"address": mist},
+        match_strategy="serial",
+    )
+    return AuditResult(address_row=row, matched_site=site, issue_type=issue, suggested_address=suggested)
+
+
+class TestCorrectable:
+    """The correctable filter selects only pushable corrections."""
+
+    def test_includes_correctable_states(self):
+        """MISSING_SUITE/MISSING_NUMBER/WRONG_STREET/CSV_BETTER/AMBIGUOUS with a diff are included."""
+        results = [
+            _result(issue=s) for s in ("MISSING_SUITE", "MISSING_NUMBER", "WRONG_STREET", "CSV_BETTER", "AMBIGUOUS")
+        ]
+        assert len(AddressCorrector(MagicMock()).correctable(results)) == 5
+
+    def test_excludes_non_correctable_states(self):
+        """ADDRESS_MATCH / MIST_BETTER / NO_RESULT / UNMATCHED are excluded."""
+        results = [_result(issue=s) for s in ("ADDRESS_MATCH", "MIST_BETTER", "NO_RESULT", "UNMATCHED")]
+        assert AddressCorrector(MagicMock()).correctable(results) == []
+
+    def test_excludes_when_no_site_id(self):
+        """A row without a site_id cannot be pushed."""
+        assert AddressCorrector(MagicMock()).correctable([_result(site_id="")]) == []
+
+    def test_excludes_when_suggestion_equals_current(self):
+        """No push when the suggestion equals the current Mist address (case-insensitive)."""
+        same = _result(mist="100 Main St Suite 5, Town, FL", suggested="100 Main St Suite 5, Town, FL")
+        assert AddressCorrector(MagicMock()).correctable([same]) == []
+
+
+class TestUpdateSiteAddress:
+    """The fetch-modify-PUT mechanics."""
+
+    def test_fetch_modify_put_preserves_other_fields(self, monkeypatch):
+        """Only 'address' changes; everything else in the site record is preserved on PUT."""
+        get_resp = MagicMock()
+        get_resp.data = {
+            "id": "s1",
+            "address": "OLD",
+            "latlng": {"lat": 1, "lng": 2},
+            "timezone": "X",
+            "country_code": "US",
+        }
+        put_resp = MagicMock()
+        put_resp.status_code = 200
+        sites = MagicMock()
+        sites.getSiteInfo.return_value = get_resp
+        sites.updateSiteInfo.return_value = put_resp
+        monkeypatch.setattr(corr_mod.mistapi.api.v1.sites, "sites", sites)
+        api = MagicMock()
+        ok = AddressCorrector(api)._update_site_address("s1", "NEW ADDRESS")
+        assert ok is True
+        body = sites.updateSiteInfo.call_args.args[2]
+        assert body["address"] == "NEW ADDRESS"  # changed
+        assert body["latlng"] == {"lat": 1, "lng": 2}  # preserved
+        assert body["timezone"] == "X" and body["country_code"] == "US"  # preserved
+
+    def test_non_2xx_is_failure(self, monkeypatch):
+        """A non-2xx status (e.g. 403 read-only token) is a failed update."""
+        get_resp = MagicMock()
+        get_resp.data = {"id": "s1", "address": "OLD"}
+        put_resp = MagicMock()
+        put_resp.status_code = 403
+        sites = MagicMock()
+        sites.getSiteInfo.return_value = get_resp
+        sites.updateSiteInfo.return_value = put_resp
+        monkeypatch.setattr(corr_mod.mistapi.api.v1.sites, "sites", sites)
+        assert AddressCorrector(MagicMock())._update_site_address("s1", "NEW") is False
+
+    def test_empty_site_record_is_failure(self, monkeypatch):
+        """An empty/list site payload cannot be written back."""
+        get_resp = MagicMock()
+        get_resp.data = []
+        sites = MagicMock()
+        sites.getSiteInfo.return_value = get_resp
+        monkeypatch.setattr(corr_mod.mistapi.api.v1.sites, "sites", sites)
+        assert AddressCorrector(MagicMock())._update_site_address("s1", "NEW") is False
+        sites.updateSiteInfo.assert_not_called()
+
+
+class TestReviewAndApply:
+    """The per-site review/confirm loop."""
+
+    def test_yes_pushes_no_skips(self, monkeypatch):
+        """'y' pushes the correction; 'n' records a skip; both appear in outcomes."""
+        corrector = AddressCorrector(MagicMock())
+        monkeypatch.setattr(corrector, "_update_site_address", lambda *_: True)
+        answers = iter(["y", "n"])
+        monkeypatch.setattr(corr_mod.InputUtils, "safe_input", staticmethod(lambda *a, **k: next(answers)))
+        outcomes = corrector.review_and_apply([_result(site_id="s1"), _result(site_id="s2")])
+        assert [o.action for o in outcomes] == ["pushed", "skipped"]
+
+    def test_push_failure_is_failed_outcome(self, monkeypatch):
+        """An exception during the push yields a failed outcome, not a crash."""
+        corrector = AddressCorrector(MagicMock())
+
+        def boom(*_):
+            raise RuntimeError("403 forbidden")
+
+        monkeypatch.setattr(corrector, "_update_site_address", boom)
+        monkeypatch.setattr(corr_mod.InputUtils, "safe_input", staticmethod(lambda *a, **k: "y"))
+        outcomes = corrector.review_and_apply([_result()])
+        assert outcomes[0].action == "failed"
+        assert "403" in outcomes[0].error
+
+    def test_no_targets_returns_empty(self, monkeypatch):
+        """With nothing correctable, review_and_apply returns [] and prompts nothing."""
+        spy = MagicMock()
+        monkeypatch.setattr(corr_mod.InputUtils, "safe_input", spy)
+        assert AddressCorrector(MagicMock()).review_and_apply([_result(issue="ADDRESS_MATCH")]) == []
+        spy.assert_not_called()

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -1,5 +1,8 @@
 """Unit tests for AddressAuditEngine classification + assembly (1003-site-address-audit)."""
 
+from unittest.mock import MagicMock
+
+from src.site.address_audit import audit_engine as eng_mod
 from src.site.address_audit.audit_engine import AddressAuditEngine
 from src.site.address_audit.models import AddressRow, MatchedSite, ResolverResult
 
@@ -70,15 +73,20 @@ class TestClassify:
 
     def test_missing_house_number_not_match(self):
         """Mist street with no house number + a numbered suggestion -> MISSING_NUMBER, not ADDRESS_MATCH."""
-        mist = {"address": "S Federal Hwy", "city": "Fort Pierce", "state": "FL", "zip": "34982"}
+        mist = {"address": "S Federal Hwy, Fort Pierce, FL 34982, USA", "city": "", "state": "", "zip": ""}
         rr = _rr("2315 S Federal Hwy Fort Pierce, FL 34982")
         assert self.engine._classify(mist, _CSV, None, rr) == "MISSING_NUMBER"
 
     def test_missing_house_number_helper(self):
-        """The helper fires only when Mist has no number but the candidate leads with one."""
-        assert self.engine._missing_house_number("S Federal Hwy", "2315 S Federal Hwy") is True
-        assert self.engine._missing_house_number("1606 E Jefferson St", "1606 West Jefferson St") is False
-        assert self.engine._missing_house_number("S Federal Hwy", "S Federal Hwy") is False
+        """The helper inspects the leading street segment, ignoring a trailing ZIP."""
+        # Full Mist string: street has no leading number even though the ZIP has digits.
+        assert (
+            self.engine._missing_house_number("S Federal Hwy, Fort Pierce, FL 34982, USA", "2315 S Federal Hwy") is True
+        )
+        assert (
+            self.engine._missing_house_number("1606 E Jefferson St, Quincy, FL 32351", "1606 W Jefferson St") is False
+        )
+        assert self.engine._missing_house_number("S Federal Hwy, Fort Pierce, FL 34982", "S Federal Hwy") is False
 
     def test_abbreviated_directional_still_matches(self):
         """Mist 'NW 107th Ave' vs web 'Northwest 107th Avenue' is the same street."""
@@ -119,6 +127,54 @@ class TestSameStreet:
     def test_leading_directional_ignores_city(self):
         """Only the directional after the house number counts, not one inside the city."""
         assert self.engine._leading_directional("940 South Military Trail #3, West Palm Beach, FL") == "S"
+
+
+class TestWriteBackWiring:
+    """The optional write-back flow is correctly gated and wired into _finish."""
+
+    def _engine_with_mocks(self):
+        """Build an engine whose renderer/reporter/corrector are mocks."""
+        engine = AddressAuditEngine(renderer=MagicMock(), reporter=MagicMock())
+        corrector = MagicMock()
+        engine._make_corrector = staticmethod(lambda _api: corrector)  # Inject the mock corrector.
+        return engine, corrector
+
+    def test_quit_skips_save_and_writeback(self):
+        """Choosing quit saves nothing and never offers write-back."""
+        engine, corrector = self._engine_with_mocks()
+        engine._renderer.prompt_post_table.return_value = "quit"
+        engine._finish([], MagicMock())
+        engine._reporter.save.assert_not_called()
+        corrector.correctable.assert_not_called()
+
+    def test_save_then_offers_writeback(self):
+        """Choosing save writes the report and then offers write-back."""
+        engine, corrector = self._engine_with_mocks()
+        engine._renderer.prompt_post_table.return_value = "save"
+        engine._reporter.save.return_value = "data/x.csv"
+        corrector.correctable.return_value = []  # No targets -> offer ends quietly.
+        engine._finish([], MagicMock())
+        engine._reporter.save.assert_called_once()
+        corrector.correctable.assert_called_once()
+
+    def test_gate_no_skips_review(self, monkeypatch):
+        """Declining the batch gate means review_and_apply is never called."""
+        engine, corrector = self._engine_with_mocks()
+        corrector.correctable.return_value = [object()]  # One target exists.
+        monkeypatch.setattr(eng_mod.InputUtils, "safe_input", staticmethod(lambda *a, **k: "n"))
+        engine._offer_write_back([], MagicMock())
+        corrector.review_and_apply.assert_not_called()
+
+    def test_gate_yes_runs_review_and_report(self, monkeypatch):
+        """Accepting the batch gate runs review_and_apply and then offers the report."""
+        engine, corrector = self._engine_with_mocks()
+        corrector.correctable.return_value = [object()]
+        corrector.review_and_apply.return_value = [object()]
+        answers = iter(["y", "y"])  # Gate yes, then save-report yes.
+        monkeypatch.setattr(eng_mod.InputUtils, "safe_input", staticmethod(lambda *a, **k: next(answers)))
+        engine._offer_write_back([], MagicMock())
+        corrector.review_and_apply.assert_called_once()
+        engine._reporter.save_corrections.assert_called_once()
 
 
 class TestBuildAuditResult:

--- a/tests/unit/site/address_audit/test_audit_reporter.py
+++ b/tests/unit/site/address_audit/test_audit_reporter.py
@@ -66,3 +66,25 @@ class TestSave:
         with open(path, encoding="utf-8") as handle:
             content = handle.read()
         assert "Y" * 80 in content
+
+
+class TestSaveCorrections:
+    """AddressAuditReporter.save_corrections before/after report."""
+
+    def test_writes_correction_report(self, tmp_path):
+        """save_corrections() writes a timestamped before/after CSV with the 6-column header."""
+        from src.site.address_audit.models import CorrectionOutcome
+
+        outcomes = [
+            CorrectionOutcome("Store 181", "s1", "100 Main St", "100 Main St Suite 5", "pushed"),
+            CorrectionOutcome("Store 7", "s2", "200 Oak Ave", "200 Oak Ave #3", "skipped"),
+            CorrectionOutcome("Store 9", "s3", "300 Pine Rd", "300 Pine Rd Unit 2", "failed", "HTTP 403"),
+        ]
+        path = AddressAuditReporter().save_corrections(outcomes, output_dir=str(tmp_path))
+        assert os.path.isfile(path)
+        assert re.search(r"address_corrections_\d{8}_\d{6}\.csv$", path)
+        with open(path, encoding="utf-8") as handle:
+            rows = list(csv.reader(handle))
+        assert rows[0] == ["Site Name", "Site ID", "Before Address", "After Address", "Action", "Error"]
+        assert rows[1] == ["Store 181", "s1", "100 Main St", "100 Main St Suite 5", "pushed", ""]
+        assert rows[3][4] == "failed" and rows[3][5] == "HTTP 403"


### PR DESCRIPTION
## Summary
Adds the **optional write-back** the operator asked for (push corrected addresses back to Mist with per-site before/after confirmation), and fixes a real bug found while reviewing the latest 44-row run.

Linked issue: #551

## Feature: write corrected addresses back to Mist (menu 195)
The audit was read-only -- you reviewed the comparison and fixed addresses by hand. Now, **after saving the comparison report**, you're offered a write-back:

1. **Batch gate**: `Push corrected addresses back to Mist for up to N site(s)? [y/N]` (default No).
2. **Per-site review**: for each correctable site it prints
   `
   Site: FLSE1294
     BEFORE: 6000 Glades Rd, Boca Raton, FL 33431, USA
     AFTER:  6000 Glades Road #1019a, Boca Raton, FL 33431
   Push this corrected address to Mist? [y/N]:
   `
   Only the sites you say **y** to are written.
3. **Before/after report**: afterwards you're prompted to save `data/address_corrections_<timestamp>.csv` listing every reviewed site and whether it was pushed/skipped/failed.

**Safe write mechanics**: a Mist site stores its address as one formatted string (`address`) alongside `latlng`, `timezone`, `country_code`, sitegroup/template IDs. The write **fetches the full site record, replaces only `address`, and PUTs it back**, so nothing else is disturbed (verified end-to-end with a mocked API -- the PUT body preserves latlng/timezone/sitegroup_ids/template ids). Every write is **fail-soft**: a read-only token (HTTP 403) or any API error becomes a `failed` outcome and never aborts the batch. Only correctable rows are offered (MISSING_SUITE, MISSING_NUMBER, WRONG_STREET, CSV_BETTER, AMBIGUOUS); ADDRESS_MATCH / MIST_BETTER / NO_RESULT / UNMATCHED are never touched.

## Fix: MISSING_NUMBER never fired on real data
The missing-house-number check (added last release) tested the whole Mist address string for any digit -- but Mist stores the address as one string ending in the ZIP (`S Federal Hwy, Fort Pierce, FL 34982, USA`), so the ZIP's digits made every address look numbered, and a number-less street was still reported **ADDRESS_MATCH**. It now inspects only the leading street segment (before the first comma) for a leading house number, so Fort Pierce is correctly flagged **MISSING_NUMBER**. The unit test was strengthened to use full Mist-style strings (the old test used a bare street, which is why it passed falsely).

## Note on the Nominatim warnings
Left as-is per request -- the `Nominatim returned no result for street '...'` lines stay at WARNING and persist to the log. They're useful diagnostics; the audit completes via Tier-3 regardless.

## Testing
- `py_compile` / `black --line-length 120` / `ruff` / `vulture@90`: clean.
- **154 unit tests pass** (+15: correctable filter, fetch-modify-PUT preserves fields, non-2xx/empty-record failure, review yes/no/exception loop, save_corrections report, engine write-back gating, MISSING_NUMBER on full Mist strings).
- End-to-end smoke with a mocked Mist API confirmed the BEFORE/AFTER display, push, and field preservation.

## Operator note
Re-run the audit; Fort Pierce will now read **MISSING_NUMBER**. To use write-back, choose save, then answer the batch + per-site prompts. Your token must have **write** scope (the audit's read token will report `failed` on push). READ path unchanged; all writes are per-site confirmed.