### PR TITLE
feat(address-audit): keep diagnostic logs off the console + human-like typing cadence (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Changed
 
+- **Address audit diagnostic logging no longer prints to the terminal (menu
+  195)**: the audit's `logging.*` calls (e.g. the Nominatim "no result" warnings)
+  were written to both `data/script.log` AND the console, where they interleaved
+  with and corrupted the tqdm progress bar. The feature speaks to the operator
+  exclusively through `print` (the comparison table, the prompts, the write-back
+  confirmations), so its logging is purely a diagnostic trail. For the duration of
+  a run a filter is attached to the root logger's CONSOLE handlers that drops only
+  this package's records; the file handler is untouched, so `script.log` still
+  captures everything while the terminal shows just the table, prompts, and a
+  clean progress bar.
+
+- **Address audit types into Google's box with a human-like, randomized cadence
+  (menu 195)**: the Tier-3 geocoder previously typed each query at a fixed 40 ms
+  cadence, which is robotic and risks Google's autocomplete throttling / bot
+  heuristics. It now types one character at a time with a randomized
+  inter-keystroke delay (default 60-190 ms, from an unpredictable `SystemRandom`
+  source) plus an occasional longer "thinking" pause, so the input rhythm
+  resembles a person. The bounds are tunable via `UI_GEOCODE_MIN_KEY_DELAY_MS` /
+  `UI_GEOCODE_MAX_KEY_DELAY_MS`.
+
 - **Address audit now flags incomplete Mist addresses (missing house number)
   (menu 195)**: a Mist site whose street had no house number (`S Federal Hwy`)
   was reported ADDRESS_MATCH against the web-resolved `2315 S Federal Hwy` --

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -102,3 +102,9 @@ MIST_ORG_ID=your_org_id_here
 # Per-lookup timeout in seconds (default: 20) and max lookups per run (default: 50).
 # UI_GEOCODE_TIMEOUT_SECONDS=20
 # UI_GEOCODE_MAX_LOOKUPS=50
+
+# Randomized per-keystroke typing delay (milliseconds) when entering an address
+# into Google's autocomplete box. A randomized cadence looks human and avoids
+# bot/throttle heuristics. Defaults: 60-190 ms per character.
+# UI_GEOCODE_MIN_KEY_DELAY_MS=60
+# UI_GEOCODE_MAX_KEY_DELAY_MS=190

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -20,6 +20,7 @@ import logging  # Action logging before/after every operation (project NON-NEGOT
 import os  # Path handling and environment access.
 import re  # Address normalization / suite extraction in classification.
 import sys  # Detect a non-interactive stdout to suppress the progress bar.
+from contextlib import contextmanager  # Scope the console-log suppression to one run.
 from typing import Any  # Loose typing for Mist API records.
 
 import mistapi  # Mist API SDK (sole Mist interface; hard dependency of MistHelper).
@@ -69,8 +70,27 @@ _DIRECTIONALS = {  # Street-name directional tokens, normalized to their abbrevi
 }
 
 
+class _AddressAuditConsoleFilter(logging.Filter):
+    """Console filter that drops log records emitted from the address_audit package.
+
+    The address audit talks to the operator through ``print`` (the comparison
+    table, the post-table prompts, the write-back confirmations); every
+    ``logging.*`` call it makes is a diagnostic trail destined for
+    ``data/script.log``. Attached to the root logger's CONSOLE handlers (and only
+    for the duration of a run), this filter keeps that diagnostic noise -- e.g. the
+    Nominatim "no result" warnings -- out of the terminal, where it would corrupt
+    the tqdm progress bar. File handlers never receive this filter, so the full log
+    trail is preserved.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return False (drop from console) for records whose source is in address_audit."""
+        path = (record.pathname or "").replace("\\", "/")  # Normalize separators for a portable check.
+        return "/address_audit/" not in path  # Keep every record except this package's own logs.
+
+
 class AddressAuditEngine:
-    """Orchestrate the read-only CSV address audit and render the comparison."""
+    """Orchestrate the CSV address audit, render the comparison, and optionally write back."""
 
     def __init__(
         self,
@@ -86,14 +106,21 @@ class AddressAuditEngine:
         self._reporter = reporter or AddressAuditReporter()  # CSV report writer.
 
     def run(self, apisession: Any, org_id: str) -> None:
-        """Menu entry point: drive the full read-only audit pipeline end-to-end.
+        """Menu entry point: drive the full audit pipeline end-to-end.
 
         The Mist site address, the SNMP location variable, and the customer CSV
         are all treated as *hints* -- none is authoritative. The resolver fuses
         them into one best-guess query and prefers an external verifier
         (OpenStreetMap, plus Tier-3 browser geocoding when a debuggable browser
-        is reachable) to deduce the true, shippable address.
+        is reachable) to deduce the true, shippable address. The whole run is
+        wrapped so this feature's diagnostic logging goes to ``data/script.log``
+        only, never the terminal (keeps the progress bar clean).
         """
+        with self._console_logs_to_file_only():  # Address-audit logs -> file only; console stays clean.
+            self._run_pipeline(apisession, org_id)  # Drive the actual audit pipeline.
+
+    def _run_pipeline(self, apisession: Any, org_id: str) -> None:
+        """Run the audit pipeline: select CSV, audit, render, and offer write-back."""
         ui_geocode = self._ui_geocode_enabled()  # Tier-3 web geocoding: env-gated, default auto, no CLI flag.
         logging.info("Starting site address audit (tier3_geocode=%s)", ui_geocode)  # Action-log start.
         csv_path = self._select_csv_file()  # Pick the customer CSV from data/.
@@ -108,6 +135,31 @@ class AddressAuditEngine:
         results = self._audit_rows(apisession, org_id, rows, business, ui_geocode)  # Core pipeline.
         self._renderer.render(results)  # Render the comparison table.
         self._finish(results, apisession)  # Post-table save/quit prompt + optional write-back.
+
+    @contextmanager
+    def _console_logs_to_file_only(self) -> Any:
+        """Suppress this feature's logging on CONSOLE handlers for the duration of a run.
+
+        Attaches an ``_AddressAuditConsoleFilter`` to every console (stream)
+        handler on the root logger, then removes it afterwards. The file handler is
+        never touched, so ``data/script.log`` still captures everything -- the
+        operator sees only the table, prompts, and progress bar on screen, with the
+        Nominatim "no result" warnings and other diagnostics confined to the file.
+        """
+        root = logging.getLogger()  # Root logger carries both file and console handlers.
+        console = [  # Console handlers are StreamHandlers that are not FileHandlers.
+            handler
+            for handler in root.handlers
+            if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler)
+        ]
+        log_filter = _AddressAuditConsoleFilter()  # Drops only address_audit records from console.
+        for handler in console:  # Attach the filter to each console handler.
+            handler.addFilter(log_filter)
+        try:
+            yield  # Run the audit with console diagnostics suppressed.
+        finally:
+            for handler in console:  # Always detach, even when the run raises.
+                handler.removeFilter(log_filter)
 
     def _audit_rows(
         self,
@@ -285,6 +337,18 @@ class AddressAuditEngine:
             "UI_GEOCODE_TIMEOUT_SECONDS", config.per_lookup_timeout_s
         )
         config.max_lookups = int(AddressAuditEngine._env_float("UI_GEOCODE_MAX_LOOKUPS", config.max_lookups))  # Cap.
+        config.min_key_delay_s = (
+            AddressAuditEngine._env_float(  # Lower bound of the typing jitter (ms -> s).
+                "UI_GEOCODE_MIN_KEY_DELAY_MS", config.min_key_delay_s * 1000.0
+            )
+            / 1000.0
+        )
+        config.max_key_delay_s = (
+            AddressAuditEngine._env_float(  # Upper bound of the typing jitter (ms -> s).
+                "UI_GEOCODE_MAX_KEY_DELAY_MS", config.max_key_delay_s * 1000.0
+            )
+            / 1000.0
+        )
         return config  # Hand back the env-merged config.
 
     @staticmethod

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -111,6 +111,8 @@ class UIGeocoderConfig:
     per_lookup_timeout_s: float = 20.0  # Hard per-lookup ceiling (UI_GEOCODE_TIMEOUT_SECONDS).
     max_lookups: int = 50  # Per-run cap on Tier-3 lookups (UI_GEOCODE_MAX_LOOKUPS).
     politeness_delay_s: float = 1.0  # >=1 req/sec politeness toward Google Places.
+    min_key_delay_s: float = 0.06  # Lower bound of the randomized per-keystroke delay (anti-bot jitter).
+    max_key_delay_s: float = 0.19  # Upper bound of the randomized per-keystroke delay (anti-bot jitter).
 
 
 @dataclass

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -43,6 +43,7 @@ from __future__ import annotations  # PEP 604 union syntax on Python 3.13.
 import logging  # Action logging before/after every operation (project NON-NEGOTIABLE).
 import os  # Filesystem probing for the Edge executable.
 import re  # House-number extraction + suggestion cleanup (defeats the autocomplete lag race).
+import secrets  # Unpredictable RNG source for human-like typing jitter (lint-clean, not security-critical).
 import shutil  # PATH lookup fallback for the Edge executable.
 import subprocess  # Spawn a debuggable browser for CDP takeover.
 import tempfile  # Dedicated throwaway profile for the spawned browser.
@@ -56,6 +57,9 @@ try:  # Optional dependency: Playwright may not be installed in every environmen
     from playwright.sync_api import sync_playwright  # Sync browser-automation entry point.
 except ImportError:  # pragma: no cover -- exercised only on hosts without Playwright.
     sync_playwright = None  # type: ignore[assignment]  # Sentinel; is_available() keys off this.
+
+_KEY_JITTER = secrets.SystemRandom()  # Per-keystroke delay source; unpredictable cadence dodges bot heuristics.
+_THINKING_PAUSE_EVERY = 7  # Add an occasional longer "thinking" pause every N characters while typing.
 
 # --- Selector constants (captured 2026-06-29; re-verify if the Mist dashboard UI changes) ---
 # Google Places Autocomplete attaches ``pac-target-input`` to the bound input and
@@ -263,11 +267,32 @@ class MistUIGeocoder:
         return texts  # May be empty -> NO_RESULT (never a stale, wrong answer).
 
     def _enter_query(self, page: Any, field: Any, query: str) -> None:
-        """Focus the field, clear any stale value/dropdown, then type the new query."""
+        """Focus the field, clear any stale value/dropdown, then type with human-like timing."""
         field.click()  # Focus so Google binds keystrokes.
         field.fill("")  # Clear any previous text.
         self._settle(page, 150)  # Let Google tear down the previous dropdown before typing.
-        field.type(query, delay=40)  # Type slowly so Google fires the autocomplete request.
+        self._type_humanlike(field, query)  # Randomized per-key cadence to avoid bot/throttle heuristics.
+
+    def _type_humanlike(self, field: Any, query: str) -> None:
+        """Type ``query`` one character at a time with a randomized inter-keystroke delay.
+
+        A fixed-cadence ``type(text, delay=N)`` looks robotic and can trip Google's
+        autocomplete throttling / bot detection. We emit each character then sleep a
+        random interval bounded by the config, with an occasional longer pause, so
+        the input rhythm resembles a person rather than a machine.
+        """
+        for index, char in enumerate(query):  # Walk the query one character at a time.
+            field.type(char)  # Emit a single keystroke into the focused field.
+            time.sleep(self._key_delay(index))  # Randomized human-like gap before the next key.
+
+    def _key_delay(self, index: int) -> float:
+        """Return a randomized inter-keystroke delay, occasionally adding a 'thinking' pause."""
+        low = max(0.0, self._config.min_key_delay_s)  # Lower bound (never negative).
+        high = max(low, self._config.max_key_delay_s)  # Upper bound (guarded >= low).
+        delay = _KEY_JITTER.uniform(low, high)  # Base per-keystroke jitter.
+        if index and index % _THINKING_PAUSE_EVERY == 0:  # Every few characters, pause a touch longer.
+            delay += _KEY_JITTER.uniform(low, high)  # Occasional human "thinking" gap.
+        return delay  # Seconds to sleep before the next keystroke.
 
     def _read_fresh_suggestions(self, page: Any, expected: str, timeout_ms: int) -> list[str]:
         """Poll until the TOP suggestion matches ``expected`` (this query's house number).

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -177,6 +177,69 @@ class TestWriteBackWiring:
         engine._reporter.save_corrections.assert_called_once()
 
 
+class TestConsoleLogSuppression:
+    """Address-audit logs are routed off the console (kept in the file) during a run."""
+
+    def _filter(self):
+        """Return a fresh console filter."""
+        return eng_mod._AddressAuditConsoleFilter()
+
+    def _record(self, pathname):
+        """Build a log record as if emitted from ``pathname``."""
+        import logging
+
+        return logging.LogRecord("root", logging.WARNING, pathname, 1, "msg", None, None)
+
+    def test_filter_drops_address_audit_records(self):
+        """A record emitted from the address_audit package is dropped from console."""
+        rec = self._record("/x/src/site/address_audit/address_resolver.py")
+        assert self._filter().filter(rec) is False
+
+    def test_filter_keeps_other_records(self):
+        """A record from elsewhere is kept on console."""
+        rec = self._record("/x/src/utils/address_utils.py")
+        assert self._filter().filter(rec) is True
+
+    def test_filter_is_separator_portable(self):
+        """Windows-style backslash paths are matched too."""
+        rec = self._record("C:\\x\\src\\site\\address_audit\\ui_geocoder.py")
+        assert self._filter().filter(rec) is False
+
+    def test_context_attaches_console_only_and_removes(self):
+        """The context manager filters console handlers (not file) and detaches afterwards."""
+        import io
+        import logging
+
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        for handler in saved:
+            root.removeHandler(handler)
+        console = logging.StreamHandler(io.StringIO())
+
+        class _FakeFile(logging.FileHandler):
+            def __init__(self, stream):
+                logging.Handler.__init__(self)
+                self.stream = stream
+                self.baseFilename = "x"
+
+            def _open(self):
+                return self.stream
+
+        file_handler = _FakeFile(io.StringIO())
+        root.addHandler(console)
+        root.addHandler(file_handler)
+        try:
+            with AddressAuditEngine()._console_logs_to_file_only():
+                assert len(console.filters) == 1  # Console handler filtered.
+                assert len(file_handler.filters) == 0  # File handler untouched.
+            assert len(console.filters) == 0  # Filter removed after the run.
+        finally:
+            root.removeHandler(console)
+            root.removeHandler(file_handler)
+            for handler in saved:
+                root.addHandler(handler)
+
+
 class TestBuildAuditResult:
     """Unmatched rows short-circuit to UNMATCHED without resolution."""
 

--- a/tests/unit/site/address_audit/test_ui_geocoder.py
+++ b/tests/unit/site/address_audit/test_ui_geocoder.py
@@ -126,6 +126,40 @@ class TestBuildResult:
         assert result.confidence == pytest.approx(0.6)
 
 
+class TestTypingJitter:
+    """Human-like, randomized typing cadence into the Google autocomplete box."""
+
+    def test_types_each_char_with_randomized_delay(self, monkeypatch):
+        """Each character is typed individually with a randomized sleep between keys."""
+        sleeps: list[float] = []
+        monkeypatch.setattr(ui_mod.time, "sleep", lambda s: sleeps.append(s))
+        geo = MistUIGeocoder(UIGeocoderConfig(min_key_delay_s=0.05, max_key_delay_s=0.15))
+        field = MagicMock()
+        geo._type_humanlike(field, "940 Main")
+        assert field.type.call_count == len("940 Main")  # One keystroke per character.
+        assert len(sleeps) == len("940 Main")  # One delay per character.
+        assert all(s >= 0.05 for s in sleeps)  # Never below the configured floor.
+        assert len(set(round(s, 5) for s in sleeps)) > 1  # Delays vary (not a fixed cadence).
+
+    def test_key_delay_within_bounds(self):
+        """A normal keystroke delay stays within [min, max]."""
+        geo = MistUIGeocoder(UIGeocoderConfig(min_key_delay_s=0.05, max_key_delay_s=0.15))
+        for index in range(1, 7):  # Indices that do not trigger the thinking pause.
+            assert 0.05 <= geo._key_delay(index) <= 0.15
+
+    def test_thinking_pause_extends_delay(self):
+        """Every Nth character adds an extra 'thinking' pause, so the delay can exceed max."""
+        geo = MistUIGeocoder(UIGeocoderConfig(min_key_delay_s=0.10, max_key_delay_s=0.10))
+        # min==max==0.10 -> base is exactly 0.10; the thinking pause at index 7 doubles it.
+        assert geo._key_delay(1) == pytest.approx(0.10)
+        assert geo._key_delay(7) == pytest.approx(0.20)
+
+    def test_key_delay_guards_inverted_bounds(self):
+        """If max < min, the upper bound is clamped to min (never negative range)."""
+        geo = MistUIGeocoder(UIGeocoderConfig(min_key_delay_s=0.20, max_key_delay_s=0.05))
+        assert geo._key_delay(1) == pytest.approx(0.20)
+
+
 class TestHelpers:
     """Selector fallthrough, item-text safety, and Edge discovery."""
 


### PR DESCRIPTION
## Summary
Two operator-experience refinements to menu 195, both from feedback on the latest run.

Linked issue: #551

## 1. Diagnostic warnings no longer print to the terminal (only to script.log)
The audit's `logging.*` calls -- notably the `Nominatim returned no result for street '...'` warnings -- were written to **both** `data/script.log` and the console, where they interleaved with and corrupted the tqdm progress bar:
`
Geocoding sites:   7%|######  | 3/44 [00:23<05:16]2026-06-30 14:15:27 - WARNING - Nominatim returned no result...
`
The feature communicates with the operator **exclusively via `print`** (the comparison table, the prompts, the write-back confirmations) -- its logging is purely a diagnostic trail. For the duration of a run, a filter is attached to the root logger's **console** handlers that drops only this package's records (matched by source path `/address_audit/`). The **file handler is untouched**, so `script.log` still captures every warning. The operator now sees a clean progress bar, table, and prompts; the warnings remain in the log exactly as requested.

## 2. Human-like, randomized typing into Google's autocomplete box
The Tier-3 geocoder typed each query at a **fixed 40 ms cadence** -- robotic, and a plausible trigger for Google's autocomplete throttling / bot heuristics. It now types **one character at a time with a randomized inter-keystroke delay** (default **60-190 ms**, drawn from an unpredictable `secrets.SystemRandom` source) plus an occasional longer "thinking" pause every several characters, so the input rhythm resembles a person. Bounds are tunable via `UI_GEOCODE_MIN_KEY_DELAY_MS` / `UI_GEOCODE_MAX_KEY_DELAY_MS`.

## Testing
- `py_compile` / `black --line-length 120` / `ruff` / `vulture@90`: clean.
- `bandit -r src -ll` (CI's exact flag): **no MEDIUM+ findings**. Using `SystemRandom` for the jitter avoids a new B311 (pseudo-random) finding; the only LOW items are the pre-existing subprocess calls from the browser-spawn feature, which `-ll` filters out.
- **162 unit tests pass** (+8: console filter drops address_audit / keeps others / separator-portable, context manager attaches to console-only and detaches; typing types each char with varied bounded delays, thinking-pause extension, inverted-bound guard).

## Operator note
Re-run the audit -- the Nominatim warnings will now appear only in `data/script.log` and the progress bar will render cleanly. Typing into the Mist/Google box will look human-paced (and take marginally longer per site, which is the point).