### PR TITLE
fix(address-audit): clean Nominatim suggestion instead of raw OSM display_name (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,18 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
+- **Address audit Nominatim suggestion leaked raw OpenStreetMap formatting (menu
+  195)**: when a row was validated by Tier-2 (OpenStreetMap) rather than Tier-3,
+  the "Suggested Address" showed OSM's verbose `display_name` -- e.g.
+  `T-Mobile, 1200, Northwest 87th Avenue, Doral, Miami-Dade County, Florida,
+  33172, United States` -- complete with the business name, county, and country.
+  OSM only validates the *street*, so the suggestion is now Mist's own
+  already-formatted address with the trailing country dropped
+  (`1200 NW 87th Ave #1st, Doral, FL 33172`), consistent with the Tier-1/Tier-3
+  outputs and never losing an existing suite. (Side effect: a row where Mist's
+  address already matches now reads ADDRESS_MATCH instead of the misleading
+  MIST_BETTER.)
+
 - **Address audit MISSING_NUMBER never fired on real data (menu 195)**: the
   missing-house-number check (added in the prior release) tested the whole Mist
   address string for any digit, but Mist stores the address as one formatted

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -167,7 +167,7 @@ class AddressResolver:
             )
             return None  # Defer to Tier 3 / NO_RESULT.
         confidence = float(comparison.get("confidence", 0.0))  # OSM importance-derived confidence.
-        canonical = comparison.get("display_name") or self._format_address(candidates.csv_address)  # Canonical.
+        canonical = self._nominatim_canonical(candidates, comparison)  # Clean street line (not raw display_name).
         logging.info("Nominatim validated street: %s (confidence=%.2f)", canonical, confidence)  # Visible hit.
         return ResolverResult(  # Build the Tier-2 result.
             query=query,  # Echo the query for caching.
@@ -177,6 +177,22 @@ class AddressResolver:
             ambiguous=confidence < 0.4,  # Low confidence flags a possible mall/ambiguous case.
             raw_response=outcome,  # Full validator payload for audit/debug.
         )
+
+    def _nominatim_canonical(self, candidates: ResolveCandidates, comparison: dict[str, Any]) -> str:
+        """Return a clean suggestion for an OSM-validated row from Mist's own address.
+
+        OpenStreetMap validates only the *street*; its ``display_name`` is verbose
+        and noisy (``Business, 1200, Northwest 87th Avenue, Doral, Miami-Dade
+        County, Florida, 33172, United States``). Since OSM merely confirms the
+        street is real, the cleanest, most useful suggestion is Mist's own
+        already-formatted address string with the trailing country dropped --
+        consistent with the Tier-1/Tier-3 outputs and never losing an existing
+        suite. Falls back to the raw display_name only if Mist has no usable address.
+        """
+        mist_address = (candidates.mist_address.get("address") or "").strip()  # Mist's full address string.
+        if mist_address:  # Mist has a usable address line.
+            return re.sub(r",?\s*(?:USA|United States)\s*$", "", mist_address, flags=re.IGNORECASE).strip()
+        return comparison.get("display_name") or self._format_address(candidates.csv_address)  # Last resort.
 
     def _maybe_ui(self, candidates: ResolveCandidates, query: str) -> ResolverResult | None:
         """Tier 3: consult the Google-via-Mist authority to find or adjudicate the suite.

--- a/tests/unit/site/address_audit/test_address_resolver.py
+++ b/tests/unit/site/address_audit/test_address_resolver.py
@@ -148,6 +148,29 @@ class TestTier2Nominatim:
         result = resolver.resolve(ResolveCandidates(mist_address=_NO_SUITE, csv_address=_NO_SUITE))
         assert result.canonical_address is None
 
+    def test_nominatim_canonical_cleans_display_name(self):
+        """An OSM-validated row surfaces Mist's clean address, not the noisy display_name."""
+        resolver = AddressResolver()
+        # Real Mist structure: 'address' is the full formatted string (no separate city/state/zip).
+        cand = ResolveCandidates(
+            mist_address={"address": "1200 NW 87th Ave #1st, Doral, FL 33172, USA", "city": "", "state": "", "zip": ""},
+            csv_address={"address": "1200 NW 87th Ave", "city": "Doral", "state": "FL", "zip": "33172"},
+        )
+        comparison = {
+            "valid": True,
+            "confidence": 0.82,
+            "display_name": "T-Mobile, 1200, Northwest 87th Avenue, Doral, Miami-Dade County, Florida, 33172, USA",
+        }
+        # Trailing country dropped, suite preserved, county/business noise gone.
+        assert resolver._nominatim_canonical(cand, comparison) == "1200 NW 87th Ave #1st, Doral, FL 33172"
+
+    def test_nominatim_canonical_falls_back_to_display_name(self):
+        """With no usable Mist address, the raw display_name is the last resort."""
+        resolver = AddressResolver()
+        cand = ResolveCandidates(mist_address={"address": ""}, csv_address={})
+        comparison = {"display_name": "5 Main St, Town, FL"}
+        assert resolver._nominatim_canonical(cand, comparison) == "5 Main St, Town, FL"
+
 
 class TestTier3Gating:
     """Tier 3 UI geocoder must be opt-in only."""


### PR DESCRIPTION
## Summary
Reviewing the latest 44-row menu 195 run surfaced one genuine data-quality issue (the other 43 rows are clean and correct). This fixes it.

Linked issue: #551

## The issue
One site (FLSE7734) was validated by **Tier-2 (OpenStreetMap)** rather than Tier-3, so its "Suggested Address" showed OSM's raw `display_name`:
`
T-Mobile, 1200, Northwest 87th Avenue, Doral, Miami-Dade County, Florida, 33172, United States
`
-- complete with the business name, county, and `United States`. Noisy and inconsistent with every other (Tier-1/Tier-3) suggestion.

## The fix
OSM validates only the *street*, so its verbose `display_name` adds no shippable detail. The Nominatim suggestion is now **Mist's own already-formatted address** with the trailing country stripped:
`
1200 NW 87th Ave #1st, Doral, FL 33172
`
This is consistent with the Tier-1/Tier-3 outputs and never drops an existing suite. It falls back to the raw `display_name` only if Mist has no usable address.

**Side effect (an improvement)**: because the suggestion now equals Mist's address when Mist is already correct, that row reads **ADDRESS_MATCH** instead of the misleading **MIST_BETTER** (which implied the suggestion was worse).

## Why this only showed up now
The real Mist site object stores its address as a single formatted string (`"1200 NW 87th Ave #1st, Doral, FL 33172, USA"`) with no separate city/state/zip -- confirmed against the live API. On this dataset 43/44 rows resolve via Tier-3 (which already cleans its output); only this one fell to Tier-2, exposing the un-cleaned OSM path.

## Other rows reviewed -- all correct
- The 6 **WRONG_STREET** rows are legitimate catches (e.g. Mist `5485 US-331` vs real `931 US Highway 331`; `163` vs `165 Eglin Pkwy`; `1606 E Jefferson` vs `West Jefferson`).
- Lowercase suite tokens (`#1019a`, `a104`) are Google's own casing -- cosmetic, units correct.
- `DeFuniak` correctly preserved (not mis-split).
- Nominatim "no result" warnings confirmed present in `script.log` (and, per the prior PR, no longer on the console).

## Testing
- `py_compile` / `black` / `ruff` / `vulture@90`: clean.
- **164 unit tests pass** (+2: display_name cleaned to Mist's address with country stripped + suite preserved; fallback to display_name when Mist has no address).