### PR TITLE
fix(logging): UnicodeEncodeError on non-cp1252 characters (utf-8 logs + console)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
-## [Unreleased]
-
 ### Mist API Coverage Audit
 
 - **OpenAPI GET endpoint catalog + diff**: Added `tools/openapi_endpoint_catalog.py`
@@ -120,6 +118,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   web to deduce the true, shippable address.
 
 ### Fixed
+
+- **Logging and on-screen output crashed on non-Western characters (all menus)**:
+  running any operation against data containing characters outside the Windows
+  console's default `cp1252` codec raised `UnicodeEncodeError` and dumped a
+  `--- Logging error ---` traceback. This surfaced in the address audit (menu 195)
+  with a real Hawaii dataset -- an address such as `315 East Makaʻala Street,
+  Hawaiʻi County` contains the Hawaiian ʻokina (`U+02BB`), which crashed the
+  `data/script.log` file handler and corrupted the progress bar. Both log file
+  handlers are now opened with `encoding="utf-8"`, and `stdout`/`stderr` are
+  reconfigured to UTF-8 with a `backslashreplace` fallback at startup, so the
+  comparison table and any other `print` of international addresses are safe too.
+  The fix is global (the logging setup lives in the root module) and fail-soft:
+  if a stream cannot be reconfigured the worst case is the prior behavior, with no
+  new failure introduced.
 
 - **Address audit Nominatim suggestion leaked raw OpenStreetMap formatting (menu
   195)**: when a row was validated by Tier-2 (OpenStreetMap) rather than Tier-3,

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -307,12 +307,23 @@ _early_file_level = int(
     os.environ.get("LOGGING_LOG_LEVEL", logging.INFO)
 )  # Read file log level from env (default: INFO=20)
 
+# Make stdout/stderr resilient to non-cp1252 characters in real data (e.g. the Hawaiian
+# 'okina in addresses like "Maka'ala Street"). Without this, printing the comparison table
+# or logging such strings raises UnicodeEncodeError under the default Windows console codec.
+for _std_stream in (sys.stdout, sys.stderr):  # Harden both standard streams (best-effort).
+    try:
+        _std_stream.reconfigure(encoding="utf-8", errors="backslashreplace")  # UTF-8 + never-crash fallback
+    except (AttributeError, ValueError):  # Stream lacks reconfigure (already wrapped/redirected) -> skip safely
+        pass  # Degradation is acceptable: worst case is the original behavior, no new failure introduced
+
 # Create handlers with appropriate levels
 _early_console_handler = logging.StreamHandler()  # Create handler for console output (stdout/stderr)
 _early_console_handler.setLevel(
     _early_console_level
 )  # Set console handler to respect CONSOLE_LOG_LEVEL environment variable
-_early_file_handler = logging.FileHandler(_early_log_path)  # Create handler for script.log file output
+_early_file_handler = logging.FileHandler(
+    _early_log_path, encoding="utf-8"
+)  # script.log file output; UTF-8 so non-cp1252 chars (e.g. Hawaiian 'okina) never crash logging
 _early_file_handler.setLevel(_early_file_level)  # Set file handler to respect LOGGING_LOG_LEVEL environment variable
 
 logging.basicConfig(  # Configure root logger with handlers and format
@@ -1017,7 +1028,9 @@ class GlobalImportManager:
         logging.debug("_build_file_log_handler: creating file handler at level %s", level)  # Log before build
         log_file_path = os.path.join("data", "script.log")  # Log path under data/ (writable in the container)
         os.makedirs("data", exist_ok=True)  # Create data/ if missing (no error if present)
-        file_handler = logging.FileHandler(log_file_path)  # Handler that writes to script.log
+        file_handler = logging.FileHandler(
+            log_file_path, encoding="utf-8"
+        )  # script.log writer; UTF-8 so non-cp1252 chars (e.g. Hawaiian 'okina) never crash logging
         file_handler.setLevel(level)  # Apply the file verbosity threshold
         file_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")  # Same timestamped format
         file_handler.setFormatter(file_formatter)  # Attach the format to the file handler


### PR DESCRIPTION
## Problem

Running any operation against data containing characters outside the Windows
console default `cp1252` codec raised `UnicodeEncodeError` and dumped a
`--- Logging error ---` traceback. It surfaced in the **Site Address Audit
(menu 195)** with a real Hawaii dataset: an address like
`315 East Maka(okina)ala Street, Hawai(okina)i County` contains the Hawaiian
okina (`U+02BB`), which crashed the `data/script.log` file handler and
corrupted the tqdm progress bar mid-run.

## Fix (root logging infra -- minimal, fail-soft)

- Open **both** `script.log` file handlers with `encoding="utf-8"` (the
  early bootstrap handler and the runtime `_build_file_log_handler` factory).
- Reconfigure `sys.stdout` / `sys.stderr` to UTF-8 with a
  `backslashreplace` fallback at import time, so the comparison table and any
  other `print` of international addresses are also safe. Wrapped in
  try/except: if a stream can't be reconfigured, behavior is exactly as before
  (no new failure path).
- Drive-by: removed a duplicate `## [Unreleased]` header in CHANGELOG.

## Why touch the root module

The logging handlers and standard streams are created in `MistHelper.py` at
import time; there is no feature-module seam for this. The change is surgical
(15 insertions), fully commented, and global-by-design so every menu benefits.

## Verification

- Reproduced the crash with the exact Hawaiian log record, confirmed the
  UTF-8 file handler + reconfigured streams write/print it without error.
- `py_compile` / `black --check` / `ruff` clean on `MistHelper.py`.
- `164 passed` in the address-audit unit suite (unchanged).