### PR TITLE
feat(address-audit): Source column names Google explicitly (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Changed
 
+- **Address audit Source column now names Google explicitly (menu 195)**: the
+  Tier-3 web authority is Google Places autocomplete, accessed by driving the Mist
+  portal's address box, but the Source column labelled it only `Mist UI` -- which
+  does not make it obvious that Google deduced the suggested address. It now reads
+  `Google (Mist UI)` so it is unmistakable when Google found, filled in, or
+  confirmed an address (the Issue Type column still says *what* changed:
+  `MISSING_SUITE`/`MISSING_NUMBER`/`WRONG_STREET` mean Google corrected a blank,
+  `ADDRESS_MATCH` means Google confirmed the existing value).
+
 - **Address audit diagnostic logging no longer prints to the terminal (menu
   195)**: the audit's `logging.*` calls (e.g. the Nominatim "no result" warnings)
   were written to both `data/script.log` AND the console, where they interleaved

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -559,7 +559,7 @@ class AddressAuditEngine:
         labels = {  # Source-code -> display label.
             "internal": "Internal",  # Tier 1 internal comparison.
             "nominatim": "Nominatim",  # Tier 2 OSM validation.
-            "mist_ui": "Mist UI",  # Tier 3 dashboard automation.
+            "mist_ui": "Google (Mist UI)",  # Tier 3: Google Places autocomplete via the Mist portal address box.
             "cache": "Cache",  # Served from the SQLite cache.
         }
         if resolver_result is None or resolver_result.canonical_address is None:  # No suggestion.

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -69,7 +69,7 @@ class AuditResult:
     resolver_result: ResolverResult | None = None  # None for UNMATCHED rows (no resolution attempted).
     issue_type: str = "UNMATCHED"  # Exactly one of the nine classification states.
     suggested_address: str = ""  # Best correction to display (full value; truncated only in terminal).
-    source: str = "-"  # Display label for the Source column (Internal/Nominatim/Mist UI/Cache/-).
+    source: str = "-"  # Source column label (Internal/Internal+OSM/Nominatim/Google (Mist UI)/Cache/-).
 
 
 @dataclass

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -360,6 +360,11 @@ class TestSourceLabel:
         rr = ResolverResult(query="q", canonical_address="X", source="nominatim")
         assert AddressAuditEngine._source_label(rr) == "Nominatim"
 
+    def test_mist_ui_label_names_google(self):
+        """A Tier-3 result is labelled to make the Google authority explicit."""
+        rr = ResolverResult(query="q", canonical_address="X #5", source="mist_ui")  # Tier-3 (Google-via-Mist).
+        assert AddressAuditEngine._source_label(rr) == "Google (Mist UI)"  # Label must name Google, not just "Mist UI".
+
     def test_no_result_label(self):
         """A result with no canonical address is labelled '-'."""
         rr = ResolverResult(query="q", canonical_address=None, source="internal")


### PR DESCRIPTION
## What

Relabel the address-audit **Source** column value for Tier-3 results from
`Mist UI` to **`Google (Mist UI)`**.

## Why

Tier-3 is Google Places autocomplete, accessed by driving the Mist portal's
address box. The old `Mist UI` label did not make it obvious that **Google**
deduced / filled in / confirmed the suggested address. A NOC engineer reading
the table could not tell the web authority was Google. The Issue Type column
still says *what* changed (`MISSING_SUITE` / `WRONG_STREET` = Google fixed a
blank; `ADDRESS_MATCH` = Google confirmed).

## Scope

Label only -- no behavior change. `_source_label` mapping + the `AuditResult`
doc comment, plus a unit test asserting the label names Google. `165 passed`.