### PR TITLE
feat(address-audit): CONFLICTING_HINTS + DUPLICATE_ADDRESS review-only guards (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Added
 
+- **Address audit now flags rows it cannot safely auto-correct, as review-only
+  (menu 195)**: two new classification states protect against pushing a wrong or
+  non-unique address to Mist, and both are **excluded from write-back** (they are
+  never offered for push, and they show a blank Suggested Address so the operator
+  decides by hand from the Mist/CSV/SNMP columns):
+  - **`CONFLICTING_HINTS`** -- the Mist address, the customer CSV, and the SNMP
+    location disagree on the **house number with no majority** (every hint names a
+    different number, or only two hints have numbers and they differ). A 2-vs-1
+    split still has a clear majority and is left alone (the lone dissenter is the
+    outlier); a suite on a dissenting hint does not rescue it, because a suite is
+    only meaningful on the agreed-upon street number. This stops the tool from
+    silently picking one of several *different valid stores* for a single site --
+    e.g. a real T-Mobile site whose SNMP location was stale ``1520 Route 38 ...
+    Hainesport NJ`` while Mist and the CSV pointed at a Hawaii address.
+  - **`DUPLICATE_ADDRESS`** -- two or more *different* sites resolve to the
+    **identical** full address (same suite, or both lacking one), which would make
+    them indistinguishable for shipping. Sites that share only a base street but
+    carry *different* suites are the normal strip-mall case and are left untouched
+    because their full addresses differ.
+
 - **Address audit can now push corrected addresses back to Mist (menu 195)**: the
   audit was read-only; you reviewed the comparison and fixed addresses by hand.
   After saving the comparison report you are now offered an **optional write-back**.

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -295,6 +295,31 @@ class AddressResolver:
         group = [hint for hint in hints if hint[2] == winner] or hints  # Sources matching the winner.
         return self._prefer_hint(group)[1]  # Suite-bearing first, then CSV > Mist > SNMP.
 
+    def has_conflicting_hints(self, candidates: ResolveCandidates) -> bool:
+        """Return True when the hints disagree on the house number with no majority.
+
+        The Mist address, the customer CSV, and the SNMP location are independent
+        hints. A 2-vs-1 split still has a clear majority (the lone dissenter is the
+        outlier and is intentionally trusted away), but when every hint that has a
+        house number names a *different* one -- or only two hints have numbers and
+        they differ -- there is no majority to break the tie. Silently picking one
+        could push a different real store's address onto the site, so such rows are
+        surfaced for manual review instead of auto-corrected. A suite on a hint does
+        not rescue it: a suite is only meaningful on the agreed-upon street number.
+        """
+        hints = self._gather_hints(candidates)  # [(label, text, house_no, has_suite), ...].
+        numbers = [house for _, _, house, _ in hints if house]  # Non-empty leading house numbers only.
+        distinct = set(numbers)  # Unique house numbers across the hints.
+        if len(distinct) < 2:  # Zero or one distinct number -> consensus or a single source.
+            return False  # Nothing for the sources to disagree about.
+        counts = {number: numbers.count(number) for number in distinct}  # Votes per distinct number.
+        top = max(counts.values())  # Highest vote count among the numbers.
+        leaders = [number for number, votes in counts.items() if votes == top]  # Numbers tied at the top.
+        conflict = len(leaders) > 1  # More than one number shares the lead -> no majority -> conflict.
+        if conflict:  # Action-log only the genuine conflict so script.log explains the flag.
+            logging.info("Conflicting hint house numbers %s; no majority to trust", sorted(distinct))
+        return conflict  # True only when the sources actively disagree with no winner.
+
     def _gather_hints(self, candidates: ResolveCandidates) -> list[tuple[str, str, str, bool]]:
         """Normalize each hint into (label, text, house_number, has_suite); drop empties."""
         raw = [  # Source label -> raw text (CSV/Mist first so ties prefer the customer data).

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -3,7 +3,7 @@
 ``AddressAuditEngine`` is the single menu entry point. It loads the customer CSV,
 matches each row to a Mist site (serial golden key, fuzzy fallback), enriches with
 SNMP location, resolves/validates the address through the free tiers, classifies
-each row into one of nine states, renders the comparison table, and offers to save
+each row into one of eleven states, renders the comparison table, and offers to save
 the results to CSV. The audit itself is read-only; afterwards the operator may
 opt in to push corrected addresses back to Mist via ``AddressCorrector``, gated by
 a batch confirmation and a per-site ``[y/N]`` before/after review.
@@ -381,7 +381,56 @@ class AddressAuditEngine:
         for row, site in self._progress(list(zip(rows, matched, strict=False)), len(rows)):  # Iterate w/ progress.
             results.append(self._build_audit_result(row, site, resolver, business, ui_geocode))  # One result.
         logging.debug("Classified %d audit rows", len(results))  # Action-log completion.
+        self._flag_duplicate_addresses(results)  # Cross-row safety: flag one address shared by 2+ sites.
         return results  # Hand back all results.
+
+    @staticmethod
+    def _flag_duplicate_addresses(results: list[AuditResult]) -> None:
+        """Flag any final address shared by two or more distinct sites as DUPLICATE_ADDRESS.
+
+        After correction each site should carry a unique, shippable address. When
+        two *different* sites resolve to the *identical* full address (same suite,
+        or both lacking one) they are indistinguishable for shipping -- a
+        data-integrity problem the operator must resolve, so the row is made
+        review-only and excluded from write-back. Sites that share only a base
+        street but carry *different* suites are the normal strip-mall case: their
+        full addresses differ, so they land in different buckets and are untouched.
+        Rows already flagged CONFLICTING_HINTS keep that (more specific) reason.
+        """
+        buckets: dict[str, list[AuditResult]] = {}  # Normalized full address -> rows sharing it.
+        for result in results:  # Bucket every row by the address that will identify its site.
+            if result.issue_type in ("UNMATCHED", "CONFLICTING_HINTS"):  # No trusted/unique address to compare.
+                continue  # Leave these rows as-is.
+            final = result.suggested_address or AddressAuditEngine._mist_address_str(result)  # Post-audit address.
+            key = AddressAuditEngine._address_key(final)  # Normalize for an apples-to-apples comparison.
+            if key:  # Only bucket rows that actually have an address.
+                buckets.setdefault(key, []).append(result)  # Group rows by identical normalized address.
+        for rows in buckets.values():  # Inspect each address bucket for a cross-site collision.
+            sites = {r.matched_site.site_id for r in rows if r.matched_site.site_id}  # Distinct sites here.
+            if len(sites) < 2:  # One site (or repeats of the same site) -> not a collision.
+                continue  # Nothing to flag.
+            for result in rows:  # Two or more different sites share this exact address -> flag them all.
+                logging.info(
+                    "Duplicate address across %d sites (e.g. %s): not unique, flagging for review",
+                    len(sites),
+                    result.matched_site.site_name,
+                )  # Action-log the collision so script.log explains the flag.
+                result.issue_type = "DUPLICATE_ADDRESS"  # Review-only: excluded from the correctable/push set.
+                result.suggested_address = ""  # Never recommend pushing a non-unique address.
+                result.source = "-"  # No trustworthy single source for a colliding address.
+
+    @staticmethod
+    def _mist_address_str(result: AuditResult) -> str:
+        """Return the row's current Mist address as one comparable string (or '')."""
+        addr = result.matched_site.mist_address  # Mist address payload (full string lives under 'address').
+        return (addr.get("address") or "") if isinstance(addr, dict) else ""  # Street string or empty.
+
+    @staticmethod
+    def _address_key(text: str) -> str:
+        """Normalize a full address into a collision key (country-stripped, lowercased, alnum-collapsed)."""
+        no_country = re.sub(r",?\s*(?:USA|United States)\s*$", "", text, flags=re.IGNORECASE)  # Drop trailing country.
+        alnum = re.sub(r"[^a-z0-9]+", " ", no_country.lower())  # Collapse punctuation/case to single spaces.
+        return " ".join(alnum.split())  # Collapse whitespace -> a stable comparison key.
 
     def _build_audit_result(
         self,
@@ -401,6 +450,15 @@ class AddressAuditEngine:
             business_name=business,  # Optional query prefix.
             ui_geocode=ui_geocode,  # Whether Tier 3 is permitted.
         )
+        if resolver.has_conflicting_hints(candidates):  # Hints disagree on the building with no majority.
+            logging.info("Conflicting address hints for site %s; flagging CONFLICTING_HINTS", site.site_name)
+            return AuditResult(  # Review-only: the tool refuses to auto-pick among divergent stores.
+                address_row=row,  # Original CSV row.
+                matched_site=site,  # Keep the three hint columns visible for manual review.
+                issue_type="CONFLICTING_HINTS",  # Never enters the correctable/push set.
+                source="-",  # No single trustworthy source to credit.
+                suggested_address="",  # Decline to recommend; operator compares Mist/CSV/SNMP by hand.
+            )
         resolver_result = resolver.resolve(candidates)  # Run the tier cascade (fail-soft).
         issue = self._classify(site.mist_address, self._csv_to_dict(row), site.snmp_location, resolver_result)
         return AuditResult(  # Compose the per-row result.
@@ -419,7 +477,8 @@ class AddressAuditEngine:
         snmp_loc: str | None,
         resolver_result: Any,
     ) -> str:
-        """Return exactly one of the nine classification states for a resolved row."""
+        """Return one of the resolved classification states for a row (excludes the
+        out-of-band UNMATCHED / CONFLICTING_HINTS / DUPLICATE_ADDRESS states)."""
         if resolver_result is None or resolver_result.canonical_address is None:  # No external result.
             return self._classify_internal(mist_addr, csv_addr, snmp_loc)  # Fall back to internal signals.
         if resolver_result.ambiguous:  # Multiple plausible candidates (mall scenario).

--- a/src/site/address_audit/comparison_display.py
+++ b/src/site/address_audit/comparison_display.py
@@ -23,7 +23,7 @@ _COLUMN_NAMES = [  # The seven table columns, in display order.
     "SNMP Location",  # SNMP-derived location reference (truncated in terminal).
     "Suggested Address",  # Resolver's best correction (truncated in terminal).
     "Source",  # Which tier produced the suggestion.
-    "Issue Type",  # One of the nine classification states.
+    "Issue Type",  # One of the eleven classification states.
 ]
 _TRUNCATE_WIDTH = 40  # Max terminal width for the two widest columns.
 

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -67,7 +67,7 @@ class AuditResult:
     address_row: AddressRow  # Original CSV input row.
     matched_site: MatchedSite  # Match outcome (+ SNMP enrichment).
     resolver_result: ResolverResult | None = None  # None for UNMATCHED rows (no resolution attempted).
-    issue_type: str = "UNMATCHED"  # Exactly one of the nine classification states.
+    issue_type: str = "UNMATCHED"  # Exactly one of the eleven classification states.
     suggested_address: str = ""  # Best correction to display (full value; truncated only in terminal).
     source: str = "-"  # Source column label (Internal/Internal+OSM/Nominatim/Google (Mist UI)/Cache/-).
 

--- a/tests/unit/site/address_audit/test_address_resolver.py
+++ b/tests/unit/site/address_audit/test_address_resolver.py
@@ -382,3 +382,61 @@ class TestHelpers:
         resolver._respect_rate_limit()
         resolver._respect_rate_limit()
         assert slept  # Second rapid call paused.
+
+
+class TestHasConflictingHints:
+    """has_conflicting_hints flags only genuine no-majority house-number disagreement."""
+
+    def test_all_three_differ_is_conflict(self):
+        """Three distinct house numbers with no majority -> conflict (three different stores)."""
+        cand = ResolveCandidates(
+            mist_address={"address": "1523 E San Marnan Dr", "city": "Waterloo", "state": "IA", "zip": "50702"},
+            csv_address={"address": "2825 Crossroads Blvd", "city": "Waterloo", "state": "IA", "zip": "50702"},
+            snmp_location="100 Mall Dr Waterloo IA 50702",
+        )
+        assert AddressResolver().has_conflicting_hints(cand) is True
+
+    def test_two_agree_one_differs_is_not_conflict(self):
+        """A 2-vs-1 split has a clear majority -> not a conflict (the outlier is trusted away)."""
+        cand = ResolveCandidates(
+            mist_address={"address": "100 Main St", "city": "T", "state": "FL", "zip": "1"},
+            csv_address={"address": "100 Main St", "city": "T", "state": "FL", "zip": "1"},
+            snmp_location="456 Oak Ave Ste 200 T FL 1",
+        )
+        assert AddressResolver().has_conflicting_hints(cand) is False
+
+    def test_all_same_number_is_not_conflict(self):
+        """All hints on the same house number -> consensus, never a conflict."""
+        cand = ResolveCandidates(
+            mist_address={"address": "100 Main St", "city": "T", "state": "FL", "zip": "1"},
+            csv_address={"address": "100 Main St Suite 5", "city": "T", "state": "FL", "zip": "1"},
+            snmp_location="100 Main St T FL 1",
+        )
+        assert AddressResolver().has_conflicting_hints(cand) is False
+
+    def test_suite_on_dissenter_does_not_rescue(self):
+        """A suite-bearing dissenter on a different number is still a conflict (suite is irrelevant off-street)."""
+        cand = ResolveCandidates(
+            mist_address={"address": "100 Main St", "city": "T", "state": "FL", "zip": "1"},
+            csv_address={"address": "200 Oak Ave", "city": "T", "state": "FL", "zip": "1"},
+            snmp_location="300 Pine Rd Ste 9 T FL 1",
+        )
+        assert AddressResolver().has_conflicting_hints(cand) is True
+
+    def test_mist_missing_number_others_agree_is_not_conflict(self):
+        """Mist lacks a house number but CSV+SNMP agree -> majority, not a conflict."""
+        cand = ResolveCandidates(
+            mist_address={"address": "S Federal Hwy", "city": "Ft Pierce", "state": "FL", "zip": "34982"},
+            csv_address={"address": "2315 S Federal Hwy", "city": "Ft Pierce", "state": "FL", "zip": "34982"},
+            snmp_location="2315 S Federal Hwy Ft Pierce FL 34982",
+        )
+        assert AddressResolver().has_conflicting_hints(cand) is False
+
+    def test_mist_missing_number_others_differ_is_conflict(self):
+        """Mist lacks a number and CSV/SNMP disagree -> no tiebreaker -> conflict."""
+        cand = ResolveCandidates(
+            mist_address={"address": "S Federal Hwy", "city": "Ft Pierce", "state": "FL", "zip": "34982"},
+            csv_address={"address": "2315 S Federal Hwy", "city": "Ft Pierce", "state": "FL", "zip": "34982"},
+            snmp_location="2400 S Federal Hwy Ft Pierce FL 34982",
+        )
+        assert AddressResolver().has_conflicting_hints(cand) is True

--- a/tests/unit/site/address_audit/test_audit_engine.py
+++ b/tests/unit/site/address_audit/test_audit_engine.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from src.site.address_audit import audit_engine as eng_mod
 from src.site.address_audit.audit_engine import AddressAuditEngine
-from src.site.address_audit.models import AddressRow, MatchedSite, ResolverResult
+from src.site.address_audit.models import AddressRow, AuditResult, MatchedSite, ResolverResult
 
 _MIST_NO_SUITE = {"address": "100 Main St", "city": "Town", "state": "FL", "zip": "33000"}
 _MIST_WITH_SUITE = {"address": "100 Main St Suite 5", "city": "Town", "state": "FL", "zip": "33000"}
@@ -369,3 +369,100 @@ class TestSourceLabel:
         """A result with no canonical address is labelled '-'."""
         rr = ResolverResult(query="q", canonical_address=None, source="internal")
         assert AddressAuditEngine._source_label(rr) == "-"
+
+
+class TestConflictingHints:
+    """A no-majority hint disagreement short-circuits to CONFLICTING_HINTS without resolving."""
+
+    def test_conflicting_hints_short_circuits(self):
+        """When the resolver reports conflicting hints, the row is review-only and resolve() never runs."""
+        engine = AddressAuditEngine()  # Real engine; resolver is a guard stub below.
+        row = AddressRow(
+            serial="111", model="SSR130", address="2825 Crossroads Blvd", city="Waterloo", state="IA", zip_code="50702"
+        )  # CSV hint.
+        site = MatchedSite(
+            site_id="s1",
+            site_name="IAS0252F",
+            mist_address={"address": "1523 E San Marnan Dr", "city": "Waterloo", "state": "IA", "zip": "50702"},
+            snmp_location="100 Mall Dr Waterloo IA 50702",
+            match_strategy="serial",
+        )  # Three divergent hints.
+
+        class _Guard:
+            def has_conflicting_hints(self, _candidates):
+                return True  # Force the conflict path.
+
+            def resolve(self, *_):
+                raise AssertionError("resolver must not run on a conflict row")  # Must be skipped.
+
+        result = engine._build_audit_result(row, site, _Guard(), "", False)  # Drive the short-circuit.
+        assert result.issue_type == "CONFLICTING_HINTS"  # Flagged review-only.
+        assert result.suggested_address == ""  # No recommendation offered.
+        assert result.source == "-"  # No single trustworthy source.
+
+
+class TestFlagDuplicateAddresses:
+    """Cross-row collision: one address shared by 2+ distinct sites -> DUPLICATE_ADDRESS."""
+
+    @staticmethod
+    def _result(site_id, name, suggested="", mist_addr=None, issue="ADDRESS_MATCH", source="Google (Mist UI)"):
+        """Build a minimal AuditResult for the collision pass."""
+        row = AddressRow(serial=site_id, model="M", address="x", city="c", state="s", zip_code="z")  # Stub row.
+        site = MatchedSite(site_id=site_id, site_name=name, mist_address=mist_addr or {}, match_strategy="serial")
+        return AuditResult(
+            address_row=row, matched_site=site, issue_type=issue, suggested_address=suggested, source=source
+        )
+
+    def test_two_sites_same_suggested_are_flagged(self):
+        """Two different sites with the identical suggested address -> both DUPLICATE_ADDRESS."""
+        a = self._result("s1", "A", suggested="100 Main St, Town, FL 33000")  # Site A.
+        b = self._result("s2", "B", suggested="100 Main St, Town, FL 33000")  # Site B, same address.
+        AddressAuditEngine._flag_duplicate_addresses([a, b])  # Run the post-pass.
+        assert a.issue_type == "DUPLICATE_ADDRESS" and b.issue_type == "DUPLICATE_ADDRESS"  # Both flagged.
+        assert a.suggested_address == "" and a.source == "-"  # No push, no credited source.
+
+    def test_strip_mall_different_suites_untouched(self):
+        """Same street but different suites are distinct full addresses -> not a collision."""
+        a = self._result("s1", "A", suggested="100 Main St Ste 100, Town, FL 33000")  # Unit 100.
+        b = self._result("s2", "B", suggested="100 Main St Ste 200, Town, FL 33000")  # Unit 200.
+        AddressAuditEngine._flag_duplicate_addresses([a, b])  # Run the post-pass.
+        assert a.issue_type == "ADDRESS_MATCH" and b.issue_type == "ADDRESS_MATCH"  # Strip-mall case preserved.
+
+    def test_single_site_not_flagged(self):
+        """A lone site is never a collision."""
+        a = self._result("s1", "A", suggested="100 Main St, Town, FL 33000")  # Only one site.
+        AddressAuditEngine._flag_duplicate_addresses([a])  # Run the post-pass.
+        assert a.issue_type == "ADDRESS_MATCH"  # Untouched.
+
+    def test_same_site_twice_not_flagged(self):
+        """Two rows for the SAME site (same id) are not a cross-site collision."""
+        a = self._result("s1", "A", suggested="100 Main St, Town, FL 33000")  # Same site_id ...
+        b = self._result("s1", "A", suggested="100 Main St, Town, FL 33000")  # ... appearing twice.
+        AddressAuditEngine._flag_duplicate_addresses([a, b])  # Run the post-pass.
+        assert a.issue_type == "ADDRESS_MATCH" and b.issue_type == "ADDRESS_MATCH"  # Not flagged.
+
+    def test_conflicting_hints_row_is_preserved(self):
+        """A CONFLICTING_HINTS row keeps its (more specific) reason and is skipped by the pass."""
+        a = self._result(
+            "s1",
+            "A",
+            suggested="",
+            mist_addr={"address": "100 Main St, Town, FL 33000"},
+            issue="CONFLICTING_HINTS",
+            source="-",
+        )  # Already review-only.
+        b = self._result("s2", "B", suggested="100 Main St, Town, FL 33000")  # Different site, same address.
+        AddressAuditEngine._flag_duplicate_addresses([a, b])  # Run the post-pass.
+        assert a.issue_type == "CONFLICTING_HINTS"  # Preserved (skipped).
+        assert b.issue_type == "ADDRESS_MATCH"  # Alone in its bucket -> not flagged.
+
+    def test_collision_detected_via_mist_fallback_and_country_strip(self):
+        """Suite-less ADDRESS_MATCH rows collide via the Mist address even when one carries a ', USA' suffix."""
+        a = self._result(
+            "s1", "A", suggested="", mist_addr={"address": "100 Main St, Town, FL 33000, USA"}, issue="ADDRESS_MATCH"
+        )  # Country suffix.
+        b = self._result(
+            "s2", "B", suggested="", mist_addr={"address": "100 Main St, Town, FL 33000"}, issue="ADDRESS_MATCH"
+        )  # No suffix.
+        AddressAuditEngine._flag_duplicate_addresses([a, b])  # Run the post-pass.
+        assert a.issue_type == "DUPLICATE_ADDRESS" and b.issue_type == "DUPLICATE_ADDRESS"  # Normalized to one key.


### PR DESCRIPTION
## What

Two new **review-only** classification states for the address audit (menu 195),
both **excluded from write-back** so the tool never pushes an address it cannot
trust. Each shows a blank Suggested Address; the operator decides from the
Mist/CSV/SNMP columns.

- **`CONFLICTING_HINTS`** -- Mist, CSV, and SNMP disagree on the **house number
  with no majority**. A 2-vs-1 split keeps its majority (the lone dissenter is the
  outlier); a suite on a dissenter does not rescue it (a suite is only meaningful
  on the agreed street number). Detected structurally *before* resolving, so no
  wasted geocode.
- **`DUPLICATE_ADDRESS`** -- a post-pass flags any final address shared by 2+
  *distinct* sites (indistinguishable for shipping). Strip-mall rows with
  *different* suites have different full addresses and are left untouched.

## Why

Answers three operator questions about the audit's judgment:
1. *Three hints all valid but different stores?* -> `CONFLICTING_HINTS` (was:
   silently trusted the CSV).
2. *Multiple sites report the same address?* -> `DUPLICATE_ADDRESS` (was: no
   cross-row check at all; would offer to push the same address to both).
3. *2 agree, 3rd dissents with a suite?* -> the 2 win; the suite-bearing dissenter
   is the outlier (documented + tested).

## Validation (real T-Mobile data, `Book1.csv`, 65 sites)

Ran the live pipeline (geocode off). `CONFLICTING_HINTS` fired on a genuine
case and nothing over-fired:

| Site | Mist | CSV | SNMP | Result |
|------|------|-----|------|--------|
| HISS2SCZ | `199 Kamehameha Hwy #98, Aiea HI` | `98-199 Kamehameha Hwy Suite B4 Aiea HI` | `1520 Route 38 ... Hainesport NJ` | **CONFLICTING_HINTS** |

Three distinct house numbers (199 / 98 / 1520) with no majority -> flagged for
review. The SNMP was the stale Hainesport-NJ value and Mist had mis-parsed a
Hawaii hyphenated address -- exactly the kind of row that must not be
auto-pushed. The two GA 2-vs-1 rows (CSV+SNMP agree vs Mist) were correctly **not**
flagged. `DUPLICATE_ADDRESS` had no trigger in this dataset (no collisions) but
is covered by unit tests.

## Scope / tests

`address_resolver.py` (conflict detector), `audit_engine.py` (short-circuit +
duplicate post-pass), `models.py` / `comparison_display.py` (docs), CHANGELOG.
**178 tests pass** (+13). black / ruff / vulture clean. No change to the
correctable set wiring -- both states are simply absent from the whitelist.