### PR TITLE
fix(address-audit): strip business name from Hawaii hyphenated house numbers (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,18 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
+- **Address audit suggestion glued the business name to Hawaii hyphenated house
+  numbers (menu 195)**: the Tier-3 (Google-via-Mist) suggestion cleaner strips the
+  establishment name that Google glues to the address (``T-Mobile931 US Highway
+  ...`` -> ``931 US Highway ...``) by anchoring on the ``<house-number> <street>``
+  start. Its anchor required the house number to be followed by a space, but
+  Hawaii's grid addresses use a hyphenated house number (``74-5450``), so the
+  anchor never matched and the business name survived in the output (real run:
+  ``T-Mobile74-5450 Makala Blvd #107`` for site HIS00364). The anchor now accepts
+  an optional ``-<digits>`` run in the house number, so the prefix is stripped
+  (``74-5450 Makala Blvd #107``) while every non-hyphenated address and suite dash
+  (``Sute A-103``) is unaffected.
+
 - **Logging and on-screen output crashed on non-Western characters (all menus)**:
   running any operation against data containing characters outside the Windows
   console's default `cp1252` codec raised `UnicodeEncodeError` and dumped a

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -392,13 +392,16 @@ class MistUIGeocoder:
         <street>`` start -- yielding the clean shippable street line. A real
         camel-cased city (``DeFuniak``) is preserved because only street suffixes
         and digits trigger a split, never a generic lowercase->uppercase boundary.
+        The leading house number may be hyphenated (Hawaii's ``74-5450`` grid
+        addresses), so the anchor accepts an optional ``-<digits>`` run before the
+        street; without this the glued business name survives (``T-Mobile74-5450``).
         """
         s = text.strip()  # Normalize surrounding whitespace.
         s = re.sub(r",?\s*(?:USA|United States)\s*$", "", s, flags=re.IGNORECASE).strip()  # Drop trailing country.
         s = re.sub(r"\b(US|NE|NW|SE|SW|N|S|E|W)([A-Z][a-z])", r"\1 \2", s)  # Split directional glue (NLive).
         s = re.sub(rf"\b({MistUIGeocoder._STREET_SUFFIXES})([A-Z][a-z])", r"\1 \2", s)  # Split street->city (HwyFort).
         s = re.sub(r"(\d)([A-Z][a-z]{2,})", r"\1 \2", s)  # Split a number glued to a city word (330Brandon).
-        match = re.match(r"^\D*?(\d+\s+\S.*)$", s)  # "<house-number> <street>..." after any name prefix.
+        match = re.match(r"^\D*?(\d+(?:-\d+)?\s+\S.*)$", s)  # "<house-number> <street>" (house# may be hyphenated).
         cleaned = match.group(1) if match else s  # Use the address tail when a real street start is present.
         return cleaned.strip().strip(",").strip() or text.strip()  # Never return empty.
 

--- a/tests/unit/site/address_audit/test_ui_geocoder.py
+++ b/tests/unit/site/address_audit/test_ui_geocoder.py
@@ -283,6 +283,16 @@ class TestCleanAddress:
         raw = "1015 A1A Beach Blvd Unit 4, St. Augustine Beach, FL 32080"
         assert MistUIGeocoder._clean_address(raw) == "1015 A1A Beach Blvd Unit 4, St. Augustine Beach, FL 32080"
 
+    def test_hyphenated_house_number_strips_business_prefix(self):
+        """A Hawaii hyphenated house number (74-5450) still sheds the glued business name."""
+        raw = "T-Mobile74-5450 Makala Blvd #107, Kailua-Kona, HI 96740, USA"  # Business name glued to 74-5450.
+        assert MistUIGeocoder._clean_address(raw) == "74-5450 Makala Blvd #107, Kailua-Kona, HI 96740"
+
+    def test_hyphenated_house_number_without_prefix_preserved(self):
+        """A hyphenated house number with no business prefix is returned intact."""
+        raw = "46-047 Kamehameha Hwy Suite E5, Kaneohe, HI 96744, USA"  # Leading 46-047 is the house number.
+        assert MistUIGeocoder._clean_address(raw) == "46-047 Kamehameha Hwy Suite E5, Kaneohe, HI 96744"
+
 
 class TestAutoConnect:
     """The default 'auto' mode: take over an existing browser, else spawn one."""


### PR DESCRIPTION
## Problem

Found while self-analyzing a full **Tier-3 (Google-via-Mist)** run of the site
address audit (menu 195) on real T-Mobile data (`Book1.csv`, 65 sites). Site
**HIS00364** produced the suggestion:

    T-Mobile74-5450 Makala Blvd #107

The business-name prefix `T-Mobile` is glued to the house number. The Tier-3
cleaner (`_clean_address`) removes that glued establishment name by anchoring on
the `<house-number> <street>` start (`T-Mobile931 US Highway ...` ->
`931 US Highway ...`), but the anchor regex required the house number to be
followed by a **space**. Hawaii's grid addresses use a **hyphenated** house number
(`74-5450`), so the anchor never matched and the prefix survived.

## Fix

One-character-class change to the anchor: allow an optional `-<digits>` run in
the house number.

    -  re.match(r"^\D*?(\d+\s+\S.*)$", s)
    +  re.match(r"^\D*?(\d+(?:-\d+)?\s+\S.*)$", s)

Result: `T-Mobile74-5450 Makala Blvd #107` -> `74-5450 Makala Blvd #107`.
Verified non-regressive against normal addresses, hyphen-free house numbers, and
suite dashes (`Sute A-103` -- the dash there is not the leading number, so it is
untouched).

## Tests

+2 unit tests in `TestCleanAddress` (hyphenated with/without business prefix).
**180 pass.** black / ruff / vulture clean.

## Context (the run that surfaced this)

The Tier-3 run was otherwise excellent and confirms the merged menu-195 code:
Google engaged on 47/65 rows, **0 NO_RESULT** (all 3 geocode-off misses
recovered), the `Google (Mist UI)` label is correct, the `CONFLICTING_HINTS`
guard fired on HISS2SCZ, and all 6 `WRONG_STREET` catches were legitimate. This
was the one output defect found.