### PR TITLE
fix(address-audit): preserve customer unit when Google autocomplete drops it (menu 195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,24 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
+- **Address audit silently dropped a customer-supplied unit when Google omitted it
+  (menu 195)**: Tier-3 types ``{business} {address}`` (including the suite) into the
+  Mist dashboard's Google Places box, but Google's autocomplete often resolves to
+  the street/establishment and drops a unit typed at the end -- and the freshness
+  guard only waited for the *house number*, so it accepted the bare street without
+  the unit. The unit then vanished from the suggestion, and because Mist also
+  lacked it the row even read ``ADDRESS_MATCH`` ("no change needed"). A real run
+  lost the unit on four sites whose CSV **and** SNMP location both confirmed it
+  (FLSS2SJB ``Unit 200``, FLS01302 ``Suite 100``, FLS01501 ``Suite 98``, FLSE8677
+  ``Unit 8``). Two changes fix this: (1) when a unit was typed, the freshness guard
+  now waits a short bounded grace (``_SUITE_GRACE_S``) for the unit to also appear
+  in the top suggestion before accepting it (Google usually catches up); and (2) if
+  the unit still never appears, the unit we typed is re-appended to Google's street
+  -- but only when it is safe (the suggestion carries no *other* unit, and the house
+  numbers agree, so a different unit or a different building is never overwritten).
+  Restored rows now correctly read ``MISSING_SUITE`` instead of a false
+  ``ADDRESS_MATCH``, so the operator can add the unit.
+
 - **Address audit suggestion glued the business name to Hawaii hyphenated house
   numbers (menu 195)**: the Tier-3 (Google-via-Mist) suggestion cleaner strips the
   establishment name that Google glues to the address (``T-Mobile931 US Highway

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -60,6 +60,7 @@ except ImportError:  # pragma: no cover -- exercised only on hosts without Playw
 
 _KEY_JITTER = secrets.SystemRandom()  # Per-keystroke delay source; unpredictable cadence dodges bot heuristics.
 _THINKING_PAUSE_EVERY = 7  # Add an occasional longer "thinking" pause every N characters while typing.
+_SUITE_GRACE_S = 2.0  # Extra seconds (after the house number matches) to let a typed suite/unit land in the dropdown.
 
 # --- Selector constants (captured 2026-06-29; re-verify if the Mist dashboard UI changes) ---
 # Google Places Autocomplete attaches ``pac-target-input`` to the bound input and
@@ -262,7 +263,8 @@ class MistUIGeocoder:
         field = self._locate_input(page, timeout_ms)  # Find the autocomplete input element.
         self._enter_query(page, field, query)  # Focus, clear the stale dropdown, type the new query.
         expected = self._house_number(query)  # House number anchors the fresh-result wait.
-        texts = self._read_fresh_suggestions(page, expected, timeout_ms)  # Wait for THIS query's suggestions.
+        expected_suite = self._suite_id(query)  # Unit id we typed (e.g. "200"); "" when none -> suite wait is a no-op.
+        texts = self._read_fresh_suggestions(page, expected, timeout_ms, expected_suite)  # Wait for THIS query.
         logging.debug("UI autocomplete returned %d fresh suggestion(s)", len(texts))  # Action-log count.
         return texts  # May be empty -> NO_RESULT (never a stale, wrong answer).
 
@@ -294,7 +296,7 @@ class MistUIGeocoder:
             delay += _KEY_JITTER.uniform(low, high)  # Occasional human "thinking" gap.
         return delay  # Seconds to sleep before the next keystroke.
 
-    def _read_fresh_suggestions(self, page: Any, expected: str, timeout_ms: int) -> list[str]:
+    def _read_fresh_suggestions(self, page: Any, expected: str, timeout_ms: int, expected_suite: str = "") -> list[str]:
         """Poll until the TOP suggestion matches ``expected`` (this query's house number).
 
         Google leaves the PREVIOUS query's suggestions in the DOM until the new
@@ -303,13 +305,34 @@ class MistUIGeocoder:
         query's house number; on timeout we return [] (NO_RESULT) rather than risk
         a stale, wrong address. Queries without a house number cannot be anchored,
         so they read the first stable list (rare for retail addresses).
+
+        The suite lags too: the unit is typed LAST, so the house number is already
+        present in the dropdown before the suite-bearing request returns, and a
+        house-number-only wait would accept the base street without the unit. When
+        ``expected_suite`` is set we therefore keep polling for a short, bounded
+        grace (``_SUITE_GRACE_S``) for the top row to also reflect that unit; if it
+        lands we use it, and if the grace expires we accept the base street (the
+        builder then re-appends the unit we typed). Google usually catches up, so
+        this recovers the unit without stalling rows where Google has no unit.
         """
         deadline = time.monotonic() + max(0.0, timeout_ms / 1000.0)  # Absolute wait deadline.
+        grace = min(_SUITE_GRACE_S, max(0.0, timeout_ms / 1000.0))  # Bounded extra window for a lagging suite.
+        house_ok_at: float | None = None  # Monotonic time the house number first matched (starts the suite grace).
+        fresh_fallback: list[str] = []  # Best house-number-fresh list seen (may lack the suite) for a timeout return.
         while time.monotonic() < deadline:  # Poll until fresh or timed out.
             texts = self._current_suggestions(page)  # Snapshot the current dropdown rows.
             if texts and (not expected or self._matches_house_number(texts[0], expected)):  # Fresh top row.
-                return texts  # The top suggestion belongs to THIS query.
+                fresh_fallback = texts  # Remember it: the street/number belongs to THIS query.
+                if not expected_suite or self._reflects_suite(texts[0], expected_suite):  # Suite present (or none).
+                    return texts  # The top suggestion fully belongs to THIS query.
+                if house_ok_at is None:  # House number just became fresh; start the suite grace clock.
+                    house_ok_at = time.monotonic()  # Give the lagging suite a moment to appear.
+                elif time.monotonic() - house_ok_at >= grace:  # Suite never showed within the grace window.
+                    logging.info("Suite '%s' not shown within grace; using base street", expected_suite)  # Note.
+                    return texts  # Accept the base street; _build_result re-appends the unit we typed.
             self._settle(page, 200)  # Brief pause before re-polling.
+        if fresh_fallback:  # Timed out mid-grace but we did see this query's street/number.
+            return fresh_fallback  # Prefer the fresh street over NO_RESULT.
         logging.info("No fresh suggestion for house number '%s' within timeout; skipping (stale-guard)", expected)
         return []  # Fail-soft to NO_RESULT.
 
@@ -337,6 +360,45 @@ class MistUIGeocoder:
         """Return True when ``expected`` is one of the digit-runs in ``text`` (glue-safe)."""
         return expected in re.findall(r"\d+", text)  # Compare extracted numbers, not a raw substring.
 
+    @staticmethod
+    def _suite_phrase(text: str) -> str:
+        """Return the full suite/unit phrase from an address/query (e.g. 'Unit 200', '#3'), or ''.
+
+        Matches an explicit keyword form (``Suite/Ste/Unit/Space/Bldg/Rm/Apt <id>``)
+        first, then a bare ``#<id>`` hash form. The id may be alphanumeric with an
+        internal hyphen (``A2``, ``1515B``, ``H0004``). Returns the raw matched token
+        (whitespace-collapsed) so it can be re-appended verbatim to a suggestion.
+        """
+        keyword = re.search(
+            r"(?i)\b(?:suite|ste|unit|space|bldg|building|rm|room|apt)\.?\s*#?\s*[A-Za-z0-9][A-Za-z0-9\-]*", text
+        )  # Keyword + id (e.g. 'Suite 100', 'Ste A2').
+        if keyword:  # Prefer the explicit keyword form.
+            return re.sub(r"\s+", " ", keyword.group(0)).strip()  # Collapse internal whitespace.
+        hashed = re.search(r"#\s*[A-Za-z0-9][A-Za-z0-9\-]*", text)  # Bare hash form (e.g. '#3', '#1515b').
+        return hashed.group(0).replace(" ", "") if hashed else ""  # '#<id>' with no gap, or empty.
+
+    @staticmethod
+    def _suite_id(text: str) -> str:
+        """Return just the bare unit identifier from a suite phrase (e.g. '200', 'A2', '3'), or ''."""
+        phrase = MistUIGeocoder._suite_phrase(text)  # Full phrase such as 'Unit 200' or '#3'.
+        if not phrase:  # No suite present.
+            return ""  # Nothing to compare/preserve.
+        return phrase.split()[-1].lstrip("#")  # Trailing token; '#3' -> '3', 'Unit 200' -> '200'.
+
+    @staticmethod
+    def _reflects_suite(text: str, suite: str) -> bool:
+        """Return True when ``suite`` appears in ``text`` beyond the leading house number (glue-safe).
+
+        The leading house number is removed first so a unit id that equals the house
+        number (``100 Main St Suite 100``) is not falsely considered 'reflected' by
+        the base street ``100 Main St``.
+        """
+        if not suite:  # No suite to look for -> treat as satisfied.
+            return True  # Caller wants no suite constraint.
+        body = re.sub(r"^\D*\d+(?:-\d+)?", "", text, count=1)  # Drop the leading (possibly hyphenated) house number.
+        tokens = [token.lower() for token in re.findall(r"[A-Za-z0-9]+", body)]  # Remaining alnum tokens, lowered.
+        return suite.lower() in tokens  # The unit id must appear somewhere after the house number.
+
     def _locate_input(self, page: Any, timeout_ms: int) -> Any:
         """Probe candidate selectors and return the first matching input element."""
         per_try = max(1000, timeout_ms // max(1, len(INPUT_SELECTORS)))  # Split budget across candidates.
@@ -362,6 +424,7 @@ class MistUIGeocoder:
             logging.debug("No UI suggestions for query: %s", query)  # Trace the empty result.
             return ResolverResult(query=query, canonical_address=None, source="mist_ui", confidence=0.0)
         top = self._clean_address(suggestions[0])  # Strip the glued business name + trailing country.
+        top = self._preserve_query_suite(query, top)  # Keep the unit we typed if Google returned the bare street.
         ambiguous = len(suggestions) > 1  # Multiple hits => mall/strip-center ambiguity.
         confidence = 0.6 if ambiguous else 0.9  # Lower confidence when several candidates exist.
         logging.info("UI geocode top suggestion: %s (ambiguous=%s)", top, ambiguous)  # Action-log result.
@@ -372,6 +435,41 @@ class MistUIGeocoder:
             confidence=confidence,  # Heuristic confidence.
             raw_response={"suggestions": suggestions, "ambiguous": ambiguous},  # Full payload for cache.
         )
+
+    def _preserve_query_suite(self, query: str, suggestion: str) -> str:
+        """Re-append the unit we typed when Google returned the SAME building without one.
+
+        Google Places autocomplete often resolves to the street/establishment and
+        drops an arbitrary unit typed at the end of the query -- so a suite the CSV
+        (and often the SNMP location) confirmed can vanish from the suggestion,
+        silently losing shipping-critical data and even reading as ADDRESS_MATCH.
+        We restore it, but only when it is safe: we typed a unit, the suggestion
+        does not already reflect that unit, the suggestion carries NO other unit
+        (a DIFFERENT unit means Google is the authority -- leave it), and the house
+        numbers agree (never graft a unit onto a different building).
+        """
+        suite_id = self._suite_id(query)  # The unit id we typed (e.g. "200"); "" when none.
+        if not suite_id:  # We never asked about a unit.
+            return suggestion  # Nothing to preserve.
+        if self._reflects_suite(suggestion, suite_id):  # Google already shows our unit.
+            return suggestion  # Already complete.
+        if self._suite_phrase(suggestion):  # Google returned a DIFFERENT unit -> it is the authority.
+            return suggestion  # Trust Google's unit over ours.
+        query_house = self._house_number(query)  # House number we asked about.
+        sugg_house = self._house_number(suggestion)  # House number Google returned.
+        if query_house and sugg_house and query_house != sugg_house:  # Different building.
+            return suggestion  # Never graft a unit across buildings.
+        phrase = self._suite_phrase(query)  # The full 'Unit 200' / '#3' token to restore.
+        restored = self._insert_suite(suggestion, phrase)  # Append it to the street segment.
+        logging.info("Preserved typed unit '%s' Google omitted: %s", phrase, restored)  # Action-log the restore.
+        return restored  # Street from Google, unit preserved from the customer data.
+
+    @staticmethod
+    def _insert_suite(address: str, phrase: str) -> str:
+        """Append ``phrase`` to the street segment (before the first comma) of ``address``."""
+        head, sep, tail = address.partition(",")  # Split off the street line (before the first comma).
+        joined = f"{head.rstrip()} {phrase}".strip()  # Street + unit, single-spaced.
+        return f"{joined}{sep}{tail}"  # Reattach the city/state/zip remainder unchanged.
 
     # Street-type suffixes (abbreviated and spelled out) used to split a street glued to a city.
     _STREET_SUFFIXES = (

--- a/tests/unit/site/address_audit/test_ui_geocoder.py
+++ b/tests/unit/site/address_audit/test_ui_geocoder.py
@@ -228,6 +228,94 @@ class TestStaleGuard:
         page.query_selector_all.return_value = [stale]
         assert geo._read_fresh_suggestions(page, "9999", 0) == []  # Zero budget -> immediate timeout.
 
+    def test_read_fresh_waits_for_lagging_suite(self):
+        """When a suite is expected, a suite-bearing row that arrives late is preferred."""
+        geo = MistUIGeocoder()
+        page = MagicMock()
+        base = MagicMock()  # First poll: correct house number but no unit yet (suite lag).
+        base.inner_text.return_value = "5550 North Military Trail, Boca Raton, FL 33431"
+        withunit = MagicMock()  # Second poll: the unit has landed.
+        withunit.inner_text.return_value = "5550 North Military Trail #200, Boca Raton, FL 33431"
+        page.query_selector_all.side_effect = [[base], [withunit]]  # Suite appears on the 2nd poll.
+        out = geo._read_fresh_suggestions(page, "5550", 5000, expected_suite="200")
+        assert out[0].endswith("#200, Boca Raton, FL 33431")  # Captured the suite-bearing row.
+        assert page.query_selector_all.call_count == 2  # Waited one extra poll for the suite.
+
+    def test_read_fresh_accepts_base_after_suite_grace(self, monkeypatch):
+        """If the suite never appears within the grace, the base street is accepted (not hung)."""
+        monkeypatch.setattr(ui_mod, "_SUITE_GRACE_S", 0.0)  # Collapse the grace so the test is instant.
+        geo = MistUIGeocoder()
+        page = MagicMock()
+        base = MagicMock()  # House number matches, unit never shows.
+        base.inner_text.return_value = "5550 North Military Trail, Boca Raton, FL 33431"
+        page.query_selector_all.return_value = [base]  # Always the suite-less base street.
+        out = geo._read_fresh_suggestions(page, "5550", 5000, expected_suite="200")
+        assert out and out[0].startswith("5550 North Military Trail")  # Falls back to the base street.
+
+    def test_read_fresh_no_suite_returns_immediately(self):
+        """With no expected suite the first house-number-fresh row returns at once (unchanged)."""
+        geo = MistUIGeocoder()
+        page = MagicMock()
+        item = MagicMock()
+        item.inner_text.return_value = "5550 North Military Trail, Boca Raton, FL 33431"
+        page.query_selector_all.return_value = [item]
+        out = geo._read_fresh_suggestions(page, "5550", 5000)  # No expected_suite.
+        assert out and page.query_selector_all.call_count == 1  # No extra suite wait.
+
+
+class TestSuitePreservation:
+    """Tier-3 keeps a customer-supplied unit that Google's autocomplete drops."""
+
+    def test_suite_id_and_phrase_extraction(self):
+        """Keyword and hash unit forms are extracted from a full query string."""
+        g = MistUIGeocoder()
+        assert g._suite_phrase("5550 N Military Traill Unit 200 Boca Raton FL 33431") == "Unit 200"
+        assert g._suite_id("5550 N Military Traill Unit 200 Boca Raton FL 33431") == "200"
+        assert g._suite_phrase("940 S Military Trail #3 West Palm Beach FL 33415") == "#3"
+        assert g._suite_id("940 S Military Trail #3 West Palm Beach FL 33415") == "3"
+        assert g._suite_phrase("1200 NW 87th Ave Doral FL 33172") == ""  # No unit present.
+
+    def test_reflects_suite_excludes_leading_house_number(self):
+        """A unit id equal to the house number is not falsely 'reflected' by the base street."""
+        assert MistUIGeocoder._reflects_suite("100 Main St, Town, FL 33000", "100") is False
+        assert MistUIGeocoder._reflects_suite("100 Main St Suite 100, Town, FL", "100") is True
+        assert MistUIGeocoder._reflects_suite("5550 N Military Trl #200, Boca, FL", "200") is True
+
+    def test_preserves_dropped_unit_from_query(self):
+        """Google returned the bare street; the unit we typed is restored to it."""
+        g = MistUIGeocoder()
+        query = "T-Mobile 5550 N Military Traill Unit 200 Boca Raton FL 33431"
+        sugg = "5550 North Military Trail, Boca Raton, FL 33431"
+        assert g._preserve_query_suite(query, sugg) == "5550 North Military Trail Unit 200, Boca Raton, FL 33431"
+
+    def test_build_result_preserves_dropped_unit(self):
+        """End-to-end: _build_result restores the dropped unit into the canonical address."""
+        g = MistUIGeocoder()
+        query = "T-Mobile 6798 Bird Rd Suite 98 Miami FL 33155"
+        result = g._build_result(query, ["6798 Bird Road, Miami, FL 33155, USA"])
+        assert result.canonical_address == "6798 Bird Road Suite 98, Miami, FL 33155"
+
+    def test_keeps_googles_different_unit(self):
+        """A DIFFERENT unit from Google is authoritative -- our unit is not grafted on."""
+        g = MistUIGeocoder()
+        query = "T-Mobile 4200 Conroy Rd #204 Orlando FL 32839"
+        sugg = "4200 Conroy Rd Suite H200, Orlando, FL 32839"
+        assert g._preserve_query_suite(query, sugg) == sugg  # Google's H200 wins.
+
+    def test_never_grafts_across_buildings(self):
+        """A different house number means a different building -- never move the unit."""
+        g = MistUIGeocoder()
+        query = "T-Mobile 901 W Indiantown Rd Suite 101 Jupiter FL 33458"
+        sugg = "903 W Indiantown Rd, Jupiter, FL 33458"
+        assert g._preserve_query_suite(query, sugg) == sugg  # 901 != 903 -> untouched.
+
+    def test_no_unit_typed_is_noop(self):
+        """When we typed no unit there is nothing to preserve."""
+        g = MistUIGeocoder()
+        assert g._preserve_query_suite("1200 NW 87th Ave Doral FL", "1200 NW 87th Ave, Doral, FL") == (
+            "1200 NW 87th Ave, Doral, FL"
+        )
+
 
 class TestCleanAddress:
     """The captured Google suggestion is reduced to a clean shippable street line."""


### PR DESCRIPTION
## Problem (found by self-analyzing a live Tier-3 run on `Book1.csv`)

Tier-3 types `{business} {address}` -- **including the suite** -- into the Mist
dashboard's Google Places box. But Google's autocomplete often resolves to the
street/establishment and drops a unit typed at the end, and the freshness guard
(`_read_fresh_suggestions`) only waited for the **house number** to appear. So it
accepted the bare street *before/without* the unit, the unit vanished from the
suggestion, and because Mist also lacked it the row even read **ADDRESS_MATCH**
("no change needed").

Real run dropped the unit on four sites whose CSV **and** SNMP location both
independently confirmed it:

| Site | CSV | SNMP | Google suggestion (before) | Verdict |
|------|-----|------|----------------------------|---------|
| FLSS2SJB | Unit 200 | Unit 200 | `5550 North Military Trail` | ADDRESS_MATCH ❌ |
| FLS01302 | Suite 100 | Ste 100 | `2199 Ponce de Leon Boulevard` | ADDRESS_MATCH ❌ |
| FLS01501 | Suite 98 | 98 | `6798 Bird Road` | ADDRESS_MATCH ❌ |
| FLSE8677 | Unit 8 | -- | `3738 Park Blvd` | ADDRESS_MATCH ❌ |

A package to `5550 North Military Trail` **without Unit 200** may never reach the store.

## Fix

1. **Suite-aware freshness** -- when a unit was typed, after the house number
   matches keep polling for a short **bounded grace** (`_SUITE_GRACE_S` = 2s) for
   the unit to also appear in the top suggestion; prefer it when it lands. Google
   usually catches up, so this captures the real unit without stalling rows where
   Google genuinely has none.
2. **Preservation net** -- if the unit still never appears, re-append the unit we
   typed to Google's street, but only when **safe**: the suggestion carries no
   *other* unit (a different unit means Google is authoritative), and the house
   numbers agree (never graft a unit across buildings). The leading house number is
   excluded from the "already reflected?" check so `Suite 100` on `100 Main St`
   is handled correctly.

Restored rows now read **MISSING_SUITE** (add the unit) instead of a false
ADDRESS_MATCH. Verified end-to-end: the four rows above restore to
`... Unit 200`/`Suite 100`/`Suite 98`/`Unit 8` and reclassify to MISSING_SUITE.

## Tests

+10 unit tests: suite extraction, house-number-excluded reflection, the lagging-
suite wait, base-street fallback after grace, preservation (restore / keep Google's
different unit / never cross buildings / no-op). **190 pass.** black / ruff /
vulture clean.

## Note

The suite-aware *timing* behavior (part 1) is best confirmed against live Google;
the deterministic logic is fully unit-tested here. I'll validate the timing on the
next live Tier-3 run.