### PR TITLE
fix: menu 196 safe_input keyword mismatch

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -12032,7 +12032,7 @@ class LicenseExportUtils:  # Hold custom license exporters.
         resolved_org_id = org_id or InputUtils.safe_input(  # Use explicit arg or interactive prompt.
             "Org ID (UUID): ",  # Prompt user for required org identifier.
             context="org_license_claim_status:org_id",  # Tag prompt context for EOF handling.
-            default=default_org_id,  # Provide .env default for convenience.
+            default_value=default_org_id,  # Provide .env default for convenience.
         )
         logging.debug("Resolved async-claim org_id=%s", resolved_org_id)  # Log resolved org id.
         if not LicenseExportUtils._is_valid_uuid(resolved_org_id):  # Validate input before any API call.
@@ -12043,7 +12043,7 @@ class LicenseExportUtils:  # Hold custom license exporters.
             detail_answer = InputUtils.safe_input(  # Collect detail preference from user.
                 "Include per-device detail? (y/N): ",  # Prompt text with safe default.
                 context="org_license_claim_status:detail",  # Tag prompt context for EOF handling.
-                default="N",  # Default to summary-only mode.
+                default_value="N",  # Default to summary-only mode.
             )
             include_detail = detail_answer.strip().lower() in {"y", "yes"}  # Parse yes/no to boolean.
             logging.debug("Resolved include_detail=%s", include_detail)  # Log parsed detail value.

--- a/tests/unit/test_org_license_async_claim_status.py
+++ b/tests/unit/test_org_license_async_claim_status.py
@@ -20,8 +20,8 @@ def test_prompt_parsing_api_call_and_dual_export_writes(monkeypatch):
     api_calls: list[dict] = []
     writes: list[dict] = []
 
-    def safe_input_stub(prompt, context=None, default=""):
-        prompts_seen.append((prompt, context, default))
+    def safe_input_stub(prompt, context=None, default="", default_value=""):
+        prompts_seen.append((prompt, context, default_value or default))
         if context == "org_license_claim_status:org_id":
             return "123e4567-e89b-12d3-a456-426614174000"
         return "yes"
@@ -69,10 +69,10 @@ def test_invalid_uuid_aborts_before_api_call(monkeypatch):
     sdk_called = {"value": False}
     write_called = {"value": False}
 
-    def safe_input_stub(_prompt, context=None, default=""):
+    def safe_input_stub(_prompt, context=None, default="", default_value=""):
         if context == "org_license_claim_status:org_id":
             return "not-a-uuid"
-        return default
+        return default_value or default
 
     def api_stub(*_args, **_kwargs):
         sdk_called["value"] = True


### PR DESCRIPTION
## Summary\n- Fix menu option 196 crash caused by calling InputUtils.safe_input with unsupported keyword default\n- Use correct keyword default_value for org-id prompt and detail prompt\n\n## Validation\n- python -m py_compile MistHelper.py\n- python -m ruff check MistHelper.py\n- python -m black --check MistHelper.py\n- python MistHelper.py --test *(fails in current env due unrelated dependency import error: requests/simplejson JSONDecodeError)*\n