### PR TITLE
fix: menu 196 uses standard org resolver instead of prompting (#576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,21 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Fixed
 
-- **Address audit silently dropped a customer-supplied unit when Google omitted it
+- **Menu 196 prompted for `Org ID (UUID)` instead of using the configured org**:
+  the async license-claim exporter
+  (`LicenseExportUtils.export_org_license_async_claim_status`) was written to read a
+  non-existent env var `MIST_ORG_ID` and then call `InputUtils.safe_input(...,
+  default_value=...)`. `safe_input` always prompts -- `default_value` only supplies
+  the fallback on empty ENTER -- so with no `MIST_ORG_ID` key set anywhere it always
+  fell through to an interactive `Org ID (UUID):` prompt, ignoring the operator's
+  configured org. It now uses the standard resolver
+  `ConfigUtils.get_cached_or_prompted_org_id()` like every other menu operation
+  (precedence: cached global -> `org_id`/`ORG_ID` env -> `.env` file -> interactive
+  org picker only as a last resort). The same helpers also stopped using the
+  deprecated naive `datetime.utcnow()` for their `polled_at_utc` column and now use
+  timezone-aware `datetime.now(UTC)` to match the rest of the codebase. Unit tests
+  updated to stub the resolver. (#576)
+
   (menu 195)**: Tier-3 types ``{business} {address}`` (including the suite) into the
   Mist dashboard's Google Places box, but Google's autocomplete often resolves to
   the street/establishment and drops a unit typed at the end -- and the freshness

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -11985,7 +11985,7 @@ class LicenseExportUtils:  # Hold custom license exporters.
         logging.info("Flattening async-claim summary for org %s", org_id_value)  # Log before summary flatten.
         completed_items = payload.get("completed") or []  # Normalize completed list for safe counting.
         incompleted_items = payload.get("incompleted") or []  # Normalize incompleted list for safe counting.
-        polled_at_utc = datetime.utcnow().isoformat() + "Z"  # Capture local poll timestamp.
+        polled_at_utc = datetime.now(UTC).isoformat()  # Capture UTC poll timestamp (timezone-aware).
         summary_row = {  # Build normalized row for DataExporter.
             "org_id": org_id_value,  # Inject org id for composite key use.
             "scheduled_at": payload.get("scheduled_at"),  # Keep stable job id from Mist.
@@ -12008,7 +12008,7 @@ class LicenseExportUtils:  # Hold custom license exporters.
         logging.info("Flattening async-claim details for org %s", org_id_value)  # Log before detail flatten.
         detail_items = payload.get("details") or []  # Normalize details list for safe iteration.
         scheduled_at_value = payload.get("scheduled_at")  # Capture parent job key for joins.
-        polled_at_utc = datetime.utcnow().isoformat() + "Z"  # Capture local poll timestamp.
+        polled_at_utc = datetime.now(UTC).isoformat()  # Capture UTC poll timestamp (timezone-aware).
         detail_rows = [  # Build one row per detail object.
             {
                 "org_id": org_id_value,  # Inject org id for composite key use.
@@ -12027,13 +12027,8 @@ class LicenseExportUtils:  # Hold custom license exporters.
     @staticmethod
     def export_org_license_async_claim_status(org_id: str | None = None, include_detail: bool | None = None) -> None:
         """Fetch and export async claim status summary plus optional details."""
-        default_org_id = os.environ.get("MIST_ORG_ID", "")  # Read optional org default from env.
-        logging.info("Prompting for org_id for async-claim export")  # Log before org-id prompt.
-        resolved_org_id = org_id or InputUtils.safe_input(  # Use explicit arg or interactive prompt.
-            "Org ID (UUID): ",  # Prompt user for required org identifier.
-            context="org_license_claim_status:org_id",  # Tag prompt context for EOF handling.
-            default_value=default_org_id,  # Provide .env default for convenience.
-        )
+        logging.info("Resolving org_id for async-claim export")  # Log before org resolution.
+        resolved_org_id = org_id or ConfigUtils.get_cached_or_prompted_org_id()  # Explicit arg else standard resolver.
         logging.debug("Resolved async-claim org_id=%s", resolved_org_id)  # Log resolved org id.
         if not LicenseExportUtils._is_valid_uuid(resolved_org_id):  # Validate input before any API call.
             logging.warning("Invalid org_id %s for async-claim export", resolved_org_id)  # Warn on invalid input.

--- a/tests/unit/test_org_license_async_claim_status.py
+++ b/tests/unit/test_org_license_async_claim_status.py
@@ -20,10 +20,11 @@ def test_prompt_parsing_api_call_and_dual_export_writes(monkeypatch):
     api_calls: list[dict] = []
     writes: list[dict] = []
 
+    def org_id_stub():
+        return "123e4567-e89b-12d3-a456-426614174000"
+
     def safe_input_stub(prompt, context=None, default="", default_value=""):
         prompts_seen.append((prompt, context, default_value or default))
-        if context == "org_license_claim_status:org_id":
-            return "123e4567-e89b-12d3-a456-426614174000"
         return "yes"
 
     def api_stub(_session, org_id, detail=None):
@@ -48,14 +49,14 @@ def test_prompt_parsing_api_call_and_dual_export_writes(monkeypatch):
         writes.append({"data": data, "filename": filename, "api_function_name": api_function_name})
         return True
 
+    monkeypatch.setattr(MistHelper.ConfigUtils, "get_cached_or_prompted_org_id", org_id_stub)
     monkeypatch.setattr(MistHelper.InputUtils, "safe_input", safe_input_stub)
     monkeypatch.setattr(MistHelper.mistapi.api.v1.orgs.claim, "GetOrgLicenseAsyncClaimStatus", api_stub)
     monkeypatch.setattr(MistHelper.DataExporter, "write_with_format_selection", write_stub)
 
     MistHelper.LicenseExportUtils.export_org_license_async_claim_status()
 
-    assert prompts_seen[0][1] == "org_license_claim_status:org_id"
-    assert prompts_seen[1][1] == "org_license_claim_status:detail"
+    assert prompts_seen[0][1] == "org_license_claim_status:detail"
     assert api_calls == [{"org_id": "123e4567-e89b-12d3-a456-426614174000", "detail": True}]
     assert writes[0]["api_function_name"] == "getOrgLicenseAsyncClaimStatus"
     assert writes[0]["filename"] == "org_123e4567_claim_status_summary"
@@ -69,10 +70,8 @@ def test_invalid_uuid_aborts_before_api_call(monkeypatch):
     sdk_called = {"value": False}
     write_called = {"value": False}
 
-    def safe_input_stub(_prompt, context=None, default="", default_value=""):
-        if context == "org_license_claim_status:org_id":
-            return "not-a-uuid"
-        return default_value or default
+    def org_id_stub():
+        return "not-a-uuid"
 
     def api_stub(*_args, **_kwargs):
         sdk_called["value"] = True
@@ -82,7 +81,7 @@ def test_invalid_uuid_aborts_before_api_call(monkeypatch):
         write_called["value"] = True
         return True
 
-    monkeypatch.setattr(MistHelper.InputUtils, "safe_input", safe_input_stub)
+    monkeypatch.setattr(MistHelper.ConfigUtils, "get_cached_or_prompted_org_id", org_id_stub)
     monkeypatch.setattr(MistHelper.mistapi.api.v1.orgs.claim, "GetOrgLicenseAsyncClaimStatus", api_stub)
     monkeypatch.setattr(MistHelper.DataExporter, "write_with_format_selection", write_stub)
 


### PR DESCRIPTION
## Summary

Fixes menu 196 (`Export async organization license-claim status`) prompting for `Org ID (UUID):` even when `org_id` is configured in `.env`.

Closes #576

## Root cause

`LicenseExportUtils.export_org_license_async_claim_status()` (written by a prior agent) read a **non-existent** env var `MIST_ORG_ID` and then called `InputUtils.safe_input(..., default_value=...)`. `safe_input` **always** prompts -- `default_value` only supplies the fallback on empty ENTER. Since nobody sets `MIST_ORG_ID` (the real key is `org_id`), it always fell through to an interactive prompt and ignored the operator's org.

## Fix

- Use the standard resolver `ConfigUtils.get_cached_or_prompted_org_id()` (precedence: cached global -> `org_id`/`ORG_ID` env -> `.env` -> interactive picker last), matching ~15 other menu operations.
- Switch the two flatten helpers off deprecated naive `datetime.utcnow()` to timezone-aware `datetime.now(UTC)` (codebase convention; removes a Python-removal-scheduled deprecation).
- Update unit tests to stub the resolver instead of `safe_input` for org id.

## Conformance

- [x] Menu 196 uses `org_id` from `.env`/env without prompting when present
- [x] Falls back to interactive org selection only when nothing is configured
- [x] Unit tests updated and green (4 passed locally)
- [x] `py_compile` / `ruff` / `black --check` clean
- [x] No secrets added
- [ ] CI (mypy, pytest, bandit, pip-audit, CodeQL) green -- pending

## Test evidence

`pytest tests/unit/test_org_license_async_claim_status.py` -> 4 passed, deprecation warnings gone.