### PR TITLE
refactor: ssh csv_loader CC 6->5 for A+/100

### DIFF
--- a/src/ssh/config/csv_loader.py
+++ b/src/ssh/config/csv_loader.py
@@ -73,8 +73,16 @@ class CommandCsvLoader:
             commands.append(first_cell)  # Accept this row's command
             return  # Done with this row
         # Format an invalid-row marker the same way the original did
-        invalid_cmd = first_cell[:50] + "..." if len(first_cell) > 50 else first_cell
+        invalid_cmd = CommandCsvLoader._truncate_invalid(first_cell)  # Extracted to keep CC<=5
         invalid.append(f"line {row_num}: {invalid_cmd}")  # Track for warning summary
+
+    @staticmethod
+    def _truncate_invalid(first_cell: str) -> str:
+        """Trim a rejected command to 50 chars with an ellipsis when needed."""
+        # WHY: pulling the ternary out of _consume_csv_row drops that method's CC from 6 to 5.
+        if len(first_cell) > 50:  # Original truncation threshold preserved
+            return first_cell[:50] + "..."  # Long form -- trim + ellipsis marker
+        return first_cell  # Short enough to display verbatim
 
     @staticmethod
     def _warn_invalid_rows(invalid: list[str], csv_file_path: str) -> None:


### PR DESCRIPTION
## Summary
- `_consume_csv_row` CC=6 -> 5 by extracting the 50-char truncation ternary into `_truncate_invalid`.
- File compliance: 99.0 A+ -> 100.0 A+.
- No behavior change; user-facing strings preserved.

## Test plan
- [x] `py -m tools.compliance_analyzer src/ssh/config/csv_loader.py -q` -> 100.0 A+
- [x] `py -m pytest tests/unit/test_ssh_runner.py -q` -> 168 passed