### PR TITLE
refactor: map_wizard_deps compliance A+/97.0 -> A+/100.0

### DIFF
--- a/src/dataclasses/map_wizard_deps.py
+++ b/src/dataclasses/map_wizard_deps.py
@@ -13,7 +13,7 @@ from typing import Any  # Wildcard inner type for the loosely-typed Mist asset d
 
 
 @dataclass(frozen=True, slots=True)
-class MapWizardPreviewContext:
+class MapWizardPreviewContext:  # Bundle inputs for the preview render step.
     """Inputs the preview step needs to render the upcoming changes."""
 
     current_map: dict[str, Any]  # Existing map record so original PPM/dimensions show in the preview.
@@ -22,7 +22,7 @@ class MapWizardPreviewContext:
 
 
 @dataclass(frozen=True, slots=True)
-class MapWizardApplyTarget:
+class MapWizardApplyTarget:  # Bundle the target-map identifiers and upload path.
     """Identifies the map being replaced and the image file going into it."""
 
     site_id: str  # Mist site UUID that owns the map being updated.
@@ -31,7 +31,7 @@ class MapWizardApplyTarget:
 
 
 @dataclass(frozen=True, slots=True)
-class MapWizardApplyContext:
+class MapWizardApplyContext:  # Bundle mutable apply-step state (assets + errors).
     """Mutable state the apply step uses to scale assets and record failures."""
 
     current_map: dict[str, Any]  # Pre-replacement record (drives wall/wayfinding path scaling).
@@ -40,7 +40,7 @@ class MapWizardApplyContext:
 
 
 @dataclass(frozen=True, slots=True)
-class MapWizardSummaryContext:
+class MapWizardSummaryContext:  # Bundle inputs for the summary printer.
     """Inputs the final wizard summary printer needs to display results."""
 
     map_name: str  # Human-readable map name printed in the summary header.


### PR DESCRIPTION
<analysis>
map_wizard_deps.py held a single medium CONV-COMMENTS violation: 78.9% inline coverage due to four class-declaration lines lacking same-line comments. Added terse purpose comments to each `class X:` line so every executable line is documented. No functional change; only comment additions.
</analysis>

<summary>
- Added inline comments to the 4 dataclass class declarations to reach 100% CONV-COMMENTS.
- File score: 97.0 (A+) -> 100.0 (A+); overall violation count for this file: 1 -> 0.
- Verified locally: compliance analyzer, Ruff, Black all clean.
</summary>