### PR TITLE
refactor: override_report_writer compliance A+/97.0 -> A+/100.0

### DIFF
--- a/src/gateway/overrides/override_report_writer.py
+++ b/src/gateway/overrides/override_report_writer.py
@@ -102,11 +102,25 @@ class OverrideReportWriter:
         target_ports: list[str],
     ) -> None:
         """Print the legacy operator-facing console summary block verbatim."""
-        if entries:  # Same distinct-device math used for the console block as for the log block
-            gateways_with_overrides = len({entry["device_id"] for entry in entries})  # Unique device_id count
-        else:
-            gateways_with_overrides = 0  # No entries means zero gateways had overrides (sanity for print line)
-        total_overridden_ports = len(entries)  # Count of CSV rows for the console summary line
+        # WHY: distinct-device math matches the log-summary branch above for parity across outputs.
+        gateways_with_overrides = len({entry["device_id"] for entry in entries}) if entries else 0
+        OverrideReportWriter._print_summary_lines(  # WHY: extracted printer keeps this method under STRUCT-LENGTH.
+            total_overridden_ports=len(entries),
+            gateways_with_overrides=gateways_with_overrides,
+            total_gateways=total_gateways,
+            devices_with_overrides_count=devices_with_overrides_count,
+            target_ports=target_ports,
+        )
+
+    @staticmethod
+    def _print_summary_lines(
+        total_overridden_ports: int,
+        gateways_with_overrides: int,
+        total_gateways: int,
+        devices_with_overrides_count: int,
+        target_ports: list[str],
+    ) -> None:
+        """Emit the legacy console summary lines given precomputed stats."""
         saved_calls = total_gateways - devices_with_overrides_count  # API calls saved by the override pre-filter
         print(f"! Gateway override report written to {OUTPUT_FILENAME}")  # Legacy console line preserved
         print(  # Legacy console line preserved verbatim across two physical lines


### PR DESCRIPTION
<analysis>
compliance-analyzer flagged src/gateway/overrides/override_report_writer.py at 97.0/A+ with a single medium STRUCT-LENGTH violation on _print_summary (28 lines, limit 25). The function computed two derived stats (distinct-gateway count, saved-calls delta) and then emitted six console lines verbatim. The natural split is the print block: pulling the six print calls into a dedicated helper leaves _print_summary as a thin coordinator that just derives the distinct-gateway count and delegates.
</analysis>

<summary>
Extracted _print_summary_lines to carry the six legacy operator console prints; _print_summary now computes gateways_with_overrides via a single conditional expression and delegates the print block. saved_calls math moved into the printer helper where its consumers live. Behavior preserved verbatim: identical console output ordering and content. Compliance now 100.0/A+; ruff and black clean.
</summary>