### PR TITLE
refactor: _ssid_template_cluster compliance A+/97.0 -> A+/100.0

### DIFF
--- a/src/ssid_consolidation/_ssid_template_cluster.py
+++ b/src/ssid_consolidation/_ssid_template_cluster.py
@@ -47,7 +47,7 @@ class _ClusterBase:  # WHY: shared wrapper base for every ssid_template cluster
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy so self.org_id / helpers work
 
-    def _call(self, name: str, *args: Any, **kwargs: Any) -> Any:
+    def _call(self, name: str, *args: Any, **kwargs: Any) -> Any:  # WHY: dynamic dispatch to parent by name
         """Invoke a method on the parent manager by name.
 
         Routes through :func:`getattr` so ``patch.object(mgr, name, ...)`` in
@@ -57,7 +57,7 @@ class _ClusterBase:  # WHY: shared wrapper base for every ssid_template cluster
         """
         return getattr(self._mm, name)(*args, **kwargs)  # WHY: dynamic dispatch bypasses W0212
 
-    def _load_cache_or_bail(self) -> bool:
+    def _load_cache_or_bail(self) -> bool:  # WHY: shared Phase 2-5 cache preamble
         """Load Phase 1 cache onto parent; return False + bail msg when missing.
 
         Phase 2/3/4/5 orchestrators all share the same "load cache or abort"
@@ -66,8 +66,8 @@ class _ClusterBase:  # WHY: shared wrapper base for every ssid_template cluster
         """
         parent = self._mm  # WHY: proxy alias
         cached = parent._load_cache()  # noqa: SLF001 — cluster helper is intra-package
-        if not cached:
+        if not cached:  # WHY: cache missing means Phase 1 was skipped
             print("! Phase 1 cache not found. Run Phase 1 first.")  # WHY: user bail msg
-            return False
+            return False  # WHY: signal to caller to abort the phase
         parent.cache = cached  # WHY: hand loaded cache to parent state
-        return True
+        return True  # WHY: cache loaded successfully, phase can proceed


### PR DESCRIPTION
<analysis>
Compliance analyzer reported one CONV-COMMENTS medium violation in
src/ssid_consolidation/_ssid_template_cluster.py: inline-comment coverage
77.3% with uncommented anchors on lines 50, 60, 69, 71, 73 — the two method
defs (_call, _load_cache_or_bail) and the bail-branch inside the cache
loader.
</analysis>

<summary>
Added same-line # WHY: comments on the two method defs and the three
uncommented executable lines inside _load_cache_or_bail (the if guard and
both return statements). No behavior change; no new suppressions.
Verified locally: analyzer 100.0/A+, ruff clean, black clean.
</summary>