### PR TITLE
refactor: tui_runner compliance A+/97.0 -> A+/100.0

### DIFF
--- a/src/ui/runtime/tui_runner.py
+++ b/src/ui/runtime/tui_runner.py
@@ -4,49 +4,49 @@ Decomposes the main TUI loop into setup, loop, and teardown phases.
 Each helper is CC <= 10.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # WHY: postponed evaluation for forward-ref type hints
 
-import logging
-import sys
-import time
-from typing import Any
+import logging  # WHY: action-log setup/loop/teardown transitions
+import sys  # WHY: stdin fd for termios cbreak setup
+import time  # WHY: sleep briefly between loop iterations
+from typing import Any  # WHY: TUI back-ref is loosely typed
 
 LOOP_SLEEP_S = 0.01  # 10ms yield between loop iterations
 REFRESH_PER_SECOND = 20  # Live() refresh frequency
 
 
-class TuiRunner:
+class TuiRunner:  # WHY: extracted from MistHelperTUI.run (was CC=33)
     """Owns the lifecycle of the TUI: terminal setup, render loop, teardown."""
 
-    def __init__(self, tui: Any) -> None:
+    def __init__(self, tui: Any) -> None:  # WHY: bind owning TUI for shared state
         """Store a back-reference to the owning TUI for shared state access."""
         self._tui = tui  # Back-reference for shared TUI state
 
-    def run(self) -> None:
+    def run(self) -> None:  # WHY: public entry point retained for compat
         """Public entry point matching the original ``MistHelperTUI.run`` shape."""
         tui = self._tui  # Local alias
         logging.info("TUI: Starting hierarchical API explorer")  # Action log before setup
         self._setup_terminal()  # Switch Unix terminal to cbreak mode
-        try:
+        try:  # WHY: teardown must always run even on setup/loop errors
             tui._discover_current_level()  # Populate the root level items
             self._render_loop()  # Drive the main Live() loop
         except Exception as error:  # Surface critical errors loudly
-            logging.exception("TUI: Critical error in run() method: %s", error)
-            raise
+            logging.exception("TUI: Critical error in run() method: %s", error)  # WHY: preserve traceback
+            raise  # WHY: re-raise so caller sees the failure
         finally:
             self._teardown_terminal()  # Restore terminal even on error
             logging.info("TUI: Explorer exited cleanly")  # Action log after teardown
-            print("\n[EXIT] MistHelper TUI - Hierarchical API Explorer closed")
+            print("\n[EXIT] MistHelper TUI - Hierarchical API Explorer closed")  # WHY: user-visible exit banner
 
-    def _setup_terminal(self) -> None:
+    def _setup_terminal(self) -> None:  # WHY: enter cbreak so keys read w/o Enter
         """Put the Unix terminal into raw (cbreak) mode for keypress capture."""
         tui = self._tui  # Local alias
         if tui.IS_WINDOWS:  # Windows uses msvcrt; nothing to set up
-            return
+            return  # WHY: no-op on Windows
         tui.old_terminal_settings = tui.termios.tcgetattr(sys.stdin)  # Save current termios for restore
         tui.tty.setcbreak(sys.stdin.fileno())  # Enter cbreak mode
 
-    def _render_loop(self) -> None:
+    def _render_loop(self) -> None:  # WHY: main input/repaint loop
         """Run the inner ``Live()`` render+input loop while ``tui.running``."""
         tui = self._tui  # Local alias
         with tui.Live(  # Live() context auto-refreshes screen
@@ -60,16 +60,16 @@ class TuiRunner:
                 if key:  # Only handle when a key is ready
                     tui._keyboard_dispatch.dispatch(key)  # Dispatch keystroke via the dispatch table
                     if not tui.running:  # Quit may have just been requested
-                        break
+                        break  # WHY: exit loop immediately on quit
                     live.update(tui.create_layout())  # Repaint with fresh layout
                 time.sleep(LOOP_SLEEP_S)  # Yield CPU briefly
 
-    def _teardown_terminal(self) -> None:
+    def _teardown_terminal(self) -> None:  # WHY: restore Unix termios if we changed it
         """Restore the Unix terminal to its original (pre-cbreak) settings."""
         tui = self._tui  # Local alias
         if tui.IS_WINDOWS:  # Windows has no termios state to restore
-            return
-        try:
-            tui.termios.tcsetattr(sys.stdin, tui.termios.TCSADRAIN, tui.old_terminal_settings)
+            return  # WHY: no-op on Windows
+        try:  # WHY: swallow restore errors to keep exit clean
+            tui.termios.tcsetattr(sys.stdin, tui.termios.TCSADRAIN, tui.old_terminal_settings)  # Restore cooked mode
         except Exception as term_error:  # Restore failures are non-fatal
-            logging.exception("TUI: Error restoring terminal settings: %s", term_error)
+            logging.exception("TUI: Error restoring terminal settings: %s", term_error)  # WHY: log for post-mortem


### PR DESCRIPTION
<analysis>
src/ui/runtime/tui_runner.py started at A+/97.0 with 58.7% inline coverage and uncommented anchors on lines 7, 9, 10, 11, 12, 18, 21, 25, 34, 35, 39, 41. The file wraps MistHelperTUI.run (originally CC=33) into a TuiRunner class with run() + _setup_terminal() + _render_loop() + _teardown_terminal(). All logic remained correct - only CONV-COMMENTS anchor coverage was below the 80% gate. Added same-line # WHY: annotations to the __future__ import, stdlib imports, typing import, class def, __init__/run/_setup_terminal/_render_loop/_teardown_terminal defs, and to the raise / logging.exception / break / early-return / exit-banner / restore-try / restore-exception branches. No behavior change; no new pragmas or noqas.
</analysis>

<summary>
Raise CONV-COMMENTS inline anchor coverage to >=80% across imports, class/def sites, and control-flow branches in src/ui/runtime/tui_runner.py. Compliance score moves from A+/97.0 to A+/100.0. Ruff, Black, and the compliance analyzer all pass cleanly. Pure documentation edit - setup, render loop, teardown, and error handling behavior are unchanged.
</summary>