### PR TITLE
chore: gitignore compliance_report.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ DEVICE*.csv
 data/
 Data/
 DATA/
+compliance_report.md
 output/
 Output/
 OUTPUT/


### PR DESCRIPTION
<analysis>
Adds compliance_report.md to .gitignore. The compliance analyzer writes to that path at repo root when invoked without an explicit -o flag, and it kept reappearing as an untracked stray during backlog remediation work. Ad-hoc reports should stay local rather than being committed accidentally.
</analysis>

<summary>
One-line .gitignore addition. No code impact.
</summary>