### PR TITLE
chore: R20 backlog refresh

### DIFF
--- a/specs/1009-compliance-backlog-remediation/tasks.md
+++ b/specs/1009-compliance-backlog-remediation/tasks.md
@@ -98,17 +98,17 @@ Follow `contracts/per-file-pr.md` for each task. Every task below expands to: ba
 - [ ] T022 Refactor `src\export\site_export_utils.py` (rank 22, current D+/67.0, 15 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-022-site_export_utils`. Follow `contracts/per-file-pr.md`.
 - [ ] T023 Refactor `src\ssid_consolidation\_ssid_template_phase1.py` (rank 23, current D+/68.0, 15 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-023-_ssid_template_phase1`. Follow `contracts/per-file-pr.md`.
 - [ ] T024 Refactor `src\ssh\ssh_runner.py` (rank 24, current D+/68.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-024-ssh_runner`. Follow `contracts/per-file-pr.md`.
-- [ ] T025 Refactor `src\maps\_maps_testing.py` (rank 25, current C-/70.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-025-_maps_testing`. Follow `contracts/per-file-pr.md`.
+- [ ] T025 Refactor `src\analytics\site_analytics_configurator.py` (rank 25, current C-/70.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-025-site_analytics_configurator`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R25** Backlog Refresh Checkpoint (after 25 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 26..99 have shifted.
+- [ ] **R25** Backlog Refresh Checkpoint (after 25 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 26..97 have shifted.
 
-- [ ] T026 Refactor `src\websocket\service_ping_manager.py` (rank 26, current C-/70.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-026-service_ping_manager`. Follow `contracts/per-file-pr.md`.
-- [ ] T027 Refactor `src\analytics\site_analytics_configurator.py` (rank 27, current C-/70.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-027-site_analytics_configurator`. Follow `contracts/per-file-pr.md`.
-- [ ] T028 Refactor `src\db\redis_writer.py` (rank 28, current C-/70.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-028-redis_writer`. Follow `contracts/per-file-pr.md`.
+- [ ] T026 Refactor `src\db\redis_writer.py` (rank 26, current C-/70.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-026-redis_writer`. Follow `contracts/per-file-pr.md`.
+- [ ] T027 Refactor `src\maps\_maps_testing.py` (rank 27, current C-/70.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-027-_maps_testing`. Follow `contracts/per-file-pr.md`.
+- [ ] T028 Refactor `src\websocket\service_ping_manager.py` (rank 28, current C-/70.0, 14 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-028-service_ping_manager`. Follow `contracts/per-file-pr.md`.
 - [ ] T029 Refactor `src\maps\_plotly_viewer.py` (rank 29, current D+/67.0, 13 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-029-_plotly_viewer`. Follow `contracts/per-file-pr.md`.
 - [ ] T030 Refactor `src\gateway\wan_probe_device_override_manager.py` (rank 30, current C-/71.0, 13 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-030-wan_probe_device_override_manager`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R30** Backlog Refresh Checkpoint (after 30 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 31..99 have shifted.
+- [ ] **R30** Backlog Refresh Checkpoint (after 30 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 31..97 have shifted.
 
 - [ ] T031 Refactor `src\capture\multi_ap_scan_workflow.py` (rank 31, current C+/77.0, 13 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-031-multi_ap_scan_workflow`. Follow `contracts/per-file-pr.md`.
 - [ ] T032 Refactor `src\maps\launcher\_viewer_clone.py` (rank 32, current C+/77.0, 13 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-032-_viewer_clone`. Follow `contracts/per-file-pr.md`.
@@ -116,108 +116,106 @@ Follow `contracts/per-file-pr.md` for each task. Every task below expands to: ba
 - [ ] T034 Refactor `src\db\arango_writer.py` (rank 34, current C/75.0, 12 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-034-arango_writer`. Follow `contracts/per-file-pr.md`.
 - [ ] T035 Refactor `src\ssh\ssh_runner_manager.py` (rank 35, current C/75.0, 12 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-035-ssh_runner_manager`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R35** Backlog Refresh Checkpoint (after 35 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 36..99 have shifted.
+- [ ] **R35** Backlog Refresh Checkpoint (after 35 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 36..97 have shifted.
 
-- [ ] T036 Refactor `src\ssh\batch\batch_executor.py` (rank 36, current C/73.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-036-batch_executor`. Follow `contracts/per-file-pr.md`.
-- [ ] T037 Refactor `src\ssh\command\command_runner.py` (rank 37, current C-/72.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-037-command_runner`. Follow `contracts/per-file-pr.md`.
-- [ ] T038 Refactor `src\maps\_maps_backup.py` (rank 38, current D/65.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-038-_maps_backup`. Follow `contracts/per-file-pr.md`.
-- [ ] T039 Refactor `src\gateway\gateway_export_utils.py` (rank 39, current D+/69.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-039-gateway_export_utils`. Follow `contracts/per-file-pr.md`.
-- [ ] T040 Refactor `src\troubleshooting\marvis_troubleshoot_utils.py` (rank 40, current C-/72.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-040-marvis_troubleshoot_utils`. Follow `contracts/per-file-pr.md`.
+- [ ] T036 Refactor `src\maps\_maps_backup.py` (rank 36, current D/65.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-036-_maps_backup`. Follow `contracts/per-file-pr.md`.
+- [ ] T037 Refactor `src\ssh\runtime\app_runner.py` (rank 37, current D+/68.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-037-app_runner`. Follow `contracts/per-file-pr.md`.
+- [ ] T038 Refactor `src\gateway\gateway_export_utils.py` (rank 38, current D+/69.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-038-gateway_export_utils`. Follow `contracts/per-file-pr.md`.
+- [ ] T039 Refactor `src\troubleshooting\marvis_troubleshoot_utils.py` (rank 39, current C-/72.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-039-marvis_troubleshoot_utils`. Follow `contracts/per-file-pr.md`.
+- [ ] T040 Refactor `src\capture\packet_capture_download.py` (rank 40, current C/75.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-040-packet_capture_download`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R40** Backlog Refresh Checkpoint (after 40 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 41..99 have shifted.
+- [ ] **R40** Backlog Refresh Checkpoint (after 40 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 41..97 have shifted.
 
-- [ ] T041 Refactor `src\capture\packet_capture_download.py` (rank 41, current C/75.0, 11 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-041-packet_capture_download`. Follow `contracts/per-file-pr.md`.
-- [ ] T042 Refactor `src\ssh\runtime\app_runner.py` (rank 42, current D+/69.0, 10 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-042-app_runner`. Follow `contracts/per-file-pr.md`.
-- [ ] T043 Refactor `src\inventory\org_device_inventory_summary.py` (rank 43, current C+/79.0, 10 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-043-org_device_inventory_summary`. Follow `contracts/per-file-pr.md`.
-- [ ] T044 Refactor `src\gateway\gateway_stats_exporter.py` (rank 44, current C/75.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-044-gateway_stats_exporter`. Follow `contracts/per-file-pr.md`.
-- [ ] T045 Refactor `src\maps\plotly_map_figure_builder.py` (rank 45, current C/75.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-045-plotly_map_figure_builder`. Follow `contracts/per-file-pr.md`.
+- [ ] T041 Refactor `src\inventory\org_device_inventory_summary.py` (rank 41, current C+/79.0, 10 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-041-org_device_inventory_summary`. Follow `contracts/per-file-pr.md`.
+- [ ] T042 Refactor `src\gateway\gateway_stats_exporter.py` (rank 42, current C/75.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-042-gateway_stats_exporter`. Follow `contracts/per-file-pr.md`.
+- [ ] T043 Refactor `src\maps\plotly_map_figure_builder.py` (rank 43, current C/75.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-043-plotly_map_figure_builder`. Follow `contracts/per-file-pr.md`.
+- [ ] T044 Refactor `src\analytics\site_inventory_health_analyzer.py` (rank 44, current C+/78.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-044-site_inventory_health_analyzer`. Follow `contracts/per-file-pr.md`.
+- [ ] T045 Refactor `src\marvis\marvis_utils.py` (rank 45, current C+/78.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-045-marvis_utils`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R45** Backlog Refresh Checkpoint (after 45 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 46..99 have shifted.
+- [ ] **R45** Backlog Refresh Checkpoint (after 45 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 46..97 have shifted.
 
-- [ ] T046 Refactor `src\analytics\site_inventory_health_analyzer.py` (rank 46, current C+/78.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-046-site_inventory_health_analyzer`. Follow `contracts/per-file-pr.md`.
-- [ ] T047 Refactor `src\marvis\marvis_utils.py` (rank 47, current C+/78.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-047-marvis_utils`. Follow `contracts/per-file-pr.md`.
-- [ ] T048 Refactor `src\websocket\manager.py` (rank 48, current C+/78.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-048-manager`. Follow `contracts/per-file-pr.md`.
-- [ ] T049 Refactor `src\websocket\polling\completion_detector.py` (rank 49, current B/84.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-049-completion_detector`. Follow `contracts/per-file-pr.md`.
-- [ ] T050 Refactor `src\maps\launcher\_viewer_site_switch.py` (rank 50, current B/83.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-050-_viewer_site_switch`. Follow `contracts/per-file-pr.md`.
+- [ ] T046 Refactor `src\websocket\manager.py` (rank 46, current C+/78.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-046-manager`. Follow `contracts/per-file-pr.md`.
+- [ ] T047 Refactor `src\maps\launcher\_viewer_site_switch.py` (rank 47, current B/83.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-047-_viewer_site_switch`. Follow `contracts/per-file-pr.md`.
+- [ ] T048 Refactor `src\websocket\polling\completion_detector.py` (rank 48, current B/84.0, 9 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-048-completion_detector`. Follow `contracts/per-file-pr.md`.
+- [ ] T049 Refactor `src\ssh\batch\host_runner.py` (rank 49, current C-/72.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-049-host_runner`. Follow `contracts/per-file-pr.md`.
+- [ ] T050 Refactor `src\troubleshooting\interactive_test_runner.py` (rank 50, current C/75.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-050-interactive_test_runner`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R50** Backlog Refresh Checkpoint (after 50 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 51..99 have shifted.
+- [ ] **R50** Backlog Refresh Checkpoint (after 50 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 51..97 have shifted.
 
-- [ ] T051 Refactor `src\ssh\batch\host_runner.py` (rank 51, current C-/72.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-051-host_runner`. Follow `contracts/per-file-pr.md`.
-- [ ] T052 Refactor `src\troubleshooting\interactive_test_runner.py` (rank 52, current C/75.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-052-interactive_test_runner`. Follow `contracts/per-file-pr.md`.
-- [ ] T053 Refactor `src\websocket\diagnostics\arp_executor.py` (rank 53, current B-/80.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-053-arp_executor`. Follow `contracts/per-file-pr.md`.
-- [ ] T054 Refactor `src\site\address_audit\address_resolver.py` (rank 54, current B/86.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-054-address_resolver`. Follow `contracts/per-file-pr.md`.
-- [ ] T055 Refactor `src\websocket\commands.py` (rank 55, current B/86.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-055-commands`. Follow `contracts/per-file-pr.md`.
+- [ ] T051 Refactor `src\websocket\diagnostics\arp_executor.py` (rank 51, current B-/80.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-051-arp_executor`. Follow `contracts/per-file-pr.md`.
+- [ ] T052 Refactor `src\site\address_audit\address_resolver.py` (rank 52, current B/86.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-052-address_resolver`. Follow `contracts/per-file-pr.md`.
+- [ ] T053 Refactor `src\websocket\commands.py` (rank 53, current B/86.0, 8 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-053-commands`. Follow `contracts/per-file-pr.md`.
+- [ ] T054 Refactor `src\refactors\serial_cc\security_events.py` (rank 54, current C/75.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-054-security_events`. Follow `contracts/per-file-pr.md`.
+- [ ] T055 Refactor `src\audit\analyzer.py` (rank 55, current B-/80.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-055-analyzer`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R55** Backlog Refresh Checkpoint (after 55 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 56..99 have shifted.
+- [ ] **R55** Backlog Refresh Checkpoint (after 55 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 56..97 have shifted.
 
-- [ ] T056 Refactor `src\refactors\serial_cc\security_events.py` (rank 56, current C/75.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-056-security_events`. Follow `contracts/per-file-pr.md`.
-- [ ] T057 Refactor `src\audit\analyzer.py` (rank 57, current B-/80.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-057-analyzer`. Follow `contracts/per-file-pr.md`.
-- [ ] T058 Refactor `src\gateway\device_template_cloner.py` (rank 58, current B/84.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-058-device_template_cloner`. Follow `contracts/per-file-pr.md`.
-- [ ] T059 Refactor `src\maps\_maps_clone.py` (rank 59, current B/84.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-059-_maps_clone`. Follow `contracts/per-file-pr.md`.
-- [ ] T060 Refactor `src\ssid_consolidation\_ssid_template_phase2.py` (rank 60, current B/84.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-060-_ssid_template_phase2`. Follow `contracts/per-file-pr.md`.
+- [ ] T056 Refactor `src\gateway\device_template_cloner.py` (rank 56, current B/84.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-056-device_template_cloner`. Follow `contracts/per-file-pr.md`.
+- [ ] T057 Refactor `src\maps\_maps_clone.py` (rank 57, current B/84.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-057-_maps_clone`. Follow `contracts/per-file-pr.md`.
+- [ ] T058 Refactor `src\ssid_consolidation\_ssid_template_phase2.py` (rank 58, current B/84.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-058-_ssid_template_phase2`. Follow `contracts/per-file-pr.md`.
+- [ ] T059 Refactor `src\refactors\serial_cc\switch_vc_stats.py` (rank 59, current B/85.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-059-switch_vc_stats`. Follow `contracts/per-file-pr.md`.
+- [ ] T060 Refactor `src\api\tenant_fetch.py` (rank 60, current B+/88.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-060-tenant_fetch`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R60** Backlog Refresh Checkpoint (after 60 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 61..99 have shifted.
+- [ ] **R60** Backlog Refresh Checkpoint (after 60 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 61..97 have shifted.
 
-- [ ] T061 Refactor `src\api\tenant_fetch.py` (rank 61, current B+/88.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-061-tenant_fetch`. Follow `contracts/per-file-pr.md`.
-- [ ] T062 Refactor `src\ui\layout\results_grid_builder.py` (rank 62, current B+/88.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-062-results_grid_builder`. Follow `contracts/per-file-pr.md`.
-- [ ] T063 Refactor `src\refactors\serial_cc\switch_vc_stats.py` (rank 63, current B/85.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-063-switch_vc_stats`. Follow `contracts/per-file-pr.md`.
-- [ ] T064 Refactor `src\maps\plotly_heatmap_renderer.py` (rank 64, current C/73.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-064-plotly_heatmap_renderer`. Follow `contracts/per-file-pr.md`.
-- [ ] T065 Refactor `src\utils\rate_limiting.py` (rank 65, current C/75.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-065-rate_limiting`. Follow `contracts/per-file-pr.md`.
+- [ ] T061 Refactor `src\ui\layout\results_grid_builder.py` (rank 61, current B+/88.0, 7 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-061-results_grid_builder`. Follow `contracts/per-file-pr.md`.
+- [ ] T062 Refactor `src\maps\plotly_heatmap_renderer.py` (rank 62, current C/73.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-062-plotly_heatmap_renderer`. Follow `contracts/per-file-pr.md`.
+- [ ] T063 Refactor `src\utils\rate_limiting.py` (rank 63, current C/75.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-063-rate_limiting`. Follow `contracts/per-file-pr.md`.
+- [ ] T064 Refactor `src\export\site_insights\device_metric_operation.py` (rank 64, current C+/79.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-064-device_metric_operation`. Follow `contracts/per-file-pr.md`.
+- [ ] T065 Refactor `src\websocket\diagnostics\ping_executor.py` (rank 65, current C+/79.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-065-ping_executor`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R65** Backlog Refresh Checkpoint (after 65 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 66..99 have shifted.
+- [ ] **R65** Backlog Refresh Checkpoint (after 65 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 66..97 have shifted.
 
-- [ ] T066 Refactor `src\websocket\diagnostics\ping_executor.py` (rank 66, current C+/79.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-066-ping_executor`. Follow `contracts/per-file-pr.md`.
-- [ ] T067 Refactor `src\maps\_maps_matplotlib.py` (rank 67, current B-/82.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-067-_maps_matplotlib`. Follow `contracts/per-file-pr.md`.
-- [ ] T068 Refactor `src\maps\plotly_map_callback_manager.py` (rank 68, current B-/82.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-068-plotly_map_callback_manager`. Follow `contracts/per-file-pr.md`.
-- [ ] T069 Refactor `src\export\site_insights\device_metric_operation.py` (rank 69, current C+/79.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-069-device_metric_operation`. Follow `contracts/per-file-pr.md`.
-- [ ] T070 Refactor `src\audit\time_parser.py` (rank 70, current B/85.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-070-time_parser`. Follow `contracts/per-file-pr.md`.
+- [ ] T066 Refactor `src\maps\_maps_matplotlib.py` (rank 66, current B-/82.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-066-_maps_matplotlib`. Follow `contracts/per-file-pr.md`.
+- [ ] T067 Refactor `src\maps\plotly_map_callback_manager.py` (rank 67, current B-/82.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-067-plotly_map_callback_manager`. Follow `contracts/per-file-pr.md`.
+- [ ] T068 Refactor `src\audit\time_parser.py` (rank 68, current B/85.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-068-time_parser`. Follow `contracts/per-file-pr.md`.
+- [ ] T069 Refactor `src\export\wifi_clients_exporter.py` (rank 69, current B/86.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-069-wifi_clients_exporter`. Follow `contracts/per-file-pr.md`.
+- [ ] T070 Refactor `src\ssh\connection\connector.py` (rank 70, current B/86.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-070-connector`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R70** Backlog Refresh Checkpoint (after 70 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 71..99 have shifted.
+- [ ] **R70** Backlog Refresh Checkpoint (after 70 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 71..97 have shifted.
 
-- [ ] T071 Refactor `src\export\wifi_clients_exporter.py` (rank 71, current B/86.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-071-wifi_clients_exporter`. Follow `contracts/per-file-pr.md`.
-- [ ] T072 Refactor `src\ssh\connection\connector.py` (rank 72, current B/86.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-072-connector`. Follow `contracts/per-file-pr.md`.
-- [ ] T073 Refactor `src\site\address_audit\ui_geocoder.py` (rank 73, current B+/88.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-073-ui_geocoder`. Follow `contracts/per-file-pr.md`.
-- [ ] T074 Refactor `src\ssh\shell_execution\shell_executor.py` (rank 74, current B+/88.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-074-shell_executor`. Follow `contracts/per-file-pr.md`.
-- [ ] T075 Refactor `src\maps\_flask_viewer.py` (rank 75, current C/74.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-075-_flask_viewer`. Follow `contracts/per-file-pr.md`.
+- [ ] T071 Refactor `src\site\address_audit\ui_geocoder.py` (rank 71, current B+/88.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-071-ui_geocoder`. Follow `contracts/per-file-pr.md`.
+- [ ] T072 Refactor `src\ssh\shell_execution\shell_executor.py` (rank 72, current B+/88.0, 6 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-072-shell_executor`. Follow `contracts/per-file-pr.md`.
+- [ ] T073 Refactor `src\maps\_flask_viewer.py` (rank 73, current C/74.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-073-_flask_viewer`. Follow `contracts/per-file-pr.md`.
+- [ ] T074 Refactor `src\org_data_collector.py` (rank 74, current B-/82.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-074-org_data_collector`. Follow `contracts/per-file-pr.md`.
+- [ ] T075 Refactor `src\websocket\polling\result_combiner.py` (rank 75, current B/83.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-075-result_combiner`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R75** Backlog Refresh Checkpoint (after 75 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 76..99 have shifted.
+- [ ] **R75** Backlog Refresh Checkpoint (after 75 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 76..97 have shifted.
 
-- [ ] T076 Refactor `src\websocket\polling\result_combiner.py` (rank 76, current B/83.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-076-result_combiner`. Follow `contracts/per-file-pr.md`.
-- [ ] T077 Refactor `src\org_data_collector.py` (rank 77, current B-/82.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-077-org_data_collector`. Follow `contracts/per-file-pr.md`.
-- [ ] T078 Refactor `src\db\router.py` (rank 78, current B/84.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-078-router`. Follow `contracts/per-file-pr.md`.
-- [ ] T079 Refactor `src\ssid_consolidation\_ssid_template_phase3.py` (rank 79, current B/86.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-079-_ssid_template_phase3`. Follow `contracts/per-file-pr.md`.
-- [ ] T080 Refactor `src\ssid_consolidation\_ssid_template_phase45.py` (rank 80, current B/86.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-080-_ssid_template_phase45`. Follow `contracts/per-file-pr.md`.
+- [ ] T076 Refactor `src\db\router.py` (rank 76, current B/84.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-076-router`. Follow `contracts/per-file-pr.md`.
+- [ ] T077 Refactor `src\ssid_consolidation\_ssid_template_phase3.py` (rank 77, current B/86.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-077-_ssid_template_phase3`. Follow `contracts/per-file-pr.md`.
+- [ ] T078 Refactor `src\ssid_consolidation\_ssid_template_phase45.py` (rank 78, current B/86.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-078-_ssid_template_phase45`. Follow `contracts/per-file-pr.md`.
+- [ ] T079 Refactor `src\refactors\serial_cc\start_site_client_capture_wireless.py` (rank 79, current B+/88.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-079-start_site_client_capture_wireless`. Follow `contracts/per-file-pr.md`.
+- [ ] T080 Refactor `src\refactors\serial_cc\start_site_scan_capture.py` (rank 80, current B+/88.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-080-start_site_scan_capture`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R80** Backlog Refresh Checkpoint (after 80 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 81..99 have shifted.
+- [ ] **R80** Backlog Refresh Checkpoint (after 80 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 81..97 have shifted.
 
-- [ ] T081 Refactor `src\refactors\serial_cc\start_site_client_capture_wireless.py` (rank 81, current B+/88.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-081-start_site_client_capture_wireless`. Follow `contracts/per-file-pr.md`.
-- [ ] T082 Refactor `src\refactors\serial_cc\start_site_scan_capture.py` (rank 82, current B+/88.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-082-start_site_scan_capture`. Follow `contracts/per-file-pr.md`.
-- [ ] T083 Refactor `src\ui\execution\item_executor.py` (rank 83, current B+/88.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-083-item_executor`. Follow `contracts/per-file-pr.md`.
-- [ ] T084 Refactor `src\bootstrap\dependency_check.py` (rank 84, current A-/90.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-084-dependency_check`. Follow `contracts/per-file-pr.md`.
-- [ ] T085 Refactor `src\websocket\polling\message_router.py` (rank 85, current A-/90.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-085-message_router`. Follow `contracts/per-file-pr.md`.
+- [ ] T081 Refactor `src\ui\execution\item_executor.py` (rank 81, current B+/88.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-081-item_executor`. Follow `contracts/per-file-pr.md`.
+- [ ] T082 Refactor `src\bootstrap\dependency_check.py` (rank 82, current A-/90.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-082-dependency_check`. Follow `contracts/per-file-pr.md`.
+- [ ] T083 Refactor `src\websocket\polling\message_router.py` (rank 83, current A-/90.0, 5 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-083-message_router`. Follow `contracts/per-file-pr.md`.
+- [ ] T084 Refactor `src\export\device_events_52w_exporter.py` (rank 84, current B/84.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-084-device_events_52w_exporter`. Follow `contracts/per-file-pr.md`.
+- [ ] T085 Refactor `src\export\site_insights_exporter.py` (rank 85, current B/84.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-085-site_insights_exporter`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R85** Backlog Refresh Checkpoint (after 85 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 86..99 have shifted.
+- [ ] **R85** Backlog Refresh Checkpoint (after 85 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 86..97 have shifted.
 
-- [ ] T086 Refactor `src\export\device_events_52w_exporter.py` (rank 86, current B/84.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-086-device_events_52w_exporter`. Follow `contracts/per-file-pr.md`.
-- [ ] T087 Refactor `src\export\site_insights_exporter.py` (rank 87, current B/84.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-087-site_insights_exporter`. Follow `contracts/per-file-pr.md`.
-- [ ] T088 Refactor `src\maps\plotly_map_templates.py` (rank 88, current B/84.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-088-plotly_map_templates`. Follow `contracts/per-file-pr.md`.
-- [ ] T089 Refactor `src\bootstrap\package_installer.py` (rank 89, current B+/89.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-089-package_installer`. Follow `contracts/per-file-pr.md`.
-- [ ] T090 Refactor `src\refactors\serial_cc\site_client_insights.py` (rank 90, current B+/89.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-090-site_client_insights`. Follow `contracts/per-file-pr.md`.
+- [ ] T086 Refactor `src\maps\plotly_map_templates.py` (rank 86, current B/84.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-086-plotly_map_templates`. Follow `contracts/per-file-pr.md`.
+- [ ] T087 Refactor `src\bootstrap\package_installer.py` (rank 87, current B+/89.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-087-package_installer`. Follow `contracts/per-file-pr.md`.
+- [ ] T088 Refactor `src\refactors\serial_cc\site_client_insights.py` (rank 88, current B+/89.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-088-site_client_insights`. Follow `contracts/per-file-pr.md`.
+- [ ] T089 Refactor `src\websocket\polling\result_collector.py` (rank 89, current B+/89.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-089-result_collector`. Follow `contracts/per-file-pr.md`.
+- [ ] T090 Refactor `src\wan_hub_group_manager.py` (rank 90, current B+/88.0, 3 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-090-wan_hub_group_manager`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R90** Backlog Refresh Checkpoint (after 90 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 91..99 have shifted.
+- [ ] **R90** Backlog Refresh Checkpoint (after 90 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 91..97 have shifted.
 
-- [ ] T091 Refactor `src\websocket\polling\result_collector.py` (rank 91, current B+/89.0, 4 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-091-result_collector`. Follow `contracts/per-file-pr.md`.
-- [ ] T092 Refactor `src\wan_hub_group_manager.py` (rank 92, current B+/88.0, 3 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-092-wan_hub_group_manager`. Follow `contracts/per-file-pr.md`.
-- [ ] T093 Refactor `src\export\site_insights\site_metric_operation.py` (rank 93, current A-/91.0, 3 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-093-site_metric_operation`. Follow `contracts/per-file-pr.md`.
-- [ ] T094 Refactor `src\maps\plotly_map_serializer.py` (rank 94, current B+/88.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-094-plotly_map_serializer`. Follow `contracts/per-file-pr.md`.
-- [ ] T095 Refactor `src\capture\org_capture_workflow.py` (rank 95, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-095-org_capture_workflow`. Follow `contracts/per-file-pr.md`.
+- [ ] T091 Refactor `src\export\site_insights\site_metric_operation.py` (rank 91, current A-/91.0, 3 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-091-site_metric_operation`. Follow `contracts/per-file-pr.md`.
+- [ ] T092 Refactor `src\maps\plotly_map_serializer.py` (rank 92, current B+/88.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-092-plotly_map_serializer`. Follow `contracts/per-file-pr.md`.
+- [ ] T093 Refactor `src\capture\org_capture_workflow.py` (rank 93, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-093-org_capture_workflow`. Follow `contracts/per-file-pr.md`.
+- [ ] T094 Refactor `src\capture\site_capture_loop.py` (rank 94, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-094-site_capture_loop`. Follow `contracts/per-file-pr.md`.
+- [ ] T095 Refactor `src\db\retention.py` (rank 95, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-095-retention`. Follow `contracts/per-file-pr.md`.
 
-- [ ] **R95** Backlog Refresh Checkpoint (after 95 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 96..99 have shifted.
+- [ ] **R95** Backlog Refresh Checkpoint (after 95 merges). Follow `contracts/backlog-refresh.md`: rerun the full-repo analyzer, regenerate `data/compliance_backlog.tsv`, and reorder remaining tasks if ranks 96..97 have shifted.
 
-- [ ] T096 Refactor `src\capture\site_capture_loop.py` (rank 96, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-096-site_capture_loop`. Follow `contracts/per-file-pr.md`.
-- [ ] T097 Refactor `src\db\retention.py` (rank 97, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-097-retention`. Follow `contracts/per-file-pr.md`.
-- [ ] T098 Refactor `src\gateway\overrides\_deps.py` (rank 98, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-098-_deps`. Follow `contracts/per-file-pr.md`.
-- [ ] T099 Refactor `src\maps\_maps_utils.py` (rank 99, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-099-_maps_utils`. Follow `contracts/per-file-pr.md`.
+- [ ] T096 Refactor `src\gateway\overrides\_deps.py` (rank 96, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-096-_deps`. Follow `contracts/per-file-pr.md`.
+- [ ] T097 Refactor `src\maps\_maps_utils.py` (rank 97, current A-/91.0, 2 issues) to A+/100.0 (floor A/>=94). Branch: `refactor/compliance-097-_maps_utils`. Follow `contracts/per-file-pr.md`.
 
 ---
 


### PR DESCRIPTION
<analysis>
Regenerated `data/full_repo_compliance_R20.md` and `data/compliance_backlog.tsv` after 20 merges from Phase 2. Overall repo compliance score moved from 92.6/A- (R15) to 93.6/A (R20). Backlog of sub-A files shrank from 85 to 76 rows.

Confirmed T002..T023 remain either merged or still-listed per policy (T001..T023 block preserved). T036 (batch_executor #663) and T037 (command_runner #664) merged out-of-order between R15 and R20 and are correctly absent from the fresh backlog.

No A+ regressions detected. No new sub-A files surfaced that were previously absent.

Reordering was required for T024..T099. First shift observed at T025; three material shifts (>3 rank positions):
- app_runner: T042 -> T037 (-5)
- switch_vc_stats: T063 -> T059 (-4)
- device_metric_operation: T069 -> T064 (-5)

Two tail tasks dropped (T098, T099) since only 74 files remain past T023. R25..R95 checkpoint ranges updated from `..99` to `..97`.
</analysis>

<summary>
- Reordered T024..T097 in `specs/1009-compliance-backlog-remediation/tasks.md` to match fresh compliance ranking.
- New head: T024 = `src\ssh\ssh_runner.py` (D+/68.0, 14 issues).
- New tail: T097 = `src\maps\_maps_utils.py` (A-/91.0, 2 issues).
- Dropped T098 and T099 (backlog now only extends to T097).
- Updated all R25..R95 checkpoint ranges to `..97`.
- T001..T023 block untouched per policy.
- `data/*` regenerated but gitignored, so only `tasks.md` is in this PR.
</summary>