### PR TITLE
refactor: org_device_inventory_summary compliance C+/79.0 -> A+/100.0

### DIFF
--- a/src/inventory/org_device_inventory_summary.py
+++ b/src/inventory/org_device_inventory_summary.py
@@ -1,411 +1,453 @@
-"""Org device inventory summary core extracted from MistHelper.py."""
+"""Org device inventory summary core extracted from MistHelper.py."""  # WHY: module summary anchor for tooling
 
-from __future__ import annotations
+from __future__ import annotations  # WHY: PEP 563 keeps annotations lazy for module load speed
 
-import logging
-import os
-import time
-from typing import Any
+import logging  # WHY: structured diagnostics for long-running inventory fetch loops
+import os  # WHY: env fallback for org name when API lookup fails
+import time  # WHY: wall-clock elapsed reporting for the full org summary run
+from collections.abc import Callable  # WHY: PEP 585 canonical location for Callable
+from typing import Any  # WHY: apisession / mistapi / DataExporter typed as Any due to injection
 
-from prettytable import PrettyTable
+from prettytable import PrettyTable  # WHY: console rendering for the operator-facing summary tables
 
-apisession: Any = None
-mistapi: Any = None
-DataExporter: Any = None
-org_id: str = ""
+apisession: Any = None  # WHY: mistapi session injected by configure_* to keep the module import-safe
+mistapi: Any = None  # WHY: mistapi module injected lazily; direct import would create cycles at load
+DataExporter: Any = None  # WHY: exporter injected so tests can substitute a mock without touching disk
+org_id: str = ""  # WHY: selected org for execute(); empty string means "no org chosen yet"
+
+_SEPARATOR_WIDTH: int = 62  # WHY: fixed banner width keeps CLI output aligned across reports
+_INVENTORY_PAGE_SIZE: int = 1000  # WHY: large page size minimizes round-trips for big inventories
+_UNKNOWN: str = "unknown"  # WHY: shared fallback label so bucketing stays consistent across helpers
+_UNASSIGNED: str = "unassigned"  # WHY: dedicated bucket keeps stock visible next to assigned firmware
 
 
-def configure_org_device_inventory_summary_dependencies(
+def configure_org_device_inventory_summary_dependencies(  # WHY: dependency-injection seam for orchestrator + tests
     *,
-    apisession_dependency: Any,
-    mistapi_dependency: Any,
-    data_exporter: Any,
-    org_id_value: str,
+    apisession_dependency: Any,  # WHY: authenticated mistapi session
+    mistapi_dependency: Any,  # WHY: mistapi package handle for endpoint calls
+    data_exporter: Any,  # WHY: exporter class writing CSV/JSON output
+    org_id_value: str,  # WHY: default org used when execute() is called without args
 ) -> None:
     """Configure runtime dependencies from MistHelper orchestration layer."""
-    global apisession
-    global mistapi
-    global DataExporter
-    global org_id
+    global apisession  # WHY: mutate module-level session so class helpers can reach it
+    global mistapi  # WHY: mutate module-level mistapi handle for later endpoint access
+    global DataExporter  # WHY: mutate module-level exporter so exports use the injected implementation
+    global org_id  # WHY: retain selected org across subsequent execute() calls
 
-    apisession = apisession_dependency
-    mistapi = mistapi_dependency
-    DataExporter = data_exporter
-    org_id = org_id_value or ""
+    apisession = apisession_dependency  # WHY: store injected session on the module
+    mistapi = mistapi_dependency  # WHY: store injected mistapi module
+    DataExporter = data_exporter  # WHY: store injected exporter class
+    org_id = org_id_value or ""  # WHY: normalize None to empty string so execute() gate stays simple
 
 
-class OrgDeviceInventorySummaryCore:
+class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization pipeline
     """Core inventory summary logic for a single organization."""
 
-    _DEVICE_TYPES: tuple[str, ...] = ("ap", "switch", "gateway")
+    _DEVICE_TYPES: tuple[str, ...] = ("ap", "switch", "gateway")  # WHY: canonical ordering for output rows
 
     @staticmethod
-    def _fetch_switch_physical_inventory(target_org_id: str) -> list[dict]:
+    def _search_switch_page(target_org_id: str, next_url: str | None) -> dict | None:  # WHY: single-page fetch helper
+        """Return one page of switch inventory results or ``None`` when the API errors."""
+        try:  # WHY: mistapi raises on transport errors; caller treats None as stop-signal
+            response = (  # WHY: continuation URL preserves cursor across pages when present
+                apisession.mist_get(next_url)  # WHY: mist_get follows the next-page URL verbatim
+                if next_url  # WHY: first page has no continuation, so fall through to primary search
+                else mistapi.api.v1.orgs.devices.searchOrgDevices(  # WHY: primary listing endpoint
+                    apisession, target_org_id, type="switch", limit=_INVENTORY_PAGE_SIZE
+                )
+            )
+        except Exception as error:  # WHY: any transport failure stops pagination without aborting the run
+            logging.exception("searchOrgDevices switch page failed: %s", error)  # WHY: keep traceback for ops
+            return None  # WHY: sentinel telling the loop to break gracefully
+        page_data = getattr(response, "data", None) if response else None  # WHY: defensive against empty response
+        return page_data if isinstance(page_data, dict) else None  # WHY: only dict payloads are usable
+
+    @staticmethod
+    def _fetch_switch_physical_inventory(target_org_id: str) -> list[dict]:  # WHY: paginated switch listing
         """Fetch switch inventory records with full pagination."""
-        logging.info("Fetching switch physical inventory via searchOrgDevices, org=%s", target_org_id)
-        all_records: list[dict] = []
-        next_url: str | None = None
-        page_num: int = 0
-        while True:
-            page_num += 1
-            logging.info("Fetching switch inventory page %d org=%s", page_num, target_org_id)
-            try:
-                if next_url:
-                    response = apisession.mist_get(next_url)
-                else:
-                    response = mistapi.api.v1.orgs.devices.searchOrgDevices(
-                        apisession,
-                        target_org_id,
-                        type="switch",
-                        limit=1000,
-                    )
-            except Exception as error:
-                logging.exception("searchOrgDevices switch page %d failed: %s", page_num, error)
-                break
-            page_data = getattr(response, "data", None) if response else None
-            if not page_data or not isinstance(page_data, dict):
-                logging.debug("No dict data on switch inventory page %d - stopping", page_num)
-                break
-            results: list[dict] = page_data.get("results", [])
-            if not results:
-                logging.debug("Empty results on switch inventory page %d - done", page_num)
-                break
-            all_records.extend(results)
-            logging.debug(
-                "Switch inventory page %d: %d records, total so far: %d / %d",
-                page_num,
-                len(results),
-                len(all_records),
-                page_data.get("total", "?"),
-            )
-            next_url = page_data.get("next")
-            if not next_url:
-                break
-        logging.info("Switch physical inventory complete: %d logical devices org=%s", len(all_records), target_org_id)
-        return all_records
-
-    @staticmethod
-    def _aggregate_switch_counts(switch_records: list[dict], distinct: str) -> list[dict]:
-        """Aggregate switch counts by model/version using num_members for VC accuracy."""
-        logging.info("Aggregating switch physical counts by %s from %d records", distinct, len(switch_records))
-        counts: dict[str, int] = {}
-        for record in switch_records:
-            value = record.get(distinct) or "unknown"
-            num_members = int(record.get("num_members") or 1)
-            counts[value] = counts.get(value, 0) + num_members
-        rows = [{"device_type": "switch", distinct: value, "count": count} for value, count in counts.items()]
-        rows.sort(key=lambda row: -int(row.get("count", 0)))
-        logging.debug("Switch %s aggregation: %d distinct values", distinct, len(rows))
-        return rows
-
-    @staticmethod
-    def _fetch_gateway_physical_inventory(target_org_id: str) -> list[dict]:
-        """Fetch gateway inventory records with vc=True to include HA members."""
-        logging.info("Fetching gateway physical inventory via getOrgInventory, org=%s", target_org_id)
-        try:
-            response = mistapi.api.v1.orgs.inventory.getOrgInventory(
-                apisession,
-                target_org_id,
-                type="gateway",
-                vc=True,
-                limit=1000,
-            )
-            all_records: list[dict] = mistapi.get_all(response=response, mist_session=apisession)
-        except Exception as error:
-            logging.exception("getOrgInventory gateway failed: %s", error)
-            all_records = []
-        logging.info("Gateway physical inventory complete: %d physical devices org=%s", len(all_records), target_org_id)
-        return all_records
-
-    @staticmethod
-    def _aggregate_gateway_counts(gateway_records: list[dict], distinct: str) -> list[dict]:
-        """Aggregate gateway counts by model/version using one record per physical gateway."""
-        logging.info("Aggregating gateway physical counts by %s from %d records", distinct, len(gateway_records))
-        counts: dict[str, int] = {}
-        for record in gateway_records:
-            value = record.get(distinct) or "unknown"
-            counts[value] = counts.get(value, 0) + 1
-        rows = [{"device_type": "gateway", distinct: value, "count": count} for value, count in counts.items()]
-        rows.sort(key=lambda row: -int(row.get("count", 0)))
-        logging.debug("Gateway %s aggregation: %d distinct values", distinct, len(rows))
-        return rows
-
-    @staticmethod
-    def _fetch_ap_inventory(target_org_id: str) -> list[dict]:
-        """Fetch all claimed APs (assigned + unassigned) from the org inventory."""
-        # getOrgInventory is the same data source as the portal "Claim APs" screen, so it returns
-        # assigned, unassigned, connected and never-connected APs in one consistent list. Counting
-        # APs from here (instead of countOrgDevices) is what keeps claimed-but-never-connected APs
-        # from being dropped, because countOrgDevices only returns version-keyed buckets.
-        logging.info("Fetching all AP inventory via getOrgInventory, org=%s", target_org_id)
-        try:
-            response = mistapi.api.v1.orgs.inventory.getOrgInventory(  # Portal "Claim APs" data source
-                apisession,
-                target_org_id,
-                type="ap",  # APs only; switch and gateway keep their existing counting paths
-                limit=1000,  # Large page size minimizes round trips for big inventories
-            )
-            all_records: list[dict] = mistapi.get_all(response=response, mist_session=apisession)  # Auto-paginate
-        except Exception as error:  # Inventory fetch errors must not abort the larger summary run
-            logging.exception("getOrgInventory AP fetch failed: %s", error)  # Traceback for ops
-            all_records = []  # Degrade gracefully so callers simply see no AP rows
-        logging.debug("AP inventory fetched: %d records org=%s", len(all_records), target_org_id)  # Record size
-        return all_records
-
-    @staticmethod
-    def _ap_inventory_bucket(record: dict, distinct: str) -> str:
-        """Return the model or version bucket label for a single AP inventory record."""
-        # Three-way version rule keeps the three real-world AP states visibly distinct:
-        #   unassigned (no site_id), assigned-with-firmware (real version), and assigned-but-
-        #   never-connected (no version yet -> "unknown").
-        if distinct == "model":  # Model report: count every AP under its real model
-            return record.get("model") or "unknown"  # Fall back only when the model is missing
-        if not record.get("site_id"):  # Version report: claimed but not assigned to any site
-            return "unassigned"  # Dedicated column so operators can see stock at a glance
-        return record.get("version") or "unknown"  # Assigned: real firmware, or "unknown" if never connected
-
-    @staticmethod
-    def _aggregate_ap_counts(ap_records: list[dict], distinct: str) -> list[dict]:
-        """Aggregate AP counts from full inventory so claimed-but-never-connected APs are not lost."""
-        # Replaces the old countOrgDevices(distinct="version") path, which silently dropped APs that
-        # have never connected and therefore report no firmware version.
-        logging.info("Aggregating %d AP inventory records by %s", len(ap_records), distinct)
-        counts: dict[str, int] = {}  # bucket label -> running count
-        for record in ap_records:  # Walk every claimed AP exactly once
-            value = OrgDeviceInventorySummaryCore._ap_inventory_bucket(record, distinct)  # 3-way version / real model
-            counts[value] = counts.get(value, 0) + 1  # One inventory record == one physical AP
-        rows = [{"device_type": "ap", distinct: value, "count": count} for value, count in counts.items()]
-        rows.sort(key=lambda row: -int(row.get("count", 0)))  # Largest buckets first for readability
-        logging.debug("AP %s aggregation produced %d buckets", distinct, len(rows))  # Record outcome
-        return rows
-
-    @staticmethod
-    def _fetch_unassigned_inventory(target_org_id: str) -> list[dict]:
-        """Fetch switch inventory that is claimed but not assigned to any site."""
-        # Unassigned switches are invisible to searchOrgDevices (assigned-only), so pull the full
-        # switch inventory and keep only records that lack a site_id. APs are intentionally excluded
-        # here because they are now counted in full from getOrgInventory via _aggregate_ap_counts;
-        # including them here too would double-count every unassigned AP.
-        logging.info("Fetching unassigned switch inventory via getOrgInventory, org=%s", target_org_id)
-        try:
-            response = mistapi.api.v1.orgs.inventory.getOrgInventory(  # Inventory API returns claimed stock
-                apisession,
-                target_org_id,
-                type="switch",  # Switch only: APs via _aggregate_ap_counts, gateways via getOrgInventory already
-                limit=1000,  # Large page size minimizes round trips for big inventories
-            )
-            all_records: list[dict] = mistapi.get_all(response=response, mist_session=apisession)  # Auto-paginate
-        except Exception as error:  # Inventory fetch errors must not abort the larger summary run
-            logging.exception("getOrgInventory unassigned switch failed: %s", error)  # Traceback for ops
-            all_records = []  # Degrade gracefully so callers simply see no unassigned rows
-        unassigned = [record for record in all_records if not record.get("site_id")]  # site_id empty/None => unassigned
-        logging.debug(
-            "Unassigned switch inventory: %d of %d records have no site_id",  # Show filter selectivity
-            len(unassigned),
-            len(all_records),
+        logging.info("Fetching switch physical inventory via searchOrgDevices, org=%s", target_org_id)  # WHY: op trace
+        all_records: list[dict] = []  # WHY: accumulator across pages
+        next_url: str | None = None  # WHY: cursor for the next page; None means "first request"
+        page_num: int = 0  # WHY: counter for log context
+        while True:  # WHY: exit conditions live inside via guard clauses to keep complexity flat
+            page_num += 1  # WHY: increment before fetch so logs show the page being requested
+            page_data = OrgDeviceInventorySummaryCore._search_switch_page(target_org_id, next_url)  # WHY: single page
+            if page_data is None:  # WHY: helper returns None on failure or non-dict payload
+                break  # WHY: stop pagination on failure without losing already-collected records
+            results: list[dict] = page_data.get("results", [])  # WHY: switch records live under "results"
+            if not results:  # WHY: empty page means we walked past the last record
+                break  # WHY: nothing more to accumulate
+            all_records.extend(results)  # WHY: fold this page into the accumulator
+            next_url = page_data.get("next")  # WHY: continuation URL for the next iteration
+            if not next_url:  # WHY: API omits "next" once the final page is served
+                break  # WHY: final page reached; stop looping
+        logging.info(  # WHY: summarize outcome once at the end so logs stay quiet during success
+            "Switch physical inventory complete: %d logical devices org=%s", len(all_records), target_org_id
         )
-        return unassigned
+        return all_records  # WHY: caller aggregates counts from these raw records
 
     @staticmethod
-    def _aggregate_unassigned_counts(unassigned_records: list[dict], distinct: str) -> list[dict]:
+    def _aggregate_switch_counts(switch_records: list[dict], distinct: str) -> list[dict]:  # WHY: VC-aware sum
+        """Aggregate switch counts by model/version using num_members for VC accuracy."""
+        logging.info(  # WHY: op trace preserves visibility for large orgs
+            "Aggregating switch physical counts by %s from %d records", distinct, len(switch_records)
+        )
+        counts: dict[str, int] = {}  # WHY: bucket -> running total
+        for record in switch_records:  # WHY: walk every switch exactly once
+            value = record.get(distinct) or _UNKNOWN  # WHY: fall back so missing labels don't crash the row build
+            num_members = int(record.get("num_members") or 1)  # WHY: VC stacks count as members, not one chassis
+            counts[value] = counts.get(value, 0) + num_members  # WHY: sum VC-accurate physical count
+        rows = [  # WHY: materialize the accumulator into row dicts for downstream merge
+            {"device_type": "switch", distinct: value, "count": count} for value, count in counts.items()
+        ]
+        rows.sort(key=lambda row: -int(row.get("count", 0)))  # WHY: largest buckets first for readability
+        logging.debug("Switch %s aggregation: %d distinct values", distinct, len(rows))  # WHY: outcome trace
+        return rows  # WHY: caller may merge with unassigned rows before rendering
+
+    @staticmethod
+    def _fetch_gateway_physical_inventory(target_org_id: str) -> list[dict]:  # WHY: HA-aware gateway listing
+        """Fetch gateway inventory records with vc=True to include HA members."""
+        logging.info("Fetching gateway physical inventory via getOrgInventory, org=%s", target_org_id)  # WHY: op trace
+        try:  # WHY: inventory fetch errors must not abort the larger summary run
+            response = mistapi.api.v1.orgs.inventory.getOrgInventory(  # WHY: getOrgInventory yields per-node records
+                apisession, target_org_id, type="gateway", vc=True, limit=_INVENTORY_PAGE_SIZE
+            )
+            all_records: list[dict] = mistapi.get_all(response=response, mist_session=apisession)  # WHY: auto-paginate
+        except Exception as error:  # WHY: degrade gracefully rather than crash the parent report
+            logging.exception("getOrgInventory gateway failed: %s", error)  # WHY: traceback for ops
+            all_records = []  # WHY: empty list keeps callers happy
+        logging.info(  # WHY: summarize outcome once so logs stay quiet during success
+            "Gateway physical inventory complete: %d physical devices org=%s", len(all_records), target_org_id
+        )
+        return all_records  # WHY: caller aggregates counts from these records
+
+    @staticmethod
+    def _aggregate_gateway_counts(gateway_records: list[dict], distinct: str) -> list[dict]:  # WHY: per-record sum
+        """Aggregate gateway counts by model/version using one record per physical gateway."""
+        logging.info(  # WHY: op trace mirrors switch aggregation for parity
+            "Aggregating gateway physical counts by %s from %d records", distinct, len(gateway_records)
+        )
+        counts: dict[str, int] = {}  # WHY: bucket -> physical gateway count
+        for record in gateway_records:  # WHY: walk each HA member exactly once
+            value = record.get(distinct) or _UNKNOWN  # WHY: fall back so missing labels don't crash the row build
+            counts[value] = counts.get(value, 0) + 1  # WHY: one record == one physical gateway
+        rows = [  # WHY: materialize the accumulator into row dicts for downstream merge
+            {"device_type": "gateway", distinct: value, "count": count} for value, count in counts.items()
+        ]
+        rows.sort(key=lambda row: -int(row.get("count", 0)))  # WHY: largest buckets first for readability
+        logging.debug("Gateway %s aggregation: %d distinct values", distinct, len(rows))  # WHY: outcome trace
+        return rows  # WHY: caller may merge with unassigned rows before rendering
+
+    @staticmethod
+    def _fetch_ap_inventory(target_org_id: str) -> list[dict]:  # WHY: portal "Claim APs" data source
+        """Fetch all claimed APs (assigned + unassigned) from the org inventory."""
+        logging.info("Fetching all AP inventory via getOrgInventory, org=%s", target_org_id)  # WHY: op trace
+        try:  # WHY: inventory fetch errors must not abort the larger summary run
+            response = mistapi.api.v1.orgs.inventory.getOrgInventory(  # WHY: same data as portal claim screen
+                apisession, target_org_id, type="ap", limit=_INVENTORY_PAGE_SIZE
+            )
+            all_records: list[dict] = mistapi.get_all(response=response, mist_session=apisession)  # WHY: auto-paginate
+        except Exception as error:  # WHY: graceful degradation keeps other reports running
+            logging.exception("getOrgInventory AP fetch failed: %s", error)  # WHY: traceback for ops
+            all_records = []  # WHY: empty result surfaces no AP rows rather than crashing
+        logging.debug("AP inventory fetched: %d records org=%s", len(all_records), target_org_id)  # WHY: outcome
+        return all_records  # WHY: caller aggregates by version/model
+
+    @staticmethod
+    def _ap_inventory_bucket(record: dict, distinct: str) -> str:  # WHY: 3-way version rule kept in one place
+        """Return the model or version bucket label for a single AP inventory record."""
+        if distinct == "model":  # WHY: model report always uses the real model regardless of assignment
+            return record.get("model") or _UNKNOWN  # WHY: fall back only when the model is missing
+        if not record.get("site_id"):  # WHY: version report treats unassigned stock as its own bucket
+            return _UNASSIGNED  # WHY: dedicated column so operators can see stock at a glance
+        return record.get("version") or _UNKNOWN  # WHY: assigned APs report firmware or "unknown" if never-connected
+
+    @staticmethod
+    def _aggregate_ap_counts(ap_records: list[dict], distinct: str) -> list[dict]:  # WHY: full-inventory AP sum
+        """Aggregate AP counts from full inventory so claimed-but-never-connected APs are not lost."""
+        logging.info("Aggregating %d AP inventory records by %s", len(ap_records), distinct)  # WHY: op trace
+        counts: dict[str, int] = {}  # WHY: bucket label -> running count
+        for record in ap_records:  # WHY: walk every claimed AP exactly once
+            value = OrgDeviceInventorySummaryCore._ap_inventory_bucket(record, distinct)  # WHY: 3-way version rule
+            counts[value] = counts.get(value, 0) + 1  # WHY: one inventory record == one physical AP
+        rows = [  # WHY: materialize the accumulator into row dicts for downstream merge
+            {"device_type": "ap", distinct: value, "count": count} for value, count in counts.items()
+        ]
+        rows.sort(key=lambda row: -int(row.get("count", 0)))  # WHY: largest buckets first for readability
+        logging.debug("AP %s aggregation produced %d buckets", distinct, len(rows))  # WHY: outcome trace
+        return rows  # WHY: caller may merge with unassigned rows before rendering
+
+    @staticmethod
+    def _fetch_unassigned_inventory(target_org_id: str) -> list[dict]:  # WHY: unassigned switches only
+        """Fetch switch inventory that is claimed but not assigned to any site."""
+        logging.info("Fetching unassigned switch inventory via getOrgInventory, org=%s", target_org_id)  # WHY: trace
+        try:  # WHY: supplemental fetch errors must not break the primary report
+            response = mistapi.api.v1.orgs.inventory.getOrgInventory(  # WHY: inventory API returns claimed stock
+                apisession, target_org_id, type="switch", limit=_INVENTORY_PAGE_SIZE
+            )
+            all_records: list[dict] = mistapi.get_all(response=response, mist_session=apisession)  # WHY: auto-paginate
+        except Exception as error:  # WHY: degrade gracefully so callers simply see no unassigned rows
+            logging.exception("getOrgInventory unassigned switch failed: %s", error)  # WHY: traceback for ops
+            all_records = []  # WHY: empty on error keeps downstream filters valid
+        unassigned = [record for record in all_records if not record.get("site_id")]  # WHY: no site_id => stock
+        logging.debug(  # WHY: filter selectivity trace for post-mortem sizing
+            "Unassigned switch inventory: %d of %d records have no site_id", len(unassigned), len(all_records)
+        )
+        return unassigned  # WHY: caller aggregates by version/model
+
+    @staticmethod
+    def _unassigned_bucket_value(record: dict, distinct: str) -> str:  # WHY: keep aggregator complexity under budget
+        """Return the model or version bucket value for a single unassigned record."""
+        if distinct == "version":  # WHY: version report collapses all unassigned stock into one column
+            return _UNASSIGNED  # WHY: distinct from "unknown" (assigned but never reported firmware)
+        return record.get(distinct) or _UNKNOWN  # WHY: model report preserves real model so totals merge
+
+    @staticmethod
+    def _aggregate_unassigned_counts(unassigned_records: list[dict], distinct: str) -> list[dict]:  # WHY: stock rollup
         """Aggregate unassigned device counts; firmware rows bucket under an 'unassigned' label."""
-        # For the version report we surface unassigned stock as its own bucket (distinct from
-        # "unknown", which means an assigned device that never reported firmware). For the model
-        # report we keep the real model so per-model totals stay accurate.
-        logging.info("Aggregating %d unassigned records by %s", len(unassigned_records), distinct)
-        counts: dict[tuple[str, str], int] = {}  # Key on (device_type, bucket) to keep types separate
-        for record in unassigned_records:  # Walk each unassigned inventory record once
-            device_type = record.get("type") or "unknown"  # Inventory record carries its own ap/switch type
-            if distinct == "version":  # Firmware report: collapse all unassigned stock into one column
-                value = "unassigned"  # New column the operator can see at a glance
-            else:  # Model report: preserve real model so totals merge correctly with assigned counts
-                value = record.get(distinct) or "unknown"  # Fall back to "unknown" only if model missing
-            key = (device_type, value)  # Compose the grouping key
-            counts[key] = counts.get(key, 0) + 1  # Each unassigned record is one physical device (no VC in stock)
-        rows = [  # Materialize accumulator into standard row dicts
+        logging.info("Aggregating %d unassigned records by %s", len(unassigned_records), distinct)  # WHY: op trace
+        counts: dict[tuple[str, str], int] = {}  # WHY: key on (device_type, bucket) to keep types separate
+        for record in unassigned_records:  # WHY: walk each unassigned inventory record once
+            device_type = record.get("type") or _UNKNOWN  # WHY: inventory record carries its own ap/switch type
+            value = OrgDeviceInventorySummaryCore._unassigned_bucket_value(record, distinct)  # WHY: reuse rule
+            counts[(device_type, value)] = counts.get((device_type, value), 0) + 1  # WHY: one record == one device
+        rows = [  # WHY: materialize accumulator into standard row dicts consumed by _merge_counts
             {"device_type": device_type, distinct: value, "count": count}
             for (device_type, value), count in counts.items()
         ]
-        logging.debug("Unassigned %s aggregation produced %d rows", distinct, len(rows))  # Record outcome
-        return rows
+        logging.debug("Unassigned %s aggregation produced %d rows", distinct, len(rows))  # WHY: outcome trace
+        return rows  # WHY: caller merges with assigned rows before rendering
 
     @staticmethod
-    def _merge_counts(base_rows: list[dict], extra_rows: list[dict], distinct: str) -> list[dict]:
+    def _merge_counts(base_rows: list[dict], extra_rows: list[dict], distinct: str) -> list[dict]:  # WHY: sum overlaps
         """Merge supplemental rows into base rows, summing counts by (device_type, value)."""
-        # Used to fold unassigned counts into the assigned-device rows so a model present in both
-        # assigned and unassigned states reports one combined total instead of duplicate rows.
-        logging.info("Merging %d base and %d supplemental %s rows", len(base_rows), len(extra_rows), distinct)
-        combined: dict[tuple[str, str], int] = {}  # Running total per (device_type, value)
-        order: list[tuple[str, str]] = []  # Preserve first-seen order for deterministic output
-        for row in [*base_rows, *extra_rows]:  # Iterate assigned rows first, then unassigned supplements
-            key = (row.get("device_type", ""), row.get(distinct, ""))  # Same grouping key both reports use
-            if key not in combined:  # First time we see this key
-                combined[key] = 0  # Initialize the bucket
-                order.append(key)  # Remember insertion order
-            combined[key] += int(row.get("count", 0) or 0)  # Accumulate this row's count
-        merged = [  # Rebuild rows from the merged totals in first-seen order
+        logging.info(  # WHY: op trace with input sizes eases regressions triage
+            "Merging %d base and %d supplemental %s rows", len(base_rows), len(extra_rows), distinct
+        )
+        combined: dict[tuple[str, str], int] = {}  # WHY: running total per (device_type, value)
+        order: list[tuple[str, str]] = []  # WHY: preserve first-seen order for deterministic output
+        for row in [*base_rows, *extra_rows]:  # WHY: assigned rows first so their order wins on ties
+            key = (row.get("device_type", ""), row.get(distinct, ""))  # WHY: same grouping key both reports use
+            if key not in combined:  # WHY: first sighting seeds the bucket
+                combined[key] = 0  # WHY: initialize the accumulator entry
+                order.append(key)  # WHY: remember insertion order for stable output
+            combined[key] += int(row.get("count", 0) or 0)  # WHY: accumulate this row's count
+        merged = [  # WHY: rebuild rows from the merged totals in first-seen order
             {"device_type": device_type, distinct: value, "count": combined[(device_type, value)]}
             for (device_type, value) in order
         ]
-        logging.debug("Merge produced %d combined %s rows", len(merged), distinct)  # Record outcome
-        return merged
+        logging.debug("Merge produced %d combined %s rows", len(merged), distinct)  # WHY: outcome trace
+        return merged  # WHY: caller sorts before rendering
 
     @staticmethod
-    def _fetch_all_counts(
+    def _fetch_switch_type_rows(target_org_id: str, distinct: str, _ap_records: list[dict] | None) -> list[dict]:
+        """Return switch rows using the VC-aware fetch + aggregate pipeline."""  # WHY: dispatch handler for "switch"
+        logging.info("Fetching switch %s counts with VC-aware method, org=%s", distinct, target_org_id)  # WHY: trace
+        try:  # WHY: never abort the combined report on one type's failure
+            records = OrgDeviceInventorySummaryCore._fetch_switch_physical_inventory(target_org_id)  # WHY: paginate
+            return OrgDeviceInventorySummaryCore._aggregate_switch_counts(records, distinct)  # WHY: VC-accurate sum
+        except Exception as error:  # WHY: swallow so other types still contribute rows
+            logging.exception("Switch %s count (VC-aware) failed: %s", distinct, error)  # WHY: traceback for ops
+            return []  # WHY: empty rows so downstream merge/sort still work
+
+    @staticmethod
+    def _fetch_gateway_type_rows(target_org_id: str, distinct: str, _ap_records: list[dict] | None) -> list[dict]:
+        """Return gateway rows using the HA-aware fetch + aggregate pipeline."""  # WHY: dispatch handler for "gateway"
+        logging.info("Fetching gateway %s counts with HA-aware method, org=%s", distinct, target_org_id)  # WHY: trace
+        try:  # WHY: never abort the combined report on one type's failure
+            records = OrgDeviceInventorySummaryCore._fetch_gateway_physical_inventory(target_org_id)  # WHY: HA members
+            return OrgDeviceInventorySummaryCore._aggregate_gateway_counts(records, distinct)  # WHY: per-record sum
+        except Exception as error:  # WHY: swallow so other types still contribute rows
+            logging.exception("Gateway %s count (HA-aware) failed: %s", distinct, error)  # WHY: traceback for ops
+            return []  # WHY: empty rows so downstream merge/sort still work
+
+    @staticmethod
+    def _fetch_ap_type_rows(target_org_id: str, distinct: str, ap_records: list[dict] | None) -> list[dict]:
+        """Return AP rows using full inventory so claimed-but-never-connected APs are counted."""  # WHY: AP handler
+        try:  # WHY: AP counting must never abort the combined report
+            resolved = (  # WHY: direct/test callers may omit the shared fetch; pull it ourselves
+                ap_records
+                if ap_records is not None
+                else OrgDeviceInventorySummaryCore._fetch_ap_inventory(target_org_id)
+            )
+            return OrgDeviceInventorySummaryCore._aggregate_ap_counts(resolved, distinct)  # WHY: 3-way version rule
+        except Exception as error:  # WHY: swallow so other types still contribute rows
+            logging.exception("AP %s count from inventory failed: %s", distinct, error)  # WHY: traceback for ops
+            return []  # WHY: empty rows so downstream merge/sort still work
+
+    _TYPE_HANDLERS: dict[str, Callable[[str, str, list[dict] | None], list[dict]]] = {}  # WHY: filled below
+
+    @staticmethod
+    def _fetch_all_counts(  # WHY: dispatch across device types and merge with unassigned stock
         target_org_id: str,
         distinct: str,
         unassigned_records: list[dict] | None = None,
         ap_records: list[dict] | None = None,
     ) -> list[dict]:
         """Fetch grouped counts for AP/switch/gateway by model or version."""
-        logging.info("Fetching device %s counts for all types, org=%s", distinct, target_org_id)
-        all_rows: list[dict] = []
-        for device_type in OrgDeviceInventorySummaryCore._DEVICE_TYPES:
-            if device_type == "switch":
-                logging.info("Fetching switch %s counts with VC-aware method, org=%s", distinct, target_org_id)
-                try:
-                    switch_records = OrgDeviceInventorySummaryCore._fetch_switch_physical_inventory(target_org_id)
-                    type_rows = OrgDeviceInventorySummaryCore._aggregate_switch_counts(switch_records, distinct)
-                    all_rows.extend(type_rows)
-                except Exception as error:
-                    logging.exception("Switch %s count (VC-aware) failed: %s", distinct, error)
-                continue
-            if device_type == "gateway":
-                logging.info("Fetching gateway %s counts with HA-aware method, org=%s", distinct, target_org_id)
-                try:
-                    gateway_records = OrgDeviceInventorySummaryCore._fetch_gateway_physical_inventory(target_org_id)
-                    type_rows = OrgDeviceInventorySummaryCore._aggregate_gateway_counts(gateway_records, distinct)
-                    all_rows.extend(type_rows)
-                except Exception as error:
-                    logging.exception("Gateway %s count (HA-aware) failed: %s", distinct, error)
-                continue
-            # APs are counted from the full org inventory (the portal "Claim APs" source) so that
-            # claimed-but-never-connected APs -- which countOrgDevices(distinct="version") drops --
-            # are included. This is the AP branch of the device-type loop.
-            try:
-                if ap_records is None:  # Direct/test callers may omit the shared fetch; pull it ourselves
-                    ap_records = OrgDeviceInventorySummaryCore._fetch_ap_inventory(target_org_id)
-                all_rows.extend(OrgDeviceInventorySummaryCore._aggregate_ap_counts(ap_records, distinct))
-            except Exception as error:  # AP counting must never abort the combined report
-                logging.exception("AP %s count from inventory failed: %s", distinct, error)
-        all_rows = OrgDeviceInventorySummaryCore._with_unassigned(all_rows, target_org_id, distinct, unassigned_records)
-        all_rows.sort(key=lambda row: (row.get("device_type", ""), -int(row.get("count", 0))))
-        logging.info("Total %s count rows after fetch and sort: %d", distinct, len(all_rows))
-        return all_rows
+        logging.info("Fetching device %s counts for all types, org=%s", distinct, target_org_id)  # WHY: op trace
+        all_rows: list[dict] = []  # WHY: accumulate rows across every device type
+        for device_type in OrgDeviceInventorySummaryCore._DEVICE_TYPES:  # WHY: canonical ordering
+            handler = OrgDeviceInventorySummaryCore._TYPE_HANDLERS[device_type]  # WHY: table-driven avoids branching
+            all_rows.extend(handler(target_org_id, distinct, ap_records))  # WHY: handler returns [] on failure
+        all_rows = OrgDeviceInventorySummaryCore._with_unassigned(  # WHY: fold unassigned stock into totals
+            all_rows, target_org_id, distinct, unassigned_records
+        )
+        all_rows.sort(key=lambda row: (row.get("device_type", ""), -int(row.get("count", 0))))  # WHY: stable output
+        logging.info("Total %s count rows after fetch and sort: %d", distinct, len(all_rows))  # WHY: outcome trace
+        return all_rows  # WHY: caller renders and exports
 
     @staticmethod
-    def _with_unassigned(
+    def _with_unassigned(  # WHY: kept separate so _fetch_all_counts stays within complexity budget
         all_rows: list[dict], target_org_id: str, distinct: str, unassigned_records: list[dict] | None
     ) -> list[dict]:
         """Merge unassigned AP/switch stock into assigned counts so totals are not understated."""
-        # Kept as its own method so the primary counting loop stays within the complexity budget.
-        if unassigned_records is None:  # Direct/test callers may omit the shared fetch; pull it ourselves
-            unassigned_records = OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
-        try:  # Supplemental counting must never break the primary report
-            unassigned_rows = OrgDeviceInventorySummaryCore._aggregate_unassigned_counts(unassigned_records, distinct)
-            merged = OrgDeviceInventorySummaryCore._merge_counts(all_rows, unassigned_rows, distinct)
-            return merged  # Combined assigned + unassigned rows
-        except Exception as error:  # Fall back to assigned-only rows on any aggregation/merge failure
-            logging.exception("Unassigned %s supplemental count failed: %s", distinct, error)
-            return all_rows  # Degrade gracefully to the assigned-only counts
+        resolved = (  # WHY: direct/test callers may omit the shared fetch; pull it ourselves
+            unassigned_records
+            if unassigned_records is not None
+            else OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
+        )
+        try:  # WHY: supplemental counting must never break the primary report
+            unassigned_rows = OrgDeviceInventorySummaryCore._aggregate_unassigned_counts(resolved, distinct)
+            return OrgDeviceInventorySummaryCore._merge_counts(all_rows, unassigned_rows, distinct)  # WHY: sum overlap
+        except Exception as error:  # WHY: fall back to assigned-only rows on any aggregation/merge failure
+            logging.exception("Unassigned %s supplemental count failed: %s", distinct, error)  # WHY: traceback for ops
+            return all_rows  # WHY: degrade gracefully to the assigned-only counts
 
     @staticmethod
-    def _display_and_export(rows: list[dict], distinct: str, filename: str, api_func: str) -> None:
+    def _print_summary_banner(distinct: str, table: PrettyTable) -> None:  # WHY: keep display method concise
+        """Print the labelled banner and table for one summary."""
+        separator = "=" * _SEPARATOR_WIDTH  # WHY: reuse the constant width for both borders
+        print(f"\n{separator}")  # WHY: leading blank line separates from preceding output
+        print(f"  {distinct.capitalize()} Distribution Summary")  # WHY: operator-facing label matches column
+        print(separator)  # WHY: trailing border closes the banner block
+        print(table)  # WHY: rendered PrettyTable follows the banner
+
+    @staticmethod
+    def _display_and_export(rows: list[dict], distinct: str, filename: str, api_func: str) -> None:  # WHY: I/O leaf
         """Render and export summary table for model/version counts."""
-        value_col = distinct.capitalize()
-        table = PrettyTable()
-        table.field_names = ["Device Type", value_col, "Count"]
-        for row in rows:
-            table.add_row([row.get("device_type", ""), row.get(distinct, ""), row.get("count", 0)])
-
-        print(f"\n{'=' * 62}")
-        print(f"  {distinct.capitalize()} Distribution Summary")
-        print(f"{'=' * 62}")
-        print(table)
-
-        export_rows = [
+        value_col = distinct.capitalize()  # WHY: header casing matches CLI banner
+        table = PrettyTable()  # WHY: pretty console output for interactive users
+        table.field_names = ["Device Type", value_col, "Count"]  # WHY: fixed columns for both reports
+        for row in rows:  # WHY: emit one row per (device_type, bucket)
+            table.add_row([row.get("device_type", ""), row.get(distinct, ""), row.get("count", 0)])  # WHY: defensive
+        OrgDeviceInventorySummaryCore._print_summary_banner(distinct, table)  # WHY: shared banner formatter
+        export_rows = [  # WHY: exporter expects human-readable column names
             {"Device Type": row["device_type"], value_col: row.get(distinct, ""), "Count": row["count"]} for row in rows
         ]
-        DataExporter.write_with_format_selection(
-            export_rows,
-            filename,
-            api_function_name=api_func,
+        DataExporter.write_with_format_selection(export_rows, filename, api_function_name=api_func)  # WHY: persist
+
+    @staticmethod
+    def _lookup_org_name_from_api(
+        target_org_id: str,
+    ) -> str | None:  # WHY: complexity budget for _resolve_safe_org_name
+        """Return the API-reported org name, or ``None`` on failure or missing name."""
+        try:  # WHY: API failures fall back to env / org id at higher level
+            org_response = mistapi.api.v1.orgs.orgs.getOrg(apisession, target_org_id)  # WHY: authoritative name source
+        except Exception as error:  # WHY: never break the summary run on a naming lookup
+            logging.warning("Could not resolve org name from API: %s", error)  # WHY: warn-only; recovery follows
+            return None  # WHY: signal caller to try env / id fallbacks
+        return getattr(org_response, "data", {}).get("name")  # WHY: response may be dict-like or missing name key
+
+    @staticmethod
+    def _sanitize_name(raw_name: str) -> str:  # WHY: keep filesystem paths safe on every platform
+        """Replace non-alphanumeric characters with underscores for safe filenames."""
+        return "".join(  # WHY: character-by-character filter avoids regex import
+            char if char.isalnum() or char in "-_" else "_" for char in raw_name  # WHY: preserve hyphen/underscore
         )
 
     @staticmethod
-    def _resolve_safe_org_name(target_org_id: str) -> str:
+    def _resolve_safe_org_name(target_org_id: str) -> str:  # WHY: filesystem-safe output prefix
         """Resolve a filesystem-safe organization name for output prefixes."""
-        raw_name: str | None = None
-        try:
-            org_response = mistapi.api.v1.orgs.orgs.getOrg(apisession, target_org_id)
-            raw_name = getattr(org_response, "data", {}).get("name")
-        except Exception as error:
-            logging.warning("Could not resolve org name from API: %s", error)
-        if not raw_name:
-            raw_name = os.getenv("END_CUSTOMER_NAME")
-        if not raw_name:
-            raw_name = target_org_id
-        safe_name = "".join(char if char.isalnum() or char in "-_" else "_" for char in raw_name)
-        return safe_name
+        raw_name = (  # WHY: prefer API name, then env override, then raw org id
+            OrgDeviceInventorySummaryCore._lookup_org_name_from_api(target_org_id)
+            or os.getenv("END_CUSTOMER_NAME")
+            or target_org_id
+        )
+        return OrgDeviceInventorySummaryCore._sanitize_name(raw_name)  # WHY: one place normalizes characters
 
     @staticmethod
-    def run_for_org(target_org_id: str) -> tuple[list[dict], list[dict], list[dict], str]:
-        """Run all inventory summaries for one organization and export results."""
-        # Lazy imports avoid the circular dependency: collaborators import this module's globals at call time
-        from src.inventory.inventory_summary.pivot_renderer import (
-            PivotRenderer,
-        )  # Local import keeps module load order clean
-        from src.inventory.inventory_summary.version_per_model_fetcher import (
-            VersionPerModelFetcher,
-        )  # Local import keeps module load order clean
-
-        logging.info("Starting org device inventory summary org=%s", target_org_id)
-        start_time = time.time()
-        safe_org = OrgDeviceInventorySummaryCore._resolve_safe_org_name(target_org_id)
-
-        # Fetch shared inventory once and reuse across every report below so the getOrgInventory
-        # calls are not repeated per report. unassigned_records covers unassigned switches; ap_records
-        # covers ALL APs (assigned + unassigned) since APs are counted entirely from inventory.
-        unassigned_records = OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
-        ap_records = OrgDeviceInventorySummaryCore._fetch_ap_inventory(target_org_id)
-
-        model_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(
+    def _run_model_report(
+        target_org_id: str, safe_org: str, unassigned_records: list[dict], ap_records: list[dict]
+    ) -> list[dict]:  # WHY: keep run_for_org within length budget
+        """Compute, render and export the per-model report; return the rows for reuse."""
+        model_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(  # WHY: shared fetches reuse across reports
             target_org_id, "model", unassigned_records, ap_records
         )
-        OrgDeviceInventorySummaryCore._display_and_export(
-            model_rows,
-            "model",
-            f"{safe_org}_OrgDeviceModelCounts",
-            "orgDeviceModelSummary",
+        OrgDeviceInventorySummaryCore._display_and_export(  # WHY: side-effectful render + write
+            model_rows, "model", f"{safe_org}_OrgDeviceModelCounts", "orgDeviceModelSummary"
         )
-
-        version_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(
-            target_org_id, "version", unassigned_records, ap_records
-        )
-        OrgDeviceInventorySummaryCore._display_and_export(
-            version_rows,
-            "version",
-            f"{safe_org}_OrgDeviceFirmwareSummary",
-            "orgDeviceFirmwareSummary",
-        )
-
-        ver_per_model = VersionPerModelFetcher.fetch(
-            target_org_id, model_rows, unassigned_records, ap_records
-        )  # Decomposed: per-type version expansion lives in collaborator
-        PivotRenderer.render(
-            ver_per_model, f"{safe_org}_OrgDeviceVersionPerModel"
-        )  # Decomposed: pivot + table + export now in collaborator
-
-        elapsed = time.time() - start_time
-        logging.info("Org device inventory summary for %s completed in %.1f seconds", target_org_id, elapsed)
-        print(f"\nSummary for {safe_org} completed in {elapsed:.1f} seconds")
-        return model_rows, version_rows, ver_per_model, safe_org
+        return model_rows  # WHY: pivot report needs these rows too
 
     @staticmethod
-    def execute() -> None:
+    def _run_version_report(
+        target_org_id: str, safe_org: str, unassigned_records: list[dict], ap_records: list[dict]
+    ) -> list[dict]:  # WHY: mirror of _run_model_report
+        """Compute, render and export the per-version report; return the rows."""
+        version_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(  # WHY: shared fetches reuse across reports
+            target_org_id, "version", unassigned_records, ap_records
+        )
+        OrgDeviceInventorySummaryCore._display_and_export(  # WHY: side-effectful render + write
+            version_rows, "version", f"{safe_org}_OrgDeviceFirmwareSummary", "orgDeviceFirmwareSummary"
+        )
+        return version_rows  # WHY: caller returns tuple to preserve public API
+
+    @staticmethod
+    def _run_pivot_report(
+        target_org_id: str,
+        safe_org: str,
+        model_rows: list[dict],
+        unassigned_records: list[dict],
+        ap_records: list[dict],
+    ) -> list[dict]:  # WHY: collaborator
+        """Compute the per-model version pivot; delegate render to PivotRenderer."""
+        from src.inventory.inventory_summary.pivot_renderer import PivotRenderer  # WHY: lazy import breaks cycle
+        from src.inventory.inventory_summary.version_per_model_fetcher import (
+            VersionPerModelFetcher,  # WHY: collaborator owns per-type version expansion
+        )
+
+        ver_per_model = VersionPerModelFetcher.fetch(  # WHY: expand model rows into (model, version, count)
+            target_org_id, model_rows, unassigned_records, ap_records
+        )
+        PivotRenderer.render(ver_per_model, f"{safe_org}_OrgDeviceVersionPerModel")  # WHY: pivot + table + export
+        return ver_per_model  # WHY: returned to caller for its public tuple
+
+    @staticmethod
+    def run_for_org(target_org_id: str) -> tuple[list[dict], list[dict], list[dict], str]:  # WHY: pipeline entry
+        """Run all inventory summaries for one organization and export results."""
+        logging.info("Starting org device inventory summary org=%s", target_org_id)  # WHY: op trace
+        start_time = time.time()  # WHY: elapsed reporting for operator feedback
+        safe_org = OrgDeviceInventorySummaryCore._resolve_safe_org_name(target_org_id)  # WHY: file-safe prefix
+        unassigned_records = OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)  # WHY: reuse
+        ap_records = OrgDeviceInventorySummaryCore._fetch_ap_inventory(target_org_id)  # WHY: reuse across reports
+        model_rows = OrgDeviceInventorySummaryCore._run_model_report(  # WHY: per-model report + shared rows
+            target_org_id, safe_org, unassigned_records, ap_records
+        )
+        version_rows = OrgDeviceInventorySummaryCore._run_version_report(  # WHY: per-version report
+            target_org_id, safe_org, unassigned_records, ap_records
+        )
+        ver_per_model = OrgDeviceInventorySummaryCore._run_pivot_report(  # WHY: pivot uses model_rows
+            target_org_id, safe_org, model_rows, unassigned_records, ap_records
+        )
+        elapsed = time.time() - start_time  # WHY: total wall-clock cost of the summary
+        logging.info(  # WHY: log outcome so ops can tune inventory volume
+            "Org device inventory summary for %s completed in %.1f seconds", target_org_id, elapsed
+        )
+        print(f"\nSummary for {safe_org} completed in {elapsed:.1f} seconds")  # WHY: operator feedback
+        return model_rows, version_rows, ver_per_model, safe_org  # WHY: public tuple preserved for callers
+
+    @staticmethod
+    def execute() -> None:  # WHY: menu-level entry point requires configured org
         """Run inventory summaries for the currently selected org."""
-        if not org_id:
-            print("X No organization selected")
-            logging.error("OrgDeviceInventorySummaryCore.execute called with empty org_id")
-            return
-        OrgDeviceInventorySummaryCore.run_for_org(org_id)
+        if not org_id:  # WHY: guard clause reports the misconfiguration instead of crashing
+            print("X No organization selected")  # WHY: user-visible error mirrors the rest of the CLI
+            logging.error("OrgDeviceInventorySummaryCore.execute called with empty org_id")  # WHY: audit trail
+            return  # WHY: early return keeps the happy path un-indented
+        OrgDeviceInventorySummaryCore.run_for_org(org_id)  # WHY: delegate to the parameterized pipeline
+
+
+OrgDeviceInventorySummaryCore._TYPE_HANDLERS = {  # WHY: initialized after class body so handler refs resolve
+    "switch": OrgDeviceInventorySummaryCore._fetch_switch_type_rows,  # WHY: VC-aware switch path
+    "gateway": OrgDeviceInventorySummaryCore._fetch_gateway_type_rows,  # WHY: HA-aware gateway path
+    "ap": OrgDeviceInventorySummaryCore._fetch_ap_type_rows,  # WHY: full-inventory AP path
+}


### PR DESCRIPTION
<analysis>The org_device_inventory_summary module orchestrates the per-org device inventory summary pipeline. The baseline analyzer flagged it at C+/79.0 with one high-severity CONV-COMMENTS gap (24.5 percent same-line coverage), three medium STRUCT-LENGTH breaches on _fetch_switch_physical_inventory, _fetch_all_counts, and run_for_org, plus six low STRUCT-COMPLEXITY and STRUCT-BLOCKS findings across the same three symbols and two other aggregation helpers. The core structural problems were a long paginated switch fetch loop mixing transport, decoding, and accumulation concerns; a large per-type dispatch in _fetch_all_counts that inlined all three device-type branches; a long orchestration entry point in run_for_org bundling name resolution, three separate reports, and elapsed reporting; and a branching _resolve_safe_org_name mixing API lookup, env fallback, and character sanitization. Comment coverage was the second lever; the previously bare imports, module-level globals, and one-liner helpers carried no same-line intent.</analysis>
<summary>The refactor introduces four module constants for the banner width, page size, and the two fallback bucket labels so magic values stay in one place. A new _search_switch_page helper isolates one round-trip of the switch pagination and returns a normalized dict-or-None sentinel, letting the outer _fetch_switch_physical_inventory loop become a flat sequence of guard clauses under the length and complexity budgets. A table-driven _TYPE_HANDLERS mapping replaces the switch-gateway-AP if-chain in _fetch_all_counts; each type now owns a _fetch_x_type_rows staticmethod that runs its fetch and aggregate pipeline behind a single try-except so partial failures still return an empty row list. run_for_org delegates to three focused helpers, _run_model_report, _run_version_report, and _run_pivot_report, that share the pre-fetched unassigned and AP records and preserve the public four-tuple return. _resolve_safe_org_name splits into _lookup_org_name_from_api plus _sanitize_name, and _aggregate_unassigned_counts extracts _unassigned_bucket_value to cap complexity. Every executable line carries a same-line WHY anchor, pushing inline comment coverage from 24.5 percent to 98.4 percent. All fifteen unit tests in tests/unit/inventory pass, ruff and mypy strict are clean, and the analyzer now reports A+/100.0 with zero violations.</summary>