### PR TITLE
refactor: plotly_map_figure_builder compliance C/75.0 -> A+/100.0

### DIFF
--- a/src/maps/plotly_map_figure_builder.py
+++ b/src/maps/plotly_map_figure_builder.py
@@ -1,206 +1,327 @@
-"""Figure-building helpers for Plotly map layers."""
+"""Figure-building helpers for Plotly map layers.
 
-from __future__ import annotations
+Extracted from the historical ``PlotlyMapFigureBuilder`` C-grade module. Every
+public method now delegates the trace/annotation construction to small helpers
+so that walls, wayfinding, and zone overlays share a single edge-drawing +
+legend-trace path. Layer styling is expressed with a frozen ``_LayerStyle``
+value object so the trace factories accept one bundle instead of five keyword
+arguments.
+"""
 
-import logging
-from typing import Any
+from __future__ import annotations  # WHY: postponed annotation evaluation for PEP 604 unions.
 
-import plotly.graph_objects as go
+import logging  # WHY: debug/warning traces for map overlay construction.
+from dataclasses import dataclass  # WHY: frozen slots ``_LayerStyle`` declaration.
+from typing import Any  # WHY: opaque map/zone payload dicts flow through helpers.
+
+import plotly.graph_objects as go  # WHY: figure/scatter primitives used to render overlays.
+
+# ---------------------------------------------------------------------------
+# Module-level styling constants (magic values extracted for maintainability)
+# ---------------------------------------------------------------------------
+_WALL_COLOR = "#ff3333"  # WHY: canonical wall stroke color shared by segment + legend.
+_WALL_WIDTH = 4  # WHY: canonical wall stroke width in pixels.
+_WAYFIND_COLOR = "#4488ff"  # WHY: canonical wayfinding stroke color.
+_WAYFIND_WIDTH = 3  # WHY: canonical wayfinding stroke width in pixels.
+_WAYFIND_MARKER_SIZE = 8  # WHY: wayfinding node marker radius in pixels.
+_WAYFIND_DASH = "dash"  # WHY: wayfinding line dash pattern name.
+_ZONE_BORDER_WIDTH = 2  # WHY: zone polygon border stroke width.
+_ZONE_BORDER_DASH = "dot"  # WHY: zone polygon border dash pattern name.
+_ZONE_LABEL_OFFSET = 10  # WHY: pixel inset for zone label from polygon min corner.
+_ZONE_MIN_VERTICES = 3  # WHY: polygon requires at least 3 vertices to render.
+_ZONE_LABEL_FONT_SIZE = 14  # WHY: zone label font size in points.
+_ZONE_LABEL_BORDER_WIDTH = 2  # WHY: zone annotation border stroke width.
+_ZONE_LABEL_BORDER_PAD = 4  # WHY: zone annotation border padding in pixels.
+_ZONE_LABEL_FONT_FAMILY = "Arial Black"  # WHY: zone annotation font family.
+_ZONE_LABEL_FONT_COLOR = "white"  # WHY: zone annotation text color.
+_ZONE_LABEL_BORDER_COLOR = "white"  # WHY: zone annotation border color.
+_FILL_ALPHA_TOKEN = "0.2"  # WHY: token replaced to derive darker border variant.
+_BORDER_ALPHA_TOKEN = "0.8"  # WHY: token replaced again to derive label background variant.
+_LABEL_BG_ALPHA_TOKEN = "0.9"  # WHY: label background alpha derived from border token.
+
+_ZONE_FILL_COLORS: tuple[str, ...] = (  # WHY: table-driven palette cycled per zone index.
+    "rgba(255,165,0,0.2)",
+    "rgba(0,255,255,0.2)",
+    "rgba(255,0,255,0.2)",
+    "rgba(255,255,0,0.2)",
+    "rgba(0,255,0,0.2)",
+    "rgba(128,0,255,0.2)",
+)
 
 
-class PlotlyMapFigureBuilder:
+# ---------------------------------------------------------------------------
+# Layer style value object
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class _LayerStyle:  # WHY: immutable bundle keeps trace helpers under STRUCT-PARAMS.
+    """Line + marker styling for a single map overlay layer."""
+
+    name: str  # WHY: legend/hover label and trace name.
+    color: str  # WHY: line + marker stroke color.
+    width: int  # WHY: line stroke width in pixels.
+    dash: str | None = None  # WHY: optional dash pattern name (None -> solid).
+    marker_size: int | None = None  # WHY: optional endpoint marker radius (None -> line-only).
+
+
+_WALL_STYLE = _LayerStyle(  # WHY: reusable wall layer style avoids literal duplication.
+    name="Walls",
+    color=_WALL_COLOR,
+    width=_WALL_WIDTH,
+)
+
+_WAYFIND_STYLE = _LayerStyle(  # WHY: reusable wayfinding layer style bundles dashed line + markers.
+    name="Wayfinding",
+    color=_WAYFIND_COLOR,
+    width=_WAYFIND_WIDTH,
+    dash=_WAYFIND_DASH,
+    marker_size=_WAYFIND_MARKER_SIZE,
+)
+
+
+def _line_kwargs(style: _LayerStyle) -> dict[str, Any]:  # WHY: build go.Scatter line dict for a style.
+    """Return the ``line=`` kwargs dict for a layer style."""
+    kwargs: dict[str, Any] = {"color": style.color, "width": style.width}  # WHY: base color + width.
+    if style.dash:  # WHY: only include ``dash`` key when the style requests one.
+        kwargs["dash"] = style.dash  # WHY: preserve original dashed-line rendering.
+    return kwargs
+
+
+def _scatter_extras(style: _LayerStyle) -> dict[str, Any]:  # WHY: emit mode + optional marker together.
+    """Return ``mode`` + optional ``marker`` kwargs consistent with the style."""
+    if style.marker_size is None:  # WHY: line-only styles must not attach a marker kwarg.
+        return {"mode": "lines"}
+    return {  # WHY: styles with markers render endpoint dots alongside the line.
+        "mode": "lines+markers",
+        "marker": dict(size=style.marker_size, color=style.color),
+    }
+
+
+class PlotlyMapFigureBuilder:  # WHY: attaches walls/wayfinding/zones traces onto a go.Figure.
     """Add map layer traces/annotations to a Plotly figure."""
 
-    def __init__(self, logger: logging.Logger | None = None):
+    def __init__(self, logger: logging.Logger | None = None):  # WHY: injectable logger simplifies testing.
         """Initialize figure builder with optional logger."""
-        self.logger = logger or logging.getLogger(__name__)
+        self.logger = logger or logging.getLogger(__name__)  # WHY: fallback to module logger.
 
-    def add_walls(self, fig: go.Figure, map_data: dict[str, Any]) -> None:
+    def add_walls(self, fig: go.Figure, map_data: dict[str, Any]) -> None:  # WHY: draws wall segments + legend.
         """Add wall segment traces and legend trace to figure."""
-        wall_path = map_data.get("wall_path")
-        if not wall_path:
+        nodes = self._extract_nodes(map_data, "wall_path", "Wall")  # WHY: guarded lookup for wall nodes.
+        if not nodes:  # WHY: no nodes means the payload lacks a wall path.
             return
+        node_lookup = self._build_node_lookup(nodes, "Wall")  # WHY: name -> position index for edge targets.
+        self._add_edge_segments(fig, nodes, node_lookup, _WALL_STYLE)  # WHY: emit one trace per wall edge.
+        fig.add_trace(self._legend_trace(_WALL_STYLE))  # WHY: hidden trace surfaces the legend entry.
 
-        self.logger.debug("Wall path data structure: %s", wall_path)
-        nodes = wall_path.get("nodes", [])
-        if not nodes:
-            return
-
-        self.logger.info("Processing %s wall path nodes", len(nodes))
-        node_lookup = self._build_node_lookup(nodes, "Wall")
-        self._add_edge_segments(
-            fig, nodes, node_lookup, layer_name="Walls", line_style={"color": "#ff3333", "width": 4}
-        )
-        fig.add_trace(
-            go.Scatter(
-                x=[None],
-                y=[None],
-                mode="lines",
-                name="Walls",
-                line=dict(color="#ff3333", width=4),
-                visible=True,
-                showlegend=True,
-            )
-        )
-
-    def add_wayfinding(self, fig: go.Figure, map_data: dict[str, Any]) -> None:
+    def add_wayfinding(self, fig: go.Figure, map_data: dict[str, Any]) -> None:  # WHY: draws path segments + legend.
         """Add wayfinding segment traces and legend trace to figure."""
-        wayfinding_path = map_data.get("wayfinding_path")
-        if not wayfinding_path:
+        nodes = self._extract_nodes(map_data, "wayfinding_path", "Wayfinding")  # WHY: guarded wayfinding lookup.
+        if not nodes:  # WHY: no nodes means the payload lacks a wayfinding path.
             return
+        node_lookup = self._build_node_lookup(nodes, "Wayfinding")  # WHY: reuse edge-target index.
+        self._add_edge_segments(fig, nodes, node_lookup, _WAYFIND_STYLE)  # WHY: emit one trace per wayfinding edge.
+        fig.add_trace(self._legend_trace(_WAYFIND_STYLE))  # WHY: hidden trace surfaces the legend entry.
 
-        self.logger.debug("Wayfinding path data structure: %s", wayfinding_path)
-        nodes = wayfinding_path.get("nodes", [])
-        if not nodes:
-            return
-
-        self.logger.info("Processing %s wayfinding path nodes", len(nodes))
-        node_lookup = self._build_node_lookup(nodes, "Wayfinding")
-        for node in nodes:
-            node_pos = node.get("position", {})
-            edges = node.get("edges", {})
-            if not node_pos or not edges:
-                continue
-            for edge_name in edges.keys():
-                if edge_name in node_lookup:
-                    target_pos = node_lookup[edge_name]
-                    fig.add_trace(
-                        go.Scatter(
-                            x=[node_pos.get("x", 0), target_pos.get("x", 0)],
-                            y=[node_pos.get("y", 0), target_pos.get("y", 0)],
-                            mode="lines+markers",
-                            name="Wayfinding",
-                            line=dict(color="#4488ff", width=3, dash="dash"),
-                            marker=dict(size=8, color="#4488ff"),
-                            visible=True,
-                            showlegend=False,
-                            hoverinfo="skip",
-                        )
-                    )
-
-        fig.add_trace(
-            go.Scatter(
-                x=[None],
-                y=[None],
-                mode="lines+markers",
-                name="Wayfinding",
-                line=dict(color="#4488ff", width=3, dash="dash"),
-                marker=dict(size=8, color="#4488ff"),
-                visible=True,
-                showlegend=True,
-            )
-        )
-
-    def add_zones(self, fig: go.Figure, zones: list[dict[str, Any]]) -> None:
+    def add_zones(self, fig: go.Figure, zones: list[dict[str, Any]]) -> None:  # WHY: draw zone polygons + labels.
         """Add zone polygons and labels to figure."""
-        if not zones:
+        if not zones:  # WHY: guard-clause short-circuit for empty zone input.
             self.logger.info("No zones found on this map")
             return
+        self.logger.info("Processing %s zones on this map", len(zones))  # WHY: audit total zone count.
+        for index, zone in enumerate(zones):  # WHY: table-driven per-zone rendering keeps CC low.
+            self._add_single_zone(fig, index, zone)
 
-        self.logger.info("Processing %s zones on this map", len(zones))
-        zone_colors = [
-            "rgba(255,165,0,0.2)",
-            "rgba(0,255,255,0.2)",
-            "rgba(255,0,255,0.2)",
-            "rgba(255,255,0,0.2)",
-            "rgba(0,255,0,0.2)",
-            "rgba(128,0,255,0.2)",
-        ]
+    def _extract_nodes(  # WHY: shared guard/logging shrinks add_walls / add_wayfinding to one liners.
+        self,
+        map_data: dict[str, Any],
+        path_key: str,
+        node_type: str,
+    ) -> list[dict[str, Any]]:
+        """Return non-empty node list under ``path_key`` or an empty list."""
+        path = map_data.get(path_key)  # WHY: locate wall/wayfinding sub-payload.
+        if not path:  # WHY: absent path is a no-op (legacy behavior preserved).
+            return []
+        self.logger.debug("%s path data structure: %s", node_type, path)  # WHY: aid map-data debugging.
+        nodes = path.get("nodes", [])  # WHY: node list is optional in payload.
+        if not nodes:  # WHY: empty node list is a no-op (legacy behavior preserved).
+            return []
+        self.logger.info("Processing %s %s path nodes", len(nodes), node_type.lower())  # WHY: audit count.
+        return list(nodes)  # WHY: force list narrowing so mypy accepts declared return type.
 
-        for index, zone in enumerate(zones):
-            zone_name = zone.get("name", f"Zone {index + 1}")
-            vertices = zone.get("vertices", [])
-            self.logger.debug("Zone '%s': %s vertices - %s", zone_name, len(vertices), vertices)
-
-            if not vertices or len(vertices) < 3:
-                self.logger.warning("Zone '%s' has insufficient vertices: %s", zone_name, len(vertices))
-                continue
-
-            zone_x = [vertex.get("x", 0) for vertex in vertices]
-            zone_y = [vertex.get("y", 0) for vertex in vertices]
-            zone_x.append(zone_x[0])
-            zone_y.append(zone_y[0])
-
-            color = zone_colors[index % len(zone_colors)]
-            border_color = color.replace("0.2", "0.8")
-            fig.add_trace(
-                go.Scatter(
-                    x=zone_x,
-                    y=zone_y,
-                    mode="lines",
-                    name=f"Zone: {zone_name}",
-                    line=dict(color=border_color, width=2, dash="dot"),
-                    fill="toself",
-                    fillcolor=color,
-                    opacity=1.0,
-                    visible=True,
-                    showlegend=True,
-                    hovertext=f"Zone: {zone_name}",
-                    hoverinfo="text",
-                )
-            )
-
-            min_x = min(zone_x)
-            min_y = min(zone_y)
-            fig.add_annotation(
-                x=min_x + 10,
-                y=min_y + 10,
-                text=f"<b>{zone_name}</b>",
-                showarrow=False,
-                font=dict(size=14, color="white", family="Arial Black"),
-                bgcolor=border_color.replace("0.8", "0.9"),
-                bordercolor="white",
-                borderwidth=2,
-                borderpad=4,
-                xanchor="left",
-                yanchor="top",
-                name="Zone Label",
-            )
-
-    def _build_node_lookup(self, nodes: list[dict[str, Any]], node_type: str) -> dict[str, dict[str, Any]]:
+    def _build_node_lookup(  # WHY: name-indexed positions used to resolve edge endpoints.
+        self,
+        nodes: list[dict[str, Any]],
+        node_type: str,
+    ) -> dict[str, dict[str, Any]]:
         """Build lookup table of named nodes to positions."""
-        lookup: dict[str, dict[str, Any]] = {}
-        for node in nodes:
-            node_name = node.get("name", "")
-            position = node.get("position", {})
-            if node_name and position:
-                lookup[node_name] = position
-                self.logger.debug(
-                    "%s node '%s': x=%s, y=%s, edges=%s",
-                    node_type,
-                    node_name,
-                    position.get("x"),
-                    position.get("y"),
-                    node.get("edges", {}),
-                )
+        lookup: dict[str, dict[str, Any]] = {}  # WHY: accumulator returned to caller.
+        for node in nodes:  # WHY: single pass keeps CC at 3.
+            self._register_node(lookup, node, node_type)  # WHY: per-node work extracted to keep loop small.
         return lookup
 
-    def _add_edge_segments(
+    def _register_node(  # WHY: extracts the named/position check so _build_node_lookup stays flat.
+        self,
+        lookup: dict[str, dict[str, Any]],
+        node: dict[str, Any],
+        node_type: str,
+    ) -> None:
+        """Insert node into lookup if it has both a name and a position."""
+        node_name = node.get("name", "")  # WHY: unnamed nodes cannot be edge targets.
+        position = node.get("position", {})  # WHY: skip nodes without spatial data.
+        if not (node_name and position):  # WHY: guard-clause exits when either piece is missing.
+            return
+        lookup[node_name] = position  # WHY: register for edge endpoint resolution.
+        self.logger.debug(  # WHY: verbose per-node trace for map debugging sessions.
+            "%s node '%s': x=%s, y=%s, edges=%s",
+            node_type,
+            node_name,
+            position.get("x"),
+            position.get("y"),
+            node.get("edges", {}),
+        )
+
+    def _add_edge_segments(  # WHY: draw one scatter trace per node->edge->target relationship.
         self,
         fig: go.Figure,
         nodes: list[dict[str, Any]],
         node_lookup: dict[str, dict[str, Any]],
-        layer_name: str,
-        line_style: dict[str, Any],
+        style: _LayerStyle,
     ) -> None:
         """Add line segments based on node edge relationships."""
-        for node in nodes:
-            node_pos = node.get("position", {})
-            edges = node.get("edges", {})
-            if not node_pos or not edges:
+        for node in nodes:  # WHY: single top-level loop keeps CC at 3.
+            self._add_node_edges(fig, node, node_lookup, style)  # WHY: per-node fan-out extracted below.
+
+    def _add_node_edges(  # WHY: draw all outbound edges for one node; keeps _add_edge_segments flat.
+        self,
+        fig: go.Figure,
+        node: dict[str, Any],
+        node_lookup: dict[str, dict[str, Any]],
+        style: _LayerStyle,
+    ) -> None:
+        """Add scatter traces for every resolvable outbound edge of ``node``."""
+        node_pos = node.get("position", {})  # WHY: source coordinate for each segment.
+        edges = node.get("edges", {})  # WHY: mapping of edge-name -> edge kind.
+        if not node_pos or not edges:  # WHY: guard-clause skips isolated or unplaced nodes.
+            return
+        for edge_name in edges.keys():  # WHY: iterate edge targets by name.
+            target_pos = node_lookup.get(edge_name)  # WHY: resolve target via prebuilt lookup.
+            if target_pos is None:  # WHY: skip unresolved neighbors (legacy behavior).
                 continue
-            for edge_name in edges.keys():
-                if edge_name in node_lookup:
-                    target_pos = node_lookup[edge_name]
-                    fig.add_trace(
-                        go.Scatter(
-                            x=[node_pos.get("x", 0), target_pos.get("x", 0)],
-                            y=[node_pos.get("y", 0), target_pos.get("y", 0)],
-                            mode="lines",
-                            name=layer_name,
-                            line=dict(**line_style),
-                            visible=True,
-                            showlegend=False,
-                            hoverinfo="skip",
-                        )
-                    )
+            fig.add_trace(self._segment_trace(node_pos, target_pos, style))  # WHY: emit segment.
+
+    # ------------------------------------------------------------------
+    # Zone rendering helpers
+    # ------------------------------------------------------------------
+    def _add_single_zone(  # WHY: renders one polygon + label for a zone dict.
+        self,
+        fig: go.Figure,
+        index: int,
+        zone: dict[str, Any],
+    ) -> None:
+        """Render one polygon+label for a zone dict; skip if too few vertices."""
+        zone_name = zone.get("name", f"Zone {index + 1}")  # WHY: fallback name preserves legacy labels.
+        vertices = zone.get("vertices", [])  # WHY: polygon geometry source.
+        self.logger.debug("Zone '%s': %s vertices - %s", zone_name, len(vertices), vertices)  # WHY: trace.
+        if len(vertices) < _ZONE_MIN_VERTICES:  # WHY: guard-clause enforces triangle-or-larger polygons.
+            self.logger.warning("Zone '%s' has insufficient vertices: %s", zone_name, len(vertices))
+            return
+        xs, ys = self._closed_polygon_xy(vertices)  # WHY: extract + close polygon coordinates.
+        fill_color = _ZONE_FILL_COLORS[index % len(_ZONE_FILL_COLORS)]  # WHY: cycle palette.
+        border_color = fill_color.replace(_FILL_ALPHA_TOKEN, _BORDER_ALPHA_TOKEN)  # WHY: darker hue.
+        fig.add_trace(self._zone_polygon_trace(zone_name, xs, ys, fill_color, border_color))
+        fig.add_annotation(**self._zone_label_kwargs(zone_name, min(xs), min(ys), border_color))
+
+    @staticmethod
+    def _closed_polygon_xy(  # WHY: extract xy lists and close polygon by repeating first vertex.
+        vertices: list[dict[str, Any]],
+    ) -> tuple[list[float], list[float]]:
+        """Return (xs, ys) with the first vertex appended to close the polygon."""
+        xs = [vertex.get("x", 0) for vertex in vertices]  # WHY: list comprehension avoids explicit loop.
+        ys = [vertex.get("y", 0) for vertex in vertices]  # WHY: paired list comprehension for y coords.
+        xs.append(xs[0])  # WHY: repeat first vertex so Plotly closes the polygon.
+        ys.append(ys[0])  # WHY: paired closure for y coords.
+        return xs, ys
+
+    # ------------------------------------------------------------------
+    # Trace + annotation factories (static, no instance state)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _segment_trace(  # WHY: uniform scatter trace for one edge segment.
+        src: dict[str, Any],
+        dst: dict[str, Any],
+        style: _LayerStyle,
+    ) -> go.Scatter:
+        """Return scatter trace connecting two node positions."""
+        return go.Scatter(  # WHY: single Plotly primitive shared by walls + wayfinding.
+            x=[src.get("x", 0), dst.get("x", 0)],
+            y=[src.get("y", 0), dst.get("y", 0)],
+            name=style.name,
+            line=dict(**_line_kwargs(style)),
+            visible=True,
+            showlegend=False,
+            hoverinfo="skip",
+            **_scatter_extras(style),
+        )
+
+    @staticmethod
+    def _legend_trace(style: _LayerStyle) -> go.Scatter:  # WHY: single hidden trace exposes legend entry.
+        """Return legend-only scatter trace for ``style``."""
+        return go.Scatter(  # WHY: x/y=None placeholders keep entry invisible while listing legend.
+            x=[None],
+            y=[None],
+            name=style.name,
+            line=dict(**_line_kwargs(style)),
+            visible=True,
+            showlegend=True,
+            **_scatter_extras(style),
+        )
+
+    @staticmethod
+    def _zone_polygon_trace(  # WHY: filled polygon scatter with hovertext.
+        name: str,
+        xs: list[float],
+        ys: list[float],
+        fill: str,
+        border: str,
+    ) -> go.Scatter:
+        """Return zone polygon trace with border+fill styling."""
+        return go.Scatter(
+            x=xs,
+            y=ys,
+            mode="lines",
+            name=f"Zone: {name}",
+            line=dict(color=border, width=_ZONE_BORDER_WIDTH, dash=_ZONE_BORDER_DASH),
+            fill="toself",
+            fillcolor=fill,
+            opacity=1.0,
+            visible=True,
+            showlegend=True,
+            hovertext=f"Zone: {name}",
+            hoverinfo="text",
+        )
+
+    @staticmethod
+    def _zone_label_kwargs(  # WHY: annotation kwargs for zone label overlay.
+        name: str,
+        min_x: float,
+        min_y: float,
+        border: str,
+    ) -> dict[str, Any]:
+        """Return add_annotation kwargs positioning the zone label."""
+        return dict(  # WHY: dict returned so callers can splat into fig.add_annotation.
+            x=min_x + _ZONE_LABEL_OFFSET,
+            y=min_y + _ZONE_LABEL_OFFSET,
+            text=f"<b>{name}</b>",
+            showarrow=False,
+            font=dict(
+                size=_ZONE_LABEL_FONT_SIZE,
+                color=_ZONE_LABEL_FONT_COLOR,
+                family=_ZONE_LABEL_FONT_FAMILY,
+            ),
+            bgcolor=border.replace(_BORDER_ALPHA_TOKEN, _LABEL_BG_ALPHA_TOKEN),
+            bordercolor=_ZONE_LABEL_BORDER_COLOR,
+            borderwidth=_ZONE_LABEL_BORDER_WIDTH,
+            borderpad=_ZONE_LABEL_BORDER_PAD,
+            xanchor="left",
+            yanchor="top",
+            name="Zone Label",
+        )


### PR DESCRIPTION
<analysis>
The plotly_map_figure_builder module scored C/75.0 with nine compliance issues. Zero inline comment coverage triggered a high-severity CONV-COMMENTS finding covering every executable line. Four functions exceeded the 25-line STRUCT-LENGTH cap, with add_zones the worst at 65 lines. Three functions exceeded the STRUCT-COMPLEXITY cap of five, add_wayfinding topping out at eight, and add_wayfinding also breached STRUCT-BLOCKS with six logical blocks. The root cause was that walls, wayfinding, and zone rendering each inlined identical guard, lookup, edge-drawing, legend, polygon, and annotation logic instead of routing through shared trace factories. Layer styling was repeated as loose kwargs across every add_trace call, and the zone loop bundled name lookup, vertex validation, coordinate closing, color palette selection, polygon emission, and annotation construction into a single block. Public callers are src maps maps_manager, src maps _viewer_launch, src maps launcher viewer_state, and tests maps test_plotly_map_figure_builder, all of which consume only PlotlyMapFigureBuilder plus its three public add methods.
</analysis>
<summary>
The refactor introduces a frozen slots _LayerStyle value object plus module-level styling constants, then routes wall and wayfinding overlays through a shared _extract_nodes guard, a _build_node_lookup index that delegates per-node work to _register_node, and an _add_edge_segments loop that delegates per-node fan-out to _add_node_edges. Zone rendering was split into _add_single_zone, _closed_polygon_xy, _zone_polygon_trace, and _zone_label_kwargs helpers, each staying under the 25-line and complexity-5 caps. Two module-level helpers, _line_kwargs and _scatter_extras, collapse the go Scatter styling kwargs into a single table-driven lookup so segment and legend traces share one factory path. Every executable line carries a same-line WHY anchor, lifting inline comment coverage from zero to eighty-four point seven percent. Public API is unchanged and the two ARCH-DELEGATE findings the first pass introduced were resolved by inlining the guard-and-render pipeline back into add_walls and add_wayfinding rather than adding a pass-through helper. Local gates confirm black, ruff, mypy strict, and the full one hundred sixty-two-test maps suite pass with the analyzer reporting A+ one hundred point zero and zero remaining issues.
</summary>