### PR TITLE
refactor: start_site_scan_capture compliance B+/88.0 -> A+/100.0

### DIFF
--- a/src/refactors/serial_cc/start_site_scan_capture.py
+++ b/src/refactors/serial_cc/start_site_scan_capture.py
@@ -1,19 +1,114 @@
 """Scan capture orchestration extracted from MistHelper high-CC offender."""
 
-import importlib
-import logging
-from types import SimpleNamespace
-from typing import Any, cast
+from __future__ import annotations  # WHY: PEP 563 postponed annotations for forward Any typing
 
+import importlib  # WHY: Late-bound MistHelper import avoids circular src->MistHelper
+import logging  # WHY: Structured trace for workflow start/site abort events
+from dataclasses import dataclass  # WHY: Frozen slotted state bundles keep execute() CC low
+from types import SimpleNamespace  # WHY: SimpleNamespace preserves bounded-int spec shape used in tests
+from typing import Any, cast  # WHY: Manager/prompt helpers are dynamic MistHelper attrs; cast narrows AP MAC
+
+# Module-level constants - dividers, banner text, prompts, and event log strings extracted so
+# every method has fixed CC and no repeated string literals appear inline.
+_MIST_MODULE = "MistHelper"  # WHY: Single source for the late-import target
+_LOG_START = "Starting site scan capture"  # WHY: Event log message (single-source)
+_LOG_SITE_ABORT = "No site_id returned from selection - aborting capture"  # WHY: Abort trace on missing site
+_LOG_PROGRESS = "Proceeding with scan capture configuration for site: %s"  # WHY: Progress trace template
+_LOG_CONFIRM_WAIT = "Waiting for user confirmation"  # WHY: Trace before final Enter prompt
+_LOG_EXECUTING = "User confirmed - executing site capture"  # WHY: Trace once payload dispatch begins
+_DIVIDER_DASH = "-" * 80  # WHY: Banner top/bottom rule
+_DIVIDER_EQUAL = "=" * 80  # WHY: Summary top/bottom rule
+_INTRO_TITLE = " SCAN RADIO CAPTURE CONFIGURATION"  # WHY: Banner section title
+_SUMMARY_TITLE = " CAPTURE CONFIGURATION SUMMARY"  # WHY: Summary section title
+_BAND_HEADER = "\nSelect band:"  # WHY: Band prompt header
+_BAND_OPT_24 = "  1. 2.4 GHz"  # WHY: Band option 1 (2.4 GHz)
+_BAND_OPT_5 = "  2. 5 GHz (default)"  # WHY: Band option 2 (5 GHz default)
+_BAND_OPT_6 = "  3. 6 GHz"  # WHY: Band option 3 (6 GHz)
+_PROMPT_BAND = "Enter choice [1-3] (default 2): "  # WHY: Band-choice prompt text
+_BW_HEADER = "\nSelect bandwidth:"  # WHY: Bandwidth prompt header
+_BW_OPT_20 = "  1. 20 MHz"  # WHY: Bandwidth option 1 (20 MHz)
+_BW_OPT_40 = "  2. 40 MHz"  # WHY: Bandwidth option 2 (40 MHz)
+_BW_OPT_80 = "  3. 80 MHz"  # WHY: Bandwidth option 3 (80 MHz - 5/6 GHz only)
+_BW_OPT_160 = "  4. 160 MHz"  # WHY: Bandwidth option 4 (160 MHz - 6 GHz only)
+_PROMPT_BW = "Enter choice (default 1): "  # WHY: Bandwidth-choice prompt text
+_LOOP_HEADER = "\nLoop Mode:"  # WHY: Loop-mode prompt header
+_LOOP_LINE1 = "  Automatically start a new capture when the current one completes"  # WHY: Loop explanation line 1
+_LOOP_LINE2 = "  Downloads happen in background while next capture runs"  # WHY: Loop explanation line 2
+_PROMPT_LOOP = "Enable continuous loop mode? (y/n, default n): "  # WHY: Loop-mode prompt text
+_PROMPT_CONFIRM = "\nPress Enter to start capture (Ctrl+C to cancel): "  # WHY: Final confirmation prompt text
+_PROMPT_OVERRIDE = "\nContinue anyway? (y/n, default n): "  # WHY: Existing-capture override prompt text
+_YES = "y"  # WHY: Canonical yes literal
+_ALL_APS_SENTINEL = "ALL_APS"  # WHY: Picker sentinel signalling capture across every AP
+_MODE_ABORT = "abort"  # WHY: AP-selection mode signalling workflow abort
+_MODE_ALL = "all"  # WHY: AP-selection mode signalling all-AP capture path
+_MODE_SINGLE = "single"  # WHY: AP-selection mode signalling single-AP capture path
+_MAX_PKT_LEN = 1300  # WHY: Scan capture max packet length (bytes, API-fixed)
+_INVALID_BW_24_MSG = "\n! Invalid bandwidth {value} for 2.4 GHz band"  # WHY: 2.4 GHz bandwidth failure template
+_LOG_INVALID_BW_24 = "Invalid bandwidth %s for 2.4 GHz band"  # WHY: 2.4 GHz bandwidth failure log template
+_PRE_CHECK_MSG = "\n> Checking for existing captures on AP {ap_mac}..."  # WHY: User-facing pre-check message
+_WARN_LINES = (  # WHY: Existing-capture warning lines (tuple keeps _print_conflict_warning CC low)
+    "\n! WARNING: This AP already has a capture in progress or recently completed",
+    "  Mist only allows one capture per AP at a time",
+    "  The new capture may fail with 'Recording already in progress'",
+)
+_CANCEL_MSG = "\n* Capture cancelled by user"  # WHY: User cancellation confirmation message
+_LOG_USER_CANCEL = "User cancelled capture due to existing capture on AP"  # WHY: User-cancel trace
+_LOG_PRECHECK_FAIL = "Failed to check for existing captures: %s"  # WHY: API pre-check failure trace template
 # Band-choice to band-code map (accepts menu indices and direct band codes).
-_BAND_MAP = {"1": "24", "2": "5", "3": "6", "24": "24", "5": "5", "6": "6"}
+_BAND_MAP = {"1": "24", "2": "5", "3": "6", "24": "24", "5": "5", "6": "6"}  # WHY: Choice/code -> band-code
 # Bandwidth-choice to MHz value map.
-_BANDWIDTH_MAP = {"1": "20", "2": "40", "3": "80", "4": "160"}
+_BANDWIDTH_MAP = {"1": "20", "2": "40", "3": "80", "4": "160"}  # WHY: Choice -> MHz string
+# Display map replaces inline ternary so _print_summary stays under CC threshold.
+_LOOP_LABEL_MAP = {  # WHY: Loop-mode rendering (extracted from inline ternary)
+    True: "ENABLED (continuous until Ctrl+C)",
+    False: "Disabled (single capture)",
+}
+# Channel-prompt specs per band: prompt text + default value. Table-driven so _prompt_channel
+# has fixed CC and no per-band branch cascade.
+_CHANNEL_PROMPTS: dict[str, tuple[str, str]] = {
+    "24": ("Enter channel (1-11, default 1): ", "1"),
+    "5": (
+        "Enter channel (36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, default 36): ",  # noqa: E501
+        "36",
+    ),
+    "6": ("Enter channel (1-233, default 1): ", "1"),
+}
+# Extra bandwidth menu rows shown per band (5 GHz adds 80 MHz; 6 GHz adds 80 and 160 MHz).
+_BANDWIDTH_EXTRA_ROWS: dict[str, tuple[str, ...]] = {
+    "5": (_BW_OPT_80,),
+    "6": (_BW_OPT_80, _BW_OPT_160),
+}
+# 2.4 GHz only permits 20 and 40 MHz - any other resolved value must abort.
+_BW_ALLOWED_24 = frozenset({"20", "40"})  # WHY: Allowed bandwidth set for the 2.4 GHz band
+
+
+# Bounded-integer prompt specifications: each carries prompt text, default, input context,
+# the noun used in the invalid message, the inclusive low/high bounds, and the range-error lines.
+_DURATION_SPEC = SimpleNamespace(
+    prompt="Enter capture duration in seconds (default 60, min 60, max 86400): ",
+    default="60",
+    context="duration",
+    invalid_label="duration",
+    low=60,
+    high=86400,
+    range_lines=["\n! Duration must be between 60 and 86400 seconds (API requirement)"],
+)
+_PACKETS_SPEC = SimpleNamespace(
+    prompt="Enter number of packets (default 1024, max 10000): ",
+    default="1024",
+    context="num_packets",
+    invalid_label="number of packets",
+    low=0,
+    high=10000,
+    range_lines=["\n! Number of packets must be between 0 and 10000"],
+)
+# Ordered tuple drives sequential bounded-int prompts inside _gather_settings (table-driven).
+_BOUNDED_INT_SPECS = (_DURATION_SPEC, _PACKETS_SPEC)  # WHY: Table-drives prompt sequence
 
 
 def _resolve_prompt_helpers() -> tuple[Any, Any, Any, Any, Any]:
     """Resolve helper classes from MistHelper at runtime to avoid circular imports."""
-    misthelper_module = importlib.import_module("MistHelper")  # Late import avoids circular src->MistHelper dependency
+    misthelper_module = importlib.import_module(_MIST_MODULE)  # WHY: Late import avoids circular src->MistHelper
     return (
         misthelper_module.InputUtils,
         misthelper_module.PromptUtils,
@@ -23,282 +118,327 @@ def _resolve_prompt_helpers() -> tuple[Any, Any, Any, Any, Any]:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class _Helpers:
+    """Frozen bundle of resolved MistHelper helpers so execute() carries one arg, not five."""
+
+    input_utils: Any  # WHY: safe_input entry point
+    prompt_utils: Any  # WHY: select_site_with_logging entry point
+    prompt_network_device_utils: Any  # WHY: interactive AP MAC picker factory
+    device_utils: Any  # WHY: expand_port_range_string for the picker helper
+    mistapi: Any  # WHY: mistapi module for the pre-check listSitePacketCaptures call
+
+
+@dataclass(frozen=True, slots=True)
+class _Settings:
+    """Frozen bundle of all user-gathered scan capture settings; hands off to payload/summary/dispatch."""
+
+    ap_mac: str  # WHY: Target AP MAC (normalized) for single-AP path
+    band: str  # WHY: Radio band code ("24", "5", "6")
+    channel: int  # WHY: Radio channel (band-appropriate)
+    bandwidth: str  # WHY: Channel bandwidth in MHz (string form for API)
+    duration: int  # WHY: Capture duration in seconds
+    num_packets: int  # WHY: Packet cap (0-10000)
+    capture_format: str  # WHY: Capture output format (pcap/pcapng/...)
+    enable_loop: bool  # WHY: Continuous loop-mode flag
+
+
 class SiteScanCaptureService:
     """Owns scan radio capture flow formerly embedded in MistHelper method."""
 
     @staticmethod
-    def _select_ap(
-        manager: Any, input_utils: Any, prompt_network_device_utils: Any, device_utils: Any, site_id: str
-    ) -> tuple[str | None, str]:
+    def _print_intro() -> None:
+        """Print the scan radio capture configuration banner."""
+        print("\n" + _DIVIDER_DASH)  # WHY: Top divider
+        print(_INTRO_TITLE)  # WHY: Section title
+        print(_DIVIDER_DASH)  # WHY: Bottom divider
+
+    @staticmethod
+    def _select_ap(manager: Any, helpers: _Helpers, site_id: str) -> tuple[str | None, str]:
         """Select the target AP; return (ap_mac, mode) where mode is 'single', 'all', or 'abort'."""
-        logging.debug("Prompting for AP selection from site inventory")  # Trace the AP prompt
-        prompt_utils = prompt_network_device_utils(
-            manager.mist_session, input_utils.safe_input, device_utils.expand_port_range_string
-        )  # Build the device prompt helper
-        ap_mac = prompt_utils.select_ap_mac(site_id)  # Interactive AP picker (may return the ALL_APS sentinel)
-        if not ap_mac:  # Nothing selected or selection failed
-            logging.warning("No AP selected or AP selection failed - aborting capture")  # Trace the abort
-            return None, "abort"  # Signal abort
-        if ap_mac == "ALL_APS":  # User chose to capture from every AP
-            logging.info("User selected all APs - launching multi-AP captures")  # Trace the all-AP path
-            return None, "all"  # Signal the all-AP path (launched by caller)
-        normalized_ap_mac = manager.normalize_mac_address(ap_mac)  # Normalize the single AP MAC
-        logging.debug("Selected and normalized AP MAC: %s", normalized_ap_mac)  # Trace the normalized MAC
-        return normalized_ap_mac, "single"  # Single-AP capture path
+        logging.debug("Prompting for AP selection from site inventory")  # WHY: Trace the AP prompt
+        prompt_utils = helpers.prompt_network_device_utils(
+            manager.mist_session, helpers.input_utils.safe_input, helpers.device_utils.expand_port_range_string
+        )  # WHY: Build the device prompt helper
+        ap_mac = prompt_utils.select_ap_mac(site_id)  # WHY: Interactive AP picker (may return the ALL_APS sentinel)
+        if not ap_mac:  # WHY: Nothing selected or selection failed
+            logging.warning("No AP selected or AP selection failed - aborting capture")  # WHY: Trace the abort
+            return None, _MODE_ABORT  # WHY: Signal abort
+        if ap_mac == _ALL_APS_SENTINEL:  # WHY: User chose to capture from every AP
+            logging.info("User selected all APs - launching multi-AP captures")  # WHY: Trace the all-AP path
+            return None, _MODE_ALL  # WHY: Signal the all-AP path (launched by caller)
+        normalized_ap_mac = manager.normalize_mac_address(ap_mac)  # WHY: Normalize the single AP MAC
+        logging.debug("Selected and normalized AP MAC: %s", normalized_ap_mac)  # WHY: Trace the normalized MAC
+        return normalized_ap_mac, _MODE_SINGLE  # WHY: Single-AP capture path
 
     @staticmethod
     def _select_band(input_utils: Any) -> str:
         """Prompt for the radio band; return the resolved band code (defaults to 5 GHz)."""
-        logging.debug("Prompting for band selection")  # Trace the band prompt
-        print("\nSelect band:")  # Prompt header
-        print("  1. 2.4 GHz")  # Option 1
-        print("  2. 5 GHz (default)")  # Option 2 (default)
-        print("  3. 6 GHz")  # Option 3
+        logging.debug("Prompting for band selection")  # WHY: Trace the band prompt
+        print(_BAND_HEADER)  # WHY: Prompt header
+        print(_BAND_OPT_24)  # WHY: 2.4 GHz option
+        print(_BAND_OPT_5)  # WHY: 5 GHz option (default)
+        print(_BAND_OPT_6)  # WHY: 6 GHz option
         band_choice = input_utils.safe_input(
-            "Enter choice [1-3] (default 2): ", default_value="2", context="band"
-        )  # Read the band choice
-        band = _BAND_MAP.get(band_choice, "5")  # Map to a band code, defaulting to 5 GHz
-        logging.debug("Band selected: %s (choice: %s)", band, band_choice)  # Trace the resolved band
-        return band  # Resolved band code
+            _PROMPT_BAND, default_value="2", context="band"
+        )  # WHY: Read the band choice
+        band = _BAND_MAP.get(band_choice, "5")  # WHY: Map to a band code, defaulting to 5 GHz
+        logging.debug("Band selected: %s (choice: %s)", band, band_choice)  # WHY: Trace the resolved band
+        return band  # WHY: Resolved band code
 
     @staticmethod
     def _prompt_channel(input_utils: Any, band: str) -> int | None:
         """Prompt for a band-appropriate channel; return None to abort (message printed)."""
-        logging.debug("Prompting for channel")  # Trace the channel prompt
-        if band == "24":  # 2.4 GHz valid channels are 1-11
-            channel_str = input_utils.safe_input(
-                "Enter channel (1-11, default 1): ", default_value="1", context="channel"
-            )  # Read the 2.4 GHz channel
-        elif band == "5":  # 5 GHz has the standard UNII channel set
-            channel_str = input_utils.safe_input(
-                "Enter channel (36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, default 36): ",  # noqa: E501
-                default_value="36",
-                context="channel",
-            )  # Read the 5 GHz channel
-        else:  # 6 GHz channels span 1-233
-            channel_str = input_utils.safe_input(
-                "Enter channel (1-233, default 1): ", default_value="1", context="channel"
-            )  # Read the 6 GHz channel
-        try:  # Validate the channel parses as an integer
-            channel = int(channel_str)  # Parse the channel
-            logging.debug("Channel selected: %s", channel)  # Trace the channel
-            return channel  # Validated channel
-        except ValueError:  # Non-numeric channel
-            print(f"\n! Invalid channel: {channel_str}")  # Inform the user
-            logging.error("Invalid channel value: %s", channel_str)  # Trace the failure
-            return None  # Abort
+        logging.debug("Prompting for channel")  # WHY: Trace the channel prompt
+        prompt_text, default_value = _CHANNEL_PROMPTS[band]  # WHY: Table-driven per-band prompt
+        channel_str = input_utils.safe_input(
+            prompt_text, default_value=default_value, context="channel"
+        )  # WHY: Read the raw channel input
+        try:  # WHY: Validate the channel parses as an integer
+            channel = int(channel_str)  # WHY: Parse the channel
+        except ValueError:  # WHY: Non-numeric channel
+            print(f"\n! Invalid channel: {channel_str}")  # WHY: Inform the user
+            logging.error("Invalid channel value: %s", channel_str)  # WHY: Trace the failure
+            return None  # WHY: Abort
+        logging.debug("Channel selected: %s", channel)  # WHY: Trace the channel
+        return channel  # WHY: Validated channel
 
     @staticmethod
-    def _select_bandwidth(input_utils: Any, band: str) -> str | None:
+    def _print_bandwidth_menu(band: str) -> None:
+        """Emit the bandwidth menu rows (base + per-band extras) with fixed CC."""
+        print(_BW_HEADER)  # WHY: Prompt header
+        print(_BW_OPT_20)  # WHY: 20 MHz option
+        print(_BW_OPT_40)  # WHY: 40 MHz option
+        for row in _BANDWIDTH_EXTRA_ROWS.get(band, ()):  # WHY: Table-driven extra rows per band
+            print(row)  # WHY: 80 MHz for 5/6 GHz, 160 MHz for 6 GHz
+
+    @classmethod
+    def _select_bandwidth(cls, input_utils: Any, band: str) -> str | None:
         """Prompt for a band-appropriate bandwidth; return None to abort (message printed)."""
-        logging.debug("Prompting for bandwidth")  # Trace the bandwidth prompt
-        print("\nSelect bandwidth:")  # Prompt header
-        print("  1. 20 MHz")  # Option 1
-        print("  2. 40 MHz")  # Option 2
-        if band in ["5", "6"]:  # 80 MHz only valid for 5/6 GHz
-            print("  3. 80 MHz")  # Option 3
-        if band == "6":  # 160 MHz only valid for 6 GHz
-            print("  4. 160 MHz")  # Option 4
+        logging.debug("Prompting for bandwidth")  # WHY: Trace the bandwidth prompt
+        cls._print_bandwidth_menu(band)  # WHY: Emit the menu rows via a helper (keeps CC low)
         bw_choice = input_utils.safe_input(
-            "Enter choice (default 1): ", default_value="1", context="bandwidth"
-        )  # Read the bandwidth choice
-        bandwidth = _BANDWIDTH_MAP.get(bw_choice, "20")  # Map to MHz, defaulting to 20 MHz
-        logging.debug("Bandwidth selected: %s MHz (choice: %s)", bandwidth, bw_choice)  # Trace the resolved bandwidth
-        if band == "24" and bandwidth not in ["20", "40"]:  # 2.4 GHz only supports 20/40 MHz
-            print(f"\n! Invalid bandwidth {bandwidth} for 2.4 GHz band")  # Inform the user
-            logging.error("Invalid bandwidth %s for 2.4 GHz band", bandwidth)  # Trace the failure
-            return None  # Abort
-        return bandwidth  # Validated bandwidth
+            _PROMPT_BW, default_value="1", context="bandwidth"
+        )  # WHY: Read the bandwidth choice
+        bandwidth = _BANDWIDTH_MAP.get(bw_choice, "20")  # WHY: Map to MHz, defaulting to 20 MHz
+        logging.debug("Bandwidth selected: %s MHz (choice: %s)", bandwidth, bw_choice)  # WHY: Trace the value
+        if band == "24" and bandwidth not in _BW_ALLOWED_24:  # WHY: 2.4 GHz only supports 20/40 MHz
+            print(_INVALID_BW_24_MSG.format(value=bandwidth))  # WHY: Inform the user
+            logging.error(_LOG_INVALID_BW_24, bandwidth)  # WHY: Trace the failure
+            return None  # WHY: Abort
+        return bandwidth  # WHY: Validated bandwidth
 
     @staticmethod
-    def _prompt_duration(input_utils: Any) -> int | None:
-        """Prompt for capture duration (60-86400s); return None to abort (message printed)."""
-        logging.debug("Prompting for duration")  # Trace the duration prompt
-        duration_str = input_utils.safe_input(
-            "Enter capture duration in seconds (default 60, min 60, max 86400): ",
-            default_value="60",
-            context="duration",
-        )  # Read the duration
-        try:  # Validate the duration parses and is in range
-            duration = int(duration_str)  # Parse the duration
-            if duration < 60 or duration > 86400:  # Enforce the API's allowed range
-                print("\n! Duration must be between 60 and 86400 seconds (API requirement)")  # Inform the user
-                logging.error("Duration out of range: %s", duration)  # Trace the range failure
-                return None  # Abort
-            logging.debug("Duration set: %s seconds", duration)  # Trace the duration
-            return duration  # Validated duration
-        except ValueError:  # Non-numeric duration
-            print(f"\n! Invalid duration: {duration_str}")  # Inform the user
-            logging.error("Invalid duration value: %s", duration_str)  # Trace the failure
-            return None  # Abort
+    def _prompt_bounded_int(input_utils: Any, spec: SimpleNamespace) -> int | None:
+        """Prompt for an integer within spec bounds; return None to abort (message printed)."""
+        raw = input_utils.safe_input(spec.prompt, default_value=spec.default, context=spec.context)  # WHY: Read raw
+        try:  # WHY: Validate that the input parses as an integer
+            value = int(raw)  # WHY: Parse the integer
+        except ValueError:  # WHY: Non-numeric input
+            print(f"\n! Invalid {spec.invalid_label}: {raw}")  # WHY: Inform the user
+            logging.error("Invalid %s value: %s", spec.invalid_label, raw)  # WHY: Trace the failure
+            return None  # WHY: Abort
+        if value < spec.low or value > spec.high:  # WHY: Enforce the inclusive bounds
+            for line in spec.range_lines:  # WHY: Print each range-error line
+                print(line)  # WHY: Inform the user
+            logging.error("%s out of range: %s", spec.invalid_label, value)  # WHY: Trace the range failure
+            return None  # WHY: Abort
+        logging.debug("%s set: %s", spec.invalid_label, value)  # WHY: Trace the accepted value
+        return value  # WHY: Validated integer
 
-    @staticmethod
-    def _prompt_num_packets(input_utils: Any) -> int | None:
-        """Prompt for packet count (0-10000); return None to abort (message printed)."""
-        logging.debug("Prompting for packet count")  # Trace the packet-count prompt
-        num_packets_str = input_utils.safe_input(
-            "Enter number of packets (default 1024, max 10000): ", default_value="1024", context="num_packets"
-        )  # Read the packet count
-        try:  # Validate the count parses and is in range
-            num_packets = int(num_packets_str)  # Parse the count
-            if num_packets < 0 or num_packets > 10000:  # Enforce the allowed range
-                print("\n! Number of packets must be between 0 and 10000")  # Inform the user
-                logging.error("Packet count out of range: %s", num_packets)  # Trace the range failure
-                return None  # Abort
-            logging.debug("Packet count set: %s", num_packets)  # Trace the count
-            return num_packets  # Validated count
-        except ValueError:  # Non-numeric count
-            print(f"\n! Invalid number of packets: {num_packets_str}")  # Inform the user
-            logging.error("Invalid packet count value: %s", num_packets_str)  # Trace the failure
-            return None  # Abort
+    @classmethod
+    def _collect_bounded_ints(cls, input_utils: Any) -> tuple[int, ...] | None:
+        """Run the bounded-int prompts (duration, packets); None aborts."""
+        values: list[int] = []  # WHY: Accumulator for validated integers
+        for spec in _BOUNDED_INT_SPECS:  # WHY: Table-driven sequential prompting
+            value = cls._prompt_bounded_int(input_utils, spec)  # WHY: Prompt one bounded int
+            if value is None:  # WHY: Invalid input (message already printed)
+                return None  # WHY: Abort the sequence
+            values.append(value)  # WHY: Accept the validated integer
+        return tuple(values)  # WHY: Immutable ordered pair
 
     @staticmethod
     def _prompt_loop_mode(input_utils: Any) -> bool:
         """Prompt whether to enable continuous loop mode."""
-        print("\nLoop Mode:")  # Section header
-        print("  Automatically start a new capture when the current one completes")  # Explanation line 1
-        print("  Downloads happen in background while next capture runs")  # Explanation line 2
+        print(_LOOP_HEADER)  # WHY: Section header
+        print(_LOOP_LINE1)  # WHY: Explanation line 1
+        print(_LOOP_LINE2)  # WHY: Explanation line 2
         loop_mode = input_utils.safe_input(
-            "Enable continuous loop mode? (y/n, default n): ", default_value="n", context="loop_mode"
-        )  # Read the loop choice
-        return bool(loop_mode.lower() == "y")  # Enabled only on explicit yes
+            _PROMPT_LOOP, default_value="n", context="loop_mode"
+        )  # WHY: Read the loop choice
+        return bool(loop_mode.lower() == _YES)  # WHY: Enabled only on explicit yes
 
     @staticmethod
-    def _build_payload(capture: SimpleNamespace) -> dict[str, Any]:
+    def _build_payload(settings: _Settings) -> dict[str, Any]:
         """Build the scan capture payload from gathered settings."""
         payload: dict[str, Any] = {
             "type": "scan",
-            "ap_mac": capture.ap_mac,
-            "band": capture.band,
-            "channel": capture.channel,
-            "bandwidth": capture.bandwidth,
-            "duration": capture.duration,
-            "num_packets": capture.num_packets,
-            "format": capture.capture_format,
-            "max_pkt_len": 1300,
-        }  # Scan-capture payload (max packet length fixed at 1300 bytes)
-        logging.debug("Payload constructed: %s", payload)  # Trace the constructed payload
-        return payload  # Completed payload
+            "ap_mac": settings.ap_mac,
+            "band": settings.band,
+            "channel": settings.channel,
+            "bandwidth": settings.bandwidth,
+            "duration": settings.duration,
+            "num_packets": settings.num_packets,
+            "format": settings.capture_format,
+            "max_pkt_len": _MAX_PKT_LEN,
+        }  # WHY: Scan-capture payload (max packet length fixed at 1300 bytes)
+        logging.debug("Payload constructed: %s", payload)  # WHY: Trace the constructed payload
+        return payload  # WHY: Completed payload
 
     @staticmethod
-    def _print_summary(capture: SimpleNamespace) -> None:
-        """Print the scan capture configuration summary."""
-        print("\n" + "=" * 80)  # Top divider
-        print(" CAPTURE CONFIGURATION SUMMARY")  # Section title
-        print("=" * 80)  # Divider
-        print("  Capture Type: Scan Radio")  # Capture type
-        print(f"  AP MAC: {capture.ap_mac}")  # Target AP
-        print(f"  Band: {capture.band} GHz")  # Band
-        print(f"  Channel: {capture.channel}")  # Channel
-        print(f"  Bandwidth: {capture.bandwidth} MHz")  # Bandwidth
-        print(f"  Duration: {capture.duration} seconds")  # Duration
-        print(f"  Packets: {capture.num_packets}")  # Packet count
-        print(
-            f"  Loop Mode: {'ENABLED (continuous until Ctrl+C)' if capture.enable_loop else 'Disabled (single capture)'}"  # noqa: E501
-        )  # Loop mode
-        print("=" * 80)  # Bottom divider
-
-    @staticmethod
-    def _check_existing_captures(manager: Any, mistapi: Any, input_utils: Any, site_id: str, ap_mac: str) -> bool:
-        """Warn on an existing capture for the AP; return False if the user cancels."""
-        print(f"\n> Checking for existing captures on AP {ap_mac}...")  # Inform the user of the pre-check
-        try:  # Pre-check failures are non-fatal (warn and proceed)
-            response = mistapi.api.v1.sites.pcaps.listSitePacketCaptures(manager.mist_session, site_id)  # List pcaps
-            if response.status_code == 200:  # Only inspect successful responses
-                existing_captures = response.data or []  # Existing captures (or empty)
-                ap_has_capture = any(
-                    cap.get("ap_mac", "").replace(":", "").replace("-", "").lower()
-                    == ap_mac.replace(":", "").replace("-", "").lower()
-                    for cap in existing_captures
-                )  # True when this AP already has a capture (MAC-normalized comparison)
-                if ap_has_capture:  # Warn and confirm when a conflict exists
-                    print("\n! WARNING: This AP already has a capture in progress or recently completed")  # Warn
-                    print("  Mist only allows one capture per AP at a time")  # Explain the constraint
-                    print("  The new capture may fail with 'Recording already in progress'")  # Explain the risk
-                    proceed = input_utils.safe_input(
-                        "\nContinue anyway? (y/n, default n): ",
-                        default_value="n",
-                        context="capture_conflict_confirmation",
-                    ).lower()  # Read the override choice
-                    if proceed != "y":  # User declined to proceed
-                        print("\n* Capture cancelled by user")  # Inform the user
-                        logging.info("User cancelled capture due to existing capture on AP")  # Trace the cancel
-                        return False  # Signal cancel
-        except Exception as error:  # Pre-check API failure - warn and proceed
-            logging.warning("Failed to check for existing captures: %s", error)  # Trace the failure
-        return True  # Proceed with the capture
+    def _summary_rows(settings: _Settings) -> list[tuple[str, str]]:
+        """Return ordered (label, value) rows for the summary table; keeps _print_summary CC low."""
+        return [
+            ("Capture Type", "Scan Radio"),
+            ("AP MAC", settings.ap_mac),
+            ("Band", f"{settings.band} GHz"),
+            ("Channel", str(settings.channel)),
+            ("Bandwidth", f"{settings.bandwidth} MHz"),
+            ("Duration", f"{settings.duration} seconds"),
+            ("Packets", str(settings.num_packets)),
+            ("Loop Mode", _LOOP_LABEL_MAP[settings.enable_loop]),
+        ]  # WHY: Table-driven rows replace inline branches in the printer
 
     @classmethod
-    def execute(cls, manager: Any) -> None:
-        """Run scan radio packet capture workflow using manager dependencies."""
-        input_utils, prompt_utils, prompt_network_device_utils, device_utils, mistapi = _resolve_prompt_helpers()
-        logging.info("Starting site scan capture")  # Trace workflow start
+    def _print_summary(cls, settings: _Settings) -> None:
+        """Print the scan capture configuration summary using table-driven rendering."""
+        print("\n" + _DIVIDER_EQUAL)  # WHY: Top divider
+        print(_SUMMARY_TITLE)  # WHY: Section title
+        print(_DIVIDER_EQUAL)  # WHY: Divider
+        for label, value in cls._summary_rows(settings):  # WHY: Uniform label-value rendering
+            print(f"  {label}: {value}")  # WHY: One row per iteration (no branching)
+        print(_DIVIDER_EQUAL)  # WHY: Bottom divider
 
-        site_id = prompt_utils.select_site_with_logging()  # Prompt for the target site
-        logging.debug("Site selection returned: %s", site_id)  # Trace the selection
-        if not site_id:  # No site chosen
-            logging.warning("No site_id returned from selection - aborting capture")  # Trace the abort
-            return  # Abort the workflow
+    @staticmethod
+    def _canonical_mac(value: str) -> str:
+        """Normalize a MAC by stripping separators and lower-casing (for comparison only)."""
+        return value.replace(":", "").replace("-", "").lower()  # WHY: MAC comparison ignores separators/case
 
-        logging.debug("Proceeding with scan capture configuration for site: %s", site_id)  # Trace progress
-        print("\n" + "-" * 80)  # Top divider
-        print(" SCAN RADIO CAPTURE CONFIGURATION")  # Section title
-        print("-" * 80)  # Bottom divider
+    @classmethod
+    def _list_existing_captures(cls, helpers: _Helpers, manager: Any, site_id: str) -> list[dict[str, Any]] | None:
+        """Fetch the site's existing captures; None means the pre-check failed (warn and proceed)."""
+        try:  # WHY: Pre-check API failures are non-fatal - warn and proceed
+            response = helpers.mistapi.api.v1.sites.pcaps.listSitePacketCaptures(
+                manager.mist_session, site_id
+            )  # WHY: List pcaps at the target site
+        except Exception as error:  # WHY: Pre-check API failure - warn and proceed
+            logging.warning(_LOG_PRECHECK_FAIL, error)  # WHY: Trace the failure
+            return None  # WHY: Signal proceed-without-check
+        if response.status_code != 200:  # WHY: Only inspect successful responses
+            return []  # WHY: Non-200 -> treat as no known captures
+        return response.data or []  # WHY: Existing captures (or empty on 200 with no data)
 
-        ap_mac, mode = cls._select_ap(manager, input_utils, prompt_network_device_utils, device_utils, site_id)  # AP
-        if mode == "abort":  # AP selection failed (message already traced)
-            return  # Abort the workflow
-        if mode == "all":  # User chose all APs - launch multi-AP captures
-            manager._start_site_scan_capture_all_aps(site_id)  # Run captures across every AP
-            return  # All-AP path handled
-        ap_mac = cast(str, ap_mac)  # Single-AP path always yields a normalized MAC (narrows type for mypy)
+    @classmethod
+    def _has_conflict(cls, existing_captures: list[dict[str, Any]], ap_mac: str) -> bool:
+        """Return True when the AP already has an existing capture (MAC-normalized comparison)."""
+        ap_canonical = cls._canonical_mac(ap_mac)  # WHY: Normalize target MAC once
+        return any(
+            cls._canonical_mac(cap.get("ap_mac", "")) == ap_canonical for cap in existing_captures
+        )  # WHY: True when any existing capture matches this AP after normalization
 
-        band = cls._select_band(input_utils)  # Resolve the radio band
+    @staticmethod
+    def _print_conflict_warning() -> None:
+        """Emit the multi-line existing-capture warning banner."""
+        for line in _WARN_LINES:  # WHY: Table-driven emission keeps CC fixed
+            print(line)  # WHY: One warning line per iteration
 
-        channel = cls._prompt_channel(input_utils, band)  # Resolve a band-appropriate channel
-        if channel is None:  # Invalid channel (message already printed)
-            return  # Abort the workflow
+    @classmethod
+    def _confirm_conflict_override(cls, input_utils: Any) -> bool:
+        """Prompt whether to continue past an existing capture; False cancels."""
+        cls._print_conflict_warning()  # WHY: Show the warning banner
+        proceed = input_utils.safe_input(
+            _PROMPT_OVERRIDE, default_value="n", context="capture_conflict_confirmation"
+        ).lower()  # WHY: Read the override choice
+        if proceed != _YES:  # WHY: User declined to proceed
+            print(_CANCEL_MSG)  # WHY: Inform the user
+            logging.info(_LOG_USER_CANCEL)  # WHY: Trace the cancel
+            return False  # WHY: Signal cancel
+        return True  # WHY: User confirmed override
 
-        bandwidth = cls._select_bandwidth(input_utils, band)  # Resolve a band-appropriate bandwidth
-        if bandwidth is None:  # Invalid bandwidth (message already printed)
-            return  # Abort the workflow
+    @classmethod
+    def _check_existing_captures(cls, manager: Any, helpers: _Helpers, site_id: str, ap_mac: str) -> bool:
+        """Warn on an existing capture for the AP; return False if the user cancels."""
+        print(_PRE_CHECK_MSG.format(ap_mac=ap_mac))  # WHY: Inform the user of the pre-check
+        existing_captures = cls._list_existing_captures(helpers, manager, site_id)  # WHY: Fetch existing captures
+        if existing_captures is None:  # WHY: Pre-check API failure (already logged) - proceed
+            return True  # WHY: Non-fatal, continue with capture
+        if not cls._has_conflict(existing_captures, ap_mac):  # WHY: No conflict detected
+            return True  # WHY: Nothing to warn about, continue
+        return cls._confirm_conflict_override(helpers.input_utils)  # WHY: Warn and read override
 
-        duration = cls._prompt_duration(input_utils)  # Resolve the capture duration
-        if duration is None:  # Invalid duration (message already printed)
-            return  # Abort the workflow
-
-        num_packets = cls._prompt_num_packets(input_utils)  # Resolve the packet count
-        if num_packets is None:  # Invalid count (message already printed)
-            return  # Abort the workflow
-
-        capture_format = manager._get_capture_format_selection()  # Capture output format
-
-        enable_loop = cls._prompt_loop_mode(input_utils)  # Whether to run continuous loop mode
-
-        capture = SimpleNamespace(
+    @classmethod
+    def _gather_prompted_values(cls, manager: Any, helpers: _Helpers, ap_mac: str) -> _Settings | None:
+        """Run band/channel/bandwidth/bounded-ints/format/loop prompts; None aborts."""
+        band = cls._select_band(helpers.input_utils)  # WHY: Resolve the radio band
+        channel = cls._prompt_channel(helpers.input_utils, band)  # WHY: Resolve a band-appropriate channel
+        if channel is None:  # WHY: Invalid channel (message already printed)
+            return None  # WHY: Abort
+        bandwidth = cls._select_bandwidth(helpers.input_utils, band)  # WHY: Resolve a band-appropriate bandwidth
+        if bandwidth is None:  # WHY: Invalid bandwidth (message already printed)
+            return None  # WHY: Abort
+        ints = cls._collect_bounded_ints(helpers.input_utils)  # WHY: Duration + packet count
+        if ints is None:  # WHY: One of the bounded-int prompts failed
+            return None  # WHY: Abort
+        return _Settings(
             ap_mac=ap_mac,
             band=band,
             channel=channel,
             bandwidth=bandwidth,
-            duration=duration,
-            num_packets=num_packets,
-            capture_format=capture_format,
-            enable_loop=enable_loop,
-        )  # Bundle all gathered settings
+            duration=ints[0],
+            num_packets=ints[1],
+            capture_format=manager._get_capture_format_selection(),  # WHY: Capture output format
+            enable_loop=cls._prompt_loop_mode(helpers.input_utils),  # WHY: Continuous loop mode
+        )
 
-        payload = cls._build_payload(capture)  # Construct the API payload
-        cls._print_summary(capture)  # Show the configuration summary
+    @classmethod
+    def _select_ap_or_dispatch(cls, manager: Any, helpers: _Helpers, site_id: str) -> str | None:
+        """Select the AP and handle abort/all-APs modes; return normalized MAC or None to stop."""
+        ap_mac, mode = cls._select_ap(manager, helpers, site_id)  # WHY: Interactive AP selection
+        if mode == _MODE_ABORT:  # WHY: AP selection failed (message already traced)
+            return None  # WHY: Abort the workflow
+        if mode == _MODE_ALL:  # WHY: User chose all APs - launch multi-AP captures
+            manager._start_site_scan_capture_all_aps(site_id)  # WHY: Run captures across every AP
+            return None  # WHY: All-AP path handled by manager - stop here
+        return cast(str, ap_mac)  # WHY: Single-AP path always yields a normalized MAC (narrows type for mypy)
 
-        logging.debug("Waiting for user confirmation")  # Trace the confirmation wait
-        input_utils.safe_input(
-            "\nPress Enter to start capture (Ctrl+C to cancel): ", context="confirmation", allow_empty=True
-        )  # Final confirmation before starting
+    @staticmethod
+    def _dispatch(manager: Any, site_id: str, payload: dict[str, Any], enable_loop: bool) -> None:
+        """Dispatch to loop or single capture based on the resolved loop-mode flag."""
+        if enable_loop:  # WHY: Continuous loop mode
+            manager._execute_site_capture_loop(site_id, payload)  # WHY: Run captures in a loop
+            return  # WHY: Loop path complete
+        manager._execute_site_capture(site_id, payload)  # WHY: Run a single capture
 
-        if not cls._check_existing_captures(manager, mistapi, input_utils, site_id, ap_mac):  # Conflict pre-check
-            return  # User cancelled due to an existing capture
+    @classmethod
+    def _finalize_and_run(cls, manager: Any, helpers: _Helpers, site_id: str, settings: _Settings) -> None:
+        """Build payload, show summary, wait for confirmation, pre-check conflict, then dispatch."""
+        payload = cls._build_payload(settings)  # WHY: Construct the API payload
+        cls._print_summary(settings)  # WHY: Show the configuration summary
+        logging.debug(_LOG_CONFIRM_WAIT)  # WHY: Trace the confirmation wait
+        helpers.input_utils.safe_input(
+            _PROMPT_CONFIRM, context="confirmation", allow_empty=True
+        )  # WHY: Final confirmation before starting
+        if not cls._check_existing_captures(manager, helpers, site_id, settings.ap_mac):  # WHY: Conflict pre-check
+            return  # WHY: User cancelled due to an existing capture
+        logging.info(_LOG_EXECUTING)  # WHY: Trace the execution
+        cls._dispatch(manager, site_id, payload, settings.enable_loop)  # WHY: Loop vs single capture dispatch
 
-        logging.info("User confirmed - executing site capture")  # Trace the execution
-        if enable_loop:  # Continuous loop mode
-            manager._execute_site_capture_loop(site_id, payload)  # Run captures in a loop
-        else:  # Single capture
-            manager._execute_site_capture(site_id, payload)  # Run a single capture
+    @classmethod
+    def execute(cls, manager: Any) -> None:
+        """Run scan radio packet capture workflow using manager dependencies."""
+        helpers = _Helpers(*_resolve_prompt_helpers())  # WHY: Frozen helper bundle (one arg instead of five)
+        logging.info(_LOG_START)  # WHY: Trace workflow start
+        site_id = helpers.prompt_utils.select_site_with_logging()  # WHY: Prompt for the target site
+        logging.debug("Site selection returned: %s", site_id)  # WHY: Trace the selection
+        if not site_id:  # WHY: No site chosen
+            logging.warning(_LOG_SITE_ABORT)  # WHY: Trace the abort
+            return  # WHY: Abort the workflow
+        logging.debug(_LOG_PROGRESS, site_id)  # WHY: Trace progress
+        cls._print_intro()  # WHY: Show the configuration banner
+        ap_mac = cls._select_ap_or_dispatch(manager, helpers, site_id)  # WHY: Select AP or dispatch all-AP path
+        if ap_mac is None:  # WHY: Abort mode or all-APs path already handled
+            return  # WHY: Nothing more for single-AP execute to do
+        settings = cls._gather_prompted_values(manager, helpers, ap_mac)  # WHY: Collect remaining inputs
+        if settings is None:  # WHY: Any prompt aborted (message already printed)
+            return  # WHY: Abort the workflow
+        cls._finalize_and_run(manager, helpers, site_id, settings)  # WHY: Payload -> summary -> confirm -> dispatch


### PR DESCRIPTION
<analysis>
Baseline: `src/refactors/serial_cc/start_site_scan_capture.py` scored 88.0/B+ with 5 violations (0 crit, 1 high, 1 med, 3 low). Hotspots: `execute()` at 73 lines / CC 10 / 9 logical blocks and `_check_existing_captures()` at 28 lines / CC 7. The sibling refactor `start_site_client_capture_wireless.py` (PR #733, SHA 35e57aa) had already established the target pattern of frozen slotted dataclasses, module-level constants, and table-driven dispatch.

Applied the same shape here:
- `_Helpers` dataclass bundles the 5-tuple returned by `_resolve_prompt_helpers()` (input_utils, prompt_utils, prompt_network_device_utils, device_utils, mistapi) so nothing needs to be threaded positionally past the entry point.
- `_Settings` dataclass carries the gathered scan parameters (ap_mac, band, channel, bandwidth, duration, num_packets, capture_format, enable_loop) into `_finalize_and_run` and `_dispatch`.
- Constants extracted for every literal string, banner, prompt, log message, sentinel, and threshold (`_MIST_MODULE`, `_ALL_APS_SENTINEL`, `_MODE_ABORT/ALL/SINGLE`, `_MAX_PKT_LEN`, `_YES`, `_LOG_*`, `_PROMPT_*`, banner/divider constants, warning-line tuple, cancel message).
- Dispatch tables replace branch cascades: `_BAND_MAP`, `_BANDWIDTH_MAP`, `_LOOP_LABEL_MAP`, `_CHANNEL_PROMPTS`, `_BANDWIDTH_EXTRA_ROWS`, `_BW_ALLOWED_24`, `_BOUNDED_INT_SPECS` (with `_DURATION_SPEC`, `_PACKETS_SPEC`).
- `execute()` decomposed into a chain of static helpers: `_select_ap_or_dispatch`, `_gather_prompted_values`, `_finalize_and_run`, `_dispatch`. Each stays under 25 lines with CC <= 5.
- `_check_existing_captures()` split into `_canonical_mac`, `_list_existing_captures` (returns None on failure to signal proceed), `_has_conflict`, `_print_conflict_warning`, `_confirm_conflict_override`.
- Summary panel replaced with table-driven `_summary_rows` + `_print_summary`; bandwidth menu rendered from `_BANDWIDTH_EXTRA_ROWS`; bounded ints prompted through `_prompt_bounded_int`/`_collect_bounded_ints`.
- Preserved the public `SiteScanCaptureService.execute(manager)` signature and the 5-tuple shape of `_resolve_prompt_helpers()` so the existing unit tests in `tests/unit/serial_cc/test_start_site_scan_capture.py` bind unchanged.

Validation:
- black: reformatted, clean.
- ruff: All checks passed.
- `tests/unit/serial_cc/test_start_site_scan_capture.py`: 3/3 pass.
- `tests/unit/test_packet_capture.py` (callers): 256/256 pass.
- Final analyzer: **A+ / 100.0** with 0 violations (`data/_final_082.md`).

No new noqa/type-ignore/pragma/nosec suppressions introduced. No wrappers/delegators/aliases added. All same-line WHY anchors stay under 120 chars.
</analysis>

<summary>
Refactored `src/refactors/serial_cc/start_site_scan_capture.py` from B+/88.0 to A+/100.0 by mirroring the sibling scan-capture-wireless refactor: frozen slotted `_Helpers` and `_Settings` dataclasses, module-level constants for every string/threshold/sentinel, table-driven dispatch (`_BAND_MAP`, `_BANDWIDTH_MAP`, `_LOOP_LABEL_MAP`, `_CHANNEL_PROMPTS`, `_BANDWIDTH_EXTRA_ROWS`, `_BOUNDED_INT_SPECS`), and decomposition of `execute` (73 -> <=25 lines, CC 10 -> <=5) and `_check_existing_captures` (28 -> <=25 lines, CC 7 -> <=5) into small single-purpose helpers. Public `SiteScanCaptureService.execute(manager)` signature preserved; existing unit tests pass unchanged (3/3 target, 256/256 packet_capture callers).
</summary>