### PR TITLE
refactor: plotly_map_serializer compliance B+/88.0 -> A+/100.0

### DIFF
--- a/src/maps/_viewer_launch.py
+++ b/src/maps/_viewer_launch.py
@@ -31,7 +31,10 @@ from src.maps.launcher import MapViewerCallbacks, MapViewerState  # WHY: Callbac
 from src.maps.plotly_heatmap_renderer import PlotlyCoverageHeatmapRenderer  # WHY: RF heatmap renderer instance.
 from src.maps.plotly_map_callback_manager import PlotlyMapCallbackManager  # WHY: Layer/click callback delegate.
 from src.maps.plotly_map_figure_builder import PlotlyMapFigureBuilder  # WHY: Walls/wayfinding/zones figure builder.
-from src.maps.plotly_map_serializer import PlotlyMapDataSerializer  # WHY: Store payload serializer.
+from src.maps.plotly_map_serializer import (  # WHY: Store payload serializer + params bundle.
+    MapConfigParams,
+    PlotlyMapDataSerializer,
+)
 from src.maps.plotly_map_templates import DashTemplateManager  # WHY: HTML/CSS template provider for the Dash shell.
 
 try:  # WHY: mistapi is required for real deletes but tests may stub it.
@@ -1490,17 +1493,18 @@ def _map_config_store(dcc_mod: Any, ctx: dict[str, Any]) -> Any:  # WHY: Split l
     """Return the ``map-config-store`` Store carrying the current map identity payload."""
     serializer = ctx["helpers"]["serializer"]  # WHY: Local shortcut.
     data, scope = ctx["data"], ctx["scope"]  # WHY: Local shortcuts.
+    params = MapConfigParams(  # WHY: Frozen bundle keeps builder signature 1-arg.
+        site_id=scope.site_id,
+        site_name=scope.site_name,
+        map_id=scope.map_id,
+        map_name=data.map_data.get("name", "Unknown"),
+        ppm=ctx["ppm"],
+        map_width=data.map_data.get("width", 1000),
+        map_height=data.map_data.get("height", 1000),
+    )
     return dcc_mod.Store(  # WHY: Store holds the map-identity dict for JS callbacks.
         id="map-config-store",
-        data=serializer.build_map_config(  # WHY: Current-map identity.
-            site_id=scope.site_id,
-            site_name=scope.site_name,
-            map_id=scope.map_id,
-            map_name=data.map_data.get("name", "Unknown"),
-            ppm=ctx["ppm"],
-            map_width=data.map_data.get("width", 1000),
-            map_height=data.map_data.get("height", 1000),
-        ),
+        data=serializer.build_map_config(params),  # WHY: Current-map identity payload.
     )
 
 

--- a/src/maps/plotly_map_serializer.py
+++ b/src/maps/plotly_map_serializer.py
@@ -1,61 +1,106 @@
 """Serialization helpers for Plotly/Dash map viewer state stores."""
 
-from __future__ import annotations
+from __future__ import annotations  # WHY: PEP 563 postponed annotations for forward refs.
+
+from dataclasses import dataclass  # WHY: frozen slotted dataclass groups wide map-config params.
+
+_KEY_SITE_ID: str = "site_id"  # WHY: map-config payload key for scope site id.
+_KEY_SITE_NAME: str = "site_name"  # WHY: map-config payload key for scope site display name.
+_KEY_MAP_ID: str = "map_id"  # WHY: map-config payload key for current floor/map id.
+_KEY_MAP_NAME: str = "map_name"  # WHY: map-config payload key for current floor/map display name.
+_KEY_PPM: str = "ppm"  # WHY: map-config payload key for pixels-per-meter scaling factor.
+_KEY_MAP_WIDTH: str = "map_width"  # WHY: map-config payload key for rendered map width in pixels.
+_KEY_MAP_HEIGHT: str = "map_height"  # WHY: map-config payload key for rendered map height in pixels.
+
+_KEY_ID: str = "id"  # WHY: canonical primary-key attribute name in Mist API records.
+_KEY_NAME: str = "name"  # WHY: canonical display-name attribute name in Mist API records.
+_KEY_LABEL: str = "label"  # WHY: dcc.Dropdown option label field.
+_KEY_VALUE: str = "value"  # WHY: dcc.Dropdown option value field.
+
+_KEY_ZONE_ID: str = "zone_id"  # WHY: selected-zone-store payload key for zone id.
+_KEY_ZONE_NAME: str = "zone_name"  # WHY: selected-zone-store payload key for zone display name.
+
+_KEY_CLIENT_LAST_REFRESH: str = "client_last_refresh"  # WHY: refresh-times key for wireless client tick.
+_KEY_COVERAGE_LAST_REFRESH: str = "coverage_last_refresh"  # WHY: refresh-times key for coverage-heatmap tick.
+
+_KEY_TRIGGER: str = "trigger"  # WHY: cache-bust-store payload key incremented on clone/delete reload.
+
+_DEFAULT_TRIGGER: int = 0  # WHY: initial cache-bust value before any reload event.
+_DEFAULT_REFRESH_TIME: int = 0  # WHY: initial refresh-tick value before any interval fires.
+
+
+@dataclass(frozen=True, slots=True)
+class MapConfigParams:
+    """Immutable bundle of the seven identity fields for ``map-config-store``."""
+
+    site_id: str  # WHY: scope site id passed through to store payload.
+    site_name: str  # WHY: scope site display name for UI badges.
+    map_id: str  # WHY: current map/floor id used by JS overlays.
+    map_name: str  # WHY: current map/floor display name for header.
+    ppm: float  # WHY: pixels-per-meter scale used by coordinate math.
+    map_width: int  # WHY: rendered map width in pixels for viewport calc.
+    map_height: int  # WHY: rendered map height in pixels for viewport calc.
 
 
 class PlotlyMapDataSerializer:
     """Build normalized payloads for Dash dcc.Store and dropdown options."""
 
     @staticmethod
-    def build_map_config(
-        site_id: str,
-        site_name: str,
-        map_id: str,
-        map_name: str,
-        ppm: float,
-        map_width: int,
-        map_height: int,
-    ) -> dict:
-        """Create canonical map-config-store payload."""
+    def build_map_config(params: MapConfigParams) -> dict:  # WHY: 1-arg dataclass fix (STRUCT-PARAMS).
+        """Create canonical map-config-store payload from an immutable params bundle."""
         return {
-            "site_id": site_id,
-            "site_name": site_name,
-            "map_id": map_id,
-            "map_name": map_name,
-            "ppm": ppm,
-            "map_width": map_width,
-            "map_height": map_height,
+            _KEY_SITE_ID: params.site_id,  # WHY: propagate scope site id to store.
+            _KEY_SITE_NAME: params.site_name,  # WHY: propagate scope site display name.
+            _KEY_MAP_ID: params.map_id,  # WHY: propagate current map id.
+            _KEY_MAP_NAME: params.map_name,  # WHY: propagate current map display name.
+            _KEY_PPM: params.ppm,  # WHY: propagate pixels-per-meter scale.
+            _KEY_MAP_WIDTH: params.map_width,  # WHY: propagate rendered map width.
+            _KEY_MAP_HEIGHT: params.map_height,  # WHY: propagate rendered map height.
         }
 
     @staticmethod
     def build_named_items(items: list | None, default_name: str) -> list[dict]:
         """Build [{id,name}] list from API records with safe defaults."""
-        records = items or []
-        return [{"id": item.get("id"), "name": item.get("name", default_name)} for item in records]
+        records = items or []  # WHY: coerce None to empty list for safe iteration.
+        return [  # WHY: return normalized list of id+name dicts for downstream stores.
+            # WHY: default_name is fallback when API record omits the "name" key.
+            {_KEY_ID: item.get(_KEY_ID), _KEY_NAME: item.get(_KEY_NAME, default_name)}
+            for item in records
+        ]
 
     @staticmethod
     def build_dropdown_options(items: list | None, default_name: str) -> list[dict]:
         """Build [{label,value}] dropdown options from API records."""
-        records = items or []
-        return [{"label": item.get("name", default_name), "value": item.get("id")} for item in records]
+        records = items or []  # WHY: coerce None to empty list for safe iteration.
+        return [  # WHY: return dcc.Dropdown-compatible options list.
+            # WHY: map API "name" -> Dash "label" and "id" -> "value".
+            {_KEY_LABEL: item.get(_KEY_NAME, default_name), _KEY_VALUE: item.get(_KEY_ID)}
+            for item in records
+        ]
 
     @staticmethod
     def build_selected_zone_store(zone_id: str | None = None, zone_name: str | None = None) -> dict:
         """Create selected-zone-store payload."""
-        return {"zone_id": zone_id, "zone_name": zone_name}
+        return {_KEY_ZONE_ID: zone_id, _KEY_ZONE_NAME: zone_name}  # WHY: nullable zone selection payload.
 
     @staticmethod
-    def build_refresh_times_store(client_last_refresh: int = 0, coverage_last_refresh: int = 0) -> dict:
+    def build_refresh_times_store(
+        client_last_refresh: int = _DEFAULT_REFRESH_TIME,
+        coverage_last_refresh: int = _DEFAULT_REFRESH_TIME,
+    ) -> dict:
         """Create refresh-times-store payload."""
-        return {"client_last_refresh": client_last_refresh, "coverage_last_refresh": coverage_last_refresh}
+        return {  # WHY: dcc.Store payload tracking last-refresh ticks per interval.
+            _KEY_CLIENT_LAST_REFRESH: client_last_refresh,  # WHY: wireless client interval tick.
+            _KEY_COVERAGE_LAST_REFRESH: coverage_last_refresh,  # WHY: coverage heatmap interval tick.
+        }
 
     @staticmethod
-    def build_cache_bust_store(trigger: int = 0) -> dict:
+    def build_cache_bust_store(trigger: int = _DEFAULT_TRIGGER) -> dict:
         """Create cache-bust-store payload."""
-        return {"trigger": trigger}
+        return {_KEY_TRIGGER: trigger}  # WHY: single-field trigger payload.
 
     @staticmethod
     def increment_cache_bust(data: dict | None) -> dict:
         """Increment cache-bust trigger payload safely."""
-        current = data.get("trigger", 0) if data else 0
-        return {"trigger": current + 1}
+        current = data.get(_KEY_TRIGGER, _DEFAULT_TRIGGER) if data else _DEFAULT_TRIGGER  # WHY: None-safe read.
+        return {_KEY_TRIGGER: current + 1}  # WHY: bump trigger to invalidate cached view.

--- a/tests/maps/test_plotly_map_serializer.py
+++ b/tests/maps/test_plotly_map_serializer.py
@@ -1,11 +1,11 @@
 """Unit tests for PlotlyMapDataSerializer."""
 
-from src.maps.plotly_map_serializer import PlotlyMapDataSerializer
+from src.maps.plotly_map_serializer import MapConfigParams, PlotlyMapDataSerializer
 
 
 def test_build_map_config() -> None:
     """Map config payload contains expected keys and values."""
-    payload = PlotlyMapDataSerializer.build_map_config(
+    params = MapConfigParams(
         site_id="s1",
         site_name="Site A",
         map_id="m1",
@@ -14,6 +14,7 @@ def test_build_map_config() -> None:
         map_width=1000,
         map_height=600,
     )
+    payload = PlotlyMapDataSerializer.build_map_config(params)
 
     assert payload == {
         "site_id": "s1",


### PR DESCRIPTION
<analysis>
R85 baseline for `src/maps/plotly_map_serializer.py`: score 88.0, grade B+, 2 high-severity issues.

Rule totals:
- CONV-COMMENTS (1): 0% inline-comment coverage across 12 executable lines.
- STRUCT-PARAMS (1): `build_map_config` took 7 positional/keyword parameters (limit 5).

Metrics before: LoC 61, max CC 3, WHY 0.0%.
Callers: `src/maps/_viewer_launch.py::_map_config_store` (only external `build_map_config` site) and `tests/maps/test_plotly_map_serializer.py`.
This file is the T088 sibling `plotly_map_templates.py` pattern — module-level constants + frozen slotted dataclass fit cleanly.
</analysis>

<summary>
- Added `MapConfigParams` frozen slotted dataclass bundling the 7 identity fields (site_id, site_name, map_id, map_name, ppm, map_width, map_height) → collapses `build_map_config` signature from 7 params to 1 (STRUCT-PARAMS resolved).
- Introduced 16 module-level string/int constants (12 payload-key names, 2 dropdown-key names, 2 default-value ints) — magic strings/values centralized.
- Added same-line `# WHY:` anchors to every executable line and dataclass field (CONV-COMMENTS resolved, >=95% coverage).
- Updated single caller `_map_config_store` in `_viewer_launch.py` to construct `MapConfigParams` before invoking `build_map_config`.
- Updated `tests/maps/test_plotly_map_serializer.py::test_build_map_config` to build the dataclass; all other public API preserved (build_named_items / build_dropdown_options / build_selected_zone_store / build_refresh_times_store / build_cache_bust_store / increment_cache_bust unchanged in signature).

Verification:
- `py -m tools.compliance_analyzer src/maps/plotly_map_serializer.py -q` → A+ / 100.0
- `ruff check` clean; `black --check` clean.
- `py -m pytest tests/maps -q` → 164 passed.

Metrics after: max CC 3 (unchanged; already well below 8), WHY coverage 100%. Public API preserved except the single-arg dataclass signature on `build_map_config`, updated in-tree at the single caller.
</summary>