### PR TITLE
refactor: gateway/overrides/_deps compliance A-/91.0 -> A+/100.0

### DIFF
--- a/src/gateway/gateway_export_utils.py
+++ b/src/gateway/gateway_export_utils.py
@@ -8,7 +8,8 @@ import re  # WHY: regex match against WAN port-config column names.
 from typing import Any  # WHY: opaque types for injected utility modules.
 
 from src.gateway.gateway_stats_exporter import configure_gateway_stats_exporter_dependencies  # WHY: delegate wiring.
-from src.gateway.overrides import (  # WHY: import walker + override wiring entry point.
+from src.gateway.overrides import (  # WHY: import walker + override wiring entry point + deps bundle.
+    GatewayOverrideDependencies,
     WanOverrideWalker,
     configure_gateway_override_dependencies,
 )
@@ -78,16 +79,18 @@ def _wire_stats_exporter(deps: dict[str, Any]) -> None:  # WHY: forward stats-ex
 
 def _wire_override_subsystem(deps: dict[str, Any]) -> None:  # WHY: forward override-subsystem slots only.
     """Prime the WAN override analysis module-level slots from the shared dependency bundle."""
-    configure_gateway_override_dependencies(  # WHY: table-driven pass-through of shared deps.
-        apisession_dependency=deps["apisession_dependency"],
-        mistapi_dependency=deps["mistapi_dependency"],
-        cache_utils=deps["cache_utils"],
-        file_path_utils=deps["file_path_utils"],
-        data_exporter=deps["data_exporter"],
-        org_site_exporter=deps["org_site_exporter"],
-        mist_wan_target_ports=deps["mist_wan_target_ports"],
-        connection_pool_fn=deps["connection_pool_fn"],
-        gateway_export_utils_ref=GatewayExportUtils,
+    configure_gateway_override_dependencies(  # WHY: pass frozen bundle to shrink call signature.
+        GatewayOverrideDependencies(
+            apisession_dependency=deps["apisession_dependency"],
+            mistapi_dependency=deps["mistapi_dependency"],
+            cache_utils=deps["cache_utils"],
+            file_path_utils=deps["file_path_utils"],
+            data_exporter=deps["data_exporter"],
+            org_site_exporter=deps["org_site_exporter"],
+            mist_wan_target_ports=deps["mist_wan_target_ports"],
+            connection_pool_fn=deps["connection_pool_fn"],
+            gateway_export_utils_ref=GatewayExportUtils,
+        )
     )
 
 

--- a/src/gateway/overrides/__init__.py
+++ b/src/gateway/overrides/__init__.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations  # Defer annotation evaluation for forward refs
 
-from ._deps import configure_gateway_override_dependencies  # Runtime DI entrypoint
+from ._deps import (  # Runtime DI entrypoint + frozen dependency bundle
+    GatewayOverrideDependencies,
+    configure_gateway_override_dependencies,
+)
 from .device_data_fetcher import DeviceDataFetcher  # Fetches live port/stats per device
 from .override_classifier import OverrideClassifier  # Decides per-row which ports are overridden
 from .override_report_writer import OverrideReportWriter  # Persists final CSV + console summary
@@ -10,6 +13,7 @@ from .wan_override_walker import WanOverrideWalker  # Top-level orchestrator
 
 __all__ = [  # Explicit public surface for the overrides submodule
     "DeviceDataFetcher",
+    "GatewayOverrideDependencies",
     "OverrideClassifier",
     "OverrideReportWriter",
     "WanOverrideWalker",

--- a/src/gateway/overrides/_deps.py
+++ b/src/gateway/overrides/_deps.py
@@ -3,7 +3,10 @@
 from __future__ import annotations  # Defer annotation evaluation for forward refs
 
 import logging  # Standard library structured logging
-from typing import Any  # Generic typing for the module-level dependency holders
+from dataclasses import dataclass  # WHY: frozen slotted bundle shrinks wiring signature to one param.
+from typing import Any, Final  # Typing helpers for module-level dependency holders
+
+_LOG_CONFIGURED: Final[str] = "Gateway override dependencies configured"  # WHY: single-source log template.
 
 apisession: Any = None  # Mist API session; set by configure_gateway_override_dependencies
 mistapi: Any = None  # mistapi SDK module; set by configure_gateway_override_dependencies
@@ -16,36 +19,33 @@ execute_with_connection_pool_management: Any = None  # Pool-managed parallel run
 GatewayExportUtilsRef: Any = None  # Gateway export helpers ref (device_configs/templates funcs)
 
 
-def configure_gateway_override_dependencies(
-    *,
-    apisession_dependency: Any,
-    mistapi_dependency: Any,
-    cache_utils: Any,
-    file_path_utils: Any,
-    data_exporter: Any,
-    org_site_exporter: Any,
-    mist_wan_target_ports: list[str],
-    connection_pool_fn: Any,
-    gateway_export_utils_ref: Any,
-) -> None:
-    """Configure runtime dependencies for the override analysis collaborators."""
-    global apisession  # Module-level holder consumed by submodules via _deps.apisession
-    global mistapi  # Module-level holder consumed by submodules via _deps.mistapi
-    global CacheUtils  # Module-level holder consumed by submodules via _deps.CacheUtils
-    global FilePathUtils  # Module-level holder consumed by submodules via _deps.FilePathUtils
-    global DataExporter  # Module-level holder consumed by submodules via _deps.DataExporter
-    global OrgSiteExporter  # Module-level holder consumed by submodules via _deps.OrgSiteExporter
-    global MIST_WAN_TARGET_PORTS  # Module-level holder consumed via _deps.MIST_WAN_TARGET_PORTS
-    global execute_with_connection_pool_management  # Module-level holder for pool-managed runner
-    global GatewayExportUtilsRef  # Module-level holder for gateway export helpers reference
+@dataclass(frozen=True, slots=True)  # WHY: immutable bundle collapses 9 wiring args (STRUCT-PARAMS).
+class GatewayOverrideDependencies:
+    """Immutable bundle carrying WAN override analysis dependencies into configure()."""
 
-    apisession = apisession_dependency  # Real Mist session for downstream API calls
-    mistapi = mistapi_dependency  # Actual mistapi SDK module
-    CacheUtils = cache_utils  # CSV cache helper class
-    FilePathUtils = file_path_utils  # Output path helper class
-    DataExporter = data_exporter  # Multi-backend data exporter
-    OrgSiteExporter = org_site_exporter  # Site list exporter helper
-    MIST_WAN_TARGET_PORTS = mist_wan_target_ports  # Operator-configured target ports
-    execute_with_connection_pool_management = connection_pool_fn  # Pool-managed parallel runner
-    GatewayExportUtilsRef = gateway_export_utils_ref  # Gateway export helpers reference
-    logging.debug("Gateway override dependencies configured")  # Confirm wiring for operator logs
+    apisession_dependency: Any  # Live Mist API session used by downstream override modules
+    mistapi_dependency: Any  # mistapi SDK reference required for API calls
+    cache_utils: Any  # CSV cache helper class exposing check_and_generate_csv
+    file_path_utils: Any  # FilePathUtils class exposing get_csv_path
+    data_exporter: Any  # DataExporter class exposing write_with_format_selection
+    org_site_exporter: Any  # OrgSiteExporter class exposing sites_list_api
+    mist_wan_target_ports: list[str]  # Operator-configured WAN target ports list from .env
+    connection_pool_fn: Any  # execute_with_connection_pool_management callable
+    gateway_export_utils_ref: Any  # GatewayExportUtils reference (device_configs / templates)
+
+
+def configure_gateway_override_dependencies(deps: GatewayOverrideDependencies) -> None:
+    """Configure runtime dependencies for the override analysis collaborators."""
+    global apisession, mistapi, CacheUtils, FilePathUtils, DataExporter  # WHY: module-level DI slots.
+    global OrgSiteExporter, MIST_WAN_TARGET_PORTS  # WHY: module-level DI slots.
+    global execute_with_connection_pool_management, GatewayExportUtilsRef  # WHY: module-level DI slots.
+    apisession = deps.apisession_dependency  # Real Mist session for downstream API calls
+    mistapi = deps.mistapi_dependency  # Actual mistapi SDK module
+    CacheUtils = deps.cache_utils  # CSV cache helper class
+    FilePathUtils = deps.file_path_utils  # Output path helper class
+    DataExporter = deps.data_exporter  # Multi-backend data exporter
+    OrgSiteExporter = deps.org_site_exporter  # Site list exporter helper
+    MIST_WAN_TARGET_PORTS = deps.mist_wan_target_ports  # Operator-configured target ports
+    execute_with_connection_pool_management = deps.connection_pool_fn  # Pool-managed parallel runner
+    GatewayExportUtilsRef = deps.gateway_export_utils_ref  # Gateway export helpers reference
+    logging.debug(_LOG_CONFIGURED)  # Confirm wiring for operator logs

--- a/tests/unit/gateway/test_wan_override_walker.py
+++ b/tests/unit/gateway/test_wan_override_walker.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from src.gateway.overrides import (
+    GatewayOverrideDependencies,
     WanOverrideWalker,
     configure_gateway_override_dependencies,
 )
@@ -52,15 +53,17 @@ def test_walk_writes_empty_header_when_no_overrides(tmp_path: Path) -> None:
     )
 
     configure_gateway_override_dependencies(
-        apisession_dependency=object(),
-        mistapi_dependency=SimpleNamespace(),
-        cache_utils=SimpleNamespace(check_and_generate_csv=MagicMock()),
-        file_path_utils=SimpleNamespace(get_csv_path=resolver.get_csv_path),
-        data_exporter=SimpleNamespace(write_with_format_selection=MagicMock()),
-        org_site_exporter=SimpleNamespace(sites_list_api=MagicMock()),
-        mist_wan_target_ports=["ge-0/0/1"],
-        connection_pool_fn=MagicMock(return_value=([], [])),
-        gateway_export_utils_ref=SimpleNamespace(device_configs=MagicMock(), templates=MagicMock()),
+        GatewayOverrideDependencies(
+            apisession_dependency=object(),
+            mistapi_dependency=SimpleNamespace(),
+            cache_utils=SimpleNamespace(check_and_generate_csv=MagicMock()),
+            file_path_utils=SimpleNamespace(get_csv_path=resolver.get_csv_path),
+            data_exporter=SimpleNamespace(write_with_format_selection=MagicMock()),
+            org_site_exporter=SimpleNamespace(sites_list_api=MagicMock()),
+            mist_wan_target_ports=["ge-0/0/1"],
+            connection_pool_fn=MagicMock(return_value=([], [])),
+            gateway_export_utils_ref=SimpleNamespace(device_configs=MagicMock(), templates=MagicMock()),
+        )
     )
 
     WanOverrideWalker.walk(fast=False)  # Run the orchestrator end-to-end

--- a/tests/unit/test_gateway_override_analysis.py
+++ b/tests/unit/test_gateway_override_analysis.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from src.gateway.overrides import (
+    GatewayOverrideDependencies,
     WanOverrideWalker,
     configure_gateway_override_dependencies,
 )
@@ -16,15 +17,17 @@ def test_wan_override_walker_returns_when_ports_not_configured(tmp_path) -> None
     org_site_exporter = MagicMock()  # Stand-in for OrgSiteExporter dependency
     gateway_ref = MagicMock()  # Stand-in for GatewayExportUtilsRef dependency
     configure_gateway_override_dependencies(
-        apisession_dependency=MagicMock(),
-        mistapi_dependency=MagicMock(),
-        cache_utils=cache_utils,
-        file_path_utils=file_path_utils,
-        data_exporter=data_exporter,
-        org_site_exporter=org_site_exporter,
-        mist_wan_target_ports=[],
-        connection_pool_fn=MagicMock(),
-        gateway_export_utils_ref=gateway_ref,
+        GatewayOverrideDependencies(
+            apisession_dependency=MagicMock(),
+            mistapi_dependency=MagicMock(),
+            cache_utils=cache_utils,
+            file_path_utils=file_path_utils,
+            data_exporter=data_exporter,
+            org_site_exporter=org_site_exporter,
+            mist_wan_target_ports=[],
+            connection_pool_fn=MagicMock(),
+            gateway_export_utils_ref=gateway_ref,
+        )
     )
     WanOverrideWalker.walk(fast=False)  # Empty target ports should trigger early return
     assert not data_exporter.write_with_format_selection.called  # No writes when ports unconfigured


### PR DESCRIPTION
<analysis>
Baseline: `src/gateway/overrides/_deps.py` scored A-/91.0 with 2 issues:
- STRUCT-PARAMS (high) at `configure_gateway_override_dependencies` (9 params, limit 5)
- STRUCT-LENGTH (medium) same symbol (33 lines, limit 25)

The module is a dependency-injection slot container: 10 module-level `Any` holders and a wiring function that assigns them from kwargs. Public API is imported by `gateway_export_utils.py` and two unit tests. Max complexity was 1 (CC 1), so the fix is purely structural: collapse the 9-kwarg call signature into a frozen slotted dataclass and shrink the function body accordingly.
</analysis>

<summary>
- Added `GatewayOverrideDependencies` (`@dataclass(frozen=True, slots=True)`) with 9 typed fields — one immutable bundle replaces the kwargs signature (STRUCT-PARAMS).
- Rewrote `configure_gateway_override_dependencies(deps)` to accept the bundle. Function body drops from 33 lines to 15 (STRUCT-LENGTH clear).
- Extracted `_LOG_CONFIGURED: Final[str]` module constant for the debug log template.
- Updated `overrides/__init__.py` to re-export `GatewayOverrideDependencies`.
- Updated three callers (`gateway_export_utils._wire_override_subsystem`, `tests/unit/test_gateway_override_analysis.py`, `tests/unit/gateway/test_wan_override_walker.py`) to build the dataclass at the call site.
- WHY-comment coverage retained on every executable line.

Local checks:
- `py -m tools.compliance_analyzer` → A+/100.0
- `ruff check` clean, `black --check` clean
- `py -m mypy --strict src/gateway/overrides/_deps.py` clean
- `pytest tests/unit/gateway tests/unit/test_gateway_override_analysis.py` → 30 passed