### PR TITLE
refactor(extract): TUILauncher to src/refactors/

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -147,6 +147,7 @@ from src.gateway.gateway_export_utils import (
 )  # Import gateway export utility configuration
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
 from src.refactors.sqlite_database_writer import SQLiteDatabaseWriter  # Extracted SQLite writer (SC-003)
+from src.refactors.tui_launcher import TUILauncher  # Extracted TUI launcher (SC-004)
 from src.reports.e911_bssid import E911BSSIDReportGenerator  # Module-level for tests
 from src.site.address_audit import AddressAuditEngine  # Menu 195: read-only CSV site-address audit
 from src.ssh.ssh_runner import EnhancedSSHRunner  # Import SSH command execution and result parsing
@@ -22235,126 +22236,6 @@ class MapsManagerLauncher:
         """Log and display fatal error message."""
         logging.error("Error running Maps Manager: %s", error, exc_info=True)
         print(f"\nERROR: {error}")
-
-
-class TUILauncher:
-    """
-    Launch Terminal User Interface mode from interactive menu.
-
-    Replicates the --tui CLI flag behavior but returns to menu instead of exiting.
-    Provides an interactive, keyboard-driven API browser.
-
-    SECURITY: Read-only browser mode with safe API exploration
-
-    Usage:
-        TUILauncher().launch()
-    """
-
-    def __init__(self):
-        """Initialize TUI launcher with console handler tracking."""
-        self.console_handlers: list = []  # type: ignore[type-arg]
-        self.debug_mode: bool = False
-
-    def launch(self) -> None:
-        """Main entry point: launch TUI mode from menu."""
-        logging.info("TUI_MODE: Starting Terminal User Interface mode from menu")
-        self._print_welcome()
-
-        if not self._ensure_api_session():
-            return
-
-        self._suppress_console_logging()
-
-        try:
-            self._run_tui()
-        except KeyboardInterrupt:
-            self._handle_keyboard_interrupt()
-        except Exception as error:
-            self._handle_fatal_error(error)
-        finally:
-            self._restore_console_logging()
-
-        self._print_exit_message()
-
-    def _print_welcome(self) -> None:
-        """Print TUI activation messages."""
-        print("\n>> Terminal User Interface mode activated")
-        print(">> Use arrow keys to navigate, Enter to select, Q to quit")
-
-    def _ensure_api_session(self) -> bool:
-        """Initialize Mist API session if needed."""
-        global apisession
-        if apisession:
-            return True
-
-        print(">> Initializing Mist API session...")
-        if not initialize_mist_session():  # type: ignore[no-untyped-call]
-            print("[ERROR] Failed to initialize Mist API session")
-            logging.error("TUI_MODE: Could not initialize API session")
-            return False
-
-        print(">> API session initialized successfully")
-        return True
-
-    def _suppress_console_logging(self) -> None:
-        """Remove console handlers to prevent interference with Rich TUI."""
-        root_logger = logging.getLogger()
-        self.console_handlers = [
-            h
-            for h in root_logger.handlers
-            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
-        ]
-        for handler in self.console_handlers:
-            root_logger.removeHandler(handler)
-            logging.debug("TUI_MODE: Removed console handler to prevent interference with Rich TUI")
-
-    def _get_debug_mode(self) -> bool:
-        """Get debug mode from global args if available."""
-        args_obj = globals().get("args", type("obj", (), {"debug": False})())
-        return getattr(args_obj, "debug", False)
-
-    def _run_tui(self) -> None:
-        """Create and run the TUI instance."""
-        global apisession
-        self.debug_mode = self._get_debug_mode()
-
-        from src.ui.tui import MistHelperTUI  # PLC0415: lazy import
-
-        tui = MistHelperTUI(debug_mode=self.debug_mode)  # type: ignore[no-untyped-call]
-        tui.apisession = apisession
-
-        if self.debug_mode:
-            logging.debug("TUI_MODE: Debug mode is ACTIVE - enhanced logging enabled")
-
-        tui.run()  # type: ignore[no-untyped-call]
-
-    def _handle_keyboard_interrupt(self) -> None:
-        """Handle user Ctrl+C interruption."""
-        logging.info("TUI_MODE: User interrupted with Ctrl+C")
-        print("\n[EXIT] TUI mode stopped by user")
-
-    def _handle_fatal_error(self, error: Exception) -> None:
-        """Handle fatal TUI errors."""
-        logging.error("TUI_MODE: Fatal error - %s", error, exc_info=True)
-        print(f"\n[ERROR] TUI mode crashed: {error}")
-
-    def _restore_console_logging(self) -> None:
-        """Restore console handlers after TUI mode exits."""
-        root_logger = logging.getLogger()
-        for handler in self.console_handlers:
-            root_logger.addHandler(handler)
-        logging.debug("TUI_MODE: Restored console handler after TUI exit")
-
-    def _print_exit_message(self) -> None:
-        """Print exit messages and debug timestamp if enabled."""
-        self.debug_mode = self._get_debug_mode()
-
-        if self.debug_mode:
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-            logging.debug("TUI_DEBUG: [%s] TUI_MODE function completed - returning to caller", timestamp)
-
-        logging.info("TUI_MODE: TUI mode completed successfully")
-        print("\n>> Returned from TUI mode to main menu")
 
 
 # ============================================================================

--- a/data/full_repo_compliance_current.md
+++ b/data/full_repo_compliance_current.md
@@ -1,8 +1,8 @@
 # Coding Guideline Compliance Report
 
-- **Generated**: 2026-07-06 04:10:19 UTC
+- **Generated**: 2026-07-06 04:30:52 UTC
 - **Tool**: compliance-analyzer (tools/compliance_analyzer)
-- **Files analyzed**: 251
+- **Files analyzed**: 252
 
 Files are graded against the project guidelines: the 5-Item Rule, no
 wrappers/delegators/aliases/shims, complexity limits, inline comments,
@@ -175,6 +175,7 @@ Plan at the end to drive fixes.
 | src\refactors\serial_cc\switch_vc_stats.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\serial_cc\test_results_by_site.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\sqlite_database_writer.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
+| src\refactors\tui_launcher.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\reports\__init__.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\reports\e911_bssid.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\site\__init__.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
@@ -1242,6 +1243,12 @@ Plan at the end to drive fixes.
       "violations": 0
     },
     {
+      "path": "src\\refactors\\tui_launcher.py",
+      "score": 100.0,
+      "grade": "A+",
+      "violations": 0
+    },
+    {
       "path": "src\\reports\\__init__.py",
       "score": 100.0,
       "grade": "A+",
@@ -1806,13 +1813,13 @@ Plan at the end to drive fixes.
 
 | Metric | Value |
 | - | - |
-| Lines of code | 24189 |
-| Executable code lines | 11179 |
-| Functions | 1377 |
-| Classes | 94 |
+| Lines of code | 24070 |
+| Executable code lines | 11113 |
+| Functions | 1366 |
+| Classes | 93 |
 | Average complexity | 2.6 |
 | Max complexity | 6 |
-| Inline comment coverage | 80.1% |
+| Inline comment coverage | 80.5% |
 
 ### Complexity Hotspots
 
@@ -1830,14 +1837,14 @@ Plan at the end to drive fixes.
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 16336 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16337 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 
 #### Structure
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 16382 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 16660 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16383 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16661 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
 
 ## File: src\__init__.py
 
@@ -6037,7 +6044,7 @@ No violations found. This file complies with the guidelines.
 
 | Metric | Value |
 | - | - |
-| Lines of code | 447 |
+| Lines of code | 446 |
 | Executable code lines | 229 |
 | Functions | 32 |
 | Classes | 1 |
@@ -6054,6 +6061,35 @@ No violations found. This file complies with the guidelines.
 | _determine_fields_and_strategy | 4 |
 | _create_schema_indexes | 4 |
 | _validate_data | 3 |
+
+No violations found. This file complies with the guidelines.
+
+## File: src\refactors\tui_launcher.py
+
+- **Score**: 100.0 / 100
+- **Grade**: A+
+
+### Metrics
+
+| Metric | Value |
+| - | - |
+| Lines of code | 165 |
+| Executable code lines | 92 |
+| Functions | 13 |
+| Classes | 1 |
+| Average complexity | 1.9 |
+| Max complexity | 5 |
+| Inline comment coverage | 84.8% |
+
+### Complexity Hotspots
+
+| Function | Cyclomatic Complexity |
+| - | - |
+| _suppress_console_logging | 5 |
+| launch | 4 |
+| _ensure_api_session | 3 |
+| _run_tui | 2 |
+| _restore_console_logging | 2 |
 
 No violations found. This file complies with the guidelines.
 
@@ -8649,12 +8685,12 @@ No violations found. This file complies with the guidelines.
 
 ### Phase: Medium (13 task(s))
 
-- [ ] **CMP-012** `MistHelper.py:16382` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-012** `MistHelper.py:16383` - STRUCT-LENGTH (Structure)
   - Symbol: `_make_ws_callbacks`
   - Problem: Function spans 28 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
   - Done when: analyzer reports no STRUCT-LENGTH for `_make_ws_callbacks` in `MistHelper.py`.
-- [ ] **CMP-013** `MistHelper.py:16660` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-013** `MistHelper.py:16661` - STRUCT-LENGTH (Structure)
   - Symbol: `_build_impl_args`
   - Problem: Function spans 26 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
@@ -8717,7 +8753,7 @@ No violations found. This file complies with the guidelines.
 
 ### Phase: Low (14 task(s))
 
-- [ ] **CMP-025** `MistHelper.py:16336` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-025** `MistHelper.py:16337` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `execute`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.

--- a/src/refactors/tui_launcher.py
+++ b/src/refactors/tui_launcher.py
@@ -1,0 +1,165 @@
+"""TUILauncher extracted from MistHelper.
+
+Launches the Rich-based Terminal User Interface (TUI) for interactive Mist API
+exploration from the numbered CLI menu. This module owns the console-handler
+suppression/restore ceremony required so the TUI can take exclusive control of
+stdout while the background logging channel keeps writing to file.
+
+Runtime dependencies (``apisession`` global, ``initialize_mist_session``, and
+the runtime ``args`` namespace) are still owned by MistHelper.py. They are
+resolved lazily via ``importlib.import_module`` to keep the extracted module
+import-graph flat and to honour monkeypatched attributes in tests.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing on 3.10+
+
+import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
+import logging  # Structured action logging required by coding standards
+from datetime import datetime  # Timestamp string for debug-only completion breadcrumb
+from types import SimpleNamespace  # Bundle runtime dependencies without coupling to a dataclass
+
+
+def _resolve_runtime_dependencies() -> SimpleNamespace:
+    """Resolve MistHelper-owned runtime dependencies without static cross-module imports."""
+    logging.info("Resolving TUILauncher runtime dependencies from MistHelper")  # Log before import
+    misthelper_module = importlib.import_module("MistHelper")  # Late import avoids circular dependency
+    logging.debug("TUILauncher runtime dependencies resolved successfully")  # Log after resolution
+    return SimpleNamespace(
+        misthelper_module=misthelper_module,  # Retained so apisession/args lookups honour monkeypatch
+    )
+
+
+class TUILauncher:  # Launch TUI mode from interactive menu.
+    """Launch Terminal User Interface mode from interactive menu.
+
+    Replicates the --tui CLI flag behavior but returns to menu instead of exiting.
+    Provides an interactive, keyboard-driven API browser.
+
+    SECURITY: Read-only browser mode with safe API exploration
+
+    Usage:
+        TUILauncher().launch()
+    """
+
+    def __init__(self) -> None:
+        """Initialize TUI launcher with console handler tracking."""
+        logging.info("TUILauncher init: starting new launcher instance")  # Log construction start
+        self.console_handlers: list = []  # type: ignore[type-arg]  # Track suppressed handlers to restore later
+        self.debug_mode: bool = False  # Populated from MistHelper args namespace at launch time
+        self._deps: SimpleNamespace = _resolve_runtime_dependencies()  # Late-bound MistHelper handles
+        logging.debug("TUILauncher init complete")  # Log after construction
+
+    def _apisession(self) -> object | None:
+        """Return the current MistHelper apisession so monkeypatched values are honoured."""
+        return getattr(self._deps.misthelper_module, "apisession", None)  # Resolve at call-time, not import-time
+
+    def launch(self) -> None:
+        """Main entry point: launch TUI mode from menu."""
+        logging.info("TUI_MODE: Starting Terminal User Interface mode from menu")  # Log launch entry
+        self._print_welcome()  # Announce TUI activation on stdout
+
+        if not self._ensure_api_session():  # Bail out early if session initialization fails
+            logging.debug("TUI_MODE: launch aborted because API session could not be initialized")  # Log abort
+            return  # Nothing further to run
+
+        self._suppress_console_logging()  # Silence console handlers so Rich TUI owns stdout
+
+        try:  # Guarded run to guarantee handler restoration in finally
+            self._run_tui()  # Enter the Rich event loop
+        except KeyboardInterrupt:  # User hit Ctrl+C inside the TUI
+            self._handle_keyboard_interrupt()  # Log and print exit banner
+        except Exception as error:  # noqa: BLE001 - TUI errors must never crash the numbered menu
+            self._handle_fatal_error(error)  # Log traceback and surface user-visible error
+        finally:  # Always run regardless of exception path
+            self._restore_console_logging()  # Re-attach console handlers before returning to menu
+
+        self._print_exit_message()  # Show "returned from TUI" banner on stdout
+        logging.debug("TUI_MODE: launch() finished cleanly")  # Log after launch completes
+
+    def _print_welcome(self) -> None:
+        """Print TUI activation messages."""
+        print("\n>> Terminal User Interface mode activated")  # User-visible activation banner
+        print(">> Use arrow keys to navigate, Enter to select, Q to quit")  # Navigation hint for first-time users
+
+    def _ensure_api_session(self) -> bool:
+        """Initialize Mist API session if needed."""
+        logging.info("TUI_MODE: ensuring apisession is initialized")  # Log before session check
+        if self._apisession():  # Session already exists - no reinitialization required
+            logging.debug("TUI_MODE: apisession already initialized; reusing existing session")  # Log reuse
+            return True  # Signal caller that session is ready
+
+        print(">> Initializing Mist API session...")  # User-visible progress line before network work
+        misthelper_module = self._deps.misthelper_module  # Cache the module handle for both calls below
+        if not misthelper_module.initialize_mist_session():  # Delegate to MistHelper's session bootstrap
+            print("[ERROR] Failed to initialize Mist API session")  # Surface user-visible failure line
+            logging.error("TUI_MODE: Could not initialize API session")  # Log the failure with error level
+            return False  # Signal caller that session initialization failed
+
+        # initialize_mist_session mutates MistHelper.apisession; no additional sync needed since we read via getattr
+        print(">> API session initialized successfully")  # Confirmation banner on success path
+        logging.debug("TUI_MODE: apisession initialized successfully")  # Log after successful init
+        return True  # Signal caller that session is ready
+
+    def _suppress_console_logging(self) -> None:
+        """Remove console handlers to prevent interference with Rich TUI."""
+        logging.info("TUI_MODE: suppressing console handlers before Rich TUI takes stdout")  # Log before mutation
+        root_logger = logging.getLogger()  # Root logger owns the StreamHandler set
+        self.console_handlers = [
+            h  # Retain each handler so it can be re-attached in _restore_console_logging
+            for h in root_logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]  # Filter to StreamHandler-only (exclude FileHandler which is stdio-safe under Rich)
+        for handler in self.console_handlers:  # Detach every captured handler
+            root_logger.removeHandler(handler)  # Remove from root so it stops writing to stdout
+            logging.debug("TUI_MODE: Removed console handler to prevent interference with Rich TUI")  # Log removal
+
+    def _get_debug_mode(self) -> bool:
+        """Get debug mode from global args if available."""
+        # Read args off MistHelper module rather than globals() to keep the extracted class self-contained
+        args_obj = getattr(self._deps.misthelper_module, "args", type("obj", (), {"debug": False})())
+        return getattr(args_obj, "debug", False)  # Fall back to False when args namespace lacks 'debug' attribute
+
+    def _run_tui(self) -> None:
+        """Create and run the TUI instance."""
+        logging.info("TUI_MODE: entering Rich TUI run loop")  # Log entry to TUI loop
+        self.debug_mode = self._get_debug_mode()  # Latch debug flag once so exit path can reuse it
+
+        from src.ui.tui import MistHelperTUI  # PLC0415: lazy import to keep startup path light
+
+        tui = MistHelperTUI(debug_mode=self.debug_mode)  # type: ignore[no-untyped-call]
+        tui.apisession = self._apisession()  # Hand the already-initialized apisession to the TUI
+
+        if self.debug_mode:  # Only log the debug-enabled banner when caller opted in
+            logging.debug("TUI_MODE: Debug mode is ACTIVE - enhanced logging enabled")  # Debug-active breadcrumb
+
+        tui.run()  # type: ignore[no-untyped-call]
+        logging.debug("TUI_MODE: Rich TUI run loop returned")  # Log after TUI loop finishes
+
+    def _handle_keyboard_interrupt(self) -> None:
+        """Handle user Ctrl+C interruption."""
+        logging.info("TUI_MODE: User interrupted with Ctrl+C")  # Log the intentional keyboard abort
+        print("\n[EXIT] TUI mode stopped by user")  # User-visible exit banner on Ctrl+C
+
+    def _handle_fatal_error(self, error: Exception) -> None:
+        """Handle fatal TUI errors."""
+        logging.error("TUI_MODE: Fatal error - %s", error, exc_info=True)  # Log with traceback for postmortem
+        print(f"\n[ERROR] TUI mode crashed: {error}")  # Surface error to user without stack details
+
+    def _restore_console_logging(self) -> None:
+        """Restore console handlers after TUI mode exits."""
+        logging.info("TUI_MODE: restoring console handlers after Rich TUI exit")  # Log before re-attach
+        root_logger = logging.getLogger()  # Same root logger we detached from earlier
+        for handler in self.console_handlers:  # Re-attach every previously-suppressed handler
+            root_logger.addHandler(handler)  # Restore the handler so console logging resumes
+        logging.debug("TUI_MODE: Restored console handler after TUI exit")  # Log after restoration completes
+
+    def _print_exit_message(self) -> None:
+        """Print exit messages and debug timestamp if enabled."""
+        self.debug_mode = self._get_debug_mode()  # Re-read debug flag in case args changed during TUI session
+
+        if self.debug_mode:  # Only emit the timestamped completion trace when debug mode is on
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]  # Local wall-clock for eyeball parity
+            logging.debug("TUI_DEBUG: [%s] TUI_MODE function completed - returning to caller", timestamp)  # Trace
+
+        logging.info("TUI_MODE: TUI mode completed successfully")  # Success-path summary log
+        print("\n>> Returned from TUI mode to main menu")  # User-visible return banner

--- a/src/refactors/tui_launcher.py
+++ b/src/refactors/tui_launcher.py
@@ -126,13 +126,13 @@ class TUILauncher:  # Launch TUI mode from interactive menu.
 
         from src.ui.tui import MistHelperTUI  # PLC0415: lazy import to keep startup path light
 
-        tui = MistHelperTUI(debug_mode=self.debug_mode)  # type: ignore[no-untyped-call]
+        tui = MistHelperTUI(debug_mode=self.debug_mode)  # Rich-based TUI, typed in src.ui.tui
         tui.apisession = self._apisession()  # Hand the already-initialized apisession to the TUI
 
         if self.debug_mode:  # Only log the debug-enabled banner when caller opted in
             logging.debug("TUI_MODE: Debug mode is ACTIVE - enhanced logging enabled")  # Debug-active breadcrumb
 
-        tui.run()  # type: ignore[no-untyped-call]
+        tui.run()  # Enter the Rich event loop (blocks until user quits)
         logging.debug("TUI_MODE: Rich TUI run loop returned")  # Log after TUI loop finishes
 
     def _handle_keyboard_interrupt(self) -> None:


### PR DESCRIPTION
## Summary

Extracts `TUILauncher` (Terminal User Interface launcher used by the numbered menu) from MistHelper.py into a dedicated module under `src/refactors/`. Implements PR-04 of the 1010 refactor extraction plan (T038-T048).

## Approach

- **New module**: `src/refactors/tui_launcher.py` (170 LoC, **100.0/A+** compliance)
- **Late-import DI pattern**: `importlib.import_module("MistHelper")` + `SimpleNamespace` to avoid circular imports and honour monkeypatched `apisession`/`args` at call-time.
- **No wrapper shim**: `MistHelper.TUILauncher` continues to resolve via the top-level import re-export (verified).
- MistHelper.py: **-120 LoC net** (class body removed, single import line added).
- Repo compliance baseline: **99.5/A+** preserved.

## Verification

- ruff/black/pydocstyle: clean
- `python -c "from MistHelper import TUILauncher"`: resolves
- No TUI-specific unit tests exist in the repo (pytest -k tui collected 0)
- No class-hierarchy diagram edits required (TUILauncher not referenced in diagrams)

## Test plan

- [x] Local gates pass (ruff, black, pydocstyle, py_compile)
- [x] `MistHelper.TUILauncher` still resolves after extraction
- [x] Extracted module scores 100.0/A+ standalone
- [x] Repo aggregate compliance preserved at 99.5/A+
- [ ] CI: all 15 functional jobs green