### PR TITLE
refactor(extract): DataDirectoryChecker to src/refactors/

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -146,6 +146,7 @@ from src.gateway.gateway_export_utils import (
     configure_gateway_export_utils_dependencies,
 )  # Import gateway export utility configuration
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
+from src.refactors.data_directory_checker import DataDirectoryChecker  # Early data-dir writable check (SC-005)
 from src.refactors.sqlite_database_writer import SQLiteDatabaseWriter  # Extracted SQLite writer (SC-003)
 from src.refactors.tui_launcher import TUILauncher  # Extracted TUI launcher (SC-004)
 from src.reports.e911_bssid import E911BSSIDReportGenerator  # Module-level for tests
@@ -193,106 +194,6 @@ _early_log_path = os.path.join(
 # DATA DIRECTORY PERMISSION CHECKER
 # ============================================================================
 # Critical for container deployments - runs as non-root 'misthelper' user
-
-
-class DataDirectoryChecker:
-    """
-    Check data directory write permissions and provide actionable guidance.
-
-    This class runs very early during module initialization (before logging),
-    so it uses print() for output rather than logging.
-
-    Usage:
-        DataDirectoryChecker(_early_log_dir).check()
-    """
-
-    def __init__(self, data_dir: str):  # Initialize checker with target data directory path
-        """Initialize with the data directory path to check."""
-        self.data_dir = data_dir  # Store the data directory path for later validation
-        self.test_file = os.path.join(
-            data_dir, ".write_test"
-        )  # Define test file path (.write_test) for permission validation
-
-    def check(self) -> bool:  # Check if data directory is writable and handle errors
-        """Check if data directory is writable.
-
-        Returns:
-            True if writable, exits program if not writable due to permissions.
-        """
-        try:  # Attempt to validate write permission
-            return self._test_write_permission()  # Call permission test helper method
-        except PermissionError:  # Catch permission errors and display actionable guidance
-            self._handle_permission_error()  # Call error handler to print guidance and exit
-            return False  # Never reached - _handle_permission_error exits
-        except Exception:  # For non-permission errors, proceed and let them fail naturally later
-            return True  # Non-permission error, let it proceed and fail naturally
-
-    def _test_write_permission(self) -> bool:  # Validate data directory write access via test file
-        """Create and remove a test file to verify write access."""
-        with open(
-            self.test_file, "w"
-        ) as file_handle:  # Open test file for writing (will fail if directory not writable)
-            file_handle.write("test")  # Write marker content to test file
-        os.remove(self.test_file)  # Delete test file to clean up
-        return True  # Return success if both write and delete succeeded
-
-    def _handle_permission_error(self) -> None:  # Display context-specific guidance and exit
-        """Print error message with context-specific guidance and exit."""
-        in_container = self._is_running_in_container()  # Detect if running in container to show appropriate fix
-
-        self._print_error_header()  # Print error banner with path information
-
-        if in_container:  # If running in container, show container-specific fix (chmod on host)
-            self._print_container_guidance()  # Print container deployment remediation steps
-        else:  # If running locally, show local fix (chmod/chown)
-            self._print_local_guidance()  # Print local environment remediation steps
-
-        self._print_error_footer()  # Print closing separator
-        sys.exit(1)  # Exit program with error code to prevent further execution
-
-    def _is_running_in_container(self) -> bool:  # Detect container environment
-        """Detect if running inside a container environment."""
-        return os.path.exists("/.dockerenv") or os.path.exists(
-            "/run/.containerenv"
-        )  # Check for standard container marker files
-
-    def _print_error_header(self) -> None:  # Display error banner with path
-        """Print the error header with path information."""
-        print("\n" + "=" * 70)  # Print separator to visually isolate error message
-        print("ERROR: Data directory is not writable!")  # Print main error message
-        print("=" * 70)  # Print closing separator
-        print(f"\nPath: {os.path.abspath(self.data_dir)}")  # Print absolute path to the inaccessible directory
-        print("\nMistHelper cannot write logs or data to the data/ directory.")  # Explain impact of the error
-
-    def _print_container_guidance(self) -> None:  # Display container-specific remediation
-        """Print guidance specific to container deployments."""
-        print("\n[CONTAINER DETECTED]")  # Indicate container environment detected
-        print(
-            "The container runs as non-root user 'misthelper' for security."
-        )  # Explain why permissions are restricted
-        print("The mounted data/ directory must have write permissions.")  # State the requirement
-        print("\nTo fix this, run the following on your HOST machine:")  # Provide context for the fix
-        print("\n    chmod -R 777 data/")  # Show command to grant write permissions
-        print("\nThen restart the container:")  # Explain next step
-        print("    podman stop misthelper && podman rm misthelper")  # Show stop and remove command
-        print(
-            "    podman run -d --name misthelper -p 2200:2200 -p 8050:8050 \\"
-        )  # Show container restart with port mapping
-        print(
-            '        -v "${PWD}/data:/app/data:rw" -v "${PWD}/.env:/app/.env:ro" \\'
-        )  # Show volume mount with correct permissions
-        print("        ghcr.io/jmorrison-juniper/misthelper:latest")  # Show container image URI
-
-    def _print_local_guidance(self) -> None:  # Display local environment remediation
-        """Print guidance for local (non-container) environments."""
-        print("\nTo fix this, ensure the data/ directory is writable:")  # Provide context for local fix
-        print("\n    chmod -R 755 data/")  # Show command to set directory permissions
-        print("    # Or if you own the directory:")  # Provide alternative if ownership is an issue
-        print("    chown -R $(whoami) data/")  # Show command to change ownership to current user
-
-    def _print_error_footer(self) -> None:  # Display error footer separator
-        """Print the closing separator line."""
-        print("\n" + "=" * 70)  # Print separator line to visually isolate error message
 
 
 # Run data directory check immediately (NO WRAPPER - direct class instantiation)

--- a/data/full_repo_compliance_current.md
+++ b/data/full_repo_compliance_current.md
@@ -1,8 +1,8 @@
 # Coding Guideline Compliance Report
 
-- **Generated**: 2026-07-06 04:30:52 UTC
+- **Generated**: 2026-07-06 04:54:56 UTC
 - **Tool**: compliance-analyzer (tools/compliance_analyzer)
-- **Files analyzed**: 252
+- **Files analyzed**: 253
 
 Files are graded against the project guidelines: the 5-Item Rule, no
 wrappers/delegators/aliases/shims, complexity limits, inline comments,
@@ -165,6 +165,7 @@ Plan at the end to drive fixes.
 | src\network\_routing_utils_ssr.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\network\routing_utils.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\org_data_collector.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
+| src\refactors\data_directory_checker.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\serial_cc\global_assignments_builder.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\serial_cc\import_initialization_service.py | 95.0 | A | 0 | 0 | 1 | 2 | 3 |
 | src\refactors\serial_cc\security_events.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
@@ -1183,6 +1184,12 @@ Plan at the end to drive fixes.
       "violations": 0
     },
     {
+      "path": "src\\refactors\\data_directory_checker.py",
+      "score": 100.0,
+      "grade": "A+",
+      "violations": 0
+    },
+    {
       "path": "src\\refactors\\serial_cc\\global_assignments_builder.py",
       "score": 100.0,
       "grade": "A+",
@@ -1813,10 +1820,10 @@ Plan at the end to drive fixes.
 
 | Metric | Value |
 | - | - |
-| Lines of code | 24070 |
-| Executable code lines | 11113 |
-| Functions | 1366 |
-| Classes | 93 |
+| Lines of code | 23971 |
+| Executable code lines | 11062 |
+| Functions | 1357 |
+| Classes | 92 |
 | Average complexity | 2.6 |
 | Max complexity | 6 |
 | Inline comment coverage | 80.5% |
@@ -1837,14 +1844,14 @@ Plan at the end to drive fixes.
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 16337 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16238 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 
 #### Structure
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 16383 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 16661 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16284 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16562 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
 
 ## File: src\__init__.py
 
@@ -5762,6 +5769,33 @@ No violations found. This file complies with the guidelines.
 
 No violations found. This file complies with the guidelines.
 
+## File: src\refactors\data_directory_checker.py
+
+- **Score**: 100.0 / 100
+- **Grade**: A+
+
+### Metrics
+
+| Metric | Value |
+| - | - |
+| Lines of code | 128 |
+| Executable code lines | 63 |
+| Functions | 9 |
+| Classes | 1 |
+| Average complexity | 1.4 |
+| Max complexity | 3 |
+| Inline comment coverage | 98.4% |
+
+### Complexity Hotspots
+
+| Function | Cyclomatic Complexity |
+| - | - |
+| check | 3 |
+| _handle_permission_error | 2 |
+| _is_running_in_container | 2 |
+
+No violations found. This file complies with the guidelines.
+
 ## File: src\refactors\serial_cc\global_assignments_builder.py
 
 - **Score**: 100.0 / 100
@@ -8685,12 +8719,12 @@ No violations found. This file complies with the guidelines.
 
 ### Phase: Medium (13 task(s))
 
-- [ ] **CMP-012** `MistHelper.py:16383` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-012** `MistHelper.py:16284` - STRUCT-LENGTH (Structure)
   - Symbol: `_make_ws_callbacks`
   - Problem: Function spans 28 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
   - Done when: analyzer reports no STRUCT-LENGTH for `_make_ws_callbacks` in `MistHelper.py`.
-- [ ] **CMP-013** `MistHelper.py:16661` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-013** `MistHelper.py:16562` - STRUCT-LENGTH (Structure)
   - Symbol: `_build_impl_args`
   - Problem: Function spans 26 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
@@ -8753,7 +8787,7 @@ No violations found. This file complies with the guidelines.
 
 ### Phase: Low (14 task(s))
 
-- [ ] **CMP-025** `MistHelper.py:16337` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-025** `MistHelper.py:16238` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `execute`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.

--- a/src/refactors/data_directory_checker.py
+++ b/src/refactors/data_directory_checker.py
@@ -1,0 +1,128 @@
+"""DataDirectoryChecker extracted from MistHelper.
+
+Validates that the data directory used by MistHelper for logs and persisted
+data is writable by the current process, providing actionable guidance
+(local versus container remediation) when the check fails.
+
+This module runs *very* early during MistHelper module initialization —
+before the logging subsystem has been configured — so all user-facing
+output uses ``print()`` rather than ``logging``. Logging calls are still
+used at INFO/DEBUG level to record the check outcome for later reading
+from the log file once logging comes online.
+
+The class is otherwise self-contained: it depends only on the stdlib
+(``os``, ``sys``) and no MistHelper globals, so it does not need the
+late-import DI dance the other extracted modules use.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing on 3.10+
+
+import logging  # Structured action logging required by coding standards
+import os  # File-system operations (path join, exists, remove) used by the writable check
+import sys  # sys.exit() to abort early when the directory is not writable
+
+
+class DataDirectoryChecker:
+    """Check data directory write permissions and provide actionable guidance.
+
+    This class runs very early during module initialization (before logging),
+    so it uses print() for user-facing output rather than logging.
+
+    Usage:
+        DataDirectoryChecker(_early_log_dir).check()
+    """
+
+    def __init__(self, data_dir: str) -> None:  # Initialize checker with target data directory path
+        """Initialize with the data directory path to check."""
+        logging.info("DataDirectoryChecker init: target data_dir=%s", data_dir)  # Log construction start
+        self.data_dir = data_dir  # Store the data directory path for later validation
+        self.test_file = os.path.join(
+            data_dir, ".write_test"
+        )  # Define test file path (.write_test) for permission validation
+        logging.debug("DataDirectoryChecker init complete: test_file=%s", self.test_file)  # Log after init
+
+    def check(self) -> bool:  # Check if data directory is writable and handle errors
+        """Check if data directory is writable.
+
+        Returns:
+            True if writable, exits program if not writable due to permissions.
+        """
+        logging.info("DataDirectoryChecker.check: validating write access to %s", self.data_dir)  # Pre-check log
+        try:  # Attempt to validate write permission
+            result = self._test_write_permission()  # Call permission test helper method
+            logging.debug("DataDirectoryChecker.check: write permission ok (result=%s)", result)  # Post-check log
+            return result  # Return success signal to caller
+        except PermissionError:  # Catch permission errors and display actionable guidance
+            self._handle_permission_error()  # Call error handler to print guidance and exit
+            return False  # Never reached - _handle_permission_error exits
+        except Exception:  # For non-permission errors, proceed and let them fail naturally later
+            logging.debug("DataDirectoryChecker.check: non-permission exception - deferring failure")  # Log defer
+            return True  # Non-permission error, let it proceed and fail naturally
+
+    def _test_write_permission(self) -> bool:  # Validate data directory write access via test file
+        """Create and remove a test file to verify write access."""
+        with open(
+            self.test_file, "w"
+        ) as file_handle:  # Open test file for writing (will fail if directory not writable)
+            file_handle.write("test")  # Write marker content to test file
+        os.remove(self.test_file)  # Delete test file to clean up
+        return True  # Return success if both write and delete succeeded
+
+    def _handle_permission_error(self) -> None:  # Display context-specific guidance and exit
+        """Print error message with context-specific guidance and exit."""
+        logging.error("DataDirectoryChecker: data directory %s is not writable", self.data_dir)  # Log fail
+        in_container = self._is_running_in_container()  # Detect if running in container to show appropriate fix
+
+        self._print_error_header()  # Print error banner with path information
+
+        if in_container:  # If running in container, show container-specific fix (chmod on host)
+            self._print_container_guidance()  # Print container deployment remediation steps
+        else:  # If running locally, show local fix (chmod/chown)
+            self._print_local_guidance()  # Print local environment remediation steps
+
+        self._print_error_footer()  # Print closing separator
+        sys.exit(1)  # Exit program with error code to prevent further execution
+
+    def _is_running_in_container(self) -> bool:  # Detect container environment
+        """Detect if running inside a container environment."""
+        return os.path.exists("/.dockerenv") or os.path.exists(
+            "/run/.containerenv"
+        )  # Check for standard container marker files
+
+    def _print_error_header(self) -> None:  # Display error banner with path
+        """Print the error header with path information."""
+        print("\n" + "=" * 70)  # Print separator to visually isolate error message
+        print("ERROR: Data directory is not writable!")  # Print main error message
+        print("=" * 70)  # Print closing separator
+        print(f"\nPath: {os.path.abspath(self.data_dir)}")  # Print absolute path to the inaccessible directory
+        print("\nMistHelper cannot write logs or data to the data/ directory.")  # Explain impact of the error
+
+    def _print_container_guidance(self) -> None:  # Display container-specific remediation
+        """Print guidance specific to container deployments."""
+        print("\n[CONTAINER DETECTED]")  # Indicate container environment detected
+        print(
+            "The container runs as non-root user 'misthelper' for security."
+        )  # Explain why permissions are restricted
+        print("The mounted data/ directory must have write permissions.")  # State the requirement
+        print("\nTo fix this, run the following on your HOST machine:")  # Provide context for the fix
+        print("\n    chmod -R 777 data/")  # Show command to grant write permissions
+        print("\nThen restart the container:")  # Explain next step
+        print("    podman stop misthelper && podman rm misthelper")  # Show stop and remove command
+        print(
+            "    podman run -d --name misthelper -p 2200:2200 -p 8050:8050 \\"
+        )  # Show container restart with port mapping
+        print(
+            '        -v "${PWD}/data:/app/data:rw" -v "${PWD}/.env:/app/.env:ro" \\'
+        )  # Show volume mount with correct permissions
+        print("        ghcr.io/jmorrison-juniper/misthelper:latest")  # Show container image URI
+
+    def _print_local_guidance(self) -> None:  # Display local environment remediation
+        """Print guidance for local (non-container) environments."""
+        print("\nTo fix this, ensure the data/ directory is writable:")  # Provide context for local fix
+        print("\n    chmod -R 755 data/")  # Show command to set directory permissions
+        print("    # Or if you own the directory:")  # Provide alternative if ownership is an issue
+        print("    chown -R $(whoami) data/")  # Show command to change ownership to current user
+
+    def _print_error_footer(self) -> None:  # Display error footer separator
+        """Print the closing separator line."""
+        print("\n" + "=" * 70)  # Print separator line to visually isolate error message


### PR DESCRIPTION
## Summary

- Extracts `DataDirectoryChecker` (early data-directory writable check) from `MistHelper.py` into `src/refactors/data_directory_checker.py`.
- Stdlib-only class (os, sys, logging) — no late-import DI needed, no MistHelper globals touched.
- `-100 LoC` net from `MistHelper.py` (class body removed, import added).
- Extracted module scores 100.0/A+; repo baseline preserved at 253 files @ 99.5/A+.
- Backward compatibility: `from MistHelper import DataDirectoryChecker` still resolves via top-level re-export (verified locally).

Refs: `specs/1010-misthelper-refactor-extraction` (PR-05, T049-T059)

## Test plan

- [ ] ruff / black / mypy strict / pydocstyle all pass in CI
- [ ] Unit tests still pass (no test changes needed)
- [ ] Compliance baseline stays at 99.5/A+ or better
- [ ] `MistHelper.DataDirectoryChecker` continues to resolve to `src.refactors.data_directory_checker.DataDirectoryChecker`