### PR TITLE
refactor(extract): MapsManagerLauncher to src/refactors/

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -147,6 +147,7 @@ from src.gateway.gateway_export_utils import (
 )  # Import gateway export utility configuration
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
 from src.refactors.data_directory_checker import DataDirectoryChecker  # Early data-dir writable check (SC-005)
+from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted Maps Manager launcher (SC-006)
 from src.refactors.sqlite_database_writer import SQLiteDatabaseWriter  # Extracted SQLite writer (SC-003)
 from src.refactors.tui_launcher import TUILauncher  # Extracted TUI launcher (SC-004)
 from src.reports.e911_bssid import E911BSSIDReportGenerator  # Module-level for tests
@@ -22069,74 +22070,6 @@ menu_actions = {
         " (Requires typing 'CREATE' to confirm)",
     ),
 }
-
-
-class MapsManagerLauncher:
-    """
-    Launch MapsManager from external maps_manager.py module.
-
-    The external module contains the full interactive map viewer implementation
-    (~7,500 lines) supporting standalone execution and MistHelper integration.
-
-    SECURITY: Read-only map viewing with interactive Dash web server
-
-    Usage:
-        MapsManagerLauncher().launch()
-    """
-
-    def __init__(self):
-        """Initialize launcher with module reference placeholder."""
-        self.maps_manager = None
-        self.org_id: str = ""
-
-    def launch(self) -> None:
-        """Main entry point - orchestrates module import and execution."""
-        logging.info("Menu #142: Starting Maps Manager")
-        if not self._import_module():
-            return
-        if not self._get_org_id():
-            return
-        self._run_interactive_menu()
-        logging.info("Menu #142: Maps Manager session completed")
-
-    def _import_module(self) -> bool:
-        """Import MapsManager from external module with error handling."""
-        try:
-            from src.maps.maps_manager import MapsManager as ExternalMapsManager
-
-            self._external_class = ExternalMapsManager
-            return True
-        except ImportError as error:
-            self._handle_import_error(error)
-            return False
-
-    def _handle_import_error(self, error: ImportError) -> None:
-        """Log and display import failure message."""
-        logging.error("Failed to import MapsManager from src/maps/maps_manager.py: %s", error)
-        print("\nERROR: Could not load Maps Manager module.")
-        print("Ensure src/maps/maps_manager.py exists")
-
-    def _get_org_id(self) -> bool:
-        """Get organization ID from cache or prompt."""
-        try:
-            self.org_id = ConfigUtils.get_cached_or_prompted_org_id()
-            return bool(self.org_id)
-        except Exception as error:
-            self._handle_fatal_error(error)
-            return False
-
-    def _run_interactive_menu(self) -> None:
-        """Instantiate and run the Maps Manager interactive menu."""
-        try:
-            self.maps_manager = self._external_class(apisession, self.org_id)
-            self.maps_manager.run_interactive_menu()
-        except Exception as error:
-            self._handle_fatal_error(error)
-
-    def _handle_fatal_error(self, error: Exception) -> None:
-        """Log and display fatal error message."""
-        logging.error("Error running Maps Manager: %s", error, exc_info=True)
-        print(f"\nERROR: {error}")
 
 
 # ============================================================================

--- a/data/full_repo_compliance_current.md
+++ b/data/full_repo_compliance_current.md
@@ -1,8 +1,8 @@
 # Coding Guideline Compliance Report
 
-- **Generated**: 2026-07-06 04:54:56 UTC
+- **Generated**: 2026-07-06 05:12:36 UTC
 - **Tool**: compliance-analyzer (tools/compliance_analyzer)
-- **Files analyzed**: 253
+- **Files analyzed**: 254
 
 Files are graded against the project guidelines: the 5-Item Rule, no
 wrappers/delegators/aliases/shims, complexity limits, inline comments,
@@ -166,6 +166,7 @@ Plan at the end to drive fixes.
 | src\network\routing_utils.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\org_data_collector.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\data_directory_checker.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
+| src\refactors\maps_manager_launcher.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\serial_cc\global_assignments_builder.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\serial_cc\import_initialization_service.py | 95.0 | A | 0 | 0 | 1 | 2 | 3 |
 | src\refactors\serial_cc\security_events.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
@@ -1190,6 +1191,12 @@ Plan at the end to drive fixes.
       "violations": 0
     },
     {
+      "path": "src\\refactors\\maps_manager_launcher.py",
+      "score": 100.0,
+      "grade": "A+",
+      "violations": 0
+    },
+    {
       "path": "src\\refactors\\serial_cc\\global_assignments_builder.py",
       "score": 100.0,
       "grade": "A+",
@@ -1820,13 +1827,13 @@ Plan at the end to drive fixes.
 
 | Metric | Value |
 | - | - |
-| Lines of code | 23971 |
-| Executable code lines | 11062 |
-| Functions | 1357 |
-| Classes | 92 |
+| Lines of code | 23904 |
+| Executable code lines | 11026 |
+| Functions | 1350 |
+| Classes | 91 |
 | Average complexity | 2.6 |
 | Max complexity | 6 |
-| Inline comment coverage | 80.5% |
+| Inline comment coverage | 80.7% |
 
 ### Complexity Hotspots
 
@@ -1844,14 +1851,14 @@ Plan at the end to drive fixes.
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 16238 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16239 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 
 #### Structure
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 16284 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 16562 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16285 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16563 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
 
 ## File: src\__init__.py
 
@@ -5796,6 +5803,34 @@ No violations found. This file complies with the guidelines.
 
 No violations found. This file complies with the guidelines.
 
+## File: src\refactors\maps_manager_launcher.py
+
+- **Score**: 100.0 / 100
+- **Grade**: A+
+
+### Metrics
+
+| Metric | Value |
+| - | - |
+| Lines of code | 116 |
+| Executable code lines | 66 |
+| Functions | 10 |
+| Classes | 1 |
+| Average complexity | 1.6 |
+| Max complexity | 3 |
+| Inline comment coverage | 83.3% |
+
+### Complexity Hotspots
+
+| Function | Cyclomatic Complexity |
+| - | - |
+| launch | 3 |
+| _run_interactive_menu | 3 |
+| _import_module | 2 |
+| _get_org_id | 2 |
+
+No violations found. This file complies with the guidelines.
+
 ## File: src\refactors\serial_cc\global_assignments_builder.py
 
 - **Score**: 100.0 / 100
@@ -8719,12 +8754,12 @@ No violations found. This file complies with the guidelines.
 
 ### Phase: Medium (13 task(s))
 
-- [ ] **CMP-012** `MistHelper.py:16284` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-012** `MistHelper.py:16285` - STRUCT-LENGTH (Structure)
   - Symbol: `_make_ws_callbacks`
   - Problem: Function spans 28 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
   - Done when: analyzer reports no STRUCT-LENGTH for `_make_ws_callbacks` in `MistHelper.py`.
-- [ ] **CMP-013** `MistHelper.py:16562` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-013** `MistHelper.py:16563` - STRUCT-LENGTH (Structure)
   - Symbol: `_build_impl_args`
   - Problem: Function spans 26 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
@@ -8787,7 +8822,7 @@ No violations found. This file complies with the guidelines.
 
 ### Phase: Low (14 task(s))
 
-- [ ] **CMP-025** `MistHelper.py:16238` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-025** `MistHelper.py:16239` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `execute`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.

--- a/src/refactors/maps_manager_launcher.py
+++ b/src/refactors/maps_manager_launcher.py
@@ -1,0 +1,116 @@
+"""MapsManagerLauncher extracted from MistHelper.
+
+Launches the external ``src.maps.maps_manager.MapsManager`` (a ~7,500 line
+interactive Dash-based map viewer) from the numbered CLI menu. This module
+only owns the thin launcher shell that handles import failure, org-id
+prompt, and top-level error surfacing.
+
+Runtime dependencies (``apisession`` global and the ``ConfigUtils`` class)
+are still owned by MistHelper.py. They are resolved lazily via
+``importlib.import_module`` so the extracted module import-graph stays
+flat and monkeypatched attributes are honoured in tests.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing on 3.10+
+
+import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
+import logging  # Structured action logging required by coding standards
+from types import SimpleNamespace  # Bundle runtime dependencies without coupling to a dataclass
+from typing import Any  # Loose typing for late-bound module attributes and external Dash object
+
+
+def _resolve_runtime_dependencies() -> SimpleNamespace:
+    """Resolve MistHelper-owned runtime dependencies without static cross-module imports."""
+    logging.info("Resolving MapsManagerLauncher runtime dependencies from MistHelper")  # Log before import
+    misthelper_module = importlib.import_module("MistHelper")  # Late import avoids circular dependency
+    logging.debug("MapsManagerLauncher runtime dependencies resolved successfully")  # Log after resolution
+    return SimpleNamespace(
+        misthelper_module=misthelper_module,  # Retained so apisession/ConfigUtils lookups honour monkeypatch
+    )
+
+
+class MapsManagerLauncher:
+    """Launch MapsManager from external maps_manager.py module.
+
+    The external module contains the full interactive map viewer implementation
+    (~7,500 lines) supporting standalone execution and MistHelper integration.
+
+    SECURITY: Read-only map viewing with interactive Dash web server
+
+    Usage:
+        MapsManagerLauncher().launch()
+    """
+
+    def __init__(self) -> None:
+        """Initialize launcher with module reference placeholder."""
+        logging.info("MapsManagerLauncher init: starting new launcher instance")  # Log construction start
+        self.maps_manager: Any = None  # Populated after successful instantiation of external class
+        self.org_id: str = ""  # Populated from cache/prompt via ConfigUtils
+        self._external_class: Any = None  # Populated by _import_module on successful import
+        self._deps: SimpleNamespace = _resolve_runtime_dependencies()  # Late-bound MistHelper handles
+        logging.debug("MapsManagerLauncher init complete")  # Log after construction
+
+    def _apisession(self) -> Any:
+        """Return the current MistHelper apisession so monkeypatched values are honoured."""
+        return getattr(self._deps.misthelper_module, "apisession", None)  # Resolve at call-time, not import-time
+
+    def _config_utils(self) -> Any:
+        """Return the current MistHelper ConfigUtils class so monkeypatched values are honoured."""
+        return self._deps.misthelper_module.ConfigUtils  # Attribute access still honours module monkeypatching
+
+    def launch(self) -> None:
+        """Main entry point - orchestrates module import and execution."""
+        logging.info("Menu #142: Starting Maps Manager")  # User-visible launch marker preserved from original
+        if not self._import_module():  # Bail out early if the external Maps module is unavailable
+            return  # Import failure handled inside _import_module
+        if not self._get_org_id():  # Bail out early if org id could not be determined
+            return  # Org-id failure handled inside _get_org_id
+        self._run_interactive_menu()  # Enter the Dash-based interactive menu (blocks until user exits)
+        logging.info("Menu #142: Maps Manager session completed")  # Log clean session close
+
+    def _import_module(self) -> bool:
+        """Import MapsManager from external module with error handling."""
+        logging.info("MapsManagerLauncher: importing MapsManager from src.maps.maps_manager")  # Log pre-import
+        try:  # Wrap the lazy import so ImportError is turned into a user-visible message
+            from src.maps.maps_manager import MapsManager as ExternalMapsManager  # PLC0415: lazy on purpose
+
+            self._external_class = ExternalMapsManager  # Cache the imported class for later instantiation
+            logging.debug("MapsManagerLauncher: MapsManager import succeeded")  # Log post-import success
+            return True  # Signal caller that the external class is ready
+        except ImportError as error:  # Missing module or bad install
+            self._handle_import_error(error)  # Log and print actionable guidance
+            return False  # Signal caller to abort the launch
+
+    def _handle_import_error(self, error: ImportError) -> None:
+        """Log and display import failure message."""
+        logging.error("Failed to import MapsManager from src/maps/maps_manager.py: %s", error)  # Log the error
+        print("\nERROR: Could not load Maps Manager module.")  # User-visible failure banner
+        print("Ensure src/maps/maps_manager.py exists")  # Suggest the fix
+
+    def _get_org_id(self) -> bool:
+        """Get organization ID from cache or prompt."""
+        logging.info("MapsManagerLauncher: resolving org id via ConfigUtils")  # Log before prompt/cache lookup
+        try:  # Wrap prompt so any exception is funneled through the fatal-error handler
+            self.org_id = self._config_utils().get_cached_or_prompted_org_id()  # Late-bound ConfigUtils
+            logging.debug("MapsManagerLauncher: org id resolved (present=%s)", bool(self.org_id))  # Log resolution
+            return bool(self.org_id)  # Empty string means the user aborted - abort launch
+        except Exception as error:  # noqa: BLE001 - prompt errors must never crash the menu
+            self._handle_fatal_error(error)  # Log traceback and surface user-visible error
+            return False  # Signal caller to abort the launch
+
+    def _run_interactive_menu(self) -> None:
+        """Instantiate and run the Maps Manager interactive menu."""
+        logging.info("MapsManagerLauncher: instantiating external MapsManager and entering menu")  # Log entry
+        try:  # Wrap instantiation + run so any error is funneled through the fatal-error handler
+            if self._external_class is None:  # Defensive - launch() calls _import_module first
+                raise RuntimeError("MapsManagerLauncher._external_class not initialized")  # Explicit error
+            self.maps_manager = self._external_class(self._apisession(), self.org_id)  # Late-bound apisession
+            self.maps_manager.run_interactive_menu()  # Enter blocking interactive loop (Dash web server)
+            logging.debug("MapsManagerLauncher: interactive menu returned cleanly")  # Log clean return
+        except Exception as error:  # noqa: BLE001 - runtime errors must never crash the numbered menu
+            self._handle_fatal_error(error)  # Log traceback and surface user-visible error
+
+    def _handle_fatal_error(self, error: Exception) -> None:
+        """Log and display fatal error message."""
+        logging.error("Error running Maps Manager: %s", error, exc_info=True)  # Log with traceback for postmortem
+        print(f"\nERROR: {error}")  # Surface error to user without stack details


### PR DESCRIPTION
## Summary

- Move `MapsManagerLauncher` (68-line class body) out of `MistHelper.py` into `src/refactors/maps_manager_launcher.py` using the established late-import DI pattern (`importlib.import_module` + `SimpleNamespace`).
- The extraction preserves monkeypatch semantics for `apisession` and `ConfigUtils` so tests continue to intercept those globals.
- Class-body landing per FR-005; class was already decomposed into 10 helper methods before this move so FR-006 is a no-op.

## Refactor extraction workflow context

- **Spec**: `specs/1010-misthelper-refactor-extraction/`
- **PR**: PR-06 of 13
- **Tasks**: T060-T070
- **Success criterion**: SC-006 (Maps Manager launcher extracted)

## Metrics

| Item | Value |
| - | - |
| New module | `src/refactors/maps_manager_launcher.py` |
| Module size | 116 LoC |
| Module compliance | 100.0 / A+ |
| MistHelper.py size | 23904 lines (-68) |
| MistHelper.py compliance | 93.0 / A (unchanged) |
| Aggregate compliance | 254 files @ 99.5 / A+ (unchanged) |

## Local gates

- ruff: clean
- black --check: clean
- mypy --strict: clean
- pydocstyle: clean
- compliance-analyzer: 100.0 / A+ on the new module

## Test plan

- [x] `python -c "from MistHelper import MapsManagerLauncher; import inspect; print(inspect.getmodule(MapsManagerLauncher).__name__)"` resolves to `src.refactors.maps_manager_launcher`
- [x] Compliance aggregate held at 99.5 / A+ across 254 files
- [x] MistHelper.py per-file compliance unchanged at 93.0 / A
- [ ] Full CI matrix (15 required jobs) passes on the PR head