### PR TITLE
refactor(delete): AddressComparisonCounters delegator shim in MistHelper

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -16516,46 +16516,6 @@ from src.utils.address_utils import (
 from src.utils.rate_limiting import RateLimitingUtils  # noqa: E402
 
 
-class AddressComparisonCounters:  # Address comparison counters.
-    """Track metrics for address comparison. Delegated to src.inventory.csv_comparator."""
-
-    def __init__(self):  # Build the counters.
-        """Initialize all counter attributes and timing."""
-        from src.inventory.csv_comparator import (
-            AddressComparisonCounters as _Impl,  # pylint: disable=import-outside-toplevel
-        )
-
-        self._impl = _Impl()  # Create the impl.
-        # Expose attrs for direct access compatibility
-        self.total_devices = self._impl.total_devices  # Mirror total devices.
-        self.devices_enriched = self._impl.devices_enriched  # Mirror enriched.
-        self.devices_skipped = self._impl.devices_skipped  # Mirror skipped.
-        self.perfect_matches = self._impl.perfect_matches  # Mirror perfect matches.
-        self.mismatches_found = self._impl.mismatches_found  # Mirror mismatches.
-        self.auto_corrections = self._impl.auto_corrections  # Mirror auto-corrections.
-        self.comparison_failures = self._impl.comparison_failures  # Mirror comparison failures.
-        self.parse_failures = self._impl.parse_failures  # Mirror parse failures.
-        self.parse_failure_reasons = self._impl.parse_failure_reasons  # Mirror failure reasons.
-        self.start_time = self._impl.start_time  # Mirror start time.
-        self.end_time = self._impl.end_time  # Mirror end time.
-
-    def start_timing(self):  # Start timing.
-        """Start the timing counter for performance tracking."""
-        self._impl.start_timing()  # Delegate to the impl.
-
-    def end_timing(self):  # End timing.
-        """End the timing counter for performance tracking."""
-        self._impl.end_timing()  # Delegate to the impl.
-
-    def get_duration(self):  # Get the duration.
-        """Get the elapsed time in seconds between start and end timing."""
-        return self._impl.get_duration()  # Delegate to the impl.
-
-    def log_summary(self):  # Log the summary.
-        """Log a comprehensive summary of all counter metrics."""
-        self._impl.log_summary()  # Delegate to the impl.
-
-
 class InventoryCSVComparator:  # Inventory CSV comparator.
     """Compare Mist inventory with CSV. Delegated to src.inventory.csv_comparator."""
 

--- a/data/full_repo_compliance_current.md
+++ b/data/full_repo_compliance_current.md
@@ -1,6 +1,6 @@
 # Coding Guideline Compliance Report
 
-- **Generated**: 2026-07-06 05:12:36 UTC
+- **Generated**: 2026-07-06 05:26:50 UTC
 - **Tool**: compliance-analyzer (tools/compliance_analyzer)
 - **Files analyzed**: 254
 
@@ -1827,10 +1827,10 @@ Plan at the end to drive fixes.
 
 | Metric | Value |
 | - | - |
-| Lines of code | 23904 |
-| Executable code lines | 11026 |
-| Functions | 1350 |
-| Classes | 91 |
+| Lines of code | 23864 |
+| Executable code lines | 11003 |
+| Functions | 1345 |
+| Classes | 90 |
 | Average complexity | 2.6 |
 | Max complexity | 6 |
 | Inline comment coverage | 80.7% |
@@ -1858,7 +1858,7 @@ Plan at the end to drive fixes.
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
 | 16285 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 16563 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16523 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
 
 ## File: src\__init__.py
 
@@ -8759,7 +8759,7 @@ No violations found. This file complies with the guidelines.
   - Problem: Function spans 28 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
   - Done when: analyzer reports no STRUCT-LENGTH for `_make_ws_callbacks` in `MistHelper.py`.
-- [ ] **CMP-013** `MistHelper.py:16563` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-013** `MistHelper.py:16523` - STRUCT-LENGTH (Structure)
   - Symbol: `_build_impl_args`
   - Problem: Function spans 26 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.


### PR DESCRIPTION
## Summary

- Delete the 38-line `AddressComparisonCounters` class body in `MistHelper.py` that was a pure delegator wrapping the real implementation at `src.inventory.csv_comparator.AddressComparisonCounters`.
- Per FR-005 the project forbids wrappers/delegators/aliases/shims.
- The shim had zero external callers (all tests already import from `csv_comparator` directly) so removal is safe.

## Refactor extraction workflow context

- **Spec**: `specs/1010-misthelper-refactor-extraction/`
- **PR**: PR-07 of 13
- **Tasks**: T071-T081
- **Success criterion**: SC-007 (AddressComparisonCounters folded into `src/inventory/csv_comparator.py`)

## Why delete instead of extract

`src/inventory/csv_comparator.py` already contains the canonical class since a prior refactor. The MistHelper.py class was a delegator maintained "for direct access compatibility" but nothing in the tree relies on that symbol location.

## Metrics

| Item | Value |
| - | - |
| MistHelper.py size | 23864 lines (-40) |
| Deleted LOC | 40 (38 body + 2 blanks) |
| MistHelper.py compliance | 93.0 / A (unchanged) |
| Aggregate compliance | 254 files @ 99.5 / A+ (unchanged) |
| Canonical class | `src.inventory.csv_comparator.AddressComparisonCounters` (untouched) |

## Local gates

- ruff: clean
- black --check: clean
- `import MistHelper` OK
- `from src.inventory.csv_comparator import AddressComparisonCounters` OK

## Test plan

- [x] No file imports `AddressComparisonCounters` from `MistHelper` (grep confirmed clean)
- [x] Canonical class still constructable and functional
- [ ] Full CI matrix (15 required jobs) passes on the PR head