### PR TITLE
refactor(1010): extract ServicePingManager to launcher module

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -148,6 +148,7 @@ from src.gateway.gateway_export_utils import (
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
 from src.refactors.data_directory_checker import DataDirectoryChecker  # Early data-dir writable check (SC-005)
 from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted Maps Manager launcher (SC-006)
+from src.refactors.service_ping_launcher import ServicePingLauncher  # Extracted Service Ping launcher (SC-008)
 from src.refactors.sqlite_database_writer import SQLiteDatabaseWriter  # Extracted SQLite writer (SC-003)
 from src.refactors.tui_launcher import TUILauncher  # Extracted TUI launcher (SC-004)
 from src.reports.e911_bssid import E911BSSIDReportGenerator  # Module-level for tests
@@ -6211,7 +6212,7 @@ class APICoreFetchUtils:  # Low-level Mist API fetch helpers.
 # APITenantFetchUtils extracted to src/api/tenant_fetch.py (issue #331).
 # Dependency injection is used so the module has no circular import with MistHelper.
 # Instances are created at each call site using the runtime apisession and org ID resolver.
-from src.api.tenant_fetch import APITenantFetchUtils  # Import the extracted instance class
+from src.api.tenant_fetch import APITenantFetchUtils  # noqa: F401  # Re-exported for ServicePingLauncher late-binding
 
 
 class APIFetchUtils:  # Higher-level org/site fetchers.
@@ -13724,59 +13725,6 @@ class GatewayHaExporter:  # Gateway HA exporter.
             vc_mac = str(row.get("vc_mac") or "")  # Shared cluster MAC address
             print(f"{name:<30} {node_name:<8} {status:<12} {node0_mac:<20} {node1_mac:<20} {vc_mac:<18}")  # Print row
         print()  # Blank line after table for readability
-
-
-def _get_service_ping_manager_instance():  # Build a ServicePingManager.
-    """Create extracted ServicePingManager instance with MistHelper runtime dependencies."""
-    from src.websocket.service_ping_manager import ServicePingManager as _SPM  # Import the extracted class.
-    from src.websocket.service_ping_manager import configure_service_ping_manager_dependencies as _configure_spm
-
-    _configure_spm(  # Wire dependencies.
-        apisession_dependency=apisession,
-        mistapi_dependency=mistapi,
-        prompt_utils=PromptUtils,
-        input_utils=InputUtils,
-        websocket_manager_class=WebSocketManager,
-        is_debug_mode=is_debug_mode,
-        api_tenant_fetch_utils=APITenantFetchUtils,
-        config_utils=ConfigUtils,
-        api_fetch_utils=APIFetchUtils,
-    )
-
-    return _SPM()  # Return the instance.
-
-
-class ServicePingManager:  # Service ping facade.
-    """Service ping manager (Menu 120).
-
-    Implementation extracted to `src/websocket/service_ping_manager.py` and
-    `src/websocket/service_ping_discovery.py`. This wrapper preserves
-    MistHelper menu orchestration and delegation only.
-    """
-
-    from src.websocket.service_ping_manager import ServicePingManager as _Extracted  # Import the extracted class.
-
-    DEFAULT_HOST = _Extracted.DEFAULT_HOST  # Re-export default host.
-    DEFAULT_COUNT = _Extracted.DEFAULT_COUNT  # Re-export default count.
-    DEFAULT_SIZE = _Extracted.DEFAULT_SIZE  # Re-export default size.
-    MIN_SIZE = _Extracted.MIN_SIZE  # Re-export min size.
-    MAX_SIZE = _Extracted.MAX_SIZE  # Re-export max size.
-    DEFAULT_TENANT = _Extracted.DEFAULT_TENANT  # Re-export default tenant.
-    DEFAULT_SERVICE = _Extracted.DEFAULT_SERVICE  # Re-export default service.
-
-    def __init__(self):  # Build the delegate.
-        """Initialize wrapper by mirroring extracted manager state for test compatibility."""
-        extracted = _get_service_ping_manager_instance()  # Create the extracted instance.
-        self.__dict__.update(extracted.__dict__)  # Copy its state.
-        self._delegate = extracted  # Keep the delegate.
-
-    def __getattr__(self, name):  # Forward unknown attributes.
-        """Delegate unknown attributes and methods to extracted implementation."""
-        return getattr(self._delegate, name)  # Delegate the attribute.
-
-    def execute(self) -> None:  # Run the ping flow.
-        """Execute menu 120 via the extracted service ping manager."""
-        self._delegate.execute()  # Delegate to the impl.
 
 
 # ============================================================================
@@ -21766,7 +21714,7 @@ menu_actions = {
         "WebSocket Device ARP - Execute ARP command on device via WebSocket stream (real-time output)",
     ),
     "120": (
-        lambda: ServicePingManager().execute(),  # type: ignore[misc]
+        lambda: ServicePingLauncher().launch(),  # type: ignore[misc]
         "WebSocket Service Ping - Execute service-specific ping on SSR gateways via WebSocket stream (real-time output)",  # noqa: E501
     ),
     # ==============================

--- a/data/full_repo_compliance_current.md
+++ b/data/full_repo_compliance_current.md
@@ -1,8 +1,8 @@
 # Coding Guideline Compliance Report
 
-- **Generated**: 2026-07-06 05:26:50 UTC
+- **Generated**: 2026-07-06 05:45:47 UTC
 - **Tool**: compliance-analyzer (tools/compliance_analyzer)
-- **Files analyzed**: 254
+- **Files analyzed**: 255
 
 Files are graded against the project guidelines: the 5-Item Rule, no
 wrappers/delegators/aliases/shims, complexity limits, inline comments,
@@ -176,6 +176,7 @@ Plan at the end to drive fixes.
 | src\refactors\serial_cc\start_site_scan_capture.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\serial_cc\switch_vc_stats.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\serial_cc\test_results_by_site.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
+| src\refactors\service_ping_launcher.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\sqlite_database_writer.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\refactors\tui_launcher.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
 | src\reports\__init__.py | 100.0 | A+ | 0 | 0 | 0 | 0 | 0 |
@@ -1251,6 +1252,12 @@ Plan at the end to drive fixes.
       "violations": 0
     },
     {
+      "path": "src\\refactors\\service_ping_launcher.py",
+      "score": 100.0,
+      "grade": "A+",
+      "violations": 0
+    },
+    {
       "path": "src\\refactors\\sqlite_database_writer.py",
       "score": 100.0,
       "grade": "A+",
@@ -1827,10 +1834,10 @@ Plan at the end to drive fixes.
 
 | Metric | Value |
 | - | - |
-| Lines of code | 23864 |
-| Executable code lines | 11003 |
-| Functions | 1345 |
-| Classes | 90 |
+| Lines of code | 23812 |
+| Executable code lines | 10982 |
+| Functions | 1341 |
+| Classes | 89 |
 | Average complexity | 2.6 |
 | Max complexity | 6 |
 | Inline comment coverage | 80.7% |
@@ -1851,14 +1858,14 @@ Plan at the end to drive fixes.
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 16239 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
+| 16187 | low | STRUCT-COMPLEXITY | execute | Cyclomatic complexity is 6 (target <= 5). | Reduce branching by extracting helpers, using guard clauses, or simplifying logic. |
 
 #### Structure
 
 | Line | Severity | Rule | Symbol | Issue | Remediation |
 | - | - | - | - | - | - |
-| 16285 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
-| 16523 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16233 | medium | STRUCT-LENGTH | _make_ws_callbacks | Function spans 28 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
+| 16471 | medium | STRUCT-LENGTH | _build_impl_args | Function spans 26 lines (limit 25). | Extract logical sections into well-named helper methods to shrink the function. |
 
 ## File: src\__init__.py
 
@@ -6104,6 +6111,31 @@ No violations found. This file complies with the guidelines.
 
 No violations found. This file complies with the guidelines.
 
+## File: src\refactors\service_ping_launcher.py
+
+- **Score**: 100.0 / 100
+- **Grade**: A+
+
+### Metrics
+
+| Metric | Value |
+| - | - |
+| Lines of code | 110 |
+| Executable code lines | 41 |
+| Functions | 7 |
+| Classes | 1 |
+| Average complexity | 1.1 |
+| Max complexity | 2 |
+| Inline comment coverage | 80.5% |
+
+### Complexity Hotspots
+
+| Function | Cyclomatic Complexity |
+| - | - |
+| launch | 2 |
+
+No violations found. This file complies with the guidelines.
+
 ## File: src\refactors\sqlite_database_writer.py
 
 - **Score**: 100.0 / 100
@@ -8754,12 +8786,12 @@ No violations found. This file complies with the guidelines.
 
 ### Phase: Medium (13 task(s))
 
-- [ ] **CMP-012** `MistHelper.py:16285` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-012** `MistHelper.py:16233` - STRUCT-LENGTH (Structure)
   - Symbol: `_make_ws_callbacks`
   - Problem: Function spans 28 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
   - Done when: analyzer reports no STRUCT-LENGTH for `_make_ws_callbacks` in `MistHelper.py`.
-- [ ] **CMP-013** `MistHelper.py:16523` - STRUCT-LENGTH (Structure)
+- [ ] **CMP-013** `MistHelper.py:16471` - STRUCT-LENGTH (Structure)
   - Symbol: `_build_impl_args`
   - Problem: Function spans 26 lines (limit 25).
   - Fix: Extract logical sections into well-named helper methods to shrink the function.
@@ -8822,7 +8854,7 @@ No violations found. This file complies with the guidelines.
 
 ### Phase: Low (14 task(s))
 
-- [ ] **CMP-025** `MistHelper.py:16239` - STRUCT-COMPLEXITY (Complexity)
+- [ ] **CMP-025** `MistHelper.py:16187` - STRUCT-COMPLEXITY (Complexity)
   - Symbol: `execute`
   - Problem: Cyclomatic complexity is 6 (target <= 5).
   - Fix: Reduce branching by extracting helpers, using guard clauses, or simplifying logic.

--- a/src/refactors/service_ping_launcher.py
+++ b/src/refactors/service_ping_launcher.py
@@ -1,0 +1,110 @@
+"""ServicePingLauncher extracted from MistHelper.
+
+Launches the canonical WebSocket Service Ping flow (Menu 120) by wiring
+MistHelper-owned runtime dependencies into the extracted
+``src.websocket.service_ping_manager.ServicePingManager`` and invoking its
+``execute()`` entry point.
+
+Runtime dependencies (``apisession`` global, ``mistapi`` module, the
+utility classes ``PromptUtils``/``InputUtils``/``APITenantFetchUtils``/
+``ConfigUtils``/``APIFetchUtils``, the ``WebSocketManager`` class, and the
+``is_debug_mode`` closure) are still owned by MistHelper.py. They are
+resolved lazily via ``importlib.import_module`` so the extracted module
+import-graph stays flat and monkeypatched attributes are honoured in
+tests.
+
+This module replaces the previous ``ServicePingManager`` delegator shim
+(mirror-and-forward pattern) with a proper launcher whose only public
+surface is ``launch()``.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing on 3.10+
+
+import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
+import logging  # Structured action logging required by coding standards
+from types import SimpleNamespace  # Bundle runtime dependencies without coupling to a dataclass
+from typing import Any  # Loose typing for late-bound module attributes and external manager instance
+
+
+def _resolve_runtime_dependencies() -> SimpleNamespace:
+    """Resolve MistHelper-owned runtime dependencies without static cross-module imports."""
+    logging.info("Resolving ServicePingLauncher runtime dependencies from MistHelper")  # Log before import
+    misthelper_module = importlib.import_module("MistHelper")  # Late import avoids circular dependency
+    logging.debug("ServicePingLauncher runtime dependencies resolved successfully")  # Log after resolution
+    return SimpleNamespace(
+        misthelper_module=misthelper_module,  # Retained so global lookups honour monkeypatch in tests
+    )
+
+
+class ServicePingLauncher:
+    """Launch WebSocket Service Ping from external service_ping_manager module.
+
+    The external module contains the full SSR service-ping implementation
+    including tenant/service discovery, WebSocket transport, and result
+    parsing. This launcher owns only the numbered-menu ceremony: wire
+    runtime dependencies into the extracted class, instantiate it, and
+    invoke ``execute()`` with fatal-error surfacing.
+
+    SECURITY: WebSocket-driven service ping to SSR gateways (read-only)
+
+    Usage:
+        ServicePingLauncher().launch()
+    """
+
+    def __init__(self) -> None:
+        """Initialize launcher with late-bound MistHelper handles."""
+        logging.info("ServicePingLauncher init: starting new launcher instance")  # Log construction start
+        self._deps: SimpleNamespace = _resolve_runtime_dependencies()  # Late-bound MistHelper handles
+        logging.debug("ServicePingLauncher init complete")  # Log after construction
+
+    def _misthelper(self) -> Any:
+        """Return the current MistHelper module so monkeypatched attributes are honoured."""
+        return self._deps.misthelper_module  # Resolve at call-time so tests can substitute values
+
+    def launch(self) -> None:
+        """Main entry point - wire dependencies and run Service Ping."""
+        logging.info("Menu #120: Starting WebSocket Service Ping")  # User-visible launch marker
+        try:  # Wrap the full flow so any runtime error is funneled through the fatal-error handler
+            self._wire_dependencies()  # Publish MistHelper globals into the extracted manager module
+            manager = self._build_manager()  # Instantiate the canonical ServicePingManager
+            manager.execute()  # Run the interactive ping flow (blocks until user exits)
+            logging.debug("Menu #120: Service Ping session returned cleanly")  # Log clean session close
+        except Exception as error:  # noqa: BLE001 - runtime errors must never crash the numbered menu
+            self._handle_fatal_error(error)  # Log traceback and surface user-visible error
+
+    def _wire_dependencies(self) -> None:
+        """Configure the extracted service_ping_manager module with MistHelper runtime globals."""
+        logging.info("ServicePingLauncher: wiring runtime dependencies into service_ping_manager")  # Log wire start
+        misthelper = self._misthelper()  # Cache module handle for the nine attribute lookups below
+        from src.websocket.service_ping_manager import (  # PLC0415: lazy import to keep startup path light
+            configure_service_ping_manager_dependencies,
+        )
+
+        configure_service_ping_manager_dependencies(  # Publish MistHelper-owned deps into the extracted module
+            apisession_dependency=getattr(misthelper, "apisession", None),  # Current apisession honours monkeypatch
+            mistapi_dependency=misthelper.mistapi,  # Bound mistapi module (attribute access on MistHelper)
+            prompt_utils=misthelper.PromptUtils,  # Prompt helper class for menu flow
+            input_utils=misthelper.InputUtils,  # Input helper class for user confirmation
+            websocket_manager_class=misthelper.WebSocketManager,  # WebSocket transport class
+            is_debug_mode=misthelper.is_debug_mode,  # Debug-mode probe closure
+            api_tenant_fetch_utils=misthelper.APITenantFetchUtils,  # Tenant utility class
+            config_utils=misthelper.ConfigUtils,  # Config utility helper class
+            api_fetch_utils=misthelper.APIFetchUtils,  # API fetch utility class
+        )
+        logging.debug("ServicePingLauncher: runtime dependencies wired successfully")  # Log wire completion
+
+    def _build_manager(self) -> Any:
+        """Instantiate the canonical ServicePingManager with dependencies already wired."""
+        logging.info("ServicePingLauncher: instantiating canonical ServicePingManager")  # Log build start
+        from src.websocket.service_ping_manager import (  # PLC0415: lazy import mirrors _wire_dependencies pattern
+            ServicePingManager as ExternalServicePingManager,
+        )
+
+        manager = ExternalServicePingManager()  # Canonical class; constructor pulls wired module globals
+        logging.debug("ServicePingLauncher: ServicePingManager instantiated successfully")  # Log build finish
+        return manager  # Return the ready-to-run manager to launch()
+
+    def _handle_fatal_error(self, error: Exception) -> None:
+        """Log and display fatal error message."""
+        logging.error("Error running Service Ping: %s", error, exc_info=True)  # Log with traceback for postmortem
+        print(f"\nERROR: {error}")  # Surface error to user without stack details

--- a/tests/guardrails/test_wave1_safe_input_paths.py
+++ b/tests/guardrails/test_wave1_safe_input_paths.py
@@ -66,7 +66,24 @@ def test_handle_client_selection_returns_none_tuple_on_eof(monkeypatch):
 
 
 def test_service_ping_parameter_prompts_fall_back_to_defaults_on_eof(monkeypatch):
-    manager = MistHelper.ServicePingManager()
+    # Wire canonical ServicePingManager with MistHelper runtime globals (delegator shim removed)
+    from src.websocket.service_ping_manager import (
+        ServicePingManager,
+        configure_service_ping_manager_dependencies,
+    )
+
+    configure_service_ping_manager_dependencies(
+        apisession_dependency=getattr(MistHelper, "apisession", None),
+        mistapi_dependency=MistHelper.mistapi,
+        prompt_utils=MistHelper.PromptUtils,
+        input_utils=MistHelper.InputUtils,
+        websocket_manager_class=MistHelper.WebSocketManager,
+        is_debug_mode=MistHelper.is_debug_mode,
+        api_tenant_fetch_utils=MistHelper.APITenantFetchUtils,
+        config_utils=MistHelper.ConfigUtils,
+        api_fetch_utils=MistHelper.APIFetchUtils,
+    )
+    manager = ServicePingManager()
 
     def raise_eof(_prompt):
         raise EOFError

--- a/tests/unit/websocket/test_service_ping_manager.py
+++ b/tests/unit/websocket/test_service_ping_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -168,15 +169,24 @@ def test_execute_runs_end_to_end_until_display_results() -> None:
     manager._cleanup.assert_called_once()
 
 
-def test_misthelper_wrapper_delegates_execute(monkeypatch) -> None:
-    """MistHelper wrapper should preserve menu orchestration while delegating execution."""
-    fake_delegate = SimpleNamespace(execute=MagicMock(), debug_mode=False)
-    monkeypatch.setattr(MistHelper, "_get_service_ping_manager_instance", lambda: fake_delegate)
+def test_misthelper_menu_120_launcher_delegates_execute(monkeypatch) -> None:
+    """Menu 120 launcher should wire deps and delegate execute() to the canonical manager."""
+    fake_manager = SimpleNamespace(execute=MagicMock())  # Fake canonical ServicePingManager instance
+    launcher_module = importlib.import_module("src.refactors.service_ping_launcher")  # Load launcher module
+    monkeypatch.setattr(  # Intercept _build_manager so no real deps are needed
+        launcher_module.ServicePingLauncher,
+        "_build_manager",
+        lambda self: fake_manager,
+    )
+    monkeypatch.setattr(  # Intercept _wire_dependencies so we don't publish real globals during the test
+        launcher_module.ServicePingLauncher,
+        "_wire_dependencies",
+        lambda self: None,
+    )
 
-    wrapper = MistHelper.ServicePingManager()
-    wrapper.execute()
+    launcher_module.ServicePingLauncher().launch()  # Exercise the public menu entry point
 
-    fake_delegate.execute.assert_called_once_with()
+    fake_manager.execute.assert_called_once_with()  # Verify launch() delegates to manager.execute()
 
 
 def test_menu_action_120_description_is_preserved() -> None:


### PR DESCRIPTION
## Summary

PR-08 of the MistHelper decomposition (spec 1010). Replaces the
`ServicePingManager` delegator shim in `MistHelper.py` with a proper
`ServicePingLauncher` at `src/refactors/service_ping_launcher.py`.

Per FR-005 (no wrappers/delegators/aliases/shims) the previous
class used `__dict__` mirroring plus `__getattr__` delegation to
forward to the canonical `src.websocket.service_ping_manager.ServicePingManager`.
That anti-pattern is gone. The new launcher owns only the menu
ceremony: resolve MistHelper globals via late-import, publish them
through `configure_service_ping_manager_dependencies(...)`, instantiate
the canonical class, and call `execute()` with fatal-error surfacing.

## Changes

- **New**: `src/refactors/service_ping_launcher.py` (100.0/A+ compliance).
- **MistHelper.py**: delete `_get_service_ping_manager_instance()`
  factory and `ServicePingManager` delegator class (53 LoC removed);
  add `ServicePingLauncher` import; update menu 120 lambda; suppress
  a resulting F401 on `APITenantFetchUtils` (now consumed via
  module-level attribute access by the launcher).
- **tests/unit/websocket/test_service_ping_manager.py**: replace the
  obsolete `test_misthelper_wrapper_delegates_execute` with
  `test_misthelper_menu_120_launcher_delegates_execute` exercising
  the new launcher via the public menu path.
- **tests/guardrails/test_wave1_safe_input_paths.py**: import the
  canonical `ServicePingManager` and configure deps explicitly instead
  of relying on the deleted `MistHelper.ServicePingManager` shim.

## Compliance

- `service_ping_launcher.py`: 100.0/A+
- Repo aggregate: 99.5/A+ (255 files)
- `MistHelper.py` shrinks by 53 lines.

## Test plan

- [x] `ruff check` clean on all modified files
- [x] `black --check` clean on all modified files
- [x] `mypy --strict src/refactors/service_ping_launcher.py` clean
- [x] `pydocstyle` clean on launcher module
- [x] `pytest tests/unit/websocket/test_service_ping_manager.py tests/guardrails/test_wave1_safe_input_paths.py` -> 13 passed
- [ ] Full CI pipeline (15 functional jobs)

## Refs

Spec: `specs/1010-misthelper-refactor-extraction/`