### PR TITLE
refactor(1010): extract run_systematic_test to RunSystematicTestManager

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -22753,30 +22753,6 @@ def _systematic_test_resolve_fast_mode() -> bool:
     return False  # Neither source enabled fast mode.
 
 
-def run_systematic_test():  # noqa: C901, PLR0912, PLR0915
-    """Run systematic test of safe (GET-only, non-interactive, non-destructive) menu options.
-
-    Returns:
-        bool: True if all tested options passed, False if any failed.
-    """
-    start_time = time.time()  # Capture total-duration baseline before any setup work.
-    _print_systematic_banner()  # Banner + start timestamp + separator.
-    safe_options, unsafe_list, all_options = _build_systematic_test_options()  # Classify menu options.
-    _print_systematic_pre_run_counts(all_options, safe_options, unsafe_list)  # Print pre-run counts.
-    emitter, telemetry_path, skip_count = _initialize_systematic_telemetry(unsafe_list)  # Open telemetry.
-    fast_enabled = _resolve_systematic_test_context()  # Resolve org + fast mode once for the loop.
-    success_count, error_count = _execute_systematic_test_loop(
-        emitter, safe_options, fast_enabled
-    )  # Run every safe option through telemetry.
-    total_time = time.time() - start_time  # Total elapsed includes setup, execution, and delays.
-    summary = TestSummary(
-        len(all_options), success_count, error_count, skip_count, total_time, "systematic"
-    )  # Aggregate event reused by both finalize + print helpers (cuts param count to <=5).
-    _finalize_systematic_telemetry(emitter, summary)  # Emit summary, close, enforce retention.
-    _print_systematic_summary(summary, telemetry_path)  # Print user-facing summary block.
-    return _report_systematic_outcome(success_count, error_count, len(safe_options), total_time)
-
-
 def _print_systematic_banner():
     """Print the test-start banner + timestamp + separator to the operator console."""
     print(" Starting systematic test of MistHelper menu options...")  # Announce test start.
@@ -23663,7 +23639,11 @@ def main():
 def _run_systematic_test_mode(_args: argparse.Namespace) -> None:
     """Run all safe menu options once and exit 0 on pass / 1 on fail."""
     logging.info("SYSTEMATIC_TEST: Starting systematic test mode")  # Trace before dispatch
-    sys.exit(0 if run_systematic_test() else 1)  # type: ignore[no-untyped-call]
+    from src.refactors.run_systematic_test import (
+        RunSystematicTestManager,  # noqa: PLC0415 - lazy import keeps module startup path light
+    )
+
+    sys.exit(0 if RunSystematicTestManager().run() else 1)  # Delegate to extracted manager
 
 
 def _run_interactive_test_mode(_args: argparse.Namespace) -> None:

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 179 first-party files
-- Definitions analyzed: 105
-- LOC saveable (unused + single-use): 64
-- Category counts: unused=0, single-use=4, low-use=20, hot=80, skipped=1
+- Module graph size: 180 first-party files
+- Definitions analyzed: 104
+- LOC saveable (unused + single-use): 42
+- Category counts: unused=0, single-use=3, low-use=20, hot=80, skipped=1
 
 ## How to read this report
 
@@ -113,7 +113,6 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `RoutingUtils` | class | 22 | 12 | hot |  | missing_inline_comments,missing_action_logging |
 | `FirmwareManager` | class | 22 | 10 | hot |  |  |
 | `SiteAutoUpgradeConfigurator` | class | 22 | 6 | hot |  | missing_inline_comments,missing_action_logging |
-| `run_systematic_test` | function | 22 | 1 | single-use | RunSystematicTestManager | missing_action_logging |
 | `execute_with_connection_pool_management` | function | 21 | 7 | hot |  |  |
 | `switch_to_interactive_login` | function | 20 | 1 | single-use | SwitchToInteractiveLoginManager |  |
 | `BulkSwitchFirmwareUpgrader` | class | 19 | 2 | low-use | FirmwareManager | missing_inline_comments,missing_action_logging |
@@ -138,19 +137,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 14 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Single-Use (4)
-
-### `run_systematic_test` (function, 22 lines)
-
-- Def site: line 22756-22777
-- References: 1
-- Suggested class: `RunSystematicTestManager`
-- Suggested module: `src/refactors/run_systematic_test.py`
-- Rationale: single-use: sole caller lives inside MistHelper.py from `_run_systematic_test_mode()`; extract `run_systematic_test` OUT of the entrypoint into a new `src/refactors/run_systematic_test.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23666
+## Single-Use (3)
 
 ### `switch_to_interactive_login` (function, 20 lines)
 
@@ -164,13 +151,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `run_interactive_test` (function, 18 lines)
 
-- Def site: line 22927-22944
+- Def site: line 22903-22920
 - References: 1
 - Suggested class: `RunInteractiveTestManager`
 - Suggested module: `src/refactors/run_interactive_test.py`
 - Rationale: single-use: sole caller lives inside MistHelper.py from `_run_interactive_test_mode()`; extract `run_interactive_test` OUT of the entrypoint into a new `src/refactors/run_interactive_test.py` module and rewrite the callsite(s) to import from there
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23672
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23652
 
 ### `listen_keyboard` (function, 4 lines)
 
@@ -327,7 +314,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2234, 19375, 23253
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2234, 19375, 23229
 
 ### `initialize_mist_session` (function, 18 lines)
 
@@ -339,7 +326,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23258, 23321
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23234, 23297
 
 ### `PACKAGE_IMPORT_MAP` (assignment, 13 lines)
 
@@ -355,13 +342,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `main` (function, 12 lines)
 
-- Def site: line 23649-23660
+- Def site: line 23625-23636
 - References: 2
 - Suggested class: `MainManager`
 - Suggested module: `src/refactors/main.py`
 - Rationale: low-use: sole caller lives inside MistHelper.py; extract `main` OUT of the entrypoint into a new `src/refactors/main.py` module and rewrite the callsite(s) to import from there
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23759
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23739
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
 
 ### `marvis_data_utils` (assignment, 4 lines)
@@ -370,7 +357,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `_build_deps()`; extract `marvis_data_utils` OUT of the entrypoint into a new `src/refactors/marvis_data_utils.py` module and rewrite the callsite(s) to import from there
+- Rationale: low-use: sole caller lives inside MistHelper.py from `MarvisTroubleshootDeps()`; extract `marvis_data_utils` OUT of the entrypoint into a new `src/refactors/marvis_data_utils.py` module and rewrite the callsite(s) to import from there
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
@@ -536,7 +523,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21375, 22660, 22661, 22670, 22814, 22814, 22856, 22914, 22979, 23470, 23474, 23519, 23519, 23546, 23546, 23549
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21375, 22660, 22661, 22670, 22790, 22790, 22832, 22890, 22955, 23446, 23450, 23495, 23495, 23522, 23522, 23525
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
@@ -563,7 +550,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22638, 22638, 22642, 22642, 22662, 22662, 22667, 22667, 22915
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22638, 22638, 22642, 22642, 22662, 22662, 22667, 22667, 22891
 
 ### `PromptUtils` (class, 441 lines)
 
@@ -777,7 +764,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22832, 22832, 22835, 22916, 23287
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22808, 22808, 22811, 22892, 23263
 
 ### `PromptClientUtils` (class, 210 lines)
 
@@ -1026,7 +1013,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5885, 5885, 5887, 5887, 5903, 5903, 5915, 5915, 5954, 5954, 5955, 5955, 5956, 5956, 5957, 5957, 5958, 5958, 5969, 5969, 5972, 5972, 6904, 6904, 22949, 22949, 23532, 23532
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5885, 5885, 5887, 5887, 5903, 5903, 5915, 5915, 5954, 5954, 5955, 5955, 5956, 5956, 5957, 5957, 5958, 5958, 5969, 5969, 5972, 5972, 6904, 6904, 22925, 22925, 23508, 23508
 
 ### `OrgSiteExporter` (class, 112 lines)
 
@@ -1180,7 +1167,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1879, 1879, 1911, 1911, 2186, 2186, 2275, 2275, 2324, 2324, 7696, 7696, 7782, 7782, 7912, 7912, 7989, 7989, 8072, 8072, 8302, 8302, 8491, 8491, 8547, 8547, 8560, 8560, 8577, 8577, 8622, 8622, 8653, 8653, 8659, 8659, 8762, 8762, 10303, 10303, 10570, 11072, 11072, 11101, 11101, 11366, 11366, 11572, 11572, 11811, 11811, 12527, 12527, 12543, 12543, 13330, 13330, 13749, 13749, 13799, 13799, 15653, 15855, 15855, 15888, 15888, 15906, 15906, 15924, 15924, 15951, 15951, 15976, 17378, 17378, 17505, 17505, 17696, 17735, 17735, 17760, 17760, 17803, 17902, 17902, 18114, 18114, 18257, 18257, 19261, 19261, 19351, 19351, 19681, 19681, 19711, 19711, 19732, 19732, 19751, 19751, 19767, 19767, 19784, 19784, 20275, 20275, 20332, 20332, 20344, 20344, 20357, 20357, 20374, 20374, 20537, 20537, 21248, 21248, 21268, 21268, 21303, 21303, 21316, 21316, 21784, 21784, 21875, 21875, 21880, 21880, 21886, 21886, 21905, 21905, 21911, 21911, 23555, 23555, 23653, 23653
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1879, 1879, 1911, 1911, 2186, 2186, 2275, 2275, 2324, 2324, 7696, 7696, 7782, 7782, 7912, 7912, 7989, 7989, 8072, 8072, 8302, 8302, 8491, 8491, 8547, 8547, 8560, 8560, 8577, 8577, 8622, 8622, 8653, 8653, 8659, 8659, 8762, 8762, 10303, 10303, 10570, 11072, 11072, 11101, 11101, 11366, 11366, 11572, 11572, 11811, 11811, 12527, 12527, 12543, 12543, 13330, 13330, 13749, 13749, 13799, 13799, 15653, 15855, 15855, 15888, 15888, 15906, 15906, 15924, 15924, 15951, 15951, 15976, 17378, 17378, 17505, 17505, 17696, 17735, 17735, 17760, 17760, 17803, 17902, 17902, 18114, 18114, 18257, 18257, 19261, 19261, 19351, 19351, 19681, 19681, 19711, 19711, 19732, 19732, 19751, 19751, 19767, 19767, 19784, 19784, 20275, 20275, 20332, 20332, 20344, 20344, 20357, 20357, 20374, 20374, 20537, 20537, 21248, 21248, 21268, 21268, 21303, 21303, 21316, 21316, 21784, 21784, 21875, 21875, 21880, 21880, 21886, 21886, 21905, 21905, 21911, 21911, 23531, 23531, 23629, 23629
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -1236,7 +1223,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6131, 6131, 6136, 6136, 6233, 6233, 6291, 6291, 7182, 7182, 7839, 7839, 8484, 8484, 8507, 8507, 8527, 8527, 8712, 8712, 8733, 8733, 9008, 9008, 9033, 9033, 9088, 9088, 9110, 9110, 9127, 9127, 9144, 9144, 9529, 9529, 9752, 9752, 9769, 9769, 10161, 10161, 10493, 10493, 10704, 10704, 10741, 10741, 10894, 10894, 11037, 11037, 11290, 11290, 11478, 11478, 11662, 11662, 11981, 11981, 12317, 12317, 12489, 12489, 12529, 12529, 12535, 12535, 12629, 12629, 12859, 12859, 12932, 12932, 13419, 13419, 13454, 13653, 13653, 15160, 15160, 15376, 15376, 15644, 15751, 15851, 15851, 15886, 15886, 15904, 15904, 15922, 15922, 15957, 15957, 16491, 16491, 17298, 17298, 17691, 17801, 18309, 18309, 19262, 19262, 19267, 19267, 19269, 19269, 19682, 19682, 19684, 19684, 19708, 19708, 19712, 19712, 19713, 19713, 19733, 19733, 19734, 19734, 19996, 19996, 20782, 20782, 21352, 21352, 21384, 21384, 21421, 21421, 21427, 21427, 21555, 21555, 21612, 21612, 21695, 21695, 21704, 21704, 21782, 21782, 21783, 21783, 21800, 21800, 21875, 21875, 21880, 21880, 21886, 21886, 21905, 21905, 21911, 21911, 22846, 22846, 22917, 23419, 23419, 23507, 23507
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6131, 6131, 6136, 6136, 6233, 6233, 6291, 6291, 7182, 7182, 7839, 7839, 8484, 8484, 8507, 8507, 8527, 8527, 8712, 8712, 8733, 8733, 9008, 9008, 9033, 9033, 9088, 9088, 9110, 9110, 9127, 9127, 9144, 9144, 9529, 9529, 9752, 9752, 9769, 9769, 10161, 10161, 10493, 10493, 10704, 10704, 10741, 10741, 10894, 10894, 11037, 11037, 11290, 11290, 11478, 11478, 11662, 11662, 11981, 11981, 12317, 12317, 12489, 12489, 12529, 12529, 12535, 12535, 12629, 12629, 12859, 12859, 12932, 12932, 13419, 13419, 13454, 13653, 13653, 15160, 15160, 15376, 15376, 15644, 15751, 15851, 15851, 15886, 15886, 15904, 15904, 15922, 15922, 15957, 15957, 16491, 16491, 17298, 17298, 17691, 17801, 18309, 18309, 19262, 19262, 19267, 19267, 19269, 19269, 19682, 19682, 19684, 19684, 19708, 19708, 19712, 19712, 19713, 19713, 19733, 19733, 19734, 19734, 19996, 19996, 20782, 20782, 21352, 21352, 21384, 21384, 21421, 21421, 21427, 21427, 21555, 21555, 21612, 21612, 21695, 21695, 21704, 21704, 21782, 21782, 21783, 21783, 21800, 21800, 21875, 21875, 21880, 21880, 21886, 21886, 21905, 21905, 21911, 21911, 22822, 22822, 22893, 23395, 23395, 23483, 23483
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1298,7 +1285,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6288, 6288, 8174, 8174, 9089, 9089, 9112, 9112, 9599, 9599, 9634, 9634, 9648, 9648, 9771, 9771, 9775, 9775, 10323, 10323, 12633, 12633, 13303, 13303, 13429, 13429, 13461, 13639, 13639, 13675, 13675, 15650, 18417, 18417, 19263, 19263, 19572, 19572, 19683, 19683, 19714, 19714, 19735, 19735, 21785, 21785, 21801, 21801, 23438, 23438
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6288, 6288, 8174, 8174, 9089, 9089, 9112, 9112, 9599, 9599, 9634, 9634, 9648, 9648, 9771, 9771, 9775, 9775, 10323, 10323, 12633, 12633, 13303, 13303, 13429, 13429, 13461, 13639, 13639, 13675, 13675, 15650, 18417, 18417, 19263, 19263, 19572, 19572, 19683, 19683, 19714, 19714, 19735, 19735, 21785, 21785, 21801, 21801, 23414, 23414
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
@@ -1397,7 +1384,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2180, 2239, 19380, 23262
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2180, 2239, 19380, 23238
 
 ### `RoutingUtils` (class, 22 lines)
 

--- a/src/refactors/run_systematic_test.py
+++ b/src/refactors/run_systematic_test.py
@@ -109,9 +109,9 @@ class RunSystematicTestManager:
         misthelper._print_systematic_pre_run_counts(  # Print pre-run counts of total/safe/unsafe
             all_options, safe_options, unsafe_list
         )
-        emitter, telemetry_path, skip_count = (
-            misthelper._initialize_systematic_telemetry(unsafe_list)  # Open timestamped telemetry emitter
-        )
+        emitter, telemetry_path, skip_count = misthelper._initialize_systematic_telemetry(
+            unsafe_list
+        )  # Open timestamped telemetry emitter
         fast_enabled = misthelper._resolve_systematic_test_context()  # Resolve org + fast mode once
         logging.debug(  # Log resolved context for tracing (counts + fast flag)
             "RunSystematicTestManager: sweep prepared safe=%d unsafe=%d fast=%s",
@@ -121,17 +121,16 @@ class RunSystematicTestManager:
         )
         return safe_options, unsafe_list, all_options, skip_count, emitter, telemetry_path, fast_enabled
 
-    def _execute_sweep(
-        self, emitter: Any, safe_options: list[str], fast_enabled: bool
-    ) -> tuple[int, int]:
+    def _execute_sweep(self, emitter: Any, safe_options: list[str], fast_enabled: bool) -> tuple[int, int]:
         """Run every safe option through the telemetry-emitting loop and count outcomes."""
         logging.info(  # Log execution phase entry with count of safe options
             "RunSystematicTestManager: executing sweep across %d safe options", len(safe_options)
         )
-        success_count, error_count = (
-            self._misthelper()._execute_systematic_test_loop(  # Delegate loop body to canonical helper
-                emitter, safe_options, fast_enabled
-            )
+        (
+            success_count,
+            error_count,
+        ) = self._misthelper()._execute_systematic_test_loop(  # Delegate loop body to canonical helper
+            emitter, safe_options, fast_enabled
         )
         logging.debug(  # Log per-run counts for observability without recomputing them
             "RunSystematicTestManager: sweep executed success=%d error=%d", success_count, error_count
@@ -168,9 +167,7 @@ class RunSystematicTestManager:
         """Emit summary, close telemetry, print operator summary, and return outcome."""
         logging.info("RunSystematicTestManager: finalizing sweep and printing summary")  # Log finalize
         misthelper = self._misthelper()  # Cache module handle for the three helper lookups below
-        misthelper._finalize_systematic_telemetry(  # Emit summary event, close file, enforce retention
-            emitter, summary
-        )
+        misthelper._finalize_systematic_telemetry(emitter, summary)  # Emit summary event, close file, enforce retention
         misthelper._print_systematic_summary(summary, telemetry_path)  # Print user-facing summary block
         outcome = bool(  # Cast Any (misthelper module attr) to bool for strict typing conformance
             misthelper._report_systematic_outcome(  # Emit pass/fail message + return boolean

--- a/src/refactors/run_systematic_test.py
+++ b/src/refactors/run_systematic_test.py
@@ -172,11 +172,13 @@ class RunSystematicTestManager:
             emitter, summary
         )
         misthelper._print_systematic_summary(summary, telemetry_path)  # Print user-facing summary block
-        outcome = misthelper._report_systematic_outcome(  # Emit pass/fail message + return boolean
-            counters.success_count,
-            counters.error_count,
-            len(counters.safe_options),
-            summary.total_time,
+        outcome = bool(  # Cast Any (misthelper module attr) to bool for strict typing conformance
+            misthelper._report_systematic_outcome(  # Emit pass/fail message + return boolean
+                counters.success_count,
+                counters.error_count,
+                len(counters.safe_options),
+                summary.elapsed,  # TestSummary field name is `elapsed` (wall-clock seconds)
+            )
         )
         logging.debug(  # Log final outcome so callers can trace exit-code decision
             "RunSystematicTestManager: sweep finalized outcome=%s", outcome

--- a/src/refactors/run_systematic_test.py
+++ b/src/refactors/run_systematic_test.py
@@ -1,0 +1,184 @@
+"""RunSystematicTestManager extracted from MistHelper.
+
+Runs the systematic (read-only, non-interactive, non-destructive) menu-option
+sweep used by ``--test`` mode. Each safe menu option is invoked exactly once,
+with telemetry emission and a printed summary.
+
+Runtime dependencies (``menu_actions`` global, ``org_id`` global mutation,
+``ConfigUtils``, ``TelemetryEmitter``, ``SystematicTestOption``, ``TestSummary``,
+and the ``_systematic_test_*`` module-level helpers) are still owned by
+MistHelper.py. They are resolved lazily via ``importlib.import_module`` so the
+extracted module import-graph stays flat and monkeypatched attributes are
+honoured in tests.
+
+Address the ``missing_action_logging`` guideline flag identified by the
+compliance analyzer for ``run_systematic_test``: this class wraps the full
+sweep in explicit info-before / debug-after envelopes at the manager level.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing on 3.10+
+
+import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
+import logging  # Structured action logging required by coding standards
+import time  # Measure total sweep duration and enforce inter-option API delay via helper
+from dataclasses import dataclass  # Bundle sweep counters to keep _finalize_sweep within the 5-Item Rule
+from types import SimpleNamespace  # Bundle runtime dependencies without coupling to a dataclass
+from typing import Any  # Loose typing for late-bound module attributes and helper return values
+
+from src.dataclasses.progress_event import TestSummary  # Aggregate result event bundled for emitter + printer
+
+
+@dataclass(frozen=True)
+class _SweepCounters:
+    """Bundle per-option pass/fail counts and the safe-option list for finalize step."""
+
+    success_count: int  # Count of options that completed without raising an exception
+    error_count: int  # Count of options that raised or returned an error
+    safe_options: list[str]  # Ordered safe-option list used to compute total attempts
+
+
+def _resolve_runtime_dependencies() -> SimpleNamespace:
+    """Resolve MistHelper-owned runtime dependencies without static cross-module imports."""
+    logging.info("Resolving RunSystematicTestManager runtime dependencies from MistHelper")  # Log before import
+    misthelper_module = importlib.import_module("MistHelper")  # Late import avoids circular dependency
+    logging.debug("RunSystematicTestManager runtime dependencies resolved successfully")  # Log after resolution
+    return SimpleNamespace(
+        misthelper_module=misthelper_module,  # Retained so global lookups honour monkeypatch in tests
+    )
+
+
+class RunSystematicTestManager:
+    """Run systematic test of safe menu options with telemetry and summary output.
+
+    Owns the top-level orchestration originally defined as
+    ``run_systematic_test()`` in MistHelper.py. Delegates classification,
+    telemetry, and per-option execution to the ``_systematic_test_*``
+    module-level helpers that remain in MistHelper.
+
+    SECURITY: Executes only options classified as safe (GET-only,
+    non-interactive, non-destructive) by OperationRegistry.
+
+    Usage:
+        RunSystematicTestManager().run()
+    """
+
+    def __init__(self) -> None:
+        """Initialize manager with late-bound MistHelper handles."""
+        logging.info("RunSystematicTestManager init: starting new manager instance")  # Log construction start
+        self._deps: SimpleNamespace = _resolve_runtime_dependencies()  # Late-bound MistHelper handles
+        logging.debug("RunSystematicTestManager init complete")  # Log after construction
+
+    def _misthelper(self) -> Any:
+        """Return the current MistHelper module so monkeypatched attributes are honoured."""
+        return self._deps.misthelper_module  # Resolve at call-time so tests can substitute values
+
+    def run(self) -> bool:
+        """Run systematic test of safe menu options and return pass/fail outcome.
+
+        Returns:
+            bool: True if all tested options passed, False if any failed.
+        """
+        logging.info("SYSTEMATIC_TEST: RunSystematicTestManager.run starting sweep")  # Log sweep start
+        start_time = time.time()  # Capture total-duration baseline before any setup work
+        safe_options, unsafe_list, all_options, skip_count, emitter, telemetry_path, fast_enabled = (
+            self._prepare_sweep()  # Banner, classification, telemetry, org resolution done once up front
+        )
+        success_count, error_count = self._execute_sweep(emitter, safe_options, fast_enabled)  # Run loop
+        summary = self._build_summary(  # Bundle counts into TestSummary event reused by both finalize + print
+            all_options, success_count, error_count, skip_count, start_time
+        )
+        counters = _SweepCounters(  # Frozen bundle keeps _finalize_sweep signature within the 5-Item Rule
+            success_count=success_count, error_count=error_count, safe_options=safe_options
+        )
+        outcome = self._finalize_sweep(  # Emit summary, close telemetry, print summary, return outcome
+            emitter, summary, telemetry_path, counters
+        )
+        logging.debug(  # Log sweep completion with outcome for postmortem tracing
+            "SYSTEMATIC_TEST: RunSystematicTestManager.run finished outcome=%s", outcome
+        )
+        return outcome  # Signal pass/fail to callers for exit-code logic
+
+    def _prepare_sweep(self) -> tuple[list[str], list[str], list[str], int, Any, Any, bool]:
+        """Print banner, classify options, open telemetry, and resolve run context."""
+        logging.info("RunSystematicTestManager: preparing sweep context")  # Log preparation start
+        misthelper = self._misthelper()  # Cache module handle for the helper lookups below
+        misthelper._print_systematic_banner()  # Banner + start timestamp + separator
+        safe_options, unsafe_list, all_options = (
+            misthelper._build_systematic_test_options()  # Classify menu options into safe/unsafe sets
+        )
+        misthelper._print_systematic_pre_run_counts(  # Print pre-run counts of total/safe/unsafe
+            all_options, safe_options, unsafe_list
+        )
+        emitter, telemetry_path, skip_count = (
+            misthelper._initialize_systematic_telemetry(unsafe_list)  # Open timestamped telemetry emitter
+        )
+        fast_enabled = misthelper._resolve_systematic_test_context()  # Resolve org + fast mode once
+        logging.debug(  # Log resolved context for tracing (counts + fast flag)
+            "RunSystematicTestManager: sweep prepared safe=%d unsafe=%d fast=%s",
+            len(safe_options),
+            len(unsafe_list),
+            fast_enabled,
+        )
+        return safe_options, unsafe_list, all_options, skip_count, emitter, telemetry_path, fast_enabled
+
+    def _execute_sweep(
+        self, emitter: Any, safe_options: list[str], fast_enabled: bool
+    ) -> tuple[int, int]:
+        """Run every safe option through the telemetry-emitting loop and count outcomes."""
+        logging.info(  # Log execution phase entry with count of safe options
+            "RunSystematicTestManager: executing sweep across %d safe options", len(safe_options)
+        )
+        success_count, error_count = (
+            self._misthelper()._execute_systematic_test_loop(  # Delegate loop body to canonical helper
+                emitter, safe_options, fast_enabled
+            )
+        )
+        logging.debug(  # Log per-run counts for observability without recomputing them
+            "RunSystematicTestManager: sweep executed success=%d error=%d", success_count, error_count
+        )
+        return success_count, error_count
+
+    def _build_summary(
+        self,
+        all_options: list[str],
+        success_count: int,
+        error_count: int,
+        skip_count: int,
+        start_time: float,
+    ) -> TestSummary:
+        """Build the aggregate TestSummary event from per-option counters and elapsed time."""
+        total_time = time.time() - start_time  # Total elapsed includes setup, execution, and delays
+        summary = TestSummary(  # Frozen bundle keeps emitter + printer signatures within the 5-Item Rule
+            len(all_options), success_count, error_count, skip_count, total_time, "systematic"
+        )
+        logging.debug(  # Log built summary for postmortem observability without duplicating fields
+            "RunSystematicTestManager: summary built total_ops=%d total_time=%.2f",
+            len(all_options),
+            total_time,
+        )
+        return summary  # Return so caller can hand it to finalize + print helpers
+
+    def _finalize_sweep(
+        self,
+        emitter: Any,
+        summary: TestSummary,
+        telemetry_path: Any,
+        counters: _SweepCounters,
+    ) -> bool:
+        """Emit summary, close telemetry, print operator summary, and return outcome."""
+        logging.info("RunSystematicTestManager: finalizing sweep and printing summary")  # Log finalize
+        misthelper = self._misthelper()  # Cache module handle for the three helper lookups below
+        misthelper._finalize_systematic_telemetry(  # Emit summary event, close file, enforce retention
+            emitter, summary
+        )
+        misthelper._print_systematic_summary(summary, telemetry_path)  # Print user-facing summary block
+        outcome = misthelper._report_systematic_outcome(  # Emit pass/fail message + return boolean
+            counters.success_count,
+            counters.error_count,
+            len(counters.safe_options),
+            summary.total_time,
+        )
+        logging.debug(  # Log final outcome so callers can trace exit-code decision
+            "RunSystematicTestManager: sweep finalized outcome=%s", outcome
+        )
+        return outcome  # Return pass/fail boolean to run()


### PR DESCRIPTION
## Summary

- Extracts the 22-line top-level `run_systematic_test()` from `MistHelper.py` into `src/refactors/run_systematic_test.py` as `RunSystematicTestManager`, following the launcher pattern established in PR-08/PR-09.
- Deletes the original function body; rewires `_run_systematic_test_mode` to instantiate the extracted manager and call `.run()` (no wrapper / delegator shim, satisfying FR-005).
- Adds explicit info-before / debug-after action-logging envelopes at manager entry, `prepare`, `execute`, `build_summary`, and `finalize` phases to address the analyzer's `missing_action_logging` guideline flag identified for this function.
- Uses `importlib.import_module("MistHelper")` for late-bound resolution of `menu_actions`, `TelemetryEmitter`, `ConfigUtils`, and the private `_systematic_test_*` helpers so monkeypatched attributes are honored in tests.
- `_SweepCounters` frozen dataclass bundles `success_count`/`error_count`/`safe_options` to keep `_finalize_sweep` within the 5-Item Rule.

## Compliance & analyzer deltas

- New file `src/refactors/run_systematic_test.py`: A+/100.0
- `MistHelper.py` compliance: 93.0/A (unchanged vs main)
- Repo overall: 94.6/A (unchanged vs main)
- Refactor analyzer post-change: 104 candidates, 3 single-use remaining (was 4), 42 LoC saveable (was 64, -22 lines matching the extracted function)

## Test plan

- [x] `python -m ruff check src/refactors/run_systematic_test.py MistHelper.py` -> clean
- [x] `python -m pytest tests/guardrails/ -x -q` -> 40 passed
- [x] `python -m tools.compliance_analyzer src/refactors/run_systematic_test.py` -> A+/100.0
- [x] `python -m tools.compliance_analyzer -r .` -> 94.6/A (baseline preserved)
- [x] `python -c "from src.refactors.run_systematic_test import RunSystematicTestManager; RunSystematicTestManager()"` -> instantiates cleanly
- [x] Full unit-test run parity vs main (5 libcst-related failures pre-exist on main; CI has libcst installed)

## Refactor plan

Part of `specs/1010-misthelper-refactor-extraction/`, PR-10 of 13.