### PR TITLE
refactor(1010): PR-13 extract listen_keyboard to KeyboardListener

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -147,6 +147,7 @@ from src.gateway.gateway_export_utils import (
 )  # Import gateway export utility configuration
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
 from src.refactors.data_directory_checker import DataDirectoryChecker  # Early data-dir writable check (SC-005)
+from src.refactors.keyboard_listener import KeyboardListener  # PR-13 extracted no-op keyboard listener stub (SC-012)
 from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted Maps Manager launcher (SC-006)
 from src.refactors.run_interactive_test import (
     RunInteractiveTestManager,  # Extracted interactive-test manager (SC-011)
@@ -640,14 +641,10 @@ try:  # rapidfuzz is optional (fast fuzzy string matching)
 except ImportError:  # rapidfuzz not installed
     fuzz = None  # type: ignore[assignment]  # None lets callers skip fuzzy matching
 
-# Keyboard listener functionality has been removed for simplicity
-# These functions are no-op fallbacks
-
-
-def listen_keyboard(*args, **kwargs):  # Removed feature; harmless stub kept for old call sites
-    """Keyboard listener has been removed - this is a no-op fallback."""
-    logging.info("Keyboard listener functionality has been removed")  # Tell any remaining caller this does nothing
-    return None  # No listener object to return
+# Keyboard listener functionality was extracted to src/refactors/keyboard_listener.py
+# (PR-13). The extracted class KeyboardListener preserves the no-op stub for the
+# single remaining call site (interactive SSR/SRX websocket shell). No wrapper or
+# alias is retained here per FR-005 (no shims left in MistHelper).
 
 
 # stop_listening() removed per issue #431: it was a `pass` no-op stub for a
@@ -16132,7 +16129,7 @@ class CLIShellManager:  # CLI shell over WebSocket.
         ws.send_binary(bytes(map(ord, "\00\n\n")))  # Send a wakeup; bytes (not bytearray) matches send_binary.
         if debug:  # Debug mode.
             print("[DEBUG] Sent wakeup sequence to Juniper SSRs")  # Trace the wakeup.
-        listen_keyboard(  # type: ignore[no-untyped-call]  # Block on keyboard input, forwarding each key to the PTY.
+        KeyboardListener().listen(  # Block on keyboard input, forwarding each key to the PTY (PR-13 extracted no-op).
             on_release=functools.partial(CLIShellManager._shell_send_key, ws, debug),
             delay_second_char=0,
             delay_other_chars=0,

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 182 first-party files
-- Definitions analyzed: 102
-- LOC saveable (unused + single-use): 4
-- Category counts: unused=0, single-use=1, low-use=20, hot=80, skipped=1
+- Module graph size: 183 first-party files
+- Definitions analyzed: 101
+- LOC saveable (unused + single-use): 0
+- Category counts: unused=0, single-use=0, low-use=20, hot=80, skipped=1
 
 ## How to read this report
 
@@ -123,7 +123,6 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `SSHConnectionConfig` | class | 9 | 6 | hot |  | missing_action_logging |
 | `DeviceFetchConfig` | class | 9 | 4 | hot |  | missing_action_logging |
 | `SSHExecutionConfig` | class | 8 | 5 | hot |  | missing_inline_comments,missing_action_logging |
-| `listen_keyboard` | function | 4 | 1 | single-use | ListenKeyboardManager |  |
 | `marvis_data_utils` | assignment | 4 | 3 | low-use | MarvisDataUtils | missing_action_logging |
 | `is_debug_mode` | function | 3 | 12 | hot |  | missing_action_logging |
 | `tqdm` | function | 3 | 43 | hot |  | missing_action_logging |
@@ -135,23 +134,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 14 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Single-Use (1)
-
-### `listen_keyboard` (function, 4 lines)
-
-- Def site: line 647-650
-- References: 1
-- Suggested class: `ListenKeyboardManager`
-- Suggested module: `src/refactors/listen_keyboard.py`
-- Rationale: single-use: sole caller lives inside MistHelper.py from `_run_interactive()`; extract `listen_keyboard` OUT of the entrypoint into a new `src/refactors/listen_keyboard.py` module and rewrite the callsite(s) to import from there
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16135
-
 ## Low-Use (20)
 
 ### `FirmwareUpgradeStatusChecker` (class, 958 lines)
 
-- Def site: line 18254-19211
+- Def site: line 18251-19208
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -165,7 +152,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `WLANRadiusTimerManager` (class, 787 lines)
 
-- Def site: line 19880-20666
+- Def site: line 19877-20663
 - References: 3
 - Suggested class: `WLANRadiusTimerManager`
 - Suggested module: `src/refactors/wlanradius_timer_manager.py`
@@ -175,11 +162,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20047, 20047, 21518
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20044, 20044, 21515
 
 ### `WANProbeConfigManager` (class, 473 lines)
 
-- Def site: line 17184-17656
+- Def site: line 17181-17653
 - References: 2
 - Suggested class: `WANProbeConfigManager`
 - Suggested module: `src/refactors/wanprobe_config_manager.py`
@@ -188,11 +175,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21723, 21723
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21720, 21720
 
 ### `AnomalyMetricsDiscovery` (class, 91 lines)
 
-- Def site: line 19782-19872
+- Def site: line 19779-19869
 - References: 2
 - Suggested class: `AnomalyMetricsDiscovery`
 - Suggested module: `src/refactors/anomaly_metrics_discovery.py`
@@ -201,11 +188,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12997, 12997
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12994, 12994
 
 ### `DeviceDataFetcher` (class, 68 lines)
 
-- Def site: line 5541-5608
+- Def site: line 5538-5605
 - References: 3
 - Suggested class: `DeviceDataFetcher`
 - Suggested module: `src/refactors/device_data_fetcher.py`
@@ -214,11 +201,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15295, 15312, 15328
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15292, 15309, 15325
 
 ### `InventoryCSVComparator` (class, 47 lines)
 
-- Def site: line 16452-16498
+- Def site: line 16449-16495
 - References: 3
 - Suggested class: `InventoryCSVComparator`
 - Suggested module: `src/refactors/inventory_csvcomparator.py`
@@ -227,11 +214,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16491, 16491, 21544
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16488, 16488, 21541
 
 ### `BulkAPFirmwareUpgrader` (class, 32 lines)
 
-- Def site: line 19224-19255
+- Def site: line 19221-19252
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -245,7 +232,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceConfigTemplateClonerManager` (class, 27 lines)
 
-- Def site: line 15917-15943
+- Def site: line 15914-15940
 - References: 2
 - Suggested class: `DeviceConfigTemplateClonerManager`
 - Suggested module: `src/refactors/device_config_template_cloner_manager.py`
@@ -254,11 +241,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21925, 21925
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21922, 21922
 
 ### `WANProbeDeviceOverrideManager` (class, 23 lines)
 
-- Def site: line 17664-17686
+- Def site: line 17661-17683
 - References: 2
 - Suggested class: `WANProbeDeviceOverrideManager`
 - Suggested module: `src/refactors/wanprobe_device_override_manager.py`
@@ -267,11 +254,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21727, 21727
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21724, 21724
 
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 19756-19774
+- Def site: line 19753-19771
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -284,7 +271,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `initialize_mist_session_interactive` (function, 18 lines)
 
-- Def site: line 2180-2197
+- Def site: line 2177-2194
 - References: 3
 - Suggested class: `InitializeMistSessionInteractiveManager`
 - Suggested module: `src/refactors/initialize_mist_session_interactive.py`
@@ -292,11 +279,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2240, 19359, 23193
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2237, 19356, 23190
 
 ### `initialize_mist_session` (function, 18 lines)
 
-- Def site: line 2806-2823
+- Def site: line 2803-2820
 - References: 2
 - Suggested class: `InitializeMistSessionManager`
 - Suggested module: `src/refactors/initialize_mist_session.py`
@@ -304,11 +291,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23198, 23261
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23195, 23258
 
 ### `PACKAGE_IMPORT_MAP` (assignment, 13 lines)
 
-- Def site: line 353-365
+- Def site: line 354-366
 - References: 2
 - Suggested class: `PackageImportMapManager`
 - Suggested module: `src/refactors/package__import__map.py`
@@ -316,22 +303,22 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 353, 537
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 354, 538
 
 ### `main` (function, 12 lines)
 
-- Def site: line 23589-23600
+- Def site: line 23586-23597
 - References: 2
 - Suggested class: `MainManager`
 - Suggested module: `src/refactors/main.py`
 - Rationale: low-use: sole caller lives inside MistHelper.py; extract `main` OUT of the entrypoint into a new `src/refactors/main.py` module and rewrite the callsite(s) to import from there
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23703
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 23700
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
 
 ### `marvis_data_utils` (assignment, 4 lines)
 
-- Def site: line 6597-6600
+- Def site: line 6594-6597
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
@@ -339,12 +326,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6597, 15739
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6594, 15736
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\marvis_troubleshoot_utils.py`: lines 21
 
 ### `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 lines)
 
-- Def site: line 1972-1974
+- Def site: line 1969-1971
 - References: 3
 - Suggested class: `FastModeBackoffMultiplierManager`
 - Suggested module: `src/refactors/fast__mode__backoff__multiplier.py`
@@ -353,11 +340,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1972, 9983, 15412
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1969, 9980, 15409
 
 ### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
 
-- Def site: line 1975-1977
+- Def site: line 1972-1974
 - References: 2
 - Suggested class: `FastModeDevicesPerThreadManager`
 - Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
@@ -366,11 +353,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1975, 7473
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1972, 7470
 
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 1980-1982
+- Def site: line 1977-1979
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -379,11 +366,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1980, 15552
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1977, 15549
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 1987-1989
+- Def site: line 1984-1986
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -391,11 +378,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1987, 7463
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1984, 7460
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 1995-1997
+- Def site: line 1992-1994
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -404,14 +391,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1995, 15641
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1992, 15638
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
 ## Hot (80)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2868-5194
+- Def site: line 2865-5191
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -422,11 +409,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2868, 6643, 6644, 6653, 6817
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2865, 6640, 6641, 6650, 6814
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13998-14756
+- Def site: line 13995-14753
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -435,11 +422,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14475, 14475, 14487, 14487, 14515, 14515, 14527, 14527, 14588, 14588, 14625, 14625, 14782, 21642
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14472, 14472, 14484, 14484, 14512, 14512, 14524, 14524, 14585, 14585, 14622, 14622, 14779, 21639
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9144-9829
+- Def site: line 9141-9826
 - References: 112
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -448,12 +435,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5650, 5650, 9267, 9267, 9318, 9318, 9321, 9321, 9362, 9362, 9401, 9401, 9419, 9419, 9497, 9497, 9504, 9504, 9514, 9514, 9517, 9517, 9530, 9530, 9531, 9531, 9532, 9532, 9533, 9533, 9541, 9541, 9543, 9543, 9544, 9544, 9545, 9545, 9546, 9546, 9549, 9549, 9552, 9552, 9555, 9555, 9558, 9558, 9604, 9604, 9627, 9627, 9628, 9628, 9629, 9629, 9631, 9631, 9667, 9667, 9683, 9683, 9737, 9737, 9738, 9738, 9739, 9739, 9742, 9742, 9743, 9743, 9762, 9762, 9764, 9764, 9765, 9765, 9800, 9800, 15151, 15151, 15204, 15204, 15635, 16474, 16474, 17713, 17713, 17737, 17737, 17761, 17761, 17904, 17904, 21417, 21417, 21424, 21424, 21433, 21433, 21437, 21437, 21446, 21446
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5647, 5647, 9264, 9264, 9315, 9315, 9318, 9318, 9359, 9359, 9398, 9398, 9416, 9416, 9494, 9494, 9501, 9501, 9511, 9511, 9514, 9514, 9527, 9527, 9528, 9528, 9529, 9529, 9530, 9530, 9538, 9538, 9540, 9540, 9541, 9541, 9542, 9542, 9543, 9543, 9546, 9546, 9549, 9549, 9552, 9552, 9555, 9555, 9601, 9601, 9624, 9624, 9625, 9625, 9626, 9626, 9628, 9628, 9664, 9664, 9680, 9680, 9734, 9734, 9735, 9735, 9736, 9736, 9739, 9739, 9740, 9740, 9759, 9759, 9761, 9761, 9762, 9762, 9797, 9797, 15148, 15148, 15201, 15201, 15632, 16471, 16471, 17710, 17710, 17734, 17734, 17758, 17758, 17901, 17901, 21414, 21414, 21421, 21421, 21430, 21430, 21434, 21434, 21443, 21443
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16504-17178
+- Def site: line 16501-17175
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -461,11 +448,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16892, 16892, 21888, 21894
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16889, 16889, 21885, 21891
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11877-12529
+- Def site: line 11874-12526
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -475,11 +462,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10654, 10654, 10663, 10663, 10751, 10751, 10758, 10758, 11432, 11432, 11718, 11718, 11723, 11723, 11730, 11730, 11735, 11735, 11949, 11949, 11971, 11971, 11974, 11974, 12000, 12000, 12009, 12009, 12010, 12010, 12031, 12031, 12074, 12074, 12120, 12120, 12131, 12131, 12158, 12158, 12163, 12163, 12164, 12164, 12165, 12165, 12197, 12197, 12203, 12203, 12228, 12228, 12248, 12248, 12283, 12283, 12298, 12298, 12304, 12304, 12306, 12306, 12309, 12309, 12311, 12311, 12315, 12315, 12319, 12319, 12324, 12324, 12331, 12331, 12338, 12338, 12345, 12345, 12354, 12354, 12364, 12364, 12371, 12371, 12378, 12378, 12385, 12385, 12392, 12392, 12399, 12399, 12409, 12409, 12418, 12418, 12427, 12427, 12436, 12436, 12445, 12445, 12474, 12474, 21378, 21378, 21559, 21559, 21636, 21636, 21637, 21637, 21645, 21645, 21850, 21850, 21851, 21851, 21870, 21870, 21877, 21877, 21878, 21878, 21879, 21879, 21880, 21880
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10651, 10651, 10660, 10660, 10748, 10748, 10755, 10755, 11429, 11429, 11715, 11715, 11720, 11720, 11727, 11727, 11732, 11732, 11946, 11946, 11968, 11968, 11971, 11971, 11997, 11997, 12006, 12006, 12007, 12007, 12028, 12028, 12071, 12071, 12117, 12117, 12128, 12128, 12155, 12155, 12160, 12160, 12161, 12161, 12162, 12162, 12194, 12194, 12200, 12200, 12225, 12225, 12245, 12245, 12280, 12280, 12295, 12295, 12301, 12301, 12303, 12303, 12306, 12306, 12308, 12308, 12312, 12312, 12316, 12316, 12321, 12321, 12328, 12328, 12335, 12335, 12342, 12342, 12351, 12351, 12361, 12361, 12368, 12368, 12375, 12375, 12382, 12382, 12389, 12389, 12396, 12396, 12406, 12406, 12415, 12415, 12424, 12424, 12433, 12433, 12442, 12442, 12471, 12471, 21375, 21375, 21556, 21556, 21633, 21633, 21634, 21634, 21642, 21642, 21847, 21847, 21848, 21848, 21867, 21867, 21874, 21874, 21875, 21875, 21876, 21876, 21877, 21877
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 20674-21260
+- Def site: line 20671-21257
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -487,11 +474,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20951, 20951, 20952, 20952, 20955, 20955, 20957, 20957, 20959, 20959, 20975, 20975, 21795
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20948, 20948, 20949, 20949, 20952, 20952, 20954, 20954, 20956, 20956, 20972, 20972, 21792
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 21359-21930
+- Def site: line 21356-21927
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -501,12 +488,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21359, 22644, 22645, 22654, 22774, 22774, 22816, 22874, 22919, 23410, 23414, 23459, 23459, 23486, 23486, 23489
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21356, 22641, 22642, 22651, 22771, 22771, 22813, 22871, 22916, 23407, 23411, 23456, 23456, 23483, 23483, 23486
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8428-8890
+- Def site: line 8425-8887
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -514,11 +501,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8469, 8469, 8474, 8474, 8484, 8484, 8492, 8492, 8497, 8497, 8502, 8502, 8512, 8512, 8517, 8517, 8522, 8522, 8542, 8542, 8552, 8552, 8553, 8553, 8556, 8556, 8586, 8586, 8672, 8672, 8674, 8674, 8698, 8698, 8704, 8704, 8709, 8709, 8718, 8718, 8722, 8722, 8741, 8741, 8744, 8744, 8755, 8755, 8756, 8756, 8851, 8851, 8872, 8872, 21918, 21918, 21919, 21919, 21920, 21920, 21921, 21921, 21922, 21922, 21923, 21923
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8466, 8466, 8471, 8471, 8481, 8481, 8489, 8489, 8494, 8494, 8499, 8499, 8509, 8509, 8514, 8514, 8519, 8519, 8539, 8539, 8549, 8549, 8550, 8550, 8553, 8553, 8583, 8583, 8669, 8669, 8671, 8671, 8695, 8695, 8701, 8701, 8706, 8706, 8715, 8715, 8719, 8719, 8738, 8738, 8741, 8741, 8752, 8752, 8753, 8753, 8848, 8848, 8869, 8869, 21915, 21915, 21916, 21916, 21917, 21917, 21918, 21918, 21919, 21919, 21920, 21920
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 22155-22615
+- Def site: line 22152-22612
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -528,11 +515,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22622, 22622, 22626, 22626, 22646, 22646, 22651, 22651, 22875
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22619, 22619, 22623, 22623, 22643, 22643, 22648, 22648, 22872
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7875-8315
+- Def site: line 7872-8312
 - References: 125
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -540,14 +527,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5579, 5579, 5587, 5587, 7820, 7820, 7836, 7836, 7840, 7840, 7841, 7841, 7842, 7842, 7857, 7857, 7863, 7863, 7890, 7890, 7893, 7893, 7901, 7901, 7919, 7919, 7969, 7969, 7977, 7977, 7982, 7982, 8028, 8028, 8039, 8039, 8064, 8064, 8083, 8083, 8084, 8084, 8087, 8087, 8088, 8088, 8178, 8178, 8180, 8180, 8184, 8184, 8212, 8212, 8213, 8213, 8214, 8214, 8215, 8215, 8216, 8216, 8225, 8225, 8269, 8269, 8293, 8293, 12609, 12609, 12659, 12659, 12664, 12664, 12807, 12890, 12890, 12944, 12944, 12965, 12965, 12970, 12970, 13234, 13234, 13437, 13639, 13639, 13726, 13726, 13731, 13731, 13781, 13781, 13782, 13782, 15278, 15278, 15737, 17720, 17720, 18242, 18242, 18343, 18343, 19971, 19971, 21283, 21283, 21284, 21284, 21570, 21570
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5576, 5576, 5584, 5584, 7817, 7817, 7833, 7833, 7837, 7837, 7838, 7838, 7839, 7839, 7854, 7854, 7860, 7860, 7887, 7887, 7890, 7890, 7898, 7898, 7916, 7916, 7966, 7966, 7974, 7974, 7979, 7979, 8025, 8025, 8036, 8036, 8061, 8061, 8080, 8080, 8081, 8081, 8084, 8084, 8085, 8085, 8175, 8175, 8177, 8177, 8181, 8181, 8209, 8209, 8210, 8210, 8211, 8211, 8212, 8212, 8213, 8213, 8222, 8222, 8266, 8266, 8290, 8290, 12606, 12606, 12656, 12656, 12661, 12661, 12804, 12887, 12887, 12941, 12941, 12962, 12962, 12967, 12967, 13231, 13231, 13434, 13636, 13636, 13723, 13723, 13728, 13728, 13778, 13778, 13779, 13779, 15275, 15275, 15734, 17717, 17717, 18239, 18239, 18340, 18340, 19968, 19968, 21280, 21280, 21281, 21281, 21567, 21567
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9832-10245
+- Def site: line 9829-10242
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -556,11 +543,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5644, 5644, 9865, 9865, 9949, 9949, 9955, 9955, 9958, 9958, 10002, 10002, 10016, 10016, 10043, 10043, 10049, 10049, 10063, 10063, 10146, 10146, 10148, 10148, 10152, 10152, 10154, 10154, 10157, 10157, 10161, 10161, 10164, 10164, 10174, 10174, 10180, 10180, 10218, 10218, 15152, 15152, 15153, 15153, 15154, 15154, 15205, 15205, 15206, 15206, 21418, 21418, 21419, 21419, 21420, 21420, 21444, 21444
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5641, 5641, 9862, 9862, 9946, 9946, 9952, 9952, 9955, 9955, 9999, 9999, 10013, 10013, 10040, 10040, 10046, 10046, 10060, 10060, 10143, 10143, 10145, 10145, 10149, 10149, 10151, 10151, 10154, 10154, 10158, 10158, 10161, 10161, 10171, 10171, 10177, 10177, 10215, 10215, 15149, 15149, 15150, 15150, 15151, 15151, 15202, 15202, 15203, 15203, 21415, 21415, 21416, 21416, 21417, 21417, 21441, 21441
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17823-18220
+- Def site: line 17820-18217
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -569,11 +556,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17844, 17844, 17849, 17849, 17853, 17853, 17856, 17856, 17863, 17863, 17865, 17865, 17866, 17866, 17869, 17869, 17872, 17872, 17875, 17875, 17917, 17917, 17949, 17949, 18016, 18016, 18029, 18029, 18034, 18034, 18086, 18086, 18119, 18119, 18120, 18120, 18121, 18121, 18151, 18151, 18180, 18180, 18181, 18181, 21601, 21601
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17841, 17841, 17846, 17846, 17850, 17850, 17853, 17853, 17860, 17860, 17862, 17862, 17863, 17863, 17866, 17866, 17869, 17869, 17872, 17872, 17914, 17914, 17946, 17946, 18013, 18013, 18026, 18026, 18031, 18031, 18083, 18083, 18116, 18116, 18117, 18117, 18118, 18118, 18148, 18148, 18177, 18177, 18178, 18178, 21598, 21598
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 19261-19648
+- Def site: line 19258-19645
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -583,11 +570,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19288, 19432, 19432, 21741, 21741
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19285, 19429, 19429, 21738, 21738
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6784-7128
+- Def site: line 6781-7125
 - References: 261
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -596,7 +583,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5607, 5607, 5740, 5740, 6830, 6830, 6846, 6846, 6847, 6847, 6870, 6870, 6872, 6872, 6875, 6875, 6889, 6889, 6891, 6891, 6900, 6900, 6902, 6902, 6903, 6903, 6909, 6909, 6910, 6910, 6910, 6927, 6927, 6931, 6931, 6973, 6973, 7004, 7004, 7007, 7007, 7009, 7009, 7055, 7055, 7065, 7065, 7098, 7098, 7103, 7103, 7110, 7110, 7332, 7332, 7364, 7364, 7375, 7375, 7400, 7400, 7420, 7420, 7932, 7932, 8725, 8725, 9004, 9004, 9019, 9083, 9083, 9100, 9100, 9118, 9118, 9139, 9139, 9698, 9698, 9773, 9773, 10103, 10103, 10454, 10454, 10539, 10555, 10675, 10675, 10679, 10679, 10699, 10699, 10712, 10712, 10716, 10716, 10734, 10734, 10896, 10896, 11243, 11243, 11390, 11390, 11467, 11467, 11471, 11471, 11476, 11476, 11609, 11609, 11628, 11628, 11679, 11679, 11682, 11682, 11833, 11833, 11836, 11836, 11935, 11935, 11941, 11941, 12238, 12238, 12255, 12255, 12270, 12270, 12484, 12484, 12512, 12512, 12528, 12528, 12565, 12565, 12603, 12603, 12692, 12692, 12721, 12721, 12759, 12759, 12810, 12875, 12875, 12881, 12881, 12923, 12923, 13092, 13092, 13098, 13098, 13217, 13217, 13225, 13225, 13389, 13389, 13440, 13613, 13613, 13784, 13784, 14297, 14297, 14658, 14658, 14664, 14664, 15572, 15572, 15631, 15738, 15874, 15874, 15892, 15892, 15910, 15910, 15937, 15937, 15938, 15938, 17588, 17588, 17681, 17767, 17767, 17788, 19096, 19096, 19614, 19614, 19699, 19699, 19720, 19720, 21109, 21109, 21770, 21770, 21786, 21786
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5604, 5604, 5737, 5737, 6827, 6827, 6843, 6843, 6844, 6844, 6867, 6867, 6869, 6869, 6872, 6872, 6886, 6886, 6888, 6888, 6897, 6897, 6899, 6899, 6900, 6900, 6906, 6906, 6907, 6907, 6907, 6924, 6924, 6928, 6928, 6970, 6970, 7001, 7001, 7004, 7004, 7006, 7006, 7052, 7052, 7062, 7062, 7095, 7095, 7100, 7100, 7107, 7107, 7329, 7329, 7361, 7361, 7372, 7372, 7397, 7397, 7417, 7417, 7929, 7929, 8722, 8722, 9001, 9001, 9016, 9080, 9080, 9097, 9097, 9115, 9115, 9136, 9136, 9695, 9695, 9770, 9770, 10100, 10100, 10451, 10451, 10536, 10552, 10672, 10672, 10676, 10676, 10696, 10696, 10709, 10709, 10713, 10713, 10731, 10731, 10893, 10893, 11240, 11240, 11387, 11387, 11464, 11464, 11468, 11468, 11473, 11473, 11606, 11606, 11625, 11625, 11676, 11676, 11679, 11679, 11830, 11830, 11833, 11833, 11932, 11932, 11938, 11938, 12235, 12235, 12252, 12252, 12267, 12267, 12481, 12481, 12509, 12509, 12525, 12525, 12562, 12562, 12600, 12600, 12689, 12689, 12718, 12718, 12756, 12756, 12807, 12872, 12872, 12878, 12878, 12920, 12920, 13089, 13089, 13095, 13095, 13214, 13214, 13222, 13222, 13386, 13386, 13437, 13610, 13610, 13781, 13781, 14294, 14294, 14655, 14655, 14661, 14661, 15569, 15569, 15628, 15735, 15871, 15871, 15889, 15889, 15907, 15907, 15934, 15934, 15935, 15935, 17585, 17585, 17678, 17764, 17764, 17785, 19093, 19093, 19611, 19611, 19696, 19696, 19717, 19717, 21106, 21106, 21767, 21767, 21783, 21783
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -607,7 +594,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12931-13271
+- Def site: line 12928-13268
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -616,11 +603,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12948, 12948, 12950, 12950, 12954, 12954, 12955, 12955, 12969, 12969, 12975, 12975, 12978, 12978, 12981, 12981, 13039, 13039, 13045, 13045, 13050, 13050, 13064, 13064, 13082, 13082, 13192, 13192, 13196, 13196, 13198, 13198, 13201, 13201, 13238, 13238, 13243, 13243, 13257, 13257, 13261, 13261, 13263, 13263, 13266, 13266, 13271, 13271, 21647, 21647, 21651, 21651, 21655, 21655
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12945, 12945, 12947, 12947, 12951, 12951, 12952, 12952, 12966, 12966, 12972, 12972, 12975, 12975, 12978, 12978, 13036, 13036, 13042, 13042, 13047, 13047, 13061, 13061, 13079, 13079, 13189, 13189, 13193, 13193, 13195, 13195, 13198, 13198, 13235, 13235, 13240, 13240, 13254, 13254, 13258, 13258, 13260, 13260, 13263, 13263, 13268, 13268, 21644, 21644, 21648, 21648, 21652, 21652
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7131-7458
+- Def site: line 7128-7455
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -628,11 +615,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7233, 7233, 8449, 8930, 8949, 9050, 9179, 9202, 9874, 10182, 10227, 10641, 11411, 11422, 11485, 11902
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7230, 7230, 8446, 8927, 8946, 9047, 9176, 9199, 9871, 10179, 10224, 10638, 11408, 11419, 11482, 11899
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14762-15089
+- Def site: line 14759-15086
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -642,13 +629,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12219, 12219, 12278, 12278, 12279, 12279, 13443, 14803, 14803, 14805, 14805, 14811, 14811, 14825, 14825, 14864, 14864, 14867, 14867, 14869, 14869, 14870, 14870, 14871, 14871, 14925, 14925, 14926, 14926, 14937, 14937, 14946, 14946, 14965, 14965, 15017, 15017, 15021, 15021, 15029, 15029, 15030, 15030, 15054, 15054, 15058, 15058
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12216, 12216, 12275, 12275, 12276, 12276, 13440, 14800, 14800, 14802, 14802, 14808, 14808, 14822, 14822, 14861, 14861, 14864, 14864, 14866, 14866, 14867, 14867, 14868, 14868, 14922, 14922, 14923, 14923, 14934, 14934, 14943, 14943, 14962, 14962, 15014, 15014, 15018, 15018, 15026, 15026, 15027, 15027, 15051, 15051, 15055, 15055
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16146-16434
+- Def site: line 16143-16431
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -658,11 +645,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16174, 16174, 16177, 16177, 16182, 16182, 16185, 16185, 16229, 16229, 16235, 16235, 16266, 16266, 16269, 16269, 16273, 16273, 16299, 16299, 16316, 16316, 16322, 16322, 16336, 16336, 16337, 16337, 16339, 16339, 16345, 16345, 16352, 16352, 16361, 16361, 16408, 16408, 16430, 16430, 16431, 16431, 16432, 16432, 21592, 21592
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16171, 16171, 16174, 16174, 16179, 16179, 16182, 16182, 16226, 16226, 16232, 16232, 16263, 16263, 16266, 16266, 16270, 16270, 16296, 16296, 16313, 16313, 16319, 16319, 16333, 16333, 16334, 16334, 16336, 16336, 16342, 16342, 16349, 16349, 16358, 16358, 16405, 16405, 16427, 16427, 16428, 16428, 16429, 16429, 21589, 21589
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10248-10520
+- Def site: line 10245-10517
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -671,11 +658,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10271, 10271, 10272, 10272, 10285, 10285, 10286, 10286, 10288, 10288, 10289, 10289, 10292, 10292, 10295, 10295, 10299, 10299, 10300, 10300, 10376, 10376, 10380, 10380, 10383, 10383, 10396, 10396, 10433, 10433, 10450, 10450, 10463, 10463, 10465, 10465, 10472, 10472, 10481, 10481, 10490, 10490, 10491, 10491, 10502, 10502, 10506, 10506, 10515, 10515, 10520, 10520, 21849, 21849
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10268, 10268, 10269, 10269, 10282, 10282, 10283, 10283, 10285, 10285, 10286, 10286, 10289, 10289, 10292, 10292, 10296, 10296, 10297, 10297, 10373, 10373, 10377, 10377, 10380, 10380, 10393, 10393, 10430, 10430, 10447, 10447, 10460, 10460, 10462, 10462, 10469, 10469, 10478, 10478, 10487, 10487, 10488, 10488, 10499, 10499, 10503, 10503, 10512, 10512, 10517, 10517, 21846, 21846
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5200-5463
+- Def site: line 5197-5460
 - References: 115
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -683,14 +670,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5240, 5240, 5242, 5242, 5324, 5324, 5330, 5330, 5367, 5367, 5369, 5369, 5378, 5378, 5388, 5388, 5398, 5398, 5434, 5434, 7968, 7968, 9626, 9626, 9627, 9627, 9938, 9938, 10784, 10784, 10804, 10804, 12805, 15211, 15211, 15217, 15217, 15218, 15218, 15219, 15219, 15220, 15220, 15221, 15221, 15222, 15222, 15229, 15229, 15257, 15257, 15629, 15875, 15875, 15893, 15893, 15911, 15911, 15961, 16472, 16472, 16473, 16473, 17301, 17301, 17302, 17302, 17676, 17712, 17712, 17736, 17736, 17760, 17760, 17904, 17904, 17905, 17905, 17906, 17906, 17907, 17907, 18243, 18243, 21334, 21334, 21886, 21886
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5237, 5237, 5239, 5239, 5321, 5321, 5327, 5327, 5364, 5364, 5366, 5366, 5375, 5375, 5385, 5385, 5395, 5395, 5431, 5431, 7965, 7965, 9623, 9623, 9624, 9624, 9935, 9935, 10781, 10781, 10801, 10801, 12802, 15208, 15208, 15214, 15214, 15215, 15215, 15216, 15216, 15217, 15217, 15218, 15218, 15219, 15219, 15226, 15226, 15254, 15254, 15626, 15872, 15872, 15890, 15890, 15908, 15908, 15958, 16469, 16469, 16470, 16470, 17298, 17298, 17299, 17299, 17673, 17709, 17709, 17733, 17733, 17757, 17757, 17901, 17901, 17902, 17902, 17903, 17903, 17904, 17904, 18240, 18240, 21331, 21331, 21883, 21883
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 11015-11265
+- Def site: line 11012-11262
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -700,11 +687,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11022, 11022, 11025, 11025, 11030, 11030, 11031, 11031, 11039, 11039, 11042, 11042, 11050, 11050, 11090, 11090, 11098, 11098, 11146, 11146, 11163, 11163, 11166, 11166, 11168, 11168, 11232, 11232, 11233, 11233, 21852, 21852
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11019, 11019, 11022, 11022, 11027, 11027, 11028, 11028, 11036, 11036, 11039, 11039, 11047, 11047, 11087, 11087, 11095, 11095, 11143, 11143, 11160, 11160, 11163, 11163, 11165, 11165, 11229, 11229, 11230, 11230, 21849, 21849
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15341-15585
+- Def site: line 15338-15582
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -714,11 +701,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15207, 15207, 15367, 15367, 15369, 15369, 15370, 15370, 15371, 15371, 15399, 15399, 15404, 15404, 15426, 15426, 15427, 15427, 15469, 15469, 15477, 15477, 15503, 15503, 15512, 15512, 15520, 15520, 15551, 15551, 21423, 21423, 21427, 21427
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15204, 15204, 15364, 15364, 15366, 15366, 15367, 15367, 15368, 15368, 15396, 15396, 15401, 15401, 15423, 15423, 15424, 15424, 15466, 15466, 15474, 15474, 15500, 15500, 15509, 15509, 15517, 15517, 15548, 15548, 21420, 21420, 21424, 21424
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6203-6423
+- Def site: line 6200-6420
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -726,14 +713,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6226, 6226, 6277, 6277, 6347, 6347, 6371, 6371, 6383, 6383, 6385, 6385, 6395, 6395, 6410, 6410, 6414, 6414, 6415, 6415, 6418, 6418, 6420, 6420, 12918, 12918, 15633
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6223, 6223, 6274, 6274, 6344, 6344, 6368, 6368, 6380, 6380, 6382, 6382, 6392, 6392, 6407, 6407, 6411, 6411, 6412, 6412, 6415, 6415, 6417, 6417, 12915, 12915, 15630
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 21936-22149
+- Def site: line 21933-22146
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -742,11 +729,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22792, 22792, 22795, 22876, 23227
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22789, 22789, 22792, 22873, 23224
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7659-7868
+- Def site: line 7656-7865
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -755,11 +742,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7672, 7672, 7678, 7678, 7679, 7679, 7682, 7682, 7705, 7705, 7708, 7708, 7711, 7711, 7712, 7712, 7714, 7714, 7781, 7781, 7825, 7825, 8290, 8290, 13239, 13239, 15736, 15999, 15999, 16159, 16159
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7669, 7669, 7675, 7675, 7676, 7676, 7679, 7679, 7702, 7702, 7705, 7705, 7708, 7708, 7709, 7709, 7711, 7711, 7778, 7778, 7822, 7822, 8287, 8287, 13236, 13236, 15733, 15996, 15996, 16156, 16156
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12537-12739
+- Def site: line 12534-12736
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -768,11 +755,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12558, 12558, 12567, 12567, 12629, 12629, 12636, 12636, 12668, 12668, 12670, 12670, 12694, 12694, 12729, 12729, 12736, 12736, 12767, 12767, 15281, 15281, 21459, 21459, 21461, 21461, 21462, 21462, 21464, 21464
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12555, 12555, 12564, 12564, 12626, 12626, 12633, 12633, 12665, 12665, 12667, 12667, 12691, 12691, 12726, 12726, 12733, 12733, 12764, 12764, 15278, 15278, 21456, 21456, 21458, 21458, 21459, 21459, 21461, 21461
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13790-13977
+- Def site: line 13787-13974
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -782,11 +769,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21809, 21809, 21810, 21810, 21811, 21811, 21812, 21812, 21813, 21813, 21814, 21814, 21815, 21815, 21816, 21816, 21818, 21818, 21819, 21819, 21820, 21820, 21821, 21821, 21822, 21822, 21823, 21823, 21824, 21824, 21826, 21826, 21827, 21827, 21828, 21828, 21829, 21829, 21830, 21830, 21831, 21831, 21832, 21832, 21833, 21833, 21834, 21834, 21836, 21836, 21837, 21837, 21838, 21838, 21839, 21839, 21840, 21840, 21841, 21841, 21842, 21842, 21843, 21843, 21844, 21844, 21846, 21846, 21847, 21847
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21806, 21806, 21807, 21807, 21808, 21808, 21809, 21809, 21810, 21810, 21811, 21811, 21812, 21812, 21813, 21813, 21815, 21815, 21816, 21816, 21817, 21817, 21818, 21818, 21819, 21819, 21820, 21820, 21821, 21821, 21823, 21823, 21824, 21824, 21825, 21825, 21826, 21826, 21827, 21827, 21828, 21828, 21829, 21829, 21830, 21830, 21831, 21831, 21833, 21833, 21834, 21834, 21835, 21835, 21836, 21836, 21837, 21837, 21838, 21838, 21839, 21839, 21840, 21840, 21841, 21841, 21843, 21843, 21844, 21844
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5615-5794
+- Def site: line 5612-5791
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -795,11 +782,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5703, 5703, 5740, 5740, 5742, 5742, 5745, 5745, 5753, 5753, 5755, 5755, 5757, 5757, 5760, 5760, 5789, 5789, 5792, 5792, 21586, 21586
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5700, 5700, 5737, 5737, 5739, 5739, 5742, 5742, 5750, 5750, 5752, 5752, 5754, 5754, 5757, 5757, 5786, 5786, 5789, 5789, 21583, 21583
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6603-6781
+- Def site: line 6600-6778
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -807,11 +794,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6648, 6648, 6686, 6686, 6697, 6697, 6723, 6723, 6724, 6724, 6726, 6726, 6732, 6732, 6733, 6733, 6736, 6736, 6742, 6742, 6743, 6743, 6746, 6746, 6748, 6748, 6758, 6758, 6760, 6760, 6761, 6761, 6763, 6763
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6645, 6645, 6683, 6683, 6694, 6694, 6720, 6720, 6721, 6721, 6723, 6723, 6729, 6729, 6730, 6730, 6733, 6733, 6739, 6739, 6740, 6740, 6743, 6743, 6745, 6745, 6755, 6755, 6757, 6757, 6758, 6758, 6760, 6760
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11495-11662
+- Def site: line 11492-11659
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -820,11 +807,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11602, 11602, 11621, 11621, 11639, 11639, 11648, 11648, 11651, 11651, 11652, 11652, 11655, 11655, 11660, 11660, 11662, 11662, 21487, 21487
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11599, 11599, 11618, 11618, 11636, 11636, 11645, 11645, 11648, 11648, 11649, 11649, 11652, 11652, 11657, 11657, 11659, 11659, 21484, 21484
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11707-11874
+- Def site: line 11704-11871
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -832,11 +819,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11744, 11744, 11746, 11746, 11749, 11749, 11820, 11820, 11822, 11822, 11835, 11835, 11839, 11839, 21490, 21490, 21491, 21491, 21492, 21492, 21530, 21530, 21535, 21535
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11741, 11741, 11743, 11743, 11746, 11746, 11817, 11817, 11819, 11819, 11832, 11832, 11836, 11836, 21487, 21487, 21488, 21488, 21489, 21489, 21527, 21527, 21532, 21532
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10740-10901
+- Def site: line 10737-10898
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -844,11 +831,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10778, 10778, 10785, 10785, 10792, 10792, 10798, 10798, 10805, 10805, 10812, 10812, 10873, 10873, 10884, 10884, 21478, 21478, 21479, 21479, 21481, 21481, 21482, 21482, 21483, 21483
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10775, 10775, 10782, 10782, 10789, 10789, 10795, 10795, 10802, 10802, 10809, 10809, 10870, 10870, 10881, 10881, 21475, 21475, 21476, 21476, 21478, 21478, 21479, 21479, 21480, 21480
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15980-16140
+- Def site: line 15977-16137
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -857,11 +844,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16003, 16003, 16005, 16005, 16074, 16074, 16076, 16076, 16095, 16095, 16097, 16097, 16097, 16113, 16113, 16129, 16129, 16130, 16130, 16136, 16136, 21591, 21591
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16000, 16000, 16002, 16002, 16071, 16071, 16073, 16073, 16092, 16092, 16094, 16094, 16094, 16110, 16110, 16126, 16126, 16127, 16127, 16133, 16133, 21588, 21588
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6431-6588
+- Def site: line 6428-6585
 - References: 205
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -871,7 +858,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5498, 5498, 5605, 5605, 5606, 5606, 6447, 6447, 6460, 6460, 6463, 6463, 6487, 6487, 6495, 6495, 6496, 6496, 6518, 6518, 6523, 6523, 6525, 6525, 6598, 6598, 6599, 6599, 7006, 7006, 7031, 7031, 7100, 7100, 7101, 7101, 7430, 7430, 7444, 7444, 7445, 7445, 7930, 7930, 7931, 7931, 8853, 8853, 9018, 9078, 9078, 9080, 9080, 9081, 9081, 9098, 9098, 9099, 9099, 9116, 9116, 9117, 9117, 9137, 9137, 9138, 9138, 9695, 9695, 9696, 9696, 9770, 9770, 9771, 9771, 10099, 10099, 10102, 10102, 10677, 10677, 10678, 10678, 10714, 10714, 10715, 10715, 10894, 10894, 10895, 10895, 11239, 11239, 11240, 11240, 11386, 11386, 11387, 11387, 11469, 11469, 11470, 11470, 11681, 11681, 11856, 11856, 11857, 11857, 11933, 11933, 11934, 11934, 12237, 12237, 12253, 12253, 12254, 12254, 12482, 12482, 12483, 12483, 12562, 12562, 12563, 12563, 12564, 12564, 12600, 12600, 12601, 12601, 12689, 12689, 12690, 12690, 12718, 12718, 12719, 12719, 12756, 12756, 12757, 12757, 12809, 12878, 12878, 12879, 12879, 12921, 12921, 12922, 12922, 13090, 13090, 13091, 13091, 13215, 13215, 13216, 13216, 13439, 13611, 13611, 14663, 14663, 15570, 15570, 15571, 15571, 15632, 15740, 17765, 17765, 17766, 17766, 19604, 19604
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5495, 5495, 5602, 5602, 5603, 5603, 6444, 6444, 6457, 6457, 6460, 6460, 6484, 6484, 6492, 6492, 6493, 6493, 6515, 6515, 6520, 6520, 6522, 6522, 6595, 6595, 6596, 6596, 7003, 7003, 7028, 7028, 7097, 7097, 7098, 7098, 7427, 7427, 7441, 7441, 7442, 7442, 7927, 7927, 7928, 7928, 8850, 8850, 9015, 9075, 9075, 9077, 9077, 9078, 9078, 9095, 9095, 9096, 9096, 9113, 9113, 9114, 9114, 9134, 9134, 9135, 9135, 9692, 9692, 9693, 9693, 9767, 9767, 9768, 9768, 10096, 10096, 10099, 10099, 10674, 10674, 10675, 10675, 10711, 10711, 10712, 10712, 10891, 10891, 10892, 10892, 11236, 11236, 11237, 11237, 11383, 11383, 11384, 11384, 11466, 11466, 11467, 11467, 11678, 11678, 11853, 11853, 11854, 11854, 11930, 11930, 11931, 11931, 12234, 12234, 12250, 12250, 12251, 12251, 12479, 12479, 12480, 12480, 12559, 12559, 12560, 12560, 12561, 12561, 12597, 12597, 12598, 12598, 12686, 12686, 12687, 12687, 12715, 12715, 12716, 12716, 12753, 12753, 12754, 12754, 12806, 12875, 12875, 12876, 12876, 12918, 12918, 12919, 12919, 13087, 13087, 13088, 13088, 13212, 13212, 13213, 13213, 13436, 13608, 13608, 14660, 14660, 15567, 15567, 15568, 15568, 15629, 15737, 17762, 17762, 17763, 17763, 19601, 19601
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -879,7 +866,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15103-15258
+- Def site: line 15100-15255
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -888,11 +875,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15125, 15125, 15131, 15131, 15133, 15133, 15161, 15161, 15187, 15187, 15190, 15190, 15193, 15193, 21577, 21577, 21581, 21581, 21589, 21589
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15122, 15122, 15128, 15128, 15130, 15130, 15158, 15158, 15184, 15184, 15187, 15187, 15190, 15190, 21574, 21574, 21578, 21578, 21586, 21586
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13274-13419
+- Def site: line 13271-13416
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -900,11 +887,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13313, 13313, 13320, 13320, 13345, 13345, 13348, 13348, 13361, 13361, 13405, 13405, 13409, 13409, 13414, 13414, 13415, 13415, 13419, 13419, 21884, 21884
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13310, 13310, 13317, 13317, 13342, 13342, 13345, 13345, 13358, 13358, 13402, 13402, 13406, 13406, 13411, 13411, 13412, 13412, 13416, 13416, 21881, 21881
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13427-13571
+- Def site: line 13424-13568
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -913,12 +900,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12648, 12648, 12824, 12824, 12902, 12902, 12907, 12907, 13456, 13456, 13462, 13462, 13468, 13468, 13474, 13474, 13480, 13480, 13486, 13486, 13492, 13492, 13498, 13498, 13504, 13504, 13510, 13510, 13516, 13516, 13522, 13522, 13528, 13528, 13534, 13534, 13540, 13540, 13546, 13546, 13552, 13552, 13558, 13558, 13564, 13564, 13570, 13570, 21497, 21497, 21638, 21638, 21640, 21640, 21755, 21755, 21881, 21881, 21882, 21882, 21883, 21883, 21902, 21902, 21903, 21903, 21904, 21904, 21905, 21905, 21906, 21906, 21907, 21907, 21908, 21908
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12645, 12645, 12821, 12821, 12899, 12899, 12904, 12904, 13453, 13453, 13459, 13459, 13465, 13465, 13471, 13471, 13477, 13477, 13483, 13483, 13489, 13489, 13495, 13495, 13501, 13501, 13507, 13507, 13513, 13513, 13519, 13519, 13525, 13525, 13531, 13531, 13537, 13537, 13543, 13543, 13549, 13549, 13555, 13555, 13561, 13561, 13567, 13567, 21494, 21494, 21635, 21635, 21637, 21637, 21752, 21752, 21878, 21878, 21879, 21879, 21880, 21880, 21899, 21899, 21900, 21900, 21901, 21901, 21902, 21902, 21903, 21903, 21904, 21904, 21905, 21905
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10594-10737
+- Def site: line 10591-10734
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -927,11 +914,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10608, 10608, 10609, 10609, 10695, 10695, 10730, 10730, 21472, 21472, 21473, 21473, 21474, 21474, 21475, 21475, 21476, 21476
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10605, 10605, 10606, 10606, 10692, 10692, 10727, 10727, 21469, 21469, 21470, 21470, 21471, 21471, 21472, 21472, 21473, 21473
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13574-13712
+- Def site: line 13571-13709
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -939,11 +926,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13643, 13643, 13646, 13646, 13647, 13647, 13648, 13648, 13668, 13668, 13671, 13671, 13679, 13679, 13684, 13684, 21910, 21910
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13640, 13640, 13643, 13643, 13644, 13644, 13645, 13645, 13665, 13665, 13668, 13668, 13676, 13676, 13681, 13681, 21907, 21907
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8896-9024
+- Def site: line 8893-9021
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -952,11 +939,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8967, 8967, 8978, 8978, 15201, 15201, 15202, 15202, 21375, 21375, 21376, 21376, 21555, 21555
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8964, 8964, 8975, 8975, 15198, 15198, 15199, 15199, 21372, 21372, 21373, 21373, 21552, 21552
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11268-11396
+- Def site: line 11265-11393
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -965,11 +952,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11275, 11275, 11280, 11280, 11281, 11281, 11282, 11282, 11285, 11285, 11286, 11286, 11349, 11349, 11356, 11356, 11383, 11383, 21854, 21854
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11272, 11272, 11277, 11277, 11278, 11278, 11279, 11279, 11282, 11282, 11283, 11283, 11346, 11346, 11353, 11353, 11380, 11380, 21851, 21851
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15726-15852
+- Def site: line 15723-15849
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -978,11 +965,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15746, 15746, 15751, 15751, 15756, 15756, 15793, 15793, 15799, 15799, 15805, 15805, 15811, 15811, 15817, 15817, 15818, 15818, 15819, 15819, 15820, 15820, 15821, 15821, 15825, 15825, 15834, 15834, 15838, 15838, 15841, 15841, 15847, 15847, 21550, 21550
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15743, 15743, 15748, 15748, 15753, 15753, 15790, 15790, 15796, 15796, 15802, 15802, 15808, 15808, 15814, 15814, 15815, 15815, 15816, 15816, 15817, 15817, 15818, 15818, 15822, 15822, 15831, 15831, 15835, 15835, 15838, 15838, 15844, 15844, 21547, 21547
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5848-5972
+- Def site: line 5845-5969
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -991,11 +978,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5869, 5869, 5871, 5871, 5887, 5887, 5899, 5899, 5938, 5938, 5939, 5939, 5940, 5940, 5941, 5941, 5942, 5942, 5953, 5953, 5956, 5956, 6888, 6888, 22889, 22889, 23472, 23472
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5866, 5866, 5868, 5868, 5884, 5884, 5896, 5896, 5935, 5935, 5936, 5936, 5937, 5937, 5938, 5938, 5939, 5939, 5950, 5950, 5953, 5953, 6885, 6885, 22886, 22886, 23469, 23469
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 9030-9141
+- Def site: line 9027-9138
 - References: 55
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1003,13 +990,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7968, 7968, 9626, 9626, 9938, 9938, 10784, 10784, 10804, 10804, 12806, 15150, 15150, 15203, 15203, 15636, 15876, 15876, 15894, 15894, 15912, 15912, 17302, 17302, 17677, 17714, 17714, 17738, 17738, 17762, 17762, 17905, 17905, 18246, 18246, 21416, 21416, 21431, 21431, 21441, 21441, 21441, 21441, 21451, 21451
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7965, 7965, 9623, 9623, 9935, 9935, 10781, 10781, 10801, 10801, 12803, 15147, 15147, 15200, 15200, 15633, 15873, 15873, 15891, 15891, 15909, 15909, 17299, 17299, 17674, 17711, 17711, 17735, 17735, 17759, 17759, 17902, 17902, 18243, 18243, 21413, 21413, 21428, 21428, 21438, 21438, 21438, 21438, 21448, 21448
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10904-11012
+- Def site: line 10901-11009
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1019,11 +1006,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10959, 10959, 10962, 10962, 10963, 10963, 10968, 10968, 10986, 10986, 10986, 10995, 10995, 10995, 10995, 10996, 10996, 10996, 10996, 11054, 11054, 11057, 11057, 11069, 11069, 11070, 11070, 11083, 11083, 11122, 11122, 11130, 11130, 11184, 11184, 11192, 11192
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10956, 10956, 10959, 10959, 10960, 10960, 10965, 10965, 10983, 10983, 10983, 10992, 10992, 10992, 10992, 10993, 10993, 10993, 10993, 11051, 11051, 11054, 11054, 11066, 11066, 11067, 11067, 11080, 11080, 11119, 11119, 11127, 11127, 11181, 11181, 11189, 11189
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12829-12928
+- Def site: line 12826-12925
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1032,11 +1019,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12894, 12894, 12896, 12896, 12897, 12897, 21425, 21425, 21493, 21493, 21495, 21495, 21496, 21496
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12891, 12891, 12893, 12893, 12894, 12894, 21422, 21422, 21490, 21490, 21492, 21492, 21493, 21493
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15618-15715
+- Def site: line 15615-15712
 - References: 81
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1045,13 +1032,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15361, 15361, 15596, 15596, 15654, 15654, 15660, 15660, 15666, 15666, 15672, 15672, 15678, 15678, 15684, 15684, 15690, 15690, 15696, 15696, 15702, 15702, 15708, 15708, 15714, 15714, 15962, 17301, 17301, 17678, 17906, 17906, 17909, 17909, 18245, 18245, 21382, 21382, 21449, 21449, 21455, 21455, 21506, 21506, 21563, 21563
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15358, 15358, 15593, 15593, 15651, 15651, 15657, 15657, 15663, 15663, 15669, 15669, 15675, 15675, 15681, 15681, 15687, 15687, 15693, 15693, 15699, 15699, 15705, 15705, 15711, 15711, 15959, 17298, 17298, 17675, 17903, 17903, 17906, 17906, 18242, 18242, 21379, 21379, 21446, 21446, 21452, 21452, 21503, 21503, 21560, 21560
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8326-8422
+- Def site: line 8323-8419
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1059,11 +1046,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8382, 8382, 8418, 8418, 16476, 16476
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8379, 8379, 8415, 8415, 16473, 16473
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11399-11492
+- Def site: line 11396-11489
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1072,11 +1059,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11451, 11451, 11464, 11464, 21485, 21485, 21527, 21527, 21528, 21528, 21533, 21533, 21534, 21534
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11448, 11448, 11461, 11461, 21482, 21482, 21524, 21524, 21525, 21525, 21530, 21530, 21531, 21531
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5978-6067
+- Def site: line 5975-6064
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1086,13 +1073,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6060, 6060, 15424, 15424, 15425, 15425, 15639, 21285, 21285
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6057, 6057, 15421, 15421, 15422, 15422, 15636, 21282, 21282
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12742-12826
+- Def site: line 12739-12823
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1102,11 +1089,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12776, 12776, 21460, 21460, 21468, 21468, 21494, 21494, 21639, 21639
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12773, 12773, 21457, 21457, 21465, 21465, 21491, 21491, 21636, 21636
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 19675-19753
+- Def site: line 19672-19750
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1116,12 +1103,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19670, 19670, 19671, 19671, 21734, 21734
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19667, 19667, 19668, 19668, 21731, 21731
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17692-17769
+- Def site: line 17689-17766
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1131,12 +1118,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21605, 21605, 21609, 21609, 21613, 21613
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21602, 21602, 21606, 21606, 21610, 21610
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1872-1945
+- Def site: line 1869-1942
 - References: 277
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1145,7 +1132,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1885, 1885, 1917, 1917, 2192, 2192, 2281, 2281, 2308, 2308, 7680, 7680, 7766, 7766, 7896, 7896, 7973, 7973, 8056, 8056, 8286, 8286, 8475, 8475, 8531, 8531, 8544, 8544, 8561, 8561, 8606, 8606, 8637, 8637, 8643, 8643, 8746, 8746, 10287, 10287, 10554, 11056, 11056, 11085, 11085, 11350, 11350, 11556, 11556, 11795, 11795, 12511, 12511, 12527, 12527, 13314, 13314, 13733, 13733, 13783, 13783, 15637, 15839, 15839, 15872, 15872, 15890, 15890, 15908, 15908, 15935, 15935, 15960, 17362, 17362, 17489, 17489, 17680, 17719, 17719, 17744, 17744, 17787, 17886, 17886, 18098, 18098, 18241, 18241, 19245, 19245, 19335, 19335, 19665, 19665, 19695, 19695, 19716, 19716, 19735, 19735, 19751, 19751, 19768, 19768, 20259, 20259, 20316, 20316, 20328, 20328, 20341, 20341, 20358, 20358, 20521, 20521, 21232, 21232, 21252, 21252, 21287, 21287, 21300, 21300, 21768, 21768, 21859, 21859, 21864, 21864, 21870, 21870, 21889, 21889, 21895, 21895, 23495, 23495, 23593, 23593
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1882, 1882, 1914, 1914, 2189, 2189, 2278, 2278, 2305, 2305, 7677, 7677, 7763, 7763, 7893, 7893, 7970, 7970, 8053, 8053, 8283, 8283, 8472, 8472, 8528, 8528, 8541, 8541, 8558, 8558, 8603, 8603, 8634, 8634, 8640, 8640, 8743, 8743, 10284, 10284, 10551, 11053, 11053, 11082, 11082, 11347, 11347, 11553, 11553, 11792, 11792, 12508, 12508, 12524, 12524, 13311, 13311, 13730, 13730, 13780, 13780, 15634, 15836, 15836, 15869, 15869, 15887, 15887, 15905, 15905, 15932, 15932, 15957, 17359, 17359, 17486, 17486, 17677, 17716, 17716, 17741, 17741, 17784, 17883, 17883, 18095, 18095, 18238, 18238, 19242, 19242, 19332, 19332, 19662, 19662, 19692, 19692, 19713, 19713, 19732, 19732, 19748, 19748, 19765, 19765, 20256, 20256, 20313, 20313, 20325, 20325, 20338, 20338, 20355, 20355, 20518, 20518, 21229, 21229, 21249, 21249, 21284, 21284, 21297, 21297, 21765, 21765, 21856, 21856, 21861, 21861, 21867, 21867, 21886, 21886, 21892, 21892, 23492, 23492, 23590, 23590
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -1166,7 +1153,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15264-15335
+- Def site: line 15261-15332
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1175,11 +1162,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21571, 21571, 21572, 21572, 21573, 21573, 21574, 21574
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21568, 21568, 21569, 21569, 21570, 21570, 21571, 21571
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5469-5538
+- Def site: line 5466-5535
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1189,11 +1176,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5501, 5501, 5502, 5502, 5517, 5517, 5519, 5519, 5608, 5608, 18614, 18614, 18653, 18653, 18712, 18712
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5498, 5498, 5499, 5499, 5514, 5514, 5516, 5516, 5605, 5605, 18611, 18611, 18650, 18650, 18709, 18709
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 6073-6142
+- Def site: line 6070-6139
 - References: 199
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1201,7 +1188,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6115, 6115, 6120, 6120, 6217, 6217, 6275, 6275, 7166, 7166, 7823, 7823, 8468, 8468, 8491, 8491, 8511, 8511, 8696, 8696, 8717, 8717, 8992, 8992, 9017, 9017, 9072, 9072, 9094, 9094, 9111, 9111, 9128, 9128, 9513, 9513, 9736, 9736, 9753, 9753, 10145, 10145, 10477, 10477, 10688, 10688, 10725, 10725, 10878, 10878, 11021, 11021, 11274, 11274, 11462, 11462, 11646, 11646, 11965, 11965, 12301, 12301, 12473, 12473, 12513, 12513, 12519, 12519, 12613, 12613, 12843, 12843, 12916, 12916, 13403, 13403, 13438, 13637, 13637, 15144, 15144, 15360, 15360, 15628, 15735, 15835, 15835, 15870, 15870, 15888, 15888, 15906, 15906, 15941, 15941, 16475, 16475, 17282, 17282, 17675, 17785, 18293, 18293, 19246, 19246, 19251, 19251, 19253, 19253, 19666, 19666, 19668, 19668, 19692, 19692, 19696, 19696, 19697, 19697, 19717, 19717, 19718, 19718, 19980, 19980, 20766, 20766, 21336, 21336, 21368, 21368, 21405, 21405, 21411, 21411, 21539, 21539, 21596, 21596, 21679, 21679, 21688, 21688, 21766, 21766, 21767, 21767, 21784, 21784, 21859, 21859, 21864, 21864, 21870, 21870, 21889, 21889, 21895, 21895, 22806, 22806, 22877, 23359, 23359, 23447, 23447
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6112, 6112, 6117, 6117, 6214, 6214, 6272, 6272, 7163, 7163, 7820, 7820, 8465, 8465, 8488, 8488, 8508, 8508, 8693, 8693, 8714, 8714, 8989, 8989, 9014, 9014, 9069, 9069, 9091, 9091, 9108, 9108, 9125, 9125, 9510, 9510, 9733, 9733, 9750, 9750, 10142, 10142, 10474, 10474, 10685, 10685, 10722, 10722, 10875, 10875, 11018, 11018, 11271, 11271, 11459, 11459, 11643, 11643, 11962, 11962, 12298, 12298, 12470, 12470, 12510, 12510, 12516, 12516, 12610, 12610, 12840, 12840, 12913, 12913, 13400, 13400, 13435, 13634, 13634, 15141, 15141, 15357, 15357, 15625, 15732, 15832, 15832, 15867, 15867, 15885, 15885, 15903, 15903, 15938, 15938, 16472, 16472, 17279, 17279, 17672, 17782, 18290, 18290, 19243, 19243, 19248, 19248, 19250, 19250, 19663, 19663, 19665, 19665, 19689, 19689, 19693, 19693, 19694, 19694, 19714, 19714, 19715, 19715, 19977, 19977, 20763, 20763, 21333, 21333, 21365, 21365, 21402, 21402, 21408, 21408, 21536, 21536, 21593, 21593, 21676, 21676, 21685, 21685, 21763, 21763, 21764, 21764, 21781, 21781, 21856, 21856, 21861, 21861, 21867, 21867, 21886, 21886, 21892, 21892, 22803, 22803, 22874, 23356, 23356, 23444, 23444
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1211,7 +1198,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10523-10591
+- Def site: line 10520-10588
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1222,11 +1209,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10563, 10563, 10568, 10568, 10573, 10573, 10574, 10574, 10580, 10580, 10581, 10581, 10587, 10587, 10588, 10588, 10589, 10589, 10590, 10590, 21912, 21912
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10560, 10560, 10565, 10565, 10570, 10570, 10571, 10571, 10577, 10577, 10578, 10578, 10584, 10584, 10585, 10585, 10586, 10586, 10587, 10587, 21909, 21909
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 21291-21356
+- Def site: line 21288-21353
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1236,11 +1223,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21339, 21339, 21347, 21347, 21356, 21356, 21885, 21885
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21336, 21336, 21344, 21344, 21353, 21353, 21882, 21882
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15859-15914
+- Def site: line 15856-15911
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1250,11 +1237,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21510, 21510, 21514, 21514, 21719, 21719
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21507, 21507, 21511, 21511, 21716, 21716
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6148-6194
+- Def site: line 6145-6191
 - References: 59
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1263,13 +1250,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6272, 6272, 8158, 8158, 9073, 9073, 9096, 9096, 9583, 9583, 9618, 9618, 9632, 9632, 9755, 9755, 9759, 9759, 10307, 10307, 12617, 12617, 13287, 13287, 13413, 13413, 13445, 13623, 13623, 13659, 13659, 15634, 18401, 18401, 19247, 19247, 19556, 19556, 19667, 19667, 19698, 19698, 19719, 19719, 21769, 21769, 21785, 21785, 23378, 23378
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6269, 6269, 8155, 8155, 9070, 9070, 9093, 9093, 9580, 9580, 9615, 9615, 9629, 9629, 9752, 9752, 9756, 9756, 10304, 10304, 12614, 12614, 13284, 13284, 13410, 13410, 13442, 13620, 13620, 13656, 13656, 15631, 18398, 18398, 19244, 19244, 19553, 19553, 19664, 19664, 19695, 19695, 19716, 19716, 21766, 21766, 21782, 21782, 23375, 23375
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5797-5842
+- Def site: line 5794-5839
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1278,14 +1265,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5239, 5239, 5281, 5281, 5326, 5326, 5432, 5432, 5447, 5447, 5787, 5787, 5788, 5788, 5832, 5832, 6298, 6298, 7992, 7992, 9283, 9283, 9594, 9594, 9610, 9610, 9939, 9939, 10820, 10820, 10839, 10839, 12808, 15227, 15227, 15630, 15873, 15873, 15891, 15891, 15909, 15909, 15936, 15936, 15963, 16385, 16385, 16425, 16425, 16426, 16426, 16427, 16427, 16471, 16471, 17303, 17303, 17310, 17310, 17679, 17711, 17711, 17735, 17735, 17739, 17739, 17759, 17759, 17786, 17861, 17861, 17895, 17895, 17916, 17916, 17948, 17948, 18010, 18010, 18049, 18049, 18199, 18199, 18244, 18244, 19248, 19248, 19819, 19819
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5236, 5236, 5278, 5278, 5323, 5323, 5429, 5429, 5444, 5444, 5784, 5784, 5785, 5785, 5829, 5829, 6295, 6295, 7989, 7989, 9280, 9280, 9591, 9591, 9607, 9607, 9936, 9936, 10817, 10817, 10836, 10836, 12805, 15224, 15224, 15627, 15870, 15870, 15888, 15888, 15906, 15906, 15933, 15933, 15960, 16382, 16382, 16422, 16422, 16423, 16423, 16424, 16424, 16468, 16468, 17300, 17300, 17307, 17307, 17676, 17708, 17708, 17732, 17732, 17736, 17736, 17756, 17756, 17783, 17858, 17858, 17892, 17892, 17913, 17913, 17945, 17945, 18007, 18007, 18046, 18046, 18196, 18196, 18241, 18241, 19245, 19245, 19816, 19816
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17775-17817
+- Def site: line 17772-17814
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1294,11 +1281,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17798, 17798, 17804, 17804, 17810, 17810, 17816, 17816, 21703, 21703, 21707, 21707, 21711, 21711, 21715, 21715
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17795, 17795, 17801, 17801, 17807, 17807, 17813, 17813, 21700, 21700, 21704, 21704, 21708, 21708, 21712, 21712
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11665-11704
+- Def site: line 11662-11701
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1307,11 +1294,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11702, 11702, 21909, 21909
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11699, 11699, 21906, 21906
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1836-1864
+- Def site: line 1833-1861
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1320,12 +1307,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8946, 8946, 8947, 8947, 8976, 8976, 8977, 8977, 8993, 8993, 8994, 8994, 9872, 9872, 9873, 9873, 10177, 10177, 10178, 10178, 10225, 10225, 10226, 10226, 10781, 10781, 10783, 10783, 10801, 10801, 10803, 10803, 11691, 11691, 11692, 11692, 12352, 12352, 12353, 12353, 12458, 12458, 12459, 12459, 13441
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8943, 8943, 8944, 8944, 8973, 8973, 8974, 8974, 8990, 8990, 8991, 8991, 9869, 9869, 9870, 9870, 10174, 10174, 10175, 10175, 10222, 10222, 10223, 10223, 10778, 10778, 10780, 10780, 10798, 10798, 10800, 10800, 11688, 11688, 11689, 11689, 12349, 12349, 12350, 12350, 12455, 12455, 12456, 12456, 13438
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15588-15615
+- Def site: line 15585-15612
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1334,12 +1321,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15602, 15602, 15608, 15608, 15614, 15614, 21617, 21617, 21621, 21621
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15599, 15599, 15605, 15605, 15611, 15611, 21614, 21614, 21618, 21618
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15949-15974
+- Def site: line 15946-15971
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1349,12 +1336,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15969, 15969, 15974, 15974, 21625, 21625, 21630, 21630
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15966, 15966, 15971, 15971, 21622, 21622, 21627, 21627
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2100-2124
+- Def site: line 2097-2121
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1362,11 +1349,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2186, 2245, 19364, 23202
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2183, 2242, 19361, 23199
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13740-13761
+- Def site: line 13737-13758
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1375,7 +1362,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21391, 21391, 21395, 21395, 21399, 21399
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21388, 21388, 21392, 21392, 21396, 21396
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1385,17 +1372,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 18227-18248
+- Def site: line 18224-18245
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19250, 19250, 21538, 21538, 21595, 21595, 21678, 21678, 21687, 21687
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19247, 19247, 21535, 21535, 21592, 21592, 21675, 21675, 21684, 21684
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 19651-19672
+- Def site: line 19648-19669
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1404,24 +1391,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21748, 21748
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21745, 21745
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7630-7650
+- Def site: line 7627-7647
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6381, 10150, 15473, 15638
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6378, 10147, 15470, 15635
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13986-13995
+- Def site: line 13983-13992
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1429,11 +1416,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14022, 14158, 14235, 14254, 14266, 14287, 14300, 14311, 14317, 14330, 14423, 14558, 14653
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14019, 14155, 14232, 14251, 14263, 14284, 14297, 14308, 14314, 14327, 14420, 14555, 14650
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 284-292
+- Def site: line 285-293
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1449,7 +1436,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 311-319
+- Def site: line 312-320
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1457,11 +1444,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5555, 15296, 15313, 15329
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5552, 15293, 15310, 15326
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 296-303
+- Def site: line 297-304
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1477,7 +1464,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 271-273
+- Def site: line 272-274
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1485,12 +1472,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13446, 13735, 19700, 19721, 20753, 20784, 20816, 21051, 21066
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13443, 13732, 19697, 19718, 20750, 20781, 20813, 21048, 21063
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 599-601
+- Def site: line 600-602
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1498,7 +1485,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1213, 1882, 1882, 1882, 1894, 1900, 6274, 6394, 7454, 7514, 9682, 9793, 10047, 10877, 13448, 15506, 15548, 15646, 17384, 17504, 21771
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1210, 1879, 1879, 1879, 1891, 1897, 6271, 6391, 7451, 7511, 9679, 9790, 10044, 10874, 13445, 15503, 15545, 15643, 17381, 17501, 21768
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1510,7 +1497,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 1984-1986
+- Def site: line 1981-1983
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1519,11 +1506,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1984, 7464, 7471, 7472, 10058, 15495
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1981, 7461, 7468, 7469, 10055, 15492
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2002-2004
+- Def site: line 1999-2001
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1532,7 +1519,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2002, 15642, 17292, 17292, 17683
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1999, 15639, 17289, 17289, 17680
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1540,7 +1527,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 719-1723
+- Def site: line 716-1720
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1548,7 +1535,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1768
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1765
 
 ## Limitations
 

--- a/src/refactors/keyboard_listener.py
+++ b/src/refactors/keyboard_listener.py
@@ -1,0 +1,62 @@
+"""KeyboardListener extracted from MistHelper.
+
+Houses the legacy ``listen_keyboard`` no-op stub as a first-class
+instance method. The original function was a harmless fallback left
+behind after the real keyboard-listener feature was removed. It stays
+as a class-level shim so any remaining call sites (currently one:
+the interactive SSR/SRX websocket shell in ``CLIShellManager``)
+receive a stable, discoverable target after the module-level function
+is deleted (FR-005 / FR-006 -- no wrappers or aliases left in
+MistHelper).
+
+No runtime dependencies on MistHelper -- the method only logs and
+returns ``None``, so no late-import machinery is needed.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing on 3.10+
+
+import logging  # Structured action logging required by coding standards
+from typing import Any  # Loose typing for the pass-through *args/**kwargs
+
+
+class KeyboardListener:  # Manager class owning the listen_keyboard() no-op stub (PR-13 extraction)
+    """Keyboard listener stub for legacy call sites of the removed feature.
+
+    The original keyboard-listener functionality was removed for
+    simplicity. This class preserves a stable, discoverable target for
+    the remaining call site (the SSR/SRX interactive websocket shell)
+    without leaving a module-level function in MistHelper.
+
+    SECURITY: This is a no-op -- it does not open any input device,
+    subscribe to keystrokes, or return a listener object. Callers
+    that expect a real listener should treat the ``None`` return as
+    "no listener available" and fall back to their own input loop.
+
+    Usage:
+        KeyboardListener().listen(on_release=..., delay_second_char=0)
+    """
+
+    def listen(self, *args: Any, **kwargs: Any) -> None:  # Instance method preserving the original signature
+        """No-op keyboard listener: log the call and return None.
+
+        Preserves the ``*args``/``**kwargs`` pass-through signature of
+        the removed ``listen_keyboard`` module-level function so no
+        existing keyword arguments (``on_release``, ``delay_second_char``,
+        ``delay_other_chars``, ``lower``) need to change at the call site.
+
+        Args:
+            *args: Positional arguments accepted but ignored.
+            **kwargs: Keyword arguments accepted but ignored.
+
+        Returns:
+            None: There is no listener object to return.
+        """
+        logging.info(  # Log entry so any lingering caller is visible in ops logs
+            "KeyboardListener.listen invoked (no-op stub; feature removed)"
+        )
+        logging.debug(  # Log exit with arg-count summary for postmortem tracing without leaking values
+            "KeyboardListener.listen returning None args_len=%d kwargs_keys=%s",
+            len(args),  # Positional-arg count without dumping the arg values themselves
+            sorted(kwargs.keys()),  # Sorted key list keeps log ordering deterministic
+        )
+        return None  # Preserve the None return contract of the removed listen_keyboard stub


### PR DESCRIPTION
## Summary
PR-13 of the 1010 MistHelper extraction plan. Extracts the legacy `listen_keyboard` no-op stub from MistHelper.py into `src/refactors/keyboard_listener.py` as `KeyboardListener.listen()`, preserving the `*args/**kwargs` pass-through signature verbatim.

Per FR-005/FR-006: no wrapper, delegator, or alias left in MistHelper. The def is deleted and the single call site (interactive SSR/SRX websocket shell in `CLIShellManager`) is rewritten directly to `KeyboardListener().listen(...)`.

## Changes
- Add `src/refactors/keyboard_listener.py` (compliance A+/100.0)
- Delete `listen_keyboard` def + explanatory comment block from MistHelper.py
- Rewire `CLIShellManager` call site to `KeyboardListener().listen(...)` (drop stale `type: ignore` since the new method is properly typed)
- Add import `from src.refactors.keyboard_listener import KeyboardListener`
- Refresh `refactor_candidates.md`

## Test plan
- [x] `py_compile` on both files
- [x] `ruff check` clean
- [x] `black --check` clean
- [x] `mypy --strict` on new file: clean
- [x] Compliance analyzer: A+/100.0 on new file
- [x] Guardrails: 40/40 passing
- [x] Zero `listen_keyboard` references remain in `MistHelper.py`