### PR TITLE
refactor(1011): extract AnomalyMetricsDiscovery (SC-016)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -146,6 +146,9 @@ from src.gateway.gateway_export_utils import (
     configure_gateway_export_utils_dependencies,
 )  # Import gateway export utility configuration
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
+from src.refactors.anomaly_metrics_discovery import (
+    AnomalyMetricsDiscovery,  # Extracted anomaly metrics discovery (SC-016)
+)
 from src.refactors.data_directory_checker import DataDirectoryChecker  # Early data-dir writable check (SC-005)
 from src.refactors.keyboard_listener import KeyboardListener  # PR-13 extracted no-op keyboard listener stub (SC-012)
 from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted Maps Manager launcher (SC-006)
@@ -19297,104 +19300,6 @@ class BulkSwitchFirmwareUpgrader:
     def execute(self) -> dict[str, Any]:
         """Orchestrate the complete upgrade workflow."""
         return self._impl.execute()
-
-
-# ============================================================================
-# ANOMALY EXPORT SECTION - Site Anomaly Events for AI/ML Analysis
-# ============================================================================
-
-
-class AnomalyMetricsDiscovery:
-    """
-    Discovers and prioritizes site-scoped anomaly metrics from ConstInsightMetrics.csv.
-
-    Provides fallback metrics when CSV is unavailable. Used for AI/ML anomaly analysis.
-    """
-
-    # Priority keywords for anomaly-related metrics
-    PRIORITY_KEYWORDS = [
-        "roam",
-        "availability",
-        "capacity",
-        "coverage",
-        "client",
-        "throughput",
-        "latency",
-        "band",
-        "ap-",
-        "switch-",
-    ]
-
-    # Fallback metrics when CSV unavailable
-    FALLBACK_METRICS = [
-        {"metric_name": "client-roam-band5", "description": "5GHz roaming anomalies", "priority": True},
-        {"metric_name": "client-roam-band24", "description": "2.4GHz roaming anomalies", "priority": True},
-        {"metric_name": "ap-availability", "description": "AP availability anomalies", "priority": True},
-    ]
-
-    @classmethod
-    def discover(cls) -> list[dict[str, Any]]:
-        """
-        Discover potential anomaly metrics from ConstInsightMetrics.csv.
-
-        Returns:
-            List of metric dictionaries with metric_name, description, and priority.
-        """
-        try:
-            metrics_path = FilePathUtils.get_csv_path("ConstInsightMetrics.csv")
-
-            if not os.path.exists(metrics_path):
-                return cls._handle_missing_csv()
-
-            return cls._parse_metrics_csv(metrics_path)
-
-        except Exception as exception:
-            logging.error("Error reading ConstInsightMetrics.csv: %s", str(exception))
-            return cls.FALLBACK_METRICS.copy()
-
-    @classmethod
-    def _handle_missing_csv(cls) -> list[dict[str, Any]]:
-        """Handle case when ConstInsightMetrics.csv is not found."""
-        logging.warning(
-            "ConstInsightMetrics.csv not found. Please export organization constants first (menu option 11)."
-        )
-        return cls.FALLBACK_METRICS.copy()
-
-    @classmethod
-    def _parse_metrics_csv(cls, csv_path: str) -> list[dict[str, Any]]:
-        """Parse metrics CSV and extract site-scoped anomaly metrics."""
-        potential_metrics = []
-
-        with open(csv_path, encoding="utf-8") as csv_file:
-            reader = csv.DictReader(csv_file)
-            for row in reader:
-                metric = cls._process_csv_row(row)
-                if metric:
-                    potential_metrics.append(metric)
-
-        return cls._sort_by_priority(potential_metrics)
-
-    @classmethod
-    def _process_csv_row(cls, row: dict[str, str]) -> dict[str, Any] | None:
-        """Process a single CSV row and return metric dict if site-scoped."""
-        metric_key = row.get("key", "").strip().lower()
-        metric_name = row.get("name", "").strip()
-        metric_scope = row.get("scope", "").strip().lower()
-
-        if metric_scope != "site" or not metric_key:
-            return None
-
-        is_priority = any(keyword in metric_key for keyword in cls.PRIORITY_KEYWORDS)
-        description = metric_name if metric_name else f"Anomaly events for {metric_key}"
-
-        return {"metric_name": metric_key, "description": description, "priority": is_priority}
-
-    @classmethod
-    def _sort_by_priority(cls, metrics: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Sort metrics with priority items first, then alphabetically."""
-        metrics.sort(key=lambda x: (not x.get("priority", False), x["metric_name"]))
-        logging.info("Found %s potential anomaly metrics from ConstInsightMetrics.csv", len(metrics))
-        return metrics
 
 
 # ============================================================================

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 185 first-party files
-- Definitions analyzed: 99
+- Module graph size: 186 first-party files
+- Definitions analyzed: 98
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=18, hot=80, skipped=1
+- Category counts: unused=0, single-use=0, low-use=17, hot=80, skipped=1
 
 ## How to read this report
 
@@ -83,7 +83,6 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `GatewayExportUtils` | class | 98 | 79 | hot |  | oversize_25_lines,missing_action_logging |
 | `DeviceUtils` | class | 97 | 6 | hot |  | oversize_25_lines |
 | `OrgAdminExporter` | class | 94 | 14 | hot |  | oversize_25_lines,hardcoded_separator |
-| `AnomalyMetricsDiscovery` | class | 91 | 2 | low-use | AnomalyMetricsDiscovery | oversize_25_lines,missing_inline_comments |
 | `ValidationUtils` | class | 90 | 15 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `SiteClientExporter` | class | 85 | 10 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `OrgLevelAPFirmwareUpgrader` | class | 79 | 33 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
@@ -98,7 +97,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `GatewayTemplateConfigManager` | class | 56 | 6 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `APICoreFetchUtils` | class | 47 | 59 | hot |  | oversize_25_lines,missing_inline_comments |
 | `InventoryCSVComparator` | class | 47 | 3 | low-use | InventoryCSVComparator | oversize_25_lines,missing_action_logging |
-| `FilePathUtils` | class | 46 | 106 | hot |  | oversize_25_lines,missing_inline_comments |
+| `FilePathUtils` | class | 46 | 104 | hot |  | oversize_25_lines,missing_inline_comments |
 | `SiteConfigManager` | class | 43 | 16 | hot |  | oversize_25_lines,missing_action_logging |
 | `SelfExportUtils` | class | 40 | 4 | hot |  | oversize_25_lines,non_ascii_logs |
 | `BulkAPFirmwareUpgrader` | class | 32 | 2 | low-use | FirmwareManager | oversize_25_lines,missing_inline_comments,missing_action_logging |
@@ -132,11 +131,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 12 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (18)
+## Low-Use (17)
 
 ### `FirmwareUpgradeStatusChecker` (class, 958 lines)
 
-- Def site: line 17780-18737
+- Def site: line 17782-18739
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -148,22 +147,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Reference sites (one PR cluster per file):
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1746, 1753
 
-### `AnomalyMetricsDiscovery` (class, 91 lines)
-
-- Def site: line 19308-19398
-- References: 2
-- Suggested class: `AnomalyMetricsDiscovery`
-- Suggested module: `src/refactors/anomaly_metrics_discovery.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `_discover_site_anomaly_metrics()`; extract `AnomalyMetricsDiscovery` OUT of the entrypoint into a new `src/refactors/anomaly_metrics_discovery.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] missing_inline_comments
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13000, 13000
-
 ### `DeviceDataFetcher` (class, 68 lines)
 
-- Def site: line 5544-5611
+- Def site: line 5547-5614
 - References: 3
 - Suggested class: `DeviceDataFetcher`
 - Suggested module: `src/refactors/device_data_fetcher.py`
@@ -172,11 +158,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15298, 15315, 15331
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15301, 15318, 15334
 
 ### `InventoryCSVComparator` (class, 47 lines)
 
-- Def site: line 16455-16501
+- Def site: line 16458-16504
 - References: 3
 - Suggested class: `InventoryCSVComparator`
 - Suggested module: `src/refactors/inventory_csvcomparator.py`
@@ -185,11 +171,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16494, 16494, 20281
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16497, 16497, 20185
 
 ### `BulkAPFirmwareUpgrader` (class, 32 lines)
 
-- Def site: line 18750-18781
+- Def site: line 18752-18783
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -203,7 +189,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceConfigTemplateClonerManager` (class, 27 lines)
 
-- Def site: line 15920-15946
+- Def site: line 15923-15949
 - References: 2
 - Suggested class: `DeviceConfigTemplateClonerManager`
 - Suggested module: `src/refactors/device_config_template_cloner_manager.py`
@@ -212,11 +198,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20662, 20662
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20566, 20566
 
 ### `WANProbeDeviceOverrideManager` (class, 23 lines)
 
-- Def site: line 17190-17212
+- Def site: line 17192-17214
 - References: 2
 - Suggested class: `WANProbeDeviceOverrideManager`
 - Suggested module: `src/refactors/wanprobe_device_override_manager.py`
@@ -225,11 +211,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20464, 20464
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20368, 20368
 
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 19282-19300
+- Def site: line 19284-19302
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -242,7 +228,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `initialize_mist_session_interactive` (function, 18 lines)
 
-- Def site: line 2183-2200
+- Def site: line 2186-2203
 - References: 3
 - Suggested class: `InitializeMistSessionInteractiveManager`
 - Suggested module: `src/refactors/initialize_mist_session_interactive.py`
@@ -250,11 +236,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2243, 18885, 21930
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2246, 18887, 21834
 
 ### `initialize_mist_session` (function, 18 lines)
 
-- Def site: line 2809-2826
+- Def site: line 2812-2829
 - References: 2
 - Suggested class: `InitializeMistSessionManager`
 - Suggested module: `src/refactors/initialize_mist_session.py`
@@ -262,11 +248,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21935, 21998
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21839, 21902
 
 ### `PACKAGE_IMPORT_MAP` (assignment, 13 lines)
 
-- Def site: line 360-372
+- Def site: line 363-375
 - References: 2
 - Suggested class: `PackageImportMapManager`
 - Suggested module: `src/refactors/package__import__map.py`
@@ -274,22 +260,22 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 360, 544
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 363, 547
 
 ### `main` (function, 12 lines)
 
-- Def site: line 22326-22337
+- Def site: line 22230-22241
 - References: 2
 - Suggested class: `MainManager`
 - Suggested module: `src/refactors/main.py`
 - Rationale: low-use: sole caller lives inside MistHelper.py; extract `main` OUT of the entrypoint into a new `src/refactors/main.py` module and rewrite the callsite(s) to import from there
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22440
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22344
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
 
 ### `marvis_data_utils` (assignment, 4 lines)
 
-- Def site: line 6600-6603
+- Def site: line 6603-6606
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
@@ -297,12 +283,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6600, 15742
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6603, 15745
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\marvis_troubleshoot_utils.py`: lines 21
 
 ### `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 lines)
 
-- Def site: line 1975-1977
+- Def site: line 1978-1980
 - References: 3
 - Suggested class: `FastModeBackoffMultiplierManager`
 - Suggested module: `src/refactors/fast__mode__backoff__multiplier.py`
@@ -311,11 +297,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1975, 9986, 15415
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1978, 9989, 15418
 
 ### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
 
-- Def site: line 1978-1980
+- Def site: line 1981-1983
 - References: 2
 - Suggested class: `FastModeDevicesPerThreadManager`
 - Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
@@ -324,11 +310,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1978, 7476
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1981, 7479
 
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 1983-1985
+- Def site: line 1986-1988
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -337,11 +323,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1983, 15555
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1986, 15558
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 1990-1992
+- Def site: line 1993-1995
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -349,11 +335,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1990, 7466
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1993, 7469
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 1998-2000
+- Def site: line 2001-2003
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -362,14 +348,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1998, 15644
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2001, 15647
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
 ## Hot (80)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2871-5197
+- Def site: line 2874-5200
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -380,11 +366,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2871, 6646, 6647, 6656, 6820
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2874, 6649, 6650, 6659, 6823
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 14001-14759
+- Def site: line 14004-14762
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -393,11 +379,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14478, 14478, 14490, 14490, 14518, 14518, 14530, 14530, 14591, 14591, 14628, 14628, 14785, 20379
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14481, 14481, 14493, 14493, 14521, 14521, 14533, 14533, 14594, 14594, 14631, 14631, 14788, 20283
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9147-9832
+- Def site: line 9150-9835
 - References: 112
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -406,12 +392,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5653, 5653, 9270, 9270, 9321, 9321, 9324, 9324, 9365, 9365, 9404, 9404, 9422, 9422, 9500, 9500, 9507, 9507, 9517, 9517, 9520, 9520, 9533, 9533, 9534, 9534, 9535, 9535, 9536, 9536, 9544, 9544, 9546, 9546, 9547, 9547, 9548, 9548, 9549, 9549, 9552, 9552, 9555, 9555, 9558, 9558, 9561, 9561, 9607, 9607, 9630, 9630, 9631, 9631, 9632, 9632, 9634, 9634, 9670, 9670, 9686, 9686, 9740, 9740, 9741, 9741, 9742, 9742, 9745, 9745, 9746, 9746, 9765, 9765, 9767, 9767, 9768, 9768, 9803, 9803, 15154, 15154, 15207, 15207, 15638, 16477, 16477, 17239, 17239, 17263, 17263, 17287, 17287, 17430, 17430, 20154, 20154, 20161, 20161, 20170, 20170, 20174, 20174, 20183, 20183
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5656, 5656, 9273, 9273, 9324, 9324, 9327, 9327, 9368, 9368, 9407, 9407, 9425, 9425, 9503, 9503, 9510, 9510, 9520, 9520, 9523, 9523, 9536, 9536, 9537, 9537, 9538, 9538, 9539, 9539, 9547, 9547, 9549, 9549, 9550, 9550, 9551, 9551, 9552, 9552, 9555, 9555, 9558, 9558, 9561, 9561, 9564, 9564, 9610, 9610, 9633, 9633, 9634, 9634, 9635, 9635, 9637, 9637, 9673, 9673, 9689, 9689, 9743, 9743, 9744, 9744, 9745, 9745, 9748, 9748, 9749, 9749, 9768, 9768, 9770, 9770, 9771, 9771, 9806, 9806, 15157, 15157, 15210, 15210, 15641, 16480, 16480, 17241, 17241, 17265, 17265, 17289, 17289, 17432, 17432, 20058, 20058, 20065, 20065, 20074, 20074, 20078, 20078, 20087, 20087
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16507-17181
+- Def site: line 16510-17184
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -419,11 +405,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16895, 16895, 20625, 20631
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16898, 16898, 20529, 20535
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11880-12532
+- Def site: line 11883-12535
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -433,11 +419,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10657, 10657, 10666, 10666, 10754, 10754, 10761, 10761, 11435, 11435, 11721, 11721, 11726, 11726, 11733, 11733, 11738, 11738, 11952, 11952, 11974, 11974, 11977, 11977, 12003, 12003, 12012, 12012, 12013, 12013, 12034, 12034, 12077, 12077, 12123, 12123, 12134, 12134, 12161, 12161, 12166, 12166, 12167, 12167, 12168, 12168, 12200, 12200, 12206, 12206, 12231, 12231, 12251, 12251, 12286, 12286, 12301, 12301, 12307, 12307, 12309, 12309, 12312, 12312, 12314, 12314, 12318, 12318, 12322, 12322, 12327, 12327, 12334, 12334, 12341, 12341, 12348, 12348, 12357, 12357, 12367, 12367, 12374, 12374, 12381, 12381, 12388, 12388, 12395, 12395, 12402, 12402, 12412, 12412, 12421, 12421, 12430, 12430, 12439, 12439, 12448, 12448, 12477, 12477, 20115, 20115, 20296, 20296, 20373, 20373, 20374, 20374, 20382, 20382, 20587, 20587, 20588, 20588, 20607, 20607, 20614, 20614, 20615, 20615, 20616, 20616, 20617, 20617
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10660, 10660, 10669, 10669, 10757, 10757, 10764, 10764, 11438, 11438, 11724, 11724, 11729, 11729, 11736, 11736, 11741, 11741, 11955, 11955, 11977, 11977, 11980, 11980, 12006, 12006, 12015, 12015, 12016, 12016, 12037, 12037, 12080, 12080, 12126, 12126, 12137, 12137, 12164, 12164, 12169, 12169, 12170, 12170, 12171, 12171, 12203, 12203, 12209, 12209, 12234, 12234, 12254, 12254, 12289, 12289, 12304, 12304, 12310, 12310, 12312, 12312, 12315, 12315, 12317, 12317, 12321, 12321, 12325, 12325, 12330, 12330, 12337, 12337, 12344, 12344, 12351, 12351, 12360, 12360, 12370, 12370, 12377, 12377, 12384, 12384, 12391, 12391, 12398, 12398, 12405, 12405, 12415, 12415, 12424, 12424, 12433, 12433, 12442, 12442, 12451, 12451, 12480, 12480, 20019, 20019, 20200, 20200, 20277, 20277, 20278, 20278, 20286, 20286, 20491, 20491, 20492, 20492, 20511, 20511, 20518, 20518, 20519, 20519, 20520, 20520, 20521, 20521
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 19411-19997
+- Def site: line 19315-19901
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -445,11 +431,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19688, 19688, 19689, 19689, 19692, 19692, 19694, 19694, 19696, 19696, 19712, 19712, 20532
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19592, 19592, 19593, 19593, 19596, 19596, 19598, 19598, 19600, 19600, 19616, 19616, 20436
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 20096-20667
+- Def site: line 20000-20571
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -459,12 +445,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20096, 21381, 21382, 21391, 21511, 21511, 21553, 21611, 21656, 22147, 22151, 22196, 22196, 22223, 22223, 22226
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20000, 21285, 21286, 21295, 21415, 21415, 21457, 21515, 21560, 22051, 22055, 22100, 22100, 22127, 22127, 22130
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8431-8893
+- Def site: line 8434-8896
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -472,11 +458,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8472, 8472, 8477, 8477, 8487, 8487, 8495, 8495, 8500, 8500, 8505, 8505, 8515, 8515, 8520, 8520, 8525, 8525, 8545, 8545, 8555, 8555, 8556, 8556, 8559, 8559, 8589, 8589, 8675, 8675, 8677, 8677, 8701, 8701, 8707, 8707, 8712, 8712, 8721, 8721, 8725, 8725, 8744, 8744, 8747, 8747, 8758, 8758, 8759, 8759, 8854, 8854, 8875, 8875, 20655, 20655, 20656, 20656, 20657, 20657, 20658, 20658, 20659, 20659, 20660, 20660
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8475, 8475, 8480, 8480, 8490, 8490, 8498, 8498, 8503, 8503, 8508, 8508, 8518, 8518, 8523, 8523, 8528, 8528, 8548, 8548, 8558, 8558, 8559, 8559, 8562, 8562, 8592, 8592, 8678, 8678, 8680, 8680, 8704, 8704, 8710, 8710, 8715, 8715, 8724, 8724, 8728, 8728, 8747, 8747, 8750, 8750, 8761, 8761, 8762, 8762, 8857, 8857, 8878, 8878, 20559, 20559, 20560, 20560, 20561, 20561, 20562, 20562, 20563, 20563, 20564, 20564
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 20892-21352
+- Def site: line 20796-21256
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -486,11 +472,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21359, 21359, 21363, 21363, 21383, 21383, 21388, 21388, 21612
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21263, 21263, 21267, 21267, 21287, 21287, 21292, 21292, 21516
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7878-8318
+- Def site: line 7881-8321
 - References: 123
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -498,14 +484,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5582, 5582, 5590, 5590, 7823, 7823, 7839, 7839, 7843, 7843, 7844, 7844, 7845, 7845, 7860, 7860, 7866, 7866, 7893, 7893, 7896, 7896, 7904, 7904, 7922, 7922, 7972, 7972, 7980, 7980, 7985, 7985, 8031, 8031, 8042, 8042, 8067, 8067, 8086, 8086, 8087, 8087, 8090, 8090, 8091, 8091, 8181, 8181, 8183, 8183, 8187, 8187, 8215, 8215, 8216, 8216, 8217, 8217, 8218, 8218, 8219, 8219, 8228, 8228, 8272, 8272, 8296, 8296, 12612, 12612, 12662, 12662, 12667, 12667, 12810, 12893, 12893, 12947, 12947, 12968, 12968, 12973, 12973, 13237, 13237, 13440, 13642, 13642, 13729, 13729, 13734, 13734, 13784, 13784, 13785, 13785, 15281, 15281, 15740, 17246, 17246, 17768, 17768, 17869, 17869, 20020, 20020, 20021, 20021, 20307, 20307
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5585, 5585, 5593, 5593, 7826, 7826, 7842, 7842, 7846, 7846, 7847, 7847, 7848, 7848, 7863, 7863, 7869, 7869, 7896, 7896, 7899, 7899, 7907, 7907, 7925, 7925, 7975, 7975, 7983, 7983, 7988, 7988, 8034, 8034, 8045, 8045, 8070, 8070, 8089, 8089, 8090, 8090, 8093, 8093, 8094, 8094, 8184, 8184, 8186, 8186, 8190, 8190, 8218, 8218, 8219, 8219, 8220, 8220, 8221, 8221, 8222, 8222, 8231, 8231, 8275, 8275, 8299, 8299, 12615, 12615, 12665, 12665, 12670, 12670, 12813, 12896, 12896, 12950, 12950, 12971, 12971, 12976, 12976, 13240, 13240, 13443, 13645, 13645, 13732, 13732, 13737, 13737, 13787, 13787, 13788, 13788, 15284, 15284, 15743, 17248, 17248, 17770, 17770, 17871, 17871, 19924, 19924, 19925, 19925, 20211, 20211
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9835-10248
+- Def site: line 9838-10251
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -514,11 +500,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5647, 5647, 9868, 9868, 9952, 9952, 9958, 9958, 9961, 9961, 10005, 10005, 10019, 10019, 10046, 10046, 10052, 10052, 10066, 10066, 10149, 10149, 10151, 10151, 10155, 10155, 10157, 10157, 10160, 10160, 10164, 10164, 10167, 10167, 10177, 10177, 10183, 10183, 10221, 10221, 15155, 15155, 15156, 15156, 15157, 15157, 15208, 15208, 15209, 15209, 20155, 20155, 20156, 20156, 20157, 20157, 20181, 20181
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5650, 5650, 9871, 9871, 9955, 9955, 9961, 9961, 9964, 9964, 10008, 10008, 10022, 10022, 10049, 10049, 10055, 10055, 10069, 10069, 10152, 10152, 10154, 10154, 10158, 10158, 10160, 10160, 10163, 10163, 10167, 10167, 10170, 10170, 10180, 10180, 10186, 10186, 10224, 10224, 15158, 15158, 15159, 15159, 15160, 15160, 15211, 15211, 15212, 15212, 20059, 20059, 20060, 20060, 20061, 20061, 20085, 20085
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17349-17746
+- Def site: line 17351-17748
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -527,11 +513,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17370, 17370, 17375, 17375, 17379, 17379, 17382, 17382, 17389, 17389, 17391, 17391, 17392, 17392, 17395, 17395, 17398, 17398, 17401, 17401, 17443, 17443, 17475, 17475, 17542, 17542, 17555, 17555, 17560, 17560, 17612, 17612, 17645, 17645, 17646, 17646, 17647, 17647, 17677, 17677, 17706, 17706, 17707, 17707, 20338, 20338
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17372, 17372, 17377, 17377, 17381, 17381, 17384, 17384, 17391, 17391, 17393, 17393, 17394, 17394, 17397, 17397, 17400, 17400, 17403, 17403, 17445, 17445, 17477, 17477, 17544, 17544, 17557, 17557, 17562, 17562, 17614, 17614, 17647, 17647, 17648, 17648, 17649, 17649, 17679, 17679, 17708, 17708, 17709, 17709, 20242, 20242
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 18787-19174
+- Def site: line 18789-19176
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -541,11 +527,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18814, 18958, 18958, 20478, 20478
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18816, 18960, 18960, 20382, 20382
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6787-7131
+- Def site: line 6790-7134
 - References: 259
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -554,7 +540,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5610, 5610, 5743, 5743, 6833, 6833, 6849, 6849, 6850, 6850, 6873, 6873, 6875, 6875, 6878, 6878, 6892, 6892, 6894, 6894, 6903, 6903, 6905, 6905, 6906, 6906, 6912, 6912, 6913, 6913, 6913, 6930, 6930, 6934, 6934, 6976, 6976, 7007, 7007, 7010, 7010, 7012, 7012, 7058, 7058, 7068, 7068, 7101, 7101, 7106, 7106, 7113, 7113, 7335, 7335, 7367, 7367, 7378, 7378, 7403, 7403, 7423, 7423, 7935, 7935, 8728, 8728, 9007, 9007, 9022, 9086, 9086, 9103, 9103, 9121, 9121, 9142, 9142, 9701, 9701, 9776, 9776, 10106, 10106, 10457, 10457, 10542, 10558, 10678, 10678, 10682, 10682, 10702, 10702, 10715, 10715, 10719, 10719, 10737, 10737, 10899, 10899, 11246, 11246, 11393, 11393, 11470, 11470, 11474, 11474, 11479, 11479, 11612, 11612, 11631, 11631, 11682, 11682, 11685, 11685, 11836, 11836, 11839, 11839, 11938, 11938, 11944, 11944, 12241, 12241, 12258, 12258, 12273, 12273, 12487, 12487, 12515, 12515, 12531, 12531, 12568, 12568, 12606, 12606, 12695, 12695, 12724, 12724, 12762, 12762, 12813, 12878, 12878, 12884, 12884, 12926, 12926, 13095, 13095, 13101, 13101, 13220, 13220, 13228, 13228, 13392, 13392, 13443, 13616, 13616, 13787, 13787, 14300, 14300, 14661, 14661, 14667, 14667, 15575, 15575, 15634, 15741, 15877, 15877, 15895, 15895, 15913, 15913, 15940, 15940, 15941, 15941, 17207, 17293, 17293, 17314, 18622, 18622, 19140, 19140, 19225, 19225, 19246, 19246, 19846, 19846, 20507, 20507, 20523, 20523
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5613, 5613, 5746, 5746, 6836, 6836, 6852, 6852, 6853, 6853, 6876, 6876, 6878, 6878, 6881, 6881, 6895, 6895, 6897, 6897, 6906, 6906, 6908, 6908, 6909, 6909, 6915, 6915, 6916, 6916, 6916, 6933, 6933, 6937, 6937, 6979, 6979, 7010, 7010, 7013, 7013, 7015, 7015, 7061, 7061, 7071, 7071, 7104, 7104, 7109, 7109, 7116, 7116, 7338, 7338, 7370, 7370, 7381, 7381, 7406, 7406, 7426, 7426, 7938, 7938, 8731, 8731, 9010, 9010, 9025, 9089, 9089, 9106, 9106, 9124, 9124, 9145, 9145, 9704, 9704, 9779, 9779, 10109, 10109, 10460, 10460, 10545, 10561, 10681, 10681, 10685, 10685, 10705, 10705, 10718, 10718, 10722, 10722, 10740, 10740, 10902, 10902, 11249, 11249, 11396, 11396, 11473, 11473, 11477, 11477, 11482, 11482, 11615, 11615, 11634, 11634, 11685, 11685, 11688, 11688, 11839, 11839, 11842, 11842, 11941, 11941, 11947, 11947, 12244, 12244, 12261, 12261, 12276, 12276, 12490, 12490, 12518, 12518, 12534, 12534, 12571, 12571, 12609, 12609, 12698, 12698, 12727, 12727, 12765, 12765, 12816, 12881, 12881, 12887, 12887, 12929, 12929, 13098, 13098, 13104, 13104, 13223, 13223, 13231, 13231, 13395, 13395, 13446, 13619, 13619, 13790, 13790, 14303, 14303, 14664, 14664, 14670, 14670, 15578, 15578, 15637, 15744, 15880, 15880, 15898, 15898, 15916, 15916, 15943, 15943, 15944, 15944, 17209, 17295, 17295, 17316, 18624, 18624, 19142, 19142, 19227, 19227, 19248, 19248, 19750, 19750, 20411, 20411, 20427, 20427
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -565,7 +551,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12934-13274
+- Def site: line 12937-13277
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -574,11 +560,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12951, 12951, 12953, 12953, 12957, 12957, 12958, 12958, 12972, 12972, 12978, 12978, 12981, 12981, 12984, 12984, 13042, 13042, 13048, 13048, 13053, 13053, 13067, 13067, 13085, 13085, 13195, 13195, 13199, 13199, 13201, 13201, 13204, 13204, 13241, 13241, 13246, 13246, 13260, 13260, 13264, 13264, 13266, 13266, 13269, 13269, 13274, 13274, 20384, 20384, 20388, 20388, 20392, 20392
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12954, 12954, 12956, 12956, 12960, 12960, 12961, 12961, 12975, 12975, 12981, 12981, 12984, 12984, 12987, 12987, 13045, 13045, 13051, 13051, 13056, 13056, 13070, 13070, 13088, 13088, 13198, 13198, 13202, 13202, 13204, 13204, 13207, 13207, 13244, 13244, 13249, 13249, 13263, 13263, 13267, 13267, 13269, 13269, 13272, 13272, 13277, 13277, 20288, 20288, 20292, 20292, 20296, 20296
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7134-7461
+- Def site: line 7137-7464
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -586,11 +572,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7236, 7236, 8452, 8933, 8952, 9053, 9182, 9205, 9877, 10185, 10230, 10644, 11414, 11425, 11488, 11905
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7239, 7239, 8455, 8936, 8955, 9056, 9185, 9208, 9880, 10188, 10233, 10647, 11417, 11428, 11491, 11908
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14765-15092
+- Def site: line 14768-15095
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -600,13 +586,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12222, 12222, 12281, 12281, 12282, 12282, 13446, 14806, 14806, 14808, 14808, 14814, 14814, 14828, 14828, 14867, 14867, 14870, 14870, 14872, 14872, 14873, 14873, 14874, 14874, 14928, 14928, 14929, 14929, 14940, 14940, 14949, 14949, 14968, 14968, 15020, 15020, 15024, 15024, 15032, 15032, 15033, 15033, 15057, 15057, 15061, 15061
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12225, 12225, 12284, 12284, 12285, 12285, 13449, 14809, 14809, 14811, 14811, 14817, 14817, 14831, 14831, 14870, 14870, 14873, 14873, 14875, 14875, 14876, 14876, 14877, 14877, 14931, 14931, 14932, 14932, 14943, 14943, 14952, 14952, 14971, 14971, 15023, 15023, 15027, 15027, 15035, 15035, 15036, 15036, 15060, 15060, 15064, 15064
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16149-16437
+- Def site: line 16152-16440
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -616,11 +602,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16177, 16177, 16180, 16180, 16185, 16185, 16188, 16188, 16232, 16232, 16238, 16238, 16269, 16269, 16272, 16272, 16276, 16276, 16302, 16302, 16319, 16319, 16325, 16325, 16339, 16339, 16340, 16340, 16342, 16342, 16348, 16348, 16355, 16355, 16364, 16364, 16411, 16411, 16433, 16433, 16434, 16434, 16435, 16435, 20329, 20329
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16180, 16180, 16183, 16183, 16188, 16188, 16191, 16191, 16235, 16235, 16241, 16241, 16272, 16272, 16275, 16275, 16279, 16279, 16305, 16305, 16322, 16322, 16328, 16328, 16342, 16342, 16343, 16343, 16345, 16345, 16351, 16351, 16358, 16358, 16367, 16367, 16414, 16414, 16436, 16436, 16437, 16437, 16438, 16438, 20233, 20233
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10251-10523
+- Def site: line 10254-10526
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -629,11 +615,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10274, 10274, 10275, 10275, 10288, 10288, 10289, 10289, 10291, 10291, 10292, 10292, 10295, 10295, 10298, 10298, 10302, 10302, 10303, 10303, 10379, 10379, 10383, 10383, 10386, 10386, 10399, 10399, 10436, 10436, 10453, 10453, 10466, 10466, 10468, 10468, 10475, 10475, 10484, 10484, 10493, 10493, 10494, 10494, 10505, 10505, 10509, 10509, 10518, 10518, 10523, 10523, 20586, 20586
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10277, 10277, 10278, 10278, 10291, 10291, 10292, 10292, 10294, 10294, 10295, 10295, 10298, 10298, 10301, 10301, 10305, 10305, 10306, 10306, 10382, 10382, 10386, 10386, 10389, 10389, 10402, 10402, 10439, 10439, 10456, 10456, 10469, 10469, 10471, 10471, 10478, 10478, 10487, 10487, 10496, 10496, 10497, 10497, 10508, 10508, 10512, 10512, 10521, 10521, 10526, 10526, 20490, 20490
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5203-5466
+- Def site: line 5206-5469
 - References: 111
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -641,14 +627,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5243, 5243, 5245, 5245, 5327, 5327, 5333, 5333, 5370, 5370, 5372, 5372, 5381, 5381, 5391, 5391, 5401, 5401, 5437, 5437, 7971, 7971, 9629, 9629, 9630, 9630, 9941, 9941, 10787, 10787, 10807, 10807, 12808, 15214, 15214, 15220, 15220, 15221, 15221, 15222, 15222, 15223, 15223, 15224, 15224, 15225, 15225, 15232, 15232, 15260, 15260, 15632, 15878, 15878, 15896, 15896, 15914, 15914, 15964, 16475, 16475, 16476, 16476, 17202, 17238, 17238, 17262, 17262, 17286, 17286, 17430, 17430, 17431, 17431, 17432, 17432, 17433, 17433, 17769, 17769, 20071, 20071, 20623, 20623
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5246, 5246, 5248, 5248, 5330, 5330, 5336, 5336, 5373, 5373, 5375, 5375, 5384, 5384, 5394, 5394, 5404, 5404, 5440, 5440, 7974, 7974, 9632, 9632, 9633, 9633, 9944, 9944, 10790, 10790, 10810, 10810, 12811, 15217, 15217, 15223, 15223, 15224, 15224, 15225, 15225, 15226, 15226, 15227, 15227, 15228, 15228, 15235, 15235, 15263, 15263, 15635, 15881, 15881, 15899, 15899, 15917, 15917, 15967, 16478, 16478, 16479, 16479, 17204, 17240, 17240, 17264, 17264, 17288, 17288, 17432, 17432, 17433, 17433, 17434, 17434, 17435, 17435, 17771, 17771, 19975, 19975, 20527, 20527
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 11018-11268
+- Def site: line 11021-11271
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -658,11 +644,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11025, 11025, 11028, 11028, 11033, 11033, 11034, 11034, 11042, 11042, 11045, 11045, 11053, 11053, 11093, 11093, 11101, 11101, 11149, 11149, 11166, 11166, 11169, 11169, 11171, 11171, 11235, 11235, 11236, 11236, 20589, 20589
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11028, 11028, 11031, 11031, 11036, 11036, 11037, 11037, 11045, 11045, 11048, 11048, 11056, 11056, 11096, 11096, 11104, 11104, 11152, 11152, 11169, 11169, 11172, 11172, 11174, 11174, 11238, 11238, 11239, 11239, 20493, 20493
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15344-15588
+- Def site: line 15347-15591
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -672,11 +658,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15210, 15210, 15370, 15370, 15372, 15372, 15373, 15373, 15374, 15374, 15402, 15402, 15407, 15407, 15429, 15429, 15430, 15430, 15472, 15472, 15480, 15480, 15506, 15506, 15515, 15515, 15523, 15523, 15554, 15554, 20160, 20160, 20164, 20164
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15213, 15213, 15373, 15373, 15375, 15375, 15376, 15376, 15377, 15377, 15405, 15405, 15410, 15410, 15432, 15432, 15433, 15433, 15475, 15475, 15483, 15483, 15509, 15509, 15518, 15518, 15526, 15526, 15557, 15557, 20064, 20064, 20068, 20068
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6206-6426
+- Def site: line 6209-6429
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -684,14 +670,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6229, 6229, 6280, 6280, 6350, 6350, 6374, 6374, 6386, 6386, 6388, 6388, 6398, 6398, 6413, 6413, 6417, 6417, 6418, 6418, 6421, 6421, 6423, 6423, 12921, 12921, 15636
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6232, 6232, 6283, 6283, 6353, 6353, 6377, 6377, 6389, 6389, 6391, 6391, 6401, 6401, 6416, 6416, 6420, 6420, 6421, 6421, 6424, 6424, 6426, 6426, 12924, 12924, 15639
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 20673-20886
+- Def site: line 20577-20790
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -700,11 +686,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21529, 21529, 21532, 21613, 21964
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21433, 21433, 21436, 21517, 21868
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7662-7871
+- Def site: line 7665-7874
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -713,11 +699,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7675, 7675, 7681, 7681, 7682, 7682, 7685, 7685, 7708, 7708, 7711, 7711, 7714, 7714, 7715, 7715, 7717, 7717, 7784, 7784, 7828, 7828, 8293, 8293, 13242, 13242, 15739, 16002, 16002, 16162, 16162
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7678, 7678, 7684, 7684, 7685, 7685, 7688, 7688, 7711, 7711, 7714, 7714, 7717, 7717, 7718, 7718, 7720, 7720, 7787, 7787, 7831, 7831, 8296, 8296, 13245, 13245, 15742, 16005, 16005, 16165, 16165
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12540-12742
+- Def site: line 12543-12745
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -726,11 +712,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12561, 12561, 12570, 12570, 12632, 12632, 12639, 12639, 12671, 12671, 12673, 12673, 12697, 12697, 12732, 12732, 12739, 12739, 12770, 12770, 15284, 15284, 20196, 20196, 20198, 20198, 20199, 20199, 20201, 20201
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12564, 12564, 12573, 12573, 12635, 12635, 12642, 12642, 12674, 12674, 12676, 12676, 12700, 12700, 12735, 12735, 12742, 12742, 12773, 12773, 15287, 15287, 20100, 20100, 20102, 20102, 20103, 20103, 20105, 20105
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13793-13980
+- Def site: line 13796-13983
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -740,11 +726,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20546, 20546, 20547, 20547, 20548, 20548, 20549, 20549, 20550, 20550, 20551, 20551, 20552, 20552, 20553, 20553, 20555, 20555, 20556, 20556, 20557, 20557, 20558, 20558, 20559, 20559, 20560, 20560, 20561, 20561, 20563, 20563, 20564, 20564, 20565, 20565, 20566, 20566, 20567, 20567, 20568, 20568, 20569, 20569, 20570, 20570, 20571, 20571, 20573, 20573, 20574, 20574, 20575, 20575, 20576, 20576, 20577, 20577, 20578, 20578, 20579, 20579, 20580, 20580, 20581, 20581, 20583, 20583, 20584, 20584
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20450, 20450, 20451, 20451, 20452, 20452, 20453, 20453, 20454, 20454, 20455, 20455, 20456, 20456, 20457, 20457, 20459, 20459, 20460, 20460, 20461, 20461, 20462, 20462, 20463, 20463, 20464, 20464, 20465, 20465, 20467, 20467, 20468, 20468, 20469, 20469, 20470, 20470, 20471, 20471, 20472, 20472, 20473, 20473, 20474, 20474, 20475, 20475, 20477, 20477, 20478, 20478, 20479, 20479, 20480, 20480, 20481, 20481, 20482, 20482, 20483, 20483, 20484, 20484, 20485, 20485, 20487, 20487, 20488, 20488
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5618-5797
+- Def site: line 5621-5800
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -753,11 +739,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5706, 5706, 5743, 5743, 5745, 5745, 5748, 5748, 5756, 5756, 5758, 5758, 5760, 5760, 5763, 5763, 5792, 5792, 5795, 5795, 20323, 20323
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5709, 5709, 5746, 5746, 5748, 5748, 5751, 5751, 5759, 5759, 5761, 5761, 5763, 5763, 5766, 5766, 5795, 5795, 5798, 5798, 20227, 20227
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6606-6784
+- Def site: line 6609-6787
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -765,11 +751,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6651, 6651, 6689, 6689, 6700, 6700, 6726, 6726, 6727, 6727, 6729, 6729, 6735, 6735, 6736, 6736, 6739, 6739, 6745, 6745, 6746, 6746, 6749, 6749, 6751, 6751, 6761, 6761, 6763, 6763, 6764, 6764, 6766, 6766
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6654, 6654, 6692, 6692, 6703, 6703, 6729, 6729, 6730, 6730, 6732, 6732, 6738, 6738, 6739, 6739, 6742, 6742, 6748, 6748, 6749, 6749, 6752, 6752, 6754, 6754, 6764, 6764, 6766, 6766, 6767, 6767, 6769, 6769
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11498-11665
+- Def site: line 11501-11668
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -778,11 +764,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11605, 11605, 11624, 11624, 11642, 11642, 11651, 11651, 11654, 11654, 11655, 11655, 11658, 11658, 11663, 11663, 11665, 11665, 20224, 20224
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11608, 11608, 11627, 11627, 11645, 11645, 11654, 11654, 11657, 11657, 11658, 11658, 11661, 11661, 11666, 11666, 11668, 11668, 20128, 20128
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11710-11877
+- Def site: line 11713-11880
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -790,11 +776,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11747, 11747, 11749, 11749, 11752, 11752, 11823, 11823, 11825, 11825, 11838, 11838, 11842, 11842, 20227, 20227, 20228, 20228, 20229, 20229, 20267, 20267, 20272, 20272
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11750, 11750, 11752, 11752, 11755, 11755, 11826, 11826, 11828, 11828, 11841, 11841, 11845, 11845, 20131, 20131, 20132, 20132, 20133, 20133, 20171, 20171, 20176, 20176
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10743-10904
+- Def site: line 10746-10907
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -802,11 +788,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10781, 10781, 10788, 10788, 10795, 10795, 10801, 10801, 10808, 10808, 10815, 10815, 10876, 10876, 10887, 10887, 20215, 20215, 20216, 20216, 20218, 20218, 20219, 20219, 20220, 20220
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10784, 10784, 10791, 10791, 10798, 10798, 10804, 10804, 10811, 10811, 10818, 10818, 10879, 10879, 10890, 10890, 20119, 20119, 20120, 20120, 20122, 20122, 20123, 20123, 20124, 20124
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15983-16143
+- Def site: line 15986-16146
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -815,11 +801,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16006, 16006, 16008, 16008, 16077, 16077, 16079, 16079, 16098, 16098, 16100, 16100, 16100, 16116, 16116, 16132, 16132, 16133, 16133, 16139, 16139, 20328, 20328
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16009, 16009, 16011, 16011, 16080, 16080, 16082, 16082, 16101, 16101, 16103, 16103, 16103, 16119, 16119, 16135, 16135, 16136, 16136, 16142, 16142, 20232, 20232
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6434-6591
+- Def site: line 6437-6594
 - References: 205
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -829,7 +815,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5501, 5501, 5608, 5608, 5609, 5609, 6450, 6450, 6463, 6463, 6466, 6466, 6490, 6490, 6498, 6498, 6499, 6499, 6521, 6521, 6526, 6526, 6528, 6528, 6601, 6601, 6602, 6602, 7009, 7009, 7034, 7034, 7103, 7103, 7104, 7104, 7433, 7433, 7447, 7447, 7448, 7448, 7933, 7933, 7934, 7934, 8856, 8856, 9021, 9081, 9081, 9083, 9083, 9084, 9084, 9101, 9101, 9102, 9102, 9119, 9119, 9120, 9120, 9140, 9140, 9141, 9141, 9698, 9698, 9699, 9699, 9773, 9773, 9774, 9774, 10102, 10102, 10105, 10105, 10680, 10680, 10681, 10681, 10717, 10717, 10718, 10718, 10897, 10897, 10898, 10898, 11242, 11242, 11243, 11243, 11389, 11389, 11390, 11390, 11472, 11472, 11473, 11473, 11684, 11684, 11859, 11859, 11860, 11860, 11936, 11936, 11937, 11937, 12240, 12240, 12256, 12256, 12257, 12257, 12485, 12485, 12486, 12486, 12565, 12565, 12566, 12566, 12567, 12567, 12603, 12603, 12604, 12604, 12692, 12692, 12693, 12693, 12721, 12721, 12722, 12722, 12759, 12759, 12760, 12760, 12812, 12881, 12881, 12882, 12882, 12924, 12924, 12925, 12925, 13093, 13093, 13094, 13094, 13218, 13218, 13219, 13219, 13442, 13614, 13614, 14666, 14666, 15573, 15573, 15574, 15574, 15635, 15743, 17291, 17291, 17292, 17292, 19130, 19130
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5504, 5504, 5611, 5611, 5612, 5612, 6453, 6453, 6466, 6466, 6469, 6469, 6493, 6493, 6501, 6501, 6502, 6502, 6524, 6524, 6529, 6529, 6531, 6531, 6604, 6604, 6605, 6605, 7012, 7012, 7037, 7037, 7106, 7106, 7107, 7107, 7436, 7436, 7450, 7450, 7451, 7451, 7936, 7936, 7937, 7937, 8859, 8859, 9024, 9084, 9084, 9086, 9086, 9087, 9087, 9104, 9104, 9105, 9105, 9122, 9122, 9123, 9123, 9143, 9143, 9144, 9144, 9701, 9701, 9702, 9702, 9776, 9776, 9777, 9777, 10105, 10105, 10108, 10108, 10683, 10683, 10684, 10684, 10720, 10720, 10721, 10721, 10900, 10900, 10901, 10901, 11245, 11245, 11246, 11246, 11392, 11392, 11393, 11393, 11475, 11475, 11476, 11476, 11687, 11687, 11862, 11862, 11863, 11863, 11939, 11939, 11940, 11940, 12243, 12243, 12259, 12259, 12260, 12260, 12488, 12488, 12489, 12489, 12568, 12568, 12569, 12569, 12570, 12570, 12606, 12606, 12607, 12607, 12695, 12695, 12696, 12696, 12724, 12724, 12725, 12725, 12762, 12762, 12763, 12763, 12815, 12884, 12884, 12885, 12885, 12927, 12927, 12928, 12928, 13096, 13096, 13097, 13097, 13221, 13221, 13222, 13222, 13445, 13617, 13617, 14669, 14669, 15576, 15576, 15577, 15577, 15638, 15746, 17293, 17293, 17294, 17294, 19132, 19132
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -837,7 +823,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15106-15261
+- Def site: line 15109-15264
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -846,11 +832,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15128, 15128, 15134, 15134, 15136, 15136, 15164, 15164, 15190, 15190, 15193, 15193, 15196, 15196, 20314, 20314, 20318, 20318, 20326, 20326
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15131, 15131, 15137, 15137, 15139, 15139, 15167, 15167, 15193, 15193, 15196, 15196, 15199, 15199, 20218, 20218, 20222, 20222, 20230, 20230
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13277-13422
+- Def site: line 13280-13425
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -858,11 +844,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13316, 13316, 13323, 13323, 13348, 13348, 13351, 13351, 13364, 13364, 13408, 13408, 13412, 13412, 13417, 13417, 13418, 13418, 13422, 13422, 20621, 20621
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13319, 13319, 13326, 13326, 13351, 13351, 13354, 13354, 13367, 13367, 13411, 13411, 13415, 13415, 13420, 13420, 13421, 13421, 13425, 13425, 20525, 20525
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13430-13574
+- Def site: line 13433-13577
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -871,12 +857,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12651, 12651, 12827, 12827, 12905, 12905, 12910, 12910, 13459, 13459, 13465, 13465, 13471, 13471, 13477, 13477, 13483, 13483, 13489, 13489, 13495, 13495, 13501, 13501, 13507, 13507, 13513, 13513, 13519, 13519, 13525, 13525, 13531, 13531, 13537, 13537, 13543, 13543, 13549, 13549, 13555, 13555, 13561, 13561, 13567, 13567, 13573, 13573, 20234, 20234, 20375, 20375, 20377, 20377, 20492, 20492, 20618, 20618, 20619, 20619, 20620, 20620, 20639, 20639, 20640, 20640, 20641, 20641, 20642, 20642, 20643, 20643, 20644, 20644, 20645, 20645
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12654, 12654, 12830, 12830, 12908, 12908, 12913, 12913, 13462, 13462, 13468, 13468, 13474, 13474, 13480, 13480, 13486, 13486, 13492, 13492, 13498, 13498, 13504, 13504, 13510, 13510, 13516, 13516, 13522, 13522, 13528, 13528, 13534, 13534, 13540, 13540, 13546, 13546, 13552, 13552, 13558, 13558, 13564, 13564, 13570, 13570, 13576, 13576, 20138, 20138, 20279, 20279, 20281, 20281, 20396, 20396, 20522, 20522, 20523, 20523, 20524, 20524, 20543, 20543, 20544, 20544, 20545, 20545, 20546, 20546, 20547, 20547, 20548, 20548, 20549, 20549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10597-10740
+- Def site: line 10600-10743
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -885,11 +871,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10611, 10611, 10612, 10612, 10698, 10698, 10733, 10733, 20209, 20209, 20210, 20210, 20211, 20211, 20212, 20212, 20213, 20213
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10614, 10614, 10615, 10615, 10701, 10701, 10736, 10736, 20113, 20113, 20114, 20114, 20115, 20115, 20116, 20116, 20117, 20117
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13577-13715
+- Def site: line 13580-13718
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -897,11 +883,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13646, 13646, 13649, 13649, 13650, 13650, 13651, 13651, 13671, 13671, 13674, 13674, 13682, 13682, 13687, 13687, 20647, 20647
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13649, 13649, 13652, 13652, 13653, 13653, 13654, 13654, 13674, 13674, 13677, 13677, 13685, 13685, 13690, 13690, 20551, 20551
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8899-9027
+- Def site: line 8902-9030
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -910,11 +896,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8970, 8970, 8981, 8981, 15204, 15204, 15205, 15205, 20112, 20112, 20113, 20113, 20292, 20292
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8973, 8973, 8984, 8984, 15207, 15207, 15208, 15208, 20016, 20016, 20017, 20017, 20196, 20196
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11271-11399
+- Def site: line 11274-11402
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -923,11 +909,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11278, 11278, 11283, 11283, 11284, 11284, 11285, 11285, 11288, 11288, 11289, 11289, 11352, 11352, 11359, 11359, 11386, 11386, 20591, 20591
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11281, 11281, 11286, 11286, 11287, 11287, 11288, 11288, 11291, 11291, 11292, 11292, 11355, 11355, 11362, 11362, 11389, 11389, 20495, 20495
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15729-15855
+- Def site: line 15732-15858
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -936,11 +922,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15749, 15749, 15754, 15754, 15759, 15759, 15796, 15796, 15802, 15802, 15808, 15808, 15814, 15814, 15820, 15820, 15821, 15821, 15822, 15822, 15823, 15823, 15824, 15824, 15828, 15828, 15837, 15837, 15841, 15841, 15844, 15844, 15850, 15850, 20287, 20287
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15752, 15752, 15757, 15757, 15762, 15762, 15799, 15799, 15805, 15805, 15811, 15811, 15817, 15817, 15823, 15823, 15824, 15824, 15825, 15825, 15826, 15826, 15827, 15827, 15831, 15831, 15840, 15840, 15844, 15844, 15847, 15847, 15853, 15853, 20191, 20191
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5851-5975
+- Def site: line 5854-5978
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -949,11 +935,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5872, 5872, 5874, 5874, 5890, 5890, 5902, 5902, 5941, 5941, 5942, 5942, 5943, 5943, 5944, 5944, 5945, 5945, 5956, 5956, 5959, 5959, 6891, 6891, 21626, 21626, 22209, 22209
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5875, 5875, 5877, 5877, 5893, 5893, 5905, 5905, 5944, 5944, 5945, 5945, 5946, 5946, 5947, 5947, 5948, 5948, 5959, 5959, 5962, 5962, 6894, 6894, 21530, 21530, 22113, 22113
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 9033-9144
+- Def site: line 9036-9147
 - References: 53
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -961,13 +947,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7971, 7971, 9629, 9629, 9941, 9941, 10787, 10787, 10807, 10807, 12809, 15153, 15153, 15206, 15206, 15639, 15879, 15879, 15897, 15897, 15915, 15915, 17203, 17240, 17240, 17264, 17264, 17288, 17288, 17431, 17431, 17772, 17772, 20153, 20153, 20168, 20168, 20178, 20178, 20178, 20178, 20188, 20188
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7974, 7974, 9632, 9632, 9944, 9944, 10790, 10790, 10810, 10810, 12812, 15156, 15156, 15209, 15209, 15642, 15882, 15882, 15900, 15900, 15918, 15918, 17205, 17242, 17242, 17266, 17266, 17290, 17290, 17433, 17433, 17774, 17774, 20057, 20057, 20072, 20072, 20082, 20082, 20082, 20082, 20092, 20092
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10907-11015
+- Def site: line 10910-11018
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -977,11 +963,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10962, 10962, 10965, 10965, 10966, 10966, 10971, 10971, 10989, 10989, 10989, 10998, 10998, 10998, 10998, 10999, 10999, 10999, 10999, 11057, 11057, 11060, 11060, 11072, 11072, 11073, 11073, 11086, 11086, 11125, 11125, 11133, 11133, 11187, 11187, 11195, 11195
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10965, 10965, 10968, 10968, 10969, 10969, 10974, 10974, 10992, 10992, 10992, 11001, 11001, 11001, 11001, 11002, 11002, 11002, 11002, 11060, 11060, 11063, 11063, 11075, 11075, 11076, 11076, 11089, 11089, 11128, 11128, 11136, 11136, 11190, 11190, 11198, 11198
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12832-12931
+- Def site: line 12835-12934
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -990,11 +976,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12897, 12897, 12899, 12899, 12900, 12900, 20162, 20162, 20230, 20230, 20232, 20232, 20233, 20233
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12900, 12900, 12902, 12902, 12903, 12903, 20066, 20066, 20134, 20134, 20136, 20136, 20137, 20137
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15621-15718
+- Def site: line 15624-15721
 - References: 79
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1003,13 +989,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15364, 15364, 15599, 15599, 15657, 15657, 15663, 15663, 15669, 15669, 15675, 15675, 15681, 15681, 15687, 15687, 15693, 15693, 15699, 15699, 15705, 15705, 15711, 15711, 15717, 15717, 15965, 17204, 17432, 17432, 17435, 17435, 17771, 17771, 20119, 20119, 20186, 20186, 20192, 20192, 20243, 20243, 20300, 20300
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15367, 15367, 15602, 15602, 15660, 15660, 15666, 15666, 15672, 15672, 15678, 15678, 15684, 15684, 15690, 15690, 15696, 15696, 15702, 15702, 15708, 15708, 15714, 15714, 15720, 15720, 15968, 17206, 17434, 17434, 17437, 17437, 17773, 17773, 20023, 20023, 20090, 20090, 20096, 20096, 20147, 20147, 20204, 20204
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8329-8425
+- Def site: line 8332-8428
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1017,11 +1003,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8385, 8385, 8421, 8421, 16479, 16479
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8388, 8388, 8424, 8424, 16482, 16482
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11402-11495
+- Def site: line 11405-11498
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1030,11 +1016,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11454, 11454, 11467, 11467, 20222, 20222, 20264, 20264, 20265, 20265, 20270, 20270, 20271, 20271
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11457, 11457, 11470, 11470, 20126, 20126, 20168, 20168, 20169, 20169, 20174, 20174, 20175, 20175
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5981-6070
+- Def site: line 5984-6073
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1044,13 +1030,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6063, 6063, 15427, 15427, 15428, 15428, 15642, 20022, 20022
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6066, 6066, 15430, 15430, 15431, 15431, 15645, 19926, 19926
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12745-12829
+- Def site: line 12748-12832
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1060,11 +1046,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12779, 12779, 20197, 20197, 20205, 20205, 20231, 20231, 20376, 20376
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12782, 12782, 20101, 20101, 20109, 20109, 20135, 20135, 20280, 20280
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 19201-19279
+- Def site: line 19203-19281
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1074,12 +1060,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19196, 19196, 19197, 19197, 20471, 20471
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19198, 19198, 19199, 19199, 20375, 20375
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17218-17295
+- Def site: line 17220-17297
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1089,12 +1075,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20342, 20342, 20346, 20346, 20350, 20350
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20246, 20246, 20250, 20250, 20254, 20254
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1875-1948
+- Def site: line 1878-1951
 - References: 261
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1103,7 +1089,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1888, 1888, 1920, 1920, 2195, 2195, 2284, 2284, 2311, 2311, 7683, 7683, 7769, 7769, 7899, 7899, 7976, 7976, 8059, 8059, 8289, 8289, 8478, 8478, 8534, 8534, 8547, 8547, 8564, 8564, 8609, 8609, 8640, 8640, 8646, 8646, 8749, 8749, 10290, 10290, 10557, 11059, 11059, 11088, 11088, 11353, 11353, 11559, 11559, 11798, 11798, 12514, 12514, 12530, 12530, 13317, 13317, 13736, 13736, 13786, 13786, 15640, 15842, 15842, 15875, 15875, 15893, 15893, 15911, 15911, 15938, 15938, 15963, 17206, 17245, 17245, 17270, 17270, 17313, 17412, 17412, 17624, 17624, 17767, 17767, 18771, 18771, 18861, 18861, 19191, 19191, 19221, 19221, 19242, 19242, 19261, 19261, 19277, 19277, 19294, 19294, 19969, 19969, 19989, 19989, 20024, 20024, 20037, 20037, 20505, 20505, 20596, 20596, 20601, 20601, 20607, 20607, 20626, 20626, 20632, 20632, 22232, 22232, 22330, 22330
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1891, 1891, 1923, 1923, 2198, 2198, 2287, 2287, 2314, 2314, 7686, 7686, 7772, 7772, 7902, 7902, 7979, 7979, 8062, 8062, 8292, 8292, 8481, 8481, 8537, 8537, 8550, 8550, 8567, 8567, 8612, 8612, 8643, 8643, 8649, 8649, 8752, 8752, 10293, 10293, 10560, 11062, 11062, 11091, 11091, 11356, 11356, 11562, 11562, 11801, 11801, 12517, 12517, 12533, 12533, 13320, 13320, 13739, 13739, 13789, 13789, 15643, 15845, 15845, 15878, 15878, 15896, 15896, 15914, 15914, 15941, 15941, 15966, 17208, 17247, 17247, 17272, 17272, 17315, 17414, 17414, 17626, 17626, 17769, 17769, 18773, 18773, 18863, 18863, 19193, 19193, 19223, 19223, 19244, 19244, 19263, 19263, 19279, 19279, 19296, 19296, 19873, 19873, 19893, 19893, 19928, 19928, 19941, 19941, 20409, 20409, 20500, 20500, 20505, 20505, 20511, 20511, 20530, 20530, 20536, 20536, 22136, 22136, 22234, 22234
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -1124,7 +1110,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15267-15338
+- Def site: line 15270-15341
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1133,11 +1119,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20308, 20308, 20309, 20309, 20310, 20310, 20311, 20311
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20212, 20212, 20213, 20213, 20214, 20214, 20215, 20215
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5472-5541
+- Def site: line 5475-5544
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1147,11 +1133,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5504, 5504, 5505, 5505, 5520, 5520, 5522, 5522, 5611, 5611, 18140, 18140, 18179, 18179, 18238, 18238
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5507, 5507, 5508, 5508, 5523, 5523, 5525, 5525, 5614, 5614, 18142, 18142, 18181, 18181, 18240, 18240
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 6076-6145
+- Def site: line 6079-6148
 - References: 195
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1159,7 +1145,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6118, 6118, 6123, 6123, 6220, 6220, 6278, 6278, 7169, 7169, 7826, 7826, 8471, 8471, 8494, 8494, 8514, 8514, 8699, 8699, 8720, 8720, 8995, 8995, 9020, 9020, 9075, 9075, 9097, 9097, 9114, 9114, 9131, 9131, 9516, 9516, 9739, 9739, 9756, 9756, 10148, 10148, 10480, 10480, 10691, 10691, 10728, 10728, 10881, 10881, 11024, 11024, 11277, 11277, 11465, 11465, 11649, 11649, 11968, 11968, 12304, 12304, 12476, 12476, 12516, 12516, 12522, 12522, 12616, 12616, 12846, 12846, 12919, 12919, 13406, 13406, 13441, 13640, 13640, 15147, 15147, 15363, 15363, 15631, 15738, 15838, 15838, 15873, 15873, 15891, 15891, 15909, 15909, 15944, 15944, 16478, 16478, 17201, 17311, 17819, 17819, 18772, 18772, 18777, 18777, 18779, 18779, 19192, 19192, 19194, 19194, 19218, 19218, 19222, 19222, 19223, 19223, 19243, 19243, 19244, 19244, 19503, 19503, 20073, 20073, 20105, 20105, 20142, 20142, 20148, 20148, 20276, 20276, 20333, 20333, 20416, 20416, 20425, 20425, 20503, 20503, 20504, 20504, 20521, 20521, 20596, 20596, 20601, 20601, 20607, 20607, 20626, 20626, 20632, 20632, 21543, 21543, 21614, 22096, 22096, 22184, 22184
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6121, 6121, 6126, 6126, 6223, 6223, 6281, 6281, 7172, 7172, 7829, 7829, 8474, 8474, 8497, 8497, 8517, 8517, 8702, 8702, 8723, 8723, 8998, 8998, 9023, 9023, 9078, 9078, 9100, 9100, 9117, 9117, 9134, 9134, 9519, 9519, 9742, 9742, 9759, 9759, 10151, 10151, 10483, 10483, 10694, 10694, 10731, 10731, 10884, 10884, 11027, 11027, 11280, 11280, 11468, 11468, 11652, 11652, 11971, 11971, 12307, 12307, 12479, 12479, 12519, 12519, 12525, 12525, 12619, 12619, 12849, 12849, 12922, 12922, 13409, 13409, 13444, 13643, 13643, 15150, 15150, 15366, 15366, 15634, 15741, 15841, 15841, 15876, 15876, 15894, 15894, 15912, 15912, 15947, 15947, 16481, 16481, 17203, 17313, 17821, 17821, 18774, 18774, 18779, 18779, 18781, 18781, 19194, 19194, 19196, 19196, 19220, 19220, 19224, 19224, 19225, 19225, 19245, 19245, 19246, 19246, 19407, 19407, 19977, 19977, 20009, 20009, 20046, 20046, 20052, 20052, 20180, 20180, 20237, 20237, 20320, 20320, 20329, 20329, 20407, 20407, 20408, 20408, 20425, 20425, 20500, 20500, 20505, 20505, 20511, 20511, 20530, 20530, 20536, 20536, 21447, 21447, 21518, 22000, 22000, 22088, 22088
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1169,7 +1155,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10526-10594
+- Def site: line 10529-10597
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1180,11 +1166,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10566, 10566, 10571, 10571, 10576, 10576, 10577, 10577, 10583, 10583, 10584, 10584, 10590, 10590, 10591, 10591, 10592, 10592, 10593, 10593, 20649, 20649
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10569, 10569, 10574, 10574, 10579, 10579, 10580, 10580, 10586, 10586, 10587, 10587, 10593, 10593, 10594, 10594, 10595, 10595, 10596, 10596, 20553, 20553
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 20028-20093
+- Def site: line 19932-19997
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1194,11 +1180,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20076, 20076, 20084, 20084, 20093, 20093, 20622, 20622
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19980, 19980, 19988, 19988, 19997, 19997, 20526, 20526
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15862-15917
+- Def site: line 15865-15920
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1208,11 +1194,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20247, 20247, 20251, 20251, 20456, 20456
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20151, 20151, 20155, 20155, 20360, 20360
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6151-6197
+- Def site: line 6154-6200
 - References: 59
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1221,14 +1207,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6275, 6275, 8161, 8161, 9076, 9076, 9099, 9099, 9586, 9586, 9621, 9621, 9635, 9635, 9758, 9758, 9762, 9762, 10310, 10310, 12620, 12620, 13290, 13290, 13416, 13416, 13448, 13626, 13626, 13662, 13662, 15637, 17927, 17927, 18773, 18773, 19082, 19082, 19193, 19193, 19224, 19224, 19245, 19245, 20506, 20506, 20522, 20522, 22115, 22115
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6278, 6278, 8164, 8164, 9079, 9079, 9102, 9102, 9589, 9589, 9624, 9624, 9638, 9638, 9761, 9761, 9765, 9765, 10313, 10313, 12623, 12623, 13293, 13293, 13419, 13419, 13451, 13629, 13629, 13665, 13665, 15640, 17929, 17929, 18775, 18775, 19084, 19084, 19195, 19195, 19226, 19226, 19247, 19247, 20410, 20410, 20426, 20426, 22019, 22019
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5800-5845
-- References: 106
+- Def site: line 5803-5848
+- References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1236,14 +1222,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5242, 5242, 5284, 5284, 5329, 5329, 5435, 5435, 5450, 5450, 5790, 5790, 5791, 5791, 5835, 5835, 6301, 6301, 7995, 7995, 9286, 9286, 9597, 9597, 9613, 9613, 9942, 9942, 10823, 10823, 10842, 10842, 12811, 15230, 15230, 15633, 15876, 15876, 15894, 15894, 15912, 15912, 15939, 15939, 15966, 16388, 16388, 16428, 16428, 16429, 16429, 16430, 16430, 16474, 16474, 17205, 17237, 17237, 17261, 17261, 17265, 17265, 17285, 17285, 17312, 17387, 17387, 17421, 17421, 17442, 17442, 17474, 17474, 17536, 17536, 17575, 17575, 17725, 17725, 17770, 17770, 18774, 18774, 19345, 19345
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5245, 5245, 5287, 5287, 5332, 5332, 5438, 5438, 5453, 5453, 5793, 5793, 5794, 5794, 5838, 5838, 6304, 6304, 7998, 7998, 9289, 9289, 9600, 9600, 9616, 9616, 9945, 9945, 10826, 10826, 10845, 10845, 12814, 15233, 15233, 15636, 15879, 15879, 15897, 15897, 15915, 15915, 15942, 15942, 15969, 16391, 16391, 16431, 16431, 16432, 16432, 16433, 16433, 16477, 16477, 17207, 17239, 17239, 17263, 17263, 17267, 17267, 17287, 17287, 17314, 17389, 17389, 17423, 17423, 17444, 17444, 17476, 17476, 17538, 17538, 17577, 17577, 17727, 17727, 17772, 17772, 18776, 18776
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17301-17343
+- Def site: line 17303-17345
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1252,11 +1238,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17324, 17324, 17330, 17330, 17336, 17336, 17342, 17342, 20440, 20440, 20444, 20444, 20448, 20448, 20452, 20452
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17326, 17326, 17332, 17332, 17338, 17338, 17344, 17344, 20344, 20344, 20348, 20348, 20352, 20352, 20356, 20356
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11668-11707
+- Def site: line 11671-11710
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1265,11 +1251,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11705, 11705, 20646, 20646
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11708, 11708, 20550, 20550
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1839-1867
+- Def site: line 1842-1870
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1278,12 +1264,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8949, 8949, 8950, 8950, 8979, 8979, 8980, 8980, 8996, 8996, 8997, 8997, 9875, 9875, 9876, 9876, 10180, 10180, 10181, 10181, 10228, 10228, 10229, 10229, 10784, 10784, 10786, 10786, 10804, 10804, 10806, 10806, 11694, 11694, 11695, 11695, 12355, 12355, 12356, 12356, 12461, 12461, 12462, 12462, 13444
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8952, 8952, 8953, 8953, 8982, 8982, 8983, 8983, 8999, 8999, 9000, 9000, 9878, 9878, 9879, 9879, 10183, 10183, 10184, 10184, 10231, 10231, 10232, 10232, 10787, 10787, 10789, 10789, 10807, 10807, 10809, 10809, 11697, 11697, 11698, 11698, 12358, 12358, 12359, 12359, 12464, 12464, 12465, 12465, 13447
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15591-15618
+- Def site: line 15594-15621
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1292,12 +1278,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15605, 15605, 15611, 15611, 15617, 15617, 20354, 20354, 20358, 20358
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15608, 15608, 15614, 15614, 15620, 15620, 20258, 20258, 20262, 20262
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15952-15977
+- Def site: line 15955-15980
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1307,12 +1293,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15972, 15972, 15977, 15977, 20362, 20362, 20367, 20367
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15975, 15975, 15980, 15980, 20266, 20266, 20271, 20271
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2103-2127
+- Def site: line 2106-2130
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1320,11 +1306,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2189, 2248, 18890, 21939
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2192, 2251, 18892, 21843
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13743-13764
+- Def site: line 13746-13767
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1333,7 +1319,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20128, 20128, 20132, 20132, 20136, 20136
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20032, 20032, 20036, 20036, 20040, 20040
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1343,17 +1329,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17753-17774
+- Def site: line 17755-17776
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18776, 18776, 20275, 20275, 20332, 20332, 20415, 20415, 20424, 20424
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18778, 18778, 20179, 20179, 20236, 20236, 20319, 20319, 20328, 20328
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 19177-19198
+- Def site: line 19179-19200
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1362,24 +1348,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20485, 20485
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20389, 20389
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7633-7653
+- Def site: line 7636-7656
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6384, 10153, 15476, 15641
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6387, 10156, 15479, 15644
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13989-13998
+- Def site: line 13992-14001
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1387,11 +1373,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14025, 14161, 14238, 14257, 14269, 14290, 14303, 14314, 14320, 14333, 14426, 14561, 14656
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14028, 14164, 14241, 14260, 14272, 14293, 14306, 14317, 14323, 14336, 14429, 14564, 14659
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 291-299
+- Def site: line 294-302
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1407,7 +1393,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 318-326
+- Def site: line 321-329
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1415,11 +1401,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5558, 15299, 15316, 15332
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5561, 15302, 15319, 15335
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 303-310
+- Def site: line 306-313
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1435,7 +1421,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 278-280
+- Def site: line 281-283
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1443,12 +1429,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13449, 13738, 19226, 19247, 19490, 19521, 19553, 19788, 19803
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13452, 13741, 19228, 19249, 19394, 19425, 19457, 19692, 19707
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 606-608
+- Def site: line 609-611
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1456,7 +1442,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1216, 1885, 1885, 1885, 1897, 1903, 6277, 6397, 7457, 7517, 9685, 9796, 10050, 10880, 13451, 15509, 15551, 15649, 20508
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1219, 1888, 1888, 1888, 1900, 1906, 6280, 6400, 7460, 7520, 9688, 9799, 10053, 10883, 13454, 15512, 15554, 15652, 20412
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1469,7 +1455,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 1987-1989
+- Def site: line 1990-1992
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1478,11 +1464,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1987, 7467, 7474, 7475, 10061, 15498
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1990, 7470, 7477, 7478, 10064, 15501
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2005-2007
+- Def site: line 2008-2010
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1491,7 +1477,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2005, 15645, 17209
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2008, 15648, 17211
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1499,7 +1485,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 722-1726
+- Def site: line 725-1729
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1507,7 +1493,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1771
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1774
 
 ## Limitations
 

--- a/src/refactors/anomaly_metrics_discovery.py
+++ b/src/refactors/anomaly_metrics_discovery.py
@@ -32,8 +32,7 @@ _MH = _MistHelperProxy()  # Sole module-level proxy handle used inside the class
 
 
 class AnomalyMetricsDiscovery:
-    """
-    Discovers and prioritizes site-scoped anomaly metrics from ConstInsightMetrics.csv.
+    """Discover and prioritize site-scoped anomaly metrics from ConstInsightMetrics.csv.
 
     Provides fallback metrics when CSV is unavailable. Used for AI/ML anomaly analysis.
     """
@@ -61,8 +60,7 @@ class AnomalyMetricsDiscovery:
 
     @classmethod
     def discover(cls) -> list[dict[str, Any]]:
-        """
-        Discover potential anomaly metrics from ConstInsightMetrics.csv.
+        """Discover potential anomaly metrics from ConstInsightMetrics.csv.
 
         Returns:
             List of metric dictionaries with metric_name, description, and priority.

--- a/src/refactors/anomaly_metrics_discovery.py
+++ b/src/refactors/anomaly_metrics_discovery.py
@@ -1,0 +1,138 @@
+"""AnomalyMetricsDiscovery extracted from MistHelper.
+
+Discovers site-scoped anomaly metrics from ConstInsightMetrics.csv for
+AI/ML analysis. Originally defined as ``AnomalyMetricsDiscovery`` inside
+MistHelper.py; extracted here per initiative 1011 to shrink the monolith.
+
+Runtime dependency ``FilePathUtils`` still lives inside MistHelper.py and
+is resolved lazily via the ``_MH`` module-level proxy so this module keeps
+its import graph flat and honours any test monkey-patches applied at
+runtime.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import csv  # Reads ConstInsightMetrics.csv into structured dictionaries
+import importlib  # Late-import MistHelper to avoid circular src<->MistHelper dependency
+import logging  # Structured action logging required by Constitution VII
+import os  # Filesystem existence check for the CSV path
+from typing import Any  # Loose typing for late-bound MistHelper attributes
+
+
+class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
+    """Forward attribute access to the currently-loaded MistHelper module."""
+
+    def __getattr__(self, name: str) -> Any:  # Called only when the attribute is not found normally
+        """Resolve name against the live MistHelper module (call-time lookup)."""
+        misthelper_module = importlib.import_module("MistHelper")  # Lazy import at call time
+        return getattr(misthelper_module, name)  # Fetch the current bound value from MistHelper
+
+
+_MH = _MistHelperProxy()  # Sole module-level proxy handle used inside the class body
+
+
+class AnomalyMetricsDiscovery:
+    """
+    Discovers and prioritizes site-scoped anomaly metrics from ConstInsightMetrics.csv.
+
+    Provides fallback metrics when CSV is unavailable. Used for AI/ML anomaly analysis.
+    """
+
+    # Priority keywords for anomaly-related metrics
+    PRIORITY_KEYWORDS = [
+        "roam",
+        "availability",
+        "capacity",
+        "coverage",
+        "client",
+        "throughput",
+        "latency",
+        "band",
+        "ap-",
+        "switch-",
+    ]
+
+    # Fallback metrics when CSV unavailable
+    FALLBACK_METRICS = [
+        {"metric_name": "client-roam-band5", "description": "5GHz roaming anomalies", "priority": True},
+        {"metric_name": "client-roam-band24", "description": "2.4GHz roaming anomalies", "priority": True},
+        {"metric_name": "ap-availability", "description": "AP availability anomalies", "priority": True},
+    ]
+
+    @classmethod
+    def discover(cls) -> list[dict[str, Any]]:
+        """
+        Discover potential anomaly metrics from ConstInsightMetrics.csv.
+
+        Returns:
+            List of metric dictionaries with metric_name, description, and priority.
+        """
+        try:
+            metrics_path = _MH.FilePathUtils.get_csv_path(
+                "ConstInsightMetrics.csv"
+            )  # Resolve CSV location via MistHelper's FilePathUtils
+
+            if not os.path.exists(metrics_path):  # Skip when the CSV was never exported
+                return cls._handle_missing_csv()  # Emit warning and fall back to defaults
+
+            return cls._parse_metrics_csv(metrics_path)  # Parse and return discovered metrics
+
+        except Exception as exception:  # Any parse/IO error yields the fallback list
+            logging.error("Error reading ConstInsightMetrics.csv: %s", str(exception))  # Structured error log
+            return cls.FALLBACK_METRICS.copy()  # Return a defensive copy of the fallback set
+
+    @classmethod
+    def _handle_missing_csv(cls) -> list[dict[str, Any]]:
+        """Handle case when ConstInsightMetrics.csv is not found."""
+        logging.warning(
+            "ConstInsightMetrics.csv not found. Please export organization constants first (menu option 11)."
+        )  # Guide operator toward the export menu that produces the CSV
+        return cls.FALLBACK_METRICS.copy()  # Defensive copy so callers can mutate without side effects
+
+    @classmethod
+    def _parse_metrics_csv(cls, csv_path: str) -> list[dict[str, Any]]:
+        """Parse metrics CSV and extract site-scoped anomaly metrics."""
+        potential_metrics = []  # Accumulator for site-scoped rows only
+
+        with open(csv_path, encoding="utf-8") as csv_file:  # UTF-8 CSV is the Mist export standard
+            reader = csv.DictReader(csv_file)  # Yield rows keyed by header names
+            for row in reader:  # Walk each metric definition
+                metric = cls._process_csv_row(row)  # Filter/transform row into an anomaly candidate
+                if metric:  # Non-site or empty-key rows return None and are skipped
+                    potential_metrics.append(metric)  # Accept eligible metric
+
+        return cls._sort_by_priority(potential_metrics)  # Priority-first ordering before returning
+
+    @classmethod
+    def _process_csv_row(cls, row: dict[str, str]) -> dict[str, Any] | None:
+        """Process a single CSV row and return metric dict if site-scoped."""
+        metric_key = row.get("key", "").strip().lower()  # Normalized key used for keyword matching
+        metric_name = row.get("name", "").strip()  # Human-readable name for the description column
+        metric_scope = row.get("scope", "").strip().lower()  # Only site-scoped metrics apply to anomaly export
+
+        if metric_scope != "site" or not metric_key:  # Reject non-site or unnamed rows
+            return None  # Signals _parse_metrics_csv to skip this row
+
+        is_priority = any(
+            keyword in metric_key for keyword in cls.PRIORITY_KEYWORDS
+        )  # Prioritize known anomaly buckets
+        description = (
+            metric_name if metric_name else f"Anomaly events for {metric_key}"
+        )  # Fallback description when name blank
+
+        return {
+            "metric_name": metric_key,
+            "description": description,
+            "priority": is_priority,
+        }  # Structured metric record
+
+    @classmethod
+    def _sort_by_priority(cls, metrics: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Sort metrics with priority items first, then alphabetically."""
+        metrics.sort(
+            key=lambda x: (not x.get("priority", False), x["metric_name"])
+        )  # False<True keeps priority items first
+        logging.info(
+            "Found %s potential anomaly metrics from ConstInsightMetrics.csv", len(metrics)
+        )  # Log discovery count
+        return metrics  # Return sorted list to caller


### PR DESCRIPTION
Third PR in initiative 1011 (Low-Use bucket, LOC-DESC dispatch #16).

## Summary
- Extracts the 91 LoC ``AnomalyMetricsDiscovery`` class from MistHelper.py into ``src/refactors/anomaly_metrics_discovery.py``.
- Class handles site-scoped anomaly metrics discovery from ``ConstInsightMetrics.csv`` for AI/ML analysis, with a fallback list when the CSV is missing.
- Applies the late-binding ``_MistHelperProxy``/``_MH`` pattern used by prior 1011 PRs to resolve MistHelper-owned ``FilePathUtils`` via ``importlib`` per attribute access.
- Rewrites the sole remaining caller (``MistHelper.py:13003``) to import the class via ``src.refactors.anomaly_metrics_discovery``. No wrapper shim left behind (FR-003).

## Landing Gates
- ``python -m py_compile`` OK on both files.
- ``python -m black --check`` clean.
- ``python -m ruff check`` clean.
- Compliance analyzer: **100.0/A+** on ``src/refactors/anomaly_metrics_discovery.py``.
- MistHelper.py compliance preserved at **93.0/A**.
- Refactor catalog regenerated: ``unused=0, single-use=0, low-use=17, hot=80, skipped=1``.

## Test Plan
- [ ] All 15 functional CI jobs pass.
- [ ] Compliance analyzer verifies no regression on repo baseline (>=99.6/A+).
- [ ] Menu #85 (Site Anomaly Events export) still discovers metrics via the extracted class.