### PR TITLE
refactor(1011): extract DeviceDataFetcher (#17)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -150,6 +150,9 @@ from src.refactors.anomaly_metrics_discovery import (
     AnomalyMetricsDiscovery,  # Extracted anomaly metrics discovery (SC-016)
 )
 from src.refactors.data_directory_checker import DataDirectoryChecker  # Early data-dir writable check (SC-005)
+from src.refactors.device_data_fetcher import (
+    DeviceDataFetcher,  # Extracted interactive device data fetcher (SC-017)
+)
 from src.refactors.keyboard_listener import KeyboardListener  # PR-13 extracted no-op keyboard listener stub (SC-012)
 from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted Maps Manager launcher (SC-006)
 from src.refactors.run_interactive_test import (
@@ -5542,76 +5545,6 @@ class DisplayUtils:
         if filled_length == 0:  # Just started: every cell empty
             return " " * bar_length  # Empty bar
         return "=" * (filled_length - 1) + ">" + " " * (bar_length - filled_length)  # Filled portion + arrow + empty
-
-
-class DeviceDataFetcher:
-    """
-    Interactive device data fetcher for single-device operations.
-
-    Fetches data for a specific device (by site_id/device_id or via user prompt),
-    writes the result to CSV, and displays as PrettyTable.
-
-    SECURITY: Uses authenticated API session for all device queries.
-
-    Usage:
-        DeviceDataFetcher(DeviceFetchConfig(fetch_function, filename, description)).fetch()
-        DeviceDataFetcher(DeviceFetchConfig(fetch_function, filename, description, device_type="gateway")).fetch()
-    """
-
-    def __init__(self, config: DeviceFetchConfig):
-        """Initialize fetcher from a DeviceFetchConfig (issue #470: 6 params bundled into one per 5-Item Rule)."""
-        self.fetch_function = config.fetch_function  # Callable that performs the actual API fetch.
-        self.filename = config.filename  # Output filename for the exported data.
-        self.description = config.description  # Human-readable description shown during the fetch.
-        self.device_type = config.device_type  # Device type filter (all/ap/switch/gateway).
-        self.site_id = config.site_id  # Optional site scope (None means an org-wide fetch).
-        self.device_id = config.device_id  # Optional single-device scope (None means all matching devices).
-
-    def fetch(self) -> None:
-        """Main entry point - orchestrates the device data fetch workflow."""
-        if not self._resolve_site_id():
-            return
-        if not self._resolve_device_id():
-            return
-        self._log_action()
-        data = self._fetch_data()
-        if data:
-            self._process_and_output(data)
-
-    def _resolve_site_id(self) -> bool:
-        """Resolve site ID from parameter or user prompt."""
-        if self.site_id:
-            return True
-        self.site_id = PromptUtils.select_site_id_from_csv()
-        return bool(self.site_id)
-
-    def _resolve_device_id(self) -> bool:
-        """Resolve device ID from parameter or user prompt."""
-        if self.device_id:
-            return True
-        assert self.site_id is not None, "Site ID must be resolved before device ID"  # nosec B101
-        self.device_id = PromptUtils.select_device_id_from_inventory(self.site_id, device_type=self.device_type)
-        return bool(self.device_id)
-
-    def _log_action(self) -> None:
-        """Log the action being performed."""
-        logging.info("%s for device ID: %s", self.description, self.device_id)
-
-    def _fetch_data(self) -> list[dict[str, Any]] | None:
-        """Fetch data using the configured API function."""
-        try:
-            response = self.fetch_function(apisession, self.site_id, self.device_id)
-            return [response.data] if response.data else None
-        except Exception as error:
-            logging.error("Failed to fetch device data: %s", error)
-            return None
-
-    def _process_and_output(self, data: list[dict[str, Any]]) -> None:
-        """Process fetched data and output to CSV and table."""
-        processed = DataProcessingUtils.flatten_nested_fields(data)
-        processed = DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
-        DataExporter.write_with_format_selection(processed, self.filename)  # type: ignore[no-untyped-call]
-        DisplayUtils.dict_list_as_pretty_table(processed)
 
 
 # Issue #431: module-level alias `PacketCaptureManager = ExtractedPacketCaptureManager`

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 186 first-party files
-- Definitions analyzed: 98
+- Module graph size: 187 first-party files
+- Definitions analyzed: 97
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=17, hot=80, skipped=1
+- Category counts: unused=0, single-use=0, low-use=16, hot=80, skipped=1
 
 ## How to read this report
 
@@ -43,11 +43,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `menu_actions` | assignment | 572 | 17 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `OrgTicketManager` | class | 463 | 66 | hot |  | oversize_25_lines |
 | `OperationRegistry` | class | 461 | 9 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
-| `PromptUtils` | class | 441 | 123 | hot |  | oversize_25_lines |
+| `PromptUtils` | class | 441 | 119 | hot |  | oversize_25_lines |
 | `OrgDeviceStatsExporter` | class | 414 | 58 | hot |  | oversize_25_lines,missing_inline_comments |
 | `DeviceRebootManager` | class | 398 | 46 | hot |  | oversize_25_lines,missing_inline_comments |
 | `MSPInventoryExporter` | class | 388 | 5 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
-| `DataExporter` | class | 345 | 259 | hot |  | oversize_25_lines,non_ascii_logs |
+| `DataExporter` | class | 345 | 257 | hot |  | oversize_25_lines,non_ascii_logs |
 | `SiteAnomalyExporter` | class | 341 | 54 | hot |  | oversize_25_lines,non_ascii_logs |
 | `APIDataFetcher` | class | 328 | 16 | hot |  | oversize_25_lines |
 | `InsightMetricsUtils` | class | 328 | 51 | hot |  | oversize_25_lines,non_ascii_logs,hardcoded_separator |
@@ -67,7 +67,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `OrgConfigExporter` | class | 168 | 24 | hot |  | oversize_25_lines |
 | `OrgClientSecurityExporter` | class | 162 | 26 | hot |  | oversize_25_lines |
 | `CLIShellManager` | class | 161 | 23 | hot |  | oversize_25_lines,missing_action_logging |
-| `DataProcessingUtils` | class | 158 | 205 | hot |  | oversize_25_lines,missing_inline_comments,hardcoded_separator |
+| `DataProcessingUtils` | class | 158 | 201 | hot |  | oversize_25_lines,missing_inline_comments,hardcoded_separator |
 | `DataCollectionManager` | class | 156 | 20 | hot |  | oversize_25_lines,missing_inline_comments |
 | `SitesByAPModelExporter` | class | 146 | 22 | hot |  | oversize_25_lines |
 | `SiteExportUtils` | class | 145 | 94 | hot |  | oversize_25_lines,missing_action_logging |
@@ -89,10 +89,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `VirtualChassisManager` | class | 78 | 104 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `InputUtils` | class | 74 | 261 | hot |  | oversize_25_lines,raw_input_call |
 | `InteractiveDisplayUtils` | class | 72 | 8 | hot |  | oversize_25_lines,missing_inline_comments |
-| `DisplayUtils` | class | 70 | 16 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
+| `DisplayUtils` | class | 70 | 14 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `ConfigUtils` | class | 70 | 195 | hot |  | oversize_25_lines |
 | `OrgDeviceInventorySummary` | class | 69 | 22 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging,non_ascii_logs |
-| `DeviceDataFetcher` | class | 68 | 3 | low-use | DeviceDataFetcher | oversize_25_lines,missing_inline_comments |
 | `AuditAnalysisOps` | class | 66 | 8 | hot |  | oversize_25_lines,missing_inline_comments,raw_input_call |
 | `GatewayTemplateConfigManager` | class | 56 | 6 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `APICoreFetchUtils` | class | 47 | 59 | hot |  | oversize_25_lines,missing_inline_comments |
@@ -131,11 +130,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 12 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (17)
+## Low-Use (16)
 
 ### `FirmwareUpgradeStatusChecker` (class, 958 lines)
 
-- Def site: line 17782-18739
+- Def site: line 17715-18672
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -147,22 +146,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Reference sites (one PR cluster per file):
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1746, 1753
 
-### `DeviceDataFetcher` (class, 68 lines)
-
-- Def site: line 5547-5614
-- References: 3
-- Suggested class: `DeviceDataFetcher`
-- Suggested module: `src/refactors/device_data_fetcher.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `device_stats()`; extract `DeviceDataFetcher` OUT of the entrypoint into a new `src/refactors/device_data_fetcher.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] missing_inline_comments
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15301, 15318, 15334
-
 ### `InventoryCSVComparator` (class, 47 lines)
 
-- Def site: line 16458-16504
+- Def site: line 16391-16437
 - References: 3
 - Suggested class: `InventoryCSVComparator`
 - Suggested module: `src/refactors/inventory_csvcomparator.py`
@@ -171,11 +157,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16497, 16497, 20185
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16430, 16430, 20118
 
 ### `BulkAPFirmwareUpgrader` (class, 32 lines)
 
-- Def site: line 18752-18783
+- Def site: line 18685-18716
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -189,7 +175,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceConfigTemplateClonerManager` (class, 27 lines)
 
-- Def site: line 15923-15949
+- Def site: line 15856-15882
 - References: 2
 - Suggested class: `DeviceConfigTemplateClonerManager`
 - Suggested module: `src/refactors/device_config_template_cloner_manager.py`
@@ -198,11 +184,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20566, 20566
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20499, 20499
 
 ### `WANProbeDeviceOverrideManager` (class, 23 lines)
 
-- Def site: line 17192-17214
+- Def site: line 17125-17147
 - References: 2
 - Suggested class: `WANProbeDeviceOverrideManager`
 - Suggested module: `src/refactors/wanprobe_device_override_manager.py`
@@ -211,11 +197,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20368, 20368
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20301, 20301
 
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 19284-19302
+- Def site: line 19217-19235
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -228,7 +214,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `initialize_mist_session_interactive` (function, 18 lines)
 
-- Def site: line 2186-2203
+- Def site: line 2189-2206
 - References: 3
 - Suggested class: `InitializeMistSessionInteractiveManager`
 - Suggested module: `src/refactors/initialize_mist_session_interactive.py`
@@ -236,11 +222,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2246, 18887, 21834
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2249, 18820, 21767
 
 ### `initialize_mist_session` (function, 18 lines)
 
-- Def site: line 2812-2829
+- Def site: line 2815-2832
 - References: 2
 - Suggested class: `InitializeMistSessionManager`
 - Suggested module: `src/refactors/initialize_mist_session.py`
@@ -248,11 +234,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21839, 21902
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21772, 21835
 
 ### `PACKAGE_IMPORT_MAP` (assignment, 13 lines)
 
-- Def site: line 363-375
+- Def site: line 366-378
 - References: 2
 - Suggested class: `PackageImportMapManager`
 - Suggested module: `src/refactors/package__import__map.py`
@@ -260,22 +246,22 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 363, 547
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 366, 550
 
 ### `main` (function, 12 lines)
 
-- Def site: line 22230-22241
+- Def site: line 22163-22174
 - References: 2
 - Suggested class: `MainManager`
 - Suggested module: `src/refactors/main.py`
 - Rationale: low-use: sole caller lives inside MistHelper.py; extract `main` OUT of the entrypoint into a new `src/refactors/main.py` module and rewrite the callsite(s) to import from there
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22344
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 22277
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
 
 ### `marvis_data_utils` (assignment, 4 lines)
 
-- Def site: line 6603-6606
+- Def site: line 6536-6539
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
@@ -283,12 +269,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6603, 15745
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6536, 15678
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\marvis_troubleshoot_utils.py`: lines 21
 
 ### `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 lines)
 
-- Def site: line 1978-1980
+- Def site: line 1981-1983
 - References: 3
 - Suggested class: `FastModeBackoffMultiplierManager`
 - Suggested module: `src/refactors/fast__mode__backoff__multiplier.py`
@@ -297,11 +283,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1978, 9989, 15418
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1981, 9922, 15351
 
 ### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
 
-- Def site: line 1981-1983
+- Def site: line 1984-1986
 - References: 2
 - Suggested class: `FastModeDevicesPerThreadManager`
 - Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
@@ -310,11 +296,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1981, 7479
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1984, 7412
 
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 1986-1988
+- Def site: line 1989-1991
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -323,11 +309,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1986, 15558
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1989, 15491
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 1993-1995
+- Def site: line 1996-1998
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -335,11 +321,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1993, 7469
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1996, 7402
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 2001-2003
+- Def site: line 2004-2006
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -348,14 +334,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2001, 15647
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2004, 15580
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
 ## Hot (80)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2874-5200
+- Def site: line 2877-5203
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -366,11 +352,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2874, 6649, 6650, 6659, 6823
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2877, 6582, 6583, 6592, 6756
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 14004-14762
+- Def site: line 13937-14695
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -379,11 +365,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14481, 14481, 14493, 14493, 14521, 14521, 14533, 14533, 14594, 14594, 14631, 14631, 14788, 20283
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14414, 14414, 14426, 14426, 14454, 14454, 14466, 14466, 14527, 14527, 14564, 14564, 14721, 20216
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9150-9835
+- Def site: line 9083-9768
 - References: 112
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -392,12 +378,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5656, 5656, 9273, 9273, 9324, 9324, 9327, 9327, 9368, 9368, 9407, 9407, 9425, 9425, 9503, 9503, 9510, 9510, 9520, 9520, 9523, 9523, 9536, 9536, 9537, 9537, 9538, 9538, 9539, 9539, 9547, 9547, 9549, 9549, 9550, 9550, 9551, 9551, 9552, 9552, 9555, 9555, 9558, 9558, 9561, 9561, 9564, 9564, 9610, 9610, 9633, 9633, 9634, 9634, 9635, 9635, 9637, 9637, 9673, 9673, 9689, 9689, 9743, 9743, 9744, 9744, 9745, 9745, 9748, 9748, 9749, 9749, 9768, 9768, 9770, 9770, 9771, 9771, 9806, 9806, 15157, 15157, 15210, 15210, 15641, 16480, 16480, 17241, 17241, 17265, 17265, 17289, 17289, 17432, 17432, 20058, 20058, 20065, 20065, 20074, 20074, 20078, 20078, 20087, 20087
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5589, 5589, 9206, 9206, 9257, 9257, 9260, 9260, 9301, 9301, 9340, 9340, 9358, 9358, 9436, 9436, 9443, 9443, 9453, 9453, 9456, 9456, 9469, 9469, 9470, 9470, 9471, 9471, 9472, 9472, 9480, 9480, 9482, 9482, 9483, 9483, 9484, 9484, 9485, 9485, 9488, 9488, 9491, 9491, 9494, 9494, 9497, 9497, 9543, 9543, 9566, 9566, 9567, 9567, 9568, 9568, 9570, 9570, 9606, 9606, 9622, 9622, 9676, 9676, 9677, 9677, 9678, 9678, 9681, 9681, 9682, 9682, 9701, 9701, 9703, 9703, 9704, 9704, 9739, 9739, 15090, 15090, 15143, 15143, 15574, 16413, 16413, 17174, 17174, 17198, 17198, 17222, 17222, 17365, 17365, 19991, 19991, 19998, 19998, 20007, 20007, 20011, 20011, 20020, 20020
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16510-17184
+- Def site: line 16443-17117
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -405,11 +391,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16898, 16898, 20529, 20535
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16831, 16831, 20462, 20468
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11883-12535
+- Def site: line 11816-12468
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -419,11 +405,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10660, 10660, 10669, 10669, 10757, 10757, 10764, 10764, 11438, 11438, 11724, 11724, 11729, 11729, 11736, 11736, 11741, 11741, 11955, 11955, 11977, 11977, 11980, 11980, 12006, 12006, 12015, 12015, 12016, 12016, 12037, 12037, 12080, 12080, 12126, 12126, 12137, 12137, 12164, 12164, 12169, 12169, 12170, 12170, 12171, 12171, 12203, 12203, 12209, 12209, 12234, 12234, 12254, 12254, 12289, 12289, 12304, 12304, 12310, 12310, 12312, 12312, 12315, 12315, 12317, 12317, 12321, 12321, 12325, 12325, 12330, 12330, 12337, 12337, 12344, 12344, 12351, 12351, 12360, 12360, 12370, 12370, 12377, 12377, 12384, 12384, 12391, 12391, 12398, 12398, 12405, 12405, 12415, 12415, 12424, 12424, 12433, 12433, 12442, 12442, 12451, 12451, 12480, 12480, 20019, 20019, 20200, 20200, 20277, 20277, 20278, 20278, 20286, 20286, 20491, 20491, 20492, 20492, 20511, 20511, 20518, 20518, 20519, 20519, 20520, 20520, 20521, 20521
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10593, 10593, 10602, 10602, 10690, 10690, 10697, 10697, 11371, 11371, 11657, 11657, 11662, 11662, 11669, 11669, 11674, 11674, 11888, 11888, 11910, 11910, 11913, 11913, 11939, 11939, 11948, 11948, 11949, 11949, 11970, 11970, 12013, 12013, 12059, 12059, 12070, 12070, 12097, 12097, 12102, 12102, 12103, 12103, 12104, 12104, 12136, 12136, 12142, 12142, 12167, 12167, 12187, 12187, 12222, 12222, 12237, 12237, 12243, 12243, 12245, 12245, 12248, 12248, 12250, 12250, 12254, 12254, 12258, 12258, 12263, 12263, 12270, 12270, 12277, 12277, 12284, 12284, 12293, 12293, 12303, 12303, 12310, 12310, 12317, 12317, 12324, 12324, 12331, 12331, 12338, 12338, 12348, 12348, 12357, 12357, 12366, 12366, 12375, 12375, 12384, 12384, 12413, 12413, 19952, 19952, 20133, 20133, 20210, 20210, 20211, 20211, 20219, 20219, 20424, 20424, 20425, 20425, 20444, 20444, 20451, 20451, 20452, 20452, 20453, 20453, 20454, 20454
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 19315-19901
+- Def site: line 19248-19834
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -431,11 +417,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19592, 19592, 19593, 19593, 19596, 19596, 19598, 19598, 19600, 19600, 19616, 19616, 20436
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19525, 19525, 19526, 19526, 19529, 19529, 19531, 19531, 19533, 19533, 19549, 19549, 20369
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 20000-20571
+- Def site: line 19933-20504
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -445,12 +431,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20000, 21285, 21286, 21295, 21415, 21415, 21457, 21515, 21560, 22051, 22055, 22100, 22100, 22127, 22127, 22130
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19933, 21218, 21219, 21228, 21348, 21348, 21390, 21448, 21493, 21984, 21988, 22033, 22033, 22060, 22060, 22063
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8434-8896
+- Def site: line 8367-8829
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -458,11 +444,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8475, 8475, 8480, 8480, 8490, 8490, 8498, 8498, 8503, 8503, 8508, 8508, 8518, 8518, 8523, 8523, 8528, 8528, 8548, 8548, 8558, 8558, 8559, 8559, 8562, 8562, 8592, 8592, 8678, 8678, 8680, 8680, 8704, 8704, 8710, 8710, 8715, 8715, 8724, 8724, 8728, 8728, 8747, 8747, 8750, 8750, 8761, 8761, 8762, 8762, 8857, 8857, 8878, 8878, 20559, 20559, 20560, 20560, 20561, 20561, 20562, 20562, 20563, 20563, 20564, 20564
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8408, 8408, 8413, 8413, 8423, 8423, 8431, 8431, 8436, 8436, 8441, 8441, 8451, 8451, 8456, 8456, 8461, 8461, 8481, 8481, 8491, 8491, 8492, 8492, 8495, 8495, 8525, 8525, 8611, 8611, 8613, 8613, 8637, 8637, 8643, 8643, 8648, 8648, 8657, 8657, 8661, 8661, 8680, 8680, 8683, 8683, 8694, 8694, 8695, 8695, 8790, 8790, 8811, 8811, 20492, 20492, 20493, 20493, 20494, 20494, 20495, 20495, 20496, 20496, 20497, 20497
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 20796-21256
+- Def site: line 20729-21189
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -472,26 +458,26 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21263, 21263, 21267, 21267, 21287, 21287, 21292, 21292, 21516
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21196, 21196, 21200, 21200, 21220, 21220, 21225, 21225, 21449
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7881-8321
-- References: 123
+- Def site: line 7814-8254
+- References: 119
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5585, 5585, 5593, 5593, 7826, 7826, 7842, 7842, 7846, 7846, 7847, 7847, 7848, 7848, 7863, 7863, 7869, 7869, 7896, 7896, 7899, 7899, 7907, 7907, 7925, 7925, 7975, 7975, 7983, 7983, 7988, 7988, 8034, 8034, 8045, 8045, 8070, 8070, 8089, 8089, 8090, 8090, 8093, 8093, 8094, 8094, 8184, 8184, 8186, 8186, 8190, 8190, 8218, 8218, 8219, 8219, 8220, 8220, 8221, 8221, 8222, 8222, 8231, 8231, 8275, 8275, 8299, 8299, 12615, 12615, 12665, 12665, 12670, 12670, 12813, 12896, 12896, 12950, 12950, 12971, 12971, 12976, 12976, 13240, 13240, 13443, 13645, 13645, 13732, 13732, 13737, 13737, 13787, 13787, 13788, 13788, 15284, 15284, 15743, 17248, 17248, 17770, 17770, 17871, 17871, 19924, 19924, 19925, 19925, 20211, 20211
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7759, 7759, 7775, 7775, 7779, 7779, 7780, 7780, 7781, 7781, 7796, 7796, 7802, 7802, 7829, 7829, 7832, 7832, 7840, 7840, 7858, 7858, 7908, 7908, 7916, 7916, 7921, 7921, 7967, 7967, 7978, 7978, 8003, 8003, 8022, 8022, 8023, 8023, 8026, 8026, 8027, 8027, 8117, 8117, 8119, 8119, 8123, 8123, 8151, 8151, 8152, 8152, 8153, 8153, 8154, 8154, 8155, 8155, 8164, 8164, 8208, 8208, 8232, 8232, 12548, 12548, 12598, 12598, 12603, 12603, 12746, 12829, 12829, 12883, 12883, 12904, 12904, 12909, 12909, 13173, 13173, 13376, 13578, 13578, 13665, 13665, 13670, 13670, 13720, 13720, 13721, 13721, 15217, 15217, 15676, 17181, 17181, 17703, 17703, 17804, 17804, 19857, 19857, 19858, 19858, 20144, 20144
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9838-10251
+- Def site: line 9771-10184
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -500,11 +486,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5650, 5650, 9871, 9871, 9955, 9955, 9961, 9961, 9964, 9964, 10008, 10008, 10022, 10022, 10049, 10049, 10055, 10055, 10069, 10069, 10152, 10152, 10154, 10154, 10158, 10158, 10160, 10160, 10163, 10163, 10167, 10167, 10170, 10170, 10180, 10180, 10186, 10186, 10224, 10224, 15158, 15158, 15159, 15159, 15160, 15160, 15211, 15211, 15212, 15212, 20059, 20059, 20060, 20060, 20061, 20061, 20085, 20085
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5583, 5583, 9804, 9804, 9888, 9888, 9894, 9894, 9897, 9897, 9941, 9941, 9955, 9955, 9982, 9982, 9988, 9988, 10002, 10002, 10085, 10085, 10087, 10087, 10091, 10091, 10093, 10093, 10096, 10096, 10100, 10100, 10103, 10103, 10113, 10113, 10119, 10119, 10157, 10157, 15091, 15091, 15092, 15092, 15093, 15093, 15144, 15144, 15145, 15145, 19992, 19992, 19993, 19993, 19994, 19994, 20018, 20018
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17351-17748
+- Def site: line 17284-17681
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -513,11 +499,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17372, 17372, 17377, 17377, 17381, 17381, 17384, 17384, 17391, 17391, 17393, 17393, 17394, 17394, 17397, 17397, 17400, 17400, 17403, 17403, 17445, 17445, 17477, 17477, 17544, 17544, 17557, 17557, 17562, 17562, 17614, 17614, 17647, 17647, 17648, 17648, 17649, 17649, 17679, 17679, 17708, 17708, 17709, 17709, 20242, 20242
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17305, 17305, 17310, 17310, 17314, 17314, 17317, 17317, 17324, 17324, 17326, 17326, 17327, 17327, 17330, 17330, 17333, 17333, 17336, 17336, 17378, 17378, 17410, 17410, 17477, 17477, 17490, 17490, 17495, 17495, 17547, 17547, 17580, 17580, 17581, 17581, 17582, 17582, 17612, 17612, 17641, 17641, 17642, 17642, 20175, 20175
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 18789-19176
+- Def site: line 18722-19109
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -527,12 +513,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18816, 18960, 18960, 20382, 20382
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18749, 18893, 18893, 20315, 20315
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6790-7134
-- References: 259
+- Def site: line 6723-7067
+- References: 257
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -540,7 +526,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5613, 5613, 5746, 5746, 6836, 6836, 6852, 6852, 6853, 6853, 6876, 6876, 6878, 6878, 6881, 6881, 6895, 6895, 6897, 6897, 6906, 6906, 6908, 6908, 6909, 6909, 6915, 6915, 6916, 6916, 6916, 6933, 6933, 6937, 6937, 6979, 6979, 7010, 7010, 7013, 7013, 7015, 7015, 7061, 7061, 7071, 7071, 7104, 7104, 7109, 7109, 7116, 7116, 7338, 7338, 7370, 7370, 7381, 7381, 7406, 7406, 7426, 7426, 7938, 7938, 8731, 8731, 9010, 9010, 9025, 9089, 9089, 9106, 9106, 9124, 9124, 9145, 9145, 9704, 9704, 9779, 9779, 10109, 10109, 10460, 10460, 10545, 10561, 10681, 10681, 10685, 10685, 10705, 10705, 10718, 10718, 10722, 10722, 10740, 10740, 10902, 10902, 11249, 11249, 11396, 11396, 11473, 11473, 11477, 11477, 11482, 11482, 11615, 11615, 11634, 11634, 11685, 11685, 11688, 11688, 11839, 11839, 11842, 11842, 11941, 11941, 11947, 11947, 12244, 12244, 12261, 12261, 12276, 12276, 12490, 12490, 12518, 12518, 12534, 12534, 12571, 12571, 12609, 12609, 12698, 12698, 12727, 12727, 12765, 12765, 12816, 12881, 12881, 12887, 12887, 12929, 12929, 13098, 13098, 13104, 13104, 13223, 13223, 13231, 13231, 13395, 13395, 13446, 13619, 13619, 13790, 13790, 14303, 14303, 14664, 14664, 14670, 14670, 15578, 15578, 15637, 15744, 15880, 15880, 15898, 15898, 15916, 15916, 15943, 15943, 15944, 15944, 17209, 17295, 17295, 17316, 18624, 18624, 19142, 19142, 19227, 19227, 19248, 19248, 19750, 19750, 20411, 20411, 20427, 20427
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5679, 5679, 6769, 6769, 6785, 6785, 6786, 6786, 6809, 6809, 6811, 6811, 6814, 6814, 6828, 6828, 6830, 6830, 6839, 6839, 6841, 6841, 6842, 6842, 6848, 6848, 6849, 6849, 6849, 6866, 6866, 6870, 6870, 6912, 6912, 6943, 6943, 6946, 6946, 6948, 6948, 6994, 6994, 7004, 7004, 7037, 7037, 7042, 7042, 7049, 7049, 7271, 7271, 7303, 7303, 7314, 7314, 7339, 7339, 7359, 7359, 7871, 7871, 8664, 8664, 8943, 8943, 8958, 9022, 9022, 9039, 9039, 9057, 9057, 9078, 9078, 9637, 9637, 9712, 9712, 10042, 10042, 10393, 10393, 10478, 10494, 10614, 10614, 10618, 10618, 10638, 10638, 10651, 10651, 10655, 10655, 10673, 10673, 10835, 10835, 11182, 11182, 11329, 11329, 11406, 11406, 11410, 11410, 11415, 11415, 11548, 11548, 11567, 11567, 11618, 11618, 11621, 11621, 11772, 11772, 11775, 11775, 11874, 11874, 11880, 11880, 12177, 12177, 12194, 12194, 12209, 12209, 12423, 12423, 12451, 12451, 12467, 12467, 12504, 12504, 12542, 12542, 12631, 12631, 12660, 12660, 12698, 12698, 12749, 12814, 12814, 12820, 12820, 12862, 12862, 13031, 13031, 13037, 13037, 13156, 13156, 13164, 13164, 13328, 13328, 13379, 13552, 13552, 13723, 13723, 14236, 14236, 14597, 14597, 14603, 14603, 15511, 15511, 15570, 15677, 15813, 15813, 15831, 15831, 15849, 15849, 15876, 15876, 15877, 15877, 17142, 17228, 17228, 17249, 18557, 18557, 19075, 19075, 19160, 19160, 19181, 19181, 19683, 19683, 20344, 20344, 20360, 20360
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -551,7 +537,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12937-13277
+- Def site: line 12870-13210
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -560,11 +546,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12954, 12954, 12956, 12956, 12960, 12960, 12961, 12961, 12975, 12975, 12981, 12981, 12984, 12984, 12987, 12987, 13045, 13045, 13051, 13051, 13056, 13056, 13070, 13070, 13088, 13088, 13198, 13198, 13202, 13202, 13204, 13204, 13207, 13207, 13244, 13244, 13249, 13249, 13263, 13263, 13267, 13267, 13269, 13269, 13272, 13272, 13277, 13277, 20288, 20288, 20292, 20292, 20296, 20296
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12887, 12887, 12889, 12889, 12893, 12893, 12894, 12894, 12908, 12908, 12914, 12914, 12917, 12917, 12920, 12920, 12978, 12978, 12984, 12984, 12989, 12989, 13003, 13003, 13021, 13021, 13131, 13131, 13135, 13135, 13137, 13137, 13140, 13140, 13177, 13177, 13182, 13182, 13196, 13196, 13200, 13200, 13202, 13202, 13205, 13205, 13210, 13210, 20221, 20221, 20225, 20225, 20229, 20229
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7137-7464
+- Def site: line 7070-7397
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -572,11 +558,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7239, 7239, 8455, 8936, 8955, 9056, 9185, 9208, 9880, 10188, 10233, 10647, 11417, 11428, 11491, 11908
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7172, 7172, 8388, 8869, 8888, 8989, 9118, 9141, 9813, 10121, 10166, 10580, 11350, 11361, 11424, 11841
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14768-15095
+- Def site: line 14701-15028
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -586,13 +572,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12225, 12225, 12284, 12284, 12285, 12285, 13449, 14809, 14809, 14811, 14811, 14817, 14817, 14831, 14831, 14870, 14870, 14873, 14873, 14875, 14875, 14876, 14876, 14877, 14877, 14931, 14931, 14932, 14932, 14943, 14943, 14952, 14952, 14971, 14971, 15023, 15023, 15027, 15027, 15035, 15035, 15036, 15036, 15060, 15060, 15064, 15064
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12158, 12158, 12217, 12217, 12218, 12218, 13382, 14742, 14742, 14744, 14744, 14750, 14750, 14764, 14764, 14803, 14803, 14806, 14806, 14808, 14808, 14809, 14809, 14810, 14810, 14864, 14864, 14865, 14865, 14876, 14876, 14885, 14885, 14904, 14904, 14956, 14956, 14960, 14960, 14968, 14968, 14969, 14969, 14993, 14993, 14997, 14997
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16152-16440
+- Def site: line 16085-16373
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -602,11 +588,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16180, 16180, 16183, 16183, 16188, 16188, 16191, 16191, 16235, 16235, 16241, 16241, 16272, 16272, 16275, 16275, 16279, 16279, 16305, 16305, 16322, 16322, 16328, 16328, 16342, 16342, 16343, 16343, 16345, 16345, 16351, 16351, 16358, 16358, 16367, 16367, 16414, 16414, 16436, 16436, 16437, 16437, 16438, 16438, 20233, 20233
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16113, 16113, 16116, 16116, 16121, 16121, 16124, 16124, 16168, 16168, 16174, 16174, 16205, 16205, 16208, 16208, 16212, 16212, 16238, 16238, 16255, 16255, 16261, 16261, 16275, 16275, 16276, 16276, 16278, 16278, 16284, 16284, 16291, 16291, 16300, 16300, 16347, 16347, 16369, 16369, 16370, 16370, 16371, 16371, 20166, 20166
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10254-10526
+- Def site: line 10187-10459
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -615,11 +601,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10277, 10277, 10278, 10278, 10291, 10291, 10292, 10292, 10294, 10294, 10295, 10295, 10298, 10298, 10301, 10301, 10305, 10305, 10306, 10306, 10382, 10382, 10386, 10386, 10389, 10389, 10402, 10402, 10439, 10439, 10456, 10456, 10469, 10469, 10471, 10471, 10478, 10478, 10487, 10487, 10496, 10496, 10497, 10497, 10508, 10508, 10512, 10512, 10521, 10521, 10526, 10526, 20490, 20490
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10210, 10210, 10211, 10211, 10224, 10224, 10225, 10225, 10227, 10227, 10228, 10228, 10231, 10231, 10234, 10234, 10238, 10238, 10239, 10239, 10315, 10315, 10319, 10319, 10322, 10322, 10335, 10335, 10372, 10372, 10389, 10389, 10402, 10402, 10404, 10404, 10411, 10411, 10420, 10420, 10429, 10429, 10430, 10430, 10441, 10441, 10445, 10445, 10454, 10454, 10459, 10459, 20423, 20423
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5206-5469
+- Def site: line 5209-5472
 - References: 111
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -627,14 +613,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5246, 5246, 5248, 5248, 5330, 5330, 5336, 5336, 5373, 5373, 5375, 5375, 5384, 5384, 5394, 5394, 5404, 5404, 5440, 5440, 7974, 7974, 9632, 9632, 9633, 9633, 9944, 9944, 10790, 10790, 10810, 10810, 12811, 15217, 15217, 15223, 15223, 15224, 15224, 15225, 15225, 15226, 15226, 15227, 15227, 15228, 15228, 15235, 15235, 15263, 15263, 15635, 15881, 15881, 15899, 15899, 15917, 15917, 15967, 16478, 16478, 16479, 16479, 17204, 17240, 17240, 17264, 17264, 17288, 17288, 17432, 17432, 17433, 17433, 17434, 17434, 17435, 17435, 17771, 17771, 19975, 19975, 20527, 20527
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5249, 5249, 5251, 5251, 5333, 5333, 5339, 5339, 5376, 5376, 5378, 5378, 5387, 5387, 5397, 5397, 5407, 5407, 5443, 5443, 7907, 7907, 9565, 9565, 9566, 9566, 9877, 9877, 10723, 10723, 10743, 10743, 12744, 15150, 15150, 15156, 15156, 15157, 15157, 15158, 15158, 15159, 15159, 15160, 15160, 15161, 15161, 15168, 15168, 15196, 15196, 15568, 15814, 15814, 15832, 15832, 15850, 15850, 15900, 16411, 16411, 16412, 16412, 17137, 17173, 17173, 17197, 17197, 17221, 17221, 17365, 17365, 17366, 17366, 17367, 17367, 17368, 17368, 17704, 17704, 19908, 19908, 20460, 20460
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 11021-11271
+- Def site: line 10954-11204
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -644,11 +630,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11028, 11028, 11031, 11031, 11036, 11036, 11037, 11037, 11045, 11045, 11048, 11048, 11056, 11056, 11096, 11096, 11104, 11104, 11152, 11152, 11169, 11169, 11172, 11172, 11174, 11174, 11238, 11238, 11239, 11239, 20493, 20493
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10961, 10961, 10964, 10964, 10969, 10969, 10970, 10970, 10978, 10978, 10981, 10981, 10989, 10989, 11029, 11029, 11037, 11037, 11085, 11085, 11102, 11102, 11105, 11105, 11107, 11107, 11171, 11171, 11172, 11172, 20426, 20426
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15347-15591
+- Def site: line 15280-15524
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -658,11 +644,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15213, 15213, 15373, 15373, 15375, 15375, 15376, 15376, 15377, 15377, 15405, 15405, 15410, 15410, 15432, 15432, 15433, 15433, 15475, 15475, 15483, 15483, 15509, 15509, 15518, 15518, 15526, 15526, 15557, 15557, 20064, 20064, 20068, 20068
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15146, 15146, 15306, 15306, 15308, 15308, 15309, 15309, 15310, 15310, 15338, 15338, 15343, 15343, 15365, 15365, 15366, 15366, 15408, 15408, 15416, 15416, 15442, 15442, 15451, 15451, 15459, 15459, 15490, 15490, 19997, 19997, 20001, 20001
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6209-6429
+- Def site: line 6142-6362
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -670,14 +656,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6232, 6232, 6283, 6283, 6353, 6353, 6377, 6377, 6389, 6389, 6391, 6391, 6401, 6401, 6416, 6416, 6420, 6420, 6421, 6421, 6424, 6424, 6426, 6426, 12924, 12924, 15639
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6165, 6165, 6216, 6216, 6286, 6286, 6310, 6310, 6322, 6322, 6324, 6324, 6334, 6334, 6349, 6349, 6353, 6353, 6354, 6354, 6357, 6357, 6359, 6359, 12857, 12857, 15572
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 20577-20790
+- Def site: line 20510-20723
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -686,11 +672,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21433, 21433, 21436, 21517, 21868
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21366, 21366, 21369, 21450, 21801
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7665-7874
+- Def site: line 7598-7807
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -699,11 +685,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7678, 7678, 7684, 7684, 7685, 7685, 7688, 7688, 7711, 7711, 7714, 7714, 7717, 7717, 7718, 7718, 7720, 7720, 7787, 7787, 7831, 7831, 8296, 8296, 13245, 13245, 15742, 16005, 16005, 16165, 16165
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7611, 7611, 7617, 7617, 7618, 7618, 7621, 7621, 7644, 7644, 7647, 7647, 7650, 7650, 7651, 7651, 7653, 7653, 7720, 7720, 7764, 7764, 8229, 8229, 13178, 13178, 15675, 15938, 15938, 16098, 16098
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12543-12745
+- Def site: line 12476-12678
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -712,11 +698,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12564, 12564, 12573, 12573, 12635, 12635, 12642, 12642, 12674, 12674, 12676, 12676, 12700, 12700, 12735, 12735, 12742, 12742, 12773, 12773, 15287, 15287, 20100, 20100, 20102, 20102, 20103, 20103, 20105, 20105
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12497, 12497, 12506, 12506, 12568, 12568, 12575, 12575, 12607, 12607, 12609, 12609, 12633, 12633, 12668, 12668, 12675, 12675, 12706, 12706, 15220, 15220, 20033, 20033, 20035, 20035, 20036, 20036, 20038, 20038
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13796-13983
+- Def site: line 13729-13916
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -726,11 +712,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20450, 20450, 20451, 20451, 20452, 20452, 20453, 20453, 20454, 20454, 20455, 20455, 20456, 20456, 20457, 20457, 20459, 20459, 20460, 20460, 20461, 20461, 20462, 20462, 20463, 20463, 20464, 20464, 20465, 20465, 20467, 20467, 20468, 20468, 20469, 20469, 20470, 20470, 20471, 20471, 20472, 20472, 20473, 20473, 20474, 20474, 20475, 20475, 20477, 20477, 20478, 20478, 20479, 20479, 20480, 20480, 20481, 20481, 20482, 20482, 20483, 20483, 20484, 20484, 20485, 20485, 20487, 20487, 20488, 20488
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20383, 20383, 20384, 20384, 20385, 20385, 20386, 20386, 20387, 20387, 20388, 20388, 20389, 20389, 20390, 20390, 20392, 20392, 20393, 20393, 20394, 20394, 20395, 20395, 20396, 20396, 20397, 20397, 20398, 20398, 20400, 20400, 20401, 20401, 20402, 20402, 20403, 20403, 20404, 20404, 20405, 20405, 20406, 20406, 20407, 20407, 20408, 20408, 20410, 20410, 20411, 20411, 20412, 20412, 20413, 20413, 20414, 20414, 20415, 20415, 20416, 20416, 20417, 20417, 20418, 20418, 20420, 20420, 20421, 20421
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5621-5800
+- Def site: line 5554-5733
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -739,11 +725,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5709, 5709, 5746, 5746, 5748, 5748, 5751, 5751, 5759, 5759, 5761, 5761, 5763, 5763, 5766, 5766, 5795, 5795, 5798, 5798, 20227, 20227
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5642, 5642, 5679, 5679, 5681, 5681, 5684, 5684, 5692, 5692, 5694, 5694, 5696, 5696, 5699, 5699, 5728, 5728, 5731, 5731, 20160, 20160
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6609-6787
+- Def site: line 6542-6720
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -751,11 +737,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6654, 6654, 6692, 6692, 6703, 6703, 6729, 6729, 6730, 6730, 6732, 6732, 6738, 6738, 6739, 6739, 6742, 6742, 6748, 6748, 6749, 6749, 6752, 6752, 6754, 6754, 6764, 6764, 6766, 6766, 6767, 6767, 6769, 6769
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6587, 6587, 6625, 6625, 6636, 6636, 6662, 6662, 6663, 6663, 6665, 6665, 6671, 6671, 6672, 6672, 6675, 6675, 6681, 6681, 6682, 6682, 6685, 6685, 6687, 6687, 6697, 6697, 6699, 6699, 6700, 6700, 6702, 6702
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11501-11668
+- Def site: line 11434-11601
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -764,11 +750,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11608, 11608, 11627, 11627, 11645, 11645, 11654, 11654, 11657, 11657, 11658, 11658, 11661, 11661, 11666, 11666, 11668, 11668, 20128, 20128
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11541, 11541, 11560, 11560, 11578, 11578, 11587, 11587, 11590, 11590, 11591, 11591, 11594, 11594, 11599, 11599, 11601, 11601, 20061, 20061
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11713-11880
+- Def site: line 11646-11813
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -776,11 +762,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11750, 11750, 11752, 11752, 11755, 11755, 11826, 11826, 11828, 11828, 11841, 11841, 11845, 11845, 20131, 20131, 20132, 20132, 20133, 20133, 20171, 20171, 20176, 20176
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11683, 11683, 11685, 11685, 11688, 11688, 11759, 11759, 11761, 11761, 11774, 11774, 11778, 11778, 20064, 20064, 20065, 20065, 20066, 20066, 20104, 20104, 20109, 20109
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10746-10907
+- Def site: line 10679-10840
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -788,11 +774,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10784, 10784, 10791, 10791, 10798, 10798, 10804, 10804, 10811, 10811, 10818, 10818, 10879, 10879, 10890, 10890, 20119, 20119, 20120, 20120, 20122, 20122, 20123, 20123, 20124, 20124
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10717, 10717, 10724, 10724, 10731, 10731, 10737, 10737, 10744, 10744, 10751, 10751, 10812, 10812, 10823, 10823, 20052, 20052, 20053, 20053, 20055, 20055, 20056, 20056, 20057, 20057
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15986-16146
+- Def site: line 15919-16079
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -801,12 +787,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16009, 16009, 16011, 16011, 16080, 16080, 16082, 16082, 16101, 16101, 16103, 16103, 16103, 16119, 16119, 16135, 16135, 16136, 16136, 16142, 16142, 20232, 20232
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15942, 15942, 15944, 15944, 16013, 16013, 16015, 16015, 16034, 16034, 16036, 16036, 16036, 16052, 16052, 16068, 16068, 16069, 16069, 16075, 16075, 20165, 20165
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6437-6594
-- References: 205
+- Def site: line 6370-6527
+- References: 201
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -815,7 +801,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5504, 5504, 5611, 5611, 5612, 5612, 6453, 6453, 6466, 6466, 6469, 6469, 6493, 6493, 6501, 6501, 6502, 6502, 6524, 6524, 6529, 6529, 6531, 6531, 6604, 6604, 6605, 6605, 7012, 7012, 7037, 7037, 7106, 7106, 7107, 7107, 7436, 7436, 7450, 7450, 7451, 7451, 7936, 7936, 7937, 7937, 8859, 8859, 9024, 9084, 9084, 9086, 9086, 9087, 9087, 9104, 9104, 9105, 9105, 9122, 9122, 9123, 9123, 9143, 9143, 9144, 9144, 9701, 9701, 9702, 9702, 9776, 9776, 9777, 9777, 10105, 10105, 10108, 10108, 10683, 10683, 10684, 10684, 10720, 10720, 10721, 10721, 10900, 10900, 10901, 10901, 11245, 11245, 11246, 11246, 11392, 11392, 11393, 11393, 11475, 11475, 11476, 11476, 11687, 11687, 11862, 11862, 11863, 11863, 11939, 11939, 11940, 11940, 12243, 12243, 12259, 12259, 12260, 12260, 12488, 12488, 12489, 12489, 12568, 12568, 12569, 12569, 12570, 12570, 12606, 12606, 12607, 12607, 12695, 12695, 12696, 12696, 12724, 12724, 12725, 12725, 12762, 12762, 12763, 12763, 12815, 12884, 12884, 12885, 12885, 12927, 12927, 12928, 12928, 13096, 13096, 13097, 13097, 13221, 13221, 13222, 13222, 13445, 13617, 13617, 14669, 14669, 15576, 15576, 15577, 15577, 15638, 15746, 17293, 17293, 17294, 17294, 19132, 19132
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5507, 5507, 6386, 6386, 6399, 6399, 6402, 6402, 6426, 6426, 6434, 6434, 6435, 6435, 6457, 6457, 6462, 6462, 6464, 6464, 6537, 6537, 6538, 6538, 6945, 6945, 6970, 6970, 7039, 7039, 7040, 7040, 7369, 7369, 7383, 7383, 7384, 7384, 7869, 7869, 7870, 7870, 8792, 8792, 8957, 9017, 9017, 9019, 9019, 9020, 9020, 9037, 9037, 9038, 9038, 9055, 9055, 9056, 9056, 9076, 9076, 9077, 9077, 9634, 9634, 9635, 9635, 9709, 9709, 9710, 9710, 10038, 10038, 10041, 10041, 10616, 10616, 10617, 10617, 10653, 10653, 10654, 10654, 10833, 10833, 10834, 10834, 11178, 11178, 11179, 11179, 11325, 11325, 11326, 11326, 11408, 11408, 11409, 11409, 11620, 11620, 11795, 11795, 11796, 11796, 11872, 11872, 11873, 11873, 12176, 12176, 12192, 12192, 12193, 12193, 12421, 12421, 12422, 12422, 12501, 12501, 12502, 12502, 12503, 12503, 12539, 12539, 12540, 12540, 12628, 12628, 12629, 12629, 12657, 12657, 12658, 12658, 12695, 12695, 12696, 12696, 12748, 12817, 12817, 12818, 12818, 12860, 12860, 12861, 12861, 13029, 13029, 13030, 13030, 13154, 13154, 13155, 13155, 13378, 13550, 13550, 14602, 14602, 15509, 15509, 15510, 15510, 15571, 15679, 17226, 17226, 17227, 17227, 19065, 19065
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -823,7 +809,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15109-15264
+- Def site: line 15042-15197
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -832,11 +818,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15131, 15131, 15137, 15137, 15139, 15139, 15167, 15167, 15193, 15193, 15196, 15196, 15199, 15199, 20218, 20218, 20222, 20222, 20230, 20230
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15064, 15064, 15070, 15070, 15072, 15072, 15100, 15100, 15126, 15126, 15129, 15129, 15132, 15132, 20151, 20151, 20155, 20155, 20163, 20163
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13280-13425
+- Def site: line 13213-13358
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -844,11 +830,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13319, 13319, 13326, 13326, 13351, 13351, 13354, 13354, 13367, 13367, 13411, 13411, 13415, 13415, 13420, 13420, 13421, 13421, 13425, 13425, 20525, 20525
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13252, 13252, 13259, 13259, 13284, 13284, 13287, 13287, 13300, 13300, 13344, 13344, 13348, 13348, 13353, 13353, 13354, 13354, 13358, 13358, 20458, 20458
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13433-13577
+- Def site: line 13366-13510
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -857,12 +843,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12654, 12654, 12830, 12830, 12908, 12908, 12913, 12913, 13462, 13462, 13468, 13468, 13474, 13474, 13480, 13480, 13486, 13486, 13492, 13492, 13498, 13498, 13504, 13504, 13510, 13510, 13516, 13516, 13522, 13522, 13528, 13528, 13534, 13534, 13540, 13540, 13546, 13546, 13552, 13552, 13558, 13558, 13564, 13564, 13570, 13570, 13576, 13576, 20138, 20138, 20279, 20279, 20281, 20281, 20396, 20396, 20522, 20522, 20523, 20523, 20524, 20524, 20543, 20543, 20544, 20544, 20545, 20545, 20546, 20546, 20547, 20547, 20548, 20548, 20549, 20549
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12587, 12587, 12763, 12763, 12841, 12841, 12846, 12846, 13395, 13395, 13401, 13401, 13407, 13407, 13413, 13413, 13419, 13419, 13425, 13425, 13431, 13431, 13437, 13437, 13443, 13443, 13449, 13449, 13455, 13455, 13461, 13461, 13467, 13467, 13473, 13473, 13479, 13479, 13485, 13485, 13491, 13491, 13497, 13497, 13503, 13503, 13509, 13509, 20071, 20071, 20212, 20212, 20214, 20214, 20329, 20329, 20455, 20455, 20456, 20456, 20457, 20457, 20476, 20476, 20477, 20477, 20478, 20478, 20479, 20479, 20480, 20480, 20481, 20481, 20482, 20482
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10600-10743
+- Def site: line 10533-10676
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -871,11 +857,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10614, 10614, 10615, 10615, 10701, 10701, 10736, 10736, 20113, 20113, 20114, 20114, 20115, 20115, 20116, 20116, 20117, 20117
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10547, 10547, 10548, 10548, 10634, 10634, 10669, 10669, 20046, 20046, 20047, 20047, 20048, 20048, 20049, 20049, 20050, 20050
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13580-13718
+- Def site: line 13513-13651
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -883,11 +869,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13649, 13649, 13652, 13652, 13653, 13653, 13654, 13654, 13674, 13674, 13677, 13677, 13685, 13685, 13690, 13690, 20551, 20551
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13582, 13582, 13585, 13585, 13586, 13586, 13587, 13587, 13607, 13607, 13610, 13610, 13618, 13618, 13623, 13623, 20484, 20484
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8902-9030
+- Def site: line 8835-8963
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -896,11 +882,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8973, 8973, 8984, 8984, 15207, 15207, 15208, 15208, 20016, 20016, 20017, 20017, 20196, 20196
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8906, 8906, 8917, 8917, 15140, 15140, 15141, 15141, 19949, 19949, 19950, 19950, 20129, 20129
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11274-11402
+- Def site: line 11207-11335
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -909,11 +895,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11281, 11281, 11286, 11286, 11287, 11287, 11288, 11288, 11291, 11291, 11292, 11292, 11355, 11355, 11362, 11362, 11389, 11389, 20495, 20495
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11214, 11214, 11219, 11219, 11220, 11220, 11221, 11221, 11224, 11224, 11225, 11225, 11288, 11288, 11295, 11295, 11322, 11322, 20428, 20428
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15732-15858
+- Def site: line 15665-15791
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -922,11 +908,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15752, 15752, 15757, 15757, 15762, 15762, 15799, 15799, 15805, 15805, 15811, 15811, 15817, 15817, 15823, 15823, 15824, 15824, 15825, 15825, 15826, 15826, 15827, 15827, 15831, 15831, 15840, 15840, 15844, 15844, 15847, 15847, 15853, 15853, 20191, 20191
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15685, 15685, 15690, 15690, 15695, 15695, 15732, 15732, 15738, 15738, 15744, 15744, 15750, 15750, 15756, 15756, 15757, 15757, 15758, 15758, 15759, 15759, 15760, 15760, 15764, 15764, 15773, 15773, 15777, 15777, 15780, 15780, 15786, 15786, 20124, 20124
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5854-5978
+- Def site: line 5787-5911
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -935,11 +921,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5875, 5875, 5877, 5877, 5893, 5893, 5905, 5905, 5944, 5944, 5945, 5945, 5946, 5946, 5947, 5947, 5948, 5948, 5959, 5959, 5962, 5962, 6894, 6894, 21530, 21530, 22113, 22113
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5808, 5808, 5810, 5810, 5826, 5826, 5838, 5838, 5877, 5877, 5878, 5878, 5879, 5879, 5880, 5880, 5881, 5881, 5892, 5892, 5895, 5895, 6827, 6827, 21463, 21463, 22046, 22046
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 9036-9147
+- Def site: line 8969-9080
 - References: 53
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -947,13 +933,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7974, 7974, 9632, 9632, 9944, 9944, 10790, 10790, 10810, 10810, 12812, 15156, 15156, 15209, 15209, 15642, 15882, 15882, 15900, 15900, 15918, 15918, 17205, 17242, 17242, 17266, 17266, 17290, 17290, 17433, 17433, 17774, 17774, 20057, 20057, 20072, 20072, 20082, 20082, 20082, 20082, 20092, 20092
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7907, 7907, 9565, 9565, 9877, 9877, 10723, 10723, 10743, 10743, 12745, 15089, 15089, 15142, 15142, 15575, 15815, 15815, 15833, 15833, 15851, 15851, 17138, 17175, 17175, 17199, 17199, 17223, 17223, 17366, 17366, 17707, 17707, 19990, 19990, 20005, 20005, 20015, 20015, 20015, 20015, 20025, 20025
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10910-11018
+- Def site: line 10843-10951
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -963,11 +949,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10965, 10965, 10968, 10968, 10969, 10969, 10974, 10974, 10992, 10992, 10992, 11001, 11001, 11001, 11001, 11002, 11002, 11002, 11002, 11060, 11060, 11063, 11063, 11075, 11075, 11076, 11076, 11089, 11089, 11128, 11128, 11136, 11136, 11190, 11190, 11198, 11198
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10898, 10898, 10901, 10901, 10902, 10902, 10907, 10907, 10925, 10925, 10925, 10934, 10934, 10934, 10934, 10935, 10935, 10935, 10935, 10993, 10993, 10996, 10996, 11008, 11008, 11009, 11009, 11022, 11022, 11061, 11061, 11069, 11069, 11123, 11123, 11131, 11131
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12835-12934
+- Def site: line 12768-12867
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -976,11 +962,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12900, 12900, 12902, 12902, 12903, 12903, 20066, 20066, 20134, 20134, 20136, 20136, 20137, 20137
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12833, 12833, 12835, 12835, 12836, 12836, 19999, 19999, 20067, 20067, 20069, 20069, 20070, 20070
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15624-15721
+- Def site: line 15557-15654
 - References: 79
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -989,13 +975,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15367, 15367, 15602, 15602, 15660, 15660, 15666, 15666, 15672, 15672, 15678, 15678, 15684, 15684, 15690, 15690, 15696, 15696, 15702, 15702, 15708, 15708, 15714, 15714, 15720, 15720, 15968, 17206, 17434, 17434, 17437, 17437, 17773, 17773, 20023, 20023, 20090, 20090, 20096, 20096, 20147, 20147, 20204, 20204
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15300, 15300, 15535, 15535, 15593, 15593, 15599, 15599, 15605, 15605, 15611, 15611, 15617, 15617, 15623, 15623, 15629, 15629, 15635, 15635, 15641, 15641, 15647, 15647, 15653, 15653, 15901, 17139, 17367, 17367, 17370, 17370, 17706, 17706, 19956, 19956, 20023, 20023, 20029, 20029, 20080, 20080, 20137, 20137
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8332-8428
+- Def site: line 8265-8361
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1003,11 +989,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8388, 8388, 8424, 8424, 16482, 16482
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8321, 8321, 8357, 8357, 16415, 16415
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11405-11498
+- Def site: line 11338-11431
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1016,11 +1002,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11457, 11457, 11470, 11470, 20126, 20126, 20168, 20168, 20169, 20169, 20174, 20174, 20175, 20175
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11390, 11390, 11403, 11403, 20059, 20059, 20101, 20101, 20102, 20102, 20107, 20107, 20108, 20108
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5984-6073
+- Def site: line 5917-6006
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1030,13 +1016,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6066, 6066, 15430, 15430, 15431, 15431, 15645, 19926, 19926
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5999, 5999, 15363, 15363, 15364, 15364, 15578, 19859, 19859
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12748-12832
+- Def site: line 12681-12765
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1046,11 +1032,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12782, 12782, 20101, 20101, 20109, 20109, 20135, 20135, 20280, 20280
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12715, 12715, 20034, 20034, 20042, 20042, 20068, 20068, 20213, 20213
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 19203-19281
+- Def site: line 19136-19214
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1060,12 +1046,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19198, 19198, 19199, 19199, 20375, 20375
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19131, 19131, 19132, 19132, 20308, 20308
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17220-17297
+- Def site: line 17153-17230
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1075,12 +1061,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20246, 20246, 20250, 20250, 20254, 20254
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20179, 20179, 20183, 20183, 20187, 20187
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1878-1951
+- Def site: line 1881-1954
 - References: 261
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1089,7 +1075,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1891, 1891, 1923, 1923, 2198, 2198, 2287, 2287, 2314, 2314, 7686, 7686, 7772, 7772, 7902, 7902, 7979, 7979, 8062, 8062, 8292, 8292, 8481, 8481, 8537, 8537, 8550, 8550, 8567, 8567, 8612, 8612, 8643, 8643, 8649, 8649, 8752, 8752, 10293, 10293, 10560, 11062, 11062, 11091, 11091, 11356, 11356, 11562, 11562, 11801, 11801, 12517, 12517, 12533, 12533, 13320, 13320, 13739, 13739, 13789, 13789, 15643, 15845, 15845, 15878, 15878, 15896, 15896, 15914, 15914, 15941, 15941, 15966, 17208, 17247, 17247, 17272, 17272, 17315, 17414, 17414, 17626, 17626, 17769, 17769, 18773, 18773, 18863, 18863, 19193, 19193, 19223, 19223, 19244, 19244, 19263, 19263, 19279, 19279, 19296, 19296, 19873, 19873, 19893, 19893, 19928, 19928, 19941, 19941, 20409, 20409, 20500, 20500, 20505, 20505, 20511, 20511, 20530, 20530, 20536, 20536, 22136, 22136, 22234, 22234
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1894, 1894, 1926, 1926, 2201, 2201, 2290, 2290, 2317, 2317, 7619, 7619, 7705, 7705, 7835, 7835, 7912, 7912, 7995, 7995, 8225, 8225, 8414, 8414, 8470, 8470, 8483, 8483, 8500, 8500, 8545, 8545, 8576, 8576, 8582, 8582, 8685, 8685, 10226, 10226, 10493, 10995, 10995, 11024, 11024, 11289, 11289, 11495, 11495, 11734, 11734, 12450, 12450, 12466, 12466, 13253, 13253, 13672, 13672, 13722, 13722, 15576, 15778, 15778, 15811, 15811, 15829, 15829, 15847, 15847, 15874, 15874, 15899, 17141, 17180, 17180, 17205, 17205, 17248, 17347, 17347, 17559, 17559, 17702, 17702, 18706, 18706, 18796, 18796, 19126, 19126, 19156, 19156, 19177, 19177, 19196, 19196, 19212, 19212, 19229, 19229, 19806, 19806, 19826, 19826, 19861, 19861, 19874, 19874, 20342, 20342, 20433, 20433, 20438, 20438, 20444, 20444, 20463, 20463, 20469, 20469, 22069, 22069, 22167, 22167
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -1110,7 +1096,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15270-15341
+- Def site: line 15203-15274
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1119,12 +1105,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20212, 20212, 20213, 20213, 20214, 20214, 20215, 20215
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20145, 20145, 20146, 20146, 20147, 20147, 20148, 20148
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5475-5544
-- References: 16
+- Def site: line 5478-5547
+- References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1133,11 +1119,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5507, 5507, 5508, 5508, 5523, 5523, 5525, 5525, 5614, 5614, 18142, 18142, 18181, 18181, 18240, 18240
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5510, 5510, 5511, 5511, 5526, 5526, 5528, 5528, 18075, 18075, 18114, 18114, 18173, 18173
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 6079-6148
+- Def site: line 6012-6081
 - References: 195
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1145,7 +1131,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6121, 6121, 6126, 6126, 6223, 6223, 6281, 6281, 7172, 7172, 7829, 7829, 8474, 8474, 8497, 8497, 8517, 8517, 8702, 8702, 8723, 8723, 8998, 8998, 9023, 9023, 9078, 9078, 9100, 9100, 9117, 9117, 9134, 9134, 9519, 9519, 9742, 9742, 9759, 9759, 10151, 10151, 10483, 10483, 10694, 10694, 10731, 10731, 10884, 10884, 11027, 11027, 11280, 11280, 11468, 11468, 11652, 11652, 11971, 11971, 12307, 12307, 12479, 12479, 12519, 12519, 12525, 12525, 12619, 12619, 12849, 12849, 12922, 12922, 13409, 13409, 13444, 13643, 13643, 15150, 15150, 15366, 15366, 15634, 15741, 15841, 15841, 15876, 15876, 15894, 15894, 15912, 15912, 15947, 15947, 16481, 16481, 17203, 17313, 17821, 17821, 18774, 18774, 18779, 18779, 18781, 18781, 19194, 19194, 19196, 19196, 19220, 19220, 19224, 19224, 19225, 19225, 19245, 19245, 19246, 19246, 19407, 19407, 19977, 19977, 20009, 20009, 20046, 20046, 20052, 20052, 20180, 20180, 20237, 20237, 20320, 20320, 20329, 20329, 20407, 20407, 20408, 20408, 20425, 20425, 20500, 20500, 20505, 20505, 20511, 20511, 20530, 20530, 20536, 20536, 21447, 21447, 21518, 22000, 22000, 22088, 22088
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6054, 6054, 6059, 6059, 6156, 6156, 6214, 6214, 7105, 7105, 7762, 7762, 8407, 8407, 8430, 8430, 8450, 8450, 8635, 8635, 8656, 8656, 8931, 8931, 8956, 8956, 9011, 9011, 9033, 9033, 9050, 9050, 9067, 9067, 9452, 9452, 9675, 9675, 9692, 9692, 10084, 10084, 10416, 10416, 10627, 10627, 10664, 10664, 10817, 10817, 10960, 10960, 11213, 11213, 11401, 11401, 11585, 11585, 11904, 11904, 12240, 12240, 12412, 12412, 12452, 12452, 12458, 12458, 12552, 12552, 12782, 12782, 12855, 12855, 13342, 13342, 13377, 13576, 13576, 15083, 15083, 15299, 15299, 15567, 15674, 15774, 15774, 15809, 15809, 15827, 15827, 15845, 15845, 15880, 15880, 16414, 16414, 17136, 17246, 17754, 17754, 18707, 18707, 18712, 18712, 18714, 18714, 19127, 19127, 19129, 19129, 19153, 19153, 19157, 19157, 19158, 19158, 19178, 19178, 19179, 19179, 19340, 19340, 19910, 19910, 19942, 19942, 19979, 19979, 19985, 19985, 20113, 20113, 20170, 20170, 20253, 20253, 20262, 20262, 20340, 20340, 20341, 20341, 20358, 20358, 20433, 20433, 20438, 20438, 20444, 20444, 20463, 20463, 20469, 20469, 21380, 21380, 21451, 21933, 21933, 22021, 22021
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1155,7 +1141,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10529-10597
+- Def site: line 10462-10530
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1166,11 +1152,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10569, 10569, 10574, 10574, 10579, 10579, 10580, 10580, 10586, 10586, 10587, 10587, 10593, 10593, 10594, 10594, 10595, 10595, 10596, 10596, 20553, 20553
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10502, 10502, 10507, 10507, 10512, 10512, 10513, 10513, 10519, 10519, 10520, 10520, 10526, 10526, 10527, 10527, 10528, 10528, 10529, 10529, 20486, 20486
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 19932-19997
+- Def site: line 19865-19930
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1180,11 +1166,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19980, 19980, 19988, 19988, 19997, 19997, 20526, 20526
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19913, 19913, 19921, 19921, 19930, 19930, 20459, 20459
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15865-15920
+- Def site: line 15798-15853
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1194,11 +1180,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20151, 20151, 20155, 20155, 20360, 20360
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20084, 20084, 20088, 20088, 20293, 20293
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6154-6200
+- Def site: line 6087-6133
 - References: 59
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1207,13 +1193,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6278, 6278, 8164, 8164, 9079, 9079, 9102, 9102, 9589, 9589, 9624, 9624, 9638, 9638, 9761, 9761, 9765, 9765, 10313, 10313, 12623, 12623, 13293, 13293, 13419, 13419, 13451, 13629, 13629, 13665, 13665, 15640, 17929, 17929, 18775, 18775, 19084, 19084, 19195, 19195, 19226, 19226, 19247, 19247, 20410, 20410, 20426, 20426, 22019, 22019
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6211, 6211, 8097, 8097, 9012, 9012, 9035, 9035, 9522, 9522, 9557, 9557, 9571, 9571, 9694, 9694, 9698, 9698, 10246, 10246, 12556, 12556, 13226, 13226, 13352, 13352, 13384, 13562, 13562, 13598, 13598, 15573, 17862, 17862, 18708, 18708, 19017, 19017, 19128, 19128, 19159, 19159, 19180, 19180, 20343, 20343, 20359, 20359, 21952, 21952
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5803-5848
+- Def site: line 5736-5781
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1222,14 +1208,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5245, 5245, 5287, 5287, 5332, 5332, 5438, 5438, 5453, 5453, 5793, 5793, 5794, 5794, 5838, 5838, 6304, 6304, 7998, 7998, 9289, 9289, 9600, 9600, 9616, 9616, 9945, 9945, 10826, 10826, 10845, 10845, 12814, 15233, 15233, 15636, 15879, 15879, 15897, 15897, 15915, 15915, 15942, 15942, 15969, 16391, 16391, 16431, 16431, 16432, 16432, 16433, 16433, 16477, 16477, 17207, 17239, 17239, 17263, 17263, 17267, 17267, 17287, 17287, 17314, 17389, 17389, 17423, 17423, 17444, 17444, 17476, 17476, 17538, 17538, 17577, 17577, 17727, 17727, 17772, 17772, 18776, 18776
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5248, 5248, 5290, 5290, 5335, 5335, 5441, 5441, 5456, 5456, 5726, 5726, 5727, 5727, 5771, 5771, 6237, 6237, 7931, 7931, 9222, 9222, 9533, 9533, 9549, 9549, 9878, 9878, 10759, 10759, 10778, 10778, 12747, 15166, 15166, 15569, 15812, 15812, 15830, 15830, 15848, 15848, 15875, 15875, 15902, 16324, 16324, 16364, 16364, 16365, 16365, 16366, 16366, 16410, 16410, 17140, 17172, 17172, 17196, 17196, 17200, 17200, 17220, 17220, 17247, 17322, 17322, 17356, 17356, 17377, 17377, 17409, 17409, 17471, 17471, 17510, 17510, 17660, 17660, 17705, 17705, 18709, 18709
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17303-17345
+- Def site: line 17236-17278
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1238,11 +1224,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17326, 17326, 17332, 17332, 17338, 17338, 17344, 17344, 20344, 20344, 20348, 20348, 20352, 20352, 20356, 20356
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17259, 17259, 17265, 17265, 17271, 17271, 17277, 17277, 20277, 20277, 20281, 20281, 20285, 20285, 20289, 20289
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11671-11710
+- Def site: line 11604-11643
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1251,11 +1237,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11708, 11708, 20550, 20550
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11641, 11641, 20483, 20483
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1842-1870
+- Def site: line 1845-1873
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1264,12 +1250,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8952, 8952, 8953, 8953, 8982, 8982, 8983, 8983, 8999, 8999, 9000, 9000, 9878, 9878, 9879, 9879, 10183, 10183, 10184, 10184, 10231, 10231, 10232, 10232, 10787, 10787, 10789, 10789, 10807, 10807, 10809, 10809, 11697, 11697, 11698, 11698, 12358, 12358, 12359, 12359, 12464, 12464, 12465, 12465, 13447
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8885, 8885, 8886, 8886, 8915, 8915, 8916, 8916, 8932, 8932, 8933, 8933, 9811, 9811, 9812, 9812, 10116, 10116, 10117, 10117, 10164, 10164, 10165, 10165, 10720, 10720, 10722, 10722, 10740, 10740, 10742, 10742, 11630, 11630, 11631, 11631, 12291, 12291, 12292, 12292, 12397, 12397, 12398, 12398, 13380
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15594-15621
+- Def site: line 15527-15554
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1278,12 +1264,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15608, 15608, 15614, 15614, 15620, 15620, 20258, 20258, 20262, 20262
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15541, 15541, 15547, 15547, 15553, 15553, 20191, 20191, 20195, 20195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15955-15980
+- Def site: line 15888-15913
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1293,12 +1279,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15975, 15975, 15980, 15980, 20266, 20266, 20271, 20271
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15908, 15908, 15913, 15913, 20199, 20199, 20204, 20204
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2106-2130
+- Def site: line 2109-2133
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1306,11 +1292,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2192, 2251, 18892, 21843
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2195, 2254, 18825, 21776
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13746-13767
+- Def site: line 13679-13700
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1319,7 +1305,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20032, 20032, 20036, 20036, 20040, 20040
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19965, 19965, 19969, 19969, 19973, 19973
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1329,17 +1315,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17755-17776
+- Def site: line 17688-17709
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18778, 18778, 20179, 20179, 20236, 20236, 20319, 20319, 20328, 20328
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18711, 18711, 20112, 20112, 20169, 20169, 20252, 20252, 20261, 20261
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 19179-19200
+- Def site: line 19112-19133
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1348,24 +1334,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20389, 20389
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20322, 20322
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7636-7656
+- Def site: line 7569-7589
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6387, 10156, 15479, 15644
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6320, 10089, 15412, 15577
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13992-14001
+- Def site: line 13925-13934
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1373,11 +1359,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14028, 14164, 14241, 14260, 14272, 14293, 14306, 14317, 14323, 14336, 14429, 14564, 14659
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13961, 14097, 14174, 14193, 14205, 14226, 14239, 14250, 14256, 14269, 14362, 14497, 14592
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 294-302
+- Def site: line 297-305
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1393,7 +1379,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 321-329
+- Def site: line 324-332
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1401,11 +1387,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5561, 15302, 15319, 15335
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15235, 15252, 15268
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 306-313
+- Def site: line 309-316
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1421,7 +1408,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 281-283
+- Def site: line 284-286
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1429,12 +1416,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13452, 13741, 19228, 19249, 19394, 19425, 19457, 19692, 19707
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13385, 13674, 19161, 19182, 19327, 19358, 19390, 19625, 19640
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 609-611
+- Def site: line 612-614
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1442,7 +1429,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1219, 1888, 1888, 1888, 1900, 1906, 6280, 6400, 7460, 7520, 9688, 9799, 10053, 10883, 13454, 15512, 15554, 15652, 20412
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1222, 1891, 1891, 1891, 1903, 1909, 6213, 6333, 7393, 7453, 9621, 9732, 9986, 10816, 13387, 15445, 15487, 15585, 20345
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1455,7 +1442,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 1990-1992
+- Def site: line 1993-1995
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1464,11 +1451,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1990, 7470, 7477, 7478, 10064, 15501
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1993, 7403, 7410, 7411, 9997, 15434
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2008-2010
+- Def site: line 2011-2013
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1477,7 +1464,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2008, 15648, 17211
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2011, 15581, 17144
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1485,7 +1472,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 725-1729
+- Def site: line 728-1732
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1493,7 +1480,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1774
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1777
 
 ## Limitations
 

--- a/src/refactors/device_data_fetcher.py
+++ b/src/refactors/device_data_fetcher.py
@@ -107,7 +107,7 @@ class DeviceDataFetcher:
         """Process fetched data and output to CSV and table."""
         logging.info("Processing %s record(s) for %s", len(data), self.filename)  # Announce processing start
         processed = _MH.DataProcessingUtils.flatten_nested_fields(data)  # Flatten nested API structures
-        processed = _MH.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
-        _MH.DataExporter.write_with_format_selection(processed, self.filename)  # type: ignore[no-untyped-call]
+        processed = _MH.DataProcessingUtils.escape_multiline(processed)  # Escape multiline strings for CSV
+        _MH.DataExporter.write_with_format_selection(processed, self.filename)  # Emit CSV/JSON per user choice
         _MH.DisplayUtils.dict_list_as_pretty_table(processed)  # Render to console via PrettyTable
         logging.debug("Wrote %s and rendered table", self.filename)  # Trace output completion

--- a/src/refactors/device_data_fetcher.py
+++ b/src/refactors/device_data_fetcher.py
@@ -1,0 +1,113 @@
+"""DeviceDataFetcher extracted from MistHelper.
+
+Interactive device data fetcher for single-device operations. Originally
+defined as ``DeviceDataFetcher`` inside MistHelper.py; extracted here per
+initiative 1011 to shrink the monolith.
+
+Runtime dependencies (``PromptUtils``, ``DataProcessingUtils``,
+``DataExporter``, ``DisplayUtils``, ``apisession``) still live inside
+MistHelper.py and are resolved lazily via the ``_MH`` module-level proxy so
+this module keeps its import graph flat and honours any test monkey-patches
+applied at runtime.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import importlib  # Late-import MistHelper to avoid circular src<->MistHelper dependency
+import logging  # Structured action logging required by Constitution VII
+from typing import TYPE_CHECKING, Any  # Loose typing for late-bound MistHelper attributes
+
+if TYPE_CHECKING:  # Only import DeviceFetchConfig for static type analysis, never at runtime
+    from MistHelper import DeviceFetchConfig  # Configuration dataclass owned by MistHelper.py
+
+
+class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
+    """Forward attribute access to the currently-loaded MistHelper module."""
+
+    def __getattr__(self, name: str) -> Any:  # Called only when the attribute is not found normally
+        """Resolve name against the live MistHelper module (call-time lookup)."""
+        misthelper_module = importlib.import_module("MistHelper")  # Lazy import at call time
+        return getattr(misthelper_module, name)  # Fetch the current bound value from MistHelper
+
+
+_MH = _MistHelperProxy()  # Sole module-level proxy handle used inside the class body
+
+
+class DeviceDataFetcher:
+    """Interactive device data fetcher for single-device operations.
+
+    Fetches data for a specific device (by site_id/device_id or via user prompt),
+    writes the result to CSV, and displays as PrettyTable.
+
+    SECURITY: Uses authenticated API session for all device queries.
+
+    Usage:
+        DeviceDataFetcher(DeviceFetchConfig(fetch_function, filename, description)).fetch()
+        DeviceDataFetcher(DeviceFetchConfig(fetch_function, filename, description, device_type="gateway")).fetch()
+    """
+
+    def __init__(self, config: DeviceFetchConfig) -> None:
+        """Initialize fetcher from a DeviceFetchConfig (issue #470: 6 params bundled into one per 5-Item Rule)."""
+        self.fetch_function = config.fetch_function  # Callable that performs the actual API fetch.
+        self.filename = config.filename  # Output filename for the exported data.
+        self.description = config.description  # Human-readable description shown during the fetch.
+        self.device_type = config.device_type  # Device type filter (all/ap/switch/gateway).
+        self.site_id = config.site_id  # Optional site scope (None means an org-wide fetch).
+        self.device_id = config.device_id  # Optional single-device scope (None means all matching devices).
+
+    def fetch(self) -> None:
+        """Orchestrate the device data fetch workflow (main entry point)."""
+        logging.info("Starting device data fetch: %s", self.description)  # Announce fetch start for observability
+        if not self._resolve_site_id():  # Bail out early if we cannot determine which site to query
+            logging.debug("Fetch aborted: site_id could not be resolved")  # Trace early exit
+            return  # Nothing else to do without a site scope
+        if not self._resolve_device_id():  # Bail out if we cannot determine which device to query
+            logging.debug("Fetch aborted: device_id could not be resolved")  # Trace early exit
+            return  # Nothing else to do without a device scope
+        self._log_action()  # Emit the descriptive action log
+        data = self._fetch_data()  # Perform the actual API call
+        if data:  # Only process and export when data is non-empty
+            self._process_and_output(data)  # Flatten, escape, write CSV, and display
+        logging.debug("Completed device data fetch: %s", self.description)  # Trace successful completion
+
+    def _resolve_site_id(self) -> bool:
+        """Resolve site ID from parameter or user prompt."""
+        if self.site_id:  # Caller may have pre-supplied the site; reuse it verbatim
+            return True  # Already resolved
+        self.site_id = _MH.PromptUtils.select_site_id_from_csv()  # Interactive site selection from CSV inventory
+        return bool(self.site_id)  # False when the user cancelled or no sites exist
+
+    def _resolve_device_id(self) -> bool:
+        """Resolve device ID from parameter or user prompt."""
+        if self.device_id:  # Caller may have pre-supplied the device; reuse it verbatim
+            return True  # Already resolved
+        assert self.site_id is not None, "Site ID must be resolved before device ID"  # nosec B101
+        self.device_id = _MH.PromptUtils.select_device_id_from_inventory(  # Interactive device selection
+            self.site_id, device_type=self.device_type
+        )  # Filter by the caller-configured device type (all/ap/switch/gateway)
+        return bool(self.device_id)  # False when the user cancelled or no matching devices exist
+
+    def _log_action(self) -> None:
+        """Log the action being performed."""
+        logging.info("%s for device ID: %s", self.description, self.device_id)  # Human-readable action trace
+
+    def _fetch_data(self) -> list[dict[str, Any]] | None:
+        """Fetch data using the configured API function."""
+        logging.info("Fetching data via %s", getattr(self.fetch_function, "__name__", "<fetch_function>"))  # API trace
+        try:  # Guard against transient API failures so we can log and return None
+            response = self.fetch_function(_MH.apisession, self.site_id, self.device_id)  # Live authenticated call
+            result = [response.data] if response.data else None  # Wrap single-device response into a one-element list
+            logging.debug("Fetch returned %s record(s)", 0 if result is None else len(result))  # Result-size trace
+            return result  # None signals empty response so callers can skip processing
+        except Exception as error:  # Any API/network error yields None with a structured log
+            logging.error("Failed to fetch device data: %s", error)  # Structured error log
+            return None  # Signal failure without raising to preserve interactive UX
+
+    def _process_and_output(self, data: list[dict[str, Any]]) -> None:
+        """Process fetched data and output to CSV and table."""
+        logging.info("Processing %s record(s) for %s", len(data), self.filename)  # Announce processing start
+        processed = _MH.DataProcessingUtils.flatten_nested_fields(data)  # Flatten nested API structures
+        processed = _MH.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
+        _MH.DataExporter.write_with_format_selection(processed, self.filename)  # type: ignore[no-untyped-call]
+        _MH.DisplayUtils.dict_list_as_pretty_table(processed)  # Render to console via PrettyTable
+        logging.debug("Wrote %s and rendered table", self.filename)  # Trace output completion


### PR DESCRIPTION
## Summary
- Extract 68-LoC `DeviceDataFetcher` class from MistHelper.py monolith into `src/refactors/device_data_fetcher.py` per initiative 1011 (SC-017).
- Uses `_MistHelperProxy` lazy-binding pattern for MistHelper-owned deps (`PromptUtils`, `DataProcessingUtils`, `DataExporter`, `DisplayUtils`, `apisession`).
- `TYPE_CHECKING` import of `DeviceFetchConfig` to avoid runtime circular.
- All 3 callsites (`device_stats`, `device_tests`, `device_config`) preserved atomically per FR-006; no wrapper shims per FR-003.
- Constitution VI/VII satisfied: inline comments on every executable line; `logging.info` before / `logging.debug` after every action.

## Compliance
- New module: **100.0 / A+**
- MistHelper.py baseline: **93.0 / A** (unchanged)
- Low-use bucket: 17 -> 16

## Test plan
- [x] `python -m black --check` clean
- [x] `python -m ruff check` clean
- [x] `python -m pydocstyle src/refactors/device_data_fetcher.py` clean
- [x] `import MistHelper; MistHelper.DeviceDataFetcher` resolves
- [x] `from src.refactors.device_data_fetcher import DeviceDataFetcher` resolves
- [ ] 15/15 CI green