### PR TITLE
refactor(1011): extract DeviceConfigTemplateClonerManager to src/refactors (SC-020)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -150,6 +150,9 @@ from src.refactors.anomaly_metrics_discovery import (
     AnomalyMetricsDiscovery,  # Extracted anomaly metrics discovery (SC-016)
 )
 from src.refactors.data_directory_checker import DataDirectoryChecker  # Early data-dir writable check (SC-005)
+from src.refactors.device_config_template_cloner_manager import (
+    DeviceConfigTemplateClonerManager,  # Extracted device config template cloner (SC-020)
+)
 from src.refactors.device_data_fetcher import (
     DeviceDataFetcher,  # Extracted interactive device data fetcher (SC-017)
 )
@@ -15856,33 +15859,9 @@ class GatewayTemplateConfigManager:  # Gateway template config manager.
         ).clone_by_location()
 
 
-class DeviceConfigTemplateClonerManager:  # Device config template cloner.
-    """Menu 194: Clone device local config to a new gateway template.
-
-    Delegated to src.gateway.device_template_cloner.
-    """
-
-    @staticmethod
-    def clone() -> None:  # Clone a config.
-        """Menu 194: Fetch gateway device config and create a new org-level gateway template."""
-        from src.gateway.device_template_cloner import (  # pylint: disable=import-outside-toplevel
-            DeviceConfigTemplateClonerManager as Impl,  # Import extracted implementation class
-        )
-        from src.gateway.device_template_cloner import (
-            DeviceTemplateClonerDeps,  # Frozen deps bundle groups injected dependencies
-        )
-
-        deps = DeviceTemplateClonerDeps(  # Bundle the 5 injected dependencies for the manager
-            apisession=apisession,  # Pass authenticated global API session
-            input_fn=InputUtils.safe_input,  # Pass EOF-safe input wrapper for SSH/container contexts
-            get_csv_path_fn=FilePathUtils.get_csv_path,  # Pass path builder for OS-safe output paths
-            save_data_fn=DataExporter.write_with_format_selection,  # Pass CSV writer for persistence
-            write_csv_fn=DataExporter.write_with_format_selection,  # Pass PK-aware format-selecting writer
-        )
-        Impl(
-            org_id=ConfigUtils.get_cached_or_prompted_org_id(),  # Resolve org_id from cache or prompt
-            deps=deps,  # Inject the frozen deps bundle
-        ).clone()  # Delegate all business logic to extracted implementation
+# NOTE: DeviceConfigTemplateClonerManager extracted per SC-020.
+# Now lives at src/refactors/device_config_template_cloner_manager.py.
+# Callers should reference the imported DeviceConfigTemplateClonerManager symbol (see top-of-file imports).
 
 
 # ============================================================================

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 188 first-party files
-- Definitions analyzed: 95
+- Module graph size: 189 first-party files
+- Definitions analyzed: 94
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=14, hot=80, skipped=1
+- Category counts: unused=0, single-use=0, low-use=13, hot=80, skipped=1
 
 ## How to read this report
 
@@ -46,7 +46,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `OrgDeviceStatsExporter` | class | 414 | 58 | hot |  | oversize_25_lines,missing_inline_comments |
 | `DeviceRebootManager` | class | 398 | 46 | hot |  | oversize_25_lines,missing_inline_comments |
 | `MSPInventoryExporter` | class | 388 | 5 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
-| `DataExporter` | class | 345 | 255 | hot |  | oversize_25_lines,non_ascii_logs |
+| `DataExporter` | class | 345 | 251 | hot |  | oversize_25_lines,non_ascii_logs |
 | `SiteAnomalyExporter` | class | 341 | 54 | hot |  | oversize_25_lines,non_ascii_logs |
 | `APIDataFetcher` | class | 328 | 16 | hot |  | oversize_25_lines |
 | `InsightMetricsUtils` | class | 328 | 51 | hot |  | oversize_25_lines,non_ascii_logs,hardcoded_separator |
@@ -86,21 +86,20 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `SiteClientExporter` | class | 85 | 10 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `OrgLevelAPFirmwareUpgrader` | class | 79 | 33 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `VirtualChassisManager` | class | 78 | 104 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
-| `InputUtils` | class | 74 | 261 | hot |  | oversize_25_lines,raw_input_call |
+| `InputUtils` | class | 74 | 259 | hot |  | oversize_25_lines,raw_input_call |
 | `InteractiveDisplayUtils` | class | 72 | 8 | hot |  | oversize_25_lines,missing_inline_comments |
 | `DisplayUtils` | class | 70 | 8 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
-| `ConfigUtils` | class | 70 | 191 | hot |  | oversize_25_lines |
+| `ConfigUtils` | class | 70 | 189 | hot |  | oversize_25_lines |
 | `OrgDeviceInventorySummary` | class | 69 | 22 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging,non_ascii_logs |
 | `AuditAnalysisOps` | class | 66 | 8 | hot |  | oversize_25_lines,missing_inline_comments,raw_input_call |
 | `GatewayTemplateConfigManager` | class | 56 | 6 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `APICoreFetchUtils` | class | 47 | 57 | hot |  | oversize_25_lines,missing_inline_comments |
-| `FilePathUtils` | class | 46 | 102 | hot |  | oversize_25_lines,missing_inline_comments |
+| `FilePathUtils` | class | 46 | 100 | hot |  | oversize_25_lines,missing_inline_comments |
 | `SiteConfigManager` | class | 43 | 16 | hot |  | oversize_25_lines,missing_action_logging |
 | `SelfExportUtils` | class | 40 | 4 | hot |  | oversize_25_lines,non_ascii_logs |
 | `BulkAPFirmwareUpgrader` | class | 32 | 2 | low-use | FirmwareManager | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `TimeUtils` | class | 29 | 51 | hot |  | oversize_25_lines,missing_inline_comments |
 | `GatewayStatsExporter` | class | 28 | 52 | hot |  | oversize_25_lines,missing_action_logging |
-| `DeviceConfigTemplateClonerManager` | class | 27 | 2 | low-use | DeviceConfigTemplateClonerManager | oversize_25_lines,missing_action_logging |
 | `SSHRunnerManager` | class | 26 | 82 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `detect_msp_privileges` | function | 25 | 4 | hot |  | missing_action_logging |
 | `WANProbeDeviceOverrideManager` | class | 23 | 2 | low-use | WANProbeDeviceOverrideManager | missing_inline_comments,missing_action_logging |
@@ -128,11 +127,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 12 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (14)
+## Low-Use (13)
 
 ### `BulkAPFirmwareUpgrader` (class, 32 lines)
 
-- Def site: line 17676-17707
+- Def site: line 17655-17686
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -144,22 +143,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Reference sites (one PR cluster per file):
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1755, 1758
 
-### `DeviceConfigTemplateClonerManager` (class, 27 lines)
-
-- Def site: line 15859-15885
-- References: 2
-- Suggested class: `DeviceConfigTemplateClonerManager`
-- Suggested module: `src/refactors/device_config_template_cloner_manager.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py; extract `DeviceConfigTemplateClonerManager` OUT of the entrypoint into a new `src/refactors/device_config_template_cloner_manager.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19490, 19490
-
 ### `WANProbeDeviceOverrideManager` (class, 23 lines)
 
-- Def site: line 17074-17096
+- Def site: line 17053-17075
 - References: 2
 - Suggested class: `WANProbeDeviceOverrideManager`
 - Suggested module: `src/refactors/wanprobe_device_override_manager.py`
@@ -168,11 +154,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19292, 19292
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19271, 19271
 
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 18208-18226
+- Def site: line 18187-18205
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -185,7 +171,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `initialize_mist_session_interactive` (function, 18 lines)
 
-- Def site: line 2192-2209
+- Def site: line 2195-2212
 - References: 3
 - Suggested class: `InitializeMistSessionInteractiveManager`
 - Suggested module: `src/refactors/initialize_mist_session_interactive.py`
@@ -193,11 +179,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2252, 17811, 20758
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2255, 17790, 20737
 
 ### `initialize_mist_session` (function, 18 lines)
 
-- Def site: line 2818-2835
+- Def site: line 2821-2838
 - References: 2
 - Suggested class: `InitializeMistSessionManager`
 - Suggested module: `src/refactors/initialize_mist_session.py`
@@ -205,11 +191,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20763, 20826
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20742, 20805
 
 ### `PACKAGE_IMPORT_MAP` (assignment, 13 lines)
 
-- Def site: line 369-381
+- Def site: line 372-384
 - References: 2
 - Suggested class: `PackageImportMapManager`
 - Suggested module: `src/refactors/package__import__map.py`
@@ -217,35 +203,35 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 369, 553
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 372, 556
 
 ### `main` (function, 12 lines)
 
-- Def site: line 21154-21165
+- Def site: line 21133-21144
 - References: 2
 - Suggested class: `MapsManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`
 - Rationale: 97 caller files detected; group callers under a shared class in `maps_manager.py` and rewrite references per file cluster
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21268
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21247
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
 
 ### `marvis_data_utils` (assignment, 4 lines)
 
-- Def site: line 6539-6542
+- Def site: line 6542-6545
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `MarvisTroubleshootDeps()`; extract `marvis_data_utils` OUT of the entrypoint into a new `src/refactors/marvis_data_utils.py` module and rewrite the callsite(s) to import from there
+- Rationale: low-use: sole caller lives inside MistHelper.py from `_build_deps()`; extract `marvis_data_utils` OUT of the entrypoint into a new `src/refactors/marvis_data_utils.py` module and rewrite the callsite(s) to import from there
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6539, 15681
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6542, 15684
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\marvis_troubleshoot_utils.py`: lines 21
 
 ### `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 lines)
 
-- Def site: line 1984-1986
+- Def site: line 1987-1989
 - References: 3
 - Suggested class: `FastModeBackoffMultiplierManager`
 - Suggested module: `src/refactors/fast__mode__backoff__multiplier.py`
@@ -254,11 +240,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1984, 9925, 15354
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1987, 9928, 15357
 
 ### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
 
-- Def site: line 1987-1989
+- Def site: line 1990-1992
 - References: 2
 - Suggested class: `FastModeDevicesPerThreadManager`
 - Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
@@ -267,11 +253,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1987, 7415
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1990, 7418
 
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 1992-1994
+- Def site: line 1995-1997
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -280,11 +266,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1992, 15494
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1995, 15497
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 1999-2001
+- Def site: line 2002-2004
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -292,11 +278,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1999, 7405
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2002, 7408
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 2007-2009
+- Def site: line 2010-2012
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -305,14 +291,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2007, 15583
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2010, 15586
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
 ## Hot (80)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2880-5206
+- Def site: line 2883-5209
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -323,11 +309,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2880, 6585, 6586, 6595, 6759
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2883, 6588, 6589, 6598, 6762
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13940-14698
+- Def site: line 13943-14701
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -336,11 +322,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14417, 14417, 14429, 14429, 14457, 14457, 14469, 14469, 14530, 14530, 14567, 14567, 14724, 19207
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14420, 14420, 14432, 14432, 14460, 14460, 14472, 14472, 14533, 14533, 14570, 14570, 14727, 19186
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9086-9771
+- Def site: line 9089-9774
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -349,12 +335,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5592, 5592, 9209, 9209, 9260, 9260, 9263, 9263, 9304, 9304, 9343, 9343, 9361, 9361, 9439, 9439, 9446, 9446, 9456, 9456, 9459, 9459, 9472, 9472, 9473, 9473, 9474, 9474, 9475, 9475, 9483, 9483, 9485, 9485, 9486, 9486, 9487, 9487, 9488, 9488, 9491, 9491, 9494, 9494, 9497, 9497, 9500, 9500, 9546, 9546, 9569, 9569, 9570, 9570, 9571, 9571, 9573, 9573, 9609, 9609, 9625, 9625, 9679, 9679, 9680, 9680, 9681, 9681, 9684, 9684, 9685, 9685, 9704, 9704, 9706, 9706, 9707, 9707, 9742, 9742, 15093, 15093, 15146, 15146, 15577, 17123, 17123, 17147, 17147, 17171, 17171, 17314, 17314, 18982, 18982, 18989, 18989, 18998, 18998, 19002, 19002, 19011, 19011
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5595, 5595, 9212, 9212, 9263, 9263, 9266, 9266, 9307, 9307, 9346, 9346, 9364, 9364, 9442, 9442, 9449, 9449, 9459, 9459, 9462, 9462, 9475, 9475, 9476, 9476, 9477, 9477, 9478, 9478, 9486, 9486, 9488, 9488, 9489, 9489, 9490, 9490, 9491, 9491, 9494, 9494, 9497, 9497, 9500, 9500, 9503, 9503, 9549, 9549, 9572, 9572, 9573, 9573, 9574, 9574, 9576, 9576, 9612, 9612, 9628, 9628, 9682, 9682, 9683, 9683, 9684, 9684, 9687, 9687, 9688, 9688, 9707, 9707, 9709, 9709, 9710, 9710, 9745, 9745, 15096, 15096, 15149, 15149, 15580, 17102, 17102, 17126, 17126, 17150, 17150, 17293, 17293, 18961, 18961, 18968, 18968, 18977, 18977, 18981, 18981, 18990, 18990
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16392-17066
+- Def site: line 16371-17045
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -362,11 +348,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16780, 16780, 19453, 19459
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16759, 16759, 19432, 19438
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11819-12471
+- Def site: line 11822-12474
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -376,11 +362,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10596, 10596, 10605, 10605, 10693, 10693, 10700, 10700, 11374, 11374, 11660, 11660, 11665, 11665, 11672, 11672, 11677, 11677, 11891, 11891, 11913, 11913, 11916, 11916, 11942, 11942, 11951, 11951, 11952, 11952, 11973, 11973, 12016, 12016, 12062, 12062, 12073, 12073, 12100, 12100, 12105, 12105, 12106, 12106, 12107, 12107, 12139, 12139, 12145, 12145, 12170, 12170, 12190, 12190, 12225, 12225, 12240, 12240, 12246, 12246, 12248, 12248, 12251, 12251, 12253, 12253, 12257, 12257, 12261, 12261, 12266, 12266, 12273, 12273, 12280, 12280, 12287, 12287, 12296, 12296, 12306, 12306, 12313, 12313, 12320, 12320, 12327, 12327, 12334, 12334, 12341, 12341, 12351, 12351, 12360, 12360, 12369, 12369, 12378, 12378, 12387, 12387, 12416, 12416, 18943, 18943, 19124, 19124, 19201, 19201, 19202, 19202, 19210, 19210, 19415, 19415, 19416, 19416, 19435, 19435, 19442, 19442, 19443, 19443, 19444, 19444, 19445, 19445
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10599, 10599, 10608, 10608, 10696, 10696, 10703, 10703, 11377, 11377, 11663, 11663, 11668, 11668, 11675, 11675, 11680, 11680, 11894, 11894, 11916, 11916, 11919, 11919, 11945, 11945, 11954, 11954, 11955, 11955, 11976, 11976, 12019, 12019, 12065, 12065, 12076, 12076, 12103, 12103, 12108, 12108, 12109, 12109, 12110, 12110, 12142, 12142, 12148, 12148, 12173, 12173, 12193, 12193, 12228, 12228, 12243, 12243, 12249, 12249, 12251, 12251, 12254, 12254, 12256, 12256, 12260, 12260, 12264, 12264, 12269, 12269, 12276, 12276, 12283, 12283, 12290, 12290, 12299, 12299, 12309, 12309, 12316, 12316, 12323, 12323, 12330, 12330, 12337, 12337, 12344, 12344, 12354, 12354, 12363, 12363, 12372, 12372, 12381, 12381, 12390, 12390, 12419, 12419, 18922, 18922, 19103, 19103, 19180, 19180, 19181, 19181, 19189, 19189, 19394, 19394, 19395, 19395, 19414, 19414, 19421, 19421, 19422, 19422, 19423, 19423, 19424, 19424
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 18239-18825
+- Def site: line 18218-18804
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -388,11 +374,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18516, 18516, 18517, 18517, 18520, 18520, 18522, 18522, 18524, 18524, 18540, 18540, 19360
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18495, 18495, 18496, 18496, 18499, 18499, 18501, 18501, 18503, 18503, 18519, 18519, 19339
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 18924-19495
+- Def site: line 18903-19474
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -402,12 +388,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18924, 20209, 20210, 20219, 20339, 20339, 20381, 20439, 20484, 20975, 20979, 21024, 21024, 21051, 21051, 21054
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18903, 20188, 20189, 20198, 20318, 20318, 20360, 20418, 20463, 20954, 20958, 21003, 21003, 21030, 21030, 21033
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8370-8832
+- Def site: line 8373-8835
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -415,11 +401,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8411, 8411, 8416, 8416, 8426, 8426, 8434, 8434, 8439, 8439, 8444, 8444, 8454, 8454, 8459, 8459, 8464, 8464, 8484, 8484, 8494, 8494, 8495, 8495, 8498, 8498, 8528, 8528, 8614, 8614, 8616, 8616, 8640, 8640, 8646, 8646, 8651, 8651, 8660, 8660, 8664, 8664, 8683, 8683, 8686, 8686, 8697, 8697, 8698, 8698, 8793, 8793, 8814, 8814, 19483, 19483, 19484, 19484, 19485, 19485, 19486, 19486, 19487, 19487, 19488, 19488
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8414, 8414, 8419, 8419, 8429, 8429, 8437, 8437, 8442, 8442, 8447, 8447, 8457, 8457, 8462, 8462, 8467, 8467, 8487, 8487, 8497, 8497, 8498, 8498, 8501, 8501, 8531, 8531, 8617, 8617, 8619, 8619, 8643, 8643, 8649, 8649, 8654, 8654, 8663, 8663, 8667, 8667, 8686, 8686, 8689, 8689, 8700, 8700, 8701, 8701, 8796, 8796, 8817, 8817, 19462, 19462, 19463, 19463, 19464, 19464, 19465, 19465, 19466, 19466, 19467, 19467
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 19720-20180
+- Def site: line 19699-20159
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -429,11 +415,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20187, 20187, 20191, 20191, 20211, 20211, 20216, 20216, 20440
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20166, 20166, 20170, 20170, 20190, 20190, 20195, 20195, 20419
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7817-8257
+- Def site: line 7820-8260
 - References: 117
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -441,14 +427,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7762, 7762, 7778, 7778, 7782, 7782, 7783, 7783, 7784, 7784, 7799, 7799, 7805, 7805, 7832, 7832, 7835, 7835, 7843, 7843, 7861, 7861, 7911, 7911, 7919, 7919, 7924, 7924, 7970, 7970, 7981, 7981, 8006, 8006, 8025, 8025, 8026, 8026, 8029, 8029, 8030, 8030, 8120, 8120, 8122, 8122, 8126, 8126, 8154, 8154, 8155, 8155, 8156, 8156, 8157, 8157, 8158, 8158, 8167, 8167, 8211, 8211, 8235, 8235, 12551, 12551, 12601, 12601, 12606, 12606, 12749, 12832, 12832, 12886, 12886, 12907, 12907, 12912, 12912, 13176, 13176, 13379, 13581, 13581, 13668, 13668, 13673, 13673, 13723, 13723, 13724, 13724, 15220, 15220, 15679, 17130, 17130, 17652, 17652, 18848, 18848, 18849, 18849, 19135, 19135
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7765, 7765, 7781, 7781, 7785, 7785, 7786, 7786, 7787, 7787, 7802, 7802, 7808, 7808, 7835, 7835, 7838, 7838, 7846, 7846, 7864, 7864, 7914, 7914, 7922, 7922, 7927, 7927, 7973, 7973, 7984, 7984, 8009, 8009, 8028, 8028, 8029, 8029, 8032, 8032, 8033, 8033, 8123, 8123, 8125, 8125, 8129, 8129, 8157, 8157, 8158, 8158, 8159, 8159, 8160, 8160, 8161, 8161, 8170, 8170, 8214, 8214, 8238, 8238, 12554, 12554, 12604, 12604, 12609, 12609, 12752, 12835, 12835, 12889, 12889, 12910, 12910, 12915, 12915, 13179, 13179, 13382, 13584, 13584, 13671, 13671, 13676, 13676, 13726, 13726, 13727, 13727, 15223, 15223, 15682, 17109, 17109, 17631, 17631, 18827, 18827, 18828, 18828, 19114, 19114
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9774-10187
+- Def site: line 9777-10190
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -457,11 +443,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5586, 5586, 9807, 9807, 9891, 9891, 9897, 9897, 9900, 9900, 9944, 9944, 9958, 9958, 9985, 9985, 9991, 9991, 10005, 10005, 10088, 10088, 10090, 10090, 10094, 10094, 10096, 10096, 10099, 10099, 10103, 10103, 10106, 10106, 10116, 10116, 10122, 10122, 10160, 10160, 15094, 15094, 15095, 15095, 15096, 15096, 15147, 15147, 15148, 15148, 18983, 18983, 18984, 18984, 18985, 18985, 19009, 19009
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5589, 5589, 9810, 9810, 9894, 9894, 9900, 9900, 9903, 9903, 9947, 9947, 9961, 9961, 9988, 9988, 9994, 9994, 10008, 10008, 10091, 10091, 10093, 10093, 10097, 10097, 10099, 10099, 10102, 10102, 10106, 10106, 10109, 10109, 10119, 10119, 10125, 10125, 10163, 10163, 15097, 15097, 15098, 15098, 15099, 15099, 15150, 15150, 15151, 15151, 18962, 18962, 18963, 18963, 18964, 18964, 18988, 18988
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17233-17630
+- Def site: line 17212-17609
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -470,11 +456,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17254, 17254, 17259, 17259, 17263, 17263, 17266, 17266, 17273, 17273, 17275, 17275, 17276, 17276, 17279, 17279, 17282, 17282, 17285, 17285, 17327, 17327, 17359, 17359, 17426, 17426, 17439, 17439, 17444, 17444, 17496, 17496, 17529, 17529, 17530, 17530, 17531, 17531, 17561, 17561, 17590, 17590, 17591, 17591, 19166, 19166
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17233, 17233, 17238, 17238, 17242, 17242, 17245, 17245, 17252, 17252, 17254, 17254, 17255, 17255, 17258, 17258, 17261, 17261, 17264, 17264, 17306, 17306, 17338, 17338, 17405, 17405, 17418, 17418, 17423, 17423, 17475, 17475, 17508, 17508, 17509, 17509, 17510, 17510, 17540, 17540, 17569, 17569, 17570, 17570, 19145, 19145
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 17713-18100
+- Def site: line 17692-18079
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -484,12 +470,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17740, 17884, 17884, 19306, 19306
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17719, 17863, 17863, 19285, 19285
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6726-7070
-- References: 255
+- Def site: line 6729-7073
+- References: 251
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -497,7 +483,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5682, 5682, 6772, 6772, 6788, 6788, 6789, 6789, 6812, 6812, 6814, 6814, 6817, 6817, 6831, 6831, 6833, 6833, 6842, 6842, 6844, 6844, 6845, 6845, 6851, 6851, 6852, 6852, 6852, 6869, 6869, 6873, 6873, 6915, 6915, 6946, 6946, 6949, 6949, 6951, 6951, 6997, 6997, 7007, 7007, 7040, 7040, 7045, 7045, 7052, 7052, 7274, 7274, 7306, 7306, 7317, 7317, 7342, 7342, 7362, 7362, 7874, 7874, 8667, 8667, 8946, 8946, 8961, 9025, 9025, 9042, 9042, 9060, 9060, 9081, 9081, 9640, 9640, 9715, 9715, 10045, 10045, 10396, 10396, 10481, 10497, 10617, 10617, 10621, 10621, 10641, 10641, 10654, 10654, 10658, 10658, 10676, 10676, 10838, 10838, 11185, 11185, 11332, 11332, 11409, 11409, 11413, 11413, 11418, 11418, 11551, 11551, 11570, 11570, 11621, 11621, 11624, 11624, 11775, 11775, 11778, 11778, 11877, 11877, 11883, 11883, 12180, 12180, 12197, 12197, 12212, 12212, 12426, 12426, 12454, 12454, 12470, 12470, 12507, 12507, 12545, 12545, 12634, 12634, 12663, 12663, 12701, 12701, 12752, 12817, 12817, 12823, 12823, 12865, 12865, 13034, 13034, 13040, 13040, 13159, 13159, 13167, 13167, 13331, 13331, 13382, 13555, 13555, 13726, 13726, 14239, 14239, 14600, 14600, 14606, 14606, 15514, 15514, 15573, 15680, 15816, 15816, 15834, 15834, 15852, 15852, 15879, 15879, 15880, 15880, 17091, 17177, 17177, 17198, 18066, 18066, 18151, 18151, 18172, 18172, 18674, 18674, 19335, 19335, 19351, 19351
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5685, 5685, 6775, 6775, 6791, 6791, 6792, 6792, 6815, 6815, 6817, 6817, 6820, 6820, 6834, 6834, 6836, 6836, 6845, 6845, 6847, 6847, 6848, 6848, 6854, 6854, 6855, 6855, 6855, 6872, 6872, 6876, 6876, 6918, 6918, 6949, 6949, 6952, 6952, 6954, 6954, 7000, 7000, 7010, 7010, 7043, 7043, 7048, 7048, 7055, 7055, 7277, 7277, 7309, 7309, 7320, 7320, 7345, 7345, 7365, 7365, 7877, 7877, 8670, 8670, 8949, 8949, 8964, 9028, 9028, 9045, 9045, 9063, 9063, 9084, 9084, 9643, 9643, 9718, 9718, 10048, 10048, 10399, 10399, 10484, 10500, 10620, 10620, 10624, 10624, 10644, 10644, 10657, 10657, 10661, 10661, 10679, 10679, 10841, 10841, 11188, 11188, 11335, 11335, 11412, 11412, 11416, 11416, 11421, 11421, 11554, 11554, 11573, 11573, 11624, 11624, 11627, 11627, 11778, 11778, 11781, 11781, 11880, 11880, 11886, 11886, 12183, 12183, 12200, 12200, 12215, 12215, 12429, 12429, 12457, 12457, 12473, 12473, 12510, 12510, 12548, 12548, 12637, 12637, 12666, 12666, 12704, 12704, 12755, 12820, 12820, 12826, 12826, 12868, 12868, 13037, 13037, 13043, 13043, 13162, 13162, 13170, 13170, 13334, 13334, 13385, 13558, 13558, 13729, 13729, 14242, 14242, 14603, 14603, 14609, 14609, 15517, 15517, 15576, 15683, 15819, 15819, 15837, 15837, 15855, 15855, 17070, 17156, 17156, 17177, 18045, 18045, 18130, 18130, 18151, 18151, 18653, 18653, 19314, 19314, 19330, 19330
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -508,7 +494,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12873-13213
+- Def site: line 12876-13216
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -517,11 +503,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12890, 12890, 12892, 12892, 12896, 12896, 12897, 12897, 12911, 12911, 12917, 12917, 12920, 12920, 12923, 12923, 12981, 12981, 12987, 12987, 12992, 12992, 13006, 13006, 13024, 13024, 13134, 13134, 13138, 13138, 13140, 13140, 13143, 13143, 13180, 13180, 13185, 13185, 13199, 13199, 13203, 13203, 13205, 13205, 13208, 13208, 13213, 13213, 19212, 19212, 19216, 19216, 19220, 19220
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12893, 12893, 12895, 12895, 12899, 12899, 12900, 12900, 12914, 12914, 12920, 12920, 12923, 12923, 12926, 12926, 12984, 12984, 12990, 12990, 12995, 12995, 13009, 13009, 13027, 13027, 13137, 13137, 13141, 13141, 13143, 13143, 13146, 13146, 13183, 13183, 13188, 13188, 13202, 13202, 13206, 13206, 13208, 13208, 13211, 13211, 13216, 13216, 19191, 19191, 19195, 19195, 19199, 19199
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7073-7400
+- Def site: line 7076-7403
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -529,11 +515,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7175, 7175, 8391, 8872, 8891, 8992, 9121, 9144, 9816, 10124, 10169, 10583, 11353, 11364, 11427, 11844
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7178, 7178, 8394, 8875, 8894, 8995, 9124, 9147, 9819, 10127, 10172, 10586, 11356, 11367, 11430, 11847
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14704-15031
+- Def site: line 14707-15034
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -543,13 +529,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12161, 12161, 12220, 12220, 12221, 12221, 13385, 14745, 14745, 14747, 14747, 14753, 14753, 14767, 14767, 14806, 14806, 14809, 14809, 14811, 14811, 14812, 14812, 14813, 14813, 14867, 14867, 14868, 14868, 14879, 14879, 14888, 14888, 14907, 14907, 14959, 14959, 14963, 14963, 14971, 14971, 14972, 14972, 14996, 14996, 15000, 15000
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12164, 12164, 12223, 12223, 12224, 12224, 13388, 14748, 14748, 14750, 14750, 14756, 14756, 14770, 14770, 14809, 14809, 14812, 14812, 14814, 14814, 14815, 14815, 14816, 14816, 14870, 14870, 14871, 14871, 14882, 14882, 14891, 14891, 14910, 14910, 14962, 14962, 14966, 14966, 14974, 14974, 14975, 14975, 14999, 14999, 15003, 15003
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16088-16376
+- Def site: line 16067-16355
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -559,11 +545,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16116, 16116, 16119, 16119, 16124, 16124, 16127, 16127, 16171, 16171, 16177, 16177, 16208, 16208, 16211, 16211, 16215, 16215, 16241, 16241, 16258, 16258, 16264, 16264, 16278, 16278, 16279, 16279, 16281, 16281, 16287, 16287, 16294, 16294, 16303, 16303, 16350, 16350, 16372, 16372, 16373, 16373, 16374, 16374, 19157, 19157
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16095, 16095, 16098, 16098, 16103, 16103, 16106, 16106, 16150, 16150, 16156, 16156, 16187, 16187, 16190, 16190, 16194, 16194, 16220, 16220, 16237, 16237, 16243, 16243, 16257, 16257, 16258, 16258, 16260, 16260, 16266, 16266, 16273, 16273, 16282, 16282, 16329, 16329, 16351, 16351, 16352, 16352, 16353, 16353, 19136, 19136
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10190-10462
+- Def site: line 10193-10465
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -572,11 +558,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10213, 10213, 10214, 10214, 10227, 10227, 10228, 10228, 10230, 10230, 10231, 10231, 10234, 10234, 10237, 10237, 10241, 10241, 10242, 10242, 10318, 10318, 10322, 10322, 10325, 10325, 10338, 10338, 10375, 10375, 10392, 10392, 10405, 10405, 10407, 10407, 10414, 10414, 10423, 10423, 10432, 10432, 10433, 10433, 10444, 10444, 10448, 10448, 10457, 10457, 10462, 10462, 19414, 19414
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10216, 10216, 10217, 10217, 10230, 10230, 10231, 10231, 10233, 10233, 10234, 10234, 10237, 10237, 10240, 10240, 10244, 10244, 10245, 10245, 10321, 10321, 10325, 10325, 10328, 10328, 10341, 10341, 10378, 10378, 10395, 10395, 10408, 10408, 10410, 10410, 10417, 10417, 10426, 10426, 10435, 10435, 10436, 10436, 10447, 10447, 10451, 10451, 10460, 10460, 10465, 10465, 19393, 19393
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5212-5475
+- Def site: line 5215-5478
 - References: 107
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -584,14 +570,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5252, 5252, 5254, 5254, 5336, 5336, 5342, 5342, 5379, 5379, 5381, 5381, 5390, 5390, 5400, 5400, 5410, 5410, 5446, 5446, 7910, 7910, 9568, 9568, 9569, 9569, 9880, 9880, 10726, 10726, 10746, 10746, 12747, 15153, 15153, 15159, 15159, 15160, 15160, 15161, 15161, 15162, 15162, 15163, 15163, 15164, 15164, 15171, 15171, 15199, 15199, 15571, 15817, 15817, 15835, 15835, 15853, 15853, 15903, 17086, 17122, 17122, 17146, 17146, 17170, 17170, 17314, 17314, 17315, 17315, 17316, 17316, 17317, 17317, 17653, 17653, 18899, 18899, 19451, 19451
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5255, 5255, 5257, 5257, 5339, 5339, 5345, 5345, 5382, 5382, 5384, 5384, 5393, 5393, 5403, 5403, 5413, 5413, 5449, 5449, 7913, 7913, 9571, 9571, 9572, 9572, 9883, 9883, 10729, 10729, 10749, 10749, 12750, 15156, 15156, 15162, 15162, 15163, 15163, 15164, 15164, 15165, 15165, 15166, 15166, 15167, 15167, 15174, 15174, 15202, 15202, 15574, 15820, 15820, 15838, 15838, 15856, 15856, 15882, 17065, 17101, 17101, 17125, 17125, 17149, 17149, 17293, 17293, 17294, 17294, 17295, 17295, 17296, 17296, 17632, 17632, 18878, 18878, 19430, 19430
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 10957-11207
+- Def site: line 10960-11210
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -601,11 +587,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10964, 10964, 10967, 10967, 10972, 10972, 10973, 10973, 10981, 10981, 10984, 10984, 10992, 10992, 11032, 11032, 11040, 11040, 11088, 11088, 11105, 11105, 11108, 11108, 11110, 11110, 11174, 11174, 11175, 11175, 19417, 19417
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10967, 10967, 10970, 10970, 10975, 10975, 10976, 10976, 10984, 10984, 10987, 10987, 10995, 10995, 11035, 11035, 11043, 11043, 11091, 11091, 11108, 11108, 11111, 11111, 11113, 11113, 11177, 11177, 11178, 11178, 19396, 19396
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15283-15527
+- Def site: line 15286-15530
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -615,11 +601,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15149, 15149, 15309, 15309, 15311, 15311, 15312, 15312, 15313, 15313, 15341, 15341, 15346, 15346, 15368, 15368, 15369, 15369, 15411, 15411, 15419, 15419, 15445, 15445, 15454, 15454, 15462, 15462, 15493, 15493, 18988, 18988, 18992, 18992
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15152, 15152, 15312, 15312, 15314, 15314, 15315, 15315, 15316, 15316, 15344, 15344, 15349, 15349, 15371, 15371, 15372, 15372, 15414, 15414, 15422, 15422, 15448, 15448, 15457, 15457, 15465, 15465, 15496, 15496, 18967, 18967, 18971, 18971
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6145-6365
+- Def site: line 6148-6368
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -627,14 +613,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6168, 6168, 6219, 6219, 6289, 6289, 6313, 6313, 6325, 6325, 6327, 6327, 6337, 6337, 6352, 6352, 6356, 6356, 6357, 6357, 6360, 6360, 6362, 6362, 12860, 12860, 15575
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6171, 6171, 6222, 6222, 6292, 6292, 6316, 6316, 6328, 6328, 6330, 6330, 6340, 6340, 6355, 6355, 6359, 6359, 6360, 6360, 6363, 6363, 6365, 6365, 12863, 12863, 15578
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 19501-19714
+- Def site: line 19480-19693
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -643,11 +629,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20357, 20357, 20360, 20441, 20792
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20336, 20336, 20339, 20420, 20771
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7601-7810
+- Def site: line 7604-7813
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -656,11 +642,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7614, 7614, 7620, 7620, 7621, 7621, 7624, 7624, 7647, 7647, 7650, 7650, 7653, 7653, 7654, 7654, 7656, 7656, 7723, 7723, 7767, 7767, 8232, 8232, 13181, 13181, 15678, 15941, 15941, 16101, 16101
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7617, 7617, 7623, 7623, 7624, 7624, 7627, 7627, 7650, 7650, 7653, 7653, 7656, 7656, 7657, 7657, 7659, 7659, 7726, 7726, 7770, 7770, 8235, 8235, 13184, 13184, 15681, 15920, 15920, 16080, 16080
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12479-12681
+- Def site: line 12482-12684
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -669,11 +655,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12500, 12500, 12509, 12509, 12571, 12571, 12578, 12578, 12610, 12610, 12612, 12612, 12636, 12636, 12671, 12671, 12678, 12678, 12709, 12709, 15223, 15223, 19024, 19024, 19026, 19026, 19027, 19027, 19029, 19029
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12503, 12503, 12512, 12512, 12574, 12574, 12581, 12581, 12613, 12613, 12615, 12615, 12639, 12639, 12674, 12674, 12681, 12681, 12712, 12712, 15226, 15226, 19003, 19003, 19005, 19005, 19006, 19006, 19008, 19008
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13732-13919
+- Def site: line 13735-13922
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -683,11 +669,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19374, 19374, 19375, 19375, 19376, 19376, 19377, 19377, 19378, 19378, 19379, 19379, 19380, 19380, 19381, 19381, 19383, 19383, 19384, 19384, 19385, 19385, 19386, 19386, 19387, 19387, 19388, 19388, 19389, 19389, 19391, 19391, 19392, 19392, 19393, 19393, 19394, 19394, 19395, 19395, 19396, 19396, 19397, 19397, 19398, 19398, 19399, 19399, 19401, 19401, 19402, 19402, 19403, 19403, 19404, 19404, 19405, 19405, 19406, 19406, 19407, 19407, 19408, 19408, 19409, 19409, 19411, 19411, 19412, 19412
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19353, 19353, 19354, 19354, 19355, 19355, 19356, 19356, 19357, 19357, 19358, 19358, 19359, 19359, 19360, 19360, 19362, 19362, 19363, 19363, 19364, 19364, 19365, 19365, 19366, 19366, 19367, 19367, 19368, 19368, 19370, 19370, 19371, 19371, 19372, 19372, 19373, 19373, 19374, 19374, 19375, 19375, 19376, 19376, 19377, 19377, 19378, 19378, 19380, 19380, 19381, 19381, 19382, 19382, 19383, 19383, 19384, 19384, 19385, 19385, 19386, 19386, 19387, 19387, 19388, 19388, 19390, 19390, 19391, 19391
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5557-5736
+- Def site: line 5560-5739
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -696,11 +682,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5645, 5645, 5682, 5682, 5684, 5684, 5687, 5687, 5695, 5695, 5697, 5697, 5699, 5699, 5702, 5702, 5731, 5731, 5734, 5734, 19151, 19151
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5648, 5648, 5685, 5685, 5687, 5687, 5690, 5690, 5698, 5698, 5700, 5700, 5702, 5702, 5705, 5705, 5734, 5734, 5737, 5737, 19130, 19130
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6545-6723
+- Def site: line 6548-6726
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -708,11 +694,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6590, 6590, 6628, 6628, 6639, 6639, 6665, 6665, 6666, 6666, 6668, 6668, 6674, 6674, 6675, 6675, 6678, 6678, 6684, 6684, 6685, 6685, 6688, 6688, 6690, 6690, 6700, 6700, 6702, 6702, 6703, 6703, 6705, 6705
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6593, 6593, 6631, 6631, 6642, 6642, 6668, 6668, 6669, 6669, 6671, 6671, 6677, 6677, 6678, 6678, 6681, 6681, 6687, 6687, 6688, 6688, 6691, 6691, 6693, 6693, 6703, 6703, 6705, 6705, 6706, 6706, 6708, 6708
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11437-11604
+- Def site: line 11440-11607
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -721,11 +707,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11544, 11544, 11563, 11563, 11581, 11581, 11590, 11590, 11593, 11593, 11594, 11594, 11597, 11597, 11602, 11602, 11604, 11604, 19052, 19052
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11547, 11547, 11566, 11566, 11584, 11584, 11593, 11593, 11596, 11596, 11597, 11597, 11600, 11600, 11605, 11605, 11607, 11607, 19031, 19031
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11649-11816
+- Def site: line 11652-11819
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -733,11 +719,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11686, 11686, 11688, 11688, 11691, 11691, 11762, 11762, 11764, 11764, 11777, 11777, 11781, 11781, 19055, 19055, 19056, 19056, 19057, 19057, 19095, 19095, 19100, 19100
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11689, 11689, 11691, 11691, 11694, 11694, 11765, 11765, 11767, 11767, 11780, 11780, 11784, 11784, 19034, 19034, 19035, 19035, 19036, 19036, 19074, 19074, 19079, 19079
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10682-10843
+- Def site: line 10685-10846
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -745,11 +731,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10720, 10720, 10727, 10727, 10734, 10734, 10740, 10740, 10747, 10747, 10754, 10754, 10815, 10815, 10826, 10826, 19043, 19043, 19044, 19044, 19046, 19046, 19047, 19047, 19048, 19048
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10723, 10723, 10730, 10730, 10737, 10737, 10743, 10743, 10750, 10750, 10757, 10757, 10818, 10818, 10829, 10829, 19022, 19022, 19023, 19023, 19025, 19025, 19026, 19026, 19027, 19027
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15922-16082
+- Def site: line 15901-16061
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -758,11 +744,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15945, 15945, 15947, 15947, 16016, 16016, 16018, 16018, 16037, 16037, 16039, 16039, 16039, 16055, 16055, 16071, 16071, 16072, 16072, 16078, 16078, 19156, 19156
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15924, 15924, 15926, 15926, 15995, 15995, 15997, 15997, 16016, 16016, 16018, 16018, 16018, 16034, 16034, 16050, 16050, 16051, 16051, 16057, 16057, 19135, 19135
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6373-6530
+- Def site: line 6376-6533
 - References: 201
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -772,7 +758,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5510, 5510, 6389, 6389, 6402, 6402, 6405, 6405, 6429, 6429, 6437, 6437, 6438, 6438, 6460, 6460, 6465, 6465, 6467, 6467, 6540, 6540, 6541, 6541, 6948, 6948, 6973, 6973, 7042, 7042, 7043, 7043, 7372, 7372, 7386, 7386, 7387, 7387, 7872, 7872, 7873, 7873, 8795, 8795, 8960, 9020, 9020, 9022, 9022, 9023, 9023, 9040, 9040, 9041, 9041, 9058, 9058, 9059, 9059, 9079, 9079, 9080, 9080, 9637, 9637, 9638, 9638, 9712, 9712, 9713, 9713, 10041, 10041, 10044, 10044, 10619, 10619, 10620, 10620, 10656, 10656, 10657, 10657, 10836, 10836, 10837, 10837, 11181, 11181, 11182, 11182, 11328, 11328, 11329, 11329, 11411, 11411, 11412, 11412, 11623, 11623, 11798, 11798, 11799, 11799, 11875, 11875, 11876, 11876, 12179, 12179, 12195, 12195, 12196, 12196, 12424, 12424, 12425, 12425, 12504, 12504, 12505, 12505, 12506, 12506, 12542, 12542, 12543, 12543, 12631, 12631, 12632, 12632, 12660, 12660, 12661, 12661, 12698, 12698, 12699, 12699, 12751, 12820, 12820, 12821, 12821, 12863, 12863, 12864, 12864, 13032, 13032, 13033, 13033, 13157, 13157, 13158, 13158, 13381, 13553, 13553, 14605, 14605, 15512, 15512, 15513, 15513, 15574, 15682, 17175, 17175, 17176, 17176, 18056, 18056
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5513, 5513, 6392, 6392, 6405, 6405, 6408, 6408, 6432, 6432, 6440, 6440, 6441, 6441, 6463, 6463, 6468, 6468, 6470, 6470, 6543, 6543, 6544, 6544, 6951, 6951, 6976, 6976, 7045, 7045, 7046, 7046, 7375, 7375, 7389, 7389, 7390, 7390, 7875, 7875, 7876, 7876, 8798, 8798, 8963, 9023, 9023, 9025, 9025, 9026, 9026, 9043, 9043, 9044, 9044, 9061, 9061, 9062, 9062, 9082, 9082, 9083, 9083, 9640, 9640, 9641, 9641, 9715, 9715, 9716, 9716, 10044, 10044, 10047, 10047, 10622, 10622, 10623, 10623, 10659, 10659, 10660, 10660, 10839, 10839, 10840, 10840, 11184, 11184, 11185, 11185, 11331, 11331, 11332, 11332, 11414, 11414, 11415, 11415, 11626, 11626, 11801, 11801, 11802, 11802, 11878, 11878, 11879, 11879, 12182, 12182, 12198, 12198, 12199, 12199, 12427, 12427, 12428, 12428, 12507, 12507, 12508, 12508, 12509, 12509, 12545, 12545, 12546, 12546, 12634, 12634, 12635, 12635, 12663, 12663, 12664, 12664, 12701, 12701, 12702, 12702, 12754, 12823, 12823, 12824, 12824, 12866, 12866, 12867, 12867, 13035, 13035, 13036, 13036, 13160, 13160, 13161, 13161, 13384, 13556, 13556, 14608, 14608, 15515, 15515, 15516, 15516, 15577, 15685, 17154, 17154, 17155, 17155, 18035, 18035
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -780,7 +766,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15045-15200
+- Def site: line 15048-15203
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -789,11 +775,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15067, 15067, 15073, 15073, 15075, 15075, 15103, 15103, 15129, 15129, 15132, 15132, 15135, 15135, 19142, 19142, 19146, 19146, 19154, 19154
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15070, 15070, 15076, 15076, 15078, 15078, 15106, 15106, 15132, 15132, 15135, 15135, 15138, 15138, 19121, 19121, 19125, 19125, 19133, 19133
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13216-13361
+- Def site: line 13219-13364
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -801,11 +787,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13255, 13255, 13262, 13262, 13287, 13287, 13290, 13290, 13303, 13303, 13347, 13347, 13351, 13351, 13356, 13356, 13357, 13357, 13361, 13361, 19449, 19449
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13258, 13258, 13265, 13265, 13290, 13290, 13293, 13293, 13306, 13306, 13350, 13350, 13354, 13354, 13359, 13359, 13360, 13360, 13364, 13364, 19428, 19428
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13369-13513
+- Def site: line 13372-13516
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -814,12 +800,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12590, 12590, 12766, 12766, 12844, 12844, 12849, 12849, 13398, 13398, 13404, 13404, 13410, 13410, 13416, 13416, 13422, 13422, 13428, 13428, 13434, 13434, 13440, 13440, 13446, 13446, 13452, 13452, 13458, 13458, 13464, 13464, 13470, 13470, 13476, 13476, 13482, 13482, 13488, 13488, 13494, 13494, 13500, 13500, 13506, 13506, 13512, 13512, 19062, 19062, 19203, 19203, 19205, 19205, 19320, 19320, 19446, 19446, 19447, 19447, 19448, 19448, 19467, 19467, 19468, 19468, 19469, 19469, 19470, 19470, 19471, 19471, 19472, 19472, 19473, 19473
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12593, 12593, 12769, 12769, 12847, 12847, 12852, 12852, 13401, 13401, 13407, 13407, 13413, 13413, 13419, 13419, 13425, 13425, 13431, 13431, 13437, 13437, 13443, 13443, 13449, 13449, 13455, 13455, 13461, 13461, 13467, 13467, 13473, 13473, 13479, 13479, 13485, 13485, 13491, 13491, 13497, 13497, 13503, 13503, 13509, 13509, 13515, 13515, 19041, 19041, 19182, 19182, 19184, 19184, 19299, 19299, 19425, 19425, 19426, 19426, 19427, 19427, 19446, 19446, 19447, 19447, 19448, 19448, 19449, 19449, 19450, 19450, 19451, 19451, 19452, 19452
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10536-10679
+- Def site: line 10539-10682
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -828,11 +814,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10550, 10550, 10551, 10551, 10637, 10637, 10672, 10672, 19037, 19037, 19038, 19038, 19039, 19039, 19040, 19040, 19041, 19041
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10553, 10553, 10554, 10554, 10640, 10640, 10675, 10675, 19016, 19016, 19017, 19017, 19018, 19018, 19019, 19019, 19020, 19020
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13516-13654
+- Def site: line 13519-13657
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -840,11 +826,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13585, 13585, 13588, 13588, 13589, 13589, 13590, 13590, 13610, 13610, 13613, 13613, 13621, 13621, 13626, 13626, 19475, 19475
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13588, 13588, 13591, 13591, 13592, 13592, 13593, 13593, 13613, 13613, 13616, 13616, 13624, 13624, 13629, 13629, 19454, 19454
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8838-8966
+- Def site: line 8841-8969
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -853,11 +839,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8909, 8909, 8920, 8920, 15143, 15143, 15144, 15144, 18940, 18940, 18941, 18941, 19120, 19120
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8912, 8912, 8923, 8923, 15146, 15146, 15147, 15147, 18919, 18919, 18920, 18920, 19099, 19099
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11210-11338
+- Def site: line 11213-11341
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -866,11 +852,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11217, 11217, 11222, 11222, 11223, 11223, 11224, 11224, 11227, 11227, 11228, 11228, 11291, 11291, 11298, 11298, 11325, 11325, 19419, 19419
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11220, 11220, 11225, 11225, 11226, 11226, 11227, 11227, 11230, 11230, 11231, 11231, 11294, 11294, 11301, 11301, 11328, 11328, 19398, 19398
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15668-15794
+- Def site: line 15671-15797
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -879,11 +865,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15688, 15688, 15693, 15693, 15698, 15698, 15735, 15735, 15741, 15741, 15747, 15747, 15753, 15753, 15759, 15759, 15760, 15760, 15761, 15761, 15762, 15762, 15763, 15763, 15767, 15767, 15776, 15776, 15780, 15780, 15783, 15783, 15789, 15789, 19115, 19115
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15691, 15691, 15696, 15696, 15701, 15701, 15738, 15738, 15744, 15744, 15750, 15750, 15756, 15756, 15762, 15762, 15763, 15763, 15764, 15764, 15765, 15765, 15766, 15766, 15770, 15770, 15779, 15779, 15783, 15783, 15786, 15786, 15792, 15792, 19094, 19094
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5790-5914
+- Def site: line 5793-5917
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -892,11 +878,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5811, 5811, 5813, 5813, 5829, 5829, 5841, 5841, 5880, 5880, 5881, 5881, 5882, 5882, 5883, 5883, 5884, 5884, 5895, 5895, 5898, 5898, 6830, 6830, 20454, 20454, 21037, 21037
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5814, 5814, 5816, 5816, 5832, 5832, 5844, 5844, 5883, 5883, 5884, 5884, 5885, 5885, 5886, 5886, 5887, 5887, 5898, 5898, 5901, 5901, 6833, 6833, 20433, 20433, 21016, 21016
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8972-9083
+- Def site: line 8975-9086
 - References: 53
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -904,13 +890,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7910, 7910, 9568, 9568, 9880, 9880, 10726, 10726, 10746, 10746, 12748, 15092, 15092, 15145, 15145, 15578, 15818, 15818, 15836, 15836, 15854, 15854, 17087, 17124, 17124, 17148, 17148, 17172, 17172, 17315, 17315, 17656, 17656, 18981, 18981, 18996, 18996, 19006, 19006, 19006, 19006, 19016, 19016
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7913, 7913, 9571, 9571, 9883, 9883, 10729, 10729, 10749, 10749, 12751, 15095, 15095, 15148, 15148, 15581, 15821, 15821, 15839, 15839, 15857, 15857, 17066, 17103, 17103, 17127, 17127, 17151, 17151, 17294, 17294, 17635, 17635, 18960, 18960, 18975, 18975, 18985, 18985, 18985, 18985, 18995, 18995
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10846-10954
+- Def site: line 10849-10957
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -920,11 +906,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10901, 10901, 10904, 10904, 10905, 10905, 10910, 10910, 10928, 10928, 10928, 10937, 10937, 10937, 10937, 10938, 10938, 10938, 10938, 10996, 10996, 10999, 10999, 11011, 11011, 11012, 11012, 11025, 11025, 11064, 11064, 11072, 11072, 11126, 11126, 11134, 11134
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10904, 10904, 10907, 10907, 10908, 10908, 10913, 10913, 10931, 10931, 10931, 10940, 10940, 10940, 10940, 10941, 10941, 10941, 10941, 10999, 10999, 11002, 11002, 11014, 11014, 11015, 11015, 11028, 11028, 11067, 11067, 11075, 11075, 11129, 11129, 11137, 11137
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12771-12870
+- Def site: line 12774-12873
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -933,11 +919,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12836, 12836, 12838, 12838, 12839, 12839, 18990, 18990, 19058, 19058, 19060, 19060, 19061, 19061
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12839, 12839, 12841, 12841, 12842, 12842, 18969, 18969, 19037, 19037, 19039, 19039, 19040, 19040
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15560-15657
+- Def site: line 15563-15660
 - References: 79
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -946,13 +932,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15303, 15303, 15538, 15538, 15596, 15596, 15602, 15602, 15608, 15608, 15614, 15614, 15620, 15620, 15626, 15626, 15632, 15632, 15638, 15638, 15644, 15644, 15650, 15650, 15656, 15656, 15904, 17088, 17316, 17316, 17319, 17319, 17655, 17655, 18947, 18947, 19014, 19014, 19020, 19020, 19071, 19071, 19128, 19128
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15306, 15306, 15541, 15541, 15599, 15599, 15605, 15605, 15611, 15611, 15617, 15617, 15623, 15623, 15629, 15629, 15635, 15635, 15641, 15641, 15647, 15647, 15653, 15653, 15659, 15659, 15883, 17067, 17295, 17295, 17298, 17298, 17634, 17634, 18926, 18926, 18993, 18993, 18999, 18999, 19050, 19050, 19107, 19107
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8268-8364
+- Def site: line 8271-8367
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -960,11 +946,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8324, 8324, 8360, 8360
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8327, 8327, 8363, 8363
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11341-11434
+- Def site: line 11344-11437
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -973,11 +959,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11393, 11393, 11406, 11406, 19050, 19050, 19092, 19092, 19093, 19093, 19098, 19098, 19099, 19099
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11396, 11396, 11409, 11409, 19029, 19029, 19071, 19071, 19072, 19072, 19077, 19077, 19078, 19078
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5920-6009
+- Def site: line 5923-6012
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -987,13 +973,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6002, 6002, 15366, 15366, 15367, 15367, 15581, 18850, 18850
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6005, 6005, 15369, 15369, 15370, 15370, 15584, 18829, 18829
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12684-12768
+- Def site: line 12687-12771
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1003,11 +989,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12718, 12718, 19025, 19025, 19033, 19033, 19059, 19059, 19204, 19204
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12721, 12721, 19004, 19004, 19012, 19012, 19038, 19038, 19183, 19183
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 18127-18205
+- Def site: line 18106-18184
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1017,12 +1003,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18122, 18122, 18123, 18123, 19299, 19299
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18101, 18101, 18102, 18102, 19278, 19278
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17102-17179
+- Def site: line 17081-17158
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1032,13 +1018,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19170, 19170, 19174, 19174, 19178, 19178
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19149, 19149, 19153, 19153, 19157, 19157
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1884-1957
-- References: 261
+- Def site: line 1887-1960
+- References: 259
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1046,7 +1032,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1897, 1897, 1929, 1929, 2204, 2204, 2293, 2293, 2320, 2320, 7622, 7622, 7708, 7708, 7838, 7838, 7915, 7915, 7998, 7998, 8228, 8228, 8417, 8417, 8473, 8473, 8486, 8486, 8503, 8503, 8548, 8548, 8579, 8579, 8585, 8585, 8688, 8688, 10229, 10229, 10496, 10998, 10998, 11027, 11027, 11292, 11292, 11498, 11498, 11737, 11737, 12453, 12453, 12469, 12469, 13256, 13256, 13675, 13675, 13725, 13725, 15579, 15781, 15781, 15814, 15814, 15832, 15832, 15850, 15850, 15877, 15877, 15902, 17090, 17129, 17129, 17154, 17154, 17197, 17296, 17296, 17508, 17508, 17651, 17651, 17697, 17697, 17787, 17787, 18117, 18117, 18147, 18147, 18168, 18168, 18187, 18187, 18203, 18203, 18220, 18220, 18797, 18797, 18817, 18817, 18852, 18852, 18865, 18865, 19333, 19333, 19424, 19424, 19429, 19429, 19435, 19435, 19454, 19454, 19460, 19460, 21060, 21060, 21158, 21158
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1900, 1900, 1932, 1932, 2207, 2207, 2296, 2296, 2323, 2323, 7625, 7625, 7711, 7711, 7841, 7841, 7918, 7918, 8001, 8001, 8231, 8231, 8420, 8420, 8476, 8476, 8489, 8489, 8506, 8506, 8551, 8551, 8582, 8582, 8588, 8588, 8691, 8691, 10232, 10232, 10499, 11001, 11001, 11030, 11030, 11295, 11295, 11501, 11501, 11740, 11740, 12456, 12456, 12472, 12472, 13259, 13259, 13678, 13678, 13728, 13728, 15582, 15784, 15784, 15817, 15817, 15835, 15835, 15853, 15853, 15881, 17069, 17108, 17108, 17133, 17133, 17176, 17275, 17275, 17487, 17487, 17630, 17630, 17676, 17676, 17766, 17766, 18096, 18096, 18126, 18126, 18147, 18147, 18166, 18166, 18182, 18182, 18199, 18199, 18776, 18776, 18796, 18796, 18831, 18831, 18844, 18844, 19312, 19312, 19403, 19403, 19408, 19408, 19414, 19414, 19433, 19433, 19439, 19439, 21039, 21039, 21137, 21137
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -1067,7 +1053,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15206-15277
+- Def site: line 15209-15280
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1076,11 +1062,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19136, 19136, 19137, 19137, 19138, 19138, 19139, 19139
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19115, 19115, 19116, 19116, 19117, 19117, 19118, 19118
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5481-5550
+- Def site: line 5484-5553
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1090,19 +1076,19 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5513, 5513, 5514, 5514, 5529, 5529, 5531, 5531
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5516, 5516, 5517, 5517, 5532, 5532, 5534, 5534
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 6015-6084
-- References: 191
+- Def site: line 6018-6087
+- References: 189
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6057, 6057, 6062, 6062, 6159, 6159, 6217, 6217, 7108, 7108, 7765, 7765, 8410, 8410, 8433, 8433, 8453, 8453, 8638, 8638, 8659, 8659, 8934, 8934, 8959, 8959, 9014, 9014, 9036, 9036, 9053, 9053, 9070, 9070, 9455, 9455, 9678, 9678, 9695, 9695, 10087, 10087, 10419, 10419, 10630, 10630, 10667, 10667, 10820, 10820, 10963, 10963, 11216, 11216, 11404, 11404, 11588, 11588, 11907, 11907, 12243, 12243, 12415, 12415, 12455, 12455, 12461, 12461, 12555, 12555, 12785, 12785, 12858, 12858, 13345, 13345, 13380, 13579, 13579, 15086, 15086, 15302, 15302, 15570, 15677, 15777, 15777, 15812, 15812, 15830, 15830, 15848, 15848, 15883, 15883, 17085, 17195, 17698, 17698, 17703, 17703, 17705, 17705, 18118, 18118, 18120, 18120, 18144, 18144, 18148, 18148, 18149, 18149, 18169, 18169, 18170, 18170, 18331, 18331, 18901, 18901, 18933, 18933, 18970, 18970, 18976, 18976, 19104, 19104, 19161, 19161, 19244, 19244, 19253, 19253, 19331, 19331, 19332, 19332, 19349, 19349, 19424, 19424, 19429, 19429, 19435, 19435, 19454, 19454, 19460, 19460, 20371, 20371, 20442, 20924, 20924, 21012, 21012
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6060, 6060, 6065, 6065, 6162, 6162, 6220, 6220, 7111, 7111, 7768, 7768, 8413, 8413, 8436, 8436, 8456, 8456, 8641, 8641, 8662, 8662, 8937, 8937, 8962, 8962, 9017, 9017, 9039, 9039, 9056, 9056, 9073, 9073, 9458, 9458, 9681, 9681, 9698, 9698, 10090, 10090, 10422, 10422, 10633, 10633, 10670, 10670, 10823, 10823, 10966, 10966, 11219, 11219, 11407, 11407, 11591, 11591, 11910, 11910, 12246, 12246, 12418, 12418, 12458, 12458, 12464, 12464, 12558, 12558, 12788, 12788, 12861, 12861, 13348, 13348, 13383, 13582, 13582, 15089, 15089, 15305, 15305, 15573, 15680, 15780, 15780, 15815, 15815, 15833, 15833, 15851, 15851, 17064, 17174, 17677, 17677, 17682, 17682, 17684, 17684, 18097, 18097, 18099, 18099, 18123, 18123, 18127, 18127, 18128, 18128, 18148, 18148, 18149, 18149, 18310, 18310, 18880, 18880, 18912, 18912, 18949, 18949, 18955, 18955, 19083, 19083, 19140, 19140, 19223, 19223, 19232, 19232, 19310, 19310, 19311, 19311, 19328, 19328, 19403, 19403, 19408, 19408, 19414, 19414, 19433, 19433, 19439, 19439, 20350, 20350, 20421, 20903, 20903, 20991, 20991
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1112,7 +1098,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10465-10533
+- Def site: line 10468-10536
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1123,11 +1109,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10505, 10505, 10510, 10510, 10515, 10515, 10516, 10516, 10522, 10522, 10523, 10523, 10529, 10529, 10530, 10530, 10531, 10531, 10532, 10532, 19477, 19477
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10508, 10508, 10513, 10513, 10518, 10518, 10519, 10519, 10525, 10525, 10526, 10526, 10532, 10532, 10533, 10533, 10534, 10534, 10535, 10535, 19456, 19456
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 18856-18921
+- Def site: line 18835-18900
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1137,11 +1123,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18904, 18904, 18912, 18912, 18921, 18921, 19450, 19450
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18883, 18883, 18891, 18891, 18900, 18900, 19429, 19429
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15801-15856
+- Def site: line 15804-15859
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1151,11 +1137,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19075, 19075, 19079, 19079, 19284, 19284
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19054, 19054, 19058, 19058, 19263, 19263
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6090-6136
+- Def site: line 6093-6139
 - References: 57
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1164,14 +1150,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6214, 6214, 8100, 8100, 9015, 9015, 9038, 9038, 9525, 9525, 9560, 9560, 9574, 9574, 9697, 9697, 9701, 9701, 10249, 10249, 12559, 12559, 13229, 13229, 13355, 13355, 13387, 13565, 13565, 13601, 13601, 15576, 17699, 17699, 18008, 18008, 18119, 18119, 18150, 18150, 18171, 18171, 19334, 19334, 19350, 19350, 20943, 20943
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6217, 6217, 8103, 8103, 9018, 9018, 9041, 9041, 9528, 9528, 9563, 9563, 9577, 9577, 9700, 9700, 9704, 9704, 10252, 10252, 12562, 12562, 13232, 13232, 13358, 13358, 13390, 13568, 13568, 13604, 13604, 15579, 17678, 17678, 17987, 17987, 18098, 18098, 18129, 18129, 18150, 18150, 19313, 19313, 19329, 19329, 20922, 20922
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5739-5784
-- References: 102
+- Def site: line 5742-5787
+- References: 100
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1179,14 +1165,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5251, 5251, 5293, 5293, 5338, 5338, 5444, 5444, 5459, 5459, 5729, 5729, 5730, 5730, 5774, 5774, 6240, 6240, 7934, 7934, 9225, 9225, 9536, 9536, 9552, 9552, 9881, 9881, 10762, 10762, 10781, 10781, 12750, 15169, 15169, 15572, 15815, 15815, 15833, 15833, 15851, 15851, 15878, 15878, 15905, 16327, 16327, 16367, 16367, 16368, 16368, 16369, 16369, 17089, 17121, 17121, 17145, 17145, 17149, 17149, 17169, 17169, 17196, 17271, 17271, 17305, 17305, 17326, 17326, 17358, 17358, 17420, 17420, 17459, 17459, 17609, 17609, 17654, 17654, 17700, 17700
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5254, 5254, 5296, 5296, 5341, 5341, 5447, 5447, 5462, 5462, 5732, 5732, 5733, 5733, 5777, 5777, 6243, 6243, 7937, 7937, 9228, 9228, 9539, 9539, 9555, 9555, 9884, 9884, 10765, 10765, 10784, 10784, 12753, 15172, 15172, 15575, 15818, 15818, 15836, 15836, 15854, 15854, 15884, 16306, 16306, 16346, 16346, 16347, 16347, 16348, 16348, 17068, 17100, 17100, 17124, 17124, 17128, 17128, 17148, 17148, 17175, 17250, 17250, 17284, 17284, 17305, 17305, 17337, 17337, 17399, 17399, 17438, 17438, 17588, 17588, 17633, 17633, 17679, 17679
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17185-17227
+- Def site: line 17164-17206
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1195,11 +1181,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17208, 17208, 17214, 17214, 17220, 17220, 17226, 17226, 19268, 19268, 19272, 19272, 19276, 19276, 19280, 19280
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17187, 17187, 17193, 17193, 17199, 17199, 17205, 17205, 19247, 19247, 19251, 19251, 19255, 19255, 19259, 19259
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11607-11646
+- Def site: line 11610-11649
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1208,11 +1194,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11644, 11644, 19474, 19474
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11647, 11647, 19453, 19453
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1848-1876
+- Def site: line 1851-1879
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1221,12 +1207,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8888, 8888, 8889, 8889, 8918, 8918, 8919, 8919, 8935, 8935, 8936, 8936, 9814, 9814, 9815, 9815, 10119, 10119, 10120, 10120, 10167, 10167, 10168, 10168, 10723, 10723, 10725, 10725, 10743, 10743, 10745, 10745, 11633, 11633, 11634, 11634, 12294, 12294, 12295, 12295, 12400, 12400, 12401, 12401, 13383
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8891, 8891, 8892, 8892, 8921, 8921, 8922, 8922, 8938, 8938, 8939, 8939, 9817, 9817, 9818, 9818, 10122, 10122, 10123, 10123, 10170, 10170, 10171, 10171, 10726, 10726, 10728, 10728, 10746, 10746, 10748, 10748, 11636, 11636, 11637, 11637, 12297, 12297, 12298, 12298, 12403, 12403, 12404, 12404, 13386
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15530-15557
+- Def site: line 15533-15560
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1235,12 +1221,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15544, 15544, 15550, 15550, 15556, 15556, 19182, 19182, 19186, 19186
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15547, 15547, 15553, 15553, 15559, 15559, 19161, 19161, 19165, 19165
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15891-15916
+- Def site: line 15870-15895
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1250,12 +1236,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15911, 15911, 15916, 15916, 19190, 19190, 19195, 19195
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15890, 15890, 15895, 15895, 19169, 19169, 19174, 19174
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2112-2136
+- Def site: line 2115-2139
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1263,11 +1249,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2198, 2257, 17816, 20767
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2201, 2260, 17795, 20746
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13682-13703
+- Def site: line 13685-13706
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1276,7 +1262,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18956, 18956, 18960, 18960, 18964, 18964
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18935, 18935, 18939, 18939, 18943, 18943
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1286,17 +1272,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17637-17658
+- Def site: line 17616-17637
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17702, 17702, 19103, 19103, 19160, 19160, 19243, 19243, 19252, 19252
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17681, 17681, 19082, 19082, 19139, 19139, 19222, 19222, 19231, 19231
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 18103-18124
+- Def site: line 18082-18103
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1305,24 +1291,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19313, 19313
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19292, 19292
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7572-7592
+- Def site: line 7575-7595
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6323, 10092, 15415, 15580
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6326, 10095, 15418, 15583
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13928-13937
+- Def site: line 13931-13940
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1330,11 +1316,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13964, 14100, 14177, 14196, 14208, 14229, 14242, 14253, 14259, 14272, 14365, 14500, 14595
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13967, 14103, 14180, 14199, 14211, 14232, 14245, 14256, 14262, 14275, 14368, 14503, 14598
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 300-308
+- Def site: line 303-311
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1350,7 +1336,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 327-335
+- Def site: line 330-338
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1358,12 +1344,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15238, 15255, 15271
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15241, 15258, 15274
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 312-319
+- Def site: line 315-322
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1379,7 +1365,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 287-289
+- Def site: line 290-292
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1387,12 +1373,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13388, 13677, 18152, 18173, 18318, 18349, 18381, 18616, 18631
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13391, 13680, 18131, 18152, 18297, 18328, 18360, 18595, 18610
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 615-617
+- Def site: line 618-620
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1400,7 +1386,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1225, 1894, 1894, 1894, 1906, 1912, 6216, 6336, 7396, 7456, 9624, 9735, 9989, 10819, 13390, 15448, 15490, 15588, 19336
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1228, 1897, 1897, 1897, 1909, 1915, 6219, 6339, 7399, 7459, 9627, 9738, 9992, 10822, 13393, 15451, 15493, 15591, 19315
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1413,7 +1399,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 1996-1998
+- Def site: line 1999-2001
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1422,11 +1408,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1996, 7406, 7413, 7414, 10000, 15437
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1999, 7409, 7416, 7417, 10003, 15440
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2014-2016
+- Def site: line 2017-2019
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1435,7 +1421,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2014, 15584, 17093
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2017, 15587, 17072
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1443,7 +1429,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 731-1735
+- Def site: line 734-1738
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1451,7 +1437,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1780
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1783
 
 ## Limitations
 

--- a/src/refactors/device_config_template_cloner_manager.py
+++ b/src/refactors/device_config_template_cloner_manager.py
@@ -1,0 +1,68 @@
+"""DeviceConfigTemplateClonerManager adapter extracted from MistHelper.
+
+Thin adapter around ``src.gateway.device_template_cloner`` that wires
+runtime dependencies (API session, input wrapper, path/data helpers,
+config utils) into the extracted implementation. Originally defined
+inline in MistHelper.py; hoisted here per initiative 1011 to shrink the
+monolith.
+
+Runtime dependencies (``apisession``, ``InputUtils``, ``FilePathUtils``,
+``DataExporter``, ``ConfigUtils``) still live inside MistHelper.py and
+are resolved lazily via the ``_MH`` module-level proxy so this module
+keeps its import graph flat and honours any test monkey-patches applied
+at runtime.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import importlib  # Late-import MistHelper to avoid circular src<->MistHelper dependency
+import logging  # Structured action logging required by Constitution VII
+from typing import Any  # Loose typing for late-bound MistHelper attributes
+
+
+class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
+    """Forward attribute access to the currently-loaded MistHelper module."""
+
+    def __getattr__(self, name: str) -> Any:  # Called only when the attribute is not found normally
+        """Resolve name against the live MistHelper module (call-time lookup)."""
+        misthelper_module = importlib.import_module("MistHelper")  # Lazy import at call time
+        return getattr(misthelper_module, name)  # Fetch the current bound value from MistHelper
+
+
+_MH = _MistHelperProxy()  # Sole module-level proxy handle used inside the class body
+
+
+class DeviceConfigTemplateClonerManager:  # Device config template cloner.
+    """Menu 194: Clone device local config to a new gateway template.
+
+    Delegated to ``src.gateway.device_template_cloner``.
+    """
+
+    @staticmethod
+    def clone() -> None:  # Clone a config.
+        """Menu 194: Fetch gateway device config and create a new org-level gateway template."""
+        logging.info("Starting DeviceConfigTemplateClonerManager.clone workflow")  # Trace entry per Constitution VII
+        from src.gateway.device_template_cloner import (  # pylint: disable=import-outside-toplevel
+            DeviceConfigTemplateClonerManager as Impl,  # Import extracted implementation class
+        )
+        from src.gateway.device_template_cloner import (
+            DeviceTemplateClonerDeps,  # Frozen deps bundle groups injected dependencies
+        )
+
+        deps = DeviceTemplateClonerDeps(  # Bundle the 5 injected dependencies for the manager
+            apisession=_MH.apisession,  # Pass authenticated global API session via _MH proxy
+            input_fn=_MH.InputUtils.safe_input,  # Pass EOF-safe input wrapper for SSH/container contexts
+            get_csv_path_fn=_MH.FilePathUtils.get_csv_path,  # Pass path builder for OS-safe output paths
+            save_data_fn=_MH.DataExporter.write_with_format_selection,  # Pass CSV writer for persistence
+            write_csv_fn=_MH.DataExporter.write_with_format_selection,  # Pass PK-aware format-selecting writer
+        )
+        logging.debug("DeviceTemplateClonerDeps bundle constructed")  # Trace successful deps build
+
+        org_id = _MH.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org_id from cache or prompt user
+        logging.info("Resolved org_id=%s for template cloning", org_id)  # Trace resolved org context
+
+        Impl(
+            org_id=org_id,  # Pass resolved org_id to the impl constructor
+            deps=deps,  # Inject the frozen deps bundle
+        ).clone()  # Delegate all business logic to extracted implementation
+        logging.debug("DeviceConfigTemplateClonerManager.clone workflow finished")  # Trace completion


### PR DESCRIPTION
## Summary
- Hoist the 27-line inline ``DeviceConfigTemplateClonerManager`` class body out of ``MistHelper.py`` into a new ``src/refactors/device_config_template_cloner_manager.py`` module per initiative 1011 (Low-Use extractions).
- Extracted module uses the ``_MistHelperProxy`` late-binding pattern (matches ``inventory_csvcomparator.py``, ``device_data_fetcher.py``, ``anomaly_metrics_discovery.py``) so runtime dependencies (``apisession``, ``InputUtils``, ``FilePathUtils``, ``DataExporter``, ``ConfigUtils``) resolve lazily from the currently-loaded MistHelper module.
- Constitution VII action logging (``logging.info`` before, ``logging.debug`` after) added around the ``clone()`` workflow at entry, deps-bundle build, org-id resolution, and exit.
- ``DeviceConfigTemplateClonerManager`` imported at the top of ``MistHelper.py`` so the existing menu 194 callsite (``19468``) continues to resolve unchanged.
- ``refactor_candidates.md`` refreshed; the class no longer appears as a low-use candidate (module graph now 189 first-party files, 94 definitions analyzed).

## Compliance
- FR-003 (no wrapper shim): class body deleted; only the top-level import remains inside MistHelper.py.
- FR-005 (class-body landing): all logic hoisted intact into the extracted class body.
- FR-006 (atomic callsite rewrite): import + delete + callsite path resolution changes ship in a single commit.

## Test plan
- [x] ``python -m black --check MistHelper.py src/refactors/device_config_template_cloner_manager.py`` clean
- [x] ``python -m ruff check MistHelper.py src/refactors/device_config_template_cloner_manager.py`` clean
- [x] ``python -m pydocstyle src/refactors/device_config_template_cloner_manager.py`` clean
- [x] ``python -m mypy --strict src/refactors/device_config_template_cloner_manager.py`` No issues
- [x] Smoke import: ``python -c "import MistHelper; ..."`` resolves ``DeviceConfigTemplateClonerManager`` to the new module.
- [ ] CI: 15/15 green