### PR TITLE
refactor(1011): extract WANProbeDeviceOverrideManager to src/refactors (SC-021)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -171,6 +171,9 @@ from src.refactors.switch_to_interactive_login import (
 )
 from src.refactors.tui_launcher import TUILauncher  # Extracted TUI launcher (SC-004)
 from src.refactors.wan2_migration_launcher import WAN2MigrationLauncher  # Extracted WAN2 migration launcher (SC-009)
+from src.refactors.wan_probe_device_override_manager import (
+    WANProbeDeviceOverrideManager,  # Extracted WAN probe device override manager (SC-021)
+)
 from src.refactors.wanprobe_config_manager import (
     WANProbeConfigManager,  # Extracted WAN probe config manager (SC-015)
 )
@@ -17043,36 +17046,6 @@ class OrgConfigMigrationManager:  # Org config migration manager.
             print(f"    Skipped:      {len(skipped)}")  # Show skipped count.
         if failed:  # Show failed count
             print(f"    Failed:       {len(failed)}")  # Show failed count.
-
-
-# ============================================================================
-# WAN PROBE DEVICE OVERRIDE MANAGER CLASS (delegated)
-# ============================================================================
-
-
-class WANProbeDeviceOverrideManager:  # WAN probe device override.
-    """Delegation wrapper for extracted WAN probe device override manager implementation."""
-
-    @classmethod
-    def configure(cls, dry_run: bool = False) -> None:  # Configure entry point.
-        """Menu #167 delegated entrypoint."""
-        from src.gateway import wan_probe_device_override_manager as wan_probe_module  # noqa: PLC0415,I001
-
-        wan_probe_module.configure_wan_probe_device_override_dependencies(  # Wire dependencies.
-            wan_probe_module.WANProbeDeviceOverrideDependencies(  # Frozen dependency bundle.
-                apisession=apisession,
-                config_utils=ConfigUtils,
-                cache_utils=CacheUtils,
-                org_site_exporter=OrgSiteExporter,
-                gateway_export_utils=GatewayExportUtils,
-                file_path_utils=FilePathUtils,
-                input_utils=InputUtils,
-                data_exporter=DataExporter,
-                mistapi=mistapi,
-                site_exclude_prefix=MIST_SITE_EXCLUDE_PREFIX,
-            )
-        )
-        return wan_probe_module.WANProbeDeviceOverrideManager.configure(dry_run=dry_run)  # Delegate the config.
 
 
 # ============================================================================

--- a/src/refactors/wan_probe_device_override_manager.py
+++ b/src/refactors/wan_probe_device_override_manager.py
@@ -1,0 +1,58 @@
+"""WANProbeDeviceOverrideManager extracted from MistHelper (SC-021 / initiative 1011).
+
+Owns Menu #167 orchestration originally defined as the top-level
+`WANProbeDeviceOverrideManager` class in MistHelper.py, and folds in the
+dependency-wiring that used to live in the MistHelper delegation wrapper.
+
+The heavy implementation continues to live in
+`src/gateway/wan_probe_device_override_manager.py`; this refactor module
+is the thin orchestration seam that wires MistHelper globals into that
+implementation. Wiring targets (apisession, ConfigUtils, CacheUtils,
+OrgSiteExporter, GatewayExportUtils, FilePathUtils, InputUtils,
+DataExporter, mistapi, MIST_SITE_EXCLUDE_PREFIX) are resolved lazily via
+the `_MH` proxy so live re-bindings after interactive login and test
+monkeypatching are always honoured. No wrapper shim remains in
+MistHelper.py after this extraction.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
+from typing import Any  # Loose typing for late-bound MistHelper attributes
+
+from src.gateway import wan_probe_device_override_manager as _wan_probe_module  # Heavy Menu #167 impl
+
+
+class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
+    """Forward attribute access to the currently-loaded MistHelper module."""
+
+    def __getattr__(self, name: str) -> Any:  # Called only when the attribute is not found normally
+        """Resolve name against the live MistHelper module (call-time lookup)."""
+        misthelper_module = importlib.import_module("MistHelper")  # Lazy import at call time
+        return getattr(misthelper_module, name)  # Fetch the current bound value from MistHelper
+
+
+_MH = _MistHelperProxy()  # Sole module-level proxy handle used inside the class body
+
+
+class WANProbeDeviceOverrideManager:  # Menu #167 orchestration seam
+    """Menu #167 orchestration seam for device-level WAN probe overrides."""
+
+    @classmethod
+    def configure(cls, dry_run: bool = False) -> None:  # Menu #167 entrypoint
+        """Wire MistHelper globals into the gateway impl and dispatch Menu #167."""
+        _wan_probe_module.configure_wan_probe_device_override_dependencies(  # Wire deps into impl
+            _wan_probe_module.WANProbeDeviceOverrideDependencies(  # Frozen dependency bundle
+                apisession=_MH.apisession,  # Authenticated Mist API session handle
+                config_utils=_MH.ConfigUtils,  # Org id + stop-signal helpers
+                cache_utils=_MH.CacheUtils,  # CSV cache generator
+                org_site_exporter=_MH.OrgSiteExporter,  # Org-scoped site exporter
+                gateway_export_utils=_MH.GatewayExportUtils,  # Gateway template exporter
+                file_path_utils=_MH.FilePathUtils,  # CSV cache path resolver
+                input_utils=_MH.InputUtils,  # safe_input wrapper for operator prompts
+                data_exporter=_MH.DataExporter,  # Report writer with format selection
+                mistapi=_MH.mistapi,  # Mist REST client library reference
+                site_exclude_prefix=_MH.MIST_SITE_EXCLUDE_PREFIX,  # Exclude lab/test site prefix
+            )
+        )
+        return _wan_probe_module.WANProbeDeviceOverrideManager.configure(dry_run=dry_run)  # Delegate the config


### PR DESCRIPTION
## Summary
- Extracts `WANProbeDeviceOverrideManager` (~23 LoC) from `MistHelper.py` to a new `src/refactors/wan_probe_device_override_manager.py` module using the `_MistHelperProxy` lazy-attribute pattern established by SC-015.
- Folds the dependency-wiring (previously in `MistHelper.py`'s delegation wrapper) into the extracted module; **no wrapper shim remains** in `MistHelper.py` (FR-003 compliant).
- Heavy Menu #167 implementation continues to live in `src/gateway/wan_probe_device_override_manager.py`; only the orchestration seam moved.

## Scope
- **New file**: `src/refactors/wan_probe_device_override_manager.py` (A+/100, 58 LoC).
- **MistHelper.py**: removed 28-line delegation wrapper class; added 3-line import block.
- **Callsites rewritten in the same commit**: lambda at MistHelper.py:19244 now resolves through the imported class (no code change to the lambda itself — just the binding source).

## Compliance
- New module: **A+/100** (0 violations).
- `MistHelper.py` baseline: **96.0/A** — unchanged (drift-neutral).
- No `--admin` bypass planned. Will merge only when `mergeStateStatus:CLEAN`.

## Local gates
- `python -m black`, `python -m ruff check --fix` — clean
- `python -m py_compile` — OK
- `python -m mypy --strict src/refactors/wan_probe_device_override_manager.py` — no issues
- `pytest tests/unit/gateway/test_wan_probe_device_override_manager.py tests/integration/test_runtime_coupling.py` — 16 passed
- `import MistHelper; MistHelper.WANProbeDeviceOverrideManager` resolves to `src.refactors.wan_probe_device_override_manager.WANProbeDeviceOverrideManager` (wrapper gone)

## Refs
- Initiative: `specs/1011-misthelper-refactor-low-use/`
- Task block: PR-21 (T085-T095) in `tasks.md`