### PR TITLE
refactor(1011): fold BulkAPFirmwareUpgrader into FirmwareManager (SC-022)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -17625,38 +17625,9 @@ class FirmwareManager:
 # now call FirmwareManager class methods directly.
 
 
-class BulkAPFirmwareUpgrader:
-    """Thin wrapper that delegates to src.firmware.bulk_ap_upgrader."""
-
-    def __init__(self, org_id, sites_override=None, dry_run=False):
-        """Initialize the bulk AP firmware upgrader."""
-        self.org_id = org_id
-        self.sites_override = sites_override
-        self.dry_run = dry_run
-
-    def execute(self):
-        """Execute - delegates to extracted module."""
-        # WHY: local import keeps MistHelper import cheap for menus that never touch bulk-AP
-        from src.firmware.bulk_ap_upgrader import BulkAPFirmwareUpgrader as _Impl
-        from src.firmware.bulk_ap_upgrader import BulkAPUpgraderConfig
-
-        # WHY: build immutable config once from wrapper state + globals per FR-004
-        config = BulkAPUpgraderConfig(
-            org_id=self.org_id,  # WHY: propagate the org id captured at wrapper construction
-            apisession=apisession,  # WHY: ambient session used by menu 195
-            sites_override=self.sites_override,  # WHY: pre-selected sites bypass interactive prompt
-            dry_run=self.dry_run,  # WHY: dry-run flag flows through unchanged
-            safe_input_fn=InputUtils.safe_input,  # WHY: preserves Ctrl+C / stop-signal behavior
-            check_stop_fn=ConfigUtils.check_stop_signal,  # WHY: polled between long steps to abort
-            fetch_sites_fn=APICoreFetchUtils.all_sites_with_limit,  # WHY: cache-aware site fetch
-            get_csv_path_fn=FilePathUtils.get_csv_path,  # WHY: OS-safe CSV path resolution
-            # WHY: lazy so we resolve org_id at the moment of use
-            check_firmware_status_fn=lambda: FirmwareManager.create(
-                apisession, ConfigUtils.get_cached_or_prompted_org_id()
-            ).check_firmware_upgrade_status(),
-            get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id,  # WHY: seam so upgrader can re-prompt
-        )
-        _Impl(config).execute()  # WHY: single-arg constructor call per contracts/constructor.md
+# NOTE: BulkAPFirmwareUpgrader wrapper removed - folded into
+# src/firmware/firmware_manager.py::FirmwareManager._dispatch_bulk_ap_upgrade
+# per initiative 1011 SC-022 (FR-015 fold-in eliminates wrapper shim).
 
 
 # NOTE: bulk_upgrade_ap_firmware_by_site_impl removed - use BulkAPFirmwareUpgrader class directly

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 189 first-party files
-- Definitions analyzed: 94
+- Module graph size: 190 first-party files
+- Definitions analyzed: 93
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=13, hot=80, skipped=1
+- Category counts: unused=0, single-use=0, low-use=12, hot=80, skipped=1
 
 ## How to read this report
 
@@ -46,13 +46,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `OrgDeviceStatsExporter` | class | 414 | 58 | hot |  | oversize_25_lines,missing_inline_comments |
 | `DeviceRebootManager` | class | 398 | 46 | hot |  | oversize_25_lines,missing_inline_comments |
 | `MSPInventoryExporter` | class | 388 | 5 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
-| `DataExporter` | class | 345 | 251 | hot |  | oversize_25_lines,non_ascii_logs |
+| `DataExporter` | class | 345 | 250 | hot |  | oversize_25_lines,non_ascii_logs |
 | `SiteAnomalyExporter` | class | 341 | 54 | hot |  | oversize_25_lines,non_ascii_logs |
 | `APIDataFetcher` | class | 328 | 16 | hot |  | oversize_25_lines |
 | `InsightMetricsUtils` | class | 328 | 51 | hot |  | oversize_25_lines,non_ascii_logs,hardcoded_separator |
 | `ARPCommandManager` | class | 289 | 46 | hot |  | oversize_25_lines,non_ascii_logs,hardcoded_separator |
 | `OfflineDeviceReporter` | class | 273 | 54 | hot |  | oversize_25_lines,missing_inline_comments |
-| `CacheUtils` | class | 264 | 107 | hot |  | oversize_25_lines |
+| `CacheUtils` | class | 264 | 106 | hot |  | oversize_25_lines |
 | `GlobalWiredClientReportGenerator` | class | 251 | 32 | hot |  | oversize_25_lines,non_ascii_logs,hardcoded_separator |
 | `GatewayTestExporter` | class | 245 | 34 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `APIFetchUtils` | class | 221 | 36 | hot |  | oversize_25_lines |
@@ -76,25 +76,25 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `WiredClientManufacturerReportGenerator` | class | 129 | 20 | hot |  | oversize_25_lines,non_ascii_logs |
 | `TroubleshootUtils` | class | 127 | 36 | hot |  | oversize_25_lines,non_ascii_logs |
 | `EnvironmentUtils` | class | 125 | 28 | hot |  | oversize_25_lines,hardcoded_separator |
-| `OrgSiteExporter` | class | 112 | 53 | hot |  | oversize_25_lines |
+| `OrgSiteExporter` | class | 112 | 52 | hot |  | oversize_25_lines |
 | `FilterOperatorEngine` | class | 109 | 37 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `SiteConfigExporter` | class | 100 | 14 | hot |  | oversize_25_lines,non_ascii_logs |
-| `GatewayExportUtils` | class | 98 | 79 | hot |  | oversize_25_lines,missing_action_logging |
+| `GatewayExportUtils` | class | 98 | 78 | hot |  | oversize_25_lines,missing_action_logging |
 | `DeviceUtils` | class | 97 | 4 | hot |  | oversize_25_lines |
 | `OrgAdminExporter` | class | 94 | 14 | hot |  | oversize_25_lines,hardcoded_separator |
 | `ValidationUtils` | class | 90 | 15 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `SiteClientExporter` | class | 85 | 10 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `OrgLevelAPFirmwareUpgrader` | class | 79 | 33 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `VirtualChassisManager` | class | 78 | 104 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
-| `InputUtils` | class | 74 | 259 | hot |  | oversize_25_lines,raw_input_call |
+| `InputUtils` | class | 74 | 258 | hot |  | oversize_25_lines,raw_input_call |
 | `InteractiveDisplayUtils` | class | 72 | 8 | hot |  | oversize_25_lines,missing_inline_comments |
 | `DisplayUtils` | class | 70 | 8 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
-| `ConfigUtils` | class | 70 | 189 | hot |  | oversize_25_lines |
+| `ConfigUtils` | class | 70 | 188 | hot |  | oversize_25_lines |
 | `OrgDeviceInventorySummary` | class | 69 | 22 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging,non_ascii_logs |
 | `AuditAnalysisOps` | class | 66 | 8 | hot |  | oversize_25_lines,missing_inline_comments,raw_input_call |
 | `GatewayTemplateConfigManager` | class | 56 | 6 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `APICoreFetchUtils` | class | 47 | 57 | hot |  | oversize_25_lines,missing_inline_comments |
-| `FilePathUtils` | class | 46 | 100 | hot |  | oversize_25_lines,missing_inline_comments |
+| `FilePathUtils` | class | 46 | 99 | hot |  | oversize_25_lines,missing_inline_comments |
 | `SiteConfigManager` | class | 43 | 16 | hot |  | oversize_25_lines,missing_action_logging |
 | `SelfExportUtils` | class | 40 | 4 | hot |  | oversize_25_lines,non_ascii_logs |
 | `BulkAPFirmwareUpgrader` | class | 32 | 2 | low-use | FirmwareManager | oversize_25_lines,missing_inline_comments,missing_action_logging |
@@ -102,7 +102,6 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `GatewayStatsExporter` | class | 28 | 52 | hot |  | oversize_25_lines,missing_action_logging |
 | `SSHRunnerManager` | class | 26 | 82 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `detect_msp_privileges` | function | 25 | 4 | hot |  | missing_action_logging |
-| `WANProbeDeviceOverrideManager` | class | 23 | 2 | low-use | WANProbeDeviceOverrideManager | missing_inline_comments,missing_action_logging |
 | `RoutingUtils` | class | 22 | 12 | hot |  | missing_inline_comments,missing_action_logging |
 | `FirmwareManager` | class | 22 | 10 | hot |  |  |
 | `SiteAutoUpgradeConfigurator` | class | 22 | 6 | hot |  | missing_inline_comments,missing_action_logging |
@@ -111,7 +110,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `initialize_mist_session_interactive` | function | 18 | 3 | low-use | InitializeMistSessionInteractiveManager | missing_action_logging |
 | `initialize_mist_session` | function | 18 | 2 | low-use | InitializeMistSessionManager | missing_action_logging |
 | `PACKAGE_IMPORT_MAP` | assignment | 13 | 2 | low-use | PackageImportMapManager | missing_action_logging |
-| `main` | function | 12 | 2 | low-use | MapsManager |  |
+| `main` | function | 12 | 2 | low-use | MainManager |  |
 | `EndpointConfig` | class | 10 | 13 | hot |  | missing_action_logging |
 | `SSHConnectionConfig` | class | 9 | 6 | hot |  | missing_action_logging |
 | `DeviceFetchConfig` | class | 9 | 4 | hot |  | missing_action_logging |
@@ -125,13 +124,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | assignment | 3 | 6 | hot |  | missing_inline_comments,missing_action_logging |
 | `FAST_MODE_USE_CONNECTION_AWARE_THREADING` | assignment | 3 | 2 | low-use | FastModeUseConnectionAwareThreadingManager | missing_action_logging |
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
-| `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 12 | hot |  | missing_inline_comments,missing_action_logging |
+| `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 11 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (13)
+## Low-Use (12)
 
 ### `BulkAPFirmwareUpgrader` (class, 32 lines)
 
-- Def site: line 17655-17686
+- Def site: line 17628-17659
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -143,22 +142,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Reference sites (one PR cluster per file):
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1755, 1758
 
-### `WANProbeDeviceOverrideManager` (class, 23 lines)
-
-- Def site: line 17053-17075
-- References: 2
-- Suggested class: `WANProbeDeviceOverrideManager`
-- Suggested module: `src/refactors/wanprobe_device_override_manager.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py; extract `WANProbeDeviceOverrideManager` OUT of the entrypoint into a new `src/refactors/wanprobe_device_override_manager.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] missing_inline_comments
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19271, 19271
-
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 18187-18205
+- Def site: line 18160-18178
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -171,7 +157,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `initialize_mist_session_interactive` (function, 18 lines)
 
-- Def site: line 2195-2212
+- Def site: line 2198-2215
 - References: 3
 - Suggested class: `InitializeMistSessionInteractiveManager`
 - Suggested module: `src/refactors/initialize_mist_session_interactive.py`
@@ -179,11 +165,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2255, 17790, 20737
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2258, 17763, 20710
 
 ### `initialize_mist_session` (function, 18 lines)
 
-- Def site: line 2821-2838
+- Def site: line 2824-2841
 - References: 2
 - Suggested class: `InitializeMistSessionManager`
 - Suggested module: `src/refactors/initialize_mist_session.py`
@@ -191,11 +177,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20742, 20805
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20715, 20778
 
 ### `PACKAGE_IMPORT_MAP` (assignment, 13 lines)
 
-- Def site: line 372-384
+- Def site: line 375-387
 - References: 2
 - Suggested class: `PackageImportMapManager`
 - Suggested module: `src/refactors/package__import__map.py`
@@ -203,22 +189,22 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 372, 556
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 375, 559
 
 ### `main` (function, 12 lines)
 
-- Def site: line 21133-21144
+- Def site: line 21106-21117
 - References: 2
-- Suggested class: `MapsManager`
-- Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`
-- Rationale: 97 caller files detected; group callers under a shared class in `maps_manager.py` and rewrite references per file cluster
+- Suggested class: `MainManager`
+- Suggested module: `src/refactors/main.py`
+- Rationale: low-use: sole caller lives inside MistHelper.py; extract `main` OUT of the entrypoint into a new `src/refactors/main.py` module and rewrite the callsite(s) to import from there
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21247
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21220
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
 
 ### `marvis_data_utils` (assignment, 4 lines)
 
-- Def site: line 6542-6545
+- Def site: line 6545-6548
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
@@ -226,12 +212,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6542, 15684
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6545, 15687
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\marvis_troubleshoot_utils.py`: lines 21
 
 ### `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 lines)
 
-- Def site: line 1987-1989
+- Def site: line 1990-1992
 - References: 3
 - Suggested class: `FastModeBackoffMultiplierManager`
 - Suggested module: `src/refactors/fast__mode__backoff__multiplier.py`
@@ -240,11 +226,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1987, 9928, 15357
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1990, 9931, 15360
 
 ### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
 
-- Def site: line 1990-1992
+- Def site: line 1993-1995
 - References: 2
 - Suggested class: `FastModeDevicesPerThreadManager`
 - Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
@@ -253,11 +239,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1990, 7418
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1993, 7421
 
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 1995-1997
+- Def site: line 1998-2000
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -266,11 +252,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1995, 15497
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1998, 15500
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2002-2004
+- Def site: line 2005-2007
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -278,11 +264,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2002, 7408
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2005, 7411
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 2010-2012
+- Def site: line 2013-2015
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -291,14 +277,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2010, 15586
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2013, 15589
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
 ## Hot (80)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2883-5209
+- Def site: line 2886-5212
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -309,11 +295,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2883, 6588, 6589, 6598, 6762
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2886, 6591, 6592, 6601, 6765
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13943-14701
+- Def site: line 13946-14704
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -322,11 +308,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14420, 14420, 14432, 14432, 14460, 14460, 14472, 14472, 14533, 14533, 14570, 14570, 14727, 19186
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14423, 14423, 14435, 14435, 14463, 14463, 14475, 14475, 14536, 14536, 14573, 14573, 14730, 19159
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9089-9774
+- Def site: line 9092-9777
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -335,12 +321,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5595, 5595, 9212, 9212, 9263, 9263, 9266, 9266, 9307, 9307, 9346, 9346, 9364, 9364, 9442, 9442, 9449, 9449, 9459, 9459, 9462, 9462, 9475, 9475, 9476, 9476, 9477, 9477, 9478, 9478, 9486, 9486, 9488, 9488, 9489, 9489, 9490, 9490, 9491, 9491, 9494, 9494, 9497, 9497, 9500, 9500, 9503, 9503, 9549, 9549, 9572, 9572, 9573, 9573, 9574, 9574, 9576, 9576, 9612, 9612, 9628, 9628, 9682, 9682, 9683, 9683, 9684, 9684, 9687, 9687, 9688, 9688, 9707, 9707, 9709, 9709, 9710, 9710, 9745, 9745, 15096, 15096, 15149, 15149, 15580, 17102, 17102, 17126, 17126, 17150, 17150, 17293, 17293, 18961, 18961, 18968, 18968, 18977, 18977, 18981, 18981, 18990, 18990
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5598, 5598, 9215, 9215, 9266, 9266, 9269, 9269, 9310, 9310, 9349, 9349, 9367, 9367, 9445, 9445, 9452, 9452, 9462, 9462, 9465, 9465, 9478, 9478, 9479, 9479, 9480, 9480, 9481, 9481, 9489, 9489, 9491, 9491, 9492, 9492, 9493, 9493, 9494, 9494, 9497, 9497, 9500, 9500, 9503, 9503, 9506, 9506, 9552, 9552, 9575, 9575, 9576, 9576, 9577, 9577, 9579, 9579, 9615, 9615, 9631, 9631, 9685, 9685, 9686, 9686, 9687, 9687, 9690, 9690, 9691, 9691, 9710, 9710, 9712, 9712, 9713, 9713, 9748, 9748, 15099, 15099, 15152, 15152, 15583, 17075, 17075, 17099, 17099, 17123, 17123, 17266, 17266, 18934, 18934, 18941, 18941, 18950, 18950, 18954, 18954, 18963, 18963
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16371-17045
+- Def site: line 16374-17048
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -348,11 +334,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16759, 16759, 19432, 19438
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16762, 16762, 19405, 19411
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11822-12474
+- Def site: line 11825-12477
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -362,11 +348,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10599, 10599, 10608, 10608, 10696, 10696, 10703, 10703, 11377, 11377, 11663, 11663, 11668, 11668, 11675, 11675, 11680, 11680, 11894, 11894, 11916, 11916, 11919, 11919, 11945, 11945, 11954, 11954, 11955, 11955, 11976, 11976, 12019, 12019, 12065, 12065, 12076, 12076, 12103, 12103, 12108, 12108, 12109, 12109, 12110, 12110, 12142, 12142, 12148, 12148, 12173, 12173, 12193, 12193, 12228, 12228, 12243, 12243, 12249, 12249, 12251, 12251, 12254, 12254, 12256, 12256, 12260, 12260, 12264, 12264, 12269, 12269, 12276, 12276, 12283, 12283, 12290, 12290, 12299, 12299, 12309, 12309, 12316, 12316, 12323, 12323, 12330, 12330, 12337, 12337, 12344, 12344, 12354, 12354, 12363, 12363, 12372, 12372, 12381, 12381, 12390, 12390, 12419, 12419, 18922, 18922, 19103, 19103, 19180, 19180, 19181, 19181, 19189, 19189, 19394, 19394, 19395, 19395, 19414, 19414, 19421, 19421, 19422, 19422, 19423, 19423, 19424, 19424
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10602, 10602, 10611, 10611, 10699, 10699, 10706, 10706, 11380, 11380, 11666, 11666, 11671, 11671, 11678, 11678, 11683, 11683, 11897, 11897, 11919, 11919, 11922, 11922, 11948, 11948, 11957, 11957, 11958, 11958, 11979, 11979, 12022, 12022, 12068, 12068, 12079, 12079, 12106, 12106, 12111, 12111, 12112, 12112, 12113, 12113, 12145, 12145, 12151, 12151, 12176, 12176, 12196, 12196, 12231, 12231, 12246, 12246, 12252, 12252, 12254, 12254, 12257, 12257, 12259, 12259, 12263, 12263, 12267, 12267, 12272, 12272, 12279, 12279, 12286, 12286, 12293, 12293, 12302, 12302, 12312, 12312, 12319, 12319, 12326, 12326, 12333, 12333, 12340, 12340, 12347, 12347, 12357, 12357, 12366, 12366, 12375, 12375, 12384, 12384, 12393, 12393, 12422, 12422, 18895, 18895, 19076, 19076, 19153, 19153, 19154, 19154, 19162, 19162, 19367, 19367, 19368, 19368, 19387, 19387, 19394, 19394, 19395, 19395, 19396, 19396, 19397, 19397
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 18218-18804
+- Def site: line 18191-18777
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -374,11 +360,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18495, 18495, 18496, 18496, 18499, 18499, 18501, 18501, 18503, 18503, 18519, 18519, 19339
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18468, 18468, 18469, 18469, 18472, 18472, 18474, 18474, 18476, 18476, 18492, 18492, 19312
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 18903-19474
+- Def site: line 18876-19447
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -388,12 +374,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18903, 20188, 20189, 20198, 20318, 20318, 20360, 20418, 20463, 20954, 20958, 21003, 21003, 21030, 21030, 21033
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18876, 20161, 20162, 20171, 20291, 20291, 20333, 20391, 20436, 20927, 20931, 20976, 20976, 21003, 21003, 21006
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8373-8835
+- Def site: line 8376-8838
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -401,11 +387,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8414, 8414, 8419, 8419, 8429, 8429, 8437, 8437, 8442, 8442, 8447, 8447, 8457, 8457, 8462, 8462, 8467, 8467, 8487, 8487, 8497, 8497, 8498, 8498, 8501, 8501, 8531, 8531, 8617, 8617, 8619, 8619, 8643, 8643, 8649, 8649, 8654, 8654, 8663, 8663, 8667, 8667, 8686, 8686, 8689, 8689, 8700, 8700, 8701, 8701, 8796, 8796, 8817, 8817, 19462, 19462, 19463, 19463, 19464, 19464, 19465, 19465, 19466, 19466, 19467, 19467
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8417, 8417, 8422, 8422, 8432, 8432, 8440, 8440, 8445, 8445, 8450, 8450, 8460, 8460, 8465, 8465, 8470, 8470, 8490, 8490, 8500, 8500, 8501, 8501, 8504, 8504, 8534, 8534, 8620, 8620, 8622, 8622, 8646, 8646, 8652, 8652, 8657, 8657, 8666, 8666, 8670, 8670, 8689, 8689, 8692, 8692, 8703, 8703, 8704, 8704, 8799, 8799, 8820, 8820, 19435, 19435, 19436, 19436, 19437, 19437, 19438, 19438, 19439, 19439, 19440, 19440
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 19699-20159
+- Def site: line 19672-20132
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -415,11 +401,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20166, 20166, 20170, 20170, 20190, 20190, 20195, 20195, 20419
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20139, 20139, 20143, 20143, 20163, 20163, 20168, 20168, 20392
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7820-8260
+- Def site: line 7823-8263
 - References: 117
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -427,14 +413,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7765, 7765, 7781, 7781, 7785, 7785, 7786, 7786, 7787, 7787, 7802, 7802, 7808, 7808, 7835, 7835, 7838, 7838, 7846, 7846, 7864, 7864, 7914, 7914, 7922, 7922, 7927, 7927, 7973, 7973, 7984, 7984, 8009, 8009, 8028, 8028, 8029, 8029, 8032, 8032, 8033, 8033, 8123, 8123, 8125, 8125, 8129, 8129, 8157, 8157, 8158, 8158, 8159, 8159, 8160, 8160, 8161, 8161, 8170, 8170, 8214, 8214, 8238, 8238, 12554, 12554, 12604, 12604, 12609, 12609, 12752, 12835, 12835, 12889, 12889, 12910, 12910, 12915, 12915, 13179, 13179, 13382, 13584, 13584, 13671, 13671, 13676, 13676, 13726, 13726, 13727, 13727, 15223, 15223, 15682, 17109, 17109, 17631, 17631, 18827, 18827, 18828, 18828, 19114, 19114
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7768, 7768, 7784, 7784, 7788, 7788, 7789, 7789, 7790, 7790, 7805, 7805, 7811, 7811, 7838, 7838, 7841, 7841, 7849, 7849, 7867, 7867, 7917, 7917, 7925, 7925, 7930, 7930, 7976, 7976, 7987, 7987, 8012, 8012, 8031, 8031, 8032, 8032, 8035, 8035, 8036, 8036, 8126, 8126, 8128, 8128, 8132, 8132, 8160, 8160, 8161, 8161, 8162, 8162, 8163, 8163, 8164, 8164, 8173, 8173, 8217, 8217, 8241, 8241, 12557, 12557, 12607, 12607, 12612, 12612, 12755, 12838, 12838, 12892, 12892, 12913, 12913, 12918, 12918, 13182, 13182, 13385, 13587, 13587, 13674, 13674, 13679, 13679, 13729, 13729, 13730, 13730, 15226, 15226, 15685, 17082, 17082, 17604, 17604, 18800, 18800, 18801, 18801, 19087, 19087
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9777-10190
+- Def site: line 9780-10193
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -443,11 +429,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5589, 5589, 9810, 9810, 9894, 9894, 9900, 9900, 9903, 9903, 9947, 9947, 9961, 9961, 9988, 9988, 9994, 9994, 10008, 10008, 10091, 10091, 10093, 10093, 10097, 10097, 10099, 10099, 10102, 10102, 10106, 10106, 10109, 10109, 10119, 10119, 10125, 10125, 10163, 10163, 15097, 15097, 15098, 15098, 15099, 15099, 15150, 15150, 15151, 15151, 18962, 18962, 18963, 18963, 18964, 18964, 18988, 18988
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5592, 5592, 9813, 9813, 9897, 9897, 9903, 9903, 9906, 9906, 9950, 9950, 9964, 9964, 9991, 9991, 9997, 9997, 10011, 10011, 10094, 10094, 10096, 10096, 10100, 10100, 10102, 10102, 10105, 10105, 10109, 10109, 10112, 10112, 10122, 10122, 10128, 10128, 10166, 10166, 15100, 15100, 15101, 15101, 15102, 15102, 15153, 15153, 15154, 15154, 18935, 18935, 18936, 18936, 18937, 18937, 18961, 18961
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17212-17609
+- Def site: line 17185-17582
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -456,11 +442,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17233, 17233, 17238, 17238, 17242, 17242, 17245, 17245, 17252, 17252, 17254, 17254, 17255, 17255, 17258, 17258, 17261, 17261, 17264, 17264, 17306, 17306, 17338, 17338, 17405, 17405, 17418, 17418, 17423, 17423, 17475, 17475, 17508, 17508, 17509, 17509, 17510, 17510, 17540, 17540, 17569, 17569, 17570, 17570, 19145, 19145
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17206, 17206, 17211, 17211, 17215, 17215, 17218, 17218, 17225, 17225, 17227, 17227, 17228, 17228, 17231, 17231, 17234, 17234, 17237, 17237, 17279, 17279, 17311, 17311, 17378, 17378, 17391, 17391, 17396, 17396, 17448, 17448, 17481, 17481, 17482, 17482, 17483, 17483, 17513, 17513, 17542, 17542, 17543, 17543, 19118, 19118
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 17692-18079
+- Def site: line 17665-18052
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -470,12 +456,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17719, 17863, 17863, 19285, 19285
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17692, 17836, 17836, 19258, 19258
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6729-7073
-- References: 251
+- Def site: line 6732-7076
+- References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -483,7 +469,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5685, 5685, 6775, 6775, 6791, 6791, 6792, 6792, 6815, 6815, 6817, 6817, 6820, 6820, 6834, 6834, 6836, 6836, 6845, 6845, 6847, 6847, 6848, 6848, 6854, 6854, 6855, 6855, 6855, 6872, 6872, 6876, 6876, 6918, 6918, 6949, 6949, 6952, 6952, 6954, 6954, 7000, 7000, 7010, 7010, 7043, 7043, 7048, 7048, 7055, 7055, 7277, 7277, 7309, 7309, 7320, 7320, 7345, 7345, 7365, 7365, 7877, 7877, 8670, 8670, 8949, 8949, 8964, 9028, 9028, 9045, 9045, 9063, 9063, 9084, 9084, 9643, 9643, 9718, 9718, 10048, 10048, 10399, 10399, 10484, 10500, 10620, 10620, 10624, 10624, 10644, 10644, 10657, 10657, 10661, 10661, 10679, 10679, 10841, 10841, 11188, 11188, 11335, 11335, 11412, 11412, 11416, 11416, 11421, 11421, 11554, 11554, 11573, 11573, 11624, 11624, 11627, 11627, 11778, 11778, 11781, 11781, 11880, 11880, 11886, 11886, 12183, 12183, 12200, 12200, 12215, 12215, 12429, 12429, 12457, 12457, 12473, 12473, 12510, 12510, 12548, 12548, 12637, 12637, 12666, 12666, 12704, 12704, 12755, 12820, 12820, 12826, 12826, 12868, 12868, 13037, 13037, 13043, 13043, 13162, 13162, 13170, 13170, 13334, 13334, 13385, 13558, 13558, 13729, 13729, 14242, 14242, 14603, 14603, 14609, 14609, 15517, 15517, 15576, 15683, 15819, 15819, 15837, 15837, 15855, 15855, 17070, 17156, 17156, 17177, 18045, 18045, 18130, 18130, 18151, 18151, 18653, 18653, 19314, 19314, 19330, 19330
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5688, 5688, 6778, 6778, 6794, 6794, 6795, 6795, 6818, 6818, 6820, 6820, 6823, 6823, 6837, 6837, 6839, 6839, 6848, 6848, 6850, 6850, 6851, 6851, 6857, 6857, 6858, 6858, 6858, 6875, 6875, 6879, 6879, 6921, 6921, 6952, 6952, 6955, 6955, 6957, 6957, 7003, 7003, 7013, 7013, 7046, 7046, 7051, 7051, 7058, 7058, 7280, 7280, 7312, 7312, 7323, 7323, 7348, 7348, 7368, 7368, 7880, 7880, 8673, 8673, 8952, 8952, 8967, 9031, 9031, 9048, 9048, 9066, 9066, 9087, 9087, 9646, 9646, 9721, 9721, 10051, 10051, 10402, 10402, 10487, 10503, 10623, 10623, 10627, 10627, 10647, 10647, 10660, 10660, 10664, 10664, 10682, 10682, 10844, 10844, 11191, 11191, 11338, 11338, 11415, 11415, 11419, 11419, 11424, 11424, 11557, 11557, 11576, 11576, 11627, 11627, 11630, 11630, 11781, 11781, 11784, 11784, 11883, 11883, 11889, 11889, 12186, 12186, 12203, 12203, 12218, 12218, 12432, 12432, 12460, 12460, 12476, 12476, 12513, 12513, 12551, 12551, 12640, 12640, 12669, 12669, 12707, 12707, 12758, 12823, 12823, 12829, 12829, 12871, 12871, 13040, 13040, 13046, 13046, 13165, 13165, 13173, 13173, 13337, 13337, 13388, 13561, 13561, 13732, 13732, 14245, 14245, 14606, 14606, 14612, 14612, 15520, 15520, 15579, 15686, 15822, 15822, 15840, 15840, 15858, 15858, 17129, 17129, 17150, 18018, 18018, 18103, 18103, 18124, 18124, 18626, 18626, 19287, 19287, 19303, 19303
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -494,7 +480,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12876-13216
+- Def site: line 12879-13219
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -503,11 +489,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12893, 12893, 12895, 12895, 12899, 12899, 12900, 12900, 12914, 12914, 12920, 12920, 12923, 12923, 12926, 12926, 12984, 12984, 12990, 12990, 12995, 12995, 13009, 13009, 13027, 13027, 13137, 13137, 13141, 13141, 13143, 13143, 13146, 13146, 13183, 13183, 13188, 13188, 13202, 13202, 13206, 13206, 13208, 13208, 13211, 13211, 13216, 13216, 19191, 19191, 19195, 19195, 19199, 19199
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12896, 12896, 12898, 12898, 12902, 12902, 12903, 12903, 12917, 12917, 12923, 12923, 12926, 12926, 12929, 12929, 12987, 12987, 12993, 12993, 12998, 12998, 13012, 13012, 13030, 13030, 13140, 13140, 13144, 13144, 13146, 13146, 13149, 13149, 13186, 13186, 13191, 13191, 13205, 13205, 13209, 13209, 13211, 13211, 13214, 13214, 13219, 13219, 19164, 19164, 19168, 19168, 19172, 19172
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7076-7403
+- Def site: line 7079-7406
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -515,11 +501,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7178, 7178, 8394, 8875, 8894, 8995, 9124, 9147, 9819, 10127, 10172, 10586, 11356, 11367, 11430, 11847
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7181, 7181, 8397, 8878, 8897, 8998, 9127, 9150, 9822, 10130, 10175, 10589, 11359, 11370, 11433, 11850
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14707-15034
+- Def site: line 14710-15037
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -529,13 +515,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12164, 12164, 12223, 12223, 12224, 12224, 13388, 14748, 14748, 14750, 14750, 14756, 14756, 14770, 14770, 14809, 14809, 14812, 14812, 14814, 14814, 14815, 14815, 14816, 14816, 14870, 14870, 14871, 14871, 14882, 14882, 14891, 14891, 14910, 14910, 14962, 14962, 14966, 14966, 14974, 14974, 14975, 14975, 14999, 14999, 15003, 15003
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12167, 12167, 12226, 12226, 12227, 12227, 13391, 14751, 14751, 14753, 14753, 14759, 14759, 14773, 14773, 14812, 14812, 14815, 14815, 14817, 14817, 14818, 14818, 14819, 14819, 14873, 14873, 14874, 14874, 14885, 14885, 14894, 14894, 14913, 14913, 14965, 14965, 14969, 14969, 14977, 14977, 14978, 14978, 15002, 15002, 15006, 15006
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16067-16355
+- Def site: line 16070-16358
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -545,11 +531,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16095, 16095, 16098, 16098, 16103, 16103, 16106, 16106, 16150, 16150, 16156, 16156, 16187, 16187, 16190, 16190, 16194, 16194, 16220, 16220, 16237, 16237, 16243, 16243, 16257, 16257, 16258, 16258, 16260, 16260, 16266, 16266, 16273, 16273, 16282, 16282, 16329, 16329, 16351, 16351, 16352, 16352, 16353, 16353, 19136, 19136
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16098, 16098, 16101, 16101, 16106, 16106, 16109, 16109, 16153, 16153, 16159, 16159, 16190, 16190, 16193, 16193, 16197, 16197, 16223, 16223, 16240, 16240, 16246, 16246, 16260, 16260, 16261, 16261, 16263, 16263, 16269, 16269, 16276, 16276, 16285, 16285, 16332, 16332, 16354, 16354, 16355, 16355, 16356, 16356, 19109, 19109
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10193-10465
+- Def site: line 10196-10468
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -558,26 +544,26 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10216, 10216, 10217, 10217, 10230, 10230, 10231, 10231, 10233, 10233, 10234, 10234, 10237, 10237, 10240, 10240, 10244, 10244, 10245, 10245, 10321, 10321, 10325, 10325, 10328, 10328, 10341, 10341, 10378, 10378, 10395, 10395, 10408, 10408, 10410, 10410, 10417, 10417, 10426, 10426, 10435, 10435, 10436, 10436, 10447, 10447, 10451, 10451, 10460, 10460, 10465, 10465, 19393, 19393
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10219, 10219, 10220, 10220, 10233, 10233, 10234, 10234, 10236, 10236, 10237, 10237, 10240, 10240, 10243, 10243, 10247, 10247, 10248, 10248, 10324, 10324, 10328, 10328, 10331, 10331, 10344, 10344, 10381, 10381, 10398, 10398, 10411, 10411, 10413, 10413, 10420, 10420, 10429, 10429, 10438, 10438, 10439, 10439, 10450, 10450, 10454, 10454, 10463, 10463, 10468, 10468, 19366, 19366
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5215-5478
-- References: 107
+- Def site: line 5218-5481
+- References: 106
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5255, 5255, 5257, 5257, 5339, 5339, 5345, 5345, 5382, 5382, 5384, 5384, 5393, 5393, 5403, 5403, 5413, 5413, 5449, 5449, 7913, 7913, 9571, 9571, 9572, 9572, 9883, 9883, 10729, 10729, 10749, 10749, 12750, 15156, 15156, 15162, 15162, 15163, 15163, 15164, 15164, 15165, 15165, 15166, 15166, 15167, 15167, 15174, 15174, 15202, 15202, 15574, 15820, 15820, 15838, 15838, 15856, 15856, 15882, 17065, 17101, 17101, 17125, 17125, 17149, 17149, 17293, 17293, 17294, 17294, 17295, 17295, 17296, 17296, 17632, 17632, 18878, 18878, 19430, 19430
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5258, 5258, 5260, 5260, 5342, 5342, 5348, 5348, 5385, 5385, 5387, 5387, 5396, 5396, 5406, 5406, 5416, 5416, 5452, 5452, 7916, 7916, 9574, 9574, 9575, 9575, 9886, 9886, 10732, 10732, 10752, 10752, 12753, 15159, 15159, 15165, 15165, 15166, 15166, 15167, 15167, 15168, 15168, 15169, 15169, 15170, 15170, 15177, 15177, 15205, 15205, 15577, 15823, 15823, 15841, 15841, 15859, 15859, 15885, 17074, 17074, 17098, 17098, 17122, 17122, 17266, 17266, 17267, 17267, 17268, 17268, 17269, 17269, 17605, 17605, 18851, 18851, 19403, 19403
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 10960-11210
+- Def site: line 10963-11213
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -587,11 +573,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10967, 10967, 10970, 10970, 10975, 10975, 10976, 10976, 10984, 10984, 10987, 10987, 10995, 10995, 11035, 11035, 11043, 11043, 11091, 11091, 11108, 11108, 11111, 11111, 11113, 11113, 11177, 11177, 11178, 11178, 19396, 19396
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10970, 10970, 10973, 10973, 10978, 10978, 10979, 10979, 10987, 10987, 10990, 10990, 10998, 10998, 11038, 11038, 11046, 11046, 11094, 11094, 11111, 11111, 11114, 11114, 11116, 11116, 11180, 11180, 11181, 11181, 19369, 19369
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15286-15530
+- Def site: line 15289-15533
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -601,11 +587,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15152, 15152, 15312, 15312, 15314, 15314, 15315, 15315, 15316, 15316, 15344, 15344, 15349, 15349, 15371, 15371, 15372, 15372, 15414, 15414, 15422, 15422, 15448, 15448, 15457, 15457, 15465, 15465, 15496, 15496, 18967, 18967, 18971, 18971
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15155, 15155, 15315, 15315, 15317, 15317, 15318, 15318, 15319, 15319, 15347, 15347, 15352, 15352, 15374, 15374, 15375, 15375, 15417, 15417, 15425, 15425, 15451, 15451, 15460, 15460, 15468, 15468, 15499, 15499, 18940, 18940, 18944, 18944
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6148-6368
+- Def site: line 6151-6371
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -613,14 +599,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6171, 6171, 6222, 6222, 6292, 6292, 6316, 6316, 6328, 6328, 6330, 6330, 6340, 6340, 6355, 6355, 6359, 6359, 6360, 6360, 6363, 6363, 6365, 6365, 12863, 12863, 15578
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6174, 6174, 6225, 6225, 6295, 6295, 6319, 6319, 6331, 6331, 6333, 6333, 6343, 6343, 6358, 6358, 6362, 6362, 6363, 6363, 6366, 6366, 6368, 6368, 12866, 12866, 15581
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 19480-19693
+- Def site: line 19453-19666
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -629,11 +615,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20336, 20336, 20339, 20420, 20771
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20309, 20309, 20312, 20393, 20744
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7604-7813
+- Def site: line 7607-7816
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -642,11 +628,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7617, 7617, 7623, 7623, 7624, 7624, 7627, 7627, 7650, 7650, 7653, 7653, 7656, 7656, 7657, 7657, 7659, 7659, 7726, 7726, 7770, 7770, 8235, 8235, 13184, 13184, 15681, 15920, 15920, 16080, 16080
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7620, 7620, 7626, 7626, 7627, 7627, 7630, 7630, 7653, 7653, 7656, 7656, 7659, 7659, 7660, 7660, 7662, 7662, 7729, 7729, 7773, 7773, 8238, 8238, 13187, 13187, 15684, 15923, 15923, 16083, 16083
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12482-12684
+- Def site: line 12485-12687
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -655,11 +641,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12503, 12503, 12512, 12512, 12574, 12574, 12581, 12581, 12613, 12613, 12615, 12615, 12639, 12639, 12674, 12674, 12681, 12681, 12712, 12712, 15226, 15226, 19003, 19003, 19005, 19005, 19006, 19006, 19008, 19008
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12506, 12506, 12515, 12515, 12577, 12577, 12584, 12584, 12616, 12616, 12618, 12618, 12642, 12642, 12677, 12677, 12684, 12684, 12715, 12715, 15229, 15229, 18976, 18976, 18978, 18978, 18979, 18979, 18981, 18981
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13735-13922
+- Def site: line 13738-13925
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -669,11 +655,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19353, 19353, 19354, 19354, 19355, 19355, 19356, 19356, 19357, 19357, 19358, 19358, 19359, 19359, 19360, 19360, 19362, 19362, 19363, 19363, 19364, 19364, 19365, 19365, 19366, 19366, 19367, 19367, 19368, 19368, 19370, 19370, 19371, 19371, 19372, 19372, 19373, 19373, 19374, 19374, 19375, 19375, 19376, 19376, 19377, 19377, 19378, 19378, 19380, 19380, 19381, 19381, 19382, 19382, 19383, 19383, 19384, 19384, 19385, 19385, 19386, 19386, 19387, 19387, 19388, 19388, 19390, 19390, 19391, 19391
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19326, 19326, 19327, 19327, 19328, 19328, 19329, 19329, 19330, 19330, 19331, 19331, 19332, 19332, 19333, 19333, 19335, 19335, 19336, 19336, 19337, 19337, 19338, 19338, 19339, 19339, 19340, 19340, 19341, 19341, 19343, 19343, 19344, 19344, 19345, 19345, 19346, 19346, 19347, 19347, 19348, 19348, 19349, 19349, 19350, 19350, 19351, 19351, 19353, 19353, 19354, 19354, 19355, 19355, 19356, 19356, 19357, 19357, 19358, 19358, 19359, 19359, 19360, 19360, 19361, 19361, 19363, 19363, 19364, 19364
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5560-5739
+- Def site: line 5563-5742
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -682,11 +668,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5648, 5648, 5685, 5685, 5687, 5687, 5690, 5690, 5698, 5698, 5700, 5700, 5702, 5702, 5705, 5705, 5734, 5734, 5737, 5737, 19130, 19130
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5651, 5651, 5688, 5688, 5690, 5690, 5693, 5693, 5701, 5701, 5703, 5703, 5705, 5705, 5708, 5708, 5737, 5737, 5740, 5740, 19103, 19103
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6548-6726
+- Def site: line 6551-6729
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -694,11 +680,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6593, 6593, 6631, 6631, 6642, 6642, 6668, 6668, 6669, 6669, 6671, 6671, 6677, 6677, 6678, 6678, 6681, 6681, 6687, 6687, 6688, 6688, 6691, 6691, 6693, 6693, 6703, 6703, 6705, 6705, 6706, 6706, 6708, 6708
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6596, 6596, 6634, 6634, 6645, 6645, 6671, 6671, 6672, 6672, 6674, 6674, 6680, 6680, 6681, 6681, 6684, 6684, 6690, 6690, 6691, 6691, 6694, 6694, 6696, 6696, 6706, 6706, 6708, 6708, 6709, 6709, 6711, 6711
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11440-11607
+- Def site: line 11443-11610
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -707,11 +693,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11547, 11547, 11566, 11566, 11584, 11584, 11593, 11593, 11596, 11596, 11597, 11597, 11600, 11600, 11605, 11605, 11607, 11607, 19031, 19031
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11550, 11550, 11569, 11569, 11587, 11587, 11596, 11596, 11599, 11599, 11600, 11600, 11603, 11603, 11608, 11608, 11610, 11610, 19004, 19004
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11652-11819
+- Def site: line 11655-11822
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -719,11 +705,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11689, 11689, 11691, 11691, 11694, 11694, 11765, 11765, 11767, 11767, 11780, 11780, 11784, 11784, 19034, 19034, 19035, 19035, 19036, 19036, 19074, 19074, 19079, 19079
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11692, 11692, 11694, 11694, 11697, 11697, 11768, 11768, 11770, 11770, 11783, 11783, 11787, 11787, 19007, 19007, 19008, 19008, 19009, 19009, 19047, 19047, 19052, 19052
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10685-10846
+- Def site: line 10688-10849
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -731,11 +717,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10723, 10723, 10730, 10730, 10737, 10737, 10743, 10743, 10750, 10750, 10757, 10757, 10818, 10818, 10829, 10829, 19022, 19022, 19023, 19023, 19025, 19025, 19026, 19026, 19027, 19027
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10726, 10726, 10733, 10733, 10740, 10740, 10746, 10746, 10753, 10753, 10760, 10760, 10821, 10821, 10832, 10832, 18995, 18995, 18996, 18996, 18998, 18998, 18999, 18999, 19000, 19000
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15901-16061
+- Def site: line 15904-16064
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -744,11 +730,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15924, 15924, 15926, 15926, 15995, 15995, 15997, 15997, 16016, 16016, 16018, 16018, 16018, 16034, 16034, 16050, 16050, 16051, 16051, 16057, 16057, 19135, 19135
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15927, 15927, 15929, 15929, 15998, 15998, 16000, 16000, 16019, 16019, 16021, 16021, 16021, 16037, 16037, 16053, 16053, 16054, 16054, 16060, 16060, 19108, 19108
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6376-6533
+- Def site: line 6379-6536
 - References: 201
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -758,7 +744,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5513, 5513, 6392, 6392, 6405, 6405, 6408, 6408, 6432, 6432, 6440, 6440, 6441, 6441, 6463, 6463, 6468, 6468, 6470, 6470, 6543, 6543, 6544, 6544, 6951, 6951, 6976, 6976, 7045, 7045, 7046, 7046, 7375, 7375, 7389, 7389, 7390, 7390, 7875, 7875, 7876, 7876, 8798, 8798, 8963, 9023, 9023, 9025, 9025, 9026, 9026, 9043, 9043, 9044, 9044, 9061, 9061, 9062, 9062, 9082, 9082, 9083, 9083, 9640, 9640, 9641, 9641, 9715, 9715, 9716, 9716, 10044, 10044, 10047, 10047, 10622, 10622, 10623, 10623, 10659, 10659, 10660, 10660, 10839, 10839, 10840, 10840, 11184, 11184, 11185, 11185, 11331, 11331, 11332, 11332, 11414, 11414, 11415, 11415, 11626, 11626, 11801, 11801, 11802, 11802, 11878, 11878, 11879, 11879, 12182, 12182, 12198, 12198, 12199, 12199, 12427, 12427, 12428, 12428, 12507, 12507, 12508, 12508, 12509, 12509, 12545, 12545, 12546, 12546, 12634, 12634, 12635, 12635, 12663, 12663, 12664, 12664, 12701, 12701, 12702, 12702, 12754, 12823, 12823, 12824, 12824, 12866, 12866, 12867, 12867, 13035, 13035, 13036, 13036, 13160, 13160, 13161, 13161, 13384, 13556, 13556, 14608, 14608, 15515, 15515, 15516, 15516, 15577, 15685, 17154, 17154, 17155, 17155, 18035, 18035
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5516, 5516, 6395, 6395, 6408, 6408, 6411, 6411, 6435, 6435, 6443, 6443, 6444, 6444, 6466, 6466, 6471, 6471, 6473, 6473, 6546, 6546, 6547, 6547, 6954, 6954, 6979, 6979, 7048, 7048, 7049, 7049, 7378, 7378, 7392, 7392, 7393, 7393, 7878, 7878, 7879, 7879, 8801, 8801, 8966, 9026, 9026, 9028, 9028, 9029, 9029, 9046, 9046, 9047, 9047, 9064, 9064, 9065, 9065, 9085, 9085, 9086, 9086, 9643, 9643, 9644, 9644, 9718, 9718, 9719, 9719, 10047, 10047, 10050, 10050, 10625, 10625, 10626, 10626, 10662, 10662, 10663, 10663, 10842, 10842, 10843, 10843, 11187, 11187, 11188, 11188, 11334, 11334, 11335, 11335, 11417, 11417, 11418, 11418, 11629, 11629, 11804, 11804, 11805, 11805, 11881, 11881, 11882, 11882, 12185, 12185, 12201, 12201, 12202, 12202, 12430, 12430, 12431, 12431, 12510, 12510, 12511, 12511, 12512, 12512, 12548, 12548, 12549, 12549, 12637, 12637, 12638, 12638, 12666, 12666, 12667, 12667, 12704, 12704, 12705, 12705, 12757, 12826, 12826, 12827, 12827, 12869, 12869, 12870, 12870, 13038, 13038, 13039, 13039, 13163, 13163, 13164, 13164, 13387, 13559, 13559, 14611, 14611, 15518, 15518, 15519, 15519, 15580, 15688, 17127, 17127, 17128, 17128, 18008, 18008
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -766,7 +752,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15048-15203
+- Def site: line 15051-15206
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -775,11 +761,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15070, 15070, 15076, 15076, 15078, 15078, 15106, 15106, 15132, 15132, 15135, 15135, 15138, 15138, 19121, 19121, 19125, 19125, 19133, 19133
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15073, 15073, 15079, 15079, 15081, 15081, 15109, 15109, 15135, 15135, 15138, 15138, 15141, 15141, 19094, 19094, 19098, 19098, 19106, 19106
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13219-13364
+- Def site: line 13222-13367
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -787,11 +773,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13258, 13258, 13265, 13265, 13290, 13290, 13293, 13293, 13306, 13306, 13350, 13350, 13354, 13354, 13359, 13359, 13360, 13360, 13364, 13364, 19428, 19428
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13261, 13261, 13268, 13268, 13293, 13293, 13296, 13296, 13309, 13309, 13353, 13353, 13357, 13357, 13362, 13362, 13363, 13363, 13367, 13367, 19401, 19401
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13372-13516
+- Def site: line 13375-13519
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -800,12 +786,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12593, 12593, 12769, 12769, 12847, 12847, 12852, 12852, 13401, 13401, 13407, 13407, 13413, 13413, 13419, 13419, 13425, 13425, 13431, 13431, 13437, 13437, 13443, 13443, 13449, 13449, 13455, 13455, 13461, 13461, 13467, 13467, 13473, 13473, 13479, 13479, 13485, 13485, 13491, 13491, 13497, 13497, 13503, 13503, 13509, 13509, 13515, 13515, 19041, 19041, 19182, 19182, 19184, 19184, 19299, 19299, 19425, 19425, 19426, 19426, 19427, 19427, 19446, 19446, 19447, 19447, 19448, 19448, 19449, 19449, 19450, 19450, 19451, 19451, 19452, 19452
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12596, 12596, 12772, 12772, 12850, 12850, 12855, 12855, 13404, 13404, 13410, 13410, 13416, 13416, 13422, 13422, 13428, 13428, 13434, 13434, 13440, 13440, 13446, 13446, 13452, 13452, 13458, 13458, 13464, 13464, 13470, 13470, 13476, 13476, 13482, 13482, 13488, 13488, 13494, 13494, 13500, 13500, 13506, 13506, 13512, 13512, 13518, 13518, 19014, 19014, 19155, 19155, 19157, 19157, 19272, 19272, 19398, 19398, 19399, 19399, 19400, 19400, 19419, 19419, 19420, 19420, 19421, 19421, 19422, 19422, 19423, 19423, 19424, 19424, 19425, 19425
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10539-10682
+- Def site: line 10542-10685
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -814,11 +800,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10553, 10553, 10554, 10554, 10640, 10640, 10675, 10675, 19016, 19016, 19017, 19017, 19018, 19018, 19019, 19019, 19020, 19020
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10556, 10556, 10557, 10557, 10643, 10643, 10678, 10678, 18989, 18989, 18990, 18990, 18991, 18991, 18992, 18992, 18993, 18993
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13519-13657
+- Def site: line 13522-13660
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -826,11 +812,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13588, 13588, 13591, 13591, 13592, 13592, 13593, 13593, 13613, 13613, 13616, 13616, 13624, 13624, 13629, 13629, 19454, 19454
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13591, 13591, 13594, 13594, 13595, 13595, 13596, 13596, 13616, 13616, 13619, 13619, 13627, 13627, 13632, 13632, 19427, 19427
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8841-8969
+- Def site: line 8844-8972
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -839,11 +825,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8912, 8912, 8923, 8923, 15146, 15146, 15147, 15147, 18919, 18919, 18920, 18920, 19099, 19099
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8915, 8915, 8926, 8926, 15149, 15149, 15150, 15150, 18892, 18892, 18893, 18893, 19072, 19072
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11213-11341
+- Def site: line 11216-11344
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -852,11 +838,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11220, 11220, 11225, 11225, 11226, 11226, 11227, 11227, 11230, 11230, 11231, 11231, 11294, 11294, 11301, 11301, 11328, 11328, 19398, 19398
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11223, 11223, 11228, 11228, 11229, 11229, 11230, 11230, 11233, 11233, 11234, 11234, 11297, 11297, 11304, 11304, 11331, 11331, 19371, 19371
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15671-15797
+- Def site: line 15674-15800
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -865,11 +851,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15691, 15691, 15696, 15696, 15701, 15701, 15738, 15738, 15744, 15744, 15750, 15750, 15756, 15756, 15762, 15762, 15763, 15763, 15764, 15764, 15765, 15765, 15766, 15766, 15770, 15770, 15779, 15779, 15783, 15783, 15786, 15786, 15792, 15792, 19094, 19094
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15694, 15694, 15699, 15699, 15704, 15704, 15741, 15741, 15747, 15747, 15753, 15753, 15759, 15759, 15765, 15765, 15766, 15766, 15767, 15767, 15768, 15768, 15769, 15769, 15773, 15773, 15782, 15782, 15786, 15786, 15789, 15789, 15795, 15795, 19067, 19067
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5793-5917
+- Def site: line 5796-5920
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -878,25 +864,25 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5814, 5814, 5816, 5816, 5832, 5832, 5844, 5844, 5883, 5883, 5884, 5884, 5885, 5885, 5886, 5886, 5887, 5887, 5898, 5898, 5901, 5901, 6833, 6833, 20433, 20433, 21016, 21016
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5817, 5817, 5819, 5819, 5835, 5835, 5847, 5847, 5886, 5886, 5887, 5887, 5888, 5888, 5889, 5889, 5890, 5890, 5901, 5901, 5904, 5904, 6836, 6836, 20406, 20406, 20989, 20989
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8975-9086
-- References: 53
+- Def site: line 8978-9089
+- References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7913, 7913, 9571, 9571, 9883, 9883, 10729, 10729, 10749, 10749, 12751, 15095, 15095, 15148, 15148, 15581, 15821, 15821, 15839, 15839, 15857, 15857, 17066, 17103, 17103, 17127, 17127, 17151, 17151, 17294, 17294, 17635, 17635, 18960, 18960, 18975, 18975, 18985, 18985, 18985, 18985, 18995, 18995
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7916, 7916, 9574, 9574, 9886, 9886, 10732, 10732, 10752, 10752, 12754, 15098, 15098, 15151, 15151, 15584, 15824, 15824, 15842, 15842, 15860, 15860, 17076, 17076, 17100, 17100, 17124, 17124, 17267, 17267, 17608, 17608, 18933, 18933, 18948, 18948, 18958, 18958, 18958, 18958, 18968, 18968
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10849-10957
+- Def site: line 10852-10960
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -906,11 +892,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10904, 10904, 10907, 10907, 10908, 10908, 10913, 10913, 10931, 10931, 10931, 10940, 10940, 10940, 10940, 10941, 10941, 10941, 10941, 10999, 10999, 11002, 11002, 11014, 11014, 11015, 11015, 11028, 11028, 11067, 11067, 11075, 11075, 11129, 11129, 11137, 11137
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10907, 10907, 10910, 10910, 10911, 10911, 10916, 10916, 10934, 10934, 10934, 10943, 10943, 10943, 10943, 10944, 10944, 10944, 10944, 11002, 11002, 11005, 11005, 11017, 11017, 11018, 11018, 11031, 11031, 11070, 11070, 11078, 11078, 11132, 11132, 11140, 11140
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12774-12873
+- Def site: line 12777-12876
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -919,12 +905,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12839, 12839, 12841, 12841, 12842, 12842, 18969, 18969, 19037, 19037, 19039, 19039, 19040, 19040
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12842, 12842, 12844, 12844, 12845, 12845, 18942, 18942, 19010, 19010, 19012, 19012, 19013, 19013
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15563-15660
-- References: 79
+- Def site: line 15566-15663
+- References: 78
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -932,13 +918,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15306, 15306, 15541, 15541, 15599, 15599, 15605, 15605, 15611, 15611, 15617, 15617, 15623, 15623, 15629, 15629, 15635, 15635, 15641, 15641, 15647, 15647, 15653, 15653, 15659, 15659, 15883, 17067, 17295, 17295, 17298, 17298, 17634, 17634, 18926, 18926, 18993, 18993, 18999, 18999, 19050, 19050, 19107, 19107
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15309, 15309, 15544, 15544, 15602, 15602, 15608, 15608, 15614, 15614, 15620, 15620, 15626, 15626, 15632, 15632, 15638, 15638, 15644, 15644, 15650, 15650, 15656, 15656, 15662, 15662, 15886, 17268, 17268, 17271, 17271, 17607, 17607, 18899, 18899, 18966, 18966, 18972, 18972, 19023, 19023, 19080, 19080
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8271-8367
+- Def site: line 8274-8370
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -946,11 +932,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8327, 8327, 8363, 8363
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8330, 8330, 8366, 8366
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11344-11437
+- Def site: line 11347-11440
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -959,11 +945,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11396, 11396, 11409, 11409, 19029, 19029, 19071, 19071, 19072, 19072, 19077, 19077, 19078, 19078
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11399, 11399, 11412, 11412, 19002, 19002, 19044, 19044, 19045, 19045, 19050, 19050, 19051, 19051
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5923-6012
+- Def site: line 5926-6015
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -973,13 +959,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6005, 6005, 15369, 15369, 15370, 15370, 15584, 18829, 18829
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6008, 6008, 15372, 15372, 15373, 15373, 15587, 18802, 18802
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12687-12771
+- Def site: line 12690-12774
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -989,11 +975,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12721, 12721, 19004, 19004, 19012, 19012, 19038, 19038, 19183, 19183
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12724, 12724, 18977, 18977, 18985, 18985, 19011, 19011, 19156, 19156
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 18106-18184
+- Def site: line 18079-18157
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1003,12 +989,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18101, 18101, 18102, 18102, 19278, 19278
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18074, 18074, 18075, 18075, 19251, 19251
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17081-17158
+- Def site: line 17054-17131
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1018,13 +1004,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19149, 19149, 19153, 19153, 19157, 19157
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19122, 19122, 19126, 19126, 19130, 19130
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1887-1960
-- References: 259
+- Def site: line 1890-1963
+- References: 258
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1032,7 +1018,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1900, 1900, 1932, 1932, 2207, 2207, 2296, 2296, 2323, 2323, 7625, 7625, 7711, 7711, 7841, 7841, 7918, 7918, 8001, 8001, 8231, 8231, 8420, 8420, 8476, 8476, 8489, 8489, 8506, 8506, 8551, 8551, 8582, 8582, 8588, 8588, 8691, 8691, 10232, 10232, 10499, 11001, 11001, 11030, 11030, 11295, 11295, 11501, 11501, 11740, 11740, 12456, 12456, 12472, 12472, 13259, 13259, 13678, 13678, 13728, 13728, 15582, 15784, 15784, 15817, 15817, 15835, 15835, 15853, 15853, 15881, 17069, 17108, 17108, 17133, 17133, 17176, 17275, 17275, 17487, 17487, 17630, 17630, 17676, 17676, 17766, 17766, 18096, 18096, 18126, 18126, 18147, 18147, 18166, 18166, 18182, 18182, 18199, 18199, 18776, 18776, 18796, 18796, 18831, 18831, 18844, 18844, 19312, 19312, 19403, 19403, 19408, 19408, 19414, 19414, 19433, 19433, 19439, 19439, 21039, 21039, 21137, 21137
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1903, 1903, 1935, 1935, 2210, 2210, 2299, 2299, 2326, 2326, 7628, 7628, 7714, 7714, 7844, 7844, 7921, 7921, 8004, 8004, 8234, 8234, 8423, 8423, 8479, 8479, 8492, 8492, 8509, 8509, 8554, 8554, 8585, 8585, 8591, 8591, 8694, 8694, 10235, 10235, 10502, 11004, 11004, 11033, 11033, 11298, 11298, 11504, 11504, 11743, 11743, 12459, 12459, 12475, 12475, 13262, 13262, 13681, 13681, 13731, 13731, 15585, 15787, 15787, 15820, 15820, 15838, 15838, 15856, 15856, 15884, 17081, 17081, 17106, 17106, 17149, 17248, 17248, 17460, 17460, 17603, 17603, 17649, 17649, 17739, 17739, 18069, 18069, 18099, 18099, 18120, 18120, 18139, 18139, 18155, 18155, 18172, 18172, 18749, 18749, 18769, 18769, 18804, 18804, 18817, 18817, 19285, 19285, 19376, 19376, 19381, 19381, 19387, 19387, 19406, 19406, 19412, 19412, 21012, 21012, 21110, 21110
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -1053,7 +1039,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15209-15280
+- Def site: line 15212-15283
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1062,11 +1048,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19115, 19115, 19116, 19116, 19117, 19117, 19118, 19118
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19088, 19088, 19089, 19089, 19090, 19090, 19091, 19091
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5484-5553
+- Def site: line 5487-5556
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1076,19 +1062,19 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5516, 5516, 5517, 5517, 5532, 5532, 5534, 5534
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5519, 5519, 5520, 5520, 5535, 5535, 5537, 5537
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 6018-6087
-- References: 189
+- Def site: line 6021-6090
+- References: 188
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6060, 6060, 6065, 6065, 6162, 6162, 6220, 6220, 7111, 7111, 7768, 7768, 8413, 8413, 8436, 8436, 8456, 8456, 8641, 8641, 8662, 8662, 8937, 8937, 8962, 8962, 9017, 9017, 9039, 9039, 9056, 9056, 9073, 9073, 9458, 9458, 9681, 9681, 9698, 9698, 10090, 10090, 10422, 10422, 10633, 10633, 10670, 10670, 10823, 10823, 10966, 10966, 11219, 11219, 11407, 11407, 11591, 11591, 11910, 11910, 12246, 12246, 12418, 12418, 12458, 12458, 12464, 12464, 12558, 12558, 12788, 12788, 12861, 12861, 13348, 13348, 13383, 13582, 13582, 15089, 15089, 15305, 15305, 15573, 15680, 15780, 15780, 15815, 15815, 15833, 15833, 15851, 15851, 17064, 17174, 17677, 17677, 17682, 17682, 17684, 17684, 18097, 18097, 18099, 18099, 18123, 18123, 18127, 18127, 18128, 18128, 18148, 18148, 18149, 18149, 18310, 18310, 18880, 18880, 18912, 18912, 18949, 18949, 18955, 18955, 19083, 19083, 19140, 19140, 19223, 19223, 19232, 19232, 19310, 19310, 19311, 19311, 19328, 19328, 19403, 19403, 19408, 19408, 19414, 19414, 19433, 19433, 19439, 19439, 20350, 20350, 20421, 20903, 20903, 20991, 20991
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6063, 6063, 6068, 6068, 6165, 6165, 6223, 6223, 7114, 7114, 7771, 7771, 8416, 8416, 8439, 8439, 8459, 8459, 8644, 8644, 8665, 8665, 8940, 8940, 8965, 8965, 9020, 9020, 9042, 9042, 9059, 9059, 9076, 9076, 9461, 9461, 9684, 9684, 9701, 9701, 10093, 10093, 10425, 10425, 10636, 10636, 10673, 10673, 10826, 10826, 10969, 10969, 11222, 11222, 11410, 11410, 11594, 11594, 11913, 11913, 12249, 12249, 12421, 12421, 12461, 12461, 12467, 12467, 12561, 12561, 12791, 12791, 12864, 12864, 13351, 13351, 13386, 13585, 13585, 15092, 15092, 15308, 15308, 15576, 15683, 15783, 15783, 15818, 15818, 15836, 15836, 15854, 15854, 17147, 17650, 17650, 17655, 17655, 17657, 17657, 18070, 18070, 18072, 18072, 18096, 18096, 18100, 18100, 18101, 18101, 18121, 18121, 18122, 18122, 18283, 18283, 18853, 18853, 18885, 18885, 18922, 18922, 18928, 18928, 19056, 19056, 19113, 19113, 19196, 19196, 19205, 19205, 19283, 19283, 19284, 19284, 19301, 19301, 19376, 19376, 19381, 19381, 19387, 19387, 19406, 19406, 19412, 19412, 20323, 20323, 20394, 20876, 20876, 20964, 20964
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1098,7 +1084,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10468-10536
+- Def site: line 10471-10539
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1109,11 +1095,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10508, 10508, 10513, 10513, 10518, 10518, 10519, 10519, 10525, 10525, 10526, 10526, 10532, 10532, 10533, 10533, 10534, 10534, 10535, 10535, 19456, 19456
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10511, 10511, 10516, 10516, 10521, 10521, 10522, 10522, 10528, 10528, 10529, 10529, 10535, 10535, 10536, 10536, 10537, 10537, 10538, 10538, 19429, 19429
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 18835-18900
+- Def site: line 18808-18873
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1123,11 +1109,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18883, 18883, 18891, 18891, 18900, 18900, 19429, 19429
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18856, 18856, 18864, 18864, 18873, 18873, 19402, 19402
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15804-15859
+- Def site: line 15807-15862
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1137,11 +1123,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19054, 19054, 19058, 19058, 19263, 19263
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19027, 19027, 19031, 19031, 19236, 19236
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6093-6139
+- Def site: line 6096-6142
 - References: 57
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1150,14 +1136,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6217, 6217, 8103, 8103, 9018, 9018, 9041, 9041, 9528, 9528, 9563, 9563, 9577, 9577, 9700, 9700, 9704, 9704, 10252, 10252, 12562, 12562, 13232, 13232, 13358, 13358, 13390, 13568, 13568, 13604, 13604, 15579, 17678, 17678, 17987, 17987, 18098, 18098, 18129, 18129, 18150, 18150, 19313, 19313, 19329, 19329, 20922, 20922
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6220, 6220, 8106, 8106, 9021, 9021, 9044, 9044, 9531, 9531, 9566, 9566, 9580, 9580, 9703, 9703, 9707, 9707, 10255, 10255, 12565, 12565, 13235, 13235, 13361, 13361, 13393, 13571, 13571, 13607, 13607, 15582, 17651, 17651, 17960, 17960, 18071, 18071, 18102, 18102, 18123, 18123, 19286, 19286, 19302, 19302, 20895, 20895
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5742-5787
-- References: 100
+- Def site: line 5745-5790
+- References: 99
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1165,14 +1151,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5254, 5254, 5296, 5296, 5341, 5341, 5447, 5447, 5462, 5462, 5732, 5732, 5733, 5733, 5777, 5777, 6243, 6243, 7937, 7937, 9228, 9228, 9539, 9539, 9555, 9555, 9884, 9884, 10765, 10765, 10784, 10784, 12753, 15172, 15172, 15575, 15818, 15818, 15836, 15836, 15854, 15854, 15884, 16306, 16306, 16346, 16346, 16347, 16347, 16348, 16348, 17068, 17100, 17100, 17124, 17124, 17128, 17128, 17148, 17148, 17175, 17250, 17250, 17284, 17284, 17305, 17305, 17337, 17337, 17399, 17399, 17438, 17438, 17588, 17588, 17633, 17633, 17679, 17679
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5257, 5257, 5299, 5299, 5344, 5344, 5450, 5450, 5465, 5465, 5735, 5735, 5736, 5736, 5780, 5780, 6246, 6246, 7940, 7940, 9231, 9231, 9542, 9542, 9558, 9558, 9887, 9887, 10768, 10768, 10787, 10787, 12756, 15175, 15175, 15578, 15821, 15821, 15839, 15839, 15857, 15857, 15887, 16309, 16309, 16349, 16349, 16350, 16350, 16351, 16351, 17073, 17073, 17097, 17097, 17101, 17101, 17121, 17121, 17148, 17223, 17223, 17257, 17257, 17278, 17278, 17310, 17310, 17372, 17372, 17411, 17411, 17561, 17561, 17606, 17606, 17652, 17652
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17164-17206
+- Def site: line 17137-17179
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1181,11 +1167,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17187, 17187, 17193, 17193, 17199, 17199, 17205, 17205, 19247, 19247, 19251, 19251, 19255, 19255, 19259, 19259
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17160, 17160, 17166, 17166, 17172, 17172, 17178, 17178, 19220, 19220, 19224, 19224, 19228, 19228, 19232, 19232
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11610-11649
+- Def site: line 11613-11652
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1194,11 +1180,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11647, 11647, 19453, 19453
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11650, 11650, 19426, 19426
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1851-1879
+- Def site: line 1854-1882
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1207,12 +1193,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8891, 8891, 8892, 8892, 8921, 8921, 8922, 8922, 8938, 8938, 8939, 8939, 9817, 9817, 9818, 9818, 10122, 10122, 10123, 10123, 10170, 10170, 10171, 10171, 10726, 10726, 10728, 10728, 10746, 10746, 10748, 10748, 11636, 11636, 11637, 11637, 12297, 12297, 12298, 12298, 12403, 12403, 12404, 12404, 13386
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8894, 8894, 8895, 8895, 8924, 8924, 8925, 8925, 8941, 8941, 8942, 8942, 9820, 9820, 9821, 9821, 10125, 10125, 10126, 10126, 10173, 10173, 10174, 10174, 10729, 10729, 10731, 10731, 10749, 10749, 10751, 10751, 11639, 11639, 11640, 11640, 12300, 12300, 12301, 12301, 12406, 12406, 12407, 12407, 13389
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15533-15560
+- Def site: line 15536-15563
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1221,12 +1207,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15547, 15547, 15553, 15553, 15559, 15559, 19161, 19161, 19165, 19165
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15550, 15550, 15556, 15556, 15562, 15562, 19134, 19134, 19138, 19138
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15870-15895
+- Def site: line 15873-15898
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1236,12 +1222,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15890, 15890, 15895, 15895, 19169, 19169, 19174, 19174
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15893, 15893, 15898, 15898, 19142, 19142, 19147, 19147
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2115-2139
+- Def site: line 2118-2142
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1249,11 +1235,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2201, 2260, 17795, 20746
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2204, 2263, 17768, 20719
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13685-13706
+- Def site: line 13688-13709
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1262,7 +1248,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18935, 18935, 18939, 18939, 18943, 18943
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18908, 18908, 18912, 18912, 18916, 18916
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1272,17 +1258,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17616-17637
+- Def site: line 17589-17610
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17681, 17681, 19082, 19082, 19139, 19139, 19222, 19222, 19231, 19231
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17654, 17654, 19055, 19055, 19112, 19112, 19195, 19195, 19204, 19204
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 18082-18103
+- Def site: line 18055-18076
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1291,24 +1277,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19292, 19292
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19265, 19265
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7575-7595
+- Def site: line 7578-7598
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6326, 10095, 15418, 15583
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6329, 10098, 15421, 15586
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13931-13940
+- Def site: line 13934-13943
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1316,11 +1302,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13967, 14103, 14180, 14199, 14211, 14232, 14245, 14256, 14262, 14275, 14368, 14503, 14598
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13970, 14106, 14183, 14202, 14214, 14235, 14248, 14259, 14265, 14278, 14371, 14506, 14601
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 303-311
+- Def site: line 306-314
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1336,7 +1322,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 330-338
+- Def site: line 333-341
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1344,12 +1330,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15241, 15258, 15274
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15244, 15261, 15277
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 315-322
+- Def site: line 318-325
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1365,7 +1351,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 290-292
+- Def site: line 293-295
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1373,12 +1359,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13391, 13680, 18131, 18152, 18297, 18328, 18360, 18595, 18610
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13394, 13683, 18104, 18125, 18270, 18301, 18333, 18568, 18583
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 618-620
+- Def site: line 621-623
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1386,7 +1372,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1228, 1897, 1897, 1897, 1909, 1915, 6219, 6339, 7399, 7459, 9627, 9738, 9992, 10822, 13393, 15451, 15493, 15591, 19315
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1231, 1900, 1900, 1900, 1912, 1918, 6222, 6342, 7402, 7462, 9630, 9741, 9995, 10825, 13396, 15454, 15496, 15594, 19288
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1399,7 +1385,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 1999-2001
+- Def site: line 2002-2004
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1408,12 +1394,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1999, 7409, 7416, 7417, 10003, 15440
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2002, 7412, 7419, 7420, 10006, 15443
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2017-2019
-- References: 12
+- Def site: line 2020-2022
+- References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1421,7 +1407,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2017, 15587, 17072
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2020, 15590
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1429,7 +1415,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 734-1738
+- Def site: line 737-1741
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1437,7 +1423,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1783
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1786
 
 ## Limitations
 

--- a/src/firmware/firmware_manager.py
+++ b/src/firmware/firmware_manager.py
@@ -1571,14 +1571,12 @@ class FirmwareManager:
         sites_for_upgrader = [  # WHY: normalize site shape expected by BulkAPFirmwareUpgrader
             {"id": s["id"], "name": s.get("name", "Unknown")} for s in sites
         ]
-        main_module = sys.modules.get("__main__") or sys.modules.get("MistHelper")  # WHY: locate host module
-        if main_module is None:  # WHY: guard against missing host (e.g., isolated unit test)
-            logging.debug("MSP upgrade skipped: MistHelper host module not loaded")  # WHY: trace skip
-            return  # WHY: no-op when host absent, caller records completion
-        bulk_upgrader_cls = main_module.BulkAPFirmwareUpgrader  # WHY: lazy attr avoids circular import
-        upgrader = bulk_upgrader_cls(target_org_id, sites_for_upgrader, dry_run=dry_run)  # WHY: construct
-        upgrader.execute()  # WHY: run the actual bulk upgrade
-        logging.info("MSP upgrade %s for org id %s", "simulated" if dry_run else "completed", target_org_id)  # WHY: log
+        self._dispatch_bulk_ap_upgrade(target_org_id, sites_for_upgrader, dry_run)  # WHY: delegate to shared dispatcher
+        logging.info(  # WHY: audit MSP org completion after dispatcher returns
+            "MSP upgrade %s for org id %s",
+            "simulated" if dry_run else "completed",
+            target_org_id,
+        )
 
     def _handle_msp_interrupt(  # WHY: format interrupted record + confirm continuation
         self,
@@ -1747,16 +1745,48 @@ class FirmwareManager:
         sites_to_upgrade_override: list[dict[str, Any]] | None,
     ) -> None:
         """Execute the bulk firmware upgrade using BulkAPFirmwareUpgrader class."""
-        import sys as _sys
+        dry_run = getattr(getattr(_MH, "args", None), "dry_run", False)  # WHY: pull dry_run from CLI args namespace
+        self._dispatch_bulk_ap_upgrade(  # WHY: delegate to shared dispatcher used by MSP path too
+            self.org_id, sites_to_upgrade_override, dry_run
+        )
 
-        _main = _sys.modules.get("__main__") or _sys.modules.get("MistHelper")
-        if _main is None:
-            return
-        BulkAPFirmwareUpgrader = _main.BulkAPFirmwareUpgrader  # lazy import avoids circular
-        # Check for dry_run flag from global args
-        dry_run = getattr(getattr(_main, "args", None), "dry_run", False)
-        upgrader = BulkAPFirmwareUpgrader(self.org_id, sites_to_upgrade_override, dry_run=dry_run)
-        upgrader.execute()
+    def _build_bulk_ap_config(  # WHY: assemble BulkAPUpgraderConfig from MistHelper globals via _MH proxy
+        self,
+        target_org_id: str,
+        sites_override: list[dict[str, Any]] | None,
+        dry_run: bool,
+    ) -> Any:
+        """Assemble the frozen BulkAPUpgraderConfig used by the upgrader."""
+        from src.firmware.bulk_ap_upgrader import BulkAPUpgraderConfig  # WHY: lazy import per Constitution
+
+        return BulkAPUpgraderConfig(  # WHY: immutable bundle per FR-004 single-arg constructor
+            org_id=target_org_id,  # WHY: caller-selected target org id
+            apisession=_MH.apisession,  # WHY: ambient session sourced from MistHelper module
+            sites_override=sites_override,  # WHY: preselected sites bypass interactive prompt
+            dry_run=dry_run,  # WHY: dry-run flag flows through unchanged
+            safe_input_fn=_MH.InputUtils.safe_input,  # WHY: preserves Ctrl+C / stop-signal behavior
+            check_stop_fn=_MH.ConfigUtils.check_stop_signal,  # WHY: cooperative abort polling
+            fetch_sites_fn=_MH.APICoreFetchUtils.all_sites_with_limit,  # WHY: cache-aware site fetch
+            get_csv_path_fn=_MH.FilePathUtils.get_csv_path,  # WHY: OS-safe CSV path resolution
+            check_firmware_status_fn=lambda: _MH.FirmwareManager.create(  # WHY: lazy status re-check factory
+                _MH.apisession, _MH.ConfigUtils.get_cached_or_prompted_org_id()
+            ).check_firmware_upgrade_status(),
+            get_org_id_fn=_MH.ConfigUtils.get_cached_or_prompted_org_id,  # WHY: seam so upgrader can re-prompt
+        )
+
+    def _dispatch_bulk_ap_upgrade(  # WHY: build config + run BulkAPFirmwareUpgrader (replaces MistHelper wrapper)
+        self,
+        target_org_id: str,
+        sites_override: list[dict[str, Any]] | None,
+        dry_run: bool,
+    ) -> None:
+        """Build BulkAPUpgraderConfig and execute the bulk AP upgrade."""
+        from src.firmware.bulk_ap_upgrader import (  # WHY: lazy import keeps module load cheap
+            BulkAPFirmwareUpgrader as _Impl,
+        )
+
+        config = self._build_bulk_ap_config(target_org_id, sites_override, dry_run)  # WHY: delegate build
+        _Impl(config).execute()  # WHY: single-arg constructor + execute per contracts/constructor.md
 
     def _execute_status_check(self, scope_choice: str, site_filter: str | None) -> None:
         """Execute the firmware status check using the co-located FirmwareUpgradeStatusChecker."""


### PR DESCRIPTION
## Summary

- Folds the 33-line `BulkAPFirmwareUpgrader` wrapper class from `MistHelper.py` into `FirmwareManager` via two new private helpers: `_build_bulk_ap_config` and `_dispatch_bulk_ap_upgrade`.
- Rewrites `_run_msp_bulk_upgrader` (MSP path) and `_execute_bulk_upgrade` (single-org path) to route through the shared dispatcher — the wrapper shim is deleted per FR-003 (no delegation wrappers) and FR-015 (fold-in consolidation).
- `_MH` `_MistHelperProxy` singleton (already present in `firmware_manager.py`) is reused for lazy resolution of `apisession`, `InputUtils`, `ConfigUtils`, `APICoreFetchUtils`, `FilePathUtils`, `FirmwareManager`, and the CLI `args.dry_run` flag — preserves live re-bindings and test monkeypatching.

## Compliance

- `src/firmware/firmware_manager.py`: **A+ 97.0/100** (baseline preserved; sole violation is a pre-existing CONV-COMMENTS entry on `from __future__ import annotations` / class-def lines, not introduced by this PR).
- `MistHelper.py`: **A 96.0/100** (unchanged from prior baseline — wrapper deletion nets neutral).
- Max cyclomatic complexity of new helpers: 2 (well under STRUCT-COMPLEXITY limit).
- New helpers are 12 and 15 executable lines respectively (well under STRUCT-LENGTH 25-line limit).

## Test plan

- [x] `python -m pytest tests/unit/` — 3861 tests pass
- [x] `python -m pytest tests/unit/test_bulk_ap_upgrader.py` — 170 tests pass (real impl tests unaffected)
- [x] `python -m mypy src/firmware/firmware_manager.py` — no issues
- [x] `python -m black --check` — clean
- [x] `python -m ruff check` — all checks passed
- [x] `python tools/check_compliance.py src/firmware/firmware_manager.py` — A+ 97.0
- [x] `python tools/check_compliance.py MistHelper.py` — A 96.0 (non-regressing)

Refs: initiative 1011 SC-022, FR-003, FR-015