### PR TITLE
refactor(1011): extract initialize_mist_session_interactive (SC-023)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -100,7 +100,7 @@ from src.audit.filter import AuditLogFilter  # Import audit log filtering to rem
 from src.audit.renderer import AuditReportRenderer  # Import Mermaid timeline + HTML report rendering
 from src.audit.time_parser import TimeRangeParser  # Import audit log time range parsing (7d, 4w, etc.)
 from src.auth.interactive import (
-    LoginOrchestrator,
+    LoginOrchestrator,  # noqa: F401  # Re-exported so extracted refactors can resolve it via MistHelper (SC-023)
     MspOrgSelector,
 )  # Duplicate import (re-stated with comment below); kept to preserve module load behavior
 from src.bootstrap.dependency_check import (
@@ -155,6 +155,9 @@ from src.refactors.device_config_template_cloner_manager import (
 )
 from src.refactors.device_data_fetcher import (
     DeviceDataFetcher,  # Extracted interactive device data fetcher (SC-017)
+)
+from src.refactors.initialize_mist_session_interactive import (
+    MistSessionInteractiveInitializer,  # Extracted interactive login initializer (SC-023)
 )
 from src.refactors.inventory_csvcomparator import (
     InventoryCSVComparator,  # Extracted inventory CSV comparator adapter (SC-018)
@@ -2195,24 +2198,9 @@ def _restore_session_globals_from_state(state: dict) -> None:
     org_id = state.get("org_id", org_id)  # Copy the selected org ID back
 
 
-def initialize_mist_session_interactive():
-    """Initialize Mist API session via extracted interactive session manager."""
-    global apisession, mistapi, msp_privileges, selected_msp, org_id  # These globals are updated on login
-    state = _snapshot_session_globals_to_state()  # Capture current globals into a mutable bag
-
-    def _detect_msp_for_login():  # DI adapter binding MSP detection to freshly-authenticated session
-        return detect_msp_privileges(
-            state.get("apisession")
-        )  # Orchestrator stores the new session in state before this runs
-
-    session_manager = LoginOrchestrator(  # Build the interactive login orchestrator with injected deps
-        state=state,  # Pass the mutable state bag the orchestrator will update
-        safe_input=InputUtils.safe_input,  # Inject the EOF-safe input function
-        detect_msp_privileges=_detect_msp_for_login,  # Inject MSP detection bound to the new login session
-    )
-    login_success = session_manager.execute()  # Run the interactive login workflow
-    _restore_session_globals_from_state(state)  # Mirror any state mutations back to module globals
-    return login_success  # Report whether the interactive login succeeded
+# NOTE: initialize_mist_session_interactive() extracted to
+# src/refactors/initialize_mist_session_interactive.py::MistSessionInteractiveInitializer.initialize
+# per initiative 1011 SC-023 (FR-003: no wrapper shim; FR-005: fn->method).
 
 
 def _print_switch_login_header():
@@ -2255,7 +2243,7 @@ def _attempt_interactive_login_with_rollback(old_session, old_org_id) -> bool:
     msp_privileges = []  # Clear cached MSP grants from the old session
     org_id = None  # Clear the selected org from the old session
 
-    if not initialize_mist_session_interactive():  # type: ignore[no-untyped-call]  # Attempt the interactive login
+    if not MistSessionInteractiveInitializer.initialize():  # Attempt the interactive login
         print("")  # Blank spacer line
         print("  X Login failed - restoring previous session")  # Inform the user of the rollback
         apisession = old_session  # Restore the prior API session
@@ -17731,7 +17719,7 @@ class MSPInventoryExporter:
         """Execute login and validate MSP privileges obtained."""
         global msp_privileges
 
-        if not initialize_mist_session_interactive():  # type: ignore[no-untyped-call]
+        if not MistSessionInteractiveInitializer.initialize():
             print("")
             print("  X Login failed.")
             return False
@@ -20678,7 +20666,7 @@ def _establish_mist_session(args: argparse.Namespace) -> None:
     logging.debug("_establish_mist_session: starting session initialization")  # Log entry
     if args.login:  # Interactive login requested via --login flag
         logging.info("Interactive login mode requested via --login flag")  # Log before interactive login
-        if not initialize_mist_session_interactive():  # type: ignore[no-untyped-call]  # Attempt email/password login
+        if not MistSessionInteractiveInitializer.initialize():  # Attempt email/password login
             logging.error("Failed to initialize Mist API session via interactive login")  # Log auth failure
             print(" Failed to initialize Mist API session. Check your credentials.")  # Inform user
             sys.exit(1)  # Exit -- cannot proceed without authenticated session

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 190 first-party files
-- Definitions analyzed: 93
+- Module graph size: 191 first-party files
+- Definitions analyzed: 91
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=12, hot=80, skipped=1
+- Category counts: unused=0, single-use=0, low-use=11, hot=79, skipped=1
 
 ## How to read this report
 
@@ -86,28 +86,26 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `SiteClientExporter` | class | 85 | 10 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `OrgLevelAPFirmwareUpgrader` | class | 79 | 33 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `VirtualChassisManager` | class | 78 | 104 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
-| `InputUtils` | class | 74 | 258 | hot |  | oversize_25_lines,raw_input_call |
+| `InputUtils` | class | 74 | 254 | hot |  | oversize_25_lines,raw_input_call |
 | `InteractiveDisplayUtils` | class | 72 | 8 | hot |  | oversize_25_lines,missing_inline_comments |
 | `DisplayUtils` | class | 70 | 8 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
-| `ConfigUtils` | class | 70 | 188 | hot |  | oversize_25_lines |
+| `ConfigUtils` | class | 70 | 182 | hot |  | oversize_25_lines |
 | `OrgDeviceInventorySummary` | class | 69 | 22 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging,non_ascii_logs |
 | `AuditAnalysisOps` | class | 66 | 8 | hot |  | oversize_25_lines,missing_inline_comments,raw_input_call |
 | `GatewayTemplateConfigManager` | class | 56 | 6 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
-| `APICoreFetchUtils` | class | 47 | 57 | hot |  | oversize_25_lines,missing_inline_comments |
-| `FilePathUtils` | class | 46 | 99 | hot |  | oversize_25_lines,missing_inline_comments |
+| `APICoreFetchUtils` | class | 47 | 55 | hot |  | oversize_25_lines,missing_inline_comments |
+| `FilePathUtils` | class | 46 | 97 | hot |  | oversize_25_lines,missing_inline_comments |
 | `SiteConfigManager` | class | 43 | 16 | hot |  | oversize_25_lines,missing_action_logging |
 | `SelfExportUtils` | class | 40 | 4 | hot |  | oversize_25_lines,non_ascii_logs |
-| `BulkAPFirmwareUpgrader` | class | 32 | 2 | low-use | FirmwareManager | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `TimeUtils` | class | 29 | 51 | hot |  | oversize_25_lines,missing_inline_comments |
 | `GatewayStatsExporter` | class | 28 | 52 | hot |  | oversize_25_lines,missing_action_logging |
 | `SSHRunnerManager` | class | 26 | 82 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
-| `detect_msp_privileges` | function | 25 | 4 | hot |  | missing_action_logging |
+| `detect_msp_privileges` | function | 25 | 3 | low-use | DetectMspPrivilegesManager | missing_action_logging |
 | `RoutingUtils` | class | 22 | 12 | hot |  | missing_inline_comments,missing_action_logging |
-| `FirmwareManager` | class | 22 | 10 | hot |  |  |
+| `FirmwareManager` | class | 22 | 8 | hot |  |  |
 | `SiteAutoUpgradeConfigurator` | class | 22 | 6 | hot |  | missing_inline_comments,missing_action_logging |
 | `execute_with_connection_pool_management` | function | 21 | 7 | hot |  |  |
 | `BulkSwitchFirmwareUpgrader` | class | 19 | 2 | low-use | FirmwareManager | missing_inline_comments,missing_action_logging |
-| `initialize_mist_session_interactive` | function | 18 | 3 | low-use | InitializeMistSessionInteractiveManager | missing_action_logging |
 | `initialize_mist_session` | function | 18 | 2 | low-use | InitializeMistSessionManager | missing_action_logging |
 | `PACKAGE_IMPORT_MAP` | assignment | 13 | 2 | low-use | PackageImportMapManager | missing_action_logging |
 | `main` | function | 12 | 2 | low-use | MainManager |  |
@@ -126,25 +124,23 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 11 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (12)
+## Low-Use (11)
 
-### `BulkAPFirmwareUpgrader` (class, 32 lines)
+### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 17628-17659
-- References: 2
-- Suggested class: `FirmwareManager`
-- Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
-- Rationale: 105 caller files detected; group callers under a shared class in `firmware_manager.py` and rewrite references per file cluster
+- Def site: line 2121-2145
+- References: 3
+- Suggested class: `DetectMspPrivilegesManager`
+- Suggested module: `src/refactors/detect_msp_privileges.py`
+- Rationale: low-use: sole caller lives inside MistHelper.py from `_attempt_interactive_login_with_rollback()`; extract `detect_msp_privileges` OUT of the entrypoint into a new `src/refactors/detect_msp_privileges.py` module and rewrite the callsite(s) to import from there
 - Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1755, 1758
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2251, 17727, 20678
 
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 18160-18178
+- Def site: line 18119-18137
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -153,23 +149,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1850, 1851
-
-### `initialize_mist_session_interactive` (function, 18 lines)
-
-- Def site: line 2198-2215
-- References: 3
-- Suggested class: `InitializeMistSessionInteractiveManager`
-- Suggested module: `src/refactors/initialize_mist_session_interactive.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `_attempt_interactive_login_with_rollback()`; extract `initialize_mist_session_interactive` OUT of the entrypoint into a new `src/refactors/initialize_mist_session_interactive.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2258, 17763, 20710
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1880, 1881
 
 ### `initialize_mist_session` (function, 18 lines)
 
-- Def site: line 2824-2841
+- Def site: line 2812-2829
 - References: 2
 - Suggested class: `InitializeMistSessionManager`
 - Suggested module: `src/refactors/initialize_mist_session.py`
@@ -177,11 +161,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20715, 20778
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20674, 20737
 
 ### `PACKAGE_IMPORT_MAP` (assignment, 13 lines)
 
-- Def site: line 375-387
+- Def site: line 378-390
 - References: 2
 - Suggested class: `PackageImportMapManager`
 - Suggested module: `src/refactors/package__import__map.py`
@@ -189,35 +173,35 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 375, 559
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 378, 562
 
 ### `main` (function, 12 lines)
 
-- Def site: line 21106-21117
+- Def site: line 21065-21076
 - References: 2
 - Suggested class: `MainManager`
 - Suggested module: `src/refactors/main.py`
 - Rationale: low-use: sole caller lives inside MistHelper.py; extract `main` OUT of the entrypoint into a new `src/refactors/main.py` module and rewrite the callsite(s) to import from there
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21220
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21179
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
 
 ### `marvis_data_utils` (assignment, 4 lines)
 
-- Def site: line 6545-6548
+- Def site: line 6533-6536
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `_build_deps()`; extract `marvis_data_utils` OUT of the entrypoint into a new `src/refactors/marvis_data_utils.py` module and rewrite the callsite(s) to import from there
+- Rationale: low-use: sole caller lives inside MistHelper.py from `MarvisTroubleshootDeps()`; extract `marvis_data_utils` OUT of the entrypoint into a new `src/refactors/marvis_data_utils.py` module and rewrite the callsite(s) to import from there
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6545, 15687
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6533, 15675
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\marvis_troubleshoot_utils.py`: lines 21
 
 ### `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 lines)
 
-- Def site: line 1990-1992
+- Def site: line 1993-1995
 - References: 3
 - Suggested class: `FastModeBackoffMultiplierManager`
 - Suggested module: `src/refactors/fast__mode__backoff__multiplier.py`
@@ -226,11 +210,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1990, 9931, 15360
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1993, 9919, 15348
 
 ### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
 
-- Def site: line 1993-1995
+- Def site: line 1996-1998
 - References: 2
 - Suggested class: `FastModeDevicesPerThreadManager`
 - Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
@@ -239,11 +223,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1993, 7421
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1996, 7409
 
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 1998-2000
+- Def site: line 2001-2003
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -252,11 +236,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1998, 15500
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2001, 15488
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2005-2007
+- Def site: line 2008-2010
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -264,11 +248,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2005, 7411
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2008, 7399
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 2013-2015
+- Def site: line 2016-2018
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -277,14 +261,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2013, 15589
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2016, 15577
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
-## Hot (80)
+## Hot (79)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2886-5212
+- Def site: line 2874-5200
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -295,11 +279,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2886, 6591, 6592, 6601, 6765
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2874, 6579, 6580, 6589, 6753
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13946-14704
+- Def site: line 13934-14692
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -308,11 +292,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14423, 14423, 14435, 14435, 14463, 14463, 14475, 14475, 14536, 14536, 14573, 14573, 14730, 19159
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14411, 14411, 14423, 14423, 14451, 14451, 14463, 14463, 14524, 14524, 14561, 14561, 14718, 19118
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9092-9777
+- Def site: line 9080-9765
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -321,12 +305,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5598, 5598, 9215, 9215, 9266, 9266, 9269, 9269, 9310, 9310, 9349, 9349, 9367, 9367, 9445, 9445, 9452, 9452, 9462, 9462, 9465, 9465, 9478, 9478, 9479, 9479, 9480, 9480, 9481, 9481, 9489, 9489, 9491, 9491, 9492, 9492, 9493, 9493, 9494, 9494, 9497, 9497, 9500, 9500, 9503, 9503, 9506, 9506, 9552, 9552, 9575, 9575, 9576, 9576, 9577, 9577, 9579, 9579, 9615, 9615, 9631, 9631, 9685, 9685, 9686, 9686, 9687, 9687, 9690, 9690, 9691, 9691, 9710, 9710, 9712, 9712, 9713, 9713, 9748, 9748, 15099, 15099, 15152, 15152, 15583, 17075, 17075, 17099, 17099, 17123, 17123, 17266, 17266, 18934, 18934, 18941, 18941, 18950, 18950, 18954, 18954, 18963, 18963
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5586, 5586, 9203, 9203, 9254, 9254, 9257, 9257, 9298, 9298, 9337, 9337, 9355, 9355, 9433, 9433, 9440, 9440, 9450, 9450, 9453, 9453, 9466, 9466, 9467, 9467, 9468, 9468, 9469, 9469, 9477, 9477, 9479, 9479, 9480, 9480, 9481, 9481, 9482, 9482, 9485, 9485, 9488, 9488, 9491, 9491, 9494, 9494, 9540, 9540, 9563, 9563, 9564, 9564, 9565, 9565, 9567, 9567, 9603, 9603, 9619, 9619, 9673, 9673, 9674, 9674, 9675, 9675, 9678, 9678, 9679, 9679, 9698, 9698, 9700, 9700, 9701, 9701, 9736, 9736, 15087, 15087, 15140, 15140, 15571, 17063, 17063, 17087, 17087, 17111, 17111, 17254, 17254, 18893, 18893, 18900, 18900, 18909, 18909, 18913, 18913, 18922, 18922
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16374-17048
+- Def site: line 16362-17036
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -334,11 +318,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16762, 16762, 19405, 19411
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16750, 16750, 19364, 19370
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11825-12477
+- Def site: line 11813-12465
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -348,11 +332,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10602, 10602, 10611, 10611, 10699, 10699, 10706, 10706, 11380, 11380, 11666, 11666, 11671, 11671, 11678, 11678, 11683, 11683, 11897, 11897, 11919, 11919, 11922, 11922, 11948, 11948, 11957, 11957, 11958, 11958, 11979, 11979, 12022, 12022, 12068, 12068, 12079, 12079, 12106, 12106, 12111, 12111, 12112, 12112, 12113, 12113, 12145, 12145, 12151, 12151, 12176, 12176, 12196, 12196, 12231, 12231, 12246, 12246, 12252, 12252, 12254, 12254, 12257, 12257, 12259, 12259, 12263, 12263, 12267, 12267, 12272, 12272, 12279, 12279, 12286, 12286, 12293, 12293, 12302, 12302, 12312, 12312, 12319, 12319, 12326, 12326, 12333, 12333, 12340, 12340, 12347, 12347, 12357, 12357, 12366, 12366, 12375, 12375, 12384, 12384, 12393, 12393, 12422, 12422, 18895, 18895, 19076, 19076, 19153, 19153, 19154, 19154, 19162, 19162, 19367, 19367, 19368, 19368, 19387, 19387, 19394, 19394, 19395, 19395, 19396, 19396, 19397, 19397
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10590, 10590, 10599, 10599, 10687, 10687, 10694, 10694, 11368, 11368, 11654, 11654, 11659, 11659, 11666, 11666, 11671, 11671, 11885, 11885, 11907, 11907, 11910, 11910, 11936, 11936, 11945, 11945, 11946, 11946, 11967, 11967, 12010, 12010, 12056, 12056, 12067, 12067, 12094, 12094, 12099, 12099, 12100, 12100, 12101, 12101, 12133, 12133, 12139, 12139, 12164, 12164, 12184, 12184, 12219, 12219, 12234, 12234, 12240, 12240, 12242, 12242, 12245, 12245, 12247, 12247, 12251, 12251, 12255, 12255, 12260, 12260, 12267, 12267, 12274, 12274, 12281, 12281, 12290, 12290, 12300, 12300, 12307, 12307, 12314, 12314, 12321, 12321, 12328, 12328, 12335, 12335, 12345, 12345, 12354, 12354, 12363, 12363, 12372, 12372, 12381, 12381, 12410, 12410, 18854, 18854, 19035, 19035, 19112, 19112, 19113, 19113, 19121, 19121, 19326, 19326, 19327, 19327, 19346, 19346, 19353, 19353, 19354, 19354, 19355, 19355, 19356, 19356
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 18191-18777
+- Def site: line 18150-18736
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -360,11 +344,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18468, 18468, 18469, 18469, 18472, 18472, 18474, 18474, 18476, 18476, 18492, 18492, 19312
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18427, 18427, 18428, 18428, 18431, 18431, 18433, 18433, 18435, 18435, 18451, 18451, 19271
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 18876-19447
+- Def site: line 18835-19406
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -374,12 +358,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18876, 20161, 20162, 20171, 20291, 20291, 20333, 20391, 20436, 20927, 20931, 20976, 20976, 21003, 21003, 21006
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18835, 20120, 20121, 20130, 20250, 20250, 20292, 20350, 20395, 20886, 20890, 20935, 20935, 20962, 20962, 20965
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8376-8838
+- Def site: line 8364-8826
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -387,11 +371,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8417, 8417, 8422, 8422, 8432, 8432, 8440, 8440, 8445, 8445, 8450, 8450, 8460, 8460, 8465, 8465, 8470, 8470, 8490, 8490, 8500, 8500, 8501, 8501, 8504, 8504, 8534, 8534, 8620, 8620, 8622, 8622, 8646, 8646, 8652, 8652, 8657, 8657, 8666, 8666, 8670, 8670, 8689, 8689, 8692, 8692, 8703, 8703, 8704, 8704, 8799, 8799, 8820, 8820, 19435, 19435, 19436, 19436, 19437, 19437, 19438, 19438, 19439, 19439, 19440, 19440
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8405, 8405, 8410, 8410, 8420, 8420, 8428, 8428, 8433, 8433, 8438, 8438, 8448, 8448, 8453, 8453, 8458, 8458, 8478, 8478, 8488, 8488, 8489, 8489, 8492, 8492, 8522, 8522, 8608, 8608, 8610, 8610, 8634, 8634, 8640, 8640, 8645, 8645, 8654, 8654, 8658, 8658, 8677, 8677, 8680, 8680, 8691, 8691, 8692, 8692, 8787, 8787, 8808, 8808, 19394, 19394, 19395, 19395, 19396, 19396, 19397, 19397, 19398, 19398, 19399, 19399
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 19672-20132
+- Def site: line 19631-20091
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -401,11 +385,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20139, 20139, 20143, 20143, 20163, 20163, 20168, 20168, 20392
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20098, 20098, 20102, 20102, 20122, 20122, 20127, 20127, 20351
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7823-8263
+- Def site: line 7811-8251
 - References: 117
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -413,14 +397,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7768, 7768, 7784, 7784, 7788, 7788, 7789, 7789, 7790, 7790, 7805, 7805, 7811, 7811, 7838, 7838, 7841, 7841, 7849, 7849, 7867, 7867, 7917, 7917, 7925, 7925, 7930, 7930, 7976, 7976, 7987, 7987, 8012, 8012, 8031, 8031, 8032, 8032, 8035, 8035, 8036, 8036, 8126, 8126, 8128, 8128, 8132, 8132, 8160, 8160, 8161, 8161, 8162, 8162, 8163, 8163, 8164, 8164, 8173, 8173, 8217, 8217, 8241, 8241, 12557, 12557, 12607, 12607, 12612, 12612, 12755, 12838, 12838, 12892, 12892, 12913, 12913, 12918, 12918, 13182, 13182, 13385, 13587, 13587, 13674, 13674, 13679, 13679, 13729, 13729, 13730, 13730, 15226, 15226, 15685, 17082, 17082, 17604, 17604, 18800, 18800, 18801, 18801, 19087, 19087
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7756, 7756, 7772, 7772, 7776, 7776, 7777, 7777, 7778, 7778, 7793, 7793, 7799, 7799, 7826, 7826, 7829, 7829, 7837, 7837, 7855, 7855, 7905, 7905, 7913, 7913, 7918, 7918, 7964, 7964, 7975, 7975, 8000, 8000, 8019, 8019, 8020, 8020, 8023, 8023, 8024, 8024, 8114, 8114, 8116, 8116, 8120, 8120, 8148, 8148, 8149, 8149, 8150, 8150, 8151, 8151, 8152, 8152, 8161, 8161, 8205, 8205, 8229, 8229, 12545, 12545, 12595, 12595, 12600, 12600, 12743, 12826, 12826, 12880, 12880, 12901, 12901, 12906, 12906, 13170, 13170, 13373, 13575, 13575, 13662, 13662, 13667, 13667, 13717, 13717, 13718, 13718, 15214, 15214, 15673, 17070, 17070, 17592, 17592, 18759, 18759, 18760, 18760, 19046, 19046
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9780-10193
+- Def site: line 9768-10181
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -429,11 +413,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5592, 5592, 9813, 9813, 9897, 9897, 9903, 9903, 9906, 9906, 9950, 9950, 9964, 9964, 9991, 9991, 9997, 9997, 10011, 10011, 10094, 10094, 10096, 10096, 10100, 10100, 10102, 10102, 10105, 10105, 10109, 10109, 10112, 10112, 10122, 10122, 10128, 10128, 10166, 10166, 15100, 15100, 15101, 15101, 15102, 15102, 15153, 15153, 15154, 15154, 18935, 18935, 18936, 18936, 18937, 18937, 18961, 18961
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5580, 5580, 9801, 9801, 9885, 9885, 9891, 9891, 9894, 9894, 9938, 9938, 9952, 9952, 9979, 9979, 9985, 9985, 9999, 9999, 10082, 10082, 10084, 10084, 10088, 10088, 10090, 10090, 10093, 10093, 10097, 10097, 10100, 10100, 10110, 10110, 10116, 10116, 10154, 10154, 15088, 15088, 15089, 15089, 15090, 15090, 15141, 15141, 15142, 15142, 18894, 18894, 18895, 18895, 18896, 18896, 18920, 18920
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17185-17582
+- Def site: line 17173-17570
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -442,11 +426,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17206, 17206, 17211, 17211, 17215, 17215, 17218, 17218, 17225, 17225, 17227, 17227, 17228, 17228, 17231, 17231, 17234, 17234, 17237, 17237, 17279, 17279, 17311, 17311, 17378, 17378, 17391, 17391, 17396, 17396, 17448, 17448, 17481, 17481, 17482, 17482, 17483, 17483, 17513, 17513, 17542, 17542, 17543, 17543, 19118, 19118
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17194, 17194, 17199, 17199, 17203, 17203, 17206, 17206, 17213, 17213, 17215, 17215, 17216, 17216, 17219, 17219, 17222, 17222, 17225, 17225, 17267, 17267, 17299, 17299, 17366, 17366, 17379, 17379, 17384, 17384, 17436, 17436, 17469, 17469, 17470, 17470, 17471, 17471, 17501, 17501, 17530, 17530, 17531, 17531, 19077, 19077
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 17665-18052
+- Def site: line 17624-18011
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -456,11 +440,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17692, 17836, 17836, 19258, 19258
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17651, 17795, 17795, 19217, 19217
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6732-7076
+- Def site: line 6720-7064
 - References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -469,7 +453,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5688, 5688, 6778, 6778, 6794, 6794, 6795, 6795, 6818, 6818, 6820, 6820, 6823, 6823, 6837, 6837, 6839, 6839, 6848, 6848, 6850, 6850, 6851, 6851, 6857, 6857, 6858, 6858, 6858, 6875, 6875, 6879, 6879, 6921, 6921, 6952, 6952, 6955, 6955, 6957, 6957, 7003, 7003, 7013, 7013, 7046, 7046, 7051, 7051, 7058, 7058, 7280, 7280, 7312, 7312, 7323, 7323, 7348, 7348, 7368, 7368, 7880, 7880, 8673, 8673, 8952, 8952, 8967, 9031, 9031, 9048, 9048, 9066, 9066, 9087, 9087, 9646, 9646, 9721, 9721, 10051, 10051, 10402, 10402, 10487, 10503, 10623, 10623, 10627, 10627, 10647, 10647, 10660, 10660, 10664, 10664, 10682, 10682, 10844, 10844, 11191, 11191, 11338, 11338, 11415, 11415, 11419, 11419, 11424, 11424, 11557, 11557, 11576, 11576, 11627, 11627, 11630, 11630, 11781, 11781, 11784, 11784, 11883, 11883, 11889, 11889, 12186, 12186, 12203, 12203, 12218, 12218, 12432, 12432, 12460, 12460, 12476, 12476, 12513, 12513, 12551, 12551, 12640, 12640, 12669, 12669, 12707, 12707, 12758, 12823, 12823, 12829, 12829, 12871, 12871, 13040, 13040, 13046, 13046, 13165, 13165, 13173, 13173, 13337, 13337, 13388, 13561, 13561, 13732, 13732, 14245, 14245, 14606, 14606, 14612, 14612, 15520, 15520, 15579, 15686, 15822, 15822, 15840, 15840, 15858, 15858, 17129, 17129, 17150, 18018, 18018, 18103, 18103, 18124, 18124, 18626, 18626, 19287, 19287, 19303, 19303
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5676, 5676, 6766, 6766, 6782, 6782, 6783, 6783, 6806, 6806, 6808, 6808, 6811, 6811, 6825, 6825, 6827, 6827, 6836, 6836, 6838, 6838, 6839, 6839, 6845, 6845, 6846, 6846, 6846, 6863, 6863, 6867, 6867, 6909, 6909, 6940, 6940, 6943, 6943, 6945, 6945, 6991, 6991, 7001, 7001, 7034, 7034, 7039, 7039, 7046, 7046, 7268, 7268, 7300, 7300, 7311, 7311, 7336, 7336, 7356, 7356, 7868, 7868, 8661, 8661, 8940, 8940, 8955, 9019, 9019, 9036, 9036, 9054, 9054, 9075, 9075, 9634, 9634, 9709, 9709, 10039, 10039, 10390, 10390, 10475, 10491, 10611, 10611, 10615, 10615, 10635, 10635, 10648, 10648, 10652, 10652, 10670, 10670, 10832, 10832, 11179, 11179, 11326, 11326, 11403, 11403, 11407, 11407, 11412, 11412, 11545, 11545, 11564, 11564, 11615, 11615, 11618, 11618, 11769, 11769, 11772, 11772, 11871, 11871, 11877, 11877, 12174, 12174, 12191, 12191, 12206, 12206, 12420, 12420, 12448, 12448, 12464, 12464, 12501, 12501, 12539, 12539, 12628, 12628, 12657, 12657, 12695, 12695, 12746, 12811, 12811, 12817, 12817, 12859, 12859, 13028, 13028, 13034, 13034, 13153, 13153, 13161, 13161, 13325, 13325, 13376, 13549, 13549, 13720, 13720, 14233, 14233, 14594, 14594, 14600, 14600, 15508, 15508, 15567, 15674, 15810, 15810, 15828, 15828, 15846, 15846, 17117, 17117, 17138, 17977, 17977, 18062, 18062, 18083, 18083, 18585, 18585, 19246, 19246, 19262, 19262
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -480,7 +464,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12879-13219
+- Def site: line 12867-13207
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -489,11 +473,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12896, 12896, 12898, 12898, 12902, 12902, 12903, 12903, 12917, 12917, 12923, 12923, 12926, 12926, 12929, 12929, 12987, 12987, 12993, 12993, 12998, 12998, 13012, 13012, 13030, 13030, 13140, 13140, 13144, 13144, 13146, 13146, 13149, 13149, 13186, 13186, 13191, 13191, 13205, 13205, 13209, 13209, 13211, 13211, 13214, 13214, 13219, 13219, 19164, 19164, 19168, 19168, 19172, 19172
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12884, 12884, 12886, 12886, 12890, 12890, 12891, 12891, 12905, 12905, 12911, 12911, 12914, 12914, 12917, 12917, 12975, 12975, 12981, 12981, 12986, 12986, 13000, 13000, 13018, 13018, 13128, 13128, 13132, 13132, 13134, 13134, 13137, 13137, 13174, 13174, 13179, 13179, 13193, 13193, 13197, 13197, 13199, 13199, 13202, 13202, 13207, 13207, 19123, 19123, 19127, 19127, 19131, 19131
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7079-7406
+- Def site: line 7067-7394
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -501,11 +485,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7181, 7181, 8397, 8878, 8897, 8998, 9127, 9150, 9822, 10130, 10175, 10589, 11359, 11370, 11433, 11850
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7169, 7169, 8385, 8866, 8885, 8986, 9115, 9138, 9810, 10118, 10163, 10577, 11347, 11358, 11421, 11838
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14710-15037
+- Def site: line 14698-15025
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -515,13 +499,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12167, 12167, 12226, 12226, 12227, 12227, 13391, 14751, 14751, 14753, 14753, 14759, 14759, 14773, 14773, 14812, 14812, 14815, 14815, 14817, 14817, 14818, 14818, 14819, 14819, 14873, 14873, 14874, 14874, 14885, 14885, 14894, 14894, 14913, 14913, 14965, 14965, 14969, 14969, 14977, 14977, 14978, 14978, 15002, 15002, 15006, 15006
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12155, 12155, 12214, 12214, 12215, 12215, 13379, 14739, 14739, 14741, 14741, 14747, 14747, 14761, 14761, 14800, 14800, 14803, 14803, 14805, 14805, 14806, 14806, 14807, 14807, 14861, 14861, 14862, 14862, 14873, 14873, 14882, 14882, 14901, 14901, 14953, 14953, 14957, 14957, 14965, 14965, 14966, 14966, 14990, 14990, 14994, 14994
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16070-16358
+- Def site: line 16058-16346
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -531,11 +515,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16098, 16098, 16101, 16101, 16106, 16106, 16109, 16109, 16153, 16153, 16159, 16159, 16190, 16190, 16193, 16193, 16197, 16197, 16223, 16223, 16240, 16240, 16246, 16246, 16260, 16260, 16261, 16261, 16263, 16263, 16269, 16269, 16276, 16276, 16285, 16285, 16332, 16332, 16354, 16354, 16355, 16355, 16356, 16356, 19109, 19109
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16086, 16086, 16089, 16089, 16094, 16094, 16097, 16097, 16141, 16141, 16147, 16147, 16178, 16178, 16181, 16181, 16185, 16185, 16211, 16211, 16228, 16228, 16234, 16234, 16248, 16248, 16249, 16249, 16251, 16251, 16257, 16257, 16264, 16264, 16273, 16273, 16320, 16320, 16342, 16342, 16343, 16343, 16344, 16344, 19068, 19068
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10196-10468
+- Def site: line 10184-10456
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -544,11 +528,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10219, 10219, 10220, 10220, 10233, 10233, 10234, 10234, 10236, 10236, 10237, 10237, 10240, 10240, 10243, 10243, 10247, 10247, 10248, 10248, 10324, 10324, 10328, 10328, 10331, 10331, 10344, 10344, 10381, 10381, 10398, 10398, 10411, 10411, 10413, 10413, 10420, 10420, 10429, 10429, 10438, 10438, 10439, 10439, 10450, 10450, 10454, 10454, 10463, 10463, 10468, 10468, 19366, 19366
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10207, 10207, 10208, 10208, 10221, 10221, 10222, 10222, 10224, 10224, 10225, 10225, 10228, 10228, 10231, 10231, 10235, 10235, 10236, 10236, 10312, 10312, 10316, 10316, 10319, 10319, 10332, 10332, 10369, 10369, 10386, 10386, 10399, 10399, 10401, 10401, 10408, 10408, 10417, 10417, 10426, 10426, 10427, 10427, 10438, 10438, 10442, 10442, 10451, 10451, 10456, 10456, 19325, 19325
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5218-5481
+- Def site: line 5206-5469
 - References: 106
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -556,14 +540,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5258, 5258, 5260, 5260, 5342, 5342, 5348, 5348, 5385, 5385, 5387, 5387, 5396, 5396, 5406, 5406, 5416, 5416, 5452, 5452, 7916, 7916, 9574, 9574, 9575, 9575, 9886, 9886, 10732, 10732, 10752, 10752, 12753, 15159, 15159, 15165, 15165, 15166, 15166, 15167, 15167, 15168, 15168, 15169, 15169, 15170, 15170, 15177, 15177, 15205, 15205, 15577, 15823, 15823, 15841, 15841, 15859, 15859, 15885, 17074, 17074, 17098, 17098, 17122, 17122, 17266, 17266, 17267, 17267, 17268, 17268, 17269, 17269, 17605, 17605, 18851, 18851, 19403, 19403
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5246, 5246, 5248, 5248, 5330, 5330, 5336, 5336, 5373, 5373, 5375, 5375, 5384, 5384, 5394, 5394, 5404, 5404, 5440, 5440, 7904, 7904, 9562, 9562, 9563, 9563, 9874, 9874, 10720, 10720, 10740, 10740, 12741, 15147, 15147, 15153, 15153, 15154, 15154, 15155, 15155, 15156, 15156, 15157, 15157, 15158, 15158, 15165, 15165, 15193, 15193, 15565, 15811, 15811, 15829, 15829, 15847, 15847, 15873, 17062, 17062, 17086, 17086, 17110, 17110, 17254, 17254, 17255, 17255, 17256, 17256, 17257, 17257, 17593, 17593, 18810, 18810, 19362, 19362
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 10963-11213
+- Def site: line 10951-11201
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -573,11 +557,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10970, 10970, 10973, 10973, 10978, 10978, 10979, 10979, 10987, 10987, 10990, 10990, 10998, 10998, 11038, 11038, 11046, 11046, 11094, 11094, 11111, 11111, 11114, 11114, 11116, 11116, 11180, 11180, 11181, 11181, 19369, 19369
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10958, 10958, 10961, 10961, 10966, 10966, 10967, 10967, 10975, 10975, 10978, 10978, 10986, 10986, 11026, 11026, 11034, 11034, 11082, 11082, 11099, 11099, 11102, 11102, 11104, 11104, 11168, 11168, 11169, 11169, 19328, 19328
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15289-15533
+- Def site: line 15277-15521
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -587,11 +571,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15155, 15155, 15315, 15315, 15317, 15317, 15318, 15318, 15319, 15319, 15347, 15347, 15352, 15352, 15374, 15374, 15375, 15375, 15417, 15417, 15425, 15425, 15451, 15451, 15460, 15460, 15468, 15468, 15499, 15499, 18940, 18940, 18944, 18944
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15143, 15143, 15303, 15303, 15305, 15305, 15306, 15306, 15307, 15307, 15335, 15335, 15340, 15340, 15362, 15362, 15363, 15363, 15405, 15405, 15413, 15413, 15439, 15439, 15448, 15448, 15456, 15456, 15487, 15487, 18899, 18899, 18903, 18903
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6151-6371
+- Def site: line 6139-6359
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -599,14 +583,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6174, 6174, 6225, 6225, 6295, 6295, 6319, 6319, 6331, 6331, 6333, 6333, 6343, 6343, 6358, 6358, 6362, 6362, 6363, 6363, 6366, 6366, 6368, 6368, 12866, 12866, 15581
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6162, 6162, 6213, 6213, 6283, 6283, 6307, 6307, 6319, 6319, 6321, 6321, 6331, 6331, 6346, 6346, 6350, 6350, 6351, 6351, 6354, 6354, 6356, 6356, 12854, 12854, 15569
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 19453-19666
+- Def site: line 19412-19625
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -615,11 +599,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20309, 20309, 20312, 20393, 20744
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20268, 20268, 20271, 20352, 20703
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7607-7816
+- Def site: line 7595-7804
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -628,11 +612,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7620, 7620, 7626, 7626, 7627, 7627, 7630, 7630, 7653, 7653, 7656, 7656, 7659, 7659, 7660, 7660, 7662, 7662, 7729, 7729, 7773, 7773, 8238, 8238, 13187, 13187, 15684, 15923, 15923, 16083, 16083
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7608, 7608, 7614, 7614, 7615, 7615, 7618, 7618, 7641, 7641, 7644, 7644, 7647, 7647, 7648, 7648, 7650, 7650, 7717, 7717, 7761, 7761, 8226, 8226, 13175, 13175, 15672, 15911, 15911, 16071, 16071
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12485-12687
+- Def site: line 12473-12675
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -641,11 +625,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12506, 12506, 12515, 12515, 12577, 12577, 12584, 12584, 12616, 12616, 12618, 12618, 12642, 12642, 12677, 12677, 12684, 12684, 12715, 12715, 15229, 15229, 18976, 18976, 18978, 18978, 18979, 18979, 18981, 18981
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12494, 12494, 12503, 12503, 12565, 12565, 12572, 12572, 12604, 12604, 12606, 12606, 12630, 12630, 12665, 12665, 12672, 12672, 12703, 12703, 15217, 15217, 18935, 18935, 18937, 18937, 18938, 18938, 18940, 18940
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13738-13925
+- Def site: line 13726-13913
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -655,11 +639,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19326, 19326, 19327, 19327, 19328, 19328, 19329, 19329, 19330, 19330, 19331, 19331, 19332, 19332, 19333, 19333, 19335, 19335, 19336, 19336, 19337, 19337, 19338, 19338, 19339, 19339, 19340, 19340, 19341, 19341, 19343, 19343, 19344, 19344, 19345, 19345, 19346, 19346, 19347, 19347, 19348, 19348, 19349, 19349, 19350, 19350, 19351, 19351, 19353, 19353, 19354, 19354, 19355, 19355, 19356, 19356, 19357, 19357, 19358, 19358, 19359, 19359, 19360, 19360, 19361, 19361, 19363, 19363, 19364, 19364
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19285, 19285, 19286, 19286, 19287, 19287, 19288, 19288, 19289, 19289, 19290, 19290, 19291, 19291, 19292, 19292, 19294, 19294, 19295, 19295, 19296, 19296, 19297, 19297, 19298, 19298, 19299, 19299, 19300, 19300, 19302, 19302, 19303, 19303, 19304, 19304, 19305, 19305, 19306, 19306, 19307, 19307, 19308, 19308, 19309, 19309, 19310, 19310, 19312, 19312, 19313, 19313, 19314, 19314, 19315, 19315, 19316, 19316, 19317, 19317, 19318, 19318, 19319, 19319, 19320, 19320, 19322, 19322, 19323, 19323
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5563-5742
+- Def site: line 5551-5730
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -668,11 +652,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5651, 5651, 5688, 5688, 5690, 5690, 5693, 5693, 5701, 5701, 5703, 5703, 5705, 5705, 5708, 5708, 5737, 5737, 5740, 5740, 19103, 19103
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5639, 5639, 5676, 5676, 5678, 5678, 5681, 5681, 5689, 5689, 5691, 5691, 5693, 5693, 5696, 5696, 5725, 5725, 5728, 5728, 19062, 19062
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6551-6729
+- Def site: line 6539-6717
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -680,11 +664,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6596, 6596, 6634, 6634, 6645, 6645, 6671, 6671, 6672, 6672, 6674, 6674, 6680, 6680, 6681, 6681, 6684, 6684, 6690, 6690, 6691, 6691, 6694, 6694, 6696, 6696, 6706, 6706, 6708, 6708, 6709, 6709, 6711, 6711
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6584, 6584, 6622, 6622, 6633, 6633, 6659, 6659, 6660, 6660, 6662, 6662, 6668, 6668, 6669, 6669, 6672, 6672, 6678, 6678, 6679, 6679, 6682, 6682, 6684, 6684, 6694, 6694, 6696, 6696, 6697, 6697, 6699, 6699
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11443-11610
+- Def site: line 11431-11598
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -693,11 +677,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11550, 11550, 11569, 11569, 11587, 11587, 11596, 11596, 11599, 11599, 11600, 11600, 11603, 11603, 11608, 11608, 11610, 11610, 19004, 19004
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11538, 11538, 11557, 11557, 11575, 11575, 11584, 11584, 11587, 11587, 11588, 11588, 11591, 11591, 11596, 11596, 11598, 11598, 18963, 18963
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11655-11822
+- Def site: line 11643-11810
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -705,11 +689,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11692, 11692, 11694, 11694, 11697, 11697, 11768, 11768, 11770, 11770, 11783, 11783, 11787, 11787, 19007, 19007, 19008, 19008, 19009, 19009, 19047, 19047, 19052, 19052
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11680, 11680, 11682, 11682, 11685, 11685, 11756, 11756, 11758, 11758, 11771, 11771, 11775, 11775, 18966, 18966, 18967, 18967, 18968, 18968, 19006, 19006, 19011, 19011
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10688-10849
+- Def site: line 10676-10837
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -717,11 +701,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10726, 10726, 10733, 10733, 10740, 10740, 10746, 10746, 10753, 10753, 10760, 10760, 10821, 10821, 10832, 10832, 18995, 18995, 18996, 18996, 18998, 18998, 18999, 18999, 19000, 19000
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10714, 10714, 10721, 10721, 10728, 10728, 10734, 10734, 10741, 10741, 10748, 10748, 10809, 10809, 10820, 10820, 18954, 18954, 18955, 18955, 18957, 18957, 18958, 18958, 18959, 18959
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15904-16064
+- Def site: line 15892-16052
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -730,11 +714,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15927, 15927, 15929, 15929, 15998, 15998, 16000, 16000, 16019, 16019, 16021, 16021, 16021, 16037, 16037, 16053, 16053, 16054, 16054, 16060, 16060, 19108, 19108
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15915, 15915, 15917, 15917, 15986, 15986, 15988, 15988, 16007, 16007, 16009, 16009, 16009, 16025, 16025, 16041, 16041, 16042, 16042, 16048, 16048, 19067, 19067
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6379-6536
+- Def site: line 6367-6524
 - References: 201
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -744,7 +728,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5516, 5516, 6395, 6395, 6408, 6408, 6411, 6411, 6435, 6435, 6443, 6443, 6444, 6444, 6466, 6466, 6471, 6471, 6473, 6473, 6546, 6546, 6547, 6547, 6954, 6954, 6979, 6979, 7048, 7048, 7049, 7049, 7378, 7378, 7392, 7392, 7393, 7393, 7878, 7878, 7879, 7879, 8801, 8801, 8966, 9026, 9026, 9028, 9028, 9029, 9029, 9046, 9046, 9047, 9047, 9064, 9064, 9065, 9065, 9085, 9085, 9086, 9086, 9643, 9643, 9644, 9644, 9718, 9718, 9719, 9719, 10047, 10047, 10050, 10050, 10625, 10625, 10626, 10626, 10662, 10662, 10663, 10663, 10842, 10842, 10843, 10843, 11187, 11187, 11188, 11188, 11334, 11334, 11335, 11335, 11417, 11417, 11418, 11418, 11629, 11629, 11804, 11804, 11805, 11805, 11881, 11881, 11882, 11882, 12185, 12185, 12201, 12201, 12202, 12202, 12430, 12430, 12431, 12431, 12510, 12510, 12511, 12511, 12512, 12512, 12548, 12548, 12549, 12549, 12637, 12637, 12638, 12638, 12666, 12666, 12667, 12667, 12704, 12704, 12705, 12705, 12757, 12826, 12826, 12827, 12827, 12869, 12869, 12870, 12870, 13038, 13038, 13039, 13039, 13163, 13163, 13164, 13164, 13387, 13559, 13559, 14611, 14611, 15518, 15518, 15519, 15519, 15580, 15688, 17127, 17127, 17128, 17128, 18008, 18008
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5504, 5504, 6383, 6383, 6396, 6396, 6399, 6399, 6423, 6423, 6431, 6431, 6432, 6432, 6454, 6454, 6459, 6459, 6461, 6461, 6534, 6534, 6535, 6535, 6942, 6942, 6967, 6967, 7036, 7036, 7037, 7037, 7366, 7366, 7380, 7380, 7381, 7381, 7866, 7866, 7867, 7867, 8789, 8789, 8954, 9014, 9014, 9016, 9016, 9017, 9017, 9034, 9034, 9035, 9035, 9052, 9052, 9053, 9053, 9073, 9073, 9074, 9074, 9631, 9631, 9632, 9632, 9706, 9706, 9707, 9707, 10035, 10035, 10038, 10038, 10613, 10613, 10614, 10614, 10650, 10650, 10651, 10651, 10830, 10830, 10831, 10831, 11175, 11175, 11176, 11176, 11322, 11322, 11323, 11323, 11405, 11405, 11406, 11406, 11617, 11617, 11792, 11792, 11793, 11793, 11869, 11869, 11870, 11870, 12173, 12173, 12189, 12189, 12190, 12190, 12418, 12418, 12419, 12419, 12498, 12498, 12499, 12499, 12500, 12500, 12536, 12536, 12537, 12537, 12625, 12625, 12626, 12626, 12654, 12654, 12655, 12655, 12692, 12692, 12693, 12693, 12745, 12814, 12814, 12815, 12815, 12857, 12857, 12858, 12858, 13026, 13026, 13027, 13027, 13151, 13151, 13152, 13152, 13375, 13547, 13547, 14599, 14599, 15506, 15506, 15507, 15507, 15568, 15676, 17115, 17115, 17116, 17116, 17967, 17967
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -752,7 +736,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15051-15206
+- Def site: line 15039-15194
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -761,11 +745,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15073, 15073, 15079, 15079, 15081, 15081, 15109, 15109, 15135, 15135, 15138, 15138, 15141, 15141, 19094, 19094, 19098, 19098, 19106, 19106
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15061, 15061, 15067, 15067, 15069, 15069, 15097, 15097, 15123, 15123, 15126, 15126, 15129, 15129, 19053, 19053, 19057, 19057, 19065, 19065
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13222-13367
+- Def site: line 13210-13355
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -773,11 +757,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13261, 13261, 13268, 13268, 13293, 13293, 13296, 13296, 13309, 13309, 13353, 13353, 13357, 13357, 13362, 13362, 13363, 13363, 13367, 13367, 19401, 19401
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13249, 13249, 13256, 13256, 13281, 13281, 13284, 13284, 13297, 13297, 13341, 13341, 13345, 13345, 13350, 13350, 13351, 13351, 13355, 13355, 19360, 19360
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13375-13519
+- Def site: line 13363-13507
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -786,12 +770,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12596, 12596, 12772, 12772, 12850, 12850, 12855, 12855, 13404, 13404, 13410, 13410, 13416, 13416, 13422, 13422, 13428, 13428, 13434, 13434, 13440, 13440, 13446, 13446, 13452, 13452, 13458, 13458, 13464, 13464, 13470, 13470, 13476, 13476, 13482, 13482, 13488, 13488, 13494, 13494, 13500, 13500, 13506, 13506, 13512, 13512, 13518, 13518, 19014, 19014, 19155, 19155, 19157, 19157, 19272, 19272, 19398, 19398, 19399, 19399, 19400, 19400, 19419, 19419, 19420, 19420, 19421, 19421, 19422, 19422, 19423, 19423, 19424, 19424, 19425, 19425
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12584, 12584, 12760, 12760, 12838, 12838, 12843, 12843, 13392, 13392, 13398, 13398, 13404, 13404, 13410, 13410, 13416, 13416, 13422, 13422, 13428, 13428, 13434, 13434, 13440, 13440, 13446, 13446, 13452, 13452, 13458, 13458, 13464, 13464, 13470, 13470, 13476, 13476, 13482, 13482, 13488, 13488, 13494, 13494, 13500, 13500, 13506, 13506, 18973, 18973, 19114, 19114, 19116, 19116, 19231, 19231, 19357, 19357, 19358, 19358, 19359, 19359, 19378, 19378, 19379, 19379, 19380, 19380, 19381, 19381, 19382, 19382, 19383, 19383, 19384, 19384
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10542-10685
+- Def site: line 10530-10673
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -800,11 +784,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10556, 10556, 10557, 10557, 10643, 10643, 10678, 10678, 18989, 18989, 18990, 18990, 18991, 18991, 18992, 18992, 18993, 18993
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10544, 10544, 10545, 10545, 10631, 10631, 10666, 10666, 18948, 18948, 18949, 18949, 18950, 18950, 18951, 18951, 18952, 18952
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13522-13660
+- Def site: line 13510-13648
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -812,11 +796,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13591, 13591, 13594, 13594, 13595, 13595, 13596, 13596, 13616, 13616, 13619, 13619, 13627, 13627, 13632, 13632, 19427, 19427
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13579, 13579, 13582, 13582, 13583, 13583, 13584, 13584, 13604, 13604, 13607, 13607, 13615, 13615, 13620, 13620, 19386, 19386
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8844-8972
+- Def site: line 8832-8960
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -825,11 +809,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8915, 8915, 8926, 8926, 15149, 15149, 15150, 15150, 18892, 18892, 18893, 18893, 19072, 19072
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8903, 8903, 8914, 8914, 15137, 15137, 15138, 15138, 18851, 18851, 18852, 18852, 19031, 19031
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11216-11344
+- Def site: line 11204-11332
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -838,11 +822,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11223, 11223, 11228, 11228, 11229, 11229, 11230, 11230, 11233, 11233, 11234, 11234, 11297, 11297, 11304, 11304, 11331, 11331, 19371, 19371
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11211, 11211, 11216, 11216, 11217, 11217, 11218, 11218, 11221, 11221, 11222, 11222, 11285, 11285, 11292, 11292, 11319, 11319, 19330, 19330
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15674-15800
+- Def site: line 15662-15788
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -851,11 +835,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15694, 15694, 15699, 15699, 15704, 15704, 15741, 15741, 15747, 15747, 15753, 15753, 15759, 15759, 15765, 15765, 15766, 15766, 15767, 15767, 15768, 15768, 15769, 15769, 15773, 15773, 15782, 15782, 15786, 15786, 15789, 15789, 15795, 15795, 19067, 19067
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15682, 15682, 15687, 15687, 15692, 15692, 15729, 15729, 15735, 15735, 15741, 15741, 15747, 15747, 15753, 15753, 15754, 15754, 15755, 15755, 15756, 15756, 15757, 15757, 15761, 15761, 15770, 15770, 15774, 15774, 15777, 15777, 15783, 15783, 19026, 19026
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5796-5920
+- Def site: line 5784-5908
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -864,11 +848,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5817, 5817, 5819, 5819, 5835, 5835, 5847, 5847, 5886, 5886, 5887, 5887, 5888, 5888, 5889, 5889, 5890, 5890, 5901, 5901, 5904, 5904, 6836, 6836, 20406, 20406, 20989, 20989
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5805, 5805, 5807, 5807, 5823, 5823, 5835, 5835, 5874, 5874, 5875, 5875, 5876, 5876, 5877, 5877, 5878, 5878, 5889, 5889, 5892, 5892, 6824, 6824, 20365, 20365, 20948, 20948
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8978-9089
+- Def site: line 8966-9077
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -876,13 +860,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7916, 7916, 9574, 9574, 9886, 9886, 10732, 10732, 10752, 10752, 12754, 15098, 15098, 15151, 15151, 15584, 15824, 15824, 15842, 15842, 15860, 15860, 17076, 17076, 17100, 17100, 17124, 17124, 17267, 17267, 17608, 17608, 18933, 18933, 18948, 18948, 18958, 18958, 18958, 18958, 18968, 18968
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7904, 7904, 9562, 9562, 9874, 9874, 10720, 10720, 10740, 10740, 12742, 15086, 15086, 15139, 15139, 15572, 15812, 15812, 15830, 15830, 15848, 15848, 17064, 17064, 17088, 17088, 17112, 17112, 17255, 17255, 17596, 17596, 18892, 18892, 18907, 18907, 18917, 18917, 18917, 18917, 18927, 18927
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10852-10960
+- Def site: line 10840-10948
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -892,11 +876,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10907, 10907, 10910, 10910, 10911, 10911, 10916, 10916, 10934, 10934, 10934, 10943, 10943, 10943, 10943, 10944, 10944, 10944, 10944, 11002, 11002, 11005, 11005, 11017, 11017, 11018, 11018, 11031, 11031, 11070, 11070, 11078, 11078, 11132, 11132, 11140, 11140
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10895, 10895, 10898, 10898, 10899, 10899, 10904, 10904, 10922, 10922, 10922, 10931, 10931, 10931, 10931, 10932, 10932, 10932, 10932, 10990, 10990, 10993, 10993, 11005, 11005, 11006, 11006, 11019, 11019, 11058, 11058, 11066, 11066, 11120, 11120, 11128, 11128
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12777-12876
+- Def site: line 12765-12864
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -905,11 +889,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12842, 12842, 12844, 12844, 12845, 12845, 18942, 18942, 19010, 19010, 19012, 19012, 19013, 19013
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12830, 12830, 12832, 12832, 12833, 12833, 18901, 18901, 18969, 18969, 18971, 18971, 18972, 18972
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15566-15663
+- Def site: line 15554-15651
 - References: 78
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -918,13 +902,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15309, 15309, 15544, 15544, 15602, 15602, 15608, 15608, 15614, 15614, 15620, 15620, 15626, 15626, 15632, 15632, 15638, 15638, 15644, 15644, 15650, 15650, 15656, 15656, 15662, 15662, 15886, 17268, 17268, 17271, 17271, 17607, 17607, 18899, 18899, 18966, 18966, 18972, 18972, 19023, 19023, 19080, 19080
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15297, 15297, 15532, 15532, 15590, 15590, 15596, 15596, 15602, 15602, 15608, 15608, 15614, 15614, 15620, 15620, 15626, 15626, 15632, 15632, 15638, 15638, 15644, 15644, 15650, 15650, 15874, 17256, 17256, 17259, 17259, 17595, 17595, 18858, 18858, 18925, 18925, 18931, 18931, 18982, 18982, 19039, 19039
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8274-8370
+- Def site: line 8262-8358
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -932,11 +916,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8330, 8330, 8366, 8366
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8318, 8318, 8354, 8354
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11347-11440
+- Def site: line 11335-11428
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -945,11 +929,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11399, 11399, 11412, 11412, 19002, 19002, 19044, 19044, 19045, 19045, 19050, 19050, 19051, 19051
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11387, 11387, 11400, 11400, 18961, 18961, 19003, 19003, 19004, 19004, 19009, 19009, 19010, 19010
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5926-6015
+- Def site: line 5914-6003
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -959,13 +943,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6008, 6008, 15372, 15372, 15373, 15373, 15587, 18802, 18802
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5996, 5996, 15360, 15360, 15361, 15361, 15575, 18761, 18761
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12690-12774
+- Def site: line 12678-12762
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -975,11 +959,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12724, 12724, 18977, 18977, 18985, 18985, 19011, 19011, 19156, 19156
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12712, 12712, 18936, 18936, 18944, 18944, 18970, 18970, 19115, 19115
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 18079-18157
+- Def site: line 18038-18116
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -989,12 +973,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18074, 18074, 18075, 18075, 19251, 19251
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18033, 18033, 18034, 18034, 19210, 19210
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17054-17131
+- Def site: line 17042-17119
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1004,13 +988,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19122, 19122, 19126, 19126, 19130, 19130
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19081, 19081, 19085, 19085, 19089, 19089
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1890-1963
-- References: 258
+- Def site: line 1893-1966
+- References: 254
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1018,7 +1002,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1903, 1903, 1935, 1935, 2210, 2210, 2299, 2299, 2326, 2326, 7628, 7628, 7714, 7714, 7844, 7844, 7921, 7921, 8004, 8004, 8234, 8234, 8423, 8423, 8479, 8479, 8492, 8492, 8509, 8509, 8554, 8554, 8585, 8585, 8591, 8591, 8694, 8694, 10235, 10235, 10502, 11004, 11004, 11033, 11033, 11298, 11298, 11504, 11504, 11743, 11743, 12459, 12459, 12475, 12475, 13262, 13262, 13681, 13681, 13731, 13731, 15585, 15787, 15787, 15820, 15820, 15838, 15838, 15856, 15856, 15884, 17081, 17081, 17106, 17106, 17149, 17248, 17248, 17460, 17460, 17603, 17603, 17649, 17649, 17739, 17739, 18069, 18069, 18099, 18099, 18120, 18120, 18139, 18139, 18155, 18155, 18172, 18172, 18749, 18749, 18769, 18769, 18804, 18804, 18817, 18817, 19285, 19285, 19376, 19376, 19381, 19381, 19387, 19387, 19406, 19406, 19412, 19412, 21012, 21012, 21110, 21110
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1906, 1906, 1938, 1938, 2287, 2287, 2314, 2314, 7616, 7616, 7702, 7702, 7832, 7832, 7909, 7909, 7992, 7992, 8222, 8222, 8411, 8411, 8467, 8467, 8480, 8480, 8497, 8497, 8542, 8542, 8573, 8573, 8579, 8579, 8682, 8682, 10223, 10223, 10490, 10992, 10992, 11021, 11021, 11286, 11286, 11492, 11492, 11731, 11731, 12447, 12447, 12463, 12463, 13250, 13250, 13669, 13669, 13719, 13719, 15573, 15775, 15775, 15808, 15808, 15826, 15826, 15844, 15844, 15872, 17069, 17069, 17094, 17094, 17137, 17236, 17236, 17448, 17448, 17591, 17591, 17698, 17698, 18028, 18028, 18058, 18058, 18079, 18079, 18098, 18098, 18114, 18114, 18131, 18131, 18708, 18708, 18728, 18728, 18763, 18763, 18776, 18776, 19244, 19244, 19335, 19335, 19340, 19340, 19346, 19346, 19365, 19365, 19371, 19371, 20971, 20971, 21069, 21069
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -1039,7 +1023,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15212-15283
+- Def site: line 15200-15271
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1048,11 +1032,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19088, 19088, 19089, 19089, 19090, 19090, 19091, 19091
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19047, 19047, 19048, 19048, 19049, 19049, 19050, 19050
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5487-5556
+- Def site: line 5475-5544
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1062,19 +1046,19 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5519, 5519, 5520, 5520, 5535, 5535, 5537, 5537
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5507, 5507, 5508, 5508, 5523, 5523, 5525, 5525
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 6021-6090
-- References: 188
+- Def site: line 6009-6078
+- References: 182
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6063, 6063, 6068, 6068, 6165, 6165, 6223, 6223, 7114, 7114, 7771, 7771, 8416, 8416, 8439, 8439, 8459, 8459, 8644, 8644, 8665, 8665, 8940, 8940, 8965, 8965, 9020, 9020, 9042, 9042, 9059, 9059, 9076, 9076, 9461, 9461, 9684, 9684, 9701, 9701, 10093, 10093, 10425, 10425, 10636, 10636, 10673, 10673, 10826, 10826, 10969, 10969, 11222, 11222, 11410, 11410, 11594, 11594, 11913, 11913, 12249, 12249, 12421, 12421, 12461, 12461, 12467, 12467, 12561, 12561, 12791, 12791, 12864, 12864, 13351, 13351, 13386, 13585, 13585, 15092, 15092, 15308, 15308, 15576, 15683, 15783, 15783, 15818, 15818, 15836, 15836, 15854, 15854, 17147, 17650, 17650, 17655, 17655, 17657, 17657, 18070, 18070, 18072, 18072, 18096, 18096, 18100, 18100, 18101, 18101, 18121, 18121, 18122, 18122, 18283, 18283, 18853, 18853, 18885, 18885, 18922, 18922, 18928, 18928, 19056, 19056, 19113, 19113, 19196, 19196, 19205, 19205, 19283, 19283, 19284, 19284, 19301, 19301, 19376, 19376, 19381, 19381, 19387, 19387, 19406, 19406, 19412, 19412, 20323, 20323, 20394, 20876, 20876, 20964, 20964
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6051, 6051, 6056, 6056, 6153, 6153, 6211, 6211, 7102, 7102, 7759, 7759, 8404, 8404, 8427, 8427, 8447, 8447, 8632, 8632, 8653, 8653, 8928, 8928, 8953, 8953, 9008, 9008, 9030, 9030, 9047, 9047, 9064, 9064, 9449, 9449, 9672, 9672, 9689, 9689, 10081, 10081, 10413, 10413, 10624, 10624, 10661, 10661, 10814, 10814, 10957, 10957, 11210, 11210, 11398, 11398, 11582, 11582, 11901, 11901, 12237, 12237, 12409, 12409, 12449, 12449, 12455, 12455, 12549, 12549, 12779, 12779, 12852, 12852, 13339, 13339, 13374, 13573, 13573, 15080, 15080, 15296, 15296, 15564, 15671, 15771, 15771, 15806, 15806, 15824, 15824, 15842, 15842, 17135, 18029, 18029, 18031, 18031, 18055, 18055, 18059, 18059, 18060, 18060, 18080, 18080, 18081, 18081, 18242, 18242, 18812, 18812, 18844, 18844, 18881, 18881, 18887, 18887, 19015, 19015, 19072, 19072, 19155, 19155, 19164, 19164, 19242, 19242, 19243, 19243, 19260, 19260, 19335, 19335, 19340, 19340, 19346, 19346, 19365, 19365, 19371, 19371, 20282, 20282, 20353, 20835, 20835, 20923, 20923
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1084,7 +1068,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10471-10539
+- Def site: line 10459-10527
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1095,11 +1079,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10511, 10511, 10516, 10516, 10521, 10521, 10522, 10522, 10528, 10528, 10529, 10529, 10535, 10535, 10536, 10536, 10537, 10537, 10538, 10538, 19429, 19429
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10499, 10499, 10504, 10504, 10509, 10509, 10510, 10510, 10516, 10516, 10517, 10517, 10523, 10523, 10524, 10524, 10525, 10525, 10526, 10526, 19388, 19388
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 18808-18873
+- Def site: line 18767-18832
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1109,11 +1093,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18856, 18856, 18864, 18864, 18873, 18873, 19402, 19402
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18815, 18815, 18823, 18823, 18832, 18832, 19361, 19361
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15807-15862
+- Def site: line 15795-15850
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1123,12 +1107,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19027, 19027, 19031, 19031, 19236, 19236
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18986, 18986, 18990, 18990, 19195, 19195
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6096-6142
-- References: 57
+- Def site: line 6084-6130
+- References: 55
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1136,14 +1120,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6220, 6220, 8106, 8106, 9021, 9021, 9044, 9044, 9531, 9531, 9566, 9566, 9580, 9580, 9703, 9703, 9707, 9707, 10255, 10255, 12565, 12565, 13235, 13235, 13361, 13361, 13393, 13571, 13571, 13607, 13607, 15582, 17651, 17651, 17960, 17960, 18071, 18071, 18102, 18102, 18123, 18123, 19286, 19286, 19302, 19302, 20895, 20895
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6208, 6208, 8094, 8094, 9009, 9009, 9032, 9032, 9519, 9519, 9554, 9554, 9568, 9568, 9691, 9691, 9695, 9695, 10243, 10243, 12553, 12553, 13223, 13223, 13349, 13349, 13381, 13559, 13559, 13595, 13595, 15570, 17919, 17919, 18030, 18030, 18061, 18061, 18082, 18082, 19245, 19245, 19261, 19261, 20854, 20854
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5745-5790
-- References: 99
+- Def site: line 5733-5778
+- References: 97
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -1151,14 +1135,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5257, 5257, 5299, 5299, 5344, 5344, 5450, 5450, 5465, 5465, 5735, 5735, 5736, 5736, 5780, 5780, 6246, 6246, 7940, 7940, 9231, 9231, 9542, 9542, 9558, 9558, 9887, 9887, 10768, 10768, 10787, 10787, 12756, 15175, 15175, 15578, 15821, 15821, 15839, 15839, 15857, 15857, 15887, 16309, 16309, 16349, 16349, 16350, 16350, 16351, 16351, 17073, 17073, 17097, 17097, 17101, 17101, 17121, 17121, 17148, 17223, 17223, 17257, 17257, 17278, 17278, 17310, 17310, 17372, 17372, 17411, 17411, 17561, 17561, 17606, 17606, 17652, 17652
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5245, 5245, 5287, 5287, 5332, 5332, 5438, 5438, 5453, 5453, 5723, 5723, 5724, 5724, 5768, 5768, 6234, 6234, 7928, 7928, 9219, 9219, 9530, 9530, 9546, 9546, 9875, 9875, 10756, 10756, 10775, 10775, 12744, 15163, 15163, 15566, 15809, 15809, 15827, 15827, 15845, 15845, 15875, 16297, 16297, 16337, 16337, 16338, 16338, 16339, 16339, 17061, 17061, 17085, 17085, 17089, 17089, 17109, 17109, 17136, 17211, 17211, 17245, 17245, 17266, 17266, 17298, 17298, 17360, 17360, 17399, 17399, 17549, 17549, 17594, 17594
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17137-17179
+- Def site: line 17125-17167
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1167,11 +1151,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17160, 17160, 17166, 17166, 17172, 17172, 17178, 17178, 19220, 19220, 19224, 19224, 19228, 19228, 19232, 19232
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17148, 17148, 17154, 17154, 17160, 17160, 17166, 17166, 19179, 19179, 19183, 19183, 19187, 19187, 19191, 19191
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11613-11652
+- Def site: line 11601-11640
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1180,11 +1164,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11650, 11650, 19426, 19426
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11638, 11638, 19385, 19385
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1854-1882
+- Def site: line 1857-1885
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1193,12 +1177,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8894, 8894, 8895, 8895, 8924, 8924, 8925, 8925, 8941, 8941, 8942, 8942, 9820, 9820, 9821, 9821, 10125, 10125, 10126, 10126, 10173, 10173, 10174, 10174, 10729, 10729, 10731, 10731, 10749, 10749, 10751, 10751, 11639, 11639, 11640, 11640, 12300, 12300, 12301, 12301, 12406, 12406, 12407, 12407, 13389
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8882, 8882, 8883, 8883, 8912, 8912, 8913, 8913, 8929, 8929, 8930, 8930, 9808, 9808, 9809, 9809, 10113, 10113, 10114, 10114, 10161, 10161, 10162, 10162, 10717, 10717, 10719, 10719, 10737, 10737, 10739, 10739, 11627, 11627, 11628, 11628, 12288, 12288, 12289, 12289, 12394, 12394, 12395, 12395, 13377
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15536-15563
+- Def site: line 15524-15551
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1207,12 +1191,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15550, 15550, 15556, 15556, 15562, 15562, 19134, 19134, 19138, 19138
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15538, 15538, 15544, 15544, 15550, 15550, 19093, 19093, 19097, 19097
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15873-15898
+- Def site: line 15861-15886
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1222,24 +1206,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15893, 15893, 15898, 15898, 19142, 19142, 19147, 19147
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15881, 15881, 15886, 15886, 19101, 19101, 19106, 19106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
-
-### `detect_msp_privileges` (function, 25 lines)
-
-- Def site: line 2118-2142
-- References: 4
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2204, 2263, 17768, 20719
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13688-13709
+- Def site: line 13676-13697
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1248,7 +1220,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18908, 18908, 18912, 18912, 18916, 18916
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18867, 18867, 18871, 18871, 18875, 18875
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1258,17 +1230,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17589-17610
-- References: 10
+- Def site: line 17577-17598
+- References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17654, 17654, 19055, 19055, 19112, 19112, 19195, 19195, 19204, 19204
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19014, 19014, 19071, 19071, 19154, 19154, 19163, 19163
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 18055-18076
+- Def site: line 18014-18035
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1277,24 +1249,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19265, 19265
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19224, 19224
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7578-7598
+- Def site: line 7566-7586
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6329, 10098, 15421, 15586
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6317, 10086, 15409, 15574
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13934-13943
+- Def site: line 13922-13931
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1302,11 +1274,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13970, 14106, 14183, 14202, 14214, 14235, 14248, 14259, 14265, 14278, 14371, 14506, 14601
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13958, 14094, 14171, 14190, 14202, 14223, 14236, 14247, 14253, 14266, 14359, 14494, 14589
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 306-314
+- Def site: line 309-317
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1322,7 +1294,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 333-341
+- Def site: line 336-344
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1330,12 +1302,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15244, 15261, 15277
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15232, 15249, 15265
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 318-325
+- Def site: line 321-328
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1351,7 +1323,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 293-295
+- Def site: line 296-298
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1359,12 +1331,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13394, 13683, 18104, 18125, 18270, 18301, 18333, 18568, 18583
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13382, 13671, 18063, 18084, 18229, 18260, 18292, 18527, 18542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 621-623
+- Def site: line 624-626
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1372,7 +1344,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1231, 1900, 1900, 1900, 1912, 1918, 6222, 6342, 7402, 7462, 9630, 9741, 9995, 10825, 13396, 15454, 15496, 15594, 19288
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1234, 1903, 1903, 1903, 1915, 1921, 6210, 6330, 7390, 7450, 9618, 9729, 9983, 10813, 13384, 15442, 15484, 15582, 19247
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1385,7 +1357,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2002-2004
+- Def site: line 2005-2007
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1394,11 +1366,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2002, 7412, 7419, 7420, 10006, 15443
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2005, 7400, 7407, 7408, 9994, 15431
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2020-2022
+- Def site: line 2023-2025
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1407,7 +1379,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2020, 15590
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2023, 15578
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1415,7 +1387,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 737-1741
+- Def site: line 740-1744
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1423,7 +1395,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1786
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1789
 
 ## Limitations
 

--- a/src/refactors/initialize_mist_session_interactive.py
+++ b/src/refactors/initialize_mist_session_interactive.py
@@ -1,0 +1,58 @@
+"""Interactive Mist session initializer extracted from MistHelper (SC-023).
+
+Owns the interactive email/password login flow originally defined as the
+top-level `initialize_mist_session_interactive` function in MistHelper.py,
+and re-lands it as a class-body method per FR-005. The three MistHelper
+callsites (login retry after args, session-switch flow, entrypoint
+`_establish_mist_session`) are rewritten in the same PR to invoke the
+class method; no wrapper shim remains in MistHelper.py after this
+extraction.
+
+MistHelper module-globals (`apisession`, `mistapi`, `msp_privileges`,
+`selected_msp`, `org_id`) are read and written via the shared
+`_snapshot_session_globals_to_state` / `_restore_session_globals_from_state`
+helpers, which stay in MistHelper.py. All dependencies are resolved
+lazily through the `_MH` proxy so live re-bindings after interactive
+login and test monkeypatching are honoured.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
+from typing import Any  # Loose typing for late-bound MistHelper attributes
+
+
+class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
+    """Forward attribute access to the currently-loaded MistHelper module."""
+
+    def __getattr__(self, name: str) -> Any:  # Called only when the attribute is not found normally
+        """Resolve name against the live MistHelper module (call-time lookup)."""
+        misthelper_module = importlib.import_module("MistHelper")  # Lazy import at call time
+        return getattr(misthelper_module, name)  # Fetch the current bound value from MistHelper
+
+
+_MH = _MistHelperProxy()  # Sole module-level proxy handle used inside the class body
+
+
+class MistSessionInteractiveInitializer:  # Interactive login orchestration seam
+    """Class-body seam for the interactive Mist API login workflow."""
+
+    @classmethod
+    def initialize(cls) -> bool:  # Interactive login entrypoint
+        """Run the interactive login flow and mirror state back to MistHelper globals."""
+        state = _MH._snapshot_session_globals_to_state()  # Capture current globals into a mutable bag
+
+        def _detect_msp_for_login() -> Any:  # DI adapter binding MSP detection to freshly-authenticated session
+            """Delegate MSP detection to the freshly-authenticated session in state."""
+            return _MH.detect_msp_privileges(  # Call MistHelper's live detector
+                state.get("apisession")  # Orchestrator stores the new session in state before this runs
+            )
+
+        session_manager = _MH.LoginOrchestrator(  # Build the interactive login orchestrator with injected deps
+            state=state,  # Pass the mutable state bag the orchestrator will update
+            safe_input=_MH.InputUtils.safe_input,  # Inject the EOF-safe input function
+            detect_msp_privileges=_detect_msp_for_login,  # Inject MSP detection bound to the new login session
+        )
+        login_success = session_manager.execute()  # Run the interactive login workflow
+        _MH._restore_session_globals_from_state(state)  # Mirror any state mutations back to module globals
+        return bool(login_success)  # Report whether the interactive login succeeded


### PR DESCRIPTION
## Summary
- Move `initialize_mist_session_interactive` out of MistHelper.py and re-land as `MistSessionInteractiveInitializer.initialize` class-body method (FR-005).
- All 3 MistHelper callsites rewritten in the same PR (FR-003: no wrapper shim).
- Dependencies (`LoginOrchestrator`, `InputUtils`, `detect_msp_privileges`, `_snapshot_session_globals_to_state`, `_restore_session_globals_from_state`) resolved lazily via `_MistHelperProxy` so live re-bindings after login and test monkeypatching are honoured.

## Local gates
- New file compliance: **A+ 100/100**
- MistHelper.py baseline: **A 96.0** (unchanged)
- Unit tests: **3861 passing**
- mypy strict: clean
- black + ruff: clean

## Test plan
- [x] py_compile passes on both files
- [x] Import smoke test: `MistHelper` loads; `MistSessionInteractiveInitializer` and `LoginOrchestrator` both resolvable
- [x] Full unit-test suite passes (3861 tests)
- [x] Guard: no bare `def initialize_mist_session_interactive` in MistHelper.py
- [x] Guard: no callsite references to old name remain (only import + NOTE comment)