### PR TITLE
refactor(1011): extract PACKAGE_IMPORT_MAP to PackageImportMapManager (SC-025)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -167,6 +167,9 @@ from src.refactors.inventory_csvcomparator import (
 )
 from src.refactors.keyboard_listener import KeyboardListener  # PR-13 extracted no-op keyboard listener stub (SC-012)
 from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted Maps Manager launcher (SC-006)
+from src.refactors.package_import_map import (
+    PackageImportMapManager,  # Extracted pip-name -> import-name mapping (SC-025)
+)
 from src.refactors.run_interactive_test import (
     RunInteractiveTestManager,  # Extracted interactive-test manager (SC-011)
 )
@@ -377,20 +380,9 @@ except Exception:  # If python-dotenv is not installed yet, fall back to a manua
     except Exception:  # nosec B110  # If .env is missing or unreadable, continue silently (the file is optional)
         pass  # No .env available; rely on the real process environment only
 
-# Package name to import name mapping for special cases
-PACKAGE_IMPORT_MAP = {  # Map pip package names to their importable module names where they differ
-    "websocket-client": "websocket",  # pip 'websocket-client' is imported as 'websocket'
-    "python-dotenv": "dotenv",  # pip 'python-dotenv' is imported as 'dotenv'
-    "usaddress-scourgify": "scourgify",  # pip 'usaddress-scourgify' is imported as 'scourgify'
-    "pillow": "PIL",  # pip 'pillow' is imported as 'PIL'
-    "beautifulsoup4": "bs4",  # pip 'beautifulsoup4' is imported as 'bs4'
-    "pyyaml": "yaml",  # pip 'pyyaml' is imported as 'yaml'
-    "python-dateutil": "dateutil",  # pip 'python-dateutil' is imported as 'dateutil'
-    "msgpack-python": "msgpack",  # pip 'msgpack-python' is imported as 'msgpack'
-    "flask": "flask",  # 'flask' package and import names match (listed for completeness)
-    "flask-wtf": "flask_wtf",  # pip 'flask-wtf' is imported as 'flask_wtf' (hyphen becomes underscore)
-    "gunicorn": "gunicorn",  # 'gunicorn' package and import names match (listed for completeness)
-}
+# NOTE: PACKAGE_IMPORT_MAP extracted to
+# src/refactors/package_import_map.py::PackageImportMapManager.MAPPING
+# per initiative 1011 SC-025 (FR-003: no wrapper shim; FR-005: fn->method).
 
 
 def _get_installed_version(package_name: str) -> str:  # Look up the installed version string for a package
@@ -562,7 +554,7 @@ def _early_dependency_check():  # Public entry point; delegates to the extracted
         os_module=os,  # Inject os for env checks (DISABLE_AUTO_INSTALL, etc.)
         logging_module=logging,  # Inject logging for progress messages
         sys_module=sys,  # Inject sys for the interpreter path
-        package_import_map=PACKAGE_IMPORT_MAP,  # Provide the pip-name -> import-name mapping
+        package_import_map=PackageImportMapManager.MAPPING,  # Provide the pip-name -> import-name mapping
         parse_requirements_file_fn=_parse_requirements_file,  # Reuse the requirements parser defined above
         get_installed_version_fn=_get_installed_version,  # Reuse the installed-version lookup
         version_satisfies_fn=_version_satisfies,  # Reuse the version-constraint checker

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 192 first-party files
-- Definitions analyzed: 90
+- Module graph size: 193 first-party files
+- Definitions analyzed: 89
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=10, hot=79, skipped=1
+- Category counts: unused=0, single-use=0, low-use=9, hot=79, skipped=1
 
 ## How to read this report
 
@@ -106,8 +106,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `SiteAutoUpgradeConfigurator` | class | 22 | 6 | hot |  | missing_inline_comments,missing_action_logging |
 | `execute_with_connection_pool_management` | function | 21 | 7 | hot |  |  |
 | `BulkSwitchFirmwareUpgrader` | class | 19 | 2 | low-use | FirmwareManager | missing_inline_comments,missing_action_logging |
-| `PACKAGE_IMPORT_MAP` | assignment | 13 | 2 | low-use | PackageImportMapManager | missing_action_logging |
-| `main` | function | 12 | 2 | low-use | MainManager |  |
+| `main` | function | 12 | 2 | low-use | MapsManager |  |
 | `EndpointConfig` | class | 10 | 13 | hot |  | missing_action_logging |
 | `SSHConnectionConfig` | class | 9 | 6 | hot |  | missing_action_logging |
 | `DeviceFetchConfig` | class | 9 | 4 | hot |  | missing_action_logging |
@@ -123,11 +122,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 11 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (10)
+## Low-Use (9)
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2124-2148
+- Def site: line 2116-2140
 - References: 3
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -135,11 +134,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2254, 17715, 20666
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2246, 17707, 20658
 
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 18107-18125
+- Def site: line 18099-18117
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -150,45 +149,33 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Reference sites (one PR cluster per file):
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1880, 1881
 
-### `PACKAGE_IMPORT_MAP` (assignment, 13 lines)
-
-- Def site: line 381-393
-- References: 2
-- Suggested class: `PackageImportMapManager`
-- Suggested module: `src/refactors/package__import__map.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `_early_dependency_check()`; extract `PACKAGE_IMPORT_MAP` OUT of the entrypoint into a new `src/refactors/package__import__map.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 381, 565
-
 ### `main` (function, 12 lines)
 
-- Def site: line 21053-21064
+- Def site: line 21045-21056
 - References: 2
-- Suggested class: `MainManager`
-- Suggested module: `src/refactors/main.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py; extract `main` OUT of the entrypoint into a new `src/refactors/main.py` module and rewrite the callsite(s) to import from there
+- Suggested class: `MapsManager`
+- Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`
+- Rationale: 97 caller files detected; group callers under a shared class in `maps_manager.py` and rewrite references per file cluster
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21167
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21159
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
 
 ### `marvis_data_utils` (assignment, 4 lines)
 
-- Def site: line 6521-6524
+- Def site: line 6513-6516
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `MarvisTroubleshootDeps()`; extract `marvis_data_utils` OUT of the entrypoint into a new `src/refactors/marvis_data_utils.py` module and rewrite the callsite(s) to import from there
+- Rationale: low-use: sole caller lives inside MistHelper.py from `_build_deps()`; extract `marvis_data_utils` OUT of the entrypoint into a new `src/refactors/marvis_data_utils.py` module and rewrite the callsite(s) to import from there
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6521, 15663
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6513, 15655
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\marvis_troubleshoot_utils.py`: lines 21
 
 ### `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 lines)
 
-- Def site: line 1996-1998
+- Def site: line 1988-1990
 - References: 3
 - Suggested class: `FastModeBackoffMultiplierManager`
 - Suggested module: `src/refactors/fast__mode__backoff__multiplier.py`
@@ -197,11 +184,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1996, 9907, 15336
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1988, 9899, 15328
 
 ### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
 
-- Def site: line 1999-2001
+- Def site: line 1991-1993
 - References: 2
 - Suggested class: `FastModeDevicesPerThreadManager`
 - Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
@@ -210,11 +197,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1999, 7397
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1991, 7389
 
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 2004-2006
+- Def site: line 1996-1998
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -223,11 +210,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2004, 15476
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1996, 15468
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2011-2013
+- Def site: line 2003-2005
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -235,11 +222,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2011, 7387
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2003, 7379
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 2019-2021
+- Def site: line 2011-2013
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -248,14 +235,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2019, 15565
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2011, 15557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
 ## Hot (79)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2862-5188
+- Def site: line 2854-5180
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -266,11 +253,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2862, 6567, 6568, 6577, 6741
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2854, 6559, 6560, 6569, 6733
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13922-14680
+- Def site: line 13914-14672
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -279,11 +266,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14399, 14399, 14411, 14411, 14439, 14439, 14451, 14451, 14512, 14512, 14549, 14549, 14706, 19106
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14391, 14391, 14403, 14403, 14431, 14431, 14443, 14443, 14504, 14504, 14541, 14541, 14698, 19098
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9068-9753
+- Def site: line 9060-9745
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -292,12 +279,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5574, 5574, 9191, 9191, 9242, 9242, 9245, 9245, 9286, 9286, 9325, 9325, 9343, 9343, 9421, 9421, 9428, 9428, 9438, 9438, 9441, 9441, 9454, 9454, 9455, 9455, 9456, 9456, 9457, 9457, 9465, 9465, 9467, 9467, 9468, 9468, 9469, 9469, 9470, 9470, 9473, 9473, 9476, 9476, 9479, 9479, 9482, 9482, 9528, 9528, 9551, 9551, 9552, 9552, 9553, 9553, 9555, 9555, 9591, 9591, 9607, 9607, 9661, 9661, 9662, 9662, 9663, 9663, 9666, 9666, 9667, 9667, 9686, 9686, 9688, 9688, 9689, 9689, 9724, 9724, 15075, 15075, 15128, 15128, 15559, 17051, 17051, 17075, 17075, 17099, 17099, 17242, 17242, 18881, 18881, 18888, 18888, 18897, 18897, 18901, 18901, 18910, 18910
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5566, 5566, 9183, 9183, 9234, 9234, 9237, 9237, 9278, 9278, 9317, 9317, 9335, 9335, 9413, 9413, 9420, 9420, 9430, 9430, 9433, 9433, 9446, 9446, 9447, 9447, 9448, 9448, 9449, 9449, 9457, 9457, 9459, 9459, 9460, 9460, 9461, 9461, 9462, 9462, 9465, 9465, 9468, 9468, 9471, 9471, 9474, 9474, 9520, 9520, 9543, 9543, 9544, 9544, 9545, 9545, 9547, 9547, 9583, 9583, 9599, 9599, 9653, 9653, 9654, 9654, 9655, 9655, 9658, 9658, 9659, 9659, 9678, 9678, 9680, 9680, 9681, 9681, 9716, 9716, 15067, 15067, 15120, 15120, 15551, 17043, 17043, 17067, 17067, 17091, 17091, 17234, 17234, 18873, 18873, 18880, 18880, 18889, 18889, 18893, 18893, 18902, 18902
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16350-17024
+- Def site: line 16342-17016
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -305,11 +292,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16738, 16738, 19352, 19358
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16730, 16730, 19344, 19350
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11801-12453
+- Def site: line 11793-12445
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -319,11 +306,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10578, 10578, 10587, 10587, 10675, 10675, 10682, 10682, 11356, 11356, 11642, 11642, 11647, 11647, 11654, 11654, 11659, 11659, 11873, 11873, 11895, 11895, 11898, 11898, 11924, 11924, 11933, 11933, 11934, 11934, 11955, 11955, 11998, 11998, 12044, 12044, 12055, 12055, 12082, 12082, 12087, 12087, 12088, 12088, 12089, 12089, 12121, 12121, 12127, 12127, 12152, 12152, 12172, 12172, 12207, 12207, 12222, 12222, 12228, 12228, 12230, 12230, 12233, 12233, 12235, 12235, 12239, 12239, 12243, 12243, 12248, 12248, 12255, 12255, 12262, 12262, 12269, 12269, 12278, 12278, 12288, 12288, 12295, 12295, 12302, 12302, 12309, 12309, 12316, 12316, 12323, 12323, 12333, 12333, 12342, 12342, 12351, 12351, 12360, 12360, 12369, 12369, 12398, 12398, 18842, 18842, 19023, 19023, 19100, 19100, 19101, 19101, 19109, 19109, 19314, 19314, 19315, 19315, 19334, 19334, 19341, 19341, 19342, 19342, 19343, 19343, 19344, 19344
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10570, 10570, 10579, 10579, 10667, 10667, 10674, 10674, 11348, 11348, 11634, 11634, 11639, 11639, 11646, 11646, 11651, 11651, 11865, 11865, 11887, 11887, 11890, 11890, 11916, 11916, 11925, 11925, 11926, 11926, 11947, 11947, 11990, 11990, 12036, 12036, 12047, 12047, 12074, 12074, 12079, 12079, 12080, 12080, 12081, 12081, 12113, 12113, 12119, 12119, 12144, 12144, 12164, 12164, 12199, 12199, 12214, 12214, 12220, 12220, 12222, 12222, 12225, 12225, 12227, 12227, 12231, 12231, 12235, 12235, 12240, 12240, 12247, 12247, 12254, 12254, 12261, 12261, 12270, 12270, 12280, 12280, 12287, 12287, 12294, 12294, 12301, 12301, 12308, 12308, 12315, 12315, 12325, 12325, 12334, 12334, 12343, 12343, 12352, 12352, 12361, 12361, 12390, 12390, 18834, 18834, 19015, 19015, 19092, 19092, 19093, 19093, 19101, 19101, 19306, 19306, 19307, 19307, 19326, 19326, 19333, 19333, 19334, 19334, 19335, 19335, 19336, 19336
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 18138-18724
+- Def site: line 18130-18716
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -331,11 +318,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18415, 18415, 18416, 18416, 18419, 18419, 18421, 18421, 18423, 18423, 18439, 18439, 19259
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18407, 18407, 18408, 18408, 18411, 18411, 18413, 18413, 18415, 18415, 18431, 18431, 19251
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 18823-19394
+- Def site: line 18815-19386
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -345,12 +332,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18823, 20108, 20109, 20118, 20238, 20238, 20280, 20338, 20383, 20874, 20878, 20923, 20923, 20950, 20950, 20953
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18815, 20100, 20101, 20110, 20230, 20230, 20272, 20330, 20375, 20866, 20870, 20915, 20915, 20942, 20942, 20945
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8352-8814
+- Def site: line 8344-8806
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -358,11 +345,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8393, 8393, 8398, 8398, 8408, 8408, 8416, 8416, 8421, 8421, 8426, 8426, 8436, 8436, 8441, 8441, 8446, 8446, 8466, 8466, 8476, 8476, 8477, 8477, 8480, 8480, 8510, 8510, 8596, 8596, 8598, 8598, 8622, 8622, 8628, 8628, 8633, 8633, 8642, 8642, 8646, 8646, 8665, 8665, 8668, 8668, 8679, 8679, 8680, 8680, 8775, 8775, 8796, 8796, 19382, 19382, 19383, 19383, 19384, 19384, 19385, 19385, 19386, 19386, 19387, 19387
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8385, 8385, 8390, 8390, 8400, 8400, 8408, 8408, 8413, 8413, 8418, 8418, 8428, 8428, 8433, 8433, 8438, 8438, 8458, 8458, 8468, 8468, 8469, 8469, 8472, 8472, 8502, 8502, 8588, 8588, 8590, 8590, 8614, 8614, 8620, 8620, 8625, 8625, 8634, 8634, 8638, 8638, 8657, 8657, 8660, 8660, 8671, 8671, 8672, 8672, 8767, 8767, 8788, 8788, 19374, 19374, 19375, 19375, 19376, 19376, 19377, 19377, 19378, 19378, 19379, 19379
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 19619-20079
+- Def site: line 19611-20071
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -372,11 +359,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20086, 20086, 20090, 20090, 20110, 20110, 20115, 20115, 20339
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20078, 20078, 20082, 20082, 20102, 20102, 20107, 20107, 20331
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7799-8239
+- Def site: line 7791-8231
 - References: 117
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -384,14 +371,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7744, 7744, 7760, 7760, 7764, 7764, 7765, 7765, 7766, 7766, 7781, 7781, 7787, 7787, 7814, 7814, 7817, 7817, 7825, 7825, 7843, 7843, 7893, 7893, 7901, 7901, 7906, 7906, 7952, 7952, 7963, 7963, 7988, 7988, 8007, 8007, 8008, 8008, 8011, 8011, 8012, 8012, 8102, 8102, 8104, 8104, 8108, 8108, 8136, 8136, 8137, 8137, 8138, 8138, 8139, 8139, 8140, 8140, 8149, 8149, 8193, 8193, 8217, 8217, 12533, 12533, 12583, 12583, 12588, 12588, 12731, 12814, 12814, 12868, 12868, 12889, 12889, 12894, 12894, 13158, 13158, 13361, 13563, 13563, 13650, 13650, 13655, 13655, 13705, 13705, 13706, 13706, 15202, 15202, 15661, 17058, 17058, 17580, 17580, 18747, 18747, 18748, 18748, 19034, 19034
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7736, 7736, 7752, 7752, 7756, 7756, 7757, 7757, 7758, 7758, 7773, 7773, 7779, 7779, 7806, 7806, 7809, 7809, 7817, 7817, 7835, 7835, 7885, 7885, 7893, 7893, 7898, 7898, 7944, 7944, 7955, 7955, 7980, 7980, 7999, 7999, 8000, 8000, 8003, 8003, 8004, 8004, 8094, 8094, 8096, 8096, 8100, 8100, 8128, 8128, 8129, 8129, 8130, 8130, 8131, 8131, 8132, 8132, 8141, 8141, 8185, 8185, 8209, 8209, 12525, 12525, 12575, 12575, 12580, 12580, 12723, 12806, 12806, 12860, 12860, 12881, 12881, 12886, 12886, 13150, 13150, 13353, 13555, 13555, 13642, 13642, 13647, 13647, 13697, 13697, 13698, 13698, 15194, 15194, 15653, 17050, 17050, 17572, 17572, 18739, 18739, 18740, 18740, 19026, 19026
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9756-10169
+- Def site: line 9748-10161
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -400,11 +387,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5568, 5568, 9789, 9789, 9873, 9873, 9879, 9879, 9882, 9882, 9926, 9926, 9940, 9940, 9967, 9967, 9973, 9973, 9987, 9987, 10070, 10070, 10072, 10072, 10076, 10076, 10078, 10078, 10081, 10081, 10085, 10085, 10088, 10088, 10098, 10098, 10104, 10104, 10142, 10142, 15076, 15076, 15077, 15077, 15078, 15078, 15129, 15129, 15130, 15130, 18882, 18882, 18883, 18883, 18884, 18884, 18908, 18908
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5560, 5560, 9781, 9781, 9865, 9865, 9871, 9871, 9874, 9874, 9918, 9918, 9932, 9932, 9959, 9959, 9965, 9965, 9979, 9979, 10062, 10062, 10064, 10064, 10068, 10068, 10070, 10070, 10073, 10073, 10077, 10077, 10080, 10080, 10090, 10090, 10096, 10096, 10134, 10134, 15068, 15068, 15069, 15069, 15070, 15070, 15121, 15121, 15122, 15122, 18874, 18874, 18875, 18875, 18876, 18876, 18900, 18900
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17161-17558
+- Def site: line 17153-17550
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -413,11 +400,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17182, 17182, 17187, 17187, 17191, 17191, 17194, 17194, 17201, 17201, 17203, 17203, 17204, 17204, 17207, 17207, 17210, 17210, 17213, 17213, 17255, 17255, 17287, 17287, 17354, 17354, 17367, 17367, 17372, 17372, 17424, 17424, 17457, 17457, 17458, 17458, 17459, 17459, 17489, 17489, 17518, 17518, 17519, 17519, 19065, 19065
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17174, 17174, 17179, 17179, 17183, 17183, 17186, 17186, 17193, 17193, 17195, 17195, 17196, 17196, 17199, 17199, 17202, 17202, 17205, 17205, 17247, 17247, 17279, 17279, 17346, 17346, 17359, 17359, 17364, 17364, 17416, 17416, 17449, 17449, 17450, 17450, 17451, 17451, 17481, 17481, 17510, 17510, 17511, 17511, 19057, 19057
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 17612-17999
+- Def site: line 17604-17991
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -427,11 +414,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17639, 17783, 17783, 19205, 19205
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17631, 17775, 17775, 19197, 19197
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6708-7052
+- Def site: line 6700-7044
 - References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -440,7 +427,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5664, 5664, 6754, 6754, 6770, 6770, 6771, 6771, 6794, 6794, 6796, 6796, 6799, 6799, 6813, 6813, 6815, 6815, 6824, 6824, 6826, 6826, 6827, 6827, 6833, 6833, 6834, 6834, 6834, 6851, 6851, 6855, 6855, 6897, 6897, 6928, 6928, 6931, 6931, 6933, 6933, 6979, 6979, 6989, 6989, 7022, 7022, 7027, 7027, 7034, 7034, 7256, 7256, 7288, 7288, 7299, 7299, 7324, 7324, 7344, 7344, 7856, 7856, 8649, 8649, 8928, 8928, 8943, 9007, 9007, 9024, 9024, 9042, 9042, 9063, 9063, 9622, 9622, 9697, 9697, 10027, 10027, 10378, 10378, 10463, 10479, 10599, 10599, 10603, 10603, 10623, 10623, 10636, 10636, 10640, 10640, 10658, 10658, 10820, 10820, 11167, 11167, 11314, 11314, 11391, 11391, 11395, 11395, 11400, 11400, 11533, 11533, 11552, 11552, 11603, 11603, 11606, 11606, 11757, 11757, 11760, 11760, 11859, 11859, 11865, 11865, 12162, 12162, 12179, 12179, 12194, 12194, 12408, 12408, 12436, 12436, 12452, 12452, 12489, 12489, 12527, 12527, 12616, 12616, 12645, 12645, 12683, 12683, 12734, 12799, 12799, 12805, 12805, 12847, 12847, 13016, 13016, 13022, 13022, 13141, 13141, 13149, 13149, 13313, 13313, 13364, 13537, 13537, 13708, 13708, 14221, 14221, 14582, 14582, 14588, 14588, 15496, 15496, 15555, 15662, 15798, 15798, 15816, 15816, 15834, 15834, 17105, 17105, 17126, 17965, 17965, 18050, 18050, 18071, 18071, 18573, 18573, 19234, 19234, 19250, 19250
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5656, 5656, 6746, 6746, 6762, 6762, 6763, 6763, 6786, 6786, 6788, 6788, 6791, 6791, 6805, 6805, 6807, 6807, 6816, 6816, 6818, 6818, 6819, 6819, 6825, 6825, 6826, 6826, 6826, 6843, 6843, 6847, 6847, 6889, 6889, 6920, 6920, 6923, 6923, 6925, 6925, 6971, 6971, 6981, 6981, 7014, 7014, 7019, 7019, 7026, 7026, 7248, 7248, 7280, 7280, 7291, 7291, 7316, 7316, 7336, 7336, 7848, 7848, 8641, 8641, 8920, 8920, 8935, 8999, 8999, 9016, 9016, 9034, 9034, 9055, 9055, 9614, 9614, 9689, 9689, 10019, 10019, 10370, 10370, 10455, 10471, 10591, 10591, 10595, 10595, 10615, 10615, 10628, 10628, 10632, 10632, 10650, 10650, 10812, 10812, 11159, 11159, 11306, 11306, 11383, 11383, 11387, 11387, 11392, 11392, 11525, 11525, 11544, 11544, 11595, 11595, 11598, 11598, 11749, 11749, 11752, 11752, 11851, 11851, 11857, 11857, 12154, 12154, 12171, 12171, 12186, 12186, 12400, 12400, 12428, 12428, 12444, 12444, 12481, 12481, 12519, 12519, 12608, 12608, 12637, 12637, 12675, 12675, 12726, 12791, 12791, 12797, 12797, 12839, 12839, 13008, 13008, 13014, 13014, 13133, 13133, 13141, 13141, 13305, 13305, 13356, 13529, 13529, 13700, 13700, 14213, 14213, 14574, 14574, 14580, 14580, 15488, 15488, 15547, 15654, 15790, 15790, 15808, 15808, 15826, 15826, 17097, 17097, 17118, 17957, 17957, 18042, 18042, 18063, 18063, 18565, 18565, 19226, 19226, 19242, 19242
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -451,7 +438,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12855-13195
+- Def site: line 12847-13187
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -460,11 +447,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12872, 12872, 12874, 12874, 12878, 12878, 12879, 12879, 12893, 12893, 12899, 12899, 12902, 12902, 12905, 12905, 12963, 12963, 12969, 12969, 12974, 12974, 12988, 12988, 13006, 13006, 13116, 13116, 13120, 13120, 13122, 13122, 13125, 13125, 13162, 13162, 13167, 13167, 13181, 13181, 13185, 13185, 13187, 13187, 13190, 13190, 13195, 13195, 19111, 19111, 19115, 19115, 19119, 19119
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12864, 12864, 12866, 12866, 12870, 12870, 12871, 12871, 12885, 12885, 12891, 12891, 12894, 12894, 12897, 12897, 12955, 12955, 12961, 12961, 12966, 12966, 12980, 12980, 12998, 12998, 13108, 13108, 13112, 13112, 13114, 13114, 13117, 13117, 13154, 13154, 13159, 13159, 13173, 13173, 13177, 13177, 13179, 13179, 13182, 13182, 13187, 13187, 19103, 19103, 19107, 19107, 19111, 19111
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7055-7382
+- Def site: line 7047-7374
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -472,11 +459,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7157, 7157, 8373, 8854, 8873, 8974, 9103, 9126, 9798, 10106, 10151, 10565, 11335, 11346, 11409, 11826
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7149, 7149, 8365, 8846, 8865, 8966, 9095, 9118, 9790, 10098, 10143, 10557, 11327, 11338, 11401, 11818
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14686-15013
+- Def site: line 14678-15005
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -486,13 +473,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12143, 12143, 12202, 12202, 12203, 12203, 13367, 14727, 14727, 14729, 14729, 14735, 14735, 14749, 14749, 14788, 14788, 14791, 14791, 14793, 14793, 14794, 14794, 14795, 14795, 14849, 14849, 14850, 14850, 14861, 14861, 14870, 14870, 14889, 14889, 14941, 14941, 14945, 14945, 14953, 14953, 14954, 14954, 14978, 14978, 14982, 14982
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12135, 12135, 12194, 12194, 12195, 12195, 13359, 14719, 14719, 14721, 14721, 14727, 14727, 14741, 14741, 14780, 14780, 14783, 14783, 14785, 14785, 14786, 14786, 14787, 14787, 14841, 14841, 14842, 14842, 14853, 14853, 14862, 14862, 14881, 14881, 14933, 14933, 14937, 14937, 14945, 14945, 14946, 14946, 14970, 14970, 14974, 14974
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16046-16334
+- Def site: line 16038-16326
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -502,11 +489,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16074, 16074, 16077, 16077, 16082, 16082, 16085, 16085, 16129, 16129, 16135, 16135, 16166, 16166, 16169, 16169, 16173, 16173, 16199, 16199, 16216, 16216, 16222, 16222, 16236, 16236, 16237, 16237, 16239, 16239, 16245, 16245, 16252, 16252, 16261, 16261, 16308, 16308, 16330, 16330, 16331, 16331, 16332, 16332, 19056, 19056
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16066, 16066, 16069, 16069, 16074, 16074, 16077, 16077, 16121, 16121, 16127, 16127, 16158, 16158, 16161, 16161, 16165, 16165, 16191, 16191, 16208, 16208, 16214, 16214, 16228, 16228, 16229, 16229, 16231, 16231, 16237, 16237, 16244, 16244, 16253, 16253, 16300, 16300, 16322, 16322, 16323, 16323, 16324, 16324, 19048, 19048
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10172-10444
+- Def site: line 10164-10436
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -515,11 +502,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10195, 10195, 10196, 10196, 10209, 10209, 10210, 10210, 10212, 10212, 10213, 10213, 10216, 10216, 10219, 10219, 10223, 10223, 10224, 10224, 10300, 10300, 10304, 10304, 10307, 10307, 10320, 10320, 10357, 10357, 10374, 10374, 10387, 10387, 10389, 10389, 10396, 10396, 10405, 10405, 10414, 10414, 10415, 10415, 10426, 10426, 10430, 10430, 10439, 10439, 10444, 10444, 19313, 19313
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10187, 10187, 10188, 10188, 10201, 10201, 10202, 10202, 10204, 10204, 10205, 10205, 10208, 10208, 10211, 10211, 10215, 10215, 10216, 10216, 10292, 10292, 10296, 10296, 10299, 10299, 10312, 10312, 10349, 10349, 10366, 10366, 10379, 10379, 10381, 10381, 10388, 10388, 10397, 10397, 10406, 10406, 10407, 10407, 10418, 10418, 10422, 10422, 10431, 10431, 10436, 10436, 19305, 19305
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5194-5457
+- Def site: line 5186-5449
 - References: 106
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -527,14 +514,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5234, 5234, 5236, 5236, 5318, 5318, 5324, 5324, 5361, 5361, 5363, 5363, 5372, 5372, 5382, 5382, 5392, 5392, 5428, 5428, 7892, 7892, 9550, 9550, 9551, 9551, 9862, 9862, 10708, 10708, 10728, 10728, 12729, 15135, 15135, 15141, 15141, 15142, 15142, 15143, 15143, 15144, 15144, 15145, 15145, 15146, 15146, 15153, 15153, 15181, 15181, 15553, 15799, 15799, 15817, 15817, 15835, 15835, 15861, 17050, 17050, 17074, 17074, 17098, 17098, 17242, 17242, 17243, 17243, 17244, 17244, 17245, 17245, 17581, 17581, 18798, 18798, 19350, 19350
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5226, 5226, 5228, 5228, 5310, 5310, 5316, 5316, 5353, 5353, 5355, 5355, 5364, 5364, 5374, 5374, 5384, 5384, 5420, 5420, 7884, 7884, 9542, 9542, 9543, 9543, 9854, 9854, 10700, 10700, 10720, 10720, 12721, 15127, 15127, 15133, 15133, 15134, 15134, 15135, 15135, 15136, 15136, 15137, 15137, 15138, 15138, 15145, 15145, 15173, 15173, 15545, 15791, 15791, 15809, 15809, 15827, 15827, 15853, 17042, 17042, 17066, 17066, 17090, 17090, 17234, 17234, 17235, 17235, 17236, 17236, 17237, 17237, 17573, 17573, 18790, 18790, 19342, 19342
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 10939-11189
+- Def site: line 10931-11181
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -544,11 +531,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10946, 10946, 10949, 10949, 10954, 10954, 10955, 10955, 10963, 10963, 10966, 10966, 10974, 10974, 11014, 11014, 11022, 11022, 11070, 11070, 11087, 11087, 11090, 11090, 11092, 11092, 11156, 11156, 11157, 11157, 19316, 19316
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10938, 10938, 10941, 10941, 10946, 10946, 10947, 10947, 10955, 10955, 10958, 10958, 10966, 10966, 11006, 11006, 11014, 11014, 11062, 11062, 11079, 11079, 11082, 11082, 11084, 11084, 11148, 11148, 11149, 11149, 19308, 19308
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15265-15509
+- Def site: line 15257-15501
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -558,11 +545,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15131, 15131, 15291, 15291, 15293, 15293, 15294, 15294, 15295, 15295, 15323, 15323, 15328, 15328, 15350, 15350, 15351, 15351, 15393, 15393, 15401, 15401, 15427, 15427, 15436, 15436, 15444, 15444, 15475, 15475, 18887, 18887, 18891, 18891
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15123, 15123, 15283, 15283, 15285, 15285, 15286, 15286, 15287, 15287, 15315, 15315, 15320, 15320, 15342, 15342, 15343, 15343, 15385, 15385, 15393, 15393, 15419, 15419, 15428, 15428, 15436, 15436, 15467, 15467, 18879, 18879, 18883, 18883
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6127-6347
+- Def site: line 6119-6339
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -570,14 +557,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6150, 6150, 6201, 6201, 6271, 6271, 6295, 6295, 6307, 6307, 6309, 6309, 6319, 6319, 6334, 6334, 6338, 6338, 6339, 6339, 6342, 6342, 6344, 6344, 12842, 12842, 15557
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6142, 6142, 6193, 6193, 6263, 6263, 6287, 6287, 6299, 6299, 6301, 6301, 6311, 6311, 6326, 6326, 6330, 6330, 6331, 6331, 6334, 6334, 6336, 6336, 12834, 12834, 15549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 19400-19613
+- Def site: line 19392-19605
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -586,11 +573,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20256, 20256, 20259, 20340, 20691
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20248, 20248, 20251, 20332, 20683
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7583-7792
+- Def site: line 7575-7784
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -599,11 +586,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7596, 7596, 7602, 7602, 7603, 7603, 7606, 7606, 7629, 7629, 7632, 7632, 7635, 7635, 7636, 7636, 7638, 7638, 7705, 7705, 7749, 7749, 8214, 8214, 13163, 13163, 15660, 15899, 15899, 16059, 16059
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7588, 7588, 7594, 7594, 7595, 7595, 7598, 7598, 7621, 7621, 7624, 7624, 7627, 7627, 7628, 7628, 7630, 7630, 7697, 7697, 7741, 7741, 8206, 8206, 13155, 13155, 15652, 15891, 15891, 16051, 16051
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12461-12663
+- Def site: line 12453-12655
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -612,11 +599,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12482, 12482, 12491, 12491, 12553, 12553, 12560, 12560, 12592, 12592, 12594, 12594, 12618, 12618, 12653, 12653, 12660, 12660, 12691, 12691, 15205, 15205, 18923, 18923, 18925, 18925, 18926, 18926, 18928, 18928
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12474, 12474, 12483, 12483, 12545, 12545, 12552, 12552, 12584, 12584, 12586, 12586, 12610, 12610, 12645, 12645, 12652, 12652, 12683, 12683, 15197, 15197, 18915, 18915, 18917, 18917, 18918, 18918, 18920, 18920
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13714-13901
+- Def site: line 13706-13893
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -626,11 +613,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19273, 19273, 19274, 19274, 19275, 19275, 19276, 19276, 19277, 19277, 19278, 19278, 19279, 19279, 19280, 19280, 19282, 19282, 19283, 19283, 19284, 19284, 19285, 19285, 19286, 19286, 19287, 19287, 19288, 19288, 19290, 19290, 19291, 19291, 19292, 19292, 19293, 19293, 19294, 19294, 19295, 19295, 19296, 19296, 19297, 19297, 19298, 19298, 19300, 19300, 19301, 19301, 19302, 19302, 19303, 19303, 19304, 19304, 19305, 19305, 19306, 19306, 19307, 19307, 19308, 19308, 19310, 19310, 19311, 19311
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19265, 19265, 19266, 19266, 19267, 19267, 19268, 19268, 19269, 19269, 19270, 19270, 19271, 19271, 19272, 19272, 19274, 19274, 19275, 19275, 19276, 19276, 19277, 19277, 19278, 19278, 19279, 19279, 19280, 19280, 19282, 19282, 19283, 19283, 19284, 19284, 19285, 19285, 19286, 19286, 19287, 19287, 19288, 19288, 19289, 19289, 19290, 19290, 19292, 19292, 19293, 19293, 19294, 19294, 19295, 19295, 19296, 19296, 19297, 19297, 19298, 19298, 19299, 19299, 19300, 19300, 19302, 19302, 19303, 19303
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5539-5718
+- Def site: line 5531-5710
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -639,11 +626,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5627, 5627, 5664, 5664, 5666, 5666, 5669, 5669, 5677, 5677, 5679, 5679, 5681, 5681, 5684, 5684, 5713, 5713, 5716, 5716, 19050, 19050
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5619, 5619, 5656, 5656, 5658, 5658, 5661, 5661, 5669, 5669, 5671, 5671, 5673, 5673, 5676, 5676, 5705, 5705, 5708, 5708, 19042, 19042
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6527-6705
+- Def site: line 6519-6697
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -651,11 +638,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6572, 6572, 6610, 6610, 6621, 6621, 6647, 6647, 6648, 6648, 6650, 6650, 6656, 6656, 6657, 6657, 6660, 6660, 6666, 6666, 6667, 6667, 6670, 6670, 6672, 6672, 6682, 6682, 6684, 6684, 6685, 6685, 6687, 6687
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6564, 6564, 6602, 6602, 6613, 6613, 6639, 6639, 6640, 6640, 6642, 6642, 6648, 6648, 6649, 6649, 6652, 6652, 6658, 6658, 6659, 6659, 6662, 6662, 6664, 6664, 6674, 6674, 6676, 6676, 6677, 6677, 6679, 6679
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11419-11586
+- Def site: line 11411-11578
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -664,11 +651,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11526, 11526, 11545, 11545, 11563, 11563, 11572, 11572, 11575, 11575, 11576, 11576, 11579, 11579, 11584, 11584, 11586, 11586, 18951, 18951
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11518, 11518, 11537, 11537, 11555, 11555, 11564, 11564, 11567, 11567, 11568, 11568, 11571, 11571, 11576, 11576, 11578, 11578, 18943, 18943
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11631-11798
+- Def site: line 11623-11790
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -676,11 +663,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11668, 11668, 11670, 11670, 11673, 11673, 11744, 11744, 11746, 11746, 11759, 11759, 11763, 11763, 18954, 18954, 18955, 18955, 18956, 18956, 18994, 18994, 18999, 18999
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11660, 11660, 11662, 11662, 11665, 11665, 11736, 11736, 11738, 11738, 11751, 11751, 11755, 11755, 18946, 18946, 18947, 18947, 18948, 18948, 18986, 18986, 18991, 18991
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10664-10825
+- Def site: line 10656-10817
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -688,11 +675,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10702, 10702, 10709, 10709, 10716, 10716, 10722, 10722, 10729, 10729, 10736, 10736, 10797, 10797, 10808, 10808, 18942, 18942, 18943, 18943, 18945, 18945, 18946, 18946, 18947, 18947
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10694, 10694, 10701, 10701, 10708, 10708, 10714, 10714, 10721, 10721, 10728, 10728, 10789, 10789, 10800, 10800, 18934, 18934, 18935, 18935, 18937, 18937, 18938, 18938, 18939, 18939
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15880-16040
+- Def site: line 15872-16032
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -701,11 +688,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15903, 15903, 15905, 15905, 15974, 15974, 15976, 15976, 15995, 15995, 15997, 15997, 15997, 16013, 16013, 16029, 16029, 16030, 16030, 16036, 16036, 19055, 19055
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15895, 15895, 15897, 15897, 15966, 15966, 15968, 15968, 15987, 15987, 15989, 15989, 15989, 16005, 16005, 16021, 16021, 16022, 16022, 16028, 16028, 19047, 19047
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6355-6512
+- Def site: line 6347-6504
 - References: 201
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -715,7 +702,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5492, 5492, 6371, 6371, 6384, 6384, 6387, 6387, 6411, 6411, 6419, 6419, 6420, 6420, 6442, 6442, 6447, 6447, 6449, 6449, 6522, 6522, 6523, 6523, 6930, 6930, 6955, 6955, 7024, 7024, 7025, 7025, 7354, 7354, 7368, 7368, 7369, 7369, 7854, 7854, 7855, 7855, 8777, 8777, 8942, 9002, 9002, 9004, 9004, 9005, 9005, 9022, 9022, 9023, 9023, 9040, 9040, 9041, 9041, 9061, 9061, 9062, 9062, 9619, 9619, 9620, 9620, 9694, 9694, 9695, 9695, 10023, 10023, 10026, 10026, 10601, 10601, 10602, 10602, 10638, 10638, 10639, 10639, 10818, 10818, 10819, 10819, 11163, 11163, 11164, 11164, 11310, 11310, 11311, 11311, 11393, 11393, 11394, 11394, 11605, 11605, 11780, 11780, 11781, 11781, 11857, 11857, 11858, 11858, 12161, 12161, 12177, 12177, 12178, 12178, 12406, 12406, 12407, 12407, 12486, 12486, 12487, 12487, 12488, 12488, 12524, 12524, 12525, 12525, 12613, 12613, 12614, 12614, 12642, 12642, 12643, 12643, 12680, 12680, 12681, 12681, 12733, 12802, 12802, 12803, 12803, 12845, 12845, 12846, 12846, 13014, 13014, 13015, 13015, 13139, 13139, 13140, 13140, 13363, 13535, 13535, 14587, 14587, 15494, 15494, 15495, 15495, 15556, 15664, 17103, 17103, 17104, 17104, 17955, 17955
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5484, 5484, 6363, 6363, 6376, 6376, 6379, 6379, 6403, 6403, 6411, 6411, 6412, 6412, 6434, 6434, 6439, 6439, 6441, 6441, 6514, 6514, 6515, 6515, 6922, 6922, 6947, 6947, 7016, 7016, 7017, 7017, 7346, 7346, 7360, 7360, 7361, 7361, 7846, 7846, 7847, 7847, 8769, 8769, 8934, 8994, 8994, 8996, 8996, 8997, 8997, 9014, 9014, 9015, 9015, 9032, 9032, 9033, 9033, 9053, 9053, 9054, 9054, 9611, 9611, 9612, 9612, 9686, 9686, 9687, 9687, 10015, 10015, 10018, 10018, 10593, 10593, 10594, 10594, 10630, 10630, 10631, 10631, 10810, 10810, 10811, 10811, 11155, 11155, 11156, 11156, 11302, 11302, 11303, 11303, 11385, 11385, 11386, 11386, 11597, 11597, 11772, 11772, 11773, 11773, 11849, 11849, 11850, 11850, 12153, 12153, 12169, 12169, 12170, 12170, 12398, 12398, 12399, 12399, 12478, 12478, 12479, 12479, 12480, 12480, 12516, 12516, 12517, 12517, 12605, 12605, 12606, 12606, 12634, 12634, 12635, 12635, 12672, 12672, 12673, 12673, 12725, 12794, 12794, 12795, 12795, 12837, 12837, 12838, 12838, 13006, 13006, 13007, 13007, 13131, 13131, 13132, 13132, 13355, 13527, 13527, 14579, 14579, 15486, 15486, 15487, 15487, 15548, 15656, 17095, 17095, 17096, 17096, 17947, 17947
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -723,7 +710,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15027-15182
+- Def site: line 15019-15174
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -732,11 +719,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15049, 15049, 15055, 15055, 15057, 15057, 15085, 15085, 15111, 15111, 15114, 15114, 15117, 15117, 19041, 19041, 19045, 19045, 19053, 19053
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15041, 15041, 15047, 15047, 15049, 15049, 15077, 15077, 15103, 15103, 15106, 15106, 15109, 15109, 19033, 19033, 19037, 19037, 19045, 19045
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13198-13343
+- Def site: line 13190-13335
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -744,11 +731,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13237, 13237, 13244, 13244, 13269, 13269, 13272, 13272, 13285, 13285, 13329, 13329, 13333, 13333, 13338, 13338, 13339, 13339, 13343, 13343, 19348, 19348
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13229, 13229, 13236, 13236, 13261, 13261, 13264, 13264, 13277, 13277, 13321, 13321, 13325, 13325, 13330, 13330, 13331, 13331, 13335, 13335, 19340, 19340
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13351-13495
+- Def site: line 13343-13487
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -757,12 +744,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12572, 12572, 12748, 12748, 12826, 12826, 12831, 12831, 13380, 13380, 13386, 13386, 13392, 13392, 13398, 13398, 13404, 13404, 13410, 13410, 13416, 13416, 13422, 13422, 13428, 13428, 13434, 13434, 13440, 13440, 13446, 13446, 13452, 13452, 13458, 13458, 13464, 13464, 13470, 13470, 13476, 13476, 13482, 13482, 13488, 13488, 13494, 13494, 18961, 18961, 19102, 19102, 19104, 19104, 19219, 19219, 19345, 19345, 19346, 19346, 19347, 19347, 19366, 19366, 19367, 19367, 19368, 19368, 19369, 19369, 19370, 19370, 19371, 19371, 19372, 19372
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12564, 12564, 12740, 12740, 12818, 12818, 12823, 12823, 13372, 13372, 13378, 13378, 13384, 13384, 13390, 13390, 13396, 13396, 13402, 13402, 13408, 13408, 13414, 13414, 13420, 13420, 13426, 13426, 13432, 13432, 13438, 13438, 13444, 13444, 13450, 13450, 13456, 13456, 13462, 13462, 13468, 13468, 13474, 13474, 13480, 13480, 13486, 13486, 18953, 18953, 19094, 19094, 19096, 19096, 19211, 19211, 19337, 19337, 19338, 19338, 19339, 19339, 19358, 19358, 19359, 19359, 19360, 19360, 19361, 19361, 19362, 19362, 19363, 19363, 19364, 19364
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10518-10661
+- Def site: line 10510-10653
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -771,11 +758,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10532, 10532, 10533, 10533, 10619, 10619, 10654, 10654, 18936, 18936, 18937, 18937, 18938, 18938, 18939, 18939, 18940, 18940
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10524, 10524, 10525, 10525, 10611, 10611, 10646, 10646, 18928, 18928, 18929, 18929, 18930, 18930, 18931, 18931, 18932, 18932
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13498-13636
+- Def site: line 13490-13628
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -783,11 +770,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13567, 13567, 13570, 13570, 13571, 13571, 13572, 13572, 13592, 13592, 13595, 13595, 13603, 13603, 13608, 13608, 19374, 19374
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13559, 13559, 13562, 13562, 13563, 13563, 13564, 13564, 13584, 13584, 13587, 13587, 13595, 13595, 13600, 13600, 19366, 19366
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8820-8948
+- Def site: line 8812-8940
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -796,11 +783,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8891, 8891, 8902, 8902, 15125, 15125, 15126, 15126, 18839, 18839, 18840, 18840, 19019, 19019
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8883, 8883, 8894, 8894, 15117, 15117, 15118, 15118, 18831, 18831, 18832, 18832, 19011, 19011
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11192-11320
+- Def site: line 11184-11312
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -809,11 +796,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11199, 11199, 11204, 11204, 11205, 11205, 11206, 11206, 11209, 11209, 11210, 11210, 11273, 11273, 11280, 11280, 11307, 11307, 19318, 19318
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11191, 11191, 11196, 11196, 11197, 11197, 11198, 11198, 11201, 11201, 11202, 11202, 11265, 11265, 11272, 11272, 11299, 11299, 19310, 19310
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15650-15776
+- Def site: line 15642-15768
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -822,11 +809,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15670, 15670, 15675, 15675, 15680, 15680, 15717, 15717, 15723, 15723, 15729, 15729, 15735, 15735, 15741, 15741, 15742, 15742, 15743, 15743, 15744, 15744, 15745, 15745, 15749, 15749, 15758, 15758, 15762, 15762, 15765, 15765, 15771, 15771, 19014, 19014
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15662, 15662, 15667, 15667, 15672, 15672, 15709, 15709, 15715, 15715, 15721, 15721, 15727, 15727, 15733, 15733, 15734, 15734, 15735, 15735, 15736, 15736, 15737, 15737, 15741, 15741, 15750, 15750, 15754, 15754, 15757, 15757, 15763, 15763, 19006, 19006
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5772-5896
+- Def site: line 5764-5888
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -835,11 +822,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5793, 5793, 5795, 5795, 5811, 5811, 5823, 5823, 5862, 5862, 5863, 5863, 5864, 5864, 5865, 5865, 5866, 5866, 5877, 5877, 5880, 5880, 6812, 6812, 20353, 20353, 20936, 20936
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5785, 5785, 5787, 5787, 5803, 5803, 5815, 5815, 5854, 5854, 5855, 5855, 5856, 5856, 5857, 5857, 5858, 5858, 5869, 5869, 5872, 5872, 6804, 6804, 20345, 20345, 20928, 20928
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8954-9065
+- Def site: line 8946-9057
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -847,13 +834,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7892, 7892, 9550, 9550, 9862, 9862, 10708, 10708, 10728, 10728, 12730, 15074, 15074, 15127, 15127, 15560, 15800, 15800, 15818, 15818, 15836, 15836, 17052, 17052, 17076, 17076, 17100, 17100, 17243, 17243, 17584, 17584, 18880, 18880, 18895, 18895, 18905, 18905, 18905, 18905, 18915, 18915
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7884, 7884, 9542, 9542, 9854, 9854, 10700, 10700, 10720, 10720, 12722, 15066, 15066, 15119, 15119, 15552, 15792, 15792, 15810, 15810, 15828, 15828, 17044, 17044, 17068, 17068, 17092, 17092, 17235, 17235, 17576, 17576, 18872, 18872, 18887, 18887, 18897, 18897, 18897, 18897, 18907, 18907
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10828-10936
+- Def site: line 10820-10928
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -863,11 +850,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10883, 10883, 10886, 10886, 10887, 10887, 10892, 10892, 10910, 10910, 10910, 10919, 10919, 10919, 10919, 10920, 10920, 10920, 10920, 10978, 10978, 10981, 10981, 10993, 10993, 10994, 10994, 11007, 11007, 11046, 11046, 11054, 11054, 11108, 11108, 11116, 11116
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10875, 10875, 10878, 10878, 10879, 10879, 10884, 10884, 10902, 10902, 10902, 10911, 10911, 10911, 10911, 10912, 10912, 10912, 10912, 10970, 10970, 10973, 10973, 10985, 10985, 10986, 10986, 10999, 10999, 11038, 11038, 11046, 11046, 11100, 11100, 11108, 11108
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12753-12852
+- Def site: line 12745-12844
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -876,11 +863,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12818, 12818, 12820, 12820, 12821, 12821, 18889, 18889, 18957, 18957, 18959, 18959, 18960, 18960
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12810, 12810, 12812, 12812, 12813, 12813, 18881, 18881, 18949, 18949, 18951, 18951, 18952, 18952
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15542-15639
+- Def site: line 15534-15631
 - References: 78
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -889,13 +876,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15285, 15285, 15520, 15520, 15578, 15578, 15584, 15584, 15590, 15590, 15596, 15596, 15602, 15602, 15608, 15608, 15614, 15614, 15620, 15620, 15626, 15626, 15632, 15632, 15638, 15638, 15862, 17244, 17244, 17247, 17247, 17583, 17583, 18846, 18846, 18913, 18913, 18919, 18919, 18970, 18970, 19027, 19027
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15277, 15277, 15512, 15512, 15570, 15570, 15576, 15576, 15582, 15582, 15588, 15588, 15594, 15594, 15600, 15600, 15606, 15606, 15612, 15612, 15618, 15618, 15624, 15624, 15630, 15630, 15854, 17236, 17236, 17239, 17239, 17575, 17575, 18838, 18838, 18905, 18905, 18911, 18911, 18962, 18962, 19019, 19019
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8250-8346
+- Def site: line 8242-8338
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -903,11 +890,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8306, 8306, 8342, 8342
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8298, 8298, 8334, 8334
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11323-11416
+- Def site: line 11315-11408
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -916,11 +903,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11375, 11375, 11388, 11388, 18949, 18949, 18991, 18991, 18992, 18992, 18997, 18997, 18998, 18998
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11367, 11367, 11380, 11380, 18941, 18941, 18983, 18983, 18984, 18984, 18989, 18989, 18990, 18990
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5902-5991
+- Def site: line 5894-5983
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -930,13 +917,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5984, 5984, 15348, 15348, 15349, 15349, 15563, 18749, 18749
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5976, 5976, 15340, 15340, 15341, 15341, 15555, 18741, 18741
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12666-12750
+- Def site: line 12658-12742
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -946,11 +933,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12700, 12700, 18924, 18924, 18932, 18932, 18958, 18958, 19103, 19103
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12692, 12692, 18916, 18916, 18924, 18924, 18950, 18950, 19095, 19095
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 18026-18104
+- Def site: line 18018-18096
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -960,12 +947,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18021, 18021, 18022, 18022, 19198, 19198
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18013, 18013, 18014, 18014, 19190, 19190
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17030-17107
+- Def site: line 17022-17099
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -975,12 +962,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19069, 19069, 19073, 19073, 19077, 19077
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19061, 19061, 19065, 19065, 19069, 19069
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1896-1969
+- Def site: line 1888-1961
 - References: 254
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -989,7 +976,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1909, 1909, 1941, 1941, 2290, 2290, 2317, 2317, 7604, 7604, 7690, 7690, 7820, 7820, 7897, 7897, 7980, 7980, 8210, 8210, 8399, 8399, 8455, 8455, 8468, 8468, 8485, 8485, 8530, 8530, 8561, 8561, 8567, 8567, 8670, 8670, 10211, 10211, 10478, 10980, 10980, 11009, 11009, 11274, 11274, 11480, 11480, 11719, 11719, 12435, 12435, 12451, 12451, 13238, 13238, 13657, 13657, 13707, 13707, 15561, 15763, 15763, 15796, 15796, 15814, 15814, 15832, 15832, 15860, 17057, 17057, 17082, 17082, 17125, 17224, 17224, 17436, 17436, 17579, 17579, 17686, 17686, 18016, 18016, 18046, 18046, 18067, 18067, 18086, 18086, 18102, 18102, 18119, 18119, 18696, 18696, 18716, 18716, 18751, 18751, 18764, 18764, 19232, 19232, 19323, 19323, 19328, 19328, 19334, 19334, 19353, 19353, 19359, 19359, 20959, 20959, 21057, 21057
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1901, 1901, 1933, 1933, 2282, 2282, 2309, 2309, 7596, 7596, 7682, 7682, 7812, 7812, 7889, 7889, 7972, 7972, 8202, 8202, 8391, 8391, 8447, 8447, 8460, 8460, 8477, 8477, 8522, 8522, 8553, 8553, 8559, 8559, 8662, 8662, 10203, 10203, 10470, 10972, 10972, 11001, 11001, 11266, 11266, 11472, 11472, 11711, 11711, 12427, 12427, 12443, 12443, 13230, 13230, 13649, 13649, 13699, 13699, 15553, 15755, 15755, 15788, 15788, 15806, 15806, 15824, 15824, 15852, 17049, 17049, 17074, 17074, 17117, 17216, 17216, 17428, 17428, 17571, 17571, 17678, 17678, 18008, 18008, 18038, 18038, 18059, 18059, 18078, 18078, 18094, 18094, 18111, 18111, 18688, 18688, 18708, 18708, 18743, 18743, 18756, 18756, 19224, 19224, 19315, 19315, 19320, 19320, 19326, 19326, 19345, 19345, 19351, 19351, 20951, 20951, 21049, 21049
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -1010,7 +997,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15188-15259
+- Def site: line 15180-15251
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1019,11 +1006,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19035, 19035, 19036, 19036, 19037, 19037, 19038, 19038
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19027, 19027, 19028, 19028, 19029, 19029, 19030, 19030
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5463-5532
+- Def site: line 5455-5524
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1033,11 +1020,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5495, 5495, 5496, 5496, 5511, 5511, 5513, 5513
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5487, 5487, 5488, 5488, 5503, 5503, 5505, 5505
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 5997-6066
+- Def site: line 5989-6058
 - References: 182
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1045,7 +1032,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6039, 6039, 6044, 6044, 6141, 6141, 6199, 6199, 7090, 7090, 7747, 7747, 8392, 8392, 8415, 8415, 8435, 8435, 8620, 8620, 8641, 8641, 8916, 8916, 8941, 8941, 8996, 8996, 9018, 9018, 9035, 9035, 9052, 9052, 9437, 9437, 9660, 9660, 9677, 9677, 10069, 10069, 10401, 10401, 10612, 10612, 10649, 10649, 10802, 10802, 10945, 10945, 11198, 11198, 11386, 11386, 11570, 11570, 11889, 11889, 12225, 12225, 12397, 12397, 12437, 12437, 12443, 12443, 12537, 12537, 12767, 12767, 12840, 12840, 13327, 13327, 13362, 13561, 13561, 15068, 15068, 15284, 15284, 15552, 15659, 15759, 15759, 15794, 15794, 15812, 15812, 15830, 15830, 17123, 18017, 18017, 18019, 18019, 18043, 18043, 18047, 18047, 18048, 18048, 18068, 18068, 18069, 18069, 18230, 18230, 18800, 18800, 18832, 18832, 18869, 18869, 18875, 18875, 19003, 19003, 19060, 19060, 19143, 19143, 19152, 19152, 19230, 19230, 19231, 19231, 19248, 19248, 19323, 19323, 19328, 19328, 19334, 19334, 19353, 19353, 19359, 19359, 20270, 20270, 20341, 20823, 20823, 20911, 20911
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6031, 6031, 6036, 6036, 6133, 6133, 6191, 6191, 7082, 7082, 7739, 7739, 8384, 8384, 8407, 8407, 8427, 8427, 8612, 8612, 8633, 8633, 8908, 8908, 8933, 8933, 8988, 8988, 9010, 9010, 9027, 9027, 9044, 9044, 9429, 9429, 9652, 9652, 9669, 9669, 10061, 10061, 10393, 10393, 10604, 10604, 10641, 10641, 10794, 10794, 10937, 10937, 11190, 11190, 11378, 11378, 11562, 11562, 11881, 11881, 12217, 12217, 12389, 12389, 12429, 12429, 12435, 12435, 12529, 12529, 12759, 12759, 12832, 12832, 13319, 13319, 13354, 13553, 13553, 15060, 15060, 15276, 15276, 15544, 15651, 15751, 15751, 15786, 15786, 15804, 15804, 15822, 15822, 17115, 18009, 18009, 18011, 18011, 18035, 18035, 18039, 18039, 18040, 18040, 18060, 18060, 18061, 18061, 18222, 18222, 18792, 18792, 18824, 18824, 18861, 18861, 18867, 18867, 18995, 18995, 19052, 19052, 19135, 19135, 19144, 19144, 19222, 19222, 19223, 19223, 19240, 19240, 19315, 19315, 19320, 19320, 19326, 19326, 19345, 19345, 19351, 19351, 20262, 20262, 20333, 20815, 20815, 20903, 20903
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1055,7 +1042,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10447-10515
+- Def site: line 10439-10507
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1066,11 +1053,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10487, 10487, 10492, 10492, 10497, 10497, 10498, 10498, 10504, 10504, 10505, 10505, 10511, 10511, 10512, 10512, 10513, 10513, 10514, 10514, 19376, 19376
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10479, 10479, 10484, 10484, 10489, 10489, 10490, 10490, 10496, 10496, 10497, 10497, 10503, 10503, 10504, 10504, 10505, 10505, 10506, 10506, 19368, 19368
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 18755-18820
+- Def site: line 18747-18812
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1080,11 +1067,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18803, 18803, 18811, 18811, 18820, 18820, 19349, 19349
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18795, 18795, 18803, 18803, 18812, 18812, 19341, 19341
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15783-15838
+- Def site: line 15775-15830
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1094,11 +1081,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18974, 18974, 18978, 18978, 19183, 19183
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18966, 18966, 18970, 18970, 19175, 19175
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6072-6118
+- Def site: line 6064-6110
 - References: 55
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1107,13 +1094,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6196, 6196, 8082, 8082, 8997, 8997, 9020, 9020, 9507, 9507, 9542, 9542, 9556, 9556, 9679, 9679, 9683, 9683, 10231, 10231, 12541, 12541, 13211, 13211, 13337, 13337, 13369, 13547, 13547, 13583, 13583, 15558, 17907, 17907, 18018, 18018, 18049, 18049, 18070, 18070, 19233, 19233, 19249, 19249, 20842, 20842
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6188, 6188, 8074, 8074, 8989, 8989, 9012, 9012, 9499, 9499, 9534, 9534, 9548, 9548, 9671, 9671, 9675, 9675, 10223, 10223, 12533, 12533, 13203, 13203, 13329, 13329, 13361, 13539, 13539, 13575, 13575, 15550, 17899, 17899, 18010, 18010, 18041, 18041, 18062, 18062, 19225, 19225, 19241, 19241, 20834, 20834
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5721-5766
+- Def site: line 5713-5758
 - References: 97
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1122,14 +1109,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5233, 5233, 5275, 5275, 5320, 5320, 5426, 5426, 5441, 5441, 5711, 5711, 5712, 5712, 5756, 5756, 6222, 6222, 7916, 7916, 9207, 9207, 9518, 9518, 9534, 9534, 9863, 9863, 10744, 10744, 10763, 10763, 12732, 15151, 15151, 15554, 15797, 15797, 15815, 15815, 15833, 15833, 15863, 16285, 16285, 16325, 16325, 16326, 16326, 16327, 16327, 17049, 17049, 17073, 17073, 17077, 17077, 17097, 17097, 17124, 17199, 17199, 17233, 17233, 17254, 17254, 17286, 17286, 17348, 17348, 17387, 17387, 17537, 17537, 17582, 17582
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5225, 5225, 5267, 5267, 5312, 5312, 5418, 5418, 5433, 5433, 5703, 5703, 5704, 5704, 5748, 5748, 6214, 6214, 7908, 7908, 9199, 9199, 9510, 9510, 9526, 9526, 9855, 9855, 10736, 10736, 10755, 10755, 12724, 15143, 15143, 15546, 15789, 15789, 15807, 15807, 15825, 15825, 15855, 16277, 16277, 16317, 16317, 16318, 16318, 16319, 16319, 17041, 17041, 17065, 17065, 17069, 17069, 17089, 17089, 17116, 17191, 17191, 17225, 17225, 17246, 17246, 17278, 17278, 17340, 17340, 17379, 17379, 17529, 17529, 17574, 17574
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17113-17155
+- Def site: line 17105-17147
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1138,11 +1125,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17136, 17136, 17142, 17142, 17148, 17148, 17154, 17154, 19167, 19167, 19171, 19171, 19175, 19175, 19179, 19179
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17128, 17128, 17134, 17134, 17140, 17140, 17146, 17146, 19159, 19159, 19163, 19163, 19167, 19167, 19171, 19171
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11589-11628
+- Def site: line 11581-11620
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1151,11 +1138,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11626, 11626, 19373, 19373
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11618, 11618, 19365, 19365
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1860-1888
+- Def site: line 1852-1880
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1164,12 +1151,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8870, 8870, 8871, 8871, 8900, 8900, 8901, 8901, 8917, 8917, 8918, 8918, 9796, 9796, 9797, 9797, 10101, 10101, 10102, 10102, 10149, 10149, 10150, 10150, 10705, 10705, 10707, 10707, 10725, 10725, 10727, 10727, 11615, 11615, 11616, 11616, 12276, 12276, 12277, 12277, 12382, 12382, 12383, 12383, 13365
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8862, 8862, 8863, 8863, 8892, 8892, 8893, 8893, 8909, 8909, 8910, 8910, 9788, 9788, 9789, 9789, 10093, 10093, 10094, 10094, 10141, 10141, 10142, 10142, 10697, 10697, 10699, 10699, 10717, 10717, 10719, 10719, 11607, 11607, 11608, 11608, 12268, 12268, 12269, 12269, 12374, 12374, 12375, 12375, 13357
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15512-15539
+- Def site: line 15504-15531
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1178,12 +1165,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15526, 15526, 15532, 15532, 15538, 15538, 19081, 19081, 19085, 19085
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15518, 15518, 15524, 15524, 15530, 15530, 19073, 19073, 19077, 19077
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15849-15874
+- Def site: line 15841-15866
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1193,12 +1180,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15869, 15869, 15874, 15874, 19089, 19089, 19094, 19094
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15861, 15861, 15866, 15866, 19081, 19081, 19086, 19086
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13664-13685
+- Def site: line 13656-13677
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1207,7 +1194,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18855, 18855, 18859, 18859, 18863, 18863
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18847, 18847, 18851, 18851, 18855, 18855
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1217,17 +1204,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17565-17586
+- Def site: line 17557-17578
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19002, 19002, 19059, 19059, 19142, 19142, 19151, 19151
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18994, 18994, 19051, 19051, 19134, 19134, 19143, 19143
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 18002-18023
+- Def site: line 17994-18015
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1236,24 +1223,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19212, 19212
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19204, 19204
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7554-7574
+- Def site: line 7546-7566
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6305, 10074, 15397, 15562
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6297, 10066, 15389, 15554
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13910-13919
+- Def site: line 13902-13911
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1261,11 +1248,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13946, 14082, 14159, 14178, 14190, 14211, 14224, 14235, 14241, 14254, 14347, 14482, 14577
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13938, 14074, 14151, 14170, 14182, 14203, 14216, 14227, 14233, 14246, 14339, 14474, 14569
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 312-320
+- Def site: line 315-323
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1281,7 +1268,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 339-347
+- Def site: line 342-350
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1289,12 +1276,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15220, 15237, 15253
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15212, 15229, 15245
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 324-331
+- Def site: line 327-334
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1310,7 +1297,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 299-301
+- Def site: line 302-304
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1318,12 +1305,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13370, 13659, 18051, 18072, 18217, 18248, 18280, 18515, 18530
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13362, 13651, 18043, 18064, 18209, 18240, 18272, 18507, 18522
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 627-629
+- Def site: line 619-621
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1331,7 +1318,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1237, 1906, 1906, 1906, 1918, 1924, 6198, 6318, 7378, 7438, 9606, 9717, 9971, 10801, 13372, 15430, 15472, 15570, 19235
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1229, 1898, 1898, 1898, 1910, 1916, 6190, 6310, 7370, 7430, 9598, 9709, 9963, 10793, 13364, 15422, 15464, 15562, 19227
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1344,7 +1331,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2008-2010
+- Def site: line 2000-2002
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1353,11 +1340,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2008, 7388, 7395, 7396, 9982, 15419
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2000, 7380, 7387, 7388, 9974, 15411
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2026-2028
+- Def site: line 2018-2020
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1366,7 +1353,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2026, 15566
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2018, 15558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1374,7 +1361,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 743-1747
+- Def site: line 735-1739
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1382,7 +1369,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1792
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1784
 
 ## Limitations
 

--- a/src/refactors/package_import_map.py
+++ b/src/refactors/package_import_map.py
@@ -1,0 +1,37 @@
+"""Package name -> import name mapping extracted from MistHelper (SC-025).
+
+Owns the `PACKAGE_IMPORT_MAP` constant originally defined at module
+scope in MistHelper.py, and re-lands it on a lightweight
+`PackageImportMapManager` seam per FR-005 / FR-015. The sole MistHelper
+callsite (`_early_dependency_check` bootstrap wiring) is rewritten in
+the same PR to import the extracted constant; no wrapper shim remains
+in MistHelper.py after this extraction.
+
+The mapping keys are pip distribution names and values are the
+corresponding importable module names -- the pair diverges whenever a
+project publishes under one name (e.g. `pillow`) but exposes its API
+under another (e.g. `PIL`). The manager class exposes the mapping as a
+class-level attribute so consumers can grab it via
+`PackageImportMapManager.MAPPING` while keeping the moved surface a
+single import symbol.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+
+class PackageImportMapManager:  # Class-body seam for the pip-name -> import-name mapping
+    """Class-body seam owning the pip-name -> import-name mapping."""
+
+    MAPPING: dict[str, str] = {  # Map pip package names to their importable module names where they differ
+        "websocket-client": "websocket",  # pip 'websocket-client' is imported as 'websocket'
+        "python-dotenv": "dotenv",  # pip 'python-dotenv' is imported as 'dotenv'
+        "usaddress-scourgify": "scourgify",  # pip 'usaddress-scourgify' is imported as 'scourgify'
+        "pillow": "PIL",  # pip 'pillow' is imported as 'PIL'
+        "beautifulsoup4": "bs4",  # pip 'beautifulsoup4' is imported as 'bs4'
+        "pyyaml": "yaml",  # pip 'pyyaml' is imported as 'yaml'
+        "python-dateutil": "dateutil",  # pip 'python-dateutil' is imported as 'dateutil'
+        "msgpack-python": "msgpack",  # pip 'msgpack-python' is imported as 'msgpack'
+        "flask": "flask",  # 'flask' package and import names match (listed for completeness)
+        "flask-wtf": "flask_wtf",  # pip 'flask-wtf' is imported as 'flask_wtf' (hyphen becomes underscore)
+        "gunicorn": "gunicorn",  # 'gunicorn' package and import names match (listed for completeness)
+    }


### PR DESCRIPTION
## Summary

Extracts `PACKAGE_IMPORT_MAP` module-level constant (13 LoC, 1 callsite) from MistHelper.py to `src/refactors/package_import_map.py::PackageImportMapManager.MAPPING` per initiative 1011 SC-025.

- FR-003 (no wrapper shim): sole callsite in `_early_dependency_check` bootstrap wiring rewritten in the same PR.
- FR-005 (fn -> method): re-landed as a class-level attribute on `PackageImportMapManager` (module-scope constant seam).
- Pure data: no runtime dependencies on MistHelper globals; no proxy needed.

## Test plan

- [x] py_compile
- [x] black
- [x] ruff --fix (clean)
- [x] mypy --strict on new file (clean)
- [x] pytest tests/unit: 3861 passed
- [x] compliance analyzer: A+ 100/100 on new file
- [x] compliance analyzer: A 96.0 baseline non-regression on MistHelper.py
- [x] grep guard: no `\bPACKAGE_IMPORT_MAP\b` references remain outside the NOTE comment
- [x] refactor_candidates.md refreshed