### PR TITLE
refactor(1011): extract main entrypoint to MainEntrypoint

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -166,6 +166,7 @@ from src.refactors.inventory_csvcomparator import (
     InventoryCSVComparator,  # Extracted inventory CSV comparator adapter (SC-018)
 )
 from src.refactors.keyboard_listener import KeyboardListener  # PR-13 extracted no-op keyboard listener stub (SC-012)
+from src.refactors.main_entrypoint import MainEntrypoint  # Extracted CLI main entrypoint (SC-026)
 from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted Maps Manager launcher (SC-006)
 from src.refactors.package_import_map import (
     PackageImportMapManager,  # Extracted pip-name -> import-name mapping (SC-025)
@@ -21042,18 +21043,9 @@ def _handle_post_menu_exception(iwant: str, error: Exception, container_mode: bo
     sys.exit(1)  # Exit with error code on unexpected exception in direct mode.
 
 
-def main():
-    """Main entry point for MistHelper CLI application."""
-    logging.debug("ENTRY: main()")  # Log application entry point.
-    _initialize_deferred_imports()  # Initialize deferred module imports if not already completed.
-    InputUtils.ensure_tqdm_available()  # Ensure tqdm is accessible via InputUtils wrapper before use.
-    parser = _build_argument_parser()  # Build argparse parser with all supported CLI flags.
-    args = parser.parse_args()  # Parse command line arguments into typed Namespace object.
-    _setup_runtime_flags(args)  # Apply --standalone env, register globals()["args"], set FAST_MODE_ENABLED.
-    _initialize_dependencies(args)  # Initialize deferred dependencies (respects --skip-deps flag).
-    _establish_mist_session(args)  # Authenticate with Mist API (--login path or API token path).
-    _configure_runtime_options(args)  # Set OUTPUT_FORMAT, init PROGRESS_EMITTER, apply --debug level.
-    _dispatch_main_mode(args)  # Choose and run the right mode (test, TUI, web portal, CLI, interactive).
+# NOTE: main entrypoint extracted to
+# src/refactors/main_entrypoint.py::MainEntrypoint.run
+# per initiative 1011 SC-026 (FR-003: no wrapper shim; FR-005: fn->method).
 
 
 def _run_systematic_test_mode(_args: argparse.Namespace) -> None:
@@ -21156,7 +21148,7 @@ if __name__ == "__main__":
             _sys_mod.excepthook = _global_excepthook
         except Exception as hook_setup_err:
             logging.warning("Failed to install global excepthook: %s", hook_setup_err)
-        main()  # type: ignore[no-untyped-call]
+        MainEntrypoint.run()  # Invoke extracted CLI main entrypoint (SC-026)
     except KeyboardInterrupt:
         logging.info("Application interrupted by user (Ctrl+C)")
         logging.debug("EXIT: __main__ - user interrupt")

--- a/src/refactors/main_entrypoint.py
+++ b/src/refactors/main_entrypoint.py
@@ -1,0 +1,55 @@
+"""CLI main entrypoint extracted from MistHelper (SC-026).
+
+Owns the top-level `main` entry function originally defined at module
+scope in MistHelper.py, and re-lands it as a class-body method per
+FR-005. The sole MistHelper callsite (the `__main__` guard invocation
+at the bottom of the module) is rewritten in the same PR to invoke the
+class method; no wrapper shim remains in MistHelper.py after this
+extraction.
+
+All six pipeline dependencies (`_initialize_deferred_imports`,
+`InputUtils`, `_build_argument_parser`, `_setup_runtime_flags`,
+`_initialize_dependencies`, `_establish_mist_session`,
+`_configure_runtime_options`, `_dispatch_main_mode`) are resolved
+lazily through the `_MH` proxy so live re-bindings after interactive
+login and test monkeypatching are honoured. The MistHelper `__main__`
+guard aliases `sys.modules["MistHelper"] = sys.modules["__main__"]`
+before invoking the entrypoint, so `importlib.import_module("MistHelper")`
+returns the live script module during class execution.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
+import logging  # Reproduce the original entry-point trace log
+from typing import Any  # Loose typing for late-bound MistHelper attributes
+
+
+class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
+    """Forward attribute access to the currently-loaded MistHelper module."""
+
+    def __getattr__(self, name: str) -> Any:  # Called only when the attribute is not found normally
+        """Resolve name against the live MistHelper module (call-time lookup)."""
+        misthelper_module = importlib.import_module("MistHelper")  # Lazy import at call time
+        return getattr(misthelper_module, name)  # Fetch the current bound value from MistHelper
+
+
+_MH = _MistHelperProxy()  # Sole module-level proxy handle used inside the class body
+
+
+class MainEntrypoint:  # CLI main entry-point seam
+    """Class-body seam for the MistHelper CLI entrypoint."""
+
+    @classmethod
+    def run(cls) -> None:  # CLI entrypoint
+        """Main entry point for MistHelper CLI application."""
+        logging.debug("ENTRY: main()")  # Log application entry point.
+        _MH._initialize_deferred_imports()  # Initialize deferred module imports if not already completed.
+        _MH.InputUtils.ensure_tqdm_available()  # Ensure tqdm is accessible via InputUtils wrapper before use.
+        parser = _MH._build_argument_parser()  # Build argparse parser with all supported CLI flags.
+        args = parser.parse_args()  # Parse command line arguments into typed Namespace object.
+        _MH._setup_runtime_flags(args)  # Apply --standalone env, register globals()["args"], set FAST_MODE_ENABLED.
+        _MH._initialize_dependencies(args)  # Initialize deferred dependencies (respects --skip-deps flag).
+        _MH._establish_mist_session(args)  # Authenticate with Mist API (--login path or API token path).
+        _MH._configure_runtime_options(args)  # Set OUTPUT_FORMAT, init PROGRESS_EMITTER, apply --debug level.
+        _MH._dispatch_main_mode(args)  # Choose and run the right mode (test, TUI, web portal, CLI, interactive).


### PR DESCRIPTION
## Summary
- Extract MistHelper `main()` CLI entrypoint (12 LoC, 1 callsite) to `src/refactors/main_entrypoint.py::MainEntrypoint.run` per initiative 1011 SC-026.
- Rewrite the sole `__main__`-guard callsite in the same PR (FR-003: no wrapper shim; FR-005: fn->method).
- All six pipeline helpers resolved lazily through `_MistHelperProxy` so the entrypoint honours the `sys.modules["MistHelper"] = sys.modules["__main__"]` alias installed just before invocation.

## Compliance
- New file: **A+ 100/100**
- MistHelper.py baseline: **A 96.0** (unchanged)
- Black / ruff --fix: clean
- Smoke import: `MainEntrypoint.run` is a `classmethod`; MistHelper imports cleanly.

## Test plan
- [x] Local: black clean
- [x] Local: ruff clean
- [x] Local: compliance A+ on new file, A 96.0 on MistHelper.py
- [x] Local: `python -c "import MistHelper"` succeeds
- [ ] CI: pytest coverage gate CLEAN