### PR TITLE
refactor(1011): extract marvis_data_utils singleton to MarvisDataUtilsFactory (SC-027)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -168,6 +168,9 @@ from src.refactors.inventory_csvcomparator import (
 from src.refactors.keyboard_listener import KeyboardListener  # PR-13 extracted no-op keyboard listener stub (SC-012)
 from src.refactors.main_entrypoint import MainEntrypoint  # Extracted CLI main entrypoint (SC-026)
 from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted Maps Manager launcher (SC-006)
+from src.refactors.marvis_data_utils import (
+    MarvisDataUtilsFactory,  # Extracted Marvis data-utils singleton factory (SC-027)
+)
 from src.refactors.package_import_map import (
     PackageImportMapManager,  # Extracted pip-name -> import-name mapping (SC-025)
 )
@@ -6507,14 +6510,10 @@ class DataProcessingUtils:  # JSON flattening/normalization.
 
 # MarvisDataUtils extracted to src/marvis/marvis_utils.py (issue #330).
 # Dependency injection is used so the module has no circular import with MistHelper.
-from src.marvis.marvis_utils import MarvisDataUtils  # Import the extracted class
 
-# Create a module-level instance with the DataProcessingUtils callables injected.
-# All callers in this module use marvis_data_utils.format_for_csv(...) directly.
-marvis_data_utils = MarvisDataUtils(  # Instantiate with the two required data-processing helpers
-    escape_fn=DataProcessingUtils.escape_multiline,  # Callable to escape CSV strings in extracted class
-    flatten_fn=DataProcessingUtils.flatten_nested_fields,  # Pass flatten_nested_fields for the legacy fallback path
-)
+# NOTE: marvis_data_utils singleton extracted to
+# src/refactors/marvis_data_utils.py::MarvisDataUtilsFactory.instance()
+# per initiative 1011 SC-027 (FR-003: no wrapper shim; FR-005: fn->method).
 
 
 class DatabaseSchemaUtils:  # Build SQLite DDL from data.
@@ -15653,7 +15652,7 @@ class TroubleshootUtils:  # Marvis troubleshoot delegators.
             prompt_client_utils=PromptClientUtils,
             prompt_utils=PromptUtils,
             data_exporter=DataExporter,
-            marvis_data_utils=marvis_data_utils,
+            marvis_data_utils=MarvisDataUtilsFactory.instance(),
             data_processing_utils=DataProcessingUtils,
         )
 

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 193 first-party files
-- Definitions analyzed: 89
+- Module graph size: 194 first-party files
+- Definitions analyzed: 88
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=9, hot=79, skipped=1
+- Category counts: unused=0, single-use=0, low-use=8, hot=79, skipped=1
 
 ## How to read this report
 
@@ -86,7 +86,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `SiteClientExporter` | class | 85 | 10 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `OrgLevelAPFirmwareUpgrader` | class | 79 | 33 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `VirtualChassisManager` | class | 78 | 104 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
-| `InputUtils` | class | 74 | 254 | hot |  | oversize_25_lines,raw_input_call |
+| `InputUtils` | class | 74 | 252 | hot |  | oversize_25_lines,raw_input_call |
 | `InteractiveDisplayUtils` | class | 72 | 8 | hot |  | oversize_25_lines,missing_inline_comments |
 | `DisplayUtils` | class | 70 | 8 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `ConfigUtils` | class | 70 | 182 | hot |  | oversize_25_lines |
@@ -106,7 +106,6 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `SiteAutoUpgradeConfigurator` | class | 22 | 6 | hot |  | missing_inline_comments,missing_action_logging |
 | `execute_with_connection_pool_management` | function | 21 | 7 | hot |  |  |
 | `BulkSwitchFirmwareUpgrader` | class | 19 | 2 | low-use | FirmwareManager | missing_inline_comments,missing_action_logging |
-| `main` | function | 12 | 2 | low-use | MapsManager |  |
 | `EndpointConfig` | class | 10 | 13 | hot |  | missing_action_logging |
 | `SSHConnectionConfig` | class | 9 | 6 | hot |  | missing_action_logging |
 | `DeviceFetchConfig` | class | 9 | 4 | hot |  | missing_action_logging |
@@ -122,11 +121,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 11 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (9)
+## Low-Use (8)
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2116-2140
+- Def site: line 2117-2141
 - References: 3
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -134,11 +133,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2246, 17707, 20658
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2247, 17708, 20659
 
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 18099-18117
+- Def site: line 18100-18118
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -149,20 +148,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Reference sites (one PR cluster per file):
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1880, 1881
 
-### `main` (function, 12 lines)
-
-- Def site: line 21045-21056
-- References: 2
-- Suggested class: `MapsManager`
-- Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`
-- Rationale: 97 caller files detected; group callers under a shared class in `maps_manager.py` and rewrite references per file cluster
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 21159
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 2794
-
 ### `marvis_data_utils` (assignment, 4 lines)
 
-- Def site: line 6513-6516
+- Def site: line 6514-6517
 - References: 3
 - Suggested class: `MarvisDataUtils`
 - Suggested module: `src/refactors/marvis_data_utils.py`
@@ -170,12 +158,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6513, 15655
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6514, 15656
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\marvis_troubleshoot_utils.py`: lines 21
 
 ### `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 lines)
 
-- Def site: line 1988-1990
+- Def site: line 1989-1991
 - References: 3
 - Suggested class: `FastModeBackoffMultiplierManager`
 - Suggested module: `src/refactors/fast__mode__backoff__multiplier.py`
@@ -184,11 +172,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1988, 9899, 15328
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1989, 9900, 15329
 
 ### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
 
-- Def site: line 1991-1993
+- Def site: line 1992-1994
 - References: 2
 - Suggested class: `FastModeDevicesPerThreadManager`
 - Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
@@ -197,11 +185,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1991, 7389
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1992, 7390
 
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 1996-1998
+- Def site: line 1997-1999
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -210,11 +198,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1996, 15468
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1997, 15469
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2003-2005
+- Def site: line 2004-2006
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -222,11 +210,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2003, 7379
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2004, 7380
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 2011-2013
+- Def site: line 2012-2014
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -235,14 +223,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2011, 15557
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2012, 15558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
 ## Hot (79)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2854-5180
+- Def site: line 2855-5181
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -253,11 +241,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2854, 6559, 6560, 6569, 6733
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2855, 6560, 6561, 6570, 6734
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13914-14672
+- Def site: line 13915-14673
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -266,11 +254,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14391, 14391, 14403, 14403, 14431, 14431, 14443, 14443, 14504, 14504, 14541, 14541, 14698, 19098
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14392, 14392, 14404, 14404, 14432, 14432, 14444, 14444, 14505, 14505, 14542, 14542, 14699, 19099
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9060-9745
+- Def site: line 9061-9746
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -279,12 +267,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5566, 5566, 9183, 9183, 9234, 9234, 9237, 9237, 9278, 9278, 9317, 9317, 9335, 9335, 9413, 9413, 9420, 9420, 9430, 9430, 9433, 9433, 9446, 9446, 9447, 9447, 9448, 9448, 9449, 9449, 9457, 9457, 9459, 9459, 9460, 9460, 9461, 9461, 9462, 9462, 9465, 9465, 9468, 9468, 9471, 9471, 9474, 9474, 9520, 9520, 9543, 9543, 9544, 9544, 9545, 9545, 9547, 9547, 9583, 9583, 9599, 9599, 9653, 9653, 9654, 9654, 9655, 9655, 9658, 9658, 9659, 9659, 9678, 9678, 9680, 9680, 9681, 9681, 9716, 9716, 15067, 15067, 15120, 15120, 15551, 17043, 17043, 17067, 17067, 17091, 17091, 17234, 17234, 18873, 18873, 18880, 18880, 18889, 18889, 18893, 18893, 18902, 18902
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5567, 5567, 9184, 9184, 9235, 9235, 9238, 9238, 9279, 9279, 9318, 9318, 9336, 9336, 9414, 9414, 9421, 9421, 9431, 9431, 9434, 9434, 9447, 9447, 9448, 9448, 9449, 9449, 9450, 9450, 9458, 9458, 9460, 9460, 9461, 9461, 9462, 9462, 9463, 9463, 9466, 9466, 9469, 9469, 9472, 9472, 9475, 9475, 9521, 9521, 9544, 9544, 9545, 9545, 9546, 9546, 9548, 9548, 9584, 9584, 9600, 9600, 9654, 9654, 9655, 9655, 9656, 9656, 9659, 9659, 9660, 9660, 9679, 9679, 9681, 9681, 9682, 9682, 9717, 9717, 15068, 15068, 15121, 15121, 15552, 17044, 17044, 17068, 17068, 17092, 17092, 17235, 17235, 18874, 18874, 18881, 18881, 18890, 18890, 18894, 18894, 18903, 18903
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16342-17016
+- Def site: line 16343-17017
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -292,11 +280,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16730, 16730, 19344, 19350
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16731, 16731, 19345, 19351
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11793-12445
+- Def site: line 11794-12446
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -306,11 +294,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10570, 10570, 10579, 10579, 10667, 10667, 10674, 10674, 11348, 11348, 11634, 11634, 11639, 11639, 11646, 11646, 11651, 11651, 11865, 11865, 11887, 11887, 11890, 11890, 11916, 11916, 11925, 11925, 11926, 11926, 11947, 11947, 11990, 11990, 12036, 12036, 12047, 12047, 12074, 12074, 12079, 12079, 12080, 12080, 12081, 12081, 12113, 12113, 12119, 12119, 12144, 12144, 12164, 12164, 12199, 12199, 12214, 12214, 12220, 12220, 12222, 12222, 12225, 12225, 12227, 12227, 12231, 12231, 12235, 12235, 12240, 12240, 12247, 12247, 12254, 12254, 12261, 12261, 12270, 12270, 12280, 12280, 12287, 12287, 12294, 12294, 12301, 12301, 12308, 12308, 12315, 12315, 12325, 12325, 12334, 12334, 12343, 12343, 12352, 12352, 12361, 12361, 12390, 12390, 18834, 18834, 19015, 19015, 19092, 19092, 19093, 19093, 19101, 19101, 19306, 19306, 19307, 19307, 19326, 19326, 19333, 19333, 19334, 19334, 19335, 19335, 19336, 19336
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10571, 10571, 10580, 10580, 10668, 10668, 10675, 10675, 11349, 11349, 11635, 11635, 11640, 11640, 11647, 11647, 11652, 11652, 11866, 11866, 11888, 11888, 11891, 11891, 11917, 11917, 11926, 11926, 11927, 11927, 11948, 11948, 11991, 11991, 12037, 12037, 12048, 12048, 12075, 12075, 12080, 12080, 12081, 12081, 12082, 12082, 12114, 12114, 12120, 12120, 12145, 12145, 12165, 12165, 12200, 12200, 12215, 12215, 12221, 12221, 12223, 12223, 12226, 12226, 12228, 12228, 12232, 12232, 12236, 12236, 12241, 12241, 12248, 12248, 12255, 12255, 12262, 12262, 12271, 12271, 12281, 12281, 12288, 12288, 12295, 12295, 12302, 12302, 12309, 12309, 12316, 12316, 12326, 12326, 12335, 12335, 12344, 12344, 12353, 12353, 12362, 12362, 12391, 12391, 18835, 18835, 19016, 19016, 19093, 19093, 19094, 19094, 19102, 19102, 19307, 19307, 19308, 19308, 19327, 19327, 19334, 19334, 19335, 19335, 19336, 19336, 19337, 19337
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 18130-18716
+- Def site: line 18131-18717
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -318,11 +306,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18407, 18407, 18408, 18408, 18411, 18411, 18413, 18413, 18415, 18415, 18431, 18431, 19251
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18408, 18408, 18409, 18409, 18412, 18412, 18414, 18414, 18416, 18416, 18432, 18432, 19252
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 18815-19386
+- Def site: line 18816-19387
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -332,12 +320,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18815, 20100, 20101, 20110, 20230, 20230, 20272, 20330, 20375, 20866, 20870, 20915, 20915, 20942, 20942, 20945
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18816, 20101, 20102, 20111, 20231, 20231, 20273, 20331, 20376, 20867, 20871, 20916, 20916, 20943, 20943, 20946
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8344-8806
+- Def site: line 8345-8807
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -345,11 +333,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8385, 8385, 8390, 8390, 8400, 8400, 8408, 8408, 8413, 8413, 8418, 8418, 8428, 8428, 8433, 8433, 8438, 8438, 8458, 8458, 8468, 8468, 8469, 8469, 8472, 8472, 8502, 8502, 8588, 8588, 8590, 8590, 8614, 8614, 8620, 8620, 8625, 8625, 8634, 8634, 8638, 8638, 8657, 8657, 8660, 8660, 8671, 8671, 8672, 8672, 8767, 8767, 8788, 8788, 19374, 19374, 19375, 19375, 19376, 19376, 19377, 19377, 19378, 19378, 19379, 19379
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8386, 8386, 8391, 8391, 8401, 8401, 8409, 8409, 8414, 8414, 8419, 8419, 8429, 8429, 8434, 8434, 8439, 8439, 8459, 8459, 8469, 8469, 8470, 8470, 8473, 8473, 8503, 8503, 8589, 8589, 8591, 8591, 8615, 8615, 8621, 8621, 8626, 8626, 8635, 8635, 8639, 8639, 8658, 8658, 8661, 8661, 8672, 8672, 8673, 8673, 8768, 8768, 8789, 8789, 19375, 19375, 19376, 19376, 19377, 19377, 19378, 19378, 19379, 19379, 19380, 19380
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 19611-20071
+- Def site: line 19612-20072
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -359,11 +347,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20078, 20078, 20082, 20082, 20102, 20102, 20107, 20107, 20331
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20079, 20079, 20083, 20083, 20103, 20103, 20108, 20108, 20332
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7791-8231
+- Def site: line 7792-8232
 - References: 117
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -371,14 +359,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7736, 7736, 7752, 7752, 7756, 7756, 7757, 7757, 7758, 7758, 7773, 7773, 7779, 7779, 7806, 7806, 7809, 7809, 7817, 7817, 7835, 7835, 7885, 7885, 7893, 7893, 7898, 7898, 7944, 7944, 7955, 7955, 7980, 7980, 7999, 7999, 8000, 8000, 8003, 8003, 8004, 8004, 8094, 8094, 8096, 8096, 8100, 8100, 8128, 8128, 8129, 8129, 8130, 8130, 8131, 8131, 8132, 8132, 8141, 8141, 8185, 8185, 8209, 8209, 12525, 12525, 12575, 12575, 12580, 12580, 12723, 12806, 12806, 12860, 12860, 12881, 12881, 12886, 12886, 13150, 13150, 13353, 13555, 13555, 13642, 13642, 13647, 13647, 13697, 13697, 13698, 13698, 15194, 15194, 15653, 17050, 17050, 17572, 17572, 18739, 18739, 18740, 18740, 19026, 19026
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7737, 7737, 7753, 7753, 7757, 7757, 7758, 7758, 7759, 7759, 7774, 7774, 7780, 7780, 7807, 7807, 7810, 7810, 7818, 7818, 7836, 7836, 7886, 7886, 7894, 7894, 7899, 7899, 7945, 7945, 7956, 7956, 7981, 7981, 8000, 8000, 8001, 8001, 8004, 8004, 8005, 8005, 8095, 8095, 8097, 8097, 8101, 8101, 8129, 8129, 8130, 8130, 8131, 8131, 8132, 8132, 8133, 8133, 8142, 8142, 8186, 8186, 8210, 8210, 12526, 12526, 12576, 12576, 12581, 12581, 12724, 12807, 12807, 12861, 12861, 12882, 12882, 12887, 12887, 13151, 13151, 13354, 13556, 13556, 13643, 13643, 13648, 13648, 13698, 13698, 13699, 13699, 15195, 15195, 15654, 17051, 17051, 17573, 17573, 18740, 18740, 18741, 18741, 19027, 19027
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9748-10161
+- Def site: line 9749-10162
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -387,11 +375,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5560, 5560, 9781, 9781, 9865, 9865, 9871, 9871, 9874, 9874, 9918, 9918, 9932, 9932, 9959, 9959, 9965, 9965, 9979, 9979, 10062, 10062, 10064, 10064, 10068, 10068, 10070, 10070, 10073, 10073, 10077, 10077, 10080, 10080, 10090, 10090, 10096, 10096, 10134, 10134, 15068, 15068, 15069, 15069, 15070, 15070, 15121, 15121, 15122, 15122, 18874, 18874, 18875, 18875, 18876, 18876, 18900, 18900
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5561, 5561, 9782, 9782, 9866, 9866, 9872, 9872, 9875, 9875, 9919, 9919, 9933, 9933, 9960, 9960, 9966, 9966, 9980, 9980, 10063, 10063, 10065, 10065, 10069, 10069, 10071, 10071, 10074, 10074, 10078, 10078, 10081, 10081, 10091, 10091, 10097, 10097, 10135, 10135, 15069, 15069, 15070, 15070, 15071, 15071, 15122, 15122, 15123, 15123, 18875, 18875, 18876, 18876, 18877, 18877, 18901, 18901
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17153-17550
+- Def site: line 17154-17551
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -400,11 +388,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17174, 17174, 17179, 17179, 17183, 17183, 17186, 17186, 17193, 17193, 17195, 17195, 17196, 17196, 17199, 17199, 17202, 17202, 17205, 17205, 17247, 17247, 17279, 17279, 17346, 17346, 17359, 17359, 17364, 17364, 17416, 17416, 17449, 17449, 17450, 17450, 17451, 17451, 17481, 17481, 17510, 17510, 17511, 17511, 19057, 19057
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17175, 17175, 17180, 17180, 17184, 17184, 17187, 17187, 17194, 17194, 17196, 17196, 17197, 17197, 17200, 17200, 17203, 17203, 17206, 17206, 17248, 17248, 17280, 17280, 17347, 17347, 17360, 17360, 17365, 17365, 17417, 17417, 17450, 17450, 17451, 17451, 17452, 17452, 17482, 17482, 17511, 17511, 17512, 17512, 19058, 19058
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 17604-17991
+- Def site: line 17605-17992
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -414,11 +402,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17631, 17775, 17775, 19197, 19197
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17632, 17776, 17776, 19198, 19198
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6700-7044
+- Def site: line 6701-7045
 - References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -427,7 +415,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5656, 5656, 6746, 6746, 6762, 6762, 6763, 6763, 6786, 6786, 6788, 6788, 6791, 6791, 6805, 6805, 6807, 6807, 6816, 6816, 6818, 6818, 6819, 6819, 6825, 6825, 6826, 6826, 6826, 6843, 6843, 6847, 6847, 6889, 6889, 6920, 6920, 6923, 6923, 6925, 6925, 6971, 6971, 6981, 6981, 7014, 7014, 7019, 7019, 7026, 7026, 7248, 7248, 7280, 7280, 7291, 7291, 7316, 7316, 7336, 7336, 7848, 7848, 8641, 8641, 8920, 8920, 8935, 8999, 8999, 9016, 9016, 9034, 9034, 9055, 9055, 9614, 9614, 9689, 9689, 10019, 10019, 10370, 10370, 10455, 10471, 10591, 10591, 10595, 10595, 10615, 10615, 10628, 10628, 10632, 10632, 10650, 10650, 10812, 10812, 11159, 11159, 11306, 11306, 11383, 11383, 11387, 11387, 11392, 11392, 11525, 11525, 11544, 11544, 11595, 11595, 11598, 11598, 11749, 11749, 11752, 11752, 11851, 11851, 11857, 11857, 12154, 12154, 12171, 12171, 12186, 12186, 12400, 12400, 12428, 12428, 12444, 12444, 12481, 12481, 12519, 12519, 12608, 12608, 12637, 12637, 12675, 12675, 12726, 12791, 12791, 12797, 12797, 12839, 12839, 13008, 13008, 13014, 13014, 13133, 13133, 13141, 13141, 13305, 13305, 13356, 13529, 13529, 13700, 13700, 14213, 14213, 14574, 14574, 14580, 14580, 15488, 15488, 15547, 15654, 15790, 15790, 15808, 15808, 15826, 15826, 17097, 17097, 17118, 17957, 17957, 18042, 18042, 18063, 18063, 18565, 18565, 19226, 19226, 19242, 19242
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5657, 5657, 6747, 6747, 6763, 6763, 6764, 6764, 6787, 6787, 6789, 6789, 6792, 6792, 6806, 6806, 6808, 6808, 6817, 6817, 6819, 6819, 6820, 6820, 6826, 6826, 6827, 6827, 6827, 6844, 6844, 6848, 6848, 6890, 6890, 6921, 6921, 6924, 6924, 6926, 6926, 6972, 6972, 6982, 6982, 7015, 7015, 7020, 7020, 7027, 7027, 7249, 7249, 7281, 7281, 7292, 7292, 7317, 7317, 7337, 7337, 7849, 7849, 8642, 8642, 8921, 8921, 8936, 9000, 9000, 9017, 9017, 9035, 9035, 9056, 9056, 9615, 9615, 9690, 9690, 10020, 10020, 10371, 10371, 10456, 10472, 10592, 10592, 10596, 10596, 10616, 10616, 10629, 10629, 10633, 10633, 10651, 10651, 10813, 10813, 11160, 11160, 11307, 11307, 11384, 11384, 11388, 11388, 11393, 11393, 11526, 11526, 11545, 11545, 11596, 11596, 11599, 11599, 11750, 11750, 11753, 11753, 11852, 11852, 11858, 11858, 12155, 12155, 12172, 12172, 12187, 12187, 12401, 12401, 12429, 12429, 12445, 12445, 12482, 12482, 12520, 12520, 12609, 12609, 12638, 12638, 12676, 12676, 12727, 12792, 12792, 12798, 12798, 12840, 12840, 13009, 13009, 13015, 13015, 13134, 13134, 13142, 13142, 13306, 13306, 13357, 13530, 13530, 13701, 13701, 14214, 14214, 14575, 14575, 14581, 14581, 15489, 15489, 15548, 15655, 15791, 15791, 15809, 15809, 15827, 15827, 17098, 17098, 17119, 17958, 17958, 18043, 18043, 18064, 18064, 18566, 18566, 19227, 19227, 19243, 19243
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -438,7 +426,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12847-13187
+- Def site: line 12848-13188
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -447,11 +435,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12864, 12864, 12866, 12866, 12870, 12870, 12871, 12871, 12885, 12885, 12891, 12891, 12894, 12894, 12897, 12897, 12955, 12955, 12961, 12961, 12966, 12966, 12980, 12980, 12998, 12998, 13108, 13108, 13112, 13112, 13114, 13114, 13117, 13117, 13154, 13154, 13159, 13159, 13173, 13173, 13177, 13177, 13179, 13179, 13182, 13182, 13187, 13187, 19103, 19103, 19107, 19107, 19111, 19111
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12865, 12865, 12867, 12867, 12871, 12871, 12872, 12872, 12886, 12886, 12892, 12892, 12895, 12895, 12898, 12898, 12956, 12956, 12962, 12962, 12967, 12967, 12981, 12981, 12999, 12999, 13109, 13109, 13113, 13113, 13115, 13115, 13118, 13118, 13155, 13155, 13160, 13160, 13174, 13174, 13178, 13178, 13180, 13180, 13183, 13183, 13188, 13188, 19104, 19104, 19108, 19108, 19112, 19112
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7047-7374
+- Def site: line 7048-7375
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -459,11 +447,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7149, 7149, 8365, 8846, 8865, 8966, 9095, 9118, 9790, 10098, 10143, 10557, 11327, 11338, 11401, 11818
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7150, 7150, 8366, 8847, 8866, 8967, 9096, 9119, 9791, 10099, 10144, 10558, 11328, 11339, 11402, 11819
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14678-15005
+- Def site: line 14679-15006
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -473,13 +461,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12135, 12135, 12194, 12194, 12195, 12195, 13359, 14719, 14719, 14721, 14721, 14727, 14727, 14741, 14741, 14780, 14780, 14783, 14783, 14785, 14785, 14786, 14786, 14787, 14787, 14841, 14841, 14842, 14842, 14853, 14853, 14862, 14862, 14881, 14881, 14933, 14933, 14937, 14937, 14945, 14945, 14946, 14946, 14970, 14970, 14974, 14974
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12136, 12136, 12195, 12195, 12196, 12196, 13360, 14720, 14720, 14722, 14722, 14728, 14728, 14742, 14742, 14781, 14781, 14784, 14784, 14786, 14786, 14787, 14787, 14788, 14788, 14842, 14842, 14843, 14843, 14854, 14854, 14863, 14863, 14882, 14882, 14934, 14934, 14938, 14938, 14946, 14946, 14947, 14947, 14971, 14971, 14975, 14975
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16038-16326
+- Def site: line 16039-16327
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -489,11 +477,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16066, 16066, 16069, 16069, 16074, 16074, 16077, 16077, 16121, 16121, 16127, 16127, 16158, 16158, 16161, 16161, 16165, 16165, 16191, 16191, 16208, 16208, 16214, 16214, 16228, 16228, 16229, 16229, 16231, 16231, 16237, 16237, 16244, 16244, 16253, 16253, 16300, 16300, 16322, 16322, 16323, 16323, 16324, 16324, 19048, 19048
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16067, 16067, 16070, 16070, 16075, 16075, 16078, 16078, 16122, 16122, 16128, 16128, 16159, 16159, 16162, 16162, 16166, 16166, 16192, 16192, 16209, 16209, 16215, 16215, 16229, 16229, 16230, 16230, 16232, 16232, 16238, 16238, 16245, 16245, 16254, 16254, 16301, 16301, 16323, 16323, 16324, 16324, 16325, 16325, 19049, 19049
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10164-10436
+- Def site: line 10165-10437
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -502,11 +490,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10187, 10187, 10188, 10188, 10201, 10201, 10202, 10202, 10204, 10204, 10205, 10205, 10208, 10208, 10211, 10211, 10215, 10215, 10216, 10216, 10292, 10292, 10296, 10296, 10299, 10299, 10312, 10312, 10349, 10349, 10366, 10366, 10379, 10379, 10381, 10381, 10388, 10388, 10397, 10397, 10406, 10406, 10407, 10407, 10418, 10418, 10422, 10422, 10431, 10431, 10436, 10436, 19305, 19305
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10188, 10188, 10189, 10189, 10202, 10202, 10203, 10203, 10205, 10205, 10206, 10206, 10209, 10209, 10212, 10212, 10216, 10216, 10217, 10217, 10293, 10293, 10297, 10297, 10300, 10300, 10313, 10313, 10350, 10350, 10367, 10367, 10380, 10380, 10382, 10382, 10389, 10389, 10398, 10398, 10407, 10407, 10408, 10408, 10419, 10419, 10423, 10423, 10432, 10432, 10437, 10437, 19306, 19306
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5186-5449
+- Def site: line 5187-5450
 - References: 106
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -514,14 +502,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5226, 5226, 5228, 5228, 5310, 5310, 5316, 5316, 5353, 5353, 5355, 5355, 5364, 5364, 5374, 5374, 5384, 5384, 5420, 5420, 7884, 7884, 9542, 9542, 9543, 9543, 9854, 9854, 10700, 10700, 10720, 10720, 12721, 15127, 15127, 15133, 15133, 15134, 15134, 15135, 15135, 15136, 15136, 15137, 15137, 15138, 15138, 15145, 15145, 15173, 15173, 15545, 15791, 15791, 15809, 15809, 15827, 15827, 15853, 17042, 17042, 17066, 17066, 17090, 17090, 17234, 17234, 17235, 17235, 17236, 17236, 17237, 17237, 17573, 17573, 18790, 18790, 19342, 19342
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5227, 5227, 5229, 5229, 5311, 5311, 5317, 5317, 5354, 5354, 5356, 5356, 5365, 5365, 5375, 5375, 5385, 5385, 5421, 5421, 7885, 7885, 9543, 9543, 9544, 9544, 9855, 9855, 10701, 10701, 10721, 10721, 12722, 15128, 15128, 15134, 15134, 15135, 15135, 15136, 15136, 15137, 15137, 15138, 15138, 15139, 15139, 15146, 15146, 15174, 15174, 15546, 15792, 15792, 15810, 15810, 15828, 15828, 15854, 17043, 17043, 17067, 17067, 17091, 17091, 17235, 17235, 17236, 17236, 17237, 17237, 17238, 17238, 17574, 17574, 18791, 18791, 19343, 19343
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 10931-11181
+- Def site: line 10932-11182
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -531,11 +519,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10938, 10938, 10941, 10941, 10946, 10946, 10947, 10947, 10955, 10955, 10958, 10958, 10966, 10966, 11006, 11006, 11014, 11014, 11062, 11062, 11079, 11079, 11082, 11082, 11084, 11084, 11148, 11148, 11149, 11149, 19308, 19308
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10939, 10939, 10942, 10942, 10947, 10947, 10948, 10948, 10956, 10956, 10959, 10959, 10967, 10967, 11007, 11007, 11015, 11015, 11063, 11063, 11080, 11080, 11083, 11083, 11085, 11085, 11149, 11149, 11150, 11150, 19309, 19309
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15257-15501
+- Def site: line 15258-15502
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -545,11 +533,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15123, 15123, 15283, 15283, 15285, 15285, 15286, 15286, 15287, 15287, 15315, 15315, 15320, 15320, 15342, 15342, 15343, 15343, 15385, 15385, 15393, 15393, 15419, 15419, 15428, 15428, 15436, 15436, 15467, 15467, 18879, 18879, 18883, 18883
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15124, 15124, 15284, 15284, 15286, 15286, 15287, 15287, 15288, 15288, 15316, 15316, 15321, 15321, 15343, 15343, 15344, 15344, 15386, 15386, 15394, 15394, 15420, 15420, 15429, 15429, 15437, 15437, 15468, 15468, 18880, 18880, 18884, 18884
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6119-6339
+- Def site: line 6120-6340
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -557,14 +545,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6142, 6142, 6193, 6193, 6263, 6263, 6287, 6287, 6299, 6299, 6301, 6301, 6311, 6311, 6326, 6326, 6330, 6330, 6331, 6331, 6334, 6334, 6336, 6336, 12834, 12834, 15549
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6143, 6143, 6194, 6194, 6264, 6264, 6288, 6288, 6300, 6300, 6302, 6302, 6312, 6312, 6327, 6327, 6331, 6331, 6332, 6332, 6335, 6335, 6337, 6337, 12835, 12835, 15550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 19392-19605
+- Def site: line 19393-19606
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -573,11 +561,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20248, 20248, 20251, 20332, 20683
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20249, 20249, 20252, 20333, 20684
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7575-7784
+- Def site: line 7576-7785
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -586,11 +574,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7588, 7588, 7594, 7594, 7595, 7595, 7598, 7598, 7621, 7621, 7624, 7624, 7627, 7627, 7628, 7628, 7630, 7630, 7697, 7697, 7741, 7741, 8206, 8206, 13155, 13155, 15652, 15891, 15891, 16051, 16051
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7589, 7589, 7595, 7595, 7596, 7596, 7599, 7599, 7622, 7622, 7625, 7625, 7628, 7628, 7629, 7629, 7631, 7631, 7698, 7698, 7742, 7742, 8207, 8207, 13156, 13156, 15653, 15892, 15892, 16052, 16052
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12453-12655
+- Def site: line 12454-12656
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -599,11 +587,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12474, 12474, 12483, 12483, 12545, 12545, 12552, 12552, 12584, 12584, 12586, 12586, 12610, 12610, 12645, 12645, 12652, 12652, 12683, 12683, 15197, 15197, 18915, 18915, 18917, 18917, 18918, 18918, 18920, 18920
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12475, 12475, 12484, 12484, 12546, 12546, 12553, 12553, 12585, 12585, 12587, 12587, 12611, 12611, 12646, 12646, 12653, 12653, 12684, 12684, 15198, 15198, 18916, 18916, 18918, 18918, 18919, 18919, 18921, 18921
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13706-13893
+- Def site: line 13707-13894
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -613,11 +601,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19265, 19265, 19266, 19266, 19267, 19267, 19268, 19268, 19269, 19269, 19270, 19270, 19271, 19271, 19272, 19272, 19274, 19274, 19275, 19275, 19276, 19276, 19277, 19277, 19278, 19278, 19279, 19279, 19280, 19280, 19282, 19282, 19283, 19283, 19284, 19284, 19285, 19285, 19286, 19286, 19287, 19287, 19288, 19288, 19289, 19289, 19290, 19290, 19292, 19292, 19293, 19293, 19294, 19294, 19295, 19295, 19296, 19296, 19297, 19297, 19298, 19298, 19299, 19299, 19300, 19300, 19302, 19302, 19303, 19303
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19266, 19266, 19267, 19267, 19268, 19268, 19269, 19269, 19270, 19270, 19271, 19271, 19272, 19272, 19273, 19273, 19275, 19275, 19276, 19276, 19277, 19277, 19278, 19278, 19279, 19279, 19280, 19280, 19281, 19281, 19283, 19283, 19284, 19284, 19285, 19285, 19286, 19286, 19287, 19287, 19288, 19288, 19289, 19289, 19290, 19290, 19291, 19291, 19293, 19293, 19294, 19294, 19295, 19295, 19296, 19296, 19297, 19297, 19298, 19298, 19299, 19299, 19300, 19300, 19301, 19301, 19303, 19303, 19304, 19304
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5531-5710
+- Def site: line 5532-5711
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -626,11 +614,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5619, 5619, 5656, 5656, 5658, 5658, 5661, 5661, 5669, 5669, 5671, 5671, 5673, 5673, 5676, 5676, 5705, 5705, 5708, 5708, 19042, 19042
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5620, 5620, 5657, 5657, 5659, 5659, 5662, 5662, 5670, 5670, 5672, 5672, 5674, 5674, 5677, 5677, 5706, 5706, 5709, 5709, 19043, 19043
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6519-6697
+- Def site: line 6520-6698
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -638,11 +626,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6564, 6564, 6602, 6602, 6613, 6613, 6639, 6639, 6640, 6640, 6642, 6642, 6648, 6648, 6649, 6649, 6652, 6652, 6658, 6658, 6659, 6659, 6662, 6662, 6664, 6664, 6674, 6674, 6676, 6676, 6677, 6677, 6679, 6679
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6565, 6565, 6603, 6603, 6614, 6614, 6640, 6640, 6641, 6641, 6643, 6643, 6649, 6649, 6650, 6650, 6653, 6653, 6659, 6659, 6660, 6660, 6663, 6663, 6665, 6665, 6675, 6675, 6677, 6677, 6678, 6678, 6680, 6680
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11411-11578
+- Def site: line 11412-11579
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -651,11 +639,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11518, 11518, 11537, 11537, 11555, 11555, 11564, 11564, 11567, 11567, 11568, 11568, 11571, 11571, 11576, 11576, 11578, 11578, 18943, 18943
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11519, 11519, 11538, 11538, 11556, 11556, 11565, 11565, 11568, 11568, 11569, 11569, 11572, 11572, 11577, 11577, 11579, 11579, 18944, 18944
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11623-11790
+- Def site: line 11624-11791
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -663,11 +651,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11660, 11660, 11662, 11662, 11665, 11665, 11736, 11736, 11738, 11738, 11751, 11751, 11755, 11755, 18946, 18946, 18947, 18947, 18948, 18948, 18986, 18986, 18991, 18991
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11661, 11661, 11663, 11663, 11666, 11666, 11737, 11737, 11739, 11739, 11752, 11752, 11756, 11756, 18947, 18947, 18948, 18948, 18949, 18949, 18987, 18987, 18992, 18992
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10656-10817
+- Def site: line 10657-10818
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -675,11 +663,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10694, 10694, 10701, 10701, 10708, 10708, 10714, 10714, 10721, 10721, 10728, 10728, 10789, 10789, 10800, 10800, 18934, 18934, 18935, 18935, 18937, 18937, 18938, 18938, 18939, 18939
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10695, 10695, 10702, 10702, 10709, 10709, 10715, 10715, 10722, 10722, 10729, 10729, 10790, 10790, 10801, 10801, 18935, 18935, 18936, 18936, 18938, 18938, 18939, 18939, 18940, 18940
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15872-16032
+- Def site: line 15873-16033
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -688,11 +676,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15895, 15895, 15897, 15897, 15966, 15966, 15968, 15968, 15987, 15987, 15989, 15989, 15989, 16005, 16005, 16021, 16021, 16022, 16022, 16028, 16028, 19047, 19047
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15896, 15896, 15898, 15898, 15967, 15967, 15969, 15969, 15988, 15988, 15990, 15990, 15990, 16006, 16006, 16022, 16022, 16023, 16023, 16029, 16029, 19048, 19048
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6347-6504
+- Def site: line 6348-6505
 - References: 201
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -702,7 +690,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5484, 5484, 6363, 6363, 6376, 6376, 6379, 6379, 6403, 6403, 6411, 6411, 6412, 6412, 6434, 6434, 6439, 6439, 6441, 6441, 6514, 6514, 6515, 6515, 6922, 6922, 6947, 6947, 7016, 7016, 7017, 7017, 7346, 7346, 7360, 7360, 7361, 7361, 7846, 7846, 7847, 7847, 8769, 8769, 8934, 8994, 8994, 8996, 8996, 8997, 8997, 9014, 9014, 9015, 9015, 9032, 9032, 9033, 9033, 9053, 9053, 9054, 9054, 9611, 9611, 9612, 9612, 9686, 9686, 9687, 9687, 10015, 10015, 10018, 10018, 10593, 10593, 10594, 10594, 10630, 10630, 10631, 10631, 10810, 10810, 10811, 10811, 11155, 11155, 11156, 11156, 11302, 11302, 11303, 11303, 11385, 11385, 11386, 11386, 11597, 11597, 11772, 11772, 11773, 11773, 11849, 11849, 11850, 11850, 12153, 12153, 12169, 12169, 12170, 12170, 12398, 12398, 12399, 12399, 12478, 12478, 12479, 12479, 12480, 12480, 12516, 12516, 12517, 12517, 12605, 12605, 12606, 12606, 12634, 12634, 12635, 12635, 12672, 12672, 12673, 12673, 12725, 12794, 12794, 12795, 12795, 12837, 12837, 12838, 12838, 13006, 13006, 13007, 13007, 13131, 13131, 13132, 13132, 13355, 13527, 13527, 14579, 14579, 15486, 15486, 15487, 15487, 15548, 15656, 17095, 17095, 17096, 17096, 17947, 17947
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5485, 5485, 6364, 6364, 6377, 6377, 6380, 6380, 6404, 6404, 6412, 6412, 6413, 6413, 6435, 6435, 6440, 6440, 6442, 6442, 6515, 6515, 6516, 6516, 6923, 6923, 6948, 6948, 7017, 7017, 7018, 7018, 7347, 7347, 7361, 7361, 7362, 7362, 7847, 7847, 7848, 7848, 8770, 8770, 8935, 8995, 8995, 8997, 8997, 8998, 8998, 9015, 9015, 9016, 9016, 9033, 9033, 9034, 9034, 9054, 9054, 9055, 9055, 9612, 9612, 9613, 9613, 9687, 9687, 9688, 9688, 10016, 10016, 10019, 10019, 10594, 10594, 10595, 10595, 10631, 10631, 10632, 10632, 10811, 10811, 10812, 10812, 11156, 11156, 11157, 11157, 11303, 11303, 11304, 11304, 11386, 11386, 11387, 11387, 11598, 11598, 11773, 11773, 11774, 11774, 11850, 11850, 11851, 11851, 12154, 12154, 12170, 12170, 12171, 12171, 12399, 12399, 12400, 12400, 12479, 12479, 12480, 12480, 12481, 12481, 12517, 12517, 12518, 12518, 12606, 12606, 12607, 12607, 12635, 12635, 12636, 12636, 12673, 12673, 12674, 12674, 12726, 12795, 12795, 12796, 12796, 12838, 12838, 12839, 12839, 13007, 13007, 13008, 13008, 13132, 13132, 13133, 13133, 13356, 13528, 13528, 14580, 14580, 15487, 15487, 15488, 15488, 15549, 15657, 17096, 17096, 17097, 17097, 17948, 17948
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -710,7 +698,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15019-15174
+- Def site: line 15020-15175
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -719,11 +707,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15041, 15041, 15047, 15047, 15049, 15049, 15077, 15077, 15103, 15103, 15106, 15106, 15109, 15109, 19033, 19033, 19037, 19037, 19045, 19045
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15042, 15042, 15048, 15048, 15050, 15050, 15078, 15078, 15104, 15104, 15107, 15107, 15110, 15110, 19034, 19034, 19038, 19038, 19046, 19046
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13190-13335
+- Def site: line 13191-13336
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -731,11 +719,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13229, 13229, 13236, 13236, 13261, 13261, 13264, 13264, 13277, 13277, 13321, 13321, 13325, 13325, 13330, 13330, 13331, 13331, 13335, 13335, 19340, 19340
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13230, 13230, 13237, 13237, 13262, 13262, 13265, 13265, 13278, 13278, 13322, 13322, 13326, 13326, 13331, 13331, 13332, 13332, 13336, 13336, 19341, 19341
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13343-13487
+- Def site: line 13344-13488
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -744,12 +732,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12564, 12564, 12740, 12740, 12818, 12818, 12823, 12823, 13372, 13372, 13378, 13378, 13384, 13384, 13390, 13390, 13396, 13396, 13402, 13402, 13408, 13408, 13414, 13414, 13420, 13420, 13426, 13426, 13432, 13432, 13438, 13438, 13444, 13444, 13450, 13450, 13456, 13456, 13462, 13462, 13468, 13468, 13474, 13474, 13480, 13480, 13486, 13486, 18953, 18953, 19094, 19094, 19096, 19096, 19211, 19211, 19337, 19337, 19338, 19338, 19339, 19339, 19358, 19358, 19359, 19359, 19360, 19360, 19361, 19361, 19362, 19362, 19363, 19363, 19364, 19364
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12565, 12565, 12741, 12741, 12819, 12819, 12824, 12824, 13373, 13373, 13379, 13379, 13385, 13385, 13391, 13391, 13397, 13397, 13403, 13403, 13409, 13409, 13415, 13415, 13421, 13421, 13427, 13427, 13433, 13433, 13439, 13439, 13445, 13445, 13451, 13451, 13457, 13457, 13463, 13463, 13469, 13469, 13475, 13475, 13481, 13481, 13487, 13487, 18954, 18954, 19095, 19095, 19097, 19097, 19212, 19212, 19338, 19338, 19339, 19339, 19340, 19340, 19359, 19359, 19360, 19360, 19361, 19361, 19362, 19362, 19363, 19363, 19364, 19364, 19365, 19365
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10510-10653
+- Def site: line 10511-10654
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -758,11 +746,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10524, 10524, 10525, 10525, 10611, 10611, 10646, 10646, 18928, 18928, 18929, 18929, 18930, 18930, 18931, 18931, 18932, 18932
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10525, 10525, 10526, 10526, 10612, 10612, 10647, 10647, 18929, 18929, 18930, 18930, 18931, 18931, 18932, 18932, 18933, 18933
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13490-13628
+- Def site: line 13491-13629
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -770,11 +758,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13559, 13559, 13562, 13562, 13563, 13563, 13564, 13564, 13584, 13584, 13587, 13587, 13595, 13595, 13600, 13600, 19366, 19366
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13560, 13560, 13563, 13563, 13564, 13564, 13565, 13565, 13585, 13585, 13588, 13588, 13596, 13596, 13601, 13601, 19367, 19367
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8812-8940
+- Def site: line 8813-8941
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -783,11 +771,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8883, 8883, 8894, 8894, 15117, 15117, 15118, 15118, 18831, 18831, 18832, 18832, 19011, 19011
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8884, 8884, 8895, 8895, 15118, 15118, 15119, 15119, 18832, 18832, 18833, 18833, 19012, 19012
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11184-11312
+- Def site: line 11185-11313
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -796,11 +784,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11191, 11191, 11196, 11196, 11197, 11197, 11198, 11198, 11201, 11201, 11202, 11202, 11265, 11265, 11272, 11272, 11299, 11299, 19310, 19310
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11192, 11192, 11197, 11197, 11198, 11198, 11199, 11199, 11202, 11202, 11203, 11203, 11266, 11266, 11273, 11273, 11300, 11300, 19311, 19311
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15642-15768
+- Def site: line 15643-15769
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -809,11 +797,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15662, 15662, 15667, 15667, 15672, 15672, 15709, 15709, 15715, 15715, 15721, 15721, 15727, 15727, 15733, 15733, 15734, 15734, 15735, 15735, 15736, 15736, 15737, 15737, 15741, 15741, 15750, 15750, 15754, 15754, 15757, 15757, 15763, 15763, 19006, 19006
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15663, 15663, 15668, 15668, 15673, 15673, 15710, 15710, 15716, 15716, 15722, 15722, 15728, 15728, 15734, 15734, 15735, 15735, 15736, 15736, 15737, 15737, 15738, 15738, 15742, 15742, 15751, 15751, 15755, 15755, 15758, 15758, 15764, 15764, 19007, 19007
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5764-5888
+- Def site: line 5765-5889
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -822,11 +810,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5785, 5785, 5787, 5787, 5803, 5803, 5815, 5815, 5854, 5854, 5855, 5855, 5856, 5856, 5857, 5857, 5858, 5858, 5869, 5869, 5872, 5872, 6804, 6804, 20345, 20345, 20928, 20928
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5786, 5786, 5788, 5788, 5804, 5804, 5816, 5816, 5855, 5855, 5856, 5856, 5857, 5857, 5858, 5858, 5859, 5859, 5870, 5870, 5873, 5873, 6805, 6805, 20346, 20346, 20929, 20929
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8946-9057
+- Def site: line 8947-9058
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -834,13 +822,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7884, 7884, 9542, 9542, 9854, 9854, 10700, 10700, 10720, 10720, 12722, 15066, 15066, 15119, 15119, 15552, 15792, 15792, 15810, 15810, 15828, 15828, 17044, 17044, 17068, 17068, 17092, 17092, 17235, 17235, 17576, 17576, 18872, 18872, 18887, 18887, 18897, 18897, 18897, 18897, 18907, 18907
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7885, 7885, 9543, 9543, 9855, 9855, 10701, 10701, 10721, 10721, 12723, 15067, 15067, 15120, 15120, 15553, 15793, 15793, 15811, 15811, 15829, 15829, 17045, 17045, 17069, 17069, 17093, 17093, 17236, 17236, 17577, 17577, 18873, 18873, 18888, 18888, 18898, 18898, 18898, 18898, 18908, 18908
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10820-10928
+- Def site: line 10821-10929
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -850,11 +838,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10875, 10875, 10878, 10878, 10879, 10879, 10884, 10884, 10902, 10902, 10902, 10911, 10911, 10911, 10911, 10912, 10912, 10912, 10912, 10970, 10970, 10973, 10973, 10985, 10985, 10986, 10986, 10999, 10999, 11038, 11038, 11046, 11046, 11100, 11100, 11108, 11108
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10876, 10876, 10879, 10879, 10880, 10880, 10885, 10885, 10903, 10903, 10903, 10912, 10912, 10912, 10912, 10913, 10913, 10913, 10913, 10971, 10971, 10974, 10974, 10986, 10986, 10987, 10987, 11000, 11000, 11039, 11039, 11047, 11047, 11101, 11101, 11109, 11109
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12745-12844
+- Def site: line 12746-12845
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -863,11 +851,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12810, 12810, 12812, 12812, 12813, 12813, 18881, 18881, 18949, 18949, 18951, 18951, 18952, 18952
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12811, 12811, 12813, 12813, 12814, 12814, 18882, 18882, 18950, 18950, 18952, 18952, 18953, 18953
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15534-15631
+- Def site: line 15535-15632
 - References: 78
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -876,13 +864,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15277, 15277, 15512, 15512, 15570, 15570, 15576, 15576, 15582, 15582, 15588, 15588, 15594, 15594, 15600, 15600, 15606, 15606, 15612, 15612, 15618, 15618, 15624, 15624, 15630, 15630, 15854, 17236, 17236, 17239, 17239, 17575, 17575, 18838, 18838, 18905, 18905, 18911, 18911, 18962, 18962, 19019, 19019
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15278, 15278, 15513, 15513, 15571, 15571, 15577, 15577, 15583, 15583, 15589, 15589, 15595, 15595, 15601, 15601, 15607, 15607, 15613, 15613, 15619, 15619, 15625, 15625, 15631, 15631, 15855, 17237, 17237, 17240, 17240, 17576, 17576, 18839, 18839, 18906, 18906, 18912, 18912, 18963, 18963, 19020, 19020
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8242-8338
+- Def site: line 8243-8339
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -890,11 +878,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8298, 8298, 8334, 8334
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8299, 8299, 8335, 8335
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11315-11408
+- Def site: line 11316-11409
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -903,11 +891,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11367, 11367, 11380, 11380, 18941, 18941, 18983, 18983, 18984, 18984, 18989, 18989, 18990, 18990
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11368, 11368, 11381, 11381, 18942, 18942, 18984, 18984, 18985, 18985, 18990, 18990, 18991, 18991
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5894-5983
+- Def site: line 5895-5984
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -917,13 +905,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5976, 5976, 15340, 15340, 15341, 15341, 15555, 18741, 18741
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5977, 5977, 15341, 15341, 15342, 15342, 15556, 18742, 18742
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12658-12742
+- Def site: line 12659-12743
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -933,11 +921,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12692, 12692, 18916, 18916, 18924, 18924, 18950, 18950, 19095, 19095
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12693, 12693, 18917, 18917, 18925, 18925, 18951, 18951, 19096, 19096
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 18018-18096
+- Def site: line 18019-18097
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -947,12 +935,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18013, 18013, 18014, 18014, 19190, 19190
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18014, 18014, 18015, 18015, 19191, 19191
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17022-17099
+- Def site: line 17023-17100
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -962,13 +950,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19061, 19061, 19065, 19065, 19069, 19069
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19062, 19062, 19066, 19066, 19070, 19070
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1888-1961
-- References: 254
+- Def site: line 1889-1962
+- References: 252
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -976,7 +964,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1901, 1901, 1933, 1933, 2282, 2282, 2309, 2309, 7596, 7596, 7682, 7682, 7812, 7812, 7889, 7889, 7972, 7972, 8202, 8202, 8391, 8391, 8447, 8447, 8460, 8460, 8477, 8477, 8522, 8522, 8553, 8553, 8559, 8559, 8662, 8662, 10203, 10203, 10470, 10972, 10972, 11001, 11001, 11266, 11266, 11472, 11472, 11711, 11711, 12427, 12427, 12443, 12443, 13230, 13230, 13649, 13649, 13699, 13699, 15553, 15755, 15755, 15788, 15788, 15806, 15806, 15824, 15824, 15852, 17049, 17049, 17074, 17074, 17117, 17216, 17216, 17428, 17428, 17571, 17571, 17678, 17678, 18008, 18008, 18038, 18038, 18059, 18059, 18078, 18078, 18094, 18094, 18111, 18111, 18688, 18688, 18708, 18708, 18743, 18743, 18756, 18756, 19224, 19224, 19315, 19315, 19320, 19320, 19326, 19326, 19345, 19345, 19351, 19351, 20951, 20951, 21049, 21049
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1902, 1902, 1934, 1934, 2283, 2283, 2310, 2310, 7597, 7597, 7683, 7683, 7813, 7813, 7890, 7890, 7973, 7973, 8203, 8203, 8392, 8392, 8448, 8448, 8461, 8461, 8478, 8478, 8523, 8523, 8554, 8554, 8560, 8560, 8663, 8663, 10204, 10204, 10471, 10973, 10973, 11002, 11002, 11267, 11267, 11473, 11473, 11712, 11712, 12428, 12428, 12444, 12444, 13231, 13231, 13650, 13650, 13700, 13700, 15554, 15756, 15756, 15789, 15789, 15807, 15807, 15825, 15825, 15853, 17050, 17050, 17075, 17075, 17118, 17217, 17217, 17429, 17429, 17572, 17572, 17679, 17679, 18009, 18009, 18039, 18039, 18060, 18060, 18079, 18079, 18095, 18095, 18112, 18112, 18689, 18689, 18709, 18709, 18744, 18744, 18757, 18757, 19225, 19225, 19316, 19316, 19321, 19321, 19327, 19327, 19346, 19346, 19352, 19352, 20952, 20952
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -997,7 +985,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15180-15251
+- Def site: line 15181-15252
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1006,11 +994,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19027, 19027, 19028, 19028, 19029, 19029, 19030, 19030
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19028, 19028, 19029, 19029, 19030, 19030, 19031, 19031
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5455-5524
+- Def site: line 5456-5525
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1020,11 +1008,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5487, 5487, 5488, 5488, 5503, 5503, 5505, 5505
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5488, 5488, 5489, 5489, 5504, 5504, 5506, 5506
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 5989-6058
+- Def site: line 5990-6059
 - References: 182
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1032,7 +1020,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6031, 6031, 6036, 6036, 6133, 6133, 6191, 6191, 7082, 7082, 7739, 7739, 8384, 8384, 8407, 8407, 8427, 8427, 8612, 8612, 8633, 8633, 8908, 8908, 8933, 8933, 8988, 8988, 9010, 9010, 9027, 9027, 9044, 9044, 9429, 9429, 9652, 9652, 9669, 9669, 10061, 10061, 10393, 10393, 10604, 10604, 10641, 10641, 10794, 10794, 10937, 10937, 11190, 11190, 11378, 11378, 11562, 11562, 11881, 11881, 12217, 12217, 12389, 12389, 12429, 12429, 12435, 12435, 12529, 12529, 12759, 12759, 12832, 12832, 13319, 13319, 13354, 13553, 13553, 15060, 15060, 15276, 15276, 15544, 15651, 15751, 15751, 15786, 15786, 15804, 15804, 15822, 15822, 17115, 18009, 18009, 18011, 18011, 18035, 18035, 18039, 18039, 18040, 18040, 18060, 18060, 18061, 18061, 18222, 18222, 18792, 18792, 18824, 18824, 18861, 18861, 18867, 18867, 18995, 18995, 19052, 19052, 19135, 19135, 19144, 19144, 19222, 19222, 19223, 19223, 19240, 19240, 19315, 19315, 19320, 19320, 19326, 19326, 19345, 19345, 19351, 19351, 20262, 20262, 20333, 20815, 20815, 20903, 20903
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6032, 6032, 6037, 6037, 6134, 6134, 6192, 6192, 7083, 7083, 7740, 7740, 8385, 8385, 8408, 8408, 8428, 8428, 8613, 8613, 8634, 8634, 8909, 8909, 8934, 8934, 8989, 8989, 9011, 9011, 9028, 9028, 9045, 9045, 9430, 9430, 9653, 9653, 9670, 9670, 10062, 10062, 10394, 10394, 10605, 10605, 10642, 10642, 10795, 10795, 10938, 10938, 11191, 11191, 11379, 11379, 11563, 11563, 11882, 11882, 12218, 12218, 12390, 12390, 12430, 12430, 12436, 12436, 12530, 12530, 12760, 12760, 12833, 12833, 13320, 13320, 13355, 13554, 13554, 15061, 15061, 15277, 15277, 15545, 15652, 15752, 15752, 15787, 15787, 15805, 15805, 15823, 15823, 17116, 18010, 18010, 18012, 18012, 18036, 18036, 18040, 18040, 18041, 18041, 18061, 18061, 18062, 18062, 18223, 18223, 18793, 18793, 18825, 18825, 18862, 18862, 18868, 18868, 18996, 18996, 19053, 19053, 19136, 19136, 19145, 19145, 19223, 19223, 19224, 19224, 19241, 19241, 19316, 19316, 19321, 19321, 19327, 19327, 19346, 19346, 19352, 19352, 20263, 20263, 20334, 20816, 20816, 20904, 20904
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1042,7 +1030,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10439-10507
+- Def site: line 10440-10508
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1053,11 +1041,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10479, 10479, 10484, 10484, 10489, 10489, 10490, 10490, 10496, 10496, 10497, 10497, 10503, 10503, 10504, 10504, 10505, 10505, 10506, 10506, 19368, 19368
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10480, 10480, 10485, 10485, 10490, 10490, 10491, 10491, 10497, 10497, 10498, 10498, 10504, 10504, 10505, 10505, 10506, 10506, 10507, 10507, 19369, 19369
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 18747-18812
+- Def site: line 18748-18813
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1067,11 +1055,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18795, 18795, 18803, 18803, 18812, 18812, 19341, 19341
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18796, 18796, 18804, 18804, 18813, 18813, 19342, 19342
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15775-15830
+- Def site: line 15776-15831
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1081,11 +1069,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18966, 18966, 18970, 18970, 19175, 19175
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18967, 18967, 18971, 18971, 19176, 19176
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6064-6110
+- Def site: line 6065-6111
 - References: 55
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1094,13 +1082,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6188, 6188, 8074, 8074, 8989, 8989, 9012, 9012, 9499, 9499, 9534, 9534, 9548, 9548, 9671, 9671, 9675, 9675, 10223, 10223, 12533, 12533, 13203, 13203, 13329, 13329, 13361, 13539, 13539, 13575, 13575, 15550, 17899, 17899, 18010, 18010, 18041, 18041, 18062, 18062, 19225, 19225, 19241, 19241, 20834, 20834
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6189, 6189, 8075, 8075, 8990, 8990, 9013, 9013, 9500, 9500, 9535, 9535, 9549, 9549, 9672, 9672, 9676, 9676, 10224, 10224, 12534, 12534, 13204, 13204, 13330, 13330, 13362, 13540, 13540, 13576, 13576, 15551, 17900, 17900, 18011, 18011, 18042, 18042, 18063, 18063, 19226, 19226, 19242, 19242, 20835, 20835
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5713-5758
+- Def site: line 5714-5759
 - References: 97
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1109,14 +1097,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5225, 5225, 5267, 5267, 5312, 5312, 5418, 5418, 5433, 5433, 5703, 5703, 5704, 5704, 5748, 5748, 6214, 6214, 7908, 7908, 9199, 9199, 9510, 9510, 9526, 9526, 9855, 9855, 10736, 10736, 10755, 10755, 12724, 15143, 15143, 15546, 15789, 15789, 15807, 15807, 15825, 15825, 15855, 16277, 16277, 16317, 16317, 16318, 16318, 16319, 16319, 17041, 17041, 17065, 17065, 17069, 17069, 17089, 17089, 17116, 17191, 17191, 17225, 17225, 17246, 17246, 17278, 17278, 17340, 17340, 17379, 17379, 17529, 17529, 17574, 17574
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5226, 5226, 5268, 5268, 5313, 5313, 5419, 5419, 5434, 5434, 5704, 5704, 5705, 5705, 5749, 5749, 6215, 6215, 7909, 7909, 9200, 9200, 9511, 9511, 9527, 9527, 9856, 9856, 10737, 10737, 10756, 10756, 12725, 15144, 15144, 15547, 15790, 15790, 15808, 15808, 15826, 15826, 15856, 16278, 16278, 16318, 16318, 16319, 16319, 16320, 16320, 17042, 17042, 17066, 17066, 17070, 17070, 17090, 17090, 17117, 17192, 17192, 17226, 17226, 17247, 17247, 17279, 17279, 17341, 17341, 17380, 17380, 17530, 17530, 17575, 17575
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17105-17147
+- Def site: line 17106-17148
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1125,11 +1113,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17128, 17128, 17134, 17134, 17140, 17140, 17146, 17146, 19159, 19159, 19163, 19163, 19167, 19167, 19171, 19171
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17129, 17129, 17135, 17135, 17141, 17141, 17147, 17147, 19160, 19160, 19164, 19164, 19168, 19168, 19172, 19172
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11581-11620
+- Def site: line 11582-11621
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1138,11 +1126,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11618, 11618, 19365, 19365
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11619, 11619, 19366, 19366
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1852-1880
+- Def site: line 1853-1881
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1151,12 +1139,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8862, 8862, 8863, 8863, 8892, 8892, 8893, 8893, 8909, 8909, 8910, 8910, 9788, 9788, 9789, 9789, 10093, 10093, 10094, 10094, 10141, 10141, 10142, 10142, 10697, 10697, 10699, 10699, 10717, 10717, 10719, 10719, 11607, 11607, 11608, 11608, 12268, 12268, 12269, 12269, 12374, 12374, 12375, 12375, 13357
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8863, 8863, 8864, 8864, 8893, 8893, 8894, 8894, 8910, 8910, 8911, 8911, 9789, 9789, 9790, 9790, 10094, 10094, 10095, 10095, 10142, 10142, 10143, 10143, 10698, 10698, 10700, 10700, 10718, 10718, 10720, 10720, 11608, 11608, 11609, 11609, 12269, 12269, 12270, 12270, 12375, 12375, 12376, 12376, 13358
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15504-15531
+- Def site: line 15505-15532
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1165,12 +1153,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15518, 15518, 15524, 15524, 15530, 15530, 19073, 19073, 19077, 19077
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15519, 15519, 15525, 15525, 15531, 15531, 19074, 19074, 19078, 19078
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15841-15866
+- Def site: line 15842-15867
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1180,12 +1168,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15861, 15861, 15866, 15866, 19081, 19081, 19086, 19086
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15862, 15862, 15867, 15867, 19082, 19082, 19087, 19087
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13656-13677
+- Def site: line 13657-13678
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1194,7 +1182,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18847, 18847, 18851, 18851, 18855, 18855
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18848, 18848, 18852, 18852, 18856, 18856
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1204,17 +1192,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17557-17578
+- Def site: line 17558-17579
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18994, 18994, 19051, 19051, 19134, 19134, 19143, 19143
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18995, 18995, 19052, 19052, 19135, 19135, 19144, 19144
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 17994-18015
+- Def site: line 17995-18016
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1223,24 +1211,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19204, 19204
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19205, 19205
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7546-7566
+- Def site: line 7547-7567
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6297, 10066, 15389, 15554
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6298, 10067, 15390, 15555
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13902-13911
+- Def site: line 13903-13912
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1248,11 +1236,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13938, 14074, 14151, 14170, 14182, 14203, 14216, 14227, 14233, 14246, 14339, 14474, 14569
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13939, 14075, 14152, 14171, 14183, 14204, 14217, 14228, 14234, 14247, 14340, 14475, 14570
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 315-323
+- Def site: line 316-324
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1268,7 +1256,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 342-350
+- Def site: line 343-351
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1276,12 +1264,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15212, 15229, 15245
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15213, 15230, 15246
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 327-334
+- Def site: line 328-335
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1297,7 +1285,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 302-304
+- Def site: line 303-305
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1305,12 +1293,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13362, 13651, 18043, 18064, 18209, 18240, 18272, 18507, 18522
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13363, 13652, 18044, 18065, 18210, 18241, 18273, 18508, 18523
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 619-621
+- Def site: line 620-622
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1318,7 +1306,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1229, 1898, 1898, 1898, 1910, 1916, 6190, 6310, 7370, 7430, 9598, 9709, 9963, 10793, 13364, 15422, 15464, 15562, 19227
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1230, 1899, 1899, 1899, 1911, 1917, 6191, 6311, 7371, 7431, 9599, 9710, 9964, 10794, 13365, 15423, 15465, 15563, 19228
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1331,7 +1319,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2000-2002
+- Def site: line 2001-2003
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1340,11 +1328,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2000, 7380, 7387, 7388, 9974, 15411
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2001, 7381, 7388, 7389, 9975, 15412
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2018-2020
+- Def site: line 2019-2021
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1353,7 +1341,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2018, 15558
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2019, 15559
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1361,7 +1349,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 735-1739
+- Def site: line 736-1740
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1369,7 +1357,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1784
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1785
 
 ## Limitations
 

--- a/src/refactors/marvis_data_utils.py
+++ b/src/refactors/marvis_data_utils.py
@@ -1,0 +1,55 @@
+"""Marvis data utilities instance extracted from MistHelper (SC-027).
+
+Owns the module-level `marvis_data_utils` singleton instance originally
+defined at module scope in MistHelper.py, and re-lands it on a
+`MarvisDataUtilsFactory` class-body seam per FR-005 / FR-015. The sole
+MistHelper callsite (the ClientTroubleshootingManager dependency-
+injection kwarg `marvis_data_utils=marvis_data_utils` at line 15656) is
+rewritten in the same PR to invoke the factory's `instance` class
+method; no wrapper shim remains in MistHelper.py after this extraction.
+
+The concrete `MarvisDataUtils` class continues to live at
+`src.marvis.marvis_utils` -- this seam owns only the wired-up singleton.
+Escape and flatten callables are resolved lazily against MistHelper's
+`DataProcessingUtils` through the `_MH` proxy on the first call to
+`instance()`, which avoids the circular import that would arise if the
+singleton were instantiated at module-import time (MistHelper.py imports
+this module at its top of file, long before `DataProcessingUtils` is
+defined at line ~6500).
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
+from typing import Any  # Loose typing for late-bound MistHelper attributes
+
+from src.marvis.marvis_utils import MarvisDataUtils  # Concrete Marvis data-formatter class
+
+
+class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
+    """Forward attribute access to the currently-loaded MistHelper module."""
+
+    def __getattr__(self, name: str) -> Any:  # Called only when the attribute is not found normally
+        """Resolve name against the live MistHelper module (call-time lookup)."""
+        misthelper_module = importlib.import_module("MistHelper")  # Lazy import at call time
+        return getattr(misthelper_module, name)  # Fetch the current bound value from MistHelper
+
+
+_MH = _MistHelperProxy()  # Sole module-level proxy handle used inside the class body
+
+
+class MarvisDataUtilsFactory:  # Class-body seam for the module-level Marvis singleton
+    """Class-body seam owning the shared MarvisDataUtils singleton instance."""
+
+    _instance: MarvisDataUtils | None = None  # Cached singleton -- built lazily on first access
+
+    @classmethod
+    def instance(cls) -> MarvisDataUtils:  # Lazy accessor for the wired-up MarvisDataUtils singleton
+        """Return the shared MarvisDataUtils singleton, building it on first access."""
+        if cls._instance is None:  # First-access branch -- wire the singleton against live MistHelper
+            data_processing_utils = _MH.DataProcessingUtils  # Resolve live DataProcessingUtils class
+            cls._instance = MarvisDataUtils(  # Instantiate with the two required data-processing helpers
+                escape_fn=data_processing_utils.escape_multiline,  # Callable to escape CSV strings
+                flatten_fn=data_processing_utils.flatten_nested_fields,  # Callable for nested flattening
+            )
+        return cls._instance  # Return the cached singleton on every subsequent call


### PR DESCRIPTION
## Summary

- **SC-027**: Extract the module-level `marvis_data_utils` singleton from `MistHelper.py` to a class-body seam at `src/refactors/marvis_data_utils.py::MarvisDataUtilsFactory.instance()`.
- Sole in-module callsite (`ClientTroubleshootingManager(marvis_data_utils=...)` at line 15655) rewritten in this same PR from `marvis_data_utils` (module global) to `MarvisDataUtilsFactory.instance()` -- **no wrapper shim** remains (FR-003).
- External DI-pattern callsites in `src/troubleshooting/marvis_troubleshoot_utils.py` require no rewrite because they consume the injected `deps.marvis_data_utils`.

## Design notes

- **Circular-import avoidance**: MistHelper.py imports this extracted module at its top (line ~172), long before `DataProcessingUtils` is defined at line ~6500. The factory resolves `DataProcessingUtils.escape_multiline` / `.flatten_nested_fields` **lazily on first `.instance()` call** via a `_MistHelperProxy` attribute forwarder -- avoids adapter-closure pass-through wrappers (which would trip ARCH-DELEGATE).
- Concrete `MarvisDataUtils` class continues to live at `src.marvis.marvis_utils` -- this seam owns only the wired-up singleton (FR-005: const->classattr).

## Compliance

- New file `src/refactors/marvis_data_utils.py`: **A+ 100.0/100**
- `MistHelper.py` baseline: **A 96.0** (unchanged)
- Black + Ruff: PASS
- Smoke test: import + singleton identity check: PASS

## Test plan

- [x] `python -m black src/refactors/marvis_data_utils.py MistHelper.py`
- [x] `python -m ruff check --fix src/refactors/marvis_data_utils.py MistHelper.py`
- [x] `python -c "import MistHelper; from src.refactors.marvis_data_utils import MarvisDataUtilsFactory; print(MarvisDataUtilsFactory.instance())"`
- [x] Compliance analyzer A+ on new file; A baseline non-regressing
- [ ] Full CI (pytest + Black format check) via GitHub Actions