### PR TITLE
refactor(1011): extract FAST_MODE_DEVICES_PER_THREAD to FastModeDevicesPerThread (SC-029)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -159,6 +159,9 @@ from src.refactors.device_data_fetcher import (
 from src.refactors.fast_mode_backoff_multiplier import (
     FastModeBackoffMultiplier,  # Extracted fast-mode backoff multiplier constant (SC-028)
 )
+from src.refactors.fast_mode_devices_per_thread import (
+    FastModeDevicesPerThread,  # Extracted fast-mode devices-per-thread constant (SC-029)
+)
 from src.refactors.initialize_mist_session import (
     MistSessionInitializer,  # Extracted token-based session initializer (SC-024)
 )
@@ -1995,9 +1998,9 @@ org_id = None  # Active organization ID, populated after the user selects an org
 # NOTE: FAST_MODE_BACKOFF_MULTIPLIER extracted to
 # src/refactors/fast_mode_backoff_multiplier.py::FastModeBackoffMultiplier.VALUE
 # per initiative 1011 SC-028 (FR-003: no wrapper shim; FR-005: const->classattr).
-FAST_MODE_DEVICES_PER_THREAD = int(
-    os.getenv("FAST_MODE_DEVICES_PER_THREAD", "10")
-)  # Devices each worker thread handles
+# NOTE: FAST_MODE_DEVICES_PER_THREAD extracted to
+# src/refactors/fast_mode_devices_per_thread.py::FastModeDevicesPerThread.VALUE
+# per initiative 1011 SC-029 (FR-003: no wrapper shim; FR-005: const->classattr).
 FAST_MODE_RETRY_THREADS = int(os.getenv("FAST_MODE_RETRY_THREADS", "4"))  # Thread count for the retry pass
 FAST_MODE_RETRY_MAX_RETRIES = int(os.getenv("FAST_MODE_RETRY_MAX_RETRIES", "2"))  # Retry ceiling within the retry pass
 FAST_MODE_SEQUENTIAL_MAX_RETRIES = int(
@@ -7389,7 +7392,9 @@ def _pool_configure(work_items: list[Any], batch_description: str) -> tuple[int,
         logging.info("! CPU-aware threading: Using %s threads (maximum CPU utilization)", max_threads)
     connection_semaphore = threading.Semaphore(FAST_MODE_MAX_CONCURRENT_CONNECTIONS)  # Bound simultaneous API calls.
     logging.info("* Connection pool protection: Maximum %s concurrent API calls", FAST_MODE_MAX_CONCURRENT_CONNECTIONS)
-    batch_size = max_threads * FAST_MODE_DEVICES_PER_THREAD  # Scale batch size to thread count and per-thread setting.
+    batch_size = (
+        max_threads * FastModeDevicesPerThread.VALUE
+    )  # Scale batch size to thread count and per-thread setting.
     logging.info("* Processing %s %s with connection pool management...", len(work_items), batch_description)
     return (max_threads, connection_semaphore, batch_size, threading_mode)  # Bundle pool configuration values.
 

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 196 first-party files
-- Definitions analyzed: 86
+- Module graph size: 197 first-party files
+- Definitions analyzed: 85
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=6, hot=79, skipped=1
+- Category counts: unused=0, single-use=0, low-use=5, hot=79, skipped=1
 
 ## How to read this report
 
@@ -112,18 +112,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `SSHExecutionConfig` | class | 8 | 5 | hot |  | missing_inline_comments,missing_action_logging |
 | `is_debug_mode` | function | 3 | 12 | hot |  | missing_action_logging |
 | `tqdm` | function | 3 | 43 | hot |  | missing_action_logging |
-| `FAST_MODE_DEVICES_PER_THREAD` | assignment | 3 | 2 | low-use | FastModeDevicesPerThreadManager | missing_inline_comments,missing_action_logging |
 | `FAST_MODE_SEQUENTIAL_MAX_RETRIES` | assignment | 3 | 2 | low-use | FastModeSequentialMaxRetriesManager | missing_inline_comments,missing_action_logging |
 | `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | assignment | 3 | 6 | hot |  | missing_inline_comments,missing_action_logging |
 | `FAST_MODE_USE_CONNECTION_AWARE_THREADING` | assignment | 3 | 2 | low-use | FastModeUseConnectionAwareThreadingManager | missing_action_logging |
 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | low-use | MistWanTargetPortsManager | missing_inline_comments,missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 11 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (6)
+## Low-Use (5)
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2123-2147
+- Def site: line 2126-2150
 - References: 3
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -131,11 +130,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2253, 17710, 20661
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2256, 17715, 20666
 
 ### `BulkSwitchFirmwareUpgrader` (class, 19 lines)
 
-- Def site: line 18102-18120
+- Def site: line 18107-18125
 - References: 2
 - Suggested class: `FirmwareManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`
@@ -146,22 +145,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Reference sites (one PR cluster per file):
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\firmware_manager.py`: lines 1880, 1881
 
-### `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 lines)
-
-- Def site: line 1998-2000
-- References: 2
-- Suggested class: `FastModeDevicesPerThreadManager`
-- Suggested module: `src/refactors/fast__mode__devices__per__thread.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `_pool_configure()`; extract `FAST_MODE_DEVICES_PER_THREAD` OUT of the entrypoint into a new `src/refactors/fast__mode__devices__per__thread.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] missing_inline_comments
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1998, 7392
-
 ### `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 lines)
 
-- Def site: line 2003-2005
+- Def site: line 2006-2008
 - References: 2
 - Suggested class: `FastModeSequentialMaxRetriesManager`
 - Suggested module: `src/refactors/fast__mode__sequential__max__retries.py`
@@ -170,11 +156,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2003, 15471
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2006, 15476
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2010-2012
+- Def site: line 2013-2015
 - References: 2
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -182,11 +168,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2010, 7382
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2013, 7385
 
 ### `MIST_WAN_TARGET_PORTS` (assignment, 3 lines)
 
-- Def site: line 2018-2020
+- Def site: line 2021-2023
 - References: 3
 - Suggested class: `MistWanTargetPortsManager`
 - Suggested module: `src/refactors/mist__wan__target__ports.py`
@@ -195,14 +181,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2018, 15560
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2021, 15565
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
 
 ## Hot (79)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2861-5187
+- Def site: line 2864-5190
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -213,11 +199,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2861, 6562, 6563, 6572, 6736
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2864, 6565, 6566, 6575, 6739
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13917-14675
+- Def site: line 13922-14680
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -226,11 +212,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14394, 14394, 14406, 14406, 14434, 14434, 14446, 14446, 14507, 14507, 14544, 14544, 14701, 19101
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14399, 14399, 14411, 14411, 14439, 14439, 14451, 14451, 14512, 14512, 14549, 14549, 14706, 19106
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9063-9748
+- Def site: line 9068-9753
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -239,12 +225,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5573, 5573, 9186, 9186, 9237, 9237, 9240, 9240, 9281, 9281, 9320, 9320, 9338, 9338, 9416, 9416, 9423, 9423, 9433, 9433, 9436, 9436, 9449, 9449, 9450, 9450, 9451, 9451, 9452, 9452, 9460, 9460, 9462, 9462, 9463, 9463, 9464, 9464, 9465, 9465, 9468, 9468, 9471, 9471, 9474, 9474, 9477, 9477, 9523, 9523, 9546, 9546, 9547, 9547, 9548, 9548, 9550, 9550, 9586, 9586, 9602, 9602, 9656, 9656, 9657, 9657, 9658, 9658, 9661, 9661, 9662, 9662, 9681, 9681, 9683, 9683, 9684, 9684, 9719, 9719, 15070, 15070, 15123, 15123, 15554, 17046, 17046, 17070, 17070, 17094, 17094, 17237, 17237, 18876, 18876, 18883, 18883, 18892, 18892, 18896, 18896, 18905, 18905
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5576, 5576, 9191, 9191, 9242, 9242, 9245, 9245, 9286, 9286, 9325, 9325, 9343, 9343, 9421, 9421, 9428, 9428, 9438, 9438, 9441, 9441, 9454, 9454, 9455, 9455, 9456, 9456, 9457, 9457, 9465, 9465, 9467, 9467, 9468, 9468, 9469, 9469, 9470, 9470, 9473, 9473, 9476, 9476, 9479, 9479, 9482, 9482, 9528, 9528, 9551, 9551, 9552, 9552, 9553, 9553, 9555, 9555, 9591, 9591, 9607, 9607, 9661, 9661, 9662, 9662, 9663, 9663, 9666, 9666, 9667, 9667, 9686, 9686, 9688, 9688, 9689, 9689, 9724, 9724, 15075, 15075, 15128, 15128, 15559, 17051, 17051, 17075, 17075, 17099, 17099, 17242, 17242, 18881, 18881, 18888, 18888, 18897, 18897, 18901, 18901, 18910, 18910
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16345-17019
+- Def site: line 16350-17024
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -252,11 +238,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16733, 16733, 19347, 19353
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16738, 16738, 19352, 19358
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11796-12448
+- Def site: line 11801-12453
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -266,11 +252,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10573, 10573, 10582, 10582, 10670, 10670, 10677, 10677, 11351, 11351, 11637, 11637, 11642, 11642, 11649, 11649, 11654, 11654, 11868, 11868, 11890, 11890, 11893, 11893, 11919, 11919, 11928, 11928, 11929, 11929, 11950, 11950, 11993, 11993, 12039, 12039, 12050, 12050, 12077, 12077, 12082, 12082, 12083, 12083, 12084, 12084, 12116, 12116, 12122, 12122, 12147, 12147, 12167, 12167, 12202, 12202, 12217, 12217, 12223, 12223, 12225, 12225, 12228, 12228, 12230, 12230, 12234, 12234, 12238, 12238, 12243, 12243, 12250, 12250, 12257, 12257, 12264, 12264, 12273, 12273, 12283, 12283, 12290, 12290, 12297, 12297, 12304, 12304, 12311, 12311, 12318, 12318, 12328, 12328, 12337, 12337, 12346, 12346, 12355, 12355, 12364, 12364, 12393, 12393, 18837, 18837, 19018, 19018, 19095, 19095, 19096, 19096, 19104, 19104, 19309, 19309, 19310, 19310, 19329, 19329, 19336, 19336, 19337, 19337, 19338, 19338, 19339, 19339
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10578, 10578, 10587, 10587, 10675, 10675, 10682, 10682, 11356, 11356, 11642, 11642, 11647, 11647, 11654, 11654, 11659, 11659, 11873, 11873, 11895, 11895, 11898, 11898, 11924, 11924, 11933, 11933, 11934, 11934, 11955, 11955, 11998, 11998, 12044, 12044, 12055, 12055, 12082, 12082, 12087, 12087, 12088, 12088, 12089, 12089, 12121, 12121, 12127, 12127, 12152, 12152, 12172, 12172, 12207, 12207, 12222, 12222, 12228, 12228, 12230, 12230, 12233, 12233, 12235, 12235, 12239, 12239, 12243, 12243, 12248, 12248, 12255, 12255, 12262, 12262, 12269, 12269, 12278, 12278, 12288, 12288, 12295, 12295, 12302, 12302, 12309, 12309, 12316, 12316, 12323, 12323, 12333, 12333, 12342, 12342, 12351, 12351, 12360, 12360, 12369, 12369, 12398, 12398, 18842, 18842, 19023, 19023, 19100, 19100, 19101, 19101, 19109, 19109, 19314, 19314, 19315, 19315, 19334, 19334, 19341, 19341, 19342, 19342, 19343, 19343, 19344, 19344
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 18133-18719
+- Def site: line 18138-18724
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -278,11 +264,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18410, 18410, 18411, 18411, 18414, 18414, 18416, 18416, 18418, 18418, 18434, 18434, 19254
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18415, 18415, 18416, 18416, 18419, 18419, 18421, 18421, 18423, 18423, 18439, 18439, 19259
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 18818-19389
+- Def site: line 18823-19394
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -292,12 +278,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18818, 20103, 20104, 20113, 20233, 20233, 20275, 20333, 20378, 20869, 20873, 20918, 20918, 20945, 20945, 20948
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18823, 20108, 20109, 20118, 20238, 20238, 20280, 20338, 20383, 20874, 20878, 20923, 20923, 20950, 20950, 20953
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 463 lines)
 
-- Def site: line 8347-8809
+- Def site: line 8352-8814
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -305,11 +291,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8388, 8388, 8393, 8393, 8403, 8403, 8411, 8411, 8416, 8416, 8421, 8421, 8431, 8431, 8436, 8436, 8441, 8441, 8461, 8461, 8471, 8471, 8472, 8472, 8475, 8475, 8505, 8505, 8591, 8591, 8593, 8593, 8617, 8617, 8623, 8623, 8628, 8628, 8637, 8637, 8641, 8641, 8660, 8660, 8663, 8663, 8674, 8674, 8675, 8675, 8770, 8770, 8791, 8791, 19377, 19377, 19378, 19378, 19379, 19379, 19380, 19380, 19381, 19381, 19382, 19382
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8393, 8393, 8398, 8398, 8408, 8408, 8416, 8416, 8421, 8421, 8426, 8426, 8436, 8436, 8441, 8441, 8446, 8446, 8466, 8466, 8476, 8476, 8477, 8477, 8480, 8480, 8510, 8510, 8596, 8596, 8598, 8598, 8622, 8622, 8628, 8628, 8633, 8633, 8642, 8642, 8646, 8646, 8665, 8665, 8668, 8668, 8679, 8679, 8680, 8680, 8775, 8775, 8796, 8796, 19382, 19382, 19383, 19383, 19384, 19384, 19385, 19385, 19386, 19386, 19387, 19387
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 19614-20074
+- Def site: line 19619-20079
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -319,11 +305,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20081, 20081, 20085, 20085, 20105, 20105, 20110, 20110, 20334
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20086, 20086, 20090, 20090, 20110, 20110, 20115, 20115, 20339
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7794-8234
+- Def site: line 7799-8239
 - References: 117
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -331,14 +317,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7739, 7739, 7755, 7755, 7759, 7759, 7760, 7760, 7761, 7761, 7776, 7776, 7782, 7782, 7809, 7809, 7812, 7812, 7820, 7820, 7838, 7838, 7888, 7888, 7896, 7896, 7901, 7901, 7947, 7947, 7958, 7958, 7983, 7983, 8002, 8002, 8003, 8003, 8006, 8006, 8007, 8007, 8097, 8097, 8099, 8099, 8103, 8103, 8131, 8131, 8132, 8132, 8133, 8133, 8134, 8134, 8135, 8135, 8144, 8144, 8188, 8188, 8212, 8212, 12528, 12528, 12578, 12578, 12583, 12583, 12726, 12809, 12809, 12863, 12863, 12884, 12884, 12889, 12889, 13153, 13153, 13356, 13558, 13558, 13645, 13645, 13650, 13650, 13700, 13700, 13701, 13701, 15197, 15197, 15656, 17053, 17053, 17575, 17575, 18742, 18742, 18743, 18743, 19029, 19029
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7744, 7744, 7760, 7760, 7764, 7764, 7765, 7765, 7766, 7766, 7781, 7781, 7787, 7787, 7814, 7814, 7817, 7817, 7825, 7825, 7843, 7843, 7893, 7893, 7901, 7901, 7906, 7906, 7952, 7952, 7963, 7963, 7988, 7988, 8007, 8007, 8008, 8008, 8011, 8011, 8012, 8012, 8102, 8102, 8104, 8104, 8108, 8108, 8136, 8136, 8137, 8137, 8138, 8138, 8139, 8139, 8140, 8140, 8149, 8149, 8193, 8193, 8217, 8217, 12533, 12533, 12583, 12583, 12588, 12588, 12731, 12814, 12814, 12868, 12868, 12889, 12889, 12894, 12894, 13158, 13158, 13361, 13563, 13563, 13650, 13650, 13655, 13655, 13705, 13705, 13706, 13706, 15202, 15202, 15661, 17058, 17058, 17580, 17580, 18747, 18747, 18748, 18748, 19034, 19034
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9751-10164
+- Def site: line 9756-10169
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -347,11 +333,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5567, 5567, 9784, 9784, 9868, 9868, 9874, 9874, 9877, 9877, 9921, 9921, 9935, 9935, 9962, 9962, 9968, 9968, 9982, 9982, 10065, 10065, 10067, 10067, 10071, 10071, 10073, 10073, 10076, 10076, 10080, 10080, 10083, 10083, 10093, 10093, 10099, 10099, 10137, 10137, 15071, 15071, 15072, 15072, 15073, 15073, 15124, 15124, 15125, 15125, 18877, 18877, 18878, 18878, 18879, 18879, 18903, 18903
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5570, 5570, 9789, 9789, 9873, 9873, 9879, 9879, 9882, 9882, 9926, 9926, 9940, 9940, 9967, 9967, 9973, 9973, 9987, 9987, 10070, 10070, 10072, 10072, 10076, 10076, 10078, 10078, 10081, 10081, 10085, 10085, 10088, 10088, 10098, 10098, 10104, 10104, 10142, 10142, 15076, 15076, 15077, 15077, 15078, 15078, 15129, 15129, 15130, 15130, 18882, 18882, 18883, 18883, 18884, 18884, 18908, 18908
 
 ### `DeviceRebootManager` (class, 398 lines)
 
-- Def site: line 17156-17553
+- Def site: line 17161-17558
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -360,11 +346,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17177, 17177, 17182, 17182, 17186, 17186, 17189, 17189, 17196, 17196, 17198, 17198, 17199, 17199, 17202, 17202, 17205, 17205, 17208, 17208, 17250, 17250, 17282, 17282, 17349, 17349, 17362, 17362, 17367, 17367, 17419, 17419, 17452, 17452, 17453, 17453, 17454, 17454, 17484, 17484, 17513, 17513, 17514, 17514, 19060, 19060
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17182, 17182, 17187, 17187, 17191, 17191, 17194, 17194, 17201, 17201, 17203, 17203, 17204, 17204, 17207, 17207, 17210, 17210, 17213, 17213, 17255, 17255, 17287, 17287, 17354, 17354, 17367, 17367, 17372, 17372, 17424, 17424, 17457, 17457, 17458, 17458, 17459, 17459, 17489, 17489, 17518, 17518, 17519, 17519, 19065, 19065
 
 ### `MSPInventoryExporter` (class, 388 lines)
 
-- Def site: line 17607-17994
+- Def site: line 17612-17999
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -374,11 +360,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17634, 17778, 17778, 19200, 19200
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17639, 17783, 17783, 19205, 19205
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6703-7047
+- Def site: line 6706-7050
 - References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -387,7 +373,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5663, 5663, 6749, 6749, 6765, 6765, 6766, 6766, 6789, 6789, 6791, 6791, 6794, 6794, 6808, 6808, 6810, 6810, 6819, 6819, 6821, 6821, 6822, 6822, 6828, 6828, 6829, 6829, 6829, 6846, 6846, 6850, 6850, 6892, 6892, 6923, 6923, 6926, 6926, 6928, 6928, 6974, 6974, 6984, 6984, 7017, 7017, 7022, 7022, 7029, 7029, 7251, 7251, 7283, 7283, 7294, 7294, 7319, 7319, 7339, 7339, 7851, 7851, 8644, 8644, 8923, 8923, 8938, 9002, 9002, 9019, 9019, 9037, 9037, 9058, 9058, 9617, 9617, 9692, 9692, 10022, 10022, 10373, 10373, 10458, 10474, 10594, 10594, 10598, 10598, 10618, 10618, 10631, 10631, 10635, 10635, 10653, 10653, 10815, 10815, 11162, 11162, 11309, 11309, 11386, 11386, 11390, 11390, 11395, 11395, 11528, 11528, 11547, 11547, 11598, 11598, 11601, 11601, 11752, 11752, 11755, 11755, 11854, 11854, 11860, 11860, 12157, 12157, 12174, 12174, 12189, 12189, 12403, 12403, 12431, 12431, 12447, 12447, 12484, 12484, 12522, 12522, 12611, 12611, 12640, 12640, 12678, 12678, 12729, 12794, 12794, 12800, 12800, 12842, 12842, 13011, 13011, 13017, 13017, 13136, 13136, 13144, 13144, 13308, 13308, 13359, 13532, 13532, 13703, 13703, 14216, 14216, 14577, 14577, 14583, 14583, 15491, 15491, 15550, 15657, 15793, 15793, 15811, 15811, 15829, 15829, 17100, 17100, 17121, 17960, 17960, 18045, 18045, 18066, 18066, 18568, 18568, 19229, 19229, 19245, 19245
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5666, 5666, 6752, 6752, 6768, 6768, 6769, 6769, 6792, 6792, 6794, 6794, 6797, 6797, 6811, 6811, 6813, 6813, 6822, 6822, 6824, 6824, 6825, 6825, 6831, 6831, 6832, 6832, 6832, 6849, 6849, 6853, 6853, 6895, 6895, 6926, 6926, 6929, 6929, 6931, 6931, 6977, 6977, 6987, 6987, 7020, 7020, 7025, 7025, 7032, 7032, 7254, 7254, 7286, 7286, 7297, 7297, 7322, 7322, 7342, 7342, 7856, 7856, 8649, 8649, 8928, 8928, 8943, 9007, 9007, 9024, 9024, 9042, 9042, 9063, 9063, 9622, 9622, 9697, 9697, 10027, 10027, 10378, 10378, 10463, 10479, 10599, 10599, 10603, 10603, 10623, 10623, 10636, 10636, 10640, 10640, 10658, 10658, 10820, 10820, 11167, 11167, 11314, 11314, 11391, 11391, 11395, 11395, 11400, 11400, 11533, 11533, 11552, 11552, 11603, 11603, 11606, 11606, 11757, 11757, 11760, 11760, 11859, 11859, 11865, 11865, 12162, 12162, 12179, 12179, 12194, 12194, 12408, 12408, 12436, 12436, 12452, 12452, 12489, 12489, 12527, 12527, 12616, 12616, 12645, 12645, 12683, 12683, 12734, 12799, 12799, 12805, 12805, 12847, 12847, 13016, 13016, 13022, 13022, 13141, 13141, 13149, 13149, 13313, 13313, 13364, 13537, 13537, 13708, 13708, 14221, 14221, 14582, 14582, 14588, 14588, 15496, 15496, 15555, 15662, 15798, 15798, 15816, 15816, 15834, 15834, 17105, 17105, 17126, 17965, 17965, 18050, 18050, 18071, 18071, 18573, 18573, 19234, 19234, 19250, 19250
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
@@ -398,7 +384,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12850-13190
+- Def site: line 12855-13195
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -407,11 +393,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12867, 12867, 12869, 12869, 12873, 12873, 12874, 12874, 12888, 12888, 12894, 12894, 12897, 12897, 12900, 12900, 12958, 12958, 12964, 12964, 12969, 12969, 12983, 12983, 13001, 13001, 13111, 13111, 13115, 13115, 13117, 13117, 13120, 13120, 13157, 13157, 13162, 13162, 13176, 13176, 13180, 13180, 13182, 13182, 13185, 13185, 13190, 13190, 19106, 19106, 19110, 19110, 19114, 19114
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12872, 12872, 12874, 12874, 12878, 12878, 12879, 12879, 12893, 12893, 12899, 12899, 12902, 12902, 12905, 12905, 12963, 12963, 12969, 12969, 12974, 12974, 12988, 12988, 13006, 13006, 13116, 13116, 13120, 13120, 13122, 13122, 13125, 13125, 13162, 13162, 13167, 13167, 13181, 13181, 13185, 13185, 13187, 13187, 13190, 13190, 13195, 13195, 19111, 19111, 19115, 19115, 19119, 19119
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7050-7377
+- Def site: line 7053-7380
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -419,11 +405,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7152, 7152, 8368, 8849, 8868, 8969, 9098, 9121, 9793, 10101, 10146, 10560, 11330, 11341, 11404, 11821
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7155, 7155, 8373, 8854, 8873, 8974, 9103, 9126, 9798, 10106, 10151, 10565, 11335, 11346, 11409, 11826
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14681-15008
+- Def site: line 14686-15013
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -433,13 +419,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12138, 12138, 12197, 12197, 12198, 12198, 13362, 14722, 14722, 14724, 14724, 14730, 14730, 14744, 14744, 14783, 14783, 14786, 14786, 14788, 14788, 14789, 14789, 14790, 14790, 14844, 14844, 14845, 14845, 14856, 14856, 14865, 14865, 14884, 14884, 14936, 14936, 14940, 14940, 14948, 14948, 14949, 14949, 14973, 14973, 14977, 14977
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12143, 12143, 12202, 12202, 12203, 12203, 13367, 14727, 14727, 14729, 14729, 14735, 14735, 14749, 14749, 14788, 14788, 14791, 14791, 14793, 14793, 14794, 14794, 14795, 14795, 14849, 14849, 14850, 14850, 14861, 14861, 14870, 14870, 14889, 14889, 14941, 14941, 14945, 14945, 14953, 14953, 14954, 14954, 14978, 14978, 14982, 14982
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16041-16329
+- Def site: line 16046-16334
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -449,11 +435,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16069, 16069, 16072, 16072, 16077, 16077, 16080, 16080, 16124, 16124, 16130, 16130, 16161, 16161, 16164, 16164, 16168, 16168, 16194, 16194, 16211, 16211, 16217, 16217, 16231, 16231, 16232, 16232, 16234, 16234, 16240, 16240, 16247, 16247, 16256, 16256, 16303, 16303, 16325, 16325, 16326, 16326, 16327, 16327, 19051, 19051
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16074, 16074, 16077, 16077, 16082, 16082, 16085, 16085, 16129, 16129, 16135, 16135, 16166, 16166, 16169, 16169, 16173, 16173, 16199, 16199, 16216, 16216, 16222, 16222, 16236, 16236, 16237, 16237, 16239, 16239, 16245, 16245, 16252, 16252, 16261, 16261, 16308, 16308, 16330, 16330, 16331, 16331, 16332, 16332, 19056, 19056
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10167-10439
+- Def site: line 10172-10444
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -462,11 +448,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10190, 10190, 10191, 10191, 10204, 10204, 10205, 10205, 10207, 10207, 10208, 10208, 10211, 10211, 10214, 10214, 10218, 10218, 10219, 10219, 10295, 10295, 10299, 10299, 10302, 10302, 10315, 10315, 10352, 10352, 10369, 10369, 10382, 10382, 10384, 10384, 10391, 10391, 10400, 10400, 10409, 10409, 10410, 10410, 10421, 10421, 10425, 10425, 10434, 10434, 10439, 10439, 19308, 19308
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10195, 10195, 10196, 10196, 10209, 10209, 10210, 10210, 10212, 10212, 10213, 10213, 10216, 10216, 10219, 10219, 10223, 10223, 10224, 10224, 10300, 10300, 10304, 10304, 10307, 10307, 10320, 10320, 10357, 10357, 10374, 10374, 10387, 10387, 10389, 10389, 10396, 10396, 10405, 10405, 10414, 10414, 10415, 10415, 10426, 10426, 10430, 10430, 10439, 10439, 10444, 10444, 19313, 19313
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5193-5456
+- Def site: line 5196-5459
 - References: 106
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -474,14 +460,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5233, 5233, 5235, 5235, 5317, 5317, 5323, 5323, 5360, 5360, 5362, 5362, 5371, 5371, 5381, 5381, 5391, 5391, 5427, 5427, 7887, 7887, 9545, 9545, 9546, 9546, 9857, 9857, 10703, 10703, 10723, 10723, 12724, 15130, 15130, 15136, 15136, 15137, 15137, 15138, 15138, 15139, 15139, 15140, 15140, 15141, 15141, 15148, 15148, 15176, 15176, 15548, 15794, 15794, 15812, 15812, 15830, 15830, 15856, 17045, 17045, 17069, 17069, 17093, 17093, 17237, 17237, 17238, 17238, 17239, 17239, 17240, 17240, 17576, 17576, 18793, 18793, 19345, 19345
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5236, 5236, 5238, 5238, 5320, 5320, 5326, 5326, 5363, 5363, 5365, 5365, 5374, 5374, 5384, 5384, 5394, 5394, 5430, 5430, 7892, 7892, 9550, 9550, 9551, 9551, 9862, 9862, 10708, 10708, 10728, 10728, 12729, 15135, 15135, 15141, 15141, 15142, 15142, 15143, 15143, 15144, 15144, 15145, 15145, 15146, 15146, 15153, 15153, 15181, 15181, 15553, 15799, 15799, 15817, 15817, 15835, 15835, 15861, 17050, 17050, 17074, 17074, 17098, 17098, 17242, 17242, 17243, 17243, 17244, 17244, 17245, 17245, 17581, 17581, 18798, 18798, 19350, 19350
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 10934-11184
+- Def site: line 10939-11189
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -491,11 +477,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10941, 10941, 10944, 10944, 10949, 10949, 10950, 10950, 10958, 10958, 10961, 10961, 10969, 10969, 11009, 11009, 11017, 11017, 11065, 11065, 11082, 11082, 11085, 11085, 11087, 11087, 11151, 11151, 11152, 11152, 19311, 19311
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10946, 10946, 10949, 10949, 10954, 10954, 10955, 10955, 10963, 10963, 10966, 10966, 10974, 10974, 11014, 11014, 11022, 11022, 11070, 11070, 11087, 11087, 11090, 11090, 11092, 11092, 11156, 11156, 11157, 11157, 19316, 19316
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15260-15504
+- Def site: line 15265-15509
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -505,11 +491,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15126, 15126, 15286, 15286, 15288, 15288, 15289, 15289, 15290, 15290, 15318, 15318, 15323, 15323, 15345, 15345, 15346, 15346, 15388, 15388, 15396, 15396, 15422, 15422, 15431, 15431, 15439, 15439, 15470, 15470, 18882, 18882, 18886, 18886
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15131, 15131, 15291, 15291, 15293, 15293, 15294, 15294, 15295, 15295, 15323, 15323, 15328, 15328, 15350, 15350, 15351, 15351, 15393, 15393, 15401, 15401, 15427, 15427, 15436, 15436, 15444, 15444, 15475, 15475, 18887, 18887, 18891, 18891
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6126-6346
+- Def site: line 6129-6349
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -517,14 +503,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6149, 6149, 6200, 6200, 6270, 6270, 6294, 6294, 6306, 6306, 6308, 6308, 6318, 6318, 6333, 6333, 6337, 6337, 6338, 6338, 6341, 6341, 6343, 6343, 12837, 12837, 15552
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6152, 6152, 6203, 6203, 6273, 6273, 6297, 6297, 6309, 6309, 6311, 6311, 6321, 6321, 6336, 6336, 6340, 6340, 6341, 6341, 6344, 6344, 6346, 6346, 12842, 12842, 15557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 19395-19608
+- Def site: line 19400-19613
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -533,11 +519,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20251, 20251, 20254, 20335, 20686
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20256, 20256, 20259, 20340, 20691
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7578-7787
+- Def site: line 7583-7792
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -546,11 +532,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7591, 7591, 7597, 7597, 7598, 7598, 7601, 7601, 7624, 7624, 7627, 7627, 7630, 7630, 7631, 7631, 7633, 7633, 7700, 7700, 7744, 7744, 8209, 8209, 13158, 13158, 15655, 15894, 15894, 16054, 16054
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7596, 7596, 7602, 7602, 7603, 7603, 7606, 7606, 7629, 7629, 7632, 7632, 7635, 7635, 7636, 7636, 7638, 7638, 7705, 7705, 7749, 7749, 8214, 8214, 13163, 13163, 15660, 15899, 15899, 16059, 16059
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12456-12658
+- Def site: line 12461-12663
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -559,11 +545,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12477, 12477, 12486, 12486, 12548, 12548, 12555, 12555, 12587, 12587, 12589, 12589, 12613, 12613, 12648, 12648, 12655, 12655, 12686, 12686, 15200, 15200, 18918, 18918, 18920, 18920, 18921, 18921, 18923, 18923
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12482, 12482, 12491, 12491, 12553, 12553, 12560, 12560, 12592, 12592, 12594, 12594, 12618, 12618, 12653, 12653, 12660, 12660, 12691, 12691, 15205, 15205, 18923, 18923, 18925, 18925, 18926, 18926, 18928, 18928
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13709-13896
+- Def site: line 13714-13901
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -573,11 +559,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19268, 19268, 19269, 19269, 19270, 19270, 19271, 19271, 19272, 19272, 19273, 19273, 19274, 19274, 19275, 19275, 19277, 19277, 19278, 19278, 19279, 19279, 19280, 19280, 19281, 19281, 19282, 19282, 19283, 19283, 19285, 19285, 19286, 19286, 19287, 19287, 19288, 19288, 19289, 19289, 19290, 19290, 19291, 19291, 19292, 19292, 19293, 19293, 19295, 19295, 19296, 19296, 19297, 19297, 19298, 19298, 19299, 19299, 19300, 19300, 19301, 19301, 19302, 19302, 19303, 19303, 19305, 19305, 19306, 19306
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19273, 19273, 19274, 19274, 19275, 19275, 19276, 19276, 19277, 19277, 19278, 19278, 19279, 19279, 19280, 19280, 19282, 19282, 19283, 19283, 19284, 19284, 19285, 19285, 19286, 19286, 19287, 19287, 19288, 19288, 19290, 19290, 19291, 19291, 19292, 19292, 19293, 19293, 19294, 19294, 19295, 19295, 19296, 19296, 19297, 19297, 19298, 19298, 19300, 19300, 19301, 19301, 19302, 19302, 19303, 19303, 19304, 19304, 19305, 19305, 19306, 19306, 19307, 19307, 19308, 19308, 19310, 19310, 19311, 19311
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5538-5717
+- Def site: line 5541-5720
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -586,11 +572,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5626, 5626, 5663, 5663, 5665, 5665, 5668, 5668, 5676, 5676, 5678, 5678, 5680, 5680, 5683, 5683, 5712, 5712, 5715, 5715, 19045, 19045
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5629, 5629, 5666, 5666, 5668, 5668, 5671, 5671, 5679, 5679, 5681, 5681, 5683, 5683, 5686, 5686, 5715, 5715, 5718, 5718, 19050, 19050
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6522-6700
+- Def site: line 6525-6703
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -598,11 +584,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6567, 6567, 6605, 6605, 6616, 6616, 6642, 6642, 6643, 6643, 6645, 6645, 6651, 6651, 6652, 6652, 6655, 6655, 6661, 6661, 6662, 6662, 6665, 6665, 6667, 6667, 6677, 6677, 6679, 6679, 6680, 6680, 6682, 6682
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6570, 6570, 6608, 6608, 6619, 6619, 6645, 6645, 6646, 6646, 6648, 6648, 6654, 6654, 6655, 6655, 6658, 6658, 6664, 6664, 6665, 6665, 6668, 6668, 6670, 6670, 6680, 6680, 6682, 6682, 6683, 6683, 6685, 6685
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11414-11581
+- Def site: line 11419-11586
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -611,11 +597,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11521, 11521, 11540, 11540, 11558, 11558, 11567, 11567, 11570, 11570, 11571, 11571, 11574, 11574, 11579, 11579, 11581, 11581, 18946, 18946
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11526, 11526, 11545, 11545, 11563, 11563, 11572, 11572, 11575, 11575, 11576, 11576, 11579, 11579, 11584, 11584, 11586, 11586, 18951, 18951
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11626-11793
+- Def site: line 11631-11798
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -623,11 +609,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11663, 11663, 11665, 11665, 11668, 11668, 11739, 11739, 11741, 11741, 11754, 11754, 11758, 11758, 18949, 18949, 18950, 18950, 18951, 18951, 18989, 18989, 18994, 18994
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11668, 11668, 11670, 11670, 11673, 11673, 11744, 11744, 11746, 11746, 11759, 11759, 11763, 11763, 18954, 18954, 18955, 18955, 18956, 18956, 18994, 18994, 18999, 18999
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10659-10820
+- Def site: line 10664-10825
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -635,11 +621,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10697, 10697, 10704, 10704, 10711, 10711, 10717, 10717, 10724, 10724, 10731, 10731, 10792, 10792, 10803, 10803, 18937, 18937, 18938, 18938, 18940, 18940, 18941, 18941, 18942, 18942
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10702, 10702, 10709, 10709, 10716, 10716, 10722, 10722, 10729, 10729, 10736, 10736, 10797, 10797, 10808, 10808, 18942, 18942, 18943, 18943, 18945, 18945, 18946, 18946, 18947, 18947
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15875-16035
+- Def site: line 15880-16040
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -648,11 +634,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15898, 15898, 15900, 15900, 15969, 15969, 15971, 15971, 15990, 15990, 15992, 15992, 15992, 16008, 16008, 16024, 16024, 16025, 16025, 16031, 16031, 19050, 19050
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15903, 15903, 15905, 15905, 15974, 15974, 15976, 15976, 15995, 15995, 15997, 15997, 15997, 16013, 16013, 16029, 16029, 16030, 16030, 16036, 16036, 19055, 19055
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6354-6511
+- Def site: line 6357-6514
 - References: 197
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -662,7 +648,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5491, 5491, 6370, 6370, 6383, 6383, 6386, 6386, 6410, 6410, 6418, 6418, 6419, 6419, 6441, 6441, 6446, 6446, 6448, 6448, 6925, 6925, 6950, 6950, 7019, 7019, 7020, 7020, 7349, 7349, 7363, 7363, 7364, 7364, 7849, 7849, 7850, 7850, 8772, 8772, 8937, 8997, 8997, 8999, 8999, 9000, 9000, 9017, 9017, 9018, 9018, 9035, 9035, 9036, 9036, 9056, 9056, 9057, 9057, 9614, 9614, 9615, 9615, 9689, 9689, 9690, 9690, 10018, 10018, 10021, 10021, 10596, 10596, 10597, 10597, 10633, 10633, 10634, 10634, 10813, 10813, 10814, 10814, 11158, 11158, 11159, 11159, 11305, 11305, 11306, 11306, 11388, 11388, 11389, 11389, 11600, 11600, 11775, 11775, 11776, 11776, 11852, 11852, 11853, 11853, 12156, 12156, 12172, 12172, 12173, 12173, 12401, 12401, 12402, 12402, 12481, 12481, 12482, 12482, 12483, 12483, 12519, 12519, 12520, 12520, 12608, 12608, 12609, 12609, 12637, 12637, 12638, 12638, 12675, 12675, 12676, 12676, 12728, 12797, 12797, 12798, 12798, 12840, 12840, 12841, 12841, 13009, 13009, 13010, 13010, 13134, 13134, 13135, 13135, 13358, 13530, 13530, 14582, 14582, 15489, 15489, 15490, 15490, 15551, 15659, 17098, 17098, 17099, 17099, 17950, 17950
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5494, 5494, 6373, 6373, 6386, 6386, 6389, 6389, 6413, 6413, 6421, 6421, 6422, 6422, 6444, 6444, 6449, 6449, 6451, 6451, 6928, 6928, 6953, 6953, 7022, 7022, 7023, 7023, 7352, 7352, 7366, 7366, 7367, 7367, 7854, 7854, 7855, 7855, 8777, 8777, 8942, 9002, 9002, 9004, 9004, 9005, 9005, 9022, 9022, 9023, 9023, 9040, 9040, 9041, 9041, 9061, 9061, 9062, 9062, 9619, 9619, 9620, 9620, 9694, 9694, 9695, 9695, 10023, 10023, 10026, 10026, 10601, 10601, 10602, 10602, 10638, 10638, 10639, 10639, 10818, 10818, 10819, 10819, 11163, 11163, 11164, 11164, 11310, 11310, 11311, 11311, 11393, 11393, 11394, 11394, 11605, 11605, 11780, 11780, 11781, 11781, 11857, 11857, 11858, 11858, 12161, 12161, 12177, 12177, 12178, 12178, 12406, 12406, 12407, 12407, 12486, 12486, 12487, 12487, 12488, 12488, 12524, 12524, 12525, 12525, 12613, 12613, 12614, 12614, 12642, 12642, 12643, 12643, 12680, 12680, 12681, 12681, 12733, 12802, 12802, 12803, 12803, 12845, 12845, 12846, 12846, 13014, 13014, 13015, 13015, 13139, 13139, 13140, 13140, 13363, 13535, 13535, 14587, 14587, 15494, 15494, 15495, 15495, 15556, 15664, 17103, 17103, 17104, 17104, 17955, 17955
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
@@ -670,7 +656,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15022-15177
+- Def site: line 15027-15182
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -679,11 +665,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15044, 15044, 15050, 15050, 15052, 15052, 15080, 15080, 15106, 15106, 15109, 15109, 15112, 15112, 19036, 19036, 19040, 19040, 19048, 19048
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15049, 15049, 15055, 15055, 15057, 15057, 15085, 15085, 15111, 15111, 15114, 15114, 15117, 15117, 19041, 19041, 19045, 19045, 19053, 19053
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13193-13338
+- Def site: line 13198-13343
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -691,11 +677,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13232, 13232, 13239, 13239, 13264, 13264, 13267, 13267, 13280, 13280, 13324, 13324, 13328, 13328, 13333, 13333, 13334, 13334, 13338, 13338, 19343, 19343
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13237, 13237, 13244, 13244, 13269, 13269, 13272, 13272, 13285, 13285, 13329, 13329, 13333, 13333, 13338, 13338, 13339, 13339, 13343, 13343, 19348, 19348
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13346-13490
+- Def site: line 13351-13495
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -704,12 +690,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12567, 12567, 12743, 12743, 12821, 12821, 12826, 12826, 13375, 13375, 13381, 13381, 13387, 13387, 13393, 13393, 13399, 13399, 13405, 13405, 13411, 13411, 13417, 13417, 13423, 13423, 13429, 13429, 13435, 13435, 13441, 13441, 13447, 13447, 13453, 13453, 13459, 13459, 13465, 13465, 13471, 13471, 13477, 13477, 13483, 13483, 13489, 13489, 18956, 18956, 19097, 19097, 19099, 19099, 19214, 19214, 19340, 19340, 19341, 19341, 19342, 19342, 19361, 19361, 19362, 19362, 19363, 19363, 19364, 19364, 19365, 19365, 19366, 19366, 19367, 19367
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12572, 12572, 12748, 12748, 12826, 12826, 12831, 12831, 13380, 13380, 13386, 13386, 13392, 13392, 13398, 13398, 13404, 13404, 13410, 13410, 13416, 13416, 13422, 13422, 13428, 13428, 13434, 13434, 13440, 13440, 13446, 13446, 13452, 13452, 13458, 13458, 13464, 13464, 13470, 13470, 13476, 13476, 13482, 13482, 13488, 13488, 13494, 13494, 18961, 18961, 19102, 19102, 19104, 19104, 19219, 19219, 19345, 19345, 19346, 19346, 19347, 19347, 19366, 19366, 19367, 19367, 19368, 19368, 19369, 19369, 19370, 19370, 19371, 19371, 19372, 19372
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10513-10656
+- Def site: line 10518-10661
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -718,11 +704,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10527, 10527, 10528, 10528, 10614, 10614, 10649, 10649, 18931, 18931, 18932, 18932, 18933, 18933, 18934, 18934, 18935, 18935
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10532, 10532, 10533, 10533, 10619, 10619, 10654, 10654, 18936, 18936, 18937, 18937, 18938, 18938, 18939, 18939, 18940, 18940
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13493-13631
+- Def site: line 13498-13636
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -730,11 +716,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13562, 13562, 13565, 13565, 13566, 13566, 13567, 13567, 13587, 13587, 13590, 13590, 13598, 13598, 13603, 13603, 19369, 19369
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13567, 13567, 13570, 13570, 13571, 13571, 13572, 13572, 13592, 13592, 13595, 13595, 13603, 13603, 13608, 13608, 19374, 19374
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8815-8943
+- Def site: line 8820-8948
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -743,11 +729,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8886, 8886, 8897, 8897, 15120, 15120, 15121, 15121, 18834, 18834, 18835, 18835, 19014, 19014
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8891, 8891, 8902, 8902, 15125, 15125, 15126, 15126, 18839, 18839, 18840, 18840, 19019, 19019
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11187-11315
+- Def site: line 11192-11320
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -756,11 +742,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11194, 11194, 11199, 11199, 11200, 11200, 11201, 11201, 11204, 11204, 11205, 11205, 11268, 11268, 11275, 11275, 11302, 11302, 19313, 19313
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11199, 11199, 11204, 11204, 11205, 11205, 11206, 11206, 11209, 11209, 11210, 11210, 11273, 11273, 11280, 11280, 11307, 11307, 19318, 19318
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15645-15771
+- Def site: line 15650-15776
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -769,11 +755,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15665, 15665, 15670, 15670, 15675, 15675, 15712, 15712, 15718, 15718, 15724, 15724, 15730, 15730, 15736, 15736, 15737, 15737, 15738, 15738, 15739, 15739, 15740, 15740, 15744, 15744, 15753, 15753, 15757, 15757, 15760, 15760, 15766, 15766, 19009, 19009
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15670, 15670, 15675, 15675, 15680, 15680, 15717, 15717, 15723, 15723, 15729, 15729, 15735, 15735, 15741, 15741, 15742, 15742, 15743, 15743, 15744, 15744, 15745, 15745, 15749, 15749, 15758, 15758, 15762, 15762, 15765, 15765, 15771, 15771, 19014, 19014
 
 ### `EnvironmentUtils` (class, 125 lines)
 
-- Def site: line 5771-5895
+- Def site: line 5774-5898
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -782,11 +768,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5792, 5792, 5794, 5794, 5810, 5810, 5822, 5822, 5861, 5861, 5862, 5862, 5863, 5863, 5864, 5864, 5865, 5865, 5876, 5876, 5879, 5879, 6807, 6807, 20348, 20348, 20931, 20931
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5795, 5795, 5797, 5797, 5813, 5813, 5825, 5825, 5864, 5864, 5865, 5865, 5866, 5866, 5867, 5867, 5868, 5868, 5879, 5879, 5882, 5882, 6810, 6810, 20353, 20353, 20936, 20936
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8949-9060
+- Def site: line 8954-9065
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -794,13 +780,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7887, 7887, 9545, 9545, 9857, 9857, 10703, 10703, 10723, 10723, 12725, 15069, 15069, 15122, 15122, 15555, 15795, 15795, 15813, 15813, 15831, 15831, 17047, 17047, 17071, 17071, 17095, 17095, 17238, 17238, 17579, 17579, 18875, 18875, 18890, 18890, 18900, 18900, 18900, 18900, 18910, 18910
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7892, 7892, 9550, 9550, 9862, 9862, 10708, 10708, 10728, 10728, 12730, 15074, 15074, 15127, 15127, 15560, 15800, 15800, 15818, 15818, 15836, 15836, 17052, 17052, 17076, 17076, 17100, 17100, 17243, 17243, 17584, 17584, 18880, 18880, 18895, 18895, 18905, 18905, 18905, 18905, 18915, 18915
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 109 lines)
 
-- Def site: line 10823-10931
+- Def site: line 10828-10936
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -810,11 +796,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10878, 10878, 10881, 10881, 10882, 10882, 10887, 10887, 10905, 10905, 10905, 10914, 10914, 10914, 10914, 10915, 10915, 10915, 10915, 10973, 10973, 10976, 10976, 10988, 10988, 10989, 10989, 11002, 11002, 11041, 11041, 11049, 11049, 11103, 11103, 11111, 11111
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10883, 10883, 10886, 10886, 10887, 10887, 10892, 10892, 10910, 10910, 10910, 10919, 10919, 10919, 10919, 10920, 10920, 10920, 10920, 10978, 10978, 10981, 10981, 10993, 10993, 10994, 10994, 11007, 11007, 11046, 11046, 11054, 11054, 11108, 11108, 11116, 11116
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12748-12847
+- Def site: line 12753-12852
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -823,11 +809,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12813, 12813, 12815, 12815, 12816, 12816, 18884, 18884, 18952, 18952, 18954, 18954, 18955, 18955
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12818, 12818, 12820, 12820, 12821, 12821, 18889, 18889, 18957, 18957, 18959, 18959, 18960, 18960
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15537-15634
+- Def site: line 15542-15639
 - References: 78
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -836,13 +822,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15280, 15280, 15515, 15515, 15573, 15573, 15579, 15579, 15585, 15585, 15591, 15591, 15597, 15597, 15603, 15603, 15609, 15609, 15615, 15615, 15621, 15621, 15627, 15627, 15633, 15633, 15857, 17239, 17239, 17242, 17242, 17578, 17578, 18841, 18841, 18908, 18908, 18914, 18914, 18965, 18965, 19022, 19022
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15285, 15285, 15520, 15520, 15578, 15578, 15584, 15584, 15590, 15590, 15596, 15596, 15602, 15602, 15608, 15608, 15614, 15614, 15620, 15620, 15626, 15626, 15632, 15632, 15638, 15638, 15862, 17244, 17244, 17247, 17247, 17583, 17583, 18846, 18846, 18913, 18913, 18919, 18919, 18970, 18970, 19027, 19027
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8245-8341
+- Def site: line 8250-8346
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -850,11 +836,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8301, 8301, 8337, 8337
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8306, 8306, 8342, 8342
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11318-11411
+- Def site: line 11323-11416
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -863,11 +849,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11370, 11370, 11383, 11383, 18944, 18944, 18986, 18986, 18987, 18987, 18992, 18992, 18993, 18993
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11375, 11375, 11388, 11388, 18949, 18949, 18991, 18991, 18992, 18992, 18997, 18997, 18998, 18998
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5901-5990
+- Def site: line 5904-5993
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -877,13 +863,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5983, 5983, 15343, 15343, 15344, 15344, 15558, 18744, 18744
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5986, 5986, 15348, 15348, 15349, 15349, 15563, 18749, 18749
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12661-12745
+- Def site: line 12666-12750
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -893,11 +879,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12695, 12695, 18919, 18919, 18927, 18927, 18953, 18953, 19098, 19098
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12700, 12700, 18924, 18924, 18932, 18932, 18958, 18958, 19103, 19103
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 18021-18099
+- Def site: line 18026-18104
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -907,12 +893,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18016, 18016, 18017, 18017, 19193, 19193
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18021, 18021, 18022, 18022, 19198, 19198
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17025-17102
+- Def site: line 17030-17107
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -922,12 +908,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19064, 19064, 19068, 19068, 19072, 19072
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19069, 19069, 19073, 19073, 19077, 19077
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1895-1968
+- Def site: line 1898-1971
 - References: 252
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -936,7 +922,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1908, 1908, 1940, 1940, 2289, 2289, 2316, 2316, 7599, 7599, 7685, 7685, 7815, 7815, 7892, 7892, 7975, 7975, 8205, 8205, 8394, 8394, 8450, 8450, 8463, 8463, 8480, 8480, 8525, 8525, 8556, 8556, 8562, 8562, 8665, 8665, 10206, 10206, 10473, 10975, 10975, 11004, 11004, 11269, 11269, 11475, 11475, 11714, 11714, 12430, 12430, 12446, 12446, 13233, 13233, 13652, 13652, 13702, 13702, 15556, 15758, 15758, 15791, 15791, 15809, 15809, 15827, 15827, 15855, 17052, 17052, 17077, 17077, 17120, 17219, 17219, 17431, 17431, 17574, 17574, 17681, 17681, 18011, 18011, 18041, 18041, 18062, 18062, 18081, 18081, 18097, 18097, 18114, 18114, 18691, 18691, 18711, 18711, 18746, 18746, 18759, 18759, 19227, 19227, 19318, 19318, 19323, 19323, 19329, 19329, 19348, 19348, 19354, 19354, 20954, 20954
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1911, 1911, 1943, 1943, 2292, 2292, 2319, 2319, 7604, 7604, 7690, 7690, 7820, 7820, 7897, 7897, 7980, 7980, 8210, 8210, 8399, 8399, 8455, 8455, 8468, 8468, 8485, 8485, 8530, 8530, 8561, 8561, 8567, 8567, 8670, 8670, 10211, 10211, 10478, 10980, 10980, 11009, 11009, 11274, 11274, 11480, 11480, 11719, 11719, 12435, 12435, 12451, 12451, 13238, 13238, 13657, 13657, 13707, 13707, 15561, 15763, 15763, 15796, 15796, 15814, 15814, 15832, 15832, 15860, 17057, 17057, 17082, 17082, 17125, 17224, 17224, 17436, 17436, 17579, 17579, 17686, 17686, 18016, 18016, 18046, 18046, 18067, 18067, 18086, 18086, 18102, 18102, 18119, 18119, 18696, 18696, 18716, 18716, 18751, 18751, 18764, 18764, 19232, 19232, 19323, 19323, 19328, 19328, 19334, 19334, 19353, 19353, 19359, 19359, 20959, 20959
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -957,7 +943,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15183-15254
+- Def site: line 15188-15259
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -966,11 +952,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19030, 19030, 19031, 19031, 19032, 19032, 19033, 19033
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19035, 19035, 19036, 19036, 19037, 19037, 19038, 19038
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5462-5531
+- Def site: line 5465-5534
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -980,11 +966,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5494, 5494, 5495, 5495, 5510, 5510, 5512, 5512
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5497, 5497, 5498, 5498, 5513, 5513, 5515, 5515
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 5996-6065
+- Def site: line 5999-6068
 - References: 182
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -992,7 +978,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6038, 6038, 6043, 6043, 6140, 6140, 6198, 6198, 7085, 7085, 7742, 7742, 8387, 8387, 8410, 8410, 8430, 8430, 8615, 8615, 8636, 8636, 8911, 8911, 8936, 8936, 8991, 8991, 9013, 9013, 9030, 9030, 9047, 9047, 9432, 9432, 9655, 9655, 9672, 9672, 10064, 10064, 10396, 10396, 10607, 10607, 10644, 10644, 10797, 10797, 10940, 10940, 11193, 11193, 11381, 11381, 11565, 11565, 11884, 11884, 12220, 12220, 12392, 12392, 12432, 12432, 12438, 12438, 12532, 12532, 12762, 12762, 12835, 12835, 13322, 13322, 13357, 13556, 13556, 15063, 15063, 15279, 15279, 15547, 15654, 15754, 15754, 15789, 15789, 15807, 15807, 15825, 15825, 17118, 18012, 18012, 18014, 18014, 18038, 18038, 18042, 18042, 18043, 18043, 18063, 18063, 18064, 18064, 18225, 18225, 18795, 18795, 18827, 18827, 18864, 18864, 18870, 18870, 18998, 18998, 19055, 19055, 19138, 19138, 19147, 19147, 19225, 19225, 19226, 19226, 19243, 19243, 19318, 19318, 19323, 19323, 19329, 19329, 19348, 19348, 19354, 19354, 20265, 20265, 20336, 20818, 20818, 20906, 20906
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6041, 6041, 6046, 6046, 6143, 6143, 6201, 6201, 7088, 7088, 7747, 7747, 8392, 8392, 8415, 8415, 8435, 8435, 8620, 8620, 8641, 8641, 8916, 8916, 8941, 8941, 8996, 8996, 9018, 9018, 9035, 9035, 9052, 9052, 9437, 9437, 9660, 9660, 9677, 9677, 10069, 10069, 10401, 10401, 10612, 10612, 10649, 10649, 10802, 10802, 10945, 10945, 11198, 11198, 11386, 11386, 11570, 11570, 11889, 11889, 12225, 12225, 12397, 12397, 12437, 12437, 12443, 12443, 12537, 12537, 12767, 12767, 12840, 12840, 13327, 13327, 13362, 13561, 13561, 15068, 15068, 15284, 15284, 15552, 15659, 15759, 15759, 15794, 15794, 15812, 15812, 15830, 15830, 17123, 18017, 18017, 18019, 18019, 18043, 18043, 18047, 18047, 18048, 18048, 18068, 18068, 18069, 18069, 18230, 18230, 18800, 18800, 18832, 18832, 18869, 18869, 18875, 18875, 19003, 19003, 19060, 19060, 19143, 19143, 19152, 19152, 19230, 19230, 19231, 19231, 19248, 19248, 19323, 19323, 19328, 19328, 19334, 19334, 19353, 19353, 19359, 19359, 20270, 20270, 20341, 20823, 20823, 20911, 20911
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
@@ -1002,7 +988,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10442-10510
+- Def site: line 10447-10515
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1013,11 +999,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10482, 10482, 10487, 10487, 10492, 10492, 10493, 10493, 10499, 10499, 10500, 10500, 10506, 10506, 10507, 10507, 10508, 10508, 10509, 10509, 19371, 19371
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10487, 10487, 10492, 10492, 10497, 10497, 10498, 10498, 10504, 10504, 10505, 10505, 10511, 10511, 10512, 10512, 10513, 10513, 10514, 10514, 19376, 19376
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 18750-18815
+- Def site: line 18755-18820
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1027,11 +1013,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18798, 18798, 18806, 18806, 18815, 18815, 19344, 19344
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18803, 18803, 18811, 18811, 18820, 18820, 19349, 19349
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15778-15833
+- Def site: line 15783-15838
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1041,11 +1027,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18969, 18969, 18973, 18973, 19178, 19178
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18974, 18974, 18978, 18978, 19183, 19183
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6071-6117
+- Def site: line 6074-6120
 - References: 55
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1054,13 +1040,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6195, 6195, 8077, 8077, 8992, 8992, 9015, 9015, 9502, 9502, 9537, 9537, 9551, 9551, 9674, 9674, 9678, 9678, 10226, 10226, 12536, 12536, 13206, 13206, 13332, 13332, 13364, 13542, 13542, 13578, 13578, 15553, 17902, 17902, 18013, 18013, 18044, 18044, 18065, 18065, 19228, 19228, 19244, 19244, 20837, 20837
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6198, 6198, 8082, 8082, 8997, 8997, 9020, 9020, 9507, 9507, 9542, 9542, 9556, 9556, 9679, 9679, 9683, 9683, 10231, 10231, 12541, 12541, 13211, 13211, 13337, 13337, 13369, 13547, 13547, 13583, 13583, 15558, 17907, 17907, 18018, 18018, 18049, 18049, 18070, 18070, 19233, 19233, 19249, 19249, 20842, 20842
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5720-5765
+- Def site: line 5723-5768
 - References: 97
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1069,14 +1055,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5232, 5232, 5274, 5274, 5319, 5319, 5425, 5425, 5440, 5440, 5710, 5710, 5711, 5711, 5755, 5755, 6221, 6221, 7911, 7911, 9202, 9202, 9513, 9513, 9529, 9529, 9858, 9858, 10739, 10739, 10758, 10758, 12727, 15146, 15146, 15549, 15792, 15792, 15810, 15810, 15828, 15828, 15858, 16280, 16280, 16320, 16320, 16321, 16321, 16322, 16322, 17044, 17044, 17068, 17068, 17072, 17072, 17092, 17092, 17119, 17194, 17194, 17228, 17228, 17249, 17249, 17281, 17281, 17343, 17343, 17382, 17382, 17532, 17532, 17577, 17577
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5235, 5235, 5277, 5277, 5322, 5322, 5428, 5428, 5443, 5443, 5713, 5713, 5714, 5714, 5758, 5758, 6224, 6224, 7916, 7916, 9207, 9207, 9518, 9518, 9534, 9534, 9863, 9863, 10744, 10744, 10763, 10763, 12732, 15151, 15151, 15554, 15797, 15797, 15815, 15815, 15833, 15833, 15863, 16285, 16285, 16325, 16325, 16326, 16326, 16327, 16327, 17049, 17049, 17073, 17073, 17077, 17077, 17097, 17097, 17124, 17199, 17199, 17233, 17233, 17254, 17254, 17286, 17286, 17348, 17348, 17387, 17387, 17537, 17537, 17582, 17582
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17108-17150
+- Def site: line 17113-17155
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1085,11 +1071,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17131, 17131, 17137, 17137, 17143, 17143, 17149, 17149, 19162, 19162, 19166, 19166, 19170, 19170, 19174, 19174
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17136, 17136, 17142, 17142, 17148, 17148, 17154, 17154, 19167, 19167, 19171, 19171, 19175, 19175, 19179, 19179
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11584-11623
+- Def site: line 11589-11628
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1098,11 +1084,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11621, 11621, 19368, 19368
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11626, 11626, 19373, 19373
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1859-1887
+- Def site: line 1862-1890
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1111,12 +1097,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8865, 8865, 8866, 8866, 8895, 8895, 8896, 8896, 8912, 8912, 8913, 8913, 9791, 9791, 9792, 9792, 10096, 10096, 10097, 10097, 10144, 10144, 10145, 10145, 10700, 10700, 10702, 10702, 10720, 10720, 10722, 10722, 11610, 11610, 11611, 11611, 12271, 12271, 12272, 12272, 12377, 12377, 12378, 12378, 13360
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8870, 8870, 8871, 8871, 8900, 8900, 8901, 8901, 8917, 8917, 8918, 8918, 9796, 9796, 9797, 9797, 10101, 10101, 10102, 10102, 10149, 10149, 10150, 10150, 10705, 10705, 10707, 10707, 10725, 10725, 10727, 10727, 11615, 11615, 11616, 11616, 12276, 12276, 12277, 12277, 12382, 12382, 12383, 12383, 13365
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15507-15534
+- Def site: line 15512-15539
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1125,12 +1111,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15521, 15521, 15527, 15527, 15533, 15533, 19076, 19076, 19080, 19080
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15526, 15526, 15532, 15532, 15538, 15538, 19081, 19081, 19085, 19085
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15844-15869
+- Def site: line 15849-15874
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1140,12 +1126,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15864, 15864, 15869, 15869, 19084, 19084, 19089, 19089
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15869, 15869, 15874, 15874, 19089, 19089, 19094, 19094
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13659-13680
+- Def site: line 13664-13685
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1154,7 +1140,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18850, 18850, 18854, 18854, 18858, 18858
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18855, 18855, 18859, 18859, 18863, 18863
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1164,17 +1150,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17560-17581
+- Def site: line 17565-17586
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18997, 18997, 19054, 19054, 19137, 19137, 19146, 19146
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19002, 19002, 19059, 19059, 19142, 19142, 19151, 19151
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 17997-18018
+- Def site: line 18002-18023
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1183,24 +1169,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19207, 19207
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19212, 19212
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `execute_with_connection_pool_management` (function, 21 lines)
 
-- Def site: line 7549-7569
+- Def site: line 7554-7574
 - References: 7
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6304, 10069, 15392, 15557
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6307, 10074, 15397, 15562
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13905-13914
+- Def site: line 13910-13919
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1208,11 +1194,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13941, 14077, 14154, 14173, 14185, 14206, 14219, 14230, 14236, 14249, 14342, 14477, 14572
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13946, 14082, 14159, 14178, 14190, 14211, 14224, 14235, 14241, 14254, 14347, 14482, 14577
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 322-330
+- Def site: line 325-333
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1228,7 +1214,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 349-357
+- Def site: line 352-360
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1236,12 +1222,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15215, 15232, 15248
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15220, 15237, 15253
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 334-341
+- Def site: line 337-344
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1257,7 +1243,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `is_debug_mode` (function, 3 lines)
 
-- Def site: line 309-311
+- Def site: line 312-314
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1265,12 +1251,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13365, 13654, 18046, 18067, 18212, 18243, 18275, 18510, 18525
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13370, 13659, 18051, 18072, 18217, 18248, 18280, 18515, 18530
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 626-628
+- Def site: line 629-631
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1278,7 +1264,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1236, 1905, 1905, 1905, 1917, 1923, 6197, 6317, 7373, 7433, 9601, 9712, 9966, 10796, 13367, 15425, 15467, 15565, 19230
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1239, 1908, 1908, 1908, 1920, 1926, 6200, 6320, 7376, 7438, 9606, 9717, 9971, 10801, 13372, 15430, 15472, 15570, 19235
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
@@ -1291,7 +1277,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2007-2009
+- Def site: line 2010-2012
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1300,11 +1286,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2007, 7383, 7390, 7391, 9977, 15414
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2010, 7386, 7393, 7394, 9982, 15419
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2025-2027
+- Def site: line 2028-2030
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1313,7 +1299,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2025, 15561
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2028, 15566
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1321,7 +1307,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 742-1746
+- Def site: line 745-1749
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1329,7 +1315,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1791
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1794
 
 ## Limitations
 

--- a/src/refactors/fast_mode_devices_per_thread.py
+++ b/src/refactors/fast_mode_devices_per_thread.py
@@ -1,0 +1,28 @@
+"""Fast-mode devices-per-thread extracted from MistHelper (SC-029).
+
+Owns the `FAST_MODE_DEVICES_PER_THREAD` constant originally defined at
+module scope in MistHelper.py, and re-lands it as a class-level
+attribute on `FastModeDevicesPerThread` per FR-005 / FR-015. The sole
+MistHelper callsite (batch-size sizing in `_pool_configure` at line
+~7392) is rewritten in the same PR to reference the extracted class
+attribute; no wrapper shim remains in MistHelper.py after this
+extraction.
+
+The value is the number of devices each worker thread handles in
+fast-mode workflows -- multiplied by `max_threads` to yield the effective
+batch size. Source of truth remains the `FAST_MODE_DEVICES_PER_THREAD`
+environment variable (default 10); the class-body evaluation preserves
+the original `os.getenv` semantics.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import os  # Read the environment override value
+
+
+class FastModeDevicesPerThread:  # Class-body seam for the fast-mode devices-per-thread setting
+    """Class-body seam owning the fast-mode devices-per-thread setting."""
+
+    VALUE: int = int(  # Number of devices each worker thread handles in fast-mode
+        os.getenv("FAST_MODE_DEVICES_PER_THREAD", "10")  # Env override with 10 default
+    )


### PR DESCRIPTION
## Summary

- **SC-029**: Extract `FAST_MODE_DEVICES_PER_THREAD` from `MistHelper.py` to `src/refactors/fast_mode_devices_per_thread.py::FastModeDevicesPerThread.VALUE`.
- Sole MistHelper callsite (batch-size sizing in `_pool_configure` at line 7392) rewritten in this same PR -- **no wrapper shim** (FR-003).
- Constant lands as class-level attribute per FR-005.

## Compliance

- New file: **A+ 100.0/100**
- `MistHelper.py` baseline: **A 96.0** (unchanged)
- Black + Ruff: PASS
- Smoke test: VALUE=10: PASS

## Test plan

- [x] Black + Ruff pass
- [x] Compliance analyzer A+ new file; baseline non-regressing
- [x] Import + attribute access smoke test
- [ ] Full CI via GitHub Actions