### PR TITLE
refactor(1011): extract MIST_WAN_TARGET_PORTS to MistWanTargetPorts (SC-032)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -180,6 +180,9 @@ from src.refactors.maps_manager_launcher import MapsManagerLauncher  # Extracted
 from src.refactors.marvis_data_utils import (
     MarvisDataUtilsFactory,  # Extracted Marvis data-utils singleton factory (SC-027)
 )
+from src.refactors.mist_wan_target_ports import (
+    MistWanTargetPorts,  # Extracted operator-configured WAN target-ports list (SC-032)
+)
 from src.refactors.package_import_map import (
     PackageImportMapManager,  # Extracted pip-name -> import-name mapping (SC-025)
 )
@@ -2018,12 +2021,8 @@ FAST_MODE_USE_CONNECTION_AWARE_THREADING = (  # Whether to size threads based on
 )
 FAST_MODE_ENABLED: bool = False  # Set to True via --fast CLI flag at startup
 
-# WAN Port Configuration from .env (REQUIRED - no defaults)
-# MIST_WAN_TARGET_PORTS: Comma-separated list of WAN port names to target
-# Example: "ge-0/0/0,ge-0/0/1,ge-0/0/2,{{wan1_interface}},{{wan2_interface}},{{wan3_interface}}"
-MIST_WAN_TARGET_PORTS = [
-    p.strip() for p in os.getenv("MIST_WAN_TARGET_PORTS", "").split(",") if p.strip()
-]  # Parse CSV env into a clean list of port names
+# NOTE: MIST_WAN_TARGET_PORTS extracted to src/refactors/mist_wan_target_ports.py
+# per initiative 1011 SC-032 (FR-003: no wrapper shim; FR-005: assignment->classattr).
 
 # Site Exclusion Configuration from .env (REQUIRED - no defaults)
 # MIST_SITE_EXCLUDE_PREFIX: Site name prefix to exclude from destructive operations
@@ -15565,7 +15564,7 @@ class GatewayExportUtils:  # Gateway export delegators.
             connection_pool_fn=execute_with_connection_pool_management,  # Pool wrapper.
             validation_utils=ValidationUtils,  # Input validation.
             rate_limiting_utils=RateLimitingUtils,  # Adaptive delay.
-            mist_wan_target_ports=MIST_WAN_TARGET_PORTS,  # Port list constant.
+            mist_wan_target_ports=MistWanTargetPorts.VALUE,  # Port list from extracted class attribute.
             mist_site_exclude_prefix=MIST_SITE_EXCLUDE_PREFIX,  # Site filter prefix.
             fast_mode_max_retries=FAST_MODE_MAX_RETRIES,  # Retry cap.
             fast_mode_retry_delay=FAST_MODE_RETRY_DELAY,  # Delay between retries.

--- a/src/refactors/mist_wan_target_ports.py
+++ b/src/refactors/mist_wan_target_ports.py
@@ -1,0 +1,39 @@
+"""MIST_WAN_TARGET_PORTS extracted from MistHelper (SC-032).
+
+Owns the `MIST_WAN_TARGET_PORTS` list constant originally defined at
+module scope in MistHelper.py, and re-lands it as a class-level
+attribute on `MistWanTargetPorts` per FR-005 / FR-015 (assignment ->
+class-body attribute). The sole MistHelper callsite -- the DI kwarg
+`mist_wan_target_ports=MIST_WAN_TARGET_PORTS` in
+`_gateway_export_dependency_kwargs` at line ~15568 -- is rewritten in
+the same PR to reference the extracted class attribute; no wrapper
+shim remains in MistHelper.py after this extraction.
+
+The value is the operator-configured, comma-separated list of WAN port
+names to target for gateway-override analysis. Source of truth remains
+the `MIST_WAN_TARGET_PORTS` environment variable (no default -- an
+unset env yields an empty list); the class-body evaluation preserves
+the original CSV-parsing semantics.
+
+FR-019 note: The local DI slots named `MIST_WAN_TARGET_PORTS` in
+`src/gateway/gateway_export_utils.py:51` and
+`src/gateway/overrides/_deps.py:17` are local module-level variables
+that receive their value at runtime via the injected `deps` struct.
+They are not references to the deleted MistHelper.py symbol and remain
+unchanged by this extraction; the cross-file audit trail verifies the
+sole external-file caller path continues to flow through the DI kwarg.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import os  # Read the environment override value
+
+
+class MistWanTargetPorts:  # Class-body seam for the operator-configured WAN target ports
+    """Class-body seam owning the operator-configured WAN target-ports list."""
+
+    VALUE: list[str] = [  # Parsed CSV env into a clean list of port names
+        p.strip()  # Trim whitespace around each entry
+        for p in os.getenv("MIST_WAN_TARGET_PORTS", "").split(",")  # CSV env with empty default
+        if p.strip()  # Drop empty entries
+    ]


### PR DESCRIPTION
## Summary
- Extract module-level `MIST_WAN_TARGET_PORTS` list constant to `src/refactors/mist_wan_target_ports.py::MistWanTargetPorts.VALUE` per FR-005 (assignment->classattr).
- Rewrite sole MistHelper callsite (DI kwarg in `_gateway_export_dependency_kwargs`) to reference the extracted class attribute in the same PR (FR-003: no wrapper shim).
- Preserve original `os.getenv("MIST_WAN_TARGET_PORTS", "")` CSV-parsing semantics at class-body evaluation.

## FR-019 Cross-File Audit (P2 candidate)
The local module-level slots named `MIST_WAN_TARGET_PORTS` in:
- `src/gateway/gateway_export_utils.py:51`
- `src/gateway/overrides/_deps.py:17`

are local DI placeholder variables (initialized to `[]`) that receive their value at runtime via the injected `deps` struct. They are **not** references to the deleted MistHelper.py symbol and remain unchanged by this extraction. Post-merge grep audit will confirm no lingering reference to the MistHelper.py-scoped constant.

## Verification
- ASCII-only logs, no emojis
- Black + Ruff clean on both changed files
- MistHelper.py Pylint 8.73 baseline preserved
- New module: Radon A (3.0), Pylint 7.50 (matches PR-30 baseline for VALUE-only classattr classes)
- Callsite grep confirms only the NOTE breadcrumb remains for the old symbol name in MistHelper.py

## Test plan
- [x] `python -c "from src.refactors.mist_wan_target_ports import MistWanTargetPorts; ..."` smoke test passes
- [x] `ast.parse(MistHelper.py)` succeeds
- [x] Black + Ruff clean
- [x] Pylint baseline unchanged (8.73)
- [ ] CI green