### PR TITLE
refactor(1011): fold BulkSwitchFirmwareUpgrader into FirmwareManager (SC-033)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -18106,25 +18106,9 @@ class OrgLevelAPFirmwareUpgrader:
         return upgrader._select_orgs_from_msp(msp)
 
 
-class BulkSwitchFirmwareUpgrader:
-    """Delegate to src.firmware.bulk_switch_upgrader.
-
-    Executes firmware upgrades on switches across selected sites with safety checks.
-    """
-
-    def __init__(self, org_id: str, sites_override: list[dict[str, Any]] | None = None):
-        from src.firmware.bulk_switch_upgrader import BulkSwitchFirmwareUpgrader as _Impl
-
-        self._impl = _Impl(
-            org_id=org_id,
-            apisession=apisession,
-            safe_input_fn=InputUtils.safe_input,
-            sites_override=sites_override,
-        )
-
-    def execute(self) -> dict[str, Any]:
-        """Orchestrate the complete upgrade workflow."""
-        return self._impl.execute()
+# NOTE: BulkSwitchFirmwareUpgrader folded into FirmwareManager per initiative 1011 SC-033
+# (FR-015: fold-in to caller; FR-003: no wrapper shim). Sole caller now dispatches directly
+# to src.firmware.bulk_switch_upgrader.BulkSwitchFirmwareUpgrader.
 
 
 # ============================================================================

--- a/src/firmware/firmware_manager.py
+++ b/src/firmware/firmware_manager.py
@@ -1872,13 +1872,16 @@ class FirmwareManager:
         """Bulk switch firmware upgrade for selected site(s) via interactive picker or template override."""
         logging.info("Starting bulk switch firmware upgrade by site...")  # WHY: audit entry
         logging.debug("FirmwareManager._bulk_upgrade_switch_firmware_by_site() initiated")  # WHY: trace call
-        import sys as _sys  # noqa: PLC0415  # WHY: lazy import to avoid circular deps
+        from src.firmware.bulk_switch_upgrader import (  # WHY: lazy import keeps module load cheap
+            BulkSwitchFirmwareUpgrader as _Impl,
+        )
 
-        _main = _sys.modules.get("__main__") or _sys.modules.get("MistHelper")  # WHY: locate entry module
-        if _main is None:  # WHY: guard when neither module surface is present
-            return  # WHY: cannot proceed without the upgrader class
-        BulkSwitchFirmwareUpgrader = _main.BulkSwitchFirmwareUpgrader  # WHY: lazy attribute access
-        BulkSwitchFirmwareUpgrader(self.org_id, sites_to_upgrade_override).execute()  # WHY: run upgrade flow
+        _Impl(  # WHY: direct dispatch replaces prior MistHelper wrapper (FR-015 fold-in)
+            org_id=self.org_id,  # WHY: instance-owned org scope
+            apisession=self.apisession,  # WHY: instance-owned Mist session
+            safe_input_fn=_MH.InputUtils.safe_input,  # WHY: preserves Ctrl+C / stop-signal semantics
+            sites_override=sites_to_upgrade_override,  # WHY: forward template-driven override if present
+        ).execute()  # WHY: run upgrade flow
 
     def _upgrade_switch_firmware_by_gateway_template(self) -> None:
         """Advanced switch firmware upgrade organized by Gateway Template assignment.


### PR DESCRIPTION
## Summary
- Deletes the 19-line \`BulkSwitchFirmwareUpgrader\` delegation wrapper at \`MistHelper.py:18109-18127\` and replaces it with a NOTE breadcrumb.
- Rewrites the sole caller (\`FirmwareManager._bulk_upgrade_switch_firmware_by_site\` in \`src/firmware/firmware_manager.py:1869-1885\`) to dispatch directly to \`src.firmware.bulk_switch_upgrader.BulkSwitchFirmwareUpgrader\`, following the PR-22 sibling pattern (\`_dispatch_bulk_ap_upgrade\`).
- Removes the prior \`sys.modules.get(\"__main__\") or sys.modules.get(\"MistHelper\")\` lookup that PR-22 has already superseded elsewhere.

## Initiative 1011 SC-033 compliance
- **FR-015 fold-in**: helper class co-located with its real caller module (\`src.firmware\`), not a fresh refactor module.
- **FR-003 no wrapper shim**: MistHelper.py class deleted outright; NOTE breadcrumb preserves the audit trail.
- **Same-PR callsite rewrite**: the single production caller is updated in the same commit; \`safe_input_fn=_MH.InputUtils.safe_input\` preserves Ctrl+C / stop-signal semantics via the existing \`_MistHelperProxy\`.

## Verification
- \`python -m black\` / \`python -m ruff check --fix\`: clean on both changed files.
- Smoke test: \`import MistHelper\` succeeds; \`hasattr(MistHelper, 'BulkSwitchFirmwareUpgrader')\` is False.
- \`python -m pytest tests/unit/test_bulk_switch_upgrader.py\`: **113 passed** (real implementation + tests unchanged).
- MistHelper.py pylint: 8.73 -> **9.44** (+0.71 vs baseline).

## Test plan
- [x] All 113 \`tests/unit/test_bulk_switch_upgrader.py\` cases pass.
- [x] MistHelper.py imports without the wrapper class present.
- [x] Black/Ruff clean on modified files.
- [ ] CI green on the branch.