### PR TITLE
docs(1012): regenerate refactor_candidates.md after hot-functions bundle

### DIFF
--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,23 +1,20 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 199 first-party files
-- Definitions analyzed: 82
-- LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=2, hot=79, skipped=1
+- Module graph size: 201 first-party files
+- Definitions analyzed: 80
+- LOC saveable (unused + single-use): 3
+- Category counts: unused=0, single-use=1, low-use=2, hot=76, skipped=1
 
 ## How to read this report
 
 Work the report **top-down inside each category**, then move to the next category:
 
 1. **Unused** -- zero references. Delete outright; no move, no callsite rewrite. Highest ROI per PR.
-2. **Single-use** -- exactly one caller. Move alongside that caller (or into a new `/src` module when the Refactor report written to refactor_candidates.md
-Entrypoint: C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py
-Module graph: 199 first-party files
-Definitions analyzed: 82
-  unused=0  single-use=0  low-use=2  hot=79  skipped=1
-LOC saveable (unused + single-use): 0
- -- pinned by bootstrap/module-load ordering (e.g. `GlobalImportManager`). DO NOT extract; the tool cannot detect load-order dependencies, so these are curated by hand via the `--skip NAME` CLI flag.
+2. **Single-use** -- exactly one caller. Move alongside that caller (or into a new `/src` module when the entrypoint is the sole caller). One PR covers move + rewrite.
+3. **Low-use** -- 2-3 callers. Evaluate before moving: worth it only when all callers can be rewritten in one bounded PR cluster.
+4. **Hot** -- 4+ callers. Leave in place until dependencies decouple. Listed for completeness only.
+5. **Skipped** -- pinned by bootstrap/module-load ordering (e.g. `GlobalImportManager`). DO NOT extract; the tool cannot detect load-order dependencies, so these are curated by hand via the `--skip NAME` CLI flag.
 
 Within each bucket, candidates are sorted by **line_count descending** so the biggest LOC wins surface first. The `LOC saveable` headline in the metadata block sums unused + single-use lines only -- that number is your extraction budget for this pass.
 
@@ -43,12 +40,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `OrgExportUtils` | class | 653 | 128 | hot |  | oversize_25_lines,non_ascii_logs,hardcoded_separator |
 | `BulkRadiusWLANConfigManager` | class | 587 | 13 | hot |  | oversize_25_lines |
 | `menu_actions` | assignment | 572 | 17 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
-| `OrgTicketManager` | class | 463 | 66 | hot |  | oversize_25_lines |
+| `OrgTicketManager` | class | 475 | 66 | hot |  | oversize_25_lines |
 | `OperationRegistry` | class | 461 | 9 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `PromptUtils` | class | 441 | 117 | hot |  | oversize_25_lines |
 | `OrgDeviceStatsExporter` | class | 414 | 58 | hot |  | oversize_25_lines,missing_inline_comments |
-| `DeviceRebootManager` | class | 398 | 46 | hot |  | oversize_25_lines,missing_inline_comments |
-| `MSPInventoryExporter` | class | 388 | 5 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
+| `DeviceRebootManager` | class | 396 | 46 | hot |  | oversize_25_lines,missing_inline_comments |
+| `MSPInventoryExporter` | class | 386 | 5 | hot |  | oversize_25_lines,missing_inline_comments,non_ascii_logs |
 | `DataExporter` | class | 345 | 250 | hot |  | oversize_25_lines,non_ascii_logs |
 | `SiteAnomalyExporter` | class | 341 | 54 | hot |  | oversize_25_lines,non_ascii_logs |
 | `APIDataFetcher` | class | 328 | 16 | hot |  | oversize_25_lines |
@@ -78,9 +75,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `OrgAlarmEventExporter` | class | 129 | 14 | hot |  | oversize_25_lines,missing_inline_comments |
 | `WiredClientManufacturerReportGenerator` | class | 129 | 20 | hot |  | oversize_25_lines,non_ascii_logs |
 | `TroubleshootUtils` | class | 127 | 36 | hot |  | oversize_25_lines,non_ascii_logs |
-| `EnvironmentUtils` | class | 125 | 28 | hot |  | oversize_25_lines,hardcoded_separator |
+| `EnvironmentUtils` | class | 114 | 28 | hot |  | oversize_25_lines,hardcoded_separator |
 | `OrgSiteExporter` | class | 112 | 52 | hot |  | oversize_25_lines |
-| `FilterOperatorEngine` | class | 109 | 37 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
+| `FilterOperatorEngine` | class | 110 | 37 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `SiteConfigExporter` | class | 100 | 14 | hot |  | oversize_25_lines,non_ascii_logs |
 | `GatewayExportUtils` | class | 98 | 78 | hot |  | oversize_25_lines,missing_action_logging |
 | `DeviceUtils` | class | 97 | 4 | hot |  | oversize_25_lines |
@@ -107,22 +104,34 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `RoutingUtils` | class | 22 | 12 | hot |  | missing_inline_comments,missing_action_logging |
 | `FirmwareManager` | class | 22 | 8 | hot |  |  |
 | `SiteAutoUpgradeConfigurator` | class | 22 | 6 | hot |  | missing_inline_comments,missing_action_logging |
-| `execute_with_connection_pool_management` | function | 21 | 7 | hot |  |  |
 | `EndpointConfig` | class | 10 | 13 | hot |  | missing_action_logging |
 | `SSHConnectionConfig` | class | 9 | 6 | hot |  | missing_action_logging |
 | `DeviceFetchConfig` | class | 9 | 4 | hot |  | missing_action_logging |
 | `SSHExecutionConfig` | class | 8 | 5 | hot |  | missing_inline_comments,missing_action_logging |
-| `is_debug_mode` | function | 3 | 12 | hot |  | missing_action_logging |
 | `tqdm` | function | 3 | 43 | hot |  | missing_action_logging |
-| `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | assignment | 3 | 6 | hot |  | missing_inline_comments,missing_action_logging |
-| `FAST_MODE_USE_CONNECTION_AWARE_THREADING` | assignment | 3 | 2 | low-use | FastModeUseConnectionAwareThreadingManager | missing_action_logging |
+| `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | assignment | 3 | 3 | low-use | FastModeMaxConcurrentConnectionsManager | missing_inline_comments,missing_action_logging |
+| `FAST_MODE_USE_CONNECTION_AWARE_THREADING` | assignment | 3 | 1 | single-use | FastModeUseConnectionAwareThreadingManager | missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 11 | hot |  | missing_inline_comments,missing_action_logging |
+
+## Single-Use (1)
+
+### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
+
+- Def site: line 2018-2020
+- References: 1
+- Suggested class: `FastModeUseConnectionAwareThreadingManager`
+- Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
+- Rationale: single-use: sole caller lives inside MistHelper.py; extract `FAST_MODE_USE_CONNECTION_AWARE_THREADING` OUT of the entrypoint into a new `src/refactors/fast__mode__use__connection__aware__threading.py` module and rewrite the callsite(s) to import from there
+- Guideline flags (address during the move):
+  - [ ] missing_action_logging
+- Reference sites (one PR cluster per file):
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2018
 
 ## Low-Use (2)
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2128-2152
+- Def site: line 2127-2151
 - References: 3
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -130,25 +139,26 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2258, 17717, 20652
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2257, 17526, 20459
 
-### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
+### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2019-2021
-- References: 2
-- Suggested class: `FastModeUseConnectionAwareThreadingManager`
-- Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `_pool_configure()`; extract `FAST_MODE_USE_CONNECTION_AWARE_THREADING` OUT of the entrypoint into a new `src/refactors/fast__mode__use__connection__aware__threading.py` module and rewrite the callsite(s) to import from there
+- Def site: line 2015-2017
+- References: 3
+- Suggested class: `FastModeMaxConcurrentConnectionsManager`
+- Suggested module: `src/refactors/fast__mode__max__concurrent__connections.py`
+- Rationale: low-use: sole caller lives inside MistHelper.py from `_retry_failed_site_port_stats()`; extract `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` OUT of the entrypoint into a new `src/refactors/fast__mode__max__concurrent__connections.py` module and rewrite the callsite(s) to import from there
 - Guideline flags (address during the move):
+  - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2019, 7387
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2015, 9794, 15232
 
-## Hot (79)
+## Hot (76)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2866-5192
+- Def site: line 2865-5191
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -159,11 +169,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2866, 6567, 6568, 6577, 6741
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2865, 6555, 6556, 6565, 6729
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13924-14682
+- Def site: line 13735-14493
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -172,11 +182,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14401, 14401, 14413, 14413, 14441, 14441, 14453, 14453, 14514, 14514, 14551, 14551, 14708, 19092
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14212, 14212, 14224, 14224, 14252, 14252, 14264, 14264, 14325, 14325, 14362, 14362, 14519, 18899
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 9070-9755
+- Def site: line 8880-9565
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -185,12 +195,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5578, 5578, 9193, 9193, 9244, 9244, 9247, 9247, 9288, 9288, 9327, 9327, 9345, 9345, 9423, 9423, 9430, 9430, 9440, 9440, 9443, 9443, 9456, 9456, 9457, 9457, 9458, 9458, 9459, 9459, 9467, 9467, 9469, 9469, 9470, 9470, 9471, 9471, 9472, 9472, 9475, 9475, 9478, 9478, 9481, 9481, 9484, 9484, 9530, 9530, 9553, 9553, 9554, 9554, 9555, 9555, 9557, 9557, 9593, 9593, 9609, 9609, 9663, 9663, 9664, 9664, 9665, 9665, 9668, 9668, 9669, 9669, 9688, 9688, 9690, 9690, 9691, 9691, 9726, 9726, 15077, 15077, 15130, 15130, 15561, 17053, 17053, 17077, 17077, 17101, 17101, 17244, 17244, 18867, 18867, 18874, 18874, 18883, 18883, 18887, 18887, 18896, 18896
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 294, 294, 342, 342, 498, 498
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5577, 5577, 9003, 9003, 9054, 9054, 9057, 9057, 9098, 9098, 9137, 9137, 9155, 9155, 9233, 9233, 9240, 9240, 9250, 9250, 9253, 9253, 9266, 9266, 9267, 9267, 9268, 9268, 9269, 9269, 9277, 9277, 9279, 9279, 9280, 9280, 9281, 9281, 9282, 9282, 9285, 9285, 9288, 9288, 9291, 9291, 9294, 9294, 9340, 9340, 9363, 9363, 9364, 9364, 9365, 9365, 9367, 9367, 9403, 9403, 9419, 9419, 9473, 9473, 9474, 9474, 9475, 9475, 9478, 9478, 9479, 9479, 9498, 9498, 9500, 9500, 9501, 9501, 9536, 9536, 14888, 14888, 14941, 14941, 15372, 16864, 16864, 16888, 16888, 16912, 16912, 17055, 17055, 18674, 18674, 18681, 18681, 18690, 18690, 18694, 18694, 18703, 18703
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 295, 295, 343, 343, 499, 499
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16352-17026
+- Def site: line 16163-16837
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -198,11 +208,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16740, 16740, 19338, 19344
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16551, 16551, 19145, 19151
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11803-12455
+- Def site: line 11614-12266
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -212,11 +222,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10580, 10580, 10589, 10589, 10677, 10677, 10684, 10684, 11358, 11358, 11644, 11644, 11649, 11649, 11656, 11656, 11661, 11661, 11875, 11875, 11897, 11897, 11900, 11900, 11926, 11926, 11935, 11935, 11936, 11936, 11957, 11957, 12000, 12000, 12046, 12046, 12057, 12057, 12084, 12084, 12089, 12089, 12090, 12090, 12091, 12091, 12123, 12123, 12129, 12129, 12154, 12154, 12174, 12174, 12209, 12209, 12224, 12224, 12230, 12230, 12232, 12232, 12235, 12235, 12237, 12237, 12241, 12241, 12245, 12245, 12250, 12250, 12257, 12257, 12264, 12264, 12271, 12271, 12280, 12280, 12290, 12290, 12297, 12297, 12304, 12304, 12311, 12311, 12318, 12318, 12325, 12325, 12335, 12335, 12344, 12344, 12353, 12353, 12362, 12362, 12371, 12371, 12400, 12400, 18828, 18828, 19009, 19009, 19086, 19086, 19087, 19087, 19095, 19095, 19300, 19300, 19301, 19301, 19320, 19320, 19327, 19327, 19328, 19328, 19329, 19329, 19330, 19330
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10390, 10390, 10399, 10399, 10487, 10487, 10494, 10494, 11169, 11169, 11455, 11455, 11460, 11460, 11467, 11467, 11472, 11472, 11686, 11686, 11708, 11708, 11711, 11711, 11737, 11737, 11746, 11746, 11747, 11747, 11768, 11768, 11811, 11811, 11857, 11857, 11868, 11868, 11895, 11895, 11900, 11900, 11901, 11901, 11902, 11902, 11934, 11934, 11940, 11940, 11965, 11965, 11985, 11985, 12020, 12020, 12035, 12035, 12041, 12041, 12043, 12043, 12046, 12046, 12048, 12048, 12052, 12052, 12056, 12056, 12061, 12061, 12068, 12068, 12075, 12075, 12082, 12082, 12091, 12091, 12101, 12101, 12108, 12108, 12115, 12115, 12122, 12122, 12129, 12129, 12136, 12136, 12146, 12146, 12155, 12155, 12164, 12164, 12173, 12173, 12182, 12182, 12211, 12211, 18635, 18635, 18816, 18816, 18893, 18893, 18894, 18894, 18902, 18902, 19107, 19107, 19108, 19108, 19127, 19127, 19134, 19134, 19135, 19135, 19136, 19136, 19137, 19137
 
 ### `BulkRadiusWLANConfigManager` (class, 587 lines)
 
-- Def site: line 18124-18710
+- Def site: line 17931-18517
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -224,11 +234,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18401, 18401, 18402, 18402, 18405, 18405, 18407, 18407, 18409, 18409, 18425, 18425, 19245
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18208, 18208, 18209, 18209, 18212, 18212, 18214, 18214, 18216, 18216, 18232, 18232, 19052
 
 ### `menu_actions` (assignment, 572 lines)
 
-- Def site: line 18809-19380
+- Def site: line 18616-19187
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -238,12 +248,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18809, 20094, 20095, 20104, 20224, 20224, 20266, 20324, 20369, 20860, 20864, 20909, 20909, 20936, 20936, 20939
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18616, 19901, 19902, 19911, 20031, 20031, 20073, 20131, 20176, 20667, 20671, 20716, 20716, 20743, 20743, 20746
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
-### `OrgTicketManager` (class, 463 lines)
+### `OrgTicketManager` (class, 475 lines)
 
-- Def site: line 8354-8816
+- Def site: line 8152-8626
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -251,11 +261,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8395, 8395, 8400, 8400, 8410, 8410, 8418, 8418, 8423, 8423, 8428, 8428, 8438, 8438, 8443, 8443, 8448, 8448, 8468, 8468, 8478, 8478, 8479, 8479, 8482, 8482, 8512, 8512, 8598, 8598, 8600, 8600, 8624, 8624, 8630, 8630, 8635, 8635, 8644, 8644, 8648, 8648, 8667, 8667, 8670, 8670, 8681, 8681, 8682, 8682, 8777, 8777, 8798, 8798, 19368, 19368, 19369, 19369, 19370, 19370, 19371, 19371, 19372, 19372, 19373, 19373
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8193, 8193, 8198, 8198, 8208, 8208, 8216, 8216, 8221, 8221, 8226, 8226, 8239, 8239, 8244, 8244, 8249, 8249, 8269, 8269, 8279, 8279, 8280, 8280, 8283, 8283, 8313, 8313, 8402, 8402, 8404, 8404, 8431, 8431, 8437, 8437, 8442, 8442, 8451, 8451, 8455, 8455, 8474, 8474, 8477, 8477, 8488, 8488, 8489, 8489, 8587, 8587, 8608, 8608, 19175, 19175, 19176, 19176, 19177, 19177, 19178, 19178, 19179, 19179, 19180, 19180
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 19605-20065
+- Def site: line 19412-19872
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -265,11 +275,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20072, 20072, 20076, 20076, 20096, 20096, 20101, 20101, 20325
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19879, 19879, 19883, 19883, 19903, 19903, 19908, 19908, 20132
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7801-8241
+- Def site: line 7599-8039
 - References: 117
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -277,14 +287,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7746, 7746, 7762, 7762, 7766, 7766, 7767, 7767, 7768, 7768, 7783, 7783, 7789, 7789, 7816, 7816, 7819, 7819, 7827, 7827, 7845, 7845, 7895, 7895, 7903, 7903, 7908, 7908, 7954, 7954, 7965, 7965, 7990, 7990, 8009, 8009, 8010, 8010, 8013, 8013, 8014, 8014, 8104, 8104, 8106, 8106, 8110, 8110, 8138, 8138, 8139, 8139, 8140, 8140, 8141, 8141, 8142, 8142, 8151, 8151, 8195, 8195, 8219, 8219, 12535, 12535, 12585, 12585, 12590, 12590, 12733, 12816, 12816, 12870, 12870, 12891, 12891, 12896, 12896, 13160, 13160, 13363, 13565, 13565, 13652, 13652, 13657, 13657, 13707, 13707, 13708, 13708, 15204, 15204, 15663, 17060, 17060, 17582, 17582, 18733, 18733, 18734, 18734, 19020, 19020
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 67, 195, 195
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7544, 7544, 7560, 7560, 7564, 7564, 7565, 7565, 7566, 7566, 7581, 7581, 7587, 7587, 7614, 7614, 7617, 7617, 7625, 7625, 7643, 7643, 7693, 7693, 7701, 7701, 7706, 7706, 7752, 7752, 7763, 7763, 7788, 7788, 7807, 7807, 7808, 7808, 7811, 7811, 7812, 7812, 7902, 7902, 7904, 7904, 7908, 7908, 7936, 7936, 7937, 7937, 7938, 7938, 7939, 7939, 7940, 7940, 7949, 7949, 7993, 7993, 8017, 8017, 12346, 12346, 12396, 12396, 12401, 12401, 12544, 12627, 12627, 12681, 12681, 12702, 12702, 12707, 12707, 12971, 12971, 13174, 13376, 13376, 13463, 13463, 13468, 13468, 13518, 13518, 13519, 13519, 15015, 15015, 15474, 16871, 16871, 17391, 17391, 18540, 18540, 18541, 18541, 18827, 18827
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 68, 196, 196
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 62, 122, 122, 127, 127
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 65, 127, 127, 132, 132
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9758-10171
+- Def site: line 9568-9981
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -293,11 +303,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5572, 5572, 9791, 9791, 9875, 9875, 9881, 9881, 9884, 9884, 9928, 9928, 9942, 9942, 9969, 9969, 9975, 9975, 9989, 9989, 10072, 10072, 10074, 10074, 10078, 10078, 10080, 10080, 10083, 10083, 10087, 10087, 10090, 10090, 10100, 10100, 10106, 10106, 10144, 10144, 15078, 15078, 15079, 15079, 15080, 15080, 15131, 15131, 15132, 15132, 18868, 18868, 18869, 18869, 18870, 18870, 18894, 18894
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5571, 5571, 9601, 9601, 9685, 9685, 9691, 9691, 9694, 9694, 9738, 9738, 9752, 9752, 9779, 9779, 9785, 9785, 9799, 9799, 9882, 9882, 9884, 9884, 9888, 9888, 9890, 9890, 9893, 9893, 9897, 9897, 9900, 9900, 9910, 9910, 9916, 9916, 9954, 9954, 14889, 14889, 14890, 14890, 14891, 14891, 14942, 14942, 14943, 14943, 18675, 18675, 18676, 18676, 18677, 18677, 18701, 18701
 
-### `DeviceRebootManager` (class, 398 lines)
+### `DeviceRebootManager` (class, 396 lines)
 
-- Def site: line 17163-17560
+- Def site: line 16974-17369
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -306,11 +316,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17184, 17184, 17189, 17189, 17193, 17193, 17196, 17196, 17203, 17203, 17205, 17205, 17206, 17206, 17209, 17209, 17212, 17212, 17215, 17215, 17257, 17257, 17289, 17289, 17356, 17356, 17369, 17369, 17374, 17374, 17426, 17426, 17459, 17459, 17460, 17460, 17461, 17461, 17491, 17491, 17520, 17520, 17521, 17521, 19051, 19051
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16995, 16995, 17000, 17000, 17004, 17004, 17007, 17007, 17014, 17014, 17016, 17016, 17017, 17017, 17020, 17020, 17023, 17023, 17026, 17026, 17068, 17068, 17100, 17100, 17167, 17167, 17180, 17180, 17185, 17185, 17235, 17235, 17268, 17268, 17269, 17269, 17270, 17270, 17300, 17300, 17329, 17329, 17330, 17330, 18858, 18858
 
-### `MSPInventoryExporter` (class, 388 lines)
+### `MSPInventoryExporter` (class, 386 lines)
 
-- Def site: line 17614-18001
+- Def site: line 17423-17808
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -320,11 +330,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17641, 17785, 17785, 19191, 19191
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17450, 17594, 17594, 18998, 18998
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6708-7052
+- Def site: line 6696-7040
 - References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -333,18 +343,18 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5668, 5668, 6754, 6754, 6770, 6770, 6771, 6771, 6794, 6794, 6796, 6796, 6799, 6799, 6813, 6813, 6815, 6815, 6824, 6824, 6826, 6826, 6827, 6827, 6833, 6833, 6834, 6834, 6834, 6851, 6851, 6855, 6855, 6897, 6897, 6928, 6928, 6931, 6931, 6933, 6933, 6979, 6979, 6989, 6989, 7022, 7022, 7027, 7027, 7034, 7034, 7256, 7256, 7288, 7288, 7299, 7299, 7324, 7324, 7344, 7344, 7858, 7858, 8651, 8651, 8930, 8930, 8945, 9009, 9009, 9026, 9026, 9044, 9044, 9065, 9065, 9624, 9624, 9699, 9699, 10029, 10029, 10380, 10380, 10465, 10481, 10601, 10601, 10605, 10605, 10625, 10625, 10638, 10638, 10642, 10642, 10660, 10660, 10822, 10822, 11169, 11169, 11316, 11316, 11393, 11393, 11397, 11397, 11402, 11402, 11535, 11535, 11554, 11554, 11605, 11605, 11608, 11608, 11759, 11759, 11762, 11762, 11861, 11861, 11867, 11867, 12164, 12164, 12181, 12181, 12196, 12196, 12410, 12410, 12438, 12438, 12454, 12454, 12491, 12491, 12529, 12529, 12618, 12618, 12647, 12647, 12685, 12685, 12736, 12801, 12801, 12807, 12807, 12849, 12849, 13018, 13018, 13024, 13024, 13143, 13143, 13151, 13151, 13315, 13315, 13366, 13539, 13539, 13710, 13710, 14223, 14223, 14584, 14584, 14590, 14590, 15498, 15498, 15557, 15664, 15800, 15800, 15818, 15818, 15836, 15836, 17107, 17107, 17128, 17967, 17967, 18052, 18052, 18073, 18073, 18559, 18559, 19220, 19220, 19236, 19236
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 70, 187, 187, 285, 285, 293, 293, 362, 362, 391, 391, 543, 543, 558, 558
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5667, 5667, 6742, 6742, 6758, 6758, 6759, 6759, 6782, 6782, 6784, 6784, 6787, 6787, 6801, 6801, 6803, 6803, 6812, 6812, 6814, 6814, 6815, 6815, 6821, 6821, 6822, 6822, 6822, 6839, 6839, 6843, 6843, 6885, 6885, 6916, 6916, 6919, 6919, 6921, 6921, 6967, 6967, 6977, 6977, 7010, 7010, 7015, 7015, 7022, 7022, 7244, 7244, 7276, 7276, 7287, 7287, 7312, 7312, 7332, 7332, 7656, 7656, 8458, 8458, 8740, 8740, 8755, 8819, 8819, 8836, 8836, 8854, 8854, 8875, 8875, 9434, 9434, 9509, 9509, 9839, 9839, 10190, 10190, 10275, 10291, 10411, 10411, 10415, 10415, 10435, 10435, 10448, 10448, 10452, 10452, 10470, 10470, 10632, 10632, 10980, 10980, 11127, 11127, 11204, 11204, 11208, 11208, 11213, 11213, 11346, 11346, 11365, 11365, 11416, 11416, 11419, 11419, 11570, 11570, 11573, 11573, 11672, 11672, 11678, 11678, 11975, 11975, 11992, 11992, 12007, 12007, 12221, 12221, 12249, 12249, 12265, 12265, 12302, 12302, 12340, 12340, 12429, 12429, 12458, 12458, 12496, 12496, 12547, 12612, 12612, 12618, 12618, 12660, 12660, 12829, 12829, 12835, 12835, 12954, 12954, 12962, 12962, 13126, 13126, 13177, 13350, 13350, 13521, 13521, 14034, 14034, 14395, 14395, 14401, 14401, 15309, 15309, 15368, 15475, 15611, 15611, 15629, 15629, 15647, 15647, 16918, 16918, 16939, 17774, 17774, 17859, 17859, 17880, 17880, 18366, 18366, 19027, 19027, 19043, 19043
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 71, 188, 188, 286, 286, 294, 294, 363, 363, 392, 392, 544, 544, 559, 559
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 379, 379, 439, 439, 456, 456, 475, 475, 548, 548
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 28, 305, 305, 449, 449
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 380, 380, 440, 440, 457, 457, 476, 476, 549, 549
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 310, 310, 454, 454
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 21, 639, 639
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\org_device_inventory_msp.py`: lines 28, 67, 380, 380, 413, 413, 424, 424
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\org_device_inventory_summary.py`: lines 15, 39, 338, 338
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12857-13197
+- Def site: line 12668-13008
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -353,11 +363,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12874, 12874, 12876, 12876, 12880, 12880, 12881, 12881, 12895, 12895, 12901, 12901, 12904, 12904, 12907, 12907, 12965, 12965, 12971, 12971, 12976, 12976, 12990, 12990, 13008, 13008, 13118, 13118, 13122, 13122, 13124, 13124, 13127, 13127, 13164, 13164, 13169, 13169, 13183, 13183, 13187, 13187, 13189, 13189, 13192, 13192, 13197, 13197, 19097, 19097, 19101, 19101, 19105, 19105
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12685, 12685, 12687, 12687, 12691, 12691, 12692, 12692, 12706, 12706, 12712, 12712, 12715, 12715, 12718, 12718, 12776, 12776, 12782, 12782, 12787, 12787, 12801, 12801, 12819, 12819, 12929, 12929, 12933, 12933, 12935, 12935, 12938, 12938, 12975, 12975, 12980, 12980, 12994, 12994, 12998, 12998, 13000, 13000, 13003, 13003, 13008, 13008, 18904, 18904, 18908, 18908, 18912, 18912
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7055-7382
+- Def site: line 7043-7370
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -365,11 +375,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7157, 7157, 8375, 8856, 8875, 8976, 9105, 9128, 9800, 10108, 10153, 10567, 11337, 11348, 11411, 11828
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7145, 7145, 8173, 8666, 8685, 8786, 8915, 8938, 9610, 9918, 9963, 10377, 11148, 11159, 11222, 11639
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14688-15015
+- Def site: line 14499-14826
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -379,13 +389,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12145, 12145, 12204, 12204, 12205, 12205, 13369, 14729, 14729, 14731, 14731, 14737, 14737, 14751, 14751, 14790, 14790, 14793, 14793, 14795, 14795, 14796, 14796, 14797, 14797, 14851, 14851, 14852, 14852, 14863, 14863, 14872, 14872, 14891, 14891, 14943, 14943, 14947, 14947, 14955, 14955, 14956, 14956, 14980, 14980, 14984, 14984
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 73
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11956, 11956, 12015, 12015, 12016, 12016, 13180, 14540, 14540, 14542, 14542, 14548, 14548, 14562, 14562, 14601, 14601, 14604, 14604, 14606, 14606, 14607, 14607, 14608, 14608, 14662, 14662, 14663, 14663, 14674, 14674, 14683, 14683, 14702, 14702, 14754, 14754, 14758, 14758, 14766, 14766, 14767, 14767, 14791, 14791, 14795, 14795
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 74
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 16048-16336
+- Def site: line 15859-16147
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -395,11 +405,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16076, 16076, 16079, 16079, 16084, 16084, 16087, 16087, 16131, 16131, 16137, 16137, 16168, 16168, 16171, 16171, 16175, 16175, 16201, 16201, 16218, 16218, 16224, 16224, 16238, 16238, 16239, 16239, 16241, 16241, 16247, 16247, 16254, 16254, 16263, 16263, 16310, 16310, 16332, 16332, 16333, 16333, 16334, 16334, 19042, 19042
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15887, 15887, 15890, 15890, 15895, 15895, 15898, 15898, 15942, 15942, 15948, 15948, 15979, 15979, 15982, 15982, 15986, 15986, 16012, 16012, 16029, 16029, 16035, 16035, 16049, 16049, 16050, 16050, 16052, 16052, 16058, 16058, 16065, 16065, 16074, 16074, 16121, 16121, 16143, 16143, 16144, 16144, 16145, 16145, 18849, 18849
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 10174-10446
+- Def site: line 9984-10256
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -408,11 +418,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10197, 10197, 10198, 10198, 10211, 10211, 10212, 10212, 10214, 10214, 10215, 10215, 10218, 10218, 10221, 10221, 10225, 10225, 10226, 10226, 10302, 10302, 10306, 10306, 10309, 10309, 10322, 10322, 10359, 10359, 10376, 10376, 10389, 10389, 10391, 10391, 10398, 10398, 10407, 10407, 10416, 10416, 10417, 10417, 10428, 10428, 10432, 10432, 10441, 10441, 10446, 10446, 19299, 19299
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10007, 10007, 10008, 10008, 10021, 10021, 10022, 10022, 10024, 10024, 10025, 10025, 10028, 10028, 10031, 10031, 10035, 10035, 10036, 10036, 10112, 10112, 10116, 10116, 10119, 10119, 10132, 10132, 10169, 10169, 10186, 10186, 10199, 10199, 10201, 10201, 10208, 10208, 10217, 10217, 10226, 10226, 10227, 10227, 10238, 10238, 10242, 10242, 10251, 10251, 10256, 10256, 19106, 19106
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5198-5461
+- Def site: line 5197-5460
 - References: 106
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -420,14 +430,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5238, 5238, 5240, 5240, 5322, 5322, 5328, 5328, 5365, 5365, 5367, 5367, 5376, 5376, 5386, 5386, 5396, 5396, 5432, 5432, 7894, 7894, 9552, 9552, 9553, 9553, 9864, 9864, 10710, 10710, 10730, 10730, 12731, 15137, 15137, 15143, 15143, 15144, 15144, 15145, 15145, 15146, 15146, 15147, 15147, 15148, 15148, 15155, 15155, 15183, 15183, 15555, 15801, 15801, 15819, 15819, 15837, 15837, 15863, 17052, 17052, 17076, 17076, 17100, 17100, 17244, 17244, 17245, 17245, 17246, 17246, 17247, 17247, 17583, 17583, 18784, 18784, 19336, 19336
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 338, 338, 340, 340, 342, 342, 344, 344, 498, 498, 499, 499, 544, 544
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 331, 331, 352, 352
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5237, 5237, 5239, 5239, 5321, 5321, 5327, 5327, 5364, 5364, 5366, 5366, 5375, 5375, 5385, 5385, 5395, 5395, 5431, 5431, 7692, 7692, 9362, 9362, 9363, 9363, 9674, 9674, 10520, 10520, 10540, 10540, 12542, 14948, 14948, 14954, 14954, 14955, 14955, 14956, 14956, 14957, 14957, 14958, 14958, 14959, 14959, 14966, 14966, 14994, 14994, 15366, 15612, 15612, 15630, 15630, 15648, 15648, 15674, 16863, 16863, 16887, 16887, 16911, 16911, 17055, 17055, 17056, 17056, 17057, 17057, 17058, 17058, 17392, 17392, 18591, 18591, 19143, 19143
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 339, 339, 341, 341, 343, 343, 345, 345, 499, 499, 500, 500, 545, 545
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32, 336, 336, 357, 357
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 10941-11191
+- Def site: line 10752-11002
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -437,11 +447,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10948, 10948, 10951, 10951, 10956, 10956, 10957, 10957, 10965, 10965, 10968, 10968, 10976, 10976, 11016, 11016, 11024, 11024, 11072, 11072, 11089, 11089, 11092, 11092, 11094, 11094, 11158, 11158, 11159, 11159, 19302, 19302
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10759, 10759, 10762, 10762, 10767, 10767, 10768, 10768, 10776, 10776, 10779, 10779, 10787, 10787, 10827, 10827, 10835, 10835, 10883, 10883, 10900, 10900, 10903, 10903, 10905, 10905, 10969, 10969, 10970, 10970, 19109, 19109
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15267-15511
+- Def site: line 15078-15322
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -451,11 +461,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15133, 15133, 15293, 15293, 15295, 15295, 15296, 15296, 15297, 15297, 15325, 15325, 15330, 15330, 15352, 15352, 15353, 15353, 15395, 15395, 15403, 15403, 15429, 15429, 15438, 15438, 15446, 15446, 15477, 15477, 18873, 18873, 18877, 18877
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14944, 14944, 15104, 15104, 15106, 15106, 15107, 15107, 15108, 15108, 15136, 15136, 15141, 15141, 15163, 15163, 15164, 15164, 15206, 15206, 15214, 15214, 15240, 15240, 15249, 15249, 15257, 15257, 15288, 15288, 18680, 18680, 18684, 18684
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6131-6351
+- Def site: line 6119-6339
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -463,14 +473,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6154, 6154, 6205, 6205, 6275, 6275, 6299, 6299, 6311, 6311, 6313, 6313, 6323, 6323, 6338, 6338, 6342, 6342, 6343, 6343, 6346, 6346, 6348, 6348, 12844, 12844, 15559
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 449, 449
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6142, 6142, 6193, 6193, 6263, 6263, 6287, 6287, 6299, 6299, 6301, 6301, 6311, 6311, 6326, 6326, 6330, 6330, 6331, 6331, 6334, 6334, 6336, 6336, 12655, 12655, 15370
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 450, 450
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 23, 68
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 25, 71
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 19386-19599
+- Def site: line 19193-19406
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -479,11 +489,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20242, 20242, 20245, 20326, 20677
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20049, 20049, 20052, 20133, 20484
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7585-7794
+- Def site: line 7383-7592
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -492,11 +502,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7598, 7598, 7604, 7604, 7605, 7605, 7608, 7608, 7631, 7631, 7634, 7634, 7637, 7637, 7638, 7638, 7640, 7640, 7707, 7707, 7751, 7751, 8216, 8216, 13165, 13165, 15662, 15901, 15901, 16061, 16061
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7396, 7396, 7402, 7402, 7403, 7403, 7406, 7406, 7429, 7429, 7432, 7432, 7435, 7435, 7436, 7436, 7438, 7438, 7505, 7505, 7549, 7549, 8014, 8014, 12976, 12976, 15473, 15712, 15712, 15872, 15872
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12463-12665
+- Def site: line 12274-12476
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -505,11 +515,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12484, 12484, 12493, 12493, 12555, 12555, 12562, 12562, 12594, 12594, 12596, 12596, 12620, 12620, 12655, 12655, 12662, 12662, 12693, 12693, 15207, 15207, 18909, 18909, 18911, 18911, 18912, 18912, 18914, 18914
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12295, 12295, 12304, 12304, 12366, 12366, 12373, 12373, 12405, 12405, 12407, 12407, 12431, 12431, 12466, 12466, 12473, 12473, 12504, 12504, 15018, 15018, 18716, 18716, 18718, 18718, 18719, 18719, 18721, 18721
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13716-13903
+- Def site: line 13527-13714
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -519,11 +529,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19259, 19259, 19260, 19260, 19261, 19261, 19262, 19262, 19263, 19263, 19264, 19264, 19265, 19265, 19266, 19266, 19268, 19268, 19269, 19269, 19270, 19270, 19271, 19271, 19272, 19272, 19273, 19273, 19274, 19274, 19276, 19276, 19277, 19277, 19278, 19278, 19279, 19279, 19280, 19280, 19281, 19281, 19282, 19282, 19283, 19283, 19284, 19284, 19286, 19286, 19287, 19287, 19288, 19288, 19289, 19289, 19290, 19290, 19291, 19291, 19292, 19292, 19293, 19293, 19294, 19294, 19296, 19296, 19297, 19297
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19066, 19066, 19067, 19067, 19068, 19068, 19069, 19069, 19070, 19070, 19071, 19071, 19072, 19072, 19073, 19073, 19075, 19075, 19076, 19076, 19077, 19077, 19078, 19078, 19079, 19079, 19080, 19080, 19081, 19081, 19083, 19083, 19084, 19084, 19085, 19085, 19086, 19086, 19087, 19087, 19088, 19088, 19089, 19089, 19090, 19090, 19091, 19091, 19093, 19093, 19094, 19094, 19095, 19095, 19096, 19096, 19097, 19097, 19098, 19098, 19099, 19099, 19100, 19100, 19101, 19101, 19103, 19103, 19104, 19104
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5543-5722
+- Def site: line 5542-5721
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -532,11 +542,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5631, 5631, 5668, 5668, 5670, 5670, 5673, 5673, 5681, 5681, 5683, 5683, 5685, 5685, 5688, 5688, 5717, 5717, 5720, 5720, 19036, 19036
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5630, 5630, 5667, 5667, 5669, 5669, 5672, 5672, 5680, 5680, 5682, 5682, 5684, 5684, 5687, 5687, 5716, 5716, 5719, 5719, 18843, 18843
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6527-6705
+- Def site: line 6515-6693
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -544,11 +554,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6572, 6572, 6610, 6610, 6621, 6621, 6647, 6647, 6648, 6648, 6650, 6650, 6656, 6656, 6657, 6657, 6660, 6660, 6666, 6666, 6667, 6667, 6670, 6670, 6672, 6672, 6682, 6682, 6684, 6684, 6685, 6685, 6687, 6687
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6560, 6560, 6598, 6598, 6609, 6609, 6635, 6635, 6636, 6636, 6638, 6638, 6644, 6644, 6645, 6645, 6648, 6648, 6654, 6654, 6655, 6655, 6658, 6658, 6660, 6660, 6670, 6670, 6672, 6672, 6673, 6673, 6675, 6675
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11421-11588
+- Def site: line 11232-11399
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -557,11 +567,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11528, 11528, 11547, 11547, 11565, 11565, 11574, 11574, 11577, 11577, 11578, 11578, 11581, 11581, 11586, 11586, 11588, 11588, 18937, 18937
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11339, 11339, 11358, 11358, 11376, 11376, 11385, 11385, 11388, 11388, 11389, 11389, 11392, 11392, 11397, 11397, 11399, 11399, 18744, 18744
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11633-11800
+- Def site: line 11444-11611
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -569,11 +579,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11670, 11670, 11672, 11672, 11675, 11675, 11746, 11746, 11748, 11748, 11761, 11761, 11765, 11765, 18940, 18940, 18941, 18941, 18942, 18942, 18980, 18980, 18985, 18985
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11481, 11481, 11483, 11483, 11486, 11486, 11557, 11557, 11559, 11559, 11572, 11572, 11576, 11576, 18747, 18747, 18748, 18748, 18749, 18749, 18787, 18787, 18792, 18792
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10666-10827
+- Def site: line 10476-10637
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -581,11 +591,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10704, 10704, 10711, 10711, 10718, 10718, 10724, 10724, 10731, 10731, 10738, 10738, 10799, 10799, 10810, 10810, 18928, 18928, 18929, 18929, 18931, 18931, 18932, 18932, 18933, 18933
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10514, 10514, 10521, 10521, 10528, 10528, 10534, 10534, 10541, 10541, 10548, 10548, 10609, 10609, 10620, 10620, 18735, 18735, 18736, 18736, 18738, 18738, 18739, 18739, 18740, 18740
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15882-16042
+- Def site: line 15693-15853
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -594,11 +604,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15905, 15905, 15907, 15907, 15976, 15976, 15978, 15978, 15997, 15997, 15999, 15999, 15999, 16015, 16015, 16031, 16031, 16032, 16032, 16038, 16038, 19041, 19041
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15716, 15716, 15718, 15718, 15787, 15787, 15789, 15789, 15808, 15808, 15810, 15810, 15810, 15826, 15826, 15842, 15842, 15843, 15843, 15849, 15849, 18848, 18848
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6359-6516
+- Def site: line 6347-6504
 - References: 197
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -608,15 +618,15 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5496, 5496, 6375, 6375, 6388, 6388, 6391, 6391, 6415, 6415, 6423, 6423, 6424, 6424, 6446, 6446, 6451, 6451, 6453, 6453, 6930, 6930, 6955, 6955, 7024, 7024, 7025, 7025, 7354, 7354, 7368, 7368, 7369, 7369, 7856, 7856, 7857, 7857, 8779, 8779, 8944, 9004, 9004, 9006, 9006, 9007, 9007, 9024, 9024, 9025, 9025, 9042, 9042, 9043, 9043, 9063, 9063, 9064, 9064, 9621, 9621, 9622, 9622, 9696, 9696, 9697, 9697, 10025, 10025, 10028, 10028, 10603, 10603, 10604, 10604, 10640, 10640, 10641, 10641, 10820, 10820, 10821, 10821, 11165, 11165, 11166, 11166, 11312, 11312, 11313, 11313, 11395, 11395, 11396, 11396, 11607, 11607, 11782, 11782, 11783, 11783, 11859, 11859, 11860, 11860, 12163, 12163, 12179, 12179, 12180, 12180, 12408, 12408, 12409, 12409, 12488, 12488, 12489, 12489, 12490, 12490, 12526, 12526, 12527, 12527, 12615, 12615, 12616, 12616, 12644, 12644, 12645, 12645, 12682, 12682, 12683, 12683, 12735, 12804, 12804, 12805, 12805, 12847, 12847, 12848, 12848, 13016, 13016, 13017, 13017, 13141, 13141, 13142, 13142, 13365, 13537, 13537, 14589, 14589, 15496, 15496, 15497, 15497, 15558, 15666, 17105, 17105, 17106, 17106, 17957, 17957
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 69, 152, 152, 153, 153, 158, 158, 186, 186, 541, 541
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5495, 5495, 6363, 6363, 6376, 6376, 6379, 6379, 6403, 6403, 6411, 6411, 6412, 6412, 6434, 6434, 6439, 6439, 6441, 6441, 6918, 6918, 6943, 6943, 7012, 7012, 7013, 7013, 7342, 7342, 7356, 7356, 7357, 7357, 7654, 7654, 7655, 7655, 8589, 8589, 8754, 8814, 8814, 8816, 8816, 8817, 8817, 8834, 8834, 8835, 8835, 8852, 8852, 8853, 8853, 8873, 8873, 8874, 8874, 9431, 9431, 9432, 9432, 9506, 9506, 9507, 9507, 9835, 9835, 9838, 9838, 10413, 10413, 10414, 10414, 10450, 10450, 10451, 10451, 10630, 10630, 10631, 10631, 10976, 10976, 10977, 10977, 11123, 11123, 11124, 11124, 11206, 11206, 11207, 11207, 11418, 11418, 11593, 11593, 11594, 11594, 11670, 11670, 11671, 11671, 11974, 11974, 11990, 11990, 11991, 11991, 12219, 12219, 12220, 12220, 12299, 12299, 12300, 12300, 12301, 12301, 12337, 12337, 12338, 12338, 12426, 12426, 12427, 12427, 12455, 12455, 12456, 12456, 12493, 12493, 12494, 12494, 12546, 12615, 12615, 12616, 12616, 12658, 12658, 12659, 12659, 12827, 12827, 12828, 12828, 12952, 12952, 12953, 12953, 13176, 13348, 13348, 14400, 14400, 15307, 15307, 15308, 15308, 15369, 15477, 16916, 16916, 16917, 16917, 17764, 17764
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 70, 153, 153, 154, 154, 159, 159, 187, 187, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 453, 453, 454, 454, 473, 473, 474, 474
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 27, 269, 269
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 454, 454, 455, 455, 474, 474, 475, 475
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 29, 274, 274
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 15029-15184
+- Def site: line 14840-14995
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -625,11 +635,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15051, 15051, 15057, 15057, 15059, 15059, 15087, 15087, 15113, 15113, 15116, 15116, 15119, 15119, 19027, 19027, 19031, 19031, 19039, 19039
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14862, 14862, 14868, 14868, 14870, 14870, 14898, 14898, 14924, 14924, 14927, 14927, 14930, 14930, 18834, 18834, 18838, 18838, 18846, 18846
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13200-13345
+- Def site: line 13011-13156
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -637,11 +647,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13239, 13239, 13246, 13246, 13271, 13271, 13274, 13274, 13287, 13287, 13331, 13331, 13335, 13335, 13340, 13340, 13341, 13341, 13345, 13345, 19334, 19334
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13050, 13050, 13057, 13057, 13082, 13082, 13085, 13085, 13098, 13098, 13142, 13142, 13146, 13146, 13151, 13151, 13152, 13152, 13156, 13156, 19141, 19141
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13353-13497
+- Def site: line 13164-13308
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -650,12 +660,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12574, 12574, 12750, 12750, 12828, 12828, 12833, 12833, 13382, 13382, 13388, 13388, 13394, 13394, 13400, 13400, 13406, 13406, 13412, 13412, 13418, 13418, 13424, 13424, 13430, 13430, 13436, 13436, 13442, 13442, 13448, 13448, 13454, 13454, 13460, 13460, 13466, 13466, 13472, 13472, 13478, 13478, 13484, 13484, 13490, 13490, 13496, 13496, 18947, 18947, 19088, 19088, 19090, 19090, 19205, 19205, 19331, 19331, 19332, 19332, 19333, 19333, 19352, 19352, 19353, 19353, 19354, 19354, 19355, 19355, 19356, 19356, 19357, 19357, 19358, 19358
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 208, 208, 351, 351, 355, 355, 365, 365, 414, 414, 423, 423, 432, 432, 496, 496, 524, 524
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12385, 12385, 12561, 12561, 12639, 12639, 12644, 12644, 13193, 13193, 13199, 13199, 13205, 13205, 13211, 13211, 13217, 13217, 13223, 13223, 13229, 13229, 13235, 13235, 13241, 13241, 13247, 13247, 13253, 13253, 13259, 13259, 13265, 13265, 13271, 13271, 13277, 13277, 13283, 13283, 13289, 13289, 13295, 13295, 13301, 13301, 13307, 13307, 18754, 18754, 18895, 18895, 18897, 18897, 19012, 19012, 19138, 19138, 19139, 19139, 19140, 19140, 19159, 19159, 19160, 19160, 19161, 19161, 19162, 19162, 19163, 19163, 19164, 19164, 19165, 19165
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 209, 209, 352, 352, 356, 356, 366, 366, 415, 415, 424, 424, 433, 433, 497, 497, 525, 525
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10520-10663
+- Def site: line 10330-10473
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -664,11 +674,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10534, 10534, 10535, 10535, 10621, 10621, 10656, 10656, 18922, 18922, 18923, 18923, 18924, 18924, 18925, 18925, 18926, 18926
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10344, 10344, 10345, 10345, 10431, 10431, 10466, 10466, 18729, 18729, 18730, 18730, 18731, 18731, 18732, 18732, 18733, 18733
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13500-13638
+- Def site: line 13311-13449
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -676,11 +686,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13569, 13569, 13572, 13572, 13573, 13573, 13574, 13574, 13594, 13594, 13597, 13597, 13605, 13605, 13610, 13610, 19360, 19360
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13380, 13380, 13383, 13383, 13384, 13384, 13385, 13385, 13405, 13405, 13408, 13408, 13416, 13416, 13421, 13421, 19167, 19167
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8822-8950
+- Def site: line 8632-8760
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -689,11 +699,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8893, 8893, 8904, 8904, 15127, 15127, 15128, 15128, 18825, 18825, 18826, 18826, 19005, 19005
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8703, 8703, 8714, 8714, 14938, 14938, 14939, 14939, 18632, 18632, 18633, 18633, 18812, 18812
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11194-11322
+- Def site: line 11005-11133
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -702,11 +712,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11201, 11201, 11206, 11206, 11207, 11207, 11208, 11208, 11211, 11211, 11212, 11212, 11275, 11275, 11282, 11282, 11309, 11309, 19304, 19304
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11012, 11012, 11017, 11017, 11018, 11018, 11019, 11019, 11022, 11022, 11023, 11023, 11086, 11086, 11093, 11093, 11120, 11120, 19111, 19111
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15652-15778
+- Def site: line 15463-15589
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -715,11 +725,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15672, 15672, 15677, 15677, 15682, 15682, 15719, 15719, 15725, 15725, 15731, 15731, 15737, 15737, 15743, 15743, 15744, 15744, 15745, 15745, 15746, 15746, 15747, 15747, 15751, 15751, 15760, 15760, 15764, 15764, 15767, 15767, 15773, 15773, 19000, 19000
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15483, 15483, 15488, 15488, 15493, 15493, 15530, 15530, 15536, 15536, 15542, 15542, 15548, 15548, 15554, 15554, 15555, 15555, 15556, 15556, 15557, 15557, 15558, 15558, 15562, 15562, 15571, 15571, 15575, 15575, 15578, 15578, 15584, 15584, 18807, 18807
 
-### `EnvironmentUtils` (class, 125 lines)
+### `EnvironmentUtils` (class, 114 lines)
 
-- Def site: line 5776-5900
+- Def site: line 5775-5888
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -728,11 +738,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5797, 5797, 5799, 5799, 5815, 5815, 5827, 5827, 5866, 5866, 5867, 5867, 5868, 5868, 5869, 5869, 5870, 5870, 5881, 5881, 5884, 5884, 6812, 6812, 20339, 20339, 20922, 20922
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5796, 5796, 5798, 5798, 5814, 5814, 5826, 5826, 5865, 5865, 5866, 5866, 5867, 5867, 5868, 5868, 5869, 5869, 5880, 5880, 5883, 5883, 6800, 6800, 20146, 20146, 20729, 20729
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8956-9067
+- Def site: line 8766-8877
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -740,13 +750,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7894, 7894, 9552, 9552, 9864, 9864, 10710, 10710, 10730, 10730, 12732, 15076, 15076, 15129, 15129, 15562, 15802, 15802, 15820, 15820, 15838, 15838, 17054, 17054, 17078, 17078, 17102, 17102, 17245, 17245, 17586, 17586, 18866, 18866, 18881, 18881, 18891, 18891, 18891, 18891, 18901, 18901
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 338, 338, 499, 499, 546, 546
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7692, 7692, 9362, 9362, 9674, 9674, 10520, 10520, 10540, 10540, 12543, 14887, 14887, 14940, 14940, 15373, 15613, 15613, 15631, 15631, 15649, 15649, 16865, 16865, 16889, 16889, 16913, 16913, 17056, 17056, 17395, 17395, 18673, 18673, 18688, 18688, 18698, 18698, 18698, 18698, 18708, 18708
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 339, 339, 500, 500, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
-### `FilterOperatorEngine` (class, 109 lines)
+### `FilterOperatorEngine` (class, 110 lines)
 
-- Def site: line 10830-10938
+- Def site: line 10640-10749
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -756,11 +766,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10885, 10885, 10888, 10888, 10889, 10889, 10894, 10894, 10912, 10912, 10912, 10921, 10921, 10921, 10921, 10922, 10922, 10922, 10922, 10980, 10980, 10983, 10983, 10995, 10995, 10996, 10996, 11009, 11009, 11048, 11048, 11056, 11056, 11110, 11110, 11118, 11118
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10695, 10695, 10698, 10698, 10699, 10699, 10704, 10704, 10723, 10723, 10723, 10732, 10732, 10732, 10732, 10733, 10733, 10733, 10733, 10791, 10791, 10794, 10794, 10806, 10806, 10807, 10807, 10820, 10820, 10859, 10859, 10867, 10867, 10921, 10921, 10929, 10929
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12755-12854
+- Def site: line 12566-12665
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -769,11 +779,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12820, 12820, 12822, 12822, 12823, 12823, 18875, 18875, 18943, 18943, 18945, 18945, 18946, 18946
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12631, 12631, 12633, 12633, 12634, 12634, 18682, 18682, 18750, 18750, 18752, 18752, 18753, 18753
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15544-15641
+- Def site: line 15355-15452
 - References: 78
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -782,13 +792,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15287, 15287, 15522, 15522, 15580, 15580, 15586, 15586, 15592, 15592, 15598, 15598, 15604, 15604, 15610, 15610, 15616, 15616, 15622, 15622, 15628, 15628, 15634, 15634, 15640, 15640, 15864, 17246, 17246, 17249, 17249, 17585, 17585, 18832, 18832, 18899, 18899, 18905, 18905, 18956, 18956, 19013, 19013
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 76, 92, 340, 340, 346, 346, 402, 402, 404, 404, 408, 408, 411, 411, 414, 414, 415, 415, 458, 458, 459, 459, 491, 491, 492, 492, 508, 508, 545, 545
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15098, 15098, 15333, 15333, 15391, 15391, 15397, 15397, 15403, 15403, 15409, 15409, 15415, 15415, 15421, 15421, 15427, 15427, 15433, 15433, 15439, 15439, 15445, 15445, 15451, 15451, 15675, 17057, 17057, 17060, 17060, 17394, 17394, 18639, 18639, 18706, 18706, 18712, 18712, 18763, 18763, 18820, 18820
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 78, 94, 341, 341, 347, 347, 403, 403, 405, 405, 409, 409, 412, 412, 415, 415, 416, 416, 459, 459, 460, 460, 492, 492, 493, 493, 509, 509, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8252-8348
+- Def site: line 8050-8146
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -796,11 +806,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8308, 8308, 8344, 8344
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8106, 8106, 8142, 8142
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11325-11418
+- Def site: line 11136-11229
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -809,11 +819,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11377, 11377, 11390, 11390, 18935, 18935, 18977, 18977, 18978, 18978, 18983, 18983, 18984, 18984
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11188, 11188, 11201, 11201, 18742, 18742, 18784, 18784, 18785, 18785, 18790, 18790, 18791, 18791
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5906-5995
+- Def site: line 5894-5983
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -823,13 +833,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5988, 5988, 15350, 15350, 15351, 15351, 15565, 18735, 18735
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 49
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 26, 138, 138, 139, 139
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5976, 5976, 15161, 15161, 15162, 15162, 15376, 18542, 18542
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 28, 143, 143, 144, 144
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12668-12752
+- Def site: line 12479-12563
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -839,11 +849,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12702, 12702, 18910, 18910, 18918, 18918, 18944, 18944, 19089, 19089
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12513, 12513, 18717, 18717, 18725, 18725, 18751, 18751, 18896, 18896
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 18028-18106
+- Def site: line 17835-17913
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -853,12 +863,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18023, 18023, 18024, 18024, 19184, 19184
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17830, 17830, 17831, 17831, 18991, 18991
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 17032-17109
+- Def site: line 16843-16920
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -868,12 +878,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19055, 19055, 19059, 19059, 19063, 19063
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18862, 18862, 18866, 18866, 18870, 18870
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1904-1977
+- Def site: line 1903-1976
 - References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -882,8 +892,8 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1917, 1917, 1949, 1949, 2294, 2294, 2321, 2321, 7606, 7606, 7692, 7692, 7822, 7822, 7899, 7899, 7982, 7982, 8212, 8212, 8401, 8401, 8457, 8457, 8470, 8470, 8487, 8487, 8532, 8532, 8563, 8563, 8569, 8569, 8672, 8672, 10213, 10213, 10480, 10982, 10982, 11011, 11011, 11276, 11276, 11482, 11482, 11721, 11721, 12437, 12437, 12453, 12453, 13240, 13240, 13659, 13659, 13709, 13709, 15563, 15765, 15765, 15798, 15798, 15816, 15816, 15834, 15834, 15862, 17059, 17059, 17084, 17084, 17127, 17226, 17226, 17438, 17438, 17581, 17581, 17688, 17688, 18018, 18018, 18048, 18048, 18069, 18069, 18088, 18088, 18104, 18104, 18682, 18682, 18702, 18702, 18737, 18737, 18750, 18750, 19218, 19218, 19309, 19309, 19314, 19314, 19320, 19320, 19339, 19339, 19345, 19345, 20945, 20945
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 549, 549
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1916, 1916, 1948, 1948, 2293, 2293, 2320, 2320, 7404, 7404, 7490, 7490, 7620, 7620, 7697, 7697, 7780, 7780, 8010, 8010, 8199, 8199, 8258, 8258, 8271, 8271, 8288, 8288, 8333, 8333, 8367, 8367, 8373, 8373, 8479, 8479, 10023, 10023, 10290, 10793, 10793, 10822, 10822, 11087, 11087, 11293, 11293, 11532, 11532, 12248, 12248, 12264, 12264, 13051, 13051, 13470, 13470, 13520, 13520, 15374, 15576, 15576, 15609, 15609, 15627, 15627, 15645, 15645, 15673, 16870, 16870, 16895, 16895, 16938, 17037, 17037, 17247, 17247, 17390, 17390, 17497, 17497, 17825, 17825, 17855, 17855, 17876, 17876, 17895, 17895, 17911, 17911, 18489, 18489, 18509, 18509, 18544, 18544, 18557, 18557, 19025, 19025, 19116, 19116, 19121, 19121, 19127, 19127, 19146, 19146, 19152, 19152, 20752, 20752
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\org_device_inventory_msp.py`: lines 27, 66, 82, 82, 107, 107, 220, 220
@@ -899,11 +909,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ui\execution\item_executor.py`: lines 224, 224
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\utils\input_utils.py`: lines 42, 42, 44, 44, 46, 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 14, 44, 452, 452, 512, 512, 609, 609, 690, 690, 706, 706, 717, 717, 729, 729, 742, 742
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 18, 63, 192, 192
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 18, 66, 197, 197
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15190-15261
+- Def site: line 15001-15072
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -912,11 +922,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19021, 19021, 19022, 19022, 19023, 19023, 19024, 19024
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18828, 18828, 18829, 18829, 18830, 18830, 18831, 18831
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5467-5536
+- Def site: line 5466-5535
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -926,11 +936,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5499, 5499, 5500, 5500, 5515, 5515, 5517, 5517
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5498, 5498, 5499, 5499, 5514, 5514, 5516, 5516
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 6001-6070
+- Def site: line 5989-6058
 - References: 182
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -938,17 +948,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6043, 6043, 6048, 6048, 6145, 6145, 6203, 6203, 7090, 7090, 7749, 7749, 8394, 8394, 8417, 8417, 8437, 8437, 8622, 8622, 8643, 8643, 8918, 8918, 8943, 8943, 8998, 8998, 9020, 9020, 9037, 9037, 9054, 9054, 9439, 9439, 9662, 9662, 9679, 9679, 10071, 10071, 10403, 10403, 10614, 10614, 10651, 10651, 10804, 10804, 10947, 10947, 11200, 11200, 11388, 11388, 11572, 11572, 11891, 11891, 12227, 12227, 12399, 12399, 12439, 12439, 12445, 12445, 12539, 12539, 12769, 12769, 12842, 12842, 13329, 13329, 13364, 13563, 13563, 15070, 15070, 15286, 15286, 15554, 15661, 15761, 15761, 15796, 15796, 15814, 15814, 15832, 15832, 17125, 18019, 18019, 18021, 18021, 18045, 18045, 18049, 18049, 18050, 18050, 18070, 18070, 18071, 18071, 18216, 18216, 18786, 18786, 18818, 18818, 18855, 18855, 18861, 18861, 18989, 18989, 19046, 19046, 19129, 19129, 19138, 19138, 19216, 19216, 19217, 19217, 19234, 19234, 19309, 19309, 19314, 19314, 19320, 19320, 19339, 19339, 19345, 19345, 20256, 20256, 20327, 20809, 20809, 20897, 20897
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 68, 245, 245, 555, 555, 556, 556
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 38, 401, 401, 448, 448, 466, 466, 507, 507, 541, 541
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 25, 316, 316
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6031, 6031, 6036, 6036, 6133, 6133, 6191, 6191, 7078, 7078, 7547, 7547, 8192, 8192, 8215, 8215, 8238, 8238, 8429, 8429, 8450, 8450, 8728, 8728, 8753, 8753, 8808, 8808, 8830, 8830, 8847, 8847, 8864, 8864, 9249, 9249, 9472, 9472, 9489, 9489, 9881, 9881, 10213, 10213, 10424, 10424, 10461, 10461, 10614, 10614, 10758, 10758, 11011, 11011, 11199, 11199, 11383, 11383, 11702, 11702, 12038, 12038, 12210, 12210, 12250, 12250, 12256, 12256, 12350, 12350, 12580, 12580, 12653, 12653, 13140, 13140, 13175, 13374, 13374, 14881, 14881, 15097, 15097, 15365, 15472, 15572, 15572, 15607, 15607, 15625, 15625, 15643, 15643, 16936, 17826, 17826, 17828, 17828, 17852, 17852, 17856, 17856, 17857, 17857, 17877, 17877, 17878, 17878, 18023, 18023, 18593, 18593, 18625, 18625, 18662, 18662, 18668, 18668, 18796, 18796, 18853, 18853, 18936, 18936, 18945, 18945, 19023, 19023, 19024, 19024, 19041, 19041, 19116, 19116, 19121, 19121, 19127, 19127, 19146, 19146, 19152, 19152, 20063, 20063, 20134, 20616, 20616, 20704, 20704
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 69, 246, 246, 556, 556, 557, 557
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 402, 402, 449, 449, 467, 467, 508, 508, 542, 542
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 27, 321, 321
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 15, 150, 150, 510, 510
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 12, 42, 86, 86
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 22, 67
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 24, 70
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10449-10517
+- Def site: line 10259-10327
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -959,11 +969,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10489, 10489, 10494, 10494, 10499, 10499, 10500, 10500, 10506, 10506, 10507, 10507, 10513, 10513, 10514, 10514, 10515, 10515, 10516, 10516, 19362, 19362
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10299, 10299, 10304, 10304, 10309, 10309, 10310, 10310, 10316, 10316, 10317, 10317, 10323, 10323, 10324, 10324, 10325, 10325, 10326, 10326, 19169, 19169
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 18741-18806
+- Def site: line 18548-18613
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -973,11 +983,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18789, 18789, 18797, 18797, 18806, 18806, 19335, 19335
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18596, 18596, 18604, 18604, 18613, 18613, 19142, 19142
 
 ### `GatewayTemplateConfigManager` (class, 56 lines)
 
-- Def site: line 15785-15840
+- Def site: line 15596-15651
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -987,11 +997,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18960, 18960, 18964, 18964, 19169, 19169
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18767, 18767, 18771, 18771, 18976, 18976
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6076-6122
+- Def site: line 6064-6110
 - References: 55
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1000,13 +1010,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6200, 6200, 8084, 8084, 8999, 8999, 9022, 9022, 9509, 9509, 9544, 9544, 9558, 9558, 9681, 9681, 9685, 9685, 10233, 10233, 12543, 12543, 13213, 13213, 13339, 13339, 13371, 13549, 13549, 13585, 13585, 15560, 17909, 17909, 18020, 18020, 18051, 18051, 18072, 18072, 19219, 19219, 19235, 19235, 20828, 20828
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 75, 557, 557
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 514, 514, 525, 525
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6188, 6188, 7882, 7882, 8809, 8809, 8832, 8832, 9319, 9319, 9354, 9354, 9368, 9368, 9491, 9491, 9495, 9495, 10043, 10043, 12354, 12354, 13024, 13024, 13150, 13150, 13182, 13360, 13360, 13396, 13396, 15371, 17716, 17716, 17827, 17827, 17858, 17858, 17879, 17879, 19026, 19026, 19042, 19042, 20635, 20635
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 76, 558, 558
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 515, 515, 526, 526
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5725-5770
+- Def site: line 5724-5769
 - References: 97
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1015,14 +1025,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5237, 5237, 5279, 5279, 5324, 5324, 5430, 5430, 5445, 5445, 5715, 5715, 5716, 5716, 5760, 5760, 6226, 6226, 7918, 7918, 9209, 9209, 9520, 9520, 9536, 9536, 9865, 9865, 10746, 10746, 10765, 10765, 12734, 15153, 15153, 15556, 15799, 15799, 15817, 15817, 15835, 15835, 15865, 16287, 16287, 16327, 16327, 16328, 16328, 16329, 16329, 17051, 17051, 17075, 17075, 17079, 17079, 17099, 17099, 17126, 17201, 17201, 17235, 17235, 17256, 17256, 17288, 17288, 17350, 17350, 17389, 17389, 17539, 17539, 17584, 17584
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 148, 148, 226, 226, 234, 234, 242, 242, 547, 547
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 31, 355, 355
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5236, 5236, 5278, 5278, 5323, 5323, 5429, 5429, 5444, 5444, 5714, 5714, 5715, 5715, 5759, 5759, 6214, 6214, 7716, 7716, 9019, 9019, 9330, 9330, 9346, 9346, 9675, 9675, 10556, 10556, 10575, 10575, 12545, 14964, 14964, 15367, 15610, 15610, 15628, 15628, 15646, 15646, 15676, 16098, 16098, 16138, 16138, 16139, 16139, 16140, 16140, 16862, 16862, 16886, 16886, 16890, 16890, 16910, 16910, 16937, 17012, 17012, 17046, 17046, 17067, 17067, 17099, 17099, 17161, 17161, 17200, 17200, 17348, 17348, 17393, 17393
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 149, 149, 227, 227, 235, 235, 243, 243, 548, 548
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 33, 360, 360
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 17115-17157
+- Def site: line 16926-16968
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1031,11 +1041,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17138, 17138, 17144, 17144, 17150, 17150, 17156, 17156, 19153, 19153, 19157, 19157, 19161, 19161, 19165, 19165
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16949, 16949, 16955, 16955, 16961, 16961, 16967, 16967, 18960, 18960, 18964, 18964, 18968, 18968, 18972, 18972
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11591-11630
+- Def site: line 11402-11441
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1044,11 +1054,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11628, 11628, 19359, 19359
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11439, 11439, 19166, 19166
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1868-1896
+- Def site: line 1867-1895
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1057,12 +1067,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8872, 8872, 8873, 8873, 8902, 8902, 8903, 8903, 8919, 8919, 8920, 8920, 9798, 9798, 9799, 9799, 10103, 10103, 10104, 10104, 10151, 10151, 10152, 10152, 10707, 10707, 10709, 10709, 10727, 10727, 10729, 10729, 11617, 11617, 11618, 11618, 12278, 12278, 12279, 12279, 12384, 12384, 12385, 12385, 13367
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 71, 206, 206, 207, 207
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8682, 8682, 8683, 8683, 8712, 8712, 8713, 8713, 8729, 8729, 8730, 8730, 9608, 9608, 9609, 9609, 9913, 9913, 9914, 9914, 9961, 9961, 9962, 9962, 10517, 10517, 10519, 10519, 10537, 10537, 10539, 10539, 11428, 11428, 11429, 11429, 12089, 12089, 12090, 12090, 12195, 12195, 12196, 12196, 13178
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 72, 207, 207, 208, 208
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15514-15541
+- Def site: line 15325-15352
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1071,12 +1081,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15528, 15528, 15534, 15534, 15540, 15540, 19067, 19067, 19071, 19071
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 198, 198, 242, 242, 245, 245, 261, 261, 303, 303, 306, 306, 322, 322, 324, 324, 325, 325, 332, 332, 342, 342, 345, 345, 346, 346, 353, 353, 372, 372, 381, 381, 382, 382, 383, 383, 400, 400, 401, 401, 454, 454
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15339, 15339, 15345, 15345, 15351, 15351, 18874, 18874, 18878, 18878
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 203, 203, 247, 247, 250, 250, 266, 266, 308, 308, 311, 311, 327, 327, 329, 329, 330, 330, 337, 337, 347, 347, 350, 350, 351, 351, 358, 358, 377, 377, 386, 386, 387, 387, 388, 388, 405, 405, 406, 406, 459, 459
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15851-15876
+- Def site: line 15662-15687
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1086,12 +1096,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15871, 15871, 15876, 15876, 19075, 19075, 19080, 19080
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15682, 15682, 15687, 15687, 18882, 18882, 18887, 18887
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13666-13687
+- Def site: line 13477-13498
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1100,7 +1110,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18841, 18841, 18845, 18845, 18849, 18849
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18648, 18648, 18652, 18652, 18656, 18656
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1110,17 +1120,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17567-17588
+- Def site: line 17376-17397
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18988, 18988, 19045, 19045, 19128, 19128, 19137, 19137
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18795, 18795, 18852, 18852, 18935, 18935, 18944, 18944
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 18004-18025
+- Def site: line 17811-17832
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1129,24 +1139,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19198, 19198
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19005, 19005
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
-
-### `execute_with_connection_pool_management` (function, 21 lines)
-
-- Def site: line 7556-7576
-- References: 7
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6309, 10076, 15399, 15564
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13912-13921
+- Def site: line 13723-13732
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1154,11 +1152,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13948, 14084, 14161, 14180, 14192, 14213, 14226, 14237, 14243, 14256, 14349, 14484, 14579
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13759, 13895, 13972, 13991, 14003, 14024, 14037, 14048, 14054, 14067, 14160, 14295, 14390
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 331-339
+- Def site: line 327-335
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1174,7 +1172,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 358-366
+- Def site: line 354-362
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1182,12 +1180,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15222, 15239, 15255
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15033, 15050, 15066
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 343-350
+- Def site: line 339-346
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1201,22 +1199,9 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\batch\interactive_batch_executor.py`: lines 104
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\batch\multi_host_runner.py`: lines 61, 84
 
-### `is_debug_mode` (function, 3 lines)
-
-- Def site: line 318-320
-- References: 12
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13372, 13661, 18053, 18074, 18203, 18234, 18266, 18501, 18516
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 32, 76, 337
-
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 635-637
+- Def site: line 634-636
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1224,33 +1209,21 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1245, 1914, 1914, 1914, 1926, 1932, 6202, 6322, 7378, 7440, 9608, 9719, 9973, 10803, 13374, 15432, 15474, 15572, 19221
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 34, 78, 162
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 56
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 36, 212, 255
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1244, 1913, 1913, 1913, 1925, 1931, 6190, 6310, 7366, 9418, 9529, 9783, 10613, 13185, 15243, 15285, 15383, 19028
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 35, 79, 163
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 58
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 41, 217, 260
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\template_config.py`: lines 401, 601, 640
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 509
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 727, 1068
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 579, 699, 707, 866, 1152, 1752
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\connection_pool_executor.py`: lines 137
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\wanprobe_config_manager.py`: lines 243, 363
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\audit_engine.py`: lines 56, 903, 905
 
-### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
-
-- Def site: line 2016-2018
-- References: 6
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] missing_inline_comments
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2016, 7388, 7395, 7396, 9984, 15421
-
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2030-2032
+- Def site: line 2029-2031
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1259,15 +1232,15 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2030, 15568
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 52, 543
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2029, 15379
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 54, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
 ## Skipped (1)
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 751-1755
+- Def site: line 750-1754
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1275,7 +1248,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1800
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1799
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

Refreshes `refactor_candidates.md` after PR #791 (SC-001/002/003) landed on main.

- tqdm skip-pin removes it from the ranked list
- IsDebugMode.check extraction retires the module-level is_debug_mode
- ConnectionPoolExecutor rename removes execute_with_connection_pool_management from the top-N

Analyzer summary: 80 defs (unused=0 single-use=1 low-use=2 hot=76 skipped=1).

## Test plan

- [x] `python -m tools.refactor_analyzer -q` regenerated cleanly on main
- [x] Diff limited to `refactor_candidates.md` only

Refs: specs/1012-misthelper-refactor-hot-functions/