### PR TITLE
fix: prevent --test hang in address-audit and repair systematic summary printer

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -20095,14 +20095,12 @@ def _print_systematic_summary(summary, telemetry_path):
     print()  # Blank line before summary.
     print("=" * 80)  # Visual separator for summary section.
     print(" Systematic Test Summary:")  # Label the results block.
-    print(f"   Successful operations: {summary.success_count}")  # Show successful count.
-    print(f"   Failed operations: {summary.error_count}")  # Show failure count.
-    print(f"   Skipped unsafe operations: {summary.skip_count}")  # Show skip count.
-    coverage_pct = summary.success_count / summary.total_ops * 100  # Coverage as a percent.
-    print(
-        f"   Total coverage: {summary.success_count}/{summary.total_ops} ({coverage_pct:.1f}%)"
-    )  # Show coverage percentage.
-    print(f"    Total execution time: {summary.total_time:.2f} seconds")  # Show total elapsed time.
+    print(f"   Successful operations: {summary.passed}")  # Show successful count.
+    print(f"   Failed operations: {summary.failed}")  # Show failure count.
+    print(f"   Skipped unsafe operations: {summary.skipped}")  # Show skip count.
+    coverage_pct = summary.passed / summary.total * 100 if summary.total else 0.0  # Coverage as a percent.
+    print(f"   Total coverage: {summary.passed}/{summary.total} ({coverage_pct:.1f}%)")  # Show coverage percentage.
+    print(f"    Total execution time: {summary.elapsed:.2f} seconds")  # Show total elapsed time.
     print(f"   Telemetry written to: {telemetry_path}")  # Tell operator where telemetry landed.
     print("   Detailed logs in: script.log")  # Remind operator of the log file location.
 

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -237,13 +237,19 @@ class AddressAuditEngine:
             return candidates[0]  # Use it without prompting.
         return self._prompt_csv_choice(candidates)  # Multiple -> ask the operator.
 
-    def _prompt_csv_choice(self, candidates: list[str]) -> str:
-        """Prompt the operator to choose one CSV from a numbered list."""
+    def _prompt_csv_choice(self, candidates: list[str]) -> str | None:
+        """Prompt the operator to choose one CSV from a numbered list; empty input aborts."""
         print("Available CSV files in data/:")  # Header for the choices.
         for index, path in enumerate(candidates, start=1):  # Enumerate options 1..N.
             print(f"  [{index}] {os.path.basename(path)}")  # Show each filename.
-        while True:  # Loop until a valid selection is made.
+        while True:  # Loop until a valid selection is made or the operator/EOF aborts.
             raw = InputUtils.safe_input("Select file number: ", context="address_audit_csv_pick").strip()
+            if (
+                not raw
+            ):  # Empty response (blank Enter or EOF sentinel from safe_input) -> abort so we cannot infinite-loop under non-interactive stdin (e.g. --test).  # noqa: E501
+                logging.info("No CSV selection made (empty input); skipping address audit")  # Action-log the abort.
+                print("No CSV selected. Skipping address audit.")  # Inform the operator (also covers non-TTY --test).
+                return None  # Caller treats None as "nothing to audit".
             if raw.isdigit() and 1 <= int(raw) <= len(candidates):  # Valid in-range integer.
                 return candidates[int(raw) - 1]  # Return the chosen path.
             print(f"Invalid selection. Please enter a number between 1 and {len(candidates)}: ")  # Re-prompt.
@@ -279,6 +285,13 @@ class AddressAuditEngine:
                 .strip()
                 .lower()
             )  # Normalize once for downstream comparisons.
+            if (
+                not raw
+            ):  # Empty response (blank Enter or EOF sentinel) is treated as explicit skip to avoid infinite loops under non-interactive stdin (e.g. --test).  # noqa: E501
+                logging.info(
+                    "Business-authoritative CSV selection skipped (empty input)"
+                )  # Action-log the implicit skip.
+                return None  # Proceed without authority data.
             picked = self._parse_business_csv_choice(raw, candidates)  # Interpret the raw operator entry.
             if picked is not _INVALID_CHOICE:  # Valid choice (path) or explicit skip (None) -> exit the retry loop.
                 return picked  # type: ignore[no-any-return]  # Sentinel guarantees str|None here.


### PR DESCRIPTION
## Summary

Two post-1012 verification bugs surfaced by `python MistHelper.py --test`:

- **Infinite loop** in `_prompt_csv_choice` / `_read_business_csv_selection` (`src/site/address_audit/audit_engine.py`) — `InputUtils.safe_input` returns `""` on EOF, which failed numeric validation and re-prompted forever under non-interactive stdin. Both methods now abort cleanly on empty input and return `None`, so the caller (already `None`-aware) skips the audit.
- **`AttributeError` in `_print_systematic_summary`** (`MistHelper.py:20093`) — printer used stale field names (`success_count`, `error_count`, `skip_count`, `total_ops`, `total_time`) that no longer exist on `TestSummary`; correct fields are `passed`, `failed`, `skipped`, `total`, `elapsed`. Also guarded coverage division against `total == 0`.

## Test plan
- [x] `python -m black --check` on both files
- [x] `python -m ruff check` on both files
- [x] `python MistHelper.py --test` → exit 0, summary prints cleanly: `66 passed / 0 failed / 131 skipped (33.5% coverage) in 215.39s`
- [x] Address-audit path now logs `"No CSV selection made (empty input); skipping address audit"` and returns instead of hanging