### PR TITLE
refactor(1013): remove GatewayTemplateConfigManager facade (SC-001, position 1)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/1012-misthelper-refactor-hot-functions"}
+{"feature_directory": "specs/1013-misthelper-refactor-hot-classes"}

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -142,6 +142,7 @@ from src.export.wifi_clients_exporter import WifiClientsExporter  # Import WiFi 
 from src.gateway.gateway_export_utils import (
     configure_gateway_export_utils_dependencies,
 )  # Import gateway export utility configuration
+from src.gateway.template_config import GatewayTemplateConfigManager  # Cat A canonical (1013 SC-001)
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
 from src.refactors.anomaly_metrics_discovery import (
     AnomalyMetricsDiscovery,  # Extracted anomaly metrics discovery (SC-016)
@@ -15589,66 +15590,9 @@ class TroubleshootUtils:  # Marvis troubleshoot delegators.
         ExtractedMarvisTroubleshootUtils._display_usage_guide()  # Delegate to the impl.
 
 
-# ============================================================================
-# GATEWAY TEMPLATE CONFIGURATION MANAGER CLASS
-# Delegated to src.gateway.template_config
-# ============================================================================
-class GatewayTemplateConfigManager:  # Gateway template config manager.
-    """Delegation stub. Implementation in src.gateway.template_config."""
-
-    @staticmethod
-    def extract():  # Extract a template.
-        """Menu 105: Extract DIA_Pico and Picocell configs. Delegated to src.gateway.template_config."""
-        from src.gateway.template_config import (
-            GatewayTemplateConfigManager as Impl,  # pylint: disable=import-outside-toplevel
-        )
-
-        Impl(  # Run the impl.
-            org_id=ConfigUtils.get_cached_or_prompted_org_id(),
-            apisession=apisession,
-            input_fn=InputUtils.safe_input,
-            get_csv_path_fn=FilePathUtils.get_csv_path,
-            save_data_fn=DataExporter.write_with_format_selection,
-            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
-            generate_sites_fn=OrgSiteExporter.sites,
-            sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename,
-        ).extract()
-
-    @staticmethod
-    def apply():  # Apply a template.
-        """Menu 106: Apply extracted configs. Delegated to src.gateway.template_config."""
-        from src.gateway.template_config import (
-            GatewayTemplateConfigManager as Impl,  # pylint: disable=import-outside-toplevel
-        )
-
-        Impl(  # Run the impl.
-            org_id=ConfigUtils.get_cached_or_prompted_org_id(),
-            apisession=apisession,
-            input_fn=InputUtils.safe_input,
-            get_csv_path_fn=FilePathUtils.get_csv_path,
-            save_data_fn=DataExporter.write_with_format_selection,
-            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
-            generate_sites_fn=OrgSiteExporter.sites,
-            sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename,
-        ).apply()
-
-    @staticmethod
-    def clone_by_location():  # Clone by location.
-        """Menu 111: Clone template by state/country. Delegated to src.gateway.template_config."""
-        from src.gateway.template_config import (
-            GatewayTemplateConfigManager as Impl,  # pylint: disable=import-outside-toplevel
-        )
-
-        Impl(  # Run the impl.
-            org_id=ConfigUtils.get_cached_or_prompted_org_id(),
-            apisession=apisession,
-            input_fn=InputUtils.safe_input,
-            get_csv_path_fn=FilePathUtils.get_csv_path,
-            save_data_fn=DataExporter.write_with_format_selection,
-            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
-            generate_sites_fn=OrgSiteExporter.sites,
-            sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename,
-        ).clone_by_location()
+# NOTE: GatewayTemplateConfigManager facade removed per 1013 SC-001 (Cat A, position 1).
+# Canonical class lives at src/gateway/template_config.py and is imported at top-of-file.
+# Menu 105/106/111 handlers construct it directly with 8 injected deps (see menu_actions).
 
 
 # NOTE: DeviceConfigTemplateClonerManager extracted per SC-020.
@@ -18517,15 +18461,6 @@ class BulkRadiusWLANConfigManager:
         logging.info("Bulk RADIUS WLAN Configuration completed successfully")  # Log completion.
 
 
-# NOTE: GatewayTemplateConfigManager class provides Menu 105, 106, 111 operations.
-# Located earlier in this file after TroubleshootUtils class.
-
-
-# The standalone functions extract_gateway_template_configuration(),
-# apply_gateway_template_configuration(), and clone_gateway_templates_by_state_and_country()
-# have been refactored into GatewayTemplateConfigManager class methods.
-
-
 # SiteAnalyticsConfigurator and SiteInventoryHealthAnalyzer were extracted to
 # src/analytics/site_analytics_configurator.py and
 # src/analytics/site_inventory_health_analyzer.py for phase-1 decomposition.
@@ -18764,11 +18699,29 @@ menu_actions = {
         " DESTRUCTIVE: Update Gateway Templates to Use WAN2 Variable - Replace hardcoded 'ge-0/0/1' references with {{wan2_interface}} variable (Requires uppercase 'MIGRATE' confirmation, supports --dry-run)",  # noqa: E501
     ),
     "150": (
-        GatewayTemplateConfigManager.extract,
+        lambda: GatewayTemplateConfigManager(
+            org_id=ConfigUtils.get_cached_or_prompted_org_id(),
+            apisession=apisession,
+            input_fn=InputUtils.safe_input,
+            get_csv_path_fn=FilePathUtils.get_csv_path,
+            save_data_fn=DataExporter.write_with_format_selection,
+            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
+            generate_sites_fn=OrgSiteExporter.sites,
+            sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename,
+        ).extract(),
         "Extract Gateway Template Configuration (DIA_Pico, Picocell) - Save specific configs to JSON for replication",
     ),
     "164": (
-        GatewayTemplateConfigManager.apply,
+        lambda: GatewayTemplateConfigManager(
+            org_id=ConfigUtils.get_cached_or_prompted_org_id(),
+            apisession=apisession,
+            input_fn=InputUtils.safe_input,
+            get_csv_path_fn=FilePathUtils.get_csv_path,
+            save_data_fn=DataExporter.write_with_format_selection,
+            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
+            generate_sites_fn=OrgSiteExporter.sites,
+            sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename,
+        ).apply(),
         " DESTRUCTIVE: Apply Gateway Template Configuration - Replicate extracted configs to other templates (Requires uppercase 'APPLY' confirmation)",  # noqa: E501
     ),
     "148": (
@@ -18973,7 +18926,16 @@ menu_actions = {
         " DESTRUCTIVE: Assign APs to Device Profiles matching their model type (AP-{model}) - Skips APs without matching profiles (Requires uppercase 'ASSIGN' confirmation)",  # noqa: E501
     ),
     "165": (
-        GatewayTemplateConfigManager.clone_by_location,
+        lambda: GatewayTemplateConfigManager(
+            org_id=ConfigUtils.get_cached_or_prompted_org_id(),
+            apisession=apisession,
+            input_fn=InputUtils.safe_input,
+            get_csv_path_fn=FilePathUtils.get_csv_path,
+            save_data_fn=DataExporter.write_with_format_selection,
+            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,
+            generate_sites_fn=OrgSiteExporter.sites,
+            sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename,
+        ).clone_by_location(),
         " DESTRUCTIVE: Clone Gateway Template by State and Country - Create state/country-specific templates and assign sites (Requires uppercase 'CLONE' confirmation)",  # noqa: E501
     ),
     "166": (

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -2,9 +2,9 @@
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
 - Module graph size: 201 first-party files
-- Definitions analyzed: 80
+- Definitions analyzed: 79
 - LOC saveable (unused + single-use): 3
-- Category counts: unused=0, single-use=1, low-use=2, hot=76, skipped=1
+- Category counts: unused=0, single-use=1, low-use=2, hot=75, skipped=1
 
 ## How to read this report
 
@@ -38,8 +38,8 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `OrgInventoryExporter` | class | 686 | 110 | hot |  | oversize_25_lines,missing_inline_comments |
 | `OrgConfigMigrationManager` | class | 675 | 4 | hot |  | oversize_25_lines |
 | `OrgExportUtils` | class | 653 | 128 | hot |  | oversize_25_lines,non_ascii_logs,hardcoded_separator |
+| `menu_actions` | assignment | 599 | 17 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `BulkRadiusWLANConfigManager` | class | 587 | 13 | hot |  | oversize_25_lines |
-| `menu_actions` | assignment | 572 | 17 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `OrgTicketManager` | class | 475 | 66 | hot |  | oversize_25_lines |
 | `OperationRegistry` | class | 461 | 9 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `PromptUtils` | class | 441 | 117 | hot |  | oversize_25_lines |
@@ -92,7 +92,6 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `ConfigUtils` | class | 70 | 182 | hot |  | oversize_25_lines |
 | `OrgDeviceInventorySummary` | class | 69 | 22 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging,non_ascii_logs |
 | `AuditAnalysisOps` | class | 66 | 8 | hot |  | oversize_25_lines,missing_inline_comments,raw_input_call |
-| `GatewayTemplateConfigManager` | class | 56 | 6 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `APICoreFetchUtils` | class | 47 | 55 | hot |  | oversize_25_lines,missing_inline_comments |
 | `FilePathUtils` | class | 46 | 97 | hot |  | oversize_25_lines,missing_inline_comments |
 | `SiteConfigManager` | class | 43 | 16 | hot |  | oversize_25_lines,missing_action_logging |
@@ -117,7 +116,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2018-2020
+- Def site: line 2019-2021
 - References: 1
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -125,13 +124,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2018
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2019
 
 ## Low-Use (2)
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2127-2151
+- Def site: line 2128-2152
 - References: 3
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -139,11 +138,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2257, 17526, 20459
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2258, 17470, 20419
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2015-2017
+- Def site: line 2016-2018
 - References: 3
 - Suggested class: `FastModeMaxConcurrentConnectionsManager`
 - Suggested module: `src/refactors/fast__mode__max__concurrent__connections.py`
@@ -152,13 +151,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2015, 9794, 15232
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2016, 9795, 15233
 
-## Hot (76)
+## Hot (75)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2865-5191
+- Def site: line 2866-5192
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -169,11 +168,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2865, 6555, 6556, 6565, 6729
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2866, 6556, 6557, 6566, 6730
 
 ### `ConstDefinitionsExporter` (class, 759 lines)
 
-- Def site: line 13735-14493
+- Def site: line 13736-14494
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -182,11 +181,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14212, 14212, 14224, 14224, 14252, 14252, 14264, 14264, 14325, 14325, 14362, 14362, 14519, 18899
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14213, 14213, 14225, 14225, 14253, 14253, 14265, 14265, 14326, 14326, 14363, 14363, 14520, 18852
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 8880-9565
+- Def site: line 8881-9566
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -195,12 +194,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5577, 5577, 9003, 9003, 9054, 9054, 9057, 9057, 9098, 9098, 9137, 9137, 9155, 9155, 9233, 9233, 9240, 9240, 9250, 9250, 9253, 9253, 9266, 9266, 9267, 9267, 9268, 9268, 9269, 9269, 9277, 9277, 9279, 9279, 9280, 9280, 9281, 9281, 9282, 9282, 9285, 9285, 9288, 9288, 9291, 9291, 9294, 9294, 9340, 9340, 9363, 9363, 9364, 9364, 9365, 9365, 9367, 9367, 9403, 9403, 9419, 9419, 9473, 9473, 9474, 9474, 9475, 9475, 9478, 9478, 9479, 9479, 9498, 9498, 9500, 9500, 9501, 9501, 9536, 9536, 14888, 14888, 14941, 14941, 15372, 16864, 16864, 16888, 16888, 16912, 16912, 17055, 17055, 18674, 18674, 18681, 18681, 18690, 18690, 18694, 18694, 18703, 18703
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5578, 5578, 9004, 9004, 9055, 9055, 9058, 9058, 9099, 9099, 9138, 9138, 9156, 9156, 9234, 9234, 9241, 9241, 9251, 9251, 9254, 9254, 9267, 9267, 9268, 9268, 9269, 9269, 9270, 9270, 9278, 9278, 9280, 9280, 9281, 9281, 9282, 9282, 9283, 9283, 9286, 9286, 9289, 9289, 9292, 9292, 9295, 9295, 9341, 9341, 9364, 9364, 9365, 9365, 9366, 9366, 9368, 9368, 9404, 9404, 9420, 9420, 9474, 9474, 9475, 9475, 9476, 9476, 9479, 9479, 9480, 9480, 9499, 9499, 9501, 9501, 9502, 9502, 9537, 9537, 14889, 14889, 14942, 14942, 15373, 16808, 16808, 16832, 16832, 16856, 16856, 16999, 16999, 18609, 18609, 18616, 18616, 18625, 18625, 18629, 18629, 18638, 18638
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 295, 295, 343, 343, 499, 499
 
 ### `OrgConfigMigrationManager` (class, 675 lines)
 
-- Def site: line 16163-16837
+- Def site: line 16107-16781
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -208,11 +207,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16551, 16551, 19145, 19151
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16495, 16495, 19107, 19113
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 11614-12266
+- Def site: line 11615-12267
 - References: 128
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -222,23 +221,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10390, 10390, 10399, 10399, 10487, 10487, 10494, 10494, 11169, 11169, 11455, 11455, 11460, 11460, 11467, 11467, 11472, 11472, 11686, 11686, 11708, 11708, 11711, 11711, 11737, 11737, 11746, 11746, 11747, 11747, 11768, 11768, 11811, 11811, 11857, 11857, 11868, 11868, 11895, 11895, 11900, 11900, 11901, 11901, 11902, 11902, 11934, 11934, 11940, 11940, 11965, 11965, 11985, 11985, 12020, 12020, 12035, 12035, 12041, 12041, 12043, 12043, 12046, 12046, 12048, 12048, 12052, 12052, 12056, 12056, 12061, 12061, 12068, 12068, 12075, 12075, 12082, 12082, 12091, 12091, 12101, 12101, 12108, 12108, 12115, 12115, 12122, 12122, 12129, 12129, 12136, 12136, 12146, 12146, 12155, 12155, 12164, 12164, 12173, 12173, 12182, 12182, 12211, 12211, 18635, 18635, 18816, 18816, 18893, 18893, 18894, 18894, 18902, 18902, 19107, 19107, 19108, 19108, 19127, 19127, 19134, 19134, 19135, 19135, 19136, 19136, 19137, 19137
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10391, 10391, 10400, 10400, 10488, 10488, 10495, 10495, 11170, 11170, 11456, 11456, 11461, 11461, 11468, 11468, 11473, 11473, 11687, 11687, 11709, 11709, 11712, 11712, 11738, 11738, 11747, 11747, 11748, 11748, 11769, 11769, 11812, 11812, 11858, 11858, 11869, 11869, 11896, 11896, 11901, 11901, 11902, 11902, 11903, 11903, 11935, 11935, 11941, 11941, 11966, 11966, 11986, 11986, 12021, 12021, 12036, 12036, 12042, 12042, 12044, 12044, 12047, 12047, 12049, 12049, 12053, 12053, 12057, 12057, 12062, 12062, 12069, 12069, 12076, 12076, 12083, 12083, 12092, 12092, 12102, 12102, 12109, 12109, 12116, 12116, 12123, 12123, 12130, 12130, 12137, 12137, 12147, 12147, 12156, 12156, 12165, 12165, 12174, 12174, 12183, 12183, 12212, 12212, 18570, 18570, 18769, 18769, 18846, 18846, 18847, 18847, 18855, 18855, 19069, 19069, 19070, 19070, 19089, 19089, 19096, 19096, 19097, 19097, 19098, 19098, 19099, 19099
 
-### `BulkRadiusWLANConfigManager` (class, 587 lines)
+### `menu_actions` (assignment, 599 lines)
 
-- Def site: line 17931-18517
-- References: 13
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18208, 18208, 18209, 18209, 18212, 18212, 18214, 18214, 18216, 18216, 18232, 18232, 19052
-
-### `menu_actions` (assignment, 572 lines)
-
-- Def site: line 18616-19187
+- Def site: line 18551-19149
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -248,12 +235,24 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18616, 19901, 19902, 19911, 20031, 20031, 20073, 20131, 20176, 20667, 20671, 20716, 20716, 20743, 20743, 20746
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18551, 19863, 19864, 19873, 19993, 19993, 20035, 20091, 20136, 20627, 20631, 20676, 20676, 20703, 20703, 20706
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
+
+### `BulkRadiusWLANConfigManager` (class, 587 lines)
+
+- Def site: line 17875-18461
+- References: 13
+- Suggested class: _n/a_
+- Suggested module: _n/a_
+- Rationale: Widely used; leave in place until dependencies decouple
+- Guideline flags (address during the move):
+  - [ ] oversize_25_lines
+- Reference sites (one PR cluster per file):
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18152, 18152, 18153, 18153, 18156, 18156, 18158, 18158, 18160, 18160, 18176, 18176, 19014
 
 ### `OrgTicketManager` (class, 475 lines)
 
-- Def site: line 8152-8626
+- Def site: line 8153-8627
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -261,11 +260,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8193, 8193, 8198, 8198, 8208, 8208, 8216, 8216, 8221, 8221, 8226, 8226, 8239, 8239, 8244, 8244, 8249, 8249, 8269, 8269, 8279, 8279, 8280, 8280, 8283, 8283, 8313, 8313, 8402, 8402, 8404, 8404, 8431, 8431, 8437, 8437, 8442, 8442, 8451, 8451, 8455, 8455, 8474, 8474, 8477, 8477, 8488, 8488, 8489, 8489, 8587, 8587, 8608, 8608, 19175, 19175, 19176, 19176, 19177, 19177, 19178, 19178, 19179, 19179, 19180, 19180
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8194, 8194, 8199, 8199, 8209, 8209, 8217, 8217, 8222, 8222, 8227, 8227, 8240, 8240, 8245, 8245, 8250, 8250, 8270, 8270, 8280, 8280, 8281, 8281, 8284, 8284, 8314, 8314, 8403, 8403, 8405, 8405, 8432, 8432, 8438, 8438, 8443, 8443, 8452, 8452, 8456, 8456, 8475, 8475, 8478, 8478, 8489, 8489, 8490, 8490, 8588, 8588, 8609, 8609, 19137, 19137, 19138, 19138, 19139, 19139, 19140, 19140, 19141, 19141, 19142, 19142
 
 ### `OperationRegistry` (class, 461 lines)
 
-- Def site: line 19412-19872
+- Def site: line 19374-19834
 - References: 9
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -275,11 +274,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19879, 19879, 19883, 19883, 19903, 19903, 19908, 19908, 20132
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19841, 19841, 19845, 19845, 19865, 19865, 19870, 19870, 20092
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7599-8039
+- Def site: line 7600-8040
 - References: 117
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -287,14 +286,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7544, 7544, 7560, 7560, 7564, 7564, 7565, 7565, 7566, 7566, 7581, 7581, 7587, 7587, 7614, 7614, 7617, 7617, 7625, 7625, 7643, 7643, 7693, 7693, 7701, 7701, 7706, 7706, 7752, 7752, 7763, 7763, 7788, 7788, 7807, 7807, 7808, 7808, 7811, 7811, 7812, 7812, 7902, 7902, 7904, 7904, 7908, 7908, 7936, 7936, 7937, 7937, 7938, 7938, 7939, 7939, 7940, 7940, 7949, 7949, 7993, 7993, 8017, 8017, 12346, 12346, 12396, 12396, 12401, 12401, 12544, 12627, 12627, 12681, 12681, 12702, 12702, 12707, 12707, 12971, 12971, 13174, 13376, 13376, 13463, 13463, 13468, 13468, 13518, 13518, 13519, 13519, 15015, 15015, 15474, 16871, 16871, 17391, 17391, 18540, 18540, 18541, 18541, 18827, 18827
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7545, 7545, 7561, 7561, 7565, 7565, 7566, 7566, 7567, 7567, 7582, 7582, 7588, 7588, 7615, 7615, 7618, 7618, 7626, 7626, 7644, 7644, 7694, 7694, 7702, 7702, 7707, 7707, 7753, 7753, 7764, 7764, 7789, 7789, 7808, 7808, 7809, 7809, 7812, 7812, 7813, 7813, 7903, 7903, 7905, 7905, 7909, 7909, 7937, 7937, 7938, 7938, 7939, 7939, 7940, 7940, 7941, 7941, 7950, 7950, 7994, 7994, 8018, 8018, 12347, 12347, 12397, 12397, 12402, 12402, 12545, 12628, 12628, 12682, 12682, 12703, 12703, 12708, 12708, 12972, 12972, 13175, 13377, 13377, 13464, 13464, 13469, 13469, 13519, 13519, 13520, 13520, 15016, 15016, 15475, 16815, 16815, 17335, 17335, 18475, 18475, 18476, 18476, 18780, 18780
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 68, 196, 196
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 65, 127, 127, 132, 132
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 9568-9981
+- Def site: line 9569-9982
 - References: 58
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -303,11 +302,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5571, 5571, 9601, 9601, 9685, 9685, 9691, 9691, 9694, 9694, 9738, 9738, 9752, 9752, 9779, 9779, 9785, 9785, 9799, 9799, 9882, 9882, 9884, 9884, 9888, 9888, 9890, 9890, 9893, 9893, 9897, 9897, 9900, 9900, 9910, 9910, 9916, 9916, 9954, 9954, 14889, 14889, 14890, 14890, 14891, 14891, 14942, 14942, 14943, 14943, 18675, 18675, 18676, 18676, 18677, 18677, 18701, 18701
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5572, 5572, 9602, 9602, 9686, 9686, 9692, 9692, 9695, 9695, 9739, 9739, 9753, 9753, 9780, 9780, 9786, 9786, 9800, 9800, 9883, 9883, 9885, 9885, 9889, 9889, 9891, 9891, 9894, 9894, 9898, 9898, 9901, 9901, 9911, 9911, 9917, 9917, 9955, 9955, 14890, 14890, 14891, 14891, 14892, 14892, 14943, 14943, 14944, 14944, 18610, 18610, 18611, 18611, 18612, 18612, 18636, 18636
 
 ### `DeviceRebootManager` (class, 396 lines)
 
-- Def site: line 16974-17369
+- Def site: line 16918-17313
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -316,11 +315,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16995, 16995, 17000, 17000, 17004, 17004, 17007, 17007, 17014, 17014, 17016, 17016, 17017, 17017, 17020, 17020, 17023, 17023, 17026, 17026, 17068, 17068, 17100, 17100, 17167, 17167, 17180, 17180, 17185, 17185, 17235, 17235, 17268, 17268, 17269, 17269, 17270, 17270, 17300, 17300, 17329, 17329, 17330, 17330, 18858, 18858
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16939, 16939, 16944, 16944, 16948, 16948, 16951, 16951, 16958, 16958, 16960, 16960, 16961, 16961, 16964, 16964, 16967, 16967, 16970, 16970, 17012, 17012, 17044, 17044, 17111, 17111, 17124, 17124, 17129, 17129, 17179, 17179, 17212, 17212, 17213, 17213, 17214, 17214, 17244, 17244, 17273, 17273, 17274, 17274, 18811, 18811
 
 ### `MSPInventoryExporter` (class, 386 lines)
 
-- Def site: line 17423-17808
+- Def site: line 17367-17752
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -330,11 +329,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17450, 17594, 17594, 18998, 18998
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17394, 17538, 17538, 18960, 18960
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6696-7040
+- Def site: line 6697-7041
 - References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -343,7 +342,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5667, 5667, 6742, 6742, 6758, 6758, 6759, 6759, 6782, 6782, 6784, 6784, 6787, 6787, 6801, 6801, 6803, 6803, 6812, 6812, 6814, 6814, 6815, 6815, 6821, 6821, 6822, 6822, 6822, 6839, 6839, 6843, 6843, 6885, 6885, 6916, 6916, 6919, 6919, 6921, 6921, 6967, 6967, 6977, 6977, 7010, 7010, 7015, 7015, 7022, 7022, 7244, 7244, 7276, 7276, 7287, 7287, 7312, 7312, 7332, 7332, 7656, 7656, 8458, 8458, 8740, 8740, 8755, 8819, 8819, 8836, 8836, 8854, 8854, 8875, 8875, 9434, 9434, 9509, 9509, 9839, 9839, 10190, 10190, 10275, 10291, 10411, 10411, 10415, 10415, 10435, 10435, 10448, 10448, 10452, 10452, 10470, 10470, 10632, 10632, 10980, 10980, 11127, 11127, 11204, 11204, 11208, 11208, 11213, 11213, 11346, 11346, 11365, 11365, 11416, 11416, 11419, 11419, 11570, 11570, 11573, 11573, 11672, 11672, 11678, 11678, 11975, 11975, 11992, 11992, 12007, 12007, 12221, 12221, 12249, 12249, 12265, 12265, 12302, 12302, 12340, 12340, 12429, 12429, 12458, 12458, 12496, 12496, 12547, 12612, 12612, 12618, 12618, 12660, 12660, 12829, 12829, 12835, 12835, 12954, 12954, 12962, 12962, 13126, 13126, 13177, 13350, 13350, 13521, 13521, 14034, 14034, 14395, 14395, 14401, 14401, 15309, 15309, 15368, 15475, 15611, 15611, 15629, 15629, 15647, 15647, 16918, 16918, 16939, 17774, 17774, 17859, 17859, 17880, 17880, 18366, 18366, 19027, 19027, 19043, 19043
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5668, 5668, 6743, 6743, 6759, 6759, 6760, 6760, 6783, 6783, 6785, 6785, 6788, 6788, 6802, 6802, 6804, 6804, 6813, 6813, 6815, 6815, 6816, 6816, 6822, 6822, 6823, 6823, 6823, 6840, 6840, 6844, 6844, 6886, 6886, 6917, 6917, 6920, 6920, 6922, 6922, 6968, 6968, 6978, 6978, 7011, 7011, 7016, 7016, 7023, 7023, 7245, 7245, 7277, 7277, 7288, 7288, 7313, 7313, 7333, 7333, 7657, 7657, 8459, 8459, 8741, 8741, 8756, 8820, 8820, 8837, 8837, 8855, 8855, 8876, 8876, 9435, 9435, 9510, 9510, 9840, 9840, 10191, 10191, 10276, 10292, 10412, 10412, 10416, 10416, 10436, 10436, 10449, 10449, 10453, 10453, 10471, 10471, 10633, 10633, 10981, 10981, 11128, 11128, 11205, 11205, 11209, 11209, 11214, 11214, 11347, 11347, 11366, 11366, 11417, 11417, 11420, 11420, 11571, 11571, 11574, 11574, 11673, 11673, 11679, 11679, 11976, 11976, 11993, 11993, 12008, 12008, 12222, 12222, 12250, 12250, 12266, 12266, 12303, 12303, 12341, 12341, 12430, 12430, 12459, 12459, 12497, 12497, 12548, 12613, 12613, 12619, 12619, 12661, 12661, 12830, 12830, 12836, 12836, 12955, 12955, 12963, 12963, 13127, 13127, 13178, 13351, 13351, 13522, 13522, 14035, 14035, 14396, 14396, 14402, 14402, 15310, 15310, 15369, 15476, 16862, 16862, 16883, 17718, 17718, 17803, 17803, 17824, 17824, 18310, 18310, 18707, 18707, 18720, 18720, 18934, 18934, 18989, 18989, 19005, 19005
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 71, 188, 188, 286, 286, 294, 294, 363, 363, 392, 392, 544, 544, 559, 559
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 380, 380, 440, 440, 457, 457, 476, 476, 549, 549
@@ -354,7 +353,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 12668-13008
+- Def site: line 12669-13009
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -363,11 +362,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12685, 12685, 12687, 12687, 12691, 12691, 12692, 12692, 12706, 12706, 12712, 12712, 12715, 12715, 12718, 12718, 12776, 12776, 12782, 12782, 12787, 12787, 12801, 12801, 12819, 12819, 12929, 12929, 12933, 12933, 12935, 12935, 12938, 12938, 12975, 12975, 12980, 12980, 12994, 12994, 12998, 12998, 13000, 13000, 13003, 13003, 13008, 13008, 18904, 18904, 18908, 18908, 18912, 18912
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12686, 12686, 12688, 12688, 12692, 12692, 12693, 12693, 12707, 12707, 12713, 12713, 12716, 12716, 12719, 12719, 12777, 12777, 12783, 12783, 12788, 12788, 12802, 12802, 12820, 12820, 12930, 12930, 12934, 12934, 12936, 12936, 12939, 12939, 12976, 12976, 12981, 12981, 12995, 12995, 12999, 12999, 13001, 13001, 13004, 13004, 13009, 13009, 18857, 18857, 18861, 18861, 18865, 18865
 
 ### `APIDataFetcher` (class, 328 lines)
 
-- Def site: line 7043-7370
+- Def site: line 7044-7371
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -375,11 +374,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7145, 7145, 8173, 8666, 8685, 8786, 8915, 8938, 9610, 9918, 9963, 10377, 11148, 11159, 11222, 11639
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7146, 7146, 8174, 8667, 8686, 8787, 8916, 8939, 9611, 9919, 9964, 10378, 11149, 11160, 11223, 11640
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 14499-14826
+- Def site: line 14500-14827
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -389,13 +388,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11956, 11956, 12015, 12015, 12016, 12016, 13180, 14540, 14540, 14542, 14542, 14548, 14548, 14562, 14562, 14601, 14601, 14604, 14604, 14606, 14606, 14607, 14607, 14608, 14608, 14662, 14662, 14663, 14663, 14674, 14674, 14683, 14683, 14702, 14702, 14754, 14754, 14758, 14758, 14766, 14766, 14767, 14767, 14791, 14791, 14795, 14795
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11957, 11957, 12016, 12016, 12017, 12017, 13181, 14541, 14541, 14543, 14543, 14549, 14549, 14563, 14563, 14602, 14602, 14605, 14605, 14607, 14607, 14608, 14608, 14609, 14609, 14663, 14663, 14664, 14664, 14675, 14675, 14684, 14684, 14703, 14703, 14755, 14755, 14759, 14759, 14767, 14767, 14768, 14768, 14792, 14792, 14796, 14796
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 74
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 15859-16147
+- Def site: line 15803-16091
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -405,11 +404,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15887, 15887, 15890, 15890, 15895, 15895, 15898, 15898, 15942, 15942, 15948, 15948, 15979, 15979, 15982, 15982, 15986, 15986, 16012, 16012, 16029, 16029, 16035, 16035, 16049, 16049, 16050, 16050, 16052, 16052, 16058, 16058, 16065, 16065, 16074, 16074, 16121, 16121, 16143, 16143, 16144, 16144, 16145, 16145, 18849, 18849
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15831, 15831, 15834, 15834, 15839, 15839, 15842, 15842, 15886, 15886, 15892, 15892, 15923, 15923, 15926, 15926, 15930, 15930, 15956, 15956, 15973, 15973, 15979, 15979, 15993, 15993, 15994, 15994, 15996, 15996, 16002, 16002, 16009, 16009, 16018, 16018, 16065, 16065, 16087, 16087, 16088, 16088, 16089, 16089, 18802, 18802
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 9984-10256
+- Def site: line 9985-10257
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -418,11 +417,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10007, 10007, 10008, 10008, 10021, 10021, 10022, 10022, 10024, 10024, 10025, 10025, 10028, 10028, 10031, 10031, 10035, 10035, 10036, 10036, 10112, 10112, 10116, 10116, 10119, 10119, 10132, 10132, 10169, 10169, 10186, 10186, 10199, 10199, 10201, 10201, 10208, 10208, 10217, 10217, 10226, 10226, 10227, 10227, 10238, 10238, 10242, 10242, 10251, 10251, 10256, 10256, 19106, 19106
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10008, 10008, 10009, 10009, 10022, 10022, 10023, 10023, 10025, 10025, 10026, 10026, 10029, 10029, 10032, 10032, 10036, 10036, 10037, 10037, 10113, 10113, 10117, 10117, 10120, 10120, 10133, 10133, 10170, 10170, 10187, 10187, 10200, 10200, 10202, 10202, 10209, 10209, 10218, 10218, 10227, 10227, 10228, 10228, 10239, 10239, 10243, 10243, 10252, 10252, 10257, 10257, 19068, 19068
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5197-5460
+- Def site: line 5198-5461
 - References: 106
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -430,14 +429,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5237, 5237, 5239, 5239, 5321, 5321, 5327, 5327, 5364, 5364, 5366, 5366, 5375, 5375, 5385, 5385, 5395, 5395, 5431, 5431, 7692, 7692, 9362, 9362, 9363, 9363, 9674, 9674, 10520, 10520, 10540, 10540, 12542, 14948, 14948, 14954, 14954, 14955, 14955, 14956, 14956, 14957, 14957, 14958, 14958, 14959, 14959, 14966, 14966, 14994, 14994, 15366, 15612, 15612, 15630, 15630, 15648, 15648, 15674, 16863, 16863, 16887, 16887, 16911, 16911, 17055, 17055, 17056, 17056, 17057, 17057, 17058, 17058, 17392, 17392, 18591, 18591, 19143, 19143
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5238, 5238, 5240, 5240, 5322, 5322, 5328, 5328, 5365, 5365, 5367, 5367, 5376, 5376, 5386, 5386, 5396, 5396, 5432, 5432, 7693, 7693, 9363, 9363, 9364, 9364, 9675, 9675, 10521, 10521, 10541, 10541, 12543, 14949, 14949, 14955, 14955, 14956, 14956, 14957, 14957, 14958, 14958, 14959, 14959, 14960, 14960, 14967, 14967, 14995, 14995, 15367, 15618, 16807, 16807, 16831, 16831, 16855, 16855, 16999, 16999, 17000, 17000, 17001, 17001, 17002, 17002, 17336, 17336, 18526, 18526, 18708, 18708, 18721, 18721, 18935, 18935, 19105, 19105
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 339, 339, 341, 341, 343, 343, 345, 345, 499, 499, 500, 500, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32, 336, 336, 357, 357
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 10752-11002
+- Def site: line 10753-11003
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -447,11 +446,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10759, 10759, 10762, 10762, 10767, 10767, 10768, 10768, 10776, 10776, 10779, 10779, 10787, 10787, 10827, 10827, 10835, 10835, 10883, 10883, 10900, 10900, 10903, 10903, 10905, 10905, 10969, 10969, 10970, 10970, 19109, 19109
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10760, 10760, 10763, 10763, 10768, 10768, 10769, 10769, 10777, 10777, 10780, 10780, 10788, 10788, 10828, 10828, 10836, 10836, 10884, 10884, 10901, 10901, 10904, 10904, 10906, 10906, 10970, 10970, 10971, 10971, 19071, 19071
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 15078-15322
+- Def site: line 15079-15323
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -461,11 +460,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14944, 14944, 15104, 15104, 15106, 15106, 15107, 15107, 15108, 15108, 15136, 15136, 15141, 15141, 15163, 15163, 15164, 15164, 15206, 15206, 15214, 15214, 15240, 15240, 15249, 15249, 15257, 15257, 15288, 15288, 18680, 18680, 18684, 18684
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14945, 14945, 15105, 15105, 15107, 15107, 15108, 15108, 15109, 15109, 15137, 15137, 15142, 15142, 15164, 15164, 15165, 15165, 15207, 15207, 15215, 15215, 15241, 15241, 15250, 15250, 15258, 15258, 15289, 15289, 18615, 18615, 18619, 18619
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 6119-6339
+- Def site: line 6120-6340
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -473,14 +472,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6142, 6142, 6193, 6193, 6263, 6263, 6287, 6287, 6299, 6299, 6301, 6301, 6311, 6311, 6326, 6326, 6330, 6330, 6331, 6331, 6334, 6334, 6336, 6336, 12655, 12655, 15370
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6143, 6143, 6194, 6194, 6264, 6264, 6288, 6288, 6300, 6300, 6302, 6302, 6312, 6312, 6327, 6327, 6331, 6331, 6332, 6332, 6335, 6335, 6337, 6337, 12656, 12656, 15371
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 450, 450
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 25, 71
 
 ### `TelemetryEmitter` (class, 214 lines)
 
-- Def site: line 19193-19406
+- Def site: line 19155-19368
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -489,11 +488,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20049, 20049, 20052, 20133, 20484
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 20011, 20011, 20014, 20093, 20444
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 7383-7592
+- Def site: line 7384-7593
 - References: 31
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -502,11 +501,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7396, 7396, 7402, 7402, 7403, 7403, 7406, 7406, 7429, 7429, 7432, 7432, 7435, 7435, 7436, 7436, 7438, 7438, 7505, 7505, 7549, 7549, 8014, 8014, 12976, 12976, 15473, 15712, 15712, 15872, 15872
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7397, 7397, 7403, 7403, 7404, 7404, 7407, 7407, 7430, 7430, 7433, 7433, 7436, 7436, 7437, 7437, 7439, 7439, 7506, 7506, 7550, 7550, 8015, 8015, 12977, 12977, 15474, 15656, 15656, 15816, 15816
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 12274-12476
+- Def site: line 12275-12477
 - References: 30
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -515,11 +514,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12295, 12295, 12304, 12304, 12366, 12366, 12373, 12373, 12405, 12405, 12407, 12407, 12431, 12431, 12466, 12466, 12473, 12473, 12504, 12504, 15018, 15018, 18716, 18716, 18718, 18718, 18719, 18719, 18721, 18721
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12296, 12296, 12305, 12305, 12367, 12367, 12374, 12374, 12406, 12406, 12408, 12408, 12432, 12432, 12467, 12467, 12474, 12474, 12505, 12505, 15019, 15019, 18651, 18651, 18653, 18653, 18654, 18654, 18656, 18656
 
 ### `DeviceUtilityCommands` (class, 188 lines)
 
-- Def site: line 13527-13714
+- Def site: line 13528-13715
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -529,11 +528,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19066, 19066, 19067, 19067, 19068, 19068, 19069, 19069, 19070, 19070, 19071, 19071, 19072, 19072, 19073, 19073, 19075, 19075, 19076, 19076, 19077, 19077, 19078, 19078, 19079, 19079, 19080, 19080, 19081, 19081, 19083, 19083, 19084, 19084, 19085, 19085, 19086, 19086, 19087, 19087, 19088, 19088, 19089, 19089, 19090, 19090, 19091, 19091, 19093, 19093, 19094, 19094, 19095, 19095, 19096, 19096, 19097, 19097, 19098, 19098, 19099, 19099, 19100, 19100, 19101, 19101, 19103, 19103, 19104, 19104
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19028, 19028, 19029, 19029, 19030, 19030, 19031, 19031, 19032, 19032, 19033, 19033, 19034, 19034, 19035, 19035, 19037, 19037, 19038, 19038, 19039, 19039, 19040, 19040, 19041, 19041, 19042, 19042, 19043, 19043, 19045, 19045, 19046, 19046, 19047, 19047, 19048, 19048, 19049, 19049, 19050, 19050, 19051, 19051, 19052, 19052, 19053, 19053, 19055, 19055, 19056, 19056, 19057, 19057, 19058, 19058, 19059, 19059, 19060, 19060, 19061, 19061, 19062, 19062, 19063, 19063, 19065, 19065, 19066, 19066
 
 ### `SFPTransceiverDataProcessor` (class, 180 lines)
 
-- Def site: line 5542-5721
+- Def site: line 5543-5722
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -542,11 +541,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5630, 5630, 5667, 5667, 5669, 5669, 5672, 5672, 5680, 5680, 5682, 5682, 5684, 5684, 5687, 5687, 5716, 5716, 5719, 5719, 18843, 18843
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5631, 5631, 5668, 5668, 5670, 5670, 5673, 5673, 5681, 5681, 5683, 5683, 5685, 5685, 5688, 5688, 5717, 5717, 5720, 5720, 18796, 18796
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6515-6693
+- Def site: line 6516-6694
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -554,11 +553,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6560, 6560, 6598, 6598, 6609, 6609, 6635, 6635, 6636, 6636, 6638, 6638, 6644, 6644, 6645, 6645, 6648, 6648, 6654, 6654, 6655, 6655, 6658, 6658, 6660, 6660, 6670, 6670, 6672, 6672, 6673, 6673, 6675, 6675
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6561, 6561, 6599, 6599, 6610, 6610, 6636, 6636, 6637, 6637, 6639, 6639, 6645, 6645, 6646, 6646, 6649, 6649, 6655, 6655, 6656, 6656, 6659, 6659, 6661, 6661, 6671, 6671, 6673, 6673, 6674, 6674, 6676, 6676
 
 ### `LicenseExportUtils` (class, 168 lines)
 
-- Def site: line 11232-11399
+- Def site: line 11233-11400
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -567,11 +566,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11339, 11339, 11358, 11358, 11376, 11376, 11385, 11385, 11388, 11388, 11389, 11389, 11392, 11392, 11397, 11397, 11399, 11399, 18744, 18744
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11340, 11340, 11359, 11359, 11377, 11377, 11386, 11386, 11389, 11389, 11390, 11390, 11393, 11393, 11398, 11398, 11400, 11400, 18679, 18679
 
 ### `OrgConfigExporter` (class, 168 lines)
 
-- Def site: line 11444-11611
+- Def site: line 11445-11612
 - References: 24
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -579,11 +578,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11481, 11481, 11483, 11483, 11486, 11486, 11557, 11557, 11559, 11559, 11572, 11572, 11576, 11576, 18747, 18747, 18748, 18748, 18749, 18749, 18787, 18787, 18792, 18792
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11482, 11482, 11484, 11484, 11487, 11487, 11558, 11558, 11560, 11560, 11573, 11573, 11577, 11577, 18682, 18682, 18683, 18683, 18684, 18684, 18740, 18740, 18745, 18745
 
 ### `OrgClientSecurityExporter` (class, 162 lines)
 
-- Def site: line 10476-10637
+- Def site: line 10477-10638
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -591,11 +590,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10514, 10514, 10521, 10521, 10528, 10528, 10534, 10534, 10541, 10541, 10548, 10548, 10609, 10609, 10620, 10620, 18735, 18735, 18736, 18736, 18738, 18738, 18739, 18739, 18740, 18740
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10515, 10515, 10522, 10522, 10529, 10529, 10535, 10535, 10542, 10542, 10549, 10549, 10610, 10610, 10621, 10621, 18670, 18670, 18671, 18671, 18673, 18673, 18674, 18674, 18675, 18675
 
 ### `CLIShellManager` (class, 161 lines)
 
-- Def site: line 15693-15853
+- Def site: line 15637-15797
 - References: 23
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -604,11 +603,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15716, 15716, 15718, 15718, 15787, 15787, 15789, 15789, 15808, 15808, 15810, 15810, 15810, 15826, 15826, 15842, 15842, 15843, 15843, 15849, 15849, 18848, 18848
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15660, 15660, 15662, 15662, 15731, 15731, 15733, 15733, 15752, 15752, 15754, 15754, 15754, 15770, 15770, 15786, 15786, 15787, 15787, 15793, 15793, 18801, 18801
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6347-6504
+- Def site: line 6348-6505
 - References: 197
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -618,7 +617,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5495, 5495, 6363, 6363, 6376, 6376, 6379, 6379, 6403, 6403, 6411, 6411, 6412, 6412, 6434, 6434, 6439, 6439, 6441, 6441, 6918, 6918, 6943, 6943, 7012, 7012, 7013, 7013, 7342, 7342, 7356, 7356, 7357, 7357, 7654, 7654, 7655, 7655, 8589, 8589, 8754, 8814, 8814, 8816, 8816, 8817, 8817, 8834, 8834, 8835, 8835, 8852, 8852, 8853, 8853, 8873, 8873, 8874, 8874, 9431, 9431, 9432, 9432, 9506, 9506, 9507, 9507, 9835, 9835, 9838, 9838, 10413, 10413, 10414, 10414, 10450, 10450, 10451, 10451, 10630, 10630, 10631, 10631, 10976, 10976, 10977, 10977, 11123, 11123, 11124, 11124, 11206, 11206, 11207, 11207, 11418, 11418, 11593, 11593, 11594, 11594, 11670, 11670, 11671, 11671, 11974, 11974, 11990, 11990, 11991, 11991, 12219, 12219, 12220, 12220, 12299, 12299, 12300, 12300, 12301, 12301, 12337, 12337, 12338, 12338, 12426, 12426, 12427, 12427, 12455, 12455, 12456, 12456, 12493, 12493, 12494, 12494, 12546, 12615, 12615, 12616, 12616, 12658, 12658, 12659, 12659, 12827, 12827, 12828, 12828, 12952, 12952, 12953, 12953, 13176, 13348, 13348, 14400, 14400, 15307, 15307, 15308, 15308, 15369, 15477, 16916, 16916, 16917, 16917, 17764, 17764
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5496, 5496, 6364, 6364, 6377, 6377, 6380, 6380, 6404, 6404, 6412, 6412, 6413, 6413, 6435, 6435, 6440, 6440, 6442, 6442, 6919, 6919, 6944, 6944, 7013, 7013, 7014, 7014, 7343, 7343, 7357, 7357, 7358, 7358, 7655, 7655, 7656, 7656, 8590, 8590, 8755, 8815, 8815, 8817, 8817, 8818, 8818, 8835, 8835, 8836, 8836, 8853, 8853, 8854, 8854, 8874, 8874, 8875, 8875, 9432, 9432, 9433, 9433, 9507, 9507, 9508, 9508, 9836, 9836, 9839, 9839, 10414, 10414, 10415, 10415, 10451, 10451, 10452, 10452, 10631, 10631, 10632, 10632, 10977, 10977, 10978, 10978, 11124, 11124, 11125, 11125, 11207, 11207, 11208, 11208, 11419, 11419, 11594, 11594, 11595, 11595, 11671, 11671, 11672, 11672, 11975, 11975, 11991, 11991, 11992, 11992, 12220, 12220, 12221, 12221, 12300, 12300, 12301, 12301, 12302, 12302, 12338, 12338, 12339, 12339, 12427, 12427, 12428, 12428, 12456, 12456, 12457, 12457, 12494, 12494, 12495, 12495, 12547, 12616, 12616, 12617, 12617, 12659, 12659, 12660, 12660, 12828, 12828, 12829, 12829, 12953, 12953, 12954, 12954, 13177, 13349, 13349, 14401, 14401, 15308, 15308, 15309, 15309, 15370, 15478, 16860, 16860, 16861, 16861, 17708, 17708
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 70, 153, 153, 154, 154, 159, 159, 187, 187, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 454, 454, 455, 455, 474, 474, 475, 475
@@ -626,7 +625,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataCollectionManager` (class, 156 lines)
 
-- Def site: line 14840-14995
+- Def site: line 14841-14996
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -635,11 +634,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14862, 14862, 14868, 14868, 14870, 14870, 14898, 14898, 14924, 14924, 14927, 14927, 14930, 14930, 18834, 18834, 18838, 18838, 18846, 18846
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 14863, 14863, 14869, 14869, 14871, 14871, 14899, 14899, 14925, 14925, 14928, 14928, 14931, 14931, 18787, 18787, 18791, 18791, 18799, 18799
 
 ### `SitesByAPModelExporter` (class, 146 lines)
 
-- Def site: line 13011-13156
+- Def site: line 13012-13157
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -647,11 +646,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13050, 13050, 13057, 13057, 13082, 13082, 13085, 13085, 13098, 13098, 13142, 13142, 13146, 13146, 13151, 13151, 13152, 13152, 13156, 13156, 19141, 19141
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13051, 13051, 13058, 13058, 13083, 13083, 13086, 13086, 13099, 13099, 13143, 13143, 13147, 13147, 13152, 13152, 13153, 13153, 13157, 13157, 19103, 19103
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 13164-13308
+- Def site: line 13165-13309
 - References: 94
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -660,12 +659,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12385, 12385, 12561, 12561, 12639, 12639, 12644, 12644, 13193, 13193, 13199, 13199, 13205, 13205, 13211, 13211, 13217, 13217, 13223, 13223, 13229, 13229, 13235, 13235, 13241, 13241, 13247, 13247, 13253, 13253, 13259, 13259, 13265, 13265, 13271, 13271, 13277, 13277, 13283, 13283, 13289, 13289, 13295, 13295, 13301, 13301, 13307, 13307, 18754, 18754, 18895, 18895, 18897, 18897, 19012, 19012, 19138, 19138, 19139, 19139, 19140, 19140, 19159, 19159, 19160, 19160, 19161, 19161, 19162, 19162, 19163, 19163, 19164, 19164, 19165, 19165
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12386, 12386, 12562, 12562, 12640, 12640, 12645, 12645, 13194, 13194, 13200, 13200, 13206, 13206, 13212, 13212, 13218, 13218, 13224, 13224, 13230, 13230, 13236, 13236, 13242, 13242, 13248, 13248, 13254, 13254, 13260, 13260, 13266, 13266, 13272, 13272, 13278, 13278, 13284, 13284, 13290, 13290, 13296, 13296, 13302, 13302, 13308, 13308, 18689, 18689, 18848, 18848, 18850, 18850, 18974, 18974, 19100, 19100, 19101, 19101, 19102, 19102, 19121, 19121, 19122, 19122, 19123, 19123, 19124, 19124, 19125, 19125, 19126, 19126, 19127, 19127
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 209, 209, 352, 352, 356, 356, 366, 366, 415, 415, 424, 424, 433, 433, 497, 497, 525, 525
 
 ### `OrgTemplateExporter` (class, 144 lines)
 
-- Def site: line 10330-10473
+- Def site: line 10331-10474
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -674,11 +673,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10344, 10344, 10345, 10345, 10431, 10431, 10466, 10466, 18729, 18729, 18730, 18730, 18731, 18731, 18732, 18732, 18733, 18733
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10345, 10345, 10346, 10346, 10432, 10432, 10467, 10467, 18664, 18664, 18665, 18665, 18666, 18666, 18667, 18667, 18668, 18668
 
 ### `GatewayHaExporter` (class, 139 lines)
 
-- Def site: line 13311-13449
+- Def site: line 13312-13450
 - References: 18
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -686,11 +685,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13380, 13380, 13383, 13383, 13384, 13384, 13385, 13385, 13405, 13405, 13408, 13408, 13416, 13416, 13421, 13421, 19167, 19167
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13381, 13381, 13384, 13384, 13385, 13385, 13386, 13386, 13406, 13406, 13409, 13409, 13417, 13417, 13422, 13422, 19129, 19129
 
 ### `OrgAlarmEventExporter` (class, 129 lines)
 
-- Def site: line 8632-8760
+- Def site: line 8633-8761
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -699,11 +698,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8703, 8703, 8714, 8714, 14938, 14938, 14939, 14939, 18632, 18632, 18633, 18633, 18812, 18812
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8704, 8704, 8715, 8715, 14939, 14939, 14940, 14940, 18567, 18567, 18568, 18568, 18765, 18765
 
 ### `WiredClientManufacturerReportGenerator` (class, 129 lines)
 
-- Def site: line 11005-11133
+- Def site: line 11006-11134
 - References: 20
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -712,11 +711,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11012, 11012, 11017, 11017, 11018, 11018, 11019, 11019, 11022, 11022, 11023, 11023, 11086, 11086, 11093, 11093, 11120, 11120, 19111, 19111
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11013, 11013, 11018, 11018, 11019, 11019, 11020, 11020, 11023, 11023, 11024, 11024, 11087, 11087, 11094, 11094, 11121, 11121, 19073, 19073
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 15463-15589
+- Def site: line 15464-15590
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -725,11 +724,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15483, 15483, 15488, 15488, 15493, 15493, 15530, 15530, 15536, 15536, 15542, 15542, 15548, 15548, 15554, 15554, 15555, 15555, 15556, 15556, 15557, 15557, 15558, 15558, 15562, 15562, 15571, 15571, 15575, 15575, 15578, 15578, 15584, 15584, 18807, 18807
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15484, 15484, 15489, 15489, 15494, 15494, 15531, 15531, 15537, 15537, 15543, 15543, 15549, 15549, 15555, 15555, 15556, 15556, 15557, 15557, 15558, 15558, 15559, 15559, 15563, 15563, 15572, 15572, 15576, 15576, 15579, 15579, 15585, 15585, 18760, 18760
 
 ### `EnvironmentUtils` (class, 114 lines)
 
-- Def site: line 5775-5888
+- Def site: line 5776-5889
 - References: 28
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -738,11 +737,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5796, 5796, 5798, 5798, 5814, 5814, 5826, 5826, 5865, 5865, 5866, 5866, 5867, 5867, 5868, 5868, 5869, 5869, 5880, 5880, 5883, 5883, 6800, 6800, 20146, 20146, 20729, 20729
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5797, 5797, 5799, 5799, 5815, 5815, 5827, 5827, 5866, 5866, 5867, 5867, 5868, 5868, 5869, 5869, 5870, 5870, 5881, 5881, 5884, 5884, 6801, 6801, 20106, 20106, 20689, 20689
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8766-8877
+- Def site: line 8767-8878
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -750,13 +749,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7692, 7692, 9362, 9362, 9674, 9674, 10520, 10520, 10540, 10540, 12543, 14887, 14887, 14940, 14940, 15373, 15613, 15613, 15631, 15631, 15649, 15649, 16865, 16865, 16889, 16889, 16913, 16913, 17056, 17056, 17395, 17395, 18673, 18673, 18688, 18688, 18698, 18698, 18698, 18698, 18708, 18708
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7693, 7693, 9363, 9363, 9675, 9675, 10521, 10521, 10541, 10541, 12544, 14888, 14888, 14941, 14941, 15374, 16809, 16809, 16833, 16833, 16857, 16857, 17000, 17000, 17339, 17339, 18608, 18608, 18623, 18623, 18633, 18633, 18633, 18633, 18643, 18643, 18709, 18709, 18722, 18722, 18936, 18936
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 339, 339, 500, 500, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 110 lines)
 
-- Def site: line 10640-10749
+- Def site: line 10641-10750
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -766,11 +765,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10695, 10695, 10698, 10698, 10699, 10699, 10704, 10704, 10723, 10723, 10723, 10732, 10732, 10732, 10732, 10733, 10733, 10733, 10733, 10791, 10791, 10794, 10794, 10806, 10806, 10807, 10807, 10820, 10820, 10859, 10859, 10867, 10867, 10921, 10921, 10929, 10929
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10696, 10696, 10699, 10699, 10700, 10700, 10705, 10705, 10724, 10724, 10724, 10733, 10733, 10733, 10733, 10734, 10734, 10734, 10734, 10792, 10792, 10795, 10795, 10807, 10807, 10808, 10808, 10821, 10821, 10860, 10860, 10868, 10868, 10922, 10922, 10930, 10930
 
 ### `SiteConfigExporter` (class, 100 lines)
 
-- Def site: line 12566-12665
+- Def site: line 12567-12666
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -779,11 +778,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12631, 12631, 12633, 12633, 12634, 12634, 18682, 18682, 18750, 18750, 18752, 18752, 18753, 18753
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12632, 12632, 12634, 12634, 12635, 12635, 18617, 18617, 18685, 18685, 18687, 18687, 18688, 18688
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 15355-15452
+- Def site: line 15356-15453
 - References: 78
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -792,13 +791,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15098, 15098, 15333, 15333, 15391, 15391, 15397, 15397, 15403, 15403, 15409, 15409, 15415, 15415, 15421, 15421, 15427, 15427, 15433, 15433, 15439, 15439, 15445, 15445, 15451, 15451, 15675, 17057, 17057, 17060, 17060, 17394, 17394, 18639, 18639, 18706, 18706, 18712, 18712, 18763, 18763, 18820, 18820
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15099, 15099, 15334, 15334, 15392, 15392, 15398, 15398, 15404, 15404, 15410, 15410, 15416, 15416, 15422, 15422, 15428, 15428, 15434, 15434, 15440, 15440, 15446, 15446, 15452, 15452, 15619, 17001, 17001, 17004, 17004, 17338, 17338, 18574, 18574, 18641, 18641, 18647, 18647, 18698, 18698, 18773, 18773
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 78, 94, 341, 341, 347, 347, 403, 403, 405, 405, 409, 409, 412, 412, 415, 415, 416, 416, 459, 459, 460, 460, 492, 492, 493, 493, 509, 509, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `DeviceUtils` (class, 97 lines)
 
-- Def site: line 8050-8146
+- Def site: line 8051-8147
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -806,11 +805,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8106, 8106, 8142, 8142
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8107, 8107, 8143, 8143
 
 ### `OrgAdminExporter` (class, 94 lines)
 
-- Def site: line 11136-11229
+- Def site: line 11137-11230
 - References: 14
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -819,11 +818,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11188, 11188, 11201, 11201, 18742, 18742, 18784, 18784, 18785, 18785, 18790, 18790, 18791, 18791
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11189, 11189, 11202, 11202, 18677, 18677, 18737, 18737, 18738, 18738, 18743, 18743, 18744, 18744
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5894-5983
+- Def site: line 5895-5984
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -833,13 +832,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5976, 5976, 15161, 15161, 15162, 15162, 15376, 18542, 18542
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5977, 5977, 15162, 15162, 15163, 15163, 15377, 18477, 18477
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 28, 143, 143, 144, 144
 
 ### `SiteClientExporter` (class, 85 lines)
 
-- Def site: line 12479-12563
+- Def site: line 12480-12564
 - References: 10
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -849,11 +848,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12513, 12513, 18717, 18717, 18725, 18725, 18751, 18751, 18896, 18896
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12514, 12514, 18652, 18652, 18660, 18660, 18686, 18686, 18849, 18849
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 17835-17913
+- Def site: line 17779-17857
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -863,12 +862,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17830, 17830, 17831, 17831, 18991, 18991
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 17774, 17774, 17775, 17775, 18953, 18953
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 16843-16920
+- Def site: line 16787-16864
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -878,12 +877,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18862, 18862, 18866, 18866, 18870, 18870
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18815, 18815, 18819, 18819, 18823, 18823
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1903-1976
+- Def site: line 1904-1977
 - References: 250
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -892,7 +891,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1916, 1916, 1948, 1948, 2293, 2293, 2320, 2320, 7404, 7404, 7490, 7490, 7620, 7620, 7697, 7697, 7780, 7780, 8010, 8010, 8199, 8199, 8258, 8258, 8271, 8271, 8288, 8288, 8333, 8333, 8367, 8367, 8373, 8373, 8479, 8479, 10023, 10023, 10290, 10793, 10793, 10822, 10822, 11087, 11087, 11293, 11293, 11532, 11532, 12248, 12248, 12264, 12264, 13051, 13051, 13470, 13470, 13520, 13520, 15374, 15576, 15576, 15609, 15609, 15627, 15627, 15645, 15645, 15673, 16870, 16870, 16895, 16895, 16938, 17037, 17037, 17247, 17247, 17390, 17390, 17497, 17497, 17825, 17825, 17855, 17855, 17876, 17876, 17895, 17895, 17911, 17911, 18489, 18489, 18509, 18509, 18544, 18544, 18557, 18557, 19025, 19025, 19116, 19116, 19121, 19121, 19127, 19127, 19146, 19146, 19152, 19152, 20752, 20752
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1917, 1917, 1949, 1949, 2294, 2294, 2321, 2321, 7405, 7405, 7491, 7491, 7621, 7621, 7698, 7698, 7781, 7781, 8011, 8011, 8200, 8200, 8259, 8259, 8272, 8272, 8289, 8289, 8334, 8334, 8368, 8368, 8374, 8374, 8480, 8480, 10024, 10024, 10291, 10794, 10794, 10823, 10823, 11088, 11088, 11294, 11294, 11533, 11533, 12249, 12249, 12265, 12265, 13052, 13052, 13471, 13471, 13521, 13521, 15375, 15577, 15577, 15617, 16814, 16814, 16839, 16839, 16882, 16981, 16981, 17191, 17191, 17334, 17334, 17441, 17441, 17769, 17769, 17799, 17799, 17820, 17820, 17839, 17839, 17855, 17855, 18433, 18433, 18453, 18453, 18479, 18479, 18492, 18492, 18705, 18705, 18718, 18718, 18932, 18932, 18987, 18987, 19078, 19078, 19083, 19083, 19089, 19089, 19108, 19108, 19114, 19114, 20712, 20712
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -901,7 +900,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\_maps_wizard.py`: lines 179, 179, 295, 295, 333, 333, 688, 688, 761, 761
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 227, 227, 280, 280, 462, 462, 994, 994, 1012, 1012, 1021, 1021, 1024, 1024, 1027, 1027, 1213, 1213, 1277, 1277, 1383, 1383, 1451, 1451, 1488, 1488, 1668, 1668, 1838, 1838, 2659, 2659, 2662, 2662, 2677, 2677, 2764, 2764
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\address_corrector.py`: lines 79, 79
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\audit_engine.py`: lines 246, 246, 276, 276, 329, 329, 872, 872, 884, 884
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\audit_engine.py`: lines 246, 246, 282, 282, 342, 342, 885, 885, 897, 897
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\comparison_display.py`: lines 82, 82
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\ui_geocoder.py`: lines 173, 173, 207, 207, 227, 227
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\runtime\app_runner.py`: lines 257, 257
@@ -913,7 +912,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `InteractiveDisplayUtils` (class, 72 lines)
 
-- Def site: line 15001-15072
+- Def site: line 15002-15073
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -922,11 +921,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18828, 18828, 18829, 18829, 18830, 18830, 18831, 18831
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18781, 18781, 18782, 18782, 18783, 18783, 18784, 18784
 
 ### `DisplayUtils` (class, 70 lines)
 
-- Def site: line 5466-5535
+- Def site: line 5467-5536
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -936,11 +935,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5498, 5498, 5499, 5499, 5514, 5514, 5516, 5516
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5499, 5499, 5500, 5500, 5515, 5515, 5517, 5517
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 5989-6058
+- Def site: line 5990-6059
 - References: 182
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -948,7 +947,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6031, 6031, 6036, 6036, 6133, 6133, 6191, 6191, 7078, 7078, 7547, 7547, 8192, 8192, 8215, 8215, 8238, 8238, 8429, 8429, 8450, 8450, 8728, 8728, 8753, 8753, 8808, 8808, 8830, 8830, 8847, 8847, 8864, 8864, 9249, 9249, 9472, 9472, 9489, 9489, 9881, 9881, 10213, 10213, 10424, 10424, 10461, 10461, 10614, 10614, 10758, 10758, 11011, 11011, 11199, 11199, 11383, 11383, 11702, 11702, 12038, 12038, 12210, 12210, 12250, 12250, 12256, 12256, 12350, 12350, 12580, 12580, 12653, 12653, 13140, 13140, 13175, 13374, 13374, 14881, 14881, 15097, 15097, 15365, 15472, 15572, 15572, 15607, 15607, 15625, 15625, 15643, 15643, 16936, 17826, 17826, 17828, 17828, 17852, 17852, 17856, 17856, 17857, 17857, 17877, 17877, 17878, 17878, 18023, 18023, 18593, 18593, 18625, 18625, 18662, 18662, 18668, 18668, 18796, 18796, 18853, 18853, 18936, 18936, 18945, 18945, 19023, 19023, 19024, 19024, 19041, 19041, 19116, 19116, 19121, 19121, 19127, 19127, 19146, 19146, 19152, 19152, 20063, 20063, 20134, 20616, 20616, 20704, 20704
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6032, 6032, 6037, 6037, 6134, 6134, 6192, 6192, 7079, 7079, 7548, 7548, 8193, 8193, 8216, 8216, 8239, 8239, 8430, 8430, 8451, 8451, 8729, 8729, 8754, 8754, 8809, 8809, 8831, 8831, 8848, 8848, 8865, 8865, 9250, 9250, 9473, 9473, 9490, 9490, 9882, 9882, 10214, 10214, 10425, 10425, 10462, 10462, 10615, 10615, 10759, 10759, 11012, 11012, 11200, 11200, 11384, 11384, 11703, 11703, 12039, 12039, 12211, 12211, 12251, 12251, 12257, 12257, 12351, 12351, 12581, 12581, 12654, 12654, 13141, 13141, 13176, 13375, 13375, 14882, 14882, 15098, 15098, 15366, 15473, 15573, 15573, 16880, 17770, 17770, 17772, 17772, 17796, 17796, 17800, 17800, 17801, 17801, 17821, 17821, 17822, 17822, 17967, 17967, 18528, 18528, 18560, 18560, 18597, 18597, 18603, 18603, 18703, 18703, 18716, 18716, 18749, 18749, 18806, 18806, 18889, 18889, 18898, 18898, 18930, 18930, 18985, 18985, 18986, 18986, 19003, 19003, 19078, 19078, 19083, 19083, 19089, 19089, 19108, 19108, 19114, 19114, 20025, 20025, 20094, 20576, 20576, 20664, 20664
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 69, 246, 246, 556, 556, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 402, 402, 449, 449, 467, 467, 508, 508, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 27, 321, 321
@@ -958,7 +957,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `OrgDeviceInventorySummary` (class, 69 lines)
 
-- Def site: line 10259-10327
+- Def site: line 10260-10328
 - References: 22
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -969,11 +968,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10299, 10299, 10304, 10304, 10309, 10309, 10310, 10310, 10316, 10316, 10317, 10317, 10323, 10323, 10324, 10324, 10325, 10325, 10326, 10326, 19169, 19169
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10300, 10300, 10305, 10305, 10310, 10310, 10311, 10311, 10317, 10317, 10318, 10318, 10324, 10324, 10325, 10325, 10326, 10326, 10327, 10327, 19131, 19131
 
 ### `AuditAnalysisOps` (class, 66 lines)
 
-- Def site: line 18548-18613
+- Def site: line 18483-18548
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -983,25 +982,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18596, 18596, 18604, 18604, 18613, 18613, 19142, 19142
-
-### `GatewayTemplateConfigManager` (class, 56 lines)
-
-- Def site: line 15596-15651
-- References: 6
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] missing_inline_comments
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18767, 18767, 18771, 18771, 18976, 18976
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18531, 18531, 18539, 18539, 18548, 18548, 19104, 19104
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 6064-6110
+- Def site: line 6065-6111
 - References: 55
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1010,13 +995,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6188, 6188, 7882, 7882, 8809, 8809, 8832, 8832, 9319, 9319, 9354, 9354, 9368, 9368, 9491, 9491, 9495, 9495, 10043, 10043, 12354, 12354, 13024, 13024, 13150, 13150, 13182, 13360, 13360, 13396, 13396, 15371, 17716, 17716, 17827, 17827, 17858, 17858, 17879, 17879, 19026, 19026, 19042, 19042, 20635, 20635
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6189, 6189, 7883, 7883, 8810, 8810, 8833, 8833, 9320, 9320, 9355, 9355, 9369, 9369, 9492, 9492, 9496, 9496, 10044, 10044, 12355, 12355, 13025, 13025, 13151, 13151, 13183, 13361, 13361, 13397, 13397, 15372, 17660, 17660, 17771, 17771, 17802, 17802, 17823, 17823, 18988, 18988, 19004, 19004, 20595, 20595
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 76, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 515, 515, 526, 526
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5724-5769
+- Def site: line 5725-5770
 - References: 97
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1025,14 +1010,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5236, 5236, 5278, 5278, 5323, 5323, 5429, 5429, 5444, 5444, 5714, 5714, 5715, 5715, 5759, 5759, 6214, 6214, 7716, 7716, 9019, 9019, 9330, 9330, 9346, 9346, 9675, 9675, 10556, 10556, 10575, 10575, 12545, 14964, 14964, 15367, 15610, 15610, 15628, 15628, 15646, 15646, 15676, 16098, 16098, 16138, 16138, 16139, 16139, 16140, 16140, 16862, 16862, 16886, 16886, 16890, 16890, 16910, 16910, 16937, 17012, 17012, 17046, 17046, 17067, 17067, 17099, 17099, 17161, 17161, 17200, 17200, 17348, 17348, 17393, 17393
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5237, 5237, 5279, 5279, 5324, 5324, 5430, 5430, 5445, 5445, 5715, 5715, 5716, 5716, 5760, 5760, 6215, 6215, 7717, 7717, 9020, 9020, 9331, 9331, 9347, 9347, 9676, 9676, 10557, 10557, 10576, 10576, 12546, 14965, 14965, 15368, 15620, 16042, 16042, 16082, 16082, 16083, 16083, 16084, 16084, 16806, 16806, 16830, 16830, 16834, 16834, 16854, 16854, 16881, 16956, 16956, 16990, 16990, 17011, 17011, 17043, 17043, 17105, 17105, 17144, 17144, 17292, 17292, 17337, 17337, 18706, 18706, 18719, 18719, 18933, 18933
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 149, 149, 227, 227, 235, 235, 243, 243, 548, 548
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 33, 360, 360
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `SiteConfigManager` (class, 43 lines)
 
-- Def site: line 16926-16968
+- Def site: line 16870-16912
 - References: 16
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1041,11 +1026,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16949, 16949, 16955, 16955, 16961, 16961, 16967, 16967, 18960, 18960, 18964, 18964, 18968, 18968, 18972, 18972
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 16893, 16893, 16899, 16899, 16905, 16905, 16911, 16911, 18913, 18913, 18917, 18917, 18921, 18921, 18925, 18925
 
 ### `SelfExportUtils` (class, 40 lines)
 
-- Def site: line 11402-11441
+- Def site: line 11403-11442
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1054,11 +1039,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11439, 11439, 19166, 19166
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11440, 11440, 19128, 19128
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1867-1895
+- Def site: line 1868-1896
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1067,12 +1052,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8682, 8682, 8683, 8683, 8712, 8712, 8713, 8713, 8729, 8729, 8730, 8730, 9608, 9608, 9609, 9609, 9913, 9913, 9914, 9914, 9961, 9961, 9962, 9962, 10517, 10517, 10519, 10519, 10537, 10537, 10539, 10539, 11428, 11428, 11429, 11429, 12089, 12089, 12090, 12090, 12195, 12195, 12196, 12196, 13178
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8683, 8683, 8684, 8684, 8713, 8713, 8714, 8714, 8730, 8730, 8731, 8731, 9609, 9609, 9610, 9610, 9914, 9914, 9915, 9915, 9962, 9962, 9963, 9963, 10518, 10518, 10520, 10520, 10538, 10538, 10540, 10540, 11429, 11429, 11430, 11430, 12090, 12090, 12091, 12091, 12196, 12196, 12197, 12197, 13179
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 72, 207, 207, 208, 208
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 15325-15352
+- Def site: line 15326-15353
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1081,12 +1066,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15339, 15339, 15345, 15345, 15351, 15351, 18874, 18874, 18878, 18878
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15340, 15340, 15346, 15346, 15352, 15352, 18827, 18827, 18831, 18831
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 203, 203, 247, 247, 250, 250, 266, 266, 308, 308, 311, 311, 327, 327, 329, 329, 330, 330, 337, 337, 347, 347, 350, 350, 351, 351, 358, 358, 377, 377, 386, 386, 387, 387, 388, 388, 405, 405, 406, 406, 459, 459
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 15662-15687
+- Def site: line 15606-15631
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1096,12 +1081,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15682, 15682, 15687, 15687, 18882, 18882, 18887, 18887
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15626, 15626, 15631, 15631, 18835, 18835, 18840, 18840
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 13477-13498
+- Def site: line 13478-13499
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1110,7 +1095,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18648, 18648, 18652, 18652, 18656, 18656
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18583, 18583, 18587, 18587, 18591, 18591
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -1120,17 +1105,17 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FirmwareManager` (class, 22 lines)
 
-- Def site: line 17376-17397
+- Def site: line 17320-17341
 - References: 8
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18795, 18795, 18852, 18852, 18935, 18935, 18944, 18944
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18748, 18748, 18805, 18805, 18888, 18888, 18897, 18897
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 17811-17832
+- Def site: line 17755-17776
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1139,12 +1124,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 19005, 19005
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 18967, 18967
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `EndpointConfig` (class, 10 lines)
 
-- Def site: line 13723-13732
+- Def site: line 13724-13733
 - References: 13
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1152,11 +1137,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13759, 13895, 13972, 13991, 14003, 14024, 14037, 14048, 14054, 14067, 14160, 14295, 14390
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13760, 13896, 13973, 13992, 14004, 14025, 14038, 14049, 14055, 14068, 14161, 14296, 14391
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 327-335
+- Def site: line 328-336
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1172,7 +1157,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 354-362
+- Def site: line 355-363
 - References: 4
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1180,12 +1165,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15033, 15050, 15066
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 15034, 15051, 15067
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`: lines 49
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 339-346
+- Def site: line 340-347
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1201,7 +1186,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 634-636
+- Def site: line 635-637
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1209,7 +1194,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1244, 1913, 1913, 1913, 1925, 1931, 6190, 6310, 7366, 9418, 9529, 9783, 10613, 13185, 15243, 15285, 15383, 19028
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1245, 1914, 1914, 1914, 1926, 1932, 6191, 6311, 7367, 9419, 9530, 9784, 10614, 13186, 15244, 15286, 15384, 18990
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 35, 79, 163
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 58
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 41, 217, 260
@@ -1219,11 +1204,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 579, 699, 707, 866, 1152, 1752
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\connection_pool_executor.py`: lines 137
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\wanprobe_config_manager.py`: lines 243, 363
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\audit_engine.py`: lines 56, 903, 905
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\audit_engine.py`: lines 56, 916, 918
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2029-2031
+- Def site: line 2030-2032
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1232,7 +1217,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2029, 15379
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2030, 15380
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 54, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -1240,7 +1225,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 750-1754
+- Def site: line 751-1755
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -1248,7 +1233,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1799
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1800
 
 ## Limitations
 

--- a/specs/1013-misthelper-refactor-hot-classes/checklists/requirements.md
+++ b/specs/1013-misthelper-refactor-hot-classes/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: MistHelper Hot-Classes Refactor (MistHelper-Only References)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+Validation observations (2026-07-07):
+
+- **Content Quality caveat — implementation details**: This spec is a refactoring initiative and unavoidably names specific Python constructs (`MistHelper.py`, `src/refactors/`, class names, `black`/`ruff`, `python MistHelper.py --test`, `pathlib.Path`, `InputUtils.safe_input()`, analyzer `guideline_flags`). These are proper nouns identifying the artifact under refactor, not new technology choices being introduced by the spec. Prior initiatives (1010/1011/1012) followed the same convention. The spec does not introduce new implementation choices; it constrains existing ones. Passing under the "no new implementation choices" reading.
+- **Stakeholder audience**: The primary stakeholders here are the engineering team executing the refactor and the reviewers gating merges. Written accordingly — technical, but framed around value (reduced `MistHelper.py` LoC, cohesive class-body modules, preserved user-facing behavior) rather than internal mechanics.
+- **Zero [NEEDS CLARIFICATION] markers**: The user-supplied initiative description was fully specified — target class list, ordering rule, per-PR success gates, non-goals, and predecessor lineage were all provided verbatim. No ambiguities required flagging.
+- **Success criteria measurability**: SC-002 uses a concrete LoC-drop floor (8,000 lines); SC-003/SC-004/SC-006/SC-015 use compliance-score thresholds tied to the existing 99.6/A+ baseline; SC-005 uses CI-job counts (15/15 green) tied to the existing gate; SC-012/SC-014 are verifiable by grep/PR walk; SC-017 defines the closing artifact.
+- **Technology-agnosticity note**: Success criteria reference tools (`black`, `ruff`, `python MistHelper.py --test`) because those tools are the merge gates — they are the observable outcomes, not implementation choices. Rewording them as "code style compliance passes locally" and "smoke test suite passes with exit 0" would lose specificity without gaining audience accessibility. Prior initiatives kept the tool names for the same reason.
+- **Scope boundedness**: The 47-row Dispatch Queue is exhaustive and the "Deferred Candidates" section handles mid-initiative deferrals. The 29 excluded classes are named as out-of-scope in Scope Boundary + FR-012 + SC-009. Non-class Hot symbols and analyzer changes are explicitly out of scope.
+- **All items pass on first validation pass** — no iterations required.

--- a/specs/1013-misthelper-refactor-hot-classes/plan.md
+++ b/specs/1013-misthelper-refactor-hot-classes/plan.md
@@ -1,0 +1,276 @@
+# Implementation Plan: MistHelper.py Refactor — Hot-Classes Serial Extraction
+
+**Branch**: `1013-misthelper-refactor-hot-classes` | **Date**: 2026-07-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/1013-misthelper-refactor-hot-classes/spec.md`
+**Predecessors**: `specs/1010-misthelper-refactor-extraction/` (13 PRs merged), `specs/1011-misthelper-refactor-low-use/` (20 PRs merged), `specs/1012-misthelper-refactor-hot-functions/` (1 bounded PR merged) — all three closed with baseline `>=99.6/A+`.
+
+## Summary
+
+Land the fourth-pass refactor initiative: **47 serial per-PR extractions** targeting Hot-bucket classes in `MistHelper.py` whose reference sites are exclusively inside `MistHelper.py` (no `src/`, `tests/`, or other first-party callers). One class per PR. Dispatch order front-loads the 4 Category A (facade-removal) candidates as a low-risk warmup (positions 1-4), then continues with the 43 Category B (fresh-extraction) candidates in Refs-ASC / LOC-DESC order (positions 5-47) derived from the freshest `refactor_candidates.md` at each hop. This mirrors the serial workflow of 1010/1011 (one candidate per PR) and deliberately does **not** repeat the bounded-bundle pattern of 1012.
+
+**Two action-types govern the PR shape** (per FR-003 and the 2026-07-07 collision audit):
+
+- **Cat A — Facade removal (4 candidates, positions 1-4)**: The `MistHelper.py` class is a delegation wrapper; the real implementation already lives in `src/` at a specific path (verified by a same-name class-definition audit on 2026-07-07). The PR **deletes the facade + rewires callsites** — no new file is created. Every Cat A PR MUST record a method-parity audit in the PR description per FR-025 before the facade is deleted, comparing the facade's public surface (methods, static methods, classmethods, instance attributes) against the `src/` counterpart to prove semantic equivalence. Silent facade deletion is prohibited.
+- **Cat B — Fresh extraction (43 candidates, positions 5-47)**: No `src/` collision. The PR extracts the class body to the landing package (new file created inside the noted package, or folded into an existing class body when semantically appropriate), deletes the original class body from `MistHelper.py`, and rewrites every callsite in the same commit. This is the 1010/1011 pattern.
+- **Cat C — Name-clash-distinct**: 0 candidates found in the 2026-07-07 audit; category listed for completeness only.
+
+Each extraction PR delivers, by category:
+
+- **Cat A PR delivers**: (a) facade deletion from `MistHelper.py`; (b) every `MistHelper.py` callsite rewritten to import directly from the pre-existing `src/` module in the same commit; (c) method-parity audit output pasted in the PR description under a `Method-Parity Audit` heading (FR-025); (d) mandatory single-line NOTE breadcrumb at the facade-deletion site pointing at the pre-existing `src/` module; (e) all 15 functional CI jobs green; (f) `MistHelper.py` pylint score non-regressing against the pre-initiative baseline; (g) repo-wide aggregate compliance `>=99.6/A+`; (h) `black --check` and `ruff check` clean; (i) `python MistHelper.py --test` reporting 0 failed with exit 0. No new file is created. Zero wrapper shims. Zero re-export modules. Zero backward-compatibility aliases.
+- **Cat B PR delivers**: (a) class body moved to a cohesive module in the landing package (new file, or fold into an existing class body when semantically appropriate); (b) every `MistHelper.py` callsite rewritten in the same commit; (c) original class body deleted from `MistHelper.py`; (d) mandatory single-line NOTE breadcrumb at the class-body-deletion site pointing at the newly created `src/` file (FR-007 template); (e) any analyzer `guideline_flags` on the moved class resolved in-flight (no deferral); (f) all 15 functional CI jobs green; (g) new/edited module at A+/100 compliance; (h) repo-wide aggregate compliance `>=99.6/A+`; (i) `MistHelper.py` pylint score non-regressing against the pre-initiative baseline; (j) `black --check` and `ruff check` clean; (k) `python MistHelper.py --test` reporting 0 failed with exit 0. Zero wrapper shims. Zero re-export modules. Zero backward-compatibility aliases.
+
+Sum of the 47 candidates' LoC across both categories: ~12,150. SC-002 target: `MistHelper.py` physical LoC drops by `>=8,000` lines relative to pre-initiative baseline (headroom for class-body overhead and reasonable decomposition retention in destination modules). Note that Cat A rows contribute only a small LoC drop each (facade wrappers are typically 22-188 lines) whereas Cat B rows contribute via full class-body movement (10-759 lines each); the Cat B block therefore accounts for the bulk of the SC-002 drop.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (project target per Constitution v1.4.0 and the repo tooling / CI matrix)
+**Primary Dependencies**: standard library only for extraction targets; existing project deps preserved (no new dependencies introduced by this initiative)
+**Storage**: N/A for extraction work itself
+**Testing**: `pytest` for unit/integration; the 15 functional CI jobs (matrix build, ruff, mypy, compliance analyzer, refactor analyzer smoke, integration suites) as the mergeability contract; `python MistHelper.py --test` smoke test (0 failed / exit 0) as an additional merge gate per FR-015; local pre-push Black + Ruff gate per `feedback_prepush_black_ruff.md`
+**Target Platform**: Windows-first CLI; extracted modules stay platform-neutral (`pathlib.Path` everywhere, ASCII-only log literals)
+**Project Type**: Single-project CLI tool with a monolithic entrypoint (`MistHelper.py`) being decomposed into `src/*` sub-packages
+**Performance Goals**: No performance regression at any callsite after extraction; interactive CLI menu latency unchanged; extracted class bodies preserve their original method contracts byte-for-byte, with any in-flight decomposition (E-2) only splitting internal method bodies rather than altering call semantics
+**Constraints**: Zero wrapper shims may be left in `MistHelper.py` (FR-003 carry-forward, formalized across Cat A + Cat B); every new/edited module lands at A+/100 compliance (FR-016); repo-wide baseline stays `>=99.6/A+` (FR-017); `MistHelper.py` pylint stays non-regressing against the pre-initiative baseline (FR-018); no `--admin` merge bypass as a routine unblock (per `feedback_no_admin_bypass.md` — check `mergeStateStatus: CLEAN` first); every extraction site carries the pinned NOTE breadcrumb (FR-007, SC-012); `refactor_candidates.md` is regenerated after every merged PR before the next dispatch (FR-014); pre-dispatch grep audit is mandatory for every PR (FR-013); no new SKIPPED CI conditionals introduced (FR-019); every Cat A PR carries a method-parity audit in its PR description (FR-025); Cat A candidates occupy dispatch positions 1-4 as a low-risk warmup (FR-026)
+**Scale/Scope**: 47 serial PRs (one class per PR: 4 Cat A + 43 Cat B); ~12,150 LoC total addressed; SC-002 requires `MistHelper.py` shrinks by `>=8,000` physical lines; landing distribution spans 15 existing packages (see Project Structure below); `src/refactors/` receives **zero** candidates; 47 mandatory NOTE breadcrumbs (one per merged PR); at most one open PR at a time (FR-023)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution version 1.4.0 (ratified 2026-03-05). Evaluated per the seven core principles.
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Five-Item Rule (all menu options in groups of 5, cross-category prohibited) | PASS | Extraction is a code-organization change; no menu structure is added, removed, or reordered by any of the 47 PRs. User-facing behavior is preserved exactly (FR-021). |
+| II. Class-Based Architecture (functions live inside cohesive classes) | PASS + REINFORCED | Every one of the 47 candidates is already a class; the extraction lands each as a cohesive class body in the destination module per FR-004. Bare module-level function/assignment landings are prohibited. Cat A PRs preserve class-body cohesion by removing dead facades that duplicate a real class already living in `src/` — after the facade is deleted, exactly one canonical class body exists per name across the codebase. Cat B PRs move the class body intact into a new landing file (or fold into an existing package class body when the semantic fit is clear). |
+| III. Safety-First Development (destructive operations gated) | PASS + REINFORCED | Extraction moves existing behavior; no new destructive operations are introduced. Pre-dispatch grep audit (FR-013) confirms zero external callers before deletion. Cat A PRs carry an additional safety gate: FR-025 method-parity verification (enumerate facade methods → confirm each is exposed with equivalent signature by the `src/` counterpart → paste audit output in PR description before deletion). Silent facade deletion is prohibited. |
+| IV. Full Deployment Pipeline (15 CI jobs must pass, no --admin bypass) | PASS + REINFORCED | FR-015 codifies the CI gate. `feedback_no_admin_bypass.md` guidance applied — check `mergeStateStatus: CLEAN` before merging; do not cargo-cult `--admin`; SKIPPED conditionals are non-blocking. FR-019 additionally forbids introducing *new* SKIPPED conditionals via this initiative. |
+| V. Observability & Logging (structured, ASCII-only, `safe_input`, `pathlib.Path`) | PASS + REINFORCED | Every new/edited module lands ASCII-only logs, no raw `input()` (replaced by `InputUtils.safe_input()` where applicable), `pathlib.Path` in place of `os.path`. Analyzer `guideline_flags` (`non_ascii_logs`, `raw_input_call`, `hardcoded_separator`) are resolved in-flight per FR-006 — never deferred. Cat A PRs have no new file to lint but MUST preserve the pre-existing `src/` module's compliance grade. |
+| VI. Inline Comments Every 5-10 Lines (NON-NEGOTIABLE) | PASS + REINFORCED | Every new/edited module must land A+/100 per FR-016, which enforces the 5-10 line inline-comment cadence. The `missing_inline_comments` `guideline_flag` is resolved during the move per FR-006. Cat A PRs preserve the pre-existing `src/` module's cadence unchanged. |
+| VII. Action Logging Before Every Non-Trivial Action (NON-NEGOTIABLE) | PASS + REINFORCED | Every extracted class body preserves its original `[LOGIN]` / `[MENU]` / `[EXECUTE]` / `[SUCCESS]` / `[FAILURE]` action-log prefixes verbatim, and any `missing_action_logging` `guideline_flag` on the moved class is resolved in-flight per FR-006. `%s` placeholder formatting used throughout. |
+
+**Result**: All seven principles pass. Principles II and III are reinforced by the new Cat A action-type + FR-025 method-parity gate. Principles VI and VII are NON-NEGOTIABLE and are reinforced rather than at risk by the A+/100 per-file gate and the FR-006 in-flight `guideline_flags` resolution rule. No violations require Complexity Tracking entries.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1013-misthelper-refactor-hot-classes/
+|-- plan.md                        # This file (/speckit.plan output)
+|-- spec.md                        # Feature specification (input)
+|-- research.md                    # Phase 0 output — Decision blocks
+|-- quickstart.md                  # Phase 1 output — mid-flight contributor recipe
+`-- checklists/
+    `-- requirements.md            # Existing checklist
+```
+
+No `contracts/` sub-directory. This initiative's contracts (extraction PR shape by category, NOTE breadcrumb template, method-parity audit shape, compliance gates) are already exhaustively specified in `spec.md` (FR-001 through FR-026, SC-001 through SC-017) and the `research.md` decisions. Adding a separate contracts folder would duplicate that content without adding audit value; the pinned FR-007 breadcrumb template and the FR-025 method-parity audit template are the only cross-file contracts and both live in the spec.
+
+No `data-model.md`. The initiative moves code; it does not introduce data entities. The Key Entities section of `spec.md` is a conceptual glossary rather than a persistent-data schema; it is complete as-is in `spec.md` and does not warrant a duplicate data-model artifact.
+
+### Source Code (repository root)
+
+```text
+MistHelper.py                                # Entrypoint monolith — loses 47 class bodies
+                                             #   over 47 merged PRs (4 facade deletions +
+                                             #   43 fresh extractions). Gains 47 NOTE
+                                             #   breadcrumbs (one per merged PR, pinned
+                                             #   FR-007 template).
+                                             #   Target: >=8,000 LoC drop (SC-002).
+tools/refactor_analyzer/                     # Analyzer package — CONSUMED AS-IS, never modified
+                                             #   (FR-011 carry-forward from 1010/1011/1012).
+tools/compliance_analyzer/                   # Compliance analyzer — used to verify A+/100 on
+                                             #   every new/edited module and >=99.6/A+ aggregate.
+refactor_candidates.md                       # Regenerated after every merged PR (FR-014).
+                                             #   Freshest catalog is the authoritative source
+                                             #   for the next dispatch (User Story 3).
+data/full_repo_compliance_current.md         # Compliance baseline snapshot — must stay
+                                             #   >=99.6/A+ throughout (FR-017).
+data/full_repo_compliance_1013_baseline.md   # NEW — captured on first branch commit
+                                             #   (Decision 7). Pinned baseline for FR-017/SC-003
+                                             #   non-regression audit.
+data/pylint_MistHelper_1013_baseline.txt     # NEW — captured on first branch commit
+                                             #   (Decision 7). Pinned pylint baseline for
+                                             #   FR-018/SC-015 non-regression audit.
+src/
+|-- gateway/                                 # Cat A row 1 target — pre-existing.
+|   `-- template_config.py                   # Cat A: MistHelper.py::GatewayTemplateConfigManager
+|                                            #   facade deleted; callsites rewired here.
+|                                            #   No new file created.
+|-- firmware/                                # Cat A row 2 target — pre-existing.
+|   `-- firmware_manager.py                  # Cat A: MistHelper.py::FirmwareManager factory
+|                                            #   facade deleted (create() + _Impl indirection
+|                                            #   removed); callsites rewired to construct the
+|                                            #   real class here. No new file created.
+|-- site/                                    # Cat A row 3 target + Cat B destinations.
+|   |-- site_config_manager.py               # Cat A: MistHelper.py::SiteConfigManager facade
+|   |                                        #   deleted; callsites rewired here.
+|   `-- (Cat B new files as dispatched)      # e.g. site_client_exporter.py,
+|                                            #   bulk_radius_wlan_config_manager.py,
+|                                            #   site_config_exporter.py, site_device_exporter.py,
+|                                            #   site_anomaly_exporter.py,
+|                                            #   sites_by_ap_model_exporter.py
+|-- device/                                  # Cat A row 4 target + Cat B destinations.
+|   |-- utility_commands.py                  # Cat A: MistHelper.py::DeviceUtilityCommands facade
+|   |                                        #   deleted (35 op-subclass wrappers rewired to
+|   |                                        #   direct imports here). FR-025 method-parity
+|   |                                        #   audit is particularly rigorous for this row.
+|   `-- (Cat B new files as dispatched)      # e.g. device_utils.py, device_reboot_manager.py,
+|                                            #   arp_command_manager.py
+|-- export/                                  # Cat B — largest cluster (20 candidates land here).
+|   `-- (Cat B new files as dispatched)      # Accepted as flat layout for this initiative;
+|                                            #   sub-partitioning explicitly deferred pending
+|                                            #   noise emergence. e.g. self_export_utils.py,
+|                                            #   msp_inventory_exporter.py,
+|                                            #   const_definitions_exporter.py,
+|                                            #   org_alarm_event_exporter.py, ...
+|-- utils/                                   # Cat B — 4 candidates land here.
+|   `-- (Cat B new files as dispatched)      # e.g. operation_registry.py,
+|                                            #   environment_utils.py, filter_operator_engine.py
+|-- reports/                                 # Cat B — 4 candidates land here.
+|   `-- (Cat B new files as dispatched)      # e.g. wired_client_manufacturer_report_generator.py,
+|                                            #   sfp_transceiver_data_processor.py,
+|                                            #   offline_device_reporter.py,
+|                                            #   global_wired_client_report_generator.py
+|-- analytics/                               # Cat B — 2 candidates land here.
+|   `-- (Cat B new files as dispatched)      # e.g. telemetry_emitter.py,
+|                                            #   data_collection_manager.py
+|-- ui/                                      # Cat B — 2 candidates land here.
+|   `-- (Cat B new files as dispatched)      # e.g. interactive_display_utils.py,
+|                                            #   display_utils.py
+|-- org/                                     # Cat B — 2 candidates land here.
+|   `-- (Cat B new files as dispatched)      # e.g. org_config_migration_manager.py,
+|                                            #   org_ticket_manager.py
+|-- audit/                                   # Cat B — 1 candidate lands here (audit_analysis_ops).
+|-- dataclasses/                             # Cat B — 1 candidate lands here (endpoint_config).
+|-- api/                                     # Cat B — 1 candidate lands here (api_data_fetcher).
+|-- inventory/                               # Cat B — 1 candidate lands here (org_device_inventory_summary).
+|-- ssh/                                     # Cat B — 1 candidate lands here (cli_shell_manager).
+|-- input/                                   # Cat B — 1 candidate lands here (prompt_client_utils).
+|-- db/                                      # Cat B — 1 candidate lands here (database_schema_utils).
+|-- troubleshooting/                         # Cat B — 1 candidate lands here (troubleshoot_utils).
+`-- refactors/                               # RECEIVES ZERO candidates in this initiative.
+    `-- (pre-existing 1010/1011/1012 files)  # Prior extractions preserved; not extended.
+```
+
+**Structure Decision**: Single-project layout preserved from 1010/1011/1012. Every row of the Dispatch Queue is pinned to a specific landing target in `spec.md` — `src/refactors/` receives **zero** candidates in this initiative, breaking from the 1010/1011 "default landing zone" pattern in favour of per-row semantic-fit destinations. The four Cat A rows target the pre-existing `src/gateway/template_config.py`, `src/firmware/firmware_manager.py`, `src/site/site_config_manager.py`, and `src/device/utility_commands.py` — the PR only deletes the facade + rewires callsites, no file is created. The 43 Cat B rows spread across 15 existing packages: `src/export/` accepts 20 (accepted as flat for this initiative; sub-partitioning explicitly deferred pending noise emergence), `src/device/` accepts 4 Cat B + 1 Cat A, `src/utils/` accepts 4, `src/reports/` accepts 4, `src/analytics/` accepts 2, `src/ui/` accepts 2, `src/org/` accepts 2, `src/site/` accepts 2 Cat B + 1 Cat A, `src/gateway/` accepts 1 Cat A, `src/firmware/` accepts 1 Cat A, all others accept 1. No candidate is split across multiple PRs — even the seven very-large Cat B candidates (E-10: `OrgExportUtils` 653 LoC, `OrgConfigMigrationManager` 675 LoC, `ConstDefinitionsExporter` 759 LoC, `BulkRadiusWLANConfigManager` 587 LoC, `OrgTicketManager` 475 LoC, `OperationRegistry` 461 LoC, `OrgDeviceStatsExporter` 414 LoC) land as one PR each, with internal decomposition (E-2 / FR-006) folded into the same PR to satisfy the `<=25`-line-per-method rule and the aggregate score floor.
+
+### Dispatch Queue (Authoritative)
+
+Per FR-001, FR-023, and FR-026, the 47 candidates dispatch in a two-block order: **Cat A block first (positions 1-4)** as a low-risk warmup because the `src/` implementation is already merged and CI-proven; then **Cat B block (positions 5-47)** in Refs-ASC / LOC-DESC order derived from the freshest `refactor_candidates.md` at each hop. Within each block, ordering is Refs-ASC / LOC-DESC (same rule). The table below reflects the post-1012 catalog snapshot (2026-07-07) with the 2026-07-07 collision audit result baked in.
+
+| # | Refs | LoC | Class | Cat | Landing target |
+|---:|---:|---:|---|:-:|---|
+| 1 | 6 | 56 | GatewayTemplateConfigManager | A | `src/gateway/template_config.py` |
+| 2 | 8 | 22 | FirmwareManager | A | `src/firmware/firmware_manager.py` |
+| 3 | 16 | 43 | SiteConfigManager | A | `src/site/site_config_manager.py` |
+| 4 | 70 | 188 | DeviceUtilityCommands | A | `src/device/utility_commands.py` |
+| 5 | 4 | 675 | OrgConfigMigrationManager | B | `src/org/` |
+| 6 | 4 | 97 | DeviceUtils | B | `src/device/` |
+| 7 | 4 | 40 | SelfExportUtils | B | `src/export/` |
+| 8 | 5 | 386 | MSPInventoryExporter | B | `src/export/` |
+| 9 | 5 | 214 | TelemetryEmitter | B | `src/analytics/` |
+| 10 | 8 | 72 | InteractiveDisplayUtils | B | `src/ui/` |
+| 11 | 8 | 70 | DisplayUtils | B | `src/ui/` |
+| 12 | 8 | 66 | AuditAnalysisOps | B | `src/audit/` |
+| 13 | 9 | 461 | OperationRegistry | B | `src/utils/` |
+| 14 | 10 | 85 | SiteClientExporter | B | `src/export/` |
+| 15 | 13 | 587 | BulkRadiusWLANConfigManager | B | `src/site/` |
+| 16 | 13 | 10 | EndpointConfig | B | `src/dataclasses/` |
+| 17 | 14 | 759 | ConstDefinitionsExporter | B | `src/export/` |
+| 18 | 14 | 129 | OrgAlarmEventExporter | B | `src/export/` |
+| 19 | 14 | 100 | SiteConfigExporter | B | `src/export/` |
+| 20 | 14 | 94 | OrgAdminExporter | B | `src/export/` |
+| 21 | 16 | 328 | APIDataFetcher | B | `src/api/` |
+| 22 | 18 | 144 | OrgTemplateExporter | B | `src/export/` |
+| 23 | 18 | 139 | GatewayHaExporter | B | `src/export/` |
+| 24 | 20 | 168 | LicenseExportUtils | B | `src/export/` |
+| 25 | 20 | 156 | DataCollectionManager | B | `src/analytics/` |
+| 26 | 20 | 129 | WiredClientManufacturerReportGenerator | B | `src/reports/` |
+| 27 | 22 | 180 | SFPTransceiverDataProcessor | B | `src/reports/` |
+| 28 | 22 | 146 | SitesByAPModelExporter | B | `src/export/` |
+| 29 | 22 | 69 | OrgDeviceInventorySummary | B | `src/inventory/` |
+| 30 | 23 | 161 | CLIShellManager | B | `src/ssh/` |
+| 31 | 24 | 168 | OrgConfigExporter | B | `src/export/` |
+| 32 | 26 | 162 | OrgClientSecurityExporter | B | `src/export/` |
+| 33 | 28 | 114 | EnvironmentUtils | B | `src/utils/` |
+| 34 | 30 | 203 | SiteDeviceExporter | B | `src/export/` |
+| 35 | 31 | 210 | PromptClientUtils | B | `src/input/` |
+| 36 | 32 | 251 | GlobalWiredClientReportGenerator | B | `src/reports/` |
+| 37 | 34 | 245 | GatewayTestExporter | B | `src/export/` |
+| 38 | 34 | 179 | DatabaseSchemaUtils | B | `src/db/` |
+| 39 | 36 | 127 | TroubleshootUtils | B | `src/troubleshooting/` |
+| 40 | 37 | 110 | FilterOperatorEngine | B | `src/utils/` |
+| 41 | 46 | 396 | DeviceRebootManager | B | `src/device/` |
+| 42 | 46 | 289 | ARPCommandManager | B | `src/device/` |
+| 43 | 54 | 341 | SiteAnomalyExporter | B | `src/export/` |
+| 44 | 54 | 273 | OfflineDeviceReporter | B | `src/reports/` |
+| 45 | 58 | 414 | OrgDeviceStatsExporter | B | `src/export/` |
+| 46 | 66 | 475 | OrgTicketManager | B | `src/org/` |
+| 47 | 128 | 653 | OrgExportUtils | B | `src/export/` |
+
+**Reordering rule (FR-014 / FR-026 / User Story 3)**: After every merged PR, regenerate `refactor_candidates.md` and re-sort the *remaining Cat B candidates* by fresh Refs-ASC / LOC-DESC before dispatching the next PR. The Cat A block cannot shift because it only contains 4 entries and they are already correctly ordered by Refs-ASC / LOC-DESC (6/56 → 8/22 → 16/43 → 70/188). A Cat B candidate whose ref count shifts (e.g. because an earlier extraction indirectly removed some of its callers) is repositioned within the Cat B block. A candidate whose classification drops below Hot bucket is deferred out of scope per FR-020. A candidate whose grep audit surfaces a new `src/` caller is deferred per FR-013. Under no circumstances does a Cat B PR interleave into the Cat A block or vice versa.
+
+**Pinned NOTE breadcrumb template** (FR-007, SC-012) — verbatim, one line per merged PR at the deletion site in `MistHelper.py`:
+
+```text
+# NOTE: <ClassName> extracted to <new-module-path>::<ClassName>. See specs/1013-misthelper-refactor-hot-classes/spec.md.
+```
+
+Per-Cat variation:
+
+- **Cat A PRs** place the breadcrumb at the **facade-deletion site**. `<new-module-path>` points at the pre-existing `src/` file that already houses the real implementation (e.g. `src/gateway/template_config.py`, `src/firmware/firmware_manager.py`, `src/site/site_config_manager.py`, `src/device/utility_commands.py`). No file is created by the Cat A PR.
+- **Cat B PRs** place the breadcrumb at the **class-body-deletion site**. `<new-module-path>` points at the newly created `src/` file inside the landing package (e.g. `src/org/org_config_migration_manager.py`).
+
+Post-merge grep audit: `grep -n "# NOTE: .* extracted to .*::.* See specs/1013-misthelper-refactor-hot-classes/spec.md." MistHelper.py` should return exactly `N` hits after `N` merged PRs.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |
+
+## Post-Design Constitution Re-Check
+
+Re-evaluated after Phase 1 design artifacts landed (`research.md` and this `plan.md`):
+
+- **I. Five-Item Rule** — Still PASS. No menu topology changed by any of the 47 PRs; user-facing behavior preserved exactly per FR-021.
+- **II. Class-Based Architecture** — Still PASS + REINFORCED. Every candidate is already a class; extraction lands each as a cohesive class body per FR-004. Cat A PRs actively reinforce cohesion by removing dead facades whose existence duplicated a `src/` counterpart — post-Cat-A, exactly one canonical class body exists per name across the codebase. Cat B PRs preserve cohesion by moving the class body intact into a new landing file (or fold into an existing package class body when appropriate).
+- **III. Safety-First** — Still PASS + REINFORCED. Pre-dispatch grep audit (FR-013) is the pre-deletion safety check analogous to 1012's Q1 "0 callers" gate. Cat A PRs carry an additional safety gate via FR-025: enumerate facade methods → confirm each is exposed by the `src/` counterpart with equivalent signature → paste the audit output in the PR description before deletion. FR-025 explicitly calls out `DeviceUtilityCommands` (35 op-subclass wrappers at dispatch position 4) for particularly rigorous audit output. No new destructive paths introduced.
+- **IV. Full Deployment Pipeline** — Still PASS + REINFORCED. FR-015 CI gate + `feedback_no_admin_bypass.md` + `feedback_prepush_black_ruff.md`. FR-019 additionally forbids introducing *new* SKIPPED conditionals via this initiative.
+- **V. Observability & Logging** — Still PASS + REINFORCED. FR-006 requires in-flight resolution of `non_ascii_logs`, `raw_input_call`, and `hardcoded_separator` flags on Cat B extractions; no deferrals. Cat A PRs have no new file to lint but MUST preserve the pre-existing `src/` module's compliance grade.
+- **VI. Inline Comments** — Still PASS + NON-NEGOTIABLE. A+/100 per-file gate (FR-016) enforces the 5-10 line inline-comment cadence on every new/edited Cat B module.
+- **VII. Action Logging** — Still PASS + NON-NEGOTIABLE. FR-006 requires in-flight resolution of `missing_action_logging` flag on Cat B extractions; original `[LOGIN]` / `[MENU]` / `[EXECUTE]` / `[SUCCESS]` / `[FAILURE]` prefixes preserved verbatim when already present.
+
+**FR-025 (method-parity gate) callout**: This gate is the Cat A analog to the FR-006 in-flight `guideline_flags` resolution rule. Where Cat B PRs prove correctness by moving the class body byte-for-byte (with only internal decomposition allowed), Cat A PRs prove correctness by auditing that every method the facade exposed is exposed by the `src/` counterpart with an equivalent signature. The audit output is a mandatory PR-description artifact; silent facade deletion is prohibited.
+
+**FR-026 (Cat A-first ordering) callout**: The 4 Cat A candidates occupy dispatch positions 1-4 as an intentional risk-front-load. Cat A PRs carry lower semantic risk (the `src/` implementation is already merged and CI-proven — the PR only removes the dead facade + rewires callsites) than Cat B PRs (which move fresh code into a new landing file). Running Cat A first validates the initiative's callsite-rewrite discipline against a smaller edit surface and warms reviewer discipline against the FR-025 method-parity gate before the fresh-extraction workflow begins at position 5.
+
+**Final verdict**: All seven principles pass post-design. No Complexity Tracking entries required.
+
+## What This Plan Does NOT Do
+
+- Does not open, sequence, or merge any of the 47 PRs — that is the parent conversation's dispatch responsibility (carry-forward from 1010/1011/1012 Assumption 7).
+- Does not modify `tools/refactor_analyzer/` (FR-011 carry-forward). The analyzer is consumed as-is; the initiative only invokes it via its documented CLI surface.
+- Does not touch any symbol in the analyzer's `SKIP_ALWAYS` bucket (`GlobalImportManager`, `tqdm` by convention per 1012) — FR-009 carry-forward, SC-008.
+- Does not re-refactor any class already extracted in 1010, 1011, or 1012 — FR-010, SC-009.
+- Does not touch any Hot-bucket class with a non-`MistHelper.py` caller. The 29 excluded classes remain deferred to a future initiative (post-1013) that will address multi-file rewrite discipline — FR-012, SC-009.
+- Does not touch any Hot-bucket function or assignment. The initiative is Hot **classes** only; Hot functions were handled by 1012 (three targeted), Hot assignments and any remaining Hot functions remain deferred.
+- Does not batch multiple classes into a single PR — FR-002, contrast with 1012's bounded-bundle pattern.
+- Does not leave wrapper shims, forwarding functions, re-export modules, or backward-compatibility aliases in `MistHelper.py` — FR-003, SC-007. This applies uniformly to both Cat A and Cat B.
+- Does not create new `src/` files for Cat A candidates. The real implementation already exists at the pinned landing target; the Cat A PR only removes the dead facade + rewires callsites. Only Cat B rows create new files.
+- Does not defer method-parity verification for any Cat A PR. FR-025 requires the audit be recorded in the PR description under a `Method-Parity Audit` heading before facade deletion; silent facade deletion is prohibited. This applies with particular rigour to the `DeviceUtilityCommands` PR (dispatch position 4, 35 op-subclass wrappers).
+- Does not interleave Cat A and Cat B rows. Cat A rows occupy dispatch positions 1-4 exclusively; Cat B rows occupy 5-47 exclusively (per FR-026). Reordering per FR-014 only shuffles remaining Cat B candidates within the Cat B block.
+- Does not defer any analyzer `guideline_flag` on a moved Cat B class to a follow-up PR — FR-006, SC-011.
+- Does not split any single candidate across multiple PRs, even the seven very-large Cat B candidates (E-10) — the internal decomposition per E-2 is folded into the same PR.
+- Does not introduce new features, new commands, new CLI flags, or user-facing behavior changes — FR-021.
+- Does not modify external-file callers of a moved class beyond what's required by the extraction itself. Files touched only for callsite rewrite are not required to reach A+/100 in the same PR *if they were not already there* — FR-022 applies only when the extracted class is folded into an existing destination package's class body.
+- Does not raise the compliance baseline. The initiative preserves `>=99.6/A+` aggregate; it does not attempt to reach 100/A+.
+- Does not enumerate the 29 excluded Hot-bucket classes or the future initiative that will address them; those are out of scope for this spec.
+- Does not add a `contracts/` directory or `data-model.md`. The initiative's contracts are exhaustively captured in `spec.md` (FR-001-FR-026, SC-001-SC-017) and `research.md` (decisions); adding duplicate documents would not add audit value.
+- Does not use `src/refactors/` as a landing target for any of the 47 rows. Every row is pinned to a domain-fitting existing package in `spec.md`.

--- a/specs/1013-misthelper-refactor-hot-classes/research.md
+++ b/specs/1013-misthelper-refactor-hot-classes/research.md
@@ -1,0 +1,351 @@
+# Phase 0 Research: Hot-Classes Serial Extraction
+
+**Feature**: `specs/1013-misthelper-refactor-hot-classes/`
+**Date**: 2026-07-07
+**Predecessors**: 1010 (13 PRs), 1011 (20 PRs), 1012 (bounded bundle) — all closed with baseline >=99.6/A+.
+
+This document consolidates the design decisions needed to lower `spec.md` into an implementable serial per-PR workflow. Each decision follows the SpecKit research contract: **Decision / Rationale / Alternatives considered**.
+
+The Phase 0 collision audit performed on 2026-07-07 partitions the 47 Hot-bucket candidates into two action-types (Cat A: facade removal; Cat B: fresh extraction). All subsequent decisions treat Cat A and Cat B as distinct sub-flows sharing common guardrails.
+
+---
+
+## Decision 1 — Action-type categorization: Cat A (facade removal) vs Cat B (fresh extraction), determined by 2026-07-07 collision audit
+
+**Decision**: Each of the 47 Hot-bucket candidates is pre-classified into one of three action-types before dispatch. The classification is fixed at dispatch time by a filesystem grep against `src/` and does not change during PR execution.
+
+**Category definitions**:
+
+- **Cat A — facade removal**: A same-name class definition already exists under `src/` (the canonical body, established by 1010/1011). The `MistHelper.py` copy is a stale facade — either a thin delegation shim retained after a prior fold, or a re-imported wrapper. The Cat A PR **deletes the facade** at the `MistHelper.py` source anchor, rewrites callsites to import directly from the existing `src/` module, and creates **zero new files**. Method-parity between facade and canonical body is verified in-flight per FR-025.
+- **Cat B — fresh extraction**: No same-name class definition exists under `src/`. The Cat B PR performs the standard extract-and-delete workflow: the class body moves to a newly-created file under the pinned landing package (per spec's Dispatch Queue), the `MistHelper.py` definition is deleted, callsites are rewritten to import from the new module. Every guideline flag surfaced by the analyzer is resolved in-flight per FR-006.
+- **Cat C — ambiguous / partial overlap**: A same-name class exists under `src/` but the two bodies diverge non-trivially (public API drift, added methods, renamed private helpers, or genuinely distinct class of the same name). A Cat C PR would require pausing dispatch and landing a discovery commit before the extraction proceeds.
+
+**Collision-audit methodology** (2026-07-07 sweep):
+
+```bash
+# For each of the 47 candidate class names, from repo root:
+git checkout main
+for CLASS in <47 candidate names>; do
+  grep -rn "^class ${CLASS}[ (:]" src/ | tee -a data/collision_audit_1013.txt
+done
+```
+
+Any hit under `src/` marks the candidate a Cat A/C. Zero hits marks it Cat B. Discrimination between Cat A and Cat C is by inspection of the facade body vs the canonical body — if the facade's public methods are all present on the canonical class with matching signatures, it is Cat A; if any method is missing, renamed, or diverges in signature, it is Cat C pending discovery.
+
+**2026-07-07 audit result**: **4 Cat A / 43 Cat B / 0 Cat C**. The four Cat A candidates and their source-line anchors:
+
+| Position | Class | MistHelper.py anchor | Existing canonical body | Facade shape |
+|---|---|---|---|---|
+| 1 | `GatewayTemplateConfigManager` | `MistHelper.py:15596` | `src/gateway/template_config.py:30` | 3 static delegation methods on the facade; all three are 1:1 present on the canonical class. |
+| 2 | `FirmwareManager` | `MistHelper.py:17376` | `src/firmware/firmware_manager.py:134` | Factory facade with 270 defs (delegation to canonical class methods); method inventory audited 1:1 against canonical body. |
+| 3 | `SiteConfigManager` | `MistHelper.py:16926` | `src/site/site_config_manager.py:54` | `_configure_module()` + 4 delegation methods; canonical class exports all 5 with matching signatures. |
+| 4 | `DeviceUtilityCommands` | `MistHelper.py:13527` | `src/device/utility_commands.py:82` | Facade orchestrator with 35 op-subclasses (Command pattern fan-out); canonical class holds all 35 op-classes as nested types or same-module peers. Method-parity audit is the largest of the four (see Decision 12). |
+
+The remaining 43 candidates (rows 5-47 in the Dispatch Queue) are Cat B: no same-name class definition exists under `src/`, so each is a fresh extraction to its pinned landing package.
+
+**Landing conventions retained from prior initiatives**:
+
+- Cat A: no new file is created. The facade deletion is the only edit to `MistHelper.py`; the existing canonical file is untouched (import-only rewrite of callsites).
+- Cat B: one class → one file. Landing is a domain-fitting existing package per the spec's pinned landing-target column. Concrete groupings from the spec:
+  - `src/site/` — `SiteConfigExporter`, `SiteClientExporter`, `SiteDeviceExporter`, `SiteAnomalyExporter`, `SitesByAPModelExporter`.
+  - `src/export/` — `OrgAlarmEventExporter`, `OrgAdminExporter`, `OrgTemplateExporter`, `OrgConfigExporter`, `OrgClientSecurityExporter`, `OrgDeviceStatsExporter`, `OrgTicketManager`, `OrgExportUtils`, `SelfExportUtils`, `LicenseExportUtils`.
+  - `src/gateway/` — `GatewayHaExporter`, `GatewayTestExporter`.
+  - `src/refactors/` — receives **zero** Cat B candidates. Every Cat B row is pinned per-row to a semantic package in the spec's Dispatch Queue.
+
+**Rationale**: Discovering facade collisions pre-dispatch is materially cheaper than discovering them mid-PR. The 2026-07-07 audit closes a class of surprise ("this class already exists in src/!") that otherwise blocks a PR mid-implementation. Fixing the action-type at dispatch time also gates the correct FR (FR-025 method-parity for Cat A; FR-006 in-flight decomposition for Cat B) so the reviewer knows which rubric applies before opening the diff.
+
+**Alternatives considered**:
+
+- *Treat all 47 as Cat B and discover collisions during PR execution*. Rejected — creates unpredictable PR abandonment when a collision surfaces at implementation time; wastes reviewer bandwidth on aborted PRs.
+- *Merge Cat A into Cat B by renaming facade-collision candidates to `<Name>Legacy` and landing them as fresh extractions*. Rejected — creates duplicate implementations in the codebase (canonical + legacy) with no functional distinction, deferring the eventual facade removal to a follow-up initiative rather than closing it out here.
+- *Fold Cat A candidates into the same PR as their canonical body's owner PR retroactively*. Rejected — canonical bodies were established under closed initiatives (1010/1011); a 1013 PR that reopens a closed 1010 PR's file violates initiative scoping.
+
+---
+
+## Decision 2 — Tiny classes (LOC < 25) still get their own module by default
+
+**Decision**: Every Cat B extraction candidate — including tiny ones like `EndpointConfig` (10 LOC) — lands in its own module under the pinned landing package. Small size alone does not trigger folding into an existing file within the landing package. If the landing package holds a natural host class and folding preserves A+/100, folding is permitted only when at least two of the following are true: (1) the candidate's name suggests it as a peer/helper of the host class; (2) the candidate's public API is invoked alongside the host class's methods in `MistHelper.py`; (3) folding does not push the destination file below A+/100 (FR-022 hard gate).
+
+**Rationale**: Uniform one-class-per-module output makes the post-initiative directory grep-friendly (`grep -l "^class EndpointConfig" src/refactors/`) and matches the pattern established by 1010/1011 which landed 30+ single-class modules. Consolidating tiny classes into a shared "small_helpers.py" grab-bag would produce exactly the kind of monolith this initiative is dismantling. The compliance-analyzer overhead per tiny file is negligible (each still scores A+/100 with the mandatory module docstring, class docstring, and comment cadence).
+
+**Alternatives considered**:
+
+- *Bundle tiny classes into a shared module*. Rejected — recreates the anti-pattern (many-classes-per-file) at a smaller scale and forces future readers to search for the file that hosts a given name.
+- *Inline tiny classes into their sole caller's module*. Rejected — Hot-bucket definition requires 4+ callers, so no candidate has a single caller to inline into.
+
+---
+
+## Decision 3 — `FirmwareManager` resolution superseded by Cat A categorization
+
+**Decision**: The Phase 0 `FirmwareManager` uncertainty (originally recorded as a dispatch-time diff decision) is **resolved by the 2026-07-07 collision audit**: `FirmwareManager` is confirmed **Cat A**. Its `MistHelper.py:17376` body is a factory facade over `src/firmware/firmware_manager.py:134`. The row-2 PR performs the Cat A workflow (facade delete, callsite rewrite, method-parity audit per FR-025) — no `firmware_manager_v2.py`, no `FirmwareManagerLegacy` rename, no `src/refactors/` landing.
+
+The three outcomes previously enumerated (identical / distinct / ambiguous) collapse to outcome (1) — identical or trivially divergent body — confirmed by the pre-dispatch audit. Outcomes (2) and (3) would have been Cat C candidates, and no Cat C candidates surfaced in the 2026-07-07 audit.
+
+**Rationale**: Formalizing the collision audit at Phase 0 (Decision 1) removed the last remaining "resolve at dispatch time" ambiguity that this decision previously covered. The row-2 PR now dispatches with the same clarity as row-1, row-3, and row-4 (all Cat A).
+
+**Alternatives considered**:
+
+- *Retain the dispatch-time diff as a belt-and-braces check*. Rejected — the audit result is deterministic; re-running the same check at dispatch time adds overhead without new information.
+- *Rename the canonical class under `src/firmware/` to disambiguate from the facade*. Rejected — the canonical class name is stable (established by 1011); renaming it would churn every existing callsite that already imports from `src/firmware/firmware_manager.py`.
+
+---
+
+## Decision 4 — Decompose-during-move rules per `guideline_flag` category (Cat B only)
+
+**Decision**: Every `guideline_flag` surfaced by the analyzer on a **Cat B** extraction candidate is resolved in the same PR (FR-006). Cat A PRs do not perform in-flight decomposition — the canonical body under `src/` is untouched and its analyzer scores are assumed compliant (pre-verified by the closing initiative that established it).
+
+Cat B per-flag playbook:
+
+| Flag | Remediation in the extraction PR |
+|------|----------------------------------|
+| `oversize_25_lines` | Split each offending method into helpers, each <= 25 lines. New helpers get private (`_leading_underscore`) names, class-body docstrings, and their own `logging.debug` breadcrumbs. Public method contracts preserved (same signature, same return type, same exceptions). |
+| `missing_inline_comments` | Every executable line gets an inline comment describing its intent (Constitution VI cadence: comment every 5-10 lines minimum). Blank lines and pure-syntax lines (closing brackets, `else:`) do not need comments. |
+| `missing_action_logging` | Every public method opens with `logging.info("[EXECUTE] <ClassName>.<method>: %s", <context>)`, closes with `logging.info("[SUCCESS] <ClassName>.<method>: %s", <result_summary>)`, and wraps any error path with `logging.error("[FAILURE] <ClassName>.<method>: %s", <exc>)`. Constitution VII prefix set enforced verbatim. `%s` formatting required (no f-strings in log calls). |
+| `non_ascii_logs` | Every log literal is transliterated to ASCII. Curly quotes -> straight quotes, en-dash -> hyphen-minus, ellipsis -> three dots. `logging.info("...")` bodies must survive `str.encode('ascii')` without loss. |
+| `hardcoded_separator` | Replace `os.path.join`, `os.sep`, and string-concatenated paths with `pathlib.Path`. All path construction goes through `Path(...)` and `Path.__truediv__`. |
+| `raw_input_call` | Replace every `input(...)` with `InputUtils.safe_input(...)`. Import from wherever `InputUtils` currently lives (surfaced by grep at dispatch). |
+
+Any additional flag surfaced by an analyzer update is handled with the same "resolve in-flight, never defer" rule. If a flag is genuinely unfixable in the extraction PR (extremely rare), the PR is deferred to the deferred pool with rationale.
+
+**Rationale**: FR-006 mandates zero forward-carried guideline violations on Cat B extractions. A per-flag playbook removes contributor guesswork and lets reviewers audit remediation quality against a fixed rubric. Cat A PRs skip this rubric because the canonical body already passed it under the closing initiative; requiring re-verification would blur the initiative boundary. The `%s` formatting rule is Constitution V's action-log contract; f-strings in log calls are the most common lint failure and worth pre-empting explicitly.
+
+**Alternatives considered**:
+
+- *Apply the same rubric to Cat A canonical bodies as a "cleanup pass"*. Rejected — Cat A PRs are engineered to have zero footprint in `src/`; touching canonical bodies expands PR scope and violates the "facade removal only" contract.
+- *Defer complex remediations (e.g. `oversize_25_lines` on 500+ LoC classes)*. Rejected — E-10 explicitly says large candidates land in one PR each; SC-011 requires zero forward-carried flags.
+- *Allow f-strings in log calls if the message is static*. Rejected — Constitution V's `%s` rule exists to preserve structured-log-parseability across the codebase; the "static message" carve-out invites drift.
+
+---
+
+## Decision 5 — Pinned NOTE breadcrumb template (per-Cat variation)
+
+**Decision**: Every extraction PR leaves exactly one NOTE breadcrumb at the deletion site in `MistHelper.py`, matching the FR-007 template with per-Cat variation:
+
+**Cat A** (facade removal — points at existing canonical body):
+```python
+# NOTE: <ClassName> facade removed; canonical body at <src-path>::<ClassName>. See specs/1013-misthelper-refactor-hot-classes/spec.md.
+```
+
+**Cat B** (fresh extraction — points at newly-created module):
+```python
+# NOTE: <ClassName> extracted to <new-module-path>::<ClassName>. See specs/1013-misthelper-refactor-hot-classes/spec.md.
+```
+
+Placeholders:
+
+- `<ClassName>` — the exact class name as it appeared in `MistHelper.py` before deletion (case-sensitive).
+- `<src-path>` (Cat A) — the path to the existing canonical file (e.g. `src/firmware/firmware_manager.py`, `src/device/utility_commands.py`).
+- `<new-module-path>` (Cat B) — the newly-created module path per the Dispatch Queue's Landing target column.
+
+Position: the NOTE replaces the deleted `class <Name>:` line, appearing as the single-line successor at the same source position. No adjacent blank lines are added or removed.
+
+**Rationale**: Breadcrumb uniformity is enforced by grep at review time (SC-012). Two pinned template shapes (one per Cat) let the reviewer's `grep -c "# NOTE: <ClassName>"` return exactly 1 while making the action-type visible at a glance from `MistHelper.py` alone. A future refactor sweep can distinguish facade-removals from fresh-extractions by grep pattern without opening the spec.
+
+**Alternatives considered**:
+
+- *Single unified template for both Cats*. Rejected — Cat A and Cat B are semantically different operations; a unified template would either omit the "facade removed" signal (obscuring history) or omit the "extracted to" signal (obscuring Cat B destinations).
+- *Optional breadcrumbs at contributor discretion*. Rejected — quality drift; SC-012 becomes unverifiable.
+- *Multi-line breadcrumb with structured YAML frontmatter*. Rejected — a single-line comment fits the existing `MistHelper.py` comment style and survives `black` re-flow without adjustment.
+
+---
+
+## Decision 6 — CI-time verification of "no wrapper shim" (SC-007) uses a fixed grep pattern
+
+**Decision**: SC-007 (zero wrapper shims survive) is verified during PR review with the following grep pattern, invoked against the merged `MistHelper.py`. The pattern is identical for Cat A and Cat B — in both cases the class name should not appear as a definition, function shim, or alias in `MistHelper.py`:
+
+```bash
+# After each extraction, no residual class definition remains:
+grep -n "^class <ClassName>[ (:]" MistHelper.py       # Expect: 0 hits
+grep -n "^def <ClassName>" MistHelper.py              # Expect: 0 hits (guard against fn shim)
+grep -n "<ClassName> = " MistHelper.py                # Expect: 0 hits (guard against alias)
+grep -n "^from .* import <ClassName>$" MistHelper.py  # Expect: 1 hit (the new import line)
+```
+
+The last grep confirms the import replaces the definition. Any extra hits (e.g. a `<ClassName> = _real_<ClassName>` alias line, or a forwarding `def <ClassName>(...)` factory) fail SC-007 and block merge until removed.
+
+For Cat A, the import target is the existing canonical module (`src/firmware/firmware_manager`, `src/device/utility_commands`, etc.). For Cat B, the import target is the newly-created module under the pinned landing package.
+
+The pattern is documented in `quickstart.md` step "Verification greps" so contributors invoke it locally before opening the PR.
+
+**Rationale**: Wrapper shims are the failure mode this initiative is engineered against. Codifying the exact grep pattern (not "look around and eyeball it") makes the review contract deterministic. All four sub-patterns are needed because different shim styles evade different single greps. The Cat A vs Cat B distinction affects the *destination* of the import line but not the *shape* of the shim check itself.
+
+**Alternatives considered**:
+
+- *AST-based verification via a custom tool*. Rejected — the grep pattern is trivial to run and understand; adding tooling introduces maintenance overhead for a check that runs once per PR.
+- *Rely on the compliance-analyzer alone*. Rejected — the analyzer verifies compliance grade, not shim absence; the two checks are complementary.
+
+---
+
+## Decision 7 — Analyzer regression guardrail: baseline captured on the first branch commit, aggregate >= 99.6/A+ per PR
+
+**Decision**: The `MistHelper.py` pylint baseline and repo-wide aggregate compliance snapshot are captured on the first commit of branch `1013-misthelper-refactor-hot-classes` (before any extraction lands). Concretely:
+
+```bash
+git checkout -b 1013-misthelper-refactor-hot-classes origin/main
+python -m tools.compliance_analyzer --repo-wide > data/full_repo_compliance_1013_baseline.md
+pylint MistHelper.py > data/pylint_MistHelper_1013_baseline.txt
+git add data/full_repo_compliance_1013_baseline.md data/pylint_MistHelper_1013_baseline.txt
+git commit -m "chore(1013): capture pre-initiative compliance and pylint baselines"
+```
+
+Per-PR gates (identical for Cat A and Cat B):
+
+- `python -m tools.compliance_analyzer --repo-wide` reports aggregate >= 99.6/A+ (SC-003).
+- Every file the PR touches (created or edited) scores A+/100 (SC-006). For Cat A, this reduces to `MistHelper.py` only (no new file created, canonical body untouched).
+- `pylint MistHelper.py` reports a score >= the value captured in `data/pylint_MistHelper_1013_baseline.txt` (SC-015). Regression by any amount blocks merge for that PR.
+
+The baseline captures are consumed as inputs to the merge gate, not modified by extraction PRs. If a legitimate baseline shift is needed (e.g. an unrelated `main` PR raises the pylint floor), a separate chore commit updates the baseline and the rationale is recorded in that commit's message.
+
+**Rationale**: A moving baseline defeats the guardrail; a fixed baseline captured at branch time gives every PR a single number to beat. The three-level gate (aggregate score, per-file score, MistHelper.py pylint) covers the three regression paths: a new file that isn't A+ (Cat B only), an edit that drops an old A+ file, and MistHelper.py-only pylint drift from the deletion churn (both Cats).
+
+**Alternatives considered**:
+
+- *Recompute baseline on every merge*. Rejected — creates a drift window where a small regression per PR compounds into a large aggregate regression over 47 PRs.
+- *Ignore MistHelper.py pylint entirely because the file is being shrunk anyway*. Rejected — pylint scoring is size-normalized; deleting code without keeping the remaining lines clean still shows up as regression.
+
+---
+
+## Decision 8 — Dispatch queue mutation policy: E-1 through E-10 conditions trigger deferral, never silent skip
+
+**Decision**: The 47-row Dispatch Queue is mutated (candidates deferred, or in the rare case of E-6 reclassifying an external-caller candidate back to MistHelper-only, added) only via explicit spec revisions. The triggers apply uniformly to Cat A and Cat B PRs:
+
+| Edge Case | Trigger | Response |
+|-----------|---------|----------|
+| E-1 | Destination package selection ambiguity | Cat B only — resolve in PR body; no queue change. (Cat A destinations are fixed by the canonical body.) |
+| E-2 | Guideline-flag decomposition scope | Cat B only — resolve in-flight in the PR; no queue change. (Cat A does not perform decomposition.) |
+| E-3 | Line-number drift only (no ref-count / classification change) | Proceed with fresh grep; no queue change. |
+| E-4 | Missing NOTE breadcrumb at review | Reviewer requests change; PR revised; no queue change. |
+| E-5 | Name collision at destination | Cat B only — rename or redirect in PR body; no queue change. (Cat A collisions are the audit's finding.) |
+| E-6 | Ref-count shift discovered at fresh catalog regeneration | If drops below Hot band (< 4 refs), defer per FR-020 and record in Deferred Candidates. If rises above the queue's ceiling, no queue change (still Hot). If an excluded external-caller candidate becomes MistHelper-only, spec revision required to add it. |
+| E-7 | `python MistHelper.py --test` failure from unrelated commit | Pause the initiative until the underlying regression is fixed; no queue change. |
+| E-8 | Aggregate score drop below 99.6/A+ | Revise the PR (resolve more flags); no queue change unless deferred outright. |
+| E-9 | SKIPPED conditionals | Non-blocking per policy; no queue change. |
+| E-10 | Very large candidate needing decomposition | Cat B only — land as one PR with substantial internal decomposition; no queue change. |
+
+Deferral procedure:
+
+1. The dispatcher runs the pre-dispatch grep audit (`grep -rn "<ClassName>" src/ tests/`) and detects an external caller (FR-013) OR the fresh catalog shows a Hot -> Low-Use reclassification (FR-020).
+2. The dispatcher opens a small docs-only commit that adds a row to the Deferred Candidates table in `spec.md`, populating (Class, Reason, Recording PR / Commit).
+3. The dispatcher advances to the next queue head.
+4. The docs-only commit is recorded in the next dispatched PR's body as prior context.
+
+**Rationale**: A "silent skip" (advance past a candidate without recording why) breaks SC-014 (auditable Refs-ASC / LOC-DESC walk within each Cat block). A docs commit that predates the next PR keeps the sequence walkable and the Deferred Candidates table honest. Cat A candidates are unlikely to trigger deferral (audit already confirmed their canonical bodies exist), but the policy applies uniformly for consistency.
+
+**Alternatives considered**:
+
+- *Batch deferrals into a monthly docs commit*. Rejected — a deferral must be visible before the next PR opens so reviewers know why the queue jumped.
+- *Delete deferred candidates from the queue entirely*. Rejected — the queue is spec history; deferrals live alongside the original 47 rows.
+
+---
+
+## Decision 9 — Interaction with in-flight residuals (1 Single-Use, 2 Low-Use) tracked separately
+
+**Decision**: The post-1012 catalog shows 1 Unused (already 0), 1 Single-Use, and 2 Low-Use residuals in addition to the 47 Hot classes. Those 3 residuals are **out of scope for this initiative**; they are tracked by a separate future initiative (`1014-*` or similar). If a residual is coincidentally on the same call chain as a 1013 extraction and the extraction reduces its ref count further, the residual's classification may shift silently in `refactor_candidates.md` — that shift is recorded but not acted upon by 1013.
+
+Ordering: 1013 PRs proceed sequentially through Cat A first (positions 1-4) then Cat B (positions 5-47); residuals are ignored throughout. No 1013 PR touches a residual class body. No 1013 PR's callsite rewrite depends on a residual class being already extracted.
+
+If a merge conflict arises because a hypothetical future `1014-*` PR touches `MistHelper.py` concurrently with a 1013 PR, the 1013 PR resolves the conflict by rebasing onto the 1014 landing (serial workflow — one PR open at a time, FR-023) rather than by expanding scope.
+
+**Rationale**: Cross-initiative scope creep is the fastest way to blow the "one class per PR" discipline. Treating residuals as an orthogonal concern keeps 1013's success criteria tractable. The 3 residuals are small enough (Single-Use + 2 Low-Use = at most 3 more PRs) that a follow-up initiative is trivially cheap.
+
+**Alternatives considered**:
+
+- *Absorb the 3 residuals into 1013's scope*. Rejected — a Hot-classes initiative that also processes Single-Use and Low-Use is a "everything left" initiative and loses the scoping discipline that makes it reviewable.
+- *Wait for residuals to be cleared before starting 1013*. Rejected — nothing about the residuals blocks Hot-class extraction; parallel initiative kickoff is safe under the "one PR open at a time" rule.
+
+---
+
+## Decision 10 — Analyzer catalog regeneration cadence: per-PR after every merge
+
+**Decision**: `refactor_candidates.md` is regenerated after every merged extraction PR, before the next PR is dispatched. Concretely:
+
+```bash
+git checkout main
+git pull                                                # after PR merges
+python -m tools.refactor_analyzer > refactor_candidates.md
+git add refactor_candidates.md
+git commit -m "chore(1013): regenerate refactor_candidates.md post-PR-<N>"
+git push
+```
+
+The freshest `refactor_candidates.md` on `main` is the authoritative dispatch source for the next PR (FR-014, SC-010, SC-014).
+
+Batching regenerations (e.g. "regenerate every 5 merges") is prohibited — a stale catalog is exactly how a candidate slips past the Refs-ASC / LOC-DESC ordering within each Cat block.
+
+**Rationale**: Regeneration cost is bounded (a few seconds); a stale catalog cost is unbounded (misdispatch, wasted PRs). Per-PR regeneration also lets each PR body cite the specific catalog snapshot it was dispatched from, giving SC-014 an auditable trail.
+
+**Alternatives considered**:
+
+- *Regenerate only at end-of-initiative*. Rejected — every subsequent dispatch would be against a snapshot that may not reflect the merged state.
+- *Regenerate every 5 merges (batched)*. Rejected — same problem, smaller drift window; the audit trail becomes non-linear.
+- *Skip regeneration if the merged PR's callsite rewrites don't touch any other candidate*. Rejected — the dispatcher would have to predict downstream ref-count effects; the analyzer is the canonical answer, run it.
+
+---
+
+## Decision 11 — Cat A-first dispatch ordering (FR-026)
+
+**Decision**: The Dispatch Queue processes all 4 Cat A candidates (positions 1-4) before any Cat B candidate (positions 5-47). Within each Cat block, ordering is Refs-ASC / LOC-DESC per FR-005. The four Cat A positions specifically:
+
+1. `GatewayTemplateConfigManager` (`MistHelper.py:15596` -> `src/gateway/template_config.py`).
+2. `FirmwareManager` (`MistHelper.py:17376` -> `src/firmware/firmware_manager.py`).
+3. `SiteConfigManager` (`MistHelper.py:16926` -> `src/site/site_config_manager.py`).
+4. `DeviceUtilityCommands` (`MistHelper.py:13527` -> `src/device/utility_commands.py`).
+
+**Rationale**: Cat A-first is a deliberate risk-front-load warmup. Each Cat A PR:
+
+- **Creates no new file** — reviewer surface reduces to `MistHelper.py` deletions + callsite import rewrites + method-parity audit table.
+- **Is bounded in scope** — the canonical body under `src/` is out of scope; the reviewer's mental model is "does this facade delete break anything?" rather than "is this new class well-designed?".
+- **Exercises the initiative's tooling once per PR** — baseline greps, method-parity gate (FR-025), NOTE breadcrumb template, per-file A+ verification — before the higher-friction Cat B work begins.
+
+Placing the 4 Cat A PRs at the front of the queue lets the initiative validate its guardrails against the lower-risk action-type before committing to 43 fresh-extraction PRs. If the Cat A workflow surfaces an unforeseen gap (missing playbook entry, breadcrumb-template ambiguity, method-parity edge case), the fix lands in the spec/plan before Cat B PRs open — cheaper than discovering the gap on PR 27 of Cat B.
+
+The Refs-ASC ordering within the Cat A block puts the least-referenced facades first, further reducing blast radius on the first PR.
+
+**Alternatives considered**:
+
+- *Pure Refs-ASC / LOC-DESC across all 47 without Cat separation*. Rejected — a Cat A candidate at position 12 would surface unexpectedly during a run of Cat B extractions, forcing the reviewer to context-switch between two mental models mid-initiative.
+- *Cat B first, Cat A last as "cleanup"*. Rejected — placing facade removals after 43 fresh extractions creates reviewer fatigue exactly when the method-parity audit needs the most careful review. Reviewers are freshest on PR 1-4.
+- *Interleave Cat A and Cat B based on ref-count*. Rejected — same context-switching cost as pure Refs-ASC, without the "warmup" benefit that Cat A-first provides.
+
+---
+
+## Decision 12 — Method-parity gate (FR-025) audit shape
+
+**Decision**: Every Cat A PR includes a method-parity audit in the PR description under a **Method-Parity Audit** heading. The audit shape is fixed:
+
+```bash
+# 1. Enumerate methods on the src/ canonical body:
+grep -n "^\s*def " <src-path>
+
+# 2. Enumerate methods on the MistHelper.py facade (before deletion):
+grep -n "^\s*def " MistHelper.py | sed -n '<facade-start>,<facade-end>p'
+
+# 3. Compare the two sets: every method on the facade must correspond 1:1 to a
+#    method on the canonical body with matching signature.
+```
+
+The audit output is pasted verbatim into the PR description as two side-by-side lists (facade methods | canonical methods), one row per method, with a check column marking each 1:1 correspondence. Any facade method absent from the canonical body is a Cat C signal — the PR is closed without merge and the row is deferred to a discovery commit per Decision 1.
+
+Signature parity includes: parameter names, parameter defaults, `*args`/`**kwargs` presence, return type annotations (if any), decorators (`@staticmethod`, `@classmethod`, `@property`). A signature drift on any facade method is treated the same as a missing method — PR closed, row deferred.
+
+**Special call-out for `DeviceUtilityCommands` (Cat A row 4)**: the facade orchestrates 35 op-subclasses (Command pattern fan-out). The method-parity audit for this row enumerates not only the 3-5 top-level facade methods but also the 35 op-subclass entry points reachable through the facade. Reviewer expectation: the audit table is long (~40 rows), and the audit-generation script may need to enumerate nested class methods:
+
+```bash
+grep -n "^\s*\(class\|def\) " <src-path>   # capture both class and method boundaries
+```
+
+The other three Cat A candidates have compact audits (3-5 rows for `GatewayTemplateConfigManager`, ~5 rows for `SiteConfigManager`; `FirmwareManager` audit is bounded by its factory-facade delegation list — the reviewer verifies each delegated method resolves to a canonical implementation).
+
+**Rationale**: FR-025 gates Cat A on visible, reviewable evidence that no method was lost in the facade deletion. Grep-based enumeration keeps the audit deterministic (same command yields same table every time) and cheap (no custom tooling). Pasting the audit into the PR description makes the review artifact permanent — future readers can verify the parity claim without re-running the audit. The `DeviceUtilityCommands` call-out exists because a 35-subclass Command pattern is genuinely different in scale from a 3-method delegation shim; papering over that with a "one size fits all" audit template would encourage skimming past the highest-risk PR of the initiative.
+
+**Alternatives considered**:
+
+- *AST-based method-parity checker as a CI job*. Rejected — the four Cat A PRs are a one-shot audit surface; investing in tooling that runs four times is not economical. Grep + PR description review is sufficient.
+- *Skip the audit for the three "small" Cat A candidates and only audit `DeviceUtilityCommands`*. Rejected — the audit's value is in the uniform reviewer contract ("every Cat A PR includes a parity table"); a per-row carve-out invites contributor confusion about when the audit applies.
+- *Verify parity by running the test suite alone*. Rejected — the test suite (`python MistHelper.py --test`) exercises reachable code paths but does not enumerate the facade's public API surface. A method deleted by mistake but unreached by tests would slip through.
+
+---
+
+## Open Questions
+
+None. All NEEDS CLARIFICATION items from Technical Context are resolved. The twelve decisions above cover the entire implementation surface for the serial 47-PR workflow (4 Cat A + 43 Cat B).

--- a/specs/1013-misthelper-refactor-hot-classes/spec.md
+++ b/specs/1013-misthelper-refactor-hot-classes/spec.md
@@ -1,0 +1,260 @@
+# Feature Specification: MistHelper Hot-Classes Refactor (MistHelper-Only References)
+
+**Feature Branch**: `1013-misthelper-refactor-hot-classes`
+**Created**: 2026-07-07
+**Status**: Draft
+**Predecessors**:
+- [`1010-misthelper-refactor-extraction`](../1010-misthelper-refactor-extraction/spec.md) — first-pass Unused + Single-Use bucket clearance (13 PRs, closed)
+- [`1011-misthelper-refactor-low-use`](../1011-misthelper-refactor-low-use/spec.md) — second-pass 20-candidate Low-Use serial workflow (closed)
+- [`1012-misthelper-refactor-hot-functions`](../1012-misthelper-refactor-hot-functions/spec.md) — third-pass Hot-function bounded single-PR bundle (closed)
+
+**Input**: User description: "Fourth-pass Hot-classes serial extraction from `MistHelper.py`. Target the 47 Hot-bucket classes in `refactor_candidates.md` whose reference sites are exclusively inside `MistHelper.py` (no `src/` callers). One class per PR (47 PRs). Extraction order: refs ascending, then LOC descending. Mirrors the 1010/1011 landing pattern; deliberately does NOT bundle like 1012. Each PR delivers class-body extraction, all-callsite rewrite, in-flight `guideline_flags` remediation, analyzer score ≥ 99.6/A+, black + ruff + `python MistHelper.py --test` all clean."
+
+## Predecessor Context
+
+The three closed predecessor initiatives together cleared the low-friction extraction surface:
+
+- **1010** established the extraction contract (FR-003 no wrappers, FR-005 class-body landing, FR-007 project non-negotiables, FR-011 CI-clean merge discipline). It landed 13 PRs against the Unused + Single-Use buckets.
+- **1011** extended that contract across 20 Low-Use candidates using a serial per-PR workflow. Its SC-009 explicitly forbade extracting Hot-bucket **source** symbols during that pass.
+- **1012** carved out three specific Hot-bucket entries as a bounded single-PR bundle (`tqdm` skip-pin, `is_debug_mode` extraction, and `execute_with_connection_pool_management` + `_pool_*` family). It narrowed 1011's SC-009 prohibition for those three symbols and expressly kept the remainder of the Hot bucket deferred.
+
+All three predecessors closed with analyzer score ≥ 99.6/A+, `black --check` clean, `ruff check` clean, and `python MistHelper.py --test` passing (0 failed, exit 0). The residuals in the current post-1012 catalog are 0 Unused / 1 Single-Use / 2 Low-Use (tracked separately) and 76 Hot classes still awaiting extraction — of which 47 are the subject of this initiative.
+
+This initiative (1013) restores the serial per-PR workflow of 1010/1011 (one class per PR) rather than the bounded-bundle pattern of 1012. Each Hot-class extraction gets its own PR, its own analyzer regeneration, and its own CI-clean merge.
+
+## Scope Boundary
+
+The initiative targets exactly the **47 Hot-bucket classes** whose reference sites are exclusively inside `MistHelper.py` — i.e. no `src/`, `tests/`, or other first-party module references. Extraction order is:
+
+1. Reference count ascending (fewest callers first — smallest blast radius extracts earliest).
+2. Ties broken by LOC descending (at the same refs band, bigger LOC lands earlier so the largest surface gets exercised first at that band).
+
+The 47 candidates are enumerated in the "Dispatch Queue" section below, quoted verbatim from the user-supplied ordered table. Each row lands as one PR.
+
+Excluded from scope (and explicitly not touched by this initiative):
+
+- The 29 Hot-bucket classes whose reference sites include any callsite outside `MistHelper.py` (any `src/` reference). Those remain deferred to a future initiative that will need multi-file rewrite discipline analogous to 1011's User Story 2.
+- All classes already extracted in 1010, 1011, or 1012.
+- The refactor analyzer itself (`tools/refactor_analyzer/`) — consumed as-is.
+- Any Hot-bucket **function** or **assignment** — this initiative is Hot **classes** only. Non-class Hot symbols remain deferred.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Extract a low-reference Hot class into a cohesive class-body module (Priority: P1)
+
+The core value-delivery workflow. For each Hot-bucket class in the Dispatch Queue whose 4-plus references are all inside `MistHelper.py`, a refactor engineer opens a PR that (a) moves the class body into a new cohesive module under `src/refactors/` (or, when the class semantically belongs to an existing package such as `src/export/`, `src/gateway/`, `src/site/`, folds into that package), (b) rewrites every `MistHelper.py` callsite in the same commit, (c) deletes the original class definition from `MistHelper.py`, (d) resolves any analyzer `guideline_flags` in-flight (decomposing during the move rather than deferring), and (e) lands with all 15 functional CI jobs green, analyzer score ≥ 99.6/A+, `black --check` clean, `ruff check` clean, and `python MistHelper.py --test` passing (0 failed, exit 0). No wrapper shims. No re-export modules. No compatibility aliases.
+
+**Why this priority**: Delivers the initiative's entire LoC drop and constitutes its unit of progress. Serial per-PR dispatch (one class per PR) preserves the mergeability contract that 1010/1011 proved out and keeps every intermediate `main` state analyzer-green. Refs-ascending, LOC-descending dispatch ordering front-loads the smallest-blast-radius extractions so the workflow validates against low-refs classes before the 128-refs `OrgExportUtils` monolith at the tail.
+
+**Independent Test**: Any single Dispatch Queue candidate (e.g. `OrgConfigMigrationManager` at 4 refs / 675 LoC, the queue's first entry) can be merged in isolation. The PR (a) creates `src/refactors/org_config_migration_manager.py` (or folds into an existing fitting package), (b) deletes the class body from `MistHelper.py`, (c) rewrites all 4 callsites, (d) leaves a NOTE breadcrumb at the extraction site, (e) lands with the analyzer reporting the class removed from Hot and the aggregate score still ≥ 99.6/A+, and (f) passes `black --check`, `ruff check`, and `python MistHelper.py --test` (0 failed, exit 0).
+
+**Acceptance Scenarios**:
+
+1. **Given** a Hot-bucket class whose 4-plus callsites are all inside `MistHelper.py`, **When** the extraction PR is opened, **Then** the target module file exists at the mapped path, the original class body is deleted from `MistHelper.py`, every listed callsite is rewritten to import from the new module, and no wrapper shim, forwarding function, or re-export module exists anywhere in the diff.
+2. **Given** the analyzer flagged the moved class with `guideline_flags` (e.g. `oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`, `non_ascii_logs`, `hardcoded_separator`, `raw_input_call`), **When** the extraction PR lands, **Then** each flagged violation is resolved during the move — methods ≤ 25 lines with ≤ 5 params, `logging.info`/`logging.debug` envelopes on every method, inline comments on every executable line, ASCII-only log literals, `pathlib.Path` in place of `os.path`, and `InputUtils.safe_input()` in place of raw `input()`.
+3. **Given** an extraction PR is under CI, **When** the pipeline completes, **Then** all 15 functional CI jobs are green, the new/edited module scores A+/100 on compliance, and no previously A+ file regresses.
+4. **Given** the freshly regenerated `refactor_candidates.md`, **When** dispatching the next PR, **Then** candidates are processed in Refs-ASC / LOC-DESC order from the fresh catalog, so any candidate whose reference count shifted mid-initiative is re-ranked before it becomes the next dispatch head.
+5. **Given** the pre-push local gate, **When** the contributor pushes the refactor branch, **Then** `black --check` and `ruff check` both pass locally before the PR opens, and `python MistHelper.py --test` reports 0 failed with exit code 0.
+
+---
+
+### User Story 2 — Preserve strict callsite exclusivity so no `src/`-callsite class is touched (Priority: P1)
+
+The initiative's scoping discipline. The 47 Dispatch Queue candidates are precisely those Hot-bucket classes whose call sites are exclusively inside `MistHelper.py`. Every extraction PR must, before opening, verify via grep that the target class has zero references from `src/`, `tests/`, or any other first-party path outside `MistHelper.py`. If verification surfaces an external caller (e.g. because a merge landed between catalog regeneration and PR opening that added a new `src/` reference), the PR is deferred and the candidate is moved to the excluded 29-class deferred pool.
+
+**Why this priority**: Same P1 as User Story 1 because the two are inseparable — extraction without this verification risks silently breaking an external caller. Deferral is the correct response to a discovered external caller; force-extracting under the MistHelper-only assumption would be an FR-002 violation.
+
+**Independent Test**: Before opening any Dispatch Queue PR, `grep -rn "<ClassName>" src/ tests/` returns zero matches. If matches surface, the candidate is deferred, the deferral is recorded in the PR description of the *next* dispatched candidate (or in a standalone commit that updates this spec's "Deferred Candidates" section), and the workflow continues from the next queue head.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Dispatch Queue candidate at the top of the queue, **When** the pre-dispatch grep audit runs, **Then** it confirms zero references to the class from `src/`, `tests/`, or any first-party path other than `MistHelper.py`, and the PR proceeds.
+2. **Given** the pre-dispatch grep audit surfaces an external caller (e.g. a new `src/export/*` file imported the class between catalog regenerations), **When** the dispatcher plans the PR, **Then** the candidate is skipped, the skip is recorded in this spec's "Deferred Candidates" section, and the workflow advances to the next queue head.
+3. **Given** the extraction PR is under review, **When** the reviewer runs the same grep against the merged `main`, **Then** the audit continues to return zero external matches — no ninja imports have crept in during the review window.
+
+---
+
+### User Story 3 — Regenerate the analyzer catalog and update dispatch order after every merged extraction (Priority: P2)
+
+Carry-forward of 1010/1011 User Story 3. Reference counts shift as extractions land — a class that removes 3 callers from `MistHelper.py` may reduce another class's ref count if the two share upstream/downstream call chains. After every merged extraction PR in this initiative, the analyzer is re-run against the new `main` head and `refactor_candidates.md` is regenerated before the next PR is dispatched. Refs-ASC / LOC-DESC ordering is applied to the fresh catalog, so a mid-initiative reference-count shift can re-rank the remaining candidates.
+
+**Why this priority**: Workflow discipline that supports P1 and P2 rather than delivering standalone value. Particularly important for the tail of the queue where the largest LoC candidates cluster (`OrgTicketManager` at 66 refs / 475 LoC, `DeviceUtilityCommands` at 70 refs / 188 LoC, `OrgExportUtils` at 128 refs / 653 LoC) — ripple effects from earlier extractions can shift their ref counts and reorder them within the tail band.
+
+**Independent Test**: After merging any extraction PR, running `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md` regenerates the catalog cleanly. The just-extracted class no longer appears in the Hot bucket. Any reference-count shifts on remaining candidates are reflected in the fresh dispatch order derived from the new catalog.
+
+**Acceptance Scenarios**:
+
+1. **Given** an extraction PR has merged to `main`, **When** the next PR is dispatched, **Then** `refactor_candidates.md` has been regenerated on the current `main` head first and the next candidate is selected from that fresh output using Refs-ASC / LOC-DESC.
+2. **Given** the regenerated catalog shows a formerly Hot candidate has dropped to Low-Use or below (e.g. an earlier extraction removed 3 of its 4 references indirectly), **When** the dispatcher plans the next PR, **Then** the candidate is deferred out of this initiative (it no longer belongs to the Hot bucket) and the deferral is recorded.
+3. **Given** the regenerated catalog shows a formerly excluded (external-caller) candidate has become MistHelper-only (e.g. a `src/` caller was itself removed by an unrelated refactor), **When** the dispatcher plans the next PR, **Then** the candidate MAY be added to the dispatch queue only via an explicit spec revision recording the reclassification — it is not silently added mid-initiative.
+
+---
+
+### Edge Cases
+
+- **E-1** — Destination package selection. Some candidates fit an existing package cleanly (`SiteConfigExporter` → `src/site/`, `OrgAlarmEventExporter` → `src/export/`, `GatewayTemplateConfigManager` → `src/gateway/`); others have no obvious existing home and land in `src/refactors/`. The PR description MUST record the destination-selection rationale in one sentence. When both are viable, prefer the existing semantic package over `src/refactors/`.
+- **E-2** — Guideline-flag decomposition mid-move. If a candidate carries `oversize_25_lines` (e.g. `ConstDefinitionsExporter` at 759 LoC or `OrgConfigMigrationManager` at 675 LoC), the move includes method-level decomposition: split methods > 25 lines into helpers each ≤ 25 lines with ≤ 5 params, add inline comments on every executable line, wrap every method body with `logging.info`/`logging.debug` envelopes, convert non-ASCII log literals to ASCII, replace `os.path` with `pathlib.Path`, replace raw `input()` with `InputUtils.safe_input()`. Deferral of any flag to a follow-up PR is prohibited (FR-006 carry-forward).
+- **E-3** — Callsite drift between catalog regeneration and PR opening. If the analyzer's recorded line numbers drift (line-number churn from unrelated commits landing on `main` after the catalog was regenerated), the PR uses fresh grep against the current `main` head at branch time. Line-number drift alone does not block the extraction; only a *count* change (ref count changed or an external `src/` caller appeared) triggers deferral.
+- **E-4** — NOTE breadcrumb at the extraction site. Every extraction PR MUST leave a single-line NOTE breadcrumb at the deletion site in `MistHelper.py` pointing to the new location and this spec (per FR-007 below): `# NOTE: <ClassName> extracted to <new-module-path>::<ClassName>. See specs/1013-misthelper-refactor-hot-classes/spec.md.` Silent (breadcrumbless) deletion is rejected.
+- **E-5** — Class name collision at destination. If the target destination already contains a class with a name that would collide (unlikely but possible for common names like `DeviceUtils`), rename the incoming class only if renaming is genuinely necessary; otherwise the destination is changed. Record the choice in the PR description.
+- **E-6** — Reference count discrepancy between spec-time table and catalog regeneration at dispatch. The user-supplied 47-row table quotes ref counts as of the post-1012 catalog. If a fresh regeneration at dispatch time shows a candidate's ref count has shifted, the dispatch ordering is re-derived from the fresh catalog per User Story 3. The 47-row table is documentation, not a runtime contract.
+- **E-7** — `python MistHelper.py --test` regression. If the test-suite invocation begins failing mid-initiative because of an unrelated commit landing on `main`, extraction PRs pause until the underlying regression is fixed. The extraction workflow does not attempt to work around a broken test suite.
+- **E-8** — Analyzer score regression below 99.6/A+. If any single extraction PR would drop the aggregate analyzer score below 99.6/A+, the PR is revised (typically by resolving additional guideline flags in the same PR) rather than merged. The score floor is a merge gate.
+- **E-9** — SKIPPED CI conditionals. Per `feedback_no_admin_bypass.md`, SKIPPED conditionals (jobs whose gating condition evaluates false in a normal PR context) are recognised as non-blocking and do not count against the 15/15 green tally. `--admin` merge bypass is not used as a routine unblock.
+- **E-10** — Very large candidates (`OrgExportUtils` at 653 LoC / 128 refs, `OrgTicketManager` at 475 LoC / 66 refs, `OrgConfigMigrationManager` at 675 LoC / 4 refs, `OrgDeviceStatsExporter` at 414 LoC / 58 refs, `DeviceRebootManager` at 396 LoC / 46 refs, `MSPInventoryExporter` at 386 LoC / 5 refs, `SiteAnomalyExporter` at 341 LoC / 54 refs, `APIDataFetcher` at 328 LoC / 16 refs, `OrgConfigExporter` at 168 LoC / 24 refs but often internally sprawling, `BulkRadiusWLANConfigManager` at 587 LoC / 13 refs). These MUST land as one PR each (no splitting across multiple PRs) but the PR MAY carry substantial internal decomposition (Edge Case E-2) to satisfy the ≤ 25-line-per-method rule and the aggregate score floor.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The initiative MUST process exactly the 47 Hot-bucket classes enumerated in the Dispatch Queue table in Refs-ASC / LOC-DESC order. Additions require a new SpecKit revision recording the reclassification event.
+- **FR-002**: The initiative MUST process exactly one class per PR. Batching multiple classes into a single PR is prohibited (contrast with 1012's bounded-bundle pattern, which is not repeated here).
+- **FR-003**: For each candidate, the PR MUST match its **action-type** designation (Cat A or Cat B in the Dispatch Queue):
+  - **Cat A — Facade removal**: (a) delete the entire delegation-wrapper class body from `MistHelper.py`, (b) rewrite every `MistHelper.py` callsite to reference the real `src/` implementation directly (no `_Impl` alias, no `_configure_module()` helper, no factory `create()` indirection surviving), (c) do NOT create a new file — the `src/` implementation already exists and is authoritative, (d) verify method-parity per FR-025 before deletion.
+  - **Cat B — Fresh extraction**: (a) create the target module file inside the landing package OR fold into an existing class body within that package when semantically appropriate, (b) delete the original class body from `MistHelper.py`, and (c) rewrite every `MistHelper.py` callsite in the same commit.
+  - **Both categories**: No wrapper shim, forwarding function, re-export module, or backward-compatibility alias may be left in `MistHelper.py`. (Constitution FR-003 carry-forward, extended to formalize the two action-types.)
+- **FR-004**: Every extracted class MUST land as a cohesive class body — either as the top-level class of a new module or folded into an existing class body when semantically appropriate. Bare module-level function/assignment landings are prohibited (carry-forward from 1010/1011 FR-005).
+- **FR-005**: For each candidate, all `MistHelper.py` references to the extracted class MUST be rewritten to import from the new location in the same commit as the extraction. Zero stale references may survive the merge.
+- **FR-006**: Analyzer-flagged `guideline_flags` on the moved class (`oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`, `non_ascii_logs`, `hardcoded_separator`, `raw_input_call`, and any other flags surfaced) MUST be resolved within the same extraction PR — never deferred to a follow-up. Decomposition during the move includes: methods ≤ 25 lines with ≤ 5 params, `logging.info`/`logging.debug` envelopes on every method (with `%s` placeholder formatting), inline comments on every executable line, ASCII-only log literals, `pathlib.Path` in place of `os.path`, and `InputUtils.safe_input()` in place of raw `input()`. (Carry-forward from 1010/1011 FR-006.)
+- **FR-007**: A **mandatory** single-line NOTE breadcrumb comment MUST be added at each extraction site in `MistHelper.py`, following the pinned template: `# NOTE: <ClassName> extracted to <new-module-path>::<ClassName>. See specs/1013-misthelper-refactor-hot-classes/spec.md.` Silent (breadcrumbless) extraction is explicitly rejected. Breadcrumb presence at the extraction site is verified by the PR reviewer's grep audit.
+- **FR-008**: All extracted modules and destination files MUST comply with project non-negotiables: ASCII-only logs, `InputUtils.safe_input()` for interactive input, `pathlib.Path` in place of `os.path`, inline comments every 5-10 lines, action logging before/after every meaningful action with `%s` formatting, ≤ 25-line methods, ≤ 5 params per function (carry-forward from 1010/1011/1012 FR-007).
+- **FR-009**: The initiative MUST NOT touch symbols in the analyzer's `SKIP_ALWAYS` bucket (`GlobalImportManager`, and `tqdm` by convention per 1012) (carry-forward from 1010/1011/1012 FR-008).
+- **FR-010**: The initiative MUST NOT re-refactor any class that was already extracted in 1010, 1011, or 1012. Those symbols are considered fully migrated and are outside scope.
+- **FR-011**: The initiative MUST NOT modify `tools/refactor_analyzer/` itself; the analyzer is consumed as-is (carry-forward from 1010/1011/1012 FR-018).
+- **FR-012**: The initiative MUST NOT touch any Hot-bucket class whose references include any callsite outside `MistHelper.py` (any reference from `src/`, `tests/`, or any other first-party path). Those 29 classes are the deferred pool and are not in scope for this initiative.
+- **FR-013**: Before opening each extraction PR, the workflow MUST run `grep -rn "<ClassName>" src/ tests/` (and any additional first-party paths surfaced by the module graph) and confirm zero matches. If any match is found, the candidate is deferred and recorded in the "Deferred Candidates" section of this spec.
+- **FR-014**: After every merged extraction PR, the workflow MUST regenerate `refactor_candidates.md` by running the analyzer against the current `main` head before the next PR is dispatched. The next candidate is selected from that fresh catalog using Refs-ASC / LOC-DESC ordering (carry-forward from 1010/1011 FR-010).
+- **FR-015**: An extraction PR MUST NOT merge until all 15 functional CI jobs report green AND `mergeStateStatus` is CLEAN AND `black --check` is clean AND `ruff check` is clean AND `python MistHelper.py --test` reports 0 failed with exit code 0. `--admin` merge bypass MUST NOT be used as a routine unblock. Reference `feedback_no_admin_bypass.md` and `feedback_prepush_black_ruff.md` (carry-forward from 1010/1011/1012 FR-011).
+- **FR-016**: Every new module under `src/refactors/` (or extended module in an existing destination package) MUST land at A+/100 compliance score. No file that was previously A+ may regress below A+ as a result of any extraction (carry-forward from 1010/1011/1012 FR-012).
+- **FR-017**: The repository-wide aggregate compliance MUST remain ≥ 99.6/A+ after each merged extraction PR (carry-forward from 1010/1011/1012 FR-013).
+- **FR-018**: `MistHelper.py`'s pylint score MUST be non-regressing against the pre-initiative baseline established on the first branch commit. Regression blocks merge for the PR that caused it.
+- **FR-019**: No new SKIPPED conditionals in CI may be introduced by any extraction PR (per the user-specified "no new SKIPPED conditionals" gate). SKIPPED conditionals that pre-date the initiative continue to be non-blocking per Edge Case E-9.
+- **FR-020**: If a candidate's `refactor_candidates.md` classification shifts mid-initiative (e.g. Hot → Low-Use because a prior extraction removed several of its references indirectly), the candidate MUST be deferred out of this initiative and recorded in "Deferred Candidates". Force-extracting under a stale classification is prohibited (carry-forward from 1010/1011/1012 FR-016).
+- **FR-021**: The initiative MUST NOT introduce new features, new commands, new CLI flags, or user-facing behavior changes. Extraction is source-level only; user-facing behavior is preserved exactly (carry-forward from 1010/1011/1012 FR-017).
+- **FR-022**: When a candidate class is folded into an existing destination package's class body (rather than a new `src/refactors/*.py` module), the existing destination file's compliance grade MUST remain at A+/100 after the fold. If the fold would regress the destination below A+, the destination is changed or the extracted class receives further decomposition within the same PR.
+- **FR-023**: The Dispatch Queue's ordering (Refs-ASC / LOC-DESC) is a **dispatch rule**, not a merge order guarantee. If a PR later in the queue is ready to merge before an earlier PR because the earlier PR is under revision, the later PR MAY merge first — but only if the earlier PR is deferred or withdrawn. Concurrent open PRs are not permitted (one PR open at a time per FR-002's serial workflow).
+- **FR-024**: The initiative is considered complete when the freshest `refactor_candidates.md` shows that all 47 Dispatch Queue candidates have been either (a) extracted and no longer appear in the Hot bucket, or (b) recorded as deferred in the "Deferred Candidates" section with documented rationale.
+- **FR-025**: Every Cat A (facade-removal) PR MUST verify **method-parity** between the `MistHelper.py` facade and its `src/` counterpart before deletion. Verification consists of: (a) enumerating every public method, static method, classmethod, and instance attribute exposed by the facade; (b) confirming each is exposed with a semantically-equivalent signature by the real `src/` implementation; (c) recording the audit output in the PR description in a fenced code block. If the facade exposes a method absent from the `src/` implementation, the PR MUST either (i) port the missing method to the `src/` class in the same commit and rewire callers, or (ii) be deferred and the gap recorded in "Deferred Candidates". Silent facade deletion without a parity audit is prohibited. This applies with particular rigour to `DeviceUtilityCommands` at dispatch position 4, whose facade fans out to 35 operation-subclasses.
+- **FR-026**: The Dispatch Queue orders the 4 Cat A candidates first (positions 1-4) as a warmup ahead of the 43 Cat B candidates. This ordering is deliberate: Cat A carries a lower semantic risk (the `src/` implementation is already merged and CI-proven) and validates the initiative's callsite-rewrite discipline against a smaller edit surface before the fresh-extraction workflow begins at position 5. Within the Cat A block, ordering is Refs-ASC / LOC-DESC (same rule as Cat B). Within the Cat B block, ordering is Refs-ASC / LOC-DESC from the freshest catalog per FR-014.
+
+### Key Entities *(include if feature involves data)*
+
+- **Extraction Candidate**: A class in `MistHelper.py` catalogued by `tools/refactor_analyzer/` — for this initiative, restricted to Hot-bucket entries (4+ references) whose callsites are all inside `MistHelper.py`. Enumerated in the Dispatch Queue table.
+- **Refactor Candidates Catalog** (`refactor_candidates.md`): Regenerated after every merged extraction PR (FR-014). The freshest catalog is the authoritative source for dispatch order.
+- **Extraction PR**: A single pull request delivering one class's move plus its callsite rewrites plus any in-place `guideline_flags` remediation plus the NOTE breadcrumb.
+- **Target Module**: The new or extended file receiving the extracted class. Typically `src/refactors/<snake_name>.py` for classes without an obvious semantic home, or an existing package file (e.g. `src/export/site_config_exporter.py`, `src/gateway/gateway_template_config_manager.py`, `src/site/site_client_exporter.py`) when the semantic fit is clear.
+- **Callsite**: The exact location where a candidate class is instantiated, referenced, or imported. For Hot-bucket classes, may be 4-128 distinct locations, all inside `MistHelper.py`, all rewritten atomically in one commit.
+- **Dispatch Queue**: The Refs-ASC / LOC-DESC-ordered list of 47 candidates below. Ordering is re-derived from the freshest catalog after every merge.
+- **Deferred Candidate**: A queue entry that has been removed from active dispatch mid-initiative because (a) a fresh catalog regeneration surfaced a new `src/` caller, or (b) its classification shifted out of the Hot bucket, or (c) the pre-dispatch grep audit surfaced an unexpected external reference. Deferrals are recorded in the "Deferred Candidates" section (initially empty).
+- **Compliance Baseline**: Repo-wide ≥ 99.6/A+ aggregate; every new/edited module at A+/100; `MistHelper.py` pylint non-regressing against the pre-initiative baseline.
+
+## Dispatch Queue
+
+The 47 candidates in dispatch order. Each row lands as one PR. Every row carries a **Cat** (action-type) designation and a **Landing target** (destination module or package). The queue front-loads the 4 Category A **facade-removal** candidates as a low-risk warmup (the `src/` implementation is already merged and CI-proven — the PR only removes the dead facade + rewires callsites), then continues with the 43 Category B **fresh-extraction** candidates in Refs-ASC / LOC-DESC order.
+
+**Action-type legend**:
+- **Cat A — Facade removal**: The `MistHelper.py` class is a delegation wrapper; the real implementation already lives in `src/` at the noted landing target. The PR deletes the facade, rewires imports at each callsite to reference the `src/` implementation directly, and MUST verify method-parity between facade and real impl before deletion (per FR-025). No new file is created.
+- **Cat B — Fresh extraction**: No `src/` collision exists. The PR extracts the class body from `MistHelper.py` to the landing package (new file created inside the noted package) and rewrites callsites (per FR-003). This is the 1010/1011 pattern.
+
+Collision audit performed 2026-07-07 against all 47 candidates confirmed exactly 4 Cat A facades and 43 Cat B fresh-extractions. Zero Cat C name-clash-distinct entries were found.
+
+| # | Refs | LOC | Class | Cat | Landing target |
+|---:|---:|---:|---|:-:|---|
+| 1 | 6 | 56 | GatewayTemplateConfigManager | A | `src/gateway/template_config.py` |
+| 2 | 8 | 22 | FirmwareManager | A | `src/firmware/firmware_manager.py` |
+| 3 | 16 | 43 | SiteConfigManager | A | `src/site/site_config_manager.py` |
+| 4 | 70 | 188 | DeviceUtilityCommands | A | `src/device/utility_commands.py` |
+| 5 | 4 | 675 | OrgConfigMigrationManager | B | `src/org/` |
+| 6 | 4 | 97 | DeviceUtils | B | `src/device/` |
+| 7 | 4 | 40 | SelfExportUtils | B | `src/export/` |
+| 8 | 5 | 386 | MSPInventoryExporter | B | `src/export/` |
+| 9 | 5 | 214 | TelemetryEmitter | B | `src/analytics/` |
+| 10 | 8 | 72 | InteractiveDisplayUtils | B | `src/ui/` |
+| 11 | 8 | 70 | DisplayUtils | B | `src/ui/` |
+| 12 | 8 | 66 | AuditAnalysisOps | B | `src/audit/` |
+| 13 | 9 | 461 | OperationRegistry | B | `src/utils/` |
+| 14 | 10 | 85 | SiteClientExporter | B | `src/export/` |
+| 15 | 13 | 587 | BulkRadiusWLANConfigManager | B | `src/site/` |
+| 16 | 13 | 10 | EndpointConfig | B | `src/dataclasses/` |
+| 17 | 14 | 759 | ConstDefinitionsExporter | B | `src/export/` |
+| 18 | 14 | 129 | OrgAlarmEventExporter | B | `src/export/` |
+| 19 | 14 | 100 | SiteConfigExporter | B | `src/export/` |
+| 20 | 14 | 94 | OrgAdminExporter | B | `src/export/` |
+| 21 | 16 | 328 | APIDataFetcher | B | `src/api/` |
+| 22 | 18 | 144 | OrgTemplateExporter | B | `src/export/` |
+| 23 | 18 | 139 | GatewayHaExporter | B | `src/export/` |
+| 24 | 20 | 168 | LicenseExportUtils | B | `src/export/` |
+| 25 | 20 | 156 | DataCollectionManager | B | `src/analytics/` |
+| 26 | 20 | 129 | WiredClientManufacturerReportGenerator | B | `src/reports/` |
+| 27 | 22 | 180 | SFPTransceiverDataProcessor | B | `src/reports/` |
+| 28 | 22 | 146 | SitesByAPModelExporter | B | `src/export/` |
+| 29 | 22 | 69 | OrgDeviceInventorySummary | B | `src/inventory/` |
+| 30 | 23 | 161 | CLIShellManager | B | `src/ssh/` |
+| 31 | 24 | 168 | OrgConfigExporter | B | `src/export/` |
+| 32 | 26 | 162 | OrgClientSecurityExporter | B | `src/export/` |
+| 33 | 28 | 114 | EnvironmentUtils | B | `src/utils/` |
+| 34 | 30 | 203 | SiteDeviceExporter | B | `src/export/` |
+| 35 | 31 | 210 | PromptClientUtils | B | `src/input/` |
+| 36 | 32 | 251 | GlobalWiredClientReportGenerator | B | `src/reports/` |
+| 37 | 34 | 245 | GatewayTestExporter | B | `src/export/` |
+| 38 | 34 | 179 | DatabaseSchemaUtils | B | `src/db/` |
+| 39 | 36 | 127 | TroubleshootUtils | B | `src/troubleshooting/` |
+| 40 | 37 | 110 | FilterOperatorEngine | B | `src/utils/` |
+| 41 | 46 | 396 | DeviceRebootManager | B | `src/device/` |
+| 42 | 46 | 289 | ARPCommandManager | B | `src/device/` |
+| 43 | 54 | 341 | SiteAnomalyExporter | B | `src/export/` |
+| 44 | 54 | 273 | OfflineDeviceReporter | B | `src/reports/` |
+| 45 | 58 | 414 | OrgDeviceStatsExporter | B | `src/export/` |
+| 46 | 66 | 475 | OrgTicketManager | B | `src/org/` |
+| 47 | 128 | 653 | OrgExportUtils | B | `src/export/` |
+
+**Landing distribution**: `src/export/` = 20 (largest cluster — accepted as flat layout for this initiative; sub-partitioning deferred pending noise emergence), `src/device/` = 4 (+1 Cat A), `src/utils/` = 4, `src/reports/` = 4, `src/analytics/` = 2, `src/ui/` = 2, `src/org/` = 2, `src/site/` = 2, `src/gateway/` = 1 Cat A, `src/firmware/` = 1 Cat A, all others = 1. Note: `src/refactors/` receives **zero** candidates — every row lands in a domain-fitting existing package.
+
+**Resolution of the `FirmwareManager` row-10 ambiguity** (previously flagged): confirmed as Cat A. The `MistHelper.py` `FirmwareManager` class at `MistHelper.py:17376` is a factory facade (`create()` builds `FirmwareManagerConfig` + returns `_Impl(config)` sourced from `src/firmware/firmware_manager.py::FirmwareManager` at 270 defs). The dispatch PR deletes the facade and rewires the 8 callsites to construct the real `src/firmware/firmware_manager.py::FirmwareManager` directly. No new file is created.
+
+**Cat A method-parity risk flag**: The `DeviceUtilityCommands` facade at `MistHelper.py:13527` fans out to 35 operation-subclasses in `src/device/utility_commands.py`. Its extraction PR (dispatch position 4) MUST run an exhaustive method-parity audit — enumerate every method exposed by the facade, confirm the identical method is exposed by the real `src/` class (including all 35 sub-op wrappers), record the audit output in the PR description — before deleting the facade. This is a Cat A-specific gate per FR-025.
+
+## Deferred Candidates
+
+*(Initially empty. Populated during the initiative if any Dispatch Queue candidate is deferred per FR-013, FR-020, or Edge Case E-6.)*
+
+| # | Class | Reason for Deferral | Recording PR / Commit |
+|---:|---|---|---|
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The Hot bucket of `refactor_candidates.md` reports **zero** of the 47 Dispatch Queue classes at initiative completion, OR each remaining Dispatch Queue class is recorded in the "Deferred Candidates" section with documented rationale.
+- **SC-002**: `MistHelper.py` physical line count drops by at least **8,000 lines** relative to the pre-initiative baseline (the sum of the 47 candidates' LoC in the Dispatch Queue is ~ 12,150 LoC; SC-002 gives headroom for class-body overhead in the new modules and reasonable decomposition retention).
+- **SC-003**: Repository-wide aggregate compliance score is ≥ 99.6/A+ at every intermediate `main`-branch state throughout the initiative and at final completion.
+- **SC-004**: Zero files that were A+/100 pre-initiative regress below A+ by the end of the initiative.
+- **SC-005**: All extraction PRs merge with 15/15 functional CI jobs green, `mergeStateStatus: CLEAN`, `black --check` clean, `ruff check` clean, and `python MistHelper.py --test` reporting 0 failed / exit 0. Zero PRs merged via `--admin` bypass except where `mergeStateStatus` was genuinely BLOCKED/DIRTY/BEHIND with root cause documented in the PR.
+- **SC-006**: Every new file created under `src/refactors/` (or extended file in an existing destination package) during the initiative scores A+/100 on compliance.
+- **SC-007**: Zero wrapper shims, forwarding functions, re-export modules, or backward-compatibility aliases remain in `MistHelper.py` after the initiative.
+- **SC-008**: Zero symbols from the analyzer's `SKIP_ALWAYS` bucket (`GlobalImportManager`, `tqdm`) are modified by any PR in this initiative.
+- **SC-009**: Zero Hot-bucket classes outside the 47 Dispatch Queue entries are extracted by this initiative — the 29 excluded classes (those with any `src/` reference) remain deferred to a future initiative that will address multi-file rewrite discipline.
+- **SC-010**: After every merged extraction PR, the analyzer is re-run and `refactor_candidates.md` is regenerated before the next PR is dispatched — verifiable by walking the merged-PR sequence.
+- **SC-011**: Every analyzer-flagged `guideline_flag` on each extracted class is resolved within the extraction PR — zero forward-carried guideline violations attributable to this initiative.
+- **SC-012**: Every extraction PR contains exactly one NOTE breadcrumb at the deletion site in `MistHelper.py` matching the pinned FR-007 template — verifiable by post-merge grep of `# NOTE: <ClassName> extracted to`.
+- **SC-013**: Pre-push local gate: `black --check` and `ruff check` both pass on every refactor branch before the PR opens, and `python MistHelper.py --test` reports 0 failed with exit code 0. Enforcement is by the pre-push hook and by the contributor's `feedback_prepush_black_ruff.md` habit.
+- **SC-014**: The workflow processes candidates in Refs-ASC / LOC-DESC order derived from the freshest catalog at each dispatch — verifiable by walking the merged-PR sequence against the sequence of regenerated catalog snapshots.
+- **SC-015**: `MistHelper.py`'s pylint score is non-regressing against the pre-initiative baseline (established on the first branch commit). No merged PR reduces the score.
+- **SC-016**: Zero new SKIPPED conditionals are introduced in CI by any extraction PR (per FR-019). Pre-existing SKIPPED conditionals remain non-blocking per Edge Case E-9.
+- **SC-017**: The initiative closes with a documented final-state summary in the last-merged PR (or a follow-up docs commit) recording: (a) count of PRs merged (target: 47, actual may be lower if any candidates deferred), (b) final `MistHelper.py` LoC and pylint score, (c) final aggregate compliance score, (d) list of deferred candidates with rationale, and (e) count of remaining Hot-bucket classes (target: the original 76 minus 47 extracted minus any deferred, i.e. ~ 29 + deferred).
+
+## Assumptions
+
+- The analyzer at `tools/refactor_analyzer/` remains functionally correct for the Hot bucket across the initiative; discrepancies discovered during extraction are filed as analyzer bugs but do not block extraction PRs.
+- The 15 functional CI jobs currently gating PRs on `main` remain the mergeability contract for the duration of this initiative.
+- The current compliance baseline (≥ 99.6/A+) is the floor; the initiative does not attempt to raise it beyond preserving it.
+- The 47-row Dispatch Queue reflects the post-1012 catalog snapshot supplied by the user at initiative kickoff (2026-07-07). Mid-initiative reclassification (Hot → Low-Use, or MistHelper-only → external-caller) is expected and handled per FR-020 / FR-013.
+- Serial per-PR workflow: at most one extraction PR is open at any time (contrast with 1012's single-PR bundle).
+- Analyzer regeneration cost per run is negligible relative to CI cycle time; the "regenerate after every merge" discipline does not create a bottleneck.
+- Refs-ASC / LOC-DESC ordering front-loads the smallest-blast-radius extractions and back-loads the largest-LoC candidates. This ordering is a dispatch rule; the merge order MAY deviate slightly if an earlier PR is under revision (per FR-023), but concurrent PRs are not permitted.
+- The `src/refactors/` layout established by 1010, extended by 1011, and continued by 1012 remains the correct destination for classes without an obvious semantic home. Classes with a clear semantic fit (e.g. `SiteConfigExporter` → `src/site/`, `OrgAlarmEventExporter` → `src/export/`, `GatewayTemplateConfigManager` → `src/gateway/`) land in the existing package (per E-1).
+- Black + Ruff pre-push discipline (`feedback_prepush_black_ruff.md`) is followed by the contributor. This spec documents the requirement in SC-013 but does not add a new CI job to enforce it — the enforcement remains local.
+- `python MistHelper.py --test` is the initiative's smoke-test contract. It runs as a merge gate per FR-015. Its passing state is a strict requirement (0 failed, exit 0) on every merged extraction PR.
+- The 29 excluded Hot-bucket classes (those with any `src/` reference) are outside scope. A future initiative (post-1013) will address them with multi-file rewrite discipline analogous to 1011's User Story 2. This spec does not attempt to enumerate that future initiative's scope.
+- The user-supplied ref counts in the Dispatch Queue reflect direct name occurrences at analyzer-scan time. Line-number drift alone does not invalidate an entry; only a change in classification (ref count band or external-caller presence) triggers deferral.
+- `FirmwareManager` at row 10 may be a duplicate reference to the existing `src/firmware/firmware_manager.py::FirmwareManager` established in 1011 (see note under the Dispatch Queue table). The extraction PR resolves the ambiguity at dispatch time.

--- a/specs/1013-misthelper-refactor-hot-classes/tasks.md
+++ b/specs/1013-misthelper-refactor-hot-classes/tasks.md
@@ -1,0 +1,553 @@
+# Tasks: MistHelper Hot-Classes Refactor (MistHelper-Only References)
+
+**Feature Directory**: `specs/1013-misthelper-refactor-hot-classes/`
+**Design docs consumed**: `spec.md` (47-row Dispatch Queue, FR-001..FR-026, SC-001..SC-017), `plan.md` (Cat A/B action-type split, pinned landing targets, Constitution Check PASS), `research.md` (destination-package rationale, method-parity audit shape, baseline gating).
+
+**Action-type legend** (from spec.md § Dispatch Queue):
+- **Cat A — Facade removal**: delete delegation wrapper from `MistHelper.py`, rewire callsites to the `src/` implementation that already exists, no new file created. MUST run method-parity audit (FR-025) before deletion.
+- **Cat B — Fresh extraction**: create new file at `src/<subfolder>/<snake_case>.py` with the extracted class body, delete original from `MistHelper.py`, rewire callsites.
+
+**Dispatch ordering** (FR-026, FR-023): the 4 Cat A candidates dispatch first (positions 1-4) as a warmup ahead of the 43 Cat B candidates. Within each block, Refs-ASC / LOC-DESC. Serial per-PR workflow (FR-002): one PR open at a time. Analyzer catalog regenerates after every merge (FR-014) and re-ranks the remaining queue from the fresh output.
+
+**Standard per-PR merge gates** (FR-015 / SC-005):
+- Local (`feedback_prepush_black_ruff.md`): `black --check` clean, `ruff check` clean, `python -m py_compile MistHelper.py`, `python MistHelper.py --test` reports **0 failed / exit 0**.
+- Analyzer: aggregate compliance ≥ 99.6/A+ (FR-017), new/edited files A+/100 (FR-016), no A+ regression (SC-004), `MistHelper.py` pylint non-regressing (FR-018).
+- Remote: 15/15 functional CI jobs green, `mergeStateStatus: CLEAN` (no `--admin` bypass per `feedback_no_admin_bypass.md`).
+- Cat A only: method-parity audit output pasted in PR body (FR-025).
+
+**Breadcrumb template** (FR-007, mandatory at every deletion site):
+
+```text
+# NOTE: <ClassName> extracted to <new-module-path>::<ClassName>. See specs/1013-misthelper-refactor-hot-classes/spec.md.
+```
+
+---
+
+## Phase A — Pre-work (single commit, no PR)
+
+- [ ] T001 Pull fresh `main`; capture pre-initiative pylint baseline for `MistHelper.py` and record in `specs/1013-misthelper-refactor-hot-classes/baseline_pylint.txt` (FR-018 anchor)
+- [ ] T002 Regenerate `refactor_candidates.md` on current `main` head via `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`; commit alongside the baseline (FR-014 anchor for T003+)
+- [ ] T003 Capture pre-initiative aggregate compliance score and per-file compliance snapshot into `specs/1013-misthelper-refactor-hot-classes/baseline_compliance.txt` (SC-003 / SC-004 anchor)
+- [ ] T004 Verify SKIP_ALWAYS integrity: `grep -n "GlobalImportManager\|tqdm" tools/refactor_analyzer/**/*.py` confirms both symbols still in the skip-pin set (FR-009 / SC-008 anchor)
+- [ ] T005 Verify Hot-source exclusion still applies: `grep -rn "class OrgConfigMigrationManager\|class DeviceUtilityCommands" src/` returns zero matches for any of the 43 Cat B classes (FR-012 / SC-009 anchor)
+
+**Phase A checkpoint**: pre-initiative baselines captured; catalog regenerated; skip-pin integrity confirmed; Hot-source cross-check clean. Phase B (Cat A dispatch) may begin.
+
+---
+
+## Phase B — Cat A dispatch block (positions 1-4)
+
+Cat A candidates are dispatched **first** per FR-026. Each block below is one PR. Serial merge: complete every step of one block before opening the next block's PR (FR-002).
+
+### Position 1 — GatewayTemplateConfigManager (Cat A, 6 refs, 56 LOC)
+
+Facade at `MistHelper.py:15596` delegates to `src/gateway/template_config.py::GatewayTemplateConfigManager`.
+
+- [ ] T010 [P1-Prep] Read facade body at `MistHelper.py:15596-15651` and the `src/gateway/template_config.py::GatewayTemplateConfigManager` counterpart in full; note public surface (methods, static, classmethods, class attrs)
+- [ ] T011 [P1-Audit] Run method-parity audit (FR-025): enumerate every public callable/attribute on the facade, confirm each is exposed with signature-equivalent semantics by `src/gateway/template_config.py::GatewayTemplateConfigManager`; capture the audit output verbatim for the PR body's fenced code block
+- [ ] T012 [P1-Grep] Run `grep -rn "GatewayTemplateConfigManager" src/ tests/`; confirm zero matches (FR-013). Non-zero → defer per FR-013 and record in spec.md § Deferred Candidates
+- [ ] T013 [P1-Rewire] In one commit: (a) delete facade body at `MistHelper.py:15596-15651`, (b) add the FR-007 NOTE breadcrumb at the deletion site pointing at `src/gateway/template_config.py::GatewayTemplateConfigManager`, (c) rewrite all 6 `MistHelper.py` callsites to construct the `src/` class directly (no `_Impl`, no `create()` indirection, no `_configure_module()` helper surviving)
+- [ ] T014 [P1-LocalGate] Run local merge gate: `black --check MistHelper.py src/gateway/`, `ruff check MistHelper.py src/gateway/`, `python -m py_compile MistHelper.py`, `python MistHelper.py --test` (must report 0 failed / exit 0)
+- [ ] T015 [P1-Compliance] Regenerate analyzer output; verify `src/gateway/template_config.py` still A+/100, aggregate score ≥ 99.6/A+, `MistHelper.py` pylint non-regressing (FR-016 / FR-017 / FR-018)
+- [ ] T016 [P1-PR] Open PR titled `refactor(1013): remove GatewayTemplateConfigManager facade (SC-001, position 1)`; paste method-parity audit output into body; push and wait for 15/15 green + mergeStateStatus CLEAN
+- [ ] T017 [P1-Merge] Merge PR (no `--admin`); pull `main`; regenerate `refactor_candidates.md` (FR-014); commit refreshed catalog as follow-up doc commit
+
+### Position 2 — FirmwareManager (Cat A, 8 refs, 22 LOC)
+
+Facade at `MistHelper.py:17376` is a factory (`create()` → `_Impl(config)`) delegating to `src/firmware/firmware_manager.py::FirmwareManager`.
+
+- [ ] T020 [P2-Prep] Read facade body at `MistHelper.py:17376-17397` and `src/firmware/firmware_manager.py::FirmwareManager` counterpart; note the `FirmwareManagerConfig` construction pattern used by `create()`
+- [ ] T021 [P2-Audit] Method-parity audit (FR-025): enumerate facade `create()` / `_Impl` public surface; confirm `src/` class exposes identical constructor signature and public methods; capture output for PR body
+- [ ] T022 [P2-Grep] `grep -rn "FirmwareManager" src/ tests/` filtered against `src/firmware/firmware_manager.py` self-references; confirm zero external Cat A callers (FR-013)
+- [ ] T023 [P2-Rewire] Single commit: delete facade body, add FR-007 NOTE breadcrumb, rewrite all 8 callsites to construct `src/firmware/firmware_manager.py::FirmwareManager(FirmwareManagerConfig(...))` directly (no factory `create()` surviving in `MistHelper.py`)
+- [ ] T024 [P2-LocalGate] `black --check`, `ruff check`, `py_compile`, `MistHelper.py --test` all clean/0-failed
+- [ ] T025 [P2-Compliance] Regenerate; verify `src/firmware/firmware_manager.py` still A+/100, aggregate ≥ 99.6/A+, MistHelper pylint non-regressing
+- [ ] T026 [P2-PR] Open PR `refactor(1013): remove FirmwareManager facade (SC-001, position 2)`; paste parity audit; push; wait 15/15 green + CLEAN
+- [ ] T027 [P2-Merge] Merge; pull; regenerate `refactor_candidates.md`; commit refreshed catalog
+
+### Position 3 — SiteConfigManager (Cat A, 16 refs, 43 LOC)
+
+Facade at `MistHelper.py:16926` delegates to `src/site/site_config_manager.py::SiteConfigManager`.
+
+- [ ] T030 [P3-Prep] Read facade body at `MistHelper.py:16926-16968` and `src/site/site_config_manager.py::SiteConfigManager`; note public method set
+- [ ] T031 [P3-Audit] Method-parity audit (FR-025) capturing every facade-exposed callable; confirm src/ parity; if a facade method is absent from src/, port it into src/ in the same PR OR defer per FR-025(ii)
+- [ ] T032 [P3-Grep] `grep -rn "SiteConfigManager" src/ tests/` filtered against `src/site/site_config_manager.py` self-references; zero external matches expected (FR-013)
+- [ ] T033 [P3-Rewire] Single commit: delete facade body, add FR-007 NOTE breadcrumb, rewrite all 16 callsites to import `src/site/site_config_manager.py::SiteConfigManager` directly
+- [ ] T034 [P3-LocalGate] `black --check`, `ruff check`, `py_compile`, `MistHelper.py --test` all clean/0-failed
+- [ ] T035 [P3-Compliance] Regenerate; verify `src/site/site_config_manager.py` still A+/100, aggregate ≥ 99.6/A+, MistHelper pylint non-regressing
+- [ ] T036 [P3-PR] Open PR `refactor(1013): remove SiteConfigManager facade (SC-001, position 3)`; paste parity audit; push; wait 15/15 green + CLEAN
+- [ ] T037 [P3-Merge] Merge; pull; regenerate `refactor_candidates.md`; commit refreshed catalog
+
+### Position 4 — DeviceUtilityCommands (Cat A, 70 refs, 188 LOC)
+
+Facade at `MistHelper.py:13527` fans out to **35 operation-subclasses** in `src/device/utility_commands.py`. Highest method-parity risk in Cat A per FR-025.
+
+- [ ] T040 [P4-Prep] Read facade body at `MistHelper.py:13527-13714` in full; read `src/device/utility_commands.py` in full including all 35 op-subclasses; produce a written mapping of every facade method → src/ target method
+- [ ] T041 [P4-Audit-Exhaustive] Method-parity audit (FR-025, particular rigor per spec.md § Cat A method-parity risk flag): enumerate every one of the 35 op-subclass dispatchers exposed by the facade + every direct method; confirm identical exposure in `src/device/utility_commands.py`; capture full audit output for PR body; if any mismatch exists, port to src/ in the same PR OR defer per FR-025(ii)
+- [ ] T042 [P4-Grep] `grep -rn "DeviceUtilityCommands" src/ tests/` filtered against `src/device/utility_commands.py` self-references; zero external matches expected (FR-013)
+- [ ] T043 [P4-Rewire] Single commit: delete facade body (all 188 LOC), add FR-007 NOTE breadcrumb, rewrite all 70 callsites (largest Cat A rewire surface) to reference `src/device/utility_commands.py::DeviceUtilityCommands` directly
+- [ ] T044 [P4-LocalGate] `black --check`, `ruff check`, `py_compile`, `MistHelper.py --test` all clean/0-failed (higher risk of test-suite exposure given 70 callsites — allocate careful smoke run)
+- [ ] T045 [P4-Compliance] Regenerate; verify `src/device/utility_commands.py` still A+/100, aggregate ≥ 99.6/A+, MistHelper pylint non-regressing; expect a visible pylint delta from the 188 LOC drop
+- [ ] T046 [P4-PR] Open PR `refactor(1013): remove DeviceUtilityCommands facade + 35 op-subclass rewire (SC-001, position 4)`; paste exhaustive parity audit; push; wait 15/15 green + CLEAN
+- [ ] T047 [P4-Merge] Merge; pull; regenerate `refactor_candidates.md`; commit refreshed catalog
+
+**Phase B checkpoint** (SC-001 partial): all 4 Cat A facades removed; method-parity audits recorded in each PR body; no wrapper shims, `_Impl` aliases, or `create()` factories survive in `MistHelper.py`. Phase C (Cat B) may begin.
+
+---
+
+## Phase C — Cat B fresh-extraction block (positions 5-47)
+
+Each Cat B candidate below is one PR. Per candidate, the workflow is: pre-flight read → external-caller grep audit (FR-013) → new-file creation with class body + in-flight `guideline_flags` remediation (FR-006) → callsite rewire + FR-007 NOTE breadcrumb (single commit) → local gate → analyzer regen → PR + CI wait → merge → catalog refresh (FR-014). All same-position tasks form one PR; do not batch across positions (FR-002).
+
+### Position 5 — OrgConfigMigrationManager (4 refs, 675 LOC → `src/org/`)
+
+- [ ] T050 [P5] Pre-flight: read class body at `MistHelper.py`, enumerate `guideline_flags` from analyzer output (expect `oversize_25_lines` on a 675-LoC class); `grep -rn "OrgConfigMigrationManager" src/ tests/` = 0 (FR-013)
+- [ ] T051 [P5] Create `src/org/org_config_migration_manager.py` with the extracted class body; decompose every > 25-line method into ≤ 25-line helpers, add `logging.info`/`logging.debug` envelopes with `%s` formatting, ASCII-only log literals, `pathlib.Path` for filesystem ops, `InputUtils.safe_input()` for any interactive input (FR-006, FR-008)
+- [ ] T052 [P5] Single commit: delete class body from `MistHelper.py`, add FR-007 NOTE breadcrumb, rewrite all 4 callsites to import from `src/org/org_config_migration_manager.py`
+- [ ] T053 [P5] Local gate: `black --check`, `ruff check`, `py_compile`, `MistHelper.py --test` (0 failed / exit 0)
+- [ ] T054 [P5] Analyzer regen: new file A+/100, no A+ regression, aggregate ≥ 99.6/A+, MistHelper pylint non-regressing
+- [ ] T055 [P5] Open PR `refactor(1013): extract OrgConfigMigrationManager to src/org/ (SC-001, position 5)`; push; wait 15/15 green + CLEAN; merge; regenerate `refactor_candidates.md`
+
+### Position 6 — DeviceUtils (4 refs, 97 LOC → `src/device/`)
+
+- [ ] T060 [P6] Pre-flight read + `grep -rn "class DeviceUtils\b" src/ tests/` = 0 (FR-013); watch for name collision with any existing `DeviceUtils` at destination (E-5)
+- [ ] T061 [P6] Create `src/device/device_utils.py` (or fold into existing device utility class if E-5 collision) with extracted body + in-flight guideline_flag remediation (FR-006 / FR-008)
+- [ ] T062 [P6] Single commit: delete from `MistHelper.py`, add FR-007 breadcrumb, rewire all 4 callsites
+- [ ] T063 [P6] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T064 [P6] Analyzer regen: A+/100 new file, no A+ regression, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T065 [P6] Open PR (SC-001, position 6); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 7 — SelfExportUtils (4 refs, 40 LOC → `src/export/`)
+
+- [ ] T070 [P7] Pre-flight read + `grep -rn "class SelfExportUtils" src/ tests/` = 0 (FR-013)
+- [ ] T071 [P7] Create `src/export/self_export_utils.py` with class body + guideline_flag remediation
+- [ ] T072 [P7] Single commit: delete, breadcrumb, rewire 4 callsites
+- [ ] T073 [P7] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T074 [P7] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T075 [P7] Open PR (SC-001, position 7); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 8 — MSPInventoryExporter (5 refs, 386 LOC → `src/export/`)
+
+- [ ] T080 [P8] Pre-flight read; enumerate `oversize_25_lines` flags on 386-LOC class; `grep -rn "class MSPInventoryExporter" src/ tests/` = 0 (FR-013)
+- [ ] T081 [P8] Create `src/export/msp_inventory_exporter.py` with class body + method decomposition to ≤ 25 lines + full FR-006/FR-008 remediation
+- [ ] T082 [P8] Single commit: delete, breadcrumb, rewire 5 callsites
+- [ ] T083 [P8] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T084 [P8] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing (expect visible LOC delta)
+- [ ] T085 [P8] Open PR (SC-001, position 8); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 9 — TelemetryEmitter (5 refs, 214 LOC → `src/analytics/`)
+
+- [ ] T090 [P9] Pre-flight read + `grep -rn "class TelemetryEmitter" src/ tests/` = 0 (FR-013)
+- [ ] T091 [P9] Create `src/analytics/telemetry_emitter.py` with class body + guideline_flag remediation
+- [ ] T092 [P9] Single commit: delete, breadcrumb, rewire 5 callsites
+- [ ] T093 [P9] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T094 [P9] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T095 [P9] Open PR (SC-001, position 9); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 10 — InteractiveDisplayUtils (8 refs, 72 LOC → `src/ui/`)
+
+- [ ] T100 [P10] Pre-flight read + `grep -rn "class InteractiveDisplayUtils" src/ tests/` = 0 (FR-013)
+- [ ] T101 [P10] Create `src/ui/interactive_display_utils.py` with class body + guideline_flag remediation
+- [ ] T102 [P10] Single commit: delete, breadcrumb, rewire 8 callsites
+- [ ] T103 [P10] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T104 [P10] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T105 [P10] Open PR (SC-001, position 10); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 11 — DisplayUtils (8 refs, 70 LOC → `src/ui/`)
+
+- [ ] T110 [P11] Pre-flight read + `grep -rn "class DisplayUtils\b" src/ tests/` = 0 (FR-013); watch for name collision with any existing `DisplayUtils` at destination (E-5)
+- [ ] T111 [P11] Create `src/ui/display_utils.py` (or fold if collision per E-5) with class body + guideline_flag remediation
+- [ ] T112 [P11] Single commit: delete, breadcrumb, rewire 8 callsites
+- [ ] T113 [P11] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T114 [P11] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T115 [P11] Open PR (SC-001, position 11); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 12 — AuditAnalysisOps (8 refs, 66 LOC → `src/audit/`)
+
+- [ ] T120 [P12] Pre-flight read + `grep -rn "class AuditAnalysisOps" src/ tests/` = 0 (FR-013); confirm `src/audit/` package exists or create `__init__.py` as part of this PR
+- [ ] T121 [P12] Create `src/audit/audit_analysis_ops.py` with class body + guideline_flag remediation
+- [ ] T122 [P12] Single commit: delete, breadcrumb, rewire 8 callsites
+- [ ] T123 [P12] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T124 [P12] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T125 [P12] Open PR (SC-001, position 12); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 13 — OperationRegistry (9 refs, 461 LOC → `src/utils/`)
+
+- [ ] T130 [P13] Pre-flight read; enumerate `oversize_25_lines` on 461-LOC class; `grep -rn "class OperationRegistry" src/ tests/` = 0 (FR-013)
+- [ ] T131 [P13] Create `src/utils/operation_registry.py` with class body + heavy method decomposition + full FR-006/FR-008 remediation
+- [ ] T132 [P13] Single commit: delete, breadcrumb, rewire 9 callsites
+- [ ] T133 [P13] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T134 [P13] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T135 [P13] Open PR (SC-001, position 13); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 14 — SiteClientExporter (10 refs, 85 LOC → `src/export/`)
+
+- [ ] T140 [P14] Pre-flight read + `grep -rn "class SiteClientExporter" src/ tests/` = 0 (FR-013)
+- [ ] T141 [P14] Create `src/export/site_client_exporter.py` with class body + guideline_flag remediation
+- [ ] T142 [P14] Single commit: delete, breadcrumb, rewire 10 callsites
+- [ ] T143 [P14] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T144 [P14] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T145 [P14] Open PR (SC-001, position 14); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 15 — BulkRadiusWLANConfigManager (13 refs, 587 LOC → `src/site/`)
+
+- [ ] T150 [P15] Pre-flight read; enumerate `oversize_25_lines` on 587-LOC class; `grep -rn "class BulkRadiusWLANConfigManager" src/ tests/` = 0 (FR-013)
+- [ ] T151 [P15] Create `src/site/bulk_radius_wlan_config_manager.py` with class body + heavy method decomposition + FR-006/FR-008 remediation
+- [ ] T152 [P15] Single commit: delete, breadcrumb, rewire 13 callsites
+- [ ] T153 [P15] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T154 [P15] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T155 [P15] Open PR (SC-001, position 15); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 16 — EndpointConfig (13 refs, 10 LOC → `src/dataclasses/`)
+
+- [ ] T160 [P16] Pre-flight read + `grep -rn "class EndpointConfig" src/ tests/` = 0 (FR-013); confirm `src/dataclasses/` exists or create `__init__.py`
+- [ ] T161 [P16] Create `src/dataclasses/endpoint_config.py` with dataclass body (trivial 10 LOC) + FR-008 non-negotiables
+- [ ] T162 [P16] Single commit: delete, breadcrumb, rewire 13 callsites
+- [ ] T163 [P16] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T164 [P16] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T165 [P16] Open PR (SC-001, position 16); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 17 — ConstDefinitionsExporter (14 refs, 759 LOC → `src/export/`)
+
+Largest single-file candidate in the queue. Expect heavy `oversize_25_lines` decomposition (E-2, E-10).
+
+- [ ] T170 [P17] Pre-flight read; enumerate all `guideline_flags` on 759-LOC class; `grep -rn "class ConstDefinitionsExporter" src/ tests/` = 0 (FR-013)
+- [ ] T171 [P17] Create `src/export/const_definitions_exporter.py` with class body + exhaustive method decomposition (every method ≤ 25 lines, ≤ 5 params) + full FR-006/FR-008 remediation
+- [ ] T172 [P17] Single commit: delete, breadcrumb, rewire 14 callsites
+- [ ] T173 [P17] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T174 [P17] Analyzer regen: A+/100 new file (critical — largest surface), aggregate ≥ 99.6/A+, pylint non-regressing (expect largest LOC delta of the initiative)
+- [ ] T175 [P17] Open PR (SC-001, position 17); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 18 — OrgAlarmEventExporter (14 refs, 129 LOC → `src/export/`)
+
+- [ ] T180 [P18] Pre-flight read + `grep -rn "class OrgAlarmEventExporter" src/ tests/` = 0 (FR-013)
+- [ ] T181 [P18] Create `src/export/org_alarm_event_exporter.py` with class body + guideline_flag remediation
+- [ ] T182 [P18] Single commit: delete, breadcrumb, rewire 14 callsites
+- [ ] T183 [P18] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T184 [P18] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T185 [P18] Open PR (SC-001, position 18); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 19 — SiteConfigExporter (14 refs, 100 LOC → `src/export/`)
+
+- [ ] T190 [P19] Pre-flight read + `grep -rn "class SiteConfigExporter" src/ tests/` = 0 (FR-013)
+- [ ] T191 [P19] Create `src/export/site_config_exporter.py` with class body + guideline_flag remediation
+- [ ] T192 [P19] Single commit: delete, breadcrumb, rewire 14 callsites
+- [ ] T193 [P19] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T194 [P19] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T195 [P19] Open PR (SC-001, position 19); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 20 — OrgAdminExporter (14 refs, 94 LOC → `src/export/`)
+
+- [ ] T200 [P20] Pre-flight read + `grep -rn "class OrgAdminExporter" src/ tests/` = 0 (FR-013)
+- [ ] T201 [P20] Create `src/export/org_admin_exporter.py` with class body + guideline_flag remediation
+- [ ] T202 [P20] Single commit: delete, breadcrumb, rewire 14 callsites
+- [ ] T203 [P20] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T204 [P20] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T205 [P20] Open PR (SC-001, position 20); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 21 — APIDataFetcher (16 refs, 328 LOC → `src/api/`)
+
+- [ ] T210 [P21] Pre-flight read; enumerate `oversize_25_lines` on 328-LOC class; `grep -rn "class APIDataFetcher" src/ tests/` = 0 (FR-013); confirm `src/api/` package exists
+- [ ] T211 [P21] Create `src/api/api_data_fetcher.py` with class body + method decomposition + FR-006/FR-008 remediation
+- [ ] T212 [P21] Single commit: delete, breadcrumb, rewire 16 callsites
+- [ ] T213 [P21] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T214 [P21] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T215 [P21] Open PR (SC-001, position 21); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 22 — OrgTemplateExporter (18 refs, 144 LOC → `src/export/`)
+
+- [ ] T220 [P22] Pre-flight read + `grep -rn "class OrgTemplateExporter" src/ tests/` = 0 (FR-013)
+- [ ] T221 [P22] Create `src/export/org_template_exporter.py` with class body + guideline_flag remediation
+- [ ] T222 [P22] Single commit: delete, breadcrumb, rewire 18 callsites
+- [ ] T223 [P22] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T224 [P22] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T225 [P22] Open PR (SC-001, position 22); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 23 — GatewayHaExporter (18 refs, 139 LOC → `src/export/`)
+
+- [ ] T230 [P23] Pre-flight read + `grep -rn "class GatewayHaExporter" src/ tests/` = 0 (FR-013)
+- [ ] T231 [P23] Create `src/export/gateway_ha_exporter.py` with class body + guideline_flag remediation
+- [ ] T232 [P23] Single commit: delete, breadcrumb, rewire 18 callsites
+- [ ] T233 [P23] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T234 [P23] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T235 [P23] Open PR (SC-001, position 23); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 24 — LicenseExportUtils (20 refs, 168 LOC → `src/export/`)
+
+- [ ] T240 [P24] Pre-flight read + `grep -rn "class LicenseExportUtils" src/ tests/` = 0 (FR-013)
+- [ ] T241 [P24] Create `src/export/license_export_utils.py` with class body + guideline_flag remediation
+- [ ] T242 [P24] Single commit: delete, breadcrumb, rewire 20 callsites
+- [ ] T243 [P24] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T244 [P24] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T245 [P24] Open PR (SC-001, position 24); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 25 — DataCollectionManager (20 refs, 156 LOC → `src/analytics/`)
+
+- [ ] T250 [P25] Pre-flight read + `grep -rn "class DataCollectionManager" src/ tests/` = 0 (FR-013)
+- [ ] T251 [P25] Create `src/analytics/data_collection_manager.py` with class body + guideline_flag remediation
+- [ ] T252 [P25] Single commit: delete, breadcrumb, rewire 20 callsites
+- [ ] T253 [P25] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T254 [P25] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T255 [P25] Open PR (SC-001, position 25); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 26 — WiredClientManufacturerReportGenerator (20 refs, 129 LOC → `src/reports/`)
+
+- [ ] T260 [P26] Pre-flight read + `grep -rn "class WiredClientManufacturerReportGenerator" src/ tests/` = 0 (FR-013)
+- [ ] T261 [P26] Create `src/reports/wired_client_manufacturer_report_generator.py` with class body + guideline_flag remediation
+- [ ] T262 [P26] Single commit: delete, breadcrumb, rewire 20 callsites
+- [ ] T263 [P26] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T264 [P26] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T265 [P26] Open PR (SC-001, position 26); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 27 — SFPTransceiverDataProcessor (22 refs, 180 LOC → `src/reports/`)
+
+- [ ] T270 [P27] Pre-flight read + `grep -rn "class SFPTransceiverDataProcessor" src/ tests/` = 0 (FR-013)
+- [ ] T271 [P27] Create `src/reports/sfp_transceiver_data_processor.py` with class body + guideline_flag remediation
+- [ ] T272 [P27] Single commit: delete, breadcrumb, rewire 22 callsites
+- [ ] T273 [P27] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T274 [P27] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T275 [P27] Open PR (SC-001, position 27); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 28 — SitesByAPModelExporter (22 refs, 146 LOC → `src/export/`)
+
+- [ ] T280 [P28] Pre-flight read + `grep -rn "class SitesByAPModelExporter" src/ tests/` = 0 (FR-013)
+- [ ] T281 [P28] Create `src/export/sites_by_ap_model_exporter.py` with class body + guideline_flag remediation
+- [ ] T282 [P28] Single commit: delete, breadcrumb, rewire 22 callsites
+- [ ] T283 [P28] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T284 [P28] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T285 [P28] Open PR (SC-001, position 28); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 29 — OrgDeviceInventorySummary (22 refs, 69 LOC → `src/inventory/`)
+
+- [ ] T290 [P29] Pre-flight read + `grep -rn "class OrgDeviceInventorySummary" src/ tests/` = 0 (FR-013); confirm `src/inventory/` exists or create `__init__.py`
+- [ ] T291 [P29] Create `src/inventory/org_device_inventory_summary.py` with class body + guideline_flag remediation
+- [ ] T292 [P29] Single commit: delete, breadcrumb, rewire 22 callsites
+- [ ] T293 [P29] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T294 [P29] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T295 [P29] Open PR (SC-001, position 29); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 30 — CLIShellManager (23 refs, 161 LOC → `src/ssh/`)
+
+- [ ] T300 [P30] Pre-flight read + `grep -rn "class CLIShellManager" src/ tests/` = 0 (FR-013)
+- [ ] T301 [P30] Create `src/ssh/cli_shell_manager.py` with class body + guideline_flag remediation
+- [ ] T302 [P30] Single commit: delete, breadcrumb, rewire 23 callsites
+- [ ] T303 [P30] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T304 [P30] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T305 [P30] Open PR (SC-001, position 30); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 31 — OrgConfigExporter (24 refs, 168 LOC → `src/export/`)
+
+Watch for internal sprawl per E-10 despite modest advertised LOC.
+
+- [ ] T310 [P31] Pre-flight read; enumerate `oversize_25_lines` on likely-sprawling class; `grep -rn "class OrgConfigExporter" src/ tests/` = 0 (FR-013)
+- [ ] T311 [P31] Create `src/export/org_config_exporter.py` with class body + method decomposition + FR-006/FR-008 remediation
+- [ ] T312 [P31] Single commit: delete, breadcrumb, rewire 24 callsites
+- [ ] T313 [P31] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T314 [P31] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T315 [P31] Open PR (SC-001, position 31); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 32 — OrgClientSecurityExporter (26 refs, 162 LOC → `src/export/`)
+
+- [ ] T320 [P32] Pre-flight read + `grep -rn "class OrgClientSecurityExporter" src/ tests/` = 0 (FR-013)
+- [ ] T321 [P32] Create `src/export/org_client_security_exporter.py` with class body + guideline_flag remediation
+- [ ] T322 [P32] Single commit: delete, breadcrumb, rewire 26 callsites
+- [ ] T323 [P32] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T324 [P32] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T325 [P32] Open PR (SC-001, position 32); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 33 — EnvironmentUtils (28 refs, 114 LOC → `src/utils/`)
+
+- [ ] T330 [P33] Pre-flight read + `grep -rn "class EnvironmentUtils" src/ tests/` = 0 (FR-013)
+- [ ] T331 [P33] Create `src/utils/environment_utils.py` with class body + guideline_flag remediation
+- [ ] T332 [P33] Single commit: delete, breadcrumb, rewire 28 callsites
+- [ ] T333 [P33] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T334 [P33] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T335 [P33] Open PR (SC-001, position 33); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 34 — SiteDeviceExporter (30 refs, 203 LOC → `src/export/`)
+
+- [ ] T340 [P34] Pre-flight read + `grep -rn "class SiteDeviceExporter" src/ tests/` = 0 (FR-013)
+- [ ] T341 [P34] Create `src/export/site_device_exporter.py` with class body + guideline_flag remediation
+- [ ] T342 [P34] Single commit: delete, breadcrumb, rewire 30 callsites
+- [ ] T343 [P34] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T344 [P34] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T345 [P34] Open PR (SC-001, position 34); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 35 — PromptClientUtils (31 refs, 210 LOC → `src/input/`)
+
+- [ ] T350 [P35] Pre-flight read + `grep -rn "class PromptClientUtils" src/ tests/` = 0 (FR-013); confirm `src/input/` exists or create `__init__.py`
+- [ ] T351 [P35] Create `src/input/prompt_client_utils.py` with class body + `InputUtils.safe_input()` in place of any raw `input()` + full FR-006/FR-008 remediation
+- [ ] T352 [P35] Single commit: delete, breadcrumb, rewire 31 callsites
+- [ ] T353 [P35] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T354 [P35] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T355 [P35] Open PR (SC-001, position 35); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 36 — GlobalWiredClientReportGenerator (32 refs, 251 LOC → `src/reports/`)
+
+- [ ] T360 [P36] Pre-flight read + `grep -rn "class GlobalWiredClientReportGenerator" src/ tests/` = 0 (FR-013)
+- [ ] T361 [P36] Create `src/reports/global_wired_client_report_generator.py` with class body + method decomposition + FR-006/FR-008 remediation
+- [ ] T362 [P36] Single commit: delete, breadcrumb, rewire 32 callsites
+- [ ] T363 [P36] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T364 [P36] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T365 [P36] Open PR (SC-001, position 36); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 37 — GatewayTestExporter (34 refs, 245 LOC → `src/export/`)
+
+- [ ] T370 [P37] Pre-flight read + `grep -rn "class GatewayTestExporter" src/ tests/` = 0 (FR-013)
+- [ ] T371 [P37] Create `src/export/gateway_test_exporter.py` with class body + guideline_flag remediation
+- [ ] T372 [P37] Single commit: delete, breadcrumb, rewire 34 callsites
+- [ ] T373 [P37] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T374 [P37] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T375 [P37] Open PR (SC-001, position 37); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 38 — DatabaseSchemaUtils (34 refs, 179 LOC → `src/db/`)
+
+- [ ] T380 [P38] Pre-flight read + `grep -rn "class DatabaseSchemaUtils" src/ tests/` = 0 (FR-013); confirm `src/db/` exists or create `__init__.py`
+- [ ] T381 [P38] Create `src/db/database_schema_utils.py` with class body + guideline_flag remediation
+- [ ] T382 [P38] Single commit: delete, breadcrumb, rewire 34 callsites
+- [ ] T383 [P38] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T384 [P38] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T385 [P38] Open PR (SC-001, position 38); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 39 — TroubleshootUtils (36 refs, 127 LOC → `src/troubleshooting/`)
+
+- [ ] T390 [P39] Pre-flight read + `grep -rn "class TroubleshootUtils" src/ tests/` = 0 (FR-013); confirm `src/troubleshooting/` exists or create `__init__.py`
+- [ ] T391 [P39] Create `src/troubleshooting/troubleshoot_utils.py` with class body + guideline_flag remediation
+- [ ] T392 [P39] Single commit: delete, breadcrumb, rewire 36 callsites
+- [ ] T393 [P39] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T394 [P39] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T395 [P39] Open PR (SC-001, position 39); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 40 — FilterOperatorEngine (37 refs, 110 LOC → `src/utils/`)
+
+- [ ] T400 [P40] Pre-flight read + `grep -rn "class FilterOperatorEngine" src/ tests/` = 0 (FR-013)
+- [ ] T401 [P40] Create `src/utils/filter_operator_engine.py` with class body + guideline_flag remediation
+- [ ] T402 [P40] Single commit: delete, breadcrumb, rewire 37 callsites
+- [ ] T403 [P40] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T404 [P40] Analyzer regen: A+/100, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T405 [P40] Open PR (SC-001, position 40); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 41 — DeviceRebootManager (46 refs, 396 LOC → `src/device/`)
+
+Large candidate per E-10; heavy decomposition expected.
+
+- [ ] T410 [P41] Pre-flight read; enumerate `oversize_25_lines` on 396-LOC class; `grep -rn "class DeviceRebootManager" src/ tests/` = 0 (FR-013)
+- [ ] T411 [P41] Create `src/device/device_reboot_manager.py` with class body + heavy method decomposition + full FR-006/FR-008 remediation
+- [ ] T412 [P41] Single commit: delete, breadcrumb, rewire 46 callsites
+- [ ] T413 [P41] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T414 [P41] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T415 [P41] Open PR (SC-001, position 41); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 42 — ARPCommandManager (46 refs, 289 LOC → `src/device/`)
+
+- [ ] T420 [P42] Pre-flight read + `grep -rn "class ARPCommandManager" src/ tests/` = 0 (FR-013)
+- [ ] T421 [P42] Create `src/device/arp_command_manager.py` with class body + method decomposition + FR-006/FR-008 remediation
+- [ ] T422 [P42] Single commit: delete, breadcrumb, rewire 46 callsites
+- [ ] T423 [P42] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T424 [P42] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T425 [P42] Open PR (SC-001, position 42); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 43 — SiteAnomalyExporter (54 refs, 341 LOC → `src/export/`)
+
+- [ ] T430 [P43] Pre-flight read; enumerate `oversize_25_lines` on 341-LOC class; `grep -rn "class SiteAnomalyExporter" src/ tests/` = 0 (FR-013)
+- [ ] T431 [P43] Create `src/export/site_anomaly_exporter.py` with class body + heavy method decomposition + full FR-006/FR-008 remediation
+- [ ] T432 [P43] Single commit: delete, breadcrumb, rewire 54 callsites
+- [ ] T433 [P43] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T434 [P43] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T435 [P43] Open PR (SC-001, position 43); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 44 — OfflineDeviceReporter (54 refs, 273 LOC → `src/reports/`)
+
+- [ ] T440 [P44] Pre-flight read + `grep -rn "class OfflineDeviceReporter" src/ tests/` = 0 (FR-013)
+- [ ] T441 [P44] Create `src/reports/offline_device_reporter.py` with class body + method decomposition + FR-006/FR-008 remediation
+- [ ] T442 [P44] Single commit: delete, breadcrumb, rewire 54 callsites
+- [ ] T443 [P44] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T444 [P44] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T445 [P44] Open PR (SC-001, position 44); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 45 — OrgDeviceStatsExporter (58 refs, 414 LOC → `src/export/`)
+
+Large candidate per E-10; heavy decomposition expected.
+
+- [ ] T450 [P45] Pre-flight read; enumerate `oversize_25_lines` on 414-LOC class; `grep -rn "class OrgDeviceStatsExporter" src/ tests/` = 0 (FR-013)
+- [ ] T451 [P45] Create `src/export/org_device_stats_exporter.py` with class body + heavy method decomposition + full FR-006/FR-008 remediation
+- [ ] T452 [P45] Single commit: delete, breadcrumb, rewire 58 callsites
+- [ ] T453 [P45] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T454 [P45] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T455 [P45] Open PR (SC-001, position 45); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 46 — OrgTicketManager (66 refs, 475 LOC → `src/org/`)
+
+Large candidate per E-10; second-largest callsite fan-out (66) in Cat B.
+
+- [ ] T460 [P46] Pre-flight read; enumerate `oversize_25_lines` on 475-LOC class; `grep -rn "class OrgTicketManager" src/ tests/` = 0 (FR-013)
+- [ ] T461 [P46] Create `src/org/org_ticket_manager.py` with class body + heavy method decomposition + full FR-006/FR-008 remediation
+- [ ] T462 [P46] Single commit: delete, breadcrumb, rewire 66 callsites (highest Cat B fan-out to date — allocate careful review)
+- [ ] T463 [P46] Local gate: black, ruff, py_compile, `--test` 0-failed
+- [ ] T464 [P46] Analyzer regen: A+/100 new file, aggregate ≥ 99.6/A+, pylint non-regressing
+- [ ] T465 [P46] Open PR (SC-001, position 46); push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+### Position 47 — OrgExportUtils (128 refs, 653 LOC → `src/export/`)
+
+Terminal candidate — largest callsite fan-out (128) and second-largest LOC (653) in the queue. E-10 heavy-decomposition profile applies.
+
+- [ ] T470 [P47] Pre-flight read; enumerate every `guideline_flag` on 653-LOC class; `grep -rn "class OrgExportUtils" src/ tests/` = 0 (FR-013)
+- [ ] T471 [P47] Create `src/export/org_export_utils.py` with class body + exhaustive method decomposition (every method ≤ 25 lines, ≤ 5 params) + full FR-006/FR-008 remediation
+- [ ] T472 [P47] Single commit: delete, breadcrumb, rewire all 128 callsites (largest single rewire surface in the initiative — allocate meticulous review and consider a dry-run compile check on a scratch branch first)
+- [ ] T473 [P47] Local gate: black, ruff, py_compile, `--test` 0-failed (critical smoke run — this PR closes the initiative's operational body)
+- [ ] T474 [P47] Analyzer regen: A+/100 new file (largest surface — hardest single A+ target), aggregate ≥ 99.6/A+, pylint non-regressing (expect the largest single-PR pylint delta of the initiative)
+- [ ] T475 [P47] Open PR `refactor(1013): extract OrgExportUtils to src/export/ (SC-001, position 47 — final Cat B)`; push; wait 15/15 green + CLEAN; merge; regenerate catalog
+
+**Phase C checkpoint** (SC-001 complete for non-deferred candidates): all 43 Cat B extractions merged (or recorded as deferred with rationale). Phase D closeout begins.
+
+---
+
+## Phase D — Closeout & aggregate verification
+
+- [ ] T500 Verify SC-001: freshest `refactor_candidates.md` reports zero of the 47 Dispatch Queue classes in the Hot bucket (or each remaining entry is listed in spec.md § Deferred Candidates with rationale)
+- [ ] T501 Verify SC-002: `MistHelper.py` LOC drop ≥ 8,000 relative to `baseline_pylint.txt` LOC captured in T001
+- [ ] T502 Verify SC-003 / SC-004: aggregate compliance ≥ 99.6/A+ at every intermediate `main` state (walkable via merged-PR sequence); zero previously-A+ files regressed
+- [ ] T503 Verify SC-005: every merged PR had 15/15 green + `mergeStateStatus: CLEAN` + `black --check` clean + `ruff check` clean + `python MistHelper.py --test` 0-failed / exit 0; zero `--admin` bypasses except where root-cause-documented
+- [ ] T504 Verify SC-006: every new file created during the initiative scores A+/100 on compliance (`python tools/refactor_analyzer` reports A+/100 for each Cat B new file listed in spec.md § Dispatch Queue landing-target column)
+- [ ] T505 Verify SC-007: `grep -n "class .* = " MistHelper.py` shows zero wrapper shims / re-export aliases attributable to this initiative
+- [ ] T506 Verify SC-008: SKIP_ALWAYS integrity — `GlobalImportManager` and `tqdm` unmodified across the initiative
+- [ ] T507 Verify SC-009: zero out-of-scope Hot-bucket classes extracted (the 29 excluded remain deferred)
+- [ ] T508 Verify SC-010: catalog regeneration recorded after every merge — walkable via commit history
+- [ ] T509 Verify SC-011: zero forward-carried `guideline_flags` on any extracted class
+- [ ] T510 Verify SC-012: NOTE breadcrumb present at every deletion site — `grep -c "# NOTE: .* extracted to" MistHelper.py` matches merged-PR count
+- [ ] T511 Verify SC-013: pre-push local-gate discipline maintained across the branch history
+- [ ] T512 Verify SC-014: dispatch order matched Refs-ASC / LOC-DESC from the freshest catalog at each step (Cat A block first per FR-026, then Cat B block)
+- [ ] T513 Verify SC-015: `MistHelper.py` pylint non-regressing vs `baseline_pylint.txt`
+- [ ] T514 Verify SC-016: zero new SKIPPED conditionals introduced by any initiative PR
+- [ ] T515 Regenerate `refactor_candidates.md` one last time on final `main` head; verify Hot-bucket count = original (76) - extracted count - deferred count; commit the terminal catalog snapshot
+- [ ] T516 [Closeout PR] SC-017 — Open a docs-only PR (or extend the position-47 PR body) recording: (a) count of PRs merged (target 47), (b) final `MistHelper.py` LoC + pylint score, (c) final aggregate compliance score, (d) list of deferred candidates with rationale, (e) count of remaining Hot-bucket classes (target ~ 29 + any deferred); merge to close initiative 1013
+
+---
+
+## Dependencies
+
+- **Phase A** (T001-T005) → gates Phase B (T010-T047). Phase A commits go direct to `main` (no PR); Phase B onwards is per-PR.
+- **Phase B block ordering** (FR-026, mandatory Cat A-first): T010-T017 (P1) → T020-T027 (P2) → T030-T037 (P3) → T040-T047 (P4). No Cat B PR opens until all four Cat A merges land.
+- **Phase C sequential ordering** (FR-002, FR-023): position N's PR (T050 + subsequent 5 tasks) must merge before position N+1's PR opens. Deferral (FR-013/FR-020) advances the next position without opening the deferred PR.
+- **Per-candidate internal ordering** (within a single position's task block): pre-flight → grep audit → module creation (Cat B only) or method-parity audit (Cat A only) → single-commit delete+rewire+breadcrumb → local gate → analyzer regen → PR open → CI wait → merge → catalog refresh.
+- **Phase D** (T500-T516) runs only after position 47 merges (T475). T516 is the initiative closeout doc commit.
+
+## Parallel Opportunities
+
+- **Zero cross-PR parallelism**: FR-002 mandates one open PR at a time. No two positions may be under PR simultaneously.
+- **Within a candidate block**, the pre-flight tasks (read def-site, grep audit, module scaffold if Cat B) may run in parallel by a single contributor at branch time, but the single delete+rewire+breadcrumb commit is atomic and non-parallelizable.
+- **Cat A method-parity audit** (T011, T021, T031, T041) MAY be conducted concurrently for all four Cat A candidates as advance research *before* opening any PR; the actual PR sequence remains strictly serial.
+
+## Implementation Strategy
+
+1. **Cat A warmup (FR-026)**: complete positions 1-4 first. These are low-risk facade deletions (the src/ implementation already exists and is CI-proven). Use this block to validate the initiative's rewire discipline and CI cycle time before the fresh-extraction workflow begins.
+2. **Cat B by ascending refs**: positions 5-47 dispatch in Refs-ASC / LOC-DESC order from the freshest catalog. Small-refs candidates (4-9 refs) exercise the extraction shape against a small callsite fan-out before the workflow scales to the 46-128-refs tail.
+3. **Method-parity audit rigor scales with facade breadth**: allocate extra prep time for position 4 (`DeviceUtilityCommands`, 35 op-subclasses) — this is the highest single-PR method-parity risk in the initiative.
+4. **Heavy-decomposition candidates** (positions 5, 8, 13, 15, 17, 21, 41, 42, 43, 44, 45, 46, 47) MUST decompose in-flight (E-2, E-10, FR-006). Allocate meaningful engineering time for these — 675/759/587/653 LOC classes cannot land as monolithic method blocks and hit A+/100.
+5. **Terminal-candidate risk (position 47)**: `OrgExportUtils` at 128 refs / 653 LOC is the initiative's final and most complex PR. Consider a scratch-branch dry-run compile check before the actual rewire commit.
+6. **Analyzer regeneration is mandatory after every merge (FR-014)**: skipping the regen means the next dispatch is derived from stale ref counts and may re-order incorrectly per SC-014.
+7. **Deferral is a legitimate outcome (FR-013, FR-020)**: a candidate that surfaces an external `src/` caller mid-initiative is deferred, not force-extracted. Deferrals are recorded in spec.md § Deferred Candidates and reduce the merged-PR count below 47 (see SC-017(a)).
+
+## Format Validation
+
+Every task above follows the strict checklist format: `- [ ] T### [Story?] Description with file path`. Task IDs are T001..T005 (5 pre-work tasks), T010..T047 (Cat A block, 32 tasks across 4 positions × 8 tasks each), T050..T475 (Cat B block, 258 tasks across 43 positions × 6 tasks each), and T500..T516 (17 closeout tasks). Total: **312 tasks**. Story-label convention: `[P#]` where # is dispatch position (1-47), used as a candidate-block identifier rather than a P1/P2/P3 story priority (all dispatch tasks are effectively equal-priority US1 per spec.md § User Story 1).


### PR DESCRIPTION
## Summary
- Cat A facade removal — first of 4 in the 1013 hot-classes initiative (positions 1-4 per FR-026 Cat A-first ordering).
- Deletes 60-line `GatewayTemplateConfigManager` delegation wrapper from `MistHelper.py`; replaces with 3-line FR-007 canonical-location breadcrumb.
- Rewires 3 menu_actions callsites to inline lambdas that construct the src class directly with the 8-kwarg DI pattern (matches established precedent at line 18759).

## Method-parity audit (FR-025)

```
Facade method                                    | Canonical src/ method                                       | Signature parity
-------------------------------------------------|-------------------------------------------------------------|-----------------
GatewayTemplateConfigManager.extract             | src/gateway/template_config.py::GatewayTemplateConfigManager.extract           | PASS (delegates via 8-kwarg __init__)
GatewayTemplateConfigManager.apply               | src/gateway/template_config.py::GatewayTemplateConfigManager.apply             | PASS (delegates via 8-kwarg __init__)
GatewayTemplateConfigManager.clone_by_location   | src/gateway/template_config.py::GatewayTemplateConfigManager.clone_by_location | PASS (delegates via 8-kwarg __init__)
```

## FR-013 verification (zero external src/ callers)
- `grep -rn "GatewayTemplateConfigManager" src/` shows only the canonical class definition; no external src/ callers.
- Existing tests already import from `src.gateway.template_config` directly.
- All 3 MistHelper.py callsites (menu_actions "150", "164", "165") rewired to construct the src class directly.

## Local gates (all PASS)
- `python -m py_compile MistHelper.py` → OK
- `black --check MistHelper.py` → 1 file would be left unchanged
- `ruff check MistHelper.py` → All checks passed
- `python MistHelper.py --test` → 66/66 successful, 131 skipped (unsafe by design), 0 failed, 198.94s
- `pylint src/gateway/template_config.py` → **10.00/10 (A+)**
- `pylint MistHelper.py` → **9.44/10** (previous: 8.74/10, +0.71 improvement, non-regressing)

## Analyzer catalog
- `refactor_candidates.md` regenerated: 80 → 79 candidates; `GatewayTemplateConfigManager` removed from surface.

## Test plan
- [x] Local py_compile, black, ruff, --test all green
- [x] Pylint canonical class A+ (10.00/10); MistHelper.py non-regressing (+0.71)
- [x] Method-parity audit shows 3/3 PASS
- [x] Zero external src/ callers verified via grep
- [ ] CI 15/15 green
- [ ] mergeStateStatus CLEAN