### PR TITLE
refactor(1013): remove SiteConfigManager facade (SC-003, position 3)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -210,6 +210,15 @@ from src.refactors.wlanradius_timer_manager import (
 )
 from src.reports.e911_bssid import E911BSSIDReportGenerator  # Module-level for tests
 from src.site.address_audit import AddressAuditEngine  # Menu 195: read-only CSV site-address audit
+from src.site.site_config_manager import (  # Cat A canonical (1013 SC-003)
+    SiteConfigDependencies as _SiteConfigDependencies,
+)
+from src.site.site_config_manager import (
+    SiteConfigManager,
+)
+from src.site.site_config_manager import (
+    configure_site_config_manager_dependencies as _configure_site_config_dependencies,
+)
 from src.ssh.ssh_runner import EnhancedSSHRunner  # Import SSH command execution and result parsing
 from src.ssh.ssh_runner_manager import (
     SSHRunnerManager as ExtractedSSHRunnerManager,
@@ -16871,49 +16880,24 @@ class VirtualChassisManager:  # Virtual chassis manager.
 # ============================================================================
 # SITE CONFIGURATION MANAGER CLASS
 # ============================================================================
-class SiteConfigManager:  # Site config manager.
-    """Delegation wrapper for extracted site configuration implementation."""
-
-    @staticmethod
-    def _configure_module():  # Configure the module.
-        """Configure extracted module dependencies and return the module handle."""
-        from src.site import site_config_manager as site_config_module  # noqa: PLC0415,I001
-
-        deps = site_config_module.SiteConfigDependencies(  # Build dependency dataclass.
-            apisession=apisession,  # Live Mist API session.
-            config_utils=ConfigUtils,  # Shared org/stop-signal helpers.
-            file_path_utils=FilePathUtils,  # CSV path resolver.
-            input_utils=InputUtils,  # Safe input prompts.
-            data_exporter=DataExporter,  # Output writer.
-            mistapi=mistapi,  # Mist SDK module.
-            default_api_page_limit=DEFAULT_API_PAGE_LIMIT,  # Bulk fetch page size.
+# NOTE: SiteConfigManager facade removed per 1013 SC-003 (Cat A, position 3).
+# Canonical class lives at src/site/site_config_manager.py and is imported at
+# top-of-file. DI wiring lives in _configure_site_config_manager() below
+# (single seam for menu 171/172/173/174 lambdas).
+def _configure_site_config_manager() -> type[SiteConfigManager]:
+    """Wire SiteConfigDependencies and return the canonical SiteConfigManager class."""
+    _configure_site_config_dependencies(
+        _SiteConfigDependencies(  # Frozen container of 7 injected collaborators
+            apisession=apisession,  # Live Mist API session
+            config_utils=ConfigUtils,  # Org id caching + stop-signal check
+            file_path_utils=FilePathUtils,  # Portable CSV path resolver
+            input_utils=InputUtils,  # Safe input for destructive confirmations
+            data_exporter=DataExporter,  # Result-report writer
+            mistapi=mistapi,  # Root SDK module for calls + pagination
+            default_api_page_limit=DEFAULT_API_PAGE_LIMIT,  # Bulk fetch page size
         )
-        site_config_module.configure_site_config_manager_dependencies(deps)  # Wire dependencies.
-        return site_config_module  # Return the module.
-
-    @staticmethod
-    def create_test_sites_from_csv():  # Create test sites from CSV.
-        """Menu #171 delegated entrypoint."""
-        module = SiteConfigManager._configure_module()  # Configure the module.
-        return module.SiteConfigManager.create_test_sites_from_csv()  # Delegate the call.
-
-    @staticmethod
-    def create_country_rf_templates_and_assign():  # Create country RF templates.
-        """Menu #172 delegated entrypoint."""
-        module = SiteConfigManager._configure_module()  # Configure the module.
-        return module.SiteConfigManager.create_country_rf_templates_and_assign()  # Delegate the call.
-
-    @staticmethod
-    def create_ap_model_device_profiles():  # Create AP device profiles.
-        """Menu #173 delegated entrypoint."""
-        module = SiteConfigManager._configure_module()  # Configure the module.
-        return module.SiteConfigManager.create_ap_model_device_profiles()  # Delegate the call.
-
-    @staticmethod
-    def assign_aps_to_matching_device_profiles():  # Assign APs to profiles.
-        """Menu #174 delegated entrypoint."""
-        module = SiteConfigManager._configure_module()  # Configure the module.
-        return module.SiteConfigManager.assign_aps_to_matching_device_profiles()  # Delegate the call.
+    )
+    return SiteConfigManager  # Canonical class ready for menu callback dispatch
 
 
 # ============================================================================
@@ -18910,19 +18894,19 @@ menu_actions = {
     # TEST DATA GENERATION
     # ==============================
     "171": (
-        SiteConfigManager.create_test_sites_from_csv,
+        lambda: _configure_site_config_manager().create_test_sites_from_csv(),
         " DESTRUCTIVE: Create 137 test sites from NorthAmericanTestSites.csv - Real landmarks across 13 North American countries (Requires uppercase 'CREATE' confirmation)",  # noqa: E501
     ),
     "172": (
-        SiteConfigManager.create_country_rf_templates_and_assign,
+        lambda: _configure_site_config_manager().create_country_rf_templates_and_assign(),
         " DESTRUCTIVE: Create country-specific RF templates and assign sites to matching templates (Requires uppercase 'CREATE' confirmation)",  # noqa: E501
     ),
     "173": (
-        SiteConfigManager.create_ap_model_device_profiles,
+        lambda: _configure_site_config_manager().create_ap_model_device_profiles(),
         " DESTRUCTIVE: Scan org for AP models and create Device Profile per model with inherit/auto settings (Requires uppercase 'CREATE' confirmation)",  # noqa: E501
     ),
     "174": (
-        SiteConfigManager.assign_aps_to_matching_device_profiles,
+        lambda: _configure_site_config_manager().assign_aps_to_matching_device_profiles(),
         " DESTRUCTIVE: Assign APs to Device Profiles matching their model type (AP-{model}) - Skips APs without matching profiles (Requires uppercase 'ASSIGN' confirmation)",  # noqa: E501
     ),
     "165": (


### PR DESCRIPTION
## Summary
Cat A facade removal — **position 3/47** in the 1013 hot-classes refactor initiative. Deletes the 43-LOC `SiteConfigManager` wrapper class in `MistHelper.py` and rewires all 4 menu callsites to the canonical class at `src/site/site_config_manager.py`.

- FR-007 satisfied: canonical NOTE breadcrumb left at deletion site
- FR-013 satisfied: zero external `src/` callers of `MistHelper.SiteConfigManager` (verified via grep; unit tests import from `src.site.site_config_manager` directly; `tests/integration/test_runtime_coupling.py` uses only the string label `\"SiteConfigManager\"` for phase 4)
- FR-026 satisfied: Cat A-first ordering (positions 1-4 before Cat B)

## Method-parity audit (FR-025)

```
facade method                                | canonical (src/site/site_config_manager.py)
---------------------------------------------|----------------------------------------------
create_test_sites_from_csv                   | SiteConfigManager.create_test_sites_from_csv               ✓
create_country_rf_templates_and_assign       | SiteConfigManager.create_country_rf_templates_and_assign   ✓
create_ap_model_device_profiles              | SiteConfigManager.create_ap_model_device_profiles          ✓
assign_aps_to_matching_device_profiles       | SiteConfigManager.assign_aps_to_matching_device_profiles   ✓
```

All 4 staticmethods present on canonical class with identical signatures. No method drift.

## Callsite rewiring

`menu_actions` entries \`\"171\"\`–\`\"174\"\` changed from bare `SiteConfigManager.method,` to `lambda: _configure_site_config_manager().method()`. The module-level `_configure_site_config_manager()` helper builds `SiteConfigDependencies` from the current `apisession/ConfigUtils/FilePathUtils/InputUtils/DataExporter/mistapi/DEFAULT_API_PAGE_LIMIT` globals and returns the canonical class — single DI seam for all 4 menu callbacks.

Imports aliased as `_SiteConfigDependencies` and `_configure_site_config_dependencies` (leading underscore = module-private).

## Gate results

| Gate | Result |
|---|---|
| `python -m py_compile MistHelper.py` | OK |
| `black --check MistHelper.py` | clean |
| `ruff check MistHelper.py` | clean (auto-fixed I001 import sort) |
| `pylint MistHelper.py --score=y` | **8.73/10** (baseline 8.75; -0.02 is LOC-denominator effect from -16 net lines, no new warnings introduced by this PR) |
| `pylint src/site/site_config_manager.py --score=y` | **9.97/10** |
| `python MistHelper.py --test` | **exit 0** — 66 pass / 0 fail / 131 skipped-unsafe in 208.39s |

## Diff surface

1 file changed, 30 insertions(+), 46 deletions(-). Net -16 LOC in MistHelper.py.

## Initiative context

- Governing spec: `specs/1013-misthelper-refactor-hot-classes/`
- Prior Cat A positions merged: P1 #798 (GatewayTemplateConfigManager), P2 #799 (FirmwareManager)
- Next in queue: P4 DeviceUtilityCommands (70 refs, 188 LOC, 35 op-subclasses)

## Test plan

- [x] Local `python MistHelper.py --test` exit 0
- [x] Local `black --check` clean
- [x] Local `ruff check` clean
- [x] Local `pylint` scored (no new warning classes)
- [ ] CI green (15+ workflows)
- [ ] `mergeStateStatus: CLEAN` before squash-merge