### PR TITLE
refactor(1013): remove DeviceUtilityCommands facade + 35 op-subclass rewire (SC-001, position 4)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -13538,194 +13538,10 @@ def _get_duc_instance():  # Build DeviceUtilityCommands.
     return _DUC(deps)  # Instantiate with bundled deps.
 
 
-class DeviceUtilityCommands:  # Device utility command facade.
-    """Device utility commands (Menus 123-157).
-
-    Implementation extracted to src/device/utility_commands.py.
-    This stub delegates to the extracted module while providing
-    access to MistHelper globals (apisession, utility classes).
-    """
-
-    from src.device.utility_commands import (  # Import the extracted class.
-        DeviceUtilityCommands as _Extracted,
-    )
-
-    DEVICE_TYPE_COMPATIBILITY_MAP = _Extracted.DEVICE_TYPE_COMPATIBILITY_MAP  # Re-export compatibility map.
-
-    @staticmethod
-    def traceroute() -> None:  # Run traceroute.
-        """Menu 123: Traceroute from device to destination host."""
-        _get_duc_instance().traceroute()  # Delegate to the impl.
-
-    @staticmethod
-    def show_ospf_neighbors() -> None:  # Show OSPF neighbors.
-        """Menu 124: Show OSPF neighbors on SSR/SRX gateway."""
-        _get_duc_instance().show_ospf_neighbors()  # Delegate to the impl.
-
-    @staticmethod
-    def show_ospf_interfaces() -> None:  # Show OSPF interfaces.
-        """Menu 125: Show OSPF interfaces on SSR/SRX gateway."""
-        _get_duc_instance().show_ospf_interfaces()  # Delegate to the impl.
-
-    @staticmethod
-    def show_ospf_database() -> None:  # Show OSPF database.
-        """Menu 126: Show OSPF database on SSR/SRX gateway."""
-        _get_duc_instance().show_ospf_database()  # Delegate to the impl.
-
-    @staticmethod
-    def show_ospf_summary() -> None:  # Show OSPF summary.
-        """Menu 127: Show OSPF summary on SSR/SRX gateway."""
-        _get_duc_instance().show_ospf_summary()  # Delegate to the impl.
-
-    @staticmethod
-    def resolve_dns() -> None:  # Resolve DNS.
-        """Menu 135: Test DNS resolution on SSR gateway."""
-        _get_duc_instance().resolve_dns()  # Delegate to the impl.
-
-    @staticmethod
-    def monitor_traffic() -> None:  # Monitor traffic.
-        """Menu 136: Monitor traffic on switch/SRX port."""
-        _get_duc_instance().monitor_traffic()  # Delegate to the impl.
-
-    @staticmethod
-    def run_top() -> None:  # Run top.
-        """Menu 137: Run top command on switch/SRX."""
-        _get_duc_instance().run_top()  # Delegate to the impl.
-
-    @staticmethod
-    def show_session() -> None:  # Show sessions.
-        """Menu 128: Show sessions on SSR/SRX gateway."""
-        _get_duc_instance().show_session()  # Delegate to the impl.
-
-    @staticmethod
-    def show_service_path() -> None:  # Show the service path.
-        """Menu 129: Show service path on SSR gateway."""
-        _get_duc_instance().show_service_path()  # Delegate to the impl.
-
-    @staticmethod
-    def show_bgp_summary() -> None:  # Show BGP summary.
-        """Menu 130: Show BGP summary on switch or gateway."""
-        _get_duc_instance().show_bgp_summary()  # Delegate to the impl.
-
-    @staticmethod
-    def show_arp_table() -> None:  # Show the ARP table.
-        """Menu 131: Show ARP table on switch or gateway."""
-        _get_duc_instance().show_arp_table()  # Delegate to the impl.
-
-    @staticmethod
-    def show_dhcp_leases() -> None:  # Show DHCP leases.
-        """Menu 132: Show DHCP leases on switch or gateway."""
-        _get_duc_instance().show_dhcp_leases()  # Delegate to the impl.
-
-    @staticmethod
-    def show_dot1x() -> None:  # Show 802.1X state.
-        """Menu 133: Show 802.1X table on switch."""
-        _get_duc_instance().show_dot1x()  # Delegate to the impl.
-
-    @staticmethod
-    def show_evpn_database() -> None:  # Show EVPN database.
-        """Menu 134: Show EVPN database on switch or gateway."""
-        _get_duc_instance().show_evpn_database()  # Delegate to the impl.
-
-    @staticmethod
-    def locate_device() -> None:  # Locate the device.
-        """Menu 138: Locate device by blinking LED."""
-        _get_duc_instance().locate_device()  # Delegate to the impl.
-
-    @staticmethod
-    def unlocate_device() -> None:  # Unlocate the device.
-        """Menu 139: Stop device LED blinking."""
-        _get_duc_instance().unlocate_device()  # Delegate to the impl.
-
-    @staticmethod
-    def bounce_port() -> None:  # Bounce a port.
-        """Menu 140: Bounce switch/gateway port."""
-        _get_duc_instance().bounce_port()  # Delegate to the impl.
-
-    @staticmethod
-    def cable_test() -> None:  # Run a cable test.
-        """Menu 141: Run cable test on switch port."""
-        _get_duc_instance().cable_test()  # Delegate to the impl.
-
-    @staticmethod
-    def reprovision_device() -> None:  # Reprovision the device.
-        """Menu 142: Reprovision switch/gateway."""
-        _get_duc_instance().reprovision_device()  # Delegate to the impl.
-
-    @staticmethod
-    def readopt_device() -> None:  # Re-adopt the device.
-        """Menu 143: Re-adopt switch device."""
-        _get_duc_instance().readopt_device()  # Delegate to the impl.
-
-    @staticmethod
-    def get_ztp_password() -> None:  # Get the ZTP password.
-        """Menu 144: Get ZTP password for switch/gateway."""
-        _get_duc_instance().get_ztp_password()  # Delegate to the impl.
-
-    @staticmethod
-    def get_config_commands() -> None:  # Get config commands.
-        """Menu 145: Get configuration CLI commands for switch."""
-        _get_duc_instance().get_config_commands()  # Delegate to the impl.
-
-    @staticmethod
-    def upload_support_file() -> None:  # Upload a support file.
-        """Menu 146: Upload support file from switch/gateway."""
-        _get_duc_instance().upload_support_file()  # Delegate to the impl.
-
-    @staticmethod
-    def clear_arp_cache() -> None:  # Clear the ARP cache.
-        """Menu 147: Clear ARP cache."""
-        _get_duc_instance().clear_arp_cache()  # Delegate to the impl.
-
-    @staticmethod
-    def clear_bgp_routes() -> None:  # Clear BGP routes.
-        """Menu 148: Clear BGP routes."""
-        _get_duc_instance().clear_bgp_routes()  # Delegate to the impl.
-
-    @staticmethod
-    def clear_session() -> None:  # Clear a session.
-        """Menu 149: Clear session on SSR/SRX gateway."""
-        _get_duc_instance().clear_session()  # Delegate to the impl.
-
-    @staticmethod
-    def clear_mac_table() -> None:  # Clear the MAC table.
-        """Menu 150: Clear MAC table."""
-        _get_duc_instance().clear_mac_table()  # Delegate to the impl.
-
-    @staticmethod
-    def clear_bpdu_error() -> None:  # Clear a BPDU error.
-        """Menu 151: Clear BPDU errors on switch."""
-        _get_duc_instance().clear_bpdu_error()  # Delegate to the impl.
-
-    @staticmethod
-    def clear_learned_macs() -> None:  # Clear learned MACs.
-        """Menu 152: Clear learned MACs from switch port."""
-        _get_duc_instance().clear_learned_macs()  # Delegate to the impl.
-
-    @staticmethod
-    def clear_policy_hit_count() -> None:  # Clear policy hit counts.
-        """Menu 153: Clear policy hit count on SSR."""
-        _get_duc_instance().clear_policy_hit_count()  # Delegate to the impl.
-
-    @staticmethod
-    def release_dhcp_lease() -> None:  # Release a DHCP lease.
-        """Menu 154: Release DHCP lease on switch/gateway."""
-        _get_duc_instance().release_dhcp_lease()  # Delegate to the impl.
-
-    @staticmethod
-    def release_dhcp_ssr() -> None:  # Release a DHCP lease (SSR).
-        """Menu 155: Release DHCP lease on SSR/SRX."""
-        _get_duc_instance().release_dhcp_ssr()  # Delegate to the impl.
-
-    @staticmethod
-    def poll_switch_stats() -> None:  # Poll switch stats.
-        """Menu 156: Poll fresh statistics from switch."""
-        _get_duc_instance().poll_switch_stats()  # Delegate to the impl.
-
-    @staticmethod
-    def create_device_snapshot() -> None:  # Create a device snapshot.
-        """Menu 157: Create device snapshot on switch."""
-        _get_duc_instance().create_device_snapshot()  # Delegate to the impl.
+# NOTE: DeviceUtilityCommands facade removed 2026-07-07 (Issue #1013, SC-001 position 4).
+# The 188-LOC facade of 35 @staticmethod delegates lived here; menu_actions callsites now
+# invoke `lambda: _get_duc_instance().method_name()` directly against the canonical
+# instance-based class in `src/device/utility_commands.py`. See PR history for details.
 
 
 # ==============================
@@ -19009,45 +18825,54 @@ menu_actions = {
     # DEVICE UTILITY COMMANDS (Menus 123-157)
     # ==============================
     # > Diagnostic Commands
-    "123": (DeviceUtilityCommands.traceroute, "Traceroute from device to destination host (AP/Switch/Gateway)"),
-    "106": (DeviceUtilityCommands.show_ospf_neighbors, "Show OSPF Neighbors on SSR/SRX Gateway"),
-    "107": (DeviceUtilityCommands.show_ospf_interfaces, "Show OSPF Interfaces on SSR/SRX Gateway"),
-    "108": (DeviceUtilityCommands.show_ospf_database, "Show OSPF Database on SSR/SRX Gateway"),
-    "109": (DeviceUtilityCommands.show_ospf_summary, "Show OSPF Summary on SSR/SRX Gateway"),
-    "117": (DeviceUtilityCommands.resolve_dns, "Test DNS Resolution on SSR Gateway"),
-    "124": (DeviceUtilityCommands.monitor_traffic, "Monitor Traffic on Switch/SRX Port (streaming, Ctrl+C to stop)"),
-    "125": (DeviceUtilityCommands.run_top, "Run Top Command on Switch/SRX (streaming, Ctrl+C to stop)"),
+    "123": (lambda: _get_duc_instance().traceroute(), "Traceroute from device to destination host (AP/Switch/Gateway)"),
+    "106": (lambda: _get_duc_instance().show_ospf_neighbors(), "Show OSPF Neighbors on SSR/SRX Gateway"),
+    "107": (lambda: _get_duc_instance().show_ospf_interfaces(), "Show OSPF Interfaces on SSR/SRX Gateway"),
+    "108": (lambda: _get_duc_instance().show_ospf_database(), "Show OSPF Database on SSR/SRX Gateway"),
+    "109": (lambda: _get_duc_instance().show_ospf_summary(), "Show OSPF Summary on SSR/SRX Gateway"),
+    "117": (lambda: _get_duc_instance().resolve_dns(), "Test DNS Resolution on SSR Gateway"),
+    "124": (
+        lambda: _get_duc_instance().monitor_traffic(),
+        "Monitor Traffic on Switch/SRX Port (streaming, Ctrl+C to stop)",
+    ),
+    "125": (lambda: _get_duc_instance().run_top(), "Run Top Command on Switch/SRX (streaming, Ctrl+C to stop)"),
     # > Show Commands
-    "110": (DeviceUtilityCommands.show_session, "Show Sessions on SSR/SRX Gateway"),
-    "111": (DeviceUtilityCommands.show_service_path, "Show Service Path on SSR Gateway"),
-    "112": (DeviceUtilityCommands.show_bgp_summary, "Show BGP Summary on Switch or Gateway"),
-    "113": (DeviceUtilityCommands.show_arp_table, "Show ARP Table on Switch or Gateway"),
-    "114": (DeviceUtilityCommands.show_dhcp_leases, "Show DHCP Leases on Switch or Gateway"),
-    "115": (DeviceUtilityCommands.show_dot1x, "Show 802.1X Table on Switch"),
-    "116": (DeviceUtilityCommands.show_evpn_database, "Show EVPN Database on Switch or Gateway"),
+    "110": (lambda: _get_duc_instance().show_session(), "Show Sessions on SSR/SRX Gateway"),
+    "111": (lambda: _get_duc_instance().show_service_path(), "Show Service Path on SSR Gateway"),
+    "112": (lambda: _get_duc_instance().show_bgp_summary(), "Show BGP Summary on Switch or Gateway"),
+    "113": (lambda: _get_duc_instance().show_arp_table(), "Show ARP Table on Switch or Gateway"),
+    "114": (lambda: _get_duc_instance().show_dhcp_leases(), "Show DHCP Leases on Switch or Gateway"),
+    "115": (lambda: _get_duc_instance().show_dot1x(), "Show 802.1X Table on Switch"),
+    "116": (lambda: _get_duc_instance().show_evpn_database(), "Show EVPN Database on Switch or Gateway"),
     # > Management Commands
-    "128": (DeviceUtilityCommands.locate_device, "Locate Device - Blink LED on AP or Switch"),
-    "129": (DeviceUtilityCommands.unlocate_device, "Unlocate Device - Stop LED Blinking on AP or Switch"),
-    "159": (DeviceUtilityCommands.bounce_port, " Bounce Switch/Gateway Port (y/N confirmation)"),
-    "122": (DeviceUtilityCommands.cable_test, "Cable Test on Switch Port"),
-    "160": (DeviceUtilityCommands.reprovision_device, " Reprovision Switch/Gateway (y/N confirmation)"),
-    "130": (DeviceUtilityCommands.readopt_device, "Re-adopt Switch Device"),
-    "131": (DeviceUtilityCommands.get_ztp_password, "Get ZTP Password for Switch/Gateway (console only)"),
-    "132": (DeviceUtilityCommands.get_config_commands, "Get Config CLI Commands for Switch Adoption"),
-    "133": (DeviceUtilityCommands.upload_support_file, "Upload Support File from Switch/Gateway"),
+    "128": (lambda: _get_duc_instance().locate_device(), "Locate Device - Blink LED on AP or Switch"),
+    "129": (lambda: _get_duc_instance().unlocate_device(), "Unlocate Device - Stop LED Blinking on AP or Switch"),
+    "159": (lambda: _get_duc_instance().bounce_port(), " Bounce Switch/Gateway Port (y/N confirmation)"),
+    "122": (lambda: _get_duc_instance().cable_test(), "Cable Test on Switch Port"),
+    "160": (lambda: _get_duc_instance().reprovision_device(), " Reprovision Switch/Gateway (y/N confirmation)"),
+    "130": (lambda: _get_duc_instance().readopt_device(), "Re-adopt Switch Device"),
+    "131": (lambda: _get_duc_instance().get_ztp_password(), "Get ZTP Password for Switch/Gateway (console only)"),
+    "132": (lambda: _get_duc_instance().get_config_commands(), "Get Config CLI Commands for Switch Adoption"),
+    "133": (lambda: _get_duc_instance().upload_support_file(), "Upload Support File from Switch/Gateway"),
     # > Clear/Reset Commands
-    "177": (DeviceUtilityCommands.clear_arp_cache, " DESTRUCTIVE: Clear ARP Cache (type CLEAR)"),
-    "178": (DeviceUtilityCommands.clear_bgp_routes, " DESTRUCTIVE: Clear BGP Routes (type CLEAR)"),
-    "179": (DeviceUtilityCommands.clear_session, " DESTRUCTIVE: Clear Session on SSR/SRX (type CLEAR)"),
-    "180": (DeviceUtilityCommands.clear_mac_table, " DESTRUCTIVE: Clear MAC Table (type CLEAR)"),
-    "181": (DeviceUtilityCommands.clear_bpdu_error, " DESTRUCTIVE: Clear BPDU Errors on Switch (type CLEAR)"),
-    "182": (DeviceUtilityCommands.clear_learned_macs, " DESTRUCTIVE: Clear Learned MACs from Switch Port (type CLEAR)"),
-    "183": (DeviceUtilityCommands.clear_policy_hit_count, " DESTRUCTIVE: Clear Policy Hit Count on SSR (type CLEAR)"),
-    "184": (DeviceUtilityCommands.release_dhcp_lease, " Release DHCP Lease on Switch/Gateway (y/N)"),
-    "185": (DeviceUtilityCommands.release_dhcp_ssr, " Release DHCP Lease on SSR/SRX (y/N)"),
+    "177": (lambda: _get_duc_instance().clear_arp_cache(), " DESTRUCTIVE: Clear ARP Cache (type CLEAR)"),
+    "178": (lambda: _get_duc_instance().clear_bgp_routes(), " DESTRUCTIVE: Clear BGP Routes (type CLEAR)"),
+    "179": (lambda: _get_duc_instance().clear_session(), " DESTRUCTIVE: Clear Session on SSR/SRX (type CLEAR)"),
+    "180": (lambda: _get_duc_instance().clear_mac_table(), " DESTRUCTIVE: Clear MAC Table (type CLEAR)"),
+    "181": (lambda: _get_duc_instance().clear_bpdu_error(), " DESTRUCTIVE: Clear BPDU Errors on Switch (type CLEAR)"),
+    "182": (
+        lambda: _get_duc_instance().clear_learned_macs(),
+        " DESTRUCTIVE: Clear Learned MACs from Switch Port (type CLEAR)",
+    ),
+    "183": (
+        lambda: _get_duc_instance().clear_policy_hit_count(),
+        " DESTRUCTIVE: Clear Policy Hit Count on SSR (type CLEAR)",
+    ),
+    "184": (lambda: _get_duc_instance().release_dhcp_lease(), " Release DHCP Lease on Switch/Gateway (y/N)"),
+    "185": (lambda: _get_duc_instance().release_dhcp_ssr(), " Release DHCP Lease on SSR/SRX (y/N)"),
     # > Hardware Commands
-    "126": (DeviceUtilityCommands.poll_switch_stats, "Poll Fresh Statistics from Switch"),
-    "127": (DeviceUtilityCommands.create_device_snapshot, "Create Device Snapshot on Switch"),
+    "126": (lambda: _get_duc_instance().poll_switch_stats(), "Poll Fresh Statistics from Switch"),
+    "127": (lambda: _get_duc_instance().create_device_snapshot(), "Create Device Snapshot on Switch"),
     # > Offline / Reporting
     "26": (OfflineDeviceReporter.execute, "Offline Device Report"),
     "145": (OrgExportUtils.ssid_template_consolidation, "SSID Template Consolidation (5-Phase Guided Workflow)"),

--- a/tests/test_clear_bpdu_error.py
+++ b/tests/test_clear_bpdu_error.py
@@ -7,24 +7,23 @@ Marked xfail until normalization is implemented.
 
 from unittest.mock import MagicMock
 
+import mistapi
 import pytest
 
-import MistHelper
+from src.device.utility_commands import DeviceUtilityCommands
 
 
 @pytest.mark.xfail(reason="Port normalization helper not yet implemented")
 def test_clear_bpdu_uses_normalized_port_identifier(monkeypatch):
     # Arrange selection
     monkeypatch.setattr(
-        MistHelper.DeviceUtilityCommands,
+        DeviceUtilityCommands,
         "_select_site_and_device",
         lambda action, *args, **kwargs: ("site1", "dev1", "Switch1"),
     )
 
     # Simulate optional port selection returning 'ge-0/0/0'
-    monkeypatch.setattr(
-        MistHelper.DeviceUtilityCommands, "_select_port_optional", lambda site_id, device_id: "ge-0/0/0"
-    )
+    monkeypatch.setattr(DeviceUtilityCommands, "_select_port_optional", lambda site_id, device_id: "ge-0/0/0")
 
     captured = {}
 
@@ -32,10 +31,10 @@ def test_clear_bpdu_uses_normalized_port_identifier(monkeypatch):
         captured["body"] = body
         return MagicMock()
 
-    monkeypatch.setattr(MistHelper.mistapi.api.v1.sites.devices, "clearBpduErrorsFromPortsOnSwitch", fake_clear_bpdu)
+    monkeypatch.setattr(mistapi.api.v1.sites.devices, "clearBpduErrorsFromPortsOnSwitch", fake_clear_bpdu)
 
     # Act
-    MistHelper.DeviceUtilityCommands.clear_bpdu_error()
+    DeviceUtilityCommands.clear_bpdu_error()
 
     # Assert: expected normalized body key (implementation TBD)
     assert "port_id" in captured.get("body", {}) or "port" in captured.get("body", {})

--- a/tests/test_clear_learned_macs.py
+++ b/tests/test_clear_learned_macs.py
@@ -6,22 +6,21 @@ Marked xfail until port-name normalization and API-format adjustments are implem
 
 from unittest.mock import MagicMock
 
+import mistapi
 import pytest
 
-import MistHelper
+from src.device.utility_commands import DeviceUtilityCommands
 
 
 @pytest.mark.xfail(reason="Port normalization / API mapping not implemented")
 def test_clear_learned_macs_accepts_junos_style_port_names(monkeypatch):
     monkeypatch.setattr(
-        MistHelper.DeviceUtilityCommands,
+        DeviceUtilityCommands,
         "_select_site_and_device",
         lambda action, *args, **kwargs: ("site1", "dev1", "Switch1"),
     )
 
-    monkeypatch.setattr(
-        MistHelper.DeviceUtilityCommands, "_select_port_from_device", lambda site_id, device_id: "ge-0/0/0"
-    )
+    monkeypatch.setattr(DeviceUtilityCommands, "_select_port_from_device", lambda site_id, device_id: "ge-0/0/0")
 
     captured = {}
 
@@ -29,9 +28,9 @@ def test_clear_learned_macs_accepts_junos_style_port_names(monkeypatch):
         captured["body"] = body
         return MagicMock()
 
-    monkeypatch.setattr(MistHelper.mistapi.api.v1.sites.devices, "clearAllLearnedMacsFromPortOnSwitch", fake_clear)
+    monkeypatch.setattr(mistapi.api.v1.sites.devices, "clearAllLearnedMacsFromPortOnSwitch", fake_clear)
 
-    MistHelper.DeviceUtilityCommands.clear_learned_macs()
+    DeviceUtilityCommands.clear_learned_macs()
 
     # Expectation: body contains normalized port identifier
     assert "port_id" in captured.get("body", {})

--- a/tests/test_clear_policy_hit_count.py
+++ b/tests/test_clear_policy_hit_count.py
@@ -6,22 +6,24 @@ Tests target node handling and model capability detection. Marked xfail until ca
 
 from unittest.mock import MagicMock
 
+import mistapi
 import pytest
 
-import MistHelper
+from src.device.utility_commands import DeviceUtilityCommands
+from src.utils.input_utils import InputUtils
 
 
 @pytest.mark.xfail(reason="Model capability detection / node handling not implemented")
 def test_clear_policy_includes_node_when_required(monkeypatch):
     monkeypatch.setattr(
-        MistHelper.DeviceUtilityCommands,
+        DeviceUtilityCommands,
         "_select_site_and_device",
         lambda action, *args, **kwargs: ("site1", "dev-ssr120", "SSR120"),
     )
 
     # Simulate user input for Node
     monkeypatch.setattr(
-        MistHelper.InputUtils, "safe_input", lambda prompt, context=None, **kwargs: "node0" if "Node" in prompt else ""
+        InputUtils, "safe_input", lambda prompt, context=None, **kwargs: "node0" if "Node" in prompt else ""
     )
 
     captured = {}
@@ -30,8 +32,8 @@ def test_clear_policy_includes_node_when_required(monkeypatch):
         captured["body"] = body
         return MagicMock()
 
-    monkeypatch.setattr(MistHelper.mistapi.api.v1.sites.devices, "clearSiteDevicePolicyHitCount", fake_clear)
+    monkeypatch.setattr(mistapi.api.v1.sites.devices, "clearSiteDevicePolicyHitCount", fake_clear)
 
-    MistHelper.DeviceUtilityCommands.clear_policy_hit_count()
+    DeviceUtilityCommands.clear_policy_hit_count()
 
     assert captured.get("body", {}).get("node") in ("node0", "node1")

--- a/tests/test_readopt.py
+++ b/tests/test_readopt.py
@@ -6,9 +6,10 @@ These tests are scaffolds and are marked xfail until the preflight VC-capability
 
 from unittest.mock import MagicMock
 
+import mistapi
 import pytest
 
-import MistHelper
+from src.device.utility_commands import DeviceUtilityCommands
 
 
 def make_mock_response(data=None, status_code=200):
@@ -22,7 +23,7 @@ def make_mock_response(data=None, status_code=200):
 def test_readopt_calls_api_when_device_is_vc(monkeypatch):
     # Arrange: select a device
     monkeypatch.setattr(
-        MistHelper.DeviceUtilityCommands,
+        DeviceUtilityCommands,
         "_select_site_and_device",
         lambda action, *args, **kwargs: ("site-1", "dev-1", "Device1"),
     )
@@ -31,7 +32,7 @@ def test_readopt_calls_api_when_device_is_vc(monkeypatch):
     def fake_get_vc(session, site_id, device_id):
         return make_mock_response(data={"is_virtual_chassis": True})
 
-    monkeypatch.setattr(MistHelper.mistapi.api.v1.sites.devices, "getSiteDeviceVirtualChassis", fake_get_vc)
+    monkeypatch.setattr(mistapi.api.v1.sites.devices, "getSiteDeviceVirtualChassis", fake_get_vc)
 
     called = {"readopt": False}
 
@@ -39,10 +40,10 @@ def test_readopt_calls_api_when_device_is_vc(monkeypatch):
         called["readopt"] = True
         return make_mock_response()
 
-    monkeypatch.setattr(MistHelper.mistapi.api.v1.sites.devices, "readoptSiteOctermDevice", fake_readopt)
+    monkeypatch.setattr(mistapi.api.v1.sites.devices, "readoptSiteOctermDevice", fake_readopt)
 
     # Act
-    MistHelper.DeviceUtilityCommands.readopt_device()
+    DeviceUtilityCommands.readopt_device()
 
     # Assert
     assert called["readopt"] is True
@@ -51,7 +52,7 @@ def test_readopt_calls_api_when_device_is_vc(monkeypatch):
 @pytest.mark.xfail(reason="Preflight VC check not yet implemented")
 def test_readopt_skips_non_vc_device(monkeypatch):
     monkeypatch.setattr(
-        MistHelper.DeviceUtilityCommands,
+        DeviceUtilityCommands,
         "_select_site_and_device",
         lambda action, *args, **kwargs: ("site-1", "dev-1", "Device1"),
     )
@@ -59,7 +60,7 @@ def test_readopt_skips_non_vc_device(monkeypatch):
     def fake_get_vc(session, site_id, device_id):
         return make_mock_response(data={"is_virtual_chassis": False})
 
-    monkeypatch.setattr(MistHelper.mistapi.api.v1.sites.devices, "getSiteDeviceVirtualChassis", fake_get_vc)
+    monkeypatch.setattr(mistapi.api.v1.sites.devices, "getSiteDeviceVirtualChassis", fake_get_vc)
 
     called = {"readopt": False}
 
@@ -67,8 +68,8 @@ def test_readopt_skips_non_vc_device(monkeypatch):
         called["readopt"] = True
         return make_mock_response()
 
-    monkeypatch.setattr(MistHelper.mistapi.api.v1.sites.devices, "readoptSiteOctermDevice", fake_readopt)
+    monkeypatch.setattr(mistapi.api.v1.sites.devices, "readoptSiteOctermDevice", fake_readopt)
 
-    MistHelper.DeviceUtilityCommands.readopt_device()
+    DeviceUtilityCommands.readopt_device()
 
     assert called["readopt"] is False


### PR DESCRIPTION
## Summary

Removes the 188-LOC `DeviceUtilityCommands` facade of 35 `@staticmethod` delegates from `MistHelper.py`. Callsites now invoke the canonical instance-based class in `src/device/utility_commands.py` directly through the retained `_get_duc_instance()` factory.

- **Facade LOC removed**: 188 (MistHelper.py 13541-13729)
- **menu_actions rewired**: 35 entries (menu keys 123-157) → `lambda: _get_duc_instance().method()`
- **xfail tests migrated**: 4 files → import from `src.device.utility_commands`
- **FR-007 breadcrumb**: inserted at deletion site
- **Behavior parity**: canonical class already carries full DI + cluster proxy machinery
- **Refs**: #1013 (Cat A position 4, SC-001)

## Method-parity audit (35 methods)

Every facade method resolves 1:1 to a canonical cluster helper via `DeviceUtilityCommands.__getattr__` proxy.

| # | Menu | Facade method | Canonical location |
|---|------|---------------|---------------------|
| 1 | 123 | traceroute | src/device/_utility_commands_show.py |
| 2 | 124 | show_ospf_neighbors | src/device/_utility_commands_show.py |
| 3 | 125 | show_ospf_interfaces | src/device/_utility_commands_show.py |
| 4 | 126 | show_ospf_database | src/device/_utility_commands_show.py |
| 5 | 127 | show_ospf_summary | src/device/_utility_commands_show.py |
| 6 | 128 | show_session | src/device/_utility_commands_show.py |
| 7 | 129 | show_service_path | src/device/_utility_commands_show.py |
| 8 | 130 | show_bgp_summary | src/device/_utility_commands_show.py |
| 9 | 131 | show_arp_table | src/device/_utility_commands_show.py |
| 10 | 132 | show_dhcp_leases | src/device/_utility_commands_show.py |
| 11 | 133 | show_dot1x | src/device/_utility_commands_show.py |
| 12 | 134 | show_evpn_database | src/device/_utility_commands_show.py |
| 13 | 135 | resolve_dns | src/device/_utility_commands_show.py |
| 14 | 136 | monitor_traffic | src/device/_utility_commands_show.py |
| 15 | 137 | run_top | src/device/_utility_commands_show.py |
| 16 | 138 | cable_test | src/device/_utility_commands_show.py |
| 17 | 139 | locate_device | src/device/_utility_commands_action.py |
| 18 | 140 | unlocate_device | src/device/_utility_commands_action.py |
| 19 | 141 | bounce_port | src/device/_utility_commands_action.py |
| 20 | 142 | reprovision_device | src/device/_utility_commands_action.py |
| 21 | 143 | readopt_device | src/device/_utility_commands_action.py |
| 22 | 144 | get_ztp_password | src/device/_utility_commands_action.py |
| 23 | 145 | get_config_commands | src/device/_utility_commands_action.py |
| 24 | 146 | upload_support_file | src/device/_utility_commands_action.py |
| 25 | 147 | poll_switch_stats | src/device/_utility_commands_action.py |
| 26 | 148 | create_device_snapshot | src/device/_utility_commands_action.py |
| 27 | 149 | clear_arp_cache | src/device/_utility_commands_clear.py |
| 28 | 150 | clear_bgp_routes | src/device/_utility_commands_clear.py |
| 29 | 151 | clear_session | src/device/_utility_commands_clear.py |
| 30 | 152 | clear_mac_table | src/device/_utility_commands_clear.py |
| 31 | 153 | clear_bpdu_error | src/device/_utility_commands_clear.py |
| 32 | 154 | clear_learned_macs | src/device/_utility_commands_clear.py |
| 33 | 155 | clear_policy_hit_count | src/device/_utility_commands_clear.py |
| 34 | 156 | release_dhcp_lease | src/device/_utility_commands_clear.py |
| 35 | 157 | release_dhcp_ssr | src/device/_utility_commands_clear.py |

## Test plan

- [x] `black --check` — clean after reformat
- [x] `ruff check` — no issues
- [x] `python -c "import MistHelper"` — clean
- [x] `python MistHelper.py --test` — exit 0, 66/66 successful
- [x] No remaining `class DeviceUtilityCommands` in MistHelper.py
- [x] All 4 xfail test files migrated to canonical import
- [ ] CI 15+ green
- [ ] mergeStateStatus CLEAN