### PR TITLE
refactor(1013): remove SelfExportUtils facade (SC-001, position 7)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -132,6 +132,9 @@ from src.device.device_utils import (  # pylint: disable=unused-import
     DeviceUtils,  # noqa: F401  # Cat B (1013 SC-001 position 6) -- re-export for dynamic _mh.DeviceUtils lookup
 )
 from src.export.device_events_52w_exporter import DeviceEvents52wExporter  # Import 52-week device events export handler
+from src.export.self_export_utils import (  # pylint: disable=unused-import
+    SelfExportUtils,  # noqa: F401  # Cat B (1013 SC-001 position 7) -- re-export for menu tuple at MistHelper:18167
+)
 from src.export.site_export_utils import (
     configure_site_export_utils_dependencies,
 )  # Import site export utility configuration
@@ -11316,46 +11319,7 @@ class LicenseExportUtils:  # Hold custom license exporters.
             LicenseExportUtils._write_async_claim_details(resolved_org_id, payload)  # Delegate detail write to helper.
 
 
-class SelfExportUtils:  # Self/account exporters.
-    """
-    Authenticated Self / Account Export Utilities
-
-    Exports data scoped to the currently authenticated admin account rather
-    than an org or site. Handles self audit logs and similar account-level
-    read operations.
-    """
-
-    @staticmethod
-    def _persist_self_audit_rows(rows: list, filename: str, hours: int) -> None:
-        """Flatten + persist self audit rows, or write an empty file when nothing was returned."""
-        if not rows:  # No data returned — write empty output rather than failing silently.
-            logging.warning("No self audit log records returned for the last %d hours", hours)  # Warn on empty result.
-            DataExporter.write_with_format_selection([], filename)  # Empty file signals successful run.
-            return  # Done.
-        rows = DataProcessingUtils.flatten_nested_fields(rows)  # Flatten nested change-detail dicts for CSV.
-        DataExporter.write_with_format_selection(rows, filename, api_function_name="listSelfAuditLogs")  # Persist.
-        logging.info("Exported %d self audit log records to %s", len(rows), filename)  # Log success.
-
-    @staticmethod
-    def audit_logs() -> None:  # Export audit logs.
-        """Export audit log of changes made by the authenticated admin account to SelfAuditLogs.csv."""
-        logging.info("Starting export of self (admin account) audit logs...")  # Log before operation.
-        filename = "SelfAuditLogs.csv"  # Output filename for self audit log entries.
-        try:
-            hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Use same lookback window as other audit log exports.
-            TimeUtils.log_dynamic_lookback("self audit logs export", hours)  # Log lookback window selection.
-            logging.info("Fetching self audit logs for last %d hours...", hours)  # Log before API call.
-            response = mistapi.api.v1.self.logs.listSelfAuditLogs(  # Call Mist API for admin account audit log.
-                apisession,
-                duration=f"{hours}h",  # Limit results to the dynamic lookback window.
-                limit=1000,  # Request large page to minimise pagination round-trips.
-            )
-            logging.debug("Raw API response received for self audit logs")  # Log after API call.
-            rows = mistapi.get_all(response=response, mist_session=apisession)  # Paginate through all results.
-            logging.debug("Received %d self audit log records after pagination", len(rows))  # Log record count.
-            SelfExportUtils._persist_self_audit_rows(rows, filename, hours)  # Persist or write empty.
-        except Exception as exception:  # Catch any API or processing error.
-            logging.exception("Failed to export self audit logs: %s", exception)  # Log full traceback.
+# NOTE: SelfExportUtils has been extracted to src/export/self_export_utils.py (issue #1013 SC-001 position 7)
 
 
 class OrgConfigExporter:  # Org config exporters.

--- a/src/export/self_export_utils.py
+++ b/src/export/self_export_utils.py
@@ -1,0 +1,60 @@
+"""SelfExportUtils -- authenticated self/account export utilities.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 7).
+Exports data scoped to the currently authenticated admin account rather
+than an org or site. Handles self audit logs and similar account-level
+read operations.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+.
+
+import importlib  # WHY: lazy MistHelper import to avoid circular load.
+import logging  # WHY: emit structured trace for export progress + failures.
+
+import mistapi  # WHY: dotted-path API resolution + pagination helper.
+
+
+class SelfExportUtils:  # Self/account exporters.
+    # pylint: disable=too-few-public-methods  # WHY: static-method utility class; grouping by domain is the point.
+    """Authenticated self/account export utilities.
+
+    Exports data scoped to the currently authenticated admin account rather
+    than an org or site. Handles self audit logs and similar account-level
+    read operations.
+    """
+
+    @staticmethod
+    def _persist_self_audit_rows(rows: list, filename: str, hours: int) -> None:
+        """Flatten + persist self audit rows, or write an empty file when nothing was returned."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live writer + processing helpers.
+        if not rows:  # No data returned -- write empty output rather than failing silently.
+            logging.warning("No self audit log records returned for the last %d hours", hours)  # Warn empty.
+            mh.DataExporter.write_with_format_selection([], filename)  # Empty file signals successful run.
+            return  # Done.
+        rows = mh.DataProcessingUtils.flatten_nested_fields(rows)  # Flatten nested change-detail dicts for CSV.
+        mh.DataExporter.write_with_format_selection(  # Persist to disk with format selection.
+            rows, filename, api_function_name="listSelfAuditLogs"
+        )
+        logging.info("Exported %d self audit log records to %s", len(rows), filename)  # Log success.
+
+    @staticmethod
+    def audit_logs() -> None:  # Export audit logs.
+        """Export audit log of changes made by the authenticated admin account to SelfAuditLogs.csv."""
+        logging.info("Starting export of self (admin account) audit logs...")  # Log before operation.
+        filename = "SelfAuditLogs.csv"  # Output filename for self audit log entries.
+        try:
+            mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live session + time helpers.
+            hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Same lookback as other audit log exports.
+            mh.TimeUtils.log_dynamic_lookback("self audit logs export", hours)  # Log lookback window selection.
+            logging.info("Fetching self audit logs for last %d hours...", hours)  # Log before API call.
+            response = mistapi.api.v1.self.logs.listSelfAuditLogs(  # Call Mist API for admin account audit log.
+                mh.apisession,
+                duration=f"{hours}h",  # Limit results to the dynamic lookback window.
+                limit=1000,  # Request large page to minimise pagination round-trips.
+            )
+            logging.debug("Raw API response received for self audit logs")  # Log after API call.
+            rows = mistapi.get_all(response=response, mist_session=mh.apisession)  # Paginate through all results.
+            logging.debug("Received %d self audit log records after pagination", len(rows))  # Log record count.
+            SelfExportUtils._persist_self_audit_rows(rows, filename, hours)  # Persist or write empty.
+        except Exception as exception:  # Catch any API or processing error.
+            logging.exception("Failed to export self audit logs: %s", exception)  # Log full traceback.


### PR DESCRIPTION
## Summary
- Extract `SelfExportUtils` (40 LOC, 2 methods) from `MistHelper.py` to `src/export/self_export_utils.py` per initiative #1013 Cat B position 7 (SC-001).
- New file scores 10.00/10 pylint; MistHelper.py pylint stable at 8.66/10 (matches P6 baseline).
- Class methods use lazy `importlib.import_module("MistHelper")` to reach live `apisession` and helper classes without circular import.
- Top-level re-export preserves the direct reference at the menu tuple (`MistHelper.py:18131`, option 23).

## Test plan
- [x] `black --check` clean
- [x] `ruff check` clean
- [x] `py_compile` clean
- [x] `pylint src/export/self_export_utils.py` = 10.00/10 (SC-006)
- [x] `pylint MistHelper.py` = 8.66/10 (no regression from P6 baseline)
- [x] `python MistHelper.py --test` = 66/66 passed, 0 failures
- [ ] CI: 15/15 green + mergeStateStatus CLEAN