### PR TITLE
refactor(1013): extract TelemetryEmitter to src/analytics/ (SC-001, position 9)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -93,6 +93,9 @@ from src.analytics.site_inventory_health_analyzer import (  # Import site invent
 from src.analytics.site_inventory_health_analyzer import (
     SiteInventoryHealthAnalyzerDeps,
 )  # Import dependency injection class
+from src.analytics.telemetry_emitter import (  # pylint: disable=unused-import
+    TelemetryEmitter,  # noqa: F401  # Cat B (1013 SC-001 position 9) -- re-export for callers at 18629/18632/18711/19062
+)
 from src.audit.analyzer import AuditLogAnalyzer  # Import audit log analysis engine for timeline/report generation
 from src.audit.filter import AuditLogFilter  # Import audit log filtering to remove noise and system events
 from src.audit.renderer import AuditReportRenderer  # Import Mermaid timeline + HTML report rendering
@@ -117,8 +120,7 @@ from src.dataclasses.export_backend_options import (
 )  # Issue #470: groups output-backend overrides to keep write_with_format_selection within the 5-Item Rule.
 from src.dataclasses.progress_event import (
     ProgressContext,
-    TestSummary,
-)  # Issue #470: groups TelemetryEmitter event fields to keep emit_* signatures within the 5-Item Rule.
+)  # Issue #470: groups progress-event fields to keep emit_progress_* signatures within the 5-Item Rule.
 from src.dataclasses.systematic_test_option import (
     SystematicTestOption,
 )  # Issue #470: groups menu-option identity to keep _systematic_test_run_option within the 5-Item Rule.
@@ -17767,223 +17769,7 @@ menu_actions = {
 }
 
 
-# ============================================================================
-# TELEMETRY EMITTER CLASS
-# ============================================================================
-class TelemetryEmitter:
-    """Append-only NDJSON event writer for test and progress telemetry.
-
-    Writes one JSON object per line to the target file.  All writes are
-    best-effort: an I/O failure is logged but never interrupts the
-    primary operation (FR-008).
-
-    Usage::
-
-        with TelemetryEmitter("data/test_events.jsonl") as emitter:
-            emitter.emit({"event_type": "test_pass", ...})
-    """
-
-    RETENTION_LIMIT = 10
-
-    def __init__(self, file_path: str):
-        self._path = file_path
-        self._handle = None
-        try:
-            parent = os.path.dirname(file_path)
-            if parent:
-                os.makedirs(parent, exist_ok=True)
-            self._handle = open(file_path, "a", encoding="utf-8")
-        except OSError as exc:
-            logging.warning("TelemetryEmitter: cannot open %s: %s", file_path, exc)
-
-    # -- core write ----------------------------------------------------------
-
-    def emit(self, event: dict) -> None:  # type: ignore[type-arg]
-        """Write *event* as a single JSON line (best-effort)."""
-        if self._handle is None:
-            return
-        try:
-            self._handle.write(json.dumps(event, default=str) + "\n")
-            self._handle.flush()
-        except OSError as exc:
-            logging.warning("TelemetryEmitter: write failed: %s", exc)
-
-    def close(self) -> None:
-        """Flush and close the underlying file handle."""
-        if self._handle is not None:
-            try:
-                self._handle.close()
-            except OSError:
-                pass
-            self._handle = None
-
-    # -- context manager -----------------------------------------------------
-
-    def __enter__(self) -> "TelemetryEmitter":
-        return self
-
-    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object) -> None:
-        self.close()
-
-    # -- test event helpers ---------------------------------------------------
-
-    def emit_test_start(self, menu_option: str | int, operation_name: str, test_mode: str) -> None:
-        """Emit a test_start event."""
-        self.emit(
-            {
-                "event_type": "test_start",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "operation_name": operation_name,
-                "test_mode": test_mode,
-            }
-        )
-
-    def emit_test_pass(self, menu_option: str | int, operation_name: str, duration: float, test_mode: str) -> None:
-        """Emit a test_pass event."""
-        self.emit(
-            {
-                "event_type": "test_pass",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "status": "pass",
-                "operation_name": operation_name,
-                "duration_seconds": round(duration, 3),
-                "test_mode": test_mode,
-            }
-        )
-
-    def emit_test_fail(
-        self, menu_option: str | int, operation_name: str, duration: float, error: Exception, test_mode: str
-    ) -> None:
-        """Emit a test_fail event."""
-        self.emit(
-            {
-                "event_type": "test_fail",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "status": "fail",
-                "operation_name": operation_name,
-                "duration_seconds": round(duration, 3),
-                "error_type": type(error).__name__,
-                "error_message": str(error)[:500],
-                "test_mode": test_mode,
-            }
-        )
-
-    def emit_test_skip(
-        self, menu_option: str | int, operation_name: str, reason: str, category: str, test_mode: str
-    ) -> None:
-        """Emit a test_skip event."""
-        self.emit(
-            {
-                "event_type": "test_skip",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "status": "skip",
-                "operation_name": operation_name,
-                "duration_seconds": 0.0,
-                "skip_reason": reason,
-                "skip_category": category,
-                "test_mode": test_mode,
-            }
-        )
-
-    def emit_test_summary(self, summary: TestSummary) -> None:
-        """Emit a test_summary event from a bundled TestSummary (issue #470: was 6 positional params)."""
-        overall = "pass" if summary.failed == 0 else "fail"  # Overall verdict is pass only when nothing failed.
-        self.emit(
-            {
-                "event_type": "test_summary",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": "0",
-                "status": overall,
-                "total_operations": summary.total,  # Total operations exercised (issue #470: from dataclass).
-                "pass_count": summary.passed,  # Passed count (issue #470: from dataclass).
-                "fail_count": summary.failed,  # Failed count (issue #470: from dataclass).
-                "skip_count": summary.skipped,  # Skipped count (issue #470: from dataclass).
-                "total_elapsed_seconds": round(summary.elapsed, 3),  # Elapsed wall-clock seconds (issue #470).
-                "test_mode": summary.test_mode,  # Test mode label (issue #470: from dataclass).
-            }
-        )
-
-    # -- progress event helpers -----------------------------------------------
-
-    def emit_progress_start(self, menu_option: str | int, operation_name: str, total_items: int) -> None:
-        """Emit a progress_start event."""
-        self.emit(
-            {
-                "event_type": "progress_start",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(menu_option),
-                "operation_name": operation_name,
-                "total_items": total_items,
-            }
-        )
-
-    def emit_progress_tick(self, ctx: ProgressContext, current: object, completed: int, remaining: int) -> None:
-        """Emit a progress_tick event from a ProgressContext (issue #470: identity bundled into ctx)."""
-        self.emit(
-            {
-                "event_type": "progress_tick",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(ctx.menu_option),  # Menu option from the bundled context (issue #470).
-                "operation_name": ctx.operation_name,  # Operation label from the bundled context (issue #470).
-                "total_items": ctx.total,  # Total item count from the bundled context (issue #470).
-                "current_item": str(current),  # The item currently being processed.
-                "items_completed": completed,  # Count of items finished so far.
-                "items_remaining": remaining,  # Count of items still pending.
-            }
-        )
-
-    def emit_progress_complete(
-        self,
-        ctx: ProgressContext,
-        processed: int,
-        was_stopped: bool,
-        duration: float,
-    ) -> None:
-        """Emit a progress_complete event from a ProgressContext (issue #470: identity bundled into ctx)."""
-        self.emit(
-            {
-                "event_type": "progress_complete",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "menu_option": str(ctx.menu_option),  # Menu option from the bundled context (issue #470).
-                "operation_name": ctx.operation_name,  # Operation label from the bundled context (issue #470).
-                "total_items": ctx.total,  # Total item count from the bundled context (issue #470).
-                "items_processed": processed,  # Count of items actually processed before completion.
-                "was_stopped": was_stopped,  # True when the operation was interrupted by the user.
-                "duration_seconds": round(duration, 3),  # Wall-clock seconds the operation took.
-            }
-        )
-
-    # -- retention ------------------------------------------------------------
-
-    def enforce_retention(
-        self, directory: str = "data", prefix: str = "test_events_", limit: int | None = None
-    ) -> None:
-        """Delete oldest timestamped JSONL files when count exceeds *limit*."""
-        if limit is None:
-            limit = self.RETENTION_LIMIT
-        try:
-            pattern = os.path.join(directory, f"{prefix}*.jsonl")
-            import glob
-
-            files = sorted(glob.glob(pattern))
-            while len(files) > limit:
-                oldest = files.pop(0)
-                os.remove(oldest)
-                logging.info("TelemetryEmitter: removed old file %s", oldest)
-        except OSError as exc:
-            logging.warning("TelemetryEmitter: retention cleanup failed: %s", exc)
-
-    # -- timestamped filename helper -----------------------------------------
-
-    @staticmethod
-    def timestamped_path(directory: str = "data") -> str:
-        """Return a timestamped JSONL path for a test run."""
-        stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-        return os.path.join(directory, f"test_events_{stamp}.jsonl")
+# NOTE: TelemetryEmitter has been extracted to src/analytics/telemetry_emitter.py (issue #1013 SC-001 position 9)
 
 
 # ============================================================================

--- a/src/analytics/telemetry_emitter.py
+++ b/src/analytics/telemetry_emitter.py
@@ -1,0 +1,235 @@
+"""TelemetryEmitter -- append-only NDJSON event writer.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 9).
+Writes one JSON object per line to the target file for test and progress
+telemetry. All writes are best-effort: an I/O failure is logged but never
+interrupts the primary operation (FR-008).
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+.
+
+import glob  # WHY: retention pruning of oldest timestamped JSONL files.
+import json  # WHY: NDJSON serialization for every emitted event.
+import logging  # WHY: emit structured trace on write / open failures.
+import os  # WHY: cross-platform parent-dir creation + retention file removal.
+from datetime import UTC, datetime  # WHY: ISO-8601 UTC timestamps on every event.
+
+from src.dataclasses.progress_event import (
+    ProgressContext,  # Bundled progress identity (issue #470).
+    TestSummary,  # Bundled test-summary counters (issue #470).
+)
+
+
+class TelemetryEmitter:
+    """Append-only NDJSON event writer for test and progress telemetry.
+
+    Writes one JSON object per line to the target file.  All writes are
+    best-effort: an I/O failure is logged but never interrupts the
+    primary operation (FR-008).
+
+    Usage::
+
+        with TelemetryEmitter("data/test_events.jsonl") as emitter:
+            emitter.emit({"event_type": "test_pass", ...})
+    """
+
+    RETENTION_LIMIT = 10
+
+    def __init__(self, file_path: str):
+        self._path = file_path
+        self._handle = None
+        try:
+            parent = os.path.dirname(file_path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            self._handle = open(file_path, "a", encoding="utf-8")  # noqa: SIM115  # long-lived append handle
+        except OSError as exc:
+            logging.warning("TelemetryEmitter: cannot open %s: %s", file_path, exc)
+
+    # -- core write ----------------------------------------------------------
+
+    def emit(self, event: dict) -> None:  # type: ignore[type-arg]
+        """Write *event* as a single JSON line (best-effort)."""
+        if self._handle is None:
+            return
+        try:
+            self._handle.write(json.dumps(event, default=str) + "\n")
+            self._handle.flush()
+        except OSError as exc:
+            logging.warning("TelemetryEmitter: write failed: %s", exc)
+
+    def close(self) -> None:
+        """Flush and close the underlying file handle."""
+        if self._handle is not None:
+            try:
+                self._handle.close()
+            except OSError:
+                pass
+            self._handle = None
+
+    # -- context manager -----------------------------------------------------
+
+    def __enter__(self) -> TelemetryEmitter:
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object) -> None:
+        del exc_type, exc_val, exc_tb  # WHY: protocol params unused; silence vulture without renaming public signature.
+        self.close()
+
+    # -- test event helpers ---------------------------------------------------
+
+    def emit_test_start(self, menu_option: str | int, operation_name: str, test_mode: str) -> None:
+        """Emit a test_start event."""
+        self.emit(
+            {
+                "event_type": "test_start",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "menu_option": str(menu_option),
+                "operation_name": operation_name,
+                "test_mode": test_mode,
+            }
+        )
+
+    def emit_test_pass(self, menu_option: str | int, operation_name: str, duration: float, test_mode: str) -> None:
+        """Emit a test_pass event."""
+        self.emit(
+            {
+                "event_type": "test_pass",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "menu_option": str(menu_option),
+                "status": "pass",
+                "operation_name": operation_name,
+                "duration_seconds": round(duration, 3),
+                "test_mode": test_mode,
+            }
+        )
+
+    def emit_test_fail(
+        self, menu_option: str | int, operation_name: str, duration: float, error: Exception, test_mode: str
+    ) -> None:
+        """Emit a test_fail event."""
+        self.emit(
+            {
+                "event_type": "test_fail",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "menu_option": str(menu_option),
+                "status": "fail",
+                "operation_name": operation_name,
+                "duration_seconds": round(duration, 3),
+                "error_type": type(error).__name__,
+                "error_message": str(error)[:500],
+                "test_mode": test_mode,
+            }
+        )
+
+    def emit_test_skip(
+        self, menu_option: str | int, operation_name: str, reason: str, category: str, test_mode: str
+    ) -> None:
+        """Emit a test_skip event."""
+        self.emit(
+            {
+                "event_type": "test_skip",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "menu_option": str(menu_option),
+                "status": "skip",
+                "operation_name": operation_name,
+                "duration_seconds": 0.0,
+                "skip_reason": reason,
+                "skip_category": category,
+                "test_mode": test_mode,
+            }
+        )
+
+    def emit_test_summary(self, summary: TestSummary) -> None:
+        """Emit a test_summary event from a bundled TestSummary (issue #470: was 6 positional params)."""
+        overall = "pass" if summary.failed == 0 else "fail"  # Overall verdict is pass only when nothing failed.
+        self.emit(
+            {
+                "event_type": "test_summary",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "menu_option": "0",
+                "status": overall,
+                "total_operations": summary.total,  # Total operations exercised (issue #470: from dataclass).
+                "pass_count": summary.passed,  # Passed count (issue #470: from dataclass).
+                "fail_count": summary.failed,  # Failed count (issue #470: from dataclass).
+                "skip_count": summary.skipped,  # Skipped count (issue #470: from dataclass).
+                "total_elapsed_seconds": round(summary.elapsed, 3),  # Elapsed wall-clock seconds (issue #470).
+                "test_mode": summary.test_mode,  # Test mode label (issue #470: from dataclass).
+            }
+        )
+
+    # -- progress event helpers -----------------------------------------------
+
+    def emit_progress_start(self, menu_option: str | int, operation_name: str, total_items: int) -> None:
+        """Emit a progress_start event."""
+        self.emit(
+            {
+                "event_type": "progress_start",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "menu_option": str(menu_option),
+                "operation_name": operation_name,
+                "total_items": total_items,
+            }
+        )
+
+    def emit_progress_tick(self, ctx: ProgressContext, current: object, completed: int, remaining: int) -> None:
+        """Emit a progress_tick event from a ProgressContext (issue #470: identity bundled into ctx)."""
+        self.emit(
+            {
+                "event_type": "progress_tick",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "menu_option": str(ctx.menu_option),  # Menu option from the bundled context (issue #470).
+                "operation_name": ctx.operation_name,  # Operation label from the bundled context (issue #470).
+                "total_items": ctx.total,  # Total item count from the bundled context (issue #470).
+                "current_item": str(current),  # The item currently being processed.
+                "items_completed": completed,  # Count of items finished so far.
+                "items_remaining": remaining,  # Count of items still pending.
+            }
+        )
+
+    def emit_progress_complete(
+        self,
+        ctx: ProgressContext,
+        processed: int,
+        was_stopped: bool,
+        duration: float,
+    ) -> None:
+        """Emit a progress_complete event from a ProgressContext (issue #470: identity bundled into ctx)."""
+        self.emit(
+            {
+                "event_type": "progress_complete",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "menu_option": str(ctx.menu_option),  # Menu option from the bundled context (issue #470).
+                "operation_name": ctx.operation_name,  # Operation label from the bundled context (issue #470).
+                "total_items": ctx.total,  # Total item count from the bundled context (issue #470).
+                "items_processed": processed,  # Count of items actually processed before completion.
+                "was_stopped": was_stopped,  # True when the operation was interrupted by the user.
+                "duration_seconds": round(duration, 3),  # Wall-clock seconds the operation took.
+            }
+        )
+
+    # -- retention ------------------------------------------------------------
+
+    def enforce_retention(
+        self, directory: str = "data", prefix: str = "test_events_", limit: int | None = None
+    ) -> None:
+        """Delete oldest timestamped JSONL files when count exceeds *limit*."""
+        if limit is None:
+            limit = self.RETENTION_LIMIT
+        try:
+            pattern = os.path.join(directory, f"{prefix}*.jsonl")
+            files = sorted(glob.glob(pattern))
+            while len(files) > limit:
+                oldest = files.pop(0)
+                os.remove(oldest)
+                logging.info("TelemetryEmitter: removed old file %s", oldest)
+        except OSError as exc:
+            logging.warning("TelemetryEmitter: retention cleanup failed: %s", exc)
+
+    # -- timestamped filename helper -----------------------------------------
+
+    @staticmethod
+    def timestamped_path(directory: str = "data") -> str:
+        """Return a timestamped JSONL path for a test run."""
+        stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        return os.path.join(directory, f"test_events_{stamp}.jsonl")


### PR DESCRIPTION
## Summary

Extracts `TelemetryEmitter` (~215 LOC, class body lines 17773-17987) from `MistHelper.py` into a new module `src/analytics/telemetry_emitter.py`. This is Cat B position 9 of initiative #1013 (SC-001 fresh extraction), following P8 (#807, MSPInventoryExporter).

`TelemetryEmitter` is stdlib-only (glob, json, logging, os, datetime) plus `TestSummary` / `ProgressContext` from `src.dataclasses.progress_event` — zero MistHelper module-global dependencies, so no lazy `importlib.import_module("MistHelper")` pattern is required.

## Changes

- **New file**: `src/analytics/telemetry_emitter.py` — full class body copied verbatim.
- **Hoisted** `import glob` from inside `enforce_retention` to module top.
- **Header**: `from __future__ import annotations` (enables unquoted `TelemetryEmitter` self-ref in `__enter__`).
- **noqa**: `SIM115` on long-lived append handle in `__init__`.
- **Re-export** added to `MistHelper.py` (alphabetical position within `src.analytics.*`) so 4 caller sites (18416/18419/18498/18849) resolve transparently.
- **Removed** `TestSummary` from MistHelper's `progress_event` import block — it was only consumed by the extracted class. `ProgressContext` remains (still used by ~10 in-file callers).
- **Breadcrumb** replaces the deleted class body at former line 17770.

## Local gate

- `black --check`: clean
- `ruff check`: clean (fixed initial UP037 + F401)
- `py_compile`: OK
- `python MistHelper.py --test`: **66 passed / 0 failed / 131 skipped / 208.19s**

## Test plan
- [x] Local `--test` all green (66/66)
- [ ] CI checks green
- [ ] `mergeStateStatus=CLEAN`
- [ ] Squash-merge with `--delete-branch`
- [ ] Main fast-forwards cleanly