### PR TITLE
refactor(1013): extract InteractiveDisplayUtils to src/ui/ (SC-001, position 10)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -165,8 +165,8 @@ from src.refactors.data_directory_checker import DataDirectoryChecker  # Early d
 from src.refactors.device_config_template_cloner_manager import (
     DeviceConfigTemplateClonerManager,  # Extracted device config template cloner (SC-020)
 )
-from src.refactors.device_data_fetcher import (
-    DeviceDataFetcher,  # Extracted interactive device data fetcher (SC-017)
+from src.refactors.device_data_fetcher import (  # pylint: disable=unused-import
+    DeviceDataFetcher,  # noqa: F401  # Extracted interactive device data fetcher (SC-017) -- re-export for src.ui.interactive_display_utils lazy access
 )
 from src.refactors.fast_mode_backoff_multiplier import (
     FastModeBackoffMultiplier,  # Extracted fast-mode backoff multiplier constant (SC-028)
@@ -242,6 +242,9 @@ from src.troubleshooting.marvis_troubleshoot_utils import (
 from src.troubleshooting.marvis_troubleshoot_utils import (
     MarvisTroubleshootUtils as ExtractedMarvisTroubleshootUtils,
 )  # Import Marvis troubleshooting utils (renamed to avoid conflicts)
+from src.ui.interactive_display_utils import (  # pylint: disable=unused-import
+    InteractiveDisplayUtils,  # noqa: F401  # Cat B (1013 SC-001 position 10) -- re-export for callers at 17392/17393/17394/17395
+)
 from src.wan_hub_group_manager import WanHubGroupNumberManager  # Import WAN hub group number manager for hub routing
 from src.wan_vpn_builder import WanVpnBuilder  # Import WAN VPN configuration builder
 from src.websocket.commands import MacTableCommand  # Import WebSocket show-MAC-table command handler
@@ -14697,78 +14700,8 @@ class DataCollectionManager:  # Continuous data collector.
 # ============================================================================
 # INTERACTIVE DISPLAY UTILITIES CLASS
 # ============================================================================
-class InteractiveDisplayUtils:  # Interactive display utils.
-    """
-    Centralized interactive display utilities.
-    Groups all interactive_display_* functions for better code organization.
-    All methods are static to avoid unnecessary object instantiation.
-    """
-
-    @staticmethod
-    def site_inventory():  # View site inventory.
-        """
-        Prompts the user to select a site and displays its device inventory.
-        """
-        logging.info("Prompting user to select a site for device inventory view...")  # Log the prompt.
-        print("Select a Site to View Device Inventory:")  # Header.
-        site_id = PromptUtils.select_site_id_from_csv()  # Select a site.
-        if site_id:  # Site selected.
-            logging.info("User selected site_id: %s for inventory display.", site_id)  # Log the selection.
-            SiteDeviceExporter.device_inventory(site_id)  # type: ignore[no-untyped-call]
-        else:
-            logging.warning("No site selected or invalid input provided for site selection.")  # Warn none selected.
-
-    @staticmethod
-    def device_stats(site_id=None, device_id=None):  # View device stats.
-        """
-        Fetches and displays detailed statistics for a specific device.
-
-        Args:
-            site_id: Optional site ID (prompts if not provided)
-            device_id: Optional device ID (prompts if not provided)
-        """
-        logging.info("Prompting user to select a device for detailed statistics view...")  # Log the prompt.
-        DeviceDataFetcher(  # Fetch and display.
-            DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
-                fetch_function=mistapi.api.v1.sites.stats.getSiteDeviceStats,
-                filename="DeviceStats.csv",
-                description="Fetching detailed stats",
-                site_id=site_id,
-                device_id=device_id,
-            )
-        ).fetch()
-        logging.info("Completed device_stats execution.")  # Log completion.
-
-    @staticmethod
-    def device_tests():  # View device tests.
-        """
-        Prompts user to select a gateway device and displays its synthetic test stats.
-        """
-        logging.info("Prompting user to select a gateway device for synthetic test stats view...")  # Log the prompt.
-        DeviceDataFetcher(  # Fetch and display.
-            DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
-                fetch_function=mistapi.api.v1.sites.devices.getSiteDeviceSyntheticTest,
-                filename="DeviceTestResults.csv",
-                description="Fetching synthetic test stats",
-                device_type="gateway",
-            )
-        ).fetch()
-        logging.info("Completed device_tests execution.")  # Log completion.
-
-    @staticmethod
-    def device_config():  # View device config.
-        """
-        Prompts user to select a device and displays its configuration details.
-        """
-        logging.info("Prompting user to select a device for configuration details view...")  # Log the prompt.
-        DeviceDataFetcher(  # Fetch and display.
-            DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
-                fetch_function=mistapi.api.v1.sites.devices.getSiteDevice,
-                filename="DeviceConfig.csv",
-                description="Fetching device configuration",
-            )
-        ).fetch()
-        logging.info("Completed device_config execution.")  # Log completion.
+# NOTE: InteractiveDisplayUtils has been extracted to
+# src/ui/interactive_display_utils.py (issue #1013 SC-001 position 10)
 
 
 # ============================================================================

--- a/src/ui/interactive_display_utils.py
+++ b/src/ui/interactive_display_utils.py
@@ -1,0 +1,85 @@
+"""InteractiveDisplayUtils -- interactive device/site display helpers.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 10).
+Groups the interactive_display_* menu handlers (site inventory, device stats,
+device tests, device config) so callers can invoke them without reaching into
+the monolith. All methods are static -- no state is kept on the class.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+.
+
+import importlib  # WHY: lazy MistHelper import to reach live helper classes without circular load.
+import logging  # WHY: emit structured trace for each menu entry.
+
+import mistapi  # WHY: dotted-path API resolution for device stats / test / config endpoints.
+
+
+class InteractiveDisplayUtils:
+    """Centralized interactive display utilities.
+
+    Groups all interactive_display_* functions for better code organization.
+    All methods are static to avoid unnecessary object instantiation.
+    """
+
+    @staticmethod
+    def site_inventory() -> None:
+        """Prompt the user to select a site and display its device inventory."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils + SiteDeviceExporter.
+        logging.info("Prompting user to select a site for device inventory view...")  # Log the prompt.
+        print("Select a Site to View Device Inventory:")  # Header.
+        site_id = mh.PromptUtils.select_site_id_from_csv()  # Select a site.
+        if site_id:  # Site selected.
+            logging.info("User selected site_id: %s for inventory display.", site_id)  # Log the selection.
+            mh.SiteDeviceExporter.device_inventory(site_id)
+        else:
+            logging.warning("No site selected or invalid input provided for site selection.")  # Warn none selected.
+
+    @staticmethod
+    def device_stats(site_id: str | None = None, device_id: str | None = None) -> None:
+        """Fetch and display detailed statistics for a specific device.
+
+        Args:
+            site_id: Optional site ID (prompts if not provided)
+            device_id: Optional device ID (prompts if not provided)
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DeviceDataFetcher + DeviceFetchConfig.
+        logging.info("Prompting user to select a device for detailed statistics view...")  # Log the prompt.
+        mh.DeviceDataFetcher(  # Fetch and display.
+            mh.DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+                fetch_function=mistapi.api.v1.sites.stats.getSiteDeviceStats,
+                filename="DeviceStats.csv",
+                description="Fetching detailed stats",
+                site_id=site_id,
+                device_id=device_id,
+            )
+        ).fetch()
+        logging.info("Completed device_stats execution.")  # Log completion.
+
+    @staticmethod
+    def device_tests() -> None:
+        """Prompt user to select a gateway device and display its synthetic test stats."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DeviceDataFetcher + DeviceFetchConfig.
+        logging.info("Prompting user to select a gateway device for synthetic test stats view...")  # Log the prompt.
+        mh.DeviceDataFetcher(  # Fetch and display.
+            mh.DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+                fetch_function=mistapi.api.v1.sites.devices.getSiteDeviceSyntheticTest,
+                filename="DeviceTestResults.csv",
+                description="Fetching synthetic test stats",
+                device_type="gateway",
+            )
+        ).fetch()
+        logging.info("Completed device_tests execution.")  # Log completion.
+
+    @staticmethod
+    def device_config() -> None:
+        """Prompt user to select a device and display its configuration details."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DeviceDataFetcher + DeviceFetchConfig.
+        logging.info("Prompting user to select a device for configuration details view...")  # Log the prompt.
+        mh.DeviceDataFetcher(  # Fetch and display.
+            mh.DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+                fetch_function=mistapi.api.v1.sites.devices.getSiteDevice,
+                filename="DeviceConfig.csv",
+                description="Fetching device configuration",
+            )
+        ).fetch()
+        logging.info("Completed device_config execution.")  # Log completion.


### PR DESCRIPTION
## Summary
- Cat B fresh-extraction position 10 of initiative #1013: move `InteractiveDisplayUtils` (4 static methods) out of `MistHelper.py` into `src/ui/interactive_display_utils.py`.
- Re-export alias keeps the 4 menu caller sites (options 93/94/95/96) working unchanged.
- Demote `DeviceDataFetcher` module-level import to `# noqa: F401` re-export so the extracted module can reach it via lazy `mh.DeviceDataFetcher`.

## Diff shape
- `MistHelper.py`: -74 class body lines, +18 breadcrumb + import block, ~net -56
- `src/ui/interactive_display_utils.py`: +86 lines (static-only class, lazy MistHelper import for `PromptUtils` / `SiteDeviceExporter` / `DeviceDataFetcher` / `DeviceFetchConfig`)

## Test plan
- [x] `python -m black --check src/ui/interactive_display_utils.py MistHelper.py`
- [x] `python -m ruff check src/ui/interactive_display_utils.py MistHelper.py`
- [x] `python -m py_compile src/ui/interactive_display_utils.py MistHelper.py`
- [x] `python -m vulture --min-confidence 100 src/ui/interactive_display_utils.py MistHelper.py` (0 findings)
- [x] `python MistHelper.py --test` -- 66 passed / 0 failed / 131 skipped (unsafe)
- [ ] CI green