### PR TITLE
refactor(1013): extract SiteClientExporter to src/export/ (SC-001, position 14)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -136,6 +136,9 @@ from src.export.msp_inventory_exporter import (  # pylint: disable=unused-import
 from src.export.self_export_utils import (  # pylint: disable=unused-import
     SelfExportUtils,  # noqa: F401  # Cat B (1013 SC-001 position 7) -- re-export for menu tuple at MistHelper:18167
 )
+from src.export.site_client_exporter import (  # pylint: disable=unused-import
+    SiteClientExporter,  # noqa: F401  # Cat B (1013 SC-001 position 14) -- re-export for MistHelper.SiteClientExporter callers
+)
 from src.export.site_export_utils import (
     configure_site_export_utils_dependencies,
 )  # Import site export utility configuration
@@ -145,7 +148,6 @@ from src.export.site_insights.device_metric_operation import (
 from src.export.site_insights.site_metric_operation import (
     SiteMetricOperation,
 )  # Decomposed Menu 74 entry point
-from src.export.wifi_clients_exporter import WifiClientsExporter  # Import WiFi client export handler
 from src.firmware.firmware_manager import (  # Cat A canonical (1013 SC-002)
     FirmwareManager,
     FirmwareManagerConfig,
@@ -12299,91 +12301,7 @@ class SiteDeviceExporter:  # Site device exporters.
             print(f"! Error fetching device data: {e}")  # Tell the user
 
 
-class SiteClientExporter:  # Site client exporters.
-    """
-    Site Client Data Exporter
-
-    Handles site-level client data, WiFi clients, and beacon exports.
-    Extracted from SiteExportUtils.
-    """
-
-    @staticmethod
-    def _persist_site_clients(rawdata: list, site_name: str) -> None:
-        """Flatten + persist site-clients rows to a per-site CSV (or tell the user when empty)."""
-        if not rawdata:  # No clients — tell the user and return.
-            print("! No client data found for this site")  # User notice.
-            return  # Done.
-        flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
-        sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # type: ignore[no-untyped-call]  # CSV-safe.
-        filename = f"SiteClients_{site_name.replace(' ', '_')}.csv"  # Per-site CSV name.
-        DataExporter.write_with_format_selection(sanitized_data, filename)  # type: ignore[no-untyped-call]  # Persist.
-        print(f"! {len(rawdata)} client records exported to {filename}")  # User notice with count.
-
-    @staticmethod
-    def clients():  # Export site client stats.
-        """Export client data for a site to SiteClients.csv."""
-        print("Site Client Statistics:")  # Header
-        logging.info("Starting export of site client statistics...")  # Trace start
-        resolved = SiteDeviceExporter._resolve_site_for_stats(
-            "client statistics"
-        )  # Prompt + org/site resolution (shared)
-        if resolved is None:  # Abort signaled by resolver
-            return
-        site_id, site_name = resolved  # Unpack resolved identifiers
-        try:
-            response = mistapi.api.v1.sites.stats.listSiteWirelessClientsStats(apisession, site_id, limit=1000)
-            rawdata = mistapi.get_all(response=response, mist_session=apisession)  # Page all rows
-            SiteClientExporter._persist_site_clients(rawdata, site_name)  # Persist or tell user empty
-        except Exception as e:  # Fetch failed
-            logging.error("Error fetching client stats for site %s: %s", site_name, e)  # Log the error
-            print(f"! Error fetching client data: {e}")  # Tell the user
-
-    @staticmethod
-    def client_insights():  # noqa: C901, PLR0912, PLR0915
-        """Delegated site client insights entrypoint preserved for compatibility."""
-        from src.refactors.serial_cc.site_client_insights import SiteClientInsightsService
-
-        SiteClientInsightsService.execute()  # Run the insights export.
-
-    @staticmethod
-    def _normalize_client_mac_or_none(client_mac: str) -> str | None:  # Normalize a client MAC.
-        """Validate and normalize client MAC for site insights endpoints."""
-        if not client_mac:  # Empty input.
-            return None  # Return None.
-        if not PacketCaptureManager.validate_mac_address(client_mac):  # Invalid MAC.
-            return None  # Return None.
-        return PacketCaptureManager.normalize_mac_address(client_mac)  # Return normalized MAC.
-
-    @staticmethod
-    def wifi_clients(site_id=None):  # Export WiFi clients.
-        """Compatibility facade that delegates WiFi client export to extracted exporter."""
-        logging.info(
-            "Delegating wifi_clients to WifiClientsExporter"
-        )  # Log before constructing extracted exporter dependencies.
-        exporter = (
-            WifiClientsExporter(  # Build extracted exporter with existing utility dependencies to preserve behavior.
-                cache_utils=CacheUtils,
-                org_site_exporter=OrgSiteExporter,
-                prompt_utils=PromptUtils,
-                file_path_utils=FilePathUtils,
-                data_processing_utils=DataProcessingUtils,
-                data_exporter=DataExporter,
-                mistapi_module=mistapi,
-                apisession=apisession,
-            )
-        )
-        logging.debug(
-            "Initialized WifiClientsExporter for site_id=%s", site_id
-        )  # Log exporter construction completion.
-        exporter.execute(site_id=site_id)  # Delegate export execution while preserving facade signature.
-        logging.debug("Completed delegated wifi_clients export workflow")  # Log delegated exporter completion.
-
-    @staticmethod
-    def beacons():  # Export beacons.
-        """Export beacons for a site to SiteBeacons.csv."""
-        SiteExportUtils._export_data(  # type: ignore[no-untyped-call]
-            api_call=mistapi.api.v1.sites.beacons.listSiteBeacons, data_type="beacons", sort_key="name"
-        )
+# SiteClientExporter moved to src/export/site_client_exporter.py (1013 SC-001 position 14)
 
 
 class SiteConfigExporter:  # Site config exporters.

--- a/src/export/site_client_exporter.py
+++ b/src/export/site_client_exporter.py
@@ -1,0 +1,107 @@
+"""SiteClientExporter -- site-level client/beacon/wifi export operations.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 14).
+Handles site-level client data, WiFi clients, and beacon exports.  All methods
+are static -- no state is kept on the class.  Callers continue to reach it
+through the ``MistHelper.SiteClientExporter`` re-export alias.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+.
+
+import importlib  # WHY: lazy MistHelper import to reach live helper classes without circular load.
+import logging  # WHY: structured trace for export lifecycle events.
+from typing import Any  # WHY: raw client rows are duck-typed dicts from mistapi.
+
+import mistapi  # WHY: direct SDK access for listSiteWirelessClientsStats + beacons endpoints.
+
+from src.export.wifi_clients_exporter import WifiClientsExporter  # Extracted WiFi export orchestrator.
+
+
+class SiteClientExporter:
+    """Site Client Data Exporter.
+
+    Handles site-level client data, WiFi clients, and beacon exports.
+    Extracted from SiteExportUtils.
+    """
+
+    @staticmethod
+    def _persist_site_clients(rawdata: list[Any], site_name: str) -> None:
+        """Flatten + persist site-clients rows to a per-site CSV (or tell the user when empty)."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter helpers.
+        if not rawdata:  # No clients -- tell the user and return.
+            print("! No client data found for this site")  # User notice.
+            return
+        flattened_data = mh.DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
+        sanitized_data = mh.DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
+        filename = f"SiteClients_{site_name.replace(' ', '_')}.csv"  # Per-site CSV name.
+        mh.DataExporter.write_with_format_selection(sanitized_data, filename)  # Persist.
+        print(f"! {len(rawdata)} client records exported to {filename}")  # User notice with count.
+
+    @staticmethod
+    def clients() -> None:
+        """Export client data for a site to SiteClients.csv."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of SiteDeviceExporter + apisession module global.
+        print("Site Client Statistics:")  # Header.
+        logging.info("Starting export of site client statistics...")  # Trace start.
+        resolved = mh.SiteDeviceExporter._resolve_site_for_stats(  # Prompt + org/site resolution (shared).
+            "client statistics"
+        )
+        if resolved is None:  # Abort signaled by resolver.
+            return
+        site_id, site_name = resolved  # Unpack resolved identifiers.
+        try:
+            response = mistapi.api.v1.sites.stats.listSiteWirelessClientsStats(mh.apisession, site_id, limit=1000)
+            rawdata = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page all rows.
+            SiteClientExporter._persist_site_clients(rawdata, site_name)  # Persist or tell user empty.
+        except Exception as e:  # Fetch failed.
+            logging.error("Error fetching client stats for site %s: %s", site_name, e)  # Log the error.
+            print(f"! Error fetching client data: {e}")  # Tell the user.
+
+    @staticmethod
+    def client_insights() -> None:
+        """Delegated site client insights entrypoint preserved for compatibility."""
+        # WHY: local import keeps the serial_cc service optional at module-load time.
+        from src.refactors.serial_cc.site_client_insights import SiteClientInsightsService
+
+        SiteClientInsightsService.execute()  # Run the insights export.
+
+    @staticmethod
+    def _normalize_client_mac_or_none(client_mac: str) -> str | None:
+        """Validate and normalize client MAC for site insights endpoints."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PacketCaptureManager helper.
+        if not client_mac:  # Empty input.
+            return None
+        if not mh.PacketCaptureManager.validate_mac_address(client_mac):  # Invalid MAC.
+            return None
+        return mh.PacketCaptureManager.normalize_mac_address(client_mac)  # Normalized MAC.
+
+    @staticmethod
+    def wifi_clients(site_id: str | None = None) -> None:
+        """Compatibility facade that delegates WiFi client export to extracted exporter."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live helper globals + apisession.
+        logging.info(
+            "Delegating wifi_clients to WifiClientsExporter"
+        )  # Log before constructing extracted exporter dependencies.
+        exporter = WifiClientsExporter(  # Preserve existing utility wiring to avoid behavior drift.
+            cache_utils=mh.CacheUtils,
+            org_site_exporter=mh.OrgSiteExporter,
+            prompt_utils=mh.PromptUtils,
+            file_path_utils=mh.FilePathUtils,
+            data_processing_utils=mh.DataProcessingUtils,
+            data_exporter=mh.DataExporter,
+            mistapi_module=mistapi,
+            apisession=mh.apisession,
+        )
+        logging.debug(
+            "Initialized WifiClientsExporter for site_id=%s", site_id
+        )  # Log exporter construction completion.
+        exporter.execute(site_id=site_id)  # Delegate export execution while preserving facade signature.
+        logging.debug("Completed delegated wifi_clients export workflow")  # Log delegated exporter completion.
+
+    @staticmethod
+    def beacons() -> None:
+        """Export beacons for a site to SiteBeacons.csv."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of SiteExportUtils._export_data helper.
+        mh.SiteExportUtils._export_data(  # Shared export scaffolding handles prompting + CSV write.
+            api_call=mistapi.api.v1.sites.beacons.listSiteBeacons, data_type="beacons", sort_key="name"
+        )


### PR DESCRIPTION
## Summary
Cat B extraction #14 (initiative 1013 SC-001 pattern): move `SiteClientExporter` from `MistHelper.py` to `src/export/site_client_exporter.py`. Facade preserved via re-export — every `MistHelper.SiteClientExporter.*` caller resolves unchanged.

## Changes
- Add `src/export/site_client_exporter.py` with all 6 static methods verbatim (`_persist_site_clients`, `clients`, `client_insights`, `_normalize_client_mac_or_none`, `wifi_clients`, `beacons`). Uses lazy `mh = importlib.import_module("MistHelper")` inside every method to reach `DataProcessingUtils`, `DataExporter`, `SiteDeviceExporter`, `PacketCaptureManager`, `CacheUtils`, `OrgSiteExporter`, `PromptUtils`, `FilePathUtils`, `SiteExportUtils`, `apisession`.
- Replace the class body in `MistHelper.py` with a one-line breadcrumb.
- Add re-export block in the `src.export.*` import group (`pylint: disable=unused-import` + `noqa: F401`).
- Drop the now-unused top-level `WifiClientsExporter` import (its only caller moved with the class).

## Test plan
- [x] `black --check` clean
- [x] `ruff check` clean
- [x] `python -m py_compile` on both files
- [x] `vulture` clean (>= 80 confidence)
- [x] `python MistHelper.py --test` — **66/66 pass, 0 failed** (131 unsafe skipped)