### PR TITLE
refactor(1013): extract EndpointConfig dataclass (SC-001, position 16)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -114,6 +114,9 @@ from src.capture.packet_capture import (
 )  # Import packet capture manager directly under its canonical name (issue #431: alias removed)
 
 # BatchWorkerConfig import removed: pool machinery moved to ConnectionPoolExecutor (1012 SC-003)
+from src.dataclasses.endpoint_config import (  # pylint: disable=unused-import
+    EndpointConfig,  # noqa: F401  # Cat B (1013 SC-001 position 16) -- re-export for MistHelper.EndpointConfig callers
+)
 from src.dataclasses.export_backend_options import (
     ExportBackendOptions,
 )  # Issue #470: groups output-backend overrides to keep write_with_format_selection within the 5-Item Rule.
@@ -13279,17 +13282,7 @@ def _get_duc_instance():  # Build DeviceUtilityCommands.
 # ==============================
 
 
-@dataclass
-class EndpointConfig:  # Const endpoint descriptor.
-    """Configuration for a discovered const endpoint."""
-
-    endpoint_name: str  # Endpoint name.
-    module: object  # Source module.
-    function_name: str  # API function name.
-    filename: str  # Output filename.
-    description: str  # Human description.
-    modname: str  # Module path.
-    special_handling: str | None = None  # 'all_models', 'all_countries', 'all_countries_channels', or None
+# EndpointConfig moved to src/dataclasses/endpoint_config.py (1013 SC-001 position 16)
 
 
 class ConstDefinitionsExporter:  # Const definitions exporter.

--- a/src/dataclasses/endpoint_config.py
+++ b/src/dataclasses/endpoint_config.py
@@ -1,0 +1,25 @@
+"""EndpointConfig -- const-endpoint descriptor dataclass.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 16).
+Used exclusively by ``ConstDefinitionsExporter`` to describe each discovered
+Mist const endpoint (name, module, function, output filename, description,
+and optional special-handling flag). Callers continue to reach it through the
+``MistHelper.EndpointConfig`` re-export alias.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+.
+
+from dataclasses import dataclass  # The standard library dataclass decorator.
+
+
+@dataclass
+class EndpointConfig:  # Const endpoint descriptor.
+    """Configuration for a discovered const endpoint."""
+
+    endpoint_name: str  # Endpoint name.
+    module: object  # Source module.
+    function_name: str  # API function name.
+    filename: str  # Output filename.
+    description: str  # Human description.
+    modname: str  # Module path.
+    special_handling: str | None = None  # 'all_models', 'all_countries', 'all_countries_channels', or None


### PR DESCRIPTION
## Summary
- Extract 10-LOC ``EndpointConfig`` dataclass from MistHelper.py to ``src/dataclasses/endpoint_config.py``.
- Re-export retained so ``MistHelper.EndpointConfig`` continues to resolve; in-file callers in ``ConstDefinitionsExporter`` bind through the re-export -- no callsite changes required.
- Category B position 16 in initiative #1013.

## Test plan
- [x] ``python -m black --check`` clean on touched files
- [x] ``python -m ruff check`` clean on touched files
- [x] ``python -m py_compile`` OK on touched files
- [x] ``python -m vulture src/dataclasses/endpoint_config.py`` clean
- [x] ``python MistHelper.py --test`` = 66 successful / 0 failed / 131 skipped
- [ ] CI green