### PR TITLE
refactor(1013): extract DataCollectionManager to src/analytics/ (SC-001, position 25)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -82,6 +82,9 @@ except ImportError:  # If database dependencies (python-arango, redis) not insta
     DatabaseRouter = None  # type: ignore[assignment, misc]  # None lets runtime guards detect DB-layer absence
     DB_LAYER_AVAILABLE = False  # Set flag to disable database output formats (CSV/SQLite only)
 
+from src.analytics.data_collection_manager import (  # pylint: disable=unused-import
+    DataCollectionManager,  # noqa: F401  # Cat B (1013 SC-001 position 25) -- re-export for MistHelper.DataCollectionManager callers
+)
 from src.analytics.site_analytics_configurator import (  # Import site analytics configuration tools
     SiteAnalyticsConfigurator as ExtractedSiteAnalyticsConfigurator,  # Rename to avoid naming conflicts
 )
@@ -12556,165 +12559,7 @@ class InsightMetricsUtils:  # Insight-metrics helpers.
 # NOTE: generate_support_package moved to DataCollectionManager.generate_support_packages
 
 
-# ============================================================================
-# DATA COLLECTION MANAGER CLASS
-# ============================================================================
-class DataCollectionManager:  # Continuous data collector.
-    """
-    Manages automated data collection and support package generation operations.
-
-    Provides methods for:
-    - Continuous loop data collection from Mist API
-    - Support package generation per site
-
-    All methods are static to avoid unnecessary object instantiation.
-    """
-
-    @staticmethod
-    def _print_continuous_loop_banner() -> None:  # Print startup banner.
-        """Print the startup banner for menu 76's continuous collection loop."""
-        print(" Starting continuous data collection loop...")  # Banner line 1.
-        print("   This will collect core organizational data every 5 seconds")  # Banner line 2.
-        print("   Press CTRL+C to stop or create 'stop_loop.txt' file")  # Banner line 3.
-
-    @staticmethod
-    def continuous_loop():  # Run the collection loop.
-        """Menu 76: continuously collect site/inventory/device-stat/port-stat/VPN-peer data until stop."""
-        logging.info("Starting DataCollectionManager.continuous_loop")  # Log start.
-        DataCollectionManager._print_continuous_loop_banner()  # Show the user what's happening.
-        loop_count = 0  # Iteration counter.
-        try:
-            while True:  # Loop until stopped.
-                loop_count += 1  # Count the iteration.
-                print(f"\n  Loop iteration {loop_count} - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-                if DataCollectionManager._check_stop_signal():  # Stop requested.
-                    break  # Exit the loop.
-                DataCollectionManager._execute_collection_cycle(loop_count)  # Run one cycle.
-        except KeyboardInterrupt:  # User pressed Ctrl+C.
-            print("\n  Continuous data collection loop stopped by user.")  # Tell the user.
-        except Exception as e:  # Unexpected failure.
-            logging.error("Fatal error in continuous loop: %s", e)  # Log the error.
-            print(f"! Fatal error in continuous loop: {e}")  # Tell the user.
-        print(" Continuous data collection loop ended.")  # Tell the user ended.
-
-    @staticmethod
-    def _check_stop_signal() -> bool:  # Check the stop signal.
-        """Check for stop file signal and remove if found."""
-        return ConfigUtils.check_stop_signal()  # Delegate to config utils.
-
-    @staticmethod
-    def _collection_cycle_steps() -> list[tuple[str, Any]]:
-        """Return the ordered (label, callable) pairs invoked each iteration of continuous_loop."""
-        return [  # Each tuple = printed banner + exporter function.
-            ("  Collecting site list...", OrgSiteExporter.sites),
-            ("  Collecting organization inventory...", OrgInventoryExporter.inventory),
-            ("  Collecting organization device stats...", OrgDeviceStatsExporter.device_stats),
-            ("  Collecting organization device port stats...", OrgDeviceStatsExporter.device_port_stats),
-            ("  Collecting VPN peer path stats...", OrgDeviceStatsExporter.vpn_peer_stats),
-        ]
-
-    @staticmethod
-    def _execute_collection_cycle(loop_count: int) -> None:  # Run one collection cycle.
-        """Execute one cycle of data collection with rate limiting."""
-        try:
-            for banner, step_callable in DataCollectionManager._collection_cycle_steps():
-                print(banner)  # Tell the user which exporter is running.
-                step_callable()  # Invoke the per-step exporter.
-                time.sleep(0.75)  # Pace the API between exporters.
-            print(f"  Loop {loop_count} completed successfully")  # Tell the user.
-        except KeyboardInterrupt:  # Propagate Ctrl+C.
-            raise  # Re-raise to outer handler
-        except Exception as e:  # Cycle failed.
-            logging.error("Error in collection cycle %s: %s", loop_count, e)  # Log the error.
-            print(f"  Error in loop {loop_count}: {e}")  # Tell the user.
-            print("  Continuing to next iteration...")  # Tell the user.
-            time.sleep(5)  # Back off then retry.
-
-    @staticmethod
-    def generate_support_packages():  # Generate support packages.
-        """
-        Menu 78: Generate support package CSV for each site with alarms or events.
-
-        Collects and packages:
-        - Org alarms, device events
-        - Device info, stats, port stats
-        - Gateway speedtest results
-        """
-        logging.info("DataCollectionManager.generate_support_packages starting")  # Log start.
-
-        # Ensure all required data is fresh
-        DataCollectionManager._refresh_support_data()  # Refresh support data.
-
-        # Load all data sources
-        data_sources = DataCollectionManager._load_support_data_sources()  # Load support sources.
-
-        # Generate packages for sites with alarms or events
-        DataCollectionManager._generate_site_packages(data_sources)  # Generate per-site packages.
-
-        logging.info("Support packages generated for applicable sites.")  # Log completion.
-
-    @staticmethod
-    def _refresh_support_data() -> None:  # Refresh required CSVs.
-        """Refresh all required CSV files for support package generation."""
-        required_files = [  # Required files and fetchers.
-            ("OrgAlarms.csv", OrgAlarmEventExporter.alarms),
-            ("OrgDeviceEvents.csv", OrgAlarmEventExporter.device_events),
-            ("SiteList.csv", OrgSiteExporter.sites),
-            ("OrgDevices.csv", OrgInventoryExporter.devices),
-            ("OrgDeviceStats.csv", OrgDeviceStatsExporter.device_stats),
-            ("OrgDevicePortStats.csv", OrgDeviceStatsExporter.device_port_stats),
-            ("AllGatewayTestResults.csv", GatewayTestExporter.test_results_by_site),
-        ]
-
-        for filename, func in required_files:  # Refresh each file.
-            CacheUtils.check_and_generate_csv(filename, func)  # type: ignore[arg-type]  # function is Callable
-
-    @staticmethod
-    def _load_support_data_sources() -> dict:  # type: ignore[type-arg]
-        """Load all CSV data sources for support package assembly."""
-        sources = {  # Load the data sources.
-            "site_data": CacheUtils.load_csv_grouped_by_key("SiteList.csv", "id"),
-            "alarms_data": CacheUtils.load_csv_grouped_by_key("OrgAlarms.csv", "site_id"),
-            "events_data": CacheUtils.load_csv_grouped_by_key("OrgDeviceEvents.csv", "site_id"),
-            "devices_data": CacheUtils.load_csv_grouped_by_key("OrgDevices.csv", "name"),
-            "device_stats_data": CacheUtils.load_csv_grouped_by_key("OrgDeviceStats.csv", "site_id"),
-            "port_stats_data": CacheUtils.load_csv_grouped_by_key("OrgDevicePortStats.csv", "site_id"),
-            "speedtest_data": {},
-        }
-
-        # Load speedtest data if available
-        gateway_test_path = FilePathUtils.get_csv_path("AllGatewayTestResults.csv")  # Speedtest CSV path.
-        if os.path.exists(gateway_test_path):  # File present.
-            sources["speedtest_data"] = CacheUtils.load_csv_grouped_by_key("AllGatewayTestResults.csv", "site_id")
-
-        return sources  # Return the sources.
-
-    @staticmethod
-    def _generate_site_packages(data_sources: dict) -> None:  # type: ignore[type-arg]
-        """Generate support package for each site with alarms or events."""
-        site_data = data_sources["site_data"]  # Read the site data.
-
-        for site_id in site_data:  # Walk sites; values are looked up per-site as needed.
-            # Skip sites without alarms or events
-            has_alarms = bool(data_sources["alarms_data"].get(site_id))  # Has alarms?
-            has_events = bool(data_sources["events_data"].get(site_id))  # Has events?
-
-            if not has_alarms and not has_events:  # Nothing to report.
-                logging.info("Skipping site %s - no alarms or events", site_id)  # Log the skip.
-                continue  # Skip it.
-
-            support_data = {  # Build the support data.
-                "alarms": data_sources["alarms_data"].get(site_id, []),
-                "events": data_sources["events_data"].get(site_id, []),
-                "devices": data_sources["devices_data"].get(site_id, []),
-                "device_stats": data_sources["device_stats_data"].get(site_id, []),
-                "port_stats": data_sources["port_stats_data"].get(site_id, []),
-                "speedtests": data_sources["speedtest_data"].get(site_id, []),
-            }
-
-            filename = f"SupportPackage_{site_id}.csv"  # Build the CSV name.
-            CacheUtils.write_support_data_to_csv(support_data, filename)  # Write the package.
-            logging.info("Support package written for site %s", site_id)  # Log the write.
+# DataCollectionManager moved to src/analytics/data_collection_manager.py (1013 SC-001 position 25)
 
 
 # ============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,7 @@ omit = [
     "setup.py",
     "*/site-packages/*",
     "src/maps/*",
+    "src/analytics/data_collection_manager.py",
     "src/api/api_data_fetcher.py",
     "src/export/const_definitions_exporter.py",
     "src/export/license_export_utils.py",

--- a/src/analytics/data_collection_manager.py
+++ b/src/analytics/data_collection_manager.py
@@ -1,0 +1,177 @@
+"""DataCollectionManager -- continuous data collection + support package generation.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 25).
+Menu 76 (continuous loop) + Menu 78 (support packages). All methods are
+static -- no state is kept on the class. Callers continue to reach it
+through the ``MistHelper.DataCollectionManager`` re-export alias.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions for return types.
+
+import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
+import logging  # WHY: structured trace for collection lifecycle events.
+import os  # WHY: filesystem existence check for optional speedtest CSV.
+import time  # WHY: pace API calls between exporters and back off on failure.
+from datetime import datetime  # WHY: timestamp banner per loop iteration.
+from typing import Any  # WHY: callable/step tuple lists are duck-typed.
+
+
+class DataCollectionManager:
+    """Manages automated data collection and support package generation operations.
+
+    Provides methods for:
+    - Continuous loop data collection from Mist API
+    - Support package generation per site
+
+    All methods are static to avoid unnecessary object instantiation.
+    """
+
+    @staticmethod
+    def _print_continuous_loop_banner() -> None:  # Print startup banner.
+        """Print the startup banner for menu 76's continuous collection loop."""
+        print(" Starting continuous data collection loop...")  # Banner line 1.
+        print("   This will collect core organizational data every 5 seconds")  # Banner line 2.
+        print("   Press CTRL+C to stop or create 'stop_loop.txt' file")  # Banner line 3.
+
+    @staticmethod
+    def continuous_loop() -> None:  # Run the collection loop.
+        """Menu 76: continuously collect site/inventory/device-stat/port-stat/VPN-peer data until stop."""
+        logging.info("Starting DataCollectionManager.continuous_loop")  # Log start.
+        DataCollectionManager._print_continuous_loop_banner()  # Show the user what's happening.
+        loop_count = 0  # Iteration counter.
+        try:
+            while True:  # Loop until stopped.
+                loop_count += 1  # Count the iteration.
+                print(f"\n  Loop iteration {loop_count} - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+                if DataCollectionManager._check_stop_signal():  # Stop requested.
+                    break  # Exit the loop.
+                DataCollectionManager._execute_collection_cycle(loop_count)  # Run one cycle.
+        except KeyboardInterrupt:  # User pressed Ctrl+C.
+            print("\n  Continuous data collection loop stopped by user.")  # Tell the user.
+        except Exception as e:  # Unexpected failure.
+            logging.error("Fatal error in continuous loop: %s", e)  # Log the error.
+            print(f"! Fatal error in continuous loop: {e}")  # Tell the user.
+        print(" Continuous data collection loop ended.")  # Tell the user ended.
+
+    @staticmethod
+    def _check_stop_signal() -> bool:  # Check the stop signal.
+        """Check for stop file signal and remove if found."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils helper.
+        return bool(mh.ConfigUtils.check_stop_signal())  # Delegate to config utils.
+
+    @staticmethod
+    def _collection_cycle_steps() -> list[tuple[str, Any]]:
+        """Return the ordered (label, callable) pairs invoked each iteration of continuous_loop."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of exporter facades.
+        return [  # Each tuple = printed banner + exporter function.
+            ("  Collecting site list...", mh.OrgSiteExporter.sites),
+            ("  Collecting organization inventory...", mh.OrgInventoryExporter.inventory),
+            ("  Collecting organization device stats...", mh.OrgDeviceStatsExporter.device_stats),
+            ("  Collecting organization device port stats...", mh.OrgDeviceStatsExporter.device_port_stats),
+            ("  Collecting VPN peer path stats...", mh.OrgDeviceStatsExporter.vpn_peer_stats),
+        ]
+
+    @staticmethod
+    def _execute_collection_cycle(loop_count: int) -> None:  # Run one collection cycle.
+        """Execute one cycle of data collection with rate limiting."""
+        try:
+            for banner, step_callable in DataCollectionManager._collection_cycle_steps():
+                print(banner)  # Tell the user which exporter is running.
+                step_callable()  # Invoke the per-step exporter.
+                time.sleep(0.75)  # Pace the API between exporters.
+            print(f"  Loop {loop_count} completed successfully")  # Tell the user.
+        except KeyboardInterrupt:  # Propagate Ctrl+C.
+            raise  # Re-raise to outer handler
+        except Exception as e:  # Cycle failed.
+            logging.error("Error in collection cycle %s: %s", loop_count, e)  # Log the error.
+            print(f"  Error in loop {loop_count}: {e}")  # Tell the user.
+            print("  Continuing to next iteration...")  # Tell the user.
+            time.sleep(5)  # Back off then retry.
+
+    @staticmethod
+    def generate_support_packages() -> None:  # Generate support packages.
+        """Menu 78: Generate support package CSV for each site with alarms or events.
+
+        Collects and packages:
+        - Org alarms, device events
+        - Device info, stats, port stats
+        - Gateway speedtest results
+        """
+        logging.info("DataCollectionManager.generate_support_packages starting")  # Log start.
+
+        # Ensure all required data is fresh
+        DataCollectionManager._refresh_support_data()  # Refresh support data.
+
+        # Load all data sources
+        data_sources = DataCollectionManager._load_support_data_sources()  # Load support sources.
+
+        # Generate packages for sites with alarms or events
+        DataCollectionManager._generate_site_packages(data_sources)  # Generate per-site packages.
+
+        logging.info("Support packages generated for applicable sites.")  # Log completion.
+
+    @staticmethod
+    def _refresh_support_data() -> None:  # Refresh required CSVs.
+        """Refresh all required CSV files for support package generation."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of exporter facades + CacheUtils.
+        required_files = [  # Required files and fetchers.
+            ("OrgAlarms.csv", mh.OrgAlarmEventExporter.alarms),
+            ("OrgDeviceEvents.csv", mh.OrgAlarmEventExporter.device_events),
+            ("SiteList.csv", mh.OrgSiteExporter.sites),
+            ("OrgDevices.csv", mh.OrgInventoryExporter.devices),
+            ("OrgDeviceStats.csv", mh.OrgDeviceStatsExporter.device_stats),
+            ("OrgDevicePortStats.csv", mh.OrgDeviceStatsExporter.device_port_stats),
+            ("AllGatewayTestResults.csv", mh.GatewayTestExporter.test_results_by_site),
+        ]
+
+        for filename, func in required_files:  # Refresh each file.
+            mh.CacheUtils.check_and_generate_csv(filename, func)  # type: ignore[arg-type]  # function is Callable
+
+    @staticmethod
+    def _load_support_data_sources() -> dict:  # type: ignore[type-arg]
+        """Load all CSV data sources for support package assembly."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of CacheUtils + FilePathUtils.
+        sources = {  # Load the data sources.
+            "site_data": mh.CacheUtils.load_csv_grouped_by_key("SiteList.csv", "id"),
+            "alarms_data": mh.CacheUtils.load_csv_grouped_by_key("OrgAlarms.csv", "site_id"),
+            "events_data": mh.CacheUtils.load_csv_grouped_by_key("OrgDeviceEvents.csv", "site_id"),
+            "devices_data": mh.CacheUtils.load_csv_grouped_by_key("OrgDevices.csv", "name"),
+            "device_stats_data": mh.CacheUtils.load_csv_grouped_by_key("OrgDeviceStats.csv", "site_id"),
+            "port_stats_data": mh.CacheUtils.load_csv_grouped_by_key("OrgDevicePortStats.csv", "site_id"),
+            "speedtest_data": {},
+        }
+
+        # Load speedtest data if available
+        gateway_test_path = mh.FilePathUtils.get_csv_path("AllGatewayTestResults.csv")  # Speedtest CSV path.
+        if os.path.exists(gateway_test_path):  # File present.
+            sources["speedtest_data"] = mh.CacheUtils.load_csv_grouped_by_key("AllGatewayTestResults.csv", "site_id")
+
+        return sources  # Return the sources.
+
+    @staticmethod
+    def _generate_site_packages(data_sources: dict) -> None:  # type: ignore[type-arg]
+        """Generate support package for each site with alarms or events."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of CacheUtils.
+        site_data = data_sources["site_data"]  # Read the site data.
+
+        for site_id in site_data:  # Walk sites; values are looked up per-site as needed.
+            # Skip sites without alarms or events
+            has_alarms = bool(data_sources["alarms_data"].get(site_id))  # Has alarms?
+            has_events = bool(data_sources["events_data"].get(site_id))  # Has events?
+
+            if not has_alarms and not has_events:  # Nothing to report.
+                logging.info("Skipping site %s - no alarms or events", site_id)  # Log the skip.
+                continue  # Skip it.
+
+            support_data = {  # Build the support data.
+                "alarms": data_sources["alarms_data"].get(site_id, []),
+                "events": data_sources["events_data"].get(site_id, []),
+                "devices": data_sources["devices_data"].get(site_id, []),
+                "device_stats": data_sources["device_stats_data"].get(site_id, []),
+                "port_stats": data_sources["port_stats_data"].get(site_id, []),
+                "speedtests": data_sources["speedtest_data"].get(site_id, []),
+            }
+
+            filename = f"SupportPackage_{site_id}.csv"  # Build the CSV name.
+            mh.CacheUtils.write_support_data_to_csv(support_data, filename)  # Write the package.
+            logging.info("Support package written for site %s", site_id)  # Log the write.


### PR DESCRIPTION
## Summary
- Extract `DataCollectionManager` (menu 76 continuous data-collection loop + menu 78 support-package generator) from `MistHelper.py` into `src/analytics/data_collection_manager.py`.
- Preserve public API via Cat B re-export alias — `MistHelper.DataCollectionManager` still works for all 3 existing callsites (unchanged dotted access).
- Extend coverage omit list.

## Extraction pattern (SC-001)
- 10 static methods migrated verbatim: `_print_continuous_loop_banner`, `continuous_loop`, `_check_stop_signal`, `_collection_cycle_steps`, `_execute_collection_cycle`, `generate_support_packages`, `_refresh_support_data`, `_load_support_data_sources`, `_generate_site_packages`.
- Each helper that needs live globals uses lazy `mh = importlib.import_module("MistHelper")` to sidestep circular import at module init.
- Original class body replaced with a pure comment breadcrumb (NOT a stub class) so the alias binding is not clobbered.

## Local gate
- `black --check` — clean
- `ruff check` — clean
- `python -m py_compile MistHelper.py src/analytics/data_collection_manager.py` — clean
- `python MistHelper.py --test` — **66 successful / 0 failed / 131 skipped** (matches baseline)

## Test plan
- [x] Local `--test` matches baseline
- [ ] CI green
- [ ] Squash-merge + delete branch