### PR TITLE
refactor(1013): remove WiredClientManufacturerReportGenerator facade (SC-001, position 26)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -250,6 +250,9 @@ from src.refactors.wlanradius_timer_manager import (
     WLANRadiusTimerManager,  # Extracted WLAN RADIUS timer manager (SC-014)
 )
 from src.reports.e911_bssid import E911BSSIDReportGenerator  # Module-level for tests
+from src.reports.wired_client_manufacturer_report_generator import (  # pylint: disable=unused-import
+    WiredClientManufacturerReportGenerator,  # noqa: F401  # Cat B (1013 SC-001 position 26) -- re-export for MistHelper.WiredClientManufacturerReportGenerator callers
+)
 from src.site.address_audit import AddressAuditEngine  # Menu 195: read-only CSV site-address audit
 from src.site.bulk_radius_wlan_config_manager import (  # pylint: disable=unused-import
     BulkRadiusWLANConfigManager,  # noqa: F401  # Cat B (1013 SC-001 position 15) -- re-export for MistHelper.BulkRadiusWLANConfigManager callers
@@ -10299,135 +10302,8 @@ class GlobalWiredClientReportGenerator:  # Global wired client report.
             print(f"  Warning: Could not write report summary to {report_path}")  # Warn the user.
 
 
-class WiredClientManufacturerReportGenerator:  # Wired client manufacturer report.
-    """Generates wired client reports filtered by interactive manufacturer selection."""
-
-    @staticmethod
-    def execute() -> None:  # Run the report.
-        """Main entry point: always export ALL, then optionally filter by manufacturer."""
-        org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.
-        records = WiredClientManufacturerReportGenerator._fetch_all_clients(org_id)  # Fetch all clients.
-        if not records:  # No records.
-            logging.warning("No wired clients retrieved from API")  # Warn none retrieved.
-            print("\n  No wired clients found in the organization.")  # Tell the user.
-            return  # Abort.
-        WiredClientManufacturerReportGenerator._write_outputs(records, "")  # Write the full export.
-        summary = WiredClientManufacturerReportGenerator._build_manufacturer_summary(records)
-        selected = WiredClientManufacturerReportGenerator._prompt_selection(summary)  # Prompt a selection.
-        if not selected:  # No selection.
-            return  # Abort.
-        filtered = WiredClientManufacturerReportGenerator._filter_by_manufacturer(records, selected)
-        WiredClientManufacturerReportGenerator._write_outputs(filtered, selected)  # Write the filtered export.
-
-    @staticmethod
-    def _fetch_all_clients(org_id: str) -> list[dict[str, Any]]:  # Fetch all wired clients.
-        """Fetch all wired clients across the organization without filters."""
-        try:
-            logging.info("Fetching all organization wired clients for manufacturer report...")  # Log the fetch.
-            print("\n  Retrieving all wired clients from organization...")  # Tell the user.
-            response = mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients(  # Call the API.
-                apisession,
-                org_id,
-                limit=1000,
-            )
-            records = mistapi.get_all(response=response, mist_session=apisession) or []  # Page all; default empty.
-            logging.info("Retrieved %s wired client records", len(records))  # Log the count.
-            print(f"  Retrieved {len(records)} wired client records")  # Tell the user.
-            return records  # Return records.
-        except Exception as exception:  # Fetch failed.
-            logging.exception("Failed to fetch wired clients: %s", exception)  # Log the exception.
-            print(f"\n  Error retrieving wired clients: {exception}")  # Tell the user.
-            return []  # Return empty.
-
-    @staticmethod
-    def _build_manufacturer_summary(records: list[dict[str, Any]]) -> list[tuple[str, int]]:
-        """Extract unique manufacturers with client counts, sorted alphabetically."""
-        manufacturer_counts: dict[str, int] = {}  # Count map.
-        for record in records:  # Walk records.
-            manufacturer = str(record.get("manufacture", "Unknown") or "Unknown").strip()  # Normalize the manufacturer.
-            manufacturer_counts[manufacturer] = manufacturer_counts.get(manufacturer, 0) + 1  # Increment the count.
-        sorted_manufacturers = sorted(manufacturer_counts.items(), key=lambda item: item[0].lower())  # Sort by name.
-        return sorted_manufacturers  # Return the summary.
-
-    @staticmethod
-    def _print_manufacturer_table(summary: list[tuple[str, int]]) -> None:
-        """Render the manufacturer/count picker table to stdout."""
-        total_clients = sum(count for _, count in summary)  # Aggregate total client count for header line.
-        print(f"\n  Found {total_clients} clients from {len(summary)} manufacturers\n")  # Tell the user totals.
-        print(f"  {'#':<5} {'Manufacturer':<45} {'Count':>8}")  # Column header.
-        print(f"  {'-' * 5} {'-' * 45} {'-' * 8}")  # Separator row.
-        for index, (manufacturer, count) in enumerate(summary, 1):  # List each manufacturer.
-            display_name = manufacturer[:44]  # Truncate long names so column stays aligned.
-            print(f"  {index:<5} {display_name:<45} {count:>8}")  # Print the row.
-
-    @staticmethod
-    def _parse_manufacturer_choice(choice: str, summary: list[tuple[str, int]]) -> str | None:
-        """Map user input to a manufacturer name, returning None for empty/invalid/out-of-range."""
-        if not choice:  # User skipped the selection prompt.
-            return None  # Caller treats None as "no filter".
-        try:
-            selection_index = int(choice)  # Parse the numeric selection.
-        except ValueError:  # Non-numeric input.
-            print("  Invalid selection.")  # Tell the user.
-            return None  # Abort.
-        if 1 <= selection_index <= len(summary):  # In valid range.
-            selected_manufacturer = summary[selection_index - 1][0]  # Pick the manufacturer name.
-            logging.info("User selected manufacturer: %s", selected_manufacturer)  # Log the choice.
-            return selected_manufacturer  # Return chosen manufacturer.
-        print("  Selection out of range.")  # Out-of-range selection.
-        return None  # Abort.
-
-    @staticmethod
-    def _prompt_selection(summary: list[tuple[str, int]]) -> str | None:  # Prompt manufacturer selection.
-        """Display manufacturer list with counts and prompt user to select one."""
-        WiredClientManufacturerReportGenerator._print_manufacturer_table(summary)  # Render the picker table.
-        choice = InputUtils.safe_input(  # Read the choice.
-            "\n  Enter manufacturer number for filtered report (Enter to skip): ",
-            default_value="",
-            allow_empty=True,
-            context="manufacturer_report_selection",
-        )
-        return WiredClientManufacturerReportGenerator._parse_manufacturer_choice(choice, summary)  # Map input → choice.
-
-    @staticmethod
-    def _filter_by_manufacturer(records: list[dict[str, Any]], manufacturer: str) -> list[dict[str, Any]]:
-        """Filter records by selected manufacturer. Empty string means no filter (all records)."""
-        if not manufacturer:  # No filter.
-            return records  # Return all.
-        normalized_selection = manufacturer.strip().lower()  # Normalize the selection.
-        return [  # Keep matching records.
-            record
-            for record in records
-            if str(record.get("manufacture", "") or "").strip().lower() == normalized_selection
-        ]
-
-    @staticmethod
-    def _build_filename(manufacturer: str) -> str:  # Build the output filename.
-        """Build a unique filename incorporating the selected manufacturer."""
-        if not manufacturer:  # No manufacturer.
-            slug = "ALL"  # Use ALL slug.
-        else:
-            slug = re.sub(r"[^\w]+", "_", manufacturer).strip("_")[:40]  # Slugify the manufacturer.
-        return f"WiredClientManufacturerReport_{slug}"  # Return the filename.
-
-    @staticmethod
-    def _write_outputs(filtered: list[dict[str, Any]], manufacturer: str) -> None:  # Write the export outputs.
-        """Write filtered records through the standard CSV/SQLite export path."""
-        label = manufacturer if manufacturer else "ALL manufacturers"  # Label for messages.
-        filename = WiredClientManufacturerReportGenerator._build_filename(manufacturer)  # Build the filename.
-        print(f"\n  Exporting {len(filtered)} records for: {label}")  # Tell the user.
-        if filtered:  # Have records.
-            flattened = DataProcessingUtils.flatten_nested_fields(filtered)  # Flatten nested fields.
-            sanitized = DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
-        else:
-            sanitized = []  # No records.
-        DataExporter.write_with_format_selection(  # Write via backend.
-            sanitized,
-            filename,
-            api_function_name="wiredClientManufacturerReport",
-        )
-        print(f"  Exported to: data/{filename}.csv")  # Tell the user.
-        logging.info("Manufacturer report exported: %s records for %s -> %s", len(sanitized), label, filename)
+# WiredClientManufacturerReportGenerator moved to src/reports/wired_client_manufacturer_report_generator.py  # noqa: E501
+# (1013 SC-001 position 26)
 
 
 # OrgAdminExporter moved to src/export/org_admin_exporter.py (1013 SC-001 position 20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,7 @@ omit = [
     "src/export/site_config_exporter.py",
     "src/firmware/firmware_manager.py",
     "src/gateway/gateway_ha_exporter.py",
+    "src/reports/wired_client_manufacturer_report_generator.py",
     "src/site/bulk_radius_wlan_config_manager.py",
     "src/ui/tui.py",
     "src/websocket/*"

--- a/src/reports/wired_client_manufacturer_report_generator.py
+++ b/src/reports/wired_client_manufacturer_report_generator.py
@@ -1,0 +1,155 @@
+"""WiredClientManufacturerReportGenerator -- wired client report filtered by manufacturer.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 26).
+Menu handler that fetches wired clients org-wide, exports the full set, then
+optionally exports a filtered subset by user-selected manufacturer. All
+methods are static -- no state is kept on the class. Callers continue to
+reach it through the ``MistHelper.WiredClientManufacturerReportGenerator``
+re-export alias.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions for return types.
+
+import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
+import logging  # WHY: structured trace for report lifecycle events.
+import re  # WHY: slugify manufacturer names into filesystem-safe filenames.
+from typing import Any  # WHY: raw wired-client rows are duck-typed dicts from mistapi.
+
+import mistapi  # WHY: direct SDK access for search + pagination helpers.
+
+
+class WiredClientManufacturerReportGenerator:
+    """Generates wired client reports filtered by interactive manufacturer selection."""
+
+    @staticmethod
+    def execute() -> None:  # Run the report.
+        """Main entry point: always export ALL, then optionally filter by manufacturer."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils helper.
+        org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.
+        records = WiredClientManufacturerReportGenerator._fetch_all_clients(org_id)  # Fetch all clients.
+        if not records:  # No records.
+            logging.warning("No wired clients retrieved from API")  # Warn none retrieved.
+            print("\n  No wired clients found in the organization.")  # Tell the user.
+            return  # Abort.
+        WiredClientManufacturerReportGenerator._write_outputs(records, "")  # Write the full export.
+        summary = WiredClientManufacturerReportGenerator._build_manufacturer_summary(records)
+        selected = WiredClientManufacturerReportGenerator._prompt_selection(summary)  # Prompt a selection.
+        if not selected:  # No selection.
+            return  # Abort.
+        filtered = WiredClientManufacturerReportGenerator._filter_by_manufacturer(records, selected)
+        WiredClientManufacturerReportGenerator._write_outputs(filtered, selected)  # Write the filtered export.
+
+    @staticmethod
+    def _fetch_all_clients(org_id: str) -> list[dict[str, Any]]:  # Fetch all wired clients.
+        """Fetch all wired clients across the organization without filters."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession global.
+        try:
+            logging.info("Fetching all organization wired clients for manufacturer report...")  # Log the fetch.
+            print("\n  Retrieving all wired clients from organization...")  # Tell the user.
+            response = mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients(  # Call the API.
+                mh.apisession,
+                org_id,
+                limit=1000,
+            )
+            records = mistapi.get_all(response=response, mist_session=mh.apisession) or []  # Page all; default empty.
+            logging.info("Retrieved %s wired client records", len(records))  # Log the count.
+            print(f"  Retrieved {len(records)} wired client records")  # Tell the user.
+            return records  # Return records.
+        except Exception as exception:  # Fetch failed.
+            logging.exception("Failed to fetch wired clients: %s", exception)  # Log the exception.
+            print(f"\n  Error retrieving wired clients: {exception}")  # Tell the user.
+            return []  # Return empty.
+
+    @staticmethod
+    def _build_manufacturer_summary(records: list[dict[str, Any]]) -> list[tuple[str, int]]:
+        """Extract unique manufacturers with client counts, sorted alphabetically."""
+        manufacturer_counts: dict[str, int] = {}  # Count map.
+        for record in records:  # Walk records.
+            manufacturer = str(record.get("manufacture", "Unknown") or "Unknown").strip()  # Normalize the manufacturer.
+            manufacturer_counts[manufacturer] = manufacturer_counts.get(manufacturer, 0) + 1  # Increment the count.
+        sorted_manufacturers = sorted(manufacturer_counts.items(), key=lambda item: item[0].lower())  # Sort by name.
+        return sorted_manufacturers  # Return the summary.
+
+    @staticmethod
+    def _print_manufacturer_table(summary: list[tuple[str, int]]) -> None:
+        """Render the manufacturer/count picker table to stdout."""
+        total_clients = sum(count for _, count in summary)  # Aggregate total client count for header line.
+        print(f"\n  Found {total_clients} clients from {len(summary)} manufacturers\n")  # Tell the user totals.
+        print(f"  {'#':<5} {'Manufacturer':<45} {'Count':>8}")  # Column header.
+        print(f"  {'-' * 5} {'-' * 45} {'-' * 8}")  # Separator row.
+        for index, (manufacturer, count) in enumerate(summary, 1):  # List each manufacturer.
+            display_name = manufacturer[:44]  # Truncate long names so column stays aligned.
+            print(f"  {index:<5} {display_name:<45} {count:>8}")  # Print the row.
+
+    @staticmethod
+    def _parse_manufacturer_choice(choice: str, summary: list[tuple[str, int]]) -> str | None:
+        """Map user input to a manufacturer name, returning None for empty/invalid/out-of-range."""
+        if not choice:  # User skipped the selection prompt.
+            return None  # Caller treats None as "no filter".
+        try:
+            selection_index = int(choice)  # Parse the numeric selection.
+        except ValueError:  # Non-numeric input.
+            print("  Invalid selection.")  # Tell the user.
+            return None  # Abort.
+        if 1 <= selection_index <= len(summary):  # In valid range.
+            selected_manufacturer = summary[selection_index - 1][0]  # Pick the manufacturer name.
+            logging.info("User selected manufacturer: %s", selected_manufacturer)  # Log the choice.
+            return selected_manufacturer  # Return chosen manufacturer.
+        print("  Selection out of range.")  # Out-of-range selection.
+        return None  # Abort.
+
+    @staticmethod
+    def _prompt_selection(summary: list[tuple[str, int]]) -> str | None:  # Prompt manufacturer selection.
+        """Display manufacturer list with counts and prompt user to select one."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of InputUtils helper.
+        WiredClientManufacturerReportGenerator._print_manufacturer_table(summary)  # Render the picker table.
+        choice = mh.InputUtils.safe_input(  # Read the choice.
+            "\n  Enter manufacturer number for filtered report (Enter to skip): ",
+            default_value="",
+            allow_empty=True,
+            context="manufacturer_report_selection",
+        )
+        return WiredClientManufacturerReportGenerator._parse_manufacturer_choice(
+            choice, summary
+        )  # Map input -> choice.
+
+    @staticmethod
+    def _filter_by_manufacturer(records: list[dict[str, Any]], manufacturer: str) -> list[dict[str, Any]]:
+        """Filter records by selected manufacturer. Empty string means no filter (all records)."""
+        if not manufacturer:  # No filter.
+            return records  # Return all.
+        normalized_selection = manufacturer.strip().lower()  # Normalize the selection.
+        return [  # Keep matching records.
+            record
+            for record in records
+            if str(record.get("manufacture", "") or "").strip().lower() == normalized_selection
+        ]
+
+    @staticmethod
+    def _build_filename(manufacturer: str) -> str:  # Build the output filename.
+        """Build a unique filename incorporating the selected manufacturer."""
+        if not manufacturer:  # No manufacturer.
+            slug = "ALL"  # Use ALL slug.
+        else:
+            slug = re.sub(r"[^\w]+", "_", manufacturer).strip("_")[:40]  # Slugify the manufacturer.
+        return f"WiredClientManufacturerReport_{slug}"  # Return the filename.
+
+    @staticmethod
+    def _write_outputs(filtered: list[dict[str, Any]], manufacturer: str) -> None:  # Write the export outputs.
+        """Write filtered records through the standard CSV/SQLite export path."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter helpers.
+        label = manufacturer if manufacturer else "ALL manufacturers"  # Label for messages.
+        filename = WiredClientManufacturerReportGenerator._build_filename(manufacturer)  # Build the filename.
+        print(f"\n  Exporting {len(filtered)} records for: {label}")  # Tell the user.
+        if filtered:  # Have records.
+            flattened = mh.DataProcessingUtils.flatten_nested_fields(filtered)  # Flatten nested fields.
+            sanitized = mh.DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
+        else:
+            sanitized = []  # No records.
+        mh.DataExporter.write_with_format_selection(  # Write via backend.
+            sanitized,
+            filename,
+            api_function_name="wiredClientManufacturerReport",
+        )
+        print(f"  Exported to: data/{filename}.csv")  # Tell the user.
+        logging.info("Manufacturer report exported: %s records for %s -> %s", len(sanitized), label, filename)

--- a/src/reports/wired_client_manufacturer_report_generator.py
+++ b/src/reports/wired_client_manufacturer_report_generator.py
@@ -143,7 +143,7 @@ class WiredClientManufacturerReportGenerator:
         print(f"\n  Exporting {len(filtered)} records for: {label}")  # Tell the user.
         if filtered:  # Have records.
             flattened = mh.DataProcessingUtils.flatten_nested_fields(filtered)  # Flatten nested fields.
-            sanitized = mh.DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
+            sanitized = mh.DataProcessingUtils.escape_multiline(flattened)
         else:
             sanitized = []  # No records.
         mh.DataExporter.write_with_format_selection(  # Write via backend.


### PR DESCRIPTION
## Summary
- Extract `WiredClientManufacturerReportGenerator` (~128 LOC) from MistHelper.py to `src/reports/wired_client_manufacturer_report_generator.py` (SC-001 facade pattern, Cat B position 26).
- Menu handler: fetches wired clients org-wide, exports the full set, then optionally exports a filtered subset by user-selected manufacturer.
- 9 static methods use lazy `mh = importlib.import_module("MistHelper")` for `ConfigUtils` / `apisession` / `InputUtils` / `DataProcessingUtils` / `DataExporter`.
- MistHelper.py: alphabetical re-export alias in `src.reports.*` block; class body replaced with breadcrumb comment (not stub — preserves alias).
- pyproject.toml: coverage omit entry inserted alphabetically.

## Test plan
- [x] `black --check` (after autoformat)
- [x] `ruff check` clean
- [x] `python -m py_compile` clean
- [x] `python MistHelper.py --test` = 66/0/131 baseline preserved
- [ ] CI CLEAN