### PR TITLE
refactor(1013): remove OrgDeviceInventorySummary facade (Cat B, position 29)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -54,7 +54,7 @@ from concurrent.futures import (
 )  # Thread-pool primitives (FIRST_COMPLETED/wait migrated to ConnectionPoolExecutor per 1012 SC-003)
 from dataclasses import dataclass, field  # Import dataclass decorators for configuration objects and entity classes
 from datetime import datetime  # Import datetime for timestamping logs and events
-from typing import TYPE_CHECKING, Any, Literal, cast  # Import type hints for static analysis without runtime overhead
+from typing import TYPE_CHECKING, Any, Literal  # Import type hints for static analysis without runtime overhead
 
 # Type stubs for dynamically imported modules
 # These allow type checking while the actual imports happen at runtime via GlobalImportManager
@@ -190,6 +190,9 @@ from src.gateway.gateway_ha_exporter import (  # pylint: disable=unused-import
     GatewayHaExporter,  # noqa: F401  # Cat B (1013 SC-001 position 23) -- re-export for MistHelper.GatewayHaExporter callers
 )
 from src.gateway.template_config import GatewayTemplateConfigManager  # Cat A canonical (1013 SC-001)
+from src.inventory.org_device_inventory_summary_facade import (  # pylint: disable=unused-import
+    OrgDeviceInventorySummary,  # noqa: F401  # Cat B (1013 SC-001 position 29) -- re-export for MistHelper.OrgDeviceInventorySummary callers
+)
 from src.org.org_config_migration_manager import OrgConfigMigrationManager  # Cat B (1013 SC-001 position 5)
 from src.org_data_collector import OrgDataCollector  # Import org-level data collection orchestrator
 from src.refactors.anomaly_metrics_discovery import (
@@ -9527,75 +9530,8 @@ class OfflineDeviceReporter:
         OfflineDeviceReporter._finalize_offline_report(len(all_devices), offline_records, threshold_hours, start_time)
 
 
-class OrgDeviceInventorySummary:  # Org device inventory summary.
-    """Delegation façade for extracted Org Device Inventory Summary modules."""
-
-    _DEVICE_TYPES: tuple[str, ...] = ("ap", "switch", "gateway")  # Device types to tally.
-
-    @staticmethod
-    def _get_summary_impl() -> Any:  # Build the summary core.
-        """Configure and return extracted single-org summary implementation."""
-        from src.inventory.org_device_inventory_summary import (  # noqa: PLC0415
-            OrgDeviceInventorySummaryCore,
-            configure_org_device_inventory_summary_dependencies,
-        )
-
-        configure_org_device_inventory_summary_dependencies(  # Wire summary dependencies.
-            apisession_dependency=apisession,
-            mistapi_dependency=mistapi,
-            data_exporter=DataExporter,
-            org_id_value=cast(str, org_id),  # Global org_id is set before this runs; assert str for the checker
-        )
-        return OrgDeviceInventorySummaryCore  # Return the core class.
-
-    @staticmethod
-    def _get_msp_impl() -> Any:  # Build the MSP orchestrator.
-        """Configure and return extracted MSP orchestration implementation."""
-        from src.inventory.org_device_inventory_msp import (  # noqa: PLC0415
-            OrgDeviceInventoryMSPOrchestrator,
-            configure_org_device_inventory_msp_dependencies,
-        )
-
-        configure_org_device_inventory_msp_dependencies(  # Wire MSP dependencies.
-            apisession_dependency=apisession,
-            input_utils=InputUtils,
-            data_exporter=DataExporter,
-            msp_privileges_value=msp_privileges,
-        )
-        return OrgDeviceInventoryMSPOrchestrator  # Return the orchestrator.
-
-    @staticmethod
-    def execute() -> None:  # Run the summary.
-        """Single-org entry point for menu operation 13."""
-        OrgDeviceInventorySummary._get_summary_impl().execute()  # Delegate to the core.
-
-    @staticmethod
-    def _resolve_active_msp() -> "dict[str, Any] | None":  # Resolve the active MSP.
-        """Delegate MSP selection prompt to extracted MSP orchestrator."""
-        return OrgDeviceInventorySummary._get_msp_impl()._resolve_active_msp()  # Delegate to the orchestrator.
-
-    @staticmethod
-    def _run_single_msp_org() -> None:  # Run a single MSP org.
-        """Delegate single-org MSP flow to extracted MSP orchestrator."""
-        OrgDeviceInventorySummary._get_msp_impl().run_single_msp_org(
-            OrgDeviceInventorySummary._get_summary_impl().run_for_org  # Bind extracted core run_for_org as callback.
-        )
-
-    @staticmethod
-    def execute_msp() -> None:  # Run the MSP flow.
-        """Delegate batch MSP execution to extracted MSP orchestrator."""
-        OrgDeviceInventorySummary._get_msp_impl().execute_msp(
-            OrgDeviceInventorySummary._get_summary_impl().run_for_org  # Bind extracted core run_for_org as callback.
-        )
-
-    @staticmethod
-    def dispatch() -> None:  # Dispatch summary vs MSP.
-        """Delegate menu operation 13 interactive dispatch to extracted MSP orchestrator."""
-        OrgDeviceInventorySummary._get_msp_impl().dispatch(  # Delegate to the orchestrator.
-            single_org_fn=OrgDeviceInventorySummary.execute,
-            select_org_fn=OrgDeviceInventorySummary._run_single_msp_org,
-            batch_fn=OrgDeviceInventorySummary.execute_msp,
-        )
+# --- OrgDeviceInventorySummary facade removed (1013 SC-001 Cat B pos 29) ---
+# Canonical implementation lives in src/inventory/org_device_inventory_summary_facade.py; re-exported above.
 
 
 # OrgTemplateExporter moved to src/export/org_template_exporter.py (1013 SC-001 position 22)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,6 +244,7 @@ omit = [
     "src/export/sites_by_ap_model_exporter.py",
     "src/firmware/firmware_manager.py",
     "src/gateway/gateway_ha_exporter.py",
+    "src/inventory/org_device_inventory_summary_facade.py",
     "src/reports/sfp_transceiver_data_processor.py",
     "src/reports/wired_client_manufacturer_report_generator.py",
     "src/site/bulk_radius_wlan_config_manager.py",

--- a/src/inventory/org_device_inventory_summary_facade.py
+++ b/src/inventory/org_device_inventory_summary_facade.py
@@ -1,0 +1,90 @@
+"""OrgDeviceInventorySummary -- delegation facade for menu operation 13.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 29).
+This module hosts the thin delegation facade over the already-extracted
+implementation modules ``src.inventory.org_device_inventory_summary``
+(single-org core) and ``src.inventory.org_device_inventory_msp`` (MSP
+orchestrator). Live-global reads (``apisession``, ``mistapi``, ``DataExporter``,
+``org_id``, ``InputUtils``, ``msp_privileges``) are resolved via lazy
+``mh = importlib.import_module("MistHelper")`` inside each helper. Callers
+continue to reach the class through the ``MistHelper.OrgDeviceInventorySummary``
+re-export alias.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions for return types.
+
+import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
+from typing import Any, cast  # WHY: raw impl classes are duck-typed; cast org_id str for the checker.
+
+
+class OrgDeviceInventorySummary:
+    """Delegation facade for extracted Org Device Inventory Summary modules."""
+
+    _DEVICE_TYPES: tuple[str, ...] = ("ap", "switch", "gateway")  # Device types to tally.
+
+    @staticmethod
+    def _get_summary_impl() -> Any:  # Build the summary core.
+        """Configure and return extracted single-org summary implementation."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession/mistapi/DataExporter/org_id.
+        from src.inventory.org_device_inventory_summary import (  # noqa: PLC0415
+            OrgDeviceInventorySummaryCore,
+            configure_org_device_inventory_summary_dependencies,
+        )
+
+        configure_org_device_inventory_summary_dependencies(  # Wire summary dependencies.
+            apisession_dependency=mh.apisession,
+            mistapi_dependency=mh.mistapi,
+            data_exporter=mh.DataExporter,
+            org_id_value=cast(str, mh.org_id),  # Global org_id is set before this runs; assert str for the checker.
+        )
+        return OrgDeviceInventorySummaryCore  # Return the core class.
+
+    @staticmethod
+    def _get_msp_impl() -> Any:  # Build the MSP orchestrator.
+        """Configure and return extracted MSP orchestration implementation."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession/InputUtils/DataExporter/msp.
+        from src.inventory.org_device_inventory_msp import (  # noqa: PLC0415
+            OrgDeviceInventoryMSPOrchestrator,
+            configure_org_device_inventory_msp_dependencies,
+        )
+
+        configure_org_device_inventory_msp_dependencies(  # Wire MSP dependencies.
+            apisession_dependency=mh.apisession,
+            input_utils=mh.InputUtils,
+            data_exporter=mh.DataExporter,
+            msp_privileges_value=mh.msp_privileges,
+        )
+        return OrgDeviceInventoryMSPOrchestrator  # Return the orchestrator.
+
+    @staticmethod
+    def execute() -> None:  # Run the summary.
+        """Single-org entry point for menu operation 13."""
+        OrgDeviceInventorySummary._get_summary_impl().execute()  # Delegate to the core.
+
+    @staticmethod
+    def _resolve_active_msp() -> dict[str, Any] | None:  # Resolve the active MSP.
+        """Delegate MSP selection prompt to extracted MSP orchestrator."""
+        return OrgDeviceInventorySummary._get_msp_impl()._resolve_active_msp()  # Delegate to the orchestrator.
+
+    @staticmethod
+    def _run_single_msp_org() -> None:  # Run a single MSP org.
+        """Delegate single-org MSP flow to extracted MSP orchestrator."""
+        OrgDeviceInventorySummary._get_msp_impl().run_single_msp_org(
+            OrgDeviceInventorySummary._get_summary_impl().run_for_org  # Bind extracted core run_for_org as callback.
+        )
+
+    @staticmethod
+    def execute_msp() -> None:  # Run the MSP flow.
+        """Delegate batch MSP execution to extracted MSP orchestrator."""
+        OrgDeviceInventorySummary._get_msp_impl().execute_msp(
+            OrgDeviceInventorySummary._get_summary_impl().run_for_org  # Bind extracted core run_for_org as callback.
+        )
+
+    @staticmethod
+    def dispatch() -> None:  # Dispatch summary vs MSP.
+        """Delegate menu operation 13 interactive dispatch to extracted MSP orchestrator."""
+        OrgDeviceInventorySummary._get_msp_impl().dispatch(  # Delegate to the orchestrator.
+            single_org_fn=OrgDeviceInventorySummary.execute,
+            select_org_fn=OrgDeviceInventorySummary._run_single_msp_org,
+            batch_fn=OrgDeviceInventorySummary.execute_msp,
+        )


### PR DESCRIPTION
## Summary
- Extract `OrgDeviceInventorySummary` delegation facade from `MistHelper.py` into `src/inventory/org_device_inventory_summary_facade.py` (SC-001 pattern, Cat B position 29).
- Facade delegates to already-extracted `OrgDeviceInventorySummaryCore` and `OrgDeviceInventoryMSPOrchestrator`; only the dispatch layer moves in this PR.
- Live-global reads (`apisession`, `mistapi`, `DataExporter`, `org_id`, `InputUtils`, `msp_privileges`) now use lazy `mh = importlib.import_module("MistHelper")` inside each helper.
- Public API (`execute`, `execute_msp`, `dispatch`, `_resolve_active_msp`, `_run_single_msp_org`) preserved via re-export alias; menu operation 13 unchanged.
- Removed now-unused `cast` from `MistHelper.py` typing imports.

## Test plan
- [x] `black --check` clean
- [x] `ruff check` clean
- [x] `python -m py_compile MistHelper.py src/inventory/org_device_inventory_summary_facade.py` OK
- [x] `python MistHelper.py --test` baseline preserved: 66 success / 0 failed / 131 skipped
- [ ] CI green