### PR TITLE
refactor(1013): extract EnvironmentUtils to src/utils/ (SC-001, position 33)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -304,6 +304,9 @@ from src.ui.display_utils import (  # pylint: disable=unused-import
 from src.ui.interactive_display_utils import (  # pylint: disable=unused-import
     InteractiveDisplayUtils,  # noqa: F401  # Cat B (1013 SC-001 position 10) -- re-export for callers at 17392/17393/17394/17395
 )
+from src.utils.environment_utils import (  # pylint: disable=unused-import
+    EnvironmentUtils,  # noqa: F401  # Cat B (1013 SC-001 position 33) -- re-export for MistHelper.EnvironmentUtils callers
+)
 from src.utils.operation_registry import (  # pylint: disable=unused-import
     OperationRegistry,  # noqa: F401  # Cat B (1013 SC-001 position 13) -- re-export for menu safety classification
 )
@@ -5613,120 +5616,7 @@ class FilePathUtils:
 # ============================================================================
 # ENVIRONMENT UTILITIES CLASS
 # ============================================================================
-class EnvironmentUtils:  # Centralized runtime/container environment detection.
-    """
-    Centralized environment detection utilities.
-    Handles container detection, runtime environment identification, etc.
-    """
-
-    # Constants for container detection
-    TRUE_VALUES = {"1", "true", "yes", "on"}  # Strings treated as boolean-true in env vars.
-    OVERRIDE_ENV_VARS = ("MISTHELPER_FORCE_CONTAINER_LOOP", "MISTHELPER_CONTAINER")  # Manual override switches.
-    CONTAINER_ENV_VARS = (  # Well-known vars set by container runtimes.
-        "CONTAINER",
-        "DOCKER_CONTAINER",
-        "PODMAN_CONTAINER",
-        "KUBERNETES_SERVICE_HOST",
-        "CONTAINERD_NAMESPACE",
-    )
-    CGROUP_INDICATORS = ("docker", "containerd", "podman", "lxc")  # Substrings that mark a container cgroup.
-
-    @staticmethod
-    def _check_override_env_vars() -> bool | None:  # Honor an explicit operator override first.
-        """Check for explicit container override environment variables."""
-        for explicit_var in EnvironmentUtils.OVERRIDE_ENV_VARS:  # Inspect each override switch.
-            value = os.environ.get(explicit_var, "").strip().lower()  # Normalize the configured value.
-            if value in EnvironmentUtils.TRUE_VALUES:  # Operator forced container mode on.
-                logging.debug("Container detection: override via %s=%s", explicit_var, value)  # Trace the override.
-                return True  # Short-circuit: treat as a container.
-        return None  # No override set; defer to other detectors.
-
-    @staticmethod
-    def _check_dockerenv_file() -> bool:  # Detect Docker's /.dockerenv sentinel file.
-        """Check for /.dockerenv sentinel file."""
-        if os.path.exists("/.dockerenv"):  # Docker drops this file inside containers.
-            logging.debug("Container detection: /.dockerenv present")  # Trace the positive signal.
-            return True  # Sentinel present means containerized.
-        return False  # Absent sentinel is inconclusive here.
-
-    @staticmethod
-    def _check_container_env_vars() -> bool:  # Detect container runtimes via env vars.
-        """Check for well-known container environment variables."""
-        for env_var in EnvironmentUtils.CONTAINER_ENV_VARS:  # Probe each known runtime variable.
-            if os.environ.get(env_var):  # Any non-empty value signals a container.
-                logging.debug("Container detection: environment variable %s present", env_var)  # Trace which one.
-                return True  # Treat as containerized.
-        return False  # None present; inconclusive here.
-
-    @staticmethod
-    def _check_cgroup_markers() -> bool:
-        """Check cgroup file for container indicators."""
-        try:
-            with open("/proc/1/cgroup", encoding="utf-8", errors="ignore") as cgroup_file:
-                cgroup_content = cgroup_file.read().lower()
-                for indicator in EnvironmentUtils.CGROUP_INDICATORS:  # Scan cgroup text for each runtime marker.
-                    if indicator in cgroup_content:  # Marker substring present in cgroup.
-                        logging.debug("Container detection: cgroup indicator '%s' found", indicator)  # marker found.
-                        return True  # Containerized: a marker was found.
-        except (FileNotFoundError, PermissionError):  # No cgroup file or no access (host/non-Linux).
-            pass  # Treat missing cgroup as not-containerized.
-        return False  # No cgroup markers: not a container.
-
-    @staticmethod
-    def _check_runtime_user() -> bool:  # Detect the container's dedicated service user.
-        """Check if running as the 'misthelper' user."""
-        try:
-            import pwd  # Unix only
-
-            current_user_name = pwd.getpwuid(os.getuid()).pw_name  # type: ignore[attr-defined]
-            if current_user_name == "misthelper":  # Image runs as the misthelper user.
-                logging.debug("Container detection: running as user 'misthelper'")  # Trace the user-based signal.
-                return True  # Running as misthelper means containerized.
-        except Exception:  # nosec B110
-            pass  # Ignore lookup failures on host systems.
-        return False  # User signal absent: inconclusive.
-
-    @staticmethod
-    def _check_app_path_with_sshd() -> bool:  # Detect the /app + sshd image layout.
-        """Check for canonical container path /app with sshd presence."""
-        try:
-            this_file_dir = os.path.abspath(os.path.dirname(__file__))  # Absolute directory of this module.
-            if this_file_dir.startswith("/app") and os.path.exists("/app/MistHelper.py"):  # In the image path.
-                if os.path.exists("/usr/sbin/sshd"):  # Image ships the SSH daemon.
-                    logging.debug("Container detection: /app path with MistHelper.py and sshd present")  # image signal.
-                    return True  # Layout matches the container image.
-        except Exception:  # nosec B110
-            pass  # Ignore path-probing errors on host.
-        return False  # Layout not present: inconclusive.
-
-    @staticmethod
-    def _run_container_detectors() -> bool:
-        """Run the ordered fallback container detectors; return True if any positive."""
-        checks = [  # Ordered fallback detectors in reliability order
-            EnvironmentUtils._check_dockerenv_file,
-            EnvironmentUtils._check_container_env_vars,
-            EnvironmentUtils._check_cgroup_markers,
-            EnvironmentUtils._check_runtime_user,
-            EnvironmentUtils._check_app_path_with_sshd,
-        ]
-        for check in checks:  # Run each detector in order
-            if check():  # First positive detector wins
-                return True
-        return False  # No detector matched
-
-    @staticmethod
-    def is_running_in_container() -> bool:  # Public aggregate container check.
-        """Multi-factor container detection: override env -> /.dockerenv -> env vars -> cgroup -> user -> /app."""
-        try:
-            override_result = EnvironmentUtils._check_override_env_vars()  # Operator override wins first
-            if override_result is not None:  # Override explicitly set the answer
-                return override_result  # Honor the forced value
-            if EnvironmentUtils._run_container_detectors():  # Run the chained detectors
-                return True  # A detector confirmed container
-        except Exception as container_detection_error:  # Never let detection crash startup
-            logging.debug("Container detection failed with exception: %s", container_detection_error)  # log failure
-        logging.debug("Container detection: no container indicators found - running in direct mode")  # direct mode
-        return False  # Default: not containerized
+# EnvironmentUtils body removed 1013 SC-001 P33 -- see src/utils/environment_utils.py.
 
 
 # ============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,7 @@ omit = [
     "src/site/bulk_radius_wlan_config_manager.py",
     "src/ssh/cli_shell_manager.py",
     "src/ui/tui.py",
+    "src/utils/environment_utils.py",
     "src/websocket/*"
 ]
 

--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,10 +1,10 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 229 first-party files
-- Definitions analyzed: 48
+- Module graph size: 230 first-party files
+- Definitions analyzed: 47
 - LOC saveable (unused + single-use): 12
-- Category counts: unused=0, single-use=2, low-use=2, hot=43, skipped=1
+- Category counts: unused=0, single-use=2, low-use=2, hot=42, skipped=1
 
 ## How to read this report
 
@@ -56,7 +56,6 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `DataProcessingUtils` | class | 158 | 143 | hot |  | oversize_25_lines,missing_inline_comments,hardcoded_separator |
 | `SiteExportUtils` | class | 145 | 88 | hot |  | oversize_25_lines,missing_action_logging |
 | `TroubleshootUtils` | class | 127 | 36 | hot |  | oversize_25_lines,non_ascii_logs |
-| `EnvironmentUtils` | class | 114 | 28 | hot |  | oversize_25_lines,hardcoded_separator |
 | `OrgSiteExporter` | class | 112 | 43 | hot |  | oversize_25_lines |
 | `FilterOperatorEngine` | class | 110 | 37 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `GatewayExportUtils` | class | 98 | 78 | hot |  | oversize_25_lines,missing_action_logging |
@@ -85,7 +84,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 442-450
+- Def site: line 445-453
 - References: 1
 - Suggested class: `DeviceDataFetcherManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`
@@ -97,7 +96,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2105-2107
+- Def site: line 2108-2110
 - References: 1
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -105,13 +104,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2105
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2108
 
 ## Low-Use (2)
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2214-2238
+- Def site: line 2217-2241
 - References: 2
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -119,11 +118,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2344, 14514
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2347, 14404
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2102-2104
+- Def site: line 2105-2107
 - References: 3
 - Suggested class: `FastModeMaxConcurrentConnectionsManager`
 - Suggested module: `src/refactors/fast__mode__max__concurrent__connections.py`
@@ -132,13 +131,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2102, 9076, 11904
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2105, 8966, 11794
 
-## Hot (43)
+## Hot (42)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2952-5278
+- Def site: line 2955-5281
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -149,11 +148,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2952, 6396, 6397, 6406, 6570
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2955, 6286, 6287, 6296, 6460
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 8162-8847
+- Def site: line 8052-8737
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -162,12 +161,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8285, 8285, 8336, 8336, 8339, 8339, 8380, 8380, 8419, 8419, 8437, 8437, 8515, 8515, 8522, 8522, 8532, 8532, 8535, 8535, 8548, 8548, 8549, 8549, 8550, 8550, 8551, 8551, 8559, 8559, 8561, 8561, 8562, 8562, 8563, 8563, 8564, 8564, 8567, 8567, 8570, 8570, 8573, 8573, 8576, 8576, 8622, 8622, 8645, 8645, 8646, 8646, 8647, 8647, 8649, 8649, 8685, 8685, 8701, 8701, 8755, 8755, 8756, 8756, 8757, 8757, 8760, 8760, 8761, 8761, 8780, 8780, 8782, 8782, 8783, 8783, 8818, 8818, 12044, 12644, 12644, 12668, 12668, 12692, 12692, 12810, 12810, 13374, 13374, 13381, 13381, 13390, 13390, 13394, 13394, 13403, 13403
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8175, 8175, 8226, 8226, 8229, 8229, 8270, 8270, 8309, 8309, 8327, 8327, 8405, 8405, 8412, 8412, 8422, 8422, 8425, 8425, 8438, 8438, 8439, 8439, 8440, 8440, 8441, 8441, 8449, 8449, 8451, 8451, 8452, 8452, 8453, 8453, 8454, 8454, 8457, 8457, 8460, 8460, 8463, 8463, 8466, 8466, 8512, 8512, 8535, 8535, 8536, 8536, 8537, 8537, 8539, 8539, 8575, 8575, 8591, 8591, 8645, 8645, 8646, 8646, 8647, 8647, 8650, 8650, 8651, 8651, 8670, 8670, 8672, 8672, 8673, 8673, 8708, 8708, 11934, 12534, 12534, 12558, 12558, 12582, 12582, 12700, 12700, 13264, 13264, 13271, 13271, 13280, 13280, 13284, 13284, 13293, 13293
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 295, 295, 343, 343, 499, 499
 
 ### `OrgExportUtils` (class, 653 lines)
 
-- Def site: line 9932-10584
+- Def site: line 9822-10474
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -177,11 +176,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10004, 10004, 10026, 10026, 10029, 10029, 10055, 10055, 10064, 10064, 10065, 10065, 10086, 10086, 10129, 10129, 10175, 10175, 10186, 10186, 10213, 10213, 10218, 10218, 10219, 10219, 10220, 10220, 10252, 10252, 10258, 10258, 10283, 10283, 10303, 10303, 10338, 10338, 10353, 10353, 10359, 10359, 10361, 10361, 10364, 10364, 10366, 10366, 10370, 10370, 10374, 10374, 10379, 10379, 10386, 10386, 10393, 10393, 10400, 10400, 10409, 10409, 10419, 10419, 10426, 10426, 10433, 10433, 10440, 10440, 10447, 10447, 10454, 10454, 10464, 10464, 10473, 10473, 10482, 10482, 10491, 10491, 10500, 10500, 10529, 10529, 13335, 13335, 13534, 13534, 13611, 13611, 13612, 13612, 13620, 13620, 13843, 13843, 13844, 13844, 13863, 13863, 13870, 13870, 13871, 13871, 13872, 13872, 13873, 13873
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 9894, 9894, 9916, 9916, 9919, 9919, 9945, 9945, 9954, 9954, 9955, 9955, 9976, 9976, 10019, 10019, 10065, 10065, 10076, 10076, 10103, 10103, 10108, 10108, 10109, 10109, 10110, 10110, 10142, 10142, 10148, 10148, 10173, 10173, 10193, 10193, 10228, 10228, 10243, 10243, 10249, 10249, 10251, 10251, 10254, 10254, 10256, 10256, 10260, 10260, 10264, 10264, 10269, 10269, 10276, 10276, 10283, 10283, 10290, 10290, 10299, 10299, 10309, 10309, 10316, 10316, 10323, 10323, 10330, 10330, 10337, 10337, 10344, 10344, 10354, 10354, 10363, 10363, 10372, 10372, 10381, 10381, 10390, 10390, 10419, 10419, 13225, 13225, 13424, 13424, 13501, 13501, 13502, 13502, 13510, 13510, 13733, 13733, 13734, 13734, 13753, 13753, 13760, 13760, 13761, 13761, 13762, 13762, 13763, 13763
 
 ### `menu_actions` (assignment, 608 lines)
 
-- Def site: line 13316-13923
+- Def site: line 13206-13813
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -191,12 +190,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13316, 13958, 13959, 13968, 14088, 14088, 14130, 14186, 14231, 14722, 14726, 14771, 14771, 14798, 14798, 14801
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13206, 13848, 13849, 13858, 13978, 13978, 14020, 14076, 14121, 14612, 14616, 14661, 14661, 14688, 14688, 14691
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgTicketManager` (class, 475 lines)
 
-- Def site: line 7565-8039
+- Def site: line 7455-7929
 - References: 66
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -204,11 +203,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7606, 7606, 7611, 7611, 7621, 7621, 7629, 7629, 7634, 7634, 7639, 7639, 7652, 7652, 7657, 7657, 7662, 7662, 7682, 7682, 7692, 7692, 7693, 7693, 7696, 7696, 7726, 7726, 7815, 7815, 7817, 7817, 7844, 7844, 7850, 7850, 7855, 7855, 7864, 7864, 7868, 7868, 7887, 7887, 7890, 7890, 7901, 7901, 7902, 7902, 8000, 8000, 8021, 8021, 13911, 13911, 13912, 13912, 13913, 13913, 13914, 13914, 13915, 13915, 13916, 13916
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7496, 7496, 7501, 7501, 7511, 7511, 7519, 7519, 7524, 7524, 7529, 7529, 7542, 7542, 7547, 7547, 7552, 7552, 7572, 7572, 7582, 7582, 7583, 7583, 7586, 7586, 7616, 7616, 7705, 7705, 7707, 7707, 7734, 7734, 7740, 7740, 7745, 7745, 7754, 7754, 7758, 7758, 7777, 7777, 7780, 7780, 7791, 7791, 7792, 7792, 7890, 7890, 7911, 7911, 13801, 13801, 13802, 13802, 13803, 13803, 13804, 13804, 13805, 13805, 13806, 13806
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 7113-7553
+- Def site: line 7003-7443
 - References: 110
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -216,14 +215,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7058, 7058, 7074, 7074, 7078, 7078, 7079, 7079, 7080, 7080, 7095, 7095, 7101, 7101, 7128, 7128, 7131, 7131, 7139, 7139, 7157, 7157, 7207, 7207, 7215, 7215, 7220, 7220, 7266, 7266, 7277, 7277, 7302, 7302, 7321, 7321, 7322, 7322, 7325, 7325, 7326, 7326, 7416, 7416, 7418, 7418, 7422, 7422, 7450, 7450, 7451, 7451, 7452, 7452, 7453, 7453, 7454, 7454, 7463, 7463, 7507, 7507, 7531, 7531, 10664, 10664, 10714, 10714, 10719, 10719, 10816, 10816, 10837, 10837, 10842, 10842, 11106, 11106, 11164, 11315, 11315, 11320, 11320, 11370, 11370, 11371, 11371, 12146, 12651, 12651, 13142, 13142, 13301, 13301, 13302, 13302, 13545, 13545
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6948, 6948, 6964, 6964, 6968, 6968, 6969, 6969, 6970, 6970, 6985, 6985, 6991, 6991, 7018, 7018, 7021, 7021, 7029, 7029, 7047, 7047, 7097, 7097, 7105, 7105, 7110, 7110, 7156, 7156, 7167, 7167, 7192, 7192, 7211, 7211, 7212, 7212, 7215, 7215, 7216, 7216, 7306, 7306, 7308, 7308, 7312, 7312, 7340, 7340, 7341, 7341, 7342, 7342, 7343, 7343, 7344, 7344, 7353, 7353, 7397, 7397, 7421, 7421, 10554, 10554, 10604, 10604, 10609, 10609, 10706, 10706, 10727, 10727, 10732, 10732, 10996, 10996, 11054, 11205, 11205, 11210, 11210, 11260, 11260, 11261, 11261, 12036, 12541, 12541, 13032, 13032, 13191, 13191, 13192, 13192, 13435, 13435
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 68, 196, 196
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 65, 127, 127, 132, 132
 
 ### `OrgDeviceStatsExporter` (class, 414 lines)
 
-- Def site: line 8850-9263
+- Def site: line 8740-9153
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -232,11 +231,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8883, 8883, 8967, 8967, 8973, 8973, 8976, 8976, 9020, 9020, 9034, 9034, 9061, 9061, 9067, 9067, 9081, 9081, 9164, 9164, 9166, 9166, 9170, 9170, 9172, 9172, 9175, 9175, 9179, 9179, 9182, 9182, 9192, 9192, 9198, 9198, 9236, 9236, 13375, 13375, 13376, 13376, 13377, 13377, 13401, 13401
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8773, 8773, 8857, 8857, 8863, 8863, 8866, 8866, 8910, 8910, 8924, 8924, 8951, 8951, 8957, 8957, 8971, 8971, 9054, 9054, 9056, 9056, 9060, 9060, 9062, 9062, 9065, 9065, 9069, 9069, 9072, 9072, 9082, 9082, 9088, 9088, 9126, 9126, 13265, 13265, 13266, 13266, 13267, 13267, 13291, 13291
 
 ### `DeviceRebootManager` (class, 396 lines)
 
-- Def site: line 12729-13124
+- Def site: line 12619-13014
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -245,11 +244,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12750, 12750, 12755, 12755, 12759, 12759, 12762, 12762, 12769, 12769, 12771, 12771, 12772, 12772, 12775, 12775, 12778, 12778, 12781, 12781, 12823, 12823, 12855, 12855, 12922, 12922, 12935, 12935, 12940, 12940, 12990, 12990, 13023, 13023, 13024, 13024, 13025, 13025, 13055, 13055, 13084, 13084, 13085, 13085, 13576, 13576
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12640, 12640, 12645, 12645, 12649, 12649, 12652, 12652, 12659, 12659, 12661, 12661, 12662, 12662, 12665, 12665, 12668, 12668, 12671, 12671, 12713, 12713, 12745, 12745, 12812, 12812, 12825, 12825, 12830, 12830, 12880, 12880, 12913, 12913, 12914, 12914, 12915, 12915, 12945, 12945, 12974, 12974, 12975, 12975, 13466, 13466
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 6537-6881
+- Def site: line 6427-6771
 - References: 176
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -258,7 +257,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6583, 6583, 6599, 6599, 6600, 6600, 6623, 6623, 6625, 6625, 6628, 6628, 6642, 6642, 6644, 6644, 6653, 6653, 6655, 6655, 6656, 6656, 6662, 6662, 6663, 6663, 6663, 6680, 6680, 6684, 6684, 6726, 6726, 6757, 6757, 6760, 6760, 6762, 6762, 6808, 6808, 6818, 6818, 6851, 6851, 6856, 6856, 6863, 6863, 7170, 7170, 7871, 7871, 8101, 8101, 8118, 8118, 8136, 8136, 8157, 8157, 8716, 8716, 8791, 8791, 9121, 9121, 9472, 9472, 9891, 9891, 9990, 9990, 9996, 9996, 10293, 10293, 10310, 10310, 10325, 10325, 10539, 10539, 10567, 10567, 10583, 10583, 10620, 10620, 10658, 10658, 10747, 10747, 10776, 10776, 10964, 10964, 10970, 10970, 11089, 11089, 11097, 11097, 11167, 11373, 11373, 11981, 11981, 12040, 12147, 12698, 12698, 12718, 13225, 13225, 13246, 13246, 13472, 13472, 13485, 13485, 13699, 13699, 13754, 13754, 13770, 13770
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6473, 6473, 6489, 6489, 6490, 6490, 6513, 6513, 6515, 6515, 6518, 6518, 6532, 6532, 6534, 6534, 6543, 6543, 6545, 6545, 6546, 6546, 6552, 6552, 6553, 6553, 6553, 6570, 6570, 6574, 6574, 6616, 6616, 6647, 6647, 6650, 6650, 6652, 6652, 6698, 6698, 6708, 6708, 6741, 6741, 6746, 6746, 6753, 6753, 7060, 7060, 7761, 7761, 7991, 7991, 8008, 8008, 8026, 8026, 8047, 8047, 8606, 8606, 8681, 8681, 9011, 9011, 9362, 9362, 9781, 9781, 9880, 9880, 9886, 9886, 10183, 10183, 10200, 10200, 10215, 10215, 10429, 10429, 10457, 10457, 10473, 10473, 10510, 10510, 10548, 10548, 10637, 10637, 10666, 10666, 10854, 10854, 10860, 10860, 10979, 10979, 10987, 10987, 11057, 11263, 11263, 11871, 11871, 11930, 12037, 12588, 12588, 12608, 13115, 13115, 13136, 13136, 13362, 13362, 13375, 13375, 13589, 13589, 13644, 13644, 13660, 13660
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 71, 188, 188, 286, 286, 294, 294, 363, 363, 392, 392, 544, 544, 559, 559
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 380, 380, 440, 440, 457, 457, 476, 476, 549, 549
@@ -269,7 +268,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAnomalyExporter` (class, 341 lines)
 
-- Def site: line 10803-11143
+- Def site: line 10693-11033
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -278,11 +277,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10820, 10820, 10822, 10822, 10826, 10826, 10827, 10827, 10841, 10841, 10847, 10847, 10850, 10850, 10853, 10853, 10911, 10911, 10917, 10917, 10922, 10922, 10936, 10936, 10954, 10954, 11064, 11064, 11068, 11068, 11070, 11070, 11073, 11073, 11110, 11110, 11115, 11115, 11129, 11129, 11133, 11133, 11135, 11135, 11138, 11138, 11143, 11143, 13622, 13622, 13626, 13626, 13630, 13630
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10710, 10710, 10712, 10712, 10716, 10716, 10717, 10717, 10731, 10731, 10737, 10737, 10740, 10740, 10743, 10743, 10801, 10801, 10807, 10807, 10812, 10812, 10826, 10826, 10844, 10844, 10954, 10954, 10958, 10958, 10960, 10960, 10963, 10963, 11000, 11000, 11005, 11005, 11019, 11019, 11023, 11023, 11025, 11025, 11028, 11028, 11033, 11033, 13512, 13512, 13516, 13516, 13520, 13520
 
 ### `InsightMetricsUtils` (class, 328 lines)
 
-- Def site: line 11399-11726
+- Def site: line 11289-11616
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -292,13 +291,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10274, 10274, 10333, 10333, 10334, 10334, 11170, 11440, 11440, 11442, 11442, 11448, 11448, 11462, 11462, 11501, 11501, 11504, 11504, 11506, 11506, 11507, 11507, 11508, 11508, 11562, 11562, 11563, 11563, 11574, 11574, 11583, 11583, 11602, 11602, 11654, 11654, 11658, 11658, 11666, 11666, 11667, 11667, 11691, 11691, 11695, 11695
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10164, 10164, 10223, 10223, 10224, 10224, 11060, 11330, 11330, 11332, 11332, 11338, 11338, 11352, 11352, 11391, 11391, 11394, 11394, 11396, 11396, 11397, 11397, 11398, 11398, 11452, 11452, 11453, 11453, 11464, 11464, 11473, 11473, 11492, 11492, 11544, 11544, 11548, 11548, 11556, 11556, 11557, 11557, 11581, 11581, 11585, 11585
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 29, 74
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 41, 55
 
 ### `ARPCommandManager` (class, 289 lines)
 
-- Def site: line 12312-12600
+- Def site: line 12202-12490
 - References: 46
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -308,11 +307,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12340, 12340, 12343, 12343, 12348, 12348, 12351, 12351, 12395, 12395, 12401, 12401, 12432, 12432, 12435, 12435, 12439, 12439, 12465, 12465, 12482, 12482, 12488, 12488, 12502, 12502, 12503, 12503, 12505, 12505, 12511, 12511, 12518, 12518, 12527, 12527, 12574, 12574, 12596, 12596, 12597, 12597, 12598, 12598, 13567, 13567
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12230, 12230, 12233, 12233, 12238, 12238, 12241, 12241, 12285, 12285, 12291, 12291, 12322, 12322, 12325, 12325, 12329, 12329, 12355, 12355, 12372, 12372, 12378, 12378, 12392, 12392, 12393, 12393, 12395, 12395, 12401, 12401, 12408, 12408, 12417, 12417, 12464, 12464, 12486, 12486, 12487, 12487, 12488, 12488, 13457, 13457
 
 ### `OfflineDeviceReporter` (class, 273 lines)
 
-- Def site: line 9266-9538
+- Def site: line 9156-9428
 - References: 54
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -321,11 +320,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 9289, 9289, 9290, 9290, 9303, 9303, 9304, 9304, 9306, 9306, 9307, 9307, 9310, 9310, 9313, 9313, 9317, 9317, 9318, 9318, 9394, 9394, 9398, 9398, 9401, 9401, 9414, 9414, 9451, 9451, 9468, 9468, 9481, 9481, 9483, 9483, 9490, 9490, 9499, 9499, 9508, 9508, 9509, 9509, 9520, 9520, 9524, 9524, 9533, 9533, 9538, 9538, 13842, 13842
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 9179, 9179, 9180, 9180, 9193, 9193, 9194, 9194, 9196, 9196, 9197, 9197, 9200, 9200, 9203, 9203, 9207, 9207, 9208, 9208, 9284, 9284, 9288, 9288, 9291, 9291, 9304, 9304, 9341, 9341, 9358, 9358, 9371, 9371, 9373, 9373, 9380, 9380, 9389, 9389, 9398, 9398, 9399, 9399, 9410, 9410, 9414, 9414, 9423, 9423, 9428, 9428, 13732, 13732
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5284-5547
+- Def site: line 5287-5550
 - References: 81
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -333,14 +332,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5324, 5324, 5326, 5326, 5408, 5408, 5414, 5414, 5451, 5451, 5453, 5453, 5462, 5462, 5472, 5472, 5482, 5482, 5518, 5518, 7206, 7206, 8644, 8644, 8645, 8645, 8956, 8956, 12038, 12289, 12643, 12643, 12667, 12667, 12691, 12691, 12810, 12810, 12811, 12811, 12812, 12812, 12813, 12813, 13143, 13143, 13473, 13473, 13486, 13486, 13700, 13700, 13879, 13879
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5327, 5327, 5329, 5329, 5411, 5411, 5417, 5417, 5454, 5454, 5456, 5456, 5465, 5465, 5475, 5475, 5485, 5485, 5521, 5521, 7096, 7096, 8534, 8534, 8535, 8535, 8846, 8846, 11928, 12179, 12533, 12533, 12557, 12557, 12581, 12581, 12700, 12700, 12701, 12701, 12702, 12702, 12703, 12703, 13033, 13033, 13363, 13363, 13376, 13376, 13590, 13590, 13769, 13769
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 339, 339, 341, 341, 343, 343, 345, 345, 499, 499, 500, 500, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32, 336, 336, 357, 357
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `GlobalWiredClientReportGenerator` (class, 251 lines)
 
-- Def site: line 9663-9913
+- Def site: line 9553-9803
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -350,11 +349,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] non_ascii_logs
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 9670, 9670, 9673, 9673, 9678, 9678, 9679, 9679, 9687, 9687, 9690, 9690, 9698, 9698, 9738, 9738, 9746, 9746, 9794, 9794, 9811, 9811, 9814, 9814, 9816, 9816, 9880, 9880, 9881, 9881, 13845, 13845
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 9560, 9560, 9563, 9563, 9568, 9568, 9569, 9569, 9577, 9577, 9580, 9580, 9588, 9588, 9628, 9628, 9636, 9636, 9684, 9684, 9701, 9701, 9704, 9704, 9706, 9706, 9770, 9770, 9771, 9771, 13735, 13735
 
 ### `GatewayTestExporter` (class, 245 lines)
 
-- Def site: line 11750-11994
+- Def site: line 11640-11884
 - References: 32
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -364,11 +363,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11776, 11776, 11778, 11778, 11779, 11779, 11780, 11780, 11808, 11808, 11813, 11813, 11835, 11835, 11836, 11836, 11878, 11878, 11886, 11886, 11912, 11912, 11921, 11921, 11929, 11929, 11960, 11960, 13380, 13380, 13384, 13384
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11666, 11666, 11668, 11668, 11669, 11669, 11670, 11670, 11698, 11698, 11703, 11703, 11725, 11725, 11726, 11726, 11768, 11768, 11776, 11776, 11802, 11802, 11811, 11811, 11819, 11819, 11850, 11850, 13270, 13270, 13274, 13274
 
 ### `APIFetchUtils` (class, 221 lines)
 
-- Def site: line 5960-6180
+- Def site: line 5850-6070
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -376,14 +375,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5983, 5983, 6034, 6034, 6104, 6104, 6128, 6128, 6140, 6140, 6142, 6142, 6152, 6152, 6167, 6167, 6171, 6171, 6172, 6172, 6175, 6175, 6177, 6177, 12042
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5873, 5873, 5924, 5924, 5994, 5994, 6018, 6018, 6030, 6030, 6032, 6032, 6042, 6042, 6057, 6057, 6061, 6061, 6062, 6062, 6065, 6065, 6067, 6067, 11932
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 44, 450, 450
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 13, 43, 108, 108
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 25, 71
 
 ### `PromptClientUtils` (class, 210 lines)
 
-- Def site: line 6897-7106
+- Def site: line 6787-6996
 - References: 29
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -392,11 +391,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6910, 6910, 6916, 6916, 6917, 6917, 6920, 6920, 6943, 6943, 6946, 6946, 6949, 6949, 6950, 6950, 6952, 6952, 7019, 7019, 7063, 7063, 7528, 7528, 11111, 11111, 12145, 12325, 12325
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6800, 6800, 6806, 6806, 6807, 6807, 6810, 6810, 6833, 6833, 6836, 6836, 6839, 6839, 6840, 6840, 6842, 6842, 6909, 6909, 6953, 6953, 7418, 7418, 11001, 11001, 12035, 12215, 12215
 
 ### `SiteDeviceExporter` (class, 203 lines)
 
-- Def site: line 10592-10794
+- Def site: line 10482-10684
 - References: 26
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -405,11 +404,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10613, 10613, 10622, 10622, 10684, 10684, 10691, 10691, 10723, 10723, 10725, 10725, 10749, 10749, 10784, 10784, 10791, 10791, 13416, 13416, 13418, 13418, 13419, 13419, 13421, 13421
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10503, 10503, 10512, 10512, 10574, 10574, 10581, 10581, 10613, 10613, 10615, 10615, 10639, 10639, 10674, 10674, 10681, 10681, 13306, 13306, 13308, 13308, 13309, 13309, 13311, 13311
 
 ### `DatabaseSchemaUtils` (class, 179 lines)
 
-- Def site: line 6356-6534
+- Def site: line 6246-6424
 - References: 34
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -417,11 +416,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6401, 6401, 6439, 6439, 6450, 6450, 6476, 6476, 6477, 6477, 6479, 6479, 6485, 6485, 6486, 6486, 6489, 6489, 6495, 6495, 6496, 6496, 6499, 6499, 6501, 6501, 6511, 6511, 6513, 6513, 6514, 6514, 6516, 6516
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6291, 6291, 6329, 6329, 6340, 6340, 6366, 6366, 6367, 6367, 6369, 6369, 6375, 6375, 6376, 6376, 6379, 6379, 6385, 6385, 6386, 6386, 6389, 6389, 6391, 6391, 6401, 6401, 6403, 6403, 6404, 6404, 6406, 6406
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 6188-6345
+- Def site: line 6078-6235
 - References: 143
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -431,7 +430,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6204, 6204, 6217, 6217, 6220, 6220, 6244, 6244, 6252, 6252, 6253, 6253, 6275, 6275, 6280, 6280, 6282, 6282, 6759, 6759, 6784, 6784, 6853, 6853, 6854, 6854, 7168, 7168, 7169, 7169, 8002, 8002, 8096, 8096, 8098, 8098, 8099, 8099, 8116, 8116, 8117, 8117, 8134, 8134, 8135, 8135, 8155, 8155, 8156, 8156, 8713, 8713, 8714, 8714, 8788, 8788, 8789, 8789, 9117, 9117, 9120, 9120, 9887, 9887, 9888, 9888, 9988, 9988, 9989, 9989, 10292, 10292, 10308, 10308, 10309, 10309, 10537, 10537, 10538, 10538, 10617, 10617, 10618, 10618, 10619, 10619, 10655, 10655, 10656, 10656, 10744, 10744, 10745, 10745, 10773, 10773, 10774, 10774, 10962, 10962, 10963, 10963, 11087, 11087, 11088, 11088, 11166, 11979, 11979, 11980, 11980, 12041, 12149, 12696, 12696, 12697, 12697
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6094, 6094, 6107, 6107, 6110, 6110, 6134, 6134, 6142, 6142, 6143, 6143, 6165, 6165, 6170, 6170, 6172, 6172, 6649, 6649, 6674, 6674, 6743, 6743, 6744, 6744, 7058, 7058, 7059, 7059, 7892, 7892, 7986, 7986, 7988, 7988, 7989, 7989, 8006, 8006, 8007, 8007, 8024, 8024, 8025, 8025, 8045, 8045, 8046, 8046, 8603, 8603, 8604, 8604, 8678, 8678, 8679, 8679, 9007, 9007, 9010, 9010, 9777, 9777, 9778, 9778, 9878, 9878, 9879, 9879, 10182, 10182, 10198, 10198, 10199, 10199, 10427, 10427, 10428, 10428, 10507, 10507, 10508, 10508, 10509, 10509, 10545, 10545, 10546, 10546, 10634, 10634, 10635, 10635, 10663, 10663, 10664, 10664, 10852, 10852, 10853, 10853, 10977, 10977, 10978, 10978, 11056, 11869, 11869, 11870, 11870, 11931, 12039, 12586, 12586, 12587, 12587
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 70, 153, 153, 154, 154, 159, 159, 187, 187, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 454, 454, 455, 455, 474, 474, 475, 475
@@ -439,7 +438,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 11154-11298
+- Def site: line 11044-11188
 - References: 88
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -448,12 +447,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10703, 10703, 11183, 11183, 11189, 11189, 11195, 11195, 11201, 11201, 11207, 11207, 11213, 11213, 11219, 11219, 11225, 11225, 11231, 11231, 11237, 11237, 11243, 11243, 11249, 11249, 11255, 11255, 11261, 11261, 11267, 11267, 11273, 11273, 11279, 11279, 11285, 11285, 11291, 11291, 11297, 11297, 13454, 13454, 13613, 13613, 13615, 13615, 13739, 13739, 13874, 13874, 13875, 13875, 13876, 13876, 13895, 13895, 13896, 13896, 13897, 13897, 13898, 13898, 13899, 13899, 13900, 13900, 13901, 13901
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 10593, 10593, 11073, 11073, 11079, 11079, 11085, 11085, 11091, 11091, 11097, 11097, 11103, 11103, 11109, 11109, 11115, 11115, 11121, 11121, 11127, 11127, 11133, 11133, 11139, 11139, 11145, 11145, 11151, 11151, 11157, 11157, 11163, 11163, 11169, 11169, 11175, 11175, 11181, 11181, 11187, 11187, 13344, 13344, 13503, 13503, 13505, 13505, 13629, 13629, 13764, 13764, 13765, 13765, 13766, 13766, 13785, 13785, 13786, 13786, 13787, 13787, 13788, 13788, 13789, 13789, 13790, 13790, 13791, 13791
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 209, 209, 352, 352, 356, 356, 366, 366, 415, 415, 424, 424, 433, 433, 497, 497, 525, 525
 
 ### `TroubleshootUtils` (class, 127 lines)
 
-- Def site: line 12135-12261
+- Def site: line 12025-12151
 - References: 36
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -462,24 +461,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12155, 12155, 12160, 12160, 12165, 12165, 12202, 12202, 12208, 12208, 12214, 12214, 12220, 12220, 12226, 12226, 12227, 12227, 12228, 12228, 12229, 12229, 12230, 12230, 12234, 12234, 12243, 12243, 12247, 12247, 12250, 12250, 12256, 12256, 13525, 13525
-
-### `EnvironmentUtils` (class, 114 lines)
-
-- Def site: line 5616-5729
-- References: 28
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] hardcoded_separator
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5637, 5637, 5639, 5639, 5655, 5655, 5667, 5667, 5706, 5706, 5707, 5707, 5708, 5708, 5709, 5709, 5710, 5710, 5721, 5721, 5724, 5724, 6641, 6641, 14201, 14201, 14784, 14784
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12045, 12045, 12050, 12050, 12055, 12055, 12092, 12092, 12098, 12098, 12104, 12104, 12110, 12110, 12116, 12116, 12117, 12117, 12118, 12118, 12119, 12119, 12120, 12120, 12124, 12124, 12133, 12133, 12137, 12137, 12140, 12140, 12146, 12146, 13415, 13415
 
 ### `OrgSiteExporter` (class, 112 lines)
 
-- Def site: line 8048-8159
+- Def site: line 7938-8049
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -487,13 +473,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7206, 7206, 8644, 8644, 8956, 8956, 12045, 12645, 12645, 12669, 12669, 12693, 12693, 12811, 12811, 13146, 13146, 13373, 13373, 13388, 13388, 13398, 13398, 13398, 13398, 13408, 13408, 13474, 13474, 13487, 13487, 13701, 13701
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7096, 7096, 8534, 8534, 8846, 8846, 11935, 12535, 12535, 12559, 12559, 12583, 12583, 12701, 12701, 13036, 13036, 13263, 13263, 13278, 13278, 13288, 13288, 13288, 13288, 13298, 13298, 13364, 13364, 13377, 13377, 13591, 13591
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 47, 339, 339, 500, 500, 547, 547
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 17, 191, 191
 
 ### `FilterOperatorEngine` (class, 110 lines)
 
-- Def site: line 9551-9660
+- Def site: line 9441-9550
 - References: 37
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -503,11 +489,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 9606, 9606, 9609, 9609, 9610, 9610, 9615, 9615, 9634, 9634, 9634, 9643, 9643, 9643, 9643, 9644, 9644, 9644, 9644, 9702, 9702, 9705, 9705, 9717, 9717, 9718, 9718, 9731, 9731, 9770, 9770, 9778, 9778, 9832, 9832, 9840, 9840
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 9496, 9496, 9499, 9499, 9500, 9500, 9505, 9505, 9524, 9524, 9524, 9533, 9533, 9533, 9533, 9534, 9534, 9534, 9534, 9592, 9592, 9595, 9595, 9607, 9607, 9608, 9608, 9621, 9621, 9660, 9660, 9668, 9668, 9722, 9722, 9730, 9730
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 12027-12124
+- Def site: line 11917-12014
 - References: 78
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -516,13 +502,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11770, 11770, 12005, 12005, 12063, 12063, 12069, 12069, 12075, 12075, 12081, 12081, 12087, 12087, 12093, 12093, 12099, 12099, 12105, 12105, 12111, 12111, 12117, 12117, 12123, 12123, 12290, 12812, 12812, 12815, 12815, 13145, 13145, 13339, 13339, 13406, 13406, 13412, 13412, 13463, 13463, 13538, 13538
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11660, 11660, 11895, 11895, 11953, 11953, 11959, 11959, 11965, 11965, 11971, 11971, 11977, 11977, 11983, 11983, 11989, 11989, 11995, 11995, 12001, 12001, 12007, 12007, 12013, 12013, 12180, 12702, 12702, 12705, 12705, 13035, 13035, 13229, 13229, 13296, 13296, 13302, 13302, 13353, 13353, 13428, 13428
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 78, 94, 341, 341, 347, 347, 403, 403, 405, 405, 409, 409, 412, 412, 415, 415, 416, 416, 459, 459, 460, 460, 492, 492, 493, 493, 509, 509, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `ValidationUtils` (class, 90 lines)
 
-- Def site: line 5735-5824
+- Def site: line 5625-5714
 - References: 15
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -532,13 +518,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5817, 5817, 11833, 11833, 11834, 11834, 12048, 13303, 13303
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5707, 5707, 11723, 11723, 11724, 11724, 11938, 13193, 13193
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 28, 143, 143, 144, 144
 
 ### `OrgLevelAPFirmwareUpgrader` (class, 79 lines)
 
-- Def site: line 13201-13279
+- Def site: line 13091-13169
 - References: 33
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -548,12 +534,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13196, 13196, 13197, 13197, 13718, 13718
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13086, 13086, 13087, 13087, 13608, 13608
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\org_ap_upgrader.py`: lines 412, 409, 425, 770, 770, 772, 772, 781, 781, 786, 786, 790, 790, 846, 846, 847, 847, 848, 848, 849, 849, 883, 883, 2223, 2223, 2226, 2226
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 12623-12700
+- Def site: line 12513-12590
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -563,12 +549,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13580, 13580, 13584, 13584, 13588, 13588
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13470, 13470, 13474, 13474, 13478, 13478
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 1990-2063
+- Def site: line 1993-2066
 - References: 233
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -577,7 +563,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2003, 2003, 2035, 2035, 2380, 2380, 2407, 2407, 6918, 6918, 7004, 7004, 7134, 7134, 7211, 7211, 7294, 7294, 7524, 7524, 7612, 7612, 7671, 7671, 7684, 7684, 7701, 7701, 7746, 7746, 7780, 7780, 7786, 7786, 7892, 7892, 9305, 9305, 9704, 9704, 9733, 9733, 10566, 10566, 10582, 10582, 11322, 11322, 11372, 11372, 12046, 12248, 12248, 12288, 12650, 12650, 12675, 12675, 12717, 12792, 12792, 13002, 13002, 13141, 13141, 13191, 13191, 13221, 13221, 13242, 13242, 13261, 13261, 13277, 13277, 13305, 13305, 13470, 13470, 13483, 13483, 13697, 13697, 13752, 13752, 13852, 13852, 13857, 13857, 13863, 13863, 13882, 13882, 13888, 13888, 14807, 14807
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2006, 2006, 2038, 2038, 2383, 2383, 2410, 2410, 6808, 6808, 6894, 6894, 7024, 7024, 7101, 7101, 7184, 7184, 7414, 7414, 7502, 7502, 7561, 7561, 7574, 7574, 7591, 7591, 7636, 7636, 7670, 7670, 7676, 7676, 7782, 7782, 9195, 9195, 9594, 9594, 9623, 9623, 10456, 10456, 10472, 10472, 11212, 11212, 11262, 11262, 11936, 12138, 12138, 12178, 12540, 12540, 12565, 12565, 12607, 12682, 12682, 12892, 12892, 13031, 13031, 13081, 13081, 13111, 13111, 13132, 13132, 13151, 13151, 13167, 13167, 13195, 13195, 13360, 13360, 13373, 13373, 13587, 13587, 13642, 13642, 13742, 13742, 13747, 13747, 13753, 13753, 13772, 13772, 13778, 13778, 14697, 14697
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -598,7 +584,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 5830-5899
+- Def site: line 5720-5789
 - References: 150
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -606,7 +592,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5872, 5872, 5877, 5877, 5974, 5974, 6032, 6032, 7061, 7061, 7605, 7605, 7628, 7628, 7651, 7651, 7842, 7842, 7863, 7863, 8090, 8090, 8112, 8112, 8129, 8129, 8146, 8146, 8531, 8531, 8754, 8754, 8771, 8771, 9163, 9163, 9495, 9495, 9669, 9669, 10020, 10020, 10356, 10356, 10528, 10528, 10568, 10568, 10574, 10574, 10668, 10668, 11165, 11769, 11769, 12037, 12144, 12244, 12244, 12715, 13192, 13192, 13194, 13194, 13218, 13218, 13222, 13222, 13223, 13223, 13243, 13243, 13244, 13244, 13325, 13325, 13362, 13362, 13368, 13368, 13468, 13468, 13481, 13481, 13514, 13514, 13571, 13571, 13654, 13654, 13663, 13663, 13695, 13695, 13750, 13750, 13751, 13751, 13768, 13768, 13852, 13852, 13857, 13857, 13863, 13863, 13882, 13882, 13888, 13888, 14120, 14120, 14189, 14671, 14671, 14759, 14759
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5762, 5762, 5767, 5767, 5864, 5864, 5922, 5922, 6951, 6951, 7495, 7495, 7518, 7518, 7541, 7541, 7732, 7732, 7753, 7753, 7980, 7980, 8002, 8002, 8019, 8019, 8036, 8036, 8421, 8421, 8644, 8644, 8661, 8661, 9053, 9053, 9385, 9385, 9559, 9559, 9910, 9910, 10246, 10246, 10418, 10418, 10458, 10458, 10464, 10464, 10558, 10558, 11055, 11659, 11659, 11927, 12034, 12134, 12134, 12605, 13082, 13082, 13084, 13084, 13108, 13108, 13112, 13112, 13113, 13113, 13133, 13133, 13134, 13134, 13215, 13215, 13252, 13252, 13258, 13258, 13358, 13358, 13371, 13371, 13404, 13404, 13461, 13461, 13544, 13544, 13553, 13553, 13585, 13585, 13640, 13640, 13641, 13641, 13658, 13658, 13742, 13742, 13747, 13747, 13753, 13753, 13772, 13772, 13778, 13778, 14010, 14010, 14079, 14561, 14561, 14649, 14649
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 69, 246, 246, 556, 556, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 402, 402, 449, 449, 467, 467, 508, 508, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 27, 321, 321
@@ -616,7 +602,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `APICoreFetchUtils` (class, 47 lines)
 
-- Def site: line 5905-5951
+- Def site: line 5795-5841
 - References: 45
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -625,13 +611,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6029, 6029, 7396, 7396, 8091, 8091, 8114, 8114, 8601, 8601, 8636, 8636, 8650, 8650, 8773, 8773, 8777, 8777, 9325, 9325, 10672, 10672, 11172, 12043, 13193, 13193, 13224, 13224, 13245, 13245, 13753, 13753, 13769, 13769, 14690, 14690
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5919, 5919, 7286, 7286, 7981, 7981, 8004, 8004, 8491, 8491, 8526, 8526, 8540, 8540, 8663, 8663, 8667, 8667, 9215, 9215, 10562, 10562, 11062, 11933, 13083, 13083, 13114, 13114, 13135, 13135, 13643, 13643, 13659, 13659, 14580, 14580
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 31, 76, 558, 558
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 45, 515, 515, 526, 526
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5565-5610
+- Def site: line 5568-5613
 - References: 86
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -640,14 +626,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5323, 5323, 5365, 5365, 5410, 5410, 5516, 5516, 5531, 5531, 5600, 5600, 6055, 6055, 7230, 7230, 8301, 8301, 8612, 8612, 8628, 8628, 8957, 8957, 12039, 12291, 12551, 12551, 12591, 12591, 12592, 12592, 12593, 12593, 12642, 12642, 12666, 12666, 12670, 12670, 12690, 12690, 12716, 12767, 12767, 12801, 12801, 12822, 12822, 12854, 12854, 12916, 12916, 12955, 12955, 13103, 13103, 13144, 13144, 13471, 13471, 13484, 13484, 13698, 13698
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5326, 5326, 5368, 5368, 5413, 5413, 5519, 5519, 5534, 5534, 5603, 5603, 5945, 5945, 7120, 7120, 8191, 8191, 8502, 8502, 8518, 8518, 8847, 8847, 11929, 12181, 12441, 12441, 12481, 12481, 12482, 12482, 12483, 12483, 12532, 12532, 12556, 12556, 12560, 12560, 12580, 12580, 12606, 12657, 12657, 12691, 12691, 12712, 12712, 12744, 12744, 12806, 12806, 12845, 12845, 12993, 12993, 13034, 13034, 13361, 13361, 13374, 13374, 13588, 13588
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 149, 149, 227, 227, 235, 235, 243, 243, 548, 548
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 33, 360, 360
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `TimeUtils` (class, 29 lines)
 
-- Def site: line 1954-1982
+- Def site: line 1957-1985
 - References: 27
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -656,12 +642,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8890, 8890, 8891, 8891, 9195, 9195, 9196, 9196, 9243, 9243, 9244, 9244, 10407, 10407, 10408, 10408, 10513, 10513, 10514, 10514, 11168
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8780, 8780, 8781, 8781, 9085, 9085, 9086, 9086, 9133, 9133, 9134, 9134, 10297, 10297, 10298, 10298, 10403, 10403, 10404, 10404, 11058
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 27, 72, 207, 207, 208, 208
 
 ### `GatewayStatsExporter` (class, 28 lines)
 
-- Def site: line 11997-12024
+- Def site: line 11887-11914
 - References: 52
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -670,12 +656,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12011, 12011, 12017, 12017, 12023, 12023, 13592, 13592, 13596, 13596
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 11901, 11901, 11907, 11907, 11913, 11913, 13482, 13482, 13486, 13486
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 203, 203, 247, 247, 250, 250, 266, 266, 308, 308, 311, 311, 327, 327, 329, 329, 330, 330, 337, 337, 347, 347, 350, 350, 351, 351, 358, 358, 377, 377, 386, 386, 387, 387, 388, 388, 405, 405, 406, 406, 459, 459
 
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 12277-12302
+- Def site: line 12167-12192
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -685,12 +671,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12297, 12297, 12302, 12302, 13600, 13600, 13605, 13605
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 12187, 12187, 12192, 12192, 13490, 13490, 13495, 13495
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `RoutingUtils` (class, 22 lines)
 
-- Def site: line 11329-11350
+- Def site: line 11219-11240
 - References: 12
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -699,7 +685,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13348, 13348, 13352, 13352, 13356, 13356
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13238, 13238, 13242, 13242, 13246, 13246
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_display.py`: lines 106
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_forwarding.py`: lines 46
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\network\_routing_utils_parsing.py`: lines 67
@@ -709,7 +695,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteAutoUpgradeConfigurator` (class, 22 lines)
 
-- Def site: line 13177-13198
+- Def site: line 13067-13088
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -718,12 +704,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13732, 13732
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 13622, 13622
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\firmware\site_auto_upgrade.py`: lines 177, 177, 742, 964
 
 ### `SSHConnectionConfig` (class, 9 lines)
 
-- Def site: line 415-423
+- Def site: line 418-426
 - References: 6
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -739,7 +725,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SSHExecutionConfig` (class, 8 lines)
 
-- Def site: line 427-434
+- Def site: line 430-437
 - References: 5
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -755,7 +741,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 721-723
+- Def site: line 724-726
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -763,7 +749,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1331, 2000, 2000, 2000, 2012, 2018, 6031, 6151, 8700, 8811, 9065, 11175, 11915, 11957, 12055, 13755
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1334, 2003, 2003, 2003, 2015, 2021, 5921, 6041, 8590, 8701, 8955, 11065, 11805, 11847, 11945, 13645
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_data_fetcher.py`: lines 359
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\org_client_security_exporter.py`: lines 177
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 35, 79, 163
@@ -779,7 +765,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2116-2118
+- Def site: line 2119-2121
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -788,7 +774,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2116, 12051
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2119, 11941
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 54, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -796,7 +782,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1005 lines)
 
-- Def site: line 837-1841
+- Def site: line 840-1844
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -804,7 +790,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1886
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1889
 
 ## Limitations
 

--- a/src/utils/environment_utils.py
+++ b/src/utils/environment_utils.py
@@ -1,0 +1,129 @@
+"""EnvironmentUtils -- runtime/container environment detection.
+
+Extracted from MistHelper.py during initiative 1013 (Cat B, position 33).
+Self-contained module: no live-global reads, so no lazy MistHelper import
+is required. Direct imports cover stdlib only (os, logging). Callers
+continue to reach the class through the ``MistHelper.EnvironmentUtils``
+re-export alias.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions for return types.
+
+import logging  # WHY: structured trace for container detection lifecycle events.
+import os  # WHY: environment variable + filesystem probes for container detection.
+
+
+class EnvironmentUtils:
+    """Centralized environment detection utilities.
+
+    Handles container detection, runtime environment identification, etc.
+    """
+
+    # Constants for container detection
+    TRUE_VALUES = {"1", "true", "yes", "on"}  # Strings treated as boolean-true in env vars.
+    OVERRIDE_ENV_VARS = ("MISTHELPER_FORCE_CONTAINER_LOOP", "MISTHELPER_CONTAINER")  # Manual override switches.
+    CONTAINER_ENV_VARS = (  # Well-known vars set by container runtimes.
+        "CONTAINER",
+        "DOCKER_CONTAINER",
+        "PODMAN_CONTAINER",
+        "KUBERNETES_SERVICE_HOST",
+        "CONTAINERD_NAMESPACE",
+    )
+    CGROUP_INDICATORS = ("docker", "containerd", "podman", "lxc")  # Substrings that mark a container cgroup.
+
+    @staticmethod
+    def _check_override_env_vars() -> bool | None:  # Honor an explicit operator override first.
+        """Check for explicit container override environment variables."""
+        for explicit_var in EnvironmentUtils.OVERRIDE_ENV_VARS:  # Inspect each override switch.
+            value = os.environ.get(explicit_var, "").strip().lower()  # Normalize the configured value.
+            if value in EnvironmentUtils.TRUE_VALUES:  # Operator forced container mode on.
+                logging.debug("Container detection: override via %s=%s", explicit_var, value)  # Trace the override.
+                return True  # Short-circuit: treat as a container.
+        return None  # No override set; defer to other detectors.
+
+    @staticmethod
+    def _check_dockerenv_file() -> bool:  # Detect Docker's /.dockerenv sentinel file.
+        """Check for /.dockerenv sentinel file."""
+        if os.path.exists("/.dockerenv"):  # Docker drops this file inside containers.
+            logging.debug("Container detection: /.dockerenv present")  # Trace the positive signal.
+            return True  # Sentinel present means containerized.
+        return False  # Absent sentinel is inconclusive here.
+
+    @staticmethod
+    def _check_container_env_vars() -> bool:  # Detect container runtimes via env vars.
+        """Check for well-known container environment variables."""
+        for env_var in EnvironmentUtils.CONTAINER_ENV_VARS:  # Probe each known runtime variable.
+            if os.environ.get(env_var):  # Any non-empty value signals a container.
+                logging.debug("Container detection: environment variable %s present", env_var)  # Trace which one.
+                return True  # Treat as containerized.
+        return False  # None present; inconclusive here.
+
+    @staticmethod
+    def _check_cgroup_markers() -> bool:
+        """Check cgroup file for container indicators."""
+        try:
+            with open("/proc/1/cgroup", encoding="utf-8", errors="ignore") as cgroup_file:
+                cgroup_content = cgroup_file.read().lower()
+                for indicator in EnvironmentUtils.CGROUP_INDICATORS:  # Scan cgroup text for each runtime marker.
+                    if indicator in cgroup_content:  # Marker substring present in cgroup.
+                        logging.debug("Container detection: cgroup indicator '%s' found", indicator)  # marker found.
+                        return True  # Containerized: a marker was found.
+        except (FileNotFoundError, PermissionError):  # No cgroup file or no access (host/non-Linux).
+            pass  # Treat missing cgroup as not-containerized.
+        return False  # No cgroup markers: not a container.
+
+    @staticmethod
+    def _check_runtime_user() -> bool:  # Detect the container's dedicated service user.
+        """Check if running as the 'misthelper' user."""
+        try:
+            import pwd  # noqa: PLC0415  # Unix only
+
+            current_user_name = pwd.getpwuid(os.getuid()).pw_name  # type: ignore[attr-defined]
+            if current_user_name == "misthelper":  # Image runs as the misthelper user.
+                logging.debug("Container detection: running as user 'misthelper'")  # Trace the user-based signal.
+                return True  # Running as misthelper means containerized.
+        except Exception:  # nosec B110
+            pass  # Ignore lookup failures on host systems.
+        return False  # User signal absent: inconclusive.
+
+    @staticmethod
+    def _check_app_path_with_sshd() -> bool:  # Detect the /app + sshd image layout.
+        """Check for canonical container path /app with sshd presence."""
+        try:
+            this_file_dir = os.path.abspath(os.path.dirname(__file__))  # Absolute directory of this module.
+            if this_file_dir.startswith("/app") and os.path.exists("/app/MistHelper.py"):  # In the image path.
+                if os.path.exists("/usr/sbin/sshd"):  # Image ships the SSH daemon.
+                    logging.debug("Container detection: /app path with MistHelper.py and sshd present")  # image signal.
+                    return True  # Layout matches the container image.
+        except Exception:  # nosec B110
+            pass  # Ignore path-probing errors on host.
+        return False  # Layout not present: inconclusive.
+
+    @staticmethod
+    def _run_container_detectors() -> bool:
+        """Run the ordered fallback container detectors; return True if any positive."""
+        checks = [  # Ordered fallback detectors in reliability order
+            EnvironmentUtils._check_dockerenv_file,
+            EnvironmentUtils._check_container_env_vars,
+            EnvironmentUtils._check_cgroup_markers,
+            EnvironmentUtils._check_runtime_user,
+            EnvironmentUtils._check_app_path_with_sshd,
+        ]
+        for check in checks:  # Run each detector in order
+            if check():  # First positive detector wins
+                return True
+        return False  # No detector matched
+
+    @staticmethod
+    def is_running_in_container() -> bool:  # Public aggregate container check.
+        """Multi-factor container detection: override env -> /.dockerenv -> env vars -> cgroup -> user -> /app."""
+        try:
+            override_result = EnvironmentUtils._check_override_env_vars()  # Operator override wins first
+            if override_result is not None:  # Override explicitly set the answer
+                return override_result  # Honor the forced value
+            if EnvironmentUtils._run_container_detectors():  # Run the chained detectors
+                return True  # A detector confirmed container
+        except Exception as container_detection_error:  # Never let detection crash startup
+            logging.debug("Container detection failed with exception: %s", container_detection_error)  # log failure
+        logging.debug("Container detection: no container indicators found - running in direct mode")  # direct mode
+        return False  # Default: not containerized

--- a/src/utils/environment_utils.py
+++ b/src/utils/environment_utils.py
@@ -78,7 +78,7 @@ class EnvironmentUtils:
         try:
             import pwd  # noqa: PLC0415  # Unix only
 
-            current_user_name = pwd.getpwuid(os.getuid()).pw_name  # type: ignore[attr-defined]
+            current_user_name = pwd.getpwuid(os.getuid()).pw_name  # os.getuid is Unix-only
             if current_user_name == "misthelper":  # Image runs as the misthelper user.
                 logging.debug("Container detection: running as user 'misthelper'")  # Trace the user-based signal.
                 return True  # Running as misthelper means containerized.


### PR DESCRIPTION
## Summary

Extracts `EnvironmentUtils` (container/runtime detection) from `MistHelper.py` to `src/utils/environment_utils.py` per initiative #1013 Cat B (SC-001, position 33).

**Notable**: this class is self-contained (only stdlib `os` / `logging` + inline `pwd`). No live globals are touched, so the lazy `mh = importlib.import_module` accessor typical of Cat B extractions is not needed.

## Changes

- **New**: `src/utils/environment_utils.py` — full `EnvironmentUtils` class (121 LOC)
- **`MistHelper.py`**: re-export alias `from src.utils.environment_utils import EnvironmentUtils` + single-line breadcrumb comment at former class location
- **`pyproject.toml`**: added `src/utils/environment_utils.py` to `[tool.coverage.run]` omit list (alphabetical)
- **`refactor_candidates.md`**: regenerated (47 → 47 candidates, LOC saveable now 12)

## Test plan

- [x] `black --check` clean
- [x] `ruff check` clean
- [x] `python -c "import MistHelper"` succeeds
- [x] `python MistHelper.py --test` = 66 passed / 0 failed / 131 skipped (matches baseline)
- [ ] CI CLEAN