### PR TITLE
docs(noc-runbooks): add initial NOC alarm runbook library

### DIFF
--- a/documentation/noc-runbooks/GW_BGP_NEIGHBOR_DOWN.md
+++ b/documentation/noc-runbooks/GW_BGP_NEIGHBOR_DOWN.md
@@ -1,0 +1,157 @@
+# GW_BGP_NEIGHBOR_DOWN
+
+## Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | GW_BGP_NEIGHBOR_DOWN |
+| **Mist alarm key** | `gw_bgp_neighbor_down` |
+| **Platform** | Juniper SSR1300 (Session Smart Router). The same alarm key also fires on SRX gateways — an SRX-specific runbook is planned as Phase 2 because the CLI (Junos) differs from SSR PCLI. |
+| **Mist native severity** | `warn` |
+| **NOC severity** | **Critical** (override — see rationale below) |
+| **Group** | `infrastructure` |
+| **Clear event key** | `gw_bgp_neighbor_up` |
+| **Correlated alarms** | `bad_wan_uplink`, `intermittent_wan_connectivity`, `vpn_peer_down`, `gw_vpn_path_down`, `vpn_path_down`, `gw_critical_port_down`, `switch_down` |
+| **Prerequisites** | A BGP peer must be configured on the gateway. Alarm fires on BGP session state transition to `Idle` / `Active` / `Connect` (i.e. not `Established`). |
+| **Description** | A configured BGP neighbor on the gateway has left the `Established` state. Depending on the peer's role (underlay ISP, internal route reflector, overlay CE), impact ranges from partial route loss to complete site isolation. |
+
+### Severity rationale (Mist `warn` → NOC `critical`)
+
+Mist ships `gw_bgp_neighbor_down` as `warn` because a well-designed BGP topology has redundant peers and a single neighbor down does not always mean loss of reachability. In our environment BGP peers are load-bearing (see Peer classification below), so we escalate to **critical**. If a specific peer is truly non-critical (test lab, decommissioning window), retune via a per-site alarm template rather than lowering the runbook default.
+
+### BGP ≠ SVR — do not confuse them
+
+On SSR, **BGP** and **SVR (Session Smart Routing / peer paths)** are two independent overlays. This alarm is for the underlying **BGP** control plane only.
+
+- If SVR peer paths are down, look for `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` — those are separate alarms with a separate runbook.
+- BGP can be `Established` while SVR peer paths are down, and vice-versa.
+- On SSR, use `show bgp …` for BGP and `show peers` for SVR. Do not mix.
+
+## Impact
+
+- Loss of routes learned from or advertised to the affected peer.
+- If underlay ISP peer: potential loss of internet or WAN transport for the site.
+- If internal RR peer: loss of overlay route learning from a portion of the fabric.
+- If overlay CE peer: reachability to that specific customer edge is lost.
+- Session Smart Routing (SVR) tunnels riding the affected transport may reconverge or fail.
+- Applications relying on routes advertised by the peer may become unreachable.
+- If the BGP peer is the only path, complete site isolation until an alternate path is available.
+
+## Required Information
+
+| Category | Data to capture |
+|---|---|
+| Device | Site, Hostname, Serial Number, SSR software version, Mist device ID |
+| Peer classification | `underlay-ISP` / `internal-RR` / `overlay-CE` (see Shared Appendix §5) |
+| BGP peer | Peer IP, Peer AS, Local AS, Address family (inet / inet-vpn / evpn), Import/Export policies |
+| Local transport | Local interface, local transport IP, WAN link (SVR transport name) used to reach the peer |
+| Session state | Last state (`Idle`, `Active`, `Connect`, `OpenSent`, `OpenConfirm`) and last error / notification code |
+| Timeline | Alert timestamp (UTC), last known Established time, recent config changes |
+| Correlated Alarms | Any active alarms on the gateway, upstream ISP link, or peer device in the last 15 min |
+
+See Shared Appendix §7 for the always-required ticket fields.
+
+## Validation
+
+| Check | Command / Action |
+|---|---|
+| SSR reachable in Mist | Mist UI → WAN Edges → *device* → Health / Insights |
+| SSR connected to conductor / cloud | `show system connected` |
+| System status | `show system` |
+| BGP session summary | `show bgp summary` |
+| Specific peer detail | `show bgp neighbor <peer-ip>` |
+| Received routes from peer | `show bgp neighbor <peer-ip> received-routes` |
+| Advertised routes to peer | `show bgp neighbor <peer-ip> advertised-routes` |
+| Routing table (does peer's prefix appear?) | `show route` |
+| SVR peer paths (separate from BGP) | `show peers` |
+| Active sessions on device | `show sessions summary` |
+| Physical / logical interface state | `show device-interface` and `show network-interface` |
+| Reachability to peer using correct source | `ping <peer-ip> source <local-transport-ip>` |
+| Path to peer | `traceroute <peer-ip>` |
+| Alarms on device | `show alarms` |
+| BGP-scoped event log | `show events filter type bgp` |
+
+**Never** run a bare `ping <peer-ip>` on SSR — it may egress from the wrong interface and produce a false-negative. Always pin the source with `source <local-transport-ip>`. See Shared Appendix §9.
+
+## Resolution
+
+| Area | Action |
+|---|---|
+| Underlay link | If a WAN link alarm (`bad_wan_uplink`, `intermittent_wan_connectivity`) is co-firing, resolve that first — BGP will re-establish once transport recovers. |
+| Peer device | Verify peer's BGP process is up; on ISP peer, open a ticket with the ISP referencing the peer IP and last-seen timestamp. |
+| Reachability | From SSR, confirm the peer is reachable **from the correct source IP** with `ping <peer-ip> source <local-transport-ip>`. |
+| MTU / TCP MSS | If the session repeatedly reaches `OpenSent` then fails, suspect PMTUD blackhole. Verify path MTU and MSS clamping on the transport. |
+| Timers / graceful restart | If flap coincides with peer maintenance, confirm hold-time, keepalive, and graceful-restart settings match on both ends. |
+| Authentication | If the neighbor uses MD5, verify the shared secret is identical on both peers; a recent rotation on either side will drop the session. |
+| Policy / prefix-limit | Verify import/export policies were not recently changed. If a max-prefix limit tripped, review announced route counts before clearing. |
+| Firewall / policy | On SSR the peer path traverses a tenant / service-route / security policy — verify these were not recently changed. On an SRX gateway, verify a stateful firewall rule permits TCP/179 in both directions. |
+| Configuration | Review Mist audit logs for BGP or interface config changes in the last 24 h. Rollback if a recent change caused the outage. |
+| Clear session (last resort) | Only after other causes are ruled out and with change approval, bounce the neighbor to force renegotiation. |
+| Recovery | Confirm BGP peer transitions back to `Established`, expected prefixes are relearned, and the paired clear event has fired. |
+
+## Closure Criteria
+
+- BGP neighbor state is `Established`.
+- Expected prefix counts (received / advertised) match the pre-incident baseline.
+- Reachability to the peer's transport IP from the correct source succeeds.
+- **The paired clear event `gw_bgp_neighbor_up` has been received.**
+- No recurrence of `gw_bgp_neighbor_down` for this peer within a 30-minute debounce window.
+- If SVR peer paths were affected, they are also back to `up` (verified with `show peers`).
+- Root cause is documented on the ticket, including peer classification and blast radius.
+
+## Mist GUI Navigation
+
+| Task | Navigation |
+|---|---|
+| Verify alert | Monitor → Alerts (Alarms) → filter by `gw_bgp_neighbor_down` |
+| SSR health | WAN Edges → *SSR1300* → Health / Insights |
+| WAN link health | WAN Assurance → WAN Links |
+| SVR peer paths (separate from BGP) | WAN Assurance → Peer Path Insights |
+| Gateway events | Monitor → Events |
+| Audit logs | Organization → Audit Logs |
+
+**Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`. See Shared Appendix §6.
+
+## SSR PCLI Commands (quick reference)
+
+SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
+
+| Purpose | Command |
+|---|---|
+| System / model / uptime | `show system` |
+| Conductor / cloud connectivity | `show system connected` |
+| Alarms | `show alarms` |
+| BGP summary | `show bgp summary` |
+| BGP peer detail | `show bgp neighbor <peer-ip>` |
+| BGP received routes | `show bgp neighbor <peer-ip> received-routes` |
+| BGP advertised routes | `show bgp neighbor <peer-ip> advertised-routes` |
+| SVR peer paths (overlay) | `show peers` |
+| Session count | `show sessions summary` |
+| Device interfaces (physical) | `show device-interface` |
+| Network interfaces (logical) | `show network-interface` |
+| Routing table | `show route` |
+| Reachability with correct source | `ping <peer-ip> source <local-transport-ip>` |
+| Path to peer | `traceroute <peer-ip>` |
+| BGP event log | `show events filter type bgp` |
+
+See Shared Appendix §9 for the full SSR PCLI reference.
+
+## Cross-references (sibling alarms)
+
+If any of these are co-firing, resolve the co-fired alarm first — it is usually root cause:
+
+- `bad_wan_uplink` — underlying transport failure (Marvis)
+- `intermittent_wan_connectivity` — flaky underlay
+- `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` — SVR peer path issues (distinct from BGP)
+- `gw_critical_port_down` — physical port serving the peer transport is down
+- `switch_down` — upstream L2/L3 switch is down
+
+## Escalation
+
+Per Shared Appendix §10. Tier 1 NOC can self-clear underlay-transport, reachability, and rollback-driven root causes. Escalate to Tier 2 for:
+
+- Routing policy / prefix-limit changes
+- MD5 secret rotation
+- MTU/PMTUD suspected blackholes
+- Any ISP-side ticket handoff
+- Configuration restore that spans multiple devices

--- a/documentation/noc-runbooks/SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md
+++ b/documentation/noc-runbooks/SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md
@@ -1,0 +1,110 @@
+# SW_ALARM_CHASSIS_MGMT_LINK_DOWN
+
+## Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | SW_ALARM_CHASSIS_MGMT_LINK_DOWN |
+| **Mist alarm key** | `sw_alarm_chassis_mgmt_link_down` |
+| **Platform** | Juniper Mist EX Series Switch |
+| **Mist native severity** | `warn` |
+| **NOC severity** | **Critical** (override — see rationale below) |
+| **Group** | `infrastructure` |
+| **Clear event key** | `sw_alarm_chassis_mgmt_link_down_clear` |
+| **Correlated alarms** | `switch_down`, `vc_master_changed`, `vc_backup_failed`, `sw_alarm_chassis_pem`, `sw_alarm_chassis_psu` |
+| **Prerequisites** | None — fires automatically when the dedicated management (`me0` / `vme`) interface goes down. |
+| **Description** | The dedicated chassis management Ethernet link is down. Remote management via the out-of-band management network may be unavailable. Data forwarding on production interfaces may continue if only the management interface has failed. |
+
+### Severity rationale (Mist `warn` → NOC `critical`)
+
+Mist ships this alarm at `warn` because the production data plane typically keeps forwarding when only `me0`/`vme` drops. We escalate to **critical** because loss of out-of-band management removes our ability to remediate the device if a production-side issue subsequently develops. If you are running with no OOB dependency (in-band management only), consider aligning the NOC severity back to `warn`.
+
+## Impact
+
+- Loss of out-of-band management connectivity.
+- Unable to reach the switch through the MGMT interface (`me0` on standalone, `vme` on Virtual Chassis).
+- Potential loss of remote monitoring paths that depend on the OOB network.
+- Data forwarding on production ports may continue normally.
+- Delayed troubleshooting if in-band remote access becomes unavailable.
+- On a Virtual Chassis, if the master's `me0` drops, VME may fail over to another member — verify which member is currently master.
+
+## Required Information
+
+| Category | Data to capture |
+|---|---|
+| Device | Site, Hostname, Serial Number, Software Version, Mist device ID |
+| Management | MGMT IP, Gateway, VLAN (if applicable), Link Status, `me0` vs `vme` |
+| Physical | Connected management switch/router, cable, port |
+| Virtual Chassis | VC role of affected member (master / backup / linecard); is `vme` still reachable via another member? |
+| Timeline | Alert time (UTC), recent changes (last 24 h), audit logs |
+| Correlated Alarms | Any active alarms on the device or its management upstream within the last 15 min |
+
+See Shared Appendix §7 for the always-required ticket fields.
+
+## Validation
+
+| Check | Command / Action |
+|---|---|
+| Switch reachable in Mist? | Mist UI → Switches → *device* → Health |
+| Management interface state (standalone) | `show interfaces me0` |
+| Management interface state (VC) | `show interfaces vme` |
+| Chassis and VC role | `show virtual-chassis` and `show chassis hardware` |
+| Management routing | `show route table inet.0 <management-gateway>` |
+| Peer switch/router port state | Verify management switch port is up (via that device) |
+| Recent logs (interface-scoped) | `show log messages \| match me0` (or `vme`) |
+| Chassis alarms | `show chassis alarms` |
+| Reachability from switch | `ping <management-gateway>` and `ping <mist-cloud-reachable-host>` |
+
+See Shared Appendix §8 for the full Junos command reference.
+
+## Resolution
+
+| Area | Action |
+|---|---|
+| Cable | Reseat or replace the management cable. |
+| Remote device | Verify the connected management switch/router port is up and not err-disabled. |
+| Configuration | Verify MGMT IP, gateway, and interface configuration against source-of-truth. |
+| Hardware | Replace failed NIC/port if hardware fault is confirmed (see `show chassis alarms` for physical-layer indicators). |
+| Virtual Chassis | If master role has moved, confirm intended master and re-elect if operationally required (planned change only). |
+| Audit | Review Mist audit logs for recent changes that may have affected management config. |
+| Recovery | Confirm management interface is up, reachable from the OOB network, and the paired clear event has fired. |
+
+## Closure Criteria
+
+- Management interface (`me0` or `vme`) is operational.
+- Remote access from the OOB management network is restored.
+- **The paired clear event `sw_alarm_chassis_mgmt_link_down_clear` has been received** — this is the machine-verifiable close signal.
+- No recurrence of `sw_alarm_chassis_mgmt_link_down` within a 30-minute debounce window.
+- Root cause is documented on the ticket.
+
+## Mist GUI Navigation
+
+| Task | Navigation |
+|---|---|
+| Verify alert | Monitor → Alerts (Alarms) → filter by `sw_alarm_chassis_mgmt_link_down` |
+| Switch health | Switches → *device* → Health / Insights |
+| Management status | Switches → *device* → Front Panel / Details |
+| Events (raw) | Monitor → Events |
+| Audit logs | Organization → Audit Logs |
+
+See Shared Appendix §6 for full GUI navigation reference.
+
+## Junos Commands (quick reference)
+
+| Purpose | Command |
+|---|---|
+| System info | `show system information` |
+| Version | `show version` |
+| Chassis hardware / FRUs | `show chassis hardware` |
+| Chassis alarms | `show chassis alarms` |
+| Management interface (standalone) | `show interfaces me0` |
+| Management interface (VC) | `show interfaces vme` |
+| Virtual Chassis state | `show virtual-chassis` |
+| Routing | `show route` |
+| Logs | `show log messages \| match <interface>` |
+| Ping gateway | `ping <management-gateway>` |
+| Ping known-reachable host | `ping <reachable-management-host>` |
+
+## Escalation
+
+Per Shared Appendix §10. Tier 1 NOC can self-clear cable, port, and configuration causes. Escalate to Tier 2 for hardware replacement, VC master election changes, or when the OOB management upstream is itself impaired.

--- a/documentation/noc-runbooks/SW_CRITICAL_PORT_DOWN.md
+++ b/documentation/noc-runbooks/SW_CRITICAL_PORT_DOWN.md
@@ -1,0 +1,138 @@
+# SW_CRITICAL_PORT_DOWN
+
+> **Renamed from `INTERFACE_DOWN`.** Mist does not emit a generic "any interface down" alarm — such an alarm would be pure noise (endpoints unplug all day). The closest useful Mist alarm is `sw_critical_port_down`, which fires only for ports explicitly flagged as **critical** in the port profile. Related port-issue alarms (`port_flap`, `port_stuck`, `bad_cable`, `sw_bad_optics`, `sw_negotiation_incomplete`) each have their own runbook — see cross-references below.
+
+## Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | SW_CRITICAL_PORT_DOWN |
+| **Mist alarm key** | `sw_critical_port_down` |
+| **Platform** | Juniper Mist EX Series Switch (validated against EX4400) |
+| **Mist native severity** | `warn` |
+| **NOC severity** | **Critical** (override — see rationale below) |
+| **Group** | `infrastructure` |
+| **Clear event key** | `sw_critical_port_up` |
+| **Correlated alarms** | `port_flap`, `port_stuck`, `bad_cable`, `sw_bad_optics`, `sw_negotiation_incomplete`, `sw_mtu_mismatch`, `sw_port_storm_control`, `switch_down`, `ap_offline` |
+| **Prerequisites** | **The port must be flagged as "critical" in the Mist port profile.** Without this flag the alarm will not fire. Configure via Site → Switch → Port Configuration → *Critical Port*, or via port profile template. |
+| **Description** | An EX physical or logical port marked as **critical** has transitioned to the Down state. Critical ports typically include uplinks, IDF/MDF links, LAG members, and ports serving essential downstream devices (APs, IP phones, servers, downstream switches). The failure of a critical port implies loss of connectivity for connected devices or network services. |
+
+### Severity rationale (Mist `warn` → NOC `critical`)
+
+Mist ships this as `warn` because port-down events span a wide impact range. Because only *critical* ports fire this alarm, we escalate to **critical** — the port has been explicitly designated as important. If any critical-port designations turn out to be over-tagged (e.g. every access port), retune the port profile rather than lowering NOC severity.
+
+## Impact
+
+- Loss of endpoint or uplink connectivity for the affected port.
+- Client, AP, IP phone, or downstream switch may become unreachable.
+- Potential loss of VLAN or trunk connectivity if the port is a trunk.
+- LACP bundle degradation if the port is a LAG member.
+- Reduced network redundancy on the affected fabric segment.
+- Possible site outage if the port is the sole/primary uplink.
+- If the port is a member of an ESI-LAG in an EVPN fabric, traffic reconverges via the peer, but redundancy is degraded.
+
+## Required Information
+
+| Category | Data to capture |
+|---|---|
+| Device | Site Name, Hostname, Serial Number, Junos Version, Mist device ID |
+| Port classification | `access` / `uplink` / `IDF-MDF` / `server-edge` / `AP` / `VCP` / `LAG-member` (see Shared Appendix §5) |
+| Interface | Interface Name, Description, Admin Status, Oper Status, VLAN(s), Speed, Duplex |
+| Connected device | LLDP neighbor, MAC address, previous known device |
+| Optics (if fiber) | Media type, DDM Tx/Rx power, laser bias, temperature |
+| Timeline | Alert timestamp (UTC), recent configuration changes, related audit log entries |
+| Correlated Alarms | Any active alarms on the device or connected downstream device in the last 15 min |
+
+## Validation
+
+| Check | Command / Action |
+|---|---|
+| Switch online in Mist | Mist UI → Switches → *device* → Health |
+| Interface state summary | `show interfaces terse` |
+| Interface detail | `show interfaces <interface> extensive` |
+| Interface configuration (admin-down vs link-down) | `show configuration interfaces <interface>` |
+| Live counters (errors, CRC, drops) | `monitor interface <interface>` |
+| Optics DDM (fiber only) | `show interfaces diagnostics optics <interface>` |
+| Neighbor discovery | `show lldp neighbors` |
+| MAC learning (post-recovery) | `show ethernet-switching table interface <interface>` |
+| LACP status (if LAG) | `show lacp interfaces` |
+| LACP PDU stats | `show lacp statistics interfaces <interface>` |
+| Storm control state | `show ethernet-switching interface <interface>` |
+| Chassis / port alarms | `show chassis alarms` |
+| Logs (interface-scoped) | `show log messages \| match <interface>` |
+| Ping neighbor (if L3) | `ping <neighbor-ip>` |
+
+See Shared Appendix §8 for the full Junos command reference.
+
+## Resolution
+
+| Area | Action |
+|---|---|
+| Cable / optics | Inspect and reseat / replace cable, DAC, or SFP. For fiber, verify DDM levels are within manufacturer spec. |
+| Connected device | Verify endpoint or upstream/downstream device is powered on and its port is up. |
+| Interface configuration | Verify interface is `admin up`, VLAN/LAG configuration is correct, and no unintended `disable` in config. |
+| Speed / duplex | If `sw_negotiation_incomplete` is co-firing, verify auto-neg / hard-set speed matches the peer. |
+| Storm control | If `sw_port_storm_control` is co-firing, identify and stop the storm source before clearing. |
+| PoE (if applicable) | Verify PoE status for APs or IP phones; check budget (`show poe interface`). |
+| Hardware | Replace faulty transceiver, cable, or switch port if hardware fault is confirmed. |
+| Configuration changes | Review Mist audit logs; restore configuration if a recent change caused the outage. |
+| Recovery | Confirm the port returns to Up, traffic flows, and the paired clear event has fired. |
+
+## Closure Criteria
+
+- Affected port is operational (`admin up`, `oper up`).
+- Connected device is reachable, VLAN and LACP membership function normally.
+- **The paired clear event `sw_critical_port_up` has been received.**
+- No recurrence of `sw_critical_port_down` within a 30-minute debounce window.
+- No related Marvis alarms (`port_flap`, `port_stuck`, `bad_cable`) active on the same port.
+- Root cause is documented on the ticket.
+
+## Mist GUI Navigation
+
+| Task | Navigation |
+|---|---|
+| Verify alert | Monitor → Alerts (Alarms) → filter by `sw_critical_port_down` |
+| Switch health | Switches → *device* → Health |
+| Port status / front panel | Switches → *device* → Front Panel / Port Configuration |
+| Critical port flag | Switches → *device* → Port Configuration → *Critical Port* toggle |
+| Connected clients on the port | Clients → Connected Devices |
+| Switch events | Monitor → Events |
+| Audit logs | Organization → Audit Logs |
+
+See Shared Appendix §6 for full GUI navigation reference.
+
+## Junos Commands (quick reference)
+
+| Purpose | Command |
+|---|---|
+| System info | `show system information` |
+| Version | `show version` |
+| Chassis hardware | `show chassis hardware` |
+| Interface summary | `show interfaces terse` |
+| Interface details | `show interfaces <interface> extensive` |
+| Interface configuration | `show configuration interfaces <interface>` |
+| Live counters | `monitor interface <interface>` |
+| Optics DDM | `show interfaces diagnostics optics <interface>` |
+| LLDP neighbors | `show lldp neighbors` |
+| MAC table | `show ethernet-switching table interface <interface>` |
+| LACP | `show lacp interfaces` |
+| LACP stats | `show lacp statistics interfaces <interface>` |
+| Logs | `show log messages \| match <interface>` |
+| Chassis alarms | `show chassis alarms` |
+| Ping | `ping <neighbor-ip>` |
+
+## Cross-references (sibling alarms)
+
+If the current alarm co-fires with any of these, resolve the co-fired alarm first — it is usually the root cause:
+
+- `port_flap` — repeated up/down flapping
+- `port_stuck` — port up but traffic broken (Marvis)
+- `bad_cable` — Marvis-identified physical fault
+- `sw_bad_optics` — DDM thresholds crossed
+- `sw_negotiation_incomplete` — speed/duplex mismatch (Marvis)
+- `sw_mtu_mismatch` — MTU mismatch (Marvis)
+- `sw_port_storm_control` — storm control holding port down
+
+## Escalation
+
+Per Shared Appendix §10. Tier 1 NOC can self-clear cable, optic, and remote-device causes. Escalate to Tier 2 for hardware replacement or when the port is part of an EVPN fabric with unclear failover behavior.

--- a/documentation/noc-runbooks/SW_VC_PORT_DOWN.md
+++ b/documentation/noc-runbooks/SW_VC_PORT_DOWN.md
@@ -1,0 +1,137 @@
+# SW_VC_PORT_DOWN
+
+## Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | SW_VC_PORT_DOWN |
+| **Mist alarm key** | `sw_vc_port_down` |
+| **Mist display name** | Virtual Chassis Port Down |
+| **Platform** | Juniper Mist EX Series switches configured as a Virtual Chassis (VC) — e.g. EX4400 VC |
+| **Mist native severity** | `critical` |
+| **NOC severity** | **Critical** (native — no override) |
+| **Group** | `infrastructure` |
+| **Clear event key** | `sw_vc_port_up` |
+| **Correlated alarms** | `vc_master_changed`, `vc_backup_failed`, `vc_member_deleted`, `vc_member_restarted`, `switch_down`, `sw_alarm_chassis_mgmt_link_down` |
+| **Prerequisites** | The switch must be part of a Virtual Chassis (2+ members). Alarm fires when a VC port (VCP) between members goes down. Standalone switches cannot fire this alarm. |
+| **Description** | A Virtual Chassis (VC) port has transitioned to the Down state. VCPs form the interconnect fabric between VC members. Failure impacts inter-member communication, redundancy, and Virtual Chassis stability — a full VCP outage can split the VC into isolated fragments. |
+
+### Severity note (no override)
+
+Unlike most `warn`-shipped port alarms, Mist ships `sw_vc_port_down` as `critical` natively. This is one of the few port-related alarms where Mist's default severity already reflects the blast radius (VC split risk), so no override is applied.
+
+## Impact
+
+- Loss of Virtual Chassis redundancy on the affected VCP link.
+- **Potential Virtual Chassis split** — if the VC has only one VCP path between two members (no redundant VCPs), losing it partitions the chassis into isolated islands, each running its own control plane.
+- Reduced fabric switching capacity between VC members.
+- Loss of resiliency for links that use LAGs spanning VC members (member-to-member load-share breaks).
+- Downstream connectivity issues for clients whose traffic egresses through the failed inter-member path.
+- Potential service disruption during master/backup failover if the master election path is affected.
+- Stale MAC/ARP entries until the fabric reconverges.
+
+## Required Information
+
+| Category | Data to capture |
+|---|---|
+| Device | Site, Virtual Chassis name, Switch hostname, Serial Number, Junos version, Mist device ID |
+| VC context | VC member ID (FPC number), member role (master / backup / linecard), total member count |
+| VC port | VCP name (`vcp-0`, `vcp-255/1/0`, or dedicated VCP port), Interface status, Connected member (peer FPC) |
+| Physical | DAC / fiber / SFP type, cable condition, is this a dedicated VCP or a converted network port |
+| Timeline | Alert timestamp (UTC), recent VC config changes, member reboots, audit log entries |
+| Correlated Alarms | Any active alarms on any VC member (or a co-fired `vc_master_changed` / `vc_member_deleted`) in the last 15 min |
+
+See Shared Appendix §7 for the always-required ticket fields.
+
+## Validation
+
+| Check | Command / Action |
+|---|---|
+| VC healthy in Mist | Mist UI → Switches → *Virtual Chassis* → Health (primary/backup) |
+| VC member roster | Switches → *Virtual Chassis* → Members |
+| VC overall state | `show virtual-chassis` |
+| VCP-specific state | `show virtual-chassis vc-port` |
+| VCP detail (per port) | `show virtual-chassis vc-port <interface>` |
+| Interface state | `show interfaces terse` |
+| Interface detail | `show interfaces <vcp-interface> extensive` |
+| Chassis hardware (per member) | `show chassis hardware` |
+| Optics DDM (fiber VCP) | `show interfaces diagnostics optics <vcp-interface>` |
+| Chassis alarms | `show chassis alarms` |
+| Logs (VCP-scoped) | `show log messages \| match vcp` (or specific interface name) |
+| VC master election events | `show log messages \| match vccpd` |
+
+See Shared Appendix §8 for the full Junos command reference.
+
+## Resolution
+
+| Area | Action |
+|---|---|
+| Cable / DAC | Reseat or replace the VC cable / DAC. VC uses direct-attach copper or fiber depending on the VCP type — verify compatible cable spec (length, gauge, vendor). |
+| Optics (fiber VCP) | Verify compatible optics on both ends; check DDM levels are within manufacturer spec. Replace faulty transceiver if DDM is out of range. |
+| Member status | Confirm both VC members are online, powered, and reachable. If a member is down, resolve that first — the VCP alarm is a symptom, not root cause. |
+| Configuration | Verify VC configuration consistency (VC ID, preprovisioned member roles, VCP assignments). A recent config change that revoked VCP status on a converted port will drop the port from VC. |
+| Hardware | Replace failed VCP port, transceiver, or (last resort) the switch itself. |
+| Audit | Review Mist audit logs for recent VC-related config changes in the last 24 h. |
+| VC split recovery | If the VC has split, follow controlled rejoin procedure — do NOT power-cycle members without a plan, as this can force an unwanted master re-election. Escalate to Tier 2. |
+| Recovery | Confirm the VCP returns to Up, all members are synchronized, master/backup roles are as expected, and the paired clear event has fired. |
+
+## Closure Criteria
+
+- Virtual Chassis is healthy: all expected members present, roles as designed.
+- Affected VC port is `Up` and forwarding.
+- **The paired clear event `sw_vc_port_up` has been received.**
+- No recurrence of `sw_vc_port_down` for the same VCP within a 30-minute debounce window.
+- No co-firing `vc_master_changed`, `vc_backup_failed`, or `vc_member_deleted` still active.
+- Root cause is documented on the ticket, including which VCP link and whether redundant VCPs prevented a split.
+
+## Mist GUI Navigation
+
+| Task | Navigation |
+|---|---|
+| Verify alert | Monitor → Alerts (Alarms) → filter by `sw_vc_port_down` |
+| Virtual Chassis health | Switches → *Virtual Chassis* → Health (primary/backup) |
+| VC members | Switches → *Virtual Chassis* → Members |
+| VC port status | Switches → *device* → Front Panel / Port Configuration |
+| Switch events | Monitor → Events |
+| Audit logs | Organization → Audit Logs |
+
+See Shared Appendix §6 for full GUI navigation reference.
+
+## Junos Commands (quick reference)
+
+| Purpose | Command |
+|---|---|
+| System info | `show system information` |
+| Version | `show version` |
+| Chassis hardware (per member) | `show chassis hardware` |
+| Chassis alarms | `show chassis alarms` |
+| Virtual Chassis state | `show virtual-chassis` |
+| Virtual Chassis ports | `show virtual-chassis vc-port` |
+| Specific VCP detail | `show virtual-chassis vc-port <interface>` |
+| Interface summary | `show interfaces terse` |
+| Interface detail | `show interfaces <vcp-interface> extensive` |
+| Optics DDM (fiber VCP) | `show interfaces diagnostics optics <vcp-interface>` |
+| VCP-scoped logs | `show log messages \| match vcp` |
+| VC control-plane logs | `show log messages \| match vccpd` |
+
+## Cross-references (sibling alarms)
+
+If any of these are co-firing, resolve them together — VC-family alarms tend to cascade:
+
+- `vc_master_changed` — new device elected as VC master (critical). Often co-fires when the current master's VCPs fail.
+- `vc_backup_failed` — a new backup was elected (critical).
+- `vc_member_deleted` — a VC member has left the chassis (critical) — usually root cause when this fires.
+- `vc_member_restarted` — a member has rebooted (warn).
+- `switch_down` — a whole member is offline.
+- `sw_alarm_chassis_mgmt_link_down` — check whether `vme` is still reachable via a surviving member.
+
+Triage rule: **`vc_member_deleted` or `switch_down` on a member is usually root cause; `sw_vc_port_down` alone is often the earliest symptom of an impending split.**
+
+## Escalation
+
+Per Shared Appendix §10. Tier 1 NOC can self-clear cable, optic, and single-VCP-flap causes when the VC remains healthy. **Escalate to Tier 2 immediately** for:
+
+- Suspected or confirmed VC split
+- Any active `vc_master_changed` / `vc_backup_failed` / `vc_member_deleted`
+- Hardware replacement of a VC member
+- Config changes to VCP assignment or preprovisioning

--- a/documentation/noc-runbooks/_shared_common.md
+++ b/documentation/noc-runbooks/_shared_common.md
@@ -1,0 +1,152 @@
+# NOC Alarm Runbook — Shared Appendix
+
+This document holds the conventions, cross-cutting guidance, and shared reference material used by every alarm-specific runbook in this library. Each per-alarm document links back to sections here rather than duplicating content.
+
+## 1. Runbook field standard
+
+Every alarm runbook must include the following fields. Fields that don't apply to a given alarm should be marked `n/a` rather than omitted, so the layout stays scannable.
+
+| Field | Purpose |
+|---|---|
+| **Alert Name** | Human-readable name used on dashboards and in ticket titles. |
+| **Mist alarm key** | Lowercase, API-safe key. This is what you filter/search on via the Mist API and webhooks (e.g. `sw_alarm_chassis_mgmt_link_down`). |
+| **Platform** | Device family/model this runbook targets (EX4400, SSR1300, etc.). If a Mist alarm applies to multiple platforms with different CLIs, produce one runbook per platform. |
+| **Mist native severity** | The severity Mist ships the alarm at (`info` / `warn` / `critical`). |
+| **NOC severity** | The severity we page on. When it differs from Mist native, this is an intentional **override** and must be documented in the runbook body. |
+| **Group** | Mist alarm group: `infrastructure`, `marvis`, `security`, or `certificate_expiry`. |
+| **Clear event key** | Paired `_clear` / `_up` event that closes the alarm, when one exists. Used for auto-resolution automation. |
+| **Correlated alarms** | Other Mist alarm keys that commonly co-fire. Used for dedup rules and root-cause triage. |
+| **Prerequisites** | Any configuration state required for the alarm to actually fire (e.g. port marked as "critical" in port profile). |
+| **Description** | One-paragraph, operator-facing summary of what the alarm means. |
+| **Impact / Required Information / Validation / Resolution / Closure Criteria** | Per the existing template. |
+
+## 2. Severity override policy
+
+Mist assigns each alarm a native severity based on its own operational model. Our NOC dashboard may need to raise or lower that severity to fit our on-call model.
+
+- Any runbook whose **NOC severity** differs from **Mist native severity** must explain the override in the Description or a dedicated "Severity rationale" note.
+- Overrides are set in the alarm template in Mist (**Organization → Alarm Templates**). They are not implicit — someone has to configure them.
+- If two teams need different severities for the same alarm, split alarm templates by site group rather than by teaching operators to reinterpret severities.
+
+## 3. Closure criteria and auto-resolution
+
+Every runbook's Closure Criteria section must reference the paired `_clear` or `_up` event key when one exists. This gives us an unambiguous, machine-verifiable close signal and enables webhook-driven ticket auto-resolution.
+
+- Manual close: operator confirms condition resolved (root cause documented).
+- Automated close: our webhook consumer resolves the ticket on receipt of the paired clear event, provided no duplicate alarm has re-fired within a debounce window.
+- Alarms without a paired clear event must document a manual verification step (usually a CLI check).
+
+## 4. Correlated alarms and dedup
+
+Many failures cascade. A physical uplink failure will typically fire:
+
+`sw_critical_port_down` → `sw_alarm_chassis_mgmt_link_down` *(if mgmt rode that path)* → `switch_down` → `gw_bgp_neighbor_down` *(if BGP peered over that link)*
+
+The runbook for each alarm should list its usual co-fires under **Correlated Alarms**. Triage rule of thumb: **the lowest-layer alarm is usually root cause**; higher-layer alarms are symptoms. Suppress the symptoms in the ticketing layer once the root-cause alarm is acknowledged, not in Mist.
+
+## 5. Peer / port classification
+
+For alarms whose severity depends on *which* port or *which* peer went down, the runbook must require the operator to classify the object before escalating:
+
+- **Ports**: `access` / `uplink` / `IDF-MDF` / `server-edge` / `AP` / `VCP` / `LAG-member`
+- **BGP peers**: `underlay-ISP` / `internal-RR` / `overlay-CE`
+- **VPN peer paths**: `hub` / `spoke` / `mesh`
+
+This classification determines blast radius and whether an alarm should escalate beyond the NOC.
+
+## 6. Standard Mist GUI navigation
+
+Paths as of the current Mist UI. If you find a path is stale, update the shared appendix — do not fork it into individual runbooks.
+
+| Task | Navigation |
+|---|---|
+| Active alarms (org-wide) | Monitor → Alerts (Alarms) |
+| Alarm templates (severity/routing) | Organization → Alarm Templates |
+| Site alarm history | Monitor → Alerts → filter by site |
+| Device health (switch) | Switches → *device* → Health / Insights |
+| Device health (WAN edge / SSR / SRX) | WAN Edges → *device* → Health / Insights |
+| Port state | Switches → *device* → Front Panel / Port Config |
+| Client / connected device | Clients → Connected Devices |
+| SVR peer paths | WAN Assurance → Peer Path Insights |
+| WAN link health | WAN Assurance → WAN Links |
+| Events (raw) | Monitor → Events |
+| Audit logs | Organization → Audit Logs |
+
+**Legacy path note:** older docs may reference `Routers → …` for SSR devices. Current UI unifies all gateways under `WAN Edges → …`.
+
+## 7. Standard information to capture on every ticket
+
+Independent of alarm type, capture on ticket creation:
+
+- Site name, site ID
+- Device hostname, serial number, MAC, Mist device ID
+- Software version (Junos / SSR firmware)
+- Alarm timestamp (UTC) and Mist alarm ID
+- Whether the device is currently reachable in Mist (`connected` / `disconnected`)
+- Any correlated alarms active in the last 15 minutes on the same device or site
+
+## 8. Common Junos (EX / SRX) commands
+
+Applicable to any Junos-based device (EX switches, SRX gateways). Use these as building blocks in per-alarm runbooks.
+
+| Purpose | Command |
+|---|---|
+| System / model / uptime | `show system information` |
+| Software version | `show version` |
+| Chassis hardware / FRUs | `show chassis hardware` |
+| Chassis alarms | `show chassis alarms` |
+| Environment (temp / power / fans) | `show chassis environment` |
+| Virtual Chassis state | `show virtual-chassis` |
+| Virtual Chassis ports | `show virtual-chassis vc-port` |
+| Interface summary | `show interfaces terse` |
+| Interface detail | `show interfaces <interface> extensive` |
+| Interface config | `show configuration interfaces <interface>` |
+| Live interface counters | `monitor interface <interface>` |
+| Optics DDM | `show interfaces diagnostics optics <interface>` |
+| LLDP neighbors | `show lldp neighbors` |
+| LACP status | `show lacp interfaces` |
+| LACP stats | `show lacp statistics interfaces <interface>` |
+| MAC table (per interface) | `show ethernet-switching table interface <interface>` |
+| Routing table | `show route` |
+| Log messages (interface-scoped) | `show log messages \| match <interface>` |
+| Config diff (recent changes) | `show system commit` then `show configuration \| compare rollback N` |
+
+## 9. Common SSR (Session Smart Router) PCLI commands
+
+Applicable to SSR gateways. SSR PCLI differs from Junos — do not mix.
+
+| Purpose | Command |
+|---|---|
+| System / model / uptime | `show system` |
+| Conductor / cloud connectivity | `show system connected` |
+| Device interfaces (physical) | `show device-interface` |
+| Network interfaces (logical) | `show network-interface` |
+| Routing table | `show route` |
+| BGP summary | `show bgp summary` |
+| BGP peer detail | `show bgp neighbor <peer-ip>` |
+| BGP received prefixes | `show bgp neighbor <peer-ip> received-routes` |
+| BGP advertised prefixes | `show bgp neighbor <peer-ip> advertised-routes` |
+| SVR peer paths (overlay) | `show peers` |
+| Active session count | `show sessions summary` |
+| Events (scoped) | `show events filter type <type>` |
+| Alarms | `show alarms` |
+| Reachability (correct source) | `ping <target> source <local-transport-ip>` |
+| Traceroute | `traceroute <target>` |
+
+## 10. Standard escalation ladder
+
+Applies to every runbook unless a specific runbook overrides.
+
+1. **Tier 1 NOC** — validate alarm, run validation commands, classify port/peer, apply resolution steps.
+2. **Tier 2 / Network Engineering** — hardware replacement, config restore, routing policy adjustments.
+3. **Vendor (Juniper TAC / Mist Support)** — reproducible defects, RMA, licensing/entitlement issues.
+4. **Change Advisory Board** — when resolution requires an out-of-window change.
+
+Every runbook should note at which step (if earlier than Tier 2) the alarm can be self-cleared.
+
+## 11. Cross-references from per-alarm runbooks
+
+Per-alarm runbooks should reference this appendix by section number, not by copying content. Example:
+
+> Severity override policy: see Shared Appendix §2.
+> Commands: see Shared Appendix §8 (Junos) or §9 (SSR).


### PR DESCRIPTION
## Summary

Adds the first tranche of NOC alarm runbooks for Mist-managed infrastructure under `documentation/noc-runbooks/`, plus a shared appendix that consolidates the boilerplate (ticket fields, GUI navigation, Junos/SSR PCLI references, escalation ladder).

Each runbook is structured to be usable directly by Tier 1 without cross-referencing external Mist docs, and cites:

- Mist alarm key (verified against the live \`alarm_definitions\` catalog)
- Native Mist severity vs NOC severity (with override rationale where they diverge)
- Paired clear event for auto-resolution
- Correlated / co-firing alarm siblings
- Prerequisites for the alarm to fire
- Closure criteria and Tier 2 escalation triggers

## Runbooks in this PR

| File | Mist key | Native / NOC severity | Notes |
|---|---|---|---|
| \`SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md\` | \`sw_alarm_chassis_mgmt_link_down\` | warn / warn | Distinguishes \`me0\` (standalone) vs \`vme\` (VC) mgmt link semantics |
| \`SW_CRITICAL_PORT_DOWN.md\` | \`sw_critical_port_down\` | warn / **critical** (override) | Only fires on ports designated \`critical: true\` in Mist |
| \`SW_VC_PORT_DOWN.md\` | \`sw_vc_port_down\` | critical / critical (native match) | Includes VC-split callout and controlled-rejoin guidance |
| \`GW_BGP_NEIGHBOR_DOWN.md\` | \`gw_bgp_neighbor_down\` | warn / **critical** (override) | SSR PCLI (not Junos); explicit BGP ≠ SVR peer-path callout. SRX variant flagged Phase 2 |
| \`_shared_common.md\` | — | — | Ticket fields, GUI paths, CLI references, escalation ladder |

## Test plan

- [ ] Verify all 5 files render correctly in the GitHub file browser (tables, escaped pipes, headings)
- [ ] Confirm Mist alarm keys match the current \`alarm_definitions\` catalog (verified at commit time — re-verify if merging much later)
- [ ] NOC review: severity overrides align with local Mist alarm-template configuration