### PR TITLE
docs(noc-runbooks): trim shared appendix, rewrite BGP runbook for SVR

### DIFF
--- a/documentation/noc-runbooks/GW_BGP_NEIGHBOR_DOWN.md
+++ b/documentation/noc-runbooks/GW_BGP_NEIGHBOR_DOWN.md
@@ -6,18 +6,23 @@
 |---|---|
 | **Alert Name** | GW_BGP_NEIGHBOR_DOWN |
 | **Mist alarm key** | `gw_bgp_neighbor_down` |
-| **Platform** | Juniper SSR1300 (Session Smart Router). The same alarm key also fires on SRX gateways — an SRX-specific runbook is planned as Phase 2 because the CLI (Junos) differs from SSR PCLI. |
+| **Platform** | Juniper SSR130 (single gateway at a retail branch — no local HA peer). The BGP peers this branch cares about are the DC hub SSR1300 pair (Dallas + Chicago). The same alarm key also fires on SRX gateways — an SRX-specific runbook is planned as Phase 2 because the CLI (Junos) differs from SSR PCLI. |
 | **Mist native severity** | `warn` |
 | **NOC severity** | **Critical** (override — see rationale below) |
 | **Group** | `infrastructure` |
 | **Clear event key** | `gw_bgp_neighbor_up` |
 | **Correlated alarms** | `bad_wan_uplink`, `intermittent_wan_connectivity`, `vpn_peer_down`, `gw_vpn_path_down`, `vpn_path_down`, `gw_critical_port_down`, `switch_down` |
-| **Prerequisites** | A BGP peer must be configured on the gateway. Alarm fires on BGP session state transition to `Idle` / `Active` / `Connect` (i.e. not `Established`). |
-| **Description** | A configured BGP neighbor on the gateway has left the `Established` state. Depending on the peer's role (underlay ISP, internal route reflector, overlay CE), impact ranges from partial route loss to complete site isolation. |
+| **Prerequisites** | A BGP peer must be configured on the SSR130. In this environment BGP is the **overlay** to the DC hub SSR1300 pair (not typically to the ISP — underlay to ISPs is normally static). Alarm fires on BGP session state transition to `Idle` / `Active` / `Connect` (i.e. not `Established`). |
+| **Description** | A configured BGP neighbor on the SSR130 has left the `Established` state. At a retail branch this is almost always an overlay peer to one of the DC hub SSR1300s (Dallas or Chicago). Losing one hub peer degrades redundancy; losing **both** hub peers isolates the branch's overlay routing entirely. |
 
 ### Severity rationale (Mist `warn` → NOC `critical`)
 
-Mist ships `gw_bgp_neighbor_down` as `warn` because a well-designed BGP topology has redundant peers and a single neighbor down does not always mean loss of reachability. In our environment BGP peers are load-bearing (see peer classification below), so the downstream paging layer escalates this alarm to **critical**. The override is enforced in our webhook consumer / paging tier, not in Mist (Mist alarm templates cannot change severity — see Shared Appendix §2). If a specific peer is truly non-critical (test lab, decommissioning window), suppress it downstream by device role or site tag.
+Mist ships `gw_bgp_neighbor_down` as `warn` on the assumption that BGP topologies are redundant. In this environment the branch SSR130 typically peers with **two** DC-hub SSR1300s (Dallas + Chicago), so losing one is degraded-but-serving. However:
+
+- **Single branch SSR130** — there is no local HA peer. Any BGP problem on the branch gateway is the branch gateway's problem alone.
+- **Both hub peers going down** isolates the branch's overlay routing entirely, so a single-peer alarm is a leading indicator we need to see immediately.
+
+The downstream paging/ticketing tier escalates this alarm to **critical** on that basis. The override lives in the webhook consumer / paging tier, not in Mist (Mist alarm templates cannot change severity — see Shared Appendix §2). If a specific peer is truly non-critical (test lab, decommissioning window), suppress it downstream by device role or site tag.
 
 ### BGP vs SVR — two independent overlays on SSR
 
@@ -38,16 +43,15 @@ The two often correlate: a shared WAN transport can bring both down at once. Val
 
 **Direct (BGP):**
 
-- Loss of routes learned from or advertised to the affected peer.
-- If underlay ISP peer: potential loss of internet or WAN transport for the site.
-- If internal RR peer: loss of overlay route learning from a portion of the fabric.
-- If overlay CE peer: reachability to that specific customer edge is lost.
-- Applications relying on routes advertised by the peer may become unreachable.
-- If the BGP peer is the only path, complete site isolation until an alternate path is available.
+- Loss of routes learned from or advertised to the affected DC-hub peer.
+- **One hub peer down (Dallas or Chicago):** overlay routing continues via the surviving hub; branch stays up but is one failure away from full overlay isolation.
+- **Both hub peers down:** the branch loses overlay reachability entirely; DC-hosted apps become unreachable even if the underlay ISP link is up.
+- Applications relying on routes advertised by the peer(s) may become unreachable.
+- Because there is only a single SSR130 at the branch, there is no gateway-side redundancy to fall back on — any BGP problem here is branch-scope.
 
 **Correlated (SVR):**
 
-- If BGP and SVR share the affected transport, SVR peer paths may also reconverge or fail — this will surface as a **separate** `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` alarm. Validate SVR independently rather than assuming it followed BGP's state.
+- If BGP and SVR share the affected WAN transport, SVR peer paths to the same DC hub may also reconverge or fail — this will surface as a **separate** `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` alarm. Validate SVR independently rather than assuming it followed BGP's state.
 
 ## Required Information
 
@@ -56,12 +60,13 @@ The two often correlate: a shared WAN transport can bring both down at once. Val
 | Category | Data to capture |
 |---|---|
 | Device | Site, Hostname, Serial Number, SSR software version, Mist device ID |
-| Peer classification | `underlay-ISP` / `internal-RR` / `overlay-CE` |
+| Peer classification | Which DC hub: `hub-Dallas-SSR1300` / `hub-Chicago-SSR1300`. (In this environment, underlay-ISP BGP is uncommon — verify with your SOR if you see a non-hub peer.) |
+| Hub redundancy state | Is the *other* hub peer (Dallas if this is Chicago, or vice versa) currently `Established`? This tells you whether the branch is degraded-but-serving or overlay-isolated. |
 | BGP peer | Peer IP, Peer AS, Local AS, Address family (inet / inet-vpn / evpn), Import/Export policies |
 | Local transport | Local interface, local transport IP, WAN link (SVR transport name) used to reach the peer |
 | Session state | Last state (`Idle`, `Active`, `Connect`, `OpenSent`, `OpenConfirm`) and last error / notification code |
 | Timeline | Alert timestamp (UTC), last known Established time, recent config changes |
-| Correlated Alarms | Any active alarms on the gateway, upstream ISP link, or peer device in the last 15 min |
+| Correlated Alarms | Any active alarms on the SSR130, on the branch EX4100 VC, on the upstream ISP link, or on the peer DC-hub SSR1300 in the last 15 min |
 
 ### SVR peer path (only if an SVR alarm is co-firing)
 
@@ -111,7 +116,7 @@ If SVR peer paths are healthy while BGP is down, transport is not the root cause
 | Area | Action |
 |---|---|
 | Underlay link | If a WAN link alarm (`bad_wan_uplink`, `intermittent_wan_connectivity`) is co-firing, resolve that first — BGP will re-establish once transport recovers. |
-| Peer device | Verify peer's BGP process is up; on ISP peer, open a ticket with the ISP referencing the peer IP and last-seen timestamp. |
+| Peer device | Verify the DC-hub SSR1300's BGP process is up (check the hub-side runbook / Mist WAN Edges view for that hub). If the hub-side gateway is impaired, coordinate with the hub-side on-call rather than driving from the branch. |
 | Reachability | From SSR, confirm the peer is reachable **from the correct source IP** with `ping <peer-ip> source <local-transport-ip>`. |
 | MTU / TCP MSS | If the session repeatedly reaches `OpenSent` then fails, suspect PMTUD blackhole. Verify path MTU and MSS clamping on the transport. |
 | Timers / graceful restart | If flap coincides with peer maintenance, confirm hold-time, keepalive, and graceful-restart settings match on both ends. |
@@ -132,7 +137,8 @@ If SVR peer paths are healthy while BGP is down, transport is not the root cause
 - Reachability to the peer's transport IP from the correct source succeeds.
 - **The paired clear event `gw_bgp_neighbor_up` has been received.**
 - No recurrence of `gw_bgp_neighbor_down` for this peer within a 30-minute debounce window.
-- Root cause is documented on the ticket, including peer classification and blast radius.
+- The *other* DC-hub peer (whichever of Dallas / Chicago was not the impaired one) is also confirmed `Established` — the branch is back to full 2-hub overlay redundancy, not just single-hub-serving.
+- Root cause is documented on the ticket, including which hub peer was affected (Dallas vs Chicago) and whether the branch was ever in the "both hubs down" isolation state during the incident.
 
 **SVR (only if SVR alarms co-fired):**
 
@@ -198,20 +204,21 @@ See Shared Appendix §7 for the full SSR PCLI reference.
 
 ## Cross-references (sibling alarms)
 
-If any of these are co-firing, resolve the co-fired alarm first — it is usually root cause:
+If any of these are co-firing, resolve the co-fired alarm first — it is usually root cause. Because the branch has a single SSR130 (no local HA), *any* gateway-side symptom here is branch-scope; coordinate with the hub-side on-call if the impairment is on the DC hub SSR1300's side of the peering:
 
-- `bad_wan_uplink` — underlying transport failure (Marvis)
-- `intermittent_wan_connectivity` — flaky underlay
-- `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` — SVR peer-path issues (distinct from BGP; follow the SVR runbook, not this one)
-- `gw_critical_port_down` — physical port serving the peer transport is down
-- `switch_down` — upstream L2/L3 switch is down
+- `bad_wan_uplink` — underlying transport failure (Marvis). Common shared root cause with SVR peer-path alarms.
+- `intermittent_wan_connectivity` — flaky underlay. Expect BGP to flap in step with the underlay.
+- `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` — SVR peer-path issues (distinct from BGP; follow the SVR runbook, not this one). Same DC-hub SSR1300 endpoints, different overlay layer.
+- `gw_critical_port_down` — physical port on the SSR130 serving the peer transport is down. Fix the port before chasing BGP.
+- `switch_down` — upstream EX4100 VC (or a member) is down; if the SSR130's LAN-side transport rides that VC, BGP can go with it.
 
 ## Escalation
 
-Per Shared Appendix §8. Tier 1 NOC can self-clear underlay-transport, reachability, and rollback-driven root causes. Escalate to Tier 2 for:
+Per Shared Appendix §8. Tier 1 NOC can self-clear underlay-transport, reachability, and rollback-driven root causes on the branch SSR130. Escalate to Tier 2 for:
 
-- Routing policy / prefix-limit changes
-- MD5 secret rotation
-- MTU/PMTUD suspected blackholes
-- Any ISP-side ticket handoff
+- Routing policy / prefix-limit changes on either the branch SSR130 or the DC-hub SSR1300
+- MD5 secret rotation (must be coordinated with the hub-side on-call)
+- MTU/PMTUD suspected blackholes on the underlay
+- Any ISP-side ticket handoff on the underlying transport
 - Configuration restore that spans multiple devices
+- **Both hub peers (Dallas + Chicago) down simultaneously** — branch overlay is isolated; page hub-side on-call in parallel and treat as a site outage, not a single-peer alarm.

--- a/documentation/noc-runbooks/GW_BGP_NEIGHBOR_DOWN.md
+++ b/documentation/noc-runbooks/GW_BGP_NEIGHBOR_DOWN.md
@@ -17,41 +17,67 @@
 
 ### Severity rationale (Mist `warn` → NOC `critical`)
 
-Mist ships `gw_bgp_neighbor_down` as `warn` because a well-designed BGP topology has redundant peers and a single neighbor down does not always mean loss of reachability. In our environment BGP peers are load-bearing (see Peer classification below), so we escalate to **critical**. If a specific peer is truly non-critical (test lab, decommissioning window), retune via a per-site alarm template rather than lowering the runbook default.
+Mist ships `gw_bgp_neighbor_down` as `warn` because a well-designed BGP topology has redundant peers and a single neighbor down does not always mean loss of reachability. In our environment BGP peers are load-bearing (see peer classification below), so the downstream paging layer escalates this alarm to **critical**. The override is enforced in our webhook consumer / paging tier, not in Mist (Mist alarm templates cannot change severity — see Shared Appendix §2). If a specific peer is truly non-critical (test lab, decommissioning window), suppress it downstream by device role or site tag.
 
-### BGP ≠ SVR — do not confuse them
+### BGP vs SVR — two independent overlays on SSR
 
-On SSR, **BGP** and **SVR (Session Smart Routing / peer paths)** are two independent overlays. This alarm is for the underlying **BGP** control plane only.
+**This runbook is for BGP only.** On SSR gateways, BGP (control plane) and SVR / Session Smart Routing (data plane peer paths) are two independent overlays. SVR peer-path outages fire under different alarm keys and have their own runbook — do not conflate them.
 
-- If SVR peer paths are down, look for `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` — those are separate alarms with a separate runbook.
-- BGP can be `Established` while SVR peer paths are down, and vice-versa.
-- On SSR, use `show bgp …` for BGP and `show peers` for SVR. Do not mix.
+| Concern | BGP (this alarm) | SVR / peer paths (separate alarms) |
+|---|---|---|
+| Alarm keys | `gw_bgp_neighbor_down` (+ `gw_bgp_neighbor_up` clear) | `vpn_peer_down`, `gw_vpn_path_down`, `vpn_path_down` |
+| Layer | Control plane — exchanges routes | Data plane — forwards session-oriented traffic between SSRs |
+| Transport | TCP/179 to peer IP over an underlay interface | UDP-based Secure Vector Routing between SSRs over one or more transports |
+| Independence | BGP can be `Established` while SVR peer paths are down | SVR peer paths can be `up` while BGP is down |
+| SSR command | `show bgp summary`, `show bgp neighbor <peer-ip>` | `show peers` |
+| Mist GUI | BGP state is not surfaced in a dedicated view — use PCLI | WAN Assurance → Peer Path Insights |
+
+The two often correlate: a shared WAN transport can bring both down at once. Validate each separately with its own commands.
 
 ## Impact
+
+**Direct (BGP):**
 
 - Loss of routes learned from or advertised to the affected peer.
 - If underlay ISP peer: potential loss of internet or WAN transport for the site.
 - If internal RR peer: loss of overlay route learning from a portion of the fabric.
 - If overlay CE peer: reachability to that specific customer edge is lost.
-- Session Smart Routing (SVR) tunnels riding the affected transport may reconverge or fail.
 - Applications relying on routes advertised by the peer may become unreachable.
 - If the BGP peer is the only path, complete site isolation until an alternate path is available.
 
+**Correlated (SVR):**
+
+- If BGP and SVR share the affected transport, SVR peer paths may also reconverge or fail — this will surface as a **separate** `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` alarm. Validate SVR independently rather than assuming it followed BGP's state.
+
 ## Required Information
+
+### BGP peer (always capture)
 
 | Category | Data to capture |
 |---|---|
 | Device | Site, Hostname, Serial Number, SSR software version, Mist device ID |
-| Peer classification | `underlay-ISP` / `internal-RR` / `overlay-CE` (see Shared Appendix §5) |
+| Peer classification | `underlay-ISP` / `internal-RR` / `overlay-CE` |
 | BGP peer | Peer IP, Peer AS, Local AS, Address family (inet / inet-vpn / evpn), Import/Export policies |
 | Local transport | Local interface, local transport IP, WAN link (SVR transport name) used to reach the peer |
 | Session state | Last state (`Idle`, `Active`, `Connect`, `OpenSent`, `OpenConfirm`) and last error / notification code |
 | Timeline | Alert timestamp (UTC), last known Established time, recent config changes |
 | Correlated Alarms | Any active alarms on the gateway, upstream ISP link, or peer device in the last 15 min |
 
-See Shared Appendix §7 for the always-required ticket fields.
+### SVR peer path (only if an SVR alarm is co-firing)
+
+| Category | Data to capture |
+|---|---|
+| Local SSR | Router name, node name |
+| Remote SSR | Peer router name, peer node name |
+| Transport | Which named WAN transport(s) the peer path uses (name from `show peers`) |
+| Path state | Per-transport `up` / `down` / `standby` status |
+| Timeline | Last state change per transport |
+
+See Shared Appendix §5 for the always-required ticket fields.
 
 ## Validation
+
+### BGP session checks (this alarm)
 
 | Check | Command / Action |
 |---|---|
@@ -63,15 +89,22 @@ See Shared Appendix §7 for the always-required ticket fields.
 | Received routes from peer | `show bgp neighbor <peer-ip> received-routes` |
 | Advertised routes to peer | `show bgp neighbor <peer-ip> advertised-routes` |
 | Routing table (does peer's prefix appear?) | `show route` |
-| SVR peer paths (separate from BGP) | `show peers` |
-| Active sessions on device | `show sessions summary` |
 | Physical / logical interface state | `show device-interface` and `show network-interface` |
 | Reachability to peer using correct source | `ping <peer-ip> source <local-transport-ip>` |
 | Path to peer | `traceroute <peer-ip>` |
 | Alarms on device | `show alarms` |
 | BGP-scoped event log | `show events filter type bgp` |
 
-**Never** run a bare `ping <peer-ip>` on SSR — it may egress from the wrong interface and produce a false-negative. Always pin the source with `source <local-transport-ip>`. See Shared Appendix §9.
+**Never** run a bare `ping <peer-ip>` on SSR — it may egress from the wrong interface and produce a false-negative. Always pin the source with `source <local-transport-ip>`. See Shared Appendix §7.
+
+### SVR peer-path checks (only if correlated SVR alarm is active, or the shared transport is suspect)
+
+| Check | Command / Action |
+|---|---|
+| Peer path status per transport | `show peers` |
+| Peer path in Mist | WAN Assurance → Peer Path Insights → filter by device |
+
+If SVR peer paths are healthy while BGP is down, transport is not the root cause — investigate BGP-specific causes (policy, MD5, peer-side process). If SVR paths are also down on the same transport, treat the shared transport as the primary suspect and prioritize the underlay-link alarms (`bad_wan_uplink`, `intermittent_wan_connectivity`).
 
 ## Resolution
 
@@ -87,54 +120,81 @@ See Shared Appendix §7 for the always-required ticket fields.
 | Firewall / policy | On SSR the peer path traverses a tenant / service-route / security policy — verify these were not recently changed. On an SRX gateway, verify a stateful firewall rule permits TCP/179 in both directions. |
 | Configuration | Review Mist audit logs for BGP or interface config changes in the last 24 h. Rollback if a recent change caused the outage. |
 | Clear session (last resort) | Only after other causes are ruled out and with change approval, bounce the neighbor to force renegotiation. |
-| Recovery | Confirm BGP peer transitions back to `Established`, expected prefixes are relearned, and the paired clear event has fired. |
+| Recovery (BGP) | Confirm BGP peer transitions back to `Established`, expected prefixes are relearned, and the paired clear event has fired. |
+| Recovery (SVR, if it was also affected) | Confirm `show peers` shows the affected peer path back to `up` on the expected transport(s). Do not close the BGP ticket until any SVR peer-path alarm has also cleared. |
 
 ## Closure Criteria
+
+**BGP (required for this alarm):**
 
 - BGP neighbor state is `Established`.
 - Expected prefix counts (received / advertised) match the pre-incident baseline.
 - Reachability to the peer's transport IP from the correct source succeeds.
 - **The paired clear event `gw_bgp_neighbor_up` has been received.**
 - No recurrence of `gw_bgp_neighbor_down` for this peer within a 30-minute debounce window.
-- If SVR peer paths were affected, they are also back to `up` (verified with `show peers`).
 - Root cause is documented on the ticket, including peer classification and blast radius.
 
+**SVR (only if SVR alarms co-fired):**
+
+- `show peers` reports the affected peer path back to `up` on the expected transport(s).
+- The paired SVR clear event(s) have been received on the correlated ticket(s).
+- Close the SVR ticket per its own runbook — do not implicitly close it from this ticket.
+
 ## Mist GUI Navigation
+
+**BGP-related:**
 
 | Task | Navigation |
 |---|---|
 | Verify alert | Monitor → Alerts (Alarms) → filter by `gw_bgp_neighbor_down` |
 | SSR health | WAN Edges → *SSR1300* → Health / Insights |
-| WAN link health | WAN Assurance → WAN Links |
-| SVR peer paths (separate from BGP) | WAN Assurance → Peer Path Insights |
+| WAN link health (shared underlay) | WAN Assurance → WAN Links |
 | Gateway events | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
-**Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`. See Shared Appendix §6.
+**SVR-related (use only when correlating with an SVR alarm):**
+
+| Task | Navigation |
+|---|---|
+| SVR peer paths | WAN Assurance → Peer Path Insights |
+
+**Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`.
 
 ## SSR PCLI Commands (quick reference)
 
 SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
+
+**System / interface:**
 
 | Purpose | Command |
 |---|---|
 | System / model / uptime | `show system` |
 | Conductor / cloud connectivity | `show system connected` |
 | Alarms | `show alarms` |
-| BGP summary | `show bgp summary` |
-| BGP peer detail | `show bgp neighbor <peer-ip>` |
-| BGP received routes | `show bgp neighbor <peer-ip> received-routes` |
-| BGP advertised routes | `show bgp neighbor <peer-ip> advertised-routes` |
-| SVR peer paths (overlay) | `show peers` |
-| Session count | `show sessions summary` |
 | Device interfaces (physical) | `show device-interface` |
 | Network interfaces (logical) | `show network-interface` |
 | Routing table | `show route` |
 | Reachability with correct source | `ping <peer-ip> source <local-transport-ip>` |
 | Path to peer | `traceroute <peer-ip>` |
+
+**BGP (this alarm):**
+
+| Purpose | Command |
+|---|---|
+| BGP summary | `show bgp summary` |
+| BGP peer detail | `show bgp neighbor <peer-ip>` |
+| BGP received routes | `show bgp neighbor <peer-ip> received-routes` |
+| BGP advertised routes | `show bgp neighbor <peer-ip> advertised-routes` |
 | BGP event log | `show events filter type bgp` |
 
-See Shared Appendix §9 for the full SSR PCLI reference.
+**SVR (only for correlated peer-path checks — SVR outages are separate alarms):**
+
+| Purpose | Command |
+|---|---|
+| SVR peer paths (all peers, all transports) | `show peers` |
+| Active sessions on device | `show sessions summary` |
+
+See Shared Appendix §7 for the full SSR PCLI reference.
 
 ## Cross-references (sibling alarms)
 
@@ -142,13 +202,13 @@ If any of these are co-firing, resolve the co-fired alarm first — it is usuall
 
 - `bad_wan_uplink` — underlying transport failure (Marvis)
 - `intermittent_wan_connectivity` — flaky underlay
-- `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` — SVR peer path issues (distinct from BGP)
+- `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` — SVR peer-path issues (distinct from BGP; follow the SVR runbook, not this one)
 - `gw_critical_port_down` — physical port serving the peer transport is down
 - `switch_down` — upstream L2/L3 switch is down
 
 ## Escalation
 
-Per Shared Appendix §10. Tier 1 NOC can self-clear underlay-transport, reachability, and rollback-driven root causes. Escalate to Tier 2 for:
+Per Shared Appendix §8. Tier 1 NOC can self-clear underlay-transport, reachability, and rollback-driven root causes. Escalate to Tier 2 for:
 
 - Routing policy / prefix-limit changes
 - MD5 secret rotation

--- a/documentation/noc-runbooks/SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md
+++ b/documentation/noc-runbooks/SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md
@@ -6,38 +6,41 @@
 |---|---|
 | **Alert Name** | SW_ALARM_CHASSIS_MGMT_LINK_DOWN |
 | **Mist alarm key** | `sw_alarm_chassis_mgmt_link_down` |
-| **Platform** | Juniper Mist EX Series Switch |
+| **Platform** | Juniper EX4100 Virtual Chassis (2-member pair at a retail branch). Standalone EX4100 uses `me0`; a VC uses `vme`. |
 | **Mist native severity** | `warn` |
 | **NOC severity** | **Critical** (override — see rationale below) |
 | **Group** | `infrastructure` |
 | **Clear event key** | `sw_alarm_chassis_mgmt_link_down_clear` |
 | **Correlated alarms** | `switch_down`, `vc_master_changed`, `vc_backup_failed`, `sw_alarm_chassis_pem`, `sw_alarm_chassis_psu` |
 | **Prerequisites** | None — fires automatically when the dedicated management (`me0` / `vme`) interface goes down. |
-| **Description** | The dedicated chassis management Ethernet link is down. Remote management via the out-of-band management network may be unavailable. Data forwarding on production interfaces may continue if only the management interface has failed. |
+| **Description** | The dedicated chassis management Ethernet link is down. On the retail-branch EX4100 VC this is the `vme` (VC-shared virtual management) interface, backed by the current master's physical `me0` port. Remote management via the out-of-band management network may be unavailable. Data forwarding on production interfaces (uplink to SSR130, downstream AP / POS / user ports) may continue if only the management interface has failed. |
 
 ### Severity rationale (Mist `warn` → NOC `critical`)
 
-Mist ships this alarm at `warn` because the production data plane typically keeps forwarding when only `me0`/`vme` drops. We escalate to **critical** because loss of out-of-band management removes our ability to remediate the device if a production-side issue subsequently develops. If you are running with no OOB dependency (in-band management only), consider aligning the NOC severity back to `warn`.
+Mist ships this alarm at `warn` because the production data plane typically keeps forwarding when only `me0`/`vme` drops. We escalate to **critical** because loss of out-of-band management removes our ability to remediate the switch if a production-side issue develops on top of it — and at a single-SSR retail branch, in-band remote access rides the very uplink most likely to fail next.
+
+**Retail-branch note:** many of our retail sites have no separate OOB management network — mgmt rides the same site LAN as production. In that case there is no independent path to lose, and `warn` is appropriate. Confirm the branch's OOB posture with your SOR before treating this as `critical`.
 
 ## Impact
 
-- Loss of out-of-band management connectivity.
-- Unable to reach the switch through the MGMT interface (`me0` on standalone, `vme` on Virtual Chassis).
+- Loss of out-of-band management connectivity to the branch EX4100 VC (if the branch has an OOB path).
+- Unable to reach the switch through the MGMT interface — `vme` on the 2-member VC (backed by whichever member is currently master).
 - Potential loss of remote monitoring paths that depend on the OOB network.
-- Data forwarding on production ports may continue normally.
-- Delayed troubleshooting if in-band remote access becomes unavailable.
-- On a Virtual Chassis, if the master's `me0` drops, VME may fail over to another member — verify which member is currently master.
+- Data forwarding on production ports (uplink to SSR130, AP / POS / user ports) usually continues normally.
+- Delayed troubleshooting if in-band remote access — which at most retail branches rides the same LAN — becomes unavailable.
+- **VC-specific:** if the master's `me0` drops, `vme` can fail over to the backup member's `me0`. Check `show virtual-chassis` for the current master; the outage may effectively resolve itself if the peer member's `me0` is healthy.
 
 ## Required Information
 
 | Category | Data to capture |
 |---|---|
-| Device | Site, Hostname, Serial Number, Software Version, Mist device ID |
-| Management | MGMT IP, Gateway, VLAN (if applicable), Link Status, `me0` vs `vme` |
-| Physical | Connected management switch/router, cable, port |
-| Virtual Chassis | VC role of affected member (master / backup / linecard); is `vme` still reachable via another member? |
+| Device | Site, Hostname, Serial Number, Junos version, Mist device ID (both VC members) |
+| Management | MGMT IP, Gateway, VLAN (if applicable), Link Status. **Always `vme` on the retail branch VC** — capture which member's `me0` currently backs it. |
+| Physical | Connected upstream device / port for the master's `me0`, and for the backup's `me0` if wired. Cable / patch panel path. |
+| Virtual Chassis | Current master / backup roles (`show virtual-chassis`); is `vme` still reachable via the peer member's `me0`? |
+| OOB context | Does this branch have a dedicated OOB path, or is management in-band? (Determines effective severity.) |
 | Timeline | Alert time (UTC), recent changes (last 24 h), audit logs |
-| Correlated Alarms | Any active alarms on the device or its management upstream within the last 15 min |
+| Correlated Alarms | Any active alarms on the VC or the SSR130 in the last 15 min (particularly `sw_vc_port_down`, `vc_master_changed`, `switch_down`) |
 
 See Shared Appendix §5 for the always-required ticket fields.
 
@@ -46,14 +49,15 @@ See Shared Appendix §5 for the always-required ticket fields.
 | Check | Command / Action |
 |---|---|
 | Switch reachable in Mist? | Mist UI → Switches → *device* → Health |
-| Management interface state (standalone) | `show interfaces me0` |
-| Management interface state (VC) | `show interfaces vme` |
-| Chassis and VC role | `show virtual-chassis` and `show chassis hardware` |
+| Virtual Chassis management interface | `show interfaces vme` |
+| Underlying master `me0` | `show interfaces me0` (run on the current master member) |
+| Backup member `me0` (fallback path) | `show interfaces me0` from the backup — is its `me0` wired and up? |
+| VC roles and members | `show virtual-chassis` and `show chassis hardware` |
 | Management routing | `show route table inet.0 <management-gateway>` |
 | Peer switch/router port state | Verify management switch port is up (via that device) |
-| Recent logs (interface-scoped) | `show log messages \| match me0` (or `vme`) |
+| Recent logs (interface-scoped) | `show log messages \| match vme` (and `me0`) |
 | Chassis alarms | `show chassis alarms` |
-| Reachability from switch | `ping <management-gateway>` and `ping <mist-cloud-reachable-host>` |
+| Reachability from switch | `ping <management-gateway>` |
 
 See Shared Appendix §6 for the full Junos command reference.
 
@@ -61,13 +65,14 @@ See Shared Appendix §6 for the full Junos command reference.
 
 | Area | Action |
 |---|---|
-| Cable | Reseat or replace the management cable. |
+| Fast triage | Check `show virtual-chassis`: if `vme` failed over to the backup member and management is reachable, the alarm may already be resolvable — the underlying `me0` still needs repair, but there is no service impact. |
+| Cable | Reseat or replace the management cable on the affected member's `me0` port. |
 | Remote device | Verify the connected management switch/router port is up and not err-disabled. |
-| Configuration | Verify MGMT IP, gateway, and interface configuration against source-of-truth. |
+| Configuration | Verify `vme` and per-member `me0` config against source-of-truth. |
 | Hardware | Replace failed NIC/port if hardware fault is confirmed (see `show chassis alarms` for physical-layer indicators). |
-| Virtual Chassis | If master role has moved, confirm intended master and re-elect if operationally required (planned change only). |
+| Virtual Chassis | If master role has moved and this is operationally undesired, plan a controlled re-election — do not force one to resolve this alarm. |
 | Audit | Review Mist audit logs for recent changes that may have affected management config. |
-| Recovery | Confirm management interface is up, reachable from the OOB network, and the paired clear event has fired. |
+| Recovery | Confirm management interface is up, reachable from the OOB network (or from the branch LAN if in-band), and the paired clear event has fired. |
 
 ## Closure Criteria
 

--- a/documentation/noc-runbooks/SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md
+++ b/documentation/noc-runbooks/SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md
@@ -39,7 +39,7 @@ Mist ships this alarm at `warn` because the production data plane typically keep
 | Timeline | Alert time (UTC), recent changes (last 24 h), audit logs |
 | Correlated Alarms | Any active alarms on the device or its management upstream within the last 15 min |
 
-See Shared Appendix §7 for the always-required ticket fields.
+See Shared Appendix §5 for the always-required ticket fields.
 
 ## Validation
 
@@ -55,7 +55,7 @@ See Shared Appendix §7 for the always-required ticket fields.
 | Chassis alarms | `show chassis alarms` |
 | Reachability from switch | `ping <management-gateway>` and `ping <mist-cloud-reachable-host>` |
 
-See Shared Appendix §8 for the full Junos command reference.
+See Shared Appendix §6 for the full Junos command reference.
 
 ## Resolution
 
@@ -87,8 +87,6 @@ See Shared Appendix §8 for the full Junos command reference.
 | Events (raw) | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
-See Shared Appendix §6 for full GUI navigation reference.
-
 ## Junos Commands (quick reference)
 
 | Purpose | Command |
@@ -107,4 +105,4 @@ See Shared Appendix §6 for full GUI navigation reference.
 
 ## Escalation
 
-Per Shared Appendix §10. Tier 1 NOC can self-clear cable, port, and configuration causes. Escalate to Tier 2 for hardware replacement, VC master election changes, or when the OOB management upstream is itself impaired.
+Per Shared Appendix §8. Tier 1 NOC can self-clear cable, port, and configuration causes. Escalate to Tier 2 for hardware replacement, VC master election changes, or when the OOB management upstream is itself impaired.

--- a/documentation/noc-runbooks/SW_CRITICAL_PORT_DOWN.md
+++ b/documentation/noc-runbooks/SW_CRITICAL_PORT_DOWN.md
@@ -36,7 +36,7 @@ Mist ships this as `warn` because port-down events span a wide impact range. Bec
 | Category | Data to capture |
 |---|---|
 | Device | Site Name, Hostname, Serial Number, Junos Version, Mist device ID |
-| Port classification | `access` / `uplink` / `IDF-MDF` / `server-edge` / `AP` / `VCP` / `LAG-member` (see Shared Appendix §5) |
+| Port classification | `access` / `uplink` / `IDF-MDF` / `server-edge` / `AP` / `VCP` / `LAG-member` |
 | Interface | Interface Name, Description, Admin Status, Oper Status, VLAN(s), Speed, Duplex |
 | Connected device | LLDP neighbor, MAC address, previous known device |
 | Optics (if fiber) | Media type, DDM Tx/Rx power, laser bias, temperature |
@@ -62,7 +62,7 @@ Mist ships this as `warn` because port-down events span a wide impact range. Bec
 | Logs (interface-scoped) | `show log messages \| match <interface>` |
 | Ping neighbor (if L3) | `ping <neighbor-ip>` |
 
-See Shared Appendix §8 for the full Junos command reference.
+See Shared Appendix §6 for the full Junos command reference.
 
 ## Resolution
 
@@ -99,8 +99,6 @@ See Shared Appendix §8 for the full Junos command reference.
 | Switch events | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
-See Shared Appendix §6 for full GUI navigation reference.
-
 ## Junos Commands (quick reference)
 
 | Purpose | Command |
@@ -135,4 +133,4 @@ If the current alarm co-fires with any of these, resolve the co-fired alarm firs
 
 ## Escalation
 
-Per Shared Appendix §10. Tier 1 NOC can self-clear cable, optic, and remote-device causes. Escalate to Tier 2 for hardware replacement or when the port is part of an EVPN fabric with unclear failover behavior.
+Per Shared Appendix §8. Tier 1 NOC can self-clear cable, optic, and remote-device causes. Escalate to Tier 2 for hardware replacement or when the port is part of an EVPN fabric with unclear failover behavior.

--- a/documentation/noc-runbooks/SW_CRITICAL_PORT_DOWN.md
+++ b/documentation/noc-runbooks/SW_CRITICAL_PORT_DOWN.md
@@ -8,14 +8,14 @@
 |---|---|
 | **Alert Name** | SW_CRITICAL_PORT_DOWN |
 | **Mist alarm key** | `sw_critical_port_down` |
-| **Platform** | Juniper Mist EX Series Switch (validated against EX4400) |
+| **Platform** | Juniper EX4100 (2-member Virtual Chassis at a retail branch — typically EX4100-48P for PoE). |
 | **Mist native severity** | `warn` |
 | **NOC severity** | **Critical** (override — see rationale below) |
 | **Group** | `infrastructure` |
 | **Clear event key** | `sw_critical_port_up` |
 | **Correlated alarms** | `port_flap`, `port_stuck`, `bad_cable`, `sw_bad_optics`, `sw_negotiation_incomplete`, `sw_mtu_mismatch`, `sw_port_storm_control`, `switch_down`, `ap_offline` |
-| **Prerequisites** | **The port must be flagged as "critical" in the Mist port profile.** Without this flag the alarm will not fire. Configure via Site → Switch → Port Configuration → *Critical Port*, or via port profile template. |
-| **Description** | An EX physical or logical port marked as **critical** has transitioned to the Down state. Critical ports typically include uplinks, IDF/MDF links, LAG members, and ports serving essential downstream devices (APs, IP phones, servers, downstream switches). The failure of a critical port implies loss of connectivity for connected devices or network services. |
+| **Prerequisites** | **The port must be flagged as "critical" in the Mist port profile.** Without this flag the alarm will not fire. Configure via Site → Switch → Port Configuration → *Critical Port*, or via port profile template. At a retail branch, ports typically flagged critical are: the uplink LAG to the SSR130, PoE-served AP ports, POS terminal ports, IP-phone ports, and any back-office server port. |
+| **Description** | An EX4100 physical or logical port marked as **critical** has transitioned to Down. At a retail branch the impact of a critical-port failure is typically visible to the store immediately — an AP drops, a POS lane stops taking cards, a phone goes offline, or in the worst case the uplink to the SSR130 loses a member and store traffic reconverges (or, if the uplink is a single link rather than a LAG, the store loses WAN). |
 
 ### Severity rationale (Mist `warn` → NOC `critical`)
 
@@ -24,24 +24,24 @@ Mist ships this as `warn` because port-down events span a wide impact range. Bec
 ## Impact
 
 - Loss of endpoint or uplink connectivity for the affected port.
-- Client, AP, IP phone, or downstream switch may become unreachable.
+- **Uplink to SSR130.** If the port is a member of the LAG to the SSR130, the LAG loses a member and forwards on the survivor; if the LAG is down to zero members (or the uplink is a single link), the branch loses WAN.
+- **Downstream device offline.** A critical port serving a Mist AP, POS terminal, IP phone, or back-office server takes that device offline. In a store this is user-visible immediately.
 - Potential loss of VLAN or trunk connectivity if the port is a trunk.
-- LACP bundle degradation if the port is a LAG member.
-- Reduced network redundancy on the affected fabric segment.
-- Possible site outage if the port is the sole/primary uplink.
-- If the port is a member of an ESI-LAG in an EVPN fabric, traffic reconverges via the peer, but redundancy is degraded.
+- LACP bundle degradation if the port is a LAG member (uplink or member-to-server bundle).
+- Reduced fabric redundancy on the affected segment.
+- PoE loss on the affected port for AP / phone / camera endpoints.
 
 ## Required Information
 
 | Category | Data to capture |
 |---|---|
-| Device | Site Name, Hostname, Serial Number, Junos Version, Mist device ID |
-| Port classification | `access` / `uplink` / `IDF-MDF` / `server-edge` / `AP` / `VCP` / `LAG-member` |
-| Interface | Interface Name, Description, Admin Status, Oper Status, VLAN(s), Speed, Duplex |
-| Connected device | LLDP neighbor, MAC address, previous known device |
+| Device | Site Name, Hostname (which EX4100 member), Serial Number, Junos Version, Mist device ID |
+| Port classification | `uplink-to-SSR130` / `AP` / `POS` / `IP-phone` / `server` / `back-office` / `access` / `VCP` / `LAG-member` |
+| Interface | Interface Name (e.g. `ge-0/0/47`, `xe-0/2/0`), Description, Admin Status, Oper Status, VLAN(s), Speed, Duplex, PoE state (if applicable) |
+| Connected device | LLDP neighbor (SSR130 hostname if uplink, AP name if AP), MAC address, previous known device |
 | Optics (if fiber) | Media type, DDM Tx/Rx power, laser bias, temperature |
 | Timeline | Alert timestamp (UTC), recent configuration changes, related audit log entries |
-| Correlated Alarms | Any active alarms on the device or connected downstream device in the last 15 min |
+| Correlated Alarms | Any active alarms on the EX4100 or on the connected downstream device (e.g. `ap_offline`) in the last 15 min |
 
 ## Validation
 
@@ -133,4 +133,4 @@ If the current alarm co-fires with any of these, resolve the co-fired alarm firs
 
 ## Escalation
 
-Per Shared Appendix §8. Tier 1 NOC can self-clear cable, optic, and remote-device causes. Escalate to Tier 2 for hardware replacement or when the port is part of an EVPN fabric with unclear failover behavior.
+Per Shared Appendix §8. Tier 1 NOC can self-clear cable, optic, and remote-device causes. Escalate to Tier 2 for hardware replacement, or when the affected port is a member of the uplink LAG to the SSR130 and the LAG is currently at zero surviving members (store WAN down).

--- a/documentation/noc-runbooks/SW_VC_PORT_DOWN.md
+++ b/documentation/noc-runbooks/SW_VC_PORT_DOWN.md
@@ -7,14 +7,14 @@
 | **Alert Name** | SW_VC_PORT_DOWN |
 | **Mist alarm key** | `sw_vc_port_down` |
 | **Mist display name** | Virtual Chassis Port Down |
-| **Platform** | Juniper Mist EX Series switches configured as a Virtual Chassis (VC) — e.g. EX4400 VC |
+| **Platform** | Juniper EX4100 Virtual Chassis (2-member pair at a retail branch — master + backup only, no linecard members). |
 | **Mist native severity** | `critical` |
 | **NOC severity** | **Critical** (native — no override) |
 | **Group** | `infrastructure` |
 | **Clear event key** | `sw_vc_port_up` |
 | **Correlated alarms** | `vc_master_changed`, `vc_backup_failed`, `vc_member_deleted`, `vc_member_restarted`, `switch_down`, `sw_alarm_chassis_mgmt_link_down` |
-| **Prerequisites** | The switch must be part of a Virtual Chassis (2+ members). Alarm fires when a VC port (VCP) between members goes down. Standalone switches cannot fire this alarm. |
-| **Description** | A Virtual Chassis (VC) port has transitioned to the Down state. VCPs form the interconnect fabric between VC members. Failure impacts inter-member communication, redundancy, and Virtual Chassis stability — a full VCP outage can split the VC into isolated fragments. |
+| **Prerequisites** | The switch must be part of a Virtual Chassis. On the retail-branch EX4100 pair this is always a 2-member VC. Alarm fires when a VC port (VCP) between the two members goes down. Standalone switches cannot fire this alarm. |
+| **Description** | A Virtual Chassis (VC) port between the two EX4100 members has transitioned to Down. VCPs form the inter-member interconnect. On a 2-member VC there is no third path to lean on: **if the branch is provisioned with only one VCP link between the members, this alarm is a pre-split warning**; if there is more than one VCP link, redundancy is degraded but the VC stays intact. |
 
 ### Severity note (no override)
 
@@ -23,23 +23,23 @@ Unlike most `warn`-shipped port alarms, Mist ships `sw_vc_port_down` as `critica
 ## Impact
 
 - Loss of Virtual Chassis redundancy on the affected VCP link.
-- **Potential Virtual Chassis split** — if the VC has only one VCP path between two members (no redundant VCPs), losing it partitions the chassis into isolated islands, each running its own control plane.
-- Reduced fabric switching capacity between VC members.
-- Loss of resiliency for links that use LAGs spanning VC members (member-to-member load-share breaks).
-- Downstream connectivity issues for clients whose traffic egresses through the failed inter-member path.
-- Potential service disruption during master/backup failover if the master election path is affected.
+- **Immediate VC split risk (2-member VC).** With only master + backup, if the site is wired with a single VCP link between them, losing it partitions the chassis into two isolated single-member fragments — each attempts to run its own control plane. If the site is wired with redundant VCPs (recommended), the VC survives the loss of one but is now unprotected against a second failure.
+- Reduced fabric switching capacity between the two members.
+- LAG bundles that span both members (e.g. the uplink to SSR130 built as a member-1 + member-2 LAG) lose the ability to load-share across members — the surviving link on each fragment continues to forward, but not as a bundle.
+- Downstream connectivity issues for clients whose traffic must egress through the peer member (e.g. AP or POS terminal on member-1 whose only path to the SSR130 uplink lives on member-2).
+- Potential service disruption during master/backup failover if the master-election path is affected.
 - Stale MAC/ARP entries until the fabric reconverges.
 
 ## Required Information
 
 | Category | Data to capture |
 |---|---|
-| Device | Site, Virtual Chassis name, Switch hostname, Serial Number, Junos version, Mist device ID |
-| VC context | VC member ID (FPC number), member role (master / backup / linecard), total member count |
-| VC port | VCP name (`vcp-0`, `vcp-255/1/0`, or dedicated VCP port), Interface status, Connected member (peer FPC) |
-| Physical | DAC / fiber / SFP type, cable condition, is this a dedicated VCP or a converted network port |
+| Device | Site, Virtual Chassis name, both member hostnames, both serial numbers, Junos version, Mist device IDs |
+| VC context | Which member (FPC 0 vs FPC 1) is currently master vs backup; total member count should be exactly 2 |
+| VC port | VCP name (dedicated rear VCP on EX4100, or a converted network port), interface status, which member the peer end is on |
+| Physical | DAC / fiber / SFP type; cable condition; is this a dedicated VCP port or a network port converted to VCP; is a second VCP link wired for redundancy? |
 | Timeline | Alert timestamp (UTC), recent VC config changes, member reboots, audit log entries |
-| Correlated Alarms | Any active alarms on any VC member (or a co-fired `vc_master_changed` / `vc_member_deleted`) in the last 15 min |
+| Correlated Alarms | Any active alarms on either VC member (particularly a co-fired `vc_master_changed` / `vc_member_deleted` / `switch_down`) in the last 15 min |
 
 See Shared Appendix §5 for the always-required ticket fields.
 
@@ -68,21 +68,21 @@ See Shared Appendix §6 for the full Junos command reference.
 |---|---|
 | Cable / DAC | Reseat or replace the VC cable / DAC. VC uses direct-attach copper or fiber depending on the VCP type — verify compatible cable spec (length, gauge, vendor). |
 | Optics (fiber VCP) | Verify compatible optics on both ends; check DDM levels are within manufacturer spec. Replace faulty transceiver if DDM is out of range. |
-| Member status | Confirm both VC members are online, powered, and reachable. If a member is down, resolve that first — the VCP alarm is a symptom, not root cause. |
-| Configuration | Verify VC configuration consistency (VC ID, preprovisioned member roles, VCP assignments). A recent config change that revoked VCP status on a converted port will drop the port from VC. |
-| Hardware | Replace failed VCP port, transceiver, or (last resort) the switch itself. |
+| Member status | Confirm both EX4100 members are online, powered, and reachable. If a member is down, resolve that first — the VCP alarm is a symptom, not root cause. |
+| Configuration | Verify VC configuration consistency (VC ID, preprovisioned master/backup roles, VCP assignments). A recent config change that revoked VCP status on a converted port will drop the port from VC. |
+| Hardware | Replace failed VCP port, transceiver, DAC, or (last resort) the EX4100 member. |
 | Audit | Review Mist audit logs for recent VC-related config changes in the last 24 h. |
-| VC split recovery | If the VC has split, follow controlled rejoin procedure — do NOT power-cycle members without a plan, as this can force an unwanted master re-election. Escalate to Tier 2. |
+| VC split recovery | If the VC has split into two single-member fragments, follow controlled rejoin procedure — do NOT power-cycle members without a plan, as this can force an unwanted master re-election. Escalate to Tier 2. |
 | Recovery | Confirm the VCP returns to Up, all members are synchronized, master/backup roles are as expected, and the paired clear event has fired. |
 
 ## Closure Criteria
 
-- Virtual Chassis is healthy: all expected members present, roles as designed.
+- Virtual Chassis is healthy: both EX4100 members present, master/backup roles as designed.
 - Affected VC port is `Up` and forwarding.
 - **The paired clear event `sw_vc_port_up` has been received.**
 - No recurrence of `sw_vc_port_down` for the same VCP within a 30-minute debounce window.
 - No co-firing `vc_master_changed`, `vc_backup_failed`, or `vc_member_deleted` still active.
-- Root cause is documented on the ticket, including which VCP link and whether redundant VCPs prevented a split.
+- Root cause is documented on the ticket, including which VCP link failed and whether the branch was wired with redundant VCPs (i.e. whether the site was one failure away from a split).
 
 ## Mist GUI Navigation
 
@@ -116,20 +116,20 @@ See Shared Appendix §6 for the full Junos command reference.
 
 If any of these are co-firing, resolve them together — VC-family alarms tend to cascade:
 
-- `vc_master_changed` — new device elected as VC master (critical). Often co-fires when the current master's VCPs fail.
+- `vc_master_changed` — new device elected as VC master (critical). On a 2-member VC this means the former backup has taken over — often because the former master's VCPs or `me0`/`vme` path failed.
 - `vc_backup_failed` — a new backup was elected (critical).
-- `vc_member_deleted` — a VC member has left the chassis (critical) — usually root cause when this fires.
+- `vc_member_deleted` — a VC member has left the chassis (critical) — on a 2-member pair this collapses the VC to a single standalone switch; usually root cause when this fires.
 - `vc_member_restarted` — a member has rebooted (warn).
-- `switch_down` — a whole member is offline.
-- `sw_alarm_chassis_mgmt_link_down` — check whether `vme` is still reachable via a surviving member.
+- `switch_down` — one of the two EX4100 members is offline.
+- `sw_alarm_chassis_mgmt_link_down` — check whether `vme` is still reachable via the surviving member's `me0`.
 
 Triage rule: **`vc_member_deleted` or `switch_down` on a member is usually root cause; `sw_vc_port_down` alone is often the earliest symptom of an impending split.**
 
 ## Escalation
 
-Per Shared Appendix §8. Tier 1 NOC can self-clear cable, optic, and single-VCP-flap causes when the VC remains healthy. **Escalate to Tier 2 immediately** for:
+Per Shared Appendix §8. Tier 1 NOC can self-clear cable, optic, and single-VCP-flap causes when the VC remains healthy (both members present, roles as designed). **Escalate to Tier 2 immediately** for:
 
-- Suspected or confirmed VC split
+- Suspected or confirmed VC split (2-member VC has partitioned into two single-member fragments)
 - Any active `vc_master_changed` / `vc_backup_failed` / `vc_member_deleted`
-- Hardware replacement of a VC member
+- Hardware replacement of an EX4100 member
 - Config changes to VCP assignment or preprovisioning

--- a/documentation/noc-runbooks/SW_VC_PORT_DOWN.md
+++ b/documentation/noc-runbooks/SW_VC_PORT_DOWN.md
@@ -41,7 +41,7 @@ Unlike most `warn`-shipped port alarms, Mist ships `sw_vc_port_down` as `critica
 | Timeline | Alert timestamp (UTC), recent VC config changes, member reboots, audit log entries |
 | Correlated Alarms | Any active alarms on any VC member (or a co-fired `vc_master_changed` / `vc_member_deleted`) in the last 15 min |
 
-See Shared Appendix §7 for the always-required ticket fields.
+See Shared Appendix §5 for the always-required ticket fields.
 
 ## Validation
 
@@ -60,7 +60,7 @@ See Shared Appendix §7 for the always-required ticket fields.
 | Logs (VCP-scoped) | `show log messages \| match vcp` (or specific interface name) |
 | VC master election events | `show log messages \| match vccpd` |
 
-See Shared Appendix §8 for the full Junos command reference.
+See Shared Appendix §6 for the full Junos command reference.
 
 ## Resolution
 
@@ -95,8 +95,6 @@ See Shared Appendix §8 for the full Junos command reference.
 | Switch events | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
-See Shared Appendix §6 for full GUI navigation reference.
-
 ## Junos Commands (quick reference)
 
 | Purpose | Command |
@@ -129,7 +127,7 @@ Triage rule: **`vc_member_deleted` or `switch_down` on a member is usually root 
 
 ## Escalation
 
-Per Shared Appendix §10. Tier 1 NOC can self-clear cable, optic, and single-VCP-flap causes when the VC remains healthy. **Escalate to Tier 2 immediately** for:
+Per Shared Appendix §8. Tier 1 NOC can self-clear cable, optic, and single-VCP-flap causes when the VC remains healthy. **Escalate to Tier 2 immediately** for:
 
 - Suspected or confirmed VC split
 - Any active `vc_master_changed` / `vc_backup_failed` / `vc_member_deleted`

--- a/documentation/noc-runbooks/_shared_common.md
+++ b/documentation/noc-runbooks/_shared_common.md
@@ -2,6 +2,24 @@
 
 This document holds the conventions, cross-cutting guidance, and shared reference material used by every alarm-specific runbook in this library. Each per-alarm document links back to sections here rather than duplicating content.
 
+## 0. Target topology (retail branch)
+
+Every runbook in this library assumes the **retail branch reference topology**:
+
+| Layer | Hardware | Notes |
+|---|---|---|
+| WAN gateway | **1 × Juniper SSR130** | Single node — no local HA peer. BGP + SVR overlay to the DC hub SSR1300 pair (Dallas / Chicago). A total gateway failure isolates the branch. |
+| Access switching | **2 × Juniper EX4100** in a Virtual Chassis | 2-member VC (master + backup). No dedicated distribution layer at the branch. |
+| Downstream | Mist APs, POS terminals, IP phones, back-office endpoints | PoE from EX4100. |
+| WAN transport | Dual ISP (typically) | Underlay to the ISPs is normally static-routed; BGP is the *overlay* to hub. |
+
+Implications that shape the runbooks:
+
+- **Single SSR130.** No gateway HA at the branch — any gateway-side outage is site-impacting. Overlay BGP peers point at the DC hub SSR1300 pair; there is no branch-local BGP peer.
+- **2-member EX4100 VC.** Only master + backup roles (no linecards). Losing the sole VCP path splits the VC into two isolated single-member fragments — split risk is immediate, not gradual.
+- **No dedicated OOB in most branches.** If your branch has no separate OOB management network, treat `sw_alarm_chassis_mgmt_link_down` as `warn` rather than the library-default `critical` (see §2).
+- **DC hub SSR1300 pair is out of scope** for this library — a separate hub-side runbook set covers Dallas/Chicago SSR1300 alarms.
+
 ## 1. Runbook field standard
 
 Every alarm runbook must include the following fields. Fields that don't apply to a given alarm should be marked `n/a` rather than omitted, so the layout stays scannable.
@@ -45,9 +63,9 @@ Every runbook's Closure Criteria section must reference the paired `_clear` or `
 
 ## 4. Correlated alarms and dedup
 
-Many failures cascade. A physical uplink failure will typically fire:
+Many failures cascade. A typical retail-branch example — the EX4100 VC uplink to the SSR130 fails:
 
-`sw_critical_port_down` → `sw_alarm_chassis_mgmt_link_down` *(if mgmt rode that path)* → `switch_down` → `gw_bgp_neighbor_down` *(if BGP peered over that link)*
+`sw_critical_port_down` (EX4100 uplink) → `sw_alarm_chassis_mgmt_link_down` *(if branch mgmt rode that path)* → `switch_down` *(if the affected member also loses its keepalive)* → `gw_bgp_neighbor_down` *(if the SSR130's LAN-side BGP peer sat behind that uplink)*
 
 The runbook for each alarm should list its usual co-fires under **Correlated Alarms**. Triage rule of thumb: **the lowest-layer alarm is usually root cause**; higher-layer alarms are symptoms. Suppress the symptoms in the ticketing layer once the root-cause alarm is acknowledged, not in Mist.
 

--- a/documentation/noc-runbooks/_shared_common.md
+++ b/documentation/noc-runbooks/_shared_common.md
@@ -22,11 +22,18 @@ Every alarm runbook must include the following fields. Fields that don't apply t
 
 ## 2. Severity override policy
 
-Mist assigns each alarm a native severity based on its own operational model. Our NOC dashboard may need to raise or lower that severity to fit our on-call model.
+Mist assigns each alarm a native severity in the alarm definitions catalog (`GET /api/v1/const/alarm_defs`). This severity is **fixed per alarm key** and is **not configurable** — Mist alarm templates (`POST/PUT /orgs/{org_id}/alarmtemplates`) only control per-alarm `enabled` state and email `delivery`. There is no `severity` field on an alarm-template rule.
+
+Where severity overrides actually live:
+
+- **Downstream paging / ticketing layer** (webhook consumer, PagerDuty, ServiceNow, etc.) — this is where we translate a Mist-native `warn` into a NOC-paged `critical`, or suppress an `info` alarm entirely.
+- Overrides are keyed off the alarm-payload `type` (Mist alarm key), optionally combined with `group`, site tags, or device role.
+
+Rules for this runbook library:
 
 - Any runbook whose **NOC severity** differs from **Mist native severity** must explain the override in the Description or a dedicated "Severity rationale" note.
-- Overrides are set in the alarm template in Mist (**Organization → Alarm Templates**). They are not implicit — someone has to configure them.
-- If two teams need different severities for the same alarm, split alarm templates by site group rather than by teaching operators to reinterpret severities.
+- The override lives in the paging/ticketing layer, not in Mist. Document *which* layer owns the mapping so operators know where to change it.
+- If two teams need different severities for the same alarm, split the mapping by site tag or device role in the downstream layer — do not teach operators to reinterpret severities.
 
 ## 3. Closure criteria and auto-resolution
 
@@ -44,37 +51,7 @@ Many failures cascade. A physical uplink failure will typically fire:
 
 The runbook for each alarm should list its usual co-fires under **Correlated Alarms**. Triage rule of thumb: **the lowest-layer alarm is usually root cause**; higher-layer alarms are symptoms. Suppress the symptoms in the ticketing layer once the root-cause alarm is acknowledged, not in Mist.
 
-## 5. Peer / port classification
-
-For alarms whose severity depends on *which* port or *which* peer went down, the runbook must require the operator to classify the object before escalating:
-
-- **Ports**: `access` / `uplink` / `IDF-MDF` / `server-edge` / `AP` / `VCP` / `LAG-member`
-- **BGP peers**: `underlay-ISP` / `internal-RR` / `overlay-CE`
-- **VPN peer paths**: `hub` / `spoke` / `mesh`
-
-This classification determines blast radius and whether an alarm should escalate beyond the NOC.
-
-## 6. Standard Mist GUI navigation
-
-Paths as of the current Mist UI. If you find a path is stale, update the shared appendix — do not fork it into individual runbooks.
-
-| Task | Navigation |
-|---|---|
-| Active alarms (org-wide) | Monitor → Alerts (Alarms) |
-| Alarm templates (severity/routing) | Organization → Alarm Templates |
-| Site alarm history | Monitor → Alerts → filter by site |
-| Device health (switch) | Switches → *device* → Health / Insights |
-| Device health (WAN edge / SSR / SRX) | WAN Edges → *device* → Health / Insights |
-| Port state | Switches → *device* → Front Panel / Port Config |
-| Client / connected device | Clients → Connected Devices |
-| SVR peer paths | WAN Assurance → Peer Path Insights |
-| WAN link health | WAN Assurance → WAN Links |
-| Events (raw) | Monitor → Events |
-| Audit logs | Organization → Audit Logs |
-
-**Legacy path note:** older docs may reference `Routers → …` for SSR devices. Current UI unifies all gateways under `WAN Edges → …`.
-
-## 7. Standard information to capture on every ticket
+## 5. Standard information to capture on every ticket
 
 Independent of alarm type, capture on ticket creation:
 
@@ -85,7 +62,7 @@ Independent of alarm type, capture on ticket creation:
 - Whether the device is currently reachable in Mist (`connected` / `disconnected`)
 - Any correlated alarms active in the last 15 minutes on the same device or site
 
-## 8. Common Junos (EX / SRX) commands
+## 6. Common Junos (EX / SRX) commands
 
 Applicable to any Junos-based device (EX switches, SRX gateways). Use these as building blocks in per-alarm runbooks.
 
@@ -111,7 +88,7 @@ Applicable to any Junos-based device (EX switches, SRX gateways). Use these as b
 | Log messages (interface-scoped) | `show log messages \| match <interface>` |
 | Config diff (recent changes) | `show system commit` then `show configuration \| compare rollback N` |
 
-## 9. Common SSR (Session Smart Router) PCLI commands
+## 7. Common SSR (Session Smart Router) PCLI commands
 
 Applicable to SSR gateways. SSR PCLI differs from Junos — do not mix.
 
@@ -133,7 +110,7 @@ Applicable to SSR gateways. SSR PCLI differs from Junos — do not mix.
 | Reachability (correct source) | `ping <target> source <local-transport-ip>` |
 | Traceroute | `traceroute <target>` |
 
-## 10. Standard escalation ladder
+## 8. Standard escalation ladder
 
 Applies to every runbook unless a specific runbook overrides.
 
@@ -144,9 +121,9 @@ Applies to every runbook unless a specific runbook overrides.
 
 Every runbook should note at which step (if earlier than Tier 2) the alarm can be self-cleared.
 
-## 11. Cross-references from per-alarm runbooks
+## 9. Cross-references from per-alarm runbooks
 
 Per-alarm runbooks should reference this appendix by section number, not by copying content. Example:
 
 > Severity override policy: see Shared Appendix §2.
-> Commands: see Shared Appendix §8 (Junos) or §9 (SSR).
+> Commands: see Shared Appendix §6 (Junos) or §7 (SSR).


### PR DESCRIPTION
## Summary
- Removes sections 5 (Peer/port classification) and 6 (Standard Mist GUI navigation) from \`_shared_common.md\` and renumbers §7–§11 to §5–§9.
- Rewrites Section 2 (Severity override policy): Mist alarm templates only expose per-rule \`enabled\` and \`delivery\` (verified against local OpenAPI docs); alarm severity is fixed in \`GET /const/alarm_defs\` and cannot be overridden in Mist. Overrides live in the downstream paging/ticketing layer.
- Rewrites \`GW_BGP_NEIGHBOR_DOWN.md\` to cleanly separate BGP (control plane, this alarm) from SVR / peer-paths (data plane, separate alarms). Adds a BGP-vs-SVR comparison table and splits Impact / Required Info / Validation / Resolution / Closure / GUI / CLI sections into BGP-primary and SVR-correlated subsections.
- Sweeps stale appendix references (§7→§5, §8→§6, §10→§8) across all four runbooks.

## Test plan
- [x] \`grep -n "Shared Appendix §"\` shows only §2, §5, §6, §7 (SSR-only), §8 references — no stragglers.
- [x] Local OpenAPI verified: no \`severity\` field on alarm-template rules.
- [x] Renders correctly in Markdown preview.