### PR TITLE
docs(noc-runbooks): add GW_VPN_PATH_DOWN and GW_STATUS runbooks

### DIFF
--- a/documentation/noc-runbooks/GW_STATUS.md
+++ b/documentation/noc-runbooks/GW_STATUS.md
@@ -1,0 +1,192 @@
+# GW_STATUS
+
+## Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | GW_STATUS |
+| **Mist alarm key** | `gw_status` (generic gateway-state alarm — fires on transition to `Offline` / `Unreachable` / `Disconnected` / `Degraded`) |
+| **Platform** | Juniper SSR130 (single gateway at a retail branch — no local HA peer). The same alarm key also fires on SRX gateways — an SRX-specific runbook is planned as Phase 2 because the CLI (Junos) differs from SSR PCLI. |
+| **Mist native severity** | `critical` |
+| **NOC severity** | **Critical** (native — no override) |
+| **Group** | `infrastructure` |
+| **Clear event key** | `gw_status_clear` (fires when the gateway returns to `Connected` / `Online`) |
+| **Correlated alarms** | `switch_down`, `gw_bgp_neighbor_down`, `gw_vpn_path_down`, `vpn_peer_down`, `bad_wan_uplink`, `intermittent_wan_connectivity`, `sw_alarm_chassis_mgmt_link_down`, `sw_critical_port_down` |
+| **Prerequisites** | None — fires automatically on any gateway operational-state transition away from `Connected` / `Online`. |
+| **Description** | The branch SSR130's operational status has changed to `Offline`, `Unreachable`, `Disconnected`, or `Degraded`. Because there is only a single SSR130 at the branch and no local HA peer, any state other than `Connected` / `Online` means the branch has either lost management visibility, lost WAN, or both. Treat this alarm as a **branch outage** until proven otherwise. |
+
+### Severity note (no override)
+
+Mist ships `gw_status` as `critical` natively — with a single-gateway branch, any gateway-state transition away from `Connected` is site-impacting by construction. No override is applied.
+
+### State-code interpretation
+
+Not every `GW_STATUS` alarm means the same thing. Read the payload state code first, because it shapes the entire triage path:
+
+| State | Meaning | Likely scope |
+|---|---|---|
+| `Disconnected` | SSR130 stopped talking to the Mist cloud, but may still be forwarding data plane. | Management plane only — check whether users are still online before treating as an outage. |
+| `Unreachable` | Mist cloud cannot reach the SSR130 over any path. | Usually WAN or gateway-fatal — branch is likely dark. |
+| `Offline` | SSR130 is confirmed down (no heartbeat, member of the site is not responding). | Full branch outage. |
+| `Degraded` | Gateway is up but a component (interface, service, resource) is impaired. | Partial — traffic may continue but capacity or redundancy is reduced. |
+
+Confirm which state fired before mobilizing hub-side on-call — a `Degraded` gateway is not the same page as an `Offline` one.
+
+## Impact
+
+- **Full branch outage (Offline / Unreachable):** the SSR130 is the only WAN gateway at the branch — when it is gone, the store is dark. All SD-WAN services stop, both SVR overlays to the DC hubs (Dallas + Chicago) fail, and every DC-hosted or Internet-hosted app becomes unreachable.
+- **Management-plane loss (Disconnected):** Mist cloud can no longer reach the SSR130, so we lose remote monitoring, config push, and Marvis analytics on this device. Data plane may or may not still be forwarding — verify from the branch side (POS pings, IP-phone health, downstream AP status) before declaring an outage.
+- **Degraded:** capacity or redundancy is reduced but traffic continues. Common triggers include a single WAN uplink down (dual-ISP branch reconverging onto the survivor), high CPU/memory, or a fabric component fault.
+- Loss of routing / BGP — the SSR130 is the branch's overlay speaker; when it goes, all learned DC-hub routes withdraw.
+- Loss of both SVR peer paths (Dallas + Chicago) — no overlay to either hub.
+- No remote remediation possible — with the gateway down, in-band access is gone; unless the branch has independent OOB (rare in this environment), any fix requires an on-site touch or ISP-side action.
+- Because there is only a single SSR130 at the branch, there is no gateway-side redundancy to fall back on. This alarm is branch-scope by construction.
+
+## Required Information
+
+| Category | Data to capture |
+|---|---|
+| Device | Site, Hostname, Serial Number, SSR software version, Mist device ID |
+| State | Which of `Offline` / `Unreachable` / `Disconnected` / `Degraded` fired; time of transition (UTC); last known `Connected` time |
+| Reachability | Can Mist reach the SSR130 at all? Can any downstream device (EX4100 VC, an AP) reach it? Are POS / phones still online? |
+| WAN underlay | State of both ISP links at the branch (up / down / degraded); any co-firing `bad_wan_uplink` or `intermittent_wan_connectivity` alarms |
+| Overlay | State of BGP peers to Dallas and Chicago hubs; state of SVR peer paths (from Mist history — the SSR130 is unreachable now) |
+| Resource pressure | If `Degraded` — CPU, memory, session count, temperature (from most recent Mist telemetry) |
+| Timeline | Alert timestamp (UTC), last successful config push, last firmware upgrade, recent audit-log entries, scheduled ISP maintenance |
+| Correlated Alarms | Any active alarms on the SSR130, the EX4100 VC, either ISP underlay, or the DC-hub SSR1300 pair in the last 15 min |
+
+See Shared Appendix §5 for the always-required ticket fields.
+
+## Validation
+
+The SSR130 may be unreachable from the NOC when this alarm fires — validate first from the Mist cloud side, then attempt PCLI only if reachability is restored.
+
+### From Mist cloud (always available)
+
+| Check | Command / Action |
+|---|---|
+| Confirm current state | Mist UI → WAN Edges → *SSR130* → Health / Insights (state, last-seen, reason for state change) |
+| Alarms on the device | Monitor → Alerts (Alarms) → filter by device |
+| Events leading up to the state change | Monitor → Events → filter by device, time range = last 1 h |
+| WAN link history (both ISPs) | WAN Assurance → WAN Links → *SSR130* |
+| SVR peer-path history (Dallas, Chicago) | WAN Assurance → Peer Path Insights → filter by device |
+| Recent config pushes | Organization → Audit Logs → filter by device |
+| Downstream reachability | Switches → *EX4100 VC* → Health (is the VC still reachable? do downstream APs / clients still show up?) |
+
+### From SSR PCLI (only if the gateway is reachable — i.e. `Degraded` or recovered `Disconnected`)
+
+| Check | Command / Action |
+|---|---|
+| System / model / uptime | `show system` |
+| Conductor / cloud connectivity | `show system connected` |
+| Alarms | `show alarms` |
+| Recent events | `show events` |
+| Interfaces (physical) | `show device-interface` |
+| Interfaces (logical) | `show network-interface` |
+| Routing table | `show route` |
+| SVR peer paths | `show peers` |
+| BGP session summary | `show bgp summary` |
+| Reachability to hub with correct source | `ping <hub-public-ip> source <local-transport-ip>` |
+
+**Never** run a bare `ping <target>` on SSR — it may egress from the wrong interface and produce a false-negative. Always pin the source with `source <local-transport-ip>`. See Shared Appendix §7.
+
+### From the branch (on-site or via alternate access)
+
+If the gateway is `Offline` / `Unreachable` and no OOB path exists, coordinate with a branch contact (store manager, field-tech dispatch):
+
+- Confirm SSR130 power state — is it powered on, are LEDs solid, are the ISP-facing ports showing link?
+- Confirm ISP modem / handoff state — did the ISP demarc go down (a cable cut or ISP-side outage will look identical to a gateway fault from Mist's perspective)?
+- Physical console access if a field tech is on site.
+
+## Resolution
+
+Sequence the response by the reported state — `Offline` and `Unreachable` need on-site / ISP-side action; `Disconnected` may be management-plane only; `Degraded` is usually a specific correlated fault.
+
+| Area | Action |
+|---|---|
+| Read the state code | Before mobilizing anyone, confirm which of `Offline` / `Unreachable` / `Disconnected` / `Degraded` fired. This determines whether the branch is dark or merely impaired. |
+| Correlated underlay | If `bad_wan_uplink` or `intermittent_wan_connectivity` is co-firing on **both** ISPs, the gateway is likely up but has no transport — treat as ISP outage, not gateway fault. Coordinate with both ISPs. If only one ISP is down, the branch should still be reachable — investigate SSR130 further. |
+| Correlated LAN | If `switch_down` is co-firing on the EX4100 VC serving the SSR130's LAN side, the SSR130 may be up but its LAN reach (and therefore Mist visibility) is broken. Fix the VC first. |
+| Correlated management | If `sw_alarm_chassis_mgmt_link_down` is co-firing and the branch is management-in-band (typical), management is riding a broken path — fix the VC / uplink first; the gateway itself may be fine. |
+| Power / physical | For `Offline` with no correlated network alarms — coordinate with branch to verify the SSR130 has power and is not showing hardware faults on the front panel. |
+| ISP handoff | For `Unreachable` on a dual-ISP branch where both underlays are marked down — open tickets with both ISPs simultaneously (single-ISP outages should not knock the gateway `Unreachable`, so a dual-ISP hit is either coincidence or a shared upstream fault). |
+| Resource pressure (`Degraded`) | Check CPU, memory, session count on the SSR130 — sustained resource exhaustion (rare on SSR130 at branch scale but possible during a scanning event or a DDoS reflection) can flip the state to `Degraded`. Investigate top talkers / sessions. |
+| Hardware (`Degraded` or `Offline`) | If `show alarms` or the front panel indicates PSU / fan / thermal fault, plan an RMA. |
+| Configuration drift | Review Mist audit logs for pushes in the last 24 h. If a recent push caused the outage, prepare a rollback via Mist (this only works if the gateway is reachable enough to receive it — otherwise a field-tech console session is required). |
+| Firmware | If the state change coincides with a firmware upgrade, be prepared to roll back. Upgrades gone bad on the only branch gateway are a Tier 2 / vendor escalation. |
+| Recovery | Confirm the SSR130 state returns to `Connected` in Mist, both ISP underlays are up, both SVR peer paths (Dallas + Chicago) are `up`, both BGP sessions are `Established`, and the paired clear event has fired. |
+
+## Closure Criteria
+
+- SSR130 state in Mist is `Connected` (not `Degraded`, `Disconnected`, `Unreachable`, or `Offline`).
+- Both WAN underlay links (ISP-A and ISP-B) are up and within performance baseline.
+- Both SVR peer paths to the DC hubs (Dallas + Chicago) are `up`.
+- Both BGP overlay sessions to the DC hubs are `Established`.
+- Downstream store services are functional (POS, IP phones, APs online, back-office reachable).
+- **The paired clear event `gw_status_clear` has been received.**
+- No recurrence of `gw_status` for this device within a 30-minute debounce window.
+- All co-fired alarms on the SSR130, EX4100 VC, and either ISP underlay have cleared on their own tickets (do not implicitly close them from this ticket).
+- Root cause is documented on the ticket, including which state code(s) the gateway transitioned through during the incident, whether the branch was fully dark or merely degraded, and (if applicable) which correlated alarm was the true root cause.
+
+## Mist GUI Navigation
+
+| Task | Navigation |
+|---|---|
+| Verify alert | Monitor → Alerts (Alarms) → filter by `gw_status` |
+| Gateway health / state | WAN Edges → *SSR130* → Health / Insights |
+| WAN link history | WAN Assurance → WAN Links |
+| SVR peer-path history | WAN Assurance → Peer Path Insights |
+| Gateway events (raw) | Monitor → Events → filter by device |
+| Downstream switch view | Switches → *EX4100 VC* → Health |
+| Audit logs | Organization → Audit Logs |
+
+**Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`.
+
+## SSR PCLI Commands (quick reference)
+
+SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR. These commands assume the gateway is reachable — during an `Offline` / `Unreachable` state they will not run.
+
+| Purpose | Command |
+|---|---|
+| System / model / uptime | `show system` |
+| Conductor / cloud connectivity | `show system connected` |
+| Alarms | `show alarms` |
+| Events (scoped) | `show events` |
+| Device interfaces (physical) | `show device-interface` |
+| Network interfaces (logical) | `show network-interface` |
+| Routing table | `show route` |
+| SVR peer paths | `show peers` |
+| BGP summary | `show bgp summary` |
+| BGP peer detail | `show bgp neighbor <peer-ip>` |
+| Active sessions on device | `show sessions summary` |
+| Reachability with correct source | `ping <target> source <local-transport-ip>` |
+| Path to remote target | `traceroute <target>` |
+
+See Shared Appendix §7 for the full SSR PCLI reference.
+
+## Cross-references (sibling alarms)
+
+`GW_STATUS` is a high-level roll-up alarm — it is often the *symptom* whose root cause is one of the sibling alarms below. When any of these are co-firing, resolve the co-fired alarm first:
+
+- `bad_wan_uplink` — underlying transport failure (Marvis). If both ISPs are hit, the gateway will flip to `Unreachable` even though the box itself is fine.
+- `intermittent_wan_connectivity` — flaky underlay. Common cause of `Degraded` / oscillating status.
+- `gw_bgp_neighbor_down` — overlay control plane down; typically follows gateway-state changes but can also be the leading indicator during a soft-fail (e.g. BGP process crash).
+- `gw_vpn_path_down` / `vpn_peer_down` — SVR overlay down; same relationship as BGP above.
+- `switch_down` — EX4100 VC serving the SSR130's LAN side is offline; the gateway may be up but unreachable from Mist because its management path rides the VC.
+- `sw_alarm_chassis_mgmt_link_down` — VC management link down; if branch is management-in-band (typical), Mist visibility to the gateway drops even though data plane may be fine.
+- `sw_critical_port_down` — the physical port on the EX4100 serving the SSR130's uplink or management is down.
+
+**Triage rule:** `gw_status` alone with no correlated alarms almost always means a gateway-local fault (power, hardware, firmware). `gw_status` co-firing with LAN or WAN sibling alarms means the gateway is a **symptom** — go find the root cause first.
+
+## Escalation
+
+Per Shared Appendix §8. Because a single SSR130 gateway state change can mean a full branch outage, escalate quickly:
+
+- **Tier 1 NOC** can self-clear cases where a correlated ISP-underlay or LAN alarm is clearly root cause and the sibling runbook resolves the issue (the gateway state will recover on its own).
+- **Escalate to Tier 2 immediately** for:
+  - `Offline` or `Unreachable` state with no correlated ISP alarm (implies gateway-local fault: hardware, firmware, or power).
+  - Suspected firmware / config rollback on the sole branch gateway (any change on the only WAN device at the branch is out-of-window by definition).
+  - Hardware replacement (RMA of the SSR130).
+  - `Degraded` state with sustained resource pressure (CPU / memory / sessions) — may need capacity or profile changes.
+- **Page hub-side on-call in parallel** if the branch is confirmed fully dark and DC-hosted apps for that branch's users are impacted — hub-side may need to withdraw the branch's routes / advertise a coverage tunnel.
+- **Change Advisory Board** for any planned config or firmware change on the recovered gateway, since it is the branch's single point of failure.

--- a/documentation/noc-runbooks/GW_VPN_PATH_DOWN.md
+++ b/documentation/noc-runbooks/GW_VPN_PATH_DOWN.md
@@ -1,0 +1,215 @@
+# GW_VPN_PATH_DOWN
+
+## Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | GW_VPN_PATH_DOWN |
+| **Mist alarm key** | `gw_vpn_path_down` |
+| **Platform** | Juniper SSR130 (single gateway at a retail branch — no local HA peer). The SVR peer paths this branch cares about are the overlays to the DC-hub SSR1300 pair (Dallas + Chicago). The same alarm key also fires on SRX gateways running SD-WAN — an SRX-specific runbook is planned as Phase 2 because the CLI (Junos) differs from SSR PCLI. |
+| **Mist native severity** | `critical` |
+| **NOC severity** | **Critical** (native — no override) |
+| **Group** | `infrastructure` |
+| **Clear event key** | `gw_vpn_path_up` |
+| **Correlated alarms** | `vpn_peer_down`, `vpn_path_down`, `bad_wan_uplink`, `intermittent_wan_connectivity`, `gw_bgp_neighbor_down`, `gw_critical_port_down`, `switch_down` |
+| **Prerequisites** | An SVR peer path must be configured between this branch SSR130 and a remote SSR (in this environment, a DC-hub SSR1300). Alarm fires when one or more transport paths that make up the peer relationship go `down` while the overall peer may or may not remain `up`. |
+| **Description** | One or more SD-WAN (SVR / Session Smart Routing) transport paths from the branch SSR130 to a remote SSR are unavailable. The overall VPN **peer** may remain `up` (traffic reconverges onto a surviving transport) or may itself go `down` (fires the separate `vpn_peer_down` alarm) — this alarm covers the per-path state, not the aggregate peer state. |
+
+### Severity note (no override)
+
+Mist ships `gw_vpn_path_down` as `critical` natively — a single-path outage on a dual-ISP branch is degraded-but-serving, but the alarm is the earliest signal that a full peer isolation is one failure away. No override is applied.
+
+### SVR vs BGP — two independent overlays on SSR
+
+**This runbook is for SVR peer paths only.** On SSR gateways, SVR (data plane, per-transport peer paths) and BGP (control plane, TCP/179 sessions) are two independent overlays. BGP outages fire under `gw_bgp_neighbor_down` and have their own runbook — do not conflate them.
+
+| Concern | SVR (this alarm) | BGP (separate alarm) |
+|---|---|---|
+| Alarm keys | `gw_vpn_path_down` (+ `gw_vpn_path_up` clear), `vpn_peer_down`, `vpn_path_down` | `gw_bgp_neighbor_down` (+ `gw_bgp_neighbor_up` clear) |
+| Layer | Data plane — forwards session-oriented traffic between SSRs | Control plane — exchanges routes |
+| Transport | UDP-based Secure Vector Routing between SSRs over one or more transports | TCP/179 to peer IP over an underlay interface |
+| Independence | SVR peer paths can be `down` while BGP is `Established` | BGP can be down while SVR paths are `up` |
+| SSR command | `show peers`, `show peers detail` | `show bgp summary`, `show bgp neighbor <peer-ip>` |
+| Mist GUI | WAN Assurance → Peer Path Insights | BGP state is not surfaced in a dedicated view — use PCLI |
+
+The two often correlate: a shared WAN transport can bring both down at once. Validate each separately with its own commands.
+
+## Impact
+
+**Direct (SVR):**
+
+- Loss of one SVR transport to the affected DC-hub peer (typically one of the two branch ISPs).
+- **One path down to one hub (typical case):** the peer stays `up` on the surviving transport; traffic reconverges — may see brief packet loss, then continues on the remaining ISP.
+- **All paths to one hub down:** the `vpn_peer_down` alarm co-fires for that hub; overlay to that hub is fully out, but the *other* hub (Dallas or Chicago) continues to carry branch traffic.
+- **All paths to both hubs down:** the branch loses overlay reachability entirely; DC-hosted apps become unreachable even if an underlay ISP link is technically up.
+- Increased latency and jitter as traffic reconverges to the surviving transport(s); voice / video quality can degrade during the transition.
+- Reduced aggregate bandwidth — a two-ISP branch operating on a single transport is capacity-halved.
+- Because there is only a single SSR130 at the branch, there is no gateway-side redundancy to fall back on — any SVR problem here is branch-scope.
+
+**Correlated (BGP):**
+
+- If SVR and BGP share the affected WAN transport, the BGP session to the same DC hub may also drop — this will surface as a **separate** `gw_bgp_neighbor_down` alarm. Validate BGP independently rather than assuming it followed SVR's state.
+
+## Required Information
+
+### SVR peer path (always capture)
+
+| Category | Data to capture |
+|---|---|
+| Device | Site, Hostname, Serial Number, SSR software version, Mist device ID |
+| Peer classification | Which DC hub: `hub-Dallas-SSR1300` / `hub-Chicago-SSR1300` |
+| Hub redundancy state | Is the *other* hub peer (Dallas if this is Chicago, or vice versa) currently reachable via SVR? Are its paths `up`? This tells you whether the branch is degraded-but-serving or overlay-isolated. |
+| SVR path | Local router / node, remote router / node, path name (from `show peers`), WAN transport name, WAN provider / circuit ID |
+| Transport underlay | Local device-interface, local WAN link (ISP-A / ISP-B), local transport IP, remote public IP |
+| Path state | Per-transport `up` / `down` / `standby` status; is the aggregate peer still `up` on another transport? |
+| Performance | Packet loss %, latency (ms), jitter (ms) captured at time of alarm (from Mist Peer Path Insights or `show peers detail`) |
+| Timeline | Alert timestamp (UTC), last known `up` time, recent config changes, upstream ISP maintenance windows |
+| Correlated Alarms | Any active alarms on the SSR130, on the branch EX4100 VC, on either ISP underlay, or on the peer DC-hub SSR1300 in the last 15 min |
+
+### BGP (only if a BGP alarm is co-firing)
+
+| Category | Data to capture |
+|---|---|
+| BGP peer | Peer IP, Peer AS, Local AS, session state |
+| Shared transport | Does the BGP session and this SVR path ride the same underlay WAN link? |
+
+See Shared Appendix §5 for the always-required ticket fields.
+
+## Validation
+
+### SVR peer-path checks (this alarm)
+
+| Check | Command / Action |
+|---|---|
+| SSR reachable in Mist | Mist UI → WAN Edges → *device* → Health / Insights |
+| SSR connected to conductor / cloud | `show system connected` |
+| System status | `show system` |
+| SVR peer path status (all peers, all transports) | `show peers` |
+| SVR peer path detail | `show peers detail` |
+| WAN transport / underlay interfaces | `show device-interface` and `show network-interface` |
+| Routing table | `show route` |
+| Reachability to remote peer using correct source | `ping <remote-public-ip> source <local-transport-ip>` |
+| Path to remote peer | `traceroute <remote-public-ip>` |
+| Alarms on device | `show alarms` |
+| Recent events (scoped) | `show events` |
+| Peer path history / performance in Mist | WAN Assurance → Peer Path Insights → filter by device → drill into affected path |
+| WAN link health | WAN Assurance → WAN Links |
+
+**Never** run a bare `ping <remote-public-ip>` on SSR — it may egress from the wrong interface and produce a false-negative. Always pin the source with `source <local-transport-ip>` so you're actually testing the ISP transport that the path uses. See Shared Appendix §7.
+
+### BGP checks (only if correlated BGP alarm is active, or the shared transport is suspect)
+
+| Check | Command / Action |
+|---|---|
+| BGP session summary | `show bgp summary` |
+| Specific peer detail | `show bgp neighbor <peer-ip>` |
+
+If BGP is `Established` while SVR paths are down, transport-to-BGP-peer-IP is fine but the SVR overlay is broken — investigate SVR-specific causes (MTU/PMTUD, UDP filtering on the underlay, tenant / service-route / security policy). If BGP is also down on the same transport, treat the shared underlay as the primary suspect and prioritize the underlay-link alarms (`bad_wan_uplink`, `intermittent_wan_connectivity`).
+
+## Resolution
+
+| Area | Action |
+|---|---|
+| Underlay link | If a WAN link alarm (`bad_wan_uplink`, `intermittent_wan_connectivity`) is co-firing on the ISP that carries this path, resolve that first — SVR will re-establish once transport recovers. |
+| ISP degradation | If the underlay is technically `up` but performance is bad (loss / latency / jitter above SVR thresholds), open an ISP ticket with the affected circuit ID; SVR is doing the right thing by marking the path down. |
+| Interface / optics | Check CRC, drops, and optics DDM on the WAN-facing interface (`show device-interface`). Replace cable / SFP if physical-layer fault is confirmed. |
+| Peer device | Verify the DC-hub SSR1300's SVR process is up and its side of the path is not the problem (hub-side runbook / Mist WAN Edges view for that hub). If the hub-side gateway is impaired, coordinate with the hub-side on-call rather than driving from the branch. |
+| Reachability | From SSR, confirm the remote peer's public IP is reachable **from the correct source IP** with `ping <remote-public-ip> source <local-transport-ip>`. |
+| MTU / PMTUD | SVR encapsulates in UDP; a PMTUD blackhole on the underlay will cause paths to flap or stay down. Verify path MTU on the affected transport. |
+| UDP filtering | Some carrier / customer-edge firewalls silently drop UDP once a session ages out. If path repeatedly flaps at a fixed interval, suspect stateful UDP filtering upstream. |
+| Firewall / policy | On SSR the peer path traverses a tenant / service-route / security policy — verify these were not recently changed. |
+| Configuration | Review Mist audit logs for SVR or interface config changes in the last 24 h. Rollback if a recent change caused the outage. |
+| Routing | Verify next-hop resolution for the peer's public IP on the affected transport (`show route`). |
+| Recovery (SVR) | Confirm `show peers` reports the affected path back to `up` on the expected transport, and the paired clear event has fired. |
+| Recovery (BGP, if it was also affected) | Confirm BGP transitions back to `Established`. Do not close the SVR ticket until any BGP alarm has also cleared. |
+
+## Closure Criteria
+
+**SVR (required for this alarm):**
+
+- `show peers` reports the affected path back to `up` on the expected transport.
+- Packet loss, latency, and jitter on the recovered path are within acceptable thresholds (per Peer Path Insights baseline).
+- Reachability to the remote peer's public IP from the correct source succeeds.
+- **The paired clear event `gw_vpn_path_up` has been received.**
+- No recurrence of `gw_vpn_path_down` for this path within a 30-minute debounce window.
+- If `vpn_peer_down` co-fired, the overall peer is also back `up`.
+- The *other* DC-hub peer (whichever of Dallas / Chicago was not the impaired one) is also confirmed reachable via SVR — the branch is back to full 2-hub overlay redundancy, not just single-hub-serving.
+- Root cause is documented on the ticket, including which hub peer and which underlay transport were affected, and whether the branch was ever in the "both hubs down" isolation state during the incident.
+
+**BGP (only if BGP alarms co-fired):**
+
+- BGP neighbor state is `Established` and the paired `gw_bgp_neighbor_up` has been received on its own ticket.
+- Close the BGP ticket per its own runbook — do not implicitly close it from this ticket.
+
+## Mist GUI Navigation
+
+**SVR-related:**
+
+| Task | Navigation |
+|---|---|
+| Verify alert | Monitor → Alerts (Alarms) → filter by `gw_vpn_path_down` |
+| Peer path health | WAN Assurance → Peer Path Insights |
+| WAN link health (underlay) | WAN Assurance → WAN Links |
+| SSR health | WAN Edges → *SSR130* → Health / Insights |
+| Gateway events | Monitor → Events |
+| Audit logs | Organization → Audit Logs |
+
+**Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`.
+
+## SSR PCLI Commands (quick reference)
+
+SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
+
+**System / interface:**
+
+| Purpose | Command |
+|---|---|
+| System / model / uptime | `show system` |
+| Conductor / cloud connectivity | `show system connected` |
+| Alarms | `show alarms` |
+| Device interfaces (physical) | `show device-interface` |
+| Network interfaces (logical) | `show network-interface` |
+| Routing table | `show route` |
+| Reachability with correct source | `ping <remote-public-ip> source <local-transport-ip>` |
+| Path to remote peer | `traceroute <remote-public-ip>` |
+
+**SVR (this alarm):**
+
+| Purpose | Command |
+|---|---|
+| SVR peer paths (all peers, all transports) | `show peers` |
+| SVR peer path detail | `show peers detail` |
+| Active sessions on device | `show sessions summary` |
+| Events (SVR-scoped) | `show events` |
+
+**BGP (only for correlated control-plane checks — BGP outages are separate alarms):**
+
+| Purpose | Command |
+|---|---|
+| BGP summary | `show bgp summary` |
+| BGP peer detail | `show bgp neighbor <peer-ip>` |
+
+See Shared Appendix §7 for the full SSR PCLI reference.
+
+## Cross-references (sibling alarms)
+
+If any of these are co-firing, resolve the co-fired alarm first — it is usually root cause. Because the branch has a single SSR130 (no local HA), *any* gateway-side symptom here is branch-scope; coordinate with the hub-side on-call if the impairment is on the DC-hub SSR1300's side of the peering:
+
+- `vpn_peer_down` — the aggregate SVR peer is down (all transports failed). This is a strict escalation of the per-path alarm; if it is co-firing, treat the peer outage as the primary incident.
+- `vpn_path_down` — related SVR path alarm on the same or peered devices; usually co-fires when a shared underlay drops.
+- `bad_wan_uplink` — underlying transport failure (Marvis). Common shared root cause; the SVR path is a symptom, the ISP link is the cause.
+- `intermittent_wan_connectivity` — flaky underlay. Expect SVR paths to flap in step with the underlay.
+- `gw_bgp_neighbor_down` — BGP control-plane session on the same DC-hub peering is down (distinct from SVR; follow the BGP runbook, not this one). Same DC-hub SSR1300 endpoints, different overlay layer.
+- `gw_critical_port_down` — physical port on the SSR130 serving the transport is down. Fix the port before chasing SVR.
+- `switch_down` — upstream EX4100 VC (or a member) is down; if the SSR130's LAN-side transport rides that VC, SVR paths can go with it.
+
+## Escalation
+
+Per Shared Appendix §8. Tier 1 NOC can self-clear underlay-transport, reachability, ISP-handoff, and rollback-driven root causes on the branch SSR130. Escalate to Tier 2 for:
+
+- Tenant / service-route / security policy changes on either the branch SSR130 or the DC-hub SSR1300
+- MTU / PMTUD suspected blackholes on the underlay
+- SVR configuration changes that span multiple devices
+- Suspected UDP filtering by an ISP or transit provider (usually needs vendor-side coordination)
+- Configuration restore that spans multiple devices
+- **All paths to both hubs (Dallas + Chicago) down simultaneously** — branch overlay is isolated; page hub-side on-call in parallel and treat as a site outage, not a single-path alarm.

--- a/documentation/noc-runbooks/GW_VPN_PEER_DOWN.md
+++ b/documentation/noc-runbooks/GW_VPN_PEER_DOWN.md
@@ -1,0 +1,223 @@
+# GW_VPN_PEER_DOWN
+
+## Overview
+
+| Field | Value |
+|---|---|
+| **Alert Name** | GW_VPN_PEER_DOWN |
+| **Mist alarm key** | `gw_vpn_peer_down` |
+| **Platform** | Juniper SSR130 (single gateway at a retail branch — no local HA peer). The SVR peers this branch cares about are the overlay peers to the DC-hub SSR1300 pair (Dallas + Chicago). The same alarm key also fires on SRX gateways running SD-WAN — an SRX-specific runbook is planned as Phase 2 because the CLI (Junos) differs from SSR PCLI. |
+| **Mist native severity** | `critical` |
+| **NOC severity** | **Critical** (native — no override) |
+| **Group** | `infrastructure` |
+| **Clear event key** | `gw_vpn_peer_up` |
+| **Correlated alarms** | `gw_vpn_path_down`, `vpn_path_down`, `bad_wan_uplink`, `intermittent_wan_connectivity`, `gw_bgp_neighbor_down`, `gw_critical_port_down`, `switch_down`, `gw_status` |
+| **Prerequisites** | An SVR peer relationship must be configured between this branch SSR130 and a remote SSR (in this environment, a DC-hub SSR1300). This alarm fires when the aggregate peer state is `down` — i.e., every transport path making up that peer is down. |
+| **Description** | The SVR (Session Smart Routing) peer relationship between the branch SSR130 and a remote SSR is fully down — every underlying transport path has failed. Overlay traffic to that peer cannot flow. This is a strict escalation of `gw_vpn_path_down`; if only one transport failed and another survived, the peer would remain `up` and only the path-down alarm would fire. |
+
+### Severity note (no override)
+
+Mist ships `gw_vpn_peer_down` as `critical` natively — an aggregate peer outage means the overlay to that hub is fully out. On a two-hub branch (Dallas + Chicago), one peer down is still degraded-but-serving via the surviving hub; but the paired-peer failure mode is one alarm away, and detection latency matters. No override is applied.
+
+### Path-down vs peer-down — which am I looking at?
+
+Both alarms cover the SVR overlay but at different granularities. Read the alarm key on the ticket before doing anything else:
+
+| Alarm | Meaning | Serving state |
+|---|---|---|
+| `gw_vpn_path_down` | One or more (but not all) transports to a peer are down | Peer stays `up`; traffic reconverges onto surviving transport |
+| `gw_vpn_peer_down` (this alarm) | **All** transports to a peer are down; aggregate peer is `down` | Overlay to that peer is fully out |
+
+If `gw_vpn_peer_down` fires, expect one or more `gw_vpn_path_down` alarms to be co-firing on the same peer — they are the constituent path failures that added up to the peer outage. Resolve the underlying path failures; the peer will come back on its own once at least one path is restored.
+
+### SVR vs BGP — two independent overlays on SSR
+
+**This runbook is for the SVR peer relationship only.** On SSR gateways, SVR (data plane, per-transport peer paths) and BGP (control plane, TCP/179) are two independent overlays. BGP outages fire under `gw_bgp_neighbor_down` and have their own runbook — do not conflate them. See `GW_VPN_PATH_DOWN.md` for the SVR-vs-BGP comparison table.
+
+## Impact
+
+**Direct (SVR):**
+
+- Loss of the entire SVR overlay to the affected DC-hub peer.
+- **One peer down (typical case):** the *other* DC-hub peer (Dallas if this is Chicago, or vice versa) still carries branch overlay traffic — branch is degraded-but-serving with no hub redundancy.
+- **Both DC-hub peers down simultaneously:** the branch is overlay-isolated; DC-hosted apps unreachable even if an underlay ISP link is technically `up`. Any branch-to-branch communication that transits a DC hub is also down.
+- Loss of dynamic path steering for the affected peer — any application policy or SLA routing that referenced that peer is offline.
+- BFD / SVR control-plane adjacency loss for the affected peer.
+- Routing convergence events on the SSR130 as it withdraws routes learned across the failed peer.
+- Increased latency and jitter during and after failover; voice / video sessions transiting the affected peer will drop and re-establish (or fail if no secondary exists).
+- Because there is only a single SSR130 at the branch, there is no gateway-side redundancy to fall back on — any SVR problem here is branch-scope.
+
+**Correlated (BGP):**
+
+- If SVR and BGP share the affected WAN transport(s), the BGP session to the same DC hub will also drop — this will surface as a **separate** `gw_bgp_neighbor_down` alarm. Validate BGP independently rather than assuming it followed SVR's state.
+
+## Required Information
+
+### SVR peer (always capture)
+
+| Category | Data to capture |
+|---|---|
+| Device | Site, Hostname, Serial Number, SSR software version, Mist device ID |
+| Peer classification | Which DC hub: `hub-Dallas-SSR1300` / `hub-Chicago-SSR1300` |
+| Hub redundancy state | Is the *other* hub peer (Dallas if this is Chicago, or vice versa) currently `up`? This tells you whether the branch is degraded-but-serving or overlay-isolated. |
+| SVR peer | Peer name, remote router / node, tunnel status, downtime duration, last known `up` time |
+| Constituent paths | Every transport path making up this peer and its state (all should be `down` when this alarm fires) |
+| Transport underlay | Local device-interfaces, local WAN links (ISP-A / ISP-B), local transport IPs, remote public IPs |
+| Performance (last known) | Packet loss %, latency (ms), jitter (ms) just before the outage (from Mist Peer Path Insights) |
+| Timeline | Alert timestamp (UTC), last known `up` time, recent config changes, upstream ISP maintenance windows |
+| Correlated Alarms | Any active alarms on the SSR130, on the branch EX4100 VC, on either ISP underlay, or on the peer DC-hub SSR1300 in the last 15 min |
+
+### BGP (only if a BGP alarm is co-firing)
+
+| Category | Data to capture |
+|---|---|
+| BGP peer | Peer IP, Peer AS, Local AS, session state |
+| Shared transport | Do the BGP session and this SVR peer's paths ride the same underlay WAN link(s)? |
+
+See Shared Appendix §5 for the always-required ticket fields.
+
+## Validation
+
+### SVR peer checks (this alarm)
+
+| Check | Command / Action |
+|---|---|
+| SSR reachable in Mist | Mist UI → WAN Edges → *device* → Health / Insights |
+| SSR connected to conductor / cloud | `show system connected` |
+| System status | `show system` |
+| SVR peer status (aggregate) | `show peers` |
+| SVR peer detail (per-path breakdown) | `show peers detail` |
+| WAN transport / underlay interfaces | `show device-interface` and `show network-interface` |
+| Routing table (routes learned from peer will be missing) | `show route` |
+| Reachability to remote peer using correct source | `ping <remote-public-ip> source <local-transport-ip>` |
+| Path to remote peer | `traceroute <remote-public-ip>` |
+| Alarms on device | `show alarms` |
+| Recent events (scoped) | `show events` |
+| Peer path history in Mist | WAN Assurance → Peer Path Insights → filter by device → drill into affected peer |
+| WAN link health | WAN Assurance → WAN Links |
+
+**Never** run a bare `ping <remote-public-ip>` on SSR — it may egress from the wrong interface and produce a false-negative. Always pin the source with `source <local-transport-ip>` so you're actually testing the ISP transport that the peer uses. See Shared Appendix §7.
+
+### BGP checks (only if correlated BGP alarm is active, or shared transports are suspect)
+
+| Check | Command / Action |
+|---|---|
+| BGP session summary | `show bgp summary` |
+| Specific peer detail | `show bgp neighbor <peer-ip>` |
+
+If BGP is `Established` on some transport while the SVR peer is fully `down`, one or more underlays are up-enough for TCP/179 but not for SVR — investigate SVR-specific causes (MTU/PMTUD, UDP filtering, tenant / service-route / security policy). If BGP is also fully down, treat the shared underlay as the primary suspect and prioritize the underlay-link alarms.
+
+## Resolution
+
+Because `gw_vpn_peer_down` is the aggregate of all constituent paths failing, resolution is almost always "restore at least one path" — but which path and why depends on the co-fired alarms.
+
+| Area | Action |
+|---|---|
+| Constituent paths | If any `gw_vpn_path_down` alarms are co-firing (they usually are), resolve them per `GW_VPN_PATH_DOWN.md` — the peer will come back on its own once at least one path is restored. |
+| Underlay link | If a WAN link alarm (`bad_wan_uplink`, `intermittent_wan_connectivity`) is co-firing on any ISP, resolve that first. |
+| Simultaneous ISP outages | If both ISPs are down, this is not an SVR problem — it is a dual-ISP branch outage. Open ISP tickets in parallel and treat as a site outage; page hub-side on-call. |
+| Interface / optics | Check CRC, drops, and optics DDM on all WAN-facing interfaces (`show device-interface`). Replace cable / SFP if physical-layer fault is confirmed. |
+| Default route / gateway | Verify default route and next-hop resolution on each transport (`show route`). |
+| Firewall / NAT (branch-side) | Verify branch firewall / NAT is not blocking outbound to the peer's public IP(s) on the transport ports SVR uses. |
+| Peer device | Verify the DC-hub SSR1300 (peer end) is up and its side of the peering is not the problem (hub-side runbook / Mist WAN Edges view for that hub). If the hub-side gateway is impaired, coordinate with the hub-side on-call rather than driving from the branch. |
+| Authentication | Verify SVR peer certificates / secrets / NTP time-sync are not the cause of a peering refusal (Mist audit logs will show if a cert / secret rolled recently). |
+| Reachability | From SSR, confirm the remote peer's public IP is reachable **from the correct source IP** with `ping <remote-public-ip> source <local-transport-ip>`. |
+| MTU / PMTUD | SVR encapsulates in UDP; a PMTUD blackhole on the underlay will cause the peer to flap or stay down. Verify path MTU on each transport. |
+| UDP filtering | If the peer flaps at a fixed interval, suspect stateful UDP filtering by an ISP or upstream firewall. |
+| Routing | Verify next-hop resolution for the peer's public IP on each transport. |
+| Configuration | Review Mist audit logs for SVR, tenant, service-route, or interface config changes in the last 24 h. Rollback if a recent change caused the outage. |
+| Recovery (SVR) | Confirm `show peers` reports the peer back to `up`, at least one constituent path is `up`, and the paired clear event has fired. |
+| Recovery (BGP, if it was also affected) | Confirm BGP transitions back to `Established`. Do not close the SVR ticket until any BGP alarm has also cleared. |
+
+## Closure Criteria
+
+**SVR (required for this alarm):**
+
+- `show peers` reports the peer back to `up`.
+- At least one constituent transport path is `up`; ideally all expected paths are `up`.
+- Packet loss, latency, and jitter on the recovered paths are within acceptable thresholds (per Peer Path Insights baseline).
+- Reachability to the remote peer's public IP from the correct source succeeds.
+- **The paired clear event `gw_vpn_peer_up` has been received.**
+- No recurrence of `gw_vpn_peer_down` for this peer within a 30-minute debounce window.
+- The *other* DC-hub peer (whichever of Dallas / Chicago was not the impaired one) is also confirmed `up` — the branch is back to full 2-hub overlay redundancy, not just single-hub-serving.
+- Any co-fired `gw_vpn_path_down` alarms have cleared on their own tickets (do not implicitly close them from this ticket).
+- Root cause is documented on the ticket, including which hub peer was affected, which underlay transport(s) failed, and whether the branch was ever in the "both hubs down" isolation state during the incident.
+
+**BGP (only if BGP alarms co-fired):**
+
+- BGP neighbor state is `Established` and the paired `gw_bgp_neighbor_up` has been received on its own ticket.
+- Close the BGP ticket per its own runbook — do not implicitly close it from this ticket.
+
+## Mist GUI Navigation
+
+| Task | Navigation |
+|---|---|
+| Verify alert | Monitor → Alerts (Alarms) → filter by `gw_vpn_peer_down` |
+| Peer path health | WAN Assurance → Peer Path Insights |
+| WAN link health (underlay) | WAN Assurance → WAN Links |
+| SSR health | WAN Edges → *SSR130* → Health / Insights |
+| Gateway events | Monitor → Events |
+| Audit logs | Organization → Audit Logs |
+
+**Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`.
+
+## SSR PCLI Commands (quick reference)
+
+SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
+
+**System / interface:**
+
+| Purpose | Command |
+|---|---|
+| System / model / uptime | `show system` |
+| Conductor / cloud connectivity | `show system connected` |
+| Alarms | `show alarms` |
+| Device interfaces (physical) | `show device-interface` |
+| Network interfaces (logical) | `show network-interface` |
+| Routing table | `show route` |
+| FIB | `show fib` |
+| Reachability with correct source | `ping <remote-public-ip> source <local-transport-ip>` |
+| Path to remote peer | `traceroute <remote-public-ip>` |
+
+**SVR (this alarm):**
+
+| Purpose | Command |
+|---|---|
+| SVR peers (aggregate state) | `show peers` |
+| SVR peer detail (per-path breakdown) | `show peers detail` |
+| Active sessions on device | `show sessions summary` |
+| Events (SVR-scoped) | `show events` |
+
+**BGP (only for correlated control-plane checks — BGP outages are separate alarms):**
+
+| Purpose | Command |
+|---|---|
+| BGP summary | `show bgp summary` |
+| BGP peer detail | `show bgp neighbor <peer-ip>` |
+
+See Shared Appendix §7 for the full SSR PCLI reference.
+
+## Cross-references (sibling alarms)
+
+If any of these are co-firing, resolve the co-fired alarm first — it is usually root cause. Because the branch has a single SSR130 (no local HA), *any* gateway-side symptom here is branch-scope; coordinate with the hub-side on-call if the impairment is on the DC-hub SSR1300's side of the peering:
+
+- `gw_vpn_path_down` — one or more constituent transport paths to this peer are down. Expected to co-fire with `gw_vpn_peer_down` (they are the constituent failures that added up to the peer outage). Resolve per `GW_VPN_PATH_DOWN.md`; the peer will recover once at least one path is restored.
+- `vpn_path_down` — related SVR path alarm on peered devices; usually co-fires when a shared underlay drops.
+- `bad_wan_uplink` — underlying transport failure (Marvis). Common shared root cause; the SVR peer is a symptom, the ISP link is the cause.
+- `intermittent_wan_connectivity` — flaky underlay. Expect the peer to flap in step with the underlay.
+- `gw_bgp_neighbor_down` — BGP control-plane session on the same DC-hub peering is down (distinct from SVR; follow the BGP runbook, not this one). Same DC-hub SSR1300 endpoints, different overlay layer.
+- `gw_critical_port_down` — physical port on the SSR130 serving a transport is down. Fix the port before chasing SVR.
+- `switch_down` — upstream EX4100 VC (or a member) is down; if the SSR130's LAN-side transport rides that VC, SVR paths can go with it.
+- `gw_status` — the gateway itself is offline / unreachable / degraded. If this is co-firing, the SVR peer is a symptom of a gateway-scope fault — chase `gw_status` root cause first.
+
+## Escalation
+
+Per Shared Appendix §8. Tier 1 NOC can self-clear underlay-transport, reachability, ISP-handoff, cert / NTP, and rollback-driven root causes on the branch SSR130. Escalate to Tier 2 for:
+
+- Tenant / service-route / security policy changes on either the branch SSR130 or the DC-hub SSR1300
+- MTU / PMTUD suspected blackholes on the underlay
+- SVR configuration changes that span multiple devices
+- Suspected UDP filtering by an ISP or transit provider (usually needs vendor-side coordination)
+- Peer authentication / certificate / secret issues that cannot be resolved by rollback
+- Configuration restore that spans multiple devices
+- **Both DC-hub peers (Dallas + Chicago) down simultaneously** — branch overlay is isolated; page hub-side on-call in parallel and treat as a site outage, not a single-peer alarm.


### PR DESCRIPTION
## Summary
- Adds two retail-branch NOC runbooks for gateway-scope Mist alarms.
- **GW_VPN_PATH_DOWN**: SVR overlay per-transport peer path failure. Triage split by transport (ISP-A/ISP-B/backup) and hub (Dallas/Chicago). Correlates with `bad_wan_uplink` and BGP siblings.
- **GW_STATUS**: gateway state-transition alarm. Adds state-code interpretation table (Disconnected / Unreachable / Offline / Degraded) since each maps to a different blast radius and response. Includes triage rule: `gw_status` alone = gateway-local fault; co-firing with LAN/WAN siblings = gateway is symptom.

Both follow the retail-branch reference topology (1× SSR130, 2× EX4100 VC, dual-ISP, overlay to DC-hub SSR1300 pair) and shared appendix conventions from `_shared_common.md`.

## Test plan
- [ ] Table renders correctly on GitHub
- [ ] Cross-references to sibling runbooks (`GW_BGP_NEIGHBOR_DOWN`, `BAD_WAN_UPLINK`, `SW_*`) resolve
- [ ] SSR PCLI commands match `_shared_common.md` §7