### PR TITLE
docs(noc-runbooks): number sections 1-10 and fix Mist GUI nav paths

### DIFF
--- a/documentation/noc-runbooks/GW_BGP_NEIGHBOR_DOWN.md
+++ b/documentation/noc-runbooks/GW_BGP_NEIGHBOR_DOWN.md
@@ -1,6 +1,6 @@
 # GW_BGP_NEIGHBOR_DOWN
 
-## Overview
+## 1. Overview
 
 | Field | Value |
 |---|---|
@@ -39,7 +39,7 @@ The downstream paging/ticketing tier escalates this alarm to **critical** on tha
 
 The two often correlate: a shared WAN transport can bring both down at once. Validate each separately with its own commands.
 
-## Impact
+## 2. Impact
 
 **Direct (BGP):**
 
@@ -53,7 +53,7 @@ The two often correlate: a shared WAN transport can bring both down at once. Val
 
 - If BGP and SVR share the affected WAN transport, SVR peer paths to the same DC hub may also reconverge or fail — this will surface as a **separate** `vpn_peer_down` / `gw_vpn_path_down` / `vpn_path_down` alarm. Validate SVR independently rather than assuming it followed BGP's state.
 
-## Required Information
+## 3. Required Information
 
 ### BGP peer (always capture)
 
@@ -80,7 +80,7 @@ The two often correlate: a shared WAN transport can bring both down at once. Val
 
 See Shared Appendix §5 for the always-required ticket fields.
 
-## Validation
+## 4. Validation
 
 ### BGP session checks (this alarm)
 
@@ -111,7 +111,7 @@ See Shared Appendix §5 for the always-required ticket fields.
 
 If SVR peer paths are healthy while BGP is down, transport is not the root cause — investigate BGP-specific causes (policy, MD5, peer-side process). If SVR paths are also down on the same transport, treat the shared transport as the primary suspect and prioritize the underlay-link alarms (`bad_wan_uplink`, `intermittent_wan_connectivity`).
 
-## Resolution
+## 5. Resolution
 
 | Area | Action |
 |---|---|
@@ -128,7 +128,7 @@ If SVR peer paths are healthy while BGP is down, transport is not the root cause
 | Recovery (BGP) | Confirm BGP peer transitions back to `Established`, expected prefixes are relearned, and the paired clear event has fired. |
 | Recovery (SVR, if it was also affected) | Confirm `show peers` shows the affected peer path back to `up` on the expected transport(s). Do not close the BGP ticket until any SVR peer-path alarm has also cleared. |
 
-## Closure Criteria
+## 6. Closure Criteria
 
 **BGP (required for this alarm):**
 
@@ -146,15 +146,15 @@ If SVR peer paths are healthy while BGP is down, transport is not the root cause
 - The paired SVR clear event(s) have been received on the correlated ticket(s).
 - Close the SVR ticket per its own runbook — do not implicitly close it from this ticket.
 
-## Mist GUI Navigation
+## 7. Mist GUI Navigation
 
 **BGP-related:**
 
 | Task | Navigation |
 |---|---|
-| Verify alert | Monitor → Alerts (Alarms) → filter by `gw_bgp_neighbor_down` |
-| SSR health | WAN Edges → *SSR1300* → Health / Insights |
-| WAN link health (shared underlay) | WAN Assurance → WAN Links |
+| Verify alert | Monitor → Alerts → filter by `gw_bgp_neighbor_down` |
+| SSR health | WAN Edges → *SSR130* → Insights |
+| WAN link health (shared underlay) | Monitor → Service Levels → WAN |
 | Gateway events | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
@@ -162,11 +162,11 @@ If SVR peer paths are healthy while BGP is down, transport is not the root cause
 
 | Task | Navigation |
 |---|---|
-| SVR peer paths | WAN Assurance → Peer Path Insights |
+| SVR peer paths | Monitor → Service Levels → WAN → Peer Paths |
 
 **Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`.
 
-## SSR PCLI Commands (quick reference)
+## 8. SSR PCLI Commands (quick reference)
 
 SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
 
@@ -202,7 +202,7 @@ SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
 
 See Shared Appendix §7 for the full SSR PCLI reference.
 
-## Cross-references (sibling alarms)
+## 9. Cross-references (sibling alarms)
 
 If any of these are co-firing, resolve the co-fired alarm first — it is usually root cause. Because the branch has a single SSR130 (no local HA), *any* gateway-side symptom here is branch-scope; coordinate with the hub-side on-call if the impairment is on the DC hub SSR1300's side of the peering:
 
@@ -212,7 +212,7 @@ If any of these are co-firing, resolve the co-fired alarm first — it is usuall
 - `gw_critical_port_down` — physical port on the SSR130 serving the peer transport is down. Fix the port before chasing BGP.
 - `switch_down` — upstream EX4100 VC (or a member) is down; if the SSR130's LAN-side transport rides that VC, BGP can go with it.
 
-## Escalation
+## 10. Escalation
 
 Per Shared Appendix §8. Tier 1 NOC can self-clear underlay-transport, reachability, and rollback-driven root causes on the branch SSR130. Escalate to Tier 2 for:
 

--- a/documentation/noc-runbooks/GW_STATUS.md
+++ b/documentation/noc-runbooks/GW_STATUS.md
@@ -1,6 +1,6 @@
 # GW_STATUS
 
-## Overview
+## 1. Overview
 
 | Field | Value |
 |---|---|
@@ -32,7 +32,7 @@ Not every `GW_STATUS` alarm means the same thing. Read the payload state code fi
 
 Confirm which state fired before mobilizing hub-side on-call — a `Degraded` gateway is not the same page as an `Offline` one.
 
-## Impact
+## 2. Impact
 
 - **Full branch outage (Offline / Unreachable):** the SSR130 is the only WAN gateway at the branch — when it is gone, the store is dark. All SD-WAN services stop, both SVR overlays to the DC hubs (Dallas + Chicago) fail, and every DC-hosted or Internet-hosted app becomes unreachable.
 - **Management-plane loss (Disconnected):** Mist cloud can no longer reach the SSR130, so we lose remote monitoring, config push, and Marvis analytics on this device. Data plane may or may not still be forwarding — verify from the branch side (POS pings, IP-phone health, downstream AP status) before declaring an outage.
@@ -42,7 +42,7 @@ Confirm which state fired before mobilizing hub-side on-call — a `Degraded` ga
 - No remote remediation possible — with the gateway down, in-band access is gone; unless the branch has independent OOB (rare in this environment), any fix requires an on-site touch or ISP-side action.
 - Because there is only a single SSR130 at the branch, there is no gateway-side redundancy to fall back on. This alarm is branch-scope by construction.
 
-## Required Information
+## 3. Required Information
 
 | Category | Data to capture |
 |---|---|
@@ -57,7 +57,7 @@ Confirm which state fired before mobilizing hub-side on-call — a `Degraded` ga
 
 See Shared Appendix §5 for the always-required ticket fields.
 
-## Validation
+## 4. Validation
 
 The SSR130 may be unreachable from the NOC when this alarm fires — validate first from the Mist cloud side, then attempt PCLI only if reachability is restored.
 
@@ -98,7 +98,7 @@ If the gateway is `Offline` / `Unreachable` and no OOB path exists, coordinate w
 - Confirm ISP modem / handoff state — did the ISP demarc go down (a cable cut or ISP-side outage will look identical to a gateway fault from Mist's perspective)?
 - Physical console access if a field tech is on site.
 
-## Resolution
+## 5. Resolution
 
 Sequence the response by the reported state — `Offline` and `Unreachable` need on-site / ISP-side action; `Disconnected` may be management-plane only; `Degraded` is usually a specific correlated fault.
 
@@ -116,7 +116,7 @@ Sequence the response by the reported state — `Offline` and `Unreachable` need
 | Firmware | If the state change coincides with a firmware upgrade, be prepared to roll back. Upgrades gone bad on the only branch gateway are a Tier 2 / vendor escalation. |
 | Recovery | Confirm the SSR130 state returns to `Connected` in Mist, both ISP underlays are up, both SVR peer paths (Dallas + Chicago) are `up`, both BGP sessions are `Established`, and the paired clear event has fired. |
 
-## Closure Criteria
+## 6. Closure Criteria
 
 - SSR130 state in Mist is `Connected` (not `Degraded`, `Disconnected`, `Unreachable`, or `Offline`).
 - Both WAN underlay links (ISP-A and ISP-B) are up and within performance baseline.
@@ -128,21 +128,21 @@ Sequence the response by the reported state — `Offline` and `Unreachable` need
 - All co-fired alarms on the SSR130, EX4100 VC, and either ISP underlay have cleared on their own tickets (do not implicitly close them from this ticket).
 - Root cause is documented on the ticket, including which state code(s) the gateway transitioned through during the incident, whether the branch was fully dark or merely degraded, and (if applicable) which correlated alarm was the true root cause.
 
-## Mist GUI Navigation
+## 7. Mist GUI Navigation
 
 | Task | Navigation |
 |---|---|
-| Verify alert | Monitor → Alerts (Alarms) → filter by `gw_status` |
-| Gateway health / state | WAN Edges → *SSR130* → Health / Insights |
-| WAN link history | WAN Assurance → WAN Links |
-| SVR peer-path history | WAN Assurance → Peer Path Insights |
+| Verify alert | Monitor → Alerts → filter by `gw_status` |
+| Gateway health / state | WAN Edges → *SSR130* → Insights |
+| WAN link history | Monitor → Service Levels → WAN |
+| SVR peer-path history | Monitor → Service Levels → WAN → Peer Paths |
 | Gateway events (raw) | Monitor → Events → filter by device |
-| Downstream switch view | Switches → *EX4100 VC* → Health |
+| Downstream switch view | Switches → *EX4100 VC* → Insights |
 | Audit logs | Organization → Audit Logs |
 
 **Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`.
 
-## SSR PCLI Commands (quick reference)
+## 8. SSR PCLI Commands (quick reference)
 
 SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR. These commands assume the gateway is reachable — during an `Offline` / `Unreachable` state they will not run.
 
@@ -164,7 +164,7 @@ SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR. These commands 
 
 See Shared Appendix §7 for the full SSR PCLI reference.
 
-## Cross-references (sibling alarms)
+## 9. Cross-references (sibling alarms)
 
 `GW_STATUS` is a high-level roll-up alarm — it is often the *symptom* whose root cause is one of the sibling alarms below. When any of these are co-firing, resolve the co-fired alarm first:
 
@@ -178,7 +178,7 @@ See Shared Appendix §7 for the full SSR PCLI reference.
 
 **Triage rule:** `gw_status` alone with no correlated alarms almost always means a gateway-local fault (power, hardware, firmware). `gw_status` co-firing with LAN or WAN sibling alarms means the gateway is a **symptom** — go find the root cause first.
 
-## Escalation
+## 10. Escalation
 
 Per Shared Appendix §8. Because a single SSR130 gateway state change can mean a full branch outage, escalate quickly:
 

--- a/documentation/noc-runbooks/GW_VPN_PATH_DOWN.md
+++ b/documentation/noc-runbooks/GW_VPN_PATH_DOWN.md
@@ -1,6 +1,6 @@
 # GW_VPN_PATH_DOWN
 
-## Overview
+## 1. Overview
 
 | Field | Value |
 |---|---|
@@ -34,7 +34,7 @@ Mist ships `gw_vpn_path_down` as `critical` natively — a single-path outage on
 
 The two often correlate: a shared WAN transport can bring both down at once. Validate each separately with its own commands.
 
-## Impact
+## 2. Impact
 
 **Direct (SVR):**
 
@@ -50,7 +50,7 @@ The two often correlate: a shared WAN transport can bring both down at once. Val
 
 - If SVR and BGP share the affected WAN transport, the BGP session to the same DC hub may also drop — this will surface as a **separate** `gw_bgp_neighbor_down` alarm. Validate BGP independently rather than assuming it followed SVR's state.
 
-## Required Information
+## 3. Required Information
 
 ### SVR peer path (always capture)
 
@@ -75,7 +75,7 @@ The two often correlate: a shared WAN transport can bring both down at once. Val
 
 See Shared Appendix §5 for the always-required ticket fields.
 
-## Validation
+## 4. Validation
 
 ### SVR peer-path checks (this alarm)
 
@@ -106,7 +106,7 @@ See Shared Appendix §5 for the always-required ticket fields.
 
 If BGP is `Established` while SVR paths are down, transport-to-BGP-peer-IP is fine but the SVR overlay is broken — investigate SVR-specific causes (MTU/PMTUD, UDP filtering on the underlay, tenant / service-route / security policy). If BGP is also down on the same transport, treat the shared underlay as the primary suspect and prioritize the underlay-link alarms (`bad_wan_uplink`, `intermittent_wan_connectivity`).
 
-## Resolution
+## 5. Resolution
 
 | Area | Action |
 |---|---|
@@ -123,7 +123,7 @@ If BGP is `Established` while SVR paths are down, transport-to-BGP-peer-IP is fi
 | Recovery (SVR) | Confirm `show peers` reports the affected path back to `up` on the expected transport, and the paired clear event has fired. |
 | Recovery (BGP, if it was also affected) | Confirm BGP transitions back to `Established`. Do not close the SVR ticket until any BGP alarm has also cleared. |
 
-## Closure Criteria
+## 6. Closure Criteria
 
 **SVR (required for this alarm):**
 
@@ -141,22 +141,22 @@ If BGP is `Established` while SVR paths are down, transport-to-BGP-peer-IP is fi
 - BGP neighbor state is `Established` and the paired `gw_bgp_neighbor_up` has been received on its own ticket.
 - Close the BGP ticket per its own runbook — do not implicitly close it from this ticket.
 
-## Mist GUI Navigation
+## 7. Mist GUI Navigation
 
 **SVR-related:**
 
 | Task | Navigation |
 |---|---|
-| Verify alert | Monitor → Alerts (Alarms) → filter by `gw_vpn_path_down` |
-| Peer path health | WAN Assurance → Peer Path Insights |
-| WAN link health (underlay) | WAN Assurance → WAN Links |
-| SSR health | WAN Edges → *SSR130* → Health / Insights |
+| Verify alert | Monitor → Alerts → filter by `gw_vpn_path_down` |
+| Peer path health | Monitor → Service Levels → WAN → Peer Paths |
+| WAN link health (underlay) | Monitor → Service Levels → WAN |
+| SSR health | WAN Edges → *SSR130* → Insights |
 | Gateway events | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
 **Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`.
 
-## SSR PCLI Commands (quick reference)
+## 8. SSR PCLI Commands (quick reference)
 
 SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
 
@@ -191,7 +191,7 @@ SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
 
 See Shared Appendix §7 for the full SSR PCLI reference.
 
-## Cross-references (sibling alarms)
+## 9. Cross-references (sibling alarms)
 
 If any of these are co-firing, resolve the co-fired alarm first — it is usually root cause. Because the branch has a single SSR130 (no local HA), *any* gateway-side symptom here is branch-scope; coordinate with the hub-side on-call if the impairment is on the DC-hub SSR1300's side of the peering:
 
@@ -203,7 +203,7 @@ If any of these are co-firing, resolve the co-fired alarm first — it is usuall
 - `gw_critical_port_down` — physical port on the SSR130 serving the transport is down. Fix the port before chasing SVR.
 - `switch_down` — upstream EX4100 VC (or a member) is down; if the SSR130's LAN-side transport rides that VC, SVR paths can go with it.
 
-## Escalation
+## 10. Escalation
 
 Per Shared Appendix §8. Tier 1 NOC can self-clear underlay-transport, reachability, ISP-handoff, and rollback-driven root causes on the branch SSR130. Escalate to Tier 2 for:
 

--- a/documentation/noc-runbooks/GW_VPN_PEER_DOWN.md
+++ b/documentation/noc-runbooks/GW_VPN_PEER_DOWN.md
@@ -1,6 +1,6 @@
 # GW_VPN_PEER_DOWN
 
-## Overview
+## 1. Overview
 
 | Field | Value |
 |---|---|
@@ -34,7 +34,7 @@ If `gw_vpn_peer_down` fires, expect one or more `gw_vpn_path_down` alarms to be 
 
 **This runbook is for the SVR peer relationship only.** On SSR gateways, SVR (data plane, per-transport peer paths) and BGP (control plane, TCP/179) are two independent overlays. BGP outages fire under `gw_bgp_neighbor_down` and have their own runbook — do not conflate them. See `GW_VPN_PATH_DOWN.md` for the SVR-vs-BGP comparison table.
 
-## Impact
+## 2. Impact
 
 **Direct (SVR):**
 
@@ -51,7 +51,7 @@ If `gw_vpn_peer_down` fires, expect one or more `gw_vpn_path_down` alarms to be 
 
 - If SVR and BGP share the affected WAN transport(s), the BGP session to the same DC hub will also drop — this will surface as a **separate** `gw_bgp_neighbor_down` alarm. Validate BGP independently rather than assuming it followed SVR's state.
 
-## Required Information
+## 3. Required Information
 
 ### SVR peer (always capture)
 
@@ -76,7 +76,7 @@ If `gw_vpn_peer_down` fires, expect one or more `gw_vpn_path_down` alarms to be 
 
 See Shared Appendix §5 for the always-required ticket fields.
 
-## Validation
+## 4. Validation
 
 ### SVR peer checks (this alarm)
 
@@ -107,7 +107,7 @@ See Shared Appendix §5 for the always-required ticket fields.
 
 If BGP is `Established` on some transport while the SVR peer is fully `down`, one or more underlays are up-enough for TCP/179 but not for SVR — investigate SVR-specific causes (MTU/PMTUD, UDP filtering, tenant / service-route / security policy). If BGP is also fully down, treat the shared underlay as the primary suspect and prioritize the underlay-link alarms.
 
-## Resolution
+## 5. Resolution
 
 Because `gw_vpn_peer_down` is the aggregate of all constituent paths failing, resolution is almost always "restore at least one path" — but which path and why depends on the co-fired alarms.
 
@@ -129,7 +129,7 @@ Because `gw_vpn_peer_down` is the aggregate of all constituent paths failing, re
 | Recovery (SVR) | Confirm `show peers` reports the peer back to `up`, at least one constituent path is `up`, and the paired clear event has fired. |
 | Recovery (BGP, if it was also affected) | Confirm BGP transitions back to `Established`. Do not close the SVR ticket until any BGP alarm has also cleared. |
 
-## Closure Criteria
+## 6. Closure Criteria
 
 **SVR (required for this alarm):**
 
@@ -148,20 +148,20 @@ Because `gw_vpn_peer_down` is the aggregate of all constituent paths failing, re
 - BGP neighbor state is `Established` and the paired `gw_bgp_neighbor_up` has been received on its own ticket.
 - Close the BGP ticket per its own runbook — do not implicitly close it from this ticket.
 
-## Mist GUI Navigation
+## 7. Mist GUI Navigation
 
 | Task | Navigation |
 |---|---|
-| Verify alert | Monitor → Alerts (Alarms) → filter by `gw_vpn_peer_down` |
-| Peer path health | WAN Assurance → Peer Path Insights |
-| WAN link health (underlay) | WAN Assurance → WAN Links |
-| SSR health | WAN Edges → *SSR130* → Health / Insights |
+| Verify alert | Monitor → Alerts → filter by `gw_vpn_peer_down` |
+| Peer path health | Monitor → Service Levels → WAN → Peer Paths |
+| WAN link health (underlay) | Monitor → Service Levels → WAN |
+| SSR health | WAN Edges → *SSR130* → Insights |
 | Gateway events | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
 **Legacy path note:** older docs may say `Routers → SSR1300`. Current Mist UI unifies all gateways under `WAN Edges → …`.
 
-## SSR PCLI Commands (quick reference)
+## 8. SSR PCLI Commands (quick reference)
 
 SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
 
@@ -197,7 +197,7 @@ SSR uses PCLI, not Junos. Do not paste Junos syntax into an SSR.
 
 See Shared Appendix §7 for the full SSR PCLI reference.
 
-## Cross-references (sibling alarms)
+## 9. Cross-references (sibling alarms)
 
 If any of these are co-firing, resolve the co-fired alarm first — it is usually root cause. Because the branch has a single SSR130 (no local HA), *any* gateway-side symptom here is branch-scope; coordinate with the hub-side on-call if the impairment is on the DC-hub SSR1300's side of the peering:
 
@@ -210,7 +210,7 @@ If any of these are co-firing, resolve the co-fired alarm first — it is usuall
 - `switch_down` — upstream EX4100 VC (or a member) is down; if the SSR130's LAN-side transport rides that VC, SVR paths can go with it.
 - `gw_status` — the gateway itself is offline / unreachable / degraded. If this is co-firing, the SVR peer is a symptom of a gateway-scope fault — chase `gw_status` root cause first.
 
-## Escalation
+## 10. Escalation
 
 Per Shared Appendix §8. Tier 1 NOC can self-clear underlay-transport, reachability, ISP-handoff, cert / NTP, and rollback-driven root causes on the branch SSR130. Escalate to Tier 2 for:
 

--- a/documentation/noc-runbooks/SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md
+++ b/documentation/noc-runbooks/SW_ALARM_CHASSIS_MGMT_LINK_DOWN.md
@@ -1,6 +1,6 @@
 # SW_ALARM_CHASSIS_MGMT_LINK_DOWN
 
-## Overview
+## 1. Overview
 
 | Field | Value |
 |---|---|
@@ -21,7 +21,7 @@ Mist ships this alarm at `warn` because the production data plane typically keep
 
 **Retail-branch note:** many of our retail sites have no separate OOB management network — mgmt rides the same site LAN as production. In that case there is no independent path to lose, and `warn` is appropriate. Confirm the branch's OOB posture with your SOR before treating this as `critical`.
 
-## Impact
+## 2. Impact
 
 - Loss of out-of-band management connectivity to the branch EX4100 VC (if the branch has an OOB path).
 - Unable to reach the switch through the MGMT interface — `vme` on the 2-member VC (backed by whichever member is currently master).
@@ -30,7 +30,7 @@ Mist ships this alarm at `warn` because the production data plane typically keep
 - Delayed troubleshooting if in-band remote access — which at most retail branches rides the same LAN — becomes unavailable.
 - **VC-specific:** if the master's `me0` drops, `vme` can fail over to the backup member's `me0`. Check `show virtual-chassis` for the current master; the outage may effectively resolve itself if the peer member's `me0` is healthy.
 
-## Required Information
+## 3. Required Information
 
 | Category | Data to capture |
 |---|---|
@@ -44,7 +44,7 @@ Mist ships this alarm at `warn` because the production data plane typically keep
 
 See Shared Appendix §5 for the always-required ticket fields.
 
-## Validation
+## 4. Validation
 
 | Check | Command / Action |
 |---|---|
@@ -61,7 +61,7 @@ See Shared Appendix §5 for the always-required ticket fields.
 
 See Shared Appendix §6 for the full Junos command reference.
 
-## Resolution
+## 5. Resolution
 
 | Area | Action |
 |---|---|
@@ -74,7 +74,7 @@ See Shared Appendix §6 for the full Junos command reference.
 | Audit | Review Mist audit logs for recent changes that may have affected management config. |
 | Recovery | Confirm management interface is up, reachable from the OOB network (or from the branch LAN if in-band), and the paired clear event has fired. |
 
-## Closure Criteria
+## 6. Closure Criteria
 
 - Management interface (`me0` or `vme`) is operational.
 - Remote access from the OOB management network is restored.
@@ -82,17 +82,17 @@ See Shared Appendix §6 for the full Junos command reference.
 - No recurrence of `sw_alarm_chassis_mgmt_link_down` within a 30-minute debounce window.
 - Root cause is documented on the ticket.
 
-## Mist GUI Navigation
+## 7. Mist GUI Navigation
 
 | Task | Navigation |
 |---|---|
-| Verify alert | Monitor → Alerts (Alarms) → filter by `sw_alarm_chassis_mgmt_link_down` |
-| Switch health | Switches → *device* → Health / Insights |
-| Management status | Switches → *device* → Front Panel / Details |
+| Verify alert | Monitor → Alerts → filter by `sw_alarm_chassis_mgmt_link_down` |
+| Switch health | Switches → *device* → Insights |
+| Management status | Switches → *device* → Front Panel |
 | Events (raw) | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
-## Junos Commands (quick reference)
+## 8. Junos Commands (quick reference)
 
 | Purpose | Command |
 |---|---|
@@ -108,6 +108,17 @@ See Shared Appendix §6 for the full Junos command reference.
 | Ping gateway | `ping <management-gateway>` |
 | Ping known-reachable host | `ping <reachable-management-host>` |
 
-## Escalation
+## 9. Cross-references (sibling alarms)
+
+If any of these are co-firing, resolve them together — chassis-mgmt-link and VC alarms often cascade:
+
+- `switch_down` — if the switch (or in a VC, a member) is fully offline, the mgmt link alarm is a downstream symptom; resolve `switch_down` first.
+- `sw_vc_port_down` — VCP failure on a 2-member VC can strand `vme` on the wrong member and manifest as a mgmt-link outage; check VC state.
+- `vc_member_deleted` / `vc_master_changed` — a collapsed or re-elected VC can flip which physical `me0` the `vme` bundle rides on.
+- `sw_critical_port_down` — if `me0`/`vme` is designated critical in the site policy, this alarm may be co-firing on the same physical port.
+
+Triage rule: **when `switch_down` or a VC-membership alarm is active, treat this alarm as a symptom, not root cause.**
+
+## 10. Escalation
 
 Per Shared Appendix §8. Tier 1 NOC can self-clear cable, port, and configuration causes. Escalate to Tier 2 for hardware replacement, VC master election changes, or when the OOB management upstream is itself impaired.

--- a/documentation/noc-runbooks/SW_CRITICAL_PORT_DOWN.md
+++ b/documentation/noc-runbooks/SW_CRITICAL_PORT_DOWN.md
@@ -2,7 +2,7 @@
 
 > **Renamed from `INTERFACE_DOWN`.** Mist does not emit a generic "any interface down" alarm — such an alarm would be pure noise (endpoints unplug all day). The closest useful Mist alarm is `sw_critical_port_down`, which fires only for ports explicitly flagged as **critical** in the port profile. Related port-issue alarms (`port_flap`, `port_stuck`, `bad_cable`, `sw_bad_optics`, `sw_negotiation_incomplete`) each have their own runbook — see cross-references below.
 
-## Overview
+## 1. Overview
 
 | Field | Value |
 |---|---|
@@ -21,7 +21,7 @@
 
 Mist ships this as `warn` because port-down events span a wide impact range. Because only *critical* ports fire this alarm, we escalate to **critical** — the port has been explicitly designated as important. If any critical-port designations turn out to be over-tagged (e.g. every access port), retune the port profile rather than lowering NOC severity.
 
-## Impact
+## 2. Impact
 
 - Loss of endpoint or uplink connectivity for the affected port.
 - **Uplink to SSR130.** If the port is a member of the LAG to the SSR130, the LAG loses a member and forwards on the survivor; if the LAG is down to zero members (or the uplink is a single link), the branch loses WAN.
@@ -31,7 +31,7 @@ Mist ships this as `warn` because port-down events span a wide impact range. Bec
 - Reduced fabric redundancy on the affected segment.
 - PoE loss on the affected port for AP / phone / camera endpoints.
 
-## Required Information
+## 3. Required Information
 
 | Category | Data to capture |
 |---|---|
@@ -43,7 +43,7 @@ Mist ships this as `warn` because port-down events span a wide impact range. Bec
 | Timeline | Alert timestamp (UTC), recent configuration changes, related audit log entries |
 | Correlated Alarms | Any active alarms on the EX4100 or on the connected downstream device (e.g. `ap_offline`) in the last 15 min |
 
-## Validation
+## 4. Validation
 
 | Check | Command / Action |
 |---|---|
@@ -64,7 +64,7 @@ Mist ships this as `warn` because port-down events span a wide impact range. Bec
 
 See Shared Appendix §6 for the full Junos command reference.
 
-## Resolution
+## 5. Resolution
 
 | Area | Action |
 |---|---|
@@ -78,7 +78,7 @@ See Shared Appendix §6 for the full Junos command reference.
 | Configuration changes | Review Mist audit logs; restore configuration if a recent change caused the outage. |
 | Recovery | Confirm the port returns to Up, traffic flows, and the paired clear event has fired. |
 
-## Closure Criteria
+## 6. Closure Criteria
 
 - Affected port is operational (`admin up`, `oper up`).
 - Connected device is reachable, VLAN and LACP membership function normally.
@@ -87,19 +87,19 @@ See Shared Appendix §6 for the full Junos command reference.
 - No related Marvis alarms (`port_flap`, `port_stuck`, `bad_cable`) active on the same port.
 - Root cause is documented on the ticket.
 
-## Mist GUI Navigation
+## 7. Mist GUI Navigation
 
 | Task | Navigation |
 |---|---|
-| Verify alert | Monitor → Alerts (Alarms) → filter by `sw_critical_port_down` |
-| Switch health | Switches → *device* → Health |
-| Port status / front panel | Switches → *device* → Front Panel / Port Configuration |
+| Verify alert | Monitor → Alerts → filter by `sw_critical_port_down` |
+| Switch health | Switches → *device* → Insights |
+| Port status / front panel | Switches → *device* → Front Panel |
 | Critical port flag | Switches → *device* → Port Configuration → *Critical Port* toggle |
-| Connected clients on the port | Clients → Connected Devices |
+| Connected clients on the port | Clients → Wired Clients |
 | Switch events | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
-## Junos Commands (quick reference)
+## 8. Junos Commands (quick reference)
 
 | Purpose | Command |
 |---|---|
@@ -119,7 +119,7 @@ See Shared Appendix §6 for the full Junos command reference.
 | Chassis alarms | `show chassis alarms` |
 | Ping | `ping <neighbor-ip>` |
 
-## Cross-references (sibling alarms)
+## 9. Cross-references (sibling alarms)
 
 If the current alarm co-fires with any of these, resolve the co-fired alarm first — it is usually the root cause:
 
@@ -131,6 +131,6 @@ If the current alarm co-fires with any of these, resolve the co-fired alarm firs
 - `sw_mtu_mismatch` — MTU mismatch (Marvis)
 - `sw_port_storm_control` — storm control holding port down
 
-## Escalation
+## 10. Escalation
 
 Per Shared Appendix §8. Tier 1 NOC can self-clear cable, optic, and remote-device causes. Escalate to Tier 2 for hardware replacement, or when the affected port is a member of the uplink LAG to the SSR130 and the LAG is currently at zero surviving members (store WAN down).

--- a/documentation/noc-runbooks/SW_VC_PORT_DOWN.md
+++ b/documentation/noc-runbooks/SW_VC_PORT_DOWN.md
@@ -1,6 +1,6 @@
 # SW_VC_PORT_DOWN
 
-## Overview
+## 1. Overview
 
 | Field | Value |
 |---|---|
@@ -20,7 +20,7 @@
 
 Unlike most `warn`-shipped port alarms, Mist ships `sw_vc_port_down` as `critical` natively. This is one of the few port-related alarms where Mist's default severity already reflects the blast radius (VC split risk), so no override is applied.
 
-## Impact
+## 2. Impact
 
 - Loss of Virtual Chassis redundancy on the affected VCP link.
 - **Immediate VC split risk (2-member VC).** With only master + backup, if the site is wired with a single VCP link between them, losing it partitions the chassis into two isolated single-member fragments — each attempts to run its own control plane. If the site is wired with redundant VCPs (recommended), the VC survives the loss of one but is now unprotected against a second failure.
@@ -30,7 +30,7 @@ Unlike most `warn`-shipped port alarms, Mist ships `sw_vc_port_down` as `critica
 - Potential service disruption during master/backup failover if the master-election path is affected.
 - Stale MAC/ARP entries until the fabric reconverges.
 
-## Required Information
+## 3. Required Information
 
 | Category | Data to capture |
 |---|---|
@@ -43,7 +43,7 @@ Unlike most `warn`-shipped port alarms, Mist ships `sw_vc_port_down` as `critica
 
 See Shared Appendix §5 for the always-required ticket fields.
 
-## Validation
+## 4. Validation
 
 | Check | Command / Action |
 |---|---|
@@ -62,7 +62,7 @@ See Shared Appendix §5 for the always-required ticket fields.
 
 See Shared Appendix §6 for the full Junos command reference.
 
-## Resolution
+## 5. Resolution
 
 | Area | Action |
 |---|---|
@@ -75,7 +75,7 @@ See Shared Appendix §6 for the full Junos command reference.
 | VC split recovery | If the VC has split into two single-member fragments, follow controlled rejoin procedure — do NOT power-cycle members without a plan, as this can force an unwanted master re-election. Escalate to Tier 2. |
 | Recovery | Confirm the VCP returns to Up, all members are synchronized, master/backup roles are as expected, and the paired clear event has fired. |
 
-## Closure Criteria
+## 6. Closure Criteria
 
 - Virtual Chassis is healthy: both EX4100 members present, master/backup roles as designed.
 - Affected VC port is `Up` and forwarding.
@@ -84,18 +84,18 @@ See Shared Appendix §6 for the full Junos command reference.
 - No co-firing `vc_master_changed`, `vc_backup_failed`, or `vc_member_deleted` still active.
 - Root cause is documented on the ticket, including which VCP link failed and whether the branch was wired with redundant VCPs (i.e. whether the site was one failure away from a split).
 
-## Mist GUI Navigation
+## 7. Mist GUI Navigation
 
 | Task | Navigation |
 |---|---|
-| Verify alert | Monitor → Alerts (Alarms) → filter by `sw_vc_port_down` |
-| Virtual Chassis health | Switches → *Virtual Chassis* → Health (primary/backup) |
-| VC members | Switches → *Virtual Chassis* → Members |
-| VC port status | Switches → *device* → Front Panel / Port Configuration |
+| Verify alert | Monitor → Alerts → filter by `sw_vc_port_down` |
+| Virtual Chassis health | Switches → *device* → Insights |
+| VC members | Switches → *device* → Front Panel (shows all VC members) |
+| VC port status | Switches → *device* → Front Panel |
 | Switch events | Monitor → Events |
 | Audit logs | Organization → Audit Logs |
 
-## Junos Commands (quick reference)
+## 8. Junos Commands (quick reference)
 
 | Purpose | Command |
 |---|---|
@@ -112,7 +112,7 @@ See Shared Appendix §6 for the full Junos command reference.
 | VCP-scoped logs | `show log messages \| match vcp` |
 | VC control-plane logs | `show log messages \| match vccpd` |
 
-## Cross-references (sibling alarms)
+## 9. Cross-references (sibling alarms)
 
 If any of these are co-firing, resolve them together — VC-family alarms tend to cascade:
 
@@ -125,7 +125,7 @@ If any of these are co-firing, resolve them together — VC-family alarms tend t
 
 Triage rule: **`vc_member_deleted` or `switch_down` on a member is usually root cause; `sw_vc_port_down` alone is often the earliest symptom of an impending split.**
 
-## Escalation
+## 10. Escalation
 
 Per Shared Appendix §8. Tier 1 NOC can self-clear cable, optic, and single-VCP-flap causes when the VC remains healthy (both members present, roles as designed). **Escalate to Tier 2 immediately** for:
 


### PR DESCRIPTION
## Summary

- Number all per-alarm runbook headings 1-10 so the same section number maps to the same topic across every runbook, and add the missing Cross-references section to `SW_ALARM_CHASSIS_MGMT_LINK_DOWN` so all 7 runbooks share the identical 10-section structure.
- Correct Mist Dashboard navigation strings across all 7 runbooks:
  - `Monitor -> Alerts (Alarms)` -> `Monitor -> Alerts`
  - `WAN Assurance -> ...` -> `Monitor -> Service Levels -> WAN [-> Peer Paths]` (WAN Assurance is a product name, not a menu item)
  - `Switches -> *Virtual Chassis* -> ...` -> `Switches -> *device* -> Insights / Front Panel` (VC is not a separate nav collection)
  - `Clients -> Connected Devices` -> `Clients -> Wired Clients`
  - `Health / Insights` -> `Insights` (single device-page tab name)
- Fix SSR1300 -> SSR130 typo in `GW_BGP_NEIGHBOR_DOWN` (retail-branch device, not DC-hub).

## Test plan

- [ ] Spot-check each of the 7 runbook Section 7 tables against the live Mist Dashboard nav.
- [ ] Confirm every runbook now has sections numbered 1-10 with matching topics.
- [ ] Confirm no stray `SSR1300` references remain in branch-scoped runbooks.