### PR TITLE
refactor(1014): remove dead-duplicate SSHExecutionConfig (P1)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -48,7 +48,7 @@ import subprocess  # nosec B404  # Import subprocess for executing external comm
 import time  # Import time for rate limiting, delays, and performance monitoring
 import traceback  # Import traceback for detailed exception context in error logs
 from collections.abc import Callable  # Import Callable type hint for callback functions passed to API methods
-from dataclasses import dataclass, field  # Import dataclass decorators for configuration objects and entity classes
+from dataclasses import dataclass  # Import dataclass decorator for configuration objects and entity classes
 from datetime import datetime  # Import datetime for timestamping logs and events
 from typing import TYPE_CHECKING, Any, Literal  # Import type hints for static analysis without runtime overhead
 
@@ -466,17 +466,9 @@ class SSHConnectionConfig:
     use_shell: bool = True  # Whether to allocate an interactive shell vs exec a single command
 
 
-@dataclass
-class SSHExecutionConfig:
-    """Configuration for SSH command execution - groups execution parameters."""
-
-    commands: list[str] = field(
-        default_factory=list
-    )  # Commands to run; default_factory avoids a shared mutable default list
-    max_threads: int = 5  # Cap on concurrent SSH sessions to avoid overloading devices/network
-    use_shell: bool = True  # Whether commands run in an interactive shell context
-
-
+# NOTE: SSHExecutionConfig removed (1014 P1) - was a dead duplicate of src/ssh/ssh_runner.py:167;
+#       nothing in MistHelper.py imported the local copy, and all src/ssh/batch/*.py callers
+#       already imported from src.ssh.ssh_runner. Import from src.ssh.ssh_runner instead.
 # NOTE: WebSocketListenerConfig removed - use ARPCommandManager._listen_for_output parameters directly
 # NOTE: MapViewerConfig removed (SC-002) - unused dataclass, MapsManager builds runtime state directly
 


### PR DESCRIPTION
## Summary
Position 1 of initiative #1014. **Reclassified from Cat E → dead-duplicate removal.**

`SSHExecutionConfig` existed as a duplicate `@dataclass` in both:
- `MistHelper.py:470` (the copy)
- `src/ssh/ssh_runner.py:167` (the real one)

All 5 references from `refactor_candidates.md` (in `src/ssh/batch/*_runner.py` + `command_runner.py`) already imported from `src.ssh.ssh_runner`. **Nothing in MistHelper.py used the local copy.**

## Why reclassify from Cat E
Spec proposed extracting to `src/ssh/batch/execution_config.py`. But that would create a *third* copy alongside the existing `src/ssh/ssh_runner.py` definition, requiring downstream callsite churn for no functional benefit. This is the SC-002 pattern (dead-code removal via breadcrumb) — a subset of Cat A behaviour rather than Cat E.

## Callsite table (FR-027)
| File | Line(s) | Import source (before → after) |
| --- | --- | --- |
| `src/ssh/batch/batch_executor.py` | 21, 61 | `src.ssh.ssh_runner` → *unchanged* |
| `src/ssh/batch/host_runner.py` | 26, 67 | `src.ssh.ssh_runner` → *unchanged* |
| `src/ssh/batch/interactive_batch_executor.py` | 27, 104 | `src.ssh.ssh_runner` → *unchanged* |
| `src/ssh/batch/multi_host_runner.py` | 19, 61, 84 | `src.ssh.ssh_runner` → *unchanged* |
| `tests/unit/test_ssh_runner.py` | 29, 81-1072 | `src.ssh.ssh_runner` → *unchanged* |
| `MistHelper.py` | 470 | **deleted** |

## Changes
- Delete `SSHExecutionConfig` `@dataclass` from `MistHelper.py` (10 LOC)
- Add FR-007 NOTE breadcrumb pointing to `src/ssh/ssh_runner.py:167`
- Drop `field` from `from dataclasses import` (no other users in MH.py)

## Local gate results (FR-006)
- ✅ `black --check MistHelper.py` — clean
- ✅ `ruff check MistHelper.py` — clean
- ✅ `python MistHelper.py --test` — 66/66 pass (exit 0)
- ✅ **IG-health probe (FR-028)**: `import src.ssh.ssh_runner` does not pull `MistHelper` into `sys.modules`; `SSHExecutionConfig()` constructs with default `max_threads=5`

## Related
Initiative #1014 (position 1). Spec PR: #867.