### PR TITLE
refactor(1014): remove SiteAutoUpgradeConfigurator facade (P2)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -209,6 +209,9 @@ from src.firmware.firmware_manager import (  # Cat A canonical (1013 SC-002)
     FirmwareManager,
     FirmwareManagerConfig,
 )
+from src.firmware.site_auto_upgrade import (  # Cat A canonical (1014 P2)
+    SiteAutoUpgradeConfigurator,
+)
 from src.gateway.gateway_export_utils import (
     configure_gateway_export_utils_dependencies,
 )  # Import gateway export utility configuration
@@ -8929,28 +8932,8 @@ def _build_firmware_manager(session: Any, target_org_id: str) -> FirmwareManager
 # NOTE: MSPInventoryExporter has been extracted to src/export/msp_inventory_exporter.py (issue #1013 SC-001 position 8)
 
 
-class SiteAutoUpgradeConfigurator:
-    """Thin wrapper that delegates to src.firmware.site_auto_upgrade."""
-
-    @staticmethod
-    def execute():
-        """Static entry point - delegates to extracted module."""
-        from src.firmware.site_auto_upgrade import SiteAutoUpgradeConfigurator as _Impl
-
-        global msp_privileges
-
-        dry_run = getattr(globals().get("args", None), "dry_run", False)
-        _Impl.execute(
-            apisession=apisession,
-            msp_privileges=msp_privileges if msp_privileges else [],
-            safe_input_fn=InputUtils.safe_input,
-            get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id,
-            fetch_sites_fn=APICoreFetchUtils.all_sites_with_limit,
-            check_stop_fn=ConfigUtils.check_stop_signal,
-            dry_run=dry_run,
-            select_msps_fn=OrgLevelAPFirmwareUpgrader._select_msps,
-            select_orgs_fn=OrgLevelAPFirmwareUpgrader._select_orgs_from_msp,
-        )
+# NOTE: SiteAutoUpgradeConfigurator facade removed (1014 P2, Cat A) - canonical body at
+# src/firmware/site_auto_upgrade.py:105. Menu 168 now inlines DI via lambda (see below).
 
 
 class OrgLevelAPFirmwareUpgrader:
@@ -9484,7 +9467,17 @@ menu_actions = {
     # SITE AUTO-UPGRADE CONFIGURATION
     # ==============================
     "168": (
-        SiteAutoUpgradeConfigurator.execute,
+        lambda: SiteAutoUpgradeConfigurator.execute(
+            apisession=apisession,
+            msp_privileges=msp_privileges if msp_privileges else [],
+            safe_input_fn=InputUtils.safe_input,
+            get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id,
+            fetch_sites_fn=APICoreFetchUtils.all_sites_with_limit,
+            check_stop_fn=ConfigUtils.check_stop_signal,
+            dry_run=getattr(globals().get("args", None), "dry_run", False),
+            select_msps_fn=OrgLevelAPFirmwareUpgrader._select_msps,
+            select_orgs_fn=OrgLevelAPFirmwareUpgrader._select_orgs_from_msp,
+        ),
         "Site Auto-Upgrade Configuration - Configure AP auto-upgrade settings for sites with MSP multi-org support (supports --dry-run)",  # noqa: E501
     ),
     # ==============================


### PR DESCRIPTION
## Summary

Removes the 22-line `SiteAutoUpgradeConfigurator` facade class from `MistHelper.py` (a thin delegation wrapper) and rewires menu 168 to call the canonical extract at `src/firmware/site_auto_upgrade.py:105` via inline lambda DI.

Dispatch queue position **P2** of initiative #1014.

## Reclassification (Cat E → Cat A)

Spec labels P2 as **Cat E** (fresh extraction), but pre-dispatch audit showed the canonical body already lives at `src/firmware/site_auto_upgrade.py` (extracted under #1013 SC-001). The MH.py class is a thin delegation wrapper — this is a **Cat A facade removal**, not a fresh extraction.

## Changes

- **Add** module-level import: `from src.firmware.site_auto_upgrade import SiteAutoUpgradeConfigurator` (Cat A canonical re-export, mirrors existing `firmware_manager` pattern at line 208).
- **Delete** the facade class at `MistHelper.py:8932-8953` (22 lines).
- **Rewire** menu 168 dispatch at `MistHelper.py:9487` with inline lambda passing `apisession`, `msp_privileges`, `safe_input_fn`, `get_org_id_fn`, `fetch_sites_fn`, `check_stop_fn`, `dry_run`, `select_msps_fn`, `select_orgs_fn` directly to `SiteAutoUpgradeConfigurator.execute()` — mirrors the pattern at menu 169 (line 9501).
- **FR-007 NOTE breadcrumb** replaces the deleted class.

Net: 16 insertions, 23 deletions (7 LOC removed from MH.py).

## Test plan

- [x] `black --check MistHelper.py`
- [x] `ruff check MistHelper.py`
- [x] `python -c \"import MistHelper\"` (import ok)
- [x] `pytest tests/unit/test_site_auto_upgrade.py -q` (184 passed)
- [x] AST parse ok
- [ ] CI: Quality Gates (Black, Ruff, mypy strict, Bandit, Vulture, Pylint, coverage, pytest, E2E smoke, pip-audit, CodeQL)

## References

- Initiative: #1014 dispatch queue position 2
- Canonical extract: `src/firmware/site_auto_upgrade.py:105` (extracted under #1013 SC-001)
- FR-023 (no concurrent PRs): P1 #868 merged before this PR opened
- FR-026 (Refs-ASC / LOC-DESC): P2 dispatched after P1
- Pattern reference: menu 169 lambda DI at `MistHelper.py:9501` (ExtractedSiteAnalyticsConfigurator)