### PR TITLE
refactor(1014): remove dead-duplicate SSHConnectionConfig (P3)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -457,18 +457,9 @@ if sys.version_info < MINIMUM_PYTHON_VERSION:  # Check if Python is below minimu
 # per function. Each dataclass encapsulates configuration for a specific domain.
 
 
-@dataclass
-class SSHConnectionConfig:
-    """Configuration for SSH connections - groups connection parameters."""
-
-    hostname: str  # Target device hostname or IP address to connect to
-    username: str  # SSH login username for authentication
-    password: str  # SSH login password (treated as a secret; never logged in plaintext)
-    port: int = 22  # TCP port for SSH (default 22; override for non-standard device setups)
-    timeout: int = 30  # Seconds to wait before giving up on a connection attempt
-    use_shell: bool = True  # Whether to allocate an interactive shell vs exec a single command
-
-
+# NOTE: SSHConnectionConfig removed (1014 P3) - was a dead duplicate of src/ssh/ssh_runner.py:155;
+#       nothing in MistHelper.py imported the local copy, and all src/ssh/*.py callers
+#       already imported from src.ssh.ssh_runner. Import from src.ssh.ssh_runner instead.
 # NOTE: SSHExecutionConfig removed (1014 P1) - was a dead duplicate of src/ssh/ssh_runner.py:167;
 #       nothing in MistHelper.py imported the local copy, and all src/ssh/batch/*.py callers
 #       already imported from src.ssh.ssh_runner. Import from src.ssh.ssh_runner instead.


### PR DESCRIPTION
## Summary
- Removes `@dataclass class SSHConnectionConfig` from `MistHelper.py` (9 LOC block at old line 460-469)
- Adds FR-007 breadcrumb NOTE pointing to canonical body at `src/ssh/ssh_runner.py:155`
- Same pattern as P1 (#868) — no callers to rewire, pure dead-duplicate removal

## Pre-dispatch audit
The spec labeled this Cat E (fresh cross-package extraction), but audit found:
- `MistHelper.py` never imports the local class (only the definition itself matches grep)
- Canonical `@dataclass class SSHConnectionConfig` already lives at `src/ssh/ssh_runner.py:155`
- All `src/ssh/*.py` callers and unit tests (`tests/unit/test_ssh_runner.py`, `tests/unit/ssh/test_command_runner.py`) import from `src.ssh.ssh_runner`

Reclassified to dead-duplicate → SC-002 pattern, same as P1 SSHExecutionConfig.

## Test plan
- [x] `python -m black --check MistHelper.py` — unchanged
- [x] `python -m ruff check MistHelper.py` — all checks passed
- [x] AST parse OK
- [x] `pytest tests/unit/test_ssh_runner.py -q` — 168 passed
- [x] `python -c "import MistHelper"` — OK

Refs: Initiative #1014, P3 (Refs-ASC / LOC-DESC dispatch queue)