### PR TITLE
refactor(1014): extract ValidationUtils to src/validation (P5, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -40,7 +40,6 @@ warnings.filterwarnings(
 import argparse  # Import argparse for command-line argument parsing (--menu, --test, --fast flags)
 import csv  # Import csv module for writing CSV export files to data/ directory
 import functools  # Import functools for partial-binding apisession to connection-pool worker callables
-import ipaddress  # Import ipaddress for parsing and validating IP addresses in device/client data
 import logging  # Import logging for structured logging to script.log and console
 import os  # Import os for file path operations, environment variables, and data/ directory setup
 import re  # Import re for regex pattern matching in data parsing (SSIDs, descriptions, etc.)
@@ -357,6 +356,7 @@ from src.utils.filter_operator_engine import (  # pylint: disable=unused-import
 from src.utils.operation_registry import (  # pylint: disable=unused-import
     OperationRegistry,  # noqa: F401  # Cat B (1013 SC-001 position 13) -- re-export for menu safety classification
 )
+from src.validation.validation_utils import ValidationUtils  # Cat E canonical (1014 P5)
 from src.wan_hub_group_manager import WanHubGroupNumberManager  # Import WAN hub group number manager for hub routing
 from src.wan_vpn_builder import WanVpnBuilder  # Import WAN VPN configuration builder
 from src.websocket.commands import MacTableCommand  # Import WebSocket show-MAC-table command handler
@@ -5652,96 +5652,10 @@ class FilePathUtils:
 # ============================================================================
 # VALIDATION UTILITIES CLASS
 # ============================================================================
-class ValidationUtils:  # Input validators for API identifiers.
-    """
-    Centralized validation utilities for input validation and sanitization.
-    All validation functions should be static methods in this class.
-    """
-
-    @staticmethod
-    def validate_site_id(site_id: str | None, function_name: str = "unknown") -> bool:  # Guard site_id before API use.
-        """
-        Validates that site_id is not None or empty before making API calls.
-
-        Args:
-            site_id: The site ID to validate
-            function_name: Name of the calling function for logging
-
-        Returns:
-            bool: True if valid, False otherwise
-
-        Raises:
-            ValueError: If site_id is None or empty
-        """
-        if site_id is None:  # Reject a missing site_id.
-            error_msg = f"! site_id is None in {function_name}. Cannot make API call."  # Build the failure message.
-            logging.error(error_msg)  # Log before raising.
-            raise ValueError(error_msg)  # Abort the call with context.
-
-        if isinstance(site_id, str) and site_id.strip() == "":  # Reject empty/whitespace site_id.
-            error_msg = f"! site_id is empty string in {function_name}. Cannot make API call."  # empty-string msg.
-            logging.error(error_msg)  # Log before raising.
-            raise ValueError(error_msg)  # Abort the call.
-
-        return True  # site_id passed validation.
-
-    @staticmethod
-    def validate_device_id(device_id: str | None, function_name: str = "unknown") -> bool:  # Guard device_id.
-        """
-        Validates that device_id is not None or empty before making API calls.
-
-        Args:
-            device_id: The device ID to validate
-            function_name: Name of the calling function for logging
-
-        Returns:
-            bool: True if valid, False otherwise
-
-        Raises:
-            ValueError: If device_id is None or empty
-        """
-        if device_id is None:  # Reject a missing device_id.
-            error_msg = f"! device_id is None in {function_name}. Cannot make API call."  # Build the failure message.
-            logging.error(error_msg)  # Log before raising.
-            raise ValueError(error_msg)  # Abort the call with context.
-
-        if isinstance(device_id, str) and device_id.strip() == "":  # Reject empty/whitespace device_id.
-            error_msg = f"! device_id is empty string in {function_name}. Cannot make API call."  # empty-string msg.
-            logging.error(error_msg)  # Log before raising.
-            raise ValueError(error_msg)  # Abort the call.
-
-        return True  # device_id passed validation.
-
-    @staticmethod
-    def validate_ping_target(target: str) -> bool:  # Validate a ping destination string.
-        """
-        Validate ping target hostname or IP address.
-
-        Args:
-            target: Target hostname or IP address
-
-        Returns:
-            bool: True if valid target, False otherwise
-        """
-        if not target or len(target.strip()) == 0:  # Reject empty targets.
-            return False  # Invalid: no target given.
-
-        target = target.strip()  # Normalize surrounding whitespace.
-
-        try:  # A literal IP address is always a valid target.
-            ipaddress.ip_address(target)  # Parse as a literal IP.
-            return True  # Valid IP target.
-        except ValueError:  # Not an IP; fall through to hostname validation.
-            pass  # Hostname check happens below.
-
-        return ValidationUtils._is_valid_hostname(target)  # Accept only well-formed hostnames
-
-    @staticmethod
-    def _is_valid_hostname(target: str) -> bool:  # Check a string is a syntactically valid hostname
-        """Return True when target uses the hostname charset, is <= 253 chars, and has no edge dot/hyphen."""
-        if not re.match(r"^[a-zA-Z0-9.-]+$", target) or len(target) > 253:  # Reject bad charset or over-length names
-            return False  # Not a valid hostname
-        return not target.startswith((".", "-")) and not target.endswith((".", "-"))  # Reject leading/trailing dot/dash
+# NOTE: ValidationUtils removed (1014 P5, Cat E) - canonical body at
+#       src/validation/validation_utils.py. Import from src.validation.validation_utils
+#       instead. MistHelper.py re-exports ValidationUtils at the top import block
+#       for legacy in-file callsites.
 
 
 # ============================================================================

--- a/src/export/gateway_test_exporter.py
+++ b/src/export/gateway_test_exporter.py
@@ -6,9 +6,10 @@ paced path), tags each result with site/device identifiers, and writes a CSV
 via the standard export backend. ``test_results_by_site`` remains a thin
 delegator to the ``src.refactors.serial_cc.test_results_by_site`` service.
 
-Direct imports cover stdlib + installed packages (mistapi, tqdm). Live-global
-reads (``apisession``, ``PROGRESS_EMITTER``, ``ProgressContext``, ``ConfigUtils``,
-``GatewayExportUtils``, ``ValidationUtils``, ``ConnectionPoolExecutor``,
+Direct imports cover stdlib + installed packages (mistapi, tqdm) plus the
+extracted ``ValidationUtils`` (1014 P5). Live-global reads
+(``apisession``, ``PROGRESS_EMITTER``, ``ProgressContext``, ``ConfigUtils``,
+``GatewayExportUtils``, ``ConnectionPoolExecutor``,
 ``RateLimitingUtils``, ``DataProcessingUtils``, ``DataExporter``,
 ``FAST_MODE_*``, ``FastModeBackoffMultiplier``, ``FastModeSequentialMaxRetries``,
 ``_api_usage_cache``) are resolved via lazy ``mh = importlib.import_module("MistHelper")``
@@ -26,6 +27,8 @@ from typing import Any  # WHY: mistapi payloads + heterogeneous stats dicts are 
 
 import mistapi  # WHY: direct call to getSiteDeviceSyntheticTest endpoint.
 from tqdm import tqdm  # WHY: progress bar for sequential + retry loops.
+
+from src.validation.validation_utils import ValidationUtils  # WHY: 1014 P5 direct import (FR-005).
 
 
 class GatewayTestExporter:
@@ -121,11 +124,10 @@ class GatewayTestExporter:
         device_info: tuple[str, str, str, str], attempt: int, connection_semaphore: Any
     ) -> dict[str, Any] | None:
         """Single attempt: validate inputs, call API, tag stats, log success. Return stats or None."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ValidationUtils.
         site_id, device_id, _, _ = device_info  # Unpack for the call + logging (names unused directly here).
         try:
-            mh.ValidationUtils.validate_site_id(site_id, "synthetic_tests")  # Validate the site id.
-            mh.ValidationUtils.validate_device_id(device_id, "synthetic_tests")  # Validate the device id.
+            ValidationUtils.validate_site_id(site_id, "synthetic_tests")  # Validate the site id.
+            ValidationUtils.validate_device_id(device_id, "synthetic_tests")  # Validate the device id.
             stats = GatewayTestExporter._call_synthetic_endpoint(site_id, device_id, connection_semaphore)  # Call API.
             GatewayTestExporter._tag_synthetic_stats(stats, device_info, attempt)  # Tag + log success.
             return stats  # Return tagged stats.

--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation helpers extracted from MistHelper.py (Initiative #1014 P5)."""

--- a/src/validation/validation_utils.py
+++ b/src/validation/validation_utils.py
@@ -1,0 +1,77 @@
+"""Centralized input validation for API identifiers and ping targets.
+
+Extracted from MistHelper.py (Initiative #1014 P5, Cat E). All methods are
+static so callers use ``ValidationUtils.validate_site_id(...)`` without
+instantiation. The public surface (validate_site_id, validate_device_id,
+validate_ping_target) is unchanged from the original class body.
+"""
+
+# pylint: disable=logging-fstring-interpolation
+
+from __future__ import annotations  # WHY: PEP 604 union syntax under Python 3.13.
+
+import ipaddress  # WHY: literal IP address parsing for ping-target validation.
+import logging  # WHY: shared logger for validation-failure audit trail.
+import re  # WHY: hostname regex enforcement.
+
+
+class ValidationUtils:
+    """Centralized validation utilities for input validation and sanitization.
+
+    All validation functions are static methods so callers do not need to
+    instantiate the class.
+    """
+
+    @staticmethod
+    def validate_site_id(site_id: str | None, function_name: str = "unknown") -> bool:
+        """Validate that ``site_id`` is not None or empty before making API calls.
+
+        Raises:
+            ValueError: If ``site_id`` is None or empty/whitespace.
+        """
+        if site_id is None:  # WHY: reject a missing site_id.
+            error_msg = f"! site_id is None in {function_name}. Cannot make API call."
+            logging.error(error_msg)  # WHY: log before raising.
+            raise ValueError(error_msg)  # WHY: abort the call with context.
+        if isinstance(site_id, str) and site_id.strip() == "":  # WHY: reject empty/whitespace.
+            error_msg = f"! site_id is empty string in {function_name}. Cannot make API call."
+            logging.error(error_msg)  # WHY: log before raising.
+            raise ValueError(error_msg)  # WHY: abort the call.
+        return True  # WHY: site_id passed validation.
+
+    @staticmethod
+    def validate_device_id(device_id: str | None, function_name: str = "unknown") -> bool:
+        """Validate that ``device_id`` is not None or empty before making API calls.
+
+        Raises:
+            ValueError: If ``device_id`` is None or empty/whitespace.
+        """
+        if device_id is None:  # WHY: reject a missing device_id.
+            error_msg = f"! device_id is None in {function_name}. Cannot make API call."
+            logging.error(error_msg)  # WHY: log before raising.
+            raise ValueError(error_msg)  # WHY: abort the call with context.
+        if isinstance(device_id, str) and device_id.strip() == "":  # WHY: reject empty/whitespace.
+            error_msg = f"! device_id is empty string in {function_name}. Cannot make API call."
+            logging.error(error_msg)  # WHY: log before raising.
+            raise ValueError(error_msg)  # WHY: abort the call.
+        return True  # WHY: device_id passed validation.
+
+    @staticmethod
+    def validate_ping_target(target: str) -> bool:
+        """Validate ping target hostname or IP address."""
+        if not target or len(target.strip()) == 0:  # WHY: reject empty targets.
+            return False  # WHY: invalid — no target given.
+        target = target.strip()  # WHY: normalize surrounding whitespace.
+        try:  # WHY: a literal IP address is always a valid target.
+            ipaddress.ip_address(target)  # WHY: parse as a literal IP.
+            return True  # WHY: valid IP target.
+        except ValueError:  # WHY: not an IP; fall through to hostname validation.
+            pass  # WHY: hostname check happens below.
+        return ValidationUtils._is_valid_hostname(target)  # WHY: accept only well-formed hostnames.
+
+    @staticmethod
+    def _is_valid_hostname(target: str) -> bool:
+        """Return True when target uses the hostname charset, is <= 253 chars, no edge dot/hyphen."""
+        if not re.match(r"^[a-zA-Z0-9.-]+$", target) or len(target) > 253:  # WHY: charset+length.
+            return False  # WHY: not a valid hostname.
+        return not target.startswith((".", "-")) and not target.endswith((".", "-"))  # WHY: edges.


### PR DESCRIPTION
## Summary
- Extract \`ValidationUtils\` class body (91 LOC) from \`MistHelper.py\` to \`src/validation/validation_utils.py\`.
- Add package marker \`src/validation/__init__.py\`; FR-007 breadcrumb NOTE at old location.
- MistHelper.py re-exports \`ValidationUtils\` at top import block for legacy in-file callsites.
- Ruff auto-removed now-unused \`ipaddress\` import from MistHelper.py.

## FR-027 Callsite Table
| Callsite | Type | Rewire |
| --- | --- | --- |
| \`MistHelper.py\` top | re-export | \`from src.validation.validation_utils import ValidationUtils\` |
| \`src/export/gateway_test_exporter.py\` | lazy importlib | direct import (FR-005) |
| \`src/gateway/gateway_export_utils.py\` | DI slot | consumes injected value via re-export |
| \`src/gateway/gateway_stats_exporter.py\` | DI slot | consumes injected value via re-export |
| \`src/refactors/serial_cc/test_results_by_site.py\` | DI kwarg | consumes injected value via re-export |
| \`tests/unit/serial_cc/test_test_results_by_site.py\` | MagicMock | no rewire needed |

## FR-028 IG-health probe
\`\`\`
python -c "import sys; import src.validation.validation_utils as m; assert 'MistHelper' not in sys.modules; print('OK')"
IG-health OK: ValidationUtils imports without MistHelper
\`\`\`

## Method-parity (FR-025) & FR-006
- \`validate_site_id\` (11 LOC), \`validate_device_id\` (11 LOC), \`validate_ping_target\` (12 LOC), \`_is_valid_hostname\` (3 LOC) — all preserved, all =<25 LOC.

## Test plan
- [x] \`python -m ruff check\` — clean
- [x] \`python -m black --check\` — clean
- [x] AST parse — OK
- [x] \`python -m pytest tests/unit\` — 3861 passed
- [x] FR-028 IG-health — passes

Refs #1014 (dispatch position 5, Refs-ASC/LOC-DESC).