### PR TITLE
refactor(1014): extract TimeUtils to src/time (P6, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -329,6 +329,7 @@ from src.ssh.ssh_runner_manager import (
     SSHRunnerManager as ExtractedSSHRunnerManager,
 )  # Import SSH runner manager (renamed to avoid conflicts)
 from src.ssh.ssh_runner_manager import SSHRunnerManagerDeps  # Import SSH runner manager dependency injection class
+from src.time.time_utils import TimeUtils  # Cat E canonical (1014 P6)
 from src.troubleshooting.interactive_test_runner import (
     InteractiveTestRunner,
 )  # Import interactive diagnostic test runner
@@ -1984,35 +1985,8 @@ IS_TEST_MODE = "--test" in sys.argv or "--testinteractive" in sys.argv
 LAST_SELECTED_SITE_ID: str | None = None
 
 
-class TimeUtils:
-    """
-    Centralized time-related utilities.
-    Handles dynamic lookback windows, timestamp conversions, etc.
-    """
-
-    @staticmethod
-    def get_dynamic_lookback_hours(default_hours: int = 24, test_hours: int = 1) -> int:
-        """Return lookback hours adjusted for test mode (shrinks to test_hours under --test).
-
-        Outside test mode the caller's default_hours window is honored. Both values are
-        clamped to a 1-hour minimum so a misconfiguration never yields a sub-hour window.
-        """
-        try:
-            chosen_hours = test_hours if IS_TEST_MODE else default_hours  # Pick the window for the active mode
-            return max(1, chosen_hours)  # Never return less than 1 hour (clamp misconfigured values)
-        except Exception as error:  # Never let lookback math crash a caller
-            logging.debug("get_dynamic_lookback_hours fallback due to error: %s", error)  # Log the unexpected failure
-            return test_hours if IS_TEST_MODE else default_hours  # Fall back to a sensible default per mode
-
-    @staticmethod
-    def log_dynamic_lookback(context: str, hours: int) -> None:
-        """Helper to produce a consistent log line when dynamic lookback applies."""
-        if IS_TEST_MODE:  # Surface the reduced window prominently during tests
-            logging.info(
-                "[TEST MODE] Using reduced lookback window of %sh for %s (normally 24h)", hours, context
-            )  # Visible test-mode notice
-        else:  # Production: keep the note at debug level
-            logging.debug("Using standard lookback window of %sh for %s", hours, context)  # Quiet production notice
+# NOTE: TimeUtils removed (1014 P6, Cat E) - canonical body at src/time/time_utils.py.
+#       Import from src.time.time_utils. MistHelper.py re-exports at top import block.
 
 
 # ============================================================================

--- a/src/export/org_alarm_event_exporter.py
+++ b/src/export/org_alarm_event_exporter.py
@@ -18,6 +18,7 @@ from typing import Any  # WHY: api_call is duck-typed mistapi callable.
 import mistapi  # WHY: direct SDK access for alarms/events endpoints.
 
 from src.export.device_events_52w_exporter import DeviceEvents52wExporter  # 52-week device events exporter.
+from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
 
 
 class OrgAlarmEventExporter:
@@ -57,11 +58,11 @@ class OrgAlarmEventExporter:
     @staticmethod
     def alarms() -> None:
         """Export open organization alarms from the past 24 hours to OrgAlarms.csv."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of TimeUtils + APIDataFetcher.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of APIDataFetcher helper.
         logging.info("Menu #20: Starting organization alarms export")  # Log alarms menu start.
         logging.debug("ENTRY: OrgAlarmEventExporter.alarms()")  # Trace entry for debugging.
-        hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve dynamic lookback hours.
-        mh.TimeUtils.log_dynamic_lookback("open org alarms export", hours)  # Log chosen lookback window.
+        hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve dynamic lookback hours.
+        TimeUtils.log_dynamic_lookback("open org alarms export", hours)  # Log chosen lookback window.
         try:
             mh.APIDataFetcher(  # Fetch and write alarms.
                 title="Search all Org Alarms:",
@@ -90,9 +91,8 @@ class OrgAlarmEventExporter:
     @staticmethod
     def events() -> None:
         """Export organization events to OrgEvents.csv."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of TimeUtils helper.
-        hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve dynamic lookback hours.
-        mh.TimeUtils.log_dynamic_lookback("org events export", hours)  # Log chosen lookback window.
+        hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve dynamic lookback hours.
+        TimeUtils.log_dynamic_lookback("org events export", hours)  # Log chosen lookback window.
         OrgAlarmEventExporter._export_data(
             api_call=mistapi.api.v1.orgs.events.searchOrgEvents,
             data_type="events",
@@ -103,14 +103,12 @@ class OrgAlarmEventExporter:
     @staticmethod
     def device_events() -> None:
         """Export all device events from the past 24 hours to OrgDeviceEvents.csv."""
-        mh = importlib.import_module(
-            "MistHelper"
-        )  # WHY: lazy fetch of ConfigUtils/TimeUtils/DataExporter + apisession.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils/DataExporter + apisession.
         logging.info("Menu #21: Starting device events export")  # Log device events menu start.
         logging.info("Search Org Device Events:")  # Log search start.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
-        hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve dynamic lookback hours.
-        mh.TimeUtils.log_dynamic_lookback("recent device events export", hours)  # Log chosen lookback window.
+        hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve dynamic lookback hours.
+        TimeUtils.log_dynamic_lookback("recent device events export", hours)  # Log chosen lookback window.
         duration_param = f"{hours}h"  # Format duration param.
         response = mistapi.api.v1.orgs.devices.searchOrgDeviceEvents(  # Search org device events.
             mh.apisession, org_id, device_type="all", limit=1000, duration=duration_param

--- a/src/export/org_client_security_exporter.py
+++ b/src/export/org_client_security_exporter.py
@@ -23,6 +23,8 @@ from typing import Any  # WHY: mistapi response payloads + site rows are duck-ty
 import mistapi  # WHY: direct calls to orgs.clients + sites.insights list endpoints + get_all pager.
 from tqdm import tqdm  # WHY: per-site progress bar for rogue fan-out.
 
+from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
+
 
 class OrgClientSecurityExporter:
     """Organization Client and Security Exporter.
@@ -64,14 +66,14 @@ class OrgClientSecurityExporter:
     @staticmethod
     def rogue_clients(fast: bool = False) -> None:
         """Export rogue clients to OrgRogueClients.csv with fast-mode cache reuse."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of TimeUtils/CacheUtils/OrgSiteExporter.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of CacheUtils/OrgSiteExporter.
         output_file = "OrgRogueClients.csv"  # Destination CSV for this export
         if OrgClientSecurityExporter._check_csv_cache_fresh(output_file, fast):  # Fast-mode cache hit short-circuits
             return  # Skip the API calls entirely
         logging.info("Starting export of rogue clients from all sites...")  # Log the start of the export
-        lookback_hours = mh.TimeUtils.get_dynamic_lookback_hours(168, 1)  # 7 days normally, 1 hour in test mode
+        lookback_hours = TimeUtils.get_dynamic_lookback_hours(168, 1)  # 7 days normally, 1 hour in test mode
         rogue_duration = f"{lookback_hours}h"  # Format the lookback as the API's duration string
-        mh.TimeUtils.log_dynamic_lookback("rogue clients fetch", lookback_hours)  # Log which lookback window is used
+        TimeUtils.log_dynamic_lookback("rogue clients fetch", lookback_hours)  # Log which lookback window is used
         mh.CacheUtils.check_and_generate_csv(
             "SiteList.csv", mh.OrgSiteExporter.sites
         )  # Ensure site list CSV is current
@@ -87,14 +89,14 @@ class OrgClientSecurityExporter:
     @staticmethod
     def rogue_aps(fast: bool = False) -> None:
         """Export rogue APs to OrgRogueAPs.csv with fast-mode cache reuse."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of TimeUtils/CacheUtils/OrgSiteExporter.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of CacheUtils/OrgSiteExporter.
         output_file = "OrgRogueAPs.csv"  # Destination CSV for this export
         if OrgClientSecurityExporter._check_csv_cache_fresh(output_file, fast):  # Fast-mode cache hit short-circuits
             return  # Skip the API calls entirely
         logging.info("Starting export of rogue APs from all sites...")  # Log the start of the export
-        lookback_hours = mh.TimeUtils.get_dynamic_lookback_hours(168, 1)  # 7 days normally, 1 hour in test mode
+        lookback_hours = TimeUtils.get_dynamic_lookback_hours(168, 1)  # 7 days normally, 1 hour in test mode
         rogue_duration = f"{lookback_hours}h"  # Format the lookback as the API's duration string
-        mh.TimeUtils.log_dynamic_lookback("rogue APs fetch", lookback_hours)  # Log which lookback window is used
+        TimeUtils.log_dynamic_lookback("rogue APs fetch", lookback_hours)  # Log which lookback window is used
         mh.CacheUtils.check_and_generate_csv(
             "SiteList.csv", mh.OrgSiteExporter.sites
         )  # Ensure site list CSV is current

--- a/src/export/org_device_stats_exporter.py
+++ b/src/export/org_device_stats_exporter.py
@@ -31,6 +31,8 @@ from concurrent.futures import ThreadPoolExecutor  # WHY: bounded retry worker p
 
 from tqdm import tqdm  # WHY: progress bar during retry pool.
 
+from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
+
 
 class OrgDeviceStatsExporter:  # Org device-stats exporters.
     """Organization Device Statistics Exporter.
@@ -73,8 +75,8 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
         if emitter:
             emitter.emit_progress_start("13", "device_stats", 1)  # Emit progress start
         op_start = time.time()  # Record operation start time
-        hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Dynamic lookback hours
-        mh.TimeUtils.log_dynamic_lookback("org device statistics export", hours)  # Log lookback window
+        hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Dynamic lookback hours
+        TimeUtils.log_dynamic_lookback("org device statistics export", hours)  # Log lookback window
         mh.APIDataFetcher(  # Fetch and write device stats
             title="Org Device Stats:",
             api_call=mh.mistapi.api.v1.orgs.stats.listOrgDevicesStats,
@@ -383,13 +385,13 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
         Fast mode caches recent CSV (CSV_FRESHNESS_MINUTES) and parallelizes site fetches with
         bounded concurrency. Non-fast mode issues one org-level paginated call. SECURITY: read-only.
         """
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of TimeUtils/APIDataFetcher/mistapi.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of APIDataFetcher/mistapi.
         output_file = "OrgDevicePortStats.csv"  # Stable filename for cache + downstream consumers.
         if OrgDeviceStatsExporter._port_stats_cache_hit(output_file, fast):  # Honor fast cache before API.
             return  # Fresh cache satisfied the request.
         logging.info("Starting export of organization device port statistics...")  # Log export start.
-        hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve test-aware lookback window.
-        mh.TimeUtils.log_dynamic_lookback("org device port statistics export", hours)  # Record chosen window.
+        hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve test-aware lookback window.
+        TimeUtils.log_dynamic_lookback("org device port statistics export", hours)  # Record chosen window.
         if fast:  # Fast mode = site-parallel collection.
             OrgDeviceStatsExporter._run_fast_device_port_stats(output_file)  # Execute decomposed fast-mode workflow.
             return  # Fast-mode path owns the full export.
@@ -438,8 +440,8 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
         if emitter:  # Emitter present.
             emitter.emit_progress_start("15", "vpn_peer_stats", 1)  # Signal progress start.
         op_start = time.time()  # Start timer.
-        hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Test-aware lookback.
-        mh.TimeUtils.log_dynamic_lookback("org vpn peer path statistics export", hours)  # Record lookback.
+        hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Test-aware lookback.
+        TimeUtils.log_dynamic_lookback("org vpn peer path statistics export", hours)  # Record lookback.
         mh.APIDataFetcher(
             title="Org VPN Peer Stats:",
             api_call=mh.mistapi.api.v1.orgs.stats.searchOrgPeerPathStats,

--- a/src/export/org_export_utils.py
+++ b/src/export/org_export_utils.py
@@ -16,6 +16,8 @@ from typing import Any  # WHY: raw insight rows are duck-typed dicts from mistap
 
 import mistapi  # WHY: direct SDK access for org export endpoints.
 
+from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
+
 
 class OrgExportUtils:
     """Centralized organization-level data export utilities.
@@ -516,9 +518,8 @@ class OrgExportUtils:
     @staticmethod
     def _nac_events():  # Export NAC events.
         """Export NAC events to OrgNacEvents.csv."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of TimeUtils helper.
-        hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve lookback hours.
-        mh.TimeUtils.log_dynamic_lookback("org NAC events export", hours)  # Log the window.
+        hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve lookback hours.
+        TimeUtils.log_dynamic_lookback("org NAC events export", hours)  # Log the window.
         OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
             api_call=mistapi.api.v1.orgs.nac_clients.searchOrgNacClientEvents,
             data_type="nac events",
@@ -617,15 +618,14 @@ class OrgExportUtils:
     @staticmethod
     def _build_audit_log_kwargs(full_history: bool, duration: str | None) -> dict[str, Any]:
         """Resolve API kwargs (limit + duration/start) for org audit-log listing based on caller flags."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of TimeUtils helper.
         kwargs: dict[str, Any] = {"limit": 1000}  # Base API params.
         if duration:  # Caller-supplied duration takes priority.
             kwargs["duration"] = duration  # Set explicit duration string.
             logging.info("Exporting audit logs for duration: %s", duration)  # Log the window.
             return kwargs  # Done.
         if not full_history:  # No duration, recent-only mode.
-            hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve lookback hours.
-            mh.TimeUtils.log_dynamic_lookback("audit logs export", hours)  # Log the window.
+            hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Resolve lookback hours.
+            TimeUtils.log_dynamic_lookback("audit logs export", hours)  # Log the window.
             kwargs["duration"] = f"{hours}h"  # Set the duration.
             logging.info("Exporting only last %s hours of audit logs (duration=%sh).", hours, hours)
             return kwargs  # Done.

--- a/src/export/self_export_utils.py
+++ b/src/export/self_export_utils.py
@@ -13,6 +13,8 @@ import logging  # WHY: emit structured trace for export progress + failures.
 
 import mistapi  # WHY: dotted-path API resolution + pagination helper.
 
+from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
+
 
 class SelfExportUtils:  # Self/account exporters.
     # pylint: disable=too-few-public-methods  # WHY: static-method utility class; grouping by domain is the point.
@@ -43,9 +45,9 @@ class SelfExportUtils:  # Self/account exporters.
         logging.info("Starting export of self (admin account) audit logs...")  # Log before operation.
         filename = "SelfAuditLogs.csv"  # Output filename for self audit log entries.
         try:
-            mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live session + time helpers.
-            hours = mh.TimeUtils.get_dynamic_lookback_hours(24, 1)  # Same lookback as other audit log exports.
-            mh.TimeUtils.log_dynamic_lookback("self audit logs export", hours)  # Log lookback window selection.
+            mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live session.
+            hours = TimeUtils.get_dynamic_lookback_hours(24, 1)  # Same lookback as other audit log exports.
+            TimeUtils.log_dynamic_lookback("self audit logs export", hours)  # Log lookback window selection.
             logging.info("Fetching self audit logs for last %d hours...", hours)  # Log before API call.
             response = mistapi.api.v1.self.logs.listSelfAuditLogs(  # Call Mist API for admin account audit log.
                 mh.apisession,

--- a/src/time/__init__.py
+++ b/src/time/__init__.py
@@ -1,0 +1,1 @@
+"""Time helpers extracted from MistHelper.py (Initiative #1014 P6)."""

--- a/src/time/time_utils.py
+++ b/src/time/time_utils.py
@@ -1,0 +1,52 @@
+"""TimeUtils -- dynamic lookback window helpers for test-vs-production runs.
+
+Extracted from MistHelper.py during initiative 1014 (Cat E, position 6).
+Callers reach the class either through direct ``from src.time.time_utils import TimeUtils``
+(preferred, FR-005) or via the ``MistHelper.TimeUtils`` re-export alias which continues
+to point at this canonical body.
+
+``IS_TEST_MODE`` is recomputed here from ``sys.argv`` so the module has no MistHelper.py
+backref (FR-028 IG-health). The value is captured at import time — identical to how
+MistHelper.py evaluates it — so all callers observe the same flag regardless of which
+module imported first.
+"""
+
+# pylint: disable=broad-exception-caught
+
+from __future__ import annotations  # WHY: PEP 604 unions for method signatures.
+
+import logging  # WHY: fallback + informational log lines.
+import sys  # WHY: recompute IS_TEST_MODE from sys.argv (no MistHelper backref).
+
+IS_TEST_MODE = "--test" in sys.argv or "--testinteractive" in sys.argv  # WHY: mirror MistHelper.py flag.
+
+
+class TimeUtils:
+    """Centralized time-related utilities.
+
+    Handles dynamic lookback windows, timestamp conversions, etc.
+    """
+
+    @staticmethod
+    def get_dynamic_lookback_hours(default_hours: int = 24, test_hours: int = 1) -> int:
+        """Return lookback hours adjusted for test mode (shrinks to test_hours under --test).
+
+        Outside test mode the caller's default_hours window is honored. Both values are
+        clamped to a 1-hour minimum so a misconfiguration never yields a sub-hour window.
+        """
+        try:
+            chosen_hours = test_hours if IS_TEST_MODE else default_hours  # Pick the window for the active mode
+            return max(1, chosen_hours)  # Never return less than 1 hour (clamp misconfigured values)
+        except Exception as error:  # Never let lookback math crash a caller
+            logging.debug("get_dynamic_lookback_hours fallback due to error: %s", error)  # Log the unexpected failure
+            return test_hours if IS_TEST_MODE else default_hours  # Fall back to a sensible default per mode
+
+    @staticmethod
+    def log_dynamic_lookback(context: str, hours: int) -> None:
+        """Helper to produce a consistent log line when dynamic lookback applies."""
+        if IS_TEST_MODE:  # Surface the reduced window prominently during tests
+            logging.info(
+                "[TEST MODE] Using reduced lookback window of %sh for %s (normally 24h)", hours, context
+            )  # Visible test-mode notice
+        else:  # Production: keep the note at debug level
+            logging.debug("Using standard lookback window of %sh for %s", hours, context)  # Quiet production notice


### PR DESCRIPTION
## Summary

Initiative #1014 dispatch queue position **P6** — extract `TimeUtils` (Cat E, fresh extraction) from `MistHelper.py` into new canonical module `src/time/time_utils.py`. `MistHelper.TimeUtils` remains as a re-export alias.

## FR-027 Callsite Table

| # | Method | File | Line | Rewire |
|---|---|---|---|---|
| 1 | `alarms()` | `src/export/org_alarm_event_exporter.py` | 64-65 | direct import |
| 2 | `events()` | `src/export/org_alarm_event_exporter.py` | 94-95 | direct import |
| 3 | `device_events()` | `src/export/org_alarm_event_exporter.py` | 112-113 | direct import |
| 4 | `rogue_clients()` | `src/export/org_client_security_exporter.py` | 74, 76 | direct import |
| 5 | `rogue_aps()` | `src/export/org_client_security_exporter.py` | 97, 99 | direct import |
| 6 | `device_stats()` | `src/export/org_device_stats_exporter.py` | 78-79 | direct import |
| 7 | `port_stats()` | `src/export/org_device_stats_exporter.py` | 393-394 | direct import |
| 8 | `vpn_peer_paths()` | `src/export/org_device_stats_exporter.py` | 443-444 | direct import |
| 9 | `_nac_events()` | `src/export/org_export_utils.py` | 521-522 | direct import |
| 10 | `_build_audit_log_kwargs()` | `src/export/org_export_utils.py` | 627-628 | direct import |
| 11 | `audit_logs()` | `src/export/self_export_utils.py` | 49-50 | direct import |

DI-pattern consumers (already using `deps.TimeUtils` slot binding):
- `src/export/site_export_utils.py` — already direct import
- `src/refactors/serial_cc/sle_metrics.py` — DI kwarg (works via re-export)
- `src/refactors/serial_cc/security_events.py` — DI kwarg (works via re-export)

## FR-028 IG-Health Probe

\`\`\`
python -c "import sys; import src.time.time_utils as m; assert 'MistHelper' not in sys.modules; print('OK')"
FR-028 IG-health OK
\`\`\`

Extracted module has no MistHelper.py backref. IS_TEST_MODE is recomputed from sys.argv at import time (identical expression to MistHelper.py) so both modules observe the same flag regardless of import order.

## Local Gate

- black: PASS
- ruff: PASS
- AST parse: PASS
- pytest tests/unit: **3861 passed**

## Test plan

- [x] AST parse
- [x] black --check
- [x] ruff check
- [x] pytest tests/unit (3861 passed)
- [x] FR-028 IG-health probe
- [ ] CI green