### PR TITLE
refactor(1014): extract APIFetchUtils to src/api/api_fetch_utils.py (P8, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -39,7 +39,6 @@ warnings.filterwarnings(
 
 import argparse  # Import argparse for command-line argument parsing (--menu, --test, --fast flags)
 import csv  # Import csv module for writing CSV export files to data/ directory
-import functools  # Import functools for partial-binding apisession to connection-pool worker callables
 import logging  # Import logging for structured logging to script.log and console
 import os  # Import os for file path operations, environment variables, and data/ directory setup
 import re  # Import re for regex pattern matching in data parsing (SSIDs, descriptions, etc.)
@@ -96,6 +95,9 @@ from src.analytics.telemetry_emitter import (  # pylint: disable=unused-import
 from src.api.api_data_fetcher import (  # pylint: disable=unused-import
     APIDataFetcher,  # noqa: F401  # Cat B (1013 SC-001 position 21) -- re-export for MistHelper.APIDataFetcher callers
 )
+from src.api.api_fetch_utils import (
+    APIFetchUtils,
+)  # Cat E canonical (1014 P8) -- re-export for MistHelper.APIFetchUtils callers
 from src.audit.audit_analysis_ops import (  # pylint: disable=unused-import
     AuditAnalysisOps,  # noqa: F401  # Cat B (1013 SC-001 position 12) -- re-export for menu_actions #25/#174 dispatch
 )
@@ -252,8 +254,8 @@ from src.refactors.fast_mode_backoff_multiplier import (  # pylint: disable=unus
 )
 
 # FastModeDevicesPerThread import removed: only referenced from within ConnectionPoolExecutor (1012 SC-003)
-from src.refactors.fast_mode_sequential_max_retries import (
-    FastModeSequentialMaxRetries,  # Extracted fast-mode sequential-fallback retry ceiling (SC-030)
+from src.refactors.fast_mode_sequential_max_retries import (  # pylint: disable=unused-import
+    FastModeSequentialMaxRetries,  # noqa: F401  # Cat E (1014 P8) -- re-export for lazy mh.FastModeSequentialMaxRetries in api_fetch_utils.py
 )
 from src.refactors.initialize_mist_session import (
     MistSessionInitializer,  # Extracted token-based session initializer (SC-024)
@@ -1633,8 +1635,6 @@ class GlobalImportManager:
             skip_deps: Whether to skip dependency installation
             max_workers: Maximum number of concurrent workers
         """
-        import threading  # Lock primitive to serialize log output across threads
-
         log_lock = threading.Lock()  # Guards logging so concurrent threads don't interleave messages
         builtin_packages, external_packages = self._partition_dependencies(packages_dict)  # Split by spec presence
         for item in builtin_packages.items():  # Built-ins import instantly with no network needed
@@ -5767,229 +5767,7 @@ class APICoreFetchUtils:  # Low-level Mist API fetch helpers.
 # Instances are created at each call site using the runtime apisession and org ID resolver.
 from src.api.tenant_fetch import APITenantFetchUtils  # noqa: F401  # Re-exported for ServicePingLauncher late-binding
 
-
-class APIFetchUtils:  # Higher-level org/site fetchers.
-    """
-    Centralized API fetch utilities.
-    Groups all data fetching functions for better code organization.
-    All methods are static to avoid unnecessary object instantiation.
-    """
-
-    @staticmethod
-    def organization_services() -> list[dict[str, Any]]:  # Fetch and flatten org services.
-        """Fetch all org-level services via the Mist API; return list of service dicts (empty on error).
-
-        SECURITY: Read-only operation fetching configuration data only.
-        """
-        try:
-            org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the target org.
-            logging.info("Fetching organization services for org_id: %s", org_id)  # Log before the API call.
-
-            # Call the Mist API to get organization services
-            response = mistapi.api.v1.orgs.services.listOrgServices(apisession, org_id, limit=1000)  # List services.
-
-            if hasattr(response, "data") and response.data:  # Only proceed with data.
-                services_data = response.data  # Unwrap the payload.
-                logging.info("Successfully retrieved %s organization services", len(services_data))  # Log the count.
-                services_list = APIFetchUtils._normalize_org_services(services_data)  # Normalize to display rows.
-                return services_list  # Return normalized services.
-
-            logging.warning("No organization services found or response data is empty")  # Warn on empty response.
-            return []  # No services to return.
-
-        except Exception as error:  # Never crash on API failure.
-            logging.error("Failed to fetch organization services: %s", error)  # Log the fetch failure.
-            return []  # Degrade to empty list.
-
-    @staticmethod
-    def _normalize_org_services(services_data: list[Any]) -> list[dict[str, Any]]:  # Flatten raw services to rows
-        """Normalize raw org service records into name/type/description rows (keeping the full config)."""
-        services_list = []  # Accumulate normalized rows.
-        for service in services_data:  # Walk each service.
-            if isinstance(service, dict):  # Skip non-dict entries.
-                services_list.append(
-                    {
-                        "name": service.get("name", "unnamed"),  # Default missing names.
-                        "type": service.get("type", "custom"),  # Default missing type.
-                        "description": service.get("description", ""),  # Default missing description.
-                        "full_config": service,  # Keep full config for reference
-                    }
-                )  # Record the normalized service row
-        return services_list  # Return normalized services.
-
-    @staticmethod
-    def _fetch_single_site_setting(apisession, site):
-        """Fetch one site's settings; tag with id/name; return dict or None on failure."""
-        site_id = site.get("id")  # Target site id
-        site_name = site.get("name", "Unnamed Site")  # Friendly site label
-        try:
-            config = mistapi.api.v1.sites.setting.getSiteSetting(apisession, site_id).data  # Fetch site settings
-            config["site_id"] = site_id  # Tag with site id
-            config["site_name"] = site_name  # Tag with site name
-            logging.info("! Fetched config for site: %s (ID: %s)", site_name, site_id)
-            return config
-        except Exception as error:  # Skip sites that fail
-            logging.warning("! Failed to fetch config for %s (ID: %s): %s", site_name, site_id, error)
-            return None
-
-    @staticmethod
-    def all_site_settings(apisession, org_id, limit=1000):  # Fetch settings for every site.
-        """Fetch per-site settings for every site in the org; limit param is unused (kept for back-compat)."""
-        del limit  # Kept in signature for back-compat; explicitly discard so linters do not flag it.
-        logging.info("Fetching all site settings...")  # Log before fetching sites
-        sites = APICoreFetchUtils.all_sites_with_limit(org_id)  # List all sites first
-        all_configs = []  # Collect per-site settings
-        for site in tqdm(sites, desc="Sites", unit="site"):  # type: ignore[no-untyped-call]
-            if ConfigUtils.check_stop_signal():  # Honor a user stop request
-                break  # Stop iterating sites
-            config = APIFetchUtils._fetch_single_site_setting(apisession, site)  # One site at a time
-            if config is not None:  # Skip failed fetches
-                all_configs.append(config)
-        logging.info("Fetched settings for %s sites.", len(all_configs))  # Log total fetched
-        return all_configs  # Return all site settings
-
-    @staticmethod
-    def _gw_load_inventory(apisession, org_id):
-        """Fetch the org inventory; return the device list, or None when the fetch fails."""
-        logging.info("Fetching org inventory to find gateway devices...")  # Log before the inventory fetch.
-        try:  # The inventory fetch is the one hard dependency; isolate its failure.
-            response = mistapi.api.v1.orgs.inventory.getOrgInventory(apisession, org_id, limit=1000)  # Fetch inventory.
-            return mistapi.get_all(response=response, mist_session=apisession)  # Page through all devices.
-        except Exception as error:  # Inventory fetch failed.
-            logging.error("! Failed to fetch org inventory: %s", error)  # Log the failure.
-            return None  # Signal failure so the caller degrades to an empty result.
-
-    @staticmethod
-    def _gw_load_site_names():
-        """Load the site id -> name map from SiteList.csv; return an empty map when the file is unavailable."""
-        try:  # The site-name CSV is optional enrichment; missing file is non-fatal.
-            site_list_path = FilePathUtils.get_csv_path("SiteList.csv")  # Locate the site list CSV.
-            with open(site_list_path, encoding="utf-8") as file_handle:  # Read site names from CSV.
-                reader = csv.DictReader(file_handle)  # Parse CSV rows.
-                return {row.get("id"): row.get("name", "Unnamed Site") for row in reader}  # id->name map.
-        except Exception as error:  # CSV missing or unreadable.
-            logging.warning("! Failed to load SiteList.csv for site names: %s", error)  # Warn names may be unknown.
-            return {}  # Degrade to an empty lookup.
-
-    @staticmethod
-    def _gw_build_work_items(inventory, site_name_lookup):
-        """Build (site_id, device_id, site_name) work items for each gateway device in the inventory."""
-        work_items = []  # Accumulate one tuple per gateway needing a config fetch.
-        for device in inventory:  # Scan every inventory device.
-            if device.get("type") != "gateway":  # Only gateways need configs; skip everything else.
-                continue  # Move to the next device.
-            site_id = device.get("site_id")  # Owning site id.
-            device_id = device.get("id")  # Device id.
-            if site_id and device_id:  # Require both ids before queueing a fetch.
-                site_name = site_name_lookup.get(site_id, "Unknown")  # Resolve the site name for enrichment.
-                work_items.append((site_id, device_id, site_name))  # Queue the fetch.
-        return work_items  # Hand the gateway work list back to the caller.
-
-    @staticmethod
-    def _gw_fetch_one_config(apisession, work_item, connection_semaphore):
-        """Fetch one gateway device's config (site-tagged); return the config dict, or None on empty/failure."""
-        work_site_id, work_device_id, work_site_name = work_item  # Unpack the work item.
-        with connection_semaphore:  # Limit concurrent connections via the pool semaphore.
-            try:  # Isolate per-device failures so one bad device doesn't abort the batch.
-                logging.debug("Fetching config for %s (%s)", work_device_id, work_site_name)  # Trace the fetch.
-                config_response = mistapi.api.v1.sites.devices.getSiteDevice(  # Call the device API.
-                    apisession, work_site_id, work_device_id
-                )
-                config = getattr(config_response, "data", {})  # Unwrap data safely.
-                if config:  # Only keep non-empty configs.
-                    config["site_name"] = work_site_name  # Tag with site name for enrichment.
-                    config["site_id"] = work_site_id  # Tag with site id for enrichment.
-                    logging.debug("! Config fetched for %s", work_device_id)  # Trace success.
-                    return config  # Return the enriched config.
-                logging.warning("! Empty config for device %s", work_device_id)  # Warn on empty config.
-                return None  # Treat empty config as a miss.
-            except Exception as inner_error:  # Per-device fetch failed.
-                logging.error("! Failed to fetch config for device %s: %s", work_device_id, inner_error)  # Log error.
-                return None  # Mark this device failed.
-
-    @staticmethod
-    def _gw_retry_one_item(apisession, failed_work_item, connection_semaphore, max_retries):
-        """Retry one failed gateway config fetch up to max_retries with backoff; return the config or None."""
-        _, failed_device_id, _ = failed_work_item  # Only the device id is needed here (for logging).
-        for attempt in range(max_retries + 1):  # Bounded retry loop (initial try plus retries).
-            result = APIFetchUtils._gw_fetch_one_config(apisession, failed_work_item, connection_semaphore)  # Try.
-            if result is not None:  # Retry succeeded.
-                return result  # Hand back the recovered config.
-            if attempt < max_retries:  # More attempts remain.
-                delay = 0.5 * (1.5**attempt)  # Exponential backoff delay.
-                logging.debug(  # Trace the retry/backoff.
-                    "Retrying device %s in %.2fs (attempt %s/%s)",
-                    failed_device_id,
-                    delay,
-                    attempt + 2,
-                    max_retries + 1,
-                )
-                time.sleep(delay)  # Back off before retrying.
-        logging.warning(  # Warn after exhausting every attempt.
-            "! Failed to fetch config for device %s after %s attempts", failed_device_id, max_retries + 1
-        )
-        return None  # Every attempt failed.
-
-    @staticmethod
-    def _gw_retry_configs(apisession, failed_items, connection_semaphore):
-        """Retry failed gateway config fetches with bounded exponential backoff; return the recovered configs."""
-        max_retries = FastModeSequentialMaxRetries.VALUE  # Configurable retry count from extracted class attribute.
-        retry_results = []  # Collect configs recovered on retry.
-        for failed_work_item in failed_items:  # Walk every failed item.
-            result = APIFetchUtils._gw_retry_one_item(
-                apisession, failed_work_item, connection_semaphore, max_retries
-            )  # Retry this item with backoff.
-            if result is not None:  # The item recovered on retry.
-                retry_results.append(result)  # Keep the recovered config.
-        return retry_results  # Return the configs recovered during retry.
-
-    @staticmethod
-    def _gw_collect_fast(apisession, work_items):
-        """Fetch gateway configs concurrently through the connection pool with retry; return the successes."""
-        successful_results, _ = ConnectionPoolExecutor.execute(  # Pooled concurrent fetch; discard failures.
-            work_items=work_items,
-            worker_function=functools.partial(APIFetchUtils._gw_fetch_one_config, apisession),  # Bind apisession.
-            batch_description="gateway device configs",
-            retry_function=functools.partial(APIFetchUtils._gw_retry_configs, apisession),  # Bind apisession.
-        )
-        return successful_results  # The pool already retried failures; return the successes.
-
-    @staticmethod
-    def _gw_collect_sequential(apisession, work_items):
-        """Fetch each gateway config sequentially using a serializing semaphore; return the collected configs."""
-        all_device_configs = []  # Accumulate sequential results.
-        dummy_semaphore = threading.Semaphore(1)  # Serialize sequential fetches with a single permit.
-        for work_item in tqdm(work_items, desc="Fetching Configs", unit="device"):  # type: ignore[no-untyped-call]
-            result = APIFetchUtils._gw_fetch_one_config(apisession, work_item, dummy_semaphore)  # Fetch one config.
-            if result is not None:  # Keep non-empty results.
-                all_device_configs.append(result)  # Collect the config.
-        return all_device_configs  # Return the sequentially fetched configs.
-
-    @staticmethod
-    def gateway_device_configs(apisession, org_id, fast=False, max_workers=None):
-        """Fetch configuration details for all gateway devices in the org inventory.
-
-        When ``fast`` is True the per-device fetches run concurrently through the
-        connection pool (with retry); otherwise they run sequentially. Returns a list
-        of site-tagged device configuration dicts (empty when the inventory fetch fails).
-        ``max_workers`` is accepted for call-site compatibility.
-        """
-        del max_workers  # Kept in signature for call-site compatibility; explicitly discard so linters do not flag it.
-        inventory = APIFetchUtils._gw_load_inventory(apisession, org_id)  # Fetch the org inventory (None on failure).
-        if inventory is None:  # The inventory fetch failed outright.
-            return []  # Degrade to an empty list.
-        logging.info("Found %s total devices in org inventory.", len(inventory))  # Log the device count.
-        site_name_lookup = APIFetchUtils._gw_load_site_names()  # Load site id->name enrichment map.
-        work_items = APIFetchUtils._gw_build_work_items(inventory, site_name_lookup)  # Build the gateway work list.
-        logging.info("Prepared %s gateway device config API calls.", len(work_items))  # Log planned API calls.
-        if fast:  # Fast mode uses the connection pool with retry.
-            all_device_configs = APIFetchUtils._gw_collect_fast(apisession, work_items)  # Pooled concurrent path.
-        else:  # Sequential processing for non-fast mode.
-            all_device_configs = APIFetchUtils._gw_collect_sequential(apisession, work_items)  # Serial fetch path.
-        all_device_configs = [config for config in all_device_configs if config is not None]  # Drop any failures.
-        logging.info("! Completed fetching %s gateway device configs.", len(all_device_configs))  # Log completion.
-        return all_device_configs  # Return the gateway configs.
-
+# NOTE: APIFetchUtils removed (1014 P8, Cat E) - canonical body at src/api/api_fetch_utils.py.
 
 # ============================================================================
 # DATA PROCESSING UTILITIES CLASS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,7 @@ omit = [
     "src/maps/*",
     "src/analytics/data_collection_manager.py",
     "src/api/api_data_fetcher.py",
+    "src/api/api_fetch_utils.py",
     "src/db/database_schema_utils.py",
     "src/device/arp_command_manager.py",
     "src/device/device_reboot_manager.py",

--- a/src/api/api_fetch_utils.py
+++ b/src/api/api_fetch_utils.py
@@ -1,0 +1,256 @@
+"""APIFetchUtils -- higher-level org/site API fetchers.
+
+Extracted from MistHelper.py during initiative 1014 (Cat E, position 8).
+Canonical body lives here; MistHelper.py provides a top-level re-export
+alias (``from src.api.api_fetch_utils import APIFetchUtils``) so historical
+``MistHelper.APIFetchUtils`` / ``mh.APIFetchUtils`` callers keep working.
+
+Cross-class references (ConfigUtils, APICoreFetchUtils, FilePathUtils,
+FastModeSequentialMaxRetries, ConnectionPoolExecutor) and the module-level
+``apisession`` are resolved lazily via ``importlib.import_module("MistHelper")``
+inside method bodies to keep FR-028 IG-health clean (no top-level MistHelper
+import statement).
+"""
+
+# pylint: disable=broad-exception-caught
+
+from __future__ import annotations  # WHY: PEP 604 unions in annotations.
+
+import csv  # WHY: parse SiteList.csv for gateway site-name enrichment.
+import functools  # WHY: functools.partial for pool worker bindings.
+import importlib  # WHY: lazy MistHelper fetch of cross-class refs + apisession.
+import logging  # WHY: structured trace + failure reporting.
+import threading  # WHY: Semaphore serialization in sequential gateway fetch.
+import time  # WHY: exponential backoff sleep between retries.
+from typing import Any  # WHY: return-type annotations for dynamic dicts.
+
+import mistapi  # WHY: dotted-path Mist API resolution + pagination helper.
+from tqdm import tqdm  # WHY: progress bar for long-running site/device fetches.
+
+
+class APIFetchUtils:  # Higher-level org/site fetchers.
+    """
+    Centralized API fetch utilities.
+    Groups all data fetching functions for better code organization.
+    All methods are static to avoid unnecessary object instantiation.
+    """
+
+    @staticmethod
+    def organization_services() -> list[dict[str, Any]]:  # Fetch and flatten org services.
+        """Fetch all org-level services via the Mist API; return list of service dicts (empty on error).
+
+        SECURITY: Read-only operation fetching configuration data only.
+        """
+        try:
+            mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils + apisession.
+            org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the target org.
+            logging.info("Fetching organization services for org_id: %s", org_id)  # Log before the API call.
+
+            # Call the Mist API to get organization services
+            response = mistapi.api.v1.orgs.services.listOrgServices(mh.apisession, org_id, limit=1000)  # List services.
+
+            if hasattr(response, "data") and response.data:  # Only proceed with data.
+                services_data = response.data  # Unwrap the payload.
+                logging.info("Successfully retrieved %s organization services", len(services_data))  # Log the count.
+                services_list = APIFetchUtils._normalize_org_services(services_data)  # Normalize to display rows.
+                return services_list  # Return normalized services.
+
+            logging.warning("No organization services found or response data is empty")  # Warn on empty response.
+            return []  # No services to return.
+
+        except Exception as error:  # Never crash on API failure.
+            logging.error("Failed to fetch organization services: %s", error)  # Log the fetch failure.
+            return []  # Degrade to empty list.
+
+    @staticmethod
+    def _normalize_org_services(services_data: list[Any]) -> list[dict[str, Any]]:  # Flatten raw services to rows
+        """Normalize raw org service records into name/type/description rows (keeping the full config)."""
+        services_list = []  # Accumulate normalized rows.
+        for service in services_data:  # Walk each service.
+            if isinstance(service, dict):  # Skip non-dict entries.
+                services_list.append(
+                    {
+                        "name": service.get("name", "unnamed"),  # Default missing names.
+                        "type": service.get("type", "custom"),  # Default missing type.
+                        "description": service.get("description", ""),  # Default missing description.
+                        "full_config": service,  # Keep full config for reference
+                    }
+                )  # Record the normalized service row
+        return services_list  # Return normalized services.
+
+    @staticmethod
+    def _fetch_single_site_setting(apisession, site):
+        """Fetch one site's settings; tag with id/name; return dict or None on failure."""
+        site_id = site.get("id")  # Target site id
+        site_name = site.get("name", "Unnamed Site")  # Friendly site label
+        try:
+            config = mistapi.api.v1.sites.setting.getSiteSetting(apisession, site_id).data  # Fetch site settings
+            config["site_id"] = site_id  # Tag with site id
+            config["site_name"] = site_name  # Tag with site name
+            logging.info("! Fetched config for site: %s (ID: %s)", site_name, site_id)
+            return config
+        except Exception as error:  # Skip sites that fail
+            logging.warning("! Failed to fetch config for %s (ID: %s): %s", site_name, site_id, error)
+            return None
+
+    @staticmethod
+    def all_site_settings(apisession, org_id, limit=1000):  # Fetch settings for every site.
+        """Fetch per-site settings for every site in the org; limit param is unused (kept for back-compat)."""
+        del limit  # Kept in signature for back-compat; explicitly discard so linters do not flag it.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of APICoreFetchUtils + ConfigUtils.
+        logging.info("Fetching all site settings...")  # Log before fetching sites
+        sites = mh.APICoreFetchUtils.all_sites_with_limit(org_id)  # List all sites first
+        all_configs = []  # Collect per-site settings
+        for site in tqdm(sites, desc="Sites", unit="site"):  # type: ignore[no-untyped-call]
+            if mh.ConfigUtils.check_stop_signal():  # Honor a user stop request
+                break  # Stop iterating sites
+            config = APIFetchUtils._fetch_single_site_setting(apisession, site)  # One site at a time
+            if config is not None:  # Skip failed fetches
+                all_configs.append(config)
+        logging.info("Fetched settings for %s sites.", len(all_configs))  # Log total fetched
+        return all_configs  # Return all site settings
+
+    @staticmethod
+    def _gw_load_inventory(apisession, org_id):
+        """Fetch the org inventory; return the device list, or None when the fetch fails."""
+        logging.info("Fetching org inventory to find gateway devices...")  # Log before the inventory fetch.
+        try:  # The inventory fetch is the one hard dependency; isolate its failure.
+            response = mistapi.api.v1.orgs.inventory.getOrgInventory(apisession, org_id, limit=1000)  # Fetch inventory.
+            return mistapi.get_all(response=response, mist_session=apisession)  # Page through all devices.
+        except Exception as error:  # Inventory fetch failed.
+            logging.error("! Failed to fetch org inventory: %s", error)  # Log the failure.
+            return None  # Signal failure so the caller degrades to an empty result.
+
+    @staticmethod
+    def _gw_load_site_names():
+        """Load the site id -> name map from SiteList.csv; return an empty map when the file is unavailable."""
+        try:  # The site-name CSV is optional enrichment; missing file is non-fatal.
+            mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FilePathUtils.
+            site_list_path = mh.FilePathUtils.get_csv_path("SiteList.csv")  # Locate the site list CSV.
+            with open(site_list_path, encoding="utf-8") as file_handle:  # Read site names from CSV.
+                reader = csv.DictReader(file_handle)  # Parse CSV rows.
+                return {row.get("id"): row.get("name", "Unnamed Site") for row in reader}  # id->name map.
+        except Exception as error:  # CSV missing or unreadable.
+            logging.warning("! Failed to load SiteList.csv for site names: %s", error)  # Warn names may be unknown.
+            return {}  # Degrade to an empty lookup.
+
+    @staticmethod
+    def _gw_build_work_items(inventory, site_name_lookup):
+        """Build (site_id, device_id, site_name) work items for each gateway device in the inventory."""
+        work_items = []  # Accumulate one tuple per gateway needing a config fetch.
+        for device in inventory:  # Scan every inventory device.
+            if device.get("type") != "gateway":  # Only gateways need configs; skip everything else.
+                continue  # Move to the next device.
+            site_id = device.get("site_id")  # Owning site id.
+            device_id = device.get("id")  # Device id.
+            if site_id and device_id:  # Require both ids before queueing a fetch.
+                site_name = site_name_lookup.get(site_id, "Unknown")  # Resolve the site name for enrichment.
+                work_items.append((site_id, device_id, site_name))  # Queue the fetch.
+        return work_items  # Hand the gateway work list back to the caller.
+
+    @staticmethod
+    def _gw_fetch_one_config(apisession, work_item, connection_semaphore):
+        """Fetch one gateway device's config (site-tagged); return the config dict, or None on empty/failure."""
+        work_site_id, work_device_id, work_site_name = work_item  # Unpack the work item.
+        with connection_semaphore:  # Limit concurrent connections via the pool semaphore.
+            try:  # Isolate per-device failures so one bad device doesn't abort the batch.
+                logging.debug("Fetching config for %s (%s)", work_device_id, work_site_name)  # Trace the fetch.
+                config_response = mistapi.api.v1.sites.devices.getSiteDevice(  # Call the device API.
+                    apisession, work_site_id, work_device_id
+                )
+                config = getattr(config_response, "data", {})  # Unwrap data safely.
+                if config:  # Only keep non-empty configs.
+                    config["site_name"] = work_site_name  # Tag with site name for enrichment.
+                    config["site_id"] = work_site_id  # Tag with site id for enrichment.
+                    logging.debug("! Config fetched for %s", work_device_id)  # Trace success.
+                    return config  # Return the enriched config.
+                logging.warning("! Empty config for device %s", work_device_id)  # Warn on empty config.
+                return None  # Treat empty config as a miss.
+            except Exception as inner_error:  # Per-device fetch failed.
+                logging.error("! Failed to fetch config for device %s: %s", work_device_id, inner_error)  # Log error.
+                return None  # Mark this device failed.
+
+    @staticmethod
+    def _gw_retry_one_item(apisession, failed_work_item, connection_semaphore, max_retries):
+        """Retry one failed gateway config fetch up to max_retries with backoff; return the config or None."""
+        _, failed_device_id, _ = failed_work_item  # Only the device id is needed here (for logging).
+        for attempt in range(max_retries + 1):  # Bounded retry loop (initial try plus retries).
+            result = APIFetchUtils._gw_fetch_one_config(apisession, failed_work_item, connection_semaphore)  # Try.
+            if result is not None:  # Retry succeeded.
+                return result  # Hand back the recovered config.
+            if attempt < max_retries:  # More attempts remain.
+                delay = 0.5 * (1.5**attempt)  # Exponential backoff delay.
+                logging.debug(  # Trace the retry/backoff.
+                    "Retrying device %s in %.2fs (attempt %s/%s)",
+                    failed_device_id,
+                    delay,
+                    attempt + 2,
+                    max_retries + 1,
+                )
+                time.sleep(delay)  # Back off before retrying.
+        logging.warning(  # Warn after exhausting every attempt.
+            "! Failed to fetch config for device %s after %s attempts", failed_device_id, max_retries + 1
+        )
+        return None  # Every attempt failed.
+
+    @staticmethod
+    def _gw_retry_configs(apisession, failed_items, connection_semaphore):
+        """Retry failed gateway config fetches with bounded exponential backoff; return the recovered configs."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FastModeSequentialMaxRetries.
+        max_retries = mh.FastModeSequentialMaxRetries.VALUE  # Configurable retry count from extracted class attribute.
+        retry_results = []  # Collect configs recovered on retry.
+        for failed_work_item in failed_items:  # Walk every failed item.
+            result = APIFetchUtils._gw_retry_one_item(
+                apisession, failed_work_item, connection_semaphore, max_retries
+            )  # Retry this item with backoff.
+            if result is not None:  # The item recovered on retry.
+                retry_results.append(result)  # Keep the recovered config.
+        return retry_results  # Return the configs recovered during retry.
+
+    @staticmethod
+    def _gw_collect_fast(apisession, work_items):
+        """Fetch gateway configs concurrently through the connection pool with retry; return the successes."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConnectionPoolExecutor.
+        successful_results, _ = mh.ConnectionPoolExecutor.execute(  # Pooled concurrent fetch; discard failures.
+            work_items=work_items,
+            worker_function=functools.partial(APIFetchUtils._gw_fetch_one_config, apisession),  # Bind apisession.
+            batch_description="gateway device configs",
+            retry_function=functools.partial(APIFetchUtils._gw_retry_configs, apisession),  # Bind apisession.
+        )
+        return successful_results  # The pool already retried failures; return the successes.
+
+    @staticmethod
+    def _gw_collect_sequential(apisession, work_items):
+        """Fetch each gateway config sequentially using a serializing semaphore; return the collected configs."""
+        all_device_configs = []  # Accumulate sequential results.
+        dummy_semaphore = threading.Semaphore(1)  # Serialize sequential fetches with a single permit.
+        for work_item in tqdm(work_items, desc="Fetching Configs", unit="device"):  # type: ignore[no-untyped-call]
+            result = APIFetchUtils._gw_fetch_one_config(apisession, work_item, dummy_semaphore)  # Fetch one config.
+            if result is not None:  # Keep non-empty results.
+                all_device_configs.append(result)  # Collect the config.
+        return all_device_configs  # Return the sequentially fetched configs.
+
+    @staticmethod
+    def gateway_device_configs(apisession, org_id, fast=False, max_workers=None):
+        """Fetch configuration details for all gateway devices in the org inventory.
+
+        When ``fast`` is True the per-device fetches run concurrently through the
+        connection pool (with retry); otherwise they run sequentially. Returns a list
+        of site-tagged device configuration dicts (empty when the inventory fetch fails).
+        ``max_workers`` is accepted for call-site compatibility.
+        """
+        del max_workers  # Kept in signature for call-site compatibility; explicitly discard so linters do not flag it.
+        inventory = APIFetchUtils._gw_load_inventory(apisession, org_id)  # Fetch the org inventory (None on failure).
+        if inventory is None:  # The inventory fetch failed outright.
+            return []  # Degrade to an empty list.
+        logging.info("Found %s total devices in org inventory.", len(inventory))  # Log the device count.
+        site_name_lookup = APIFetchUtils._gw_load_site_names()  # Load site id->name enrichment map.
+        work_items = APIFetchUtils._gw_build_work_items(inventory, site_name_lookup)  # Build the gateway work list.
+        logging.info("Prepared %s gateway device config API calls.", len(work_items))  # Log planned API calls.
+        if fast:  # Fast mode uses the connection pool with retry.
+            all_device_configs = APIFetchUtils._gw_collect_fast(apisession, work_items)  # Pooled concurrent path.
+        else:  # Sequential processing for non-fast mode.
+            all_device_configs = APIFetchUtils._gw_collect_sequential(apisession, work_items)  # Serial fetch path.
+        all_device_configs = [config for config in all_device_configs if config is not None]  # Drop any failures.
+        logging.info("! Completed fetching %s gateway device configs.", len(all_device_configs))  # Log completion.
+        return all_device_configs  # Return the gateway configs.

--- a/src/api/api_fetch_utils.py
+++ b/src/api/api_fetch_utils.py
@@ -29,8 +29,8 @@ from tqdm import tqdm  # WHY: progress bar for long-running site/device fetches.
 
 
 class APIFetchUtils:  # Higher-level org/site fetchers.
-    """
-    Centralized API fetch utilities.
+    """Centralized API fetch utilities.
+
     Groups all data fetching functions for better code organization.
     All methods are static to avoid unnecessary object instantiation.
     """

--- a/src/export/site_config_exporter.py
+++ b/src/export/site_config_exporter.py
@@ -14,6 +14,8 @@ from typing import Any  # WHY: raw WLAN rows are duck-typed dicts from mistapi.
 
 import mistapi  # WHY: direct SDK access for sites/orgs endpoints.
 
+from src.api.api_fetch_utils import APIFetchUtils  # WHY: 1014 P8 direct import (FR-005).
+
 
 class SiteConfigExporter:
     """Site Configuration Exporter.
@@ -114,7 +116,7 @@ class SiteConfigExporter:
         logging.info("Starting export of all site configuration settings...")  # Log start.
         current_org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.
         logging.debug("Using org_id: %s for site settings export.", current_org_id)  # Trace the org.
-        data = mh.APIFetchUtils.all_site_settings(mh.apisession, current_org_id, limit=1000)
+        data = APIFetchUtils.all_site_settings(mh.apisession, current_org_id, limit=1000)
         if data:  # Have data.
             logging.info("Fetched settings for %s sites. Flattening and sanitizing data...", len(data))
             data = mh.DataProcessingUtils.flatten_nested_fields(data)  # Flatten nested fields.

--- a/tests/test_issue_429_log_parity.py
+++ b/tests/test_issue_429_log_parity.py
@@ -29,7 +29,20 @@ from tools.capture_log_baseline import (  # Reuse the rendering primitives.
 
 REPO_ROOT = Path(__file__).resolve().parent.parent  # tests/ -> repo root.
 BASELINE_PATH = REPO_ROOT / "tests" / "fixtures" / "issue_429_log_baseline.json"  # Frozen baseline JSON.
-SOURCE_PATH = REPO_ROOT / "MistHelper.py"  # File the sweep is rewriting.
+SOURCE_PATH = REPO_ROOT / "MistHelper.py"  # Default source; fixture may override via `source` field.
+_MODULE_CACHE: dict[Path, cst.Module] = {}  # WHY: parse each source file at most once per test run.
+
+
+def _load_module(source_path: Path) -> cst.Module:
+    """Parse and cache a python source path as a libcst.Module."""
+    cached = _MODULE_CACHE.get(source_path)  # Reuse prior parse when available.
+    if cached is not None:
+        return cached
+    if not source_path.exists():
+        pytest.skip(f"source not found at {source_path}")  # Skip cleanly if missing.
+    module = cst.parse_module(source_path.read_text(encoding="utf-8"))  # Parse via libcst.
+    _MODULE_CACHE[source_path] = module  # Cache for future lookups.
+    return module
 
 
 def _build_inputs_for_pattern(pattern: str, raw_inputs: dict[str, Any]) -> dict[str, Any]:
@@ -58,30 +71,22 @@ def baseline() -> dict[str, dict[str, Any]]:
     return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))  # Parse the JSON into a dict.
 
 
-@pytest.fixture(scope="module")
-def module() -> cst.Module:
-    """Parse `MistHelper.py` exactly once for the whole test module."""
-    if not SOURCE_PATH.exists():  # Defensive: the only thing this test cares about.
-        pytest.skip(f"source not found at {SOURCE_PATH}")  # Skip cleanly if missing.
-    source = SOURCE_PATH.read_text(encoding="utf-8")  # Read once; libcst parse is the slow step.
-    return cst.parse_module(source)  # Parse with libcst.
-
-
 @pytest.mark.parametrize("site_id", [s["site_id"] for s in FIXTURE_SITES])  # One test per fixture site.
 def test_log_render_matches_baseline(
     site_id: str,
     baseline: dict[str, dict[str, Any]],
-    module: cst.Module,
 ) -> None:
     """Find a logging call that renders to the baseline string and confirm."""
     if site_id not in baseline:  # The baseline may legitimately miss sites that failed capture.
         pytest.skip(f"site {site_id} missing from baseline fixture")  # Skip rather than fail.
     expected = baseline[site_id]["rendered"]  # The frozen ground truth.
     site_def = next(s for s in FIXTURE_SITES if s["site_id"] == site_id)  # Operator-curated entry.
+    source_rel = site_def.get("source", "MistHelper.py")  # Per-site override; defaults to MistHelper.py.
+    module = _load_module(REPO_ROOT / source_rel)  # Parse (cached) the file this site lives in.
     inputs = _build_inputs_for_pattern(site_def["pattern"], site_def["inputs"])  # Same enrichment as capture.
     actual = _find_matching_render(module, site_def["line"], inputs, expected)  # Robust lookup.
     assert actual is not None, (  # No call in the file renders to the expected string.
-        f"site {site_id}: no logging call (near line {site_def['line']}) "
+        f"site {site_id}: no logging call (near line {site_def['line']}) in {source_rel} "
         f"renders to {expected!r} with inputs {sorted(inputs)}"
     )
     assert (

--- a/tools/capture_log_baseline.py
+++ b/tools/capture_log_baseline.py
@@ -63,7 +63,8 @@ FIXTURE_SITES: list[dict[str, Any]] = [  # Minimal but representative baseline.
     },
     {  # Multi-argument f-string with arithmetic on substitution.
         "site_id": "L6988",
-        "line": 6988,
+        "line": 183,  # Extracted to src/api/api_fetch_utils.py (1014 P8); logging.debug at line 183.
+        "source": "src/api/api_fetch_utils.py",  # Per-site override; defaults to MistHelper.py.
         "inputs": {
             "failed_device_id": "dev-abc",
             "delay": 2.5,


### PR DESCRIPTION
## Summary

Initiative #1014, position 8 of 24 (Category E extraction). Moves the canonical `APIFetchUtils` body (13 static methods, 221 LOC) from `MistHelper.py` to `src/api/api_fetch_utils.py`. `MistHelper.py` keeps a top-level re-export alias so historical `MistHelper.APIFetchUtils` / `mh.APIFetchUtils` callers continue to resolve.

Cross-class references (ConfigUtils, APICoreFetchUtils, FilePathUtils, FastModeSequentialMaxRetries, ConnectionPoolExecutor, apisession) are resolved lazily inside method bodies via `importlib.import_module("MistHelper")`, so the extracted module carries no top-level MistHelper import statement (FR-028 IG-health clean).

## Method-parity audit (FR-025)

| Symbol | Canonical | Re-export | Match |
|---|---|---|---|
| `src.api.api_fetch_utils.APIFetchUtils` | 13 methods | -- | -- |
| `MistHelper.APIFetchUtils` (alias) | -- | 13 methods | Yes |

Methods: `organization_services`, `_normalize_org_services`, `_fetch_single_site_setting`, `all_site_settings`, `_gw_load_inventory`, `_gw_load_site_names`, `_gw_build_work_items`, `_gw_fetch_one_config`, `_gw_retry_one_item`, `_gw_retry_configs`, `_gw_collect_fast`, `_gw_collect_sequential`, `gateway_device_configs`.

## Callsite table (FR-027)

| Callsite | Handling |
|---|---|
| `MistHelper.py:8462` -- `api_fetch_utils=APIFetchUtils` DI wiring | Kept via top-level re-export |
| `MistHelper.py:9983` -- `"APIFetchUtils.gateway_device_configs"` in lookup dict | Kept via re-export (string reference) |
| `src/export/site_config_exporter.py:117` -- `mh.APIFetchUtils.all_site_settings(...)` | Rewired to direct import (FR-005): `from src.api.api_fetch_utils import APIFetchUtils` |
| 20 self-references inside the class body | Moved with the body, unchanged semantics |

## Local gate

- AST parse -- OK
- `black --check --line-length=120` -- 3 files unchanged
- `ruff check` -- no issues
- `pytest tests/unit` -- **3861 passed**
- FR-028 IG-health probe against `src.api.api_fetch_utils` -- no top-level MistHelper import statement; dynamic import verified.

## Test plan

- [x] AST parse of MistHelper.py, src/api/api_fetch_utils.py, src/export/site_config_exporter.py
- [x] Black + Ruff clean
- [x] Full unit test suite passes locally
- [x] FR-028 IG-health probe
- [x] Method-parity audit (canonical vs re-export)
- [ ] CI (coverage gate, pylint gate, contract tests, unit-tests-strict)

Refs #433 (Phase C initiative 1014, position 8/24).