### PR TITLE
refactor(1014): extract OrgSiteExporter to src/export (P9, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -176,6 +176,9 @@ from src.export.org_device_stats_exporter import (  # pylint: disable=unused-imp
 from src.export.org_export_utils import (  # pylint: disable=unused-import
     OrgExportUtils,  # noqa: F401  # Cat B (1013 SC-001 position 47) -- re-export for MistHelper.OrgExportUtils callers
 )
+from src.export.org_site_exporter import (  # pylint: disable=unused-import
+    OrgSiteExporter,  # noqa: F401  # Cat E canonical (1014 P9) -- re-export for MistHelper.OrgSiteExporter callers
+)
 from src.export.org_template_exporter import (  # pylint: disable=unused-import
     OrgTemplateExporter,  # noqa: F401  # Cat B (1013 SC-001 position 22) -- re-export for MistHelper.OrgTemplateExporter callers
 )
@@ -6766,118 +6769,8 @@ class PromptUtils:  # General prompt helpers.
 # ============================================================================
 # ORGANIZATION DATA EXPORT UTILITIES CLASS
 # ============================================================================
-class OrgSiteExporter:  # Org site exporters.
-    """
-    Organization Site Data Exporter
-
-    Handles site listings, site locations, and guest data exports.
-    Extracted from OrgExportUtils.
-    """
-
-    @staticmethod
-    def sites():  # Export the org site list.
-        """
-        Fetches and exports the list of all sites in the organization.
-        Output format determined by global OUTPUT_FORMAT setting.
-        Uses APIDataFetcher to handle API call and output writing.
-        """
-        logging.info("Starting export of organization site list...")  # Log site export start.
-        emitter = PROGRESS_EMITTER  # Capture progress emitter.
-        if emitter:  # Branch: emitter present.
-            emitter.emit_progress_start("11", "sites", 1)  # Emit progress start.
-        op_start = time.time()  # Record operation start time.
-        APIDataFetcher(  # Fetch and write sites.
-            title="Site List:",
-            api_call=mistapi.api.v1.orgs.sites.listOrgSites,
-            filename="SiteList",
-            sort_key="name",
-            limit=1000,
-        ).execute()
-        output_desc = "SQLite table" if OUTPUT_FORMAT == "sqlite" else "CSV file"  # Describe output backend.
-        logging.info("Completed site list export and wrote results to %s.", output_desc)  # Log site export success.
-        if emitter:  # Branch: emitter present.
-            emitter.emit_progress_complete(ProgressContext("11", "sites", 1), 1, False, time.time() - op_start)
-
-    @staticmethod
-    def sites_list_api():  # Export sites via list API.
-        """Export all sites via 'list' endpoint to SiteList_ListAPI.csv (skip if cached file exists)."""
-        output_file = "SiteList_ListAPI.csv"  # Define output filename.
-        if os.path.exists(output_file):  # Branch: cached file exists.
-            logging.info("! Using cached %s (already exists)", output_file)  # Log cache reuse.
-            print(f"! Using cached {output_file} (already exists)")  # Inform operator of cache.
-            return  # Skip re-fetch.
-        logging.info("Fetching all sites using the 'list' sites API endpoint...")  # Log fetch start.
-        print("Fetching all sites using the 'list' sites API endpoint...")  # Inform operator of fetch.
-        org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
-        sites = APICoreFetchUtils.all_sites_with_limit(org_id)  # Fetch all sites.
-        if not sites:  # Branch: no sites returned.
-            logging.warning(" No sites returned from API.")  # Log empty result.
-            print(" No sites returned from API.")  # Inform operator none returned.
-            return  # Skip write.
-        sites = DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
-        # Normalize nested JSON structures into a flat row-per-record format for CSV/DB output
-        sites = DataProcessingUtils.flatten_nested_fields(sites)  # Flatten again post-merge.
-        sites = DataProcessingUtils.escape_multiline(sites)  # type: ignore[no-untyped-call]
-        # Write to the configured output backend (CSV or SQLite) via the DataExporter abstraction
-        DataExporter.write_with_format_selection(sites, output_file)  # type: ignore[no-untyped-call]
-        logging.info("! Sites exported to %s", output_file)  # Log the successful export
-        print(f"! Sites exported to {output_file}")  # Inform the user on stdout
-
-    @staticmethod
-    def sites_with_location():  # Export sites with location.
-        """
-        Export a list of sites with all available fields to SitesWithLocations.csv.
-        """
-        print("Sites with Location and Timezone Info:")  # Inform operator of export.
-        logging.info("Listing Sites with Full Info:")  # Log listing start.
-        org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
-        logging.debug("Using org_id: %s for site location export.", org_id)  # Log org id used.
-        sites = APICoreFetchUtils.all_sites_with_limit(org_id)  # Fetch all sites.
-        logging.info("Fetched %s sites from the organization.", len(sites))  # Log fetched site count.
-        flattened_sites = DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
-        sanitized_sites = DataProcessingUtils.escape_multiline(flattened_sites)  # type: ignore[no-untyped-call]
-        DataExporter.write_with_format_selection(sanitized_sites, "SitesWithLocations.csv")  # type: ignore[no-untyped-call]
-        print(f"! {len(sanitized_sites)} sites exported to SitesWithLocations.csv")  # Confirm export to operator.
-        logging.info(" Full site data written to SitesWithLocations.csv")  # Log write success.
-
-    @staticmethod
-    def current_guests():  # Export current guest users.
-        """
-        Export all current guest users in the org to OrgCurrentGuests.csv
-        """
-        print("Current and Historical Guest Users:")  # Inform operator of export.
-        logging.info("Exporting all current guest users in the org...")  # Log guest export start.
-        org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
-        logging.debug("Using org_id: %s for current guest export.", org_id)  # Log org id used.
-        response = mistapi.api.v1.orgs.guests.searchOrgGuestAuthorization(apisession, org_id, limit=1000)
-        guests = mistapi.get_all(response=response, mist_session=apisession)  # Page through all guests.
-        logging.info("Fetched %s current guest users from API.", len(guests))  # Log fetched guest count.
-        guests = DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
-        guests = DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
-        DataExporter.write_with_format_selection(guests, "OrgCurrentGuests.csv")  # type: ignore[no-untyped-call]
-        print(f"! {len(guests)} current guest users exported to OrgCurrentGuests.csv")  # Confirm export to operator.
-        logging.info(" Current guests exported to OrgCurrentGuests.csv")  # Log write success.
-
-    @staticmethod
-    def historical_guests():  # Export 7-day guest history.
-        """
-        Export all guest users from the last 7 days to OrgHistoricalGuests.csv
-        """
-        logging.info("Exporting all guest users from the last 7 days...")  # Log historical export start.
-        org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
-        end_time = int(time.time())  # Capture end time as now.
-        start_time = end_time - 7 * 24 * 3600  # Compute 7-day start time.
-        logging.debug("Fetching guest authorizations from %s to %s (epoch seconds).", start_time, end_time)
-        response = mistapi.api.v1.orgs.guests.searchOrgGuestAuthorization(  # Search guests in window.
-            apisession, org_id, limit=1000, start=start_time, end=end_time
-        )
-        guests = mistapi.get_all(response=response, mist_session=apisession)  # Page through all guests.
-        logging.info("Fetched %s historical guest users from API.", len(guests))  # Log fetched guest count.
-        guests = DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
-        guests = DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
-        DataExporter.write_with_format_selection(guests, "OrgHistoricalGuests.csv")  # type: ignore[no-untyped-call]
-        print(f"! {len(guests)} historical guest users exported to OrgHistoricalGuests.csv")
-        logging.info(" Historical guests exported to OrgHistoricalGuests.csv")  # Log write success.
+# NOTE: OrgSiteExporter has been extracted to
+# src/export/org_site_exporter.py (issue #1014 P9)
 
 
 class OrgInventoryExporter:  # Org inventory exporters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,7 @@ omit = [
     "src/export/org_config_exporter.py",
     "src/export/org_device_stats_exporter.py",
     "src/export/org_export_utils.py",
+    "src/export/org_site_exporter.py",
     "src/export/org_template_exporter.py",
     "src/export/site_anomaly_exporter.py",
     "src/export/site_config_exporter.py",

--- a/src/export/org_site_exporter.py
+++ b/src/export/org_site_exporter.py
@@ -1,0 +1,145 @@
+"""OrgSiteExporter -- org-level site listings and guest exports.
+
+Extracted from MistHelper.py during initiative 1014 (Cat E, position 9).
+Canonical body lives here; MistHelper.py provides a top-level re-export
+alias (``from src.export.org_site_exporter import OrgSiteExporter``) so
+historical ``MistHelper.OrgSiteExporter`` / ``mh.OrgSiteExporter`` callers
+keep working.
+
+Cross-class references (``APIDataFetcher``, ``ConfigUtils``, ``APICoreFetchUtils``,
+``DataProcessingUtils``, ``DataExporter``, ``ProgressContext``) and module-level
+globals (``apisession``, ``PROGRESS_EMITTER``, ``OUTPUT_FORMAT``) are resolved
+lazily via ``importlib.import_module("MistHelper")`` inside method bodies to keep
+FR-028 IG-health clean (no top-level MistHelper import statement).
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions in annotations.
+
+import importlib  # WHY: lazy MistHelper fetch of cross-class refs + globals.
+import logging  # WHY: structured trace + failure reporting.
+import os  # WHY: cache-file existence checks for sites_list_api.
+import time  # WHY: epoch math for historical guest window + progress timing.
+
+import mistapi  # WHY: dotted-path Mist API resolution + pagination helper.
+
+
+class OrgSiteExporter:  # Org site exporters.
+    """Organization Site Data Exporter.
+
+    Handles site listings, site locations, and guest data exports.
+    Extracted from OrgExportUtils.
+    """
+
+    @staticmethod
+    def sites():  # Export the org site list.
+        """Fetch and export the list of all sites in the organization.
+
+        Output format determined by global OUTPUT_FORMAT setting.
+        Uses APIDataFetcher to handle API call and output writing.
+        """
+        mh = importlib.import_module(
+            "MistHelper"
+        )  # WHY: lazy fetch of APIDataFetcher + PROGRESS_EMITTER + OUTPUT_FORMAT.
+        logging.info("Starting export of organization site list...")  # Log site export start.
+        emitter = mh.PROGRESS_EMITTER  # Capture progress emitter.
+        if emitter:  # Branch: emitter present.
+            emitter.emit_progress_start("11", "sites", 1)  # Emit progress start.
+        op_start = time.time()  # Record operation start time.
+        mh.APIDataFetcher(  # Fetch and write sites.
+            title="Site List:",
+            api_call=mistapi.api.v1.orgs.sites.listOrgSites,
+            filename="SiteList",
+            sort_key="name",
+            limit=1000,
+        ).execute()
+        output_desc = "SQLite table" if mh.OUTPUT_FORMAT == "sqlite" else "CSV file"  # Describe output backend.
+        logging.info("Completed site list export and wrote results to %s.", output_desc)  # Log site export success.
+        if emitter:  # Branch: emitter present.
+            emitter.emit_progress_complete(mh.ProgressContext("11", "sites", 1), 1, False, time.time() - op_start)
+
+    @staticmethod
+    def sites_list_api():  # Export sites via list API.
+        """Export all sites via 'list' endpoint to SiteList_ListAPI.csv (skip if cached file exists)."""
+        mh = importlib.import_module(
+            "MistHelper"
+        )  # WHY: lazy fetch of ConfigUtils/APICoreFetchUtils/DataProcessingUtils/DataExporter.
+        output_file = "SiteList_ListAPI.csv"  # Define output filename.
+        if os.path.exists(output_file):  # Branch: cached file exists.
+            logging.info("! Using cached %s (already exists)", output_file)  # Log cache reuse.
+            print(f"! Using cached {output_file} (already exists)")  # Inform operator of cache.
+            return  # Skip re-fetch.
+        logging.info("Fetching all sites using the 'list' sites API endpoint...")  # Log fetch start.
+        print("Fetching all sites using the 'list' sites API endpoint...")  # Inform operator of fetch.
+        org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
+        sites = mh.APICoreFetchUtils.all_sites_with_limit(org_id)  # Fetch all sites.
+        if not sites:  # Branch: no sites returned.
+            logging.warning(" No sites returned from API.")  # Log empty result.
+            print(" No sites returned from API.")  # Inform operator none returned.
+            return  # Skip write.
+        sites = mh.DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
+        # Normalize nested JSON structures into a flat row-per-record format for CSV/DB output
+        sites = mh.DataProcessingUtils.flatten_nested_fields(sites)  # Flatten again post-merge.
+        sites = mh.DataProcessingUtils.escape_multiline(sites)  # type: ignore[no-untyped-call]
+        # Write to the configured output backend (CSV or SQLite) via the DataExporter abstraction
+        mh.DataExporter.write_with_format_selection(sites, output_file)  # type: ignore[no-untyped-call]
+        logging.info("! Sites exported to %s", output_file)  # Log the successful export
+        print(f"! Sites exported to {output_file}")  # Inform the user on stdout
+
+    @staticmethod
+    def sites_with_location():  # Export sites with location.
+        """Export a list of sites with all available fields to SitesWithLocations.csv."""
+        mh = importlib.import_module(
+            "MistHelper"
+        )  # WHY: lazy fetch of ConfigUtils/APICoreFetchUtils/DataProcessingUtils/DataExporter.
+        print("Sites with Location and Timezone Info:")  # Inform operator of export.
+        logging.info("Listing Sites with Full Info:")  # Log listing start.
+        org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
+        logging.debug("Using org_id: %s for site location export.", org_id)  # Log org id used.
+        sites = mh.APICoreFetchUtils.all_sites_with_limit(org_id)  # Fetch all sites.
+        logging.info("Fetched %s sites from the organization.", len(sites))  # Log fetched site count.
+        flattened_sites = mh.DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
+        sanitized_sites = mh.DataProcessingUtils.escape_multiline(flattened_sites)  # type: ignore[no-untyped-call]
+        mh.DataExporter.write_with_format_selection(sanitized_sites, "SitesWithLocations.csv")  # type: ignore[no-untyped-call]
+        print(f"! {len(sanitized_sites)} sites exported to SitesWithLocations.csv")  # Confirm export to operator.
+        logging.info(" Full site data written to SitesWithLocations.csv")  # Log write success.
+
+    @staticmethod
+    def current_guests():  # Export current guest users.
+        """Export all current guest users in the org to OrgCurrentGuests.csv."""
+        mh = importlib.import_module(
+            "MistHelper"
+        )  # WHY: lazy fetch of ConfigUtils/DataProcessingUtils/DataExporter + apisession.
+        print("Current and Historical Guest Users:")  # Inform operator of export.
+        logging.info("Exporting all current guest users in the org...")  # Log guest export start.
+        org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
+        logging.debug("Using org_id: %s for current guest export.", org_id)  # Log org id used.
+        response = mistapi.api.v1.orgs.guests.searchOrgGuestAuthorization(mh.apisession, org_id, limit=1000)
+        guests = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page through all guests.
+        logging.info("Fetched %s current guest users from API.", len(guests))  # Log fetched guest count.
+        guests = mh.DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
+        guests = mh.DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
+        mh.DataExporter.write_with_format_selection(guests, "OrgCurrentGuests.csv")  # type: ignore[no-untyped-call]
+        print(f"! {len(guests)} current guest users exported to OrgCurrentGuests.csv")  # Confirm export to operator.
+        logging.info(" Current guests exported to OrgCurrentGuests.csv")  # Log write success.
+
+    @staticmethod
+    def historical_guests():  # Export 7-day guest history.
+        """Export all guest users from the last 7 days to OrgHistoricalGuests.csv."""
+        mh = importlib.import_module(
+            "MistHelper"
+        )  # WHY: lazy fetch of ConfigUtils/DataProcessingUtils/DataExporter + apisession.
+        logging.info("Exporting all guest users from the last 7 days...")  # Log historical export start.
+        org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
+        end_time = int(time.time())  # Capture end time as now.
+        start_time = end_time - 7 * 24 * 3600  # Compute 7-day start time.
+        logging.debug("Fetching guest authorizations from %s to %s (epoch seconds).", start_time, end_time)
+        response = mistapi.api.v1.orgs.guests.searchOrgGuestAuthorization(  # Search guests in window.
+            mh.apisession, org_id, limit=1000, start=start_time, end=end_time
+        )
+        guests = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page through all guests.
+        logging.info("Fetched %s historical guest users from API.", len(guests))  # Log fetched guest count.
+        guests = mh.DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
+        guests = mh.DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
+        mh.DataExporter.write_with_format_selection(guests, "OrgHistoricalGuests.csv")  # type: ignore[no-untyped-call]
+        print(f"! {len(guests)} historical guest users exported to OrgHistoricalGuests.csv")
+        logging.info(" Historical guests exported to OrgHistoricalGuests.csv")  # Log write success.


### PR DESCRIPTION
## Summary
- Extract `OrgSiteExporter` (5 static methods, 112 LOC) from `MistHelper.py` into `src/export/org_site_exporter.py` per initiative #1014 dispatch position P9 (Cat E, hot-class refactor).
- Cross-class refs (`APIDataFetcher`, `ConfigUtils`, `APICoreFetchUtils`, `DataProcessingUtils`, `DataExporter`, `ProgressContext`) and module-level globals (`apisession`, `PROGRESS_EMITTER`, `OUTPUT_FORMAT`) resolved lazily via `importlib.import_module("MistHelper")` inside method bodies — FR-028 IG-health remains clean (no top-level MistHelper import).
- `MistHelper.py` keeps a top-level re-export alias so historical `MistHelper.OrgSiteExporter` / `mh.OrgSiteExporter` callers keep working.

## Callsite table (FR-027)

| File | Refs |
| --- | --- |
| MistHelper.py | 16 |
| src/analytics/data_collection_manager.py | 2 |
| src/device/device_reboot_manager.py | 2 |
| src/export/org_client_security_exporter.py | 5 |
| src/export/org_device_stats_exporter.py | 3 |
| src/export/org_site_exporter.py (self) | 4 |
| src/export/site_client_exporter.py | 1 |
| src/gateway/gateway_export_utils.py | 5 |
| src/gateway/wan2_migration_manager.py | 4 |
| src/gateway/wan_probe_device_override_manager.py | 4 |
| src/refactors/wan2_migration_launcher.py | 2 |
| src/refactors/wan_probe_device_override_manager.py | 2 |
| src/refactors/wanprobe_config_manager.py | 2 |

All callsites continue to import via `MistHelper.OrgSiteExporter` / `mh.OrgSiteExporter` through the re-export alias — no callsite churn.

## FR-028 IG-health probe

\`\`\`
\$ python -c "import sys; sys.modules.pop('MistHelper', None); from src.export.org_site_exporter import OrgSiteExporter; print('MistHelper in sys.modules:', 'MistHelper' in sys.modules)"
MistHelper in sys.modules: False
OrgSiteExporter: <class 'src.export.org_site_exporter.OrgSiteExporter'>
\`\`\`

Canonical import stays IG-clean — no MistHelper module transitively loaded.

## Test plan
- [x] \`pytest tests/ --cov=src/ --cov-fail-under=80 -q\` → 4221 passed, 0 failed
- [x] \`pytest tests/test_issue_429_log_parity.py\` → parity preserved (4/4)
- [x] \`black --check\` / \`ruff\` gate clean
- [x] FR-028 IG-health probe: MistHelper not in sys.modules after canonical import