### PR TITLE
refactor(1014): extract APICoreFetchUtils to src/api/api_core_fetch_utils.py (P10, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -92,6 +92,9 @@ from src.analytics.site_inventory_health_analyzer import (
 from src.analytics.telemetry_emitter import (  # pylint: disable=unused-import
     TelemetryEmitter,  # noqa: F401  # Cat B (1013 SC-001 position 9) -- re-export for callers at 18629/18632/18711/19062
 )
+from src.api.api_core_fetch_utils import (
+    APICoreFetchUtils,
+)  # Cat E canonical (1014 P10) -- re-export for MistHelper.APICoreFetchUtils callers
 from src.api.api_data_fetcher import (  # pylint: disable=unused-import
     APIDataFetcher,  # noqa: F401  # Cat B (1013 SC-001 position 21) -- re-export for MistHelper.APIDataFetcher callers
 )
@@ -5716,53 +5719,7 @@ class ConfigUtils:  # Org id and run-control helpers.
 # ============================================================================
 # API FETCH UTILITIES CLASS
 # ============================================================================
-class APICoreFetchUtils:  # Low-level Mist API fetch helpers.
-    """
-    Core API Fetch Utilities
-
-    Handles site and inventory fetching with pagination.
-    Extracted from APIFetchUtils.
-    """
-
-    @staticmethod
-    def all_sites_with_limit(org_id: str) -> list[dict]:  # type: ignore[type-arg]
-        """
-        Fetch all sites with unified pagination.
-
-        Args:
-            org_id: The organization ID
-
-        Returns:
-            List of site dictionaries
-
-        SECURITY: Read-only; no sensitive data logged.
-        """
-        response = mistapi.api.v1.orgs.sites.listOrgSites(apisession, org_id, limit=DEFAULT_API_PAGE_LIMIT)
-        return mistapi.get_all(response=response, mist_session=apisession)  # type: ignore[no-any-return]
-
-    @staticmethod
-    def all_inventory_with_limit(org_id: str) -> list[dict]:  # type: ignore[type-arg]
-        """
-        Fetch full org inventory with unified pagination.
-
-        Args:
-            org_id: The organization ID
-
-        Returns:
-            List of inventory dictionaries (includes all VC physical members)
-
-        SECURITY: Read-only; no secrets in inventory object fields.
-        """
-        response = mistapi.api.v1.orgs.inventory.getOrgInventory(
-            apisession, org_id, vc=True, limit=DEFAULT_API_PAGE_LIMIT
-        )  # vc=True includes all physical VC member devices
-        return mistapi.get_all(response=response, mist_session=apisession)  # type: ignore[no-any-return]
-
-    @staticmethod
-    def get_api_response_data(response: Any) -> Any:
-        """Return a mistapi response's .data payload, or the response itself when .data is absent."""
-        logging.debug("Unwrapping API response payload (type=%s)", type(response).__name__)  # Trace unwrap calls
-        return getattr(response, "data", response)  # mistapi carries parsed JSON on .data; fall back to the raw object
+# NOTE: APICoreFetchUtils removed (1014 P10, Cat E) - canonical body at src/api/api_core_fetch_utils.py.
 
 
 # APITenantFetchUtils extracted to src/api/tenant_fetch.py (issue #331).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,6 +239,7 @@ omit = [
     "src/analytics/data_collection_manager.py",
     "src/api/api_data_fetcher.py",
     "src/api/api_fetch_utils.py",
+    "src/api/api_core_fetch_utils.py",
     "src/db/database_schema_utils.py",
     "src/device/arp_command_manager.py",
     "src/device/device_reboot_manager.py",

--- a/src/api/api_core_fetch_utils.py
+++ b/src/api/api_core_fetch_utils.py
@@ -1,0 +1,69 @@
+"""APICoreFetchUtils -- low-level Mist API fetch helpers.
+
+Extracted from MistHelper.py during initiative 1014 (Cat E, position 10).
+Canonical body lives here; MistHelper.py provides a top-level re-export
+alias (``from src.api.api_core_fetch_utils import APICoreFetchUtils``) so
+historical ``MistHelper.APICoreFetchUtils`` / ``mh.APICoreFetchUtils``
+callers keep working.
+
+The module-level ``apisession`` and ``DEFAULT_API_PAGE_LIMIT`` globals are
+resolved lazily via ``importlib.import_module("MistHelper")`` inside method
+bodies to keep FR-028 IG-health clean (no top-level MistHelper import
+statement).
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions in annotations.
+
+import importlib  # WHY: lazy MistHelper fetch of apisession + page-limit global.
+import logging  # WHY: debug trace for API-response unwrap.
+from typing import Any  # WHY: dynamic response-object annotation.
+
+import mistapi  # WHY: dotted-path Mist API resolution + pagination helper.
+
+
+class APICoreFetchUtils:  # Low-level Mist API fetch helpers.
+    """Core API Fetch Utilities.
+
+    Handles site and inventory fetching with pagination.
+    Extracted from APIFetchUtils.
+    """
+
+    @staticmethod
+    def all_sites_with_limit(org_id: str) -> list[dict]:  # type: ignore[type-arg]
+        """Fetch all sites with unified pagination.
+
+        Args:
+            org_id: The organization ID
+
+        Returns:
+            List of site dictionaries
+
+        SECURITY: Read-only; no sensitive data logged.
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + DEFAULT_API_PAGE_LIMIT.
+        response = mistapi.api.v1.orgs.sites.listOrgSites(mh.apisession, org_id, limit=mh.DEFAULT_API_PAGE_LIMIT)
+        return mistapi.get_all(response=response, mist_session=mh.apisession)  # type: ignore[no-any-return]
+
+    @staticmethod
+    def all_inventory_with_limit(org_id: str) -> list[dict]:  # type: ignore[type-arg]
+        """Fetch full org inventory with unified pagination.
+
+        Args:
+            org_id: The organization ID
+
+        Returns:
+            List of inventory dictionaries (includes all VC physical members)
+
+        SECURITY: Read-only; no secrets in inventory object fields.
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + DEFAULT_API_PAGE_LIMIT.
+        response = mistapi.api.v1.orgs.inventory.getOrgInventory(
+            mh.apisession, org_id, vc=True, limit=mh.DEFAULT_API_PAGE_LIMIT
+        )  # vc=True includes all physical VC member devices
+        return mistapi.get_all(response=response, mist_session=mh.apisession)  # type: ignore[no-any-return]
+
+    @staticmethod
+    def get_api_response_data(response: Any) -> Any:
+        """Return a mistapi response's .data payload, or the response itself when .data is absent."""
+        logging.debug("Unwrapping API response payload (type=%s)", type(response).__name__)  # Trace unwrap calls
+        return getattr(response, "data", response)  # mistapi carries parsed JSON on .data; fall back to the raw object


### PR DESCRIPTION
## Summary
- Extract `APICoreFetchUtils` to `src/api/api_core_fetch_utils.py` (Position 10 of initiative #1014).
- MistHelper.py retains a top-level re-export alias so `MistHelper.APICoreFetchUtils` / `mh.APICoreFetchUtils` callers keep working with zero callsite churn.
- Lazy `importlib.import_module("MistHelper")` inside each method body resolves `apisession` + `DEFAULT_API_PAGE_LIMIT` — FR-028 IG-health clean.
- pyproject.toml: add extracted module to `[tool.coverage.run] omit` list (matches P8/P9 pattern).

## Callsites (FR-027)
- MistHelper.py: 14 direct refs (all resolve via re-export alias)
- src/ files: 11 modules use `mh.APICoreFetchUtils` (api_fetch_utils, offline_device_reporter, site_device_exporter, sites_by_ap_model_exporter, gateway_ha_exporter, msp_inventory_exporter, firmware_manager, gateway_export_utils, site_export_utils, bulk_ap_upgrader, org_site_exporter) — no rewire needed
- tests/: 2 files reference `MistHelper.APICoreFetchUtils` — continue to resolve via alias

## Test plan
- [x] `ruff check` clean on modified files
- [x] `black --check` clean on modified files
- [x] FR-028 IG-health probe: `MistHelper` NOT in `sys.modules` after importing `src.api.api_core_fetch_utils`
- [x] Local pytest: 4259 passed (one pre-existing stdin-capture failure in `test_menu_org_license_async_claim_status.py` also present on main, unrelated to P10)