### PR TITLE
chore(1014): regenerate refactor_candidates.md after P12 merge

### DIFF
--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -2,9 +2,9 @@
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
 - Module graph size: 250 first-party files
-- Definitions analyzed: 22
+- Definitions analyzed: 21
 - LOC saveable (unused + single-use): 15
-- Category counts: unused=0, single-use=3, low-use=2, hot=16, skipped=1
+- Category counts: unused=0, single-use=3, low-use=2, hot=15, skipped=1
 
 ## How to read this report
 
@@ -41,12 +41,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `CacheUtils` | class | 264 | 71 | hot |  | oversize_25_lines |
 | `DataProcessingUtils` | class | 158 | 70 | hot |  | oversize_25_lines,missing_inline_comments,hardcoded_separator |
 | `SiteExportUtils` | class | 145 | 86 | hot |  | oversize_25_lines,missing_action_logging |
-| `GatewayExportUtils` | class | 98 | 72 | hot |  | oversize_25_lines,missing_action_logging |
+| `GatewayExportUtils` | class | 98 | 74 | hot |  | oversize_25_lines,missing_action_logging |
 | `VirtualChassisManager` | class | 78 | 104 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `InputUtils` | class | 74 | 195 | hot |  | oversize_25_lines,raw_input_call |
 | `ConfigUtils` | class | 70 | 99 | hot |  | oversize_25_lines |
 | `FilePathUtils` | class | 46 | 60 | hot |  | oversize_25_lines,missing_inline_comments |
-| `GatewayStatsExporter` | class | 28 | 52 | hot |  | oversize_25_lines,missing_action_logging |
 | `SSHRunnerManager` | class | 26 | 82 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `detect_msp_privileges` | function | 25 | 2 | low-use | DetectMspPrivilegesManager | missing_action_logging |
 | `DeviceFetchConfig` | class | 9 | 1 | single-use | DeviceDataFetcherManager | missing_action_logging |
@@ -59,7 +58,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 490-498
+- Def site: line 493-501
 - References: 1
 - Suggested class: `DeviceDataFetcherManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`
@@ -71,7 +70,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2121-2123
+- Def site: line 2124-2126
 - References: 1
 - Suggested class: `FastModeMaxConcurrentConnectionsManager`
 - Suggested module: `src/refactors/fast__mode__max__concurrent__connections.py`
@@ -80,11 +79,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2121
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2124
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2124-2126
+- Def site: line 2127-2129
 - References: 1
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -92,13 +91,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2124
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2127
 
 ## Low-Use (2)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2971-5297
+- Def site: line 2974-5300
 - References: 2
 - Suggested class: `EndpointPrimaryKeyStrategiesManager`
 - Suggested module: `src/refactors/endpoint__primary__key__strategies.py`
@@ -109,11 +108,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2971, 5944
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2974, 5947
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2233-2257
+- Def site: line 2236-2260
 - References: 2
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -121,13 +120,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2363, 9393
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2366, 9385
 
-## Hot (16)
+## Hot (15)
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 6736-7421
+- Def site: line 6739-7424
 - References: 102
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -136,12 +135,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6859, 6859, 6910, 6910, 6913, 6913, 6954, 6954, 6993, 6993, 7011, 7011, 7089, 7089, 7096, 7096, 7106, 7106, 7109, 7109, 7122, 7122, 7123, 7123, 7124, 7124, 7125, 7125, 7133, 7133, 7135, 7135, 7136, 7136, 7137, 7137, 7138, 7138, 7141, 7141, 7144, 7144, 7147, 7147, 7150, 7150, 7196, 7196, 7219, 7219, 7220, 7220, 7221, 7221, 7223, 7223, 7259, 7259, 7275, 7275, 7329, 7329, 7330, 7330, 7331, 7331, 7334, 7334, 7335, 7335, 7354, 7354, 7356, 7356, 7357, 7357, 7392, 7392, 7767, 7948, 7948, 7972, 7972, 7996, 7996, 8243, 8243, 8250, 8250, 8259, 8259, 8263, 8263, 8272, 8272
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6862, 6862, 6913, 6913, 6916, 6916, 6957, 6957, 6996, 6996, 7014, 7014, 7092, 7092, 7099, 7099, 7109, 7109, 7112, 7112, 7125, 7125, 7126, 7126, 7127, 7127, 7128, 7128, 7136, 7136, 7138, 7138, 7139, 7139, 7140, 7140, 7141, 7141, 7144, 7144, 7147, 7147, 7150, 7150, 7153, 7153, 7199, 7199, 7222, 7222, 7223, 7223, 7224, 7224, 7226, 7226, 7262, 7262, 7278, 7278, 7332, 7332, 7333, 7333, 7334, 7334, 7337, 7337, 7338, 7338, 7357, 7357, 7359, 7359, 7360, 7360, 7395, 7395, 7759, 7940, 7940, 7964, 7964, 7988, 7988, 8235, 8235, 8242, 8242, 8251, 8251, 8255, 8255, 8264, 8264
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 295, 295, 343, 343, 499, 499
 
 ### `menu_actions` (assignment, 651 lines)
 
-- Def site: line 8152-8802
+- Def site: line 8144-8794
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -151,12 +150,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8152, 8837, 8838, 8847, 8967, 8967, 9009, 9065, 9110, 9601, 9605, 9650, 9650, 9677, 9677, 9680
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8144, 8829, 8830, 8839, 8959, 8959, 9001, 9057, 9102, 9593, 9597, 9642, 9642, 9669, 9669, 9672
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 6274-6714
+- Def site: line 6277-6717
 - References: 89
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -164,14 +163,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6289, 6289, 6292, 6292, 6300, 6300, 6318, 6318, 6368, 6368, 6376, 6376, 6381, 6381, 6427, 6427, 6438, 6438, 6463, 6463, 6482, 6482, 6483, 6483, 6486, 6486, 6487, 6487, 6577, 6577, 6579, 6579, 6583, 6583, 6611, 6611, 6612, 6612, 6613, 6613, 6614, 6614, 6615, 6615, 6624, 6624, 6668, 6668, 6692, 6692, 7503, 7670, 7670, 7671, 7671, 7955, 7955, 8048, 8048, 8137, 8137, 8138, 8138, 8187, 8187, 8188, 8188, 8202, 8202, 8203, 8203, 8217, 8217, 8218, 8218, 8414, 8414
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6292, 6292, 6295, 6295, 6303, 6303, 6321, 6321, 6371, 6371, 6379, 6379, 6384, 6384, 6430, 6430, 6441, 6441, 6466, 6466, 6485, 6485, 6486, 6486, 6489, 6489, 6490, 6490, 6580, 6580, 6582, 6582, 6586, 6586, 6614, 6614, 6615, 6615, 6616, 6616, 6617, 6617, 6618, 6618, 6627, 6627, 6671, 6671, 6695, 6695, 7506, 7673, 7673, 7674, 7674, 7947, 7947, 8040, 8040, 8129, 8129, 8130, 8130, 8179, 8179, 8180, 8180, 8194, 8194, 8195, 8195, 8209, 8209, 8210, 8210, 8406, 8406
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 68, 196, 196
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 65, 127, 127, 132, 132
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 5911-6255
+- Def site: line 5914-6258
 - References: 123
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -180,7 +179,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5957, 5957, 5973, 5973, 5974, 5974, 5997, 5997, 5999, 5999, 6002, 6002, 6016, 6016, 6018, 6018, 6027, 6027, 6029, 6029, 6030, 6030, 6036, 6036, 6037, 6037, 6037, 6054, 6054, 6058, 6058, 6100, 6100, 6131, 6131, 6134, 6134, 6136, 6136, 6182, 6182, 6192, 6192, 6225, 6225, 6230, 6230, 6237, 6237, 6331, 6331, 7290, 7290, 7365, 7365, 7506, 7673, 7673, 7763, 8002, 8002, 8022, 8109, 8109, 8341, 8341, 8354, 8354, 8568, 8568, 8633, 8633, 8649, 8649
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5960, 5960, 5976, 5976, 5977, 5977, 6000, 6000, 6002, 6002, 6005, 6005, 6019, 6019, 6021, 6021, 6030, 6030, 6032, 6032, 6033, 6033, 6039, 6039, 6040, 6040, 6040, 6057, 6057, 6061, 6061, 6103, 6103, 6134, 6134, 6137, 6137, 6139, 6139, 6185, 6185, 6195, 6195, 6228, 6228, 6233, 6233, 6240, 6240, 6334, 6334, 7293, 7293, 7368, 7368, 7509, 7676, 7676, 7755, 7994, 7994, 8014, 8101, 8101, 8333, 8333, 8346, 8346, 8560, 8560, 8625, 8625, 8641, 8641
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 71, 188, 188, 286, 286, 294, 294, 363, 363, 392, 392, 544, 544, 559, 559
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 380, 380, 440, 440, 457, 457, 476, 476, 549, 549
@@ -191,7 +190,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5303-5566
+- Def site: line 5306-5569
 - References: 71
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -199,14 +198,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5343, 5343, 5345, 5345, 5427, 5427, 5433, 5433, 5470, 5470, 5472, 5472, 5481, 5481, 5491, 5491, 5501, 5501, 5537, 5537, 6367, 6367, 7218, 7218, 7219, 7219, 7761, 7886, 7947, 7947, 7971, 7971, 7995, 7995, 8049, 8049, 8342, 8342, 8355, 8355, 8569, 8569, 8758, 8758
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5346, 5346, 5348, 5348, 5430, 5430, 5436, 5436, 5473, 5473, 5475, 5475, 5484, 5484, 5494, 5494, 5504, 5504, 5540, 5540, 6370, 6370, 7221, 7221, 7222, 7222, 7753, 7878, 7939, 7939, 7963, 7963, 7987, 7987, 8041, 8041, 8334, 8334, 8347, 8347, 8561, 8561, 8750, 8750
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 339, 339, 341, 341, 343, 343, 345, 345, 499, 499, 500, 500, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32, 336, 336, 357, 357
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 5740-5897
+- Def site: line 5743-5900
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -216,7 +215,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5756, 5756, 5769, 5769, 5772, 5772, 5796, 5796, 5804, 5804, 5805, 5805, 5827, 5827, 5832, 5832, 5834, 5834, 6133, 6133, 6158, 6158, 6227, 6227, 6228, 6228, 6329, 6329, 6330, 6330, 7287, 7287, 7288, 7288, 7362, 7362, 7363, 7363, 7505, 7764, 8000, 8000, 8001, 8001
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5759, 5759, 5772, 5772, 5775, 5775, 5799, 5799, 5807, 5807, 5808, 5808, 5830, 5830, 5835, 5835, 5837, 5837, 6136, 6136, 6161, 6161, 6230, 6230, 6231, 6231, 6332, 6332, 6333, 6333, 7290, 7290, 7291, 7291, 7365, 7365, 7366, 7366, 7508, 7756, 7992, 7992, 7993, 7993
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 70, 153, 153, 154, 154, 159, 159, 187, 187, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 454, 454, 455, 455, 474, 474, 475, 475
@@ -224,7 +223,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 7493-7637
+- Def site: line 7496-7640
 - References: 86
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -233,13 +232,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7522, 7522, 7528, 7528, 7534, 7534, 7540, 7540, 7546, 7546, 7552, 7552, 7558, 7558, 7564, 7564, 7570, 7570, 7576, 7576, 7582, 7582, 7588, 7588, 7594, 7594, 7600, 7600, 7606, 7606, 7612, 7612, 7618, 7618, 7624, 7624, 7630, 7630, 7636, 7636, 8323, 8323, 8482, 8482, 8484, 8484, 8618, 8618, 8753, 8753, 8754, 8754, 8755, 8755, 8774, 8774, 8775, 8775, 8776, 8776, 8777, 8777, 8778, 8778, 8779, 8779, 8780, 8780
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7525, 7525, 7531, 7531, 7537, 7537, 7543, 7543, 7549, 7549, 7555, 7555, 7561, 7561, 7567, 7567, 7573, 7573, 7579, 7579, 7585, 7585, 7591, 7591, 7597, 7597, 7603, 7603, 7609, 7609, 7615, 7615, 7621, 7621, 7627, 7627, 7633, 7633, 7639, 7639, 8315, 8315, 8474, 8474, 8476, 8476, 8610, 8610, 8745, 8745, 8746, 8746, 8747, 8747, 8766, 8766, 8767, 8767, 8768, 8768, 8769, 8769, 8770, 8770, 8771, 8771, 8772, 8772
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 209, 209, 352, 352, 356, 356, 366, 366, 415, 415, 424, 424, 433, 433, 497, 497, 525, 525
 
 ### `GatewayExportUtils` (class, 98 lines)
 
-- Def site: line 7750-7847
-- References: 72
+- Def site: line 7742-7839
+- References: 74
 - Suggested class: _n/a_
 - Suggested module: _n/a_
 - Rationale: Widely used; leave in place until dependencies decouple
@@ -247,13 +246,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7728, 7728, 7786, 7786, 7792, 7792, 7798, 7798, 7804, 7804, 7810, 7810, 7816, 7816, 7822, 7822, 7828, 7828, 7834, 7834, 7840, 7840, 7846, 7846, 7887, 8051, 8051, 8175, 8175, 8275, 8275, 8281, 8281, 8332, 8332, 8407, 8407
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7732, 7732, 7738, 7738, 7778, 7778, 7784, 7784, 7790, 7790, 7796, 7796, 7802, 7802, 7808, 7808, 7814, 7814, 7820, 7820, 7826, 7826, 7832, 7832, 7838, 7838, 7879, 8043, 8043, 8167, 8167, 8267, 8267, 8273, 8273, 8324, 8324, 8399, 8399
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 78, 94, 341, 341, 347, 347, 403, 403, 405, 405, 409, 409, 412, 412, 415, 415, 416, 416, 459, 459, 460, 460, 492, 492, 493, 493, 509, 509, 546, 546
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 7927-8004
+- Def site: line 7919-7996
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -263,12 +262,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8449, 8449, 8453, 8453, 8457, 8457
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8441, 8441, 8445, 8445, 8449, 8449
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 2009-2082
+- Def site: line 2012-2085
 - References: 195
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -277,7 +276,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2022, 2022, 2054, 2054, 2399, 2399, 2426, 2426, 6295, 6295, 6372, 6372, 6455, 6455, 6685, 6685, 7672, 7672, 7769, 7885, 7954, 7954, 7979, 7979, 8021, 8047, 8047, 8105, 8105, 8141, 8141, 8191, 8191, 8206, 8206, 8221, 8221, 8339, 8339, 8352, 8352, 8566, 8566, 8604, 8604, 8631, 8631, 8731, 8731, 8736, 8736, 8742, 8742, 8761, 8761, 8767, 8767, 9686, 9686
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2025, 2025, 2057, 2057, 2402, 2402, 2429, 2429, 6298, 6298, 6375, 6375, 6458, 6458, 6688, 6688, 7675, 7675, 7761, 7877, 7946, 7946, 7971, 7971, 8013, 8039, 8039, 8097, 8097, 8133, 8133, 8183, 8183, 8198, 8198, 8213, 8213, 8331, 8331, 8344, 8344, 8558, 8558, 8596, 8596, 8623, 8623, 8723, 8723, 8728, 8728, 8734, 8734, 8753, 8753, 8759, 8759, 9678, 9678
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -298,7 +297,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 5650-5719
+- Def site: line 5653-5722
 - References: 99
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -306,7 +305,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5692, 5692, 5697, 5697, 7105, 7105, 7328, 7328, 7345, 7345, 7504, 7760, 8019, 8102, 8102, 8106, 8106, 8107, 8107, 8161, 8161, 8231, 8231, 8237, 8237, 8337, 8337, 8350, 8350, 8383, 8383, 8440, 8440, 8523, 8523, 8532, 8532, 8564, 8564, 8605, 8605, 8607, 8607, 8629, 8629, 8630, 8630, 8647, 8647, 8731, 8731, 8736, 8736, 8742, 8742, 8761, 8761, 8767, 8767, 8999, 8999, 9068, 9550, 9550, 9638, 9638
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5695, 5695, 5700, 5700, 7108, 7108, 7331, 7331, 7348, 7348, 7507, 7752, 8011, 8094, 8094, 8098, 8098, 8099, 8099, 8153, 8153, 8223, 8223, 8229, 8229, 8329, 8329, 8342, 8342, 8375, 8375, 8432, 8432, 8515, 8515, 8524, 8524, 8556, 8556, 8597, 8597, 8599, 8599, 8621, 8621, 8622, 8622, 8639, 8639, 8723, 8723, 8728, 8728, 8734, 8734, 8753, 8753, 8759, 8759, 8991, 8991, 9060, 9542, 9542, 9630, 9630
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 69, 246, 246, 556, 556, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 402, 402, 449, 449, 467, 467, 508, 508, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 27, 321, 321
@@ -316,7 +315,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5584-5629
+- Def site: line 5587-5632
 - References: 60
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -325,28 +324,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5342, 5342, 5384, 5384, 5429, 5429, 5535, 5535, 5550, 5550, 5619, 5619, 6391, 6391, 6875, 6875, 7186, 7186, 7202, 7202, 7762, 7888, 7946, 7946, 7970, 7970, 7974, 7974, 7994, 7994, 8020, 8050, 8050, 8340, 8340, 8353, 8353, 8567, 8567
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5345, 5345, 5387, 5387, 5432, 5432, 5538, 5538, 5553, 5553, 5622, 5622, 6394, 6394, 6878, 6878, 7189, 7189, 7205, 7205, 7754, 7880, 7938, 7938, 7962, 7962, 7966, 7966, 7986, 7986, 8012, 8042, 8042, 8332, 8332, 8345, 8345, 8559, 8559
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 149, 149, 227, 227, 235, 235, 243, 243, 548, 548
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 33, 360, 360
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
-### `GatewayStatsExporter` (class, 28 lines)
-
-- Def site: line 7720-7747
-- References: 52
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7734, 7734, 7740, 7740, 7746, 7746, 8461, 8461, 8465, 8465
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 203, 203, 247, 247, 250, 250, 266, 266, 308, 308, 311, 311, 327, 327, 329, 329, 330, 330, 337, 337, 347, 347, 350, 350, 351, 351, 358, 358, 377, 377, 386, 386, 387, 387, 388, 388, 405, 405, 406, 406, 459, 459
-
 ### `SSHRunnerManager` (class, 26 lines)
 
-- Def site: line 7874-7899
+- Def site: line 7866-7891
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -356,12 +341,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7894, 7894, 7899, 7899, 8469, 8469, 8474, 8474
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7886, 7886, 7891, 7891, 8461, 8461, 8466, 8466
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 769-771
+- Def site: line 772-774
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -369,7 +354,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1379, 2019, 2019, 2019, 2031, 2037, 7274, 7385, 7514, 7778, 8634
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1382, 2022, 2022, 2022, 2034, 2040, 7277, 7388, 7517, 7770, 8626
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_data_fetcher.py`: lines 359
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_fetch_utils.py`: lines 104, 227
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\gateway_test_exporter.py`: lines 218, 268
@@ -388,7 +373,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2135-2137
+- Def site: line 2138-2140
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -397,7 +382,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2135, 7774
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2138, 7766
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 54, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -405,7 +390,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1003 lines)
 
-- Def site: line 885-1887
+- Def site: line 888-1890
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -413,7 +398,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1932
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1935
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

Post-merge catalog refresh confirming Hot bucket decrement after PR #906 (P12 GatewayStatsExporter facade removal).

## Category counts (post-P12)

| Bucket      | Count |
|-------------|-------|
| unused      | 0     |
| single-use  | 3     |
| low-use     | 2     |
| hot         | 15    |
| skipped     | 1     |

LOC saveable (unused + single-use): 15

Refs: initiative #1014, SC-001 position 12