### PR TITLE
chore(1014): regenerate refactor_candidates.md after P13 merge

### DIFF
--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -2,9 +2,9 @@
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
 - Module graph size: 250 first-party files
-- Definitions analyzed: 21
+- Definitions analyzed: 20
 - LOC saveable (unused + single-use): 15
-- Category counts: unused=0, single-use=3, low-use=2, hot=15, skipped=1
+- Category counts: unused=0, single-use=3, low-use=2, hot=14, skipped=1
 
 ## How to read this report
 
@@ -41,12 +41,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `CacheUtils` | class | 264 | 71 | hot |  | oversize_25_lines |
 | `DataProcessingUtils` | class | 158 | 70 | hot |  | oversize_25_lines,missing_inline_comments,hardcoded_separator |
 | `SiteExportUtils` | class | 145 | 86 | hot |  | oversize_25_lines,missing_action_logging |
-| `GatewayExportUtils` | class | 98 | 74 | hot |  | oversize_25_lines,missing_action_logging |
 | `VirtualChassisManager` | class | 78 | 104 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `InputUtils` | class | 74 | 195 | hot |  | oversize_25_lines,raw_input_call |
 | `ConfigUtils` | class | 70 | 99 | hot |  | oversize_25_lines |
 | `FilePathUtils` | class | 46 | 60 | hot |  | oversize_25_lines,missing_inline_comments |
-| `SSHRunnerManager` | class | 26 | 82 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
+| `SSHRunnerManager` | class | 27 | 82 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `detect_msp_privileges` | function | 25 | 2 | low-use | DetectMspPrivilegesManager | missing_action_logging |
 | `DeviceFetchConfig` | class | 9 | 1 | single-use | DeviceDataFetcherManager | missing_action_logging |
 | `tqdm` | function | 3 | 43 | hot |  | missing_action_logging |
@@ -58,7 +57,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DeviceFetchConfig` (class, 9 lines)
 
-- Def site: line 493-501
+- Def site: line 494-502
 - References: 1
 - Suggested class: `DeviceDataFetcherManager`
 - Suggested module: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\device_data_fetcher.py`
@@ -70,7 +69,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (assignment, 3 lines)
 
-- Def site: line 2124-2126
+- Def site: line 2125-2127
 - References: 1
 - Suggested class: `FastModeMaxConcurrentConnectionsManager`
 - Suggested module: `src/refactors/fast__mode__max__concurrent__connections.py`
@@ -79,11 +78,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2124
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2125
 
 ### `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 lines)
 
-- Def site: line 2127-2129
+- Def site: line 2128-2130
 - References: 1
 - Suggested class: `FastModeUseConnectionAwareThreadingManager`
 - Suggested module: `src/refactors/fast__mode__use__connection__aware__threading.py`
@@ -91,13 +90,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2127
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2128
 
 ## Low-Use (2)
 
 ### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
 
-- Def site: line 2974-5300
+- Def site: line 2975-5301
 - References: 2
 - Suggested class: `EndpointPrimaryKeyStrategiesManager`
 - Suggested module: `src/refactors/endpoint__primary__key__strategies.py`
@@ -108,11 +107,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_action_logging
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2974, 5947
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2975, 5948
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2236-2260
+- Def site: line 2237-2261
 - References: 2
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -120,13 +119,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2366, 9385
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2367, 9356
 
-## Hot (15)
+## Hot (14)
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 6739-7424
+- Def site: line 6740-7425
 - References: 102
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -135,12 +134,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6862, 6862, 6913, 6913, 6916, 6916, 6957, 6957, 6996, 6996, 7014, 7014, 7092, 7092, 7099, 7099, 7109, 7109, 7112, 7112, 7125, 7125, 7126, 7126, 7127, 7127, 7128, 7128, 7136, 7136, 7138, 7138, 7139, 7139, 7140, 7140, 7141, 7141, 7144, 7144, 7147, 7147, 7150, 7150, 7153, 7153, 7199, 7199, 7222, 7222, 7223, 7223, 7224, 7224, 7226, 7226, 7262, 7262, 7278, 7278, 7332, 7332, 7333, 7333, 7334, 7334, 7337, 7337, 7338, 7338, 7357, 7357, 7359, 7359, 7360, 7360, 7395, 7395, 7759, 7940, 7940, 7964, 7964, 7988, 7988, 8235, 8235, 8242, 8242, 8251, 8251, 8255, 8255, 8264, 8264
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6863, 6863, 6914, 6914, 6917, 6917, 6958, 6958, 6997, 6997, 7015, 7015, 7093, 7093, 7100, 7100, 7110, 7110, 7113, 7113, 7126, 7126, 7127, 7127, 7128, 7128, 7129, 7129, 7137, 7137, 7139, 7139, 7140, 7140, 7141, 7141, 7142, 7142, 7145, 7145, 7148, 7148, 7151, 7151, 7154, 7154, 7200, 7200, 7223, 7223, 7224, 7224, 7225, 7225, 7227, 7227, 7263, 7263, 7279, 7279, 7333, 7333, 7334, 7334, 7335, 7335, 7338, 7338, 7339, 7339, 7358, 7358, 7360, 7360, 7361, 7361, 7396, 7396, 7743, 7910, 7910, 7934, 7934, 7958, 7958, 8206, 8206, 8213, 8213, 8222, 8222, 8226, 8226, 8235, 8235
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 295, 295, 343, 343, 499, 499
 
 ### `menu_actions` (assignment, 651 lines)
 
-- Def site: line 8144-8794
+- Def site: line 8115-8765
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -150,12 +149,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8144, 8829, 8830, 8839, 8959, 8959, 9001, 9057, 9102, 9593, 9597, 9642, 9642, 9669, 9669, 9672
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8115, 8800, 8801, 8810, 8930, 8930, 8972, 9028, 9073, 9564, 9568, 9613, 9613, 9640, 9640, 9643
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 6277-6717
+- Def site: line 6278-6718
 - References: 89
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -163,14 +162,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6292, 6292, 6295, 6295, 6303, 6303, 6321, 6321, 6371, 6371, 6379, 6379, 6384, 6384, 6430, 6430, 6441, 6441, 6466, 6466, 6485, 6485, 6486, 6486, 6489, 6489, 6490, 6490, 6580, 6580, 6582, 6582, 6586, 6586, 6614, 6614, 6615, 6615, 6616, 6616, 6617, 6617, 6618, 6618, 6627, 6627, 6671, 6671, 6695, 6695, 7506, 7673, 7673, 7674, 7674, 7947, 7947, 8040, 8040, 8129, 8129, 8130, 8130, 8179, 8179, 8180, 8180, 8194, 8194, 8195, 8195, 8209, 8209, 8210, 8210, 8406, 8406
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6293, 6293, 6296, 6296, 6304, 6304, 6322, 6322, 6372, 6372, 6380, 6380, 6385, 6385, 6431, 6431, 6442, 6442, 6467, 6467, 6486, 6486, 6487, 6487, 6490, 6490, 6491, 6491, 6581, 6581, 6583, 6583, 6587, 6587, 6615, 6615, 6616, 6616, 6617, 6617, 6618, 6618, 6619, 6619, 6628, 6628, 6672, 6672, 6696, 6696, 7507, 7674, 7674, 7675, 7675, 7917, 7917, 8011, 8011, 8100, 8100, 8101, 8101, 8150, 8150, 8151, 8151, 8165, 8165, 8166, 8166, 8180, 8180, 8181, 8181, 8377, 8377
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 23, 68, 196, 196
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 37, 51
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 65, 127, 127, 132, 132
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 5914-6258
+- Def site: line 5915-6259
 - References: 123
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -179,7 +178,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5960, 5960, 5976, 5976, 5977, 5977, 6000, 6000, 6002, 6002, 6005, 6005, 6019, 6019, 6021, 6021, 6030, 6030, 6032, 6032, 6033, 6033, 6039, 6039, 6040, 6040, 6040, 6057, 6057, 6061, 6061, 6103, 6103, 6134, 6134, 6137, 6137, 6139, 6139, 6185, 6185, 6195, 6195, 6228, 6228, 6233, 6233, 6240, 6240, 6334, 6334, 7293, 7293, 7368, 7368, 7509, 7676, 7676, 7755, 7994, 7994, 8014, 8101, 8101, 8333, 8333, 8346, 8346, 8560, 8560, 8625, 8625, 8641, 8641
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5961, 5961, 5977, 5977, 5978, 5978, 6001, 6001, 6003, 6003, 6006, 6006, 6020, 6020, 6022, 6022, 6031, 6031, 6033, 6033, 6034, 6034, 6040, 6040, 6041, 6041, 6041, 6058, 6058, 6062, 6062, 6104, 6104, 6135, 6135, 6138, 6138, 6140, 6140, 6186, 6186, 6196, 6196, 6229, 6229, 6234, 6234, 6241, 6241, 6335, 6335, 7294, 7294, 7369, 7369, 7510, 7677, 7677, 7739, 7964, 7964, 7984, 8072, 8072, 8304, 8304, 8317, 8317, 8531, 8531, 8596, 8596, 8612, 8612
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 26, 71, 188, 188, 286, 286, 294, 294, 363, 363, 392, 392, 544, 544, 559, 559
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 39, 53
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 380, 380, 440, 440, 457, 457, 476, 476, 549, 549
@@ -190,7 +189,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `CacheUtils` (class, 264 lines)
 
-- Def site: line 5306-5569
+- Def site: line 5307-5570
 - References: 71
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -198,14 +197,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5346, 5346, 5348, 5348, 5430, 5430, 5436, 5436, 5473, 5473, 5475, 5475, 5484, 5484, 5494, 5494, 5504, 5504, 5540, 5540, 6370, 6370, 7221, 7221, 7222, 7222, 7753, 7878, 7939, 7939, 7963, 7963, 7987, 7987, 8041, 8041, 8334, 8334, 8347, 8347, 8561, 8561, 8750, 8750
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5347, 5347, 5349, 5349, 5431, 5431, 5437, 5437, 5474, 5474, 5476, 5476, 5485, 5485, 5495, 5495, 5505, 5505, 5541, 5541, 6371, 6371, 7222, 7222, 7223, 7223, 7737, 7848, 7909, 7909, 7933, 7933, 7957, 7957, 8012, 8012, 8305, 8305, 8318, 8318, 8532, 8532, 8721, 8721
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 40, 339, 339, 341, 341, 343, 343, 345, 345, 499, 499, 500, 500, 545, 545
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 32, 336, 336, 357, 357
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 16, 191, 191, 192, 192, 195, 195
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 5743-5900
+- Def site: line 5744-5901
 - References: 70
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -215,7 +214,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5759, 5759, 5772, 5772, 5775, 5775, 5799, 5799, 5807, 5807, 5808, 5808, 5830, 5830, 5835, 5835, 5837, 5837, 6136, 6136, 6161, 6161, 6230, 6230, 6231, 6231, 6332, 6332, 6333, 6333, 7290, 7290, 7291, 7291, 7365, 7365, 7366, 7366, 7508, 7756, 7992, 7992, 7993, 7993
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5760, 5760, 5773, 5773, 5776, 5776, 5800, 5800, 5808, 5808, 5809, 5809, 5831, 5831, 5836, 5836, 5838, 5838, 6137, 6137, 6162, 6162, 6231, 6231, 6232, 6232, 6333, 6333, 6334, 6334, 7291, 7291, 7292, 7292, 7366, 7366, 7367, 7367, 7509, 7740, 7962, 7962, 7963, 7963
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 25, 70, 153, 153, 154, 154, 159, 159, 187, 187, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_insights_exporter.py`: lines 38, 52
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 454, 454, 455, 455, 474, 474, 475, 475
@@ -223,7 +222,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `SiteExportUtils` (class, 145 lines)
 
-- Def site: line 7496-7640
+- Def site: line 7497-7641
 - References: 86
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -232,27 +231,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7525, 7525, 7531, 7531, 7537, 7537, 7543, 7543, 7549, 7549, 7555, 7555, 7561, 7561, 7567, 7567, 7573, 7573, 7579, 7579, 7585, 7585, 7591, 7591, 7597, 7597, 7603, 7603, 7609, 7609, 7615, 7615, 7621, 7621, 7627, 7627, 7633, 7633, 7639, 7639, 8315, 8315, 8474, 8474, 8476, 8476, 8610, 8610, 8745, 8745, 8746, 8746, 8747, 8747, 8766, 8766, 8767, 8767, 8768, 8768, 8769, 8769, 8770, 8770, 8771, 8771, 8772, 8772
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7526, 7526, 7532, 7532, 7538, 7538, 7544, 7544, 7550, 7550, 7556, 7556, 7562, 7562, 7568, 7568, 7574, 7574, 7580, 7580, 7586, 7586, 7592, 7592, 7598, 7598, 7604, 7604, 7610, 7610, 7616, 7616, 7622, 7622, 7628, 7628, 7634, 7634, 7640, 7640, 8286, 8286, 8445, 8445, 8447, 8447, 8581, 8581, 8716, 8716, 8717, 8717, 8718, 8718, 8737, 8737, 8738, 8738, 8739, 8739, 8740, 8740, 8741, 8741, 8742, 8742, 8743, 8743
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 209, 209, 352, 352, 356, 356, 366, 366, 415, 415, 424, 424, 433, 433, 497, 497, 525, 525
-
-### `GatewayExportUtils` (class, 98 lines)
-
-- Def site: line 7742-7839
-- References: 74
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7732, 7732, 7738, 7738, 7778, 7778, 7784, 7784, 7790, 7790, 7796, 7796, 7802, 7802, 7808, 7808, 7814, 7814, 7820, 7820, 7826, 7826, 7832, 7832, 7838, 7838, 7879, 8043, 8043, 8167, 8167, 8267, 8267, 8273, 8273, 8324, 8324, 8399, 8399
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 78, 94, 341, 341, 347, 347, 403, 403, 405, 405, 409, 409, 412, 412, 415, 415, 416, 416, 459, 459, 460, 460, 492, 492, 493, 493, 509, 509, 546, 546
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 18, 193, 193, 196, 196
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 7919-7996
+- Def site: line 7889-7966
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -262,12 +246,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8441, 8441, 8445, 8445, 8449, 8449
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8412, 8412, 8416, 8416, 8420, 8420
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 2012-2085
+- Def site: line 2013-2086
 - References: 195
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -276,7 +260,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2025, 2025, 2057, 2057, 2402, 2402, 2429, 2429, 6298, 6298, 6375, 6375, 6458, 6458, 6688, 6688, 7675, 7675, 7761, 7877, 7946, 7946, 7971, 7971, 8013, 8039, 8039, 8097, 8097, 8133, 8133, 8183, 8183, 8198, 8198, 8213, 8213, 8331, 8331, 8344, 8344, 8558, 8558, 8596, 8596, 8623, 8623, 8723, 8723, 8728, 8728, 8734, 8734, 8753, 8753, 8759, 8759, 9678, 9678
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2026, 2026, 2058, 2058, 2403, 2403, 2430, 2430, 6299, 6299, 6376, 6376, 6459, 6459, 6689, 6689, 7676, 7676, 7745, 7847, 7916, 7916, 7941, 7941, 7983, 8010, 8010, 8068, 8068, 8104, 8104, 8154, 8154, 8169, 8169, 8184, 8184, 8302, 8302, 8315, 8315, 8529, 8529, 8567, 8567, 8594, 8594, 8694, 8694, 8699, 8699, 8705, 8705, 8724, 8724, 8730, 8730, 9649, 9649
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -297,7 +281,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 5653-5722
+- Def site: line 5654-5723
 - References: 99
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -305,7 +289,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5695, 5695, 5700, 5700, 7108, 7108, 7331, 7331, 7348, 7348, 7507, 7752, 8011, 8094, 8094, 8098, 8098, 8099, 8099, 8153, 8153, 8223, 8223, 8229, 8229, 8329, 8329, 8342, 8342, 8375, 8375, 8432, 8432, 8515, 8515, 8524, 8524, 8556, 8556, 8597, 8597, 8599, 8599, 8621, 8621, 8622, 8622, 8639, 8639, 8723, 8723, 8728, 8728, 8734, 8734, 8753, 8753, 8759, 8759, 8991, 8991, 9060, 9542, 9542, 9630, 9630
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5696, 5696, 5701, 5701, 7109, 7109, 7332, 7332, 7349, 7349, 7508, 7736, 7981, 8065, 8065, 8069, 8069, 8070, 8070, 8124, 8124, 8194, 8194, 8200, 8200, 8300, 8300, 8313, 8313, 8346, 8346, 8403, 8403, 8486, 8486, 8495, 8495, 8527, 8527, 8568, 8568, 8570, 8570, 8592, 8592, 8593, 8593, 8610, 8610, 8694, 8694, 8699, 8699, 8705, 8705, 8724, 8724, 8730, 8730, 8962, 8962, 9031, 9513, 9513, 9601, 9601
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\site_export_utils.py`: lines 24, 69, 246, 246, 556, 556, 557, 557
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 402, 402, 449, 449, 467, 467, 508, 508, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 27, 321, 321
@@ -315,7 +299,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5587-5632
+- Def site: line 5588-5633
 - References: 60
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -324,14 +308,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5345, 5345, 5387, 5387, 5432, 5432, 5538, 5538, 5553, 5553, 5622, 5622, 6394, 6394, 6878, 6878, 7189, 7189, 7205, 7205, 7754, 7880, 7938, 7938, 7962, 7962, 7966, 7966, 7986, 7986, 8012, 8042, 8042, 8332, 8332, 8345, 8345, 8559, 8559
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5346, 5346, 5388, 5388, 5433, 5433, 5539, 5539, 5554, 5554, 5623, 5623, 6395, 6395, 6879, 6879, 7190, 7190, 7206, 7206, 7738, 7850, 7908, 7908, 7932, 7932, 7936, 7936, 7956, 7956, 7982, 8013, 8013, 8303, 8303, 8316, 8316, 8530, 8530
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 149, 149, 227, 227, 235, 235, 243, 243, 548, 548
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 33, 360, 360
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
-### `SSHRunnerManager` (class, 26 lines)
+### `SSHRunnerManager` (class, 27 lines)
 
-- Def site: line 7866-7891
+- Def site: line 7835-7861
 - References: 82
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -341,12 +325,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7886, 7886, 7891, 7891, 8461, 8461, 8466, 8466
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7856, 7856, 7861, 7861, 8432, 8432, 8437, 8437
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\ssh\ssh_runner_manager.py`: lines 61, 61, 62, 62, 64, 64, 68, 68, 73, 73, 86, 86, 87, 87, 96, 96, 97, 97, 129, 129, 130, 130, 131, 131, 136, 136, 137, 137, 139, 139, 162, 162, 165, 165, 168, 168, 189, 189, 193, 193, 209, 209, 210, 210, 211, 211, 278, 278, 280, 280, 281, 281, 327, 327, 369, 369, 373, 373, 382, 382, 400, 400, 416, 416, 438, 438, 495, 495, 499, 499, 500, 500, 503, 503
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 772-774
+- Def site: line 773-775
 - References: 43
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -354,7 +338,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1382, 2022, 2022, 2022, 2034, 2040, 7277, 7388, 7517, 7770, 8626
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1383, 2023, 2023, 2023, 2035, 2041, 7278, 7389, 7518, 7754, 8597
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_data_fetcher.py`: lines 359
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_fetch_utils.py`: lines 104, 227
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\gateway_test_exporter.py`: lines 218, 268
@@ -373,7 +357,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2138-2140
+- Def site: line 2139-2141
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -382,7 +366,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2138, 7766
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2139, 7750
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 54, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -390,7 +374,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1003 lines)
 
-- Def site: line 888-1890
+- Def site: line 889-1891
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -398,7 +382,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1935
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1936
 
 ## Limitations
 


### PR DESCRIPTION
GatewayExportUtils no longer listed as candidate (facade removed in #908; canonical body lives at `src/gateway/gateway_export_utils.py`). Catalog now shows hot=14 (was 15), definitions=20.