### PR TITLE
refactor(1014): remove SSHRunnerManager facade (SC-001, position 15)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -345,10 +345,7 @@ from src.site.site_config_manager import (
 )
 from src.ssh.cli_shell_manager import CLIShellManager  # pylint: disable=unused-import  # noqa: F401
 from src.ssh.ssh_runner import EnhancedSSHRunner  # Import SSH command execution and result parsing
-from src.ssh.ssh_runner_manager import (
-    SSHRunnerManager as ExtractedSSHRunnerManager,
-)  # Import SSH runner manager (renamed to avoid conflicts)
-from src.ssh.ssh_runner_manager import SSHRunnerManagerDeps  # Import SSH runner manager dependency injection class
+from src.ssh.ssh_runner_manager import SSHRunnerManager, SSHRunnerManagerDeps  # Cat A canonical (1014 P15)
 from src.time.time_utils import TimeUtils  # Cat E canonical (1014 P6)
 from src.troubleshooting.interactive_test_runner import (
     InteractiveTestRunner,
@@ -7572,35 +7569,23 @@ def _dispatch_gateway_device_configs(debug: bool = False, fast: bool = False) ->
 
 
 # ============================================================================
-# SSH RUNNER MANAGER CLASS
+# SSH RUNNER MANAGER FACADE REMOVED (1014 P15, Cat A)
 # ============================================================================
-class SSHRunnerManager:  # SSH runner delegators.
-    """Delegation wrapper for extracted SSH runner manager implementation."""
-
-    @staticmethod
-    def _build_deps() -> SSHRunnerManagerDeps:  # Build the deps bundle.
-        """Build dependency container for extracted SSH runner logic."""
-        cli_args = globals().get("args") if "args" in globals() else None  # Read parsed CLI args.
-        _configure_gateway_module()  # 1014 P13: DI wire canonical gateway module before packaging class ref.
-        return SSHRunnerManagerDeps(  # Assemble the deps.
-            args=cli_args,
-            progress_emitter=PROGRESS_EMITTER,
-            enhanced_ssh_runner=EnhancedSSHRunner,
-            input_utils=InputUtils,
-            cache_utils=CacheUtils,
-            gateway_export_utils=GatewayExportUtils,
-            file_path_utils=FilePathUtils,
-        )
-
-    @staticmethod
-    def interactive():  # Run interactive SSH.
-        """Delegated interactive SSH runner entrypoint."""
-        return ExtractedSSHRunnerManager.interactive(SSHRunnerManager._build_deps())  # Delegate to the impl.
-
-    @staticmethod
-    def _load_gateway_data():  # Load gateway data.
-        """Delegated helper to load gateway management data."""
-        return ExtractedSSHRunnerManager._load_gateway_data(SSHRunnerManager._build_deps())  # Delegate to the impl.
+# Canonical class lives at src/ssh/ssh_runner_manager.py; imported at top of file.
+# The helper below builds the DI container from MistHelper module globals.
+def _build_ssh_runner_deps() -> SSHRunnerManagerDeps:  # Build the deps bundle for SSHRunnerManager entrypoints.
+    """Build dependency container for SSH runner logic (reads MistHelper globals)."""
+    cli_args = globals().get("args") if "args" in globals() else None  # Read parsed CLI args.
+    _configure_gateway_module()  # 1014 P13: DI wire canonical gateway module before packaging class ref.
+    return SSHRunnerManagerDeps(  # Assemble the deps.
+        args=cli_args,
+        progress_emitter=PROGRESS_EMITTER,
+        enhanced_ssh_runner=EnhancedSSHRunner,
+        input_utils=InputUtils,
+        cache_utils=CacheUtils,
+        gateway_export_utils=GatewayExportUtils,
+        file_path_utils=FilePathUtils,
+    )
 
 
 # CLIShellManager was extracted to src/ssh/cli_shell_manager.py in initiative 1013 (Cat B, position 30).
@@ -8171,12 +8156,12 @@ menu_actions = {
         "Check and export gateways with duplicate WAN port IP addresses (0/0/0, 0/0/1, 0/0/2)",
     ),
     "175": (
-        SSHRunnerManager.interactive,
+        lambda: SSHRunnerManager.interactive(_build_ssh_runner_deps()),
         "Enhanced SSH Command Runner - Execute commands on remote network devices via SSH",
     ),
     "176": (
-        # Wire menu directly to extracted SSH runner impl (facade wrapper removed).
-        lambda: ExtractedSSHRunnerManager.by_gateway_template(SSHRunnerManager._build_deps()),
+        # Wire menu directly to canonical SSH runner impl (facade wrapper removed, 1014 P15).
+        lambda: SSHRunnerManager.by_gateway_template(_build_ssh_runner_deps()),
         "SSH Runner - Target gateways by template name (online gateways with management IPs only)",
     ),
     # ==============================

--- a/tests/guardrails/test_wave1_logging_envelopes.py
+++ b/tests/guardrails/test_wave1_logging_envelopes.py
@@ -54,9 +54,9 @@ class TestCollectMissingDataEnvelopes:
         monkeypatch.setattr(  # Stub getpass so no stdin read attempted in pytest capture mode
             _getpass_mod, "getpass", lambda prompt="Enter SSH password: ": "stubbed-pw"
         )
-        deps = MistHelper.SSHRunnerManager._build_deps()  # Build deps; facade wrapper removed
+        deps = MistHelper._build_ssh_runner_deps()  # Build deps; facade wrapper removed
         with caplog.at_level(logging.INFO, logger="root"):  # Capture INFO+ logs
-            MistHelper.ExtractedSSHRunnerManager._collect_missing_data(deps, [], None, None, [])  # All-missing data
+            MistHelper.SSHRunnerManager._collect_missing_data(deps, [], None, None, [])  # All-missing data
         entry_msgs = _entry_messages(caplog.records)  # Collect entry envelope lines
         assert entry_msgs, (  # At least one entry envelope must be present
             "No entry envelope logged by _collect_missing_data; " "expected a message containing 'Entering'"
@@ -67,9 +67,9 @@ class TestCollectMissingDataEnvelopes:
         monkeypatch.setattr(  # Stub safe_input to return pre-filled values
             MistHelper.InputUtils, "safe_input", lambda prompt, context="": "admin"
         )
-        deps = MistHelper.SSHRunnerManager._build_deps()  # Build deps; facade wrapper removed
+        deps = MistHelper._build_ssh_runner_deps()  # Build deps; facade wrapper removed
         with caplog.at_level(logging.DEBUG, logger="root"):  # DEBUG to catch debug-level exit
-            MistHelper.ExtractedSSHRunnerManager._collect_missing_data(  # Supply hosts; only user/cmd prompted
+            MistHelper.SSHRunnerManager._collect_missing_data(  # Supply hosts; only user/cmd prompted
                 deps, ["10.0.0.1"], None, "secret", []
             )
         exit_msgs = _exit_messages(caplog.records)  # Collect exit envelope lines
@@ -83,9 +83,9 @@ class TestCollectMissingDataEnvelopes:
         monkeypatch.setattr(  # Return empty string to simulate user pressing Enter
             MistHelper.InputUtils, "safe_input", lambda prompt, context="": ""
         )
-        deps = MistHelper.SSHRunnerManager._build_deps()  # Build deps; facade wrapper removed
+        deps = MistHelper._build_ssh_runner_deps()  # Build deps; facade wrapper removed
         with caplog.at_level(logging.INFO, logger="root"):  # Capture INFO+ logs
-            MistHelper.ExtractedSSHRunnerManager._collect_missing_data(deps, [], None, None, [])
+            MistHelper.SSHRunnerManager._collect_missing_data(deps, [], None, None, [])
         exit_msgs = _exit_messages(caplog.records)  # Collect exit envelope lines
         assert (
             exit_msgs
@@ -102,18 +102,18 @@ class TestConfirmExecutionEnvelopes:
         monkeypatch.setattr(  # Stub safe_input to auto-confirm
             MistHelper.InputUtils, "safe_input", lambda prompt, context="": "y"
         )
-        deps = MistHelper.SSHRunnerManager._build_deps()  # Build deps; facade wrapper removed
+        deps = MistHelper._build_ssh_runner_deps()  # Build deps; facade wrapper removed
         with caplog.at_level(logging.INFO, logger="root"):  # Capture INFO+ logs
-            MistHelper.ExtractedSSHRunnerManager._confirm_execution(deps, 5)
+            MistHelper.SSHRunnerManager._confirm_execution(deps, 5)
         entry_msgs = _entry_messages(caplog.records)  # Collect entry envelope lines
         assert entry_msgs, "No entry envelope logged by _confirm_execution"
 
     def test_exit_envelope_emitted_on_confirm(self, caplog, monkeypatch):
         """Exit log must appear when user confirms with 'y'."""
         monkeypatch.setattr(MistHelper.InputUtils, "safe_input", lambda prompt, context="": "y")  # Auto-confirm
-        deps = MistHelper.SSHRunnerManager._build_deps()  # Build deps; facade wrapper removed
+        deps = MistHelper._build_ssh_runner_deps()  # Build deps; facade wrapper removed
         with caplog.at_level(logging.INFO, logger="root"):  # Capture INFO+ logs
-            result = MistHelper.ExtractedSSHRunnerManager._confirm_execution(deps, 5)
+            result = MistHelper.SSHRunnerManager._confirm_execution(deps, 5)
         exit_msgs = _exit_messages(caplog.records)  # Collect exit envelope lines
         assert result is True  # Confirm returns True for 'y'
         assert exit_msgs, "No exit envelope logged by _confirm_execution on confirm path"
@@ -121,9 +121,9 @@ class TestConfirmExecutionEnvelopes:
     def test_exit_envelope_emitted_on_cancel(self, caplog, monkeypatch):
         """Exit log must appear when user cancels."""
         monkeypatch.setattr(MistHelper.InputUtils, "safe_input", lambda prompt, context="": "n")  # Return 'n' to cancel
-        deps = MistHelper.SSHRunnerManager._build_deps()  # Build deps; facade wrapper removed
+        deps = MistHelper._build_ssh_runner_deps()  # Build deps; facade wrapper removed
         with caplog.at_level(logging.INFO, logger="root"):  # Capture INFO+ logs
-            result = MistHelper.ExtractedSSHRunnerManager._confirm_execution(deps, 5)
+            result = MistHelper.SSHRunnerManager._confirm_execution(deps, 5)
         exit_msgs = _exit_messages(caplog.records)  # Collect exit envelope lines
         assert result is False  # Cancel returns False
         assert exit_msgs, "No exit envelope logged by _confirm_execution on cancel path"
@@ -308,9 +308,9 @@ class TestNoSecretExposureInLogs:
         monkeypatch.setattr(  # Stub safe_input for username/command prompts
             MistHelper.InputUtils, "safe_input", lambda prompt, context="": "admin"
         )
-        deps = MistHelper.SSHRunnerManager._build_deps()  # Build deps; facade wrapper removed
+        deps = MistHelper._build_ssh_runner_deps()  # Build deps; facade wrapper removed
         with caplog.at_level(logging.DEBUG, logger="root"):  # Capture all levels
-            MistHelper.ExtractedSSHRunnerManager._collect_missing_data(
+            MistHelper.SSHRunnerManager._collect_missing_data(
                 deps,  # Injected dependency container (facade previously built this)
                 ["10.0.0.1"],  # Hosts pre-supplied so only username/command prompted
                 "admin",  # Username pre-supplied
@@ -327,9 +327,9 @@ class TestNoSecretExposureInLogs:
     def test_confirm_execution_does_not_log_sensitive_data(self, caplog, monkeypatch):
         """Confirmation function must not expose count as sensitive but must not log credentials."""
         monkeypatch.setattr(MistHelper.InputUtils, "safe_input", lambda prompt, context="": "y")  # Auto-confirm
-        deps = MistHelper.SSHRunnerManager._build_deps()  # Build deps; facade wrapper removed
+        deps = MistHelper._build_ssh_runner_deps()  # Build deps; facade wrapper removed
         with caplog.at_level(logging.DEBUG, logger="root"):  # Capture all levels
-            MistHelper.ExtractedSSHRunnerManager._confirm_execution(deps, 5)
+            MistHelper.SSHRunnerManager._confirm_execution(deps, 5)
         all_log_text = " ".join(r.getMessage() for r in caplog.records)  # Concat all log messages
         # No password flows through _confirm_execution; just ensure no raw secret token patterns
         assert (

--- a/tests/guardrails/test_wave1_safe_input_paths.py
+++ b/tests/guardrails/test_wave1_safe_input_paths.py
@@ -11,9 +11,9 @@ def test_ssh_runner_confirm_execution_returns_false_on_eof(monkeypatch):
         raise EOFError
 
     monkeypatch.setattr("builtins.input", raise_eof)
-    # Facade wrapper removed; call extracted impl directly with built deps.
-    deps = MistHelper.SSHRunnerManager._build_deps()
-    assert MistHelper.ExtractedSSHRunnerManager._confirm_execution(deps, 3) is False
+    # Facade wrapper removed (1014 P15); call canonical impl directly with built deps.
+    deps = MistHelper._build_ssh_runner_deps()
+    assert MistHelper.SSHRunnerManager._confirm_execution(deps, 3) is False
 
 
 def test_wan2_confirm_operation_handles_eof_as_cancel(monkeypatch):


### PR DESCRIPTION
## Summary
- Removes the SSHRunnerManager delegation wrapper in MistHelper.py (Cat A, position 15) — canonical class already lives at `src/ssh/ssh_runner_manager.py`.
- Introduces module-level `_build_ssh_runner_deps()` helper that reads MistHelper globals and calls `_configure_gateway_module()` (1014 P13) before packaging the frozen deps bundle.
- Menu 175/176 lambdas invoke `SSHRunnerManager.interactive()` / `.by_gateway_template()` directly with the built deps.

## Rewire scope
- Import alias consolidated: `SSHRunnerManager` + `SSHRunnerManagerDeps` imported by their canonical names.
- Guardrail tests rewired: 8× `_build_deps()` → `_build_ssh_runner_deps()`, 8× `ExtractedSSHRunnerManager.X` → `SSHRunnerManager.X`.

## Test plan
- [x] `black --check` clean on edited files
- [x] `ruff check` clean on edited files
- [x] `mypy MistHelper.py` — no new errors (pre-existing only)
- [x] `pytest tests/unit/ssh tests/guardrails` — 91 passed
- [x] Compliance: `src/ssh/ssh_runner_manager.py` 100.0/A+