### PR TITLE
refactor(1014): remove SiteExportUtils facade (P16, Cat A)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -205,9 +205,9 @@ from src.export.site_config_exporter import (  # pylint: disable=unused-import
 from src.export.site_device_exporter import (  # pylint: disable=unused-import
     SiteDeviceExporter,  # noqa: F401  # Cat B (1013 SC-001 position 34) -- re-export for MistHelper.SiteDeviceExporter callers
 )
-from src.export.site_export_utils import (
-    configure_site_export_utils_dependencies,
-)  # Import site export utility configuration
+from src.export.site_export_utils import (  # Cat A canonical (1014 P16)
+    SiteExportUtils,
+)
 from src.export.site_insights.device_metric_operation import (
     DeviceMetricOperation,
 )  # Decomposed Menu 76 entry point
@@ -7233,153 +7233,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
 # ============================================================================
 
 
-class SiteExportUtils:  # Site export delegators.
-    """Delegation wrapper for extracted site export implementation."""
-
-    @staticmethod
-    def _configure_module():  # Configure the export module.
-        """Configure extracted module dependencies and return module handle."""
-        from src.export import site_export_utils as site_export_module  # noqa: PLC0415,I001
-
-        configure_site_export_utils_dependencies(  # Wire dependencies.
-            apisession_dependency=apisession,
-            prompt_utils=PromptUtils,
-            config_utils=ConfigUtils,
-            data_processing_utils=DataProcessingUtils,
-            data_exporter=DataExporter,
-            time_utils=TimeUtils,
-            enhanced_ssh_runner=EnhancedSSHRunner,
-            insight_metrics_utils=InsightMetricsUtils,
-            packet_capture_manager=PacketCaptureManager,
-            api_core_fetch_utils=APICoreFetchUtils,
-            check_fn=IsDebugMode.check,
-            pretty_table_class=PrettyTable,
-            tqdm_module=tqdm,
-            mistapi_dependency=mistapi,
-        )
-        return site_export_module  # Return the module.
-
-    @staticmethod
-    def _export_data(api_call, data_type, sort_key="name", **api_kwargs):  # Export a site endpoint.
-        """Delegate generic site export flow to extracted module."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils._export_data(api_call, data_type, sort_key=sort_key, **api_kwargs)
-
-    @staticmethod
-    def insight_metrics():  # Export site insight metrics.
-        """Menu #74 entry: configures deps then runs decomposed SiteMetricOperation."""
-        SiteExportUtils._configure_module()  # Wire apisession / mistapi / DataExporter globals on the extracted module
-        SiteMetricOperation.execute()  # Run the decomposed operation directly (no inheritance delegation)
-
-    @staticmethod
-    def device_insights():  # Export device insights.
-        """Menu #76 entry: configures deps then runs decomposed DeviceMetricOperation."""
-        SiteExportUtils._configure_module()  # Wire apisession / mistapi / DataExporter globals on the extracted module
-        DeviceMetricOperation.execute()  # Run the decomposed operation directly (no inheritance delegation)
-
-    @staticmethod
-    def insights():  # Export site insights.
-        """Menu #73 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.insights()  # Delegate the export.
-
-    @staticmethod
-    def _system_events():  # Export system events.
-        """Delegated site system events export."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils._system_events()  # Delegate the export.
-
-    @staticmethod
-    def _fast_roam_events():  # Export fast-roam events.
-        """Delegated site fast-roam events export."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils._fast_roam_events()  # Delegate the export.
-
-    @staticmethod
-    def ospf_stats():  # Export OSPF stats.
-        """Menu #70 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.ospf_stats()  # Delegate the export.
-
-    @staticmethod
-    def mxedge_upgrade_status():  # Export Mist Edge upgrades.
-        """Menu #71 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.mxedge_upgrade_status()  # Delegate the export.
-
-    @staticmethod
-    def auto_map_assignment_status():  # Export auto-map status.
-        """Menu #72 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.auto_map_assignment_status()  # Delegate the export.
-
-    @staticmethod
-    def site_stats() -> None:  # Export site stats.
-        """Menu #80 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.site_stats()  # Delegate the export.
-
-    @staticmethod
-    def gateway_metrics() -> None:  # Export gateway metrics.
-        """Menu #81 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.gateway_metrics()  # Delegate the export.
-
-    @staticmethod
-    def switches_metrics() -> None:  # Export switch metrics.
-        """Menu #82 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.switches_metrics()  # Delegate the export.
-
-    @staticmethod
-    def beacons_stats() -> None:  # Export beacon stats.
-        """Menu #83 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.beacons_stats()  # Delegate the export.
-
-    @staticmethod
-    def wxrules_usage() -> None:  # Export WxRules usage.
-        """Menu #84 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.wxrules_usage()  # Delegate the export.
-
-    @staticmethod
-    def assets_stats() -> None:  # Export asset stats.
-        """Menu #85 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.assets_stats()  # Delegate the export.
-
-    @staticmethod
-    def current_channel_planning() -> None:  # Export channel planning.
-        """Menu #86 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.current_channel_planning()  # Delegate the export.
-
-    @staticmethod
-    def zone_config_analysis() -> None:  # Export zone analysis.
-        """Menu #6 delegated entrypoint."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils.zone_config_analysis()  # Delegate the export.
-
-    @staticmethod
-    def _classify_device_platform(device_model: str) -> str:  # Classify a device platform.
-        """Delegate device platform classification helper."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils._classify_device_platform(device_model)  # Delegate the call.
-
-    @staticmethod
-    def _metric_supported_on_platform(metric_name: str, device_platform: str) -> bool:  # Check metric platform support.
-        """Delegate metric/platform support check to the extracted SiteExportUtils impl."""
-        module = SiteExportUtils._configure_module()  # resolve wired src module
-        return module.SiteExportUtils._metric_compatible_with_platform(metric_name, device_platform)  # call src impl
-
-    @staticmethod
-    def _normalize_device_mac_or_none(device_mac: str) -> str | None:  # Normalize a device MAC.
-        """Delegate device MAC normalization helper."""
-        module = SiteExportUtils._configure_module()  # Configure the module.
-        return module.SiteExportUtils._normalize_device_mac_or_none(device_mac)  # Delegate the call.
-
-
+# SiteExportUtils moved to src/export/site_export_utils.py (1014 P16 Cat A) — imported at top
 # GatewayHaExporter moved to src/gateway/gateway_ha_exporter.py (1013 SC-001 position 23)
 
 
@@ -8010,7 +7864,25 @@ menu_actions = {
     "66": (SiteClientExporter.beacons, "Export beacon information for a selected site"),
     "67": (SiteConfigExporter.maps, "Export map information for a selected site"),
     "68": (SiteConfigExporter.zones, "Export zone information for a selected site"),
-    "73": (SiteExportUtils.insights, "Export SLE (Service Level Experience) metrics insights for a selected site"),
+    "73": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).insights(),
+        "Export SLE (Service Level Experience) metrics insights for a selected site",
+    ),
     # ==============================
     # GATEWAY TEMPLATE VARIABLE OPERATIONS
     # ==============================
@@ -8169,9 +8041,32 @@ menu_actions = {
     # ==============================
     "51": (OrgExportUtils.sle_metrics, "Export Organization SLE Metrics (Service Level Experience)"),
     "52": (OrgExportUtils.sites_sle_summary, "Export SLE summary metrics for all sites in the organization"),
-    "74": (SiteExportUtils.insight_metrics, "Export general insight metrics for a selected site"),
+    "74": (
+        lambda: SiteMetricOperation(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            mistapi=mistapi,
+        ).execute(),
+        "Export general insight metrics for a selected site",
+    ),
     "75": (SiteClientExporter.client_insights, "Export client-specific insight metrics for a selected site"),
-    "76": (SiteExportUtils.device_insights, "Export device-specific insight metrics for a selected site"),
+    "76": (
+        lambda: DeviceMetricOperation(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            mistapi=mistapi,
+        ).execute(),
+        "Export device-specific insight metrics for a selected site",
+    ),
     "54": (
         lambda: ConstDefinitionsExporter(apisession).export_all(),  # type: ignore[no-untyped-call]
         "Export all available const definitions from the Mist API (comprehensive endpoint coverage)",
@@ -8305,7 +8200,22 @@ menu_actions = {
     # ZONE & ENGAGEMENT CONFIGURATION ANALYSIS
     # ==============================
     "6": (
-        SiteExportUtils.zone_config_analysis,
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).zone_config_analysis(),
         "Site Config Analysis - Scan all sites for zone, engagement dwell tag, and occupancy setting deviations",
     ),
     # ==============================
@@ -8440,9 +8350,63 @@ menu_actions = {
     "56": (OrgExportUtils.jsi_pbn, "Export JSI PBN (Product Bulletin Notifications) data"),
     "57": (OrgExportUtils.jsi_sirt, "Export JSI SIRT (Security Incident Response) advisories"),
     "55": (OrgExportUtils.ospf_stats, "Export OSPF adjacency statistics for the organization"),
-    "70": (SiteExportUtils.ospf_stats, "Export OSPF adjacency statistics for a selected site"),
-    "71": (SiteExportUtils.mxedge_upgrade_status, "Export MxEdge upgrade status for a selected site"),
-    "72": (SiteExportUtils.auto_map_assignment_status, "Export auto-map assignment status for a selected site"),
+    "70": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).ospf_stats(),
+        "Export OSPF adjacency statistics for a selected site",
+    ),
+    "71": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).mxedge_upgrade_status(),
+        "Export MxEdge upgrade status for a selected site",
+    ),
+    "72": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).auto_map_assignment_status(),
+        "Export auto-map assignment status for a selected site",
+    ),
     "88": (SitesByAPModelExporter.export_sites_by_ap_model, "Export sites by AP model with site address (CSV)"),
     "25": (AuditAnalysisOps.audit_log_analysis, "Audit Log Analysis - Mermaid timeline + interactive HTML report"),
     "186": (CacheUtils.clear_cache, "Clear CSV Cache Files (delete all generated cache CSVs)"),
@@ -8461,13 +8425,139 @@ menu_actions = {
     # ==============================
     # SITE STATS, METRICS & CHANNEL PLANNING
     # ==============================
-    "80": (SiteExportUtils.site_stats, "Export site aggregate health & capacity statistics"),
-    "81": (SiteExportUtils.gateway_metrics, "Export site gateway performance metrics summary"),
-    "82": (SiteExportUtils.switches_metrics, "Export site switch performance metrics summary"),
-    "83": (SiteExportUtils.beacons_stats, "Export site BLE beacon statistics"),
-    "84": (SiteExportUtils.wxrules_usage, "Export site WxLAN rule usage statistics"),
-    "85": (SiteExportUtils.assets_stats, "Export site asset statistics"),
-    "86": (SiteExportUtils.current_channel_planning, "Export current RRM channel & power plan per AP radio"),
+    "80": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).site_stats(),
+        "Export site aggregate health & capacity statistics",
+    ),
+    "81": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).gateway_metrics(),
+        "Export site gateway performance metrics summary",
+    ),
+    "82": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).switches_metrics(),
+        "Export site switch performance metrics summary",
+    ),
+    "83": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).beacons_stats(),
+        "Export site BLE beacon statistics",
+    ),
+    "84": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).wxrules_usage(),
+        "Export site WxLAN rule usage statistics",
+    ),
+    "85": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).assets_stats(),
+        "Export site asset statistics",
+    ),
+    "86": (
+        lambda: SiteExportUtils(
+            apisession=apisession,
+            PromptUtils=PromptUtils,
+            ConfigUtils=ConfigUtils,
+            DataProcessingUtils=DataProcessingUtils,
+            DataExporter=DataExporter,
+            TimeUtils=TimeUtils,
+            EnhancedSSHRunner=EnhancedSSHRunner,
+            InsightMetricsUtils=InsightMetricsUtils,
+            PacketCaptureManager=PacketCaptureManager,
+            APICoreFetchUtils=APICoreFetchUtils,
+            check_fn=IsDebugMode.check,
+            PrettyTable=PrettyTable,
+            tqdm=tqdm,
+            mistapi=mistapi,
+        ).current_channel_planning(),
+        "Export current RRM channel & power plan per AP radio",
+    ),
     "23": (SelfExportUtils.audit_logs, "Export self (admin account) audit log"),
     "87": (GatewayHaExporter.ha_cluster_info, "Export HA gateway cluster info, stats & node pair for a site"),
     "13": (

--- a/src/export/site_client_exporter.py
+++ b/src/export/site_client_exporter.py
@@ -14,6 +14,7 @@ from typing import Any  # WHY: raw client rows are duck-typed dicts from mistapi
 
 import mistapi  # WHY: direct SDK access for listSiteWirelessClientsStats + beacons endpoints.
 
+from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for beacons export.
 from src.export.wifi_clients_exporter import WifiClientsExporter  # Extracted WiFi export orchestrator.
 
 
@@ -101,7 +102,22 @@ class SiteClientExporter:
     @staticmethod
     def beacons() -> None:
         """Export beacons for a site to SiteBeacons.csv."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of SiteExportUtils._export_data helper.
-        mh.SiteExportUtils._export_data(  # Shared export scaffolding handles prompting + CSV write.
+        mh = importlib.import_module("MistHelper")  # WHY: fetch live dep symbols for SiteExportUtils construction.
+        SiteExportUtils(
+            apisession=mh.apisession,
+            PromptUtils=mh.PromptUtils,
+            ConfigUtils=mh.ConfigUtils,
+            DataProcessingUtils=mh.DataProcessingUtils,
+            DataExporter=mh.DataExporter,
+            TimeUtils=mh.TimeUtils,
+            EnhancedSSHRunner=mh.EnhancedSSHRunner,
+            InsightMetricsUtils=mh.InsightMetricsUtils,
+            PacketCaptureManager=mh.PacketCaptureManager,
+            APICoreFetchUtils=mh.APICoreFetchUtils,
+            check_fn=mh.IsDebugMode.check,
+            PrettyTable=mh.PrettyTable,
+            tqdm=mh.tqdm,
+            mistapi=mh.mistapi,
+        )._export_data(  # Shared export scaffolding handles prompting + CSV write.
             api_call=mistapi.api.v1.sites.beacons.listSiteBeacons, data_type="beacons", sort_key="name"
         )

--- a/src/export/site_config_exporter.py
+++ b/src/export/site_config_exporter.py
@@ -15,6 +15,7 @@ from typing import Any  # WHY: raw WLAN rows are duck-typed dicts from mistapi.
 import mistapi  # WHY: direct SDK access for sites/orgs endpoints.
 
 from src.api.api_fetch_utils import APIFetchUtils  # WHY: 1014 P8 direct import (FR-005).
+from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for maps/zones exports.
 
 
 class SiteConfigExporter:
@@ -93,16 +94,46 @@ class SiteConfigExporter:
     @staticmethod
     def maps() -> None:
         """Export maps for a site to SiteMaps.csv."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of SiteExportUtils._export_data helper.
-        mh.SiteExportUtils._export_data(  # Shared export scaffolding handles prompting + CSV write.
+        mh = importlib.import_module("MistHelper")  # WHY: fetch live dep symbols for SiteExportUtils construction.
+        SiteExportUtils(
+            apisession=mh.apisession,
+            PromptUtils=mh.PromptUtils,
+            ConfigUtils=mh.ConfigUtils,
+            DataProcessingUtils=mh.DataProcessingUtils,
+            DataExporter=mh.DataExporter,
+            TimeUtils=mh.TimeUtils,
+            EnhancedSSHRunner=mh.EnhancedSSHRunner,
+            InsightMetricsUtils=mh.InsightMetricsUtils,
+            PacketCaptureManager=mh.PacketCaptureManager,
+            APICoreFetchUtils=mh.APICoreFetchUtils,
+            check_fn=mh.IsDebugMode.check,
+            PrettyTable=mh.PrettyTable,
+            tqdm=mh.tqdm,
+            mistapi=mh.mistapi,
+        )._export_data(  # Shared export scaffolding handles prompting + CSV write.
             api_call=mistapi.api.v1.sites.maps.listSiteMaps, data_type="maps", sort_key="name"
         )
 
     @staticmethod
     def zones() -> None:
         """Export zones for a site to SiteZones.csv."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of SiteExportUtils._export_data helper.
-        mh.SiteExportUtils._export_data(  # Shared export scaffolding handles prompting + CSV write.
+        mh = importlib.import_module("MistHelper")  # WHY: fetch live dep symbols for SiteExportUtils construction.
+        SiteExportUtils(
+            apisession=mh.apisession,
+            PromptUtils=mh.PromptUtils,
+            ConfigUtils=mh.ConfigUtils,
+            DataProcessingUtils=mh.DataProcessingUtils,
+            DataExporter=mh.DataExporter,
+            TimeUtils=mh.TimeUtils,
+            EnhancedSSHRunner=mh.EnhancedSSHRunner,
+            InsightMetricsUtils=mh.InsightMetricsUtils,
+            PacketCaptureManager=mh.PacketCaptureManager,
+            APICoreFetchUtils=mh.APICoreFetchUtils,
+            check_fn=mh.IsDebugMode.check,
+            PrettyTable=mh.PrettyTable,
+            tqdm=mh.tqdm,
+            mistapi=mh.mistapi,
+        )._export_data(  # Shared export scaffolding handles prompting + CSV write.
             api_call=mistapi.api.v1.sites.zones.listSiteZones, data_type="zones", sort_key="name"
         )
 

--- a/src/export/site_device_exporter.py
+++ b/src/export/site_device_exporter.py
@@ -21,6 +21,8 @@ from typing import Any  # WHY: mistapi response payloads + inventory rows are du
 import mistapi  # WHY: direct calls to sites.devices + sites.stats endpoints + get_all pager.
 from prettytable import PrettyTable  # WHY: debug-log a formatted inventory table.
 
+from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for port_stats export.
+
 
 class SiteDeviceExporter:
     """Site Device Data Exporter.
@@ -140,12 +142,27 @@ class SiteDeviceExporter:
         """Export port statistics for a site to SitePortStats.csv."""
         mh = importlib.import_module(
             "MistHelper"
-        )  # WHY: lazy fetch of PROGRESS_EMITTER + ProgressContext + SiteExport.
+        )  # WHY: fetch live dep symbols for SiteExportUtils construction + progress emitter access.
         emitter = mh.PROGRESS_EMITTER  # Progress emitter.
         if emitter:  # Emitter present.
             emitter.emit_progress_start("29", "port_stats", 1)  # Signal progress start.
         op_start = time.time()  # Start the timer.
-        mh.SiteExportUtils._export_data(
+        SiteExportUtils(
+            apisession=mh.apisession,
+            PromptUtils=mh.PromptUtils,
+            ConfigUtils=mh.ConfigUtils,
+            DataProcessingUtils=mh.DataProcessingUtils,
+            DataExporter=mh.DataExporter,
+            TimeUtils=mh.TimeUtils,
+            EnhancedSSHRunner=mh.EnhancedSSHRunner,
+            InsightMetricsUtils=mh.InsightMetricsUtils,
+            PacketCaptureManager=mh.PacketCaptureManager,
+            APICoreFetchUtils=mh.APICoreFetchUtils,
+            check_fn=mh.IsDebugMode.check,
+            PrettyTable=mh.PrettyTable,
+            tqdm=mh.tqdm,
+            mistapi=mh.mistapi,
+        )._export_data(
             api_call=mistapi.api.v1.sites.stats.searchSiteSwOrGwPorts, data_type="port stats", sort_key="mac"
         )
         if emitter:  # Emitter present.

--- a/src/export/site_export_utils.py
+++ b/src/export/site_export_utils.py
@@ -5,12 +5,10 @@ from __future__ import annotations  # WHY: enable forward-reference typing.
 import inspect  # WHY: introspect API signatures to gate limit kwarg.
 import logging  # WHY: structured export progress + error logging.
 import os  # WHY: derive display path for operator feedback.
-from dataclasses import dataclass  # WHY: bundle 14 DI params into a frozen slots record.
 from typing import Any  # WHY: dependencies are unknown-type runtime injections.
 
 from src.export.site_insights_exporter import (  # WHY: reuse insights exporter via inheritance.
     SiteInsightsExporter,
-    configure_site_insights_exporter_dependencies,
 )
 
 _LIMIT_DEFAULT: int = 1000  # WHY: default page size for mistapi list endpoints.
@@ -18,89 +16,6 @@ _LOOKBACK_DEFAULT_HOURS: int = 24  # WHY: default dynamic lookback window (hours
 _LOOKBACK_MIN_HOURS: int = 1  # WHY: minimum floor for dynamic lookback.
 _DATA_SUBDIR: str = "data"  # WHY: default output folder for exports.
 _INSIGHT_METRIC_SCOPE: str = "site"  # WHY: constant scope used for SLE metric queries.
-
-apisession: Any = None  # WHY: injected mistapi session handle.
-PromptUtils: Any = None  # WHY: injected operator-prompt helpers.
-ConfigUtils: Any = None  # WHY: injected config/org resolution helpers.
-DataProcessingUtils: Any = None  # WHY: injected row-flattening helpers.
-DataExporter: Any = None  # WHY: injected CSV/format writer.
-TimeUtils: Any = None  # WHY: injected time-window computation helpers.
-EnhancedSSHRunner: Any = None  # WHY: injected SSH runner for filename sanitization.
-InsightMetricsUtils: Any = None  # WHY: injected insight metric helpers.
-PacketCaptureManager: Any = None  # WHY: injected MAC validation/normalization.
-APICoreFetchUtils: Any = None  # WHY: injected org-wide fetch helpers.
-# NOTE: renamed from is_debug_mode; wiring source IsDebugMode.check at MistHelper.py:13361.
-check_fn: Any = None  # WHY: injected debug-mode predicate.
-PrettyTable: Any = None  # WHY: injected table renderer for debug output.
-tqdm: Any = None  # WHY: injected progress bar module.
-mistapi: Any = None  # WHY: injected mistapi client module.
-
-
-@dataclass(frozen=True, slots=True)
-class _ExportDeps:  # WHY: bundle 14 DI kwargs into a single frozen record for handoff.
-    """Bundle 14 runtime dependencies into a single immutable config record."""
-
-    apisession_dependency: Any  # WHY: mistapi session handle.
-    prompt_utils: Any  # WHY: operator-prompt helpers.
-    config_utils: Any  # WHY: config/org resolution helpers.
-    data_processing_utils: Any  # WHY: row-flattening helpers.
-    data_exporter: Any  # WHY: CSV/format writer.
-    time_utils: Any  # WHY: time-window computation helpers.
-    enhanced_ssh_runner: Any  # WHY: SSH runner for filename sanitization.
-    insight_metrics_utils: Any  # WHY: insight metric helpers.
-    packet_capture_manager: Any  # WHY: MAC validation/normalization.
-    api_core_fetch_utils: Any  # WHY: org-wide fetch helpers.
-    check_fn: Any  # WHY: debug-mode predicate (renamed from is_debug_mode_fn per plan L52).
-    pretty_table_class: Any  # WHY: table renderer for debug output.
-    tqdm_module: Any  # WHY: progress bar module.
-    mistapi_dependency: Any  # WHY: mistapi client module.
-
-
-def _apply_module_globals(
-    deps: _ExportDeps,
-) -> None:  # WHY: assign 14 injected deps to module globals for class methods.
-    """Assign injected dependencies to module-level globals used by class methods."""
-    global apisession, PromptUtils, ConfigUtils, DataProcessingUtils  # WHY: publish session + config + processing.
-    global DataExporter, TimeUtils, EnhancedSSHRunner, InsightMetricsUtils  # WHY: publish writer/time/ssh/metrics.
-    global PacketCaptureManager, APICoreFetchUtils, check_fn  # WHY: publish MAC + fetch + debug predicate.
-    global PrettyTable, tqdm, mistapi  # WHY: publish table + progress + mistapi module.
-    apisession = deps.apisession_dependency  # WHY: bind session for exporters.
-    PromptUtils = deps.prompt_utils  # WHY: bind prompt helpers.
-    ConfigUtils = deps.config_utils  # WHY: bind config helpers.
-    DataProcessingUtils = deps.data_processing_utils  # WHY: bind flatten helpers.
-    DataExporter = deps.data_exporter  # WHY: bind writer.
-    TimeUtils = deps.time_utils  # WHY: bind time helpers.
-    EnhancedSSHRunner = deps.enhanced_ssh_runner  # WHY: bind SSH runner.
-    InsightMetricsUtils = deps.insight_metrics_utils  # WHY: bind insight metrics.
-    PacketCaptureManager = deps.packet_capture_manager  # WHY: bind packet capture manager.
-    APICoreFetchUtils = deps.api_core_fetch_utils  # WHY: bind fetch helpers.
-    check_fn = deps.check_fn  # WHY: bind debug predicate.
-    PrettyTable = deps.pretty_table_class  # WHY: bind table renderer.
-    tqdm = deps.tqdm_module  # WHY: bind progress bar.
-    mistapi = deps.mistapi_dependency  # WHY: bind mistapi module.
-
-
-def _forward_insights_dependencies(deps: _ExportDeps) -> None:  # WHY: relay dep subset to sibling insights module.
-    """Forward the insights subset of dependencies to the insights exporter module."""
-    configure_site_insights_exporter_dependencies(  # WHY: keep insights exporter globals wired.
-        apisession_dependency=deps.apisession_dependency,
-        prompt_utils=deps.prompt_utils,
-        data_processing_utils=deps.data_processing_utils,
-        data_exporter=deps.data_exporter,
-        enhanced_ssh_runner=deps.enhanced_ssh_runner,
-        insight_metrics_utils=deps.insight_metrics_utils,
-        packet_capture_manager=deps.packet_capture_manager,
-        mistapi_dependency=deps.mistapi_dependency,
-    )
-
-
-def configure_site_export_utils_dependencies(
-    **deps: Any,
-) -> None:  # WHY: single kwargs param satisfies STRUCT-PARAMS budget.
-    """Configure runtime dependencies from MistHelper orchestration layer."""
-    record = _ExportDeps(**deps)  # WHY: validate + freeze the 14 kwargs into a record.
-    _apply_module_globals(record)  # WHY: publish deps as module globals.
-    _forward_insights_dependencies(record)  # WHY: keep insights exporter deps in sync.
 
 
 def _sanitize_for_filename(text: str) -> str:  # WHY: shared filename-token normalization for exports.
@@ -124,47 +39,9 @@ def _api_supports_limit(api_call: Any) -> bool:  # WHY: introspect signature so 
         return True  # WHY: default to sending limit if signature unavailable.
 
 
-def _fetch_site_data(
-    api_call: Any, site_id: str, api_kwargs: dict[str, Any]
-) -> Any:  # WHY: paged fetch helper for site endpoints.
-    """Call site API respecting limit support and return paginated rawdata."""
-    if _api_supports_limit(api_call):  # WHY: branch on limit-kwarg support to avoid TypeError.
-        logging.info(
-            "Calling %s with limit=%s for site %s", api_call.__name__, _LIMIT_DEFAULT, site_id
-        )  # WHY: audit pre-call.
-        response = api_call(apisession, site_id, limit=_LIMIT_DEFAULT, **api_kwargs)  # WHY: paged call.
-    else:
-        logging.debug("API function %s does not support 'limit' parameter", api_call.__name__)  # WHY: audit unpaged.
-        response = api_call(apisession, site_id, **api_kwargs)  # WHY: call without limit.
-    return mistapi.get_all(response=response, mist_session=apisession)  # WHY: full pagination.
-
-
 def _resolve_site_display_path(filename: str) -> str:  # WHY: helper to compute confirmation path.
     """Return storage-relative display path for operator confirmation."""
     return filename if os.path.dirname(filename) else os.path.join(_DATA_SUBDIR, filename)  # WHY: legacy display path.
-
-
-def _prepare_rows(
-    rawdata: list[dict[str, Any]], sort_key: str
-) -> list[dict[str, Any]]:  # WHY: shared row prep pipeline.
-    """Sort (when key provided) then flatten and escape rows for export."""
-    if sort_key:  # WHY: skip sorting when caller omits key.
-        rawdata = sorted(rawdata, key=lambda x: x.get(sort_key, ""))  # WHY: stable operator-facing sort.
-    data = DataProcessingUtils.flatten_nested_fields(rawdata)  # WHY: flatten nested JSON for CSV.
-    return DataProcessingUtils.escape_multiline(data)  # WHY: escape newlines for CSV safety.
-
-
-def _emit_debug_table(data: list[dict[str, Any]]) -> None:  # WHY: renders PrettyTable in debug mode only.
-    """Render PrettyTable of exported rows for debug-mode operators."""
-    fields = DataProcessingUtils.get_unique_keys(data)  # WHY: union of keys as columns.
-    table = PrettyTable()  # WHY: instantiate debug table renderer.
-    table.field_names = fields  # WHY: set stable column order.
-    table.valign = "t"  # WHY: preserve legacy top alignment.
-    for item in tqdm(data, desc="Processing", unit="record"):  # WHY: progress bar per row.
-        row = [item.get(field, "") for field in table.field_names]  # WHY: row in stable order.
-        table.add_row(row)  # WHY: append to table.
-    print(table)  # WHY: legacy debug console output.
-    logging.debug("Site data displayed in table format (debug mode).")  # WHY: audit debug render.
 
 
 def _read_site_response_rows(response: Any) -> list[dict[str, Any]]:  # WHY: normalizes heterogeneous API shapes.
@@ -173,45 +50,6 @@ def _read_site_response_rows(response: Any) -> list[dict[str, Any]]:  # WHY: nor
     if isinstance(raw, dict):  # WHY: dict payloads represent a single-row report.
         return [raw]  # WHY: single-dict wraps into single-row list.
     return raw if isinstance(raw, list) else []  # WHY: fall back to empty when shape unknown.
-
-
-def _write_site_report(  # WHY: single-endpoint export helper reused by many exports.
-    api_call: Any,
-    site_id: str,
-    filename: str,
-    api_function_name: str,
-) -> int:
-    """Export a single-endpoint site report and return the number of rows written."""
-    response = api_call(apisession, site_id)  # WHY: fetch site endpoint payload.
-    rows = _read_site_response_rows(response)  # WHY: normalize shape.
-    rows = DataProcessingUtils.flatten_nested_fields(rows)  # WHY: flatten for CSV.
-    DataExporter.write_with_format_selection(
-        rows, filename, api_function_name=api_function_name
-    )  # WHY: dispatch CSV/JSON writer.
-    return len(rows)  # WHY: count for legacy log line.
-
-
-def _prompt_site_or_abort(abort_message: str) -> str | None:  # WHY: shared prompt-with-abort helper.
-    """Prompt for a site ID and log an abort message when the operator declines."""
-    site_id = PromptUtils.select_site()  # WHY: operator picks target site.
-    if site_id:  # WHY: happy-path return when a valid site is chosen.
-        return site_id  # WHY: valid selection.
-    logging.error(abort_message)  # WHY: preserve legacy abort log.
-    return None  # WHY: signal caller to bail out.
-
-
-def _run_dynamic_event_export(
-    api_call: Any, data_type: str, description: str
-) -> None:  # WHY: dynamic-window event exporter.
-    """Run a dynamic-lookback event export using the shared ``_export_data`` helper."""
-    hours = TimeUtils.get_dynamic_lookback_hours(_LOOKBACK_DEFAULT_HOURS, _LOOKBACK_MIN_HOURS)  # WHY: compute window.
-    TimeUtils.log_dynamic_lookback(description, hours)  # WHY: operator-visible window log.
-    SiteExportUtils._export_data(  # WHY: reuse generic exporter path.
-        api_call=api_call,
-        data_type=data_type,
-        sort_key="timestamp",
-        duration=f"{hours}h",
-    )
 
 
 def _flatten_channel_planning_dict(
@@ -240,27 +78,6 @@ def _channel_planning_rows_from_raw(
     return raw if isinstance(raw, list) else [raw]  # WHY: list stays as-is; scalar wraps.
 
 
-def _fetch_org_site_name(site_id: str) -> str:  # WHY: cross-endpoint site-name resolver.
-    """Resolve a site's human-readable name from the org site listing."""
-    response = mistapi.api.v1.orgs.sites.listOrgSites(
-        apisession, ConfigUtils.get_cached_or_prompted_org_id()
-    )  # WHY: fetch org sites for name resolution.
-    sites = mistapi.get_all(response=response, mist_session=apisession)  # WHY: paginate full list.
-    return next((site["name"] for site in sites if site["id"] == site_id), site_id)  # WHY: fallback to id.
-
-
-def _fetch_site_sle_metrics_payload(site_id: str) -> dict[str, Any]:  # WHY: SLE-metrics API fetch helper.
-    """Fetch SLE metric availability payload for a site (enabled + supported lists)."""
-    response = mistapi.api.v1.sites.sle.listSiteSlesMetrics(
-        apisession,
-        site_id,
-        scope=_INSIGHT_METRIC_SCOPE,
-        scope_id=site_id,
-    )  # WHY: SLE metric availability endpoint.
-    payload = getattr(response, "data", response) or {}  # WHY: tolerate dataclass or dict.
-    return payload if isinstance(payload, dict) else {}  # WHY: guard non-dict shapes.
-
-
 def _build_insight_rows(  # WHY: per-metric availability row builder.
     site_id: str, site_name: str, enabled: list[str], supported: list[str]
 ) -> list[dict[str, Any]]:
@@ -278,174 +95,290 @@ def _build_insight_rows(  # WHY: per-metric availability row builder.
     ]
 
 
-def _write_insight_rows(
-    rows: list[dict[str, Any]], filename: str, site_name: str
-) -> None:  # WHY: insight-rows CSV writer.
-    """Write insight rows to CSV, emitting operator messages for empty-payload cases."""
-    if rows:  # WHY: happy-path when metric availability payload had data.
-        DataExporter.write_with_format_selection(rows, filename)  # WHY: persist rows.
-        print(f"! {len(rows)} records exported to data\\{filename}")  # WHY: legacy operator message.
-        logging.info(
-            "Exported %s site SLE metric insight records to %s", len(rows), filename
-        )  # WHY: success audit log.
-        return  # WHY: skip empty-file emission when rows exist.
-    print(f"! 0 records exported to data\\{filename} (no metrics available)")  # WHY: legacy empty message.
-    logging.warning("No site SLE metric insight data available for site %s", site_name)  # WHY: warn on empty payload.
-    DataExporter.write_with_format_selection([], filename)  # WHY: still emit empty file for pipeline continuity.
-
-
-def _resolve_insights_site_name(site_id: str) -> str:  # WHY: insights-flow name resolver with fallback.
-    """Resolve site display name for insights export with fallback on API failure."""
-    try:
-        return _fetch_org_site_name(site_id)  # WHY: happy-path resolution.
-    except Exception as exception:  # noqa: BLE001  # WHY: preserve legacy broad-except behavior.
-        logging.error("Error getting site name: %s", exception)  # WHY: preserve legacy log line.
-        return site_id  # WHY: fall back to raw id.
-
-
 class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters and add site-specific exports.
     """Centralized site-level data export utilities."""
 
-    @staticmethod
-    def _resolve_site_name(site_id: str) -> str:  # WHY: class-side name resolver with legacy log format.
+    def __init__(  # WHY: constructor injection replaces 14 module globals per Pattern 1.
+        self,
+        *,
+        apisession: Any,
+        PromptUtils: Any,
+        ConfigUtils: Any,
+        DataProcessingUtils: Any,
+        DataExporter: Any,
+        TimeUtils: Any,
+        EnhancedSSHRunner: Any,
+        InsightMetricsUtils: Any,
+        PacketCaptureManager: Any,
+        APICoreFetchUtils: Any,
+        check_fn: Any,
+        PrettyTable: Any,
+        tqdm: Any,
+        mistapi: Any,
+    ) -> None:
+        """Store all 14 runtime dependencies as instance attributes for method access."""
+        super().__init__(PacketCaptureManager=PacketCaptureManager)  # WHY: parent needs MAC validator.
+        self.apisession = apisession  # WHY: bind mistapi session for API calls.
+        self.PromptUtils = PromptUtils  # WHY: bind operator prompt helpers.
+        self.ConfigUtils = ConfigUtils  # WHY: bind org/config resolution helpers.
+        self.DataProcessingUtils = DataProcessingUtils  # WHY: bind flatten/escape helpers.
+        self.DataExporter = DataExporter  # WHY: bind CSV/format writer.
+        self.TimeUtils = TimeUtils  # WHY: bind time-window helpers.
+        self.EnhancedSSHRunner = EnhancedSSHRunner  # WHY: bind SSH runner for filename sanitization.
+        self.InsightMetricsUtils = InsightMetricsUtils  # WHY: bind insight metric helpers.
+        self.APICoreFetchUtils = APICoreFetchUtils  # WHY: bind org-wide fetch helpers.
+        self.check_fn = check_fn  # WHY: bind debug-mode predicate.
+        self.PrettyTable = PrettyTable  # WHY: bind table renderer for debug output.
+        self.tqdm = tqdm  # WHY: bind progress bar module.
+        self.mistapi = mistapi  # WHY: bind mistapi client module.
+
+    def _fetch_site_data(
+        self, api_call: Any, site_id: str, api_kwargs: dict[str, Any]
+    ) -> Any:  # WHY: paged fetch helper for site endpoints.
+        """Call site API respecting limit support and return paginated rawdata."""
+        if _api_supports_limit(api_call):  # WHY: branch on limit-kwarg support to avoid TypeError.
+            logging.info(
+                "Calling %s with limit=%s for site %s", api_call.__name__, _LIMIT_DEFAULT, site_id
+            )  # WHY: audit pre-call.
+            response = api_call(self.apisession, site_id, limit=_LIMIT_DEFAULT, **api_kwargs)  # WHY: paged call.
+        else:
+            logging.debug(
+                "API function %s does not support 'limit' parameter", api_call.__name__
+            )  # WHY: audit unpaged.
+            response = api_call(self.apisession, site_id, **api_kwargs)  # WHY: call without limit.
+        return self.mistapi.get_all(response=response, mist_session=self.apisession)  # WHY: full pagination.
+
+    def _prepare_rows(
+        self, rawdata: list[dict[str, Any]], sort_key: str
+    ) -> list[dict[str, Any]]:  # WHY: shared row prep pipeline.
+        """Sort (when key provided) then flatten and escape rows for export."""
+        if sort_key:  # WHY: skip sorting when caller omits key.
+            rawdata = sorted(rawdata, key=lambda x: x.get(sort_key, ""))  # WHY: stable operator-facing sort.
+        data = self.DataProcessingUtils.flatten_nested_fields(rawdata)  # WHY: flatten nested JSON for CSV.
+        return self.DataProcessingUtils.escape_multiline(data)  # WHY: escape newlines for CSV safety.
+
+    def _emit_debug_table(self, data: list[dict[str, Any]]) -> None:  # WHY: renders PrettyTable in debug mode only.
+        """Render PrettyTable of exported rows for debug-mode operators."""
+        fields = self.DataProcessingUtils.get_unique_keys(data)  # WHY: union of keys as columns.
+        table = self.PrettyTable()  # WHY: instantiate debug table renderer.
+        table.field_names = fields  # WHY: set stable column order.
+        table.valign = "t"  # WHY: preserve legacy top alignment.
+        for item in self.tqdm(data, desc="Processing", unit="record"):  # WHY: progress bar per row.
+            row = [item.get(field, "") for field in table.field_names]  # WHY: row in stable order.
+            table.add_row(row)  # WHY: append to table.
+        print(table)  # WHY: legacy debug console output.
+        logging.debug("Site data displayed in table format (debug mode).")  # WHY: audit debug render.
+
+    def _write_site_report(  # WHY: single-endpoint export helper reused by many exports.
+        self,
+        api_call: Any,
+        site_id: str,
+        filename: str,
+        api_function_name: str,
+    ) -> int:
+        """Export a single-endpoint site report and return the number of rows written."""
+        response = api_call(self.apisession, site_id)  # WHY: fetch site endpoint payload.
+        rows = _read_site_response_rows(response)  # WHY: normalize shape.
+        rows = self.DataProcessingUtils.flatten_nested_fields(rows)  # WHY: flatten for CSV.
+        self.DataExporter.write_with_format_selection(
+            rows, filename, api_function_name=api_function_name
+        )  # WHY: dispatch CSV/JSON writer.
+        return len(rows)  # WHY: count for legacy log line.
+
+    def _prompt_site_or_abort(self, abort_message: str) -> str | None:  # WHY: shared prompt-with-abort helper.
+        """Prompt for a site ID and log an abort message when the operator declines."""
+        site_id = self.PromptUtils.select_site()  # WHY: operator picks target site.
+        if site_id:  # WHY: happy-path return when a valid site is chosen.
+            return site_id  # WHY: valid selection.
+        logging.error(abort_message)  # WHY: preserve legacy abort log.
+        return None  # WHY: signal caller to bail out.
+
+    def _run_dynamic_event_export(
+        self, api_call: Any, data_type: str, description: str
+    ) -> None:  # WHY: dynamic-window event exporter.
+        """Run a dynamic-lookback event export using the shared ``_export_data`` helper."""
+        hours = self.TimeUtils.get_dynamic_lookback_hours(
+            _LOOKBACK_DEFAULT_HOURS, _LOOKBACK_MIN_HOURS
+        )  # WHY: compute window.
+        self.TimeUtils.log_dynamic_lookback(description, hours)  # WHY: operator-visible window log.
+        self._export_data(  # WHY: reuse generic exporter path.
+            api_call=api_call,
+            data_type=data_type,
+            sort_key="timestamp",
+            duration=f"{hours}h",
+        )
+
+    def _fetch_org_site_name(self, site_id: str) -> str:  # WHY: cross-endpoint site-name resolver.
+        """Resolve a site's human-readable name from the org site listing."""
+        response = self.mistapi.api.v1.orgs.sites.listOrgSites(
+            self.apisession, self.ConfigUtils.get_cached_or_prompted_org_id()
+        )  # WHY: fetch org sites for name resolution.
+        sites = self.mistapi.get_all(response=response, mist_session=self.apisession)  # WHY: paginate full list.
+        return next((site["name"] for site in sites if site["id"] == site_id), site_id)  # WHY: fallback to id.
+
+    def _fetch_site_sle_metrics_payload(self, site_id: str) -> dict[str, Any]:  # WHY: SLE-metrics API fetch helper.
+        """Fetch SLE metric availability payload for a site (enabled + supported lists)."""
+        response = self.mistapi.api.v1.sites.sle.listSiteSlesMetrics(
+            self.apisession,
+            site_id,
+            scope=_INSIGHT_METRIC_SCOPE,
+            scope_id=site_id,
+        )  # WHY: SLE metric availability endpoint.
+        payload = getattr(response, "data", response) or {}  # WHY: tolerate dataclass or dict.
+        return payload if isinstance(payload, dict) else {}  # WHY: guard non-dict shapes.
+
+    def _write_insight_rows(
+        self, rows: list[dict[str, Any]], filename: str, site_name: str
+    ) -> None:  # WHY: insight-rows CSV writer.
+        """Write insight rows to CSV, emitting operator messages for empty-payload cases."""
+        if rows:  # WHY: happy-path when metric availability payload had data.
+            self.DataExporter.write_with_format_selection(rows, filename)  # WHY: persist rows.
+            print(f"! {len(rows)} records exported to data\\{filename}")  # WHY: legacy operator message.
+            logging.info(
+                "Exported %s site SLE metric insight records to %s", len(rows), filename
+            )  # WHY: success audit log.
+            return  # WHY: skip empty-file emission when rows exist.
+        print(f"! 0 records exported to data\\{filename} (no metrics available)")  # WHY: legacy empty message.
+        logging.warning("No site SLE metric insight data available for site %s", site_name)  # WHY: warn empty.
+        self.DataExporter.write_with_format_selection([], filename)  # WHY: still emit empty file for pipeline.
+
+    def _resolve_insights_site_name(self, site_id: str) -> str:  # WHY: insights-flow name resolver with fallback.
+        """Resolve site display name for insights export with fallback on API failure."""
+        try:
+            return self._fetch_org_site_name(site_id)  # WHY: happy-path resolution.
+        except Exception as exception:  # noqa: BLE001  # WHY: preserve legacy broad-except behavior.
+            logging.error("Error getting site name: %s", exception)  # WHY: preserve legacy log line.
+            return site_id  # WHY: fall back to raw id.
+
+    def _resolve_site_name(self, site_id: str) -> str:  # WHY: class-side name resolver with legacy log format.
         """Resolve human-readable site name from org sites list; fall back to site_id."""
         try:
             logging.info("Fetching org sites to resolve site name for %s", site_id)  # WHY: pre-API log.
-            site_name = _fetch_org_site_name(site_id)  # WHY: shared org-name lookup.
+            site_name = self._fetch_org_site_name(site_id)  # WHY: shared org-name lookup.
             logging.debug("Resolved site_name=%s for site_id=%s", site_name, site_id)  # WHY: post-log.
             return site_name  # WHY: hand back to caller.
         except Exception as e:  # noqa: BLE001  # WHY: preserve legacy broad-except behavior.
             logging.error("Error getting site name: %s", e)  # WHY: preserve legacy error string.
             return site_id  # WHY: fall back to raw site_id.
 
-    @staticmethod
     def _call_site_api(
-        api_call: Any, site_id: str, api_kwargs: dict[str, Any]
+        self, api_call: Any, site_id: str, api_kwargs: dict[str, Any]
     ) -> Any:  # WHY: bridge to fetch helper with logs.
         """Invoke site API call, respecting limit-parameter support; return paginated rawdata."""
         logging.debug(
             "Making site-specific API call: %s with site_id: %s", api_call.__name__, site_id
         )  # WHY: pre-call log.
-        rawdata = _fetch_site_data(api_call, site_id, api_kwargs)  # WHY: shared fetch + paginate.
+        rawdata = self._fetch_site_data(api_call, site_id, api_kwargs)  # WHY: shared fetch + paginate.
         logging.debug("Retrieved rawdata with %s records", len(rawdata) if rawdata else 0)  # WHY: count log.
         return rawdata  # WHY: return paginated rawdata.
 
-    @staticmethod
     def _display_or_log_results(
-        data: list[dict[str, Any]], data_type: str, filename: str
+        self, data: list[dict[str, Any]], data_type: str, filename: str
     ) -> None:  # WHY: post-export operator feedback.
         """Render debug-mode PrettyTable or log completion summary."""
-        if check_fn():  # WHY: debug operators see full table dump.
-            _emit_debug_table(data)  # WHY: extract debug rendering into helper.
+        if self.check_fn():  # WHY: debug operators see full table dump.
+            self._emit_debug_table(data)  # WHY: extract debug rendering into helper.
             return  # WHY: skip completion log after debug render.
         logging.info(
             "Site %s export completed - %s records saved to %s.", data_type, len(data), filename
         )  # WHY: legacy completion line.
 
-    @staticmethod
-    def _export_data(api_call: Any, data_type: str, sort_key: str = "name", **api_kwargs: Any) -> None:
+    def _export_data(self, api_call: Any, data_type: str, sort_key: str = "name", **api_kwargs: Any) -> None:
         """Generic function to export site-specific data to CSV."""
         logging.info("Starting export of site %s...", data_type)
-        site_id = _prompt_site_or_abort("No site selected. Exiting.")  # WHY: shared prompt + abort.
+        site_id = self._prompt_site_or_abort("No site selected. Exiting.")  # WHY: shared prompt + abort.
         if site_id is None:
             return  # WHY: abort when operator declines.
-        site_name = SiteExportUtils._resolve_site_name(site_id)  # WHY: resolve for filename + log.
+        site_name = self._resolve_site_name(site_id)  # WHY: resolve for filename + log.
         logging.info("Exporting %s for site: %s", data_type, site_name)
         filename = _build_export_filename(data_type, site_name)  # WHY: legacy CamelCase filename.
         try:
-            rawdata = SiteExportUtils._call_site_api(api_call, site_id, api_kwargs)  # WHY: fetch site data.
+            rawdata = self._call_site_api(api_call, site_id, api_kwargs)  # WHY: fetch site data.
             if rawdata is None:
                 logging.warning("! No data returned from API for %s at site %s. Skipping.", data_type, site_name)
                 return  # WHY: abort on empty response.
             logging.info("Fetched %s raw records for %s from site %s.", len(rawdata), data_type, site_name)
-            data = _prepare_rows(rawdata, sort_key)  # WHY: sort, flatten, escape.
+            data = self._prepare_rows(rawdata, sort_key)  # WHY: sort, flatten, escape.
             logging.info("Saving exported site data to %s", filename)  # WHY: pre-save log.
-            DataExporter.write_with_format_selection(data, filename)  # WHY: legacy writer entry.
+            self.DataExporter.write_with_format_selection(data, filename)  # WHY: legacy writer entry.
             print(f"! {len(data)} records exported to {_resolve_site_display_path(filename)}")
             logging.info("Site %s data written to %s (%s rows).", data_type, filename, len(data))
-            SiteExportUtils._display_or_log_results(data, data_type, filename)  # WHY: display or log.
+            self._display_or_log_results(data, data_type, filename)  # WHY: display or log.
         except Exception as e:
             logging.error("! Error during site %s export for %s: %s", data_type, site_name, e)
             raise  # WHY: re-raise to preserve legacy bubbling.
 
-    @staticmethod
-    def insights() -> None:
+    def insights(self) -> None:
         """Export SLE metric availability for a selected site."""
         logging.info("Starting export of site SLE metric insights...")
-        site_id = _prompt_site_or_abort("No site selected. Exiting.")  # WHY: shared prompt.
+        site_id = self._prompt_site_or_abort("No site selected. Exiting.")  # WHY: shared prompt.
         if site_id is None:
             return  # WHY: abort when operator declines.
-        site_name = _resolve_insights_site_name(site_id)  # WHY: resolve with fallback.
+        site_name = self._resolve_insights_site_name(site_id)  # WHY: resolve with fallback.
         filename = f"SiteSleMetricsInsights_{_sanitize_for_filename(site_name)}.csv"  # WHY: legacy filename.
         try:
-            payload = _fetch_site_sle_metrics_payload(site_id)  # WHY: fetch enabled+supported lists.
+            payload = self._fetch_site_sle_metrics_payload(site_id)  # WHY: fetch enabled+supported lists.
             rows = _build_insight_rows(  # WHY: assemble one row per metric.
                 site_id,
                 site_name,
                 payload.get("enabled", []),
                 payload.get("supported", []),
             )
-            _write_insight_rows(rows, filename, site_name)  # WHY: persist and log.
+            self._write_insight_rows(rows, filename, site_name)  # WHY: persist and log.
         except Exception as exception:  # noqa: BLE001
             print(f"! Error exporting site SLE metric insights: {exception}")  # WHY: legacy operator msg.
             logging.error("Failed to export site SLE metric insights for site %s: %s", site_name, exception)
-            DataExporter.write_with_format_selection([], filename)  # WHY: empty file preserves pipeline.
+            self.DataExporter.write_with_format_selection([], filename)  # WHY: empty file preserves pipeline.
 
-    @staticmethod
-    def _system_events() -> None:
+    def _system_events(self) -> None:
         """Export system events for a site to SiteSystemEvents.csv."""
-        _run_dynamic_event_export(  # WHY: shared dynamic-lookback wrapper.
-            mistapi.api.v1.sites.events.searchSiteSystemEvents,
+        self._run_dynamic_event_export(  # WHY: shared dynamic-lookback wrapper.
+            self.mistapi.api.v1.sites.events.searchSiteSystemEvents,
             "system events",
             "site system events export",
         )
 
-    @staticmethod
-    def _fast_roam_events() -> None:
+    def _fast_roam_events(self) -> None:
         """Export fast roam events for a site to SiteFastRoamEvents.csv."""
-        _run_dynamic_event_export(  # WHY: shared dynamic-lookback wrapper.
-            mistapi.api.v1.sites.events.searchSiteFastRoamEvents,
+        self._run_dynamic_event_export(  # WHY: shared dynamic-lookback wrapper.
+            self.mistapi.api.v1.sites.events.searchSiteFastRoamEvents,
             "fast roam events",
             "site fast roam events export",
         )
 
-    @staticmethod
-    def ospf_stats() -> None:
+    def ospf_stats(self) -> None:
         """Export OSPF adjacency statistics for a selected site to SiteOspfStats.csv."""
-        SiteExportUtils._export_data(  # WHY: generic exporter path.
-            api_call=mistapi.api.v1.sites.stats.searchSiteOspfStats,
+        self._export_data(  # WHY: generic exporter path.
+            api_call=self.mistapi.api.v1.sites.stats.searchSiteOspfStats,
             data_type="ospf stats",
             sort_key="mac",
         )
 
-    @staticmethod
-    def mxedge_upgrade_status() -> None:
+    def mxedge_upgrade_status(self) -> None:
         """Export MxEdge upgrade status for a selected site to SiteMxEdgeUpgrades.csv."""
-        SiteExportUtils._export_data(  # WHY: generic exporter path.
-            api_call=mistapi.api.v1.sites.mxedges.listSiteMxEdgeUpgrades,
+        self._export_data(  # WHY: generic exporter path.
+            api_call=self.mistapi.api.v1.sites.mxedges.listSiteMxEdgeUpgrades,
             data_type="mxedge upgrade status",
             sort_key="id",
         )
 
-    @staticmethod
-    def auto_map_assignment_status() -> None:
+    def auto_map_assignment_status(self) -> None:
         """Export auto-map assignment status for a selected site to SiteAutoMapAssignmentStatus.csv."""
-        SiteExportUtils._export_data(  # WHY: generic exporter path.
-            api_call=mistapi.api.v1.sites.auto_map_assignment.getSiteAutoMapAssignmentStatus,
+        self._export_data(  # WHY: generic exporter path.
+            api_call=self.mistapi.api.v1.sites.auto_map_assignment.getSiteAutoMapAssignmentStatus,
             data_type="auto map assignment status",
             sort_key="id",
         )
 
-    @staticmethod
-    def site_stats() -> None:
+    def site_stats(self) -> None:
         """Export aggregate health and capacity statistics for a selected site to SiteSiteStats.csv."""
         logging.info("Starting export of site statistics...")
-        site_id = _prompt_site_or_abort("No site selected. Aborting site stats export.")  # WHY: shared prompt.
+        site_id = self._prompt_site_or_abort("No site selected. Aborting site stats export.")  # WHY: shared prompt.
         if site_id is None:
             return  # WHY: abort when operator declines.
         try:
-            count = _write_site_report(  # WHY: shared single-endpoint report flow.
-                mistapi.api.v1.sites.stats.getSiteStats,
+            count = self._write_site_report(  # WHY: shared single-endpoint report flow.
+                self.mistapi.api.v1.sites.stats.getSiteStats,
                 site_id,
                 "SiteSiteStats.csv",
                 "getSiteStats",
@@ -454,16 +387,17 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
         except Exception as exception:  # noqa: BLE001
             logging.exception("Failed to export site stats: %s", exception)  # WHY: preserve legacy log.
 
-    @staticmethod
-    def gateway_metrics() -> None:
+    def gateway_metrics(self) -> None:
         """Export gateway performance metrics summary for a selected site to SiteGatewayMetrics.csv."""
         logging.info("Starting export of site gateway metrics...")
-        site_id = _prompt_site_or_abort("No site selected. Aborting gateway metrics export.")  # WHY: shared prompt.
+        site_id = self._prompt_site_or_abort(
+            "No site selected. Aborting gateway metrics export."
+        )  # WHY: shared prompt.
         if site_id is None:
             return  # WHY: abort when operator declines.
         try:
-            count = _write_site_report(  # WHY: shared single-endpoint report flow.
-                mistapi.api.v1.sites.stats.getSiteGatewayMetrics,
+            count = self._write_site_report(  # WHY: shared single-endpoint report flow.
+                self.mistapi.api.v1.sites.stats.getSiteGatewayMetrics,
                 site_id,
                 "SiteGatewayMetrics.csv",
                 "getSiteGatewayMetrics",
@@ -472,16 +406,17 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
         except Exception as exception:  # noqa: BLE001
             logging.exception("Failed to export gateway metrics: %s", exception)  # WHY: preserve legacy log.
 
-    @staticmethod
-    def switches_metrics() -> None:
+    def switches_metrics(self) -> None:
         """Export switch performance metrics summary for a selected site to SiteSwitchesMetrics.csv."""
         logging.info("Starting export of site switches metrics...")
-        site_id = _prompt_site_or_abort("No site selected. Aborting switches metrics export.")  # WHY: shared prompt.
+        site_id = self._prompt_site_or_abort(
+            "No site selected. Aborting switches metrics export."
+        )  # WHY: shared prompt.
         if site_id is None:
             return  # WHY: abort when operator declines.
         try:
-            count = _write_site_report(  # WHY: shared single-endpoint report flow.
-                mistapi.api.v1.sites.stats.getSiteSwitchesMetrics,
+            count = self._write_site_report(  # WHY: shared single-endpoint report flow.
+                self.mistapi.api.v1.sites.stats.getSiteSwitchesMetrics,
                 site_id,
                 "SiteSwitchesMetrics.csv",
                 "getSiteSwitchesMetrics",
@@ -490,26 +425,24 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
         except Exception as exception:  # noqa: BLE001
             logging.exception("Failed to export switches metrics: %s", exception)  # WHY: preserve legacy log.
 
-    @staticmethod
-    def beacons_stats() -> None:
+    def beacons_stats(self) -> None:
         """Export BLE beacon statistics for a selected site to SiteBeaconsStats.csv."""
         logging.info("Starting export of site BLE beacon statistics...")
-        SiteExportUtils._export_data(  # WHY: generic exporter path.
-            api_call=mistapi.api.v1.sites.stats.listSiteBeaconsStats,
+        self._export_data(  # WHY: generic exporter path.
+            api_call=self.mistapi.api.v1.sites.stats.listSiteBeaconsStats,
             data_type="beacons stats",
             sort_key="id",
         )
 
-    @staticmethod
-    def wxrules_usage() -> None:
+    def wxrules_usage(self) -> None:
         """Export WxLAN rule usage statistics for a selected site to SiteWxrulesUsage.csv."""
         logging.info("Starting export of site WxLAN rules usage statistics...")
-        site_id = _prompt_site_or_abort("No site selected. Aborting WxRules usage export.")  # WHY: shared prompt.
+        site_id = self._prompt_site_or_abort("No site selected. Aborting WxRules usage export.")  # WHY: shared prompt.
         if site_id is None:
             return  # WHY: abort when operator declines.
         try:
-            count = _write_site_report(  # WHY: shared single-endpoint report flow.
-                mistapi.api.v1.sites.stats.getSiteWxRulesUsage,
+            count = self._write_site_report(  # WHY: shared single-endpoint report flow.
+                self.mistapi.api.v1.sites.stats.getSiteWxRulesUsage,
                 site_id,
                 "SiteWxrulesUsage.csv",
                 "getSiteWxRulesUsage",
@@ -518,43 +451,46 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
         except Exception as exception:  # noqa: BLE001
             logging.exception("Failed to export WxRules usage: %s", exception)  # WHY: preserve legacy log.
 
-    @staticmethod
-    def assets_stats() -> None:
+    def assets_stats(self) -> None:
         """Export asset statistics for a selected site to SiteAssetsStats.csv."""
         logging.info("Starting export of site asset statistics...")
-        SiteExportUtils._export_data(  # WHY: generic exporter path.
-            api_call=mistapi.api.v1.sites.stats.listSiteAssetsStats,
+        self._export_data(  # WHY: generic exporter path.
+            api_call=self.mistapi.api.v1.sites.stats.listSiteAssetsStats,
             data_type="assets stats",
             sort_key="mac",
         )
 
-    @staticmethod
-    def current_channel_planning() -> None:
+    def current_channel_planning(self) -> None:
         """Export current RRM channel and power plan per AP radio for a selected site."""
         logging.info("Starting export of site current channel planning (RRM)...")
-        site_id = _prompt_site_or_abort("No site selected. Aborting channel planning export.")  # WHY: shared prompt.
+        site_id = self._prompt_site_or_abort(
+            "No site selected. Aborting channel planning export."
+        )  # WHY: shared prompt.
         if site_id is None:
             return  # WHY: abort when operator declines.
         try:
-            response = mistapi.api.v1.sites.rrm.getSiteCurrentChannelPlanning(apisession, site_id)  # WHY: RRM plan.
+            response = self.mistapi.api.v1.sites.rrm.getSiteCurrentChannelPlanning(
+                self.apisession, site_id
+            )  # WHY: RRM plan.
             raw = getattr(response, "data", response) or {}  # WHY: tolerate dataclass or dict.
             rows = _channel_planning_rows_from_raw(raw, site_id)  # WHY: normalize payload shape to rows.
-            rows = DataProcessingUtils.flatten_nested_fields(rows)  # WHY: flatten for CSV.
+            rows = self.DataProcessingUtils.flatten_nested_fields(rows)  # WHY: flatten for CSV.
             filename = "SiteCurrentChannelPlanning.csv"  # WHY: legacy output filename.
-            DataExporter.write_with_format_selection(rows, filename, api_function_name="getSiteCurrentChannelPlanning")
+            self.DataExporter.write_with_format_selection(
+                rows, filename, api_function_name="getSiteCurrentChannelPlanning"
+            )
             logging.info("Exported %d channel planning records to %s", len(rows), filename)
         except Exception as exception:  # noqa: BLE001
             logging.exception("Failed to export channel planning: %s", exception)  # WHY: preserve legacy log.
 
-    @staticmethod
-    def zone_config_analysis() -> None:
+    def zone_config_analysis(self) -> None:
         """Zone, engagement, and occupancy config analysis (Menu #6). Delegates to src.analytics.zone_analyzer."""
         from src.analytics.zone_analyzer import ZoneConfigurationAnalyzer as _ZCA  # noqa: PLC0415
 
         _ZCA.analyze(  # WHY: reuse zone analyzer for menu #6.
-            apisession=apisession,
-            get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id,
-            check_stop_fn=ConfigUtils.check_stop_signal,
-            all_sites_fn=APICoreFetchUtils.all_sites_with_limit,
-            save_data_fn=DataExporter.write_with_format_selection,
+            apisession=self.apisession,
+            get_org_id_fn=self.ConfigUtils.get_cached_or_prompted_org_id,
+            check_stop_fn=self.ConfigUtils.check_stop_signal,
+            all_sites_fn=self.APICoreFetchUtils.all_sites_with_limit,
+            save_data_fn=self.DataExporter.write_with_format_selection,
         )

--- a/src/export/site_insights/device_metric_operation.py
+++ b/src/export/site_insights/device_metric_operation.py
@@ -5,7 +5,7 @@ from __future__ import annotations  # WHY: Defer annotation evaluation for cheap
 import logging  # WHY: Standard logging keeps ops-visible trace + error output aligned with legacy behaviour
 from dataclasses import dataclass  # WHY: Frozen slotted bundle keeps helper signatures under STRUCT-PARAMS limit
 
-from src.export import site_insights_exporter as _parent  # WHY: Parent exposes globals + classification helpers
+from src.export.site_insights_exporter import SiteInsightsExporter  # WHY: Static classifier + MAC normalizer access
 
 _EMPTY_METRICS_PROMPT = (
     "! No metrics found for device scope. Check ConstInsightMetrics.csv file."  # WHY: Reused literal
@@ -31,45 +31,66 @@ class DeviceRunContext:  # WHY: Frozen bundle collapses six-param signatures und
 class DeviceMetricOperation:
     """Decomposed replacement for SiteInsightsExporter.device_insights()."""
 
-    @staticmethod
-    def execute() -> None:  # WHY: Menu 76 dispatcher entry point invoked by MistHelper top-level menu
+    def __init__(  # WHY: Constructor injection replaces module globals from parent module
+        self,
+        *,
+        apisession,
+        PromptUtils,
+        DataProcessingUtils,
+        DataExporter,
+        EnhancedSSHRunner,
+        InsightMetricsUtils,
+        PacketCaptureManager,
+        mistapi,
+    ) -> None:
+        """Store injected dependencies on the instance for use by operation methods."""
+        self.apisession = apisession  # WHY: bind session for insight API calls.
+        self.PromptUtils = PromptUtils  # WHY: bind prompt helpers for site/device selection.
+        self.DataProcessingUtils = DataProcessingUtils  # WHY: bind flatten/escape helpers for CSV output.
+        self.DataExporter = DataExporter  # WHY: bind backend writer for CSV/SQLite output.
+        self.EnhancedSSHRunner = EnhancedSSHRunner  # WHY: bind filename sanitizer.
+        self.InsightMetricsUtils = InsightMetricsUtils  # WHY: bind insight metric helpers.
+        self.mistapi = mistapi  # WHY: bind mistapi module for API dispatch.
+        # WHY: Sibling insights exporter instance provides MAC normalizer using PacketCaptureManager.
+        self._insights_exporter = SiteInsightsExporter(PacketCaptureManager=PacketCaptureManager)
+
+    def execute(self) -> None:  # WHY: Menu 76 dispatcher entry point invoked by MistHelper top-level menu
         """Top-level entry point invoked by the menu dispatcher for menu 76."""
         print("Export Site Device Insights:")  # WHY: User-facing banner preserved verbatim from legacy implementation
         logging.info("Starting export of site device insights...")  # WHY: Trace operation start for ops visibility
-        DeviceMetricOperation._refresh_const_metrics()  # WHY: Refresh ConstInsightMetrics.csv before reading it
-        prompts = DeviceMetricOperation._prompt_site_and_device()  # WHY: Run both selection prompts up front
+        self._refresh_const_metrics()  # WHY: Refresh ConstInsightMetrics.csv before reading it
+        prompts = self._prompt_site_and_device()  # WHY: Run both selection prompts up front
         if prompts is None:
             return  # WHY: Helper already logged the cancel reason; exit cleanly
-        context = DeviceMetricOperation._build_context(*prompts)  # WHY: Resolve names, MAC, and validate MAC once
+        context = self._build_context(*prompts)  # WHY: Resolve names, MAC, and validate MAC once
         if context is None:
             return  # WHY: Helper already surfaced the specific validation failure
-        DeviceMetricOperation._run_export(context)  # WHY: Orchestrate filter + collect + finalize using bundled context
+        self._run_export(context)  # WHY: Orchestrate filter + collect + finalize using bundled context
 
-    @staticmethod
-    def _refresh_const_metrics() -> None:  # WHY: Isolated call keeps execute() short and testable
+    def _refresh_const_metrics(self) -> None:  # WHY: Isolated call keeps execute() short and testable
         """Refresh ConstInsightMetrics.csv so metric lists reflect the latest API surface."""
         print("! Refreshing available insight metrics from Mist API...")  # WHY: User-facing progress preserved verbatim
-        _parent.InsightMetricsUtils.export_const_insight_metrics()  # WHY: Refresh cache before scope-filtering metrics
+        self.InsightMetricsUtils.export_const_insight_metrics()  # WHY: Refresh cache before scope-filtering metrics
 
-    @staticmethod
-    def _prompt_site_and_device() -> tuple[str, str] | None:  # WHY: Two prompts share cancel semantics
+    def _prompt_site_and_device(self) -> tuple[str, str] | None:  # WHY: Two prompts share cancel semantics
         """Prompt for site then device; return None on either cancel."""
-        site_id = _parent.PromptUtils.select_site()  # WHY: Existing prompt utility handles cancel / invalid input
+        site_id = self.PromptUtils.select_site()  # WHY: Existing prompt utility handles cancel / invalid input
         if not site_id:
             logging.error("No site selected. Exiting.")  # WHY: Match legacy error log message verbatim
             return None
-        device_id = _parent.PromptUtils.select_device(site_id)  # WHY: Device prompt is scoped by site
+        device_id = self.PromptUtils.select_device(site_id)  # WHY: Device prompt is scoped by site
         if not device_id:
             logging.error("No device selected. Exiting.")  # WHY: Match legacy error log message verbatim
             return None
         return site_id, device_id  # WHY: Both selections succeeded; pass to downstream context builder
 
-    @staticmethod
-    def _build_context(site_id: str, device_id: str) -> DeviceRunContext | None:  # WHY: Consolidate lookup + validation
+    def _build_context(
+        self, site_id: str, device_id: str
+    ) -> DeviceRunContext | None:  # WHY: Consolidate lookup + validation
         """Resolve names + MAC and return the immutable per-run context, or None on validation failure."""
-        site_name = DeviceMetricOperation._resolve_site_name(site_id)  # WHY: Best-effort site label
-        device_info = DeviceMetricOperation._resolve_device_info(site_id, device_id)  # WHY: Dict with name/mac/model
-        normalized_mac = DeviceMetricOperation._validate_mac(  # WHY: Bail on missing / malformed MAC
+        site_name = self._resolve_site_name(site_id)  # WHY: Best-effort site label
+        device_info = self._resolve_device_info(site_id, device_id)  # WHY: Dict with name/mac/model
+        normalized_mac = self._validate_mac(  # WHY: Bail on missing / malformed MAC
             device_id, device_info["name"], device_info["mac"]
         )
         if normalized_mac is None:
@@ -83,33 +104,30 @@ class DeviceMetricOperation:
             device_model=device_info.get("model", ""),
         )
 
-    @staticmethod
-    def _run_export(context: DeviceRunContext) -> None:  # WHY: Orchestrates the post-validation export pipeline
+    def _run_export(self, context: DeviceRunContext) -> None:  # WHY: Orchestrates the post-validation export pipeline
         """Filter compatible metrics, collect responses, and finalize output for the resolved device."""
-        filename = DeviceMetricOperation._build_filename(context)  # WHY: Sanitized output path
-        device_metrics = DeviceMetricOperation._filter_metrics(context.device_model)  # WHY: Skip incompatible metrics
+        filename = self._build_filename(context)  # WHY: Sanitized output path
+        device_metrics = self._filter_metrics(context.device_model)  # WHY: Skip incompatible metrics
         if not device_metrics:
-            DeviceMetricOperation._emit_empty_metric_list(filename)  # WHY: Consistent empty-file emit on missing const
+            self._emit_empty_metric_list(filename)  # WHY: Consistent empty-file emit on missing const
             return
-        all_data, retrieved = DeviceMetricOperation._collect_metrics(context, device_metrics)  # WHY: Per-metric loop
-        DeviceMetricOperation._finalize(all_data, retrieved, filename, context)  # WHY: Flatten + save + summary
+        all_data, retrieved = self._collect_metrics(context, device_metrics)  # WHY: Per-metric loop
+        self._finalize(all_data, retrieved, filename, context)  # WHY: Flatten + save + summary
 
-    @staticmethod
-    def _emit_empty_metric_list(filename: str) -> None:  # WHY: Defensive branch used when const file is empty
+    def _emit_empty_metric_list(self, filename: str) -> None:  # WHY: Defensive branch used when const file is empty
         """Emit the empty-file + error trio when scope filter yields zero metrics."""
         print(_EMPTY_METRICS_PROMPT)  # WHY: User-facing error preserved verbatim
         logging.error(_EMPTY_METRICS_LOG)  # WHY: Persist failure cause in the log
-        _parent.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]
+        self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]
 
-    @staticmethod
-    def _resolve_site_name(site_id: str) -> str:  # WHY: Named lookup keeps execute path narrative
+    def _resolve_site_name(self, site_id: str) -> str:  # WHY: Named lookup keeps execute path narrative
         """Best-effort site-name lookup; fall back to site_id when API call fails."""
         try:
-            response = _parent.mistapi.api.v1.sites.listSites(  # WHY: API call may raise on auth / network
-                _parent.apisession, site_id
+            response = self.mistapi.api.v1.sites.listSites(  # WHY: API call may raise on auth / network
+                self.apisession, site_id
             )
-            sites = _parent.mistapi.get_all(  # WHY: Materialize paged result list
-                response=response, mist_session=_parent.apisession
+            sites = self.mistapi.get_all(  # WHY: Materialize paged result list
+                response=response, mist_session=self.apisession
             )
             return next(  # WHY: Match by id; fall back to id on miss
                 (site["name"] for site in sites if site["id"] == site_id), site_id
@@ -117,17 +135,18 @@ class DeviceMetricOperation:
         except Exception:
             return site_id  # WHY: Silent fallback preserves legacy behaviour for offline / degraded API
 
-    @staticmethod
-    def _resolve_device_info(site_id: str, device_id: str) -> dict:  # WHY: Return dict decouples caller from API shape
+    def _resolve_device_info(
+        self, site_id: str, device_id: str
+    ) -> dict:  # WHY: Return dict decouples caller from API shape
         """Best-effort device-name / MAC / model lookup; return shaped dict with defaults on failure."""
         try:
-            response = _parent.mistapi.api.v1.sites.devices.listSiteDevices(  # WHY: type=all covers switches/gateways
-                _parent.apisession,
+            response = self.mistapi.api.v1.sites.devices.listSiteDevices(  # WHY: type=all covers switches/gateways
+                self.apisession,
                 site_id,
                 type="all",
             )
-            devices = _parent.mistapi.get_all(  # WHY: Materialize paged result list
-                response=response, mist_session=_parent.apisession
+            devices = self.mistapi.get_all(  # WHY: Materialize paged result list
+                response=response, mist_session=self.apisession
             )
             device = next(  # WHY: Locate the device by id within the site
                 (dev for dev in devices if dev["id"] == device_id), None
@@ -142,14 +161,15 @@ class DeviceMetricOperation:
             pass  # WHY: Degrade gracefully so the rest of the flow can still emit a friendly error
         return {"name": device_id, "mac": None, "model": ""}  # WHY: Defaults match legacy fallback exactly
 
-    @staticmethod
-    def _validate_mac(device_id: str, device_name: str, device_mac: str | None) -> str | None:  # WHY: Guard MAC use
+    def _validate_mac(
+        self, device_id: str, device_name: str, device_mac: str | None
+    ) -> str | None:  # WHY: Guard MAC use
         """Confirm MAC is present and well-formed; print + log error and return None on failure."""
         if not device_mac:
             print(_MISSING_MAC_PROMPT.format(name=device_name))  # WHY: User-facing error preserved verbatim
             logging.error("Could not find MAC address for device %s", device_id)  # WHY: Persist failure cause
             return None
-        normalized = _parent.SiteInsightsExporter._normalize_device_mac_or_none(device_mac)  # WHY: Reuse normalizer
+        normalized = self._insights_exporter._normalize_device_mac_or_none(device_mac)  # WHY: Reuse normalizer
         if not normalized:
             print(_INVALID_MAC_PROMPT.format(name=device_name, mac=device_mac))  # WHY: User-facing error preserved
             logging.error(  # WHY: Persist failure cause with device id + raw MAC for triage
@@ -158,30 +178,26 @@ class DeviceMetricOperation:
             return None
         return normalized  # WHY: Normalized MAC is safe to pass to the insight API
 
-    @staticmethod
-    def _build_filename(context: DeviceRunContext) -> str:  # WHY: Single-arg helper mirrors the SiteMetric peer
+    def _build_filename(self, context: DeviceRunContext) -> str:  # WHY: Single-arg helper mirrors the SiteMetric peer
         """Build the sanitized output filename used by both CSV and DB exports."""
-        site_token = _parent.EnhancedSSHRunner.sanitize_filename(  # WHY: Reuse filename sanitizer
+        site_token = self.EnhancedSSHRunner.sanitize_filename(  # WHY: Reuse filename sanitizer
             context.site_name or context.site_id
         )
-        device_token = _parent.EnhancedSSHRunner.sanitize_filename(  # WHY: Reuse filename sanitizer
+        device_token = self.EnhancedSSHRunner.sanitize_filename(  # WHY: Reuse filename sanitizer
             context.device_name or context.device_id
         )
         return _FILENAME_TEMPLATE.format(site=site_token, device=device_token)  # WHY: Preserve legacy filename shape
 
-    @staticmethod
-    def _filter_metrics(device_model: str) -> list[str]:  # WHY: Compatible-metric list drives per-metric loop
+    def _filter_metrics(self, device_model: str) -> list[str]:  # WHY: Compatible-metric list drives per-metric loop
         """Filter the device-scope metric list to those compatible with this device's platform."""
-        metrics = _parent.InsightMetricsUtils.get_by_scope("device")  # WHY: Pull device-scope list from cache
-        platform = _parent.SiteInsightsExporter._classify_device_platform(device_model)  # WHY: AP / switch / gateway
+        metrics = self.InsightMetricsUtils.get_by_scope("device")  # WHY: Pull device-scope list from cache
+        platform = SiteInsightsExporter._classify_device_platform(device_model)  # WHY: AP / switch / gateway
         return [  # WHY: Keep only metrics the platform classifier deems compatible
-            metric
-            for metric in metrics
-            if _parent.SiteInsightsExporter._metric_compatible_with_platform(metric, platform)
+            metric for metric in metrics if SiteInsightsExporter._metric_compatible_with_platform(metric, platform)
         ]
 
-    @staticmethod
     def _collect_metrics(  # WHY: Two-arg loop replaces the legacy six-arg gathering signature
+        self,
         context: DeviceRunContext,
         device_metrics: list[str],
     ) -> tuple[list[dict], int]:
@@ -192,18 +208,19 @@ class DeviceMetricOperation:
             f"! Retrieving {len(device_metrics)} different device insight metrics for {context.device_name}..."
         )
         for metric in device_metrics:  # WHY: One API call per metric; individual failures must not abort the batch
-            data = DeviceMetricOperation._fetch_one_metric(context, metric)  # WHY: Enriched dict or None
+            data = self._fetch_one_metric(context, metric)  # WHY: Enriched dict or None
             if data is not None:
                 all_device_data.append(data)  # WHY: Append enriched record for export
                 retrieved += 1  # WHY: Bump only on successful, non-empty payload
         return all_device_data, retrieved  # WHY: Downstream finalize consumes both list and count
 
-    @staticmethod
-    def _fetch_one_metric(context: DeviceRunContext, metric: str) -> dict | None:  # WHY: Per-metric API + annotate
+    def _fetch_one_metric(
+        self, context: DeviceRunContext, metric: str
+    ) -> dict | None:  # WHY: Per-metric API + annotate
         """Fetch a single device insight metric, returning the enriched dict or None on miss / error."""
         try:
-            response = _parent.mistapi.api.v1.sites.insights.getSiteInsightMetricsForDevice(  # WHY: Device endpoint
-                _parent.apisession,
+            response = self.mistapi.api.v1.sites.insights.getSiteInsightMetricsForDevice(  # WHY: Device endpoint
+                self.apisession,
                 context.site_id,
                 metric,
                 context.device_mac,
@@ -214,10 +231,10 @@ class DeviceMetricOperation:
                 "Failed to get device insight data for metric %s: %s", metric, exception
             )
             return None
-        return DeviceMetricOperation._annotate_row(raw, metric, context)  # WHY: Annotate + short-circuit empty payload
+        return self._annotate_row(raw, metric, context)  # WHY: Annotate + short-circuit empty payload
 
     @staticmethod
-    def _annotate_row(raw: dict, metric: str, context: DeviceRunContext) -> dict | None:  # WHY: Split enrichment out
+    def _annotate_row(raw: dict, metric: str, context: DeviceRunContext) -> dict | None:  # WHY: Pure annotation helper
         """Copy scope labels into the row and return None for empty payloads."""
         if not raw:
             logging.debug("No data available for device metric: %s", metric)  # WHY: Trace empty payload at debug only
@@ -231,8 +248,8 @@ class DeviceMetricOperation:
         logging.debug("Retrieved device insight data for metric: %s", metric)  # WHY: Trace success at debug level
         return raw  # WHY: Enriched row ready for CSV / DB export
 
-    @staticmethod
     def _finalize(  # WHY: Dispatcher chooses success / empty / error emit path
+        self,
         all_device_data: list[dict],
         retrieved: int,
         filename: str,
@@ -241,25 +258,25 @@ class DeviceMetricOperation:
         """Flatten, escape, and save collected data; emit summary user output."""
         try:
             if all_device_data:
-                DeviceMetricOperation._export_with_data(  # WHY: Non-empty path writes flattened rows and summary
+                self._export_with_data(  # WHY: Non-empty path writes flattened rows and summary
                     all_device_data, retrieved, filename, context
                 )
                 return
-            DeviceMetricOperation._export_empty(filename, context)  # WHY: Zero-data path still emits an empty file
+            self._export_empty(filename, context)  # WHY: Zero-data path still emits an empty file
         except Exception as exception:
-            DeviceMetricOperation._export_error(exception, filename, context)  # WHY: Guarantee file emit on failure
+            self._export_error(exception, filename, context)  # WHY: Guarantee file emit on failure
 
-    @staticmethod
     def _export_with_data(  # WHY: Isolated success path keeps _finalize under STRUCT-LENGTH limit
+        self,
         all_device_data: list[dict],
         retrieved: int,
         filename: str,
         context: DeviceRunContext,
     ) -> None:
         """Flatten, escape, and write the non-empty result set; log the success summary."""
-        processed = _parent.DataProcessingUtils.flatten_nested_fields(all_device_data)  # WHY: Flatten nested API objs
-        processed = _parent.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
-        _parent.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]
+        processed = self.DataProcessingUtils.flatten_nested_fields(all_device_data)  # WHY: Flatten nested API objs
+        processed = self.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
+        self.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]
         print(f"! {retrieved} device insight metrics exported to {filename}")  # WHY: User-facing summary preserved
         logging.info(  # WHY: Persist success summary at info level for ops visibility
             "Exported %s device insight metrics for %s at %s to %s",
@@ -269,8 +286,7 @@ class DeviceMetricOperation:
             filename,
         )
 
-    @staticmethod
-    def _export_empty(filename: str, context: DeviceRunContext) -> None:  # WHY: Zero-data emit path
+    def _export_empty(self, filename: str, context: DeviceRunContext) -> None:  # WHY: Zero-data emit path
         """Emit user-visible zero-data summary and write an empty file for consistency."""
         print(f"! 0 device insights exported to {filename} (no data available)")  # WHY: User-facing summary preserved
         logging.warning(  # WHY: Distinguish empty result from error for ops triage
@@ -278,10 +294,10 @@ class DeviceMetricOperation:
             context.device_name,
             context.site_name,
         )
-        _parent.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]
+        self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]
 
-    @staticmethod
     def _export_error(  # WHY: Exception emit path - preserve failure visibility while still writing a file
+        self,
         exception: Exception,
         filename: str,
         context: DeviceRunContext,
@@ -294,4 +310,4 @@ class DeviceMetricOperation:
             context.site_name,
             exception,
         )
-        _parent.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]
+        self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]

--- a/src/export/site_insights/site_metric_operation.py
+++ b/src/export/site_insights/site_metric_operation.py
@@ -5,10 +5,6 @@ from __future__ import annotations  # WHY: Defer annotation evaluation for cheap
 import logging  # WHY: Standard logging keeps ops-visible trace + error output aligned with legacy behaviour
 from dataclasses import dataclass  # WHY: Frozen slotted bundle keeps helper signatures under STRUCT-PARAMS limit
 
-from src.export import (
-    site_insights_exporter as _parent,
-)  # WHY: Parent module exposes mistapi / apisession / DataExporter globals
-
 _BANNER = "Export Site Insight Metrics:"  # WHY: User-facing banner preserved verbatim from legacy implementation
 _START_LOG = "Starting export of site insight metrics..."  # WHY: Ops-visible trace message on operation start
 _REFRESH_PROMPT = "! Refreshing available insight metrics from Mist API..."  # WHY: User-facing progress preserved
@@ -30,68 +26,83 @@ class SiteRunContext:  # WHY: Frozen bundle collapses site identifiers into a si
 class SiteMetricOperation:
     """Decomposed replacement for SiteInsightsExporter.insight_metrics()."""
 
-    @staticmethod
-    def execute() -> None:  # WHY: Menu 74 dispatcher entry point invoked by MistHelper top-level menu
+    def __init__(  # WHY: Constructor injection replaces module globals from parent module
+        self,
+        *,
+        apisession,
+        PromptUtils,
+        DataProcessingUtils,
+        DataExporter,
+        EnhancedSSHRunner,
+        InsightMetricsUtils,
+        mistapi,
+    ) -> None:
+        """Store injected dependencies on the instance for use by operation methods."""
+        self.apisession = apisession  # WHY: bind session for insight API calls.
+        self.PromptUtils = PromptUtils  # WHY: bind prompt helpers for site selection.
+        self.DataProcessingUtils = DataProcessingUtils  # WHY: bind flatten/escape helpers for CSV output.
+        self.DataExporter = DataExporter  # WHY: bind backend writer for CSV/SQLite output.
+        self.EnhancedSSHRunner = EnhancedSSHRunner  # WHY: bind filename sanitizer.
+        self.InsightMetricsUtils = InsightMetricsUtils  # WHY: bind insight metric helpers.
+        self.mistapi = mistapi  # WHY: bind mistapi module for API dispatch.
+
+    def execute(self) -> None:  # WHY: Menu 74 dispatcher entry point invoked by MistHelper top-level menu
         """Top-level entry point invoked by the menu dispatcher for menu 74."""
         print(_BANNER)  # WHY: User-facing banner preserved verbatim from legacy implementation
         logging.info(_START_LOG)  # WHY: Trace operation start for ops visibility
-        context = SiteMetricOperation._prompt_and_build_context()  # WHY: Resolve site id + name, or bail on cancel
+        context = self._prompt_and_build_context()  # WHY: Resolve site id + name, or bail on cancel
         if context is None:
             return  # WHY: Helper already logged the cancel reason; exit cleanly
-        SiteMetricOperation._run_export(context)  # WHY: Orchestrate refresh + collect + finalize using bundled context
+        self._run_export(context)  # WHY: Orchestrate refresh + collect + finalize using bundled context
 
-    @staticmethod
-    def _prompt_and_build_context() -> SiteRunContext | None:  # WHY: Consolidate prompt + name lookup for execute()
+    def _prompt_and_build_context(self) -> SiteRunContext | None:  # WHY: Consolidate prompt + name lookup for execute()
         """Prompt for site selection and resolve name; return None on cancel."""
-        site_id = SiteMetricOperation._prompt_site_id()  # WHY: Bail out early if user cancels selection
+        site_id = self._prompt_site_id()  # WHY: Bail out early if user cancels selection
         if not site_id:
             return None  # WHY: Prompt helper already logged the cancel reason for ops visibility
-        site_name = SiteMetricOperation._resolve_site_name(site_id)  # WHY: Best-effort site label for filename and logs
+        site_name = self._resolve_site_name(site_id)  # WHY: Best-effort site label for filename and logs
         return SiteRunContext(site_id=site_id, site_name=site_name)  # WHY: Freeze identifiers into an immutable bundle
 
-    @staticmethod
-    def _run_export(context: SiteRunContext) -> None:  # WHY: Orchestrates the post-selection export pipeline
+    def _run_export(self, context: SiteRunContext) -> None:  # WHY: Orchestrates the post-selection export pipeline
         """Refresh const metrics, collect responses, and finalize output for the resolved site."""
-        filename = SiteMetricOperation._build_filename(context)  # WHY: Sanitized output path mirroring legacy naming
-        SiteMetricOperation._refresh_const_metrics()  # WHY: Refresh ConstInsightMetrics.csv before reading it
-        site_metrics = _parent.InsightMetricsUtils.get_by_scope("site")  # WHY: Pull site-scope list from cache
+        filename = self._build_filename(context)  # WHY: Sanitized output path mirroring legacy naming
+        self._refresh_const_metrics()  # WHY: Refresh ConstInsightMetrics.csv before reading it
+        site_metrics = self.InsightMetricsUtils.get_by_scope("site")  # WHY: Pull site-scope list from cache
         if not site_metrics:
-            SiteMetricOperation._emit_empty_metric_list(filename)  # WHY: Defensive: missing const file emits empty file
+            self._emit_empty_metric_list(filename)  # WHY: Defensive: missing const file emits empty file
             return
-        all_data, retrieved = SiteMetricOperation._collect_metrics(context, site_metrics)  # WHY: Per-metric API loop
-        SiteMetricOperation._finalize(all_data, retrieved, filename, context)  # WHY: Flatten + save + summary print
+        all_data, retrieved = self._collect_metrics(context, site_metrics)  # WHY: Per-metric API loop
+        self._finalize(all_data, retrieved, filename, context)  # WHY: Flatten + save + summary print
 
-    @staticmethod
-    def _refresh_const_metrics() -> None:  # WHY: Isolated call keeps execute() short and testable
+    def _refresh_const_metrics(self) -> None:  # WHY: Isolated call keeps execute() short and testable
         """Refresh ConstInsightMetrics.csv so metric lists reflect the latest API surface."""
         print(_REFRESH_PROMPT)  # WHY: User-facing progress preserved verbatim from legacy implementation
-        _parent.InsightMetricsUtils.export_const_insight_metrics()  # WHY: Refresh cache before scope-filtering metrics
+        self.InsightMetricsUtils.export_const_insight_metrics()  # WHY: Refresh cache before scope-filtering metrics
 
-    @staticmethod
-    def _emit_empty_metric_list(filename: str) -> None:  # WHY: Defensive branch used when const file is empty
+    def _emit_empty_metric_list(self, filename: str) -> None:  # WHY: Defensive branch used when const file is empty
         """Emit the empty-file + error trio when scope filter yields zero metrics."""
         print(_EMPTY_METRICS_PROMPT)  # WHY: User-facing error preserved verbatim from legacy implementation
         logging.error(_EMPTY_METRICS_LOG)  # WHY: Persist failure cause in the log
-        _parent.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Emit empty file for downstream consistency
+        self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Emit empty file for downstream consistency
 
-    @staticmethod
-    def _prompt_site_id() -> str | None:  # WHY: Wrap prompt in cancel-aware helper for execute()
+    def _prompt_site_id(self) -> str | None:  # WHY: Wrap prompt in cancel-aware helper for execute()
         """Prompt the user for a site selection; return None when the user cancels."""
-        site_id = _parent.PromptUtils.select_site()  # WHY: Existing prompt utility handles cancel / invalid input
+        site_id = self.PromptUtils.select_site()  # WHY: Existing prompt utility handles cancel / invalid input
         if not site_id:
             logging.error(_NO_SITE_LOG)  # WHY: Match legacy error log message verbatim
             return None
         return site_id  # WHY: Selection succeeded; downstream will resolve name and run export
 
-    @staticmethod
-    def _resolve_site_name(site_id: str) -> str:  # WHY: Best-effort name lookup keeps execute path narrative clean
+    def _resolve_site_name(
+        self, site_id: str
+    ) -> str:  # WHY: Best-effort name lookup keeps execute path narrative clean
         """Best-effort site-name lookup; fall back to site_id when API call fails."""
         try:
-            response = _parent.mistapi.api.v1.sites.listSites(  # WHY: API call may raise on auth / network
-                _parent.apisession, site_id
+            response = self.mistapi.api.v1.sites.listSites(  # WHY: API call may raise on auth / network
+                self.apisession, site_id
             )
-            sites = _parent.mistapi.get_all(  # WHY: Materialize paged result list
-                response=response, mist_session=_parent.apisession
+            sites = self.mistapi.get_all(  # WHY: Materialize paged result list
+                response=response, mist_session=self.apisession
             )
             return next(  # WHY: Match by id; fall back to id on miss
                 (site["name"] for site in sites if site["id"] == site_id), site_id
@@ -99,16 +110,15 @@ class SiteMetricOperation:
         except Exception:
             return site_id  # WHY: Silent fallback preserves legacy behaviour for offline / degraded API
 
-    @staticmethod
-    def _build_filename(context: SiteRunContext) -> str:  # WHY: Single-arg helper mirrors the DeviceMetric peer
+    def _build_filename(self, context: SiteRunContext) -> str:  # WHY: Single-arg helper mirrors the DeviceMetric peer
         """Build the sanitized output filename used by both CSV and DB exports."""
-        sanitized = _parent.EnhancedSSHRunner.sanitize_filename(  # WHY: Reuse filename sanitizer from SSH runner
+        sanitized = self.EnhancedSSHRunner.sanitize_filename(  # WHY: Reuse filename sanitizer from SSH runner
             context.site_name or context.site_id
         )
         return _FILENAME_TEMPLATE.format(site=sanitized)  # WHY: Preserve legacy filename shape
 
-    @staticmethod
     def _collect_metrics(  # WHY: Two-arg loop replaces the legacy three-arg gathering signature
+        self,
         context: SiteRunContext,
         site_metrics: list[str],
     ) -> tuple[list[dict], int]:
@@ -117,18 +127,17 @@ class SiteMetricOperation:
         retrieved = 0  # WHY: User-facing counter shown in the final summary line
         print(f"! Retrieving {len(site_metrics)} different site insight metrics...")  # WHY: Progress preserved verbatim
         for metric in site_metrics:  # WHY: One API call per metric; individual failures must not abort the batch
-            data = SiteMetricOperation._fetch_one_metric(context, metric)  # WHY: Enriched dict or None
+            data = self._fetch_one_metric(context, metric)  # WHY: Enriched dict or None
             if data is not None:
                 all_insight_data.append(data)  # WHY: Append the enriched per-metric record for export
                 retrieved += 1  # WHY: Bump only on successful, non-empty payload
         return all_insight_data, retrieved  # WHY: Downstream finalize consumes both list and count
 
-    @staticmethod
-    def _fetch_one_metric(context: SiteRunContext, metric: str) -> dict | None:  # WHY: Per-metric API + annotate
+    def _fetch_one_metric(self, context: SiteRunContext, metric: str) -> dict | None:  # WHY: Per-metric API + annotate
         """Fetch a single site insight metric, returning the enriched dict or None on miss / error."""
         try:
-            response = _parent.mistapi.api.v1.sites.insights.getSiteInsightMetrics(  # WHY: Single-metric API call
-                _parent.apisession,
+            response = self.mistapi.api.v1.sites.insights.getSiteInsightMetrics(  # WHY: Single-metric API call
+                self.apisession,
                 context.site_id,
                 metric,
             )
@@ -138,10 +147,10 @@ class SiteMetricOperation:
                 "Failed to get site insight data for metric %s: %s", metric, exception
             )
             return None
-        return SiteMetricOperation._annotate_row(raw, metric, context)  # WHY: Annotate + short-circuit empty payload
+        return self._annotate_row(raw, metric, context)  # WHY: Annotate + short-circuit empty payload
 
     @staticmethod
-    def _annotate_row(raw: dict, metric: str, context: SiteRunContext) -> dict | None:  # WHY: Split enrichment out
+    def _annotate_row(raw: dict, metric: str, context: SiteRunContext) -> dict | None:  # WHY: Pure annotation helper
         """Copy scope labels into the row and return None for empty payloads."""
         if not raw:
             logging.debug("No data available for metric: %s", metric)  # WHY: Trace empty payload at debug level only
@@ -152,8 +161,8 @@ class SiteMetricOperation:
         logging.debug("Retrieved site insight data for metric: %s", metric)  # WHY: Trace success at debug level only
         return raw  # WHY: Enriched row ready for CSV / DB export
 
-    @staticmethod
     def _finalize(  # WHY: Dispatcher chooses success / empty / error emit path
+        self,
         all_insight_data: list[dict],
         retrieved: int,
         filename: str,
@@ -162,25 +171,25 @@ class SiteMetricOperation:
         """Flatten, escape, and save collected data; emit summary user output."""
         try:
             if all_insight_data:
-                SiteMetricOperation._export_with_data(  # WHY: Non-empty path writes flattened rows and summary
+                self._export_with_data(  # WHY: Non-empty path writes flattened rows and summary
                     all_insight_data, retrieved, filename, context
                 )
                 return
-            SiteMetricOperation._export_empty(filename, context)  # WHY: Zero-data path still emits an empty file
+            self._export_empty(filename, context)  # WHY: Zero-data path still emits an empty file
         except Exception as exception:
-            SiteMetricOperation._export_error(exception, filename, context)  # WHY: Guarantee file emit on failure
+            self._export_error(exception, filename, context)  # WHY: Guarantee file emit on failure
 
-    @staticmethod
     def _export_with_data(  # WHY: Isolated success path keeps _finalize under STRUCT-LENGTH limit
+        self,
         all_insight_data: list[dict],
         retrieved: int,
         filename: str,
         context: SiteRunContext,
     ) -> None:
         """Flatten, escape, and write the non-empty result set; log the success summary."""
-        processed = _parent.DataProcessingUtils.flatten_nested_fields(all_insight_data)  # WHY: Flatten nested API objs
-        processed = _parent.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]  # WHY: CSV-safe text
-        _parent.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]  # WHY: Write to disk / DB
+        processed = self.DataProcessingUtils.flatten_nested_fields(all_insight_data)  # WHY: Flatten nested API objs
+        processed = self.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]  # WHY: CSV-safe text
+        self.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]  # WHY: Write to disk / DB
         print(f"! {retrieved} site insight metrics exported to {filename}")  # WHY: User-facing summary preserved
         logging.info(  # WHY: Persist success summary at info level for ops visibility
             "Exported %d site insight metrics for %s to %s",
@@ -189,15 +198,14 @@ class SiteMetricOperation:
             filename,
         )
 
-    @staticmethod
-    def _export_empty(filename: str, context: SiteRunContext) -> None:  # WHY: Zero-data emit path
+    def _export_empty(self, filename: str, context: SiteRunContext) -> None:  # WHY: Zero-data emit path
         """Emit user-visible zero-data summary and write an empty file for consistency."""
         print(f"! 0 insight metrics exported to {filename} (no data available)")  # WHY: User-facing summary preserved
         logging.warning("No insight data available for site %s", context.site_name)  # WHY: Distinguish empty from error
-        _parent.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Emit empty file for consistency
+        self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Emit empty file for consistency
 
-    @staticmethod
     def _export_error(  # WHY: Exception emit path - preserve failure visibility while still writing a file
+        self,
         exception: Exception,
         filename: str,
         context: SiteRunContext,
@@ -207,4 +215,4 @@ class SiteMetricOperation:
         logging.error(  # WHY: Persist failure cause with site context for triage
             "Failed to export site insight metrics for %s: %s", context.site_name, exception
         )
-        _parent.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Always emit a file for consistency
+        self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Always emit a file for consistency

--- a/src/export/site_insights_exporter.py
+++ b/src/export/site_insights_exporter.py
@@ -1,8 +1,6 @@
 """Site insights exporter extracted from SiteExportUtils high-complexity branch."""
 
-from __future__ import annotations  # WHY: PEP 563 postponed annotations for forward Any typing.
-
-from typing import Any  # WHY: dependencies are unknown-type runtime injections.
+from __future__ import annotations  # WHY: PEP 563 postponed annotations for forward references.
 
 # Module-level constants - centralize platform tokens so branch logic stays low-complexity.
 _PLATFORM_AP: str = "ap"  # WHY: canonical AP platform identifier for metric routing.
@@ -23,39 +21,6 @@ _METRIC_PLATFORM_RULES: tuple[tuple[tuple[str, ...], frozenset[str]], ...] = (  
     (_AP_TOKENS, frozenset({_PLATFORM_AP, _PLATFORM_UNKNOWN})),  # WHY: AP metrics + unknown allowed.
 )
 
-# Dependency-injection keys - accepted kwargs from configure_site_insights_exporter_dependencies.
-_DEP_KEY_APISESSION: str = "apisession_dependency"  # WHY: mistapi session handle key.
-_DEP_KEY_PROMPT: str = "prompt_utils"  # WHY: operator-prompt helpers key.
-_DEP_KEY_PROCESSING: str = "data_processing_utils"  # WHY: row-flattening helpers key.
-_DEP_KEY_EXPORTER: str = "data_exporter"  # WHY: CSV/format writer key.
-_DEP_KEY_SSH: str = "enhanced_ssh_runner"  # WHY: SSH runner for filename sanitization key.
-_DEP_KEY_METRICS: str = "insight_metrics_utils"  # WHY: insight metric helpers key.
-_DEP_KEY_PCAP: str = "packet_capture_manager"  # WHY: MAC validation/normalization key.
-_DEP_KEY_MISTAPI: str = "mistapi_dependency"  # WHY: mistapi client module key.
-
-apisession: Any = None  # WHY: injected mistapi session handle used by exporter methods.
-PromptUtils: Any = None  # WHY: injected operator-prompt helpers used during interactive flows.
-DataProcessingUtils: Any = None  # WHY: injected row-flattening + escape helpers for CSV output.
-DataExporter: Any = None  # WHY: injected backend writer supporting CSV and SQLite formats.
-EnhancedSSHRunner: Any = None  # WHY: injected SSH runner used for filename sanitization.
-InsightMetricsUtils: Any = None  # WHY: injected insight metric helpers for scope + metric lookups.
-PacketCaptureManager: Any = None  # WHY: injected MAC address validator and normalizer.
-mistapi: Any = None  # WHY: injected mistapi client module for API call dispatch.
-
-
-def configure_site_insights_exporter_dependencies(**deps: Any) -> None:  # WHY: **kwargs bundles 8 DI params.
-    """Configure runtime dependencies from MistHelper orchestration layer."""
-    global apisession, PromptUtils, DataProcessingUtils, DataExporter  # WHY: publish session/prompt/processing/writer.
-    global EnhancedSSHRunner, InsightMetricsUtils, PacketCaptureManager, mistapi  # WHY: publish SSH/metrics/pcap/api.
-    apisession = deps[_DEP_KEY_APISESSION]  # WHY: bind session for exporters.
-    PromptUtils = deps[_DEP_KEY_PROMPT]  # WHY: bind prompt helpers.
-    DataProcessingUtils = deps[_DEP_KEY_PROCESSING]  # WHY: bind flatten/escape helpers.
-    DataExporter = deps[_DEP_KEY_EXPORTER]  # WHY: bind CSV/format writer.
-    EnhancedSSHRunner = deps[_DEP_KEY_SSH]  # WHY: bind SSH runner.
-    InsightMetricsUtils = deps[_DEP_KEY_METRICS]  # WHY: bind insight metrics helpers.
-    PacketCaptureManager = deps[_DEP_KEY_PCAP]  # WHY: bind packet capture manager.
-    mistapi = deps[_DEP_KEY_MISTAPI]  # WHY: bind mistapi module.
-
 
 def _allowed_platforms_for_metric(metric: str) -> frozenset[str] | None:  # WHY: table-driven compat lookup helper.
     """Return the platform set allowed for the given metric name, or None if unrestricted."""
@@ -67,6 +32,10 @@ def _allowed_platforms_for_metric(metric: str) -> frozenset[str] | None:  # WHY:
 
 class SiteInsightsExporter:
     """Extracted site insights export implementation for menu paths 74 and 76."""
+
+    def __init__(self, *, PacketCaptureManager) -> None:  # WHY: constructor injection replaces module globals.
+        """Store injected dependencies on the instance for use by exporter methods."""
+        self.PacketCaptureManager = PacketCaptureManager  # WHY: bind MAC validator/normalizer to instance.
 
     @staticmethod
     def _classify_device_platform(device_model: str) -> str:
@@ -89,11 +58,10 @@ class SiteInsightsExporter:
             return True  # WHY: unrestricted metrics are compatible with any platform.
         return device_platform in allowed  # WHY: only compatible when platform is in allowed set.
 
-    @staticmethod
-    def _normalize_device_mac_or_none(device_mac: str) -> str | None:
+    def _normalize_device_mac_or_none(self, device_mac: str) -> str | None:
         """Validate and normalize device MAC for device insights endpoints."""
         if not device_mac:  # WHY: empty MAC has no meaningful normalization.
             return None  # WHY: signal absence to caller.
-        if not PacketCaptureManager.validate_mac_address(device_mac):  # WHY: reject invalid MAC format.
+        if not self.PacketCaptureManager.validate_mac_address(device_mac):  # WHY: reject invalid MAC format.
             return None  # WHY: signal invalid input to caller.
-        return PacketCaptureManager.normalize_mac_address(device_mac)  # WHY: normalized canonical form.
+        return self.PacketCaptureManager.normalize_mac_address(device_mac)  # WHY: normalized canonical form.

--- a/tests/unit/export/test_site_export_utils.py
+++ b/tests/unit/export/test_site_export_utils.py
@@ -1,11 +1,11 @@
-"""Unit tests for extracted SiteExportUtils module."""
+"""Unit tests for extracted SiteExportUtils module (Pattern 1 constructor injection)."""
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from src.export.site_export_utils import SiteExportUtils, configure_site_export_utils_dependencies
+from src.export.site_export_utils import SiteExportUtils
 
 
 class _ApiCallWithLimit:
@@ -17,8 +17,8 @@ class _ApiCallWithLimit:
         return {"site_id": site_id, "limit": limit, "kwargs": kwargs}
 
 
-def _configure_dependencies(select_site_return: str | None = "site-1") -> tuple[SimpleNamespace, MagicMock]:
-    """Configure extracted module dependencies for unit tests."""
+def _build_exporter(select_site_return: str | None = "site-1") -> tuple[SiteExportUtils, MagicMock]:
+    """Construct a SiteExportUtils instance with mocked dependencies via Pattern 1 constructor injection."""
     exporter_mock = MagicMock()
     get_all_mock = MagicMock(
         side_effect=[
@@ -40,56 +40,56 @@ def _configure_dependencies(select_site_return: str | None = "site-1") -> tuple[
         get_all=get_all_mock,
     )
 
-    configure_site_export_utils_dependencies(
-        apisession_dependency=object(),
-        prompt_utils=SimpleNamespace(select_site=MagicMock(return_value=select_site_return)),
-        config_utils=SimpleNamespace(
+    exporter = SiteExportUtils(
+        apisession=object(),
+        PromptUtils=SimpleNamespace(select_site=MagicMock(return_value=select_site_return)),
+        ConfigUtils=SimpleNamespace(
             get_cached_or_prompted_org_id=MagicMock(return_value="org-1"),
             check_stop_signal=MagicMock(return_value=False),
         ),
-        data_processing_utils=SimpleNamespace(
+        DataProcessingUtils=SimpleNamespace(
             flatten_nested_fields=MagicMock(side_effect=lambda rows: rows),
             escape_multiline=MagicMock(side_effect=lambda rows: rows),
             get_unique_keys=MagicMock(return_value=["name"]),
         ),
-        data_exporter=SimpleNamespace(write_with_format_selection=exporter_mock),
-        time_utils=SimpleNamespace(
+        DataExporter=SimpleNamespace(write_with_format_selection=exporter_mock),
+        TimeUtils=SimpleNamespace(
             get_dynamic_lookback_hours=MagicMock(return_value=24), log_dynamic_lookback=MagicMock()
         ),
-        enhanced_ssh_runner=SimpleNamespace(
+        EnhancedSSHRunner=SimpleNamespace(
             sanitize_filename=MagicMock(side_effect=lambda value: value.replace(" ", "_"))
         ),
-        insight_metrics_utils=SimpleNamespace(
+        InsightMetricsUtils=SimpleNamespace(
             export_const_insight_metrics=MagicMock(), get_by_scope=MagicMock(return_value=[])
         ),
-        packet_capture_manager=SimpleNamespace(
+        PacketCaptureManager=SimpleNamespace(
             validate_mac_address=MagicMock(return_value=True),
             normalize_mac_address=MagicMock(return_value="aa:bb:cc:dd:ee:ff"),
         ),
-        api_core_fetch_utils=SimpleNamespace(all_sites_with_limit=MagicMock(return_value=[])),
-        check_fn=MagicMock(return_value=False),  # WHY: renamed from is_debug_mode_fn per 1012 DI-cluster rename
-        pretty_table_class=SimpleNamespace,
-        tqdm_module=MagicMock(side_effect=lambda rows, **kwargs: rows),
-        mistapi_dependency=mistapi_dependency,
+        APICoreFetchUtils=SimpleNamespace(all_sites_with_limit=MagicMock(return_value=[])),
+        check_fn=MagicMock(return_value=False),
+        PrettyTable=SimpleNamespace,
+        tqdm=MagicMock(side_effect=lambda rows, **kwargs: rows),
+        mistapi=mistapi_dependency,
     )
 
-    return mistapi_dependency, exporter_mock
+    return exporter, exporter_mock
 
 
 def test_export_data_returns_early_when_no_site_selected() -> None:
     """Generic export helper should exit cleanly when no site is selected."""
-    _, exporter_mock = _configure_dependencies(select_site_return=None)
+    exporter, exporter_mock = _build_exporter(select_site_return=None)
 
-    SiteExportUtils._export_data(api_call=_ApiCallWithLimit(), data_type="test data")
+    exporter._export_data(api_call=_ApiCallWithLimit(), data_type="test data")
 
     exporter_mock.assert_not_called()
 
 
 def test_export_data_sorts_and_writes_output() -> None:
     """Generic export helper should sort rows and write expected filename."""
-    _, exporter_mock = _configure_dependencies(select_site_return="site-1")
+    exporter, exporter_mock = _build_exporter(select_site_return="site-1")
 
-    SiteExportUtils._export_data(api_call=_ApiCallWithLimit(), data_type="test data", sort_key="name")
+    exporter._export_data(api_call=_ApiCallWithLimit(), data_type="test data", sort_key="name")
 
     exporter_mock.assert_called_once()
     saved_rows, saved_filename = exporter_mock.call_args[0]

--- a/tests/unit/export/test_site_insights_exporter.py
+++ b/tests/unit/export/test_site_insights_exporter.py
@@ -1,36 +1,25 @@
-"""Unit tests for extracted SiteInsightsExporter helper logic."""
+"""Unit tests for extracted SiteInsightsExporter helper logic (Pattern 1 constructor injection)."""
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from src.export.site_insights_exporter import SiteInsightsExporter, configure_site_insights_exporter_dependencies
+from src.export.site_insights_exporter import SiteInsightsExporter
 
 
-def _configure_dependencies() -> None:
-    """Configure minimal dependencies for insights helper tests."""
-    configure_site_insights_exporter_dependencies(
-        apisession_dependency=object(),
-        prompt_utils=SimpleNamespace(select_site=MagicMock(), select_device=MagicMock()),
-        data_processing_utils=SimpleNamespace(flatten_nested_fields=MagicMock(), escape_multiline=MagicMock()),
-        data_exporter=SimpleNamespace(write_with_format_selection=MagicMock()),
-        enhanced_ssh_runner=SimpleNamespace(sanitize_filename=MagicMock(side_effect=lambda value: value)),
-        insight_metrics_utils=SimpleNamespace(
-            export_const_insight_metrics=MagicMock(), get_by_scope=MagicMock(return_value=[])
-        ),
-        packet_capture_manager=SimpleNamespace(
-            validate_mac_address=MagicMock(return_value=True),
+def _build_exporter(validator_return: bool = True) -> SiteInsightsExporter:
+    """Construct a SiteInsightsExporter with a stub PacketCaptureManager for MAC normalization tests."""
+    return SiteInsightsExporter(
+        PacketCaptureManager=SimpleNamespace(
+            validate_mac_address=MagicMock(return_value=validator_return),
             normalize_mac_address=MagicMock(return_value="aa:bb:cc:dd:ee:ff"),
-        ),
-        mistapi_dependency=SimpleNamespace(),
+        )
     )
 
 
 def test_classify_device_platform_by_model_prefix() -> None:
     """Device model prefixes should map to expected platform classification."""
-    _configure_dependencies()
-
     assert SiteInsightsExporter._classify_device_platform("AP32") == "ap"
     assert SiteInsightsExporter._classify_device_platform("EX4300") == "switch"
     assert SiteInsightsExporter._classify_device_platform("SSR120") == "gateway"
@@ -39,8 +28,6 @@ def test_classify_device_platform_by_model_prefix() -> None:
 
 def test_metric_compatible_with_platform_filters_expected_tokens() -> None:
     """Metric compatibility should enforce platform-specific keyword filters."""
-    _configure_dependencies()
-
     assert SiteInsightsExporter._metric_compatible_with_platform("switch_health", "switch") is True
     assert SiteInsightsExporter._metric_compatible_with_platform("switch_health", "ap") is False
     assert SiteInsightsExporter._metric_compatible_with_platform("gateway_uptime", "gateway") is True
@@ -50,7 +37,8 @@ def test_metric_compatible_with_platform_filters_expected_tokens() -> None:
 
 def test_normalize_device_mac_or_none_respects_validator() -> None:
     """MAC normalizer should return None for invalid input and normalized value for valid input."""
-    _configure_dependencies()
+    exporter_invalid = _build_exporter(validator_return=False)
+    assert exporter_invalid._normalize_device_mac_or_none("") is None
 
-    assert SiteInsightsExporter._normalize_device_mac_or_none("") is None
-    assert SiteInsightsExporter._normalize_device_mac_or_none("aa-bb") == "aa:bb:cc:dd:ee:ff"
+    exporter_valid = _build_exporter(validator_return=True)
+    assert exporter_valid._normalize_device_mac_or_none("aa-bb") == "aa:bb:cc:dd:ee:ff"

--- a/tests/unit/test_exports.py
+++ b/tests/unit/test_exports.py
@@ -9,6 +9,7 @@ import sqlite3
 from unittest.mock import MagicMock
 
 import MistHelper
+from src.export.site_insights_exporter import SiteInsightsExporter
 
 
 def test_device_events_52w_streams_and_writes_csv(monkeypatch, tmp_path):
@@ -106,17 +107,19 @@ def test_classify_device_platform_by_model_prefix():
 
 
 def test_metric_compatibility_filters_switch_metrics_for_ap():
-    assert MistHelper.SiteExportUtils._metric_supported_on_platform("switch-metrics", "ap") is False
-    assert MistHelper.SiteExportUtils._metric_supported_on_platform("switch-metrics", "switch") is True
-    assert MistHelper.SiteExportUtils._metric_supported_on_platform("switch-metrics", "unknown") is True
+    assert MistHelper.SiteExportUtils._metric_compatible_with_platform("switch-metrics", "ap") is False
+    assert MistHelper.SiteExportUtils._metric_compatible_with_platform("switch-metrics", "switch") is True
+    assert MistHelper.SiteExportUtils._metric_compatible_with_platform("switch-metrics", "unknown") is True
 
 
 def test_normalize_device_mac_or_none_accepts_and_normalizes():
-    assert MistHelper.SiteExportUtils._normalize_device_mac_or_none("209339051780") == "20:93:39:05:17:80"
+    exporter = SiteInsightsExporter(PacketCaptureManager=MistHelper.PacketCaptureManager)
+    assert exporter._normalize_device_mac_or_none("209339051780") == "20:93:39:05:17:80"
 
 
 def test_normalize_device_mac_or_none_rejects_invalid():
-    assert MistHelper.SiteExportUtils._normalize_device_mac_or_none("not-a-mac") is None
+    exporter = SiteInsightsExporter(PacketCaptureManager=MistHelper.PacketCaptureManager)
+    assert exporter._normalize_device_mac_or_none("not-a-mac") is None
 
 
 def test_normalize_client_mac_or_none_accepts_and_normalizes():


### PR DESCRIPTION
## Summary
- Remove the `SiteExportUtils` facade class from `MistHelper.py` (Cat A facade removal, P16).
- Convert `SiteExportUtils` and `SiteInsightsExporter` to constructor-injection (Pattern 1): callers instantiate inline with all 14 dependencies spelled out.
- Rewire 16 menu-registry callsites and 4 sibling exporters (beacons, maps, zones, port_stats) to the inline Pattern 1 construction.
- Preserve pure helpers (`_classify_device_platform`, `_metric_compatible_with_platform`, `_annotate_row`) as `@staticmethod`; convert dep-consuming helpers to instance methods.
- Rename `_metric_supported_on_platform` → `_metric_compatible_with_platform` for accuracy.
- Rewrite `tests/unit/export/test_site_export_utils.py` and `tests/unit/export/test_site_insights_exporter.py` to the constructor-injection contract.

## Test plan
- [x] `pytest tests/unit/export/test_site_export_utils.py tests/unit/export/test_site_insights_exporter.py tests/unit/test_exports.py`
- [x] Full sweep: 4259 passed, 1 pre-existing failure (`test_menu_196_dispatches_to_async_claim_exporter`, unrelated stdin-capture flake in `LicenseExportUtils`)
- [x] `black --check` + `ruff check` clean on modified files