### PR TITLE
refactor(1015): extract DeviceFetchConfig to src/refactors/device_data_fetcher.py (T-01, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -45,7 +45,6 @@ import re  # Import re for regex pattern matching in data parsing (SSIDs, descri
 import subprocess  # nosec B404  # Import subprocess for executing external commands (SSH, JSON parsing) with security review
 import time  # Import time for rate limiting, delays, and performance monitoring
 import traceback  # Import traceback for detailed exception context in error logs
-from dataclasses import dataclass  # Import dataclass decorator for configuration objects and entity classes
 from datetime import datetime  # Import datetime for timestamping logs and events
 from typing import TYPE_CHECKING, Any, Literal  # Import type hints for static analysis without runtime overhead
 
@@ -489,16 +488,8 @@ if sys.version_info < MINIMUM_PYTHON_VERSION:  # Check if Python is below minimu
 # NOTE: MapViewerConfig removed (SC-002) - unused dataclass, MapsManager builds runtime state directly
 
 
-@dataclass
-class DeviceFetchConfig:
-    """Configuration for interactive device data fetching - groups fetch parameters."""
-
-    fetch_function: Any  # Callable that performs the actual API fetch for the chosen data
-    filename: str  # Output filename for the exported data
-    description: str  # Human-readable description shown to the user during the fetch
-    device_type: str = "all"  # Device type filter (all/ap/switch/gateway); 'all' avoids the AP-only API default
-    site_id: str | None = None  # Optional site scope; None means an org-wide fetch
-    device_id: str | None = None  # Optional single-device scope; None means all matching devices
+# NOTE: DeviceFetchConfig extracted to src/refactors/device_data_fetcher.py::DeviceFetchConfig.
+# See specs/1015-misthelper-refactor-final-15/spec.md.
 
 
 # ============================================================================

--- a/src/refactors/device_data_fetcher.py
+++ b/src/refactors/device_data_fetcher.py
@@ -15,10 +15,27 @@ from __future__ import annotations  # Enable postponed evaluation for forward-re
 
 import importlib  # Late-import MistHelper to avoid circular src<->MistHelper dependency
 import logging  # Structured action logging required by Constitution VII
-from typing import TYPE_CHECKING, Any  # Loose typing for late-bound MistHelper attributes
+from dataclasses import dataclass  # Underpins the DeviceFetchConfig configuration container
+from typing import Any  # Loose typing for late-bound MistHelper attributes and fetch callables
 
-if TYPE_CHECKING:  # Only import DeviceFetchConfig for static type analysis, never at runtime
-    from MistHelper import DeviceFetchConfig  # Configuration dataclass owned by MistHelper.py
+# ============================================================================
+# CONFIGURATION DATACLASS (5-Item Rule Compliance)
+# ============================================================================
+# DeviceFetchConfig groups the six parameters needed for an interactive fetch
+# so callers stay within the 5-parameter limit per function (Constitution).
+# Extracted from MistHelper.py per initiative 1015 (T-01, Cat E).
+
+
+@dataclass
+class DeviceFetchConfig:
+    """Configuration for interactive device data fetching - groups fetch parameters."""
+
+    fetch_function: Any  # Callable that performs the actual API fetch for the chosen data
+    filename: str  # Output filename for the exported data
+    description: str  # Human-readable description shown to the user during the fetch
+    device_type: str = "all"  # Device type filter (all/ap/switch/gateway); 'all' avoids the AP-only API default
+    site_id: str | None = None  # Optional site scope; None means an org-wide fetch
+    device_id: str | None = None  # Optional single-device scope; None means all matching devices
 
 
 class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes

--- a/src/ui/interactive_display_utils.py
+++ b/src/ui/interactive_display_utils.py
@@ -13,6 +13,10 @@ import logging  # WHY: emit structured trace for each menu entry.
 
 import mistapi  # WHY: dotted-path API resolution for device stats / test / config endpoints.
 
+from src.refactors.device_data_fetcher import (
+    DeviceFetchConfig,
+)  # T-01: DeviceFetchConfig now lives with DeviceDataFetcher.
+
 
 class InteractiveDisplayUtils:
     """Centralized interactive display utilities.
@@ -42,10 +46,12 @@ class InteractiveDisplayUtils:
             site_id: Optional site ID (prompts if not provided)
             device_id: Optional device ID (prompts if not provided)
         """
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DeviceDataFetcher + DeviceFetchConfig.
+        mh = importlib.import_module(
+            "MistHelper"
+        )  # WHY: lazy fetch of DeviceDataFetcher (still lives in MistHelper.py).
         logging.info("Prompting user to select a device for detailed statistics view...")  # Log the prompt.
         mh.DeviceDataFetcher(  # Fetch and display.
-            mh.DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+            DeviceFetchConfig(  # Issue #470: bundle fetch params (T-01: imported from src.refactors).
                 fetch_function=mistapi.api.v1.sites.stats.getSiteDeviceStats,
                 filename="DeviceStats.csv",
                 description="Fetching detailed stats",
@@ -58,10 +64,12 @@ class InteractiveDisplayUtils:
     @staticmethod
     def device_tests() -> None:
         """Prompt user to select a gateway device and display its synthetic test stats."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DeviceDataFetcher + DeviceFetchConfig.
+        mh = importlib.import_module(
+            "MistHelper"
+        )  # WHY: lazy fetch of DeviceDataFetcher (still lives in MistHelper.py).
         logging.info("Prompting user to select a gateway device for synthetic test stats view...")  # Log the prompt.
         mh.DeviceDataFetcher(  # Fetch and display.
-            mh.DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+            DeviceFetchConfig(  # Issue #470: bundle fetch params (T-01: imported from src.refactors).
                 fetch_function=mistapi.api.v1.sites.devices.getSiteDeviceSyntheticTest,
                 filename="DeviceTestResults.csv",
                 description="Fetching synthetic test stats",
@@ -73,10 +81,12 @@ class InteractiveDisplayUtils:
     @staticmethod
     def device_config() -> None:
         """Prompt user to select a device and display its configuration details."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DeviceDataFetcher + DeviceFetchConfig.
+        mh = importlib.import_module(
+            "MistHelper"
+        )  # WHY: lazy fetch of DeviceDataFetcher (still lives in MistHelper.py).
         logging.info("Prompting user to select a device for configuration details view...")  # Log the prompt.
         mh.DeviceDataFetcher(  # Fetch and display.
-            mh.DeviceFetchConfig(  # Issue #470: bundle fetch params into the config dataclass.
+            DeviceFetchConfig(  # Issue #470: bundle fetch params (T-01: imported from src.refactors).
                 fetch_function=mistapi.api.v1.sites.devices.getSiteDevice,
                 filename="DeviceConfig.csv",
                 description="Fetching device configuration",


### PR DESCRIPTION
## Summary

Initiative 1015, task **T-01** (Bucket A, position 1 of 15) — extract the 9-LOC `DeviceFetchConfig` dataclass from `MistHelper.py` to `src/refactors/device_data_fetcher.py`, co-locating it with its only consumer (`DeviceDataFetcher`).

Landing decision: **top-level `@dataclass`** at the top of `device_data_fetcher.py` (not nested inside a `DeviceDataFetcherManager`). Rationale: the dataclass is a pure parameter container with no manager wrapper on the destination module; nesting would not improve the public surface. Follows E-1 default per plan.md.

Reference: [`specs/1015-misthelper-refactor-final-15/spec.md#T-01`](../blob/main/specs/1015-misthelper-refactor-final-15/spec.md)

## Callsite table

**Before** (`grep -n "DeviceFetchConfig" MistHelper.py src/`):
| File | Line | Reference |
|------|------|-----------|
| `MistHelper.py` | 477 | `class DeviceFetchConfig:` (definition) |
| `src/refactors/device_data_fetcher.py` | 21 | `from MistHelper import DeviceFetchConfig` (TYPE_CHECKING) |
| `src/refactors/device_data_fetcher.py` | 49 | `def __init__(self, config: DeviceFetchConfig)` |
| `src/ui/interactive_display_utils.py` | 48 | `mh.DeviceFetchConfig(...)` (device_stats) |
| `src/ui/interactive_display_utils.py` | 64 | `mh.DeviceFetchConfig(...)` (device_tests) |
| `src/ui/interactive_display_utils.py` | 79 | `mh.DeviceFetchConfig(...)` (device_config) |

**After**:
| File | Line | Reference |
|------|------|-----------|
| `MistHelper.py` | 488 | `# NOTE: DeviceFetchConfig extracted to ...` (breadcrumb) |
| `src/refactors/device_data_fetcher.py` | 31 | `class DeviceFetchConfig:` (definition, top-level dataclass) |
| `src/refactors/device_data_fetcher.py` | 67 | `def __init__(self, config: DeviceFetchConfig)` (local ref) |
| `src/ui/interactive_display_utils.py` | 16-18 | `from src.refactors.device_data_fetcher import DeviceFetchConfig` |
| `src/ui/interactive_display_utils.py` | 54, 72, 89 | `DeviceFetchConfig(...)` (direct calls) |

**Callsite delta**: tasks.md listed 1 callsite; audit found 4 (1 in `device_data_fetcher.py:49`, 3 in `interactive_display_utils.py` via `mh.DeviceFetchConfig`). All 4 rewritten in this PR to reference the new home directly — no delegator, shim, or re-export left on `MistHelper.py` per hard constraint.

Removed now-unused `from dataclasses import dataclass` import from `MistHelper.py` (F401 would fire otherwise).

## Acceptance criteria

- [x] Sole primary callsite (`src/refactors/device_data_fetcher.py:49`) rewritten to reference the new dataclass locally.
- [x] All 3 secondary callsites in `src/ui/interactive_display_utils.py` rewritten to import from `src.refactors.device_data_fetcher`.
- [x] `missing_action_logging` guideline flag — n/a; consuming `__init__` is a pure field assignment (already covered by the existing `fetch()` logging).
- [x] NOTE breadcrumb left in `MistHelper.py` at prior definition site.
- [x] No delegator / shim / re-export in `MistHelper.py`.
- [x] `black --check` and `ruff check` clean on all 3 touched files.
- [x] `python MistHelper.py --test` — same known Option 33 flake as `main` HEAD (not introduced by T-01, verified via stash comparison).

## Test plan
- [ ] CI green on PR
- [ ] Manual: `python -c "from src.refactors.device_data_fetcher import DeviceFetchConfig; import MistHelper; assert not hasattr(MistHelper, 'DeviceFetchConfig')"` (already verified locally)
- [ ] Verify `mergeStateStatus: CLEAN` before any merge (no `--admin` bypass)