### PR TITLE
refactor(1015): extract FAST_MODE_MAX_CONCURRENT_CONNECTIONS to fast_mode_constants (T-02, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -2112,9 +2112,9 @@ org_id = None  # Active organization ID, populated after the user selects an org
 FAST_MODE_RETRY_THREADS = int(os.getenv("FAST_MODE_RETRY_THREADS", "4"))  # Thread count for the retry pass
 FAST_MODE_RETRY_MAX_RETRIES = int(os.getenv("FAST_MODE_RETRY_MAX_RETRIES", "2"))  # Retry ceiling within the retry pass
 FAST_MODE_FALLBACK_THREADS = int(os.getenv("FAST_MODE_FALLBACK_THREADS", "8"))  # Thread count for the fallback pass
-FAST_MODE_MAX_CONCURRENT_CONNECTIONS = int(
-    os.getenv("FAST_MODE_MAX_CONCURRENT_CONNECTIONS", "8")
-)  # Cap on simultaneous API connections
+# NOTE: FAST_MODE_MAX_CONCURRENT_CONNECTIONS extracted to
+# src/refactors/fast_mode_constants.py::FAST_MODE_MAX_CONCURRENT_CONNECTIONS.
+# See specs/1015-misthelper-refactor-final-15/spec.md.
 FAST_MODE_USE_CONNECTION_AWARE_THREADING = (  # Whether to size threads based on connection limits
     os.getenv("FAST_MODE_USE_CONNECTION_AWARE_THREADING", "true").lower() == "true"  # Parse the boolean env flag
 )

--- a/src/export/gateway_test_exporter.py
+++ b/src/export/gateway_test_exporter.py
@@ -198,13 +198,15 @@ class GatewayTestExporter:
         failed_devices: list[Any], connection_semaphore: Any
     ) -> tuple[list[Any], list[Any]]:
         """Retry failed devices through a small dedicated pool. Return (results, still_failed)."""
-        mh = importlib.import_module(
-            "MistHelper"
-        )  # WHY: lazy fetch of FAST_MODE_RETRY_THREADS + FAST_MODE_MAX_CONCURRENT_CONNECTIONS.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FAST_MODE_RETRY_THREADS.
+        from src.refactors.fast_mode_constants import (
+            FAST_MODE_MAX_CONCURRENT_CONNECTIONS,
+        )  # WHY: post-T-02 direct import from landing module (no more mh.SYMBOL bypass)
+
         retry_threads = min(  # Size the retry pool.
             mh.FAST_MODE_RETRY_THREADS,
             len(failed_devices),
-            max(1, mh.FAST_MODE_MAX_CONCURRENT_CONNECTIONS - 2),
+            max(1, FAST_MODE_MAX_CONCURRENT_CONNECTIONS - 2),
         )
         if retry_threads <= 0:  # No threads available.
             logging.warning(" FAST MODE: No available threads for retry; skipping retries")

--- a/src/export/org_device_stats_exporter.py
+++ b/src/export/org_device_stats_exporter.py
@@ -264,11 +264,15 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
     @staticmethod
     def _retry_failed_site_port_stats(failed_sites, connection_semaphore):  # Retry failed site port stats.
         """Retry previously failed site fetches using a smaller worker pool."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FAST_MODE_RETRY_THREADS/MAX_CONCURRENT.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FAST_MODE_RETRY_THREADS.
+        from src.refactors.fast_mode_constants import (
+            FAST_MODE_MAX_CONCURRENT_CONNECTIONS,
+        )  # WHY: post-T-02 direct import from landing module (no more mh.SYMBOL bypass)
+
         retry_results: list = []  # Successful retry rows
         still_failed: list = []  # Sites remaining failed after retries
         retry_threads = min(
-            mh.FAST_MODE_RETRY_THREADS, len(failed_sites), max(1, mh.FAST_MODE_MAX_CONCURRENT_CONNECTIONS - 2)
+            mh.FAST_MODE_RETRY_THREADS, len(failed_sites), max(1, FAST_MODE_MAX_CONCURRENT_CONNECTIONS - 2)
         )  # Smaller retry pool
         if retry_threads <= 0:  # Defensive guard
             logging.warning(" FAST MODE: No available threads for retry; skipping retries")  # Explain skip

--- a/src/refactors/connection_pool_executor.py
+++ b/src/refactors/connection_pool_executor.py
@@ -35,12 +35,20 @@ def _resolve_fast_mode_env() -> tuple[bool, int, int]:  # Late-bind MistHelper m
     load time (MistHelper.py imports ConnectionPoolExecutor and vice-versa
     would deadlock). By the time these executor methods are called at
     runtime, MistHelper is fully initialized and the constants are readable.
+
+    Note: FAST_MODE_MAX_CONCURRENT_CONNECTIONS is now imported directly from
+    src/refactors/fast_mode_constants.py per initiative 1015 T-02 (no more
+    ``MistHelper.FAST_MODE_MAX_CONCURRENT_CONNECTIONS`` module-attribute
+    bypass); the other two remain on MistHelper pending later extractions.
     """
     import MistHelper  # Late-binding import; MistHelper is fully loaded by the time methods run
+    from src.refactors.fast_mode_constants import (
+        FAST_MODE_MAX_CONCURRENT_CONNECTIONS,
+    )  # Direct import of the extracted concurrent-connection cap (post-T-02)
 
     return (  # Bundle the 3 fast-mode env-derived constants into a tuple
         MistHelper.FAST_MODE_USE_CONNECTION_AWARE_THREADING,  # Threading strategy toggle
-        MistHelper.FAST_MODE_MAX_CONCURRENT_CONNECTIONS,  # Cap on simultaneous API calls
+        FAST_MODE_MAX_CONCURRENT_CONNECTIONS,  # Cap on simultaneous API calls (from landing module)
         MistHelper.FAST_MODE_FALLBACK_THREADS,  # CPU-aware fallback thread count
     )
 

--- a/src/refactors/fast_mode_constants.py
+++ b/src/refactors/fast_mode_constants.py
@@ -1,0 +1,22 @@
+"""Fast-mode module-level constants extracted from MistHelper (initiative 1015, T-02).
+
+Home for bare module-level constants that tune the fast-mode concurrent-execution
+pipeline in MistHelper. Kept as plain module-level names (not class attributes) per
+the T-02 landing-target decision: single co-location file for the remaining
+fast-mode env-derived constants (T-02 + T-03 anticipated additions) to avoid
+per-constant module proliferation. No wrapper class, no facade, no shim -- all
+callers import the bare name directly from this module.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
+
+import os  # Read the environment override value at import time
+
+# WHAT: Ceiling on simultaneous outbound API connections used by fast-mode workflows.
+# WHY: fast-mode concurrent-connection cap -- bounds ThreadPoolExecutor sizing and
+#      the connection-aware semaphore so we do not exceed the Mist API rate limits
+#      or exhaust the local HTTP connection pool. Sourced from the
+#      FAST_MODE_MAX_CONCURRENT_CONNECTIONS env var (default 8) at import time.
+FAST_MODE_MAX_CONCURRENT_CONNECTIONS: int = int(  # Cap on simultaneous API connections in fast mode
+    os.getenv("FAST_MODE_MAX_CONCURRENT_CONNECTIONS", "8")  # Env override with 8 default
+)

--- a/src/refactors/serial_cc/switch_vc_stats.py
+++ b/src/refactors/serial_cc/switch_vc_stats.py
@@ -7,6 +7,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed  # Parallelize p
 from types import SimpleNamespace  # Bundle resolved runtime dependencies
 from typing import Any  # Runtime dependency surface is dynamic from MistHelper module
 
+from src.refactors.fast_mode_constants import (
+    FAST_MODE_MAX_CONCURRENT_CONNECTIONS,
+)  # Post-T-02 direct import of the fast-mode concurrent-connection cap
+
 _VC_PREVIEW_FIELDS = (  # Summary columns kept aligned with prior in-method PrettyTable preview
     "name",
     "mac",
@@ -34,11 +38,6 @@ def _resolve_runtime_dependencies() -> SimpleNamespace:
         apisession=misthelper_module.apisession,  # Active API session object
         tqdm=misthelper_module.tqdm,  # Existing progress-bar implementation used throughout MistHelper
         FAST_MODE_ENABLED=getattr(misthelper_module, "FAST_MODE_ENABLED", False),  # Fast-mode toggle flag
-        FAST_MODE_MAX_CONCURRENT_CONNECTIONS=getattr(
-            misthelper_module,
-            "FAST_MODE_MAX_CONCURRENT_CONNECTIONS",
-            8,
-        ),  # Fast-mode worker cap (defaults to 8)
     )
 
 
@@ -99,7 +98,7 @@ class SwitchVcStatsService:
     @classmethod
     def _collect_vc_stats_parallel(cls, deps: SimpleNamespace, switches: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Fetch VC stats concurrently with a bounded thread pool for fast mode."""
-        max_workers = deps.FAST_MODE_MAX_CONCURRENT_CONNECTIONS  # Respect configured worker cap
+        max_workers = FAST_MODE_MAX_CONCURRENT_CONNECTIONS  # Respect configured worker cap (post-T-02 module import)
         logging.info(
             "Fast mode: fetching VC stats for %d switches with %d concurrent workers", len(switches), max_workers
         )  # Log concurrency plan before pool starts

--- a/tests/unit/serial_cc/test_switch_vc_stats.py
+++ b/tests/unit/serial_cc/test_switch_vc_stats.py
@@ -20,7 +20,6 @@ class DummyDeps:
         self.apisession = MagicMock()  # Active API session
         self.tqdm = lambda items=None, **_kwargs: items if items is not None else _TqdmContext()  # Progress wrapper
         self.FAST_MODE_ENABLED = False  # Default to sequential path in tests
-        self.FAST_MODE_MAX_CONCURRENT_CONNECTIONS = 4  # Fast-mode worker cap used by parallel path
 
 
 class _TqdmContext:


### PR DESCRIPTION
## Summary

Initiative 1015, task T-02 -- extract the module-level constant `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` out of `MistHelper.py` into a new bare-module landing target (`src/refactors/fast_mode_constants.py`).

**Landing decision recorded**: NEW file `src/refactors/fast_mode_constants.py`, bare module-level constant (no wrapper class -- analyzer's `FastModeMaxConcurrentConnectionsManager` suggestion was a naming hint only). Single co-location file so T-03 can fold-in alongside without per-constant module proliferation. Prior fast-mode constants (`fast_mode_backoff_multiplier`, `fast_mode_devices_per_thread`, `fast_mode_sequential_max_retries`) intentionally left as separate class-attribute modules -- they were extracted under different guidance (initiative 1011 SC-030 series, `FR-005: const->classattr`).

## Callsite audit

Analyzer's `refactor_candidates.md` reported **1 ref**. Whole-repo grep found **4 non-definition Python references** -- once again confirming the `mh.SYMBOL` / `getattr(mh, "SYMBOL")` bypass distorts the analyzer's structural count.

| # | File | Before | After |
|---|------|--------|-------|
| 1 | `src/export/org_device_stats_exporter.py:271` | `mh.FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | `from src.refactors.fast_mode_constants import FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (function-local) |
| 2 | `src/export/gateway_test_exporter.py:207` | `mh.FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | function-local direct import |
| 3 | `src/refactors/connection_pool_executor.py:43` | `MistHelper.FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | function-local direct import |
| 4 | `src/refactors/serial_cc/switch_vc_stats.py:37-42, 102` | `getattr(mh, SYMBOL, 8)` then `deps.SYMBOL` | module-level direct import; entry removed from `_resolve_runtime_dependencies` deps bundle |

**Test knock-on**: `tests/unit/serial_cc/test_switch_vc_stats.py:23` (`DummyDeps.FAST_MODE_MAX_CONCURRENT_CONNECTIONS = 4`) was set on a mock deps bundle now that the deps entry no longer exists. Removed -- all 3 tests in the module still pass.

**Definition** (MistHelper.py:2115-2117) replaced with a 3-line NOTE breadcrumb pointing at the landing module.

## Guideline flags addressed

Analyzer flagged `missing_inline_comments,missing_action_logging`. New landing module carries a WHAT/WHY docstring block explaining the constant tunes the fast-mode concurrent-connection ceiling (bounds `ThreadPoolExecutor` sizing + the connection-aware semaphore), with an inline `# Cap on simultaneous API connections in fast mode` on the assignment expression. `action_logging` is n/a for a bare env-derived constant assigned at import time.

## Test plan

- [x] `black --check` clean on all touched files
- [x] `ruff check` clean on all touched files
- [x] `pytest tests/unit/serial_cc/test_switch_vc_stats.py` -- 3/3 pass
- [x] `python MistHelper.py --test` -- 65/66 (1 pre-existing Option 196 license-claim 404 API flake, matches main HEAD baseline; no new failures)
- [x] Grep confirms zero `mh.FAST_MODE_MAX_CONCURRENT_CONNECTIONS`, `MistHelper.FAST_MODE_MAX_CONCURRENT_CONNECTIONS`, or `deps.FAST_MODE_MAX_CONCURRENT_CONNECTIONS` remain in Python source