### PR TITLE
refactor(1015): extract FAST_MODE_USE_CONNECTION_AWARE_THREADING (T-03, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -2115,9 +2115,9 @@ FAST_MODE_FALLBACK_THREADS = int(os.getenv("FAST_MODE_FALLBACK_THREADS", "8"))  
 # NOTE: FAST_MODE_MAX_CONCURRENT_CONNECTIONS extracted to
 # src/refactors/fast_mode_constants.py::FAST_MODE_MAX_CONCURRENT_CONNECTIONS.
 # See specs/1015-misthelper-refactor-final-15/spec.md.
-FAST_MODE_USE_CONNECTION_AWARE_THREADING = (  # Whether to size threads based on connection limits
-    os.getenv("FAST_MODE_USE_CONNECTION_AWARE_THREADING", "true").lower() == "true"  # Parse the boolean env flag
-)
+# NOTE: FAST_MODE_USE_CONNECTION_AWARE_THREADING extracted to
+# src/refactors/fast_mode_constants.py::FAST_MODE_USE_CONNECTION_AWARE_THREADING (T-03).
+# See specs/1015-misthelper-refactor-final-15/spec.md.
 FAST_MODE_ENABLED: bool = False  # Set to True via --fast CLI flag at startup
 
 # NOTE: MIST_WAN_TARGET_PORTS extracted to src/refactors/mist_wan_target_ports.py

--- a/src/refactors/connection_pool_executor.py
+++ b/src/refactors/connection_pool_executor.py
@@ -36,18 +36,21 @@ def _resolve_fast_mode_env() -> tuple[bool, int, int]:  # Late-bind MistHelper m
     would deadlock). By the time these executor methods are called at
     runtime, MistHelper is fully initialized and the constants are readable.
 
-    Note: FAST_MODE_MAX_CONCURRENT_CONNECTIONS is now imported directly from
-    src/refactors/fast_mode_constants.py per initiative 1015 T-02 (no more
-    ``MistHelper.FAST_MODE_MAX_CONCURRENT_CONNECTIONS`` module-attribute
-    bypass); the other two remain on MistHelper pending later extractions.
+    Note: FAST_MODE_MAX_CONCURRENT_CONNECTIONS is imported directly from
+    src/refactors/fast_mode_constants.py per initiative 1015 T-02, and
+    FAST_MODE_USE_CONNECTION_AWARE_THREADING is imported from the same
+    module per T-03 (both bypass the ``MistHelper.SYMBOL`` module-attribute
+    hop); FAST_MODE_FALLBACK_THREADS remains on MistHelper pending later
+    extraction.
     """
     import MistHelper  # Late-binding import; MistHelper is fully loaded by the time methods run
     from src.refactors.fast_mode_constants import (
-        FAST_MODE_MAX_CONCURRENT_CONNECTIONS,
-    )  # Direct import of the extracted concurrent-connection cap (post-T-02)
+        FAST_MODE_MAX_CONCURRENT_CONNECTIONS,  # Direct import of the extracted concurrent-connection cap (post-T-02)
+        FAST_MODE_USE_CONNECTION_AWARE_THREADING,  # Direct import of the threading-strategy toggle (post-T-03)
+    )
 
     return (  # Bundle the 3 fast-mode env-derived constants into a tuple
-        MistHelper.FAST_MODE_USE_CONNECTION_AWARE_THREADING,  # Threading strategy toggle
+        FAST_MODE_USE_CONNECTION_AWARE_THREADING,  # Threading strategy toggle (from landing module)
         FAST_MODE_MAX_CONCURRENT_CONNECTIONS,  # Cap on simultaneous API calls (from landing module)
         MistHelper.FAST_MODE_FALLBACK_THREADS,  # CPU-aware fallback thread count
     )

--- a/src/refactors/fast_mode_constants.py
+++ b/src/refactors/fast_mode_constants.py
@@ -1,11 +1,12 @@
-"""Fast-mode module-level constants extracted from MistHelper (initiative 1015, T-02).
+"""Fast-mode module-level constants extracted from MistHelper (initiative 1015, T-02 + T-03).
 
 Home for bare module-level constants that tune the fast-mode concurrent-execution
 pipeline in MistHelper. Kept as plain module-level names (not class attributes) per
-the T-02 landing-target decision: single co-location file for the remaining
-fast-mode env-derived constants (T-02 + T-03 anticipated additions) to avoid
-per-constant module proliferation. No wrapper class, no facade, no shim -- all
-callers import the bare name directly from this module.
+the T-02 landing-target decision: single co-location file for the fast-mode
+env-derived constants (T-02 added the connection cap; T-03 folded in the
+connection-aware threading toggle) to avoid per-constant module proliferation. No
+wrapper class, no facade, no shim -- all callers import the bare name directly
+from this module.
 """
 
 from __future__ import annotations  # Enable postponed evaluation for forward-ref typing
@@ -19,4 +20,13 @@ import os  # Read the environment override value at import time
 #      FAST_MODE_MAX_CONCURRENT_CONNECTIONS env var (default 8) at import time.
 FAST_MODE_MAX_CONCURRENT_CONNECTIONS: int = int(  # Cap on simultaneous API connections in fast mode
     os.getenv("FAST_MODE_MAX_CONCURRENT_CONNECTIONS", "8")  # Env override with 8 default
+)
+
+# WHAT: Toggle selecting the threading strategy for fast-mode batch executors.
+# WHY: When True, ThreadPoolExecutor sizing tracks FAST_MODE_MAX_CONCURRENT_CONNECTIONS
+#      (connection-aware mode); when False, executors fall back to CPU-aware sizing
+#      (os.cpu_count() or FAST_MODE_FALLBACK_THREADS). Sourced from the
+#      FAST_MODE_USE_CONNECTION_AWARE_THREADING env var (default "true") at import time.
+FAST_MODE_USE_CONNECTION_AWARE_THREADING: bool = (  # Whether to size threads based on connection limits
+    os.getenv("FAST_MODE_USE_CONNECTION_AWARE_THREADING", "true").lower() == "true"  # Parse the boolean env flag
 )


### PR DESCRIPTION
## Summary

Extracts the module-level `FAST_MODE_USE_CONNECTION_AWARE_THREADING` boolean toggle from `MistHelper.py` into the existing `src/refactors/fast_mode_constants.py` landing module (created by T-02). Bare module-level constant -- no wrapper class, no facade, no shim. Fully removes the `MistHelper.FAST_MODE_USE_CONNECTION_AWARE_THREADING` module-attribute bypass at the single real callsite.

Initiative: [1015](specs/1015-misthelper-refactor-final-15) task T-03 (Cat E).

## Callsite Audit

| Location | Kind | Action |
|---|---|---|
| `MistHelper.py:2118` | definition | Deleted; NOTE breadcrumb left pointing at `src/refactors/fast_mode_constants.py` |
| `src/refactors/connection_pool_executor.py:50` (was `MistHelper.FAST_MODE_USE_CONNECTION_AWARE_THREADING`) | reference | Rewritten to import `FAST_MODE_USE_CONNECTION_AWARE_THREADING` directly from `src.refactors.fast_mode_constants` alongside the T-02 `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` import |
| `documentation/sample.env:100` | env-var docs | No code change needed (env var name unchanged) |

Total code callsites: **1** (matches refactor_candidates report; no hidden `mh.SYMBOL` / `getattr` bypasses found in `MistHelper.py`, `src/`, or `tests/`).

## Guideline Flags Resolved

- `missing_action_logging`: constant is a bare module-level `bool` read at import time -- no action to log. Resolved via a docstring on the module and an inline WHAT/WHY block above the assignment describing what the toggle controls (thread-sizing strategy: connection-aware vs CPU-aware fallback).

## Test Plan

- [x] `black --check` clean on touched files (`fast_mode_constants.py`, `connection_pool_executor.py`, `MistHelper.py`)
- [x] `ruff check` clean on touched files
- [x] `python MistHelper.py --test`: 65 successful, 1 known Option 196 flake (unrelated HTTP 404 on `/orgs/{id}/claim/status`), 0 new failures
- [ ] CI green