### PR TITLE
chore(1015): regenerate refactor_candidates.md after T-04 merge

### DIFF
--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,20 +1,23 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 251 first-party files
-- Definitions analyzed: 14
+- Module graph size: 252 first-party files
+- Definitions analyzed: 13
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=2, hot=11, skipped=1
+- Category counts: unused=0, single-use=0, low-use=1, hot=11, skipped=1
 
 ## How to read this report
 
 Work the report **top-down inside each category**, then move to the next category:
 
 1. **Unused** -- zero references. Delete outright; no move, no callsite rewrite. Highest ROI per PR.
-2. **Single-use** -- exactly one caller. Move alongside that caller (or into a new `/src` module when the entrypoint is the sole caller). One PR covers move + rewrite.
-3. **Low-use** -- 2-3 callers. Evaluate before moving: worth it only when all callers can be rewritten in one bounded PR cluster.
-4. **Hot** -- 4+ callers. Leave in place until dependencies decouple. Listed for completeness only.
-5. **Skipped** -- pinned by bootstrap/module-load ordering (e.g. `GlobalImportManager`). DO NOT extract; the tool cannot detect load-order dependencies, so these are curated by hand via the `--skip NAME` CLI flag.
+2. **Single-use** -- exactly one caller. Move alongside that caller (or into a new `/src` module when the Refactor report written to refactor_candidates.md
+Entrypoint: C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py
+Module graph: 252 first-party files
+Definitions analyzed: 13
+  unused=0  single-use=0  low-use=1  hot=11  skipped=1
+LOC saveable (unused + single-use): 0
+ -- pinned by bootstrap/module-load ordering (e.g. `GlobalImportManager`). DO NOT extract; the tool cannot detect load-order dependencies, so these are curated by hand via the `--skip NAME` CLI flag.
 
 Within each bucket, candidates are sorted by **line_count descending** so the biggest LOC wins surface first. The `LOC saveable` headline in the metadata block sums unused + single-use lines only -- that number is your extraction budget for this pass.
 
@@ -32,7 +35,6 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 | Name | Kind | Lines | Refs | Category | Suggested class | Flags |
 |---|---|---:|---:|---|---|---|
-| `ENDPOINT_PRIMARY_KEY_STRATEGIES` | assignment | 2327 | 2 | low-use | EndpointPrimaryKeyStrategiesManager | oversize_25_lines,missing_inline_comments,missing_action_logging,non_ascii_logs |
 | `GlobalImportManager` | class | 1003 | 1 | skipped |  | oversize_25_lines |
 | `menu_actions` | assignment | 887 | 17 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `OrgInventoryExporter` | class | 686 | 102 | hot |  | oversize_25_lines,missing_inline_comments |
@@ -47,26 +49,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `tqdm` | function | 3 | 51 | hot |  | missing_action_logging |
 | `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 11 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Low-Use (2)
-
-### `ENDPOINT_PRIMARY_KEY_STRATEGIES` (assignment, 2327 lines)
-
-- Def site: line 2965-5291
-- References: 2
-- Suggested class: `EndpointPrimaryKeyStrategiesManager`
-- Suggested module: `src/refactors/endpoint__primary__key__strategies.py`
-- Rationale: low-use: sole caller lives inside MistHelper.py from `_build_polyglot_router()`; extract `ENDPOINT_PRIMARY_KEY_STRATEGIES` OUT of the entrypoint into a new `src/refactors/endpoint__primary__key__strategies.py` module and rewrite the callsite(s) to import from there
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-  - [ ] missing_inline_comments
-  - [ ] missing_action_logging
-  - [ ] non_ascii_logs
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2965, 5678
+## Low-Use (1)
 
 ### `detect_msp_privileges` (function, 25 lines)
 
-- Def site: line 2227-2251
+- Def site: line 2232-2256
 - References: 2
 - Suggested class: `DetectMspPrivilegesManager`
 - Suggested module: `src/refactors/detect_msp_privileges.py`
@@ -74,13 +61,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2357, 9164
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2362, 6847
 
 ## Hot (11)
 
 ### `menu_actions` (assignment, 887 lines)
 
-- Def site: line 7687-8573
+- Def site: line 5370-6256
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -90,12 +77,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 7687, 8608, 8609, 8618, 8738, 8738, 8780, 8836, 8881, 9372, 9376, 9421, 9421, 9448, 9448, 9451
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5370, 6291, 6292, 6301, 6421, 6421, 6463, 6519, 6564, 7055, 7059, 7104, 7104, 7131, 7131, 7134
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 6470-7155
+- Def site: line 4153-4838
 - References: 102
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -104,12 +91,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6593, 6593, 6644, 6644, 6647, 6647, 6688, 6688, 6727, 6727, 6745, 6745, 6823, 6823, 6830, 6830, 6840, 6840, 6843, 6843, 6856, 6856, 6857, 6857, 6858, 6858, 6859, 6859, 6867, 6867, 6869, 6869, 6870, 6870, 6871, 6871, 6872, 6872, 6875, 6875, 6878, 6878, 6881, 6881, 6884, 6884, 6930, 6930, 6953, 6953, 6954, 6954, 6955, 6955, 6957, 6957, 6993, 6993, 7009, 7009, 7063, 7063, 7064, 7064, 7065, 7065, 7068, 7068, 7069, 7069, 7088, 7088, 7090, 7090, 7091, 7091, 7126, 7126, 7327, 7482, 7482, 7506, 7506, 7530, 7530, 7778, 7778, 7785, 7785, 7794, 7794, 7798, 7798, 7807, 7807
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 4276, 4276, 4327, 4327, 4330, 4330, 4371, 4371, 4410, 4410, 4428, 4428, 4506, 4506, 4513, 4513, 4523, 4523, 4526, 4526, 4539, 4539, 4540, 4540, 4541, 4541, 4542, 4542, 4550, 4550, 4552, 4552, 4553, 4553, 4554, 4554, 4555, 4555, 4558, 4558, 4561, 4561, 4564, 4564, 4567, 4567, 4613, 4613, 4636, 4636, 4637, 4637, 4638, 4638, 4640, 4640, 4676, 4676, 4692, 4692, 4746, 4746, 4747, 4747, 4748, 4748, 4751, 4751, 4752, 4752, 4771, 4771, 4773, 4773, 4774, 4774, 4809, 4809, 5010, 5165, 5165, 5189, 5189, 5213, 5213, 5461, 5461, 5468, 5468, 5477, 5477, 5481, 5481, 5490, 5490
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 295, 295, 343, 343, 499, 499
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 6008-6448
+- Def site: line 3691-4131
 - References: 96
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -117,12 +104,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 6023, 6023, 6026, 6026, 6034, 6034, 6052, 6052, 6102, 6102, 6110, 6110, 6115, 6115, 6161, 6161, 6172, 6172, 6197, 6197, 6216, 6216, 6217, 6217, 6220, 6220, 6221, 6221, 6311, 6311, 6313, 6313, 6317, 6317, 6345, 6345, 6346, 6346, 6347, 6347, 6348, 6348, 6349, 6349, 6358, 6358, 6402, 6402, 6426, 6426, 7258, 7258, 7259, 7259, 7489, 7489, 7583, 7583, 7672, 7672, 7673, 7673, 7722, 7722, 7723, 7723, 7737, 7737, 7738, 7738, 7752, 7752, 7753, 7753, 7861, 7967, 7967, 8038, 8051, 8196, 8347, 8366, 8385, 8422, 8441, 8460, 8479, 8498, 8517, 8536
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3706, 3706, 3709, 3709, 3717, 3717, 3735, 3735, 3785, 3785, 3793, 3793, 3798, 3798, 3844, 3844, 3855, 3855, 3880, 3880, 3899, 3899, 3900, 3900, 3903, 3903, 3904, 3904, 3994, 3994, 3996, 3996, 4000, 4000, 4028, 4028, 4029, 4029, 4030, 4030, 4031, 4031, 4032, 4032, 4041, 4041, 4085, 4085, 4109, 4109, 4941, 4941, 4942, 4942, 5172, 5172, 5266, 5266, 5355, 5355, 5356, 5356, 5405, 5405, 5406, 5406, 5420, 5420, 5421, 5421, 5435, 5435, 5436, 5436, 5544, 5650, 5650, 5721, 5734, 5879, 6030, 6049, 6068, 6105, 6124, 6143, 6162, 6181, 6200, 6219
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 65, 127, 127, 132, 132
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 5645-5989
+- Def site: line 3328-3672
 - References: 118
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -131,7 +118,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5691, 5691, 5707, 5707, 5708, 5708, 5731, 5731, 5733, 5733, 5736, 5736, 5750, 5750, 5752, 5752, 5761, 5761, 5763, 5763, 5764, 5764, 5770, 5770, 5771, 5771, 5771, 5788, 5788, 5792, 5792, 5834, 5834, 5865, 5865, 5868, 5868, 5870, 5870, 5916, 5916, 5926, 5926, 5959, 5959, 5964, 5964, 5971, 5971, 6065, 6065, 7024, 7024, 7099, 7099, 7261, 7261, 7323, 7536, 7536, 7556, 7644, 7644, 7864, 7894, 7894, 7907, 7907, 8040, 8053, 8144, 8144, 8199, 8224, 8224, 8240, 8240, 8350, 8369, 8388, 8425, 8444, 8463, 8482, 8501, 8520, 8539
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3374, 3374, 3390, 3390, 3391, 3391, 3414, 3414, 3416, 3416, 3419, 3419, 3433, 3433, 3435, 3435, 3444, 3444, 3446, 3446, 3447, 3447, 3453, 3453, 3454, 3454, 3454, 3471, 3471, 3475, 3475, 3517, 3517, 3548, 3548, 3551, 3551, 3553, 3553, 3599, 3599, 3609, 3609, 3642, 3642, 3647, 3647, 3654, 3654, 3748, 3748, 4707, 4707, 4782, 4782, 4944, 4944, 5006, 5219, 5219, 5239, 5327, 5327, 5547, 5577, 5577, 5590, 5590, 5723, 5736, 5827, 5827, 5882, 5907, 5907, 5923, 5923, 6033, 6052, 6071, 6108, 6127, 6146, 6165, 6184, 6203, 6222
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 380, 380, 440, 440, 457, 457, 476, 476, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 310, 310, 454, 454
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 21, 639, 639
@@ -140,7 +127,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 5474-5631
+- Def site: line 3157-3314
 - References: 69
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -150,13 +137,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5490, 5490, 5503, 5503, 5506, 5506, 5530, 5530, 5538, 5538, 5539, 5539, 5561, 5561, 5566, 5566, 5568, 5568, 5867, 5867, 5892, 5892, 5961, 5961, 5962, 5962, 6063, 6063, 6064, 6064, 7021, 7021, 7022, 7022, 7096, 7096, 7097, 7097, 7324, 7534, 7534, 7535, 7535, 7863, 8039, 8052, 8198, 8349, 8368, 8387, 8424, 8443, 8462, 8481, 8500, 8519, 8538
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3173, 3173, 3186, 3186, 3189, 3189, 3213, 3213, 3221, 3221, 3222, 3222, 3244, 3244, 3249, 3249, 3251, 3251, 3550, 3550, 3575, 3575, 3644, 3644, 3645, 3645, 3746, 3746, 3747, 3747, 4704, 4704, 4705, 4705, 4779, 4779, 4780, 4780, 5007, 5217, 5217, 5218, 5218, 5546, 5722, 5735, 5881, 6032, 6051, 6070, 6107, 6126, 6145, 6164, 6183, 6202, 6221
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 454, 454, 455, 455, 474, 474, 475, 475
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 29, 274, 274
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 7461-7538
+- Def site: line 5144-5221
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -166,12 +153,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 8002, 8002, 8006, 8006, 8010, 8010
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5685, 5685, 5689, 5689, 5693, 5693
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 2003-2076
+- Def site: line 2008-2081
 - References: 195
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -180,7 +167,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2016, 2016, 2048, 2048, 2393, 2393, 2420, 2420, 6029, 6029, 6106, 6106, 6189, 6189, 6419, 6419, 7260, 7260, 7329, 7429, 7488, 7488, 7513, 7513, 7555, 7582, 7582, 7640, 7640, 7676, 7676, 7726, 7726, 7741, 7741, 7756, 7756, 7892, 7892, 7905, 7905, 8142, 8142, 8180, 8180, 8222, 8222, 8322, 8322, 8327, 8327, 8333, 8333, 8406, 8406, 8412, 8412, 9457, 9457
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2021, 2021, 2053, 2053, 2398, 2398, 2425, 2425, 3712, 3712, 3789, 3789, 3872, 3872, 4102, 4102, 4943, 4943, 5012, 5112, 5171, 5171, 5196, 5196, 5238, 5265, 5265, 5323, 5323, 5359, 5359, 5409, 5409, 5424, 5424, 5439, 5439, 5575, 5575, 5588, 5588, 5825, 5825, 5863, 5863, 5905, 5905, 6005, 6005, 6010, 6010, 6016, 6016, 6089, 6089, 6095, 6095, 7140, 7140
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -201,7 +188,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `ConfigUtils` (class, 70 lines)
 
-- Def site: line 5384-5453
+- Def site: line 3067-3136
 - References: 102
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -209,7 +196,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5426, 5426, 5431, 5431, 6839, 6839, 7062, 7062, 7079, 7079, 7320, 7553, 7637, 7637, 7641, 7641, 7642, 7642, 7696, 7696, 7766, 7766, 7772, 7772, 7862, 7890, 7890, 7903, 7903, 7936, 7936, 7993, 7993, 8099, 8099, 8108, 8108, 8140, 8140, 8181, 8181, 8183, 8183, 8197, 8220, 8220, 8221, 8221, 8238, 8238, 8322, 8322, 8327, 8327, 8333, 8333, 8348, 8367, 8386, 8406, 8406, 8412, 8412, 8423, 8442, 8461, 8480, 8499, 8518, 8537, 8770, 8770, 8839, 9321, 9321, 9409, 9409
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3109, 3109, 3114, 3114, 4522, 4522, 4745, 4745, 4762, 4762, 5003, 5236, 5320, 5320, 5324, 5324, 5325, 5325, 5379, 5379, 5449, 5449, 5455, 5455, 5545, 5573, 5573, 5586, 5586, 5619, 5619, 5676, 5676, 5782, 5782, 5791, 5791, 5823, 5823, 5864, 5864, 5866, 5866, 5880, 5903, 5903, 5904, 5904, 5921, 5921, 6005, 6005, 6010, 6010, 6016, 6016, 6031, 6050, 6069, 6089, 6089, 6095, 6095, 6106, 6125, 6144, 6163, 6182, 6201, 6220, 6453, 6453, 6522, 7004, 7004, 7092, 7092
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 402, 402, 449, 449, 467, 467, 508, 508, 542, 542
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 27, 321, 321
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 15, 150, 150, 510, 510
@@ -218,7 +205,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `FilePathUtils` (class, 46 lines)
 
-- Def site: line 5318-5363
+- Def site: line 3001-3046
 - References: 50
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -227,14 +214,14 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5353, 5353, 6125, 6125, 6609, 6609, 6920, 6920, 6936, 6936, 7322, 7432, 7480, 7480, 7504, 7504, 7508, 7508, 7528, 7528, 7554, 7585, 7585, 7893, 7893, 7906, 7906, 8143, 8143
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3036, 3036, 3808, 3808, 4292, 4292, 4603, 4603, 4619, 4619, 5005, 5115, 5163, 5163, 5187, 5187, 5191, 5191, 5211, 5211, 5237, 5268, 5268, 5576, 5576, 5589, 5589, 5826, 5826
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 41, 149, 149, 227, 227, 235, 235, 243, 243, 548, 548
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 33, 360, 360
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 19, 198, 198, 341, 341, 347, 347
 
 ### `tqdm` (function, 3 lines)
 
-- Def site: line 763-765
+- Def site: line 768-770
 - References: 51
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -242,7 +229,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1373, 2013, 2013, 2013, 2025, 2031, 7008, 7119, 7338, 7872, 8207, 8225, 8358, 8377, 8396, 8433, 8452, 8471, 8490, 8509, 8528, 8547
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1378, 2018, 2018, 2018, 2030, 2036, 4691, 4802, 5021, 5555, 5890, 5908, 6041, 6060, 6079, 6116, 6135, 6154, 6173, 6192, 6211, 6230
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_data_fetcher.py`: lines 359
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_fetch_utils.py`: lines 104, 227
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\gateway_test_exporter.py`: lines 220, 270
@@ -260,7 +247,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
 
-- Def site: line 2129-2131
+- Def site: line 2134-2136
 - References: 11
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -269,7 +256,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2129, 7334
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2134, 5017
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 54, 544
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
 
@@ -277,7 +264,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `GlobalImportManager` (class, 1003 lines)
 
-- Def site: line 879-1881
+- Def site: line 884-1886
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -285,7 +272,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1926
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1931
 
 ## Limitations
 


### PR DESCRIPTION
Regenerates the refactor candidates report following T-04 (ENDPOINT_PRIMARY_KEY_STRATEGIES extraction, PR #921).

Part of initiative 1015.