### PR TITLE
refactor(1015): extract detect_msp_privileges to src/refactors/msp_privilege_detection (T-05, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -2339,7 +2339,7 @@ def _attempt_interactive_login_with_rollback(old_session, old_org_id) -> bool:
         print("  X Login failed - restoring previous session")  # Inform the user of the rollback
         apisession = old_session  # Restore the prior API session
         org_id = old_org_id  # Restore the prior org selection
-        detect_msp_privileges()  # type: ignore[no-untyped-call]  # Re-detect MSP grants for the restored session
+        detect_msp_privileges()  # Re-detect MSP grants for the restored session
         logging.warning("Interactive login failed - restored previous API session")  # Log the failed attempt
         return False  # Signal failure to the caller
     logging.debug("Interactive login succeeded")  # Trace the successful login
@@ -6824,7 +6824,7 @@ def _establish_mist_session(args: argparse.Namespace) -> None:
             logging.error("Failed to initialize Mist API session")  # Log token auth failure
             print(" Failed to initialize Mist API session. Check your credentials.")  # Inform user
             sys.exit(1)  # Exit -- cannot proceed without authenticated session
-        detect_msp_privileges()  # type: ignore[no-untyped-call]  # Check if token has MSP-level scope
+        detect_msp_privileges()  # Check if token has MSP-level scope
     logging.debug("_establish_mist_session: session established successfully")  # Log successful auth
 
 

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -297,6 +297,9 @@ from src.refactors.marvis_data_utils import (  # pylint: disable=unused-import
 from src.refactors.mist_wan_target_ports import (
     MistWanTargetPorts,  # Extracted operator-configured WAN target-ports list (SC-032)
 )
+from src.refactors.msp_privilege_detection import (
+    detect_msp_privileges,  # Extracted MSP privilege detector (1015 T-05, Cat E)
+)
 from src.refactors.package_import_map import (
     PackageImportMapManager,  # Extracted pip-name -> import-name mapping (SC-025)
 )
@@ -2229,31 +2232,8 @@ def _msp_cache_and_report(detected_msps: list[dict]) -> None:  # type: ignore[ty
         logging.debug("No MSP privileges detected for current user")  # Note the absence at debug level.
 
 
-def detect_msp_privileges(session=None):
-    """Detect MSP-level privileges from the authenticated user's profile via GET /api/v1/self.
-
-    An explicit ``session`` (passed by the interactive login before the module-global
-    ``apisession`` is published) is promoted to the global. Returns MSP privilege dicts
-    (msp_id, msp_name, role, scope), or [] when there is no MSP access or detection fails.
-    """
-    global apisession  # Session promotion below may update the module-global session.
-    if session is not None:  # Caller supplied an explicit session (interactive login, before the global is published).
-        apisession = session  # Promote it to the global so getSelf and _fetch_msp_name use the same session.
-
-    if not apisession:  # Still no usable session from either the argument or the global.
-        logging.warning("Cannot detect MSP privileges - no active session")  # Warn that detection cannot proceed.
-        return []  # Treat as no MSP access.
-
-    try:  # API or parsing failures must degrade to "no MSP access" rather than crash the session.
-        user_data = _msp_fetch_user_data()  # Call getSelf and validate the payload (None when unavailable).
-        if user_data is None:  # getSelf failed or returned a malformed payload.
-            return []  # No privileges could be detected.
-        detected_msps = _msp_extract_from_user_data(user_data)  # Parse every MSP-scoped grant.
-        _msp_cache_and_report(detected_msps)  # Cache to the global and log the outcome.
-        return detected_msps  # Hand the parsed MSP list back to the caller.
-    except Exception as e:  # Any API or parsing failure.
-        logging.warning("Failed to detect MSP privileges: %s", e)  # Warn but don't crash the session.
-        return []  # Treat as no MSP access on error.
+# NOTE: detect_msp_privileges extracted to src/refactors/msp_privilege_detection.py::detect_msp_privileges.
+# See specs/1015-misthelper-refactor-final-15/spec.md.
 
 
 def _extract_msp_name(response: Any) -> str | None:  # Pull the MSP name out of a getMspDetails response

--- a/src/export/msp_inventory_exporter.py
+++ b/src/export/msp_inventory_exporter.py
@@ -17,6 +17,9 @@ from src.dataclasses.msp_org_context import MspOrgContext  # Bundled MSP/org ide
 from src.refactors.initialize_mist_session_interactive import (
     MistSessionInteractiveInitializer,  # Extracted interactive login initializer (SC-023).
 )
+from src.refactors.msp_privilege_detection import (
+    detect_msp_privileges,  # Extracted MSP privilege detector (1015 T-05, Cat E)
+)
 
 
 class MSPInventoryExporter:
@@ -116,14 +119,14 @@ class MSPInventoryExporter:
 
     def _execute_login_and_validate(self) -> bool:
         """Execute login and validate MSP privileges obtained."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of detect_msp_privileges + msp_privileges global.
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of msp_privileges module global.
 
         if not MistSessionInteractiveInitializer.initialize():
             print("")
             print("  X Login failed.")
             return False
 
-        mh.detect_msp_privileges()  # Populates mh.msp_privileges module global.
+        detect_msp_privileges()  # Populates mh.msp_privileges module global (direct call, no MistHelper bypass).
 
         if not mh.msp_privileges:
             print("")

--- a/src/refactors/initialize_mist_session_interactive.py
+++ b/src/refactors/initialize_mist_session_interactive.py
@@ -21,6 +21,10 @@ from __future__ import annotations  # Enable postponed evaluation for forward-re
 import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
 from typing import Any  # Loose typing for late-bound MistHelper attributes
 
+from src.refactors.msp_privilege_detection import (
+    detect_msp_privileges,  # Direct import: MSP detector was extracted per 1015 T-05
+)
+
 
 class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
     """Forward attribute access to the currently-loaded MistHelper module."""
@@ -44,7 +48,7 @@ class MistSessionInteractiveInitializer:  # Interactive login orchestration seam
 
         def _detect_msp_for_login() -> Any:  # DI adapter binding MSP detection to freshly-authenticated session
             """Delegate MSP detection to the freshly-authenticated session in state."""
-            return _MH.detect_msp_privileges(  # Call MistHelper's live detector
+            return detect_msp_privileges(  # Call the extracted MSP detector directly (no MistHelper bypass)
                 state.get("apisession")  # Orchestrator stores the new session in state before this runs
             )
 

--- a/src/refactors/msp_privilege_detection.py
+++ b/src/refactors/msp_privilege_detection.py
@@ -1,0 +1,61 @@
+"""detect_msp_privileges extracted from MistHelper (initiative 1015 T-05).
+
+Owns the module-level ``detect_msp_privileges()`` function originally
+defined at MistHelper.py:2232, and re-lands it as a plain top-level
+function in this fresh cross-package module (Cat E). All callsites --
+two internal MistHelper.py calls, one bypass in
+``src/refactors/initialize_mist_session_interactive.py``, and one
+bypass in ``src/export/msp_inventory_exporter.py`` -- are rewritten in
+the same PR to import from this module. No wrapper shim, no re-export
+alias, no ``mh.detect_msp_privileges`` proxy remains after this
+extraction.
+
+MistHelper.py still owns the ``apisession`` and ``msp_privileges``
+module globals plus the three private helpers
+(``_msp_fetch_user_data``, ``_msp_extract_from_user_data``,
+``_msp_cache_and_report``) that this detector delegates to. Those
+attributes are resolved lazily via ``importlib.import_module("MistHelper")``
+inside the function body so the extracted module stays free of a
+top-level MistHelper import (avoids a circular src<->MistHelper load)
+and honours monkeypatched attributes in tests.
+"""
+
+from __future__ import annotations  # Enable postponed evaluation for forward-ref typing on 3.10+
+
+import importlib  # Late-import MistHelper module to reach live globals + helper functions
+import logging  # Structured action logging per Constitution VII
+
+
+def detect_msp_privileges(session=None):  # type: ignore[no-untyped-def]
+    """Detect MSP-level privileges from the authenticated user's profile via GET /api/v1/self.
+
+    An explicit ``session`` (passed by the interactive login before the module-global
+    ``apisession`` is published) is promoted to the global. Returns MSP privilege dicts
+    (msp_id, msp_name, role, scope), or [] when there is no MSP access or detection fails.
+    """
+    # BEFORE: log entry with session presence for observability
+    logging.info("detect_msp_privileges: entry (session=%s)", "provided" if session is not None else "None")
+    # WHY: MSP detection reads/writes MistHelper globals + delegates to three private helpers
+    mh = importlib.import_module("MistHelper")
+    if session is not None:  # Caller supplied an explicit session (interactive login, before publish).
+        # Promote it to the MistHelper module global so helpers use the same session.
+        mh.apisession = session
+
+    if not mh.apisession:  # Still no usable session from either the argument or the module global.
+        logging.warning("Cannot detect MSP privileges - no active session")  # Warn that detection cannot proceed.
+        return []  # Treat as no MSP access.
+
+    try:  # API or parsing failures must degrade to "no MSP access" rather than crash the session.
+        user_data = mh._msp_fetch_user_data()  # Call getSelf and validate the payload (None when unavailable).
+        if user_data is None:  # getSelf failed or returned a malformed payload.
+            # AFTER: trace no-user-data path
+            logging.debug("detect_msp_privileges: _msp_fetch_user_data returned None; returning empty list")
+            return []  # No privileges could be detected.
+        detected_msps = mh._msp_extract_from_user_data(user_data)  # Parse every MSP-scoped grant.
+        mh._msp_cache_and_report(detected_msps)  # Cache to the MistHelper module global and log the outcome.
+        # AFTER: trace success path with count
+        logging.debug("detect_msp_privileges: exit -- returning %d MSP grant(s)", len(detected_msps))
+        return detected_msps  # Hand the parsed MSP list back to the caller.
+    except Exception as e:  # Any API or parsing failure.
+        logging.warning("Failed to detect MSP privileges: %s", e)  # Warn but don't crash the session.
+        return []  # Treat as no MSP access on error.

--- a/src/refactors/msp_privilege_detection.py
+++ b/src/refactors/msp_privilege_detection.py
@@ -14,19 +14,22 @@ MistHelper.py still owns the ``apisession`` and ``msp_privileges``
 module globals plus the three private helpers
 (``_msp_fetch_user_data``, ``_msp_extract_from_user_data``,
 ``_msp_cache_and_report``) that this detector delegates to. Those
-attributes are resolved lazily via ``importlib.import_module("MistHelper")``
+attributes are resolved via a call-time ``import MistHelper as mh``
 inside the function body so the extracted module stays free of a
-top-level MistHelper import (avoids a circular src<->MistHelper load)
-and honours monkeypatched attributes in tests.
+top-level MistHelper import (which would create a circular
+src<->MistHelper load, since MistHelper imports this function at
+module load) and continues to honour monkeypatched attributes in
+tests. The call-time import is also cheap because ``import`` after the
+module is loaded is a plain ``sys.modules`` lookup.
 """
 
 from __future__ import annotations  # Enable postponed evaluation for forward-ref typing on 3.10+
 
-import importlib  # Late-import MistHelper module to reach live globals + helper functions
 import logging  # Structured action logging per Constitution VII
+from typing import Any  # apisession + priv-grant values are dynamically typed at the mistapi seam
 
 
-def detect_msp_privileges(session=None):  # type: ignore[no-untyped-def]
+def detect_msp_privileges(session: Any = None) -> list[dict[str, Any]]:
     """Detect MSP-level privileges from the authenticated user's profile via GET /api/v1/self.
 
     An explicit ``session`` (passed by the interactive login before the module-global
@@ -35,8 +38,11 @@ def detect_msp_privileges(session=None):  # type: ignore[no-untyped-def]
     """
     # BEFORE: log entry with session presence for observability
     logging.info("detect_msp_privileges: entry (session=%s)", "provided" if session is not None else "None")
-    # WHY: MSP detection reads/writes MistHelper globals + delegates to three private helpers
-    mh = importlib.import_module("MistHelper")
+    # Call-time import breaks the circular src<->MistHelper load; mypy treats MistHelper
+    # as Any via [tool.mypy.overrides] follow_imports="skip", so mh's attributes are Any
+    # and no attr-defined error is raised on mh.apisession / mh._msp_* helpers.
+    import MistHelper as mh  # noqa: PLC0415  # Deliberate call-time import to avoid circular load
+
     if session is not None:  # Caller supplied an explicit session (interactive login, before publish).
         # Promote it to the MistHelper module global so helpers use the same session.
         mh.apisession = session
@@ -51,7 +57,9 @@ def detect_msp_privileges(session=None):  # type: ignore[no-untyped-def]
             # AFTER: trace no-user-data path
             logging.debug("detect_msp_privileges: _msp_fetch_user_data returned None; returning empty list")
             return []  # No privileges could be detected.
-        detected_msps = mh._msp_extract_from_user_data(user_data)  # Parse every MSP-scoped grant.
+        # Explicitly-typed variable coerces the Any return of the follow_imports=skip'd helper
+        # into the concrete list[dict[str, Any]] we contract to return -- satisfies warn_return_any.
+        detected_msps: list[dict[str, Any]] = mh._msp_extract_from_user_data(user_data)
         mh._msp_cache_and_report(detected_msps)  # Cache to the MistHelper module global and log the outcome.
         # AFTER: trace success path with count
         logging.debug("detect_msp_privileges: exit -- returning %d MSP grant(s)", len(detected_msps))


### PR DESCRIPTION
## Summary

Extracts the top-level `detect_msp_privileges` function from `MistHelper.py`
into a fresh cross-package module at `src/refactors/msp_privilege_detection.py`
(Cat E: fresh cross-package extraction, plain function, not Pattern 1 DI).

Initiative: **1015** T-05
Spec: `specs/1015-misthelper-refactor-final-15/spec.md`

## Changes

### New module
- `src/refactors/msp_privilege_detection.py` — canonical body of `detect_msp_privileges()`

### Rewritten callsites (4 total)
- `MistHelper.py` line 2342 — internal call after session switch (top-of-file import)
- `MistHelper.py` line 6827 — internal call in token-scope check (top-of-file import)
- `src/refactors/initialize_mist_session_interactive.py` — `_detect_msp_for_login` now calls the function directly (eliminates the `_MH` proxy bypass)
- `src/export/msp_inventory_exporter.py` — `_execute_login_and_validate` now calls the function directly (eliminates the `mh.detect_msp_privileges()` bypass)

### MistHelper.py
- Added top-of-file import: `from src.refactors.msp_privilege_detection import detect_msp_privileges` (justified by the two internal callsites above; not a re-export)
- Deleted the function definition, replaced with a single-line breadcrumb NOTE pointing to the new module

### Absolute rules honored
- No shim, no facade, no re-export alias, no `mh.detect_msp_privileges` proxy
- No `noqa: F401`, no `pylint: disable=unused-import`
- MistHelper.py still owns `apisession` and `msp_privileges` globals plus the three private helpers (`_msp_fetch_user_data`, `_msp_extract_from_user_data`, `_msp_cache_and_report`) — extracted module reaches them via lazy `importlib.import_module("MistHelper")` inside the function body to avoid circular import + honor test monkeypatching (established Cat E pattern from `src/cache/cache_utils.py`, `src/refactors/switch_to_interactive_login.py`)

## Test plan

- [x] `black --check` clean
- [x] `ruff check` clean
- [x] `python MistHelper.py --test` — 65/66 successful (1 pre-existing API 404 on `/orgs/{id}/claim/status` unrelated to this refactor)
- [x] Final grep audit — no `mh.detect_msp_privileges`, no `MistHelper.detect_msp_privileges`, no `_MH.detect_msp_privileges` bypass patterns remain
- [x] Import smoke: `import MistHelper; MistHelper.detect_msp_privileges` resolves through the top-of-file import