### PR TITLE
refactor(1015): extract FilePathUtils to src/utils/file_path_utils (T-13, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -375,6 +375,9 @@ from src.ui.interactive_display_utils import (  # pylint: disable=unused-import
 from src.utils.environment_utils import (  # pylint: disable=unused-import
     EnvironmentUtils,  # noqa: F401  # Cat B (1013 SC-001 position 33) -- re-export for MistHelper.EnvironmentUtils callers
 )
+from src.utils.file_path_utils import (  # pylint: disable=unused-import
+    FilePathUtils,  # noqa: F401  # Cat E canonical (1015 T-13) -- re-export for MistHelper.FilePathUtils callers
+)
 from src.utils.filter_operator_engine import (  # pylint: disable=unused-import
     FilterOperatorEngine,  # noqa: F401  # Cat B (1013 SC-001 position 40) -- re-export for MistHelper.FilterOperatorEngine callers
 )
@@ -2883,52 +2886,9 @@ def _configure_session_timeout(session_obj: Any) -> None:
 # (1013 SC-001 position 27)
 
 
-class FilePathUtils:
-    """
-    Centralized file path utilities for consistent data directory handling.
-    Ensures all CSV and data files are placed in the correct data directory.
-    All methods are static to avoid unnecessary object instantiation.
-    """
-
-    @staticmethod
-    def get_csv_path(filename: str) -> str:  # Resolve a CSV name to a path under data/.
-        """
-        Helper function to ensure consistent CSV file paths in the data directory.
-
-        Args:
-            filename (str): The CSV filename (with or without path)
-
-        Returns:
-            str: Full path to the CSV file in the data directory
-        """
-        # Ensure data directory exists
-        data_dir = "data"  # All exports are confined to the data/ directory.
-        os.makedirs(data_dir, exist_ok=True)  # Create data/ on first use; no error if it exists.
-
-        # If filename already includes a path, use it as-is
-        if os.path.dirname(filename):  # Caller supplied an explicit directory.
-            return filename  # Respect caller-provided paths verbatim.
-
-        # Otherwise, place it in the data directory
-        return os.path.join(data_dir, filename)  # Join bare names under data/ portably.
-
-    @staticmethod
-    def create_csv_template(
-        filename: str, headers: list[str] | None = None, sample_data: list[list[str]] | None = None
-    ) -> str:  # Create an empty CSV placeholder with optional headers.
-        """Create an empty CSV under data/ with optional header row; sample_data is intentionally ignored."""
-        del sample_data  # Kept in signature for API compatibility; explicitly discard so linters do not flag it.
-        file_path = FilePathUtils.get_csv_path(filename)  # Normalize the destination under data/.
-        try:
-            with open(file_path, "w", newline="", encoding="utf-8") as f:  # Truncate/create the file.
-                if headers:  # Only write a header row when headers were provided.
-                    writer = csv.writer(f)  # Wrap the handle in a CSV writer.
-                    writer.writerow(headers)  # Emit the single header row.
-            logging.info("Created template file: %s", file_path)  # Record the created placeholder.
-            return file_path  # Hand the path back to the caller.
-        except Exception as error:  # Never leave a partial file without surfacing the cause.
-            logging.error("Failed to create template file %s: %s", filename, error)  # Log the failure cause.
-            raise  # Re-raise so callers can handle the failure.
+# FilePathUtils moved to src/utils/file_path_utils.py (initiative 1015 T-13).
+# The top-level from src.utils.file_path_utils import FilePathUtils re-export
+# alias keeps historical MistHelper.FilePathUtils callers working unchanged.
 
 
 # ============================================================================

--- a/src/utils/file_path_utils.py
+++ b/src/utils/file_path_utils.py
@@ -20,16 +20,15 @@ import os  # Filesystem primitives for data/ directory management.
 
 
 class FilePathUtils:
-    """
-    Centralized file path utilities for consistent data directory handling.
+    """Centralized file path utilities for consistent data directory handling.
+
     Ensures all CSV and data files are placed in the correct data directory.
     All methods are static to avoid unnecessary object instantiation.
     """
 
     @staticmethod
     def get_csv_path(filename: str) -> str:  # Resolve a CSV name to a path under data/.
-        """
-        Helper function to ensure consistent CSV file paths in the data directory.
+        """Ensure consistent CSV file paths in the data directory.
 
         Args:
             filename (str): The CSV filename (with or without path)

--- a/src/utils/file_path_utils.py
+++ b/src/utils/file_path_utils.py
@@ -1,0 +1,67 @@
+"""FilePathUtils extracted from MistHelper (initiative 1015 T-13).
+
+Owns the ``FilePathUtils`` class originally defined at MistHelper.py:2886.
+This module is fully self-contained: no ``import MistHelper``, no ``mh.*``
+reach-back, no dependency on any MistHelper module-global. The class is
+a pure static utility that resolves filenames under the ``data/`` output
+directory and can render empty CSV placeholders.
+
+MistHelper.py re-exports ``FilePathUtils`` at the top of the file so
+historical ``MistHelper.FilePathUtils`` / ``mh.FilePathUtils`` callers
+keep working transparently -- the re-exported symbol is the same class
+object, not a delegator.
+"""
+
+from __future__ import annotations  # Enable PEP 604 unions in annotations on 3.10+.
+
+import csv  # CSV writer for optional header row in create_csv_template.
+import logging  # Structured action logging per Constitution VII.
+import os  # Filesystem primitives for data/ directory management.
+
+
+class FilePathUtils:
+    """
+    Centralized file path utilities for consistent data directory handling.
+    Ensures all CSV and data files are placed in the correct data directory.
+    All methods are static to avoid unnecessary object instantiation.
+    """
+
+    @staticmethod
+    def get_csv_path(filename: str) -> str:  # Resolve a CSV name to a path under data/.
+        """
+        Helper function to ensure consistent CSV file paths in the data directory.
+
+        Args:
+            filename (str): The CSV filename (with or without path)
+
+        Returns:
+            str: Full path to the CSV file in the data directory
+        """
+        # Ensure data directory exists
+        data_dir = "data"  # All exports are confined to the data/ directory.
+        os.makedirs(data_dir, exist_ok=True)  # Create data/ on first use; no error if it exists.
+
+        # If filename already includes a path, use it as-is
+        if os.path.dirname(filename):  # Caller supplied an explicit directory.
+            return filename  # Respect caller-provided paths verbatim.
+
+        # Otherwise, place it in the data directory
+        return os.path.join(data_dir, filename)  # Join bare names under data/ portably.
+
+    @staticmethod
+    def create_csv_template(
+        filename: str, headers: list[str] | None = None, sample_data: list[list[str]] | None = None
+    ) -> str:  # Create an empty CSV placeholder with optional headers.
+        """Create an empty CSV under data/ with optional header row; sample_data is intentionally ignored."""
+        del sample_data  # Kept in signature for API compatibility; explicitly discard so linters do not flag it.
+        file_path = FilePathUtils.get_csv_path(filename)  # Normalize the destination under data/.
+        try:
+            with open(file_path, "w", newline="", encoding="utf-8") as f:  # Truncate/create the file.
+                if headers:  # Only write a header row when headers were provided.
+                    writer = csv.writer(f)  # Wrap the handle in a CSV writer.
+                    writer.writerow(headers)  # Emit the single header row.
+            logging.info("Created template file: %s", file_path)  # Record the created placeholder.
+            return file_path  # Hand the path back to the caller.
+        except Exception as error:  # Never leave a partial file without surfacing the cause.
+            logging.error("Failed to create template file %s: %s", filename, error)  # Log the failure cause.
+            raise  # Re-raise so callers can handle the failure.

--- a/tests/unit/test_file_path_utils.py
+++ b/tests/unit/test_file_path_utils.py
@@ -1,0 +1,106 @@
+"""Unit tests for src.utils.file_path_utils.FilePathUtils.
+
+Covers both @staticmethod entry points end-to-end using tmp_path:
+- get_csv_path: bare name normalization, explicit-directory passthrough, data/ auto-create.
+- create_csv_template: header-row write, missing-headers no-write, sample_data discard,
+  IO failure re-raise.
+"""
+
+from __future__ import annotations  # PEP 604 unions in type hints.
+
+import csv  # Read back the header row for round-trip assertions.
+import os  # cwd manipulation + path assertions.
+from unittest.mock import patch  # Force open() to raise for the failure-path test.
+
+import pytest  # Fixtures + expected-exception assertions.
+
+from src.utils.file_path_utils import FilePathUtils  # System under test.
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path, monkeypatch):
+    """Redirect the module's data/ scratch dir to a tmp path per-test."""
+    monkeypatch.chdir(tmp_path)  # Any relative 'data/' becomes tmp_path/data/.
+    yield tmp_path  # Hand the sandbox to the test body.
+
+
+# ---------------------------------------------------------------------------
+# get_csv_path
+# ---------------------------------------------------------------------------
+
+
+def test_get_csv_path_bare_name_joins_under_data():
+    """Bare filenames should be joined under the data/ directory."""
+    result = FilePathUtils.get_csv_path("SiteList.csv")  # Bare name; no directory component.
+    assert result == os.path.join("data", "SiteList.csv")  # Portable join under data/.
+
+
+def test_get_csv_path_creates_data_dir(_isolate_cwd):
+    """Calling get_csv_path must create data/ on first use."""
+    FilePathUtils.get_csv_path("anything.csv")  # Trigger data/ auto-create.
+    assert (_isolate_cwd / "data").is_dir()  # data/ now exists under tmp cwd.
+
+
+def test_get_csv_path_idempotent_on_existing_dir(_isolate_cwd):
+    """Repeated calls must not raise even when data/ already exists."""
+    (_isolate_cwd / "data").mkdir()  # Pre-create data/ to prove idempotence.
+    result = FilePathUtils.get_csv_path("again.csv")  # Should not raise on existing dir.
+    assert result == os.path.join("data", "again.csv")  # Path still normalizes.
+
+
+def test_get_csv_path_explicit_dir_returns_verbatim():
+    """When the caller passes a path with a directory, respect it verbatim."""
+    explicit = os.path.join("elsewhere", "custom.csv")  # Contains a directory component.
+    assert FilePathUtils.get_csv_path(explicit) == explicit  # No re-anchoring under data/.
+
+
+def test_get_csv_path_nested_explicit_dir_returns_verbatim(_isolate_cwd):
+    """Deep explicit paths should also pass through untouched."""
+    explicit = str(_isolate_cwd / "sub" / "dir" / "file.csv")  # Absolute nested path.
+    assert FilePathUtils.get_csv_path(explicit) == explicit  # Preserved as-is.
+
+
+# ---------------------------------------------------------------------------
+# create_csv_template
+# ---------------------------------------------------------------------------
+
+
+def test_create_csv_template_writes_header_row(_isolate_cwd):
+    """Providing headers must emit a single header row to the file."""
+    headers = ["col_a", "col_b", "col_c"]  # Header row to persist.
+    path = FilePathUtils.create_csv_template("template.csv", headers=headers)  # Write template.
+    assert path == os.path.join("data", "template.csv")  # Returned path is data/-anchored.
+    with open(path, encoding="utf-8", newline="") as f:  # Read the written file back.
+        rows = list(csv.reader(f))  # Parse the CSV rows.
+    assert rows == [headers]  # Only the header row was written.
+
+
+def test_create_csv_template_no_headers_writes_empty_file(_isolate_cwd):
+    """Omitting headers must produce an empty (zero-byte) CSV placeholder."""
+    path = FilePathUtils.create_csv_template("empty.csv")  # No header list supplied.
+    assert os.path.getsize(path) == 0  # File exists but has no content.
+
+
+def test_create_csv_template_sample_data_ignored(_isolate_cwd):
+    """The sample_data parameter must be discarded even when passed."""
+    path = FilePathUtils.create_csv_template(
+        "ignored.csv",
+        headers=["only", "the", "headers"],
+        sample_data=[["should", "be", "dropped"]],  # Intentionally provided but must not be written.
+    )
+    with open(path, encoding="utf-8", newline="") as f:  # Read written file.
+        rows = list(csv.reader(f))  # Parse.
+    assert rows == [["only", "the", "headers"]]  # Sample data was discarded.
+
+
+def test_create_csv_template_reraises_on_io_error(_isolate_cwd):
+    """When the underlying open() fails, the error must be re-raised."""
+    with patch("src.utils.file_path_utils.open", side_effect=PermissionError("nope")):  # Force IO failure.
+        with pytest.raises(PermissionError):  # Caller must observe the exception.
+            FilePathUtils.create_csv_template("boom.csv", headers=["x"])  # Trigger the failure path.
+
+
+def test_create_csv_template_places_bare_name_under_data(_isolate_cwd):
+    """Bare filenames must still land under data/ when the template is written."""
+    path = FilePathUtils.create_csv_template("bare.csv", headers=["only"])  # Bare name write.
+    assert os.path.commonpath([path, "data"]) == "data"  # File resides under data/.


### PR DESCRIPTION
## Summary
- Extract `FilePathUtils` (previously at `MistHelper.py:2886`, 46 LOC, 50 call-site refs) to `src/utils/file_path_utils.py` as part of initiative 1015 hot-class refactor.
- The new module is **fully self-contained**: no `import MistHelper`, no `mh.*` reach-back, no MistHelper globals. Pure static utility.
- `MistHelper.py` re-exports `FilePathUtils` at the top (`from src.utils.file_path_utils import FilePathUtils`) so all historical `MistHelper.FilePathUtils` / `mh.FilePathUtils` callers keep working. Same class object, not a delegator.
- Former class body replaced with a breadcrumb comment matching the established `SFPTransceiverDataProcessor moved to...` convention.
- Smallest leaf in the remaining 15 tasks — unblocks **T-06** (OrgInventoryExporter) which depends on FilePathUtils.

## Test plan
- [x] `pytest tests/unit/test_file_path_utils.py -v` → 10/10 passed
- [x] `pytest --cov=src.utils.file_path_utils` → 100% coverage on new module
- [x] `pytest tests/unit -q` → 3904 passed
- [x] `black --check src/utils/file_path_utils.py tests/unit/test_file_path_utils.py MistHelper.py` → clean
- [x] `ruff check src/utils/file_path_utils.py tests/unit/test_file_path_utils.py MistHelper.py` → clean
- [x] Smoke test: `MistHelper.FilePathUtils.get_csv_path('foo.csv')` → `data\foo.csv` ✓

## Refactor pattern
Cat E fresh extraction — pure static class. Because `FilePathUtils` had zero reach-backs into MistHelper (no globals, no private helpers), the co-migration guidance from `feedback_plain_function_extractions.md` didn't apply: this is a clean, single-file move with a re-export alias to preserve the public API.