### PR TITLE
refactor(1015): extract ConfigUtils to src/config/config_utils (T-12, Cat E)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,6 +236,8 @@ config/
 configs/
 !src/ssh/config/
 !src/ssh/config/*.py
+!src/config/
+!src/config/*.py
 
 # Archives
 *.zip

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -121,6 +121,9 @@ from src.cache.cache_utils import (
 from src.capture.packet_capture import (
     PacketCaptureManager,
 )  # Import packet capture manager directly under its canonical name (issue #431: alias removed)
+from src.config.config_utils import (  # pylint: disable=unused-import
+    ConfigUtils,  # noqa: F401  # Cat E canonical (1015 T-12) -- re-export for MistHelper.ConfigUtils callers
+)
 
 # BatchWorkerConfig import removed: pool machinery moved to ConnectionPoolExecutor (1012 SC-003)
 from src.dataclasses.endpoint_config import (  # pylint: disable=unused-import
@@ -2195,6 +2198,8 @@ def _restore_session_globals_from_state(state: dict) -> None:
     msp_privileges = state.get("msp_privileges", msp_privileges)  # Copy detected MSP grants back
     selected_msp = state.get("selected_msp", selected_msp)  # Copy the selected MSP back
     org_id = state.get("org_id", org_id)  # Copy the selected org ID back
+    ConfigUtils.set_apisession(apisession)  # Mirror the restored session into ConfigUtils class cache (1015 T-12)
+    ConfigUtils.set_cached_org_id(org_id)  # Mirror the restored org_id into ConfigUtils class cache (1015 T-12)
 
 
 # NOTE: initialize_mist_session_interactive() extracted to
@@ -2241,6 +2246,8 @@ def _attempt_interactive_login_with_rollback(old_session, old_org_id) -> bool:
     apisession = None  # Drop the current session so the interactive flow starts clean
     msp_privileges = []  # Clear cached MSP grants from the old session
     org_id = None  # Clear the selected org from the old session
+    ConfigUtils.set_apisession(None)  # Clear the ConfigUtils session cache to match (1015 T-12)
+    ConfigUtils.set_cached_org_id(None)  # Clear the ConfigUtils org_id cache to match (1015 T-12)
 
     if not MistSessionInteractiveInitializer.initialize():  # Attempt the interactive login
         print("")  # Blank spacer line
@@ -2248,9 +2255,12 @@ def _attempt_interactive_login_with_rollback(old_session, old_org_id) -> bool:
         apisession = old_session  # Restore the prior API session
         org_id = old_org_id  # Restore the prior org selection
         msp_privileges = detect_msp_privileges(apisession)  # Re-detect MSP grants and publish to module global
+        ConfigUtils.set_apisession(apisession)  # Mirror the restored session into ConfigUtils cache (1015 T-12)
+        ConfigUtils.set_cached_org_id(org_id)  # Mirror the restored org_id into ConfigUtils cache (1015 T-12)
         logging.warning("Interactive login failed - restored previous API session")  # Log the failed attempt
         return False  # Signal failure to the caller
     logging.debug("Interactive login succeeded")  # Trace the successful login
+    ConfigUtils.set_apisession(apisession)  # Publish new interactive session to ConfigUtils cache (1015 T-12)
     return True  # Signal success to the caller
 
 
@@ -2320,6 +2330,8 @@ def _select_msp_and_org():
     msp_privileges = state.get("msp_privileges", msp_privileges)  # Copy MSP grants back
     selected_msp = state.get("selected_msp", selected_msp)  # Copy the chosen MSP back
     org_id = state.get("org_id", org_id)  # Copy the chosen org ID back
+    ConfigUtils.set_apisession(apisession)  # Mirror the switched session into ConfigUtils cache (1015 T-12)
+    ConfigUtils.set_cached_org_id(org_id)  # Mirror the chosen org_id into ConfigUtils cache (1015 T-12)
 
 
 def _invoke_mistapi_org_picker_and_apply() -> None:
@@ -2330,6 +2342,7 @@ def _invoke_mistapi_org_picker_and_apply() -> None:
         org_id_list = mistapi.cli.select_org(apisession)  # Let mistapi present an org picker and return the choice
         if org_id_list and len(org_id_list) > 0:  # The user selected at least one org
             org_id = org_id_list[0]  # Use the first selected org ID
+            ConfigUtils.set_cached_org_id(org_id)  # Mirror the picker's choice into ConfigUtils cache (1015 T-12)
             print(f"  + Organization ID set: {org_id}")  # Confirm the selection to the user
             logging.info("User selected org from session: %s", org_id)  # Log the chosen org
         else:  # Nothing was selected
@@ -2909,76 +2922,10 @@ def _configure_session_timeout(session_obj: Any) -> None:
 # ============================================================================
 # CONFIGURATION UTILITIES CLASS
 # ============================================================================
-class ConfigUtils:  # Org id and run-control helpers.
-    """
-    Centralized configuration utilities.
-    Handles org_id retrieval, credentials, and configuration management.
-    """
-
-    @staticmethod
-    def _resolve_org_id_from_dotenv() -> str | None:
-        """Try to parse org_id from a sibling .env file; return value or None."""
-        try:
-            with open(".env") as env_file:  # Fall back to the .env file
-                for line in env_file:  # Scan each line for org_id
-                    if line.strip().startswith("org_id="):  # Match the org_id assignment
-                        return line.strip().split("=", 1)[1].strip().strip('"')  # Extract and unquote
-        except FileNotFoundError:  # No .env file present
-            logging.warning("! .env file not found.")
-        return None  # No value found
-
-    @staticmethod
-    def _resolve_org_id_via_prompt() -> str:
-        """Prompt the user (via mistapi) to select an org; sys.exit on failure."""
-        logging.info("* No org_id found in .env or CLI. Prompting user...")  # Prompt the user as last resort
-        org_id_list = mistapi.cli.select_org(apisession)  # Interactive org selection
-        if not org_id_list:  # Selection returned nothing
-            logging.error("Failed to retrieve org list. Check your API token and authentication.")
-            print("[ERROR] Unable to retrieve organizations. Your API token may be invalid or expired.")
-            print("[ERROR] Please update MIST_API_TOKEN in your .env file and try again.")
-            sys.exit(1)  # Abort: no org to proceed with
-        return org_id_list[0]  # Use the first selected org
-
-    @staticmethod
-    def get_cached_or_prompted_org_id() -> str:  # Resolve org_id from cache/env/.env/prompt.
-        """Resolve org_id by precedence: module global -> env vars -> .env file -> interactive prompt."""
-        global org_id  # Cache resolved id in the module global
-        if org_id:  # Reuse an already-resolved id
-            logging.info("! Using org_id from global variable: %s", org_id)
-            return org_id  # type: ignore[no-any-return]
-        org_id_env = os.environ.get("org_id") or os.environ.get("ORG_ID")  # Try environment variables next
-        if org_id_env:  # Environment provided the id
-            org_id = org_id_env  # Cache the env value
-            logging.info("! Loaded org_id from environment: %s", org_id)
-            return org_id
-        dotenv_org = ConfigUtils._resolve_org_id_from_dotenv()  # Try the .env file fallback
-        if dotenv_org:  # .env file provided the id
-            org_id = dotenv_org  # Cache the .env value
-            logging.info("! Loaded org_id from .env: %s", org_id)
-            return org_id
-        org_id = ConfigUtils._resolve_org_id_via_prompt()  # Last resort: interactive prompt
-        return org_id  # type: ignore[no-any-return]
-
-    @staticmethod
-    def check_stop_signal() -> bool:  # Check for the user stop sentinel.
-        """Check for stop_loop.txt signal file and remove if found.
-
-        Any long-running loop that iterates over sites or devices with API
-        calls should call this once per iteration so the user can cancel
-        gracefully by creating the stop file.
-
-        Returns:
-            True if the stop signal was detected (caller should break).
-        """
-        if os.path.exists("stop_loop.txt"):  # Sentinel file requests a stop.
-            try:
-                os.remove("stop_loop.txt")  # Consume the sentinel once.
-            except OSError:  # Ignore removal races.
-                pass  # Best-effort cleanup only.
-            print(" Stop signal detected. Ending operation early.")  # Notify the user of early stop.
-            logging.info("Stop signal (stop_loop.txt) detected - operation stopped by user.")  # Log user stop.
-            return True  # Signal callers to stop.
-        return False  # No stop requested.
+# NOTE: ConfigUtils removed (1015 T-12, Cat E) - canonical body at
+#       src/config/config_utils.py. Import from src.config.config_utils
+#       instead. MistHelper.py re-exports ConfigUtils at the top import block
+#       for legacy in-file callsites.
 
 
 # ============================================================================
@@ -6685,11 +6632,13 @@ def _establish_mist_session(args: argparse.Namespace) -> None:
             logging.error("Failed to initialize Mist API session via interactive login")  # Log auth failure
             print(" Failed to initialize Mist API session. Check your credentials.")  # Inform user
             sys.exit(1)  # Exit -- cannot proceed without authenticated session
+        ConfigUtils.set_apisession(apisession)  # Publish authenticated session to ConfigUtils cache (1015 T-12)
     else:  # Default path: use API token from .env or environment variables
         if not MistSessionInitializer.initialize():  # Attempt token-based session init
             logging.error("Failed to initialize Mist API session")  # Log token auth failure
             print(" Failed to initialize Mist API session. Check your credentials.")  # Inform user
             sys.exit(1)  # Exit -- cannot proceed without authenticated session
+        ConfigUtils.set_apisession(apisession)  # Publish authenticated session to ConfigUtils cache (1015 T-12)
         msp_privileges = detect_msp_privileges(apisession)  # Detect MSP grants for token session and publish to global
     logging.debug("_establish_mist_session: session established successfully")  # Log successful auth
 

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,7 @@
+"""Configuration-related helpers extracted from MistHelper.py.
+
+Initiative 1015 (T-12, Cat E): ConfigUtils lives here as its canonical
+home. MistHelper.py provides a top-level re-export alias so historical
+``MistHelper.ConfigUtils`` / ``mh.ConfigUtils`` callers keep working
+unchanged.
+"""

--- a/src/config/config_utils.py
+++ b/src/config/config_utils.py
@@ -1,0 +1,158 @@
+"""ConfigUtils extracted from MistHelper (initiative 1015 T-12).
+
+Owns the ``ConfigUtils`` class originally defined at MistHelper.py:2912.
+This module is fully self-contained: no ``import MistHelper``, no ``mh.*``
+reach-back, no dependency on any MistHelper module-global. The class
+holds its own class-level state for the resolved ``org_id`` (replacing
+the former ``MistHelper.org_id`` module-global as source of truth) and
+for the authenticated mistapi ``apisession`` (injected by the login
+pipeline via ``set_apisession``).
+
+MistHelper.py re-exports ``ConfigUtils`` at the top of the file so
+historical ``MistHelper.ConfigUtils`` / ``mh.ConfigUtils`` callers keep
+working transparently -- the re-exported symbol is the same class
+object, not a delegator.
+
+Design notes:
+- The class owns two ClassVars: ``_org_id_cache`` (the resolved org_id)
+  and ``_apisession`` (the authenticated mistapi session used by the
+  interactive prompt path).
+- ``set_apisession(session)`` is invoked once by the login pipeline
+  after a successful ``mistapi.APISession`` login so the prompt path
+  can drive ``mistapi.cli.select_org`` without reaching a module-global.
+- ``set_cached_org_id(value)`` is provided so external boundary points
+  (wsgi entry, state restore, CLI arg parsing) can publish an
+  externally-obtained org_id into the cache without triggering the
+  prompt path.
+- Callers of ``get_cached_or_prompted_org_id()`` do NOT need to thread
+  the session -- this preserves the pre-extraction call signature and
+  keeps the callsite blast radius zero while eliminating the
+  MistHelper-module-global dependency inside the class body.
+"""
+
+from __future__ import annotations  # Enable PEP 604 unions in annotations on 3.10+.
+
+import logging  # Structured action logging per Constitution VII.
+import os  # Filesystem + environment primitives for .env parsing and stop-signal check.
+import sys  # sys.exit when org selection fails.
+from typing import Any, ClassVar  # ClassVar for cached state; Any for the mistapi session.
+
+import mistapi  # Third-party API SDK used only for interactive org selection.
+
+
+class ConfigUtils:
+    """Centralized configuration utilities.
+
+    Handles org_id retrieval, credentials, and configuration management.
+    All methods are class-level or static to avoid unnecessary instantiation.
+    """
+
+    _org_id_cache: ClassVar[str | None] = None  # Cached resolved org_id (single source of truth for this module).
+    _apisession: ClassVar[Any] = None  # Authenticated mistapi session, injected by login pipeline for prompt path.
+
+    @classmethod
+    def set_apisession(cls, session: Any) -> None:
+        """Inject the authenticated mistapi session used by the interactive prompt path.
+
+        Called once by the login pipeline (or test fixture) after a successful
+        ``mistapi.APISession`` login. The stored reference is used only when
+        ``get_cached_or_prompted_org_id`` needs to drive ``mistapi.cli.select_org``.
+        """
+        cls._apisession = session  # Store the authenticated session reference.
+        logging.debug("ConfigUtils.set_apisession: session %s", "<set>" if session is not None else "None")
+
+    @classmethod
+    def set_cached_org_id(cls, value: str | None) -> None:
+        """Publish an externally-obtained org_id into the class-level cache.
+
+        Called from boundary points (wsgi entry, state restore, CLI arg parsing)
+        that resolve org_id outside the normal detection chain and need to prime
+        the cache so subsequent ``get_cached_or_prompted_org_id`` calls hit.
+        """
+        cls._org_id_cache = value  # Overwrite whatever was cached before.
+        logging.debug("ConfigUtils.set_cached_org_id: cache primed (%s)", "<set>" if value else "None")
+
+    @classmethod
+    def get_cached_org_id(cls) -> str | None:
+        """Return the class-level cache value directly (no resolution attempted)."""
+        return cls._org_id_cache  # Bare peek at the classvar.
+
+    @staticmethod
+    def _resolve_org_id_from_dotenv() -> str | None:
+        """Parse org_id from a sibling .env file; return the value or None."""
+        try:
+            with open(".env") as env_file:  # Fall back to the .env file.
+                for line in env_file:  # Scan each line for org_id.
+                    if line.strip().startswith("org_id="):  # Match the org_id assignment.
+                        return line.strip().split("=", 1)[1].strip().strip('"')  # Extract and unquote.
+        except FileNotFoundError:  # No .env file present.
+            logging.warning("! .env file not found.")
+        return None  # No value found.
+
+    @classmethod
+    def _resolve_org_id_via_prompt(cls) -> str:
+        """Prompt the user (via mistapi) to select an org; sys.exit on failure.
+
+        Uses the class-level ``_apisession`` injected by the login pipeline via
+        ``set_apisession``. If no session has been injected, the interactive
+        prompt cannot run and this helper exits with a clear error.
+        """
+        logging.info("* No org_id found in .env or CLI. Prompting user...")  # Prompt the user as last resort.
+        if cls._apisession is None:  # No session was ever injected.
+            logging.error("Cannot prompt for org selection: no mistapi session injected via set_apisession().")
+            print("[ERROR] Cannot select an organization without an authenticated API session.")
+            sys.exit(1)  # Abort: prompt path is unreachable without a session.
+        org_id_list = mistapi.cli.select_org(cls._apisession)  # Interactive org selection using injected session.
+        if not org_id_list:  # Selection returned nothing.
+            logging.error("Failed to retrieve org list. Check your API token and authentication.")
+            print("[ERROR] Unable to retrieve organizations. Your API token may be invalid or expired.")
+            print("[ERROR] Please update MIST_API_TOKEN in your .env file and try again.")
+            sys.exit(1)  # Abort: no org to proceed with.
+        return org_id_list[0]  # Use the first selected org.
+
+    @classmethod
+    def get_cached_or_prompted_org_id(cls) -> str:
+        """Resolve org_id by precedence: class cache -> env vars -> .env file -> interactive prompt.
+
+        The interactive prompt path uses the ``_apisession`` classvar that the
+        login pipeline injects via ``set_apisession``. Callers do not need to
+        thread the session through their code -- this preserves the
+        pre-extraction call signature while eliminating the module-global
+        dependency inside the class body.
+        """
+        if cls._org_id_cache:  # Reuse an already-resolved id.
+            logging.info("! Using org_id from class cache: %s", cls._org_id_cache)
+            return cls._org_id_cache
+        org_id_env = os.environ.get("org_id") or os.environ.get("ORG_ID")  # Try environment variables next.
+        if org_id_env:  # Environment provided the id.
+            cls._org_id_cache = org_id_env  # Cache the env value.
+            logging.info("! Loaded org_id from environment: %s", cls._org_id_cache)
+            return cls._org_id_cache
+        dotenv_org = cls._resolve_org_id_from_dotenv()  # Try the .env file fallback.
+        if dotenv_org:  # .env file provided the id.
+            cls._org_id_cache = dotenv_org  # Cache the .env value.
+            logging.info("! Loaded org_id from .env: %s", cls._org_id_cache)
+            return cls._org_id_cache
+        cls._org_id_cache = cls._resolve_org_id_via_prompt()  # Last resort: interactive prompt.
+        return cls._org_id_cache
+
+    @staticmethod
+    def check_stop_signal() -> bool:
+        """Check for stop_loop.txt signal file and remove if found.
+
+        Any long-running loop that iterates over sites or devices with API
+        calls should call this once per iteration so the user can cancel
+        gracefully by creating the stop file.
+
+        Returns:
+            True if the stop signal was detected (caller should break).
+        """
+        if os.path.exists("stop_loop.txt"):  # Sentinel file requests a stop.
+            try:
+                os.remove("stop_loop.txt")  # Consume the sentinel once.
+            except OSError:  # Ignore removal races.
+                pass  # Best-effort cleanup only.
+            print(" Stop signal detected. Ending operation early.")  # Notify the user of early stop.
+            logging.info("Stop signal (stop_loop.txt) detected - operation stopped by user.")  # Log user stop.
+            return True  # Signal callers to stop.
+        return False  # No stop requested.

--- a/src/config/config_utils.py
+++ b/src/config/config_utils.py
@@ -108,7 +108,7 @@ class ConfigUtils:
             print("[ERROR] Unable to retrieve organizations. Your API token may be invalid or expired.")
             print("[ERROR] Please update MIST_API_TOKEN in your .env file and try again.")
             sys.exit(1)  # Abort: no org to proceed with.
-        return org_id_list[0]  # Use the first selected org.
+        return str(org_id_list[0])  # Use the first selected org (explicit str cast: mistapi returns Any).
 
     @classmethod
     def get_cached_or_prompted_org_id(cls) -> str:

--- a/tests/unit/test_config_utils.py
+++ b/tests/unit/test_config_utils.py
@@ -1,90 +1,158 @@
-"""Unit tests for ConfigUtils.check_stop_signal() logic.
+"""Unit tests for src.config.config_utils.ConfigUtils (1015 T-12).
 
-Duplicates the pure function from MistHelper.py to avoid import side effects
-(research.md R1 pattern). Tests the file-based stop signal mechanism that
-allows users to cancel long-running loops by creating stop_loop.txt.
+Covers the full public surface of the extracted class:
+- Class-level cache (``_org_id_cache``) via setters/getters and the resolver.
+- Class-level apisession (``_apisession``) injection via ``set_apisession``.
+- Precedence chain in ``get_cached_or_prompted_org_id``: cache -> env -> .env -> prompt.
+- Prompt path uses the injected session and exits when no session is available.
+- ``check_stop_signal`` file-based cancellation semantics.
+
+The module is imported directly (no MistHelper.py load) because it is fully
+self-contained per the T-12 extraction contract.
 """
 
+from __future__ import annotations
+
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-# ---------------------------------------------------------------------------
-# Duplicated pure function (R1: avoid MistHelper.py import side effects)
-# ---------------------------------------------------------------------------
-def check_stop_signal():
-    """Mirror of ConfigUtils.check_stop_signal() from MistHelper.py."""
-    if os.path.exists("stop_loop.txt"):
-        try:
-            os.remove("stop_loop.txt")
-        except OSError:
-            pass
-        print("  Stop signal detected. Ending operation early.")
-        return True
-    return False
+from src.config.config_utils import ConfigUtils
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 @pytest.fixture(autouse=True)
-def _cleanup():
-    """Remove stop_loop.txt before and after each test."""
-    if os.path.exists("stop_loop.txt"):
-        os.remove("stop_loop.txt")
+def _reset_state(tmp_path, monkeypatch):
+    """Reset ConfigUtils class state and isolate cwd + env before each test."""
+    ConfigUtils._org_id_cache = None
+    ConfigUtils._apisession = None
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("org_id", raising=False)
+    monkeypatch.delenv("ORG_ID", raising=False)
     yield
-    if os.path.exists("stop_loop.txt"):
-        os.remove("stop_loop.txt")
+    ConfigUtils._org_id_cache = None
+    ConfigUtils._apisession = None
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# set_apisession / set_cached_org_id / get_cached_org_id
+# ---------------------------------------------------------------------------
+class TestClassLevelState:
+    """Tests for the ClassVar cache primitives."""
+
+    def test_set_apisession_stores_session(self):
+        session = MagicMock(name="fake_session")
+        ConfigUtils.set_apisession(session)
+        assert ConfigUtils._apisession is session
+
+    def test_set_apisession_none_clears_session(self):
+        ConfigUtils._apisession = MagicMock()
+        ConfigUtils.set_apisession(None)
+        assert ConfigUtils._apisession is None
+
+    def test_set_cached_org_id_populates_cache(self):
+        ConfigUtils.set_cached_org_id("abc-123")
+        assert ConfigUtils.get_cached_org_id() == "abc-123"
+
+    def test_set_cached_org_id_none_clears_cache(self):
+        ConfigUtils._org_id_cache = "prev"
+        ConfigUtils.set_cached_org_id(None)
+        assert ConfigUtils.get_cached_org_id() is None
+
+
+# ---------------------------------------------------------------------------
+# get_cached_or_prompted_org_id precedence chain
+# ---------------------------------------------------------------------------
+class TestGetCachedOrPromptedOrgId:
+    """Tests for the precedence chain: cache -> env -> .env -> prompt."""
+
+    def test_cache_hit_returns_cached_value(self, monkeypatch):
+        ConfigUtils.set_cached_org_id("cached-org")
+        # Even with an env var set, the cache should win.
+        monkeypatch.setenv("org_id", "env-org")
+        assert ConfigUtils.get_cached_or_prompted_org_id() == "cached-org"
+
+    def test_env_var_lower_case_populates_cache(self, monkeypatch):
+        monkeypatch.setenv("org_id", "env-lower")
+        result = ConfigUtils.get_cached_or_prompted_org_id()
+        assert result == "env-lower"
+        assert ConfigUtils.get_cached_org_id() == "env-lower"
+
+    def test_env_var_upper_case_populates_cache(self, monkeypatch):
+        monkeypatch.setenv("ORG_ID", "env-upper")
+        assert ConfigUtils.get_cached_or_prompted_org_id() == "env-upper"
+
+    def test_dotenv_resolution_populates_cache(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text('org_id="dotenv-org"\n')
+        result = ConfigUtils.get_cached_or_prompted_org_id()
+        assert result == "dotenv-org"
+        assert ConfigUtils.get_cached_org_id() == "dotenv-org"
+
+    def test_dotenv_unquoted_value_parsed(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text("org_id=bare-value\n")
+        assert ConfigUtils.get_cached_or_prompted_org_id() == "bare-value"
+
+    def test_prompt_path_uses_injected_session(self):
+        session = MagicMock(name="session")
+        ConfigUtils.set_apisession(session)
+        with patch("src.config.config_utils.mistapi.cli.select_org", return_value=["picked-org"]) as picker:
+            result = ConfigUtils.get_cached_or_prompted_org_id()
+        picker.assert_called_once_with(session)
+        assert result == "picked-org"
+        assert ConfigUtils.get_cached_org_id() == "picked-org"
+
+    def test_prompt_path_no_session_exits(self):
+        # No session injected and no cache/env/.env source available.
+        with pytest.raises(SystemExit) as excinfo:
+            ConfigUtils.get_cached_or_prompted_org_id()
+        assert excinfo.value.code == 1
+
+    def test_prompt_path_empty_selection_exits(self):
+        ConfigUtils.set_apisession(MagicMock())
+        with patch("src.config.config_utils.mistapi.cli.select_org", return_value=[]):
+            with pytest.raises(SystemExit) as excinfo:
+                ConfigUtils.get_cached_or_prompted_org_id()
+        assert excinfo.value.code == 1
+
+    def test_dotenv_missing_falls_through_to_prompt(self):
+        # No cache, no env, no .env file, no session -> exits.
+        with pytest.raises(SystemExit):
+            ConfigUtils.get_cached_or_prompted_org_id()
+
+
+# ---------------------------------------------------------------------------
+# check_stop_signal
 # ---------------------------------------------------------------------------
 class TestCheckStopSignal:
-    """Tests for the check_stop_signal file-based cancellation mechanism."""
+    """Tests for the file-based cancellation mechanism."""
 
     def test_no_file_returns_false(self):
-        """No stop file present should return False."""
-        assert check_stop_signal() is False
+        assert ConfigUtils.check_stop_signal() is False
 
-    def test_file_present_returns_true(self):
-        """Stop file present should return True and delete the file."""
+    def test_file_present_returns_true_and_deletes(self):
         with open("stop_loop.txt", "w") as handle:
             handle.write("")
-        assert os.path.exists("stop_loop.txt")
-        assert check_stop_signal() is True
+        assert ConfigUtils.check_stop_signal() is True
         assert not os.path.exists("stop_loop.txt")
 
-    def test_consumed_signal_returns_false(self):
-        """After signal is consumed, next call should return False."""
+    def test_consumed_signal_returns_false_next_call(self):
         with open("stop_loop.txt", "w") as handle:
             handle.write("")
-        check_stop_signal()
-        assert check_stop_signal() is False
+        ConfigUtils.check_stop_signal()
+        assert ConfigUtils.check_stop_signal() is False
 
     def test_loop_breaks_on_signal(self):
-        """Simulated site loop should break when stop signal is detected."""
-        sites = ["site_a", "site_b", "site_c", "site_d", "site_e"]
+        sites = ["site_a", "site_b", "site_c"]
         processed = []
         with open("stop_loop.txt", "w") as handle:
             handle.write("")
         for site in sites:
-            if check_stop_signal():
+            if ConfigUtils.check_stop_signal():
                 break
             processed.append(site)
-        assert len(processed) == 0
-        assert not os.path.exists("stop_loop.txt")
-
-    def test_loop_processes_until_mid_run_signal(self):
-        """Loop should process sites normally until stop file appears mid-run."""
-        sites = ["site_a", "site_b", "site_c", "site_d", "site_e"]
-        processed = []
-        for i, site in enumerate(sites):
-            if i == 3:
-                with open("stop_loop.txt", "w") as handle:
-                    handle.write("")
-            if check_stop_signal():
-                break
-            processed.append(site)
-        assert processed == ["site_a", "site_b", "site_c"]
+        assert processed == []


### PR DESCRIPTION
## Summary
- Extract ConfigUtils from MistHelper.py:2912 into fully self-contained src/config/config_utils.py
- Replace two MistHelper module-globals (apisession, org_id) with class-level state owned by ConfigUtils
- Wire every pipeline write point to publish into the class cache via set_apisession / set_cached_org_id (dual-write keeps legacy mh.apisession / mh.org_id readable)
- Re-export ConfigUtils from MistHelper.py so historical MistHelper.ConfigUtils / mh.ConfigUtils callsites keep working (same class object, not a delegator)
- Un-ignore src/config/ in .gitignore (the generic config/ glob was blocking the new package)
- Full-surface rewrite of tests/unit/test_config_utils.py: 17 cases, 97% coverage on the extracted module

Refs #1015 T-12

## Test plan
- [x] python -m pytest tests/unit/test_config_utils.py -q (17 passed)
- [x] python -m pytest tests/unit/ -q (3916 passed)
- [x] coverage src/config/config_utils.py = 97% (miss = OSError branch)
- [x] python -m black --check src/config/ tests/unit/test_config_utils.py MistHelper.py
- [x] python -m ruff check src/config/ tests/unit/test_config_utils.py
- [x] python -m pydocstyle src/config/