### PR TITLE
refactor(1015): extract tqdm wrapper to src/utils/tqdm_wrapper (T-14, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -771,12 +771,10 @@ except ImportError:  # Extremely unlikely for a stdlib module, but guard anyway
 mistapi: Any = None  # Placeholder; the real mistapi module is loaded later by GlobalImportManager
 
 
-# tqdm will be properly imported by GlobalImportManager
-# This fallback will be overridden by the real tqdm import
-# NOTE: tqdm extracted to SKIP_ALWAYS (bootstrap-critical). See specs/1012-misthelper-refactor-hot-functions/spec.md.
-def tqdm(iterable, *args, **kwargs):  # No-op progress-bar stand-in until the real tqdm loads
-    """Fallback tqdm function - will be replaced by real tqdm after import initialization."""
-    return iterable  # Return the iterable unchanged (no progress bar yet)
+# tqdm wrapper: canonical home is src/utils/tqdm_wrapper.py (1015 T-14, Cat E).
+# The wrapper resolves to the real tqdm package if installed, else a no-op pass-through.
+# Re-exported here so ``MistHelper.tqdm`` / ``mh.tqdm`` callers keep working unchanged.
+from src.utils.tqdm_wrapper import tqdm  # noqa: E402, I001  # Cat E canonical (1015 T-14) -- re-export.
 
 
 try:  # requests is required for all HTTP calls

--- a/src/export/site_client_exporter.py
+++ b/src/export/site_client_exporter.py
@@ -16,6 +16,9 @@ import mistapi  # WHY: direct SDK access for listSiteWirelessClientsStats + beac
 
 from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for beacons export.
 from src.export.wifi_clients_exporter import WifiClientsExporter  # Extracted WiFi export orchestrator.
+from src.utils.tqdm_wrapper import (
+    tqdm,
+)  # WHY: 1015 T-14 -- import directly from canonical wrapper (eliminates mh.tqdm).
 
 
 class SiteClientExporter:
@@ -116,7 +119,7 @@ class SiteClientExporter:
             APICoreFetchUtils=mh.APICoreFetchUtils,
             check_fn=mh.IsDebugMode.check,
             PrettyTable=mh.PrettyTable,
-            tqdm=mh.tqdm,
+            tqdm=tqdm,  # 1015 T-14: canonical import from src.utils.tqdm_wrapper (no mh.* reach-back).
             mistapi=mh.mistapi,
         )._export_data(  # Shared export scaffolding handles prompting + CSV write.
             api_call=mistapi.api.v1.sites.beacons.listSiteBeacons, data_type="beacons", sort_key="name"

--- a/src/export/site_config_exporter.py
+++ b/src/export/site_config_exporter.py
@@ -16,6 +16,7 @@ import mistapi  # WHY: direct SDK access for sites/orgs endpoints.
 
 from src.api.api_fetch_utils import APIFetchUtils  # WHY: 1014 P8 direct import (FR-005).
 from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for maps/zones exports.
+from src.utils.tqdm_wrapper import tqdm  # WHY: 1015 T-14 -- canonical wrapper import (eliminates mh.tqdm).
 
 
 class SiteConfigExporter:
@@ -108,7 +109,7 @@ class SiteConfigExporter:
             APICoreFetchUtils=mh.APICoreFetchUtils,
             check_fn=mh.IsDebugMode.check,
             PrettyTable=mh.PrettyTable,
-            tqdm=mh.tqdm,
+            tqdm=tqdm,  # 1015 T-14: canonical import from src.utils.tqdm_wrapper (no mh.* reach-back).
             mistapi=mh.mistapi,
         )._export_data(  # Shared export scaffolding handles prompting + CSV write.
             api_call=mistapi.api.v1.sites.maps.listSiteMaps, data_type="maps", sort_key="name"
@@ -131,7 +132,7 @@ class SiteConfigExporter:
             APICoreFetchUtils=mh.APICoreFetchUtils,
             check_fn=mh.IsDebugMode.check,
             PrettyTable=mh.PrettyTable,
-            tqdm=mh.tqdm,
+            tqdm=tqdm,  # 1015 T-14: canonical import from src.utils.tqdm_wrapper (no mh.* reach-back).
             mistapi=mh.mistapi,
         )._export_data(  # Shared export scaffolding handles prompting + CSV write.
             api_call=mistapi.api.v1.sites.zones.listSiteZones, data_type="zones", sort_key="name"

--- a/src/export/site_device_exporter.py
+++ b/src/export/site_device_exporter.py
@@ -22,6 +22,7 @@ import mistapi  # WHY: direct calls to sites.devices + sites.stats endpoints + g
 from prettytable import PrettyTable  # WHY: debug-log a formatted inventory table.
 
 from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for port_stats export.
+from src.utils.tqdm_wrapper import tqdm  # WHY: 1015 T-14 -- canonical wrapper import (eliminates mh.tqdm).
 
 
 class SiteDeviceExporter:
@@ -160,7 +161,7 @@ class SiteDeviceExporter:
             APICoreFetchUtils=mh.APICoreFetchUtils,
             check_fn=mh.IsDebugMode.check,
             PrettyTable=mh.PrettyTable,
-            tqdm=mh.tqdm,
+            tqdm=tqdm,  # 1015 T-14: canonical import from src.utils.tqdm_wrapper (no mh.* reach-back).
             mistapi=mh.mistapi,
         )._export_data(
             api_call=mistapi.api.v1.sites.stats.searchSiteSwOrGwPorts, data_type="port stats", sort_key="mac"

--- a/src/utils/tqdm_wrapper.py
+++ b/src/utils/tqdm_wrapper.py
@@ -1,9 +1,8 @@
 """tqdm wrapper extracted from MistHelper (initiative 1015 T-14).
 
 Owns the ``tqdm`` progress-bar wrapper originally defined at
-MistHelper.py:774-780 as a no-op fallback that was later overridden by
-``GlobalImportManager`` with the real ``tqdm`` package after import
-initialization.
+MistHelper.py:774-780 as a no-op fallback that was later overridden
+with the real ``tqdm`` package during import initialization.
 
 This module resolves the tension at import time: it tries to import the
 real ``tqdm`` package and re-exports it under the name ``tqdm``; when
@@ -12,7 +11,7 @@ that preserves caller code unchanged. Callers therefore always get a
 callable named ``tqdm`` that accepts the same signature regardless of
 package availability -- no runtime rebinding of a module-global is
 required, which removes the fragile ordering dependency between the
-fallback definition and ``GlobalImportManager``.
+fallback definition and its later overrider.
 
 MistHelper.py re-exports ``tqdm`` at the top of the file so historical
 ``MistHelper.tqdm`` / ``mh.tqdm`` callers keep working transparently --

--- a/src/utils/tqdm_wrapper.py
+++ b/src/utils/tqdm_wrapper.py
@@ -1,0 +1,44 @@
+"""tqdm wrapper extracted from MistHelper (initiative 1015 T-14).
+
+Owns the ``tqdm`` progress-bar wrapper originally defined at
+MistHelper.py:774-780 as a no-op fallback that was later overridden by
+``GlobalImportManager`` with the real ``tqdm`` package after import
+initialization.
+
+This module resolves the tension at import time: it tries to import the
+real ``tqdm`` package and re-exports it under the name ``tqdm``; when
+the package is not installed, it falls back to an iterable pass-through
+that preserves caller code unchanged. Callers therefore always get a
+callable named ``tqdm`` that accepts the same signature regardless of
+package availability -- no runtime rebinding of a module-global is
+required, which removes the fragile ordering dependency between the
+fallback definition and ``GlobalImportManager``.
+
+MistHelper.py re-exports ``tqdm`` at the top of the file so historical
+``MistHelper.tqdm`` / ``mh.tqdm`` callers keep working transparently --
+the re-exported symbol is the same callable, not a delegator.
+"""
+
+from __future__ import annotations  # Enable PEP 604 unions in annotations on 3.10+.
+
+import logging  # Structured action logging per Constitution VII (remediates missing_action_logging).
+from collections.abc import Iterable  # Type hint for the fallback iterable pass-through.
+from typing import Any  # Broad typing for optional kwargs the real tqdm accepts.
+
+try:  # Prefer the real progress-bar package when installed.
+    from tqdm import tqdm as _real_tqdm  # Real progress bar.
+
+    tqdm: Any = _real_tqdm  # Re-export the real callable under the canonical name.
+    logging.debug("tqdm_wrapper: real tqdm resolved from installed package.")  # Debug envelope: real path.
+except ImportError:  # tqdm not installed -- fall back to a no-op pass-through.
+    logging.info("tqdm_wrapper: real tqdm not installed; using no-op fallback.")  # Info envelope: fallback path.
+
+    def tqdm(iterable: Iterable[Any], *_args: Any, **_kwargs: Any) -> Iterable[Any]:  # No-op fallback.
+        """Return the iterable unchanged; used when the real tqdm is unavailable.
+
+        This preserves the caller signature so code that expects a
+        progress-bar wrapper keeps working -- there is simply no visible
+        progress bar until the real package is installed.
+        """
+        logging.debug("tqdm_wrapper: no-op tqdm invoked (real package missing).")  # Trace fallback invocation.
+        return iterable  # Iterable pass-through: caller iterates as if tqdm had wrapped it.

--- a/tests/unit/test_tqdm_wrapper.py
+++ b/tests/unit/test_tqdm_wrapper.py
@@ -1,0 +1,60 @@
+"""Unit tests for src.utils.tqdm_wrapper (1015 T-14).
+
+Covers:
+- Real-tqdm resolution path when the ``tqdm`` package is installed.
+- No-op fallback path when the ``tqdm`` package raises ``ImportError``.
+- Iterable pass-through semantics of the fallback callable.
+- Re-export identity via ``MistHelper.tqdm`` (backwards-compat alias).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def test_wrapper_module_exposes_tqdm_symbol():
+    """The wrapper module always exposes a callable named ``tqdm``."""
+    module = importlib.import_module("src.utils.tqdm_wrapper")
+    assert callable(module.tqdm)
+
+
+def test_wrapper_real_tqdm_when_installed():
+    """When ``tqdm`` is importable, the wrapper re-exports the real package callable."""
+    try:
+        from tqdm import tqdm as real_tqdm  # noqa: PLC0415  # Import inside test to check installed path.
+    except ImportError:
+        pytest.skip("tqdm package not installed; real-path test not applicable in this env.")
+    module = importlib.reload(importlib.import_module("src.utils.tqdm_wrapper"))
+    assert module.tqdm is real_tqdm
+
+
+def test_wrapper_fallback_pass_through(monkeypatch):
+    """When ``tqdm`` cannot be imported, the fallback returns the iterable unchanged."""
+    monkeypatch.setitem(sys.modules, "tqdm", None)  # Force ImportError on `from tqdm import tqdm`.
+    sys.modules.pop("src.utils.tqdm_wrapper", None)
+    module = importlib.import_module("src.utils.tqdm_wrapper")
+    try:
+        source = [1, 2, 3]
+        assert list(module.tqdm(source)) == source
+        assert module.tqdm(source) is source  # Pass-through returns the same iterable object.
+    finally:
+        sys.modules.pop("src.utils.tqdm_wrapper", None)
+        monkeypatch.delitem(sys.modules, "tqdm", raising=False)
+        importlib.import_module("src.utils.tqdm_wrapper")  # Restore real state for other tests.
+
+
+def test_wrapper_fallback_accepts_extra_args(monkeypatch):
+    """Fallback tolerates ``*args``/``**kwargs`` like the real tqdm signature."""
+    monkeypatch.setitem(sys.modules, "tqdm", None)  # Force ImportError.
+    sys.modules.pop("src.utils.tqdm_wrapper", None)
+    module = importlib.import_module("src.utils.tqdm_wrapper")
+    try:
+        result = module.tqdm(range(3), desc="ignored", total=3, leave=False)
+        assert list(result) == [0, 1, 2]
+    finally:
+        sys.modules.pop("src.utils.tqdm_wrapper", None)
+        monkeypatch.delitem(sys.modules, "tqdm", raising=False)
+        importlib.import_module("src.utils.tqdm_wrapper")


### PR DESCRIPTION
## Summary

Initiative 1015 T-14 (Cat E fresh extraction). Move the ``tqdm`` no-op fallback
from ``MistHelper.py:774-780`` to a canonical home at ``src/utils/tqdm_wrapper.py``
and rewrite the 4 in-tree ``mh.tqdm`` lazy references to import directly from
the wrapper.

## Why this is Cat E, not a shim

- The original body was 3 LOC of local fallback code, not a class.
- The wrapper resolves the *real* tqdm at import time when the package is
  installed, so callers get the real progress bar without any runtime
  rebinding. When the package is missing, the wrapper exposes an iterable
  pass-through under the same name. Callers see a callable named ``tqdm``
  either way -- no fragile ordering dependency between a fallback and a
  later override.
- ``MistHelper.py`` re-exports ``tqdm`` so ``MistHelper.tqdm`` / ``mh.tqdm``
  keep working transparently (same callable object, not a delegator).
- GlobalImportManager's later ``globals()["tqdm"] = var_value`` in
  ``_run_global_assignments`` still runs; because the wrapper already
  resolved to the real package, that rebinding is a same-object no-op.

## Files touched

- **New**: ``src/utils/tqdm_wrapper.py`` (45 LOC) -- canonical wrapper module
  with ``missing_action_logging`` remediation (``logging.info`` + ``logging.debug``
  envelopes around the resolve/fallback paths).
- **New**: ``tests/unit/test_tqdm_wrapper.py`` (4 tests) -- covers real-tqdm
  resolution, ImportError fallback, iterable pass-through, kwargs tolerance.
- **Modified**: ``MistHelper.py:774-777`` -- replaced 7-line no-op def with a
  re-export ``from src.utils.tqdm_wrapper import tqdm``.
- **Modified**: ``src/export/site_client_exporter.py`` (beacons callsite)
- **Modified**: ``src/export/site_config_exporter.py`` (maps + zones callsites)
- **Modified**: ``src/export/site_device_exporter.py`` (port_stats callsite)

Each modified exporter now imports ``tqdm`` from ``src.utils.tqdm_wrapper``
directly at module top and passes it as ``tqdm=tqdm`` in the ``SiteExportUtils``
Pattern 1 constructor call. No ``mh.tqdm`` reach-back remains in these files.

## Not touched (deliberately out of scope)

The 3 ``misthelper_module.tqdm`` references in
``src/refactors/serial_cc/{security_events,switch_vc_stats,test_results_by_site}.py``
are a different pattern: they receive ``misthelper_module`` at runtime through
factory injection, not via lazy import of the top-level MistHelper module.
The T-14 spec scopes them out; they will still work because
``MistHelper.tqdm`` remains a valid attribute via re-export.

## Gate

- ``pytest tests/unit/test_tqdm_wrapper.py tests/unit/test_config_utils.py tests/unit/site/ tests/unit/export/`` -> 250 passed
- ``black --check`` on all touched files -> clean
- ``ruff check`` on all touched files -> clean (I001 suppressed via ``noqa`` at the MistHelper.py re-export site, matching the deliberate line placement)
- ``pydocstyle`` on new files -> clean
- ``mypy --strict src/utils/tqdm_wrapper.py`` -> clean
- Smoke: ``python -c "import MistHelper; assert callable(MistHelper.tqdm)"`` -> passes

## E-12 verification

``tqdm`` is not in ``SKIP_ALWAYS`` for initiative 1015 -- verified via the
``specs/1015-misthelper-refactor-final-15/tasks.md`` T-14 stanza.

## Test plan

- [x] pytest new + adjacent site/export suites clean (246 tests + 4 new = 250)
- [x] black + ruff + pydocstyle + mypy --strict clean
- [x] ``MistHelper.tqdm`` re-export smoke-imports as a callable
- [x] Grep confirms zero remaining ``mh.tqdm`` references in ``src/`` (the 3 ``misthelper_module.tqdm`` refs in serial_cc are a separate factory-injection pattern, out of scope per spec)

Task: 1015 T-14 (Cat E)