### PR TITLE
chore(1015): regenerate refactor_candidates.md after T-15 merge

### DIFF
--- a/refactor_candidates.md
+++ b/refactor_candidates.md
@@ -1,20 +1,23 @@
 # Refactor candidates: MistHelper.py
 
 - Entrypoint: `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`
-- Module graph size: 254 first-party files
-- Definitions analyzed: 11
+- Module graph size: 257 first-party files
+- Definitions analyzed: 8
 - LOC saveable (unused + single-use): 0
-- Category counts: unused=0, single-use=0, low-use=0, hot=10, skipped=1
+- Category counts: unused=0, single-use=0, low-use=0, hot=7, skipped=1
 
 ## How to read this report
 
 Work the report **top-down inside each category**, then move to the next category:
 
 1. **Unused** -- zero references. Delete outright; no move, no callsite rewrite. Highest ROI per PR.
-2. **Single-use** -- exactly one caller. Move alongside that caller (or into a new `/src` module when the entrypoint is the sole caller). One PR covers move + rewrite.
-3. **Low-use** -- 2-3 callers. Evaluate before moving: worth it only when all callers can be rewritten in one bounded PR cluster.
-4. **Hot** -- 4+ callers. Leave in place until dependencies decouple. Listed for completeness only.
-5. **Skipped** -- pinned by bootstrap/module-load ordering (e.g. `GlobalImportManager`). DO NOT extract; the tool cannot detect load-order dependencies, so these are curated by hand via the `--skip NAME` CLI flag.
+2. **Single-use** -- exactly one caller. Move alongside that caller (or into a new `/src` module when the eRefactor report written to refactor_candidates.md
+Entrypoint: C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py
+Module graph: 257 first-party files
+Definitions analyzed: 8
+  unused=0  single-use=0  low-use=0  hot=7  skipped=1
+LOC saveable (unused + single-use): 0
+* -- pinned by bootstrap/module-load ordering (e.g. `GlobalImportManager`). DO NOT extract; the tool cannot detect load-order dependencies, so these are curated by hand via the `--skip NAME` CLI flag.
 
 Within each bucket, candidates are sorted by **line_count descending** so the biggest LOC wins surface first. The `LOC saveable` headline in the metadata block sums unused + single-use lines only -- that number is your extraction budget for this pass.
 
@@ -40,15 +43,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 | `DataProcessingUtils` | class | 158 | 69 | hot |  | oversize_25_lines,missing_inline_comments,hardcoded_separator |
 | `VirtualChassisManager` | class | 78 | 104 | hot |  | oversize_25_lines,missing_inline_comments,missing_action_logging |
 | `InputUtils` | class | 74 | 195 | hot |  | oversize_25_lines,raw_input_call |
-| `ConfigUtils` | class | 70 | 102 | hot |  | oversize_25_lines |
-| `tqdm` | function | 3 | 51 | hot |  | missing_action_logging |
-| `MIST_SITE_EXCLUDE_PREFIX` | assignment | 3 | 11 | hot |  | missing_inline_comments,missing_action_logging |
 
-## Hot (10)
+## Hot (7)
 
 ### `menu_actions` (assignment, 887 lines)
 
-- Def site: line 5215-6101
+- Def site: line 5161-6047
 - References: 17
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -58,12 +58,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5215, 6136, 6137, 6146, 6266, 6266, 6308, 6364, 6409, 6901, 6905, 6950, 6950, 6977, 6977, 6980
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5161, 6082, 6083, 6092, 6212, 6212, 6254, 6310, 6355, 6849, 6853, 6898, 6898, 6925, 6925, 6928
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\troubleshooting\interactive_test_runner.py`: lines 43
 
 ### `OrgInventoryExporter` (class, 686 lines)
 
-- Def site: line 3998-4683
+- Def site: line 3944-4629
 - References: 102
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -72,12 +72,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] missing_inline_comments
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 4121, 4121, 4172, 4172, 4175, 4175, 4216, 4216, 4255, 4255, 4273, 4273, 4351, 4351, 4358, 4358, 4368, 4368, 4371, 4371, 4384, 4384, 4385, 4385, 4386, 4386, 4387, 4387, 4395, 4395, 4397, 4397, 4398, 4398, 4399, 4399, 4400, 4400, 4403, 4403, 4406, 4406, 4409, 4409, 4412, 4412, 4458, 4458, 4481, 4481, 4482, 4482, 4483, 4483, 4485, 4485, 4521, 4521, 4537, 4537, 4591, 4591, 4592, 4592, 4593, 4593, 4596, 4596, 4597, 4597, 4616, 4616, 4618, 4618, 4619, 4619, 4654, 4654, 4855, 5010, 5010, 5034, 5034, 5058, 5058, 5306, 5306, 5313, 5313, 5322, 5322, 5326, 5326, 5335, 5335
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 4067, 4067, 4118, 4118, 4121, 4121, 4162, 4162, 4201, 4201, 4219, 4219, 4297, 4297, 4304, 4304, 4314, 4314, 4317, 4317, 4330, 4330, 4331, 4331, 4332, 4332, 4333, 4333, 4341, 4341, 4343, 4343, 4344, 4344, 4345, 4345, 4346, 4346, 4349, 4349, 4352, 4352, 4355, 4355, 4358, 4358, 4404, 4404, 4427, 4427, 4428, 4428, 4429, 4429, 4431, 4431, 4467, 4467, 4483, 4483, 4537, 4537, 4538, 4538, 4539, 4539, 4542, 4542, 4543, 4543, 4562, 4562, 4564, 4564, 4565, 4565, 4600, 4600, 4801, 4956, 4956, 4980, 4980, 5004, 5004, 5252, 5252, 5259, 5259, 5268, 5268, 5272, 5272, 5281, 5281
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 46, 295, 295, 343, 343, 499, 499
 
 ### `PromptUtils` (class, 441 lines)
 
-- Def site: line 3536-3976
+- Def site: line 3482-3922
 - References: 96
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -85,12 +85,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3551, 3551, 3554, 3554, 3562, 3562, 3580, 3580, 3630, 3630, 3638, 3638, 3643, 3643, 3689, 3689, 3700, 3700, 3725, 3725, 3744, 3744, 3745, 3745, 3748, 3748, 3749, 3749, 3839, 3839, 3841, 3841, 3845, 3845, 3873, 3873, 3874, 3874, 3875, 3875, 3876, 3876, 3877, 3877, 3886, 3886, 3930, 3930, 3954, 3954, 4786, 4786, 4787, 4787, 5017, 5017, 5111, 5111, 5200, 5200, 5201, 5201, 5250, 5250, 5251, 5251, 5265, 5265, 5266, 5266, 5280, 5280, 5281, 5281, 5389, 5495, 5495, 5566, 5579, 5724, 5875, 5894, 5913, 5950, 5969, 5988, 6007, 6026, 6045, 6064
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3497, 3497, 3500, 3500, 3508, 3508, 3526, 3526, 3576, 3576, 3584, 3584, 3589, 3589, 3635, 3635, 3646, 3646, 3671, 3671, 3690, 3690, 3691, 3691, 3694, 3694, 3695, 3695, 3785, 3785, 3787, 3787, 3791, 3791, 3819, 3819, 3820, 3820, 3821, 3821, 3822, 3822, 3823, 3823, 3832, 3832, 3876, 3876, 3900, 3900, 4732, 4732, 4733, 4733, 4963, 4963, 5057, 5057, 5146, 5146, 5147, 5147, 5196, 5196, 5197, 5197, 5211, 5211, 5212, 5212, 5226, 5226, 5227, 5227, 5335, 5441, 5441, 5512, 5525, 5670, 5821, 5840, 5859, 5896, 5915, 5934, 5953, 5972, 5991, 6010
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 17, 65, 127, 127, 132, 132
 
 ### `DataExporter` (class, 345 lines)
 
-- Def site: line 3173-3517
+- Def site: line 3119-3463
 - References: 118
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -99,7 +99,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] non_ascii_logs
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3219, 3219, 3235, 3235, 3236, 3236, 3259, 3259, 3261, 3261, 3264, 3264, 3278, 3278, 3280, 3280, 3289, 3289, 3291, 3291, 3292, 3292, 3298, 3298, 3299, 3299, 3299, 3316, 3316, 3320, 3320, 3362, 3362, 3393, 3393, 3396, 3396, 3398, 3398, 3444, 3444, 3454, 3454, 3487, 3487, 3492, 3492, 3499, 3499, 3593, 3593, 4552, 4552, 4627, 4627, 4789, 4789, 4851, 5064, 5064, 5084, 5172, 5172, 5392, 5422, 5422, 5435, 5435, 5568, 5581, 5672, 5672, 5727, 5752, 5752, 5768, 5768, 5878, 5897, 5916, 5953, 5972, 5991, 6010, 6029, 6048, 6067
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3165, 3165, 3181, 3181, 3182, 3182, 3205, 3205, 3207, 3207, 3210, 3210, 3224, 3224, 3226, 3226, 3235, 3235, 3237, 3237, 3238, 3238, 3244, 3244, 3245, 3245, 3245, 3262, 3262, 3266, 3266, 3308, 3308, 3339, 3339, 3342, 3342, 3344, 3344, 3390, 3390, 3400, 3400, 3433, 3433, 3438, 3438, 3445, 3445, 3539, 3539, 4498, 4498, 4573, 4573, 4735, 4735, 4797, 5010, 5010, 5030, 5118, 5118, 5338, 5368, 5368, 5381, 5381, 5514, 5527, 5618, 5618, 5673, 5698, 5698, 5714, 5714, 5824, 5843, 5862, 5899, 5918, 5937, 5956, 5975, 5994, 6013
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 42, 380, 380, 440, 440, 457, 457, 476, 476, 549, 549
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 30, 310, 310, 454, 454
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 21, 639, 639
@@ -108,7 +108,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 
 ### `DataProcessingUtils` (class, 158 lines)
 
-- Def site: line 3002-3159
+- Def site: line 2948-3105
 - References: 69
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -118,13 +118,13 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] hardcoded_separator
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 3018, 3018, 3031, 3031, 3034, 3034, 3058, 3058, 3066, 3066, 3067, 3067, 3089, 3089, 3094, 3094, 3096, 3096, 3395, 3395, 3420, 3420, 3489, 3489, 3490, 3490, 3591, 3591, 3592, 3592, 4549, 4549, 4550, 4550, 4624, 4624, 4625, 4625, 4852, 5062, 5062, 5063, 5063, 5391, 5567, 5580, 5726, 5877, 5896, 5915, 5952, 5971, 5990, 6009, 6028, 6047, 6066
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2964, 2964, 2977, 2977, 2980, 2980, 3004, 3004, 3012, 3012, 3013, 3013, 3035, 3035, 3040, 3040, 3042, 3042, 3341, 3341, 3366, 3366, 3435, 3435, 3436, 3436, 3537, 3537, 3538, 3538, 4495, 4495, 4496, 4496, 4570, 4570, 4571, 4571, 4798, 5008, 5008, 5009, 5009, 5337, 5513, 5526, 5672, 5823, 5842, 5861, 5898, 5917, 5936, 5955, 5974, 5993, 6012
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 43, 454, 454, 455, 455, 474, 474, 475, 475
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 29, 274, 274
 
 ### `VirtualChassisManager` (class, 78 lines)
 
-- Def site: line 4989-5066
+- Def site: line 4935-5012
 - References: 104
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -134,12 +134,12 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] missing_inline_comments
   - [ ] missing_action_logging
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5530, 5530, 5534, 5534, 5538, 5538
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 5476, 5476, 5480, 5480, 5484, 5484
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\device\virtual_chassis.py`: lines 87, 87, 88, 88, 92, 92, 95, 95, 101, 101, 112, 112, 117, 117, 124, 124, 125, 125, 127, 127, 136, 136, 139, 139, 141, 141, 143, 143, 146, 146, 147, 147, 154, 154, 176, 176, 188, 188, 199, 199, 210, 210, 214, 214, 219, 219, 234, 234, 249, 249, 259, 259, 262, 262, 263, 263, 315, 315, 318, 318, 365, 365, 381, 381, 383, 383, 385, 385, 440, 440, 444, 444, 457, 457, 472, 472, 515, 515, 517, 517, 544, 544, 546, 546, 598, 598, 600, 600, 657, 657, 701, 701, 771, 771, 871, 871, 874, 874
 
 ### `InputUtils` (class, 74 lines)
 
-- Def site: line 2014-2087
+- Def site: line 2015-2088
 - References: 195
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -148,7 +148,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - [ ] oversize_25_lines
   - [ ] raw_input_call
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2027, 2027, 2059, 2059, 2286, 2286, 2313, 2313, 3557, 3557, 3634, 3634, 3717, 3717, 3947, 3947, 4788, 4788, 4857, 4957, 5016, 5016, 5041, 5041, 5083, 5110, 5110, 5168, 5168, 5204, 5204, 5254, 5254, 5269, 5269, 5284, 5284, 5420, 5420, 5433, 5433, 5670, 5670, 5708, 5708, 5750, 5750, 5850, 5850, 5855, 5855, 5861, 5861, 5934, 5934, 5940, 5940, 6986, 6986
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2028, 2028, 2060, 2060, 2295, 2295, 2322, 2322, 3503, 3503, 3580, 3580, 3663, 3663, 3893, 3893, 4734, 4734, 4803, 4903, 4962, 4962, 4987, 4987, 5029, 5056, 5056, 5114, 5114, 5150, 5150, 5200, 5200, 5215, 5215, 5230, 5230, 5366, 5366, 5379, 5379, 5616, 5616, 5654, 5654, 5696, 5696, 5796, 5796, 5801, 5801, 5807, 5807, 5880, 5880, 5886, 5886, 6934, 6934
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 48, 550, 550
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 20, 226, 226, 244, 244, 313, 313
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 411, 411
@@ -167,69 +167,11 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 14, 44, 452, 452, 512, 512, 609, 609, 690, 690, 706, 706, 717, 717, 729, 729, 742, 742
   - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 18, 66, 197, 197
 
-### `ConfigUtils` (class, 70 lines)
-
-- Def site: line 2912-2981
-- References: 102
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] oversize_25_lines
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2954, 2954, 2959, 2959, 4367, 4367, 4590, 4590, 4607, 4607, 4848, 5081, 5165, 5165, 5169, 5169, 5170, 5170, 5224, 5224, 5294, 5294, 5300, 5300, 5390, 5418, 5418, 5431, 5431, 5464, 5464, 5521, 5521, 5627, 5627, 5636, 5636, 5668, 5668, 5709, 5709, 5711, 5711, 5725, 5748, 5748, 5749, 5749, 5766, 5766, 5850, 5850, 5855, 5855, 5861, 5861, 5876, 5895, 5914, 5934, 5934, 5940, 5940, 5951, 5970, 5989, 6008, 6027, 6046, 6065, 6298, 6298, 6367, 6850, 6850, 6938, 6938
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 39, 402, 402, 449, 449, 467, 467, 508, 508, 542, 542
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 27, 321, 321
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 15, 150, 150, 510, 510
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_discovery.py`: lines 12, 42, 86, 86
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\websocket\service_ping_manager.py`: lines 24, 70
-
-### `tqdm` (function, 3 lines)
-
-- Def site: line 774-776
-- References: 51
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1384, 2024, 2024, 2024, 2036, 2042, 4536, 4647, 4866, 5400, 5735, 5753, 5886, 5905, 5924, 5961, 5980, 5999, 6018, 6037, 6056, 6075
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_data_fetcher.py`: lines 359
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\api\api_fetch_utils.py`: lines 104, 227
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\gateway_test_exporter.py`: lines 220, 270
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\org_client_security_exporter.py`: lines 179
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\export\org_device_stats_exporter.py`: lines 259
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 58
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_stats_exporter.py`: lines 41, 217, 260
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\template_config.py`: lines 401, 601, 640
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 509
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\inventory\csv_comparator.py`: lines 727, 1068
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\maps\maps_manager.py`: lines 579, 699, 707, 866, 1152, 1752
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\connection_pool_executor.py`: lines 148
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\refactors\wanprobe_config_manager.py`: lines 243, 363
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\site\address_audit\audit_engine.py`: lines 56, 916, 918
-
-### `MIST_SITE_EXCLUDE_PREFIX` (assignment, 3 lines)
-
-- Def site: line 2140-2142
-- References: 11
-- Suggested class: _n/a_
-- Suggested module: _n/a_
-- Rationale: Widely used; leave in place until dependencies decouple
-- Guideline flags (address during the move):
-  - [ ] missing_inline_comments
-  - [ ] missing_action_logging
-- Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 2140, 4862
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\gateway_export_utils.py`: lines 54, 544
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\src\gateway\wan2_migration_manager.py`: lines 23, 270, 272, 287, 290, 294, 297
-
 ## Skipped (1)
 
 ### `GlobalImportManager` (class, 1003 lines)
 
-- Def site: line 890-1892
+- Def site: line 891-1893
 - References: 1
 - Suggested class: _n/a_
 - Suggested module: _n/a_
@@ -237,7 +179,7 @@ Reference sites are grouped **per file** so each candidate maps cleanly to one P
 - Guideline flags (address during the move):
   - [ ] oversize_25_lines
 - Reference sites (one PR cluster per file):
-  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1937
+  - `C:\Users\jmorrison\OneDrive - Hewlett Packard Enterprise\Code\MistHelper\MistHelper.py`: lines 1938
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

Regenerate `refactor_candidates.md` following the merge of #936 (T-15: extract `MIST_SITE_EXCLUDE_PREFIX`).

## Report delta

- `MIST_SITE_EXCLUDE_PREFIX` no longer appears in the Hot bucket (extracted to `src/refactors/mist_site_exclude_prefix.py`).
- 7 Hot candidates remain: `menu_actions`, `OrgInventoryExporter`, `PromptUtils`, `DataExporter`, `DataProcessingUtils`, `VirtualChassisManager`, `InputUtils`.
- `GlobalImportManager` remains in the Skipped bucket (deferred per initiative decision).

Per FR-014 / SC-010, analyzer must be regenerated after every extraction merge.

## Test plan

- [ ] CI green (docs-only change; expect Quality Gates to pass).