### PR TITLE
refactor(1015): fold VirtualChassisManager into src/device/virtual_chassis.py (T-11)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -153,6 +153,15 @@ from src.device.device_reboot_manager import (  # pylint: disable=unused-import
 from src.device.device_utils import (  # pylint: disable=unused-import
     DeviceUtils,  # noqa: F401  # Cat B (1013 SC-001 position 6) -- re-export for dynamic _mh.DeviceUtils lookup
 )
+from src.device.virtual_chassis import (  # Cat E canonical (1015 T-11) -- fold-in of stub facade
+    VirtualChassisDependencies as _VirtualChassisDependencies,
+)
+from src.device.virtual_chassis import (
+    VirtualChassisManager,
+)
+from src.device.virtual_chassis import (
+    configure_virtual_chassis_dependencies as _configure_virtual_chassis_dependencies,
+)
 from src.export.const_definitions_exporter import (  # pylint: disable=unused-import
     ConstDefinitionsExporter,  # noqa: F401  # Cat B (1013 SC-001 position 17) -- re-export for MistHelper.ConstDefinitionsExporter callers
 )
@@ -4932,84 +4941,26 @@ from src.utils.rate_limiting import RateLimitingUtils  # noqa: E402
 # ============================================================================
 # VIRTUAL CHASSIS MANAGER CLASS
 # ============================================================================
-class VirtualChassisManager:  # Virtual chassis manager.
-    """Virtual chassis to virtual MAC conversion operations (Menus 92-94).
-
-    Implementation extracted to src/device/virtual_chassis.py.
-    This stub delegates to the extracted module while providing
-    access to MistHelper globals (apisession, utility classes).
-    """
-
-    @staticmethod
-    def convert_single(dry_run: bool = False) -> None:  # Convert a single VC.
-        """Convert a single VC switch to virtual MAC (Menu 92)."""
-        from src.device.virtual_chassis import (  # Import the impl.
-            VCIODeps,
+# NOTE: VirtualChassisManager folded fully into src/device/virtual_chassis.py
+# per 1015 T-11 (Cat E). Menu wire-up lives in _configure_virtual_chassis_manager()
+# below (single seam for menu 161/162/14 dispatch lambdas). No stub or delegator
+# remains in MistHelper.py after this extraction.
+def _configure_virtual_chassis_manager() -> type[VirtualChassisManager]:
+    """Wire VirtualChassisDependencies and return the canonical VirtualChassisManager class."""
+    _configure_virtual_chassis_dependencies(  # Publish MistHelper globals into the impl module.
+        _VirtualChassisDependencies(  # Frozen container of 9 injected collaborators.
+            apisession=apisession,  # Live Mist API session.
+            file_path_utils=FilePathUtils,  # Portable CSV path resolver + template writer.
+            cache_utils=CacheUtils,  # check_and_generate_csv freshness gate.
+            org_inventory_exporter=OrgInventoryExporter,  # Regenerates OrgInventory.csv.
+            org_site_exporter=OrgSiteExporter,  # Regenerates SiteList.csv.
+            input_utils=InputUtils,  # safe_input for destructive prompts.
+            prompt_utils=PromptUtils,  # select_site interactive picker.
+            data_processing_utils=DataProcessingUtils,  # flatten + escape helpers for CSV export.
+            data_exporter=DataExporter,  # write_with_format_selection CSV writer.
         )
-        from src.device.virtual_chassis import (
-            VirtualChassisManager as _VC,
-        )
-
-        io_deps = VCIODeps(  # Bundle IO/cache dependencies to satisfy the 5-param limit.
-            get_csv_path_fn=FilePathUtils.get_csv_path,  # Resolve cache paths.
-            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,  # Refresh cached CSV.
-            inventory_generator=OrgInventoryExporter.inventory,  # Rebuild OrgInventory.csv.
-            sites_generator=OrgSiteExporter.sites,  # Rebuild SiteList.csv (unused here).
-        )
-        _VC.convert_single(  # Delegate the conversion.
-            apisession=apisession,
-            io_deps=io_deps,
-            safe_input_fn=InputUtils.safe_input,
-            select_site_fn=PromptUtils.select_site,
-            dry_run=dry_run,
-        )
-
-    @staticmethod
-    def convert_by_site_list() -> None:  # Convert by site list.
-        """Bulk convert VC switches from site list CSV (Menu 93)."""
-        from src.device.virtual_chassis import (  # Import the impl.
-            VCIODeps,
-        )
-        from src.device.virtual_chassis import (
-            VirtualChassisManager as _VC,
-        )
-
-        io_deps = VCIODeps(  # Bundle IO/cache dependencies for the bulk path.
-            get_csv_path_fn=FilePathUtils.get_csv_path,  # Cache path resolver.
-            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,  # Refresh cached CSV.
-            inventory_generator=OrgInventoryExporter.inventory,  # Rebuild OrgInventory.csv.
-            sites_generator=OrgSiteExporter.sites,  # Rebuild SiteList.csv.
-            create_csv_template_fn=FilePathUtils.create_csv_template,  # Write empty VCConvert.CSV.
-        )
-        _VC.convert_by_site_list(  # Delegate the conversion.
-            apisession=apisession,
-            io_deps=io_deps,
-            safe_input_fn=InputUtils.safe_input,
-        )
-
-    @staticmethod
-    def check_status() -> None:  # Check VC status.
-        """Check conversion status of all VC switches (Menu 94)."""
-        from src.device.virtual_chassis import (  # Import the impl.
-            VCExportDeps,
-            VCIODeps,
-        )
-        from src.device.virtual_chassis import (
-            VirtualChassisManager as _VC,
-        )
-
-        io_deps = VCIODeps(  # Bundle IO/cache dependencies.
-            get_csv_path_fn=FilePathUtils.get_csv_path,  # Cache path resolver.
-            check_and_generate_csv_fn=CacheUtils.check_and_generate_csv,  # Refresh cached CSV.
-            inventory_generator=OrgInventoryExporter.inventory,  # Rebuild OrgInventory.csv.
-            sites_generator=OrgSiteExporter.sites,  # Rebuild SiteList.csv.
-        )
-        export_deps = VCExportDeps(  # Bundle export dependencies.
-            flatten_fields_fn=DataProcessingUtils.flatten_nested_fields,  # Flatten nested rows.
-            escape_multiline_fn=DataProcessingUtils.escape_multiline,  # Escape multiline content.
-            save_data_fn=DataExporter.write_with_format_selection,  # Physical writer.
-        )
-        _VC.check_status(io_deps=io_deps, export_deps=export_deps)  # Delegate the check.
+    )
+    return VirtualChassisManager  # Canonical class ready for menu callback dispatch.
 
 
 # ============================================================================
@@ -5473,15 +5424,15 @@ menu_actions = {
         " DESTRUCTIVE: Reboot all devices associated with templates listed in GatewayTemplateRebootList.CSV and log results",  # noqa: E501
     ),
     "161": (
-        lambda dry_run=False: VirtualChassisManager.convert_single(dry_run=dry_run),  # type: ignore[misc]
+        lambda dry_run=False: _configure_virtual_chassis_manager().launch_convert_single(dry_run=dry_run),  # type: ignore[misc]
         " DESTRUCTIVE: Convert a virtual chassis switch to virtual MAC (interactive, supports --dry-run)",
     ),
     "162": (
-        VirtualChassisManager.convert_by_site_list,
+        lambda: _configure_virtual_chassis_manager().launch_convert_by_site_list(),
         " DESTRUCTIVE: Convert all virtual chassis switches in sites listed in VCConvert.CSV (bulk operation)",
     ),
     "14": (
-        VirtualChassisManager.check_status,
+        lambda: _configure_virtual_chassis_manager().launch_check_status(),
         "Check virtual chassis to virtual MAC conversion status for all switches",
     ),
     "18": (

--- a/src/device/virtual_chassis.py
+++ b/src/device/virtual_chassis.py
@@ -62,6 +62,41 @@ class _ConvertTarget:
     device_id: str  # WHY: mistapi convert endpoint requires device_id.
 
 
+# ---------------------------------------------------------------------------
+# Pattern 1 module-level dependency container (initiative 1015 T-11)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VirtualChassisDependencies:
+    """Immutable bundle of MistHelper-owned collaborators wired at menu-dispatch time."""
+
+    apisession: Any = None  # WHY: authenticated mistapi session shared across all VC calls.
+    file_path_utils: Any = None  # WHY: resolves cache CSV paths and creates VCConvert templates.
+    cache_utils: Any = None  # WHY: check_and_generate_csv gate for OrgInventory/SiteList freshness.
+    org_inventory_exporter: Any = None  # WHY: regenerates OrgInventory.csv on cache miss.
+    org_site_exporter: Any = None  # WHY: regenerates SiteList.csv on cache miss.
+    input_utils: Any = None  # WHY: safe_input gate for destructive prompts (Menu 92/93).
+    prompt_utils: Any = None  # WHY: select_site interactive prompt for Menu 92.
+    data_processing_utils: Any = None  # WHY: flatten_nested_fields + escape_multiline for Menu 94 export.
+    data_exporter: Any = None  # WHY: write_with_format_selection writer for Menu 94 CSV output.
+
+
+_DEPS: VirtualChassisDependencies = VirtualChassisDependencies()  # WHY: shared holder mutated by wire-up.
+
+
+def _deps() -> VirtualChassisDependencies:  # WHY: single accessor used by every launch method.
+    """Return the active dependency container so launchers can pull collaborators."""
+    return _DEPS  # WHY: indirection keeps tests able to swap the whole graph atomically.
+
+
+def configure_virtual_chassis_dependencies(deps: VirtualChassisDependencies) -> None:
+    """Wire runtime collaborators from the MistHelper orchestration layer (Menus 92/93/94)."""
+    global _DEPS  # WHY: rebind the module-level holder used by every launch method.
+    logging.info("configure_virtual_chassis_dependencies: wiring MistHelper globals for VC menus")  # WHY.
+    _DEPS = deps  # WHY: single assignment ensures atomic swap of collaborators.
+
+
 class VirtualChassisManager:
     """Manage virtual chassis to virtual MAC conversion operations.
 
@@ -72,6 +107,65 @@ class VirtualChassisManager:
 
     # ------------------------------------------------------------------
     # Public entry-points (menus 92, 93, 94)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def launch_convert_single(cls, dry_run: bool = False) -> None:
+        """Menu 92 launcher: build IO deps from `_deps()` and delegate to `convert_single`."""
+        logging.info("VirtualChassisManager.launch_convert_single: wiring VCIODeps (dry_run=%s)", dry_run)  # WHY.
+        deps = _deps()  # WHY: pull the shared dependency container populated at menu wire-up.
+        io_deps = VCIODeps(  # WHY: bundle IO/cache dependencies to satisfy the 5-param limit.
+            get_csv_path_fn=deps.file_path_utils.get_csv_path,  # WHY: resolve cache paths.
+            check_and_generate_csv_fn=deps.cache_utils.check_and_generate_csv,  # WHY: refresh cached CSV.
+            inventory_generator=deps.org_inventory_exporter.inventory,  # WHY: rebuild OrgInventory.csv.
+            sites_generator=deps.org_site_exporter.sites,  # WHY: rebuild SiteList.csv (unused here).
+        )
+        cls.convert_single(  # WHY: delegate to the injected static entry-point.
+            apisession=deps.apisession,  # WHY: authenticated mistapi session for API calls.
+            io_deps=io_deps,  # WHY: bundled IO/cache dependencies.
+            safe_input_fn=deps.input_utils.safe_input,  # WHY: gated input for destructive prompts.
+            select_site_fn=deps.prompt_utils.select_site,  # WHY: interactive site picker.
+            dry_run=dry_run,  # WHY: forward operator's --dry-run flag.
+        )
+
+    @classmethod
+    def launch_convert_by_site_list(cls) -> None:
+        """Menu 93 launcher: build IO deps from `_deps()` and delegate to `convert_by_site_list`."""
+        logging.info("VirtualChassisManager.launch_convert_by_site_list: wiring VCIODeps for bulk")  # WHY.
+        deps = _deps()  # WHY: pull the shared dependency container populated at menu wire-up.
+        io_deps = VCIODeps(  # WHY: bundle IO/cache dependencies for the bulk path.
+            get_csv_path_fn=deps.file_path_utils.get_csv_path,  # WHY: cache path resolver.
+            check_and_generate_csv_fn=deps.cache_utils.check_and_generate_csv,  # WHY: refresh cached CSV.
+            inventory_generator=deps.org_inventory_exporter.inventory,  # WHY: rebuild OrgInventory.csv.
+            sites_generator=deps.org_site_exporter.sites,  # WHY: rebuild SiteList.csv.
+            create_csv_template_fn=deps.file_path_utils.create_csv_template,  # WHY: write empty VCConvert.CSV.
+        )
+        cls.convert_by_site_list(  # WHY: delegate to the injected static entry-point.
+            apisession=deps.apisession,  # WHY: authenticated mistapi session for API calls.
+            io_deps=io_deps,  # WHY: bundled IO/cache dependencies.
+            safe_input_fn=deps.input_utils.safe_input,  # WHY: gated input for destructive prompts.
+        )
+
+    @classmethod
+    def launch_check_status(cls) -> None:
+        """Menu 94 launcher: build IO+export deps from `_deps()` and delegate to `check_status`."""
+        logging.info("VirtualChassisManager.launch_check_status: wiring VCIODeps + VCExportDeps")  # WHY.
+        deps = _deps()  # WHY: pull the shared dependency container populated at menu wire-up.
+        io_deps = VCIODeps(  # WHY: bundle IO/cache dependencies for status check.
+            get_csv_path_fn=deps.file_path_utils.get_csv_path,  # WHY: cache path resolver.
+            check_and_generate_csv_fn=deps.cache_utils.check_and_generate_csv,  # WHY: refresh cached CSV.
+            inventory_generator=deps.org_inventory_exporter.inventory,  # WHY: rebuild OrgInventory.csv.
+            sites_generator=deps.org_site_exporter.sites,  # WHY: rebuild SiteList.csv.
+        )
+        export_deps = VCExportDeps(  # WHY: bundle export dependencies for CSV writer.
+            flatten_fields_fn=deps.data_processing_utils.flatten_nested_fields,  # WHY: flatten nested rows.
+            escape_multiline_fn=deps.data_processing_utils.escape_multiline,  # WHY: escape multiline content.
+            save_data_fn=deps.data_exporter.write_with_format_selection,  # WHY: physical writer.
+        )
+        cls.check_status(io_deps=io_deps, export_deps=export_deps)  # WHY: delegate the check.
+
+    # ------------------------------------------------------------------
+    # Static per-call entry-points (kept for direct-injection callers + tests)
     # ------------------------------------------------------------------
 
     @staticmethod


### PR DESCRIPTION
## Summary

Initiative 1015 T-11 (Cat E fold-in). The `VirtualChassisManager` class in
`MistHelper.py` was already a delegation stub for the canonical impl in
`src/device/virtual_chassis.py`. This PR completes the fold-in:

* Adds Pattern 1 module-level dependency container in
  `src/device/virtual_chassis.py`:
  * `VirtualChassisDependencies` frozen dataclass
  * `_DEPS` holder + `_deps()` accessor
  * `configure_virtual_chassis_dependencies()` wire-up
* Adds three `@classmethod` launchers (`launch_convert_single`,
  `launch_convert_by_site_list`, `launch_check_status`) that build
  `VCIODeps`/`VCExportDeps` from `_deps()` and delegate to the
  existing static entry points, preserving 88 direct-kwarg test refs
  in `tests/unit/test_virtual_chassis.py`.
* Deletes the stub `VirtualChassisManager` from `MistHelper.py`;
  replaces it with a single `_configure_virtual_chassis_manager() -> type[VirtualChassisManager]`
  seam that mirrors the `_configure_site_config_manager()` pattern.
* Rewrites Menu 161/162/14 dispatch lambdas to call
  `_configure_virtual_chassis_manager().launch_*(...)` so
  MistHelper globals are wired at menu-dispatch time and monkeypatched
  attributes are honoured in tests.

No stub or delegator remains in `MistHelper.py` after this extraction.

## Test plan

- [x] `python -m black --check MistHelper.py src/device/virtual_chassis.py` — 2 files unchanged
- [x] `python -m ruff check MistHelper.py src/device/virtual_chassis.py` — all checks passed
- [x] `python -c "import MistHelper"` — clean import
- [x] `python -m pytest tests/test_virtual_chassis.py tests/unit/test_virtual_chassis.py` — 80 passed, 1 xpassed
- [x] Verified failing `test_menu_196_dispatches_to_async_claim_exporter` is pre-existing (fails on `main`)

## Initiative context

Part of initiative 1015 (refactor final 15 hot classes). Follows the
Cat E extraction pattern established by T-13 (FilePathUtils), T-12
(ConfigUtils), T-14 (tqdm wrapper), and T-15 (`MIST_SITE_EXCLUDE_PREFIX`).

Serial dispatch invariant (FR-023): confirmed no other extraction PR
open before dispatching this one.