### PR TITLE
refactor(1015): fold InputUtils into src/utils/input_utils (T-09, Cat E)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -2021,80 +2021,15 @@ LAST_SELECTED_SITE_ID: str | None = None
 # ============================================================================
 
 
-class InputUtils:
-    """
-    Centralized input handling utilities.
-    Handles safe input with EOF handling, tqdm availability, etc.
-    """
-
-    @staticmethod
-    def ensure_tqdm_available() -> bool:
-        """Ensure tqdm is available and properly imported."""
-        global tqdm  # Rebind the module-level tqdm if we recover a better implementation
-        if hasattr(tqdm, "__module__") and tqdm.__module__ == "tqdm":  # Real tqdm already active
-            logging.debug("tqdm is properly imported and available")  # Nothing to do
-            return True  # Progress bars are functional
-        return InputUtils._try_recover_tqdm()  # Probe import_manager then direct import
-
-    @staticmethod
-    def _try_recover_tqdm() -> bool:
-        """Try to recover tqdm from import_manager cache, then by direct import."""
-        global tqdm  # We may rebind the module global with the recovered implementation
-        logging.debug("_try_recover_tqdm: probing import_manager.imports and direct import")  # Log before probe
-        tqdm_from_manager = import_manager.imports.get("tqdm")  # Issue #431: inlined get_import.
-        if tqdm_from_manager:  # The manager has a usable tqdm
-            tqdm = tqdm_from_manager  # Replace the fallback with the real implementation
-            logging.info("Retrieved tqdm from import manager")  # Record the recovery
-            return True  # Progress bars are now functional
-        try:  # Last-resort direct import path
-            from tqdm import tqdm as real_tqdm  # Last-resort direct import
-
-            tqdm = real_tqdm  # Adopt the directly-imported progress bar
-            logging.info("Successfully imported tqdm directly")  # Record the successful import
-            return True  # Progress bars are now functional
-        except ImportError:  # tqdm simply is not installed
-            logging.warning("tqdm package is not available - progress bars will be disabled")  # Warn of degraded UX
-            return False  # Caller should proceed without progress bars
-
-    @staticmethod
-    def safe_input(prompt: str, default_value: str = "", allow_empty: bool = True, context: str = "unknown") -> str:
-        """EOF/Interrupt-safe input wrapper that returns default_value on EOF and "" on Ctrl+C.
-
-        allow_empty: when False, blank input returns "" (the caller decides what to do).
-        context: short label used in the EOF/interrupt messages and logs.
-        """
-        try:  # Read may raise EOFError on disconnect or KeyboardInterrupt on Ctrl+C
-            user_input = input(prompt).strip()  # Read a line and trim surrounding whitespace
-            if not user_input:  # Blank input -- delegate the 3-way decision to the helper
-                return InputUtils._resolve_empty_input(default_value, allow_empty, context)  # Default/empty/reject
-            return user_input  # Normal path: return the trimmed user response
-        except EOFError:  # Stream closed (Ctrl+D, broken pipe, SSH disconnect)
-            print(
-                f"\n[EOF] Input stream closed during {context}. Using default value: '{default_value}'"
-            )  # Inform the user
-            logging.info(
-                "EOF encountered on input during %s - returning default: '%s'", context, default_value
-            )  # Log the disconnect
-            return default_value  # Degrade gracefully to the default instead of crashing
-        except KeyboardInterrupt:  # User pressed Ctrl+C
-            print(f"\n[INTERRUPT] User interrupted {context}. Canceling...")  # Acknowledge the cancellation
-            logging.info("KeyboardInterrupt encountered during %s", context)  # Log the interrupt
-            return ""  # Return empty to signal the caller should abort this prompt
-
-    @staticmethod
-    def _resolve_empty_input(default_value: str, allow_empty: bool, context: str) -> str:
-        """Decide what to return when safe_input received a blank line."""
-        if default_value:  # A default is configured -- substitute it
-            logging.debug(
-                "Empty input for %s, using default: '%s'", context, default_value
-            )  # Note the default substitution
-            return default_value  # Return the caller-supplied default
-        if allow_empty:  # Blank entry is acceptable here
-            return ""  # Return the empty string as-is
-        logging.warning(
-            "Empty input not allowed for %s, returning empty string", context
-        )  # Warn about the rejected blank
-        return ""  # Signal an invalid/empty response to the caller
+# NOTE: ``InputUtils`` extracted to ``src/utils/input_utils.py`` per initiative
+# 1015 T-09 (Cat E fold-in). ``MistHelper.py`` re-exports the class so
+# ``MistHelper.InputUtils`` / ``mh.InputUtils`` callers keep working
+# transparently -- the re-exported symbol is the same class, not a delegator.
+# The rebind dance ``ensure_tqdm_available`` used to perform is no longer
+# needed since T-14 makes ``tqdm`` resolve through ``src.utils.tqdm_wrapper``
+# at import time; the probe was retained for its logging side effect at the
+# single caller (``src/refactors/main_entrypoint.py``).
+from src.utils.input_utils import InputUtils  # noqa: E402, I001  # Cat E canonical (1015 T-09) -- re-export.
 
 
 # ============================================================================

--- a/src/utils/input_utils.py
+++ b/src/utils/input_utils.py
@@ -1,29 +1,53 @@
 """EOF-safe input helpers used across MistHelper and its src/ packages.
 
-The legacy ``InputUtils.safe_input`` lives on a class inside ``MistHelper.py``
-which makes it awkward to import from sibling ``src/`` modules without
-introducing circular imports. This module exposes the same behavior as a
-standalone class-method so any src/ module can ``from src.utils.input_utils
-import InputUtils`` and call ``InputUtils.safe_input(prompt, context=...)``.
+This module is the canonical home of the ``InputUtils`` class after
+initiative 1015 T-09. ``MistHelper.py`` re-exports the class so historical
+``MistHelper.InputUtils`` / ``mh.InputUtils`` callers keep working
+transparently -- the re-exported symbol is the same class, not a
+delegator.
 
-The implementation matches the original line-for-line so log output and
-return semantics stay identical for both call paths.
+The ``ensure_tqdm_available()`` probe was retained for the single call
+site in ``src/refactors/main_entrypoint.py``. Since initiative 1015 T-14
+made ``tqdm`` resolve through ``src.utils.tqdm_wrapper`` at import time
+(with a no-op fallback when the real package is missing), no runtime
+rebinding of a module global is required -- the probe simply reports
+whether the real ``tqdm`` package is active.
 
-Issue: https://github.com/jmorrison-juniper/MistHelper/issues/433 (Phase C)
+Issue: https://github.com/jmorrison-juniper/MistHelper/issues/433 (Phase C).
 """
 
 from __future__ import annotations  # Enable PEP 604 union syntax on Python 3.13.
 
 import logging  # Used by every action-log line below per the project's NON-NEGOTIABLE rule.
 
+from src.utils.tqdm_wrapper import tqdm as _tqdm  # Canonical tqdm handle (T-14) for the availability probe.
+
 
 class InputUtils:
-    """Centralized input handling utilities (extracted to ``src/utils/`` for reuse).
+    """Centralized input handling utilities (canonical home in ``src/utils/``).
 
-    Same name and same public API as the MistHelper.py class. Any future
-    consolidation should re-export this implementation from MistHelper.py
-    rather than maintain two copies.
+    ``MistHelper.py`` re-exports this class so ``MistHelper.InputUtils``
+    callers keep working without a delegator.
     """
+
+    @staticmethod
+    def ensure_tqdm_available() -> bool:
+        """Return True when the real ``tqdm`` package is active; False when the wrapper's fallback is in use.
+
+        The rebind dance that lived in ``MistHelper.InputUtils`` before
+        initiative 1015 T-09 is no longer needed: T-14 made
+        ``src.utils.tqdm_wrapper`` resolve the real ``tqdm`` at import
+        time and expose a no-op iterable-passthrough when the package is
+        missing. Callers still invoke this probe for its logging side
+        effect; the return value is informational.
+        """
+        if hasattr(_tqdm, "__module__") and _tqdm.__module__.startswith("tqdm"):  # Real tqdm package is active.
+            logging.debug("ensure_tqdm_available: real tqdm package is active")  # Action-log the healthy path.
+            return True  # Progress bars are functional.
+        logging.warning(  # Warn once that progress bars are degraded to the no-op fallback.
+            "ensure_tqdm_available: tqdm fallback in use - progress bars will be disabled"
+        )
+        return False  # Caller may proceed without progress bars.
 
     @staticmethod
     def safe_input(


### PR DESCRIPTION
## Summary

Fold-in for **initiative 1015 T-09**. Consolidates the previously-parallel `InputUtils` implementations (one in `MistHelper.py`, one in `src/utils/input_utils.py`) into a single canonical class living in `src/utils/input_utils.py`. `MistHelper.py` re-exports the class so all historical `MistHelper.InputUtils.*` / `mh.InputUtils.*` callers keep working transparently -- **no delegator, no shim, no behavior change**.

- MistHelper.InputUtils class body removed (74 LOC -> 8-line re-export).
- `ensure_tqdm_available()` retained (single caller at `src/refactors/main_entrypoint.py:48`); implementation simplified because T-14 already resolves `tqdm` through `src.utils.tqdm_wrapper` at import time -- the runtime rebind path is no longer needed.
- `_try_recover_tqdm` removed (dead after T-14 -- verified via cross-repo grep that no callers remain).
- `_resolve_empty_input` folded into `_handle_empty` (the name the earlier `src/utils` copy was already using; internal-only, no external callers).

## Test plan

- [x] `black --check MistHelper.py src/utils/input_utils.py` -- clean.
- [x] `ruff check MistHelper.py src/utils/input_utils.py` -- clean.
- [x] `tests/guardrails/test_wave1_safe_input_paths.py` -- 6 passed.
- [x] `tests/unit/gateway/test_wan2_migration_manager.py` + `test_wan_probe_device_override_manager.py` + `tests/unit/site/address_audit/` -- 222 passed.
- [x] `MistHelper.InputUtils is src.utils.input_utils.InputUtils` -> True.
- [ ] Full CI suite (delegated to GitHub Actions).