### PR TITLE
refactor(1015): extract DataProcessingUtils to src/data/data_processing_utils (T-10, Cat E)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ DEVICE*.csv
 data/
 Data/
 DATA/
+!src/data/
+!src/data/**
 compliance_report.md
 output/
 Output/

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -736,7 +736,6 @@ def _early_dependency_check():  # Public entry point; delegates to the extracted
 _early_dependency_check()  # type: ignore[no-untyped-call]  # Run the bootstrap immediately at import time
 
 # Additional standard library imports
-import ast  # Safely parse Python literals from strings (config/data deserialization)
 import concurrent.futures  # High-level parallelism primitives for batched API calls
 import inspect  # Introspect functions/classes at runtime (signatures, source lookup)
 import json  # Encode/decode JSON for API payloads and cache files
@@ -2883,171 +2882,16 @@ def _configure_session_timeout(session_obj: Any) -> None:
 from src.api.tenant_fetch import APITenantFetchUtils  # noqa: F401  # Re-exported for ServicePingLauncher late-binding
 
 # NOTE: APIFetchUtils removed (1014 P8, Cat E) - canonical body at src/api/api_fetch_utils.py.
-
 # ============================================================================
 # DATA PROCESSING UTILITIES CLASS
 # ============================================================================
-
-
-class DataProcessingUtils:  # JSON flattening/normalization.
-    """
-    Centralized data processing utilities.
-    Groups all data transformation functions for better code organization.
-    All methods are static to avoid unnecessary object instantiation.
-
-    Implementation Note: Methods contain the actual logic rather than delegating
-    to standalone functions, per the 5-Item Rule class organization requirement.
-    """
-
-    @staticmethod
-    def _flatten_list_value(new_key: str, sep: str, v: list) -> list[tuple[str, Any]]:
-        """Flatten a list value: list-of-dicts gets index keys; scalar lists join as CSV. Returns pairs to extend."""
-        out: list[tuple[str, Any]] = []  # Accumulator for produced pairs
-        if all(isinstance(i, dict) for i in v):  # List of dicts: index each
-            for idx, item in enumerate(v):  # Walk list items
-                out.extend(DataProcessingUtils.flatten_dict(item, f"{new_key}{sep}{idx}", sep=sep).items())
-            return out
-        out.append((new_key, ",".join(map(str, v))))  # Join scalar list as CSV
-        return out
-
-    @staticmethod
-    def flatten_dict(d: dict[str, Any], parent_key: str = "", sep: str = "_") -> dict[str, Any]:  # Flatten nested dict.
-        """Recursively flatten nested dict for CSV/JSON; lists-of-dicts get index keys, scalar lists join as CSV."""
-        items: list[tuple[str, Any]] = []  # Accumulate flattened pairs
-        for k, v in d.items():  # Walk each key/value
-            k_str = str(k)  # Stringify the key
-            new_key = f"{parent_key}{sep}{k_str}" if parent_key else k_str  # Compose the dotted key
-            if isinstance(v, dict):  # Recurse into nested dicts
-                items.extend(DataProcessingUtils.flatten_dict(v, new_key, sep=sep).items())
-                continue
-            if isinstance(v, list):  # Lists need index expansion
-                items.extend(DataProcessingUtils._flatten_list_value(new_key, sep, v))
-                continue
-            items.append((new_key, v))  # Keep scalar value as-is
-        return dict(items)  # Return the flat dict
-
-    @staticmethod
-    def flatten_nested_fields(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """
-        Flatten nested fields in a list of dictionaries.
-        Attempts to parse stringified dicts/lists.
-        Recursively flattens nested dicts and lists of dicts.
-        Joins non-dict lists as comma-separated strings.
-
-        Args:
-            data: List of dictionaries to process
-
-        Returns:
-            list: List of dictionaries with flattened nested fields
-        """
-        flattened = []  # Collect flattened rows.
-        for entry in data:  # Process each record.
-            if not isinstance(entry, dict):  # Skip non-dict records.
-                logging.debug("Skipping non-dictionary entry: %s", type(entry).__name__)  # Trace skipped entry.
-                continue  # Move to next record.
-            flattened.append(DataProcessingUtils._flatten_entry(entry))  # Delegate per-entry flattening.
-        return flattened  # Return all flattened rows.
-
-    @staticmethod
-    def _flatten_entry(entry):
-        """Flatten a single dict entry, returning a new dict with nested values expanded."""
-        new_entry = {}  # Accumulator for the flattened output of this entry
-        for key, value in entry.items():  # Walk every field of the entry
-            parsed = DataProcessingUtils._parse_stringified_value(value)  # Maybe parse stringified JSON
-            DataProcessingUtils._flatten_value_into(new_entry, key, parsed)  # Expand nested into new_entry
-        return new_entry  # Return the flattened entry
-
-    @staticmethod
-    def _parse_stringified_value(value):
-        """Try to parse a string starting with { or [ as Python literal or JSON; return original on failure."""
-        if not isinstance(value, str):  # Non-string values pass through unchanged
-            return value  # Nothing to parse
-        if not value.startswith(("{", "[")):  # Not embedded JSON-ish - skip parsing
-            return value  # Return as-is
-        try:
-            return ast.literal_eval(value)  # Try Python-literal parse first
-        except Exception:  # ast.literal_eval failed
-            try:
-                return json.loads(value)  # Fall back to JSON parse
-            except Exception:  # nosec B110 - both parses failed, leave as string
-                return value  # Final fallback: original string
-
-    @staticmethod
-    def _flatten_value_into(new_entry, key, value):
-        """Merge a single (key, value) into new_entry, expanding nested dicts/lists per legacy rules."""
-        if isinstance(value, dict):  # Nested dict needs flattening
-            new_entry.update(DataProcessingUtils.flatten_dict(value, parent_key=key))  # Merge flattened keys
-            return  # Done for dict path
-        if not isinstance(value, list):  # Scalar (non-dict, non-list)
-            new_entry[key] = value  # Keep scalar value as-is
-            return  # Done for scalar path
-        if DataProcessingUtils._is_list_of_dicts(value):  # List of dicts: index each element
-            for idx, item in enumerate(value):  # Walk list items
-                new_entry.update(DataProcessingUtils.flatten_dict(item, parent_key=f"{key}_{idx}"))  # Merge item keys
-            return  # Done for list-of-dicts path
-        new_entry[key] = ",".join(map(str, value))  # Scalar list - join as CSV
-
-    @staticmethod
-    def _is_list_of_dicts(value):
-        """Return True when every element of value is a dict (used by _flatten_value_into)."""
-        return all(isinstance(i, dict) for i in value)  # Check every element is dict-typed
-
-    @staticmethod
-    def convert_list_values_to_strings(data):  # Stringify list-valued fields.
-        """
-        Convert list, tuple, or set values to CSV-compatible comma-separated strings.
-
-        Args:
-            data: List of dictionaries containing list values
-
-        Returns:
-            Data with list values converted to strings
-        """
-        for entry in data:  # Process each record.
-            for key, value in entry.items():  # Walk each field.
-                if isinstance(value, (list, tuple, set)):  # Only convert collections.
-                    logging.debug("Converting list/tuple/set at key '%s' to string", key)  # Trace the conversion.
-                    entry[key] = ",".join(map(str, value))  # Join as CSV string.
-        return data  # Return converted records.
-
-    @staticmethod
-    def get_unique_keys(data):  # Collect the union of all keys.
-        """
-        Get all unique dictionary keys from a list of dictionaries.
-        Returns a sorted list of string keys.
-
-        Args:
-            data: List of dictionaries
-
-        Returns:
-            list: Sorted list of unique keys as strings
-        """
-        fields = set()  # Accumulate distinct keys.
-        for entry in data:  # Scan each record.
-            fields.update(entry.keys())  # Add this record's keys.
-        return sorted(str(f) for f in fields)  # Return sorted field names.
-
-    @staticmethod
-    def escape_multiline(data):  # Escape newlines for CSV safety.
-        """
-        Escape multiline strings for CSV compatibility.
-        Joins list values as comma-separated strings.
-        Replaces newline characters with escaped versions.
-
-        Args:
-            data: List of dictionaries containing multiline strings
-
-        Returns:
-            Data with escaped multiline strings
-        """
-        for entry in data:  # Process each record.
-            for key, value in entry.items():  # Walk each field.
-                if isinstance(value, list):  # Join lists to a string.
-                    entry[key] = ",".join(map(str, value))  # CSV-join the list.
-                elif isinstance(value, str):  # Escape string newlines.
-                    entry[key] = value.replace("\n", "\\n").replace("\r", "")  # Escape CR/LF for CSV.
-        return data  # Return escaped records.
-
+# NOTE: ``DataProcessingUtils`` extracted to ``src/data/data_processing_utils.py``
+# per initiative 1015 T-10 (Cat E). ``MistHelper.py`` re-exports the class so
+# historical ``MistHelper.DataProcessingUtils`` / ``mh.DataProcessingUtils``
+# callers keep working transparently -- the re-exported symbol is the same
+# class, not a delegator. All methods are ``@staticmethod`` with no runtime
+# dependencies, so no Pattern 1 wrapper is required.
+from src.data.data_processing_utils import DataProcessingUtils  # noqa: E402, I001  # Cat E canonical (1015 T-10).
 
 # MarvisDataUtils extracted to src/marvis/marvis_utils.py (issue #330).
 # Dependency injection is used so the module has no circular import with MistHelper.

--- a/src/api/api_data_fetcher.py
+++ b/src/api/api_data_fetcher.py
@@ -18,6 +18,10 @@ import mistapi  # WHY: direct SDK access for mistapi.get_all pagination.
 from prettytable import PrettyTable  # WHY: render result rows for logging.
 from tqdm import tqdm  # WHY: progress bar during table build.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class APIDataFetcher:
     """Fetches data from Mist API, processes it, and exports to CSV/SQLite.
@@ -329,9 +333,8 @@ class APIDataFetcher:
 
     def _display_table(self) -> None:  # Build and log a table.
         """Prepare and display data in PrettyTable format."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils helper.
         data = self._prepare_data_for_display()  # Normalize rows.
-        fields = mh.DataProcessingUtils.get_unique_keys(data)
+        fields = DataProcessingUtils.get_unique_keys(data)
         logging.debug("Unique fields for table: %s", fields)  # Trace fields.
 
         table = self._build_pretty_table(data, fields)  # Build the table.
@@ -339,15 +342,14 @@ class APIDataFetcher:
 
     def _prepare_data_for_display(self) -> list[dict[str, Any]]:  # Filter, sort, flatten rows.
         """Prepare raw data for table display."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils helper.
         data = [entry for entry in self.rawdata if isinstance(entry, dict)]  # Dict rows only.
 
         if self.sort_key:  # Optional sort.
             sort_key_str: str = self.sort_key  # Type narrowing
             data = sorted(data, key=lambda x: x.get(sort_key_str, ""))  # Sort by key.
 
-        data = mh.DataProcessingUtils.flatten_nested_fields(data)  # Flatten nested fields.
-        data = mh.DataProcessingUtils.escape_multiline(data)
+        data = DataProcessingUtils.flatten_nested_fields(data)  # Flatten nested fields.
+        data = DataProcessingUtils.escape_multiline(data)
         return data  # type: ignore[no-any-return]
 
     def _build_pretty_table(self, data: list[dict[str, Any]], fields: list[str]) -> Any:  # Build a PrettyTable.

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data-transformation utilities extracted from MistHelper (initiative 1015)."""

--- a/src/data/data_processing_utils.py
+++ b/src/data/data_processing_utils.py
@@ -31,7 +31,7 @@ class DataProcessingUtils:
     """
 
     @staticmethod
-    def _flatten_list_value(new_key: str, sep: str, v: list) -> list[tuple[str, Any]]:
+    def _flatten_list_value(new_key: str, sep: str, v: list[Any]) -> list[tuple[str, Any]]:
         """Flatten a list value: list-of-dicts gets index keys; scalar lists join as CSV."""
         out: list[tuple[str, Any]] = []  # Accumulator for produced pairs.
         if all(isinstance(i, dict) for i in v):  # List of dicts: index each entry.
@@ -112,7 +112,7 @@ class DataProcessingUtils:
         new_entry[key] = ",".join(map(str, value))  # Scalar list -- join as CSV.
 
     @staticmethod
-    def _is_list_of_dicts(value: list) -> bool:
+    def _is_list_of_dicts(value: list[Any]) -> bool:
         """Return ``True`` when every element of ``value`` is a dict."""
         return all(isinstance(i, dict) for i in value)  # Check every element is dict-typed.
 

--- a/src/data/data_processing_utils.py
+++ b/src/data/data_processing_utils.py
@@ -1,0 +1,150 @@
+"""``DataProcessingUtils`` extracted from MistHelper (initiative 1015 T-10).
+
+Owns the JSON-flattening / CSV-normalization helpers originally defined
+at ``MistHelper.py`` lines 2892-3049. All methods are ``@staticmethod``
+with no runtime dependencies -- the class is a pure utility bundle, so
+this extraction lands as a bare re-export from ``MistHelper.py`` (no
+Pattern 1 DI wrapper, no delegator).
+
+``MistHelper.py`` re-exports the class so historical
+``MistHelper.DataProcessingUtils`` / ``mh.DataProcessingUtils`` callers
+keep working transparently -- the re-exported symbol is the same class,
+not a delegator.
+
+Issue: https://github.com/jmorrison-juniper/MistHelper/issues/896 (initiative 1015 T-10).
+"""
+
+from __future__ import annotations  # Enable PEP 604 unions on 3.10+.
+
+import ast  # ast.literal_eval fallback for stringified Python literals.
+import json  # json.loads fallback for stringified JSON payloads.
+import logging  # Structured action logging per Constitution VII.
+from typing import Any  # Broad typing for arbitrary field values.
+
+
+class DataProcessingUtils:
+    """Centralized data-transformation utilities (canonical home in ``src/data/``).
+
+    All methods are static; the class is a namespace for JSON flattening,
+    key normalization, and CSV-safety helpers. ``MistHelper.py`` re-exports
+    this class so historical callers keep working without a delegator.
+    """
+
+    @staticmethod
+    def _flatten_list_value(new_key: str, sep: str, v: list) -> list[tuple[str, Any]]:
+        """Flatten a list value: list-of-dicts gets index keys; scalar lists join as CSV."""
+        out: list[tuple[str, Any]] = []  # Accumulator for produced pairs.
+        if all(isinstance(i, dict) for i in v):  # List of dicts: index each entry.
+            for idx, item in enumerate(v):  # Walk list items.
+                out.extend(DataProcessingUtils.flatten_dict(item, f"{new_key}{sep}{idx}", sep=sep).items())
+            return out  # Return the indexed pairs.
+        out.append((new_key, ",".join(map(str, v))))  # Join scalar list as CSV.
+        return out  # Return the single joined pair.
+
+    @staticmethod
+    def flatten_dict(d: dict[str, Any], parent_key: str = "", sep: str = "_") -> dict[str, Any]:
+        """Recursively flatten nested dict for CSV/JSON; lists-of-dicts get index keys."""
+        items: list[tuple[str, Any]] = []  # Accumulate flattened (key, value) pairs.
+        for k, v in d.items():  # Walk every key/value in the input dict.
+            k_str = str(k)  # Stringify the key for safe concatenation.
+            new_key = f"{parent_key}{sep}{k_str}" if parent_key else k_str  # Compose the dotted key.
+            if isinstance(v, dict):  # Recurse into nested dicts.
+                items.extend(DataProcessingUtils.flatten_dict(v, new_key, sep=sep).items())
+                continue  # Move to next field.
+            if isinstance(v, list):  # Lists need index expansion or CSV join.
+                items.extend(DataProcessingUtils._flatten_list_value(new_key, sep, v))
+                continue  # Move to next field.
+            items.append((new_key, v))  # Scalar value: keep as-is.
+        return dict(items)  # Return the flat dict.
+
+    @staticmethod
+    def flatten_nested_fields(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Flatten nested fields in a list of dictionaries.
+
+        Attempts to parse stringified dicts/lists; recursively flattens
+        nested dicts and lists of dicts; joins non-dict lists as CSV.
+        """
+        flattened = []  # Collect flattened rows.
+        for entry in data:  # Process each record.
+            if not isinstance(entry, dict):  # Skip non-dict records defensively.
+                logging.debug("Skipping non-dictionary entry: %s", type(entry).__name__)  # Trace skipped entry.
+                continue  # Move to next record.
+            flattened.append(DataProcessingUtils._flatten_entry(entry))  # Delegate per-entry flattening.
+        return flattened  # Return all flattened rows.
+
+    @staticmethod
+    def _flatten_entry(entry: dict[str, Any]) -> dict[str, Any]:
+        """Flatten a single dict entry, returning a new dict with nested values expanded."""
+        new_entry: dict[str, Any] = {}  # Accumulator for the flattened output of this entry.
+        for key, value in entry.items():  # Walk every field of the entry.
+            parsed = DataProcessingUtils._parse_stringified_value(value)  # Maybe parse stringified JSON.
+            DataProcessingUtils._flatten_value_into(new_entry, key, parsed)  # Expand nested value.
+        return new_entry  # Return the flattened entry.
+
+    @staticmethod
+    def _parse_stringified_value(value: Any) -> Any:
+        """Try to parse a string starting with ``{`` or ``[`` as Python literal or JSON."""
+        if not isinstance(value, str):  # Non-string values pass through unchanged.
+            return value  # Nothing to parse.
+        if not value.startswith(("{", "[")):  # Not embedded JSON-ish; skip parsing.
+            return value  # Return as-is.
+        try:
+            return ast.literal_eval(value)  # Try Python-literal parse first.
+        except Exception:  # ast.literal_eval failed; try JSON.
+            try:
+                return json.loads(value)  # Fall back to JSON parse.
+            except Exception:  # nosec B110 - both parses failed; leave value as string.
+                return value  # Final fallback: original string.
+
+    @staticmethod
+    def _flatten_value_into(new_entry: dict[str, Any], key: str, value: Any) -> None:
+        """Merge a single (key, value) into ``new_entry``, expanding nested dicts/lists."""
+        if isinstance(value, dict):  # Nested dict needs flattening.
+            new_entry.update(DataProcessingUtils.flatten_dict(value, parent_key=key))  # Merge flattened keys.
+            return  # Done for dict path.
+        if not isinstance(value, list):  # Scalar (non-dict, non-list).
+            new_entry[key] = value  # Keep scalar value as-is.
+            return  # Done for scalar path.
+        if DataProcessingUtils._is_list_of_dicts(value):  # List of dicts: index each element.
+            for idx, item in enumerate(value):  # Walk list items.
+                new_entry.update(DataProcessingUtils.flatten_dict(item, parent_key=f"{key}_{idx}"))  # Merge item keys.
+            return  # Done for list-of-dicts path.
+        new_entry[key] = ",".join(map(str, value))  # Scalar list -- join as CSV.
+
+    @staticmethod
+    def _is_list_of_dicts(value: list) -> bool:
+        """Return ``True`` when every element of ``value`` is a dict."""
+        return all(isinstance(i, dict) for i in value)  # Check every element is dict-typed.
+
+    @staticmethod
+    def convert_list_values_to_strings(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Convert list, tuple, or set values to CSV-compatible comma-separated strings."""
+        for entry in data:  # Process each record.
+            for key, value in entry.items():  # Walk each field.
+                if isinstance(value, (list, tuple, set)):  # Only convert collections.
+                    logging.debug("Converting list/tuple/set at key '%s' to string", key)  # Trace the conversion.
+                    entry[key] = ",".join(map(str, value))  # Join as CSV string.
+        return data  # Return converted records.
+
+    @staticmethod
+    def get_unique_keys(data: list[dict[str, Any]]) -> list[str]:
+        """Return a sorted list of unique keys across all dicts in ``data``."""
+        fields: set[Any] = set()  # Accumulate distinct keys.
+        for entry in data:  # Scan each record.
+            fields.update(entry.keys())  # Add this record's keys.
+        return sorted(str(f) for f in fields)  # Return sorted field names.
+
+    @staticmethod
+    def escape_multiline(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Escape multiline strings for CSV compatibility.
+
+        Joins list values as CSV-separated strings; replaces newline
+        characters with escaped versions on string fields.
+        """
+        for entry in data:  # Process each record.
+            for key, value in entry.items():  # Walk each field.
+                if isinstance(value, list):  # Join lists to a CSV string.
+                    entry[key] = ",".join(map(str, value))  # CSV-join the list.
+                elif isinstance(value, str):  # Escape string newlines for CSV safety.
+                    entry[key] = value.replace("\n", "\\n").replace("\r", "")  # Escape CR/LF for CSV.
+        return data  # Return escaped records.

--- a/src/export/const_definitions_exporter.py
+++ b/src/export/const_definitions_exporter.py
@@ -15,6 +15,9 @@ import importlib  # WHY: lazy MistHelper import to reach DataExporter + DataProc
 import logging  # WHY: structured trace for discovery/fetch/export lifecycle events.
 from typing import Any  # WHY: helper return types normalize heterogenous mistapi payloads.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.dataclasses.endpoint_config import EndpointConfig  # Const endpoint descriptor.
 
 
@@ -677,7 +680,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
             return  # Abort.
 
         data_list = self._convert_to_list(config.endpoint_name, const_data)  # Normalize to a list.
-        processed = mh.DataProcessingUtils.escape_multiline(data_list)  # type: ignore[no-untyped-call]
+        processed = DataProcessingUtils.escape_multiline(data_list)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(processed, config.filename)  # type: ignore[no-untyped-call]
 
         print(f"  ! {len(processed)} {config.description.lower()} exported to {config.filename}")  # Tell the user.

--- a/src/export/gateway_test_exporter.py
+++ b/src/export/gateway_test_exporter.py
@@ -28,6 +28,9 @@ from typing import Any  # WHY: mistapi payloads + heterogeneous stats dicts are 
 import mistapi  # WHY: direct call to getSiteDeviceSyntheticTest endpoint.
 from tqdm import tqdm  # WHY: progress bar for sequential + retry loops.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.validation.validation_utils import ValidationUtils  # WHY: 1014 P5 direct import (FR-005).
 
 
@@ -290,8 +293,8 @@ class GatewayTestExporter:
             print("! No synthetic test results found. CSV not created.")  # Tell the user.
             return  # Nothing to write.
         filename = "AllGatewaySyntheticTests.csv"  # Build the CSV name.
-        flattened = mh.DataProcessingUtils.flatten_nested_fields(all_stats)  # Flatten nested fields.
-        sanitized = mh.DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
+        flattened = DataProcessingUtils.flatten_nested_fields(all_stats)  # Flatten nested fields.
+        sanitized = DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(sanitized, filename)  # type: ignore[no-untyped-call]
         print(f"! {len(all_stats)} gateway synthetic test results exported to {filename}")  # Tell user.
         logging.info("! Synthetic test results saved to %s (%s records).", filename, len(all_stats))

--- a/src/export/msp_inventory_exporter.py
+++ b/src/export/msp_inventory_exporter.py
@@ -13,6 +13,9 @@ import logging  # WHY: emit structured trace for MSP + org iteration.
 import os  # WHY: build cross-platform output path for CSV artifact.
 from typing import Any  # WHY: duck-typed device dicts + Mist API responses.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.dataclasses.msp_org_context import MspOrgContext  # Bundled MSP/org identity (issue #470).
 from src.refactors.initialize_mist_session_interactive import (
     MistSessionInteractiveInitializer,  # Extracted interactive login initializer (SC-023).
@@ -374,7 +377,7 @@ class MSPInventoryExporter:
         """Write all devices to CSV."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         priority_fields = self._get_priority_fields()
-        flattened = mh.DataProcessingUtils.flatten_nested_fields(self.all_devices)
+        flattened = DataProcessingUtils.flatten_nested_fields(self.all_devices)
 
         all_fields: set[str] = set()
         for device in flattened:

--- a/src/export/org_admin_exporter.py
+++ b/src/export/org_admin_exporter.py
@@ -14,6 +14,10 @@ from typing import Any  # WHY: raw license rows are duck-typed dicts from mistap
 
 import mistapi  # WHY: direct SDK access for org admin/license endpoints.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class OrgAdminExporter:
     """Organization Admin and License Exporter.
@@ -93,8 +97,8 @@ class OrgAdminExporter:
                 logging.info("No license records returned from canonical endpoint; writing empty OrgLicenses.csv")
                 mh.DataExporter.write_with_format_selection([], filename, api_function_name="listOrgLicenses")
                 return  # Abort.
-            processed = mh.DataProcessingUtils.flatten_nested_fields(raw_items)  # Flatten nested fields.
-            processed = mh.DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
+            processed = DataProcessingUtils.flatten_nested_fields(raw_items)  # Flatten nested fields.
+            processed = DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
             mh.DataExporter.write_with_format_selection(processed, filename, api_function_name="listOrgLicenses")
             logging.info("Exported %s license records to %s.", len(processed), filename)  # Log export count.
         except Exception as e:  # Export failed.

--- a/src/export/org_alarm_event_exporter.py
+++ b/src/export/org_alarm_event_exporter.py
@@ -17,6 +17,9 @@ from typing import Any  # WHY: api_call is duck-typed mistapi callable.
 
 import mistapi  # WHY: direct SDK access for alarms/events endpoints.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.export.device_events_52w_exporter import DeviceEvents52wExporter  # 52-week device events exporter.
 from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
 
@@ -133,7 +136,7 @@ class OrgAlarmEventExporter:
             apisession=mh.apisession,
             mistapi=mistapi,
             org_id=mh.ConfigUtils.get_cached_or_prompted_org_id(),
-            data_processing_utils=mh.DataProcessingUtils,
+            data_processing_utils=DataProcessingUtils,
             data_exporter=mh.DataExporter,
             output_format=mh.OUTPUT_FORMAT,
             database_path=mh.DATABASE_PATH,

--- a/src/export/org_client_security_exporter.py
+++ b/src/export/org_client_security_exporter.py
@@ -23,6 +23,9 @@ from typing import Any  # WHY: mistapi response payloads + site rows are duck-ty
 import mistapi  # WHY: direct calls to orgs.clients + sites.insights list endpoints + get_all pager.
 from tqdm import tqdm  # WHY: per-site progress bar for rogue fan-out.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
 
 
@@ -194,8 +197,8 @@ class OrgClientSecurityExporter:
         """Flatten + escape + write the aggregated rogue list, or report the empty-result case."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if rogues:  # At least one rogue was found
-            flattened = mh.DataProcessingUtils.flatten_nested_fields(rogues)  # Flatten nested JSON to CSV rows
-            sanitized = mh.DataProcessingUtils.escape_multiline(flattened)
+            flattened = DataProcessingUtils.flatten_nested_fields(rogues)  # Flatten nested JSON to CSV rows
+            sanitized = DataProcessingUtils.escape_multiline(flattened)
             mh.DataExporter.write_with_format_selection(sanitized, csv_basename)
             logging.info("! %s %s exported to %s", len(rogues), label, csv_basename)  # Log the export
             print(f"! {len(rogues)} {label} exported to {csv_basename}")  # Report the count to the user

--- a/src/export/org_config_exporter.py
+++ b/src/export/org_config_exporter.py
@@ -18,6 +18,10 @@ from typing import Any  # WHY: mistapi response payloads are duck-typed here.
 
 import mistapi  # WHY: direct calls to orgs.psks/webhooks/wlans/mxedges list endpoints.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class OrgConfigExporter:
     """Organization Configuration Exporter.
@@ -176,9 +180,8 @@ class OrgConfigExporter:
     @staticmethod
     def _process_msp_orgs(orgs_data: list, msp_id: str, msp_name: str) -> list:  # type: ignore[type-arg]
         """Flatten + escape + tag each org dict with its parent ``msp_id`` and ``msp_name``."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils facade.
-        processed = mh.DataProcessingUtils.flatten_nested_fields(orgs_data)  # Flatten nested fields.
-        processed = mh.DataProcessingUtils.escape_multiline(processed)  # Escape multiline text.
+        processed = DataProcessingUtils.flatten_nested_fields(orgs_data)  # Flatten nested fields.
+        processed = DataProcessingUtils.escape_multiline(processed)  # Escape multiline text.
         for record in processed:  # Tag each org.
             record["msp_id"] = msp_id  # Add MSP id.
             record["msp_name"] = msp_name  # Add MSP name.

--- a/src/export/org_device_stats_exporter.py
+++ b/src/export/org_device_stats_exporter.py
@@ -31,6 +31,9 @@ from concurrent.futures import ThreadPoolExecutor  # WHY: bounded retry worker p
 
 from tqdm import tqdm  # WHY: progress bar during retry pool.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
 
 
@@ -314,10 +317,10 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
             )  # Sort by MAC to produce deterministic CSV ordering.
         except Exception as exception:  # Sorting failures should not block export.
             logging.debug("Could not sort by MAC: %s", exception)  # Record sort failure while continuing unsorted.
-        flattened = mh.DataProcessingUtils.flatten_nested_fields(
+        flattened = DataProcessingUtils.flatten_nested_fields(
             all_port_stats
         )  # Normalize nested API payloads into flat CSV-friendly records.
-        sanitized = mh.DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]  # Escape embedded newlines so CSV stays row-stable.
+        sanitized = DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]  # Escape embedded newlines so CSV stays row-stable.
         mh.DataExporter.write_with_format_selection(sanitized, output_file, api_function_name="searchSiteSwOrGwPorts")  # type: ignore[no-untyped-call]  # Persist to configured backend with endpoint metadata.
         print(
             f"! {len(all_port_stats)} port stat records exported to {output_file}"

--- a/src/export/org_export_utils.py
+++ b/src/export/org_export_utils.py
@@ -16,6 +16,9 @@ from typing import Any  # WHY: raw insight rows are duck-typed dicts from mistap
 
 import mistapi  # WHY: direct SDK access for org export endpoints.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
 
 
@@ -78,8 +81,8 @@ class OrgExportUtils:
         """Persist aggregated sites-SLE rows to OrgSitesSLESummary.csv (or write empty + warn)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if all_sites_sle_data:  # Have data -- flatten + write + tell user.
-            processed = mh.DataProcessingUtils.flatten_nested_fields(all_sites_sle_data)  # Flatten nested fields.
-            processed = mh.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]  # CSV-safe.
+            processed = DataProcessingUtils.flatten_nested_fields(all_sites_sle_data)  # Flatten nested fields.
+            processed = DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]  # CSV-safe.
             mh.DataExporter.write_with_format_selection(processed, "OrgSitesSLESummary.csv")  # type: ignore[no-untyped-call]
             print(f"! {len(processed)} sites SLE summary exported to OrgSitesSLESummary.csv")  # Tell the user.
             logging.info("Exported %s sites SLE summary to OrgSitesSLESummary.csv", len(processed))  # Log count.
@@ -399,7 +402,7 @@ class OrgExportUtils:
             (buckets["sites_data"], "OrgSitesData.csv", "sites"),  # Sites file + label.
         ]
         for rows, filename, label in outputs:  # Write each normalized bucket to its CSV.
-            processed = mh.DataProcessingUtils.escape_multiline(rows)  # type: ignore[no-untyped-call]  # Escape newlines.
+            processed = DataProcessingUtils.escape_multiline(rows)  # type: ignore[no-untyped-call]  # Escape newlines.
             mh.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]  # Write it.
             print(f"  !? {len(processed)} {label} records -> {filename}")  # Report this file's row count.
         print(
@@ -416,8 +419,8 @@ class OrgExportUtils:
     def _insight_write_combined(all_insight_data: list[dict[str, Any]]) -> None:
         """Write the flattened combined insight file (OrgInsightMetrics_Legacy.csv) for backward compatibility."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter helpers.
-        processed_combined = mh.DataProcessingUtils.flatten_nested_fields(all_insight_data)  # Flatten for combined.
-        processed_combined = mh.DataProcessingUtils.escape_multiline(processed_combined)  # type: ignore[no-untyped-call]
+        processed_combined = DataProcessingUtils.flatten_nested_fields(all_insight_data)  # Flatten for combined.
+        processed_combined = DataProcessingUtils.escape_multiline(processed_combined)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(processed_combined, "OrgInsightMetrics_Legacy.csv")  # type: ignore[no-untyped-call]
         print("  !? Legacy format maintained -> OrgInsightMetrics_Legacy.csv")  # Confirm the file write.
 
@@ -649,8 +652,8 @@ class OrgExportUtils:
                 logging.warning(" No audit logs returned from API.")  # Warn none returned.
                 logging.debug("EXIT: OrgExportUtils.audit_logs - no data")  # Trace exit.
                 return  # Abort.
-            data = mh.DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
-            data = mh.DataProcessingUtils.escape_multiline(data)  # type: ignore[no-untyped-call]
+            data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
+            data = DataProcessingUtils.escape_multiline(data)  # type: ignore[no-untyped-call]
             mh.DataExporter.write_with_format_selection(data, "OrgAuditLogs.csv")  # type: ignore[no-untyped-call]
             print(f"! {len(data)} audit logs exported to OrgAuditLogs.csv")  # Tell the user.
             logging.info("Completed audit logs export and wrote results to OrgAuditLogs.csv.")  # Log completion.

--- a/src/export/org_site_exporter.py
+++ b/src/export/org_site_exporter.py
@@ -22,6 +22,10 @@ import time  # WHY: epoch math for historical guest window + progress timing.
 
 import mistapi  # WHY: dotted-path Mist API resolution + pagination helper.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class OrgSiteExporter:  # Org site exporters.
     """Organization Site Data Exporter.
@@ -76,10 +80,10 @@ class OrgSiteExporter:  # Org site exporters.
             logging.warning(" No sites returned from API.")  # Log empty result.
             print(" No sites returned from API.")  # Inform operator none returned.
             return  # Skip write.
-        sites = mh.DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
+        sites = DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
         # Normalize nested JSON structures into a flat row-per-record format for CSV/DB output
-        sites = mh.DataProcessingUtils.flatten_nested_fields(sites)  # Flatten again post-merge.
-        sites = mh.DataProcessingUtils.escape_multiline(sites)  # type: ignore[no-untyped-call]
+        sites = DataProcessingUtils.flatten_nested_fields(sites)  # Flatten again post-merge.
+        sites = DataProcessingUtils.escape_multiline(sites)  # type: ignore[no-untyped-call]
         # Write to the configured output backend (CSV or SQLite) via the DataExporter abstraction
         mh.DataExporter.write_with_format_selection(sites, output_file)  # type: ignore[no-untyped-call]
         logging.info("! Sites exported to %s", output_file)  # Log the successful export
@@ -97,8 +101,8 @@ class OrgSiteExporter:  # Org site exporters.
         logging.debug("Using org_id: %s for site location export.", org_id)  # Log org id used.
         sites = mh.APICoreFetchUtils.all_sites_with_limit(org_id)  # Fetch all sites.
         logging.info("Fetched %s sites from the organization.", len(sites))  # Log fetched site count.
-        flattened_sites = mh.DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
-        sanitized_sites = mh.DataProcessingUtils.escape_multiline(flattened_sites)  # type: ignore[no-untyped-call]
+        flattened_sites = DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
+        sanitized_sites = DataProcessingUtils.escape_multiline(flattened_sites)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(sanitized_sites, "SitesWithLocations.csv")  # type: ignore[no-untyped-call]
         print(f"! {len(sanitized_sites)} sites exported to SitesWithLocations.csv")  # Confirm export to operator.
         logging.info(" Full site data written to SitesWithLocations.csv")  # Log write success.
@@ -116,8 +120,8 @@ class OrgSiteExporter:  # Org site exporters.
         response = mistapi.api.v1.orgs.guests.searchOrgGuestAuthorization(mh.apisession, org_id, limit=1000)
         guests = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page through all guests.
         logging.info("Fetched %s current guest users from API.", len(guests))  # Log fetched guest count.
-        guests = mh.DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
-        guests = mh.DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
+        guests = DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
+        guests = DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(guests, "OrgCurrentGuests.csv")  # type: ignore[no-untyped-call]
         print(f"! {len(guests)} current guest users exported to OrgCurrentGuests.csv")  # Confirm export to operator.
         logging.info(" Current guests exported to OrgCurrentGuests.csv")  # Log write success.
@@ -138,8 +142,8 @@ class OrgSiteExporter:  # Org site exporters.
         )
         guests = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page through all guests.
         logging.info("Fetched %s historical guest users from API.", len(guests))  # Log fetched guest count.
-        guests = mh.DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
-        guests = mh.DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
+        guests = DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
+        guests = DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(guests, "OrgHistoricalGuests.csv")  # type: ignore[no-untyped-call]
         print(f"! {len(guests)} historical guest users exported to OrgHistoricalGuests.csv")
         logging.info(" Historical guests exported to OrgHistoricalGuests.csv")  # Log write success.

--- a/src/export/org_template_exporter.py
+++ b/src/export/org_template_exporter.py
@@ -14,6 +14,10 @@ from typing import Any  # WHY: raw template rows are duck-typed dicts from mista
 
 import mistapi  # WHY: direct SDK access for org template endpoints.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class OrgTemplateExporter:
     """Organization Template Exporter.
@@ -99,8 +103,8 @@ class OrgTemplateExporter:
             )  # Log empty.
             mh.DataExporter.write_with_format_selection([], filename)  # Write empty file for consistency.
             return
-        processed = mh.DataProcessingUtils.flatten_nested_fields(ap_profiles)  # Flatten nested JSON.
-        processed = mh.DataProcessingUtils.escape_multiline(processed)  # Escape multiline.
+        processed = DataProcessingUtils.flatten_nested_fields(ap_profiles)  # Flatten nested JSON.
+        processed = DataProcessingUtils.escape_multiline(processed)  # Escape multiline.
         mh.DataExporter.write_with_format_selection(processed, filename)  # Persist.
         print(f"! {len(processed)} AP templates exported to {filename}")  # Tell user.
         logging.info("Exported %s AP templates to %s.", len(processed), filename)  # Log count.
@@ -138,8 +142,8 @@ class OrgTemplateExporter:
             )
             mh.DataExporter.write_with_format_selection([], filename)
             return  # Done; empty CSV written.
-        processed = mh.DataProcessingUtils.flatten_nested_fields(switch_profiles)  # Flatten nested template fields.
-        processed = mh.DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
+        processed = DataProcessingUtils.flatten_nested_fields(switch_profiles)  # Flatten nested template fields.
+        processed = DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
         mh.DataExporter.write_with_format_selection(processed, filename)  # Persist.
         print(f"! {len(processed)} switch templates exported to {filename}")  # User notice.
         logging.info("Exported %s switch templates to %s.", len(processed), filename)  # Trace count.

--- a/src/export/self_export_utils.py
+++ b/src/export/self_export_utils.py
@@ -13,6 +13,9 @@ import logging  # WHY: emit structured trace for export progress + failures.
 
 import mistapi  # WHY: dotted-path API resolution + pagination helper.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005).
 
 
@@ -33,7 +36,7 @@ class SelfExportUtils:  # Self/account exporters.
             logging.warning("No self audit log records returned for the last %d hours", hours)  # Warn empty.
             mh.DataExporter.write_with_format_selection([], filename)  # Empty file signals successful run.
             return  # Done.
-        rows = mh.DataProcessingUtils.flatten_nested_fields(rows)  # Flatten nested change-detail dicts for CSV.
+        rows = DataProcessingUtils.flatten_nested_fields(rows)  # Flatten nested change-detail dicts for CSV.
         mh.DataExporter.write_with_format_selection(  # Persist to disk with format selection.
             rows, filename, api_function_name="listSelfAuditLogs"
         )

--- a/src/export/site_anomaly_exporter.py
+++ b/src/export/site_anomaly_exporter.py
@@ -23,6 +23,10 @@ import logging  # WHY: structured trace + mistapi logger suppression by name.
 from collections.abc import Callable  # WHY: fetch_builder is Callable[[str], Callable].
 from typing import Any  # WHY: row rows are dict[str, Any].
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class SiteAnomalyExporter:  # Site anomaly exporters.
     """
@@ -194,8 +198,8 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
         """Flatten + escape + write the aggregated anomaly rows, or write an empty CSV when there is no data."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if data_list:  # At least one metric returned data.
-            processed = mh.DataProcessingUtils.flatten_nested_fields(data_list)  # Flatten nested fields.
-            processed = mh.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
+            processed = DataProcessingUtils.flatten_nested_fields(data_list)  # Flatten nested fields.
+            processed = DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
             mh.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]
             print(f"! {success_count} {label} types exported to {filename}")  # Tell the user the count.
             logging.info("Exported %s %s types for %s to %s", success_count, label, scope_name, filename)  # Log.
@@ -324,8 +328,8 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
         """Flatten and write the collected client anomaly rows to CSV (writes an empty file when there is no data)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if all_data:  # At least one metric returned data.
-            processed = mh.DataProcessingUtils.flatten_nested_fields(all_data)  # Flatten nested fields.
-            processed = mh.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
+            processed = DataProcessingUtils.flatten_nested_fields(all_data)  # Flatten nested fields.
+            processed = DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
             mh.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]
             print(f"! {metrics_retrieved} client anomaly event types exported to {filename}")  # Tell the user.
             logging.info(

--- a/src/export/site_client_exporter.py
+++ b/src/export/site_client_exporter.py
@@ -14,6 +14,9 @@ from typing import Any  # WHY: raw client rows are duck-typed dicts from mistapi
 
 import mistapi  # WHY: direct SDK access for listSiteWirelessClientsStats + beacons endpoints.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for beacons export.
 from src.export.wifi_clients_exporter import WifiClientsExporter  # Extracted WiFi export orchestrator.
 from src.utils.tqdm_wrapper import (
@@ -35,8 +38,8 @@ class SiteClientExporter:
         if not rawdata:  # No clients -- tell the user and return.
             print("! No client data found for this site")  # User notice.
             return
-        flattened_data = mh.DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
-        sanitized_data = mh.DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
+        flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
+        sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
         filename = f"SiteClients_{site_name.replace(' ', '_')}.csv"  # Per-site CSV name.
         mh.DataExporter.write_with_format_selection(sanitized_data, filename)  # Persist.
         print(f"! {len(rawdata)} client records exported to {filename}")  # User notice with count.
@@ -91,7 +94,7 @@ class SiteClientExporter:
             org_site_exporter=mh.OrgSiteExporter,
             prompt_utils=mh.PromptUtils,
             file_path_utils=mh.FilePathUtils,
-            data_processing_utils=mh.DataProcessingUtils,
+            data_processing_utils=DataProcessingUtils,
             data_exporter=mh.DataExporter,
             mistapi_module=mistapi,
             apisession=mh.apisession,
@@ -110,7 +113,7 @@ class SiteClientExporter:
             apisession=mh.apisession,
             PromptUtils=mh.PromptUtils,
             ConfigUtils=mh.ConfigUtils,
-            DataProcessingUtils=mh.DataProcessingUtils,
+            DataProcessingUtils=DataProcessingUtils,
             DataExporter=mh.DataExporter,
             TimeUtils=mh.TimeUtils,
             EnhancedSSHRunner=mh.EnhancedSSHRunner,

--- a/src/export/site_config_exporter.py
+++ b/src/export/site_config_exporter.py
@@ -15,6 +15,9 @@ from typing import Any  # WHY: raw WLAN rows are duck-typed dicts from mistapi.
 import mistapi  # WHY: direct SDK access for sites/orgs endpoints.
 
 from src.api.api_fetch_utils import APIFetchUtils  # WHY: 1014 P8 direct import (FR-005).
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for maps/zones exports.
 from src.utils.tqdm_wrapper import tqdm  # WHY: 1015 T-14 -- canonical wrapper import (eliminates mh.tqdm).
 
@@ -70,8 +73,8 @@ class SiteConfigExporter:
             mh.DataExporter.write_with_format_selection([], filename)  # Empty CSV.
             print(f"! 0 records exported to data\\{filename}")  # Tell the user zero.
             return  # Done.
-        processed = mh.DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
-        processed = mh.DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
+        processed = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
+        processed = DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
         processed = sorted(processed, key=lambda row: row.get("ssid", ""))  # Sort by SSID.
         mh.DataExporter.write_with_format_selection(processed, filename)  # Persist.
         print(f"! {len(processed)} records exported to data\\{filename}")  # Tell the user.
@@ -100,7 +103,7 @@ class SiteConfigExporter:
             apisession=mh.apisession,
             PromptUtils=mh.PromptUtils,
             ConfigUtils=mh.ConfigUtils,
-            DataProcessingUtils=mh.DataProcessingUtils,
+            DataProcessingUtils=DataProcessingUtils,
             DataExporter=mh.DataExporter,
             TimeUtils=mh.TimeUtils,
             EnhancedSSHRunner=mh.EnhancedSSHRunner,
@@ -123,7 +126,7 @@ class SiteConfigExporter:
             apisession=mh.apisession,
             PromptUtils=mh.PromptUtils,
             ConfigUtils=mh.ConfigUtils,
-            DataProcessingUtils=mh.DataProcessingUtils,
+            DataProcessingUtils=DataProcessingUtils,
             DataExporter=mh.DataExporter,
             TimeUtils=mh.TimeUtils,
             EnhancedSSHRunner=mh.EnhancedSSHRunner,
@@ -151,8 +154,8 @@ class SiteConfigExporter:
         data = APIFetchUtils.all_site_settings(mh.apisession, current_org_id, limit=1000)
         if data:  # Have data.
             logging.info("Fetched settings for %s sites. Flattening and sanitizing data...", len(data))
-            data = mh.DataProcessingUtils.flatten_nested_fields(data)  # Flatten nested fields.
-            data = mh.DataProcessingUtils.escape_multiline(data)  # CSV-safe.
+            data = DataProcessingUtils.flatten_nested_fields(data)  # Flatten nested fields.
+            data = DataProcessingUtils.escape_multiline(data)  # CSV-safe.
             mh.DataExporter.write_with_format_selection(data, "AllSiteConfigs.csv")  # Persist.
             print(f"! {len(data)} site configurations exported to AllSiteConfigs.csv")  # Tell the user.
             logging.info(" Site configs saved to AllSiteConfigs.csv")  # Log the save.

--- a/src/export/site_device_exporter.py
+++ b/src/export/site_device_exporter.py
@@ -21,6 +21,9 @@ from typing import Any  # WHY: mistapi response payloads + inventory rows are du
 import mistapi  # WHY: direct calls to sites.devices + sites.stats endpoints + get_all pager.
 from prettytable import PrettyTable  # WHY: debug-log a formatted inventory table.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for port_stats export.
 from src.utils.tqdm_wrapper import tqdm  # WHY: 1015 T-14 -- canonical wrapper import (eliminates mh.tqdm).
 
@@ -54,9 +57,9 @@ class SiteDeviceExporter:
             if rawdata is None:  # No devices remained after filtering (already logged/printed).
                 return  # Abort.
         inventory = sorted(rawdata, key=lambda x: x.get("model", ""))  # Sort by model for easier viewing.
-        inventory = mh.DataProcessingUtils.flatten_nested_fields(inventory)  # Flatten nested fields.
-        inventory = mh.DataProcessingUtils.escape_multiline(inventory)
-        fields = mh.DataProcessingUtils.get_unique_keys(inventory)
+        inventory = DataProcessingUtils.flatten_nested_fields(inventory)  # Flatten nested fields.
+        inventory = DataProcessingUtils.escape_multiline(inventory)
+        fields = DataProcessingUtils.get_unique_keys(inventory)
         mh.DataExporter.write_with_format_selection(inventory, csv_filename)
         logging.info("Device inventory written to %s (%s rows)", csv_filename, len(inventory))  # Log the write.
         SiteDeviceExporter._display_inventory_table(inventory, fields)  # Debug-log a PrettyTable of the inventory.
@@ -95,8 +98,8 @@ class SiteDeviceExporter:
         if not rawdata:  # No data -- tell the user and return.
             print("! No device statistics found for this site")  # User notice.
             return  # Done.
-        flattened_data = mh.DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
-        sanitized_data = mh.DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
+        flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
+        sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
         filename = f"SiteDeviceStats_{site_name.replace(' ', '_')}.csv"  # Build per-site CSV name.
         mh.DataExporter.write_with_format_selection(sanitized_data, filename)  # Persist.
         print(f"! {len(rawdata)} device stats exported to {filename}")  # User notice with count.
@@ -152,7 +155,7 @@ class SiteDeviceExporter:
             apisession=mh.apisession,
             PromptUtils=mh.PromptUtils,
             ConfigUtils=mh.ConfigUtils,
-            DataProcessingUtils=mh.DataProcessingUtils,
+            DataProcessingUtils=DataProcessingUtils,
             DataExporter=mh.DataExporter,
             TimeUtils=mh.TimeUtils,
             EnhancedSSHRunner=mh.EnhancedSSHRunner,
@@ -213,8 +216,8 @@ class SiteDeviceExporter:
                 print(f"! No virtual chassis data found for device {device_name}")  # Tell the user.
                 return  # Nothing to export.
             vc_data = [response.data] if isinstance(response.data, dict) else response.data  # Normalize to a list.
-            flattened = mh.DataProcessingUtils.flatten_nested_fields(vc_data)  # Flatten nested fields.
-            sanitized = mh.DataProcessingUtils.escape_multiline(flattened)
+            flattened = DataProcessingUtils.flatten_nested_fields(vc_data)  # Flatten nested fields.
+            sanitized = DataProcessingUtils.escape_multiline(flattened)
             filename = f"VirtualChassis_{device_name.replace(' ', '_')}.csv"  # Build the CSV name.
             mh.DataExporter.write_with_format_selection(sanitized, filename)
             logging.info("! Virtual chassis information exported to %s", filename)  # Log the export.
@@ -243,8 +246,8 @@ class SiteDeviceExporter:
         if not rawdata:  # No devices -- tell the user and return.
             print("! No devices found for this site")  # User notice.
             return  # Done.
-        flattened_data = mh.DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
-        sanitized_data = mh.DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
+        flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
+        sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
         filename = f"SiteDevices_{site_name.replace(' ', '_')}.csv"  # Per-site CSV name.
         mh.DataExporter.write_with_format_selection(sanitized_data, filename)  # Persist.
         print(f"! {len(rawdata)} devices exported to {filename}")  # User notice with count.

--- a/src/gateway/gateway_ha_exporter.py
+++ b/src/gateway/gateway_ha_exporter.py
@@ -14,6 +14,10 @@ from typing import Any  # WHY: raw gateway rows are duck-typed dicts from mistap
 
 import mistapi  # WHY: direct SDK access for site device stats + HA cluster endpoints.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class GatewayHaExporter:
     """Exporter for HA (High-Availability) gateway cluster information.
@@ -52,7 +56,7 @@ class GatewayHaExporter:
     def _persist_ha_export(rows: list[Any]) -> None:
         """Flatten + write HA gateway rows to CSV/backend and log the count."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter helpers.
-        flat_rows = mh.DataProcessingUtils.flatten_nested_fields(rows)  # Flatten nested dicts for CSV/DB.
+        flat_rows = DataProcessingUtils.flatten_nested_fields(rows)  # Flatten nested dicts for CSV/DB.
         filename = "GatewayHaClusterInfo.csv"  # Output filename for the export.
         mh.DataExporter.write_with_format_selection(
             flat_rows, filename, api_function_name="listSiteGatewayHaStats"

--- a/src/org/org_ticket_manager.py
+++ b/src/org/org_ticket_manager.py
@@ -20,6 +20,10 @@ import importlib  # WHY: lazy MistHelper import avoids circular load at module i
 import logging  # WHY: structured trace + info/warn/error logging.
 import os  # WHY: os.path.isfile() to detect attachments before multipart upload.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class OrgTicketManager:  # Support ticket operations.
     """Full lifecycle management for Juniper Mist support tickets.
@@ -467,7 +471,6 @@ class OrgTicketManager:  # Support ticket operations.
     @staticmethod
     def _collect_ticket_details(org_id: str, tickets: list) -> list:
         """For each summary in tickets, fetch + flatten its full detail. Returns list of flat dicts."""
-        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils.
         all_details = []  # Accumulate flattened ticket+comment records
         print(f"\n  Fetching details for {len(tickets)} tickets...")  # Progress indicator
         for index, ticket in enumerate(tickets, 1):  # Iterate each ticket summary
@@ -477,7 +480,7 @@ class OrgTicketManager:  # Support ticket operations.
             logging.info("Fetching detail %d/%d: ticket %s", index, len(tickets), tid)  # Progress log
             detail = OrgTicketManager._fetch_ticket_detail(org_id, tid)  # Get full ticket data
             if detail:  # Only include tickets that returned data
-                all_details.append(mh.DataProcessingUtils.flatten_dict(detail))  # Flatten and add
+                all_details.append(DataProcessingUtils.flatten_dict(detail))  # Flatten and add
             logging.debug("Fetched detail %d/%d", index, len(tickets))  # Progress debug log
         return all_details  # All flattened records (may be empty)
 

--- a/src/reports/global_wired_client_report_generator.py
+++ b/src/reports/global_wired_client_report_generator.py
@@ -25,6 +25,10 @@ from typing import Any, Literal  # WHY: Literal[False] to distinguish user cance
 
 import mistapi  # WHY: direct SDK access for search + pagination helpers.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class GlobalWiredClientReportGenerator:
     """Generates organization-wide wired client reports with operator-based MAC/manufacturer filtering."""
@@ -258,8 +262,8 @@ class GlobalWiredClientReportGenerator:
         """Write matched records through the standard CSV/SQLite export path."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if matched:  # Have matches.
-            flattened = mh.DataProcessingUtils.flatten_nested_fields(matched)  # Flatten nested fields.
-            sanitized = mh.DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
+            flattened = DataProcessingUtils.flatten_nested_fields(matched)  # Flatten nested fields.
+            sanitized = DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
         else:
             sanitized = []  # No matches.
         mh.DataExporter.write_with_format_selection(  # Write via backend.

--- a/src/reports/wired_client_manufacturer_report_generator.py
+++ b/src/reports/wired_client_manufacturer_report_generator.py
@@ -17,6 +17,10 @@ from typing import Any  # WHY: raw wired-client rows are duck-typed dicts from m
 
 import mistapi  # WHY: direct SDK access for search + pagination helpers.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class WiredClientManufacturerReportGenerator:
     """Generates wired client reports filtered by interactive manufacturer selection."""
@@ -142,8 +146,8 @@ class WiredClientManufacturerReportGenerator:
         filename = WiredClientManufacturerReportGenerator._build_filename(manufacturer)  # Build the filename.
         print(f"\n  Exporting {len(filtered)} records for: {label}")  # Tell the user.
         if filtered:  # Have records.
-            flattened = mh.DataProcessingUtils.flatten_nested_fields(filtered)  # Flatten nested fields.
-            sanitized = mh.DataProcessingUtils.escape_multiline(flattened)
+            flattened = DataProcessingUtils.flatten_nested_fields(filtered)  # Flatten nested fields.
+            sanitized = DataProcessingUtils.escape_multiline(flattened)
         else:
             sanitized = []  # No records.
         mh.DataExporter.write_with_format_selection(  # Write via backend.

--- a/src/troubleshooting/troubleshoot_utils.py
+++ b/src/troubleshooting/troubleshoot_utils.py
@@ -22,6 +22,10 @@ import importlib  # WHY: lazy MistHelper import avoids circular load at module i
 import logging  # WHY: structured trace for menu-dispatch lifecycle events.
 from typing import Any  # WHY: MarvisTroubleshootDeps is resolved lazily; annotate as Any.
 
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
+
 
 class TroubleshootUtils:  # Marvis troubleshoot delegators.
     """Delegation wrapper for extracted Marvis troubleshooting implementation."""
@@ -38,7 +42,7 @@ class TroubleshootUtils:  # Marvis troubleshoot delegators.
             prompt_utils=mh.PromptUtils,
             data_exporter=mh.DataExporter,
             marvis_data_utils=mh.MarvisDataUtilsFactory.instance(),
-            data_processing_utils=mh.DataProcessingUtils,
+            data_processing_utils=DataProcessingUtils,
         )
 
     @staticmethod

--- a/src/ui/display_utils.py
+++ b/src/ui/display_utils.py
@@ -8,11 +8,14 @@ kept on the class.
 
 from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+.
 
-import importlib  # WHY: lazy MistHelper import to reach DataProcessingUtils without circular load.
 import logging  # WHY: emit rendered PrettyTable at debug level.
 from typing import Any  # WHY: duck-typed row dicts flow through PrettyTable.
 
 from prettytable import PrettyTable  # WHY: rendering engine for dict_list_as_pretty_table.
+
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: 1015 T-10 canonical import (eliminates mh.DataProcessingUtils).
 
 
 class DisplayUtils:
@@ -45,8 +48,7 @@ class DisplayUtils:
         if not data:  # Nothing to render
             return
         if fields is None:
-            mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils helper.
-            fields = mh.DataProcessingUtils.get_unique_keys(data)
+            fields = DataProcessingUtils.get_unique_keys(data)
         table = PrettyTable()  # Build a fresh table per call
         table.field_names = fields  # Apply column ordering
         DisplayUtils._apply_sort_if_valid(table, sortby, fields)  # Optional sort


### PR DESCRIPTION
## Summary

Cat E fresh extraction (initiative #1015, T-10). The 158-LOC `DataProcessingUtils` class moves from `MistHelper.py` to its own canonical module at `src/data/data_processing_utils.py`. `MistHelper.py` keeps a bare `from src.data.data_processing_utils import DataProcessingUtils` re-export so the `mh.DataProcessingUtils` compatibility shim continues to resolve for any residual callers.

- 23 in-repo call-sites now import `DataProcessingUtils` directly from `src.data.data_processing_utils`, eliminating the `mh.*` seam.
- Removed the now-dead `import ast` from `MistHelper.py` and five dead `mh = importlib.import_module("MistHelper")` locals in `src/api/api_data_fetcher.py`, `src/export/org_config_exporter.py`, `src/org/org_ticket_manager.py`, and `src/ui/display_utils.py` (plus the module-level `import importlib` in `display_utils.py` that became unused).
- `.gitignore` gains `!src/data/` and `!src/data/**` negation rules so the new package escapes the case-insensitive `data/` ignore on Windows.

## Test plan

- [x] `python -m ruff check MistHelper.py src/` — All checks passed
- [x] `python -m black --check MistHelper.py src/` — 343 files unchanged
- [x] `grep -rn 'mh\.DataProcessingUtils' src/ MistHelper.py` — only matches remain in docstrings/comments
- [x] `python -m pytest tests/` — 76 passed, 4 skipped (one pre-existing stdin-capture failure in `test_menu_196_dispatches_to_async_claim_exporter` is unrelated to T-10)