### PR TITLE
chore: add tools/refactor_analyzer (analyzer for refactor_candidates.md)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,10 @@ known-first-party = ["src"]
 # rendered verbatim into subagent task payloads; reflowing the lines would
 # change the prompt content sent to the model.
 "tools/plan_wave_builder.py" = ["E501"]
+# refactor_analyzer/reporting.py emits literal markdown strings for the
+# refactor_candidates.md report; reflowing the lines would break the rendered
+# markdown structure of the generated report.
+"tools/refactor_analyzer/reporting.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.13"

--- a/tools/refactor_analyzer/__init__.py
+++ b/tools/refactor_analyzer/__init__.py
@@ -1,0 +1,1 @@
+"""Refactor analyzer: rank top-level symbols in an entrypoint by refactor potential."""

--- a/tools/refactor_analyzer/__main__.py
+++ b/tools/refactor_analyzer/__main__.py
@@ -1,0 +1,139 @@
+"""Command-line interface for the refactor analyzer.
+
+Run as a module from the repository root::
+
+    python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md
+"""
+
+from __future__ import annotations  # Enable modern annotation syntax.
+
+import argparse  # Parse command-line arguments.
+import logging  # Configure action logging for the CLI run.
+from pathlib import Path  # Portable filesystem path handling.
+
+from tools.refactor_analyzer.analysis import RefactorAnalyzer  # Core analysis orchestrator.
+from tools.refactor_analyzer.models import (  # Category constants for summary line.
+    CATEGORY_HOT,
+    CATEGORY_LOW_USE,
+    CATEGORY_SINGLE_USE,
+    CATEGORY_SKIPPED,
+    CATEGORY_UNUSED,
+    AnalysisResult,
+)
+from tools.refactor_analyzer.reporting import MarkdownReportGenerator  # Markdown renderer.
+
+logger = logging.getLogger(__name__)  # Module-scoped logger for action logging.
+
+
+class RefactorCLI:
+    """Parse arguments, run the analyzer, write the report, and print a summary."""
+
+    def run(self, argv: list[str] | None = None) -> int:
+        """Execute the full CLI workflow and return a process exit code (always 0)."""
+        args = self._parse_args(argv)  # Parse the command-line arguments.
+        self._configure_logging(args.quiet)  # Configure logging verbosity.
+        logger.info("Starting refactor analysis of %s", args.entrypoint)  # Log start of run.
+        analyzer = RefactorAnalyzer(  # Build the analysis engine with parsed options.
+            src_root=Path(args.src_root),  # First-party src/ anchor for import resolution.
+            extra_packages=tuple(args.extra_package),  # Additional first-party top-level names.
+            min_lines=args.min_lines,  # Skip trivially small defs shorter than this.
+            include_private=args.include_private,  # Whether to include _underscore symbols.
+            skip_names=tuple(args.skip),  # User-supplied bootstrap-pin names merged with SKIP_ALWAYS.
+        )
+        result = analyzer.analyze(Path(args.entrypoint))  # Run the full analysis pipeline.
+        report_text = MarkdownReportGenerator().generate(result)  # Render the Markdown report.
+        self._write_report(args.output, report_text)  # Persist the report to disk.
+        self._print_summary(result, args.output)  # Print a concise console summary.
+        return 0  # Advisory tool: always exit success regardless of findings.
+
+    @staticmethod
+    def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+        """Build the argument parser and parse the provided arguments."""
+        parser = argparse.ArgumentParser(  # Standalone parser instance for this CLI.
+            prog="refactor-analyzer",  # Program name shown in help text.
+            description="Rank top-level symbols in an entrypoint file for refactor extraction.",
+        )
+        parser.add_argument(  # Positional entrypoint file (default MistHelper.py).
+            "entrypoint",
+            nargs="?",
+            default="MistHelper.py",
+            help="Python entrypoint file to analyze (default: MistHelper.py).",
+        )
+        parser.add_argument(  # Output report path.
+            "-o",
+            "--output",
+            default="refactor_candidates.md",
+            help="Output path for the Markdown report (default: refactor_candidates.md).",
+        )
+        parser.add_argument(  # First-party src/ root directory.
+            "--src-root",
+            default="src",
+            help="First-party source root used for import resolution (default: src).",
+        )
+        parser.add_argument(  # Repeatable extra first-party top-level packages.
+            "--extra-package",
+            action="append",
+            default=[],
+            metavar="NAME",
+            help="Additional first-party top-level package name (may be repeated).",
+        )
+        parser.add_argument(  # Minimum def size for inclusion.
+            "--min-lines",
+            type=int,
+            default=3,
+            metavar="N",
+            help="Skip definitions shorter than N lines (default: 3).",
+        )
+        parser.add_argument(  # Whether to include _leading_underscore names.
+            "--include-private",
+            action="store_true",
+            help="Include private symbols (names starting with underscore).",
+        )
+        parser.add_argument(  # Repeatable bootstrap-pin names merged with SKIP_ALWAYS.
+            "--skip",
+            action="append",
+            default=[],
+            metavar="NAME",
+            help="Symbol name to pin in the entrypoint (bootstrap/module-load order). May be repeated.",
+        )
+        parser.add_argument("-q", "--quiet", action="store_true", help="Log only warnings and errors.")
+        return parser.parse_args(argv)  # Parse and return the namespace.
+
+    @staticmethod
+    def _configure_logging(quiet: bool) -> None:
+        """Configure root logging based on the quiet flag."""
+        level = logging.WARNING if quiet else logging.INFO  # Quiet mode hides info logs.
+        logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(message)s")  # ASCII format.
+
+    @staticmethod
+    def _write_report(output: str, text: str) -> None:
+        """Write the rendered report text to the output path, creating parents."""
+        path = Path(output)  # Normalize the output path.
+        if path.parent and not path.parent.exists():  # Ensure the parent directory exists.
+            path.parent.mkdir(parents=True, exist_ok=True)  # Create missing parent directories.
+        logger.info("Writing refactor report to %s", path)  # Log before writing.
+        path.write_text(text, encoding="utf-8")  # Persist the report as UTF-8.
+        logger.debug("Wrote %d characters to %s", len(text), path)  # Log bytes written.
+
+    @staticmethod
+    def _print_summary(result: AnalysisResult, output: str) -> None:
+        """Print a concise console summary of the analysis outcome."""
+        counts = {CATEGORY_UNUSED: 0, CATEGORY_SINGLE_USE: 0, CATEGORY_LOW_USE: 0, CATEGORY_HOT: 0, CATEGORY_SKIPPED: 0}
+        for candidate in result.candidates:  # Tally candidates per category.
+            counts[candidate.category] = counts.get(candidate.category, 0) + 1  # Bump bucket.
+        print(f"Refactor report written to {output}")  # Tell the user where the report is.
+        print(f"Entrypoint: {result.entrypoint}")  # Echo the analyzed file.
+        print(f"Module graph: {result.module_graph_size} first-party files")  # Reach of analysis.
+        print(f"Definitions analyzed: {len(result.definitions)}")  # Total defs considered.
+        print(  # Category breakdown line.
+            f"  unused={counts[CATEGORY_UNUSED]}  "
+            f"single-use={counts[CATEGORY_SINGLE_USE]}  "
+            f"low-use={counts[CATEGORY_LOW_USE]}  "
+            f"hot={counts[CATEGORY_HOT]}  "
+            f"skipped={counts[CATEGORY_SKIPPED]}"
+        )
+        print(f"LOC saveable (unused + single-use): {result.loc_saveable}")  # Headline extractable LOC.
+
+
+if __name__ == "__main__":  # Allow direct module execution.
+    raise SystemExit(RefactorCLI().run())  # Run the CLI and propagate its exit code.

--- a/tools/refactor_analyzer/analysis.py
+++ b/tools/refactor_analyzer/analysis.py
@@ -1,0 +1,433 @@
+"""Orchestrator that produces AnalysisResult for one entrypoint file."""
+
+from __future__ import annotations  # Enable modern annotation syntax.
+
+import ast  # AST powers definition inventory + guideline scanning.
+import logging  # Module-scoped logger for action logging.
+from collections import Counter  # Counter drives the sole-caller heuristic.
+from pathlib import Path  # Portable filesystem path handling.
+
+from tools.refactor_analyzer.graph import ModuleGraphBuilder  # BFS import graph.
+from tools.refactor_analyzer.models import (  # Data models produced/consumed here.
+    CATEGORY_HOT,
+    CATEGORY_LOW_USE,
+    CATEGORY_SINGLE_USE,
+    CATEGORY_SKIPPED,
+    CATEGORY_UNUSED,
+    FLAG_HARDCODED_SEPARATOR,
+    FLAG_MISSING_ACTION_LOGGING,
+    FLAG_MISSING_INLINE_COMMENTS,
+    FLAG_NON_ASCII_LOGS,
+    FLAG_OVERSIZE,
+    FLAG_RAW_INPUT,
+    FLAG_TOO_MANY_PARAMS,
+    AnalysisResult,
+    Candidate,
+    Definition,
+    Reference,
+)
+from tools.refactor_analyzer.references import ReferenceIndex  # Reference index.
+
+logger = logging.getLogger(__name__)  # Module-scoped logger for action logging.
+
+
+# Symbols that reference-count analysis would flag as movable but which MUST stay
+# in the entrypoint because of module-load / bootstrap ordering. Static analysis
+# cannot detect this; the list is curated. Extend via the CLI --skip flag.
+SKIP_ALWAYS: frozenset[str] = frozenset(
+    {
+        "GlobalImportManager",  # Wires sys.path + import hooks before anything else loads; moving it breaks bootstrap.
+    }
+)
+
+
+class RefactorAnalyzer:
+    """Glue the graph builder, definition inventory, and reference index together."""
+
+    _CLASS_NAME_SUFFIXES = (
+        "Manager",
+        "Utils",
+        "Helper",
+        "Handler",
+        "Runner",
+        "Exporter",
+        "Processor",
+        "Builder",
+    )  # Existing suffixes to strip so we don't double them (e.g. FirmwareManagerManager).
+
+    def __init__(
+        self,
+        src_root: Path,
+        extra_packages: tuple[str, ...],
+        min_lines: int,
+        include_private: bool,
+        skip_names: tuple[str, ...] = (),
+    ) -> None:
+        """Store configuration used across analyze() invocations."""
+        self._src_root = src_root.resolve()  # First-party source root.
+        self._extra_packages = extra_packages  # Additional first-party top-level names.
+        self._min_lines = min_lines  # Skip trivial defs below this LOC.
+        self._include_private = include_private  # Whether `_leading_underscore` names are analyzed.
+        self._skip_names = SKIP_ALWAYS | frozenset(skip_names)  # Curated bootstrap pins plus user overrides.
+        self._entrypoint_path: Path | None = None  # Set during analyze() so home-suggestion can detect self-refs.
+        logger.debug(
+            "RefactorAnalyzer configured (min_lines=%d, private=%s, skip=%d)",
+            min_lines,
+            include_private,
+            len(self._skip_names),
+        )
+
+    def analyze(self, entrypoint: Path) -> AnalysisResult:
+        """Run the full pipeline: graph -> definitions -> references -> candidates."""
+        logger.info("Analyzing %s", entrypoint)  # Log before starting.
+        entrypoint = entrypoint.resolve()  # Normalise for consistent path comparisons.
+        self._entrypoint_path = entrypoint  # Remember so home-suggestion can detect self-references.
+        source_lines = entrypoint.read_text(encoding="utf-8").splitlines()  # Full source for LOC counting.
+        tree = ast.parse("\n".join(source_lines), filename=str(entrypoint))  # Parse the entrypoint.
+        definitions = self._inventory_definitions(tree, source_lines)  # Column-0 defs/classes/assigns.
+        logger.debug("Inventoried %d definitions", len(definitions))  # Post-log the count.
+        graph = ModuleGraphBuilder(self._src_root, self._extra_packages).build(entrypoint)  # Reachable files.
+        targets = {defn.name for defn in definitions}  # Names to count references for.
+        refs_by_name = ReferenceIndex(targets, entrypoint).index_all(graph)  # Aggregate refs.
+        candidates = self._build_candidates(definitions, refs_by_name, source_lines, tree)  # Assemble output.
+        candidates.sort(key=lambda c: c.definition.line_count, reverse=True)  # Biggest wins first.
+        loc_saveable = sum(  # Sum LOC across easily-removable categories.
+            c.definition.line_count for c in candidates if c.category in {CATEGORY_UNUSED, CATEGORY_SINGLE_USE}
+        )
+        logger.info("Analysis complete: %d candidates, %d LOC saveable", len(candidates), loc_saveable)
+        return AnalysisResult(  # Wrap everything in the result dataclass.
+            entrypoint=str(entrypoint),  # Path of analyzed file.
+            module_graph_size=len(graph),  # First-party files reached.
+            definitions=definitions,  # Full definition inventory.
+            candidates=candidates,  # Ranked candidates.
+            loc_saveable=loc_saveable,  # Line total removable via unused + single-use.
+        )
+
+    def _inventory_definitions(self, tree: ast.Module, source_lines: list[str]) -> list[Definition]:
+        """Return every column-0 def/class/assignment eligible for reference counting."""
+        results: list[Definition] = []  # Accumulate matching definitions.
+        for node in tree.body:  # Only top-level statements count.
+            defn = self._definition_from_node(node, source_lines)  # Try to build a Definition.
+            if defn is None:  # Node type not handled or filtered out.
+                continue  # Skip and move on.
+            if defn.is_private and not self._include_private:  # Respect private-name filter.
+                continue  # Skip private names unless flag set.
+            if defn.line_count < self._min_lines:  # Skip trivial defs shorter than threshold.
+                continue  # Ignore small defs.
+            results.append(defn)  # Keep this definition.
+        return results  # Full inventory.
+
+    def _definition_from_node(self, node: ast.AST, source_lines: list[str]) -> Definition | None:
+        """Turn a top-level AST node into a Definition record, or None if unsupported."""
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):  # Function definitions.
+            kind = "async_function" if isinstance(node, ast.AsyncFunctionDef) else "function"  # Async flag.
+            return self._make_definition(node.name, kind, node, source_lines, node.decorator_list)  # Build.
+        if isinstance(node, ast.ClassDef):  # Class definitions.
+            return self._make_definition(node.name, "class", node, source_lines, node.decorator_list)  # Build.
+        if isinstance(node, ast.Assign):  # Simple `NAME = ...` assignment.
+            return self._definition_from_assign(node, source_lines)  # Delegate specialised handling.
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):  # `NAME: T = ...`.
+            return self._make_definition(node.target.id, "assignment", node, source_lines, [])  # Build.
+        return None  # Unsupported node type.
+
+    def _definition_from_assign(self, node: ast.Assign, source_lines: list[str]) -> Definition | None:
+        """Handle single-target `NAME = expr` assignments; skip dunder/multi-target cases."""
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):  # Multi-target or non-Name.
+            return None  # Skip complex assignments.
+        name = node.targets[0].id  # Extract the bound name.
+        if name.startswith("__") and name.endswith("__"):  # Dunder like __all__.
+            return None  # Skip dunders which aren't refactor candidates.
+        return self._make_definition(name, "assignment", node, source_lines, [])  # Build the record.
+
+    @staticmethod
+    def _make_definition(
+        name: str, kind: str, node: ast.AST, source_lines: list[str], decorators: list[ast.expr]
+    ) -> Definition:
+        """Assemble a Definition from an AST node's location + decorator list."""
+        lineno = getattr(node, "lineno", 1)  # 1-based start line.
+        end_lineno = getattr(node, "end_lineno", lineno) or lineno  # Fallback if end_lineno missing.
+        line_count = max(1, end_lineno - lineno + 1)  # Inclusive physical line count.
+        decorator_names = tuple(RefactorAnalyzer._decorator_name(dec) for dec in decorators)  # Best-effort names.
+        _ = source_lines  # Reserved for future span-based analysis; kept in signature for clarity.
+        return Definition(  # Immutable record ready for downstream stages.
+            name=name,  # Public symbol name.
+            kind=kind,  # function / async_function / class / assignment.
+            lineno=lineno,  # Start line (1-based).
+            end_lineno=end_lineno,  # End line (inclusive).
+            line_count=line_count,  # Physical line count.
+            is_private=name.startswith("_") and not name.startswith("__"),  # Single-underscore private.
+            decorators=decorator_names,  # Best-effort dotted attribute strings.
+        )
+
+    @staticmethod
+    def _decorator_name(node: ast.expr) -> str:
+        """Return a dotted string for a decorator expression (best-effort)."""
+        if isinstance(node, ast.Name):  # Bare `@foo`.
+            return node.id  # Return the name.
+        if isinstance(node, ast.Attribute):  # `@module.foo`.
+            parts: list[str] = []  # Accumulate attribute chain in reverse.
+            current: ast.AST = node  # Walk down the attribute chain.
+            while isinstance(current, ast.Attribute):  # Descend attributes.
+                parts.append(current.attr)  # Append current attribute name.
+                current = current.value  # Move to inner node.
+            if isinstance(current, ast.Name):  # Root is a bare name.
+                parts.append(current.id)  # Add root name.
+            return ".".join(reversed(parts))  # Reverse to get dotted order.
+        if isinstance(node, ast.Call):  # `@foo(...)` — recurse into func.
+            return RefactorAnalyzer._decorator_name(node.func)  # Return the callable name.
+        return "<expr>"  # Fallback for exotic expressions.
+
+    def _build_candidates(
+        self,
+        definitions: list[Definition],
+        refs_by_name: dict[str, list[Reference]],
+        source_lines: list[str],
+        tree: ast.Module,
+    ) -> list[Candidate]:
+        """Combine definitions + references + guideline flags into Candidate records."""
+        nodes_by_name = self._index_nodes_by_name(tree)  # {name: ast.AST} for guideline scans.
+        candidates: list[Candidate] = []  # Accumulate the output list.
+        for defn in definitions:  # One candidate per inventoried definition.
+            refs = refs_by_name.get(defn.name, [])  # References found for this name.
+            reference_files = self._group_refs_by_file(refs)  # For PR-per-cluster planning.
+            flags = self._scan_guideline_flags(defn, nodes_by_name.get(defn.name), source_lines)  # Body flags.
+            if defn.name in self._skip_names:  # Curated bootstrap pin overrides normal categorization.
+                category = CATEGORY_SKIPPED  # Force the skipped bucket regardless of reference count.
+                suggested_class = None  # No landing target; the symbol stays put.
+                suggested_module = None  # No landing target; the symbol stays put.
+                rationale = (  # Explicit rationale so the report clearly warns operators.
+                    f"PINNED: `{defn.name}` must remain in the entrypoint because of "
+                    f"module-load / bootstrap ordering; static analysis cannot detect this "
+                    f"but moving it would break import wiring. Do NOT extract."
+                )
+            else:  # Normal reference-count-driven categorization.
+                category = self._categorize(refs)  # Bucket by reference count.
+                suggested_class, suggested_module, rationale = self._suggest_home(defn, refs)  # Landing target.
+            candidates.append(  # Package the assembled candidate.
+                Candidate(
+                    definition=defn,  # Symbol being evaluated.
+                    references=refs,  # Full reference list.
+                    category=category,  # Bucket name.
+                    suggested_class=suggested_class,  # Semantic class landing target.
+                    suggested_module=suggested_module,  # File-level landing target.
+                    move_rationale=rationale,  # Human-readable justification.
+                    reference_files=reference_files,  # Refs grouped by file.
+                    guideline_flags=flags,  # Pre-existing guideline violations.
+                )
+            )
+        return candidates  # Return the ranked-shape output.
+
+    @staticmethod
+    def _index_nodes_by_name(tree: ast.Module) -> dict[str, ast.AST]:
+        """Return {top_level_name: node} to hand the guideline scanner."""
+        mapping: dict[str, ast.AST] = {}  # Name -> node lookup.
+        for node in tree.body:  # Only top-level nodes matter here.
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):  # Named defs.
+                mapping[node.name] = node  # Store the def node.
+            elif (
+                isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)
+            ):  # Simple assign.
+                mapping[node.targets[0].id] = node  # Store the assign node.
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):  # Typed assign.
+                mapping[node.target.id] = node  # Store the annotated assign node.
+        return mapping  # Return the assembled index.
+
+    @staticmethod
+    def _categorize(refs: list[Reference]) -> str:
+        """Bucket by reference count: 0=unused, 1=single-use, 2-3=low-use, 4+=hot."""
+        count = len(refs)  # Reference footprint size.
+        if count == 0:  # No callers at all.
+            return CATEGORY_UNUSED  # Dead code.
+        if count == 1:  # Exactly one caller.
+            return CATEGORY_SINGLE_USE  # Move it next to its sole caller.
+        if count <= 3:  # 2 or 3 callers.
+            return CATEGORY_LOW_USE  # Evaluate before moving.
+        return CATEGORY_HOT  # 4+ callers; leave alone.
+
+    @staticmethod
+    def _group_refs_by_file(refs: list[Reference]) -> dict[str, list[Reference]]:
+        """Group references by their file_path for PR-per-cluster rewrites."""
+        grouped: dict[str, list[Reference]] = {}  # File -> list-of-refs mapping.
+        for ref in refs:  # Bucket each reference by its file.
+            grouped.setdefault(ref.file_path, []).append(ref)  # Append into the file's list.
+        return grouped  # Return the assembled mapping.
+
+    def _suggest_home(self, defn: Definition, refs: list[Reference]) -> tuple[str | None, str | None, str | None]:
+        """Propose (class, module, rationale) for a move; None-triple for hot/unused."""
+        category = self._categorize(refs)  # Bucket to decide suggestion strategy.
+        if category == CATEGORY_UNUSED:  # No callers -> delete instead of moving.
+            return (None, None, "No references found; delete this symbol rather than moving it")
+        if category == CATEGORY_HOT:  # 4+ callers -> leave alone.
+            return (None, None, "Widely used; leave in place until dependencies decouple")
+        caller_files = Counter(ref.file_path for ref in refs)  # Ranking by file frequency.
+        top_file, _top_count = caller_files.most_common(1)[0]  # Dominant caller file.
+        enclosing_counter: Counter[str] = Counter(  # Rank enclosing symbols to guess class targets.
+            ref.enclosing_symbol for ref in refs if ref.enclosing_symbol is not None
+        )
+        top_enclosing = enclosing_counter.most_common(1)[0][0] if enclosing_counter else None  # Dominant caller.
+        if self._is_self_reference(top_file):  # Sole caller lives inside the entrypoint we're extracting FROM.
+            return self._suggest_new_src_home(defn, category, top_enclosing)  # Propose a fresh /src landing target.
+        suggested_module = self._suggested_module_for(top_file, top_enclosing)  # File-level landing target.
+        suggested_class = self._suggested_class_for(top_enclosing, top_file, defn)  # Class-level landing target.
+        rationale = self._rationale(category, top_file, top_enclosing, defn)  # Human-readable why.
+        return (suggested_class, suggested_module, rationale)  # Full triple for the report.
+
+    def _is_self_reference(self, caller_file: str) -> bool:
+        """Return True when the dominant caller lives inside the entrypoint being analyzed."""
+        if self._entrypoint_path is None:  # Defensive guard; should always be set during analyze().
+            return False  # Cannot compare without an entrypoint path.
+        try:
+            return Path(caller_file).resolve() == self._entrypoint_path  # Compare canonical paths.
+        except OSError:  # Path resolution can fail on missing intermediate dirs on Windows.
+            logger.debug("Path resolve failed for %s", caller_file)  # Log for diagnosis.
+            return False  # Fall back to non-self-reference behaviour.
+
+    def _suggest_new_src_home(
+        self, defn: Definition, category: str, enclosing_symbol: str | None
+    ) -> tuple[str, str, str]:
+        """Propose a brand-new /src module + class when the sole caller is the entrypoint itself."""
+        snake_name = self._to_snake_case(defn.name)  # Snake-case module filename derived from symbol.
+        suggested_module = f"src/refactors/{snake_name}.py"  # Landing target inside the extraction root.
+        suggested_class = self._propose_class_name(defn)  # Fresh semantic class name for the new module.
+        entrypoint_label = self._entrypoint_path.name if self._entrypoint_path else "the entrypoint"  # Friendly.
+        enclosing_hint = (
+            f" from `{enclosing_symbol}()`" if enclosing_symbol else ""
+        )  # Optional context; backticks avoid markdown emphasis on dunders.
+        rationale = (  # Explicit rationale that names the extraction intent.
+            f"{category}: sole caller lives inside {entrypoint_label}{enclosing_hint}; "
+            f"extract `{defn.name}` OUT of the entrypoint into a new `{suggested_module}` module "
+            f"and rewrite the callsite(s) to import from there"
+        )
+        return (suggested_class, suggested_module, rationale)  # Return the assembled proposal.
+
+    @classmethod
+    def _propose_class_name(cls, defn: Definition) -> str:
+        """Derive a semantic PascalCase class name from the symbol being extracted."""
+        if defn.kind == "class":  # Already a class; reuse its name verbatim.
+            return defn.name  # Class body relocates as-is.
+        pascal = "".join(part.capitalize() for part in defn.name.split("_") if part)  # snake -> Pascal.
+        pascal = pascal or defn.name.capitalize()  # Fallback if splitting produced nothing usable.
+        return cls._append_manager_suffix(pascal)  # Append 'Manager' unless one is already there.
+
+    @classmethod
+    def _append_manager_suffix(cls, pascal: str) -> str:
+        """Append 'Manager' to a PascalCase name unless a semantic suffix is already present."""
+        for suffix in cls._CLASS_NAME_SUFFIXES:  # Check every known semantic suffix.
+            if pascal.endswith(suffix):  # Already ends in Manager/Utils/Handler/etc.
+                return pascal  # Keep as-is; do not double the suffix.
+        return f"{pascal}Manager"  # No semantic suffix yet; append the default.
+
+    @staticmethod
+    def _to_snake_case(name: str) -> str:
+        """Convert a PascalCase or camelCase name to snake_case for filenames."""
+        if "_" in name and name == name.lower():  # Already snake_case with lowercase letters.
+            return name  # Nothing to convert.
+        buffer: list[str] = []  # Accumulate output characters.
+        for index, char in enumerate(name):  # Iterate letter-by-letter.
+            if char.isupper() and index > 0 and not name[index - 1].isupper():  # Word boundary detected.
+                buffer.append("_")  # Insert separator before the uppercase letter.
+            buffer.append(char.lower())  # Append the lowercased character.
+        return "".join(buffer)  # Return the assembled snake_case string.
+
+    @staticmethod
+    def _suggested_module_for(caller_file: str, enclosing_symbol: str | None) -> str:
+        """Return the target module path where the symbol should land."""
+        caller_path = Path(caller_file)  # Convert to Path for portable manipulation.
+        if enclosing_symbol and caller_path.suffix == ".py":  # Prefer the caller's file if it's a src module.
+            return str(caller_path)  # Landing next to the sole caller is the default.
+        return str(caller_path.with_suffix(".py"))  # Fallback: same file, ensured .py suffix.
+
+    @classmethod
+    def _suggested_class_for(cls, enclosing_symbol: str | None, caller_file: str, defn: Definition) -> str:
+        """Return the semantic class name the move should land inside."""
+        if enclosing_symbol and enclosing_symbol[:1].isupper():  # Caller looks like a class (PascalCase).
+            return enclosing_symbol  # Use the existing class name directly.
+        stem = Path(caller_file).stem  # File-name-derived class hint as a fallback.
+        pascal = "".join(part.capitalize() for part in stem.split("_") if part)  # Convert snake_case -> Pascal.
+        _ = defn  # Reserved for future definition-based hinting; keeps signature stable.
+        return cls._append_manager_suffix(pascal) if pascal else "RefactoredManager"  # Avoid double-Manager.
+
+    @staticmethod
+    def _rationale(category: str, caller_file: str, enclosing_symbol: str | None, defn: Definition) -> str:
+        """Compose a human-readable rationale sentence for the report."""
+        caller_label = Path(caller_file).name  # Short caller filename for readability.
+        if category == CATEGORY_SINGLE_USE:  # Exactly one caller anywhere.
+            enclosing_hint = (
+                f" inside `{enclosing_symbol}()`" if enclosing_symbol else ""
+            )  # Backticks avoid markdown emphasis on dunders.
+            return (
+                f"Sole caller lives in `{caller_label}`{enclosing_hint}; "
+                f"move `{defn.name}` into that module's semantic class so callers rewrite in one PR"
+            )
+        return (
+            f"{len(caller_file)} caller files detected; group callers under a shared class "
+            f"in `{caller_label}` and rewrite references per file cluster"
+        )
+
+    def _scan_guideline_flags(self, defn: Definition, node: ast.AST | None, source_lines: list[str]) -> list[str]:
+        """Return the list of guideline violations present in the candidate's body."""
+        flags: list[str] = []  # Accumulate flag identifiers.
+        if defn.line_count > 25:  # 5-Item Rule: functions must stay under 25 physical lines.
+            flags.append(FLAG_OVERSIZE)  # Flag oversize for downstream decomposition.
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and self._param_count(node) > 5:  # >5 params.
+            flags.append(FLAG_TOO_MANY_PARAMS)  # 5-Item Rule: max 5 params.
+        body_lines = source_lines[defn.lineno - 1 : defn.end_lineno]  # Physical lines for scanning.
+        if not self._has_inline_comment_coverage(body_lines):  # Non-negotiable inline commenting.
+            flags.append(FLAG_MISSING_INLINE_COMMENTS)  # Flag for the SpecKit spec to remediate.
+        if not self._has_action_logging(body_lines):  # Non-negotiable action logging.
+            flags.append(FLAG_MISSING_ACTION_LOGGING)  # Flag for the SpecKit spec to remediate.
+        if self._has_non_ascii(body_lines):  # ASCII-only logs / literals.
+            flags.append(FLAG_NON_ASCII_LOGS)  # Flag for cleanup during the move.
+        if self._has_raw_input(body_lines):  # Bare input() must be safe_input().
+            flags.append(FLAG_RAW_INPUT)  # Flag for cleanup during the move.
+        if self._has_hardcoded_separator(body_lines):  # Path separator literal check.
+            flags.append(FLAG_HARDCODED_SEPARATOR)  # Flag for pathlib migration during the move.
+        return flags  # Return the assembled list.
+
+    @staticmethod
+    def _param_count(node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+        """Return total parameter count across positional/keyword-only slots."""
+        args = node.args  # Cached reference to the arguments record.
+        total = len(args.args) + len(args.kwonlyargs) + len(args.posonlyargs)  # Regular slots.
+        if args.vararg:  # *args counts as one parameter.
+            total += 1  # Add varargs.
+        if args.kwarg:  # **kwargs counts as one parameter.
+            total += 1  # Add kwargs.
+        return total  # Report full arity.
+
+    @staticmethod
+    def _has_inline_comment_coverage(body_lines: list[str]) -> bool:
+        """Return True when >=50% of executable lines carry an inline `#` comment."""
+        code = [line for line in body_lines if line.strip() and not line.strip().startswith("#")]  # Exec lines.
+        if not code:  # No executable lines to evaluate.
+            return True  # Trivially satisfies the guideline.
+        commented = sum(1 for line in code if "#" in line)  # Count lines with an inline hash.
+        return commented / len(code) >= 0.5  # 50% threshold aligns with the project rule.
+
+    @staticmethod
+    def _has_action_logging(body_lines: list[str]) -> bool:
+        """Return True when the body contains at least one logging.info/debug call."""
+        joined = "\n".join(body_lines)  # Concatenate for a single substring scan.
+        return (
+            "logging.info(" in joined
+            or "logging.debug(" in joined
+            or "logger.info(" in joined
+            or "logger.debug(" in joined
+        )  # Common forms.
+
+    @staticmethod
+    def _has_non_ascii(body_lines: list[str]) -> bool:
+        """Return True when any body line contains a non-ASCII character."""
+        return any(any(ord(ch) > 127 for ch in line) for line in body_lines)  # Byte-scan each line.
+
+    @staticmethod
+    def _has_raw_input(body_lines: list[str]) -> bool:
+        """Return True when the body calls bare input() instead of safe_input()."""
+        return any("input(" in line and "safe_input(" not in line for line in body_lines)  # Naive but effective.
+
+    @staticmethod
+    def _has_hardcoded_separator(body_lines: list[str]) -> bool:
+        """Return True when a body line contains a hardcoded path separator literal."""
+        return any(
+            ('"/' in line or "'/" in line or '"\\\\' in line or "'\\\\" in line) for line in body_lines
+        )  # Heuristic.

--- a/tools/refactor_analyzer/graph.py
+++ b/tools/refactor_analyzer/graph.py
@@ -1,0 +1,92 @@
+"""BFS-discover first-party Python modules reachable from an entrypoint file."""
+
+from __future__ import annotations  # Enable modern annotation syntax.
+
+import ast  # AST module powers import extraction.
+import logging  # Module-scoped logger for action logging.
+from collections import deque  # Deque backs the BFS frontier.
+from pathlib import Path  # Portable filesystem path handling.
+
+logger = logging.getLogger(__name__)  # Module-scoped logger for action logging.
+
+
+class ModuleGraphBuilder:
+    """Walk imports (top-level and lazy) to enumerate first-party modules."""
+
+    def __init__(self, src_root: Path, extra_packages: tuple[str, ...]) -> None:
+        """Store the first-party roots so import resolution stays deterministic."""
+        self._src_root = src_root.resolve()  # Anchor resolution at the repo's src directory.
+        self._repo_root = self._src_root.parent  # Repo root houses top-level packages.
+        self._extra_packages = extra_packages  # Additional first-party top-level names.
+        logger.debug("ModuleGraphBuilder anchored at %s (extras=%s)", self._src_root, extra_packages)
+
+    def build(self, entrypoint: Path) -> set[Path]:
+        """Return every first-party .py file reachable via imports (BFS)."""
+        logger.info("Building module graph starting at %s", entrypoint)  # Log before traversal.
+        entrypoint = entrypoint.resolve()  # Normalise to an absolute path for the visited set.
+        visited: set[Path] = {entrypoint}  # Track visited files to bound the traversal.
+        frontier: deque[Path] = deque([entrypoint])  # BFS frontier begins at the entrypoint.
+        while frontier:  # Continue until every reachable module is expanded.
+            current = frontier.popleft()  # Pop the next module to inspect.
+            self._expand_module(current, visited, frontier)  # Add its imports to the frontier.
+        logger.debug("Module graph closure size: %d files", len(visited))  # Log final size.
+        return visited  # Return the full first-party closure.
+
+    def _expand_module(self, path: Path, visited: set[Path], frontier: deque[Path]) -> None:
+        """Parse one module and push any new first-party imports onto the frontier."""
+        tree = self._safe_parse(path)  # Best-effort AST parse; None on failure.
+        if tree is None:  # Parse failed; skip expansion for this file.
+            return  # Nothing further to do for a broken source file.
+        for module in self._collect_imports(tree):  # Walk every import in the AST.
+            resolved = self._resolve(module)  # Try to map the dotted module name to a file.
+            if resolved is None or resolved in visited:  # Skip stdlib/third-party/already-seen.
+                continue  # Nothing new to enqueue.
+            visited.add(resolved)  # Record before enqueue to prevent duplicate queueing.
+            frontier.append(resolved)  # Queue the newly discovered file for expansion.
+
+    @staticmethod
+    def _safe_parse(path: Path) -> ast.Module | None:
+        """Parse a Python file to AST, logging (and swallowing) any syntax error."""
+        logger.debug("Parsing %s for imports", path)  # Log before reading the file.
+        try:
+            source = path.read_text(encoding="utf-8")  # Read source as UTF-8.
+        except OSError as exc:  # Missing or unreadable file.
+            logger.warning("Cannot read %s: %s", path, exc)  # Warn and continue.
+            return None  # Signal the caller to skip this file.
+        try:
+            return ast.parse(source, filename=str(path))  # Parse into an AST module.
+        except SyntaxError as exc:  # File is not valid Python; likely template/test fixture.
+            logger.warning("Skipping %s: %s", path, exc)  # Warn and continue.
+            return None  # Signal the caller to skip this file.
+
+    @staticmethod
+    def _collect_imports(tree: ast.AST) -> list[str]:
+        """Return every dotted module name referenced by Import/ImportFrom (incl. lazy imports)."""
+        modules: list[str] = []  # Accumulate dotted module names.
+        for node in ast.walk(tree):  # ast.walk catches lazy imports inside function bodies.
+            if isinstance(node, ast.Import):  # `import foo, bar.baz` form.
+                modules.extend(alias.name for alias in node.names)  # Each alias.name is dotted.
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:  # Absolute from-import.
+                modules.append(node.module)  # Record the module portion; symbol names ignored.
+        return modules  # Return the raw dotted names for downstream resolution.
+
+    def _resolve(self, module: str) -> Path | None:
+        """Map a dotted module name to a first-party .py file, or None if external."""
+        if not self._is_first_party(module):  # Reject stdlib / third-party imports quickly.
+            return None  # Caller will skip external modules.
+        parts = module.split(".")  # Split dotted name into path segments.
+        candidate_module = self._repo_root.joinpath(*parts).with_suffix(".py")  # module.py form.
+        if candidate_module.is_file():  # Direct-module hit.
+            return candidate_module.resolve()  # Normalise before returning.
+        candidate_pkg = self._repo_root.joinpath(*parts, "__init__.py")  # Package __init__ form.
+        if candidate_pkg.is_file():  # Package hit.
+            return candidate_pkg.resolve()  # Normalise before returning.
+        logger.debug("Unresolvable first-party module: %s", module)  # Log gap without failing.
+        return None  # Nothing on disk maps to this dotted name.
+
+    def _is_first_party(self, module: str) -> bool:
+        """Return True when the dotted module lives under src/ or an extra-package root."""
+        head = module.split(".", 1)[0]  # Top-level package name drives the classification.
+        if head == self._src_root.name:  # Anything under src/... is first-party by definition.
+            return True  # Fast-path the common case.
+        return head in self._extra_packages  # Otherwise consult the caller-supplied extras.

--- a/tools/refactor_analyzer/models.py
+++ b/tools/refactor_analyzer/models.py
@@ -1,0 +1,70 @@
+"""Data models used by the refactor analyzer package."""
+
+from __future__ import annotations  # Enable modern union/builtin generic annotations.
+
+from dataclasses import dataclass, field  # Dataclasses keep record types concise.
+
+# Category thresholds by reference count; single-source-of-truth for the analyzer.
+CATEGORY_UNUSED: str = "unused"  # Zero references outside the def site.
+CATEGORY_SINGLE_USE: str = "single-use"  # Exactly one caller anywhere in the graph.
+CATEGORY_LOW_USE: str = "low-use"  # 2..3 callers; evaluate before moving.
+CATEGORY_HOT: str = "hot"  # 4+ callers; leave alone.
+CATEGORY_SKIPPED: str = "skipped"  # Bootstrap/module-load pinned; must stay in entrypoint.
+
+
+# Guideline-flag identifiers surfaced to SpecKit so the downstream spec can gate them.
+FLAG_OVERSIZE: str = "oversize_25_lines"  # Function body exceeds 25 physical lines.
+FLAG_TOO_MANY_PARAMS: str = "too_many_params"  # Function signature exceeds 5 parameters.
+FLAG_MISSING_INLINE_COMMENTS: str = "missing_inline_comments"  # <50% of code lines have inline #.
+FLAG_MISSING_ACTION_LOGGING: str = "missing_action_logging"  # No logging.info/debug calls found.
+FLAG_NON_ASCII_LOGS: str = "non_ascii_logs"  # String literal contains non-ASCII bytes.
+FLAG_RAW_INPUT: str = "raw_input_call"  # Bare input() call, not safe_input().
+FLAG_HARDCODED_SEPARATOR: str = "hardcoded_separator"  # Literal "/" or "\\" in a path context.
+
+
+@dataclass(frozen=True)
+class Definition:
+    """A single top-level symbol declared at column 0 in the entrypoint file."""
+
+    name: str  # Public symbol name (function, class, or bound variable).
+    kind: str  # One of "function" | "async_function" | "class" | "assignment".
+    lineno: int  # 1-based start line of the definition in the entrypoint source.
+    end_lineno: int  # 1-based end line of the definition (inclusive).
+    line_count: int  # Physical line count of the definition; drives LOC accounting.
+    is_private: bool  # True when the name starts with a single underscore.
+    decorators: tuple[str, ...]  # Decorator names (best-effort dotted-attribute strings).
+
+
+@dataclass(frozen=True)
+class Reference:
+    """A single Name/Attribute node in the module graph that resolves to a Definition."""
+
+    target_name: str  # Definition name this reference points at (post-alias resolution).
+    file_path: str  # Absolute or repo-relative path of the file that holds the reference.
+    lineno: int  # 1-based line number of the reference site.
+    enclosing_symbol: str | None  # Function/class containing the ref; None if module scope.
+
+
+@dataclass
+class Candidate:
+    """A definition plus its reference footprint plus SpecKit-ready move guidance."""
+
+    definition: Definition  # The symbol being evaluated for extraction.
+    references: list[Reference]  # All references discovered across the module graph.
+    category: str  # One of the CATEGORY_* constants above.
+    suggested_class: str | None = None  # Semantic class the symbol should land inside.
+    suggested_module: str | None = None  # Destination module path (e.g. src/foo/bar.py).
+    move_rationale: str | None = None  # Human-readable rationale for the suggestion.
+    reference_files: dict[str, list[Reference]] = field(default_factory=dict)  # Refs grouped by file.
+    guideline_flags: list[str] = field(default_factory=list)  # Pre-existing guideline violations.
+
+
+@dataclass
+class AnalysisResult:
+    """The full output of a refactor analysis run for one entrypoint."""
+
+    entrypoint: str  # Path of the entrypoint file that was analyzed.
+    module_graph_size: int  # Count of first-party modules reached during import discovery.
+    definitions: list[Definition]  # Every top-level symbol inventoried in the entrypoint.
+    candidates: list[Candidate]  # One candidate per definition; sorted by LOC saved.
+    loc_saveable: int  # Sum of line_count across unused + single-use candidates.

--- a/tools/refactor_analyzer/references.py
+++ b/tools/refactor_analyzer/references.py
@@ -1,0 +1,215 @@
+"""Scope-aware reference indexing for top-level names across the module graph."""
+
+from __future__ import annotations  # Enable modern annotation syntax.
+
+import ast  # AST powers the visitor + alias table construction.
+import logging  # Module-scoped logger for action logging.
+from collections.abc import Iterable  # Typed protocol for the file iterator.
+from pathlib import Path  # Portable filesystem path handling.
+
+from tools.refactor_analyzer.models import Reference  # Data record produced by this module.
+
+logger = logging.getLogger(__name__)  # Module-scoped logger for action logging.
+
+
+class _NameCollector(ast.NodeVisitor):
+    """AST visitor that records references to target names, honoring local scopes."""
+
+    def __init__(self, targets: set[str], aliases: dict[str, str], file_path: str) -> None:
+        """Store the target set and per-file alias map so visits stay stateless."""
+        self._targets = targets  # Set of top-level names we want to count.
+        self._aliases = aliases  # Local-alias -> canonical target-name mapping.
+        self._file_path = file_path  # Path emitted on every recorded Reference.
+        self._scopes: list[set[str]] = [set()]  # Stack of locally-bound names per scope.
+        self._enclosing: list[str] = []  # Stack of enclosing symbol names (for reporting).
+        self._refs: list[Reference] = []  # Accumulated reference records.
+
+    def references(self) -> list[Reference]:
+        """Expose the accumulated reference list after visiting the tree."""
+        return self._refs  # Simple accessor; caller owns the list from here.
+
+    def visit_Module(self, node: ast.Module) -> None:  # Module scope is scope[0].
+        """Pre-bind every top-level name so intra-module refs resolve deterministically."""
+        for child in node.body:  # Only look at top-level statements at this stage.
+            self._bind_top_level(child)  # Pre-populate module scope with local names.
+        self.generic_visit(node)  # Walk children as usual once bindings are known.
+
+    def _bind_top_level(self, node: ast.AST) -> None:
+        """Record module-level `def`/`class`/import/assignment names into scope[0]."""
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):  # Named def/class.
+            self._scopes[0].add(node.name)  # Bind the local name at module scope.
+        elif isinstance(node, ast.Import):  # `import foo` binds `foo` locally.
+            for alias in node.names:  # Iterate each dotted import.
+                self._scopes[0].add(alias.asname or alias.name.split(".")[0])  # Root name binding.
+        elif isinstance(node, ast.ImportFrom):  # `from x import y as z` binds `z` (or `y`).
+            for alias in node.names:  # Iterate each imported symbol.
+                self._scopes[0].add(alias.asname or alias.name)  # Prefer alias then real name.
+        elif isinstance(node, ast.Assign):  # Simple assignments bind their LHS names.
+            for target in node.targets:  # Multiple targets: `a = b = expr`.
+                self._bind_assign_target(target)  # Delegate name extraction.
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):  # Typed assign.
+            self._scopes[0].add(node.target.id)  # Bind the annotated name.
+
+    def _bind_assign_target(self, target: ast.AST) -> None:
+        """Bind Name targets on the LHS of an assignment into the current scope."""
+        if isinstance(target, ast.Name):  # `foo = ...` case.
+            self._scopes[-1].add(target.id)  # Add to the current (top) scope.
+        elif isinstance(target, ast.Tuple | ast.List):  # Tuple/list unpacking.
+            for element in target.elts:  # Recurse into each element.
+                self._bind_assign_target(element)  # Named elements get bound.
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """Enter a function scope, bind params and inner defs, then walk the body."""
+        self._enter_function_scope(node)  # Push scope + bind params/locals.
+        self.generic_visit(node)  # Visit children within the new scope.
+        self._exit_scope()  # Pop scope + enclosing symbol.
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        """Async functions behave identically for scope purposes."""
+        self._enter_function_scope(node)  # Push + bind.
+        self.generic_visit(node)  # Descend.
+        self._exit_scope()  # Pop.
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """Class body opens a scope; class name itself is bound in its parent."""
+        self._scopes[-1].add(node.name)  # Bind the class name in the enclosing scope.
+        self._scopes.append(set())  # New scope for the class body.
+        self._enclosing.append(node.name)  # Track enclosing symbol name for reports.
+        self.generic_visit(node)  # Visit methods and nested defs.
+        self._exit_scope()  # Pop.
+
+    def _enter_function_scope(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        """Bind the function name in the parent scope, then push a fresh local scope."""
+        self._scopes[-1].add(node.name)  # Function name binds in enclosing scope.
+        scope: set[str] = set()  # Fresh scope for the function body.
+        for arg_group in (node.args.args, node.args.kwonlyargs, node.args.posonlyargs):  # All arg groups.
+            for arg in arg_group:  # Every positional/keyword-only arg.
+                scope.add(arg.arg)  # Bind each argument name.
+        if node.args.vararg:  # `*args` if present.
+            scope.add(node.args.vararg.arg)  # Bind varargs name.
+        if node.args.kwarg:  # `**kwargs` if present.
+            scope.add(node.args.kwarg.arg)  # Bind kwargs name.
+        for child in node.body:  # Pre-bind nested defs/imports so forward refs resolve.
+            self._bind_top_level_into(child, scope)  # Use helper to pre-bind names.
+        self._scopes.append(scope)  # Push the assembled scope.
+        self._enclosing.append(node.name)  # Track for enclosing_symbol on refs.
+
+    def _bind_top_level_into(self, node: ast.AST, scope: set[str]) -> None:
+        """Same as _bind_top_level but writes into an explicitly-passed scope set."""
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):  # Named def/class.
+            scope.add(node.name)  # Bind the nested definition name.
+        elif isinstance(node, ast.Import):  # Local `import foo`.
+            for alias in node.names:  # Each import target.
+                scope.add(alias.asname or alias.name.split(".")[0])  # Root name binding.
+        elif isinstance(node, ast.ImportFrom):  # Local `from x import y`.
+            for alias in node.names:  # Each imported symbol.
+                scope.add(alias.asname or alias.name)  # Prefer alias then real name.
+
+    def _exit_scope(self) -> None:
+        """Pop the last scope frame and its enclosing-symbol counterpart."""
+        self._scopes.pop()  # Drop the top scope.
+        if self._enclosing:  # Guard: only pop if we pushed.
+            self._enclosing.pop()  # Drop matching enclosing symbol name.
+
+    def visit_Name(self, node: ast.Name) -> None:
+        """Record a reference when the Name resolves to one of our target symbols."""
+        canonical = self._canonical_target(node.id)  # Map alias -> canonical target name.
+        if canonical is None:  # Not one of our targets at all.
+            return  # Nothing to record.
+        if self._is_shadowed(node.id):  # Local scope hides the module-level binding.
+            return  # Skip shadowed references.
+        self._refs.append(  # Record a Reference row for this name-use site.
+            Reference(
+                target_name=canonical,  # Canonical name (post-alias resolution).
+                file_path=self._file_path,  # Where the reference lives.
+                lineno=node.lineno,  # 1-based line number of the site.
+                enclosing_symbol=self._enclosing[-1] if self._enclosing else None,  # Nearest def/class.
+            )
+        )
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        """Root-name attribute chains (e.g. Manager.method) count as one reference."""
+        root = node  # Walk to the leftmost Name to find the chain root.
+        while isinstance(root, ast.Attribute):  # Descend attribute nesting.
+            root = root.value  # Follow the value chain leftward.
+        if isinstance(root, ast.Name):  # Chain rooted at a bare name; check it.
+            self.visit_Name(root)  # Delegate to visit_Name for the counting logic.
+        self.generic_visit(node)  # Continue walking nested Attributes.
+
+    def _canonical_target(self, name: str) -> str | None:
+        """Return the canonical target name for `name`, or None if it's not a target."""
+        if name in self._aliases:  # Locally aliased import of a target.
+            return self._aliases[name]  # Return the canonical name.
+        if name in self._targets:  # Direct reference to a target.
+            return name  # Already canonical.
+        return None  # Not one of our targets.
+
+    def _is_shadowed(self, name: str) -> bool:
+        """Return True when a scope above module level locally binds `name`."""
+        for scope in self._scopes[1:]:  # Inspect every scope above module scope.
+            if name in scope:  # Local binding shadows the module-level target.
+                return True  # Shadowed; skip this reference.
+        return False  # No local binding; reference is real.
+
+
+class ReferenceIndex:
+    """Index references to a set of target names across many files."""
+
+    def __init__(self, targets: set[str], entrypoint: Path) -> None:
+        """Store targets and entrypoint metadata used during per-file indexing."""
+        self._targets = targets  # Names we are counting references to.
+        self._entrypoint = entrypoint.resolve()  # Normalised entrypoint path.
+        self._entrypoint_module = entrypoint.stem  # Dotted module name for alias lookup.
+        logger.debug("ReferenceIndex targets=%d entrypoint=%s", len(targets), self._entrypoint)
+
+    def index_all(self, files: Iterable[Path]) -> dict[str, list[Reference]]:
+        """Return {target_name: [Reference, ...]} across every file in the graph."""
+        logger.info("Indexing references across module graph")  # Log before traversal.
+        aggregated: dict[str, list[Reference]] = {name: [] for name in self._targets}  # Pre-seed keys.
+        for file_path in files:  # Iterate every discovered first-party file.
+            for reference in self.index_file(file_path):  # Collect refs from this file.
+                aggregated.setdefault(reference.target_name, []).append(reference)  # Bucket by target.
+        logger.debug("Reference index built: %d targets", len(aggregated))  # Post-log the size.
+        return aggregated  # Return the full mapping to the caller.
+
+    def index_file(self, path: Path) -> list[Reference]:
+        """Parse one file, build its alias map, run the collector, and return refs."""
+        tree = self._safe_parse(path)  # Best-effort AST parse; None on failure.
+        if tree is None:  # Parse failed; nothing to collect.
+            return []  # Empty list keeps callers simple.
+        aliases = self._build_alias_map(tree)  # Map local aliases -> canonical target names.
+        collector = _NameCollector(  # Instantiate the visitor with all context.
+            targets=self._targets,  # Names to count.
+            aliases=aliases,  # Alias map for `from X import Y as Z`.
+            file_path=str(path),  # Absolute path emitted on every Reference.
+        )
+        collector.visit(tree)  # Walk the AST to gather references.
+        return collector.references()  # Return the raw list of references found.
+
+    @staticmethod
+    def _safe_parse(path: Path) -> ast.Module | None:
+        """Parse a Python file to AST, logging any read/syntax error."""
+        logger.debug("Parsing %s for references", path)  # Log before reading the file.
+        try:
+            source = path.read_text(encoding="utf-8")  # Read source as UTF-8.
+        except OSError as exc:  # Missing or unreadable file.
+            logger.warning("Cannot read %s: %s", path, exc)  # Warn and continue.
+            return None  # Signal the caller to skip.
+        try:
+            return ast.parse(source, filename=str(path))  # Return a Module AST.
+        except SyntaxError as exc:  # Not valid Python; skip.
+            logger.warning("Skipping %s: %s", path, exc)  # Warn and continue.
+            return None  # Signal the caller to skip.
+
+    def _build_alias_map(self, tree: ast.Module) -> dict[str, str]:
+        """Return {local_alias: canonical_target_name} for imports of our targets."""
+        aliases: dict[str, str] = {}  # Local-name -> canonical-target-name mapping.
+        for node in ast.walk(tree):  # ast.walk catches lazy imports inside functions.
+            if not isinstance(node, ast.ImportFrom):  # Only from-imports carry aliases we care about.
+                continue  # Skip Import / other nodes here.
+            if node.module != self._entrypoint_module or node.level != 0:  # Wrong module or relative.
+                continue  # Only aliases against the entrypoint module count.
+            for alias in node.names:  # Every imported symbol from the entrypoint.
+                if alias.name in self._targets:  # Only track aliases for our targets.
+                    aliases[alias.asname or alias.name] = alias.name  # Local -> canonical.
+        return aliases  # Return the assembled alias table.

--- a/tools/refactor_analyzer/reporting.py
+++ b/tools/refactor_analyzer/reporting.py
@@ -1,0 +1,212 @@
+"""Render AnalysisResult as a SpecKit-consumable Markdown report."""
+
+from __future__ import annotations  # Enable modern annotation syntax.
+
+import logging  # Module-scoped logger for action logging.
+from pathlib import Path  # Portable filesystem path handling.
+
+from tools.refactor_analyzer.models import (  # Data models rendered here.
+    CATEGORY_HOT,
+    CATEGORY_LOW_USE,
+    CATEGORY_SINGLE_USE,
+    CATEGORY_SKIPPED,
+    CATEGORY_UNUSED,
+    AnalysisResult,
+    Candidate,
+)
+
+logger = logging.getLogger(__name__)  # Module-scoped logger for action logging.
+
+
+class MarkdownReportGenerator:
+    """Turn an AnalysisResult into a Markdown string ready for `speckit.specify`."""
+
+    def generate(self, result: AnalysisResult) -> str:
+        """Assemble the full report from ordered section builders."""
+        logger.info("Generating markdown report for %s", result.entrypoint)  # Log before rendering.
+        sections = [  # Ordered list of section fragments for the final report.
+            self._header(result),  # Top-level metadata and category counts.
+            self._how_to_read(),  # Explain the prioritization scheme up front.
+            self._speckit_directives(),  # Non-negotiable SpecKit rules for downstream refactors.
+            self._summary_table(result.candidates),  # One-row-per-candidate overview.
+            self._detail_sections(result.candidates),  # Per-category deep-dive.
+            self._limitations_footer(),  # What the tool cannot detect.
+        ]
+        logger.debug("Report assembled from %d sections", len(sections))  # Post-log the section count.
+        body = "\n\n".join(section for section in sections if section)  # Join with blank-line spacing.
+        return f"{body}\n"  # Ensure a single trailing newline per markdownlint MD047.
+
+    @staticmethod
+    def _header(result: AnalysisResult) -> str:
+        """Return the top-level metadata block with counts by category."""
+        counts = {
+            CATEGORY_UNUSED: 0,
+            CATEGORY_SINGLE_USE: 0,
+            CATEGORY_LOW_USE: 0,
+            CATEGORY_HOT: 0,
+            CATEGORY_SKIPPED: 0,
+        }  # Init.
+        for candidate in result.candidates:  # Count candidates per category.
+            counts[candidate.category] = counts.get(candidate.category, 0) + 1  # Increment bucket.
+        entrypoint_name = Path(result.entrypoint).name  # Short name for readability.
+        lines = [  # Assemble the header lines.
+            f"# Refactor candidates: {entrypoint_name}",  # Report title.
+            "",  # Blank line before metadata.
+            f"- Entrypoint: `{result.entrypoint}`",  # Full path for tooling.
+            f"- Module graph size: {result.module_graph_size} first-party files",  # Reach of the analysis.
+            f"- Definitions analyzed: {len(result.definitions)}",  # Total defs considered.
+            f"- LOC saveable (unused + single-use): {result.loc_saveable}",  # Movable-line total.
+            f"- Category counts: unused={counts[CATEGORY_UNUSED]}, "  # Split for readability.
+            f"single-use={counts[CATEGORY_SINGLE_USE]}, "
+            f"low-use={counts[CATEGORY_LOW_USE]}, hot={counts[CATEGORY_HOT]}, "
+            f"skipped={counts[CATEGORY_SKIPPED]}",
+        ]
+        return "\n".join(lines)  # Return the joined header string.
+
+    @staticmethod
+    def _how_to_read() -> str:
+        """Return the priority-explanation block so operators know which files to touch first."""
+        return "\n".join(  # Multi-line prioritization guide joined for markdown output.
+            [
+                "## How to read this report",  # Section header.
+                "",  # Blank line for readability.
+                "Work the report **top-down inside each category**, then move to the next category:",
+                "",  # Blank line before the ordered list.
+                "1. **Unused** -- zero references. Delete outright; no move, no callsite rewrite. Highest ROI per PR.",
+                "2. **Single-use** -- exactly one caller. Move alongside that caller (or into a new `/src` module when the entrypoint is the sole caller). One PR covers move + rewrite.",
+                "3. **Low-use** -- 2-3 callers. Evaluate before moving: worth it only when all callers can be rewritten in one bounded PR cluster.",
+                "4. **Hot** -- 4+ callers. Leave in place until dependencies decouple. Listed for completeness only.",
+                "5. **Skipped** -- pinned by bootstrap/module-load ordering (e.g. `GlobalImportManager`). DO NOT extract; the tool cannot detect load-order dependencies, so these are curated by hand via the `--skip NAME` CLI flag.",
+                "",  # Blank line before secondary rules.
+                "Within each bucket, candidates are sorted by **line_count descending** so the biggest LOC wins surface first. The `LOC saveable` headline in the metadata block sums unused + single-use lines only -- that number is your extraction budget for this pass.",
+                "",  # Blank line before reference-cluster note.
+                "Reference sites are grouped **per file** so each candidate maps cleanly to one PR per reference-holding file (move + rewrite in the same PR). When multiple single-use candidates share the same dominant caller (see `Suggested class`), bundle them into one PR that lands them in the same class body.",
+            ]
+        )
+
+    @staticmethod
+    def _speckit_directives() -> str:
+        """Return the fixed instruction block SpecKit workflows must obey."""
+        return "\n".join(  # Multi-line directive block joined for markdown output.
+            [
+                "## SpecKit non-negotiables",  # Section header.
+                "",  # Blank line for readability.
+                "1. **No wrapper shims**: do NOT create `def old(...): return NewClass().new(...)` "
+                "or thin re-export modules. Move the code into a semantic class body and delete the old symbol.",
+                "2. **Rewrite every callsite**: for each candidate below, produce one PR per reference-holding "
+                "file cluster. Every listed `file:lineno` must be updated in the same PR as the move.",
+                "3. **Decompose while moving**: if a candidate lists `guideline_flags`, do NOT lift-and-shift. "
+                "Split into <=25-line methods with <=5 params, add inline comments on every executable line, "
+                "and add `logging.info/debug` before/after every operation.",
+                "4. **Landing target is a class body**: `Suggested class` names the destination. Prefer an "
+                "existing class (`WebSocketManager`, `FirmwareManager`, `SFPTransceiverDataProcessor`, "
+                "`EnhancedSSHRunner`, etc.) when one already lives in the target module; otherwise create the "
+                "proposed new class rather than adding a bare module-level function.",
+                "5. **ASCII-only logs, `safe_input()`, `pathlib.Path`**: any candidate flagged for non-ASCII "
+                "literals, raw `input()`, or hardcoded separators must be cleaned up during the move.",
+            ]
+        )
+
+    def _summary_table(self, candidates: list[Candidate]) -> str:
+        """Return a single markdown table with one row per candidate."""
+        header = "| Name | Kind | Lines | Refs | Category | Suggested class | Flags |"  # Column headings.
+        separator = "|---|---|---:|---:|---|---|---|"  # Alignment row for markdown table syntax.
+        rows = [self._summary_row(candidate) for candidate in candidates]  # One row per candidate.
+        return "\n".join(["## Summary", "", header, separator, *rows])  # Full table with a section header.
+
+    @staticmethod
+    def _summary_row(candidate: Candidate) -> str:
+        """Format one Candidate as a markdown table row."""
+        flags = ",".join(candidate.guideline_flags) if candidate.guideline_flags else ""  # Compact flag list.
+        suggested = candidate.suggested_class or ""  # Empty string when no class was suggested.
+        return (  # Build the row string; use inline backticks for name to avoid markdown clash.
+            f"| `{candidate.definition.name}` | {candidate.definition.kind} | "
+            f"{candidate.definition.line_count} | {len(candidate.references)} | "
+            f"{candidate.category} | {suggested} | {flags} |"
+        )
+
+    def _detail_sections(self, candidates: list[Candidate]) -> str:
+        """Return one section per category, with per-candidate detail rendered inside."""
+        buckets: dict[str, list[Candidate]] = {  # Pre-seed with ordered category keys.
+            CATEGORY_UNUSED: [],
+            CATEGORY_SINGLE_USE: [],
+            CATEGORY_LOW_USE: [],
+            CATEGORY_HOT: [],
+            CATEGORY_SKIPPED: [],
+        }
+        for candidate in candidates:  # Bucket candidates by category.
+            buckets.setdefault(candidate.category, []).append(candidate)  # Append into the bucket.
+        rendered = []  # Accumulate rendered fragments.
+        for category, items in buckets.items():  # Iterate in the fixed order defined above.
+            if not items:  # Skip empty categories for a cleaner report.
+                continue  # Nothing to render.
+            rendered.append(self._category_section(category, items))  # Render this category.
+        return "\n\n".join(rendered)  # Blank line between category sections.
+
+    def _category_section(self, category: str, candidates: list[Candidate]) -> str:
+        """Render one category header plus every candidate inside it."""
+        heading = f"## {category.title()} ({len(candidates)})"  # Section heading with count.
+        body = "\n\n".join(self._candidate_detail(candidate) for candidate in candidates)  # Per-cand bodies.
+        return f"{heading}\n\n{body}"  # Section header followed by candidate bodies.
+
+    def _candidate_detail(self, candidate: Candidate) -> str:
+        """Render one candidate as a bullet block with def, class, refs, and flags."""
+        defn = candidate.definition  # Cached alias for readability.
+        header = f"### `{defn.name}` ({defn.kind}, {defn.line_count} lines)"  # Sub-section header.
+        lines = [  # Bullet list of key facts + refs.
+            header,
+            "",  # Blank line before bullets.
+            f"- Def site: line {defn.lineno}-{defn.end_lineno}",  # Where the symbol is defined.
+            f"- References: {len(candidate.references)}",  # Total refs found.
+            (
+                f"- Suggested class: `{candidate.suggested_class}`"
+                if candidate.suggested_class
+                else "- Suggested class: _n/a_"
+            ),
+            (
+                f"- Suggested module: `{candidate.suggested_module}`"
+                if candidate.suggested_module
+                else "- Suggested module: _n/a_"
+            ),
+            f"- Rationale: {candidate.move_rationale}" if candidate.move_rationale else "- Rationale: _n/a_",
+        ]
+        if candidate.guideline_flags:  # Only render checklist when flags exist.
+            lines.append(self._flag_checklist(candidate.guideline_flags))  # Bullet checklist of flags.
+        if candidate.reference_files:  # Only render call-site groupings if we have any.
+            lines.append(self._reference_groups(candidate.reference_files))  # File-grouped refs.
+        return "\n".join(lines)  # Return the rendered block.
+
+    @staticmethod
+    def _flag_checklist(flags: list[str]) -> str:
+        """Render guideline flags as a markdown checklist for SpecKit remediation."""
+        header = "- Guideline flags (address during the move):"  # Section bullet.
+        items = "\n".join(f"  - [ ] {flag}" for flag in flags)  # One checkbox per flag.
+        return f"{header}\n{items}"  # Return the assembled checklist.
+
+    @staticmethod
+    def _reference_groups(reference_files: dict[str, list]) -> str:
+        """Render references grouped by file, one sub-bullet per file with linenos."""
+        header = "- Reference sites (one PR cluster per file):"  # Section bullet.
+        rows = []  # Accumulate rows.
+        for file_path, refs in sorted(reference_files.items()):  # Deterministic ordering.
+            linenos = ", ".join(str(r.lineno) for r in refs)  # Comma-joined lineno list.
+            rows.append(f"  - `{file_path}`: lines {linenos}")  # One sub-bullet per file.
+        return "\n".join([header, *rows])  # Return the assembled bullet block.
+
+    @staticmethod
+    def _limitations_footer() -> str:
+        """Return the documented limitations block at the bottom of the report."""
+        return "\n".join(  # Multi-line footer joined for markdown output.
+            [
+                "## Limitations",  # Section header.
+                "",  # Blank line before content.
+                '- `getattr(module, "name")` string-form lookups are not detected.',  # Dynamic lookups miss.
+                '- Class-registration decorators (`@registry.register("foo")`) with literal-string wiring '
+                "are invisible to static analysis.",
+                "- Runtime `importlib` / plugin discovery is not followed.",
+                "- Because `src/` files rarely `from MistHelper import ...`, external ref counts are near zero "
+                "by design; the tool primarily surfaces intra-entrypoint single-use symbols that can be moved "
+                "alongside their sole caller into `src/`.",
+                "- Constants inside `if TYPE_CHECKING:` or other conditional module-scope blocks are skipped.",
+            ]
+        )


### PR DESCRIPTION
## Summary
- Adds `tools/refactor_analyzer/` — static-analysis tool that categorizes top-level definitions in `MistHelper.py` (or any entrypoint) as unused / single-use / low-use / hot / skipped, and renders a SpecKit-consumable markdown report.
- Used by the 1015 refactor initiative (now complete) to prioritize extraction candidates. Emits `refactor_candidates.md`.
- Adds `tools/refactor_analyzer/reporting.py = ["E501"]` per-file-ignore in `pyproject.toml`, mirroring the existing `tools/plan_wave_builder.py` precedent. Justification: `reporting.py` emits literal markdown strings that render verbatim into `refactor_candidates.md`; reflowing lines would break the rendered structure.

## Test plan
- [x] `rtk black --check tools/refactor_analyzer/` — 7 files unchanged
- [x] `rtk ruff check tools/refactor_analyzer/` — clean
- [x] `python -m tools.refactor_analyzer -o refactor_candidates.md` regenerates the report (last regeneration landed via #948)