### PR TITLE
docs(1015): archive spec/plan/tasks for completed refactor initiative

### DIFF
--- a/specs/1015-misthelper-refactor-final-15/checklists/requirements.md
+++ b/specs/1015-misthelper-refactor-final-15/checklists/requirements.md
@@ -1,0 +1,53 @@
+# Specification Quality Checklist: MistHelper Refactor — Final 15
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Refactor-Initiative-Specific Validation
+
+- [x] Predecessor initiatives (1010-1014) documented and linked
+- [x] Scope boundary explicitly enumerates the 15 in-scope candidates
+- [x] Explicit exclusions documented (`menu_actions`, `GlobalImportManager`) with rationale
+- [x] Category-bucket ordering rule stated (Single-use → Low-use → Hot) with rationale for deviation from 1014's Refs-ASC rule
+- [x] Cat A vs Cat E designations declared for the queue (0 Cat A, 15 Cat E in current catalog)
+- [x] Non-negotiable constraints from user brief reflected in FRs (Pattern 1 constructor injection, `@staticmethod` for pure helpers, atomic callsite rewire, decompose-while-moving, ASCII/`safe_input()`/`pathlib.Path`, test conversion, class-body landing, no wrapper shims)
+- [x] Dispatch Queue table lists all 15 tasks (T-01 through T-15) with symbol name, kind, LOC, refs, landing target, analyzer flags
+- [x] Compliance floor (≥ 99.6/A+ aggregate, A+/100 per new/edited module) captured in SCs
+- [x] `python MistHelper.py --test` smoke-test contract captured with known-flake exception
+- [x] User-feedback references included (`feedback_no_admin_bypass.md`, `feedback_prepush_black_ruff.md`)
+
+## Notes
+
+Notes on validation status:
+
+- Spec is a serial-refactor initiative in the same family as 1010-1014; all mandatory Spec Kit sections completed and adapted to the refactor workflow domain.
+- Success Criteria (SC-001 through SC-023) mix quantitative (aggregate score floor, callsite counts, PR counts) with qualitative (workflow discipline preserved, no wrapper-shim regressions).
+- The catalog is a live snapshot; FR-032 acknowledges that mid-initiative reclassification is permitted per the same handling as 1014 FR-020 / E-12.
+- No [NEEDS CLARIFICATION] markers were needed — all 15 tasks have explicit landing targets from the analyzer report, and every non-negotiable constraint from the user brief has an unambiguous default in the predecessor initiatives.
+- Ready for `/speckit.plan` (Dispatch Queue is the plan skeleton) or optionally `/speckit.clarify` if landing-target semantics need to be re-visited before implementation begins.

--- a/specs/1015-misthelper-refactor-final-15/plan.md
+++ b/specs/1015-misthelper-refactor-final-15/plan.md
@@ -1,0 +1,297 @@
+# Implementation Plan: MistHelper Refactor — Final 15 (All Remaining Analyzer Candidates)
+
+**Branch**: `1015-misthelper-refactor-final-15` | **Date**: 2026-07-09 | **Spec**: [`spec.md`](./spec.md)
+**Input**: Feature specification from `/specs/1015-misthelper-refactor-final-15/spec.md`
+
+## Summary
+
+Retire the 15 remaining `MistHelper.py` extraction candidates surfaced by `tools/refactor_analyzer/` at commit `8523596` — 3 Single-use, 2 Low-use, 10 Hot — as fifteen atomic Cat E cross-package extraction PRs, one candidate per PR, in the bucket-first (Single-use -> Low-use -> Hot descending-by-LOC) order fixed in the spec's Dispatch Queue. Every hot class with runtime deps lands under **Pattern 1 constructor injection** (`__init__(self, **deps)`, kwargs spelled out at every callsite; NO factories, NO cached module-level instance, NO `sys.modules` self-resolution, NO shims or facades). Module-level constants (T-02, T-03, T-15) land as bare module-level assignments in a semantically appropriate submodule; pure static helpers stay `@staticmethod`. Every `mh = importlib.import_module("MistHelper")` + `mh.<Name>` lazy-import in `src/` is eliminated in the same commit as the body move. `menu_actions` and `GlobalImportManager` are excluded per FR-010 / FR-009. Initiative closes with `refactor_candidates.md` showing only those two entries.
+
+## Technical Context
+
+**Language/Version**: Python 3.13+ (constitution technology-constraint)
+**Primary Dependencies**: `mistapi 0.59+`, `tqdm`, `PrettyTable`, project-internal `src/*` packages (`src.api.apisession`, `src.time.time_utils`, `src.refactors.is_debug_mode`, etc.)
+**Storage**: N/A (refactor initiative — data flow unchanged)
+**Testing**: `python MistHelper.py --test` (functional smoke suite; 15 CI jobs); pre-push `black --check` + `ruff check` gate per `feedback_prepush_black_ruff.md`
+**Target Platform**: Windows 11 local dev + Linux container (podman `ghcr.io/jmorrison-juniper/misthelper:latest`)
+**Project Type**: Single-project CLI (Python entrypoint `MistHelper.py` + `src/` package tree)
+**Performance Goals**: No behavior change — extractions are byte-for-byte semantic equivalents post-move; `python MistHelper.py --test` must report 0 failed / exit 0 modulo the `test_menu_196_dispatches_to_async_claim_exporter` flake (E-7)
+**Constraints**: Repo-wide compliance floor >= 99.6/A+ per merge (SC-003); every new file at A+/100 (SC-006); `MistHelper.py` pylint non-regressing (SC-015); zero new mypy strict violations (SC-019); zero new SKIPPED CI conditionals (SC-016); one open PR at a time (FR-023); `--admin` merge bypass prohibited as routine unblock (FR-015 / `feedback_no_admin_bypass.md`)
+**Scale/Scope**: 15 PRs, ~4,271 LoC removed from `MistHelper.py` (dominated by T-04 `ENDPOINT_PRIMARY_KEY_STRATEGIES` at 2,327 LoC); SC-002 target >= 3,500 LoC net drop; 17 `src/` files touched for the highest-refs candidate T-09 (`InputUtils`, 195 refs)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Cross-check against `.specify/memory/constitution.md` v1.4.0 (all seven Core Principles + Technology Constraints + Multi-Agent Git Workflow):
+
+| Principle | Compliance | Notes |
+|---|---|---|
+| I. Five-Item Rule | PASS | Every new module lands classes/methods <= 25 lines, <= 5 params; oversize-flagged candidates (T-04, T-06, T-07, T-08, T-10) carry mandatory in-flight decomposition per FR-006 / E-2 / E-10. |
+| II. Class-Based Architecture (No Wrappers) | PASS | Pattern 1 constructor injection preserves class-based ownership; FR-003 explicitly prohibits wrapper shims, forwarding functions, re-export modules, delegators, pointers, and backward-compat aliases (SC-007). Module-level constants (T-02, T-03, T-15) are pure data — not wrappers. |
+| III. Safety-First (NON-NEGOTIABLE) | PASS | T-09 (`InputUtils`) carries `raw_input_call` flag — FR-006 requires in-flight remediation to `InputUtils.safe_input()`. No destructive-operation code paths modified. |
+| IV. Full Deployment Pipeline (NON-NEGOTIABLE) | PASS | Every PR runs `python -m py_compile MistHelper.py` implicitly via `python MistHelper.py --test` gate; merged main triggers container rebuild via `container-build.yml`. |
+| V. Observability & Logging | PASS | FR-006 remediates `non_ascii_logs` (T-04, T-08) and `missing_action_logging` (T-01, T-02, T-03, T-05, T-11, T-14, T-15) in-flight. Every new module uses `%s` formatting per constitution VII. |
+| VI. Inline Comments (NON-NEGOTIABLE) | PASS | FR-006 remediates `missing_inline_comments` (T-02, T-04, T-06, T-10, T-11, T-13, T-15) in-flight. New modules land with inline comment on every executable line. |
+| VII. Action Logging (NON-NEGOTIABLE) | PASS | FR-006 remediates `missing_action_logging` flags in-flight; every method in every new module lands with `logging.info` before / `logging.debug` after envelopes. |
+| Complexity-Driven SpecKit Escalation | PASS | Multi-file, multi-class initiative — spec authored (FR-021: no new features / CLI flags / behavior). |
+| Multi-Agent Git Workflow | PASS | Branch pattern `refactor/1015-tNN-<slug>` off `main`; squash-merge; one open PR at a time (FR-023); no branching from feature branches. |
+
+**Gate result**: PASS. No violations. Complexity Tracking table empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1015-misthelper-refactor-final-15/
+├── spec.md              # Feature specification (authored 2026-07-09)
+├── plan.md              # This file (/speckit.plan output)
+├── checklists/
+│   └── requirements.md  # 26 items, all passing pre-plan
+└── tasks.md             # /speckit.tasks output (15 tasks, one per Dispatch Queue row)
+```
+
+Research, data-model, quickstart, and contracts artifacts are NOT produced for this initiative. Rationale documented in Phase 0 below.
+
+### Source Code (repository root)
+
+```text
+MistHelper.py                              # Entrypoint — 15 symbols excised across the initiative
+src/
+├── api/                                   # apisession, api_core_fetch_utils (deps injected into hot classes)
+├── config/                                # NEW landing dir for T-12 (ConfigUtils)  -- may already exist as fold-in target
+│   └── config_utils.py                    # T-12 lands here
+├── data/                                  # NEW landing dir for T-10 (DataProcessingUtils)
+│   └── data_processing_utils.py           # T-10 lands here
+├── device/
+│   ├── prompt_utils.py                    # existing (52 KB) -- E-1 review: fold T-07 in OR override to src/ui/prompt_utils.py
+│   └── virtual_chassis.py                 # T-11 folds into existing class body
+├── export/
+│   ├── data_exporter.py                   # T-08 lands here
+│   └── org_inventory_exporter.py          # T-06 lands here
+├── refactors/                             # fallback landing when no closer semantic fit exists
+│   ├── device_data_fetcher.py             # T-01 folds into DeviceDataFetcherManager or dataclass (per E-1)
+│   ├── endpoint__primary__key__strategies.py     # T-04 (2327 LoC) lands here (or src/api/*.py per E-1)
+│   ├── fast__mode__max__concurrent__connections.py       # T-02
+│   ├── fast__mode__use__connection__aware__threading.py  # T-03
+│   ├── mist_site_exclude_prefix.py        # T-15
+│   ├── detect_msp_privileges.py           # T-05 (or src/msp/*.py per E-1)
+│   └── ... (existing modules unchanged)
+├── ui/
+│   ├── input_utils.py                     # T-09 lands here (existing src/utils/input_utils.py, E-1 review at dispatch)
+│   └── prompt_utils.py                    # T-07 candidate landing (existing src/device/prompt_utils.py, E-1 review)
+├── utils/
+│   ├── file_path_utils.py                 # T-13 lands here
+│   └── tqdm_wrapper.py                    # T-14 lands here (or src/ui/*.py per E-1)
+tests/
+└── (test files converted per FR-030 in same commit as each extraction PR)
+```
+
+**Structure Decision**: Single-project layout (constitution technology). New landings prefer domain-fitting semantic packages (`src/export/`, `src/ui/`, `src/device/`, `src/data/`, `src/config/`, `src/utils/`) over the `src/refactors/` fallback. Two directories (`src/config/`, `src/data/`) do not yet exist and will be created at dispatch time if T-10 / T-12 land there rather than folding into another module (E-1 dispatch-time choice). Every landing decision is recorded in the PR description per E-1 / FR-029.
+
+## Architecture Strategy
+
+### Guiding Principles (durable user directive — DO NOT DEVIATE)
+
+1. **Pattern 1 constructor injection is the ONLY landing pattern for hot classes with runtime deps.** Every extracted hot class exposes `def __init__(self, **deps)` where every dependency is a **required kwarg**. The 14 typical DI kwargs (subset per class) are: `apisession`, `PromptUtils`, `ConfigUtils`, `DataProcessingUtils`, `DataExporter`, `TimeUtils`, `EnhancedSSHRunner`, `InsightMetricsUtils`, `PacketCaptureManager`, `APICoreFetchUtils`, `check_fn=IsDebugMode.check`, `PrettyTable`, `tqdm`, `mistapi`. Every callsite constructs the instance inline with the full kwargs list spelled out. **NO factory helpers. NO cached module-level instance. NO `sys.modules` self-resolution. NO delegators/shims/pointers. NO backwards-compat facades.**
+2. **Cat A facade removal** — delete the class entirely, rewrite every callsite. Applies only if a candidate reclassifies to Cat A mid-initiative (0 Cat A at initiative start per spec).
+3. **Cat E pure module extraction** — for module-level constants and pure single-use symbols with no runtime deps, land as bare module-level assignments or plain `@staticmethod` collections in `src/refactors/<name>.py` (or a semantically appropriate submodule) and rewrite import paths.
+4. **No wrapper shim, forwarding function, re-export module, delegator, pointer, helper, or backward-compat alias may survive in `MistHelper.py`** (SC-007). Only a single-line NOTE breadcrumb is left at the deletion site (FR-007 / SC-012).
+5. **Every `mh = importlib.import_module("MistHelper")` + `mh.<Name>` lazy-import pattern is eliminated** for the extracted symbol in the same commit (SC-009). This pattern was tolerated during 1014's transition and is now retired.
+
+### Per-Bucket Implementation Approach
+
+**Bucket A — Single-use (T-01, T-02, T-03) — Queue-head validation, 1 caller each**
+
+Purpose: warm up the workflow at the minimum blast radius before touching Low-use and Hot candidates.
+
+- **T-01 (`DeviceFetchConfig`, class, 9 LoC, 1 ref)**: Fold as top-level `@dataclass` into `src/refactors/device_data_fetcher.py` (E-1 override: fold into `DeviceDataFetcherManager` class body ONLY if the class's public surface would benefit from a nested config; default is top-level dataclass). Sole callsite at `src/refactors/device_data_fetcher.py:49` rewritten in same commit. Remediate `missing_action_logging` in-flight.
+- **T-02 (`FAST_MODE_MAX_CONCURRENT_CONNECTIONS`, assignment, 3 LoC, 1 ref)**: Module-level constant at `src/refactors/fast__mode__max__concurrent__connections.py` (E-14: bare module-level constant, ignore analyzer's `Suggested class` `FastModeMaxConcurrentConnectionsManager` naming hint). Prefer fold into an existing fast-mode constants module in the destination package if one exists. Remediate `missing_inline_comments` + `missing_action_logging` in-flight (constant carries no methods — flag remediation is exercised on the read-side documentation).
+- **T-03 (`FAST_MODE_USE_CONNECTION_AWARE_THREADING`, assignment, 3 LoC, 1 ref)**: Same landing pattern as T-02. Consider co-locating with T-02 in the same destination file if the fold-in target exists.
+
+**Bucket B — Low-use (T-04, T-05) — 2 callers each**
+
+Purpose: prove the 2-callsite atomic-rewire pattern; T-04 is the largest LOC win in the whole initiative and reclaims 2,327 lines from `MistHelper.py` early.
+
+- **T-04 (`ENDPOINT_PRIMARY_KEY_STRATEGIES`, assignment, 2327 LoC, 2 refs)**: Land at `src/refactors/endpoint__primary__key__strategies.py` OR domain-fit under `src/api/*.py` (per E-1; the dict is intimately tied to the primary-key strategy layer that the constitution's "Adding New Menu Operations" section already codifies). PR description records E-1 rationale. **Substantial internal decomposition required per E-10**: 2,327 lines of dict entries stay as data but any embedded lambdas / callables must be split into `@staticmethod` methods <= 25 lines. Remediate `oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`, and `non_ascii_logs` flags in-flight. **Dispatch this task early (position 4 in the queue) to reclaim the LoC.**
+- **T-05 (`detect_msp_privileges`, function, 25 LoC, 2 refs)**: Land at `src/refactors/detect_msp_privileges.py` OR `src/msp/*.py` (new package, per E-1). Remediate `missing_action_logging` in-flight.
+
+**Bucket C — Hot (T-06 through T-15) — >= 4 refs, >= 1 `src/` caller each**
+
+Purpose: complete the initiative. Ordered descending by LOC (per FR-026): T-06 -> T-07 -> T-08 -> T-10 -> T-11 -> T-09 -> T-12 -> T-13 -> T-14 -> T-15.
+
+Every candidate here follows **Pattern 1 constructor injection** if it has runtime deps (`apisession`, `logger`, config accessors, etc.). Applies to: T-06, T-07, T-08, T-09, T-10, T-11, T-12, T-13. Applies partially to T-14 (`tqdm` wrapper — trivial deps, likely stays a bare function). T-15 is a pure module-level constant (E-14).
+
+- **T-06 (`OrgInventoryExporter`, class, 686 LoC, 102 refs)**: Land at `src/export/org_inventory_exporter.py`. Pattern 1 constructor. Method decomposition mandatory (`oversize_25_lines`) — 686 -> N methods each <= 25 lines. Remediate `missing_inline_comments` in-flight. 102 callsites rewritten to `from src.export.org_inventory_exporter import OrgInventoryExporter` + inline instantiation with kwargs.
+- **T-07 (`PromptUtils`, class, 441 LoC, 96 refs)**: Land at `src/ui/prompt_utils.py`. **E-1 collision check at dispatch**: `src/device/prompt_utils.py` already exists at ~52 KB — verify whether that file is a related-but-distinct symbol or a stale forward. If collision, either co-locate in `src/device/prompt_utils.py` (fold-in) or leave `src/device/` untouched and land at `src/ui/prompt_utils.py`. Decision recorded in PR description. Pattern 1 constructor. Decompose per `oversize_25_lines`.
+- **T-08 (`DataExporter`, class, 345 LoC, 118 refs)**: Land at `src/export/data_exporter.py`. Pattern 1 constructor. Remediate `oversize_25_lines` + `non_ascii_logs` in-flight (constitution V). 118 callsites — the second-highest refs count.
+- **T-10 (`DataProcessingUtils`, class, 158 LoC, 69 refs)**: Land at `src/data/data_processing_utils.py` (create `src/data/` if not present). Pattern 1 constructor. Remediate `oversize_25_lines`, `missing_inline_comments`, `hardcoded_separator` (use `os.sep` / `pathlib.Path` per constitution technology-constraint).
+- **T-11 (`VirtualChassisManager`, class, 78 LoC, 104 refs)**: Fold into existing `src/device/virtual_chassis.py` (E-1: existing 53 KB module is the natural home). Pattern 1 constructor. Remediate `oversize_25_lines`, `missing_inline_comments`, `missing_action_logging` in-flight. Fold must not regress `src/device/virtual_chassis.py` below A+/100 (FR-022).
+- **T-09 (`InputUtils`, class, 74 LoC, 195 refs)**: Land at `src/ui/input_utils.py`. **E-1 collision check at dispatch**: `src/utils/input_utils.py` already exists at ~4.6 KB — determine whether to fold, replace, or override the landing to `src/ui/input_utils.py`. **195 refs across 17 files — the highest-refs candidate in the initiative.** Pre-dispatch `grep -rn "InputUtils" src/ tests/` recorded in PR description (FR-013 / FR-027). Pattern 1 constructor. Remediate `oversize_25_lines` + `raw_input_call` (in-flight rewrite to `safe_input()` per constitution III).
+- **T-12 (`ConfigUtils`, class, 70 LoC, 102 refs)**: Land at `src/config/config_utils.py` (create `src/config/` if not present). Pattern 1 constructor. Remediate `oversize_25_lines`.
+- **T-13 (`FilePathUtils`, class, 46 LoC, 50 refs)**: Land at `src/utils/file_path_utils.py`. Pattern 1 constructor (or `@staticmethod` collection if no runtime deps — verify at dispatch). Remediate `oversize_25_lines` + `missing_inline_comments`.
+- **T-14 (`tqdm`, function, 3 LoC, 51 refs)**: Land at `src/utils/tqdm_wrapper.py` OR domain-fit under `src/ui/*.py` (E-1). E-12 clarification: NOT `SKIP_ALWAYS` here; the 1012 skip-pin was per-initiative. Remediate `missing_action_logging` in-flight. This is a 3-line wrapper — expect a Pattern-1-style constructor is NOT required (trivial deps).
+- **T-15 (`MIST_SITE_EXCLUDE_PREFIX`, assignment, 3 LoC, 11 refs)**: Bare module-level constant at `src/refactors/mist_site_exclude_prefix.py` OR fold into an existing constants module in `src/gateway/*.py` (E-1 / E-14). Remediate `missing_inline_comments` + `missing_action_logging` in-flight.
+
+## Dependency Graph Between Tasks
+
+Most of the 15 tasks are **independent** — different symbols in different regions of `MistHelper.py`, different callsite sets. A few overlapping-callsite risks warrant coordination but no serial gating beyond FR-023 (one open PR at a time):
+
+**Overlap risks noted (not blockers — mitigated by FR-023 and dispatch-time grep audit)**:
+
+- **T-07 (PromptUtils) <-> T-11 (VirtualChassisManager)**: `src/device/virtual_chassis.py` (T-11 landing) and `src/device/prompt_utils.py` (T-07 potential collision landing) are in the same directory. If T-07 folds into `src/device/prompt_utils.py`, both PRs touch `src/device/`. Serial merges (per FR-023) plus fresh grep at each dispatch avoid conflict.
+- **T-09 (InputUtils, 195 refs, 17 files) <-> every other Hot task**: `InputUtils.safe_input()` is called from many Hot-bucket classes' method bodies. If T-09 lands BEFORE another Hot class, that class's extraction PR must use the new `from src.ui.input_utils import InputUtils` path. If T-09 lands AFTER, the callsite table for T-09 must include the freshly-landed Hot class's file. Either order works; the dispatch-time grep audit ensures both directions are covered. **Recommendation**: dispatch T-09 late in the Hot bucket (position 11 of 15) — as spec's Dispatch Queue already sequences — so Hot classes T-06/T-07/T-08/T-10/T-11 that precede it can bundle their `InputUtils` uses into their own atomic rewires.
+- **T-08 (DataExporter, 118 refs) <-> T-06 (OrgInventoryExporter, 102 refs)**: `OrgInventoryExporter` likely calls `DataExporter.write_with_format_selection()` (constitution's canonical export pattern). Whichever lands first passes the freshly-landed class to the second via Pattern 1 kwargs (`DataExporter` kwarg to `OrgInventoryExporter.__init__`, per the 14 typical DI kwargs).
+- **T-04 (ENDPOINT_PRIMARY_KEY_STRATEGIES) <-> T-08 (DataExporter)**: Constitution's "Adding New Menu Operations" flow makes T-04 an input to `DataExporter`. If T-08 lands first, T-08's `__init__` needs an import of the still-in-MistHelper.py `ENDPOINT_PRIMARY_KEY_STRATEGIES` — routed via constructor injection (`primary_key_strategies=ENDPOINT_PRIMARY_KEY_STRATEGIES` kwarg). If T-04 lands first, T-08 imports from the new landing module directly. Dispatch T-04 EARLY (position 4) — the spec already sequences it there — to eliminate this coupling before Hot bucket starts.
+- **T-15 (MIST_SITE_EXCLUDE_PREFIX)**: Referenced from `src/gateway/*.py` and MistHelper.py. Independent of every other task.
+
+**Fully independent** (no shared callsite files at spec time): T-01, T-02, T-03, T-05, T-13, T-14.
+
+**Sequencing rationale (matches spec's Dispatch Queue exactly)**:
+
+1. T-01 -> T-02 -> T-03: warm up (1 callsite each, minimum risk).
+2. T-04 early (position 4): reclaim 2,327 LoC and remove the T-04 <-> T-08 coupling before Hot bucket.
+3. T-05: exercises new-package creation (`src/msp/`) at low risk.
+4. Hot descending-by-LOC: T-06, T-07, T-08, T-10, T-11, T-09, T-12, T-13, T-14, T-15.
+
+## Workflow Per Task (identical structure — /speckit.tasks will emit one task row per Dispatch Queue entry)
+
+For **each** of T-01 through T-15:
+
+1. **Branch**: `git checkout -b refactor/1015-tNN-<slug>` off latest `main`.
+2. **Pre-dispatch audit**: `grep -rn "<Name>" src/ tests/ MistHelper.py` -> record file:line callsite table in PR description (FR-013 / FR-027).
+3. **Implement**:
+   - Create (or select) landing module per spec's Dispatch Queue + E-1 override rationale.
+   - Move body verbatim; then remediate `guideline_flags` in-flight (FR-006 / FR-008).
+   - For hot classes with runtime deps: apply **Pattern 1 constructor injection** (`__init__(self, **deps)` — required kwargs, spelled out at every callsite; NO factory, NO cached instance, NO `sys.modules` self-resolution, NO shim, NO facade).
+   - Delete original body from `MistHelper.py`.
+   - Add mandatory single-line NOTE breadcrumb at deletion site: `# NOTE: <Name> extracted to <new-module-path>::<Name>. See specs/1015-misthelper-refactor-final-15/spec.md.` (FR-007 / SC-012).
+   - Rewrite every `MistHelper.py` callsite in same commit.
+   - Rewrite every `src/` / `tests/` callsite in same commit — including elimination of every `mh = importlib.import_module("MistHelper")` + `mh.<Name>` lazy-import for this symbol (SC-009).
+   - Convert existing tests to new import path + Pattern 1 construction contract (FR-030).
+4. **Import-graph health check** (FR-028 / SC-018): `python -c "import <landing_module>; print('OK')"` must succeed without traversing `MistHelper.py`. If genuine cycle remains, inject Pattern 1 DI surface at the cycle boundary. NO `mh.<name>` lazy import in the new module.
+5. **Pre-push local gate** (`feedback_prepush_black_ruff.md`):
+   ```
+   black src/ MistHelper.py tools/
+   ruff check src/ MistHelper.py tools/
+   python MistHelper.py --test    # expect 0 failed, exit 0 (E-7 flake exempt)
+   ```
+6. **Commit**: `refactor(1015): <what> (T-NN, Cat E)`.
+7. **Push + open PR** against `main` (via `git push` + web URL if EMU blocks `gh pr create` per spec Assumptions).
+8. **Wait for CI**: all 15 functional jobs green + `mergeStateStatus: CLEAN` + `black --check` clean + `ruff check` clean.
+9. **Merge**: `gh pr merge --squash --delete-branch` — **never `--admin`** as routine unblock (`feedback_no_admin_bypass.md`). SKIPPED conditionals are NOT blocking (E-9).
+10. **Post-merge**:
+    - `git checkout main && git pull`.
+    - Regenerate: `python -m tools.refactor_analyzer` -> writes fresh `refactor_candidates.md`.
+    - Commit as `chore(1015): regenerate refactor_candidates.md after T-NN merge` on `main` (may piggyback in the next task's branch or land as a standalone commit per prior initiative practice).
+    - Verify T-NN symbol is absent from every bucket in the fresh catalog.
+11. **Advance**: next task in bucket-first order.
+
+## Quality Gates (aggregate across the initiative)
+
+| Gate | Enforcement | Traceability |
+|---|---|---|
+| 15 functional CI jobs green | Per PR | FR-015 / SC-005 |
+| `mergeStateStatus: CLEAN` | Per PR | FR-015 / `feedback_no_admin_bypass.md` |
+| `black --check` clean | Per PR (pre-push + CI) | FR-015 / SC-005 / SC-013 / `feedback_prepush_black_ruff.md` |
+| `ruff check` clean | Per PR (pre-push + CI) | FR-015 / SC-005 / SC-013 / `feedback_prepush_black_ruff.md` |
+| `python MistHelper.py --test` = 0 failed / exit 0 | Per PR | FR-015 / SC-005 / SC-013 (E-7 flake exempt) |
+| Repo aggregate compliance >= 99.6/A+ | Per PR | SC-003 / FR-017 |
+| Every new module A+/100 | Per PR | SC-006 / FR-016 |
+| No A+ file regresses below A+ | Per PR | SC-004 / FR-022 |
+| `MistHelper.py` pylint non-regressing | Per PR | SC-015 / FR-018 |
+| Zero new mypy strict violations | Per PR | SC-019 / FR-031 |
+| Zero new SKIPPED CI conditionals | Per PR | SC-016 / FR-019 |
+| Zero `mh.<Name>` remainders for extracted symbol | Per PR (post-merge grep) | SC-009 |
+| Zero wrapper shim / facade / delegator in `MistHelper.py` | Per PR + final | SC-007 |
+| Exactly one NOTE breadcrumb per deletion site | Per PR | SC-012 / FR-007 |
+| Callsite table in PR description | Per PR | SC-017 / FR-027 |
+| Analyzer regenerated after every merge | Per merged PR | SC-010 / FR-014 |
+| One open PR at a time | Sequenced dispatch | FR-023 |
+| Every analyzer `guideline_flag` on extracted symbol resolved in-flight | Per PR | SC-011 / FR-006 |
+| No `menu_actions` diff | Per PR + final | SC-020 / FR-010 |
+| No `GlobalImportManager` diff | Per PR + final | SC-021 / FR-009 |
+| MistHelper.py LoC -3,500 by initiative close | Cumulative | SC-002 |
+| Final catalog shows only `menu_actions` + `GlobalImportManager` | Final | SC-001 / FR-024 / FR-032 |
+| Final-state summary in last PR or follow-up docs commit | Final | SC-022 |
+
+## Rollback Strategy
+
+**Per-PR rollback (rare — expected only on merged regression)**:
+
+1. Identify the merged PR causing the regression (`gh pr list --state merged --search "1015"` + `git bisect` if needed).
+2. Open a revert PR: `gh pr create --title "revert(1015): revert T-NN <slug>" --body "Reverts #<PR>. Root cause: <one-line>."` — do NOT rebase or force-push.
+3. Merge the revert PR with the same quality gates (all 15 green, `mergeStateStatus: CLEAN`, `black --check` + `ruff check` clean, `python MistHelper.py --test` clean).
+4. Re-run `python -m tools.refactor_analyzer` — the reverted symbol reappears in the catalog.
+5. File a follow-up issue capturing the root cause; the reverted candidate stays in this initiative's Dispatch Queue and is re-attempted with the root cause fixed.
+6. The initiative's SC-001 / SC-002 targets are re-evaluated only at final closure — a temporary revert does not close the initiative.
+
+**Mid-PR rollback (branch-local, no merge)**:
+
+- `git reset --hard origin/main` on the refactor branch.
+- Re-run pre-push gate before re-pushing.
+- No cross-branch impact.
+
+**Never**:
+
+- Force-push to `main`.
+- Amend a merged commit.
+- Use `--admin` merge bypass to paper over a failing CI job (`feedback_no_admin_bypass.md`).
+- Leave a `mh.<Name>` lazy-import in place as a "temporary" backward-compat bridge (SC-009 — zero remainders permitted).
+- Introduce a wrapper shim / delegator / facade / re-export module as a rollback lever (SC-007 — zero remainders permitted).
+
+**Full-initiative rollback (worst case, expected never)**:
+
+If the aggregate compliance floor (SC-003) drifts below 99.6/A+ due to a compounding sequence of extractions:
+
+1. Pause new dispatches.
+2. Diagnose which merged PR(s) contributed to the drift (per-file compliance-score diff against pre-initiative baseline).
+3. Revert the offending PR(s) via standard revert-PR flow.
+4. Resume dispatch from the queue position immediately after the last clean PR.
+
+The initiative is stateless across dispatches: every PR is independently revertable and no PR blocks any other PR's revert.
+
+## Phase 0: Outline & Research
+
+**Decision: Skip standalone research.md.**
+
+Rationale: 1015 is the direct successor to 1010/1011/1012/1013/1014, all of which have merged, closed, and shipped. Every unknown that could apply to 1015 has been resolved by predecessor initiatives:
+
+| Prior unknown | Resolved by |
+|---|---|
+| Cat E cross-package extraction workflow | 1014 (18 Cat E PRs merged) |
+| Cat A facade removal workflow | 1013 + 1014 (10 Cat A PRs merged) |
+| Pattern 1 constructor injection | 1013 (established) + 1014 (applied 18x) |
+| `mh = importlib.import_module("MistHelper")` elimination | 1014 (pattern retired for every extracted symbol) |
+| Serial-PR dispatch with `--squash` merges | 1010/1011/1012/1013/1014 (56+ merged PRs) |
+| Analyzer regeneration cadence | 1010-1014 (established `chore(NNNN): regenerate ...` convention) |
+| `python MistHelper.py --test` flake `test_menu_196_dispatches_to_async_claim_exporter` | 1014 (E-7 exemption established) |
+| Pre-push `black --check` + `ruff check` gate | `feedback_prepush_black_ruff.md` (user memory) |
+| `--admin` merge bypass prohibition | `feedback_no_admin_bypass.md` (user memory) |
+
+The 14 typical DI kwargs enumerated in the user directive are the exact set observed in merged 1013/1014 PRs. No further research is required to dispatch T-01.
+
+**Output**: (implicit — this plan.md encodes every decision that a research.md would have surfaced)
+
+## Phase 1: Design & Contracts
+
+**Decision: Skip data-model.md, contracts/, quickstart.md.**
+
+Rationale:
+
+- **data-model.md**: 1015 introduces no new entities. Every extracted symbol preserves its runtime behavior byte-for-byte modulo `guideline_flags` remediation. The spec's "Key Entities" section already captures the workflow-level entities (Extraction Candidate, Callsite, Callsite Table, Dispatch Queue, Reclassification, Pattern 1). No further data modelling is required.
+- **contracts/**: 1015 exposes no new public interfaces. `FR-021` explicitly prohibits new features, new commands, new CLI flags, or user-facing behavior changes. Every Pattern 1 `__init__(self, **deps)` signature is an internal construction contract, not a public API contract — enumerated in the spec's Key Entities under "Pattern 1 (Constructor Injection)".
+- **quickstart.md**: The Workflow-Per-Task section above IS the quickstart. Duplicating it into a separate file adds no signal.
+
+**Agent context update**: The plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `.github/copilot-instructions.md` will be updated to point to this plan file on request. Not performed automatically as part of this /speckit.plan run — flagged for the caller.
+
+**Output**: (this plan.md is the complete Phase 1 artifact for a pure-refactor initiative with no new entities, no new interfaces, and no new user-facing behavior)
+
+## Complexity Tracking
+
+*Empty — no Constitution Check violations.*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |

--- a/specs/1015-misthelper-refactor-final-15/spec.md
+++ b/specs/1015-misthelper-refactor-final-15/spec.md
@@ -1,0 +1,296 @@
+# Feature Specification: MistHelper Refactor — Final 15 (All Remaining Analyzer Candidates)
+
+**Feature Branch**: `1015-misthelper-refactor-final-15`
+**Created**: 2026-07-09
+**Status**: Draft
+**Catalog snapshot**: `refactor_candidates.md` regenerated 2026-07-09 against `origin/main` at commit `8523596` (PR #914 — SiteExportUtils facade removal — merged).
+
+**Predecessors** (all closed):
+
+- [`1010-misthelper-refactor-extraction`](../1010-misthelper-refactor-extraction/spec.md) — Unused + Single-use bucket clearance (13 PRs).
+- [`1011-misthelper-refactor-low-use`](../1011-misthelper-refactor-low-use/spec.md) — Low-Use serial workflow (20 candidates).
+- [`1012-misthelper-refactor-hot-functions`](../1012-misthelper-refactor-hot-functions/spec.md) — Hot-function bounded bundle (`tqdm` skip-pin, `is_debug_mode`, `_pool_*` family).
+- [`1013-misthelper-refactor-hot-classes`](../1013-misthelper-refactor-hot-classes/spec.md) — 47-candidate MistHelper-only Hot-class serial workflow.
+- [`1014-misthelper-refactor-hot-classes-with-src-callers`](../1014-misthelper-refactor-hot-classes-with-src-callers/spec.md) — 24-candidate Hot-class initiative with `src/` external callers (Cat A facade removal + Cat E fresh cross-package extraction). Closed by PR #914 removing the last Cat A facade (`SiteExportUtils`).
+
+**Input**: User description: "Extract all remaining MistHelper.py refactor candidates from analytics report (excluding `menu_actions` and `GlobalImportManager`). Sixteen prior extraction PRs (P1-P16) closed initiatives 1010-1014. The freshly regenerated analyzer report at `refactor_candidates.md` surfaces 17 remaining catalog entries: 3 Single-use, 2 Low-Use, 11 Hot, and 1 Skipped. Removing `menu_actions` (deferred indefinitely per user directive) and the pinned `GlobalImportManager` (`SKIP_ALWAYS`, module-load-order-critical) leaves **15 tasks**, one per PR, in the same serial workflow discipline established by 1010/1011/1013/1014. This initiative retires the analyzer report to `menu_actions` + `GlobalImportManager` only."
+
+## Predecessor Context
+
+The five closed predecessor initiatives (1010-1014) collectively cleared every actionable extraction the analyzer has surfaced across four buckets:
+
+- **1010** cleared 13 candidates in the Unused + Single-Use buckets and established the extraction contract (no wrapper shims, class-body landing, callsite rewrite in the same PR).
+- **1011** cleared 20 Low-Use candidates using the serial per-PR workflow.
+- **1012** cleared three specific Hot-bucket entries as a bounded single-PR bundle.
+- **1013** cleared 47 MistHelper-only Hot-bucket classes across 4 Cat A + 43 Cat B PRs.
+- **1014** cleared the 24-candidate Hot-class queue whose callsites span `src/` (6 Cat A facades + 18 Cat E fresh cross-package extractions). Closed by PR #914 (SiteExportUtils, Cat A, position 16 of the 1014 queue). Note: 1014's queue was expanded mid-initiative — the "24" in its spec was the initial snapshot; the actual merged count differs slightly as candidates reclassified per 1014 FR-020 / E-12.
+
+After PR #914 (2026-07-08), the analyzer was re-run against `origin/main` at commit `8523596`. The regenerated `refactor_candidates.md` shows 17 catalog entries. **Two are explicitly out of scope for this initiative** — `menu_actions` (887 LoC, 17 refs; deferred indefinitely per user directive) and `GlobalImportManager` (1003 LoC, 1 ref; pinned by bootstrap / module-load ordering; the analyzer's `SKIP_ALWAYS` list). The remaining **15 candidates** are this initiative's Dispatch Queue.
+
+This initiative retires the analyzer output. When it closes, `refactor_candidates.md` will show only `menu_actions` (deferred by policy) and `GlobalImportManager` (skipped by policy). No further MistHelper.py refactor initiative is planned unless net-new extractable symbols are added to the entrypoint.
+
+## Scope Boundary
+
+The initiative targets exactly **15 candidates**, enumerated in the Dispatch Queue below. Each row lands as one PR. The queue interleaves three category-buckets (Single-use → Low-use → Hot) in the analyzer's canonical order (highest-ROI, smallest-blast-radius first) rather than a strict global Refs-ASC sort — this differs from 1014's ordering rule because the bucket-boundary is itself a meaningful risk gradient (Single-use PRs have 1 caller each; Low-use have 2-3; Hot have 4+ up to 195).
+
+Two action-type designations coexist in the queue:
+
+- **Cat A — Facade removal** (0 candidates in this initiative). No candidate in the current catalog is a delegation wrapper over an existing `src/` implementation — 1013 and 1014 have already retired every Cat A facade the analyzer surfaced. If a candidate reclassifies to Cat A mid-initiative (e.g. a new facade is introduced by an unrelated commit), the FR-025 method-parity discipline from 1014 applies.
+- **Cat E — Fresh cross-package extraction** (all 15 candidates). MistHelper.py holds the real body (class body, function body, or module-level constant / assignment); one or more callsites currently reference the symbol via a direct name resolution in MistHelper.py's namespace. For hot candidates with `src/` callers (T-06 through T-15), one or more `src/` modules also reference the symbol via `mh = importlib.import_module("MistHelper")` + `mh.<Name>` lazy imports. Each PR (a) creates the landing module (or folds into an existing module when semantically appropriate), (b) deletes the original body from `MistHelper.py`, (c) rewrites every `MistHelper.py` callsite in the same commit, AND (d) rewrites every `src/` (or other first-party) callsite in the same commit.
+
+**Explicit exclusions**:
+
+- **`menu_actions`** (887 LoC, 17 refs, Hot). Deferred indefinitely per user directive. Not in this initiative's queue and not planned for any follow-up initiative.
+- **`GlobalImportManager`** (1003 LoC, 1 ref, Skipped). Pinned by module-load / bootstrap ordering. Static analysis cannot detect the load-order dependency; the analyzer curates it via the `--skip NAME` CLI flag. Moving it would break import wiring. Not in this initiative's queue and not planned for any follow-up initiative.
+- All classes already extracted in 1010, 1011, 1012, 1013, or 1014. Those symbols are fully migrated.
+- The refactor analyzer itself (`tools/refactor_analyzer/`) — consumed as-is.
+
+The 15 in-scope candidates cover three analyzer categories:
+
+- **Single-use bucket (3 candidates)** — T-01 through T-03. One PR each. Sole caller is the sole rewrite site (plus the extraction itself in MistHelper.py).
+- **Low-use bucket (2 candidates)** — T-04, T-05. Two callers each. Two-callsite PRs.
+- **Hot bucket (10 candidates)** — T-06 through T-15. 11 to 195 refs each; every candidate has at least one `src/` caller. Same Cat E discipline as the 18 Cat E candidates from 1014.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Extract a Single-use or Low-use candidate to `src/refactors/*.py` (or the sole caller's semantic module) and rewrite its callsites atomically (Priority: P1)
+
+The queue-head workflow. For each of T-01 through T-05, the refactor engineer opens a PR that (a) creates the landing module (either the analyzer's `Suggested module` path or a semantically closer target per E-1), (b) deletes the symbol body from `MistHelper.py`, (c) rewrites every callsite in the same commit (1-2 sites for Single-use / Low-use), (d) resolves any analyzer `guideline_flags` in-flight, and (e) lands with all 15 functional CI jobs green, aggregate analyzer score ≥ 99.6/A+, `black --check` clean, `ruff check` clean, and `python MistHelper.py --test` passing (0 failed, exit 0).
+
+**Why this priority**: These are the lowest-blast-radius extractions in the initiative — Single-use has one caller, Low-use has two. Front-loading them validates the workflow before the higher-refs Hot-bucket PRs and produces early merges that thin the queue quickly.
+
+**Independent Test**: Any single Single-use candidate (e.g. `DeviceFetchConfig` at 1 ref / 9 LoC, the smallest) can be merged in isolation. The PR (a) moves `DeviceFetchConfig` into `src/refactors/device_data_fetcher.py`'s `DeviceDataFetcherManager` class body (or a top-level dataclass in that module, per E-1), (b) deletes the definition from `MistHelper.py`, (c) rewrites the single callsite at `src/refactors/device_data_fetcher.py:49`, (d) resolves the `missing_action_logging` flag, (e) leaves a NOTE breadcrumb at the extraction site in `MistHelper.py`, (f) lands green.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Single-use or Low-use candidate with N callsites (N ∈ {1, 2}), **When** the PR is opened, **Then** the diff shows the body moved to the landing module, deleted from `MistHelper.py`, and every one of the N callsites rewritten — with zero stale references surviving.
+2. **Given** the extracted candidate carried analyzer `guideline_flags`, **When** the PR lands, **Then** each flag is resolved in-flight — decomposition to ≤ 25 lines per method, `logging.info` / `logging.debug` envelopes on every method, inline comments on every executable line, ASCII-only log literals, `pathlib.Path` in place of `os.path`, `InputUtils.safe_input()` in place of raw `input()`, hardcoded separators replaced with `os.sep` or `pathlib` idioms.
+3. **Given** the pre-push local gate, **When** the contributor pushes the refactor branch, **Then** `black --check` and `ruff check` both pass locally before the PR opens, and `python MistHelper.py --test` reports 0 failed with exit code 0.
+4. **Given** T-04 (`ENDPOINT_PRIMARY_KEY_STRATEGIES`, 2327 LoC, 2 refs) is the largest LOC line-item in the initiative, **When** its PR is opened, **Then** the move is atomic (no split across multiple PRs) but the new module MAY carry substantial internal decomposition (broken into ≤ 25-line methods, inline comments every 5-10 lines, action logging envelopes) to satisfy compliance.
+
+---
+
+### User Story 2 — Extract a Hot-bucket candidate from `MistHelper.py` into a cohesive class-body / module-body module AND rewire every `MistHelper.py` and `src/` callsite atomically (Priority: P1)
+
+The Cat E dual-side rewire workflow — carried forward from 1014 User Story 2. For each of T-06 through T-15, MistHelper.py holds the real body while one or more `src/` modules reach it either (a) directly via a resolution against MistHelper.py's namespace at import time, or (b) via `mh = importlib.import_module("MistHelper")` + `mh.<Name>` lazy imports (the pattern 1014 spent extensive effort eliminating). Extraction is inseparable across the two sides: the body moves to the landing target, all `MistHelper.py` callsites are rewritten, AND every `src/` callsite is rewritten to `from src.<package>.<module> import <Name>` in the SAME commit. The PR does NOT land in two parts. The pre-dispatch grep audit enumerates the exact set of `src/` callsites to be rewritten and their count is recorded in the PR description alongside the callsite table.
+
+**Why this priority**: Same P1 as User Story 1. Cat E is the higher-risk of the two workflow paths because these are the highest-refs candidates (`InputUtils` at 195, `DataExporter` at 118, `OrgInventoryExporter` at 102, `VirtualChassisManager` at 104, `ConfigUtils` at 102, `PromptUtils` at 96, `DataProcessingUtils` at 69, `tqdm` at 51, `FilePathUtils` at 50, `MIST_SITE_EXCLUDE_PREFIX` at 11). A partial extraction (body moved but callers still doing direct-namespace or `mh.<Name>` resolution) would break `python MistHelper.py --test`. Atomicity is not optional.
+
+**Independent Test**: Any single Hot-bucket candidate can be merged in isolation. Example: T-15 (`MIST_SITE_EXCLUDE_PREFIX`, 3 LoC, 11 refs — the smallest LOC hot candidate) can be extracted as: (a) create `src/refactors/mist_site_exclude_prefix.py` with a module-level constant, (b) delete the definition from `MistHelper.py`, (c) rewrite the MistHelper.py callsites, (d) rewrite the `src/gateway/*.py` callsites, (e) leave a NOTE breadcrumb, (f) land green.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Cat E candidate with M `MistHelper.py` callsites and N `src/` callsites, **When** the PR is opened, **Then** the diff shows the body moved to the landing target, deleted from `MistHelper.py`, every one of the M `MistHelper.py` callsites rewritten, and every one of the N `src/` callsites rewritten — with zero stale references surviving.
+2. **Given** the callsite table in the PR description enumerates M `MistHelper.py` callsites and N `src/` callsites, **When** the reviewer runs `grep -rn "<Name>" .` against the merged PR, **Then** every match is either in the new landing module, in a `src/` file importing from the landing module, or a NOTE breadcrumb — with zero stale namespace-lookup or `mh.<Name>` matches.
+3. **Given** the extracted class carried analyzer `guideline_flags`, **When** the PR lands, **Then** each flag is resolved in-flight (per FR-006).
+4. **Given** the pre-push local gate, **When** the contributor pushes the refactor branch, **Then** `black --check` and `ruff check` both pass, and `python MistHelper.py --test` reports 0 failed with exit code 0.
+5. **Given** T-06 (`OrgInventoryExporter`, 686 LoC, 102 refs) and T-07 (`PromptUtils`, 441 LoC, 96 refs) are the largest LOC Hot candidates, **When** their PRs are opened, **Then** the moves are atomic but MAY carry substantial internal decomposition (per FR-006) to satisfy the ≤ 25-line-per-method rule and the aggregate score floor.
+6. **Given** T-09 (`InputUtils`, 74 LoC, 195 refs) is the highest-refs candidate in the initiative and spans 17 files, **When** the PR is opened, **Then** the callsite table enumerates the exact file:line list of every rewritten site and the pre-dispatch grep audit is recorded in the PR description.
+7. **Given** T-14 (`tqdm`, 3 LoC, 51 refs) is a bare function wrapper flagged `missing_action_logging`, **When** the PR is opened, **Then** the wrapper is extracted from MistHelper.py's `SKIP_ALWAYS`-adjacent surface without violating FR-009 (T-14 is emphatically NOT in the `SKIP_ALWAYS` bucket — 1012 skip-pinned it only for that initiative; the analyzer now surfaces `tqdm` again for this initiative because it is a normal Hot candidate).
+
+---
+
+### User Story 3 — Regenerate the analyzer catalog and re-derive dispatch order after every merged extraction (Priority: P2)
+
+Carry-forward of 1010/1011/1013/1014 User Story 3. Reference counts and callsite locations shift as extractions land. After every merged extraction PR, the analyzer is re-run against the new `main` head and `refactor_candidates.md` is regenerated before the next PR is dispatched. Bucket ordering (Single-use → Low-use → Hot) is applied to the fresh catalog. Category designation is re-verified against the fresh catalog — a Hot candidate whose `src/` callers have all been coincidentally removed by a prior extraction may reclassify to MistHelper-only Cat B or drop to Low-use, but every candidate stays in this initiative's scope unless it drops to Unused (in which case a deletion PR replaces the extraction PR).
+
+**Why this priority**: Workflow discipline that supports P1 rather than delivering standalone value.
+
+**Independent Test**: After merging any extraction PR, running `python -m tools.refactor_analyzer` regenerates the catalog cleanly. The just-extracted symbol no longer appears in any bucket except (possibly) as a new definition in its new home. Any reference-count shifts on remaining candidates are reflected in the fresh dispatch order.
+
+**Acceptance Scenarios**:
+
+1. **Given** an extraction PR has merged to `main`, **When** the next PR is dispatched, **Then** `refactor_candidates.md` has been regenerated on the current `main` head first and the next candidate is selected from that fresh output following the bucket ordering rule.
+2. **Given** the regenerated catalog shows a formerly Hot candidate has dropped to Low-use or Unused, **When** the dispatcher plans the next PR, **Then** the candidate's task ID stays in the queue but its category is updated in "Reclassifications", and (if Unused) the PR becomes a pure-deletion PR.
+3. **Given** the regenerated catalog surfaces a new symbol not in the original 15-row queue (e.g. an unrelated commit adds a new module-scope symbol to MistHelper.py that meets the extraction criteria), **When** the dispatcher plans the next PR, **Then** the new symbol is appended to this initiative's Deferred/Reclassifications table and evaluated for inclusion — do NOT silently expand the queue mid-initiative.
+
+---
+
+### Edge Cases
+
+- **E-1** — Landing target selection. Each candidate has a suggested landing target in the Dispatch Queue (drawn from the analyzer's `Suggested module` field or a curated override). The dispatch PR MAY override the suggestion at PR time if a closer semantic fit exists. Prefer an existing semantic package over creating a new `src/refactors/*.py` module when both are viable. The PR description records the destination-selection rationale in one sentence.
+- **E-2** — Guideline-flag decomposition mid-move. If a candidate carries `oversize_25_lines` (e.g. `OrgInventoryExporter` at 686 LoC, `PromptUtils` at 441 LoC, `DataExporter` at 345 LoC, `ENDPOINT_PRIMARY_KEY_STRATEGIES` at 2327 LoC, `DataProcessingUtils` at 158 LoC, `InsightMetricsUtils` — retired in 1014), the move includes method-level decomposition per FR-006. Deferral of any flag to a follow-up PR is prohibited.
+- **E-3** — Callsite drift between catalog regeneration and PR opening. If the analyzer's recorded line numbers drift, the PR uses fresh grep against the current `main` head at branch time. Line-number drift alone does not block extraction; only a *count* change triggers re-evaluation.
+- **E-4** — NOTE breadcrumb at the extraction site. Every extraction PR MUST leave a single-line NOTE breadcrumb at the deletion site in `MistHelper.py` (per FR-007): `# NOTE: <Name> extracted to <new-module-path>::<Name>. See specs/1015-misthelper-refactor-final-15/spec.md.` Silent (breadcrumbless) deletion is rejected.
+- **E-5** — Name collision at destination. If the target destination already contains a symbol whose name would collide, rename the incoming symbol only if renaming is genuinely necessary; otherwise the destination is changed. Record the choice in the PR description.
+- **E-6** — Reference count discrepancy between spec-time table and catalog regeneration at dispatch. The 15-row table quotes ref counts as of the 2026-07-09 catalog. If a fresh regeneration at dispatch time shows a candidate's ref count has shifted, the fresh catalog wins. The 15-row table is documentation, not a runtime contract.
+- **E-7** — `python MistHelper.py --test` regression. If the test-suite invocation begins failing mid-initiative because of an unrelated commit landing on `main`, extraction PRs pause until the underlying regression is fixed. **Pre-existing flake exception**: `test_menu_196_dispatches_to_async_claim_exporter` is a known flake that is NOT considered a blocking regression for this initiative.
+- **E-8** — Analyzer score regression below 99.6/A+. If any single extraction PR would drop the aggregate analyzer score below 99.6/A+, the PR is revised rather than merged.
+- **E-9** — SKIPPED CI conditionals. Per `feedback_no_admin_bypass.md`, SKIPPED conditionals are non-blocking and do not count against the 15/15 green tally. `--admin` merge bypass is not used as a routine unblock.
+- **E-10** — Very large candidates. `ENDPOINT_PRIMARY_KEY_STRATEGIES` (2327 LoC), `OrgInventoryExporter` (686 LoC), `PromptUtils` (441 LoC), `DataExporter` (345 LoC), `DataProcessingUtils` (158 LoC). These MUST land as one PR each (no splitting) but the PR MAY carry substantial internal decomposition to satisfy the ≤ 25-line-per-method rule and the aggregate score floor.
+- **E-11** — Circular-import trap. Hot-bucket candidates often have `src/` modules that today lazy-import MistHelper.py *specifically to avoid* import cycles. When the body moves to the landing target, cycles MAY re-emerge if the new landing module itself imports symbols still living in `MistHelper.py` (e.g. globals such as `apisession`). Verify import-graph health post-move per FR-028 — `python -c "import <landing_module>"` must succeed without traversing `MistHelper.py`. If a genuine cycle remains, inject a small dependency-injection surface (Pattern 1 — constructor injection) but do NOT leave a `mh.<name>` lazy-import in the new module.
+- **E-12** — `tqdm` clarification. T-14 (`tqdm`, 3 LoC, 51 refs, `missing_action_logging`) is emphatically NOT in the analyzer's `SKIP_ALWAYS` bucket for this initiative. 1012's skip-pin was per-initiative. The current catalog surfaces `tqdm` as a normal Hot candidate. FR-009's `SKIP_ALWAYS` exclusion applies only to `GlobalImportManager` for this initiative.
+- **E-13** — Constructor injection for hot classes with runtime deps. Where the extracted symbol is a hot class with runtime dependencies (e.g. `apisession`, `logger`, config accessors), the extraction MUST follow Pattern 1 established by 1013/1014 — `__init__(self, **deps)` accepting all needed dependencies; every callsite constructs the instance inline with the full kwargs list spelled out. No factory helpers, no module-level cached instance, no self-resolving via `sys.modules`, no `_configure_module()` shims. Pure static helpers with no runtime deps remain `@staticmethod`.
+- **E-14** — Module-level constant candidates (T-02, T-03, T-15). These are pure module-level assignments with no runtime deps. The landing pattern is a bare module-level constant in the new file (or folded into an existing constants module in the destination package). The analyzer's `Suggested class` (e.g. `FastModeMaxConcurrentConnectionsManager`) is a naming hint only — the PR MAY implement the landing as a plain module-level constant when semantically appropriate, and the destination-selection rationale is recorded in the PR description.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The initiative MUST process exactly the 15 candidates enumerated in the Dispatch Queue. Additions require a new spec revision recording the reclassification event.
+- **FR-002**: The initiative MUST process exactly one candidate per PR. Batching multiple candidates into a single PR is prohibited (carry-forward from 1010-1014 FR-002).
+- **FR-003**: For each candidate, the PR MUST perform a **Cat E fresh cross-package extraction**: (a) create the landing module OR fold into an existing module / class body within the landing package when semantically appropriate, (b) delete the original body from `MistHelper.py`, (c) rewrite every `MistHelper.py` callsite in the same commit, AND (d) rewrite every `src/` (or other first-party) callsite currently referencing the symbol via direct namespace resolution or `mh = importlib.import_module("MistHelper")` + `mh.<Name>`. No wrapper shim, forwarding function, re-export module, or backward-compatibility alias may be left in `MistHelper.py`.
+- **FR-004**: Every extracted symbol MUST land in a cohesive destination — top-level of a new module for class or function extractions, module-level constant (or existing constants module) for assignments. Bare unmotivated module-level function landings are prohibited when a semantic class body already exists in the destination package.
+- **FR-005**: For each candidate, all `MistHelper.py` references AND all `src/` (and other first-party) references MUST be rewritten to import from the new location in the same commit as the extraction. Zero stale references — including zero `importlib.import_module("MistHelper")` + `mh.<Name>` remainders — may survive the merge.
+- **FR-006**: Analyzer-flagged `guideline_flags` on the moved symbol MUST be resolved within the same extraction PR — never deferred. Decomposition during the move includes: methods ≤ 25 lines with ≤ 5 params, `logging.info` / `logging.debug` envelopes on every method (`%s` formatting), inline comments on every executable line, ASCII-only log literals, `pathlib.Path` in place of `os.path`, `InputUtils.safe_input()` in place of raw `input()`, hardcoded separators replaced with `os.sep` or `pathlib` idioms.
+- **FR-007**: A **mandatory** single-line NOTE breadcrumb comment MUST be added at each extraction site in `MistHelper.py`, following the template: `# NOTE: <Name> extracted to <new-module-path>::<Name>. See specs/1015-misthelper-refactor-final-15/spec.md.` Silent (breadcrumbless) extraction is rejected.
+- **FR-008**: All extracted modules MUST comply with project non-negotiables: ASCII-only logs, `InputUtils.safe_input()` for interactive input, `pathlib.Path` in place of `os.path`, inline comments every 5-10 lines, action logging before/after every meaningful action with `%s` formatting, ≤ 25-line methods, ≤ 5 params per function.
+- **FR-009**: The initiative MUST NOT touch symbols in the analyzer's `SKIP_ALWAYS` bucket. For this initiative that means **only `GlobalImportManager`**. `tqdm` was skip-pinned per-initiative by 1012 and is NOT in `SKIP_ALWAYS` here (see E-12); T-14 explicitly targets `tqdm`.
+- **FR-010**: The initiative MUST NOT touch `menu_actions`. Deferred indefinitely per user directive. No follow-up initiative is planned for `menu_actions`.
+- **FR-011**: The initiative MUST NOT re-refactor any symbol already extracted in 1010, 1011, 1012, 1013, or 1014.
+- **FR-012**: The initiative MUST NOT modify `tools/refactor_analyzer/` itself; the analyzer is consumed as-is.
+- **FR-013**: Before opening each extraction PR, the workflow MUST run `grep -rn "<Name>" src/ tests/` and enumerate every callsite in the PR description. The audit produces the exact set of files whose reference lines will be rewritten in the same commit.
+- **FR-014**: After every merged extraction PR, the workflow MUST regenerate `refactor_candidates.md` by running `python -m tools.refactor_analyzer` against the current `main` head. The regenerated file is committed in a follow-up `chore(1015): regenerate refactor_candidates.md after P<N> merge` commit (or the same PR when the extraction PR includes the regeneration).
+- **FR-015**: An extraction PR MUST NOT merge until all 15 functional CI jobs report green AND `mergeStateStatus` is CLEAN AND `black --check` is clean AND `ruff check` is clean AND `python MistHelper.py --test` reports 0 failed with exit code 0 (modulo the known `test_menu_196_dispatches_to_async_claim_exporter` flake — see E-7). `--admin` merge bypass MUST NOT be used as a routine unblock. Reference `feedback_no_admin_bypass.md` and `feedback_prepush_black_ruff.md`.
+- **FR-016**: Every new module under the landing package MUST land at A+/100 compliance score. No file that was previously A+ may regress below A+.
+- **FR-017**: The repository-wide aggregate compliance MUST remain ≥ 99.6/A+ after each merged extraction PR.
+- **FR-018**: `MistHelper.py`'s pylint score MUST be non-regressing against the pre-initiative baseline established on the first branch commit. Regression blocks merge.
+- **FR-019**: No new SKIPPED conditionals in CI may be introduced by any extraction PR.
+- **FR-020**: If a candidate's classification shifts mid-initiative (Hot → Low-use, Low-use → Single-use, or a symbol's `src/` callers are removed indirectly), the candidate stays in this initiative's scope but its Dispatch Queue metadata is updated in "Reclassifications". Only a drop to Unused converts the extraction PR to a deletion PR.
+- **FR-021**: The initiative MUST NOT introduce new features, new commands, new CLI flags, or user-facing behavior changes.
+- **FR-022**: When a candidate is folded into an existing destination package's class body (rather than a new `src/<pkg>/*.py` module), the existing destination file's compliance grade MUST remain at A+/100 after the fold. If the fold would regress the destination below A+, the destination is changed or the extracted symbol receives further decomposition within the same PR.
+- **FR-023**: The Dispatch Queue's ordering (Single-use → Low-use → Hot descending by LOC within Hot) is a **dispatch rule**, not a merge order guarantee. Concurrent open PRs are not permitted (one PR open at a time).
+- **FR-024**: The initiative is considered complete when `refactor_candidates.md` regenerated on `main` shows exactly two remaining entries — `menu_actions` and `GlobalImportManager` — both explicitly out of scope per FR-010 and FR-009.
+- **FR-025**: Cat A method-parity verification (from 1014 FR-025) applies if any candidate reclassifies to Cat A mid-initiative. No candidate is Cat A at initiative start.
+- **FR-026**: The queue is ordered by bucket first (Single-use → Low-use → Hot) then by descending LOC within Hot. Within Single-use / Low-use the analyzer's canonical order is preserved. This bucket-first ordering differs from 1014's strict global Refs-ASC ordering because the bucket-boundary is itself a meaningful risk gradient in this catalog.
+- **FR-027**: Every extraction PR MUST record a **callsite table** in the PR description enumerating: (a) the total count of `MistHelper.py` callsites rewritten, (b) the exact list of `src/` files (with line numbers) whose reference lines were rewritten, (c) the exact list of any `tests/` or other first-party callsites rewritten. The table is verifiable by post-merge grep.
+- **FR-028**: Every extraction PR MUST verify import-graph health post-move: `python -c "import <landing_module>"` succeeds without traversing `MistHelper.py` AND `python MistHelper.py --test` reports 0 failed / exit 0 (modulo E-7). If a genuine circular import remains after the naive extraction, inject a Pattern 1 constructor-injection surface (per E-13) but do NOT leave a `mh.<name>` lazy-import in the new landing module.
+- **FR-029**: Landing targets in the Dispatch Queue are advisory. The PR MAY override the suggestion if a closer semantic fit exists at dispatch time. Overrides are recorded in the PR description with one-sentence rationale (per E-1).
+- **FR-030**: Existing tests MUST be converted to the new import path AND the new Pattern 1 construction contract (constructor injection) in the same commit as the extraction. Where the move surfaces a testable seam not previously tested, add a new test — do not defer.
+- **FR-031**: No new mypy strict violations may be introduced by any extraction PR. Any pre-existing violations in `MistHelper.py` that touch the extracted symbol MUST be resolved in-flight during the move.
+- **FR-032**: This initiative closes the MistHelper.py refactor family for the analyzer's current output. When the last of the 15 PRs merges and `refactor_candidates.md` is regenerated, the report will show only `menu_actions` + `GlobalImportManager`. No further initiative is planned unless net-new extractable symbols are added to `MistHelper.py` by subsequent unrelated work.
+
+### Key Entities *(include if feature involves data)*
+
+- **Extraction Candidate**: A symbol in `MistHelper.py` catalogued by `tools/refactor_analyzer/` — for this initiative, the 15 entries surfaced in `refactor_candidates.md` at commit `8523596` (2026-07-09) minus `menu_actions` (excluded by policy) and `GlobalImportManager` (excluded by `SKIP_ALWAYS`).
+- **Refactor Candidates Catalog** (`refactor_candidates.md`): Regenerated after every merged extraction PR (FR-014). The freshest catalog is the authoritative source for dispatch order.
+- **Extraction PR**: A single pull request delivering one symbol's move plus its callsite rewrites (both `MistHelper.py` and `src/` and any `tests/`), in-place `guideline_flags` remediation, a NOTE breadcrumb, a callsite table in the description, and updated tests.
+- **Target Module**: The new file (or existing module) receiving the extracted symbol. Landing targets are advisory in the Dispatch Queue and may be overridden per FR-029.
+- **Callsite**: The exact location where a candidate symbol is instantiated, referenced, or imported. Each PR rewires ALL callsites atomically.
+- **Callsite Table**: The mandatory PR-description artifact per FR-027 enumerating the exact file:line list of every rewritten callsite.
+- **Dispatch Queue**: The bucket-ordered (Single-use → Low-use → Hot descending-LOC) list of 15 candidates. Ordering is re-derived from the freshest catalog after every merge.
+- **Reclassification**: A queue entry whose analyzer category shifts mid-initiative (per FR-020). Recorded in the "Reclassifications" table. Reclassification does NOT remove the entry from scope unless it drops to Unused (in which case the PR becomes a deletion PR).
+- **Compliance Baseline**: Repo-wide ≥ 99.6/A+ aggregate; every new/edited module at A+/100; `MistHelper.py` pylint non-regressing; no new mypy strict violations.
+- **Pattern 1 (Constructor Injection)**: The extraction landing pattern for hot classes with runtime deps, established by 1013 and 1014. `__init__(self, **deps)` accepting all needed dependencies; every callsite constructs the instance inline with the full kwargs list spelled out. No factory helpers, no module-level cached instance, no self-resolving via `sys.modules`, no `_configure_module()` shims.
+
+## Dispatch Queue
+
+The 15 candidates in dispatch order (bucket-first: Single-use → Low-use → Hot descending by LOC). Each row lands as one PR. Every row is Cat E (fresh cross-package extraction) at initiative start; a reclassification to Cat A would require a mid-initiative parity audit per FR-025.
+
+**Action-type legend**:
+
+- **Cat E — Fresh cross-package extraction**: MistHelper.py holds the real body; callers reference the symbol via direct namespace resolution or `mh = importlib.import_module("MistHelper")` + `mh.<Name>` lazy-imports (for hot candidates with `src/` callers). The PR extracts the body to the landing target, rewires every `MistHelper.py` callsite, AND rewires every `src/` / `tests/` callsite in the same commit (per FR-003 + FR-005 + FR-027).
+
+Bucket / category audit performed 2026-07-09 against all 15 candidates confirmed **15 Cat E** and **0 Cat A**. Zero Cat B (fresh MistHelper-only extractions surviving from the 1013 era) — the analyzer's `Reference sites` field on every hot candidate lists at least one `src/` (or `tests/`) file, matching the 1014 Cat E discipline.
+
+### Single-use bucket (3 tasks)
+
+| # | Task | Kind | Refs | LOC | Symbol | Cat | Landing target | Flags |
+|---:|:---:|---|---:|---:|---|:-:|---|---|
+| 1 | T-01 | class | 1 | 9 | `DeviceFetchConfig` | E | `src/refactors/device_data_fetcher.py` (fold into `DeviceDataFetcherManager` or top-level dataclass per E-1) | missing_action_logging |
+| 2 | T-02 | assignment | 1 | 3 | `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | E | `src/refactors/fast__mode__max__concurrent__connections.py` (or existing constants module per E-1 / E-14) | missing_inline_comments, missing_action_logging |
+| 3 | T-03 | assignment | 1 | 3 | `FAST_MODE_USE_CONNECTION_AWARE_THREADING` | E | `src/refactors/fast__mode__use__connection__aware__threading.py` (or existing constants module per E-1 / E-14) | missing_action_logging |
+
+### Low-use bucket (2 tasks)
+
+| # | Task | Kind | Refs | LOC | Symbol | Cat | Landing target | Flags |
+|---:|:---:|---|---:|---:|---|:-:|---|---|
+| 4 | T-04 | assignment | 2 | 2327 | `ENDPOINT_PRIMARY_KEY_STRATEGIES` | E | `src/refactors/endpoint__primary__key__strategies.py` (or a domain-fitting `src/api/*.py` per E-1) | oversize_25_lines, missing_inline_comments, missing_action_logging, non_ascii_logs |
+| 5 | T-05 | function | 2 | 25 | `detect_msp_privileges` | E | `src/refactors/detect_msp_privileges.py` (or a domain-fitting `src/msp/*.py` per E-1) | missing_action_logging |
+
+### Hot bucket (10 tasks, descending by LOC)
+
+| # | Task | Kind | Refs | LOC | Symbol | Cat | Landing target | Flags |
+|---:|:---:|---|---:|---:|---|:-:|---|---|
+| 6 | T-06 | class | 102 | 686 | `OrgInventoryExporter` | E | `src/export/org_inventory_exporter.py` | oversize_25_lines, missing_inline_comments |
+| 7 | T-07 | class | 96 | 441 | `PromptUtils` | E | `src/ui/prompt_utils.py` | oversize_25_lines |
+| 8 | T-08 | class | 118 | 345 | `DataExporter` | E | `src/export/data_exporter.py` | oversize_25_lines, non_ascii_logs |
+| 9 | T-10 | class | 69 | 158 | `DataProcessingUtils` | E | `src/data/data_processing_utils.py` | oversize_25_lines, missing_inline_comments, hardcoded_separator |
+| 10 | T-11 | class | 104 | 78 | `VirtualChassisManager` | E | `src/device/virtual_chassis.py` (fold-in) | oversize_25_lines, missing_inline_comments, missing_action_logging |
+| 11 | T-09 | class | 195 | 74 | `InputUtils` | E | `src/ui/input_utils.py` | oversize_25_lines, raw_input_call |
+| 12 | T-12 | class | 102 | 70 | `ConfigUtils` | E | `src/config/config_utils.py` | oversize_25_lines |
+| 13 | T-13 | class | 50 | 46 | `FilePathUtils` | E | `src/utils/file_path_utils.py` | oversize_25_lines, missing_inline_comments |
+| 14 | T-14 | function | 51 | 3 | `tqdm` | E | `src/utils/tqdm_wrapper.py` (or a domain-fitting `src/ui/*.py` per E-1) | missing_action_logging |
+| 15 | T-15 | assignment | 11 | 3 | `MIST_SITE_EXCLUDE_PREFIX` | E | `src/refactors/mist_site_exclude_prefix.py` (or an existing constants module per E-1 / E-14) | missing_inline_comments, missing_action_logging |
+
+**Category distribution**: 15 Cat E + 0 Cat A + 0 Cat B.
+
+**Landing distribution**: `src/refactors/` = 5 (or fewer if E-1 overrides land elsewhere), `src/ui/` = 2 (`prompt_utils.py`, `input_utils.py`), `src/export/` = 2 (`org_inventory_exporter.py`, `data_exporter.py`), `src/utils/` = 1 (`file_path_utils.py`), `src/data/` = 1 (`data_processing_utils.py`), `src/device/` = 1 (fold-in to `virtual_chassis.py`), `src/config/` = 1 (`config_utils.py`), plus 2 destinations pending E-1 override (`tqdm`, `detect_msp_privileges`). Every row lands in a domain-fitting existing or new package; `src/refactors/` is used as a fallback when no closer semantic fit exists.
+
+**Queue-head validation candidates**: The three Single-use candidates cluster at the queue head — `DeviceFetchConfig` (1r/9L, T-01), `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` (1r/3L, T-02), `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (1r/3L, T-03). These are 1-callsite extractions and validate the Cat E workflow at minimum blast radius before the Low-use and Hot PRs.
+
+**Largest-LOC candidate**: T-04 (`ENDPOINT_PRIMARY_KEY_STRATEGIES`, 2327 LoC, 2 refs) is the single largest LOC win in the initiative — a Low-use assignment whose extraction reclaims 2,327 lines from `MistHelper.py` against a mere 2-callsite rewrite. This is the highest-ROI PR in the queue and the primary driver of SC-002.
+
+**Highest-refs candidate**: T-09 (`InputUtils`, 195 refs, 74 LoC) has the highest ref count in the initiative and spans 17 files. The Cat E dual-side rewire touches every `input()` and `safe_input()` callsite across the codebase.
+
+## Deferred Candidates
+
+*(Initially empty. Populated during the initiative if any Dispatch Queue candidate is deferred per FR-013, FR-020, or Edge Case E-6.)*
+
+| # | Task | Symbol | Reason for Deferral | Recording PR / Commit |
+|---:|:---:|---|---|---|
+
+### Reclassifications
+
+*(Initially empty. Populated during the initiative if any Cat E → Cat A / Cat A → Cat E reclassification event or a bucket-shift occurs per FR-020.)*
+
+| # | Task | Symbol | Original Bucket / Cat | New Bucket / Cat | Cause | Recording PR / Commit |
+|---:|:---:|---|:-:|:-:|---|---|
+
+## Out of Scope
+
+The 2026-07-09 catalog surfaced 17 total entries. This initiative addresses 15. The remaining 2 are **explicitly excluded**:
+
+| # | Refs | LOC | Symbol | Reason |
+|---:|---:|---:|---|---|
+| 1 | 17 | 887 | `menu_actions` | Deferred indefinitely per user directive. No follow-up initiative planned. |
+| 2 | 1 | 1003 | `GlobalImportManager` | Pinned by module-load / bootstrap ordering. `SKIP_ALWAYS` in the analyzer. Static analysis cannot detect the load-order dependency; moving it would break import wiring. |
+
+When this initiative closes, `refactor_candidates.md` regenerated on `main` will show exactly these 2 entries and no others (barring net-new symbols added by unrelated work).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `refactor_candidates.md` regenerated on `main` at initiative completion shows exactly 2 remaining entries — `menu_actions` and `GlobalImportManager` — with all 15 Dispatch Queue candidates removed from every bucket (or, if any deferred, recorded in "Deferred Candidates" with documented rationale).
+- **SC-002**: `MistHelper.py` physical line count drops by at least **3,500 lines** relative to the pre-initiative baseline. (Sum of the 15 candidates' LoC in the Dispatch Queue is 4,271 — `ENDPOINT_PRIMARY_KEY_STRATEGIES` alone contributes 2,327; SC-002 gives modest headroom for class-body overhead in new modules and reasonable decomposition retention.)
+- **SC-003**: Repository-wide aggregate compliance score is ≥ 99.6/A+ at every intermediate `main`-branch state throughout the initiative and at final completion.
+- **SC-004**: Zero files that were A+/100 pre-initiative regress below A+ by the end of the initiative.
+- **SC-005**: All extraction PRs merge with 15/15 functional CI jobs green, `mergeStateStatus: CLEAN`, `black --check` clean, `ruff check` clean, `python MistHelper.py --test` reporting 0 failed / exit 0 (modulo the known `test_menu_196_dispatches_to_async_claim_exporter` flake per E-7). Zero `--admin` bypasses except where `mergeStateStatus` was genuinely BLOCKED/DIRTY/BEHIND with root cause documented.
+- **SC-006**: Every new file created during the initiative scores A+/100 on compliance.
+- **SC-007**: Zero wrapper shims, forwarding functions, re-export modules, delegators, pointers, helpers, or backward-compatibility aliases remain in `MistHelper.py` after the initiative.
+- **SC-008**: Zero symbols from the analyzer's `SKIP_ALWAYS` bucket (`GlobalImportManager` for this initiative) are modified by any PR.
+- **SC-009**: Zero `importlib.import_module("MistHelper")` + `mh.<Name>` remainders survive for any extracted symbol name — verifiable via post-merge grep against merged `main`.
+- **SC-010**: After every merged extraction PR, the analyzer is re-run and `refactor_candidates.md` is regenerated before the next PR is dispatched — verifiable by walking the merged-PR sequence.
+- **SC-011**: Every analyzer-flagged `guideline_flag` on each extracted symbol is resolved within the extraction PR — zero forward-carried guideline violations attributable to this initiative.
+- **SC-012**: Every extraction PR contains exactly one NOTE breadcrumb at the deletion site in `MistHelper.py` matching the pinned FR-007 template — verifiable via `grep -rn "extracted to .*::" MistHelper.py`.
+- **SC-013**: Pre-push local gate: `black --check` and `ruff check` both pass on every refactor branch before the PR opens, and `python MistHelper.py --test` reports 0 failed with exit code 0 (modulo E-7).
+- **SC-014**: The workflow processes candidates in bucket-first (Single-use → Low-use → Hot descending by LOC) order derived from the freshest catalog at each dispatch — verifiable by walking the merged-PR sequence against the sequence of regenerated catalog snapshots.
+- **SC-015**: `MistHelper.py`'s pylint score is non-regressing against the pre-initiative baseline. No merged PR reduces the score.
+- **SC-016**: Zero new SKIPPED conditionals are introduced in CI by any extraction PR.
+- **SC-017**: Every extraction PR contains a callsite table in the description matching FR-027 (MistHelper.py + `src/` + tests/ callsites enumerated) — verifiable by PR-description grep.
+- **SC-018**: Every extraction PR verifies import-graph health per FR-028 — verifiable by post-merge `python -c "import <landing_module>; print('OK')"` succeeding without traversing `MistHelper.py`.
+- **SC-019**: Zero new mypy strict violations are introduced by any extraction PR (per FR-031).
+- **SC-020**: `menu_actions` is not touched by any PR in this initiative (per FR-010) — verifiable via post-merge `git log` showing no diff hunks against the `menu_actions` definition or any of its 17 callsites.
+- **SC-021**: `GlobalImportManager` is not touched by any PR in this initiative (per FR-009) — verifiable via post-merge `git log` showing no diff hunks against the `GlobalImportManager` class body.
+- **SC-022**: The initiative closes with a documented final-state summary in the last-merged PR (or a follow-up docs commit) recording: (a) count of PRs merged (target: 15), (b) final `MistHelper.py` LoC and pylint score, (c) final aggregate compliance score, (d) list of deferred candidates with rationale, (e) confirmation that the regenerated `refactor_candidates.md` shows only `menu_actions` + `GlobalImportManager`.
+- **SC-023**: Existing tests are converted to the new import path and Pattern 1 construction contract for every extracted hot class (per FR-030) — verifiable by post-merge grep for the old MistHelper.py import path in `tests/` (zero matches expected for each extracted symbol).
+
+## Assumptions
+
+- The analyzer at `tools/refactor_analyzer/` remains functionally correct across the initiative; discrepancies discovered during extraction are filed as analyzer bugs but do not block extraction PRs.
+- The 15 functional CI jobs currently gating PRs on `main` remain the mergeability contract for the duration of this initiative.
+- The current compliance baseline (≥ 99.6/A+) is the floor; the initiative does not attempt to raise it beyond preserving it.
+- The 15-row Dispatch Queue reflects the 2026-07-09 catalog snapshot regenerated on `origin/main` at commit `8523596`. Mid-initiative reclassification is expected and handled per FR-020 / E-6.
+- Serial per-PR workflow: at most one extraction PR is open at any time.
+- Analyzer regeneration cost per run is negligible relative to CI cycle time.
+- Bucket-first ordering (Single-use → Low-use → Hot descending by LOC within Hot) front-loads the smallest-blast-radius extractions and reserves the highest-LOC / highest-refs candidates (`ENDPOINT_PRIMARY_KEY_STRATEGIES`, `OrgInventoryExporter`, `PromptUtils`, `DataExporter`, `InputUtils`) for later dispatch when the workflow is fully validated.
+- Landing targets are advisory; the PR chooses at dispatch time per FR-029.
+- The Cat E lazy-import-back-into-MistHelper.py pattern (`mh = importlib.import_module("MistHelper")` + `mh.<Name>`) is exactly the pattern this initiative eliminates for the remaining 10 hot candidates. It is not preserved.
+- Black + Ruff pre-push discipline (`feedback_prepush_black_ruff.md`) is followed by the contributor.
+- `python MistHelper.py --test` is the initiative's smoke-test contract, run as a merge gate per FR-015, with the known `test_menu_196_dispatches_to_async_claim_exporter` flake exempt (per E-7).
+- Constructor injection (Pattern 1) established by 1013/1014 is the landing pattern for every hot class with runtime deps (per E-13). Pure static helpers remain `@staticmethod`.
+- `menu_actions` is out of scope by user directive and no follow-up initiative is planned for it. If a future user directive reverses that decision, a new spec will be authored.
+- `GlobalImportManager` is out of scope by the analyzer's `SKIP_ALWAYS` policy and no initiative can move it without breaking import wiring. This is a permanent exclusion, not a deferral.
+- EMU-related `gh pr create` (401) / MCP `create_pull_request` (403) restrictions carry over from prior initiatives — the contributor opens PRs via the GitHub web URL after `git push` when EMU blocks automated creation.
+- After the last PR (T-15 or the final reclassified equivalent) merges and `refactor_candidates.md` is regenerated one final time, no further MistHelper.py refactor initiative is planned. This spec effectively closes the MistHelper.py refactor family for the analyzer's current output.

--- a/specs/1015-misthelper-refactor-final-15/tasks.md
+++ b/specs/1015-misthelper-refactor-final-15/tasks.md
@@ -1,0 +1,437 @@
+# Tasks: MistHelper Refactor — Final 15 (All Remaining Analyzer Candidates)
+
+**Feature Branch**: `1015-misthelper-refactor-final-15`
+**Spec**: [`spec.md`](./spec.md)
+**Plan**: [`plan.md`](./plan.md)
+**Catalog snapshot**: `refactor_candidates.md` regenerated 2026-07-09 against `origin/main` at commit `8523596`.
+
+## Overview
+
+Fifteen atomic **Cat E fresh cross-package extraction** PRs — one candidate per PR — clearing every remaining actionable entry from the analyzer catalog (excluding `menu_actions` and `GlobalImportManager` per FR-010 / FR-009). Dispatch order mirrors the Dispatch Queue in the spec (bucket-first: Single-use → Low-use → Hot descending-by-LOC).
+
+**Bucket distribution**: 3 Single-use, 2 Low-use, 10 Hot. **Category distribution**: 15 Cat E, 0 Cat A, 0 Cat B.
+
+**Task-ID scheme**: `T-01` through `T-15` are the semantic task IDs pinned by the spec's Dispatch Queue. The dispatch *position* (1..15) differs from the task ID number for T-09/T-10/T-11 within the Hot bucket where descending-LOC ordering rearranges the semantic IDs. Position column below is the canonical execution order.
+
+**Pattern 1 (Constructor Injection)** is the ONLY landing pattern for hot classes with runtime deps. Every extracted class exposes `__init__(self, **deps)` with required kwargs spelled out at every callsite. NO factory helpers, NO cached module-level instance, NO `sys.modules` self-resolution, NO delegators / shims / pointers / facades. Module-level constants (T-02, T-03, T-15) land as bare assignments.
+
+## Common Per-Task Acceptance Criteria
+
+Every task (T-01..T-15) MUST satisfy the following gates before merge — enforced per PR:
+
+- [ ] Landing module created (or fold-in target selected per E-1) and body moved verbatim, then `guideline_flags` remediated in-flight (FR-006 / FR-008).
+- [ ] Zero wrapper shim / forwarding function / re-export module / delegator / pointer / helper / backward-compat alias survives in `MistHelper.py` (SC-007 / FR-003).
+- [ ] Single-line NOTE breadcrumb left at deletion site matching template `# NOTE: <Name> extracted to <new-module-path>::<Name>. See specs/1015-misthelper-refactor-final-15/spec.md.` (FR-007 / SC-012).
+- [ ] Every `MistHelper.py` callsite rewritten in same commit (FR-005).
+- [ ] Every `src/` and `tests/` callsite rewritten in same commit; zero `mh = importlib.import_module("MistHelper")` + `mh.<Name>` remainders for extracted symbol (SC-009).
+- [ ] Callsite table recorded in PR description (MistHelper.py count + `src/` file:line list + `tests/` file:line list) per FR-027 / SC-017.
+- [ ] Pre-push local gate passes on refactor branch:
+  - [ ] `black --check src/ MistHelper.py tools/` clean.
+  - [ ] `ruff check src/ MistHelper.py tools/` clean.
+  - [ ] `python MistHelper.py --test` reports 0 failed / exit 0 (modulo `test_menu_196_dispatches_to_async_claim_exporter` flake per E-7).
+- [ ] Import-graph health verified: `python -c "import <landing_module>; print('OK')"` succeeds without traversing `MistHelper.py` (FR-028 / SC-018).
+- [ ] Post-merge callsite count matches the pre-dispatch grep audit (zero stale references — verifiable via `grep -rn "<Name>" .` against merged `main`).
+- [ ] 15 functional CI jobs green + `mergeStateStatus: CLEAN` (FR-015 / SC-005). Merge is squash + delete-branch; NO `--admin` bypass as routine unblock (`feedback_no_admin_bypass.md`).
+- [ ] Repo aggregate compliance ≥ 99.6/A+ post-merge; new module scores A+/100; no A+ file regresses (SC-003 / SC-004 / SC-006 / FR-016 / FR-017 / FR-022).
+- [ ] `MistHelper.py` pylint score non-regressing (SC-015 / FR-018).
+- [ ] Zero new mypy strict violations, zero new SKIPPED CI conditionals (SC-019 / SC-016 / FR-031 / FR-019).
+- [ ] Existing tests converted to new import path + Pattern 1 construction contract in same commit (FR-030 / SC-023).
+- [ ] Analyzer regenerated post-merge (`python -m tools.refactor_analyzer`) and committed as `chore(1015): regenerate refactor_candidates.md after T-NN merge` (may piggyback on next task's branch per prior initiative practice) — FR-014 / SC-010.
+
+---
+
+## Bucket A — Single-use (T-01, T-02, T-03) — 1 caller each, queue-head validation
+
+### T-01: Extract `DeviceFetchConfig` to `src/refactors/device_data_fetcher.py`
+
+- **Dispatch position**: 1 of 15
+- **Symbol**: `DeviceFetchConfig`
+- **Symbol type**: class (small dataclass, 9 LOC)
+- **Refactor category**: Cat E (fresh cross-package extraction) — Single-use bucket
+- **LOC reclaimed from MistHelper.py**: 9
+- **Callsite count**: 1 ref (`src/refactors/device_data_fetcher.py:49`)
+- **Landing module**: `src/refactors/device_data_fetcher.py` — fold as top-level `@dataclass` (E-1 override: fold into `DeviceDataFetcherManager` class body ONLY if the class's public surface benefits from a nested config)
+- **Branch**: `refactor/1015-t01-device-fetch-config`
+- **Commit message template**: `refactor(1015): extract DeviceFetchConfig to src/refactors/device_data_fetcher.py (T-01, Cat E)`
+- **Analyzer flags to resolve in-flight**: `missing_action_logging`
+- **Dependencies**: none — fully independent.
+- **Task-specific acceptance criteria** (in addition to Common gates above):
+  - [ ] Sole callsite at `src/refactors/device_data_fetcher.py:49` rewritten to reference the new dataclass at its new home.
+  - [ ] `missing_action_logging` flag resolved via `logging.info` / `logging.debug` envelopes on any consuming method touched by the move.
+  - [ ] NOTE breadcrumb left in `MistHelper.py` at prior `DeviceFetchConfig` deletion site.
+  - [ ] No delegator / shim / re-export left in `MistHelper.py`.
+
+---
+
+### T-02: Extract `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` to `src/refactors/fast__mode__max__concurrent__connections.py`
+
+- **Dispatch position**: 2 of 15
+- **Symbol**: `FAST_MODE_MAX_CONCURRENT_CONNECTIONS`
+- **Symbol type**: constant (module-level assignment, 3 LOC)
+- **Refactor category**: Cat E — Single-use bucket
+- **LOC reclaimed from MistHelper.py**: 3
+- **Callsite count**: 1 ref
+- **Landing module**: `src/refactors/fast__mode__max__concurrent__connections.py` (bare module-level constant per E-14; MAY fold into an existing fast-mode constants module if one exists in the destination package — E-1 override recorded in PR description). Analyzer's `Suggested class` `FastModeMaxConcurrentConnectionsManager` is a naming hint only — NOT a required class wrapper.
+- **Branch**: `refactor/1015-t02-fast-mode-max-concurrent-connections`
+- **Commit message template**: `refactor(1015): extract FAST_MODE_MAX_CONCURRENT_CONNECTIONS to src/refactors/fast__mode__max__concurrent__connections.py (T-02, Cat E)`
+- **Analyzer flags to resolve in-flight**: `missing_inline_comments`, `missing_action_logging`
+- **Dependencies**: none — fully independent. MAY co-locate with T-03 in same destination file if fold-in target exists.
+- **Task-specific acceptance criteria**:
+  - [ ] Landing is a bare module-level constant (E-14) — NO wrapper class.
+  - [ ] `missing_inline_comments` resolved via inline comments on the constant declaration line and any documentation context.
+  - [ ] `missing_action_logging` resolved on the read-side (any consumer method touched by the callsite rewrite gets `logging.info` / `logging.debug` envelopes).
+  - [ ] NOTE breadcrumb at prior definition site.
+
+---
+
+### T-03: Extract `FAST_MODE_USE_CONNECTION_AWARE_THREADING` to `src/refactors/fast__mode__use__connection__aware__threading.py`
+
+- **Dispatch position**: 3 of 15
+- **Symbol**: `FAST_MODE_USE_CONNECTION_AWARE_THREADING`
+- **Symbol type**: constant (module-level assignment, 3 LOC)
+- **Refactor category**: Cat E — Single-use bucket
+- **LOC reclaimed from MistHelper.py**: 3
+- **Callsite count**: 1 ref
+- **Landing module**: `src/refactors/fast__mode__use__connection__aware__threading.py` (bare module-level constant per E-14; MAY co-locate with T-02 in a shared fast-mode constants module — E-1 override recorded).
+- **Branch**: `refactor/1015-t03-fast-mode-use-connection-aware-threading`
+- **Commit message template**: `refactor(1015): extract FAST_MODE_USE_CONNECTION_AWARE_THREADING to src/refactors/fast__mode__use__connection__aware__threading.py (T-03, Cat E)`
+- **Analyzer flags to resolve in-flight**: `missing_action_logging`
+- **Dependencies**: none — fully independent. Consider co-locating with T-02 if a fast-mode constants module is chosen.
+- **Task-specific acceptance criteria**:
+  - [ ] Landing is a bare module-level constant (E-14).
+  - [ ] `missing_action_logging` resolved on the read-side of consumers touched by the rewrite.
+  - [ ] NOTE breadcrumb at prior definition site.
+
+---
+
+## Bucket B — Low-use (T-04, T-05) — 2 callers each
+
+### T-04: Extract `ENDPOINT_PRIMARY_KEY_STRATEGIES` to `src/refactors/endpoint__primary__key__strategies.py`
+
+- **Dispatch position**: 4 of 15 — **largest LOC win in the entire initiative; dispatch early to reclaim 2,327 lines and eliminate T-04↔T-08 coupling before Hot bucket starts** (per plan.md dependency graph).
+- **Symbol**: `ENDPOINT_PRIMARY_KEY_STRATEGIES`
+- **Symbol type**: constant (module-level assignment / dict, 2327 LOC — the initiative's largest LoC line-item)
+- **Refactor category**: Cat E — Low-use bucket
+- **LOC reclaimed from MistHelper.py**: 2327
+- **Callsite count**: 2 refs
+- **Landing module**: `src/refactors/endpoint__primary__key__strategies.py` OR a domain-fitting `src/api/*.py` submodule (per E-1; the dict is intimately tied to the primary-key strategy layer in the constitution's "Adding New Menu Operations" flow — PR description records the E-1 override rationale in one sentence).
+- **Branch**: `refactor/1015-t04-endpoint-primary-key-strategies`
+- **Commit message template**: `refactor(1015): extract ENDPOINT_PRIMARY_KEY_STRATEGIES to <landing-path> (T-04, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`, `non_ascii_logs`
+- **Dependencies**: **T-04 → T-08 ordering coupling**. If T-04 lands first (spec's chosen order), T-08 can `from src.refactors.endpoint__primary__key__strategies import ENDPOINT_PRIMARY_KEY_STRATEGIES` directly. If T-08 dispatches first, T-08's `__init__` must accept a `primary_key_strategies` kwarg pointing at the still-in-MistHelper.py symbol — added coupling to avoid. **Spec sequences T-04 at position 4 specifically to eliminate this coupling before Hot bucket begins.**
+- **Task-specific acceptance criteria**:
+  - [ ] Atomic single-PR move (no split across multiple PRs per E-10).
+  - [ ] `oversize_25_lines` remediated via method decomposition — the 2,327-line dict body stays as data, but any embedded lambdas / callables split into `@staticmethod` methods ≤ 25 lines (per E-10 / FR-006).
+  - [ ] `missing_inline_comments` remediated — inline comment on every executable line in the new module.
+  - [ ] `missing_action_logging` remediated on any accessor / helper methods surfaced during decomposition.
+  - [ ] `non_ascii_logs` remediated — all log literals ASCII-only.
+  - [ ] Both 2 MistHelper.py callsites rewritten in same commit.
+  - [ ] NOTE breadcrumb at prior definition site.
+  - [ ] LoC reduction of ≥ 2,327 lines confirmed against `MistHelper.py` diff.
+
+---
+
+### T-05: Extract `detect_msp_privileges` to `src/refactors/detect_msp_privileges.py`
+
+- **Dispatch position**: 5 of 15
+- **Symbol**: `detect_msp_privileges`
+- **Symbol type**: function (25 LOC)
+- **Refactor category**: Cat E — Low-use bucket
+- **LOC reclaimed from MistHelper.py**: 25
+- **Callsite count**: 2 refs
+- **Landing module**: `src/refactors/detect_msp_privileges.py` OR a new domain-fitting `src/msp/*.py` package (per E-1; creating a new `src/msp/` package is acceptable if the analyzer-suggested fallback is a poor semantic fit — rationale recorded in PR description).
+- **Branch**: `refactor/1015-t05-detect-msp-privileges`
+- **Commit message template**: `refactor(1015): extract detect_msp_privileges to <landing-path> (T-05, Cat E)`
+- **Analyzer flags to resolve in-flight**: `missing_action_logging`
+- **Dependencies**: none — fully independent. Exercises new-package creation (`src/msp/`) at low risk if that landing is chosen.
+- **Task-specific acceptance criteria**:
+  - [ ] Function landing at top-level of new module (or `src/msp/*.py` if new package created).
+  - [ ] Method body kept ≤ 25 lines (already ≤ 25 per catalog; verify post-move).
+  - [ ] `missing_action_logging` resolved via `logging.info` / `logging.debug` envelopes.
+  - [ ] Both 2 callsites rewritten in same commit.
+  - [ ] NOTE breadcrumb at prior definition site.
+
+---
+
+## Bucket C — Hot (10 tasks, descending by LOC) — 11 to 195 refs each, ≥ 1 `src/` caller each
+
+### T-06: Extract `OrgInventoryExporter` to `src/export/org_inventory_exporter.py`
+
+- **Dispatch position**: 6 of 15 — **highest-LOC Hot candidate, dispatched first in Hot bucket per FR-026 descending-by-LOC ordering.**
+- **Symbol**: `OrgInventoryExporter`
+- **Symbol type**: class (Pattern 1 Hot — runtime deps, `apisession` + peers)
+- **Refactor category**: Cat E — Hot bucket
+- **LOC reclaimed from MistHelper.py**: 686
+- **Callsite count**: 102 refs (MistHelper.py + `src/` combined)
+- **Landing module**: `src/export/org_inventory_exporter.py`
+- **Branch**: `refactor/1015-t06-org-inventory-exporter`
+- **Commit message template**: `refactor(1015): extract OrgInventoryExporter to src/export/org_inventory_exporter.py (T-06, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`, `missing_inline_comments`
+- **Dependencies**: **Coupling with T-08 (DataExporter)** — `OrgInventoryExporter` likely calls `DataExporter.write_with_format_selection()`. Whichever of T-06 / T-08 lands second constructs the first via Pattern 1 kwargs (`data_exporter=DataExporter(**data_exporter_kwargs)` at every `OrgInventoryExporter` callsite). Spec dispatches T-06 first (position 6) then T-08 (position 8) — T-08 will see the freshly-landed `OrgInventoryExporter` via `from src.export.org_inventory_exporter import OrgInventoryExporter`.
+- **Task-specific acceptance criteria**:
+  - [ ] Pattern 1 constructor injection: `__init__(self, **deps)` with required kwargs (subset of the 14 canonical DI kwargs — apisession, PromptUtils, ConfigUtils, DataProcessingUtils, DataExporter, TimeUtils, EnhancedSSHRunner, InsightMetricsUtils, PacketCaptureManager, APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable, tqdm, mistapi).
+  - [ ] Every one of 102 callsites constructs the instance inline with the full kwargs list spelled out — NO factory, NO cached instance, NO `sys.modules` self-resolution.
+  - [ ] `oversize_25_lines` remediated via method decomposition: 686 LoC split into methods each ≤ 25 lines.
+  - [ ] `missing_inline_comments` remediated — inline comment on every executable line in new module.
+  - [ ] Every `mh = importlib.import_module("MistHelper")` + `mh.OrgInventoryExporter` lazy-import in `src/` eliminated in same commit (SC-009).
+  - [ ] Callsite table in PR description enumerates all 102 file:line refs.
+  - [ ] Tests converted to new import path + Pattern 1 kwarg construction (FR-030 / SC-023).
+
+---
+
+### T-07: Extract `PromptUtils` to `src/ui/prompt_utils.py`
+
+- **Dispatch position**: 7 of 15
+- **Symbol**: `PromptUtils`
+- **Symbol type**: class (Pattern 1 Hot — runtime deps)
+- **Refactor category**: Cat E — Hot bucket
+- **LOC reclaimed from MistHelper.py**: 441
+- **Callsite count**: 96 refs
+- **Landing module**: `src/ui/prompt_utils.py` — **E-1 collision check at dispatch**: `src/device/prompt_utils.py` already exists at ~52 KB. Verify whether that file is a related-but-distinct symbol or a stale forward. If collision, EITHER co-locate in `src/device/prompt_utils.py` (fold-in — must NOT regress that file below A+/100 per FR-022) OR leave `src/device/` untouched and land at `src/ui/prompt_utils.py`. E-1 rationale recorded in PR description.
+- **Branch**: `refactor/1015-t07-prompt-utils`
+- **Commit message template**: `refactor(1015): extract PromptUtils to <landing-path> (T-07, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`
+- **Dependencies**: **T-07 ↔ T-11 overlap in `src/device/`** — if T-07 folds into `src/device/prompt_utils.py`, both T-07 and T-11 (VirtualChassisManager, folding into `src/device/virtual_chassis.py`) touch the same directory. **Not a merge blocker** — FR-023 (one open PR at a time) + dispatch-time grep audit + serial merges resolve any conflict. If T-07 lands at `src/ui/prompt_utils.py` instead, this overlap goes away entirely.
+- **Task-specific acceptance criteria**:
+  - [ ] E-1 collision-check decision recorded in PR description (co-locate vs. new-module landing).
+  - [ ] Pattern 1 constructor injection with required kwargs; every callsite constructs inline.
+  - [ ] `oversize_25_lines` remediated via method decomposition — 441 LoC split into methods ≤ 25 lines.
+  - [ ] Every `mh.PromptUtils` lazy-import in `src/` eliminated.
+  - [ ] 96 callsites enumerated in PR description callsite table.
+  - [ ] If fold-in to `src/device/prompt_utils.py`: that file's compliance score remains A+/100 (FR-022).
+  - [ ] Tests converted to new import path + Pattern 1 kwarg construction.
+
+---
+
+### T-08: Extract `DataExporter` to `src/export/data_exporter.py`
+
+- **Dispatch position**: 8 of 15
+- **Symbol**: `DataExporter`
+- **Symbol type**: class (Pattern 1 Hot — runtime deps)
+- **Refactor category**: Cat E — Hot bucket
+- **LOC reclaimed from MistHelper.py**: 345
+- **Callsite count**: 118 refs — **second-highest ref count in the initiative** (after T-09 InputUtils at 195).
+- **Landing module**: `src/export/data_exporter.py`
+- **Branch**: `refactor/1015-t08-data-exporter`
+- **Commit message template**: `refactor(1015): extract DataExporter to src/export/data_exporter.py (T-08, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`, `non_ascii_logs`
+- **Dependencies**:
+  - **T-04 → T-08 ordering** (see T-04): T-04 dispatched first at position 4 ensures `ENDPOINT_PRIMARY_KEY_STRATEGIES` is already at its new home when T-08 lands. T-08 imports the constant directly from the new landing module — no coupling to MistHelper.py residual.
+  - **T-06 ↔ T-08** (see T-06): T-06 dispatched first at position 6. T-08 injects the already-landed `OrgInventoryExporter` via Pattern 1 kwargs when its methods orchestrate exports.
+- **Task-specific acceptance criteria**:
+  - [ ] Pattern 1 constructor injection with required kwargs (including `primary_key_strategies` if the strategy dict is passed as a kwarg, OR the module-level `from src.refactors.endpoint__primary__key__strategies import ENDPOINT_PRIMARY_KEY_STRATEGIES` import inside `data_exporter.py`).
+  - [ ] `oversize_25_lines` remediated via method decomposition — 345 LoC → methods ≤ 25 lines.
+  - [ ] `non_ascii_logs` remediated — every log literal ASCII-only (constitution V).
+  - [ ] Every `mh.DataExporter` lazy-import in `src/` eliminated.
+  - [ ] 118 callsites enumerated in PR description callsite table.
+  - [ ] Tests converted.
+
+---
+
+### T-10: Extract `DataProcessingUtils` to `src/data/data_processing_utils.py`
+
+- **Dispatch position**: 9 of 15
+- **Symbol**: `DataProcessingUtils`
+- **Symbol type**: class (Pattern 1 Hot — runtime deps)
+- **Refactor category**: Cat E — Hot bucket
+- **LOC reclaimed from MistHelper.py**: 158
+- **Callsite count**: 69 refs
+- **Landing module**: `src/data/data_processing_utils.py` — creates `src/data/` package if not already present.
+- **Branch**: `refactor/1015-t10-data-processing-utils`
+- **Commit message template**: `refactor(1015): extract DataProcessingUtils to src/data/data_processing_utils.py (T-10, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`, `missing_inline_comments`, `hardcoded_separator`
+- **Dependencies**: none direct — fully independent of T-11 despite ordering-adjacency. May be consumed as a Pattern 1 kwarg by other Hot classes (`DataProcessingUtils` is one of the 14 canonical DI kwargs); those consuming classes will pick up the new import path when they extract.
+- **Task-specific acceptance criteria**:
+  - [ ] `src/data/` package created (with `__init__.py`) if not already present.
+  - [ ] Pattern 1 constructor injection with required kwargs.
+  - [ ] `oversize_25_lines` remediated via decomposition — 158 LoC → methods ≤ 25 lines.
+  - [ ] `missing_inline_comments` remediated.
+  - [ ] `hardcoded_separator` remediated — replace hardcoded `/` or `\\` with `os.sep` or `pathlib.Path` idioms (constitution technology-constraint).
+  - [ ] Every `mh.DataProcessingUtils` lazy-import in `src/` eliminated.
+  - [ ] 69 callsites enumerated in PR description callsite table.
+  - [ ] Tests converted.
+
+---
+
+### T-11: Fold `VirtualChassisManager` into `src/device/virtual_chassis.py`
+
+- **Dispatch position**: 10 of 15
+- **Symbol**: `VirtualChassisManager`
+- **Symbol type**: class (Pattern 1 Hot — runtime deps)
+- **Refactor category**: Cat E — Hot bucket (fold-in)
+- **LOC reclaimed from MistHelper.py**: 78
+- **Callsite count**: 104 refs
+- **Landing module**: `src/device/virtual_chassis.py` — **fold into existing module** (existing 53 KB module is the natural home per E-1).
+- **Branch**: `refactor/1015-t11-virtual-chassis-manager`
+- **Commit message template**: `refactor(1015): fold VirtualChassisManager into src/device/virtual_chassis.py (T-11, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`
+- **Dependencies**: **T-07 ↔ T-11 overlap in `src/device/`** — if T-07 (PromptUtils) also lands in `src/device/`, both PRs touch the same directory. Spec dispatches T-07 at position 7 and T-11 at position 10 — T-07's PR is merged before T-11 opens (FR-023 serial dispatch). Fresh grep at T-11 dispatch time reflects any T-07 landing.
+- **Task-specific acceptance criteria**:
+  - [ ] Fold-in target `src/device/virtual_chassis.py` retains A+/100 after fold (FR-022) — verify with per-file compliance score check pre/post merge.
+  - [ ] Pattern 1 constructor injection with required kwargs.
+  - [ ] `oversize_25_lines` remediated — 78 LoC → methods ≤ 25 lines.
+  - [ ] `missing_inline_comments` remediated.
+  - [ ] `missing_action_logging` remediated on every method.
+  - [ ] Every `mh.VirtualChassisManager` lazy-import in `src/` eliminated.
+  - [ ] 104 callsites enumerated in PR description callsite table.
+  - [ ] Tests converted.
+
+---
+
+### T-09: Extract `InputUtils` to `src/ui/input_utils.py`
+
+- **Dispatch position**: 11 of 15 — **highest-refs candidate in the initiative (195 refs across 17 files); dispatched late in Hot bucket per plan.md so that preceding Hot classes (T-06/T-07/T-08/T-10/T-11) bundle their `InputUtils` uses into their own atomic rewires** rather than requiring a T-09-late catch-up.
+- **Symbol**: `InputUtils`
+- **Symbol type**: class (Pattern 1 Hot — runtime deps; safety-first NON-NEGOTIABLE per constitution III)
+- **Refactor category**: Cat E — Hot bucket
+- **LOC reclaimed from MistHelper.py**: 74
+- **Callsite count**: 195 refs across 17 files — **highest ref count in the initiative.**
+- **Landing module**: `src/ui/input_utils.py` — **E-1 collision check at dispatch**: `src/utils/input_utils.py` already exists at ~4.6 KB. Determine whether to fold, replace, or override landing to `src/ui/input_utils.py`. E-1 rationale recorded in PR description.
+- **Branch**: `refactor/1015-t09-input-utils`
+- **Commit message template**: `refactor(1015): extract InputUtils to <landing-path> (T-09, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`, `raw_input_call`
+- **Dependencies**: **T-09 broadly touches Hot-bucket predecessor callsites**. Every Hot class that lands before T-09 (T-06, T-07, T-08, T-10, T-11) SHOULD rewire its own `InputUtils.safe_input()` uses to the eventual `from src.ui.input_utils import InputUtils` path in-flight — reducing T-09's callsite fanout at dispatch. Either order works; the dispatch-time grep audit at T-09 must include every freshly-landed Hot class.
+- **Task-specific acceptance criteria**:
+  - [ ] E-1 collision-check decision recorded in PR description (fold vs. new-landing).
+  - [ ] Pre-dispatch `grep -rn "InputUtils" src/ tests/ MistHelper.py` recorded verbatim in PR description (FR-013 / FR-027) — expect ~195 hits.
+  - [ ] Pattern 1 constructor injection with required kwargs.
+  - [ ] `oversize_25_lines` remediated — 74 LoC → methods ≤ 25 lines.
+  - [ ] `raw_input_call` remediated — every raw `input()` in the extracted body rewritten to `InputUtils.safe_input()` per constitution III (safety-first NON-NEGOTIABLE).
+  - [ ] Every `mh.InputUtils` lazy-import in `src/` eliminated.
+  - [ ] All 195 callsites across 17 files enumerated in PR description callsite table.
+  - [ ] Tests converted to new import path + Pattern 1 kwarg construction (SC-023 — verify `grep -rn "InputUtils" tests/` shows zero old-path matches post-merge).
+
+---
+
+### T-12: Extract `ConfigUtils` to `src/config/config_utils.py`
+
+- **Dispatch position**: 12 of 15
+- **Symbol**: `ConfigUtils`
+- **Symbol type**: class (Pattern 1 Hot — runtime deps)
+- **Refactor category**: Cat E — Hot bucket
+- **LOC reclaimed from MistHelper.py**: 70
+- **Callsite count**: 102 refs
+- **Landing module**: `src/config/config_utils.py` — creates `src/config/` package if not already present.
+- **Branch**: `refactor/1015-t12-config-utils`
+- **Commit message template**: `refactor(1015): extract ConfigUtils to src/config/config_utils.py (T-12, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`
+- **Dependencies**: none direct — fully independent. May be consumed as a Pattern 1 kwarg by other Hot classes (`ConfigUtils` is one of the 14 canonical DI kwargs); consumers that already extracted before T-12 will need to be updated to the new import path in T-12's commit.
+- **Task-specific acceptance criteria**:
+  - [ ] `src/config/` package created (with `__init__.py`) if not already present.
+  - [ ] Pattern 1 constructor injection with required kwargs.
+  - [ ] `oversize_25_lines` remediated — 70 LoC → methods ≤ 25 lines.
+  - [ ] Every `mh.ConfigUtils` lazy-import in `src/` eliminated.
+  - [ ] 102 callsites enumerated in PR description callsite table.
+  - [ ] Tests converted.
+
+---
+
+### T-13: Extract `FilePathUtils` to `src/utils/file_path_utils.py`
+
+- **Dispatch position**: 13 of 15
+- **Symbol**: `FilePathUtils`
+- **Symbol type**: class (Pattern 1 Hot if runtime deps present; else `@staticmethod` collection — verify at dispatch)
+- **Refactor category**: Cat E — Hot bucket
+- **LOC reclaimed from MistHelper.py**: 46
+- **Callsite count**: 50 refs
+- **Landing module**: `src/utils/file_path_utils.py`
+- **Branch**: `refactor/1015-t13-file-path-utils`
+- **Commit message template**: `refactor(1015): extract FilePathUtils to src/utils/file_path_utils.py (T-13, Cat E)`
+- **Analyzer flags to resolve in-flight**: `oversize_25_lines`, `missing_inline_comments`
+- **Dependencies**: none — fully independent.
+- **Task-specific acceptance criteria**:
+  - [ ] Landing pattern verified at dispatch: Pattern 1 constructor if runtime deps; `@staticmethod` collection if pure.
+  - [ ] `oversize_25_lines` remediated — 46 LoC → methods ≤ 25 lines.
+  - [ ] `missing_inline_comments` remediated.
+  - [ ] Every `mh.FilePathUtils` lazy-import in `src/` eliminated.
+  - [ ] 50 callsites enumerated in PR description callsite table.
+  - [ ] Tests converted.
+
+---
+
+### T-14: Extract `tqdm` wrapper to `src/utils/tqdm_wrapper.py`
+
+- **Dispatch position**: 14 of 15
+- **Symbol**: `tqdm` (the wrapper function, not the third-party library)
+- **Symbol type**: function (3 LOC bare wrapper)
+- **Refactor category**: Cat E — Hot bucket. **E-12 clarification**: NOT in `SKIP_ALWAYS` for this initiative — the 1012 skip-pin was per-initiative and does NOT carry over.
+- **LOC reclaimed from MistHelper.py**: 3
+- **Callsite count**: 51 refs
+- **Landing module**: `src/utils/tqdm_wrapper.py` — OR domain-fit under `src/ui/*.py` per E-1 (rationale recorded in PR description).
+- **Branch**: `refactor/1015-t14-tqdm-wrapper`
+- **Commit message template**: `refactor(1015): extract tqdm wrapper to <landing-path> (T-14, Cat E)`
+- **Analyzer flags to resolve in-flight**: `missing_action_logging`
+- **Dependencies**: none — fully independent. Trivial deps → Pattern 1 constructor NOT required (bare function landing).
+- **Task-specific acceptance criteria**:
+  - [ ] Landing as bare module-level function (no Pattern 1 constructor needed for trivial 3-line wrapper).
+  - [ ] E-12 verified: FR-009's `SKIP_ALWAYS` exclusion does NOT apply here — T-14 explicitly targets `tqdm` per this initiative's scope.
+  - [ ] `missing_action_logging` remediated on the wrapper via `logging.info` / `logging.debug` envelopes.
+  - [ ] Every `mh.tqdm` lazy-import in `src/` eliminated.
+  - [ ] All 51 callsites enumerated in PR description callsite table.
+  - [ ] Tests converted.
+
+---
+
+### T-15: Extract `MIST_SITE_EXCLUDE_PREFIX` to `src/refactors/mist_site_exclude_prefix.py`
+
+- **Dispatch position**: 15 of 15 — **final PR of the initiative; last-merge PR carries the FR-024 / SC-022 final-state summary in its description (or a follow-up docs commit).**
+- **Symbol**: `MIST_SITE_EXCLUDE_PREFIX`
+- **Symbol type**: constant (module-level assignment, 3 LOC)
+- **Refactor category**: Cat E — Hot bucket
+- **LOC reclaimed from MistHelper.py**: 3
+- **Callsite count**: 11 refs (across MistHelper.py + `src/gateway/*.py`)
+- **Landing module**: `src/refactors/mist_site_exclude_prefix.py` — OR fold into an existing constants module in `src/gateway/*.py` per E-1 / E-14 (rationale recorded).
+- **Branch**: `refactor/1015-t15-mist-site-exclude-prefix`
+- **Commit message template**: `refactor(1015): extract MIST_SITE_EXCLUDE_PREFIX to <landing-path> (T-15, Cat E)`
+- **Analyzer flags to resolve in-flight**: `missing_inline_comments`, `missing_action_logging`
+- **Dependencies**: none — fully independent of every other task.
+- **Task-specific acceptance criteria**:
+  - [ ] Landing as bare module-level constant per E-14 (no wrapper class).
+  - [ ] `missing_inline_comments` remediated — inline comment on constant declaration and context.
+  - [ ] `missing_action_logging` remediated on read-side consumers touched by the rewrite.
+  - [ ] Every `mh.MIST_SITE_EXCLUDE_PREFIX` reference in `src/gateway/*.py` (or elsewhere) rewritten to import from new location.
+  - [ ] All 11 callsites enumerated in PR description callsite table.
+  - [ ] **Final-state summary (SC-022) recorded in this PR description OR follow-up docs commit**: (a) count of PRs merged (target: 15), (b) final `MistHelper.py` LoC + pylint score, (c) final aggregate compliance score, (d) list of any deferred candidates + rationale, (e) confirmation that regenerated `refactor_candidates.md` on `main` shows only `menu_actions` + `GlobalImportManager`.
+
+---
+
+## Dependencies Summary
+
+Mirrors plan.md's Dependency Graph exactly:
+
+**Fully independent** (no shared callsite files at spec time): T-01, T-02, T-03, T-05, T-13, T-14.
+
+**Coordinated overlap risks** (not blockers — mitigated by FR-023 serial dispatch + dispatch-time grep audit):
+
+- **T-07 ↔ T-11** — both potentially touch `src/device/`. T-07 dispatched first (position 7); T-11 later (position 10) refreshes grep before its own dispatch.
+- **T-04 → T-08 ordering** — T-04 dispatched at position 4 to eliminate the `ENDPOINT_PRIMARY_KEY_STRATEGIES` MistHelper.py residual before T-08 (position 8) needs it.
+- **T-06 ↔ T-08** — Pattern 1 kwarg coupling (`data_exporter` kwarg on `OrgInventoryExporter`). Spec dispatches T-06 first (position 6) so T-08 (position 8) picks up the already-landed class via `from src.export.org_inventory_exporter import OrgInventoryExporter`.
+- **T-09 broad fanout** — 195 refs across 17 files; Hot classes that precede T-09 (T-06/T-07/T-08/T-10/T-11) SHOULD bundle their `InputUtils.safe_input()` migrations in-flight so T-09's dispatch grep sees a reduced (but still comprehensive) callsite set.
+
+**Serial dispatch invariant** (FR-023): at most one extraction PR open at any time. Analyzer regenerated after every merge (FR-014 / SC-010). Dispatch order is bucket-first (Single-use → Low-use → Hot) then descending-by-LOC within Hot.
+
+---
+
+## Dispatch Order Summary
+
+| Position | Task | Symbol | Kind | Bucket | LOC | Refs | Landing |
+|---:|:---:|---|:-:|:---|---:|---:|---|
+| 1  | T-01 | `DeviceFetchConfig` | class | Single-use | 9 | 1 | `src/refactors/device_data_fetcher.py` |
+| 2  | T-02 | `FAST_MODE_MAX_CONCURRENT_CONNECTIONS` | constant | Single-use | 3 | 1 | `src/refactors/fast__mode__max__concurrent__connections.py` |
+| 3  | T-03 | `FAST_MODE_USE_CONNECTION_AWARE_THREADING` | constant | Single-use | 3 | 1 | `src/refactors/fast__mode__use__connection__aware__threading.py` |
+| 4  | T-04 | `ENDPOINT_PRIMARY_KEY_STRATEGIES` | constant | Low-use | 2327 | 2 | `src/refactors/endpoint__primary__key__strategies.py` (or `src/api/*.py`) |
+| 5  | T-05 | `detect_msp_privileges` | function | Low-use | 25 | 2 | `src/refactors/detect_msp_privileges.py` (or `src/msp/*.py`) |
+| 6  | T-06 | `OrgInventoryExporter` | class (Pattern 1) | Hot | 686 | 102 | `src/export/org_inventory_exporter.py` |
+| 7  | T-07 | `PromptUtils` | class (Pattern 1) | Hot | 441 | 96 | `src/ui/prompt_utils.py` (E-1 collision) |
+| 8  | T-08 | `DataExporter` | class (Pattern 1) | Hot | 345 | 118 | `src/export/data_exporter.py` |
+| 9  | T-10 | `DataProcessingUtils` | class (Pattern 1) | Hot | 158 | 69 | `src/data/data_processing_utils.py` |
+| 10 | T-11 | `VirtualChassisManager` | class (Pattern 1) | Hot | 78 | 104 | `src/device/virtual_chassis.py` (fold-in) |
+| 11 | T-09 | `InputUtils` | class (Pattern 1) | Hot | 74 | 195 | `src/ui/input_utils.py` (E-1 collision) |
+| 12 | T-12 | `ConfigUtils` | class (Pattern 1) | Hot | 70 | 102 | `src/config/config_utils.py` |
+| 13 | T-13 | `FilePathUtils` | class (Pattern 1 or static) | Hot | 46 | 50 | `src/utils/file_path_utils.py` |
+| 14 | T-14 | `tqdm` (wrapper) | function | Hot | 3 | 51 | `src/utils/tqdm_wrapper.py` (or `src/ui/*.py`) |
+| 15 | T-15 | `MIST_SITE_EXCLUDE_PREFIX` | constant | Hot | 3 | 11 | `src/refactors/mist_site_exclude_prefix.py` (or `src/gateway/*.py`) |
+
+**Cumulative LOC reclaimed**: 4,271 (target per SC-002: ≥ 3,500 net drop after class-body overhead retention).
+
+**Initiative closure**: When T-15 (or the final reclassified equivalent) merges and `refactor_candidates.md` is regenerated one final time, the report shows only `menu_actions` + `GlobalImportManager` (per SC-001 / FR-024 / FR-032). No further MistHelper.py refactor initiative is planned.


### PR DESCRIPTION
## Summary
- Archives the SpecKit artifacts for initiative #1015 (MistHelper refactor — final 15 hot-class candidates) as historical record.
- All T-01..T-15 extraction PRs already merged to main; this PR only lands the spec docs.
- Cherry-picked 4 files from the stale `1015-misthelper-refactor-final-15` branch onto a fresh branch from main to avoid reverting downstream work.

Files:
- `specs/1015-misthelper-refactor-final-15/spec.md` (+296)
- `specs/1015-misthelper-refactor-final-15/plan.md` (+297)
- `specs/1015-misthelper-refactor-final-15/tasks.md` (+437)
- `specs/1015-misthelper-refactor-final-15/checklists/requirements.md` (+53)

## Test plan
- [x] No production code changes; docs-only PR
- [x] Diff confirmed limited to 4 files under `specs/1015-*/`