### PR TITLE
docs(1016): SpecKit workflow for MistHelper.py suppression cleanup (#895-#902)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -600,7 +600,7 @@ When implementing a Feature Spec, AI agents must follow this protocol:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/1012-misthelper-refactor-hot-functions/plan.md
+at specs/1016-misthelper-suppression-cleanup/plan.md
 <!-- SPECKIT END -->
 
 <!-- rtk-instructions v2 -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/1013-misthelper-refactor-hot-classes"}
+{"feature_directory": "specs/1016-misthelper-suppression-cleanup"}

--- a/specs/1016-misthelper-suppression-cleanup/checklists/requirements.md
+++ b/specs/1016-misthelper-suppression-cleanup/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: MistHelper.py Suppression Cleanup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation performed on the initial draft written 2026-07-13.
+- The spec contains explicit references to lint tool names (ruff, pylint, mypy, bandit, black) and one file path (`src/utils/misthelper_facade.py`, `src/_bootstrap.py`). These are treated as accepted stakeholder-visible artifacts because the feature IS about lint suppressions — the reader cannot understand the requirements without those names. This is consistent with the "Content Quality" rule's intent (no *unnecessary* implementation leakage) rather than a strict prohibition.
+- The workflow's success is measured by grep counts on suppression comment patterns; those patterns are the actual product surface, not implementation choices, so they appear directly in acceptance criteria and success criteria.
+- No `[NEEDS CLARIFICATION]` markers were introduced. All ambiguity in the input was resolved via the informed-guess/reasonable-default rule and documented under Assumptions.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/1016-misthelper-suppression-cleanup/contracts/misthelper_facade_protocols.md
+++ b/specs/1016-misthelper-suppression-cleanup/contracts/misthelper_facade_protocols.md
@@ -1,0 +1,62 @@
+# Contract: `src/utils/misthelper_facade.py` Protocol Classes
+
+**Feature**: `specs/1016-misthelper-suppression-cleanup/`
+
+**Owning Story**: Story 4 / Issue #898
+
+**Date**: 2026-07-13
+
+## Purpose
+
+Define the Protocol classes that describe the call surface `MistHelper.py` uses on its facade globals. Once these Protocols exist, `MistHelper.py` can type-annotate its references so mypy resolves the calls without `# type: ignore[no-untyped-call]`.
+
+## File location and structure
+
+```
+src/utils/misthelper_facade.py
+```
+
+If the file does not exist at Story 4 start, it is created; the file is one of only two permitted `src/` additions in this workflow per FR-012 (the other is `src/utils/subprocess_runner.py`).
+
+The file contains only Protocol class definitions and their supporting `TypeAlias` or `TypeVar` declarations. It does NOT import from `MistHelper.py` (would create a cycle) and does NOT import concrete subsystem classes (would defeat the facade indirection).
+
+## Protocol enumeration
+
+The complete list is populated during Story 4 preparation from the fresh audit. Template per Protocol:
+
+```markdown
+### `<FacadeName>Protocol`
+
+**Backing facade global**: `MistHelper.<attribute_name>`
+
+**Call sites in `MistHelper.py`**: (list line numbers or symbol paths — this is a source-level contract note, not a stable citation)
+
+**Methods**:
+
+- `def <method_name>(self, <arg>: <type>, ...) -> <return_type>: ...`
+  - Contract: <two-line note on what the caller expects>.
+
+**Coverage note**: exact-match required — this Protocol MUST list every method `MistHelper.py` calls on this facade global, and MUST NOT list any method that is not called. Verify with a static grep of `MistHelper.py` for `<attribute_name>.` before Story 4 merge.
+```
+
+## Consumption pattern
+
+In `MistHelper.py`, the facade global is annotated with the Protocol type at assignment:
+
+```python
+from src.utils.misthelper_facade import <FacadeName>Protocol
+
+<attribute_name>: <FacadeName>Protocol = <concrete_construction>()
+```
+
+Once annotated, mypy resolves calls of the form `<attribute_name>.<method_name>(...)` without `# type: ignore[no-untyped-call]`, satisfying Story 4's independent test.
+
+## Validation checklist (Story 4 PR review)
+
+- [ ] `src/utils/misthelper_facade.py` exists and contains only Protocol classes plus their type-support declarations.
+- [ ] Every Protocol lists exactly the methods `MistHelper.py` calls on its backing facade global (grep-verified).
+- [ ] Every method signature on a Protocol matches the underlying implementation exactly.
+- [ ] `MistHelper.py` imports the Protocol types and annotates every facade global.
+- [ ] `mypy MistHelper.py --strict` reports zero `no-untyped-call` findings.
+- [ ] Zero `# type: ignore[no-untyped-call]` comments remain in `MistHelper.py`.
+- [ ] Constitution Principles VI and VII (inline comments, action logging) satisfied on any new/modified lines.

--- a/specs/1016-misthelper-suppression-cleanup/contracts/public_api.md
+++ b/specs/1016-misthelper-suppression-cleanup/contracts/public_api.md
@@ -1,0 +1,46 @@
+# Contract: `MistHelper.py` Public API Surface
+
+**Feature**: `specs/1016-misthelper-suppression-cleanup/`
+
+**Date**: 2026-07-13
+
+**Status**: Frozen for the duration of workflow #1016 per FR-007 / SC-007.
+
+## Purpose
+
+This document is the authoritative baseline for the set of module-level names accessible on the `MistHelper` module object at the start of Story 1. Every PR in this workflow MUST preserve every name in this list; Story 1's `__all__` MUST be a strict superset of the inventory below.
+
+## Method for capturing the inventory
+
+Executed once at Story 1 preparation:
+
+```bash
+python -c "import MistHelper; print('\n'.join(sorted(n for n in dir(MistHelper) if not n.startswith('_'))))" > contracts/public_api_snapshot.txt
+```
+
+The output of the above command is the ground truth. The tabular inventory below is populated from that snapshot before Story 1 opens its PR.
+
+## Public API inventory
+
+**Snapshot date**: *(to be filled by Story 1 preparation, e.g., 2026-07-14)*
+
+**Total public names**: *(to be filled)*
+
+| Name | Kind (class / function / constant) | Origin (`src/*` subsystem or `MistHelper.py` local) | Notes |
+|------|------------------------------------|------------------------------------------------------|-------|
+| *(populated from `public_api_snapshot.txt` before Story 1 PR opens)* | | | |
+
+## Verification recipe
+
+To confirm the public API surface is unchanged at any point in the workflow:
+
+```bash
+python -c "import MistHelper; print('\n'.join(sorted(n for n in dir(MistHelper) if not n.startswith('_'))))" > /tmp/current_public_api.txt
+diff contracts/public_api_snapshot.txt /tmp/current_public_api.txt
+```
+
+The `diff` MUST produce empty output. Any diff — including additions — indicates a public-API violation and blocks merge. Additions require a follow-up spec update; they cannot be introduced silently in a suppression-cleanup PR.
+
+## Non-public names (excluded)
+
+Names beginning with `_` are excluded from the frozen surface. This workflow is permitted to add, rename, or remove such names as part of helper extractions (Story 3) or Protocol / subprocess_runner introductions (Stories 4 and 7).

--- a/specs/1016-misthelper-suppression-cleanup/contracts/subprocess_runner.md
+++ b/specs/1016-misthelper-suppression-cleanup/contracts/subprocess_runner.md
@@ -1,0 +1,100 @@
+# Contract: `src/utils/subprocess_runner.py` Helper
+
+**Feature**: `specs/1016-misthelper-suppression-cleanup/`
+
+**Owning Story**: Story 7 / Issue #900
+
+**Date**: 2026-07-13
+
+**Status**: Conditional. Introduced only if the post-audit subprocess call-site count in `MistHelper.py` is ≥ 3 per `research.md` §4.
+
+## Purpose
+
+Centralize the `import subprocess` statement at a single audited entry point so that `B404` (subprocess module import) can be justified in exactly one place, and `B603` (subprocess call without shell review) resolves at every `MistHelper.py` call site because each routes through a validating helper.
+
+## File location and structure
+
+```
+src/utils/subprocess_runner.py
+```
+
+The file is one of only two permitted `src/` additions in this workflow per FR-012 (the other is `src/utils/misthelper_facade.py`).
+
+## Public entry point
+
+```python
+class SubprocessRunner:
+    """Centralized, audited subprocess dispatch for MistHelper.py callers."""
+
+    ALLOWED_EXECUTABLES: frozenset[str] = frozenset({
+        # populated during Story 7 audit from the actual set MistHelper.py invokes
+    })
+
+    @classmethod
+    def run(
+        cls,
+        argv: Sequence[str],
+        *,
+        timeout: float,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        """Validate `argv` and dispatch. Raises ValueError on validation failure."""
+```
+
+## Input validation contract
+
+Every call to `SubprocessRunner.run(argv, timeout=..., check=...)` MUST validate:
+
+1. `argv` is a non-empty sequence.
+2. `argv[0]` is a member of `SubprocessRunner.ALLOWED_EXECUTABLES`.
+3. Each element of `argv[1:]` matches a conservative character allow-list (alphanumeric, dash, underscore, dot, slash, colon, equals). Elements containing shell metacharacters (`;`, `&`, `|`, `>`, `<`, backtick, `$`, newline) are rejected with `ValueError`.
+4. `timeout` is a positive finite float.
+5. `shell=True` is never surfaced to callers; the parameter is not part of the signature.
+
+Validation failure raises `ValueError` with a message that identifies the offending element by index but does NOT log the argument value itself (constitution: secrets never in logs).
+
+## Logging contract
+
+Per constitution Principle VII:
+
+- `logging.info("SubprocessRunner dispatching %s", argv[0])` before invocation.
+- `logging.debug("SubprocessRunner completed %s rc=%s", argv[0], result.returncode)` after invocation.
+- `logging.error("SubprocessRunner failed %s: %s", argv[0], exc)` on exception, with traceback context.
+- Argument values (`argv[1:]`) are NEVER logged, only the executable name and result code.
+
+## Error-handling contract
+
+- `subprocess.TimeoutExpired`: allowed to propagate to caller after `error` log.
+- `subprocess.CalledProcessError`: propagates when `check=True`; caller catches and handles.
+- `ValueError` from validation: propagates immediately; no subprocess is spawned.
+
+## Consumption pattern
+
+At each `MistHelper.py` call site that previously carried `# nosec`:
+
+```python
+# Before (with suppression):
+# subprocess.run([...], timeout=30)  # nosec B603
+
+# After (routed through helper):
+from src.utils.subprocess_runner import SubprocessRunner
+SubprocessRunner.run([...], timeout=30)
+```
+
+The `import subprocess` line in `MistHelper.py` is removed (satisfying `B404`).
+
+## Test coverage contract
+
+- Unit tests cover: valid dispatch, allow-list rejection, metacharacter rejection, timeout propagation, empty-argv rejection.
+- Coverage ≥ 90% per Story 7 Acceptance Scenario 3.
+
+## Validation checklist (Story 7 PR review)
+
+- [ ] `src/utils/subprocess_runner.py` created (only if threshold met).
+- [ ] `SubprocessRunner.ALLOWED_EXECUTABLES` matches the actual set of executables `MistHelper.py` invokes.
+- [ ] Every `MistHelper.py` subprocess call site routes through `SubprocessRunner.run(...)`.
+- [ ] `import subprocess` removed from `MistHelper.py` (or reduced to the single point required for type-hint imports if any remain).
+- [ ] `bandit -r MistHelper.py` reports zero findings.
+- [ ] Zero `# nosec` comments remain in `MistHelper.py`.
+- [ ] `SubprocessRunner` test coverage ≥ 90%.
+- [ ] Constitution Principles VI and VII (inline comments, action logging) satisfied on new lines.

--- a/specs/1016-misthelper-suppression-cleanup/data-model.md
+++ b/specs/1016-misthelper-suppression-cleanup/data-model.md
@@ -1,0 +1,160 @@
+# Data Model: MistHelper.py Suppression Cleanup
+
+**Feature**: `specs/1016-misthelper-suppression-cleanup/`
+
+**Date**: 2026-07-13
+
+## Purpose
+
+Record the concrete shape of the four operational entities the workflow touches. This workflow has no runtime data schema; the "data model" here is the set of source-code artifacts each Story produces or freezes.
+
+Every entity below carries: a concrete shape, the validation rule that determines success, and the Story that owns it.
+
+---
+
+## 1. `__all__` list (owned by Story 1 / Issue #895)
+
+### Concrete shape
+
+A module-level assignment in `MistHelper.py`:
+
+```python
+__all__: list[str] = [
+    # -- from src.analytics --
+    "AnalyticsSubsystemA",
+    "AnalyticsSubsystemB",
+    # -- from src.api --
+    "ApiClient",
+    # ... one entry per re-exported name, grouped by source subsystem ...
+]
+```
+
+The list is grouped by the `src/` subsystem the name originates from, with a same-line comment header before each subsystem block. Ordering within a subsystem is alphabetical. The concrete list is enumerated by:
+
+1. Running `python -c "import MistHelper; print('\n'.join(sorted(n for n in dir(MistHelper) if not n.startswith('_'))))"` at workflow start.
+2. Filtering to names imported from `src/` (i.e., excluding names defined in `MistHelper.py` itself, unless they are part of the frozen public API per `contracts/public_api.md`).
+
+The precise inventory is captured in `contracts/public_api.md`; `__all__` MUST be equal to (or a strict superset of) that inventory.
+
+**Hoist decision**: Inline in `MistHelper.py` by default. Hoisted to `src/_bootstrap.py` only if the Phase 0 threshold (≥ 20 additional suppressions removable) is met per `research.md` §4.
+
+### Validation rules
+
+- Every name in `__all__` MUST be an attribute of the `MistHelper` module at import time (import-time smoke test).
+- Every name currently accessible via `from MistHelper import <name>` at workflow start MUST appear in `__all__` (SC-007 preservation).
+- No name in `__all__` may be prefixed with `_` (dunders excepted only where legacy public API includes them, which per current audit it does not).
+
+---
+
+## 2. Facade Global → Protocol mapping (owned by Story 4 / Issue #898)
+
+### Concrete shape
+
+For each Any-typed module-level attribute in `MistHelper.py` currently exposed to callers, a Protocol class is defined in `src/utils/misthelper_facade.py`:
+
+```python
+# src/utils/misthelper_facade.py
+from typing import Protocol
+
+class <FacadeName>Protocol(Protocol):
+    def <method_1>(self, arg: <type>) -> <return_type>: ...
+    def <method_2>(self, arg: <type>) -> <return_type>: ...
+```
+
+The mapping table is populated during Story 4 preparation:
+
+| Facade Global (attribute in `MistHelper.py`) | Protocol class name | Methods on Protocol | Call sites in `MistHelper.py` |
+|----------------------------------------------|---------------------|---------------------|-------------------------------|
+| *(to be populated during Story 4 preparation from fresh audit)* | | | |
+
+The full method-signature contract for each Protocol is captured in `contracts/misthelper_facade_protocols.md`.
+
+### Validation rules
+
+- **Exact coverage**: each Protocol MUST list exactly the methods `MistHelper.py` calls on the corresponding facade global — no more, no less (Story 4 Acceptance Scenario 3).
+- **Signature fidelity**: method signatures on the Protocol MUST match the underlying implementation exactly, so no covariance / contravariance surprises appear at type-check time.
+- **No implementation coupling**: `MistHelper.py` references only the Protocol type, not any concrete subsystem class.
+
+---
+
+## 3. Helper extraction boundaries (owned by Story 3 / Issue #901)
+
+### Concrete shape
+
+For each of the three complexity-flagged symbols, enumerated helpers with name, one-line purpose, and target size:
+
+**`GlobalImportManager`** — extract helpers so the main method stays under `C901` threshold:
+
+| Helper name (proposed) | Purpose | Target LOC |
+|------------------------|---------|-----------:|
+| `_resolve_import_target` | Look up the target module/name for a given legacy alias. | ≤ 25 |
+| `_install_into_namespace` | Bind the resolved target into the module namespace. | ≤ 25 |
+| `_record_import_diagnostics` | Emit the info/debug logging pair around each install. | ≤ 25 |
+
+**`DeviceFetchConfig`** — reduce `PLR0913` by grouping construction arguments:
+
+| Helper name (proposed) | Purpose | Target LOC |
+|------------------------|---------|-----------:|
+| `_from_dict_args` | Build the config from a dict-shaped source (menu path). | ≤ 25 |
+| `_validate_config` | Validate normalized fields per constitution safety-first pattern. | ≤ 25 |
+
+**`main()`** — extract per-menu-phase helpers so `main()` is a thin orchestrator:
+
+| Helper name (proposed) | Purpose | Target LOC |
+|------------------------|---------|-----------:|
+| `_parse_cli_args` | Wrap argparse invocation with logging. | ≤ 25 |
+| `_bootstrap_subsystems` | Call `GlobalImportManager` once and record readiness. | ≤ 25 |
+| `_dispatch_menu` | Route to the appropriate menu handler; single-return exit. | ≤ 25 |
+
+The proposed names above are recommendations; final helper names are settled by Story 3 during implementation and MUST be reflected back into this file before Story 3 merge.
+
+### Validation rules
+
+- Public signatures of `GlobalImportManager`, `DeviceFetchConfig`, and `main()` MUST NOT change (Story 3 Acceptance Scenario 2).
+- Every extracted helper MUST have at least one direct unit test invoked from the existing `tests/` tree (Story 3 Independent Test).
+- Every helper MUST fit under constitution Principle I's 25-LOC ceiling.
+- Every helper MUST carry inline comments and before/after action logging per constitution Principles VI and VII.
+
+---
+
+## 4. `subprocess_runner` surface (owned by Story 7 / Issue #900, conditional)
+
+### Concrete shape
+
+Introduced only if the Phase 0 threshold is met (≥ 3 remaining subprocess call sites in `MistHelper.py`). If introduced:
+
+```python
+# src/utils/subprocess_runner.py
+import subprocess  # single audited import in the repo for MistHelper.py's sites
+from typing import Sequence
+
+class SubprocessRunner:
+    ALLOWED_EXECUTABLES: frozenset[str] = frozenset({
+        # populated during Story 7 audit
+    })
+
+    @classmethod
+    def run(
+        cls,
+        argv: Sequence[str],
+        *,
+        timeout: float,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        """Validate and dispatch. Rejects unknown executables and shell metacharacters."""
+```
+
+Full contract in `contracts/subprocess_runner.md`.
+
+### Validation rules
+
+- Every element of `argv` MUST be validated against the allow-list (index 0) or a strict character set (remaining indices) before `subprocess.run` is invoked.
+- No caller may pass `shell=True`; the parameter is not surfaced.
+- Unit test coverage ≥ 90% (Story 7 Acceptance Scenario 3).
+- Inline comments and before/after action logging per constitution Principles VI and VII.
+
+---
+
+## State transitions
+
+There are no runtime state transitions in this workflow. The "state" that changes is source-code hygiene, measured externally by the suppression-count delta captured in `research.md` §2 and refreshed by `tools/refactor_analyzer/` between stories per FR-014 / FR-015.

--- a/specs/1016-misthelper-suppression-cleanup/plan.md
+++ b/specs/1016-misthelper-suppression-cleanup/plan.md
@@ -1,0 +1,295 @@
+# Implementation Plan: MistHelper.py Suppression Cleanup
+
+**Branch**: `1016-misthelper-suppression-cleanup` | **Date**: 2026-07-13 | **Spec**: `specs/1016-misthelper-suppression-cleanup/spec.md`
+
+**Input**: Feature specification from `specs/1016-misthelper-suppression-cleanup/spec.md`
+
+## Summary
+
+Drive the four suppression comment families (`# noqa`, `# type: ignore`, `# nosec`, `# pylint: disable`) in `MistHelper.py` to exactly zero across 8 serial pull requests, one per GitHub issue in `{#895–#902}`. The technical approach is a targeted, low-blast-radius sequence: bootstrap `__all__` declaration first (removes the ~124-site import-suppression cluster and lets subsequent lint runs produce trustworthy signal), then typing hardening (assignment/misc mypy fixes, Protocol classes for the facade globals, concrete generic parameters), then complexity extraction on the residual monolithic symbols (`GlobalImportManager`, `DeviceFetchConfig`, `main()`), then presentation cleanup (E501 hand-wraps), then security review of subprocess call sites (with optional `subprocess_runner` helper), and finally a long-tail sweep. The public API surface of `MistHelper.py` is frozen for the entire workflow (FR-007), no new suppressions may be introduced anywhere in the repo (FR-008), and each PR waits for `mergeStateStatus=CLEAN` without administrative bypass.
+
+## Technical Context
+
+**Language/Version**: Python 3.13+ (per constitution Technology & Compatibility Constraints).
+
+**Primary Dependencies**: `ruff`, `pylint`, `mypy` (strict), `bandit`, `black`, `pytest`, `coverage`. Runtime deps unchanged (`mistapi>=0.59`, `structlog`, `sqlite3`).
+
+**Storage**: N/A for this workflow — no schema or DB changes.
+
+**Testing**: `pytest -v --tb=short` with `coverage.fail_under=90`; `pylint --fail-under=9.5`. Full test suite must pass on every merged commit.
+
+**Target Platform**: Windows 11 dev (local venv), Linux container runtime (Podman) for CI. No platform-specific code touched.
+
+**Project Type**: Single-project CLI tool with extracted `src/` subsystems.
+
+**Performance Goals**: N/A — this is a suppression-hygiene workflow with no perf implications. Runtime behavior of `MistHelper.py` MUST be byte-identical from Story 1 start to Story 8 merge (SC-007).
+
+**Constraints**:
+- Public API surface of `MistHelper.py` frozen (FR-007); verified by `dir(MistHelper)` diff.
+- Zero net new suppressions anywhere in the repository (FR-008).
+- `pyproject.toml` edits limited to per-file-ignore removals (FR-010) — no rule disables, no fail-under lowering.
+- Coverage ≥ 90% and pylint ≥ 9.5 hold on every merged commit (FR-016).
+- Serial dispatch: PR N+1 does not open until PR N lands cleanly on `main` (FR-003).
+- Each delivery PR branches from current `main` at PR-open time, NOT from `1016-misthelper-suppression-cleanup` (FR-004).
+
+**Scale/Scope**:
+- Target file: `MistHelper.py` (~5000 LOC residual after #1014). Contains bootstrap glue, module-level CLI/main, and `GlobalImportManager`/`DeviceFetchConfig`/`main()` symbols coupled to globals.
+- Extracted subsystems in `src/`: `analytics`, `api`, `cache`, `device`, `export`, `gateway`, `input`, `inventory`, `org`, `reports`, `site`, `ssh`, `troubleshooting`, `ui`, `websocket`, `utils`, `db`.
+- Two conditional `src/` additions permitted (FR-012): `src/utils/misthelper_facade.py` Protocol classes (Story 4) and `src/utils/subprocess_runner.py` helper (Story 7). Only these two additions to `src/` are allowed; all other edits must land in `MistHelper.py`.
+- Audit source of truth: `tools/refactor_analyzer/` run on 2026-07-13; issue-body projections are stale (FR-014).
+
+**Repo layout notes**:
+- `MistHelper.py` residual functions are module-level CLI/bootstrap glue coupled to globals set by `GlobalImportManager`. Refactoring residual module-level functions into classes is **out of scope** for this workflow (FR-011); helper extraction is permitted only when narrowly required to eliminate a suppression in the current story.
+
+**Development gates (mandatory before every push)**:
+1. `rtk black --check .` — repo-wide format check; fix locally, never push and rely on CI.
+2. `rtk ruff check .` — repo-wide lint; fix locally.
+3. Full pytest suite green locally before opening PR.
+
+**PR gates (mandatory before every merge)**:
+- Wait for `mergeStateStatus=CLEAN` from `gh pr view <N> --json mergeStateStatus`. No `--admin` bypass under any circumstance (FR-006).
+- Merge command pattern: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch` armed once, then poll.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Status**: PASS (with explicit alignment).
+
+The MistHelper Constitution v1.4.0 exists at `.specify/memory/constitution.md`. The most relevant principle for this workflow is **"Security Findings: Fix Over Suppress (NON-NEGOTIABLE)"** in the Development Workflow & Quality Gates section, which states:
+
+> Never use `#nosec`, `# type: ignore`, `# noqa`, or similar suppressions as a shortcut to silence legitimate findings. If a finding requires more than a trivial fix, create a GitHub issue and track it.
+
+This workflow is the direct realization of that principle: every suppression in `MistHelper.py` is being resolved at the root cause rather than moved, renamed, or bulk-disabled. No principle gates are violated. No entries are required in the Complexity Tracking table below on the basis of constitution violations.
+
+Secondary alignment:
+- **Principle II (Class-Based Architecture, No Wrappers)**: FR-011 explicitly forbids extracting further classes beyond narrow suppression-fix helpers, preserving the completed #1013/#1014 class boundaries.
+- **Principle IV (Full Deployment Pipeline)**: The mandatory `rtk black --check .` + `rtk ruff check .` local gate documented above is the pre-push slice of the deployment pipeline; the container-build slice is unaffected because runtime behavior is unchanged.
+- **Principles VI & VII (Inline Comments & Action Logging)**: Any new lines introduced by helper extractions (Story 3), Protocol definitions (Story 4), or `subprocess_runner` helpers (Story 7) MUST carry inline comments and, where they wrap meaningful actions, before/after logging.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1016-misthelper-suppression-cleanup/
+├── plan.md              # This file (/speckit.plan output)
+├── research.md          # Phase 0 output: audit + per-issue fix patterns
+├── data-model.md        # Phase 1 output: __all__ list, Protocol shapes, helper boundaries
+├── quickstart.md        # Phase 1 output: verification recipes per PR
+├── contracts/           # Phase 1 output: contract fragments for public API + Protocols
+│   ├── public_api.md
+│   ├── misthelper_facade_protocols.md
+│   └── subprocess_runner.md
+└── tasks.md             # NOT produced by this command — /speckit.tasks generates it
+```
+
+### Source Code (repository root)
+
+```text
+MistHelper.py                                 # Target of every PR in this workflow.
+                                              # Only the __all__ declaration, per-site
+                                              # suppression removals, and narrow helper
+                                              # extractions land here. No class extractions.
+
+src/
+├── utils/
+│   ├── misthelper_facade.py                  # NEW in Story 4 (if not already present):
+│   │                                         # Protocol classes covering facade call
+│   │                                         # surface exposed to MistHelper.py.
+│   └── subprocess_runner.py                  # NEW in Story 7 (conditional):
+│                                             # centralized, audited subprocess entry
+│                                             # point so B404 import moves to one file.
+├── analytics/  api/  cache/  device/  export/  gateway/  input/  inventory/
+├── org/        reports/  site/  ssh/  troubleshooting/  ui/  websocket/  db/
+                                              # Untouched by this workflow (FR-012).
+
+tools/refactor_analyzer/                      # Audit source of truth for FR-014/FR-015.
+                                              # Re-run between stories to refresh deltas.
+
+tests/                                        # Existing structure preserved. New tests
+                                              # land next to the helpers/Protocols they
+                                              # cover (Story 3 helpers, Story 4 Protocols,
+                                              # Story 7 subprocess_runner).
+```
+
+**Structure Decision**: The Option 1 (single-project) layout is unchanged. This workflow does not introduce new top-level packages, does not restructure `src/`, and does not create a new `tests/` hierarchy. Two conditional additions inside `src/utils/` are the only permitted `src/` modifications (FR-012). All other work is confined to `MistHelper.py` and its accompanying test files.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+Constitution Check passed with explicit alignment; no violations to track. The table below repurposes the section for its analogue use in this workflow: **per-issue effort estimate** to help pace serial dispatch under SC-009 (four calendar weeks target).
+
+| Issue | Category | Est. suppression count | Est. effort | Ordering rationale |
+|-------|----------|------------------------|-------------|--------------------|
+| #895 | Bootstrap re-exports (`F401`, `pylint:unused-import`) | ~124 | Largest single cluster; day-scale | Must land first — cleans import signal for all subsequent lint runs. |
+| #899 | Mypy grab-bag (`misc`, `assignment`, `no-any-return`, `arg-type`, `operator`) | 12–20 | Half-day–day | Fixes assignment sites (`X: type[Foo] \| None = None`) that gate Story 4's `no-untyped-call` fixes. |
+| #901 | Complexity (`C901`, `PLR0913`) | 3–5 | Day | Helper extraction on `GlobalImportManager`, `DeviceFetchConfig`, `main()`. Landing before typing PRs shrinks their diff surface. |
+| #898 | `no-untyped-call` | 8–15 | Day | Requires Protocol classes in `src/utils/misthelper_facade.py`. Depends on #899 assignment cleanup and #901 helper stabilization. |
+| #897 | `type-arg` | ~3 | Half-day | Concrete generics; small isolated cluster. Runs after Protocols exist so annotations can reference them. |
+| #896 | Line length (`E501`) | 5–15 | Half-day | Hand-wraps. Deferred so typing PRs don't reflow the same lines. Literal-template exemptions follow `plan_wave_builder.py` precedent. |
+| #900 | Bandit (`B603`, `B404`) | 4–8 | Day | Input-validation audit + optional `subprocess_runner` helper. Deferred so security review lands on stable code. |
+| #902 | Long tail (`PLC0415`, `E402`, `PLW0602`, residual mypy-misc) | 5–10 | Half-day | Final sweep; runs last so residual set is well-defined. |
+
+Effort estimates assume the standard review cadence of ~1 PR per 2–3 working days (SC-009) and are advisory, not gating.
+
+---
+
+## Phase 0: Outline & Research
+
+**Prerequisite**: none (spec captured all clarifications).
+
+Phase 0 for this workflow is short — the spec already captured the audit, the ordering, and the fix pattern per cluster. The Phase 0 deliverable (`research.md`) consolidates three inputs into a single reviewable document:
+
+1. **Read all 8 GitHub issue bodies** (`#895` through `#902`) via `gh issue view` and record their claimed suppression counts and locations. These numbers are historical projections and MUST be flagged as stale per FR-014 wherever they disagree with the 2026-07-13 audit.
+2. **Re-run `tools/refactor_analyzer/`** on `MistHelper.py` at current `main` HEAD and capture fresh 2026-07-13 counts per suppression family. These counts are the ground truth (FR-014). Preserve the raw analyzer output as an appendix in `research.md`.
+3. **Record the fix pattern per cluster** in the format Decision / Rationale / Alternatives Considered, mirroring the "Fix patterns per issue cluster" list embedded in this plan's Technical Context. Explicitly resolve the following pattern decisions:
+   - **#895 hoist vs. inline `__all__`**: Decide whether to add `__all__` directly in `MistHelper.py` or hoist to `src/_bootstrap.py`. Default per user guidance: inline `__all__`; hoist only if it materially reduces suppression count. Record the trigger threshold for choosing hoist.
+   - **#900 `subprocess_runner` helper**: Decide whether Story 7 introduces `src/utils/subprocess_runner.py` or performs per-site validation without a helper module. Trigger: if 3+ subprocess call sites remain post-audit, introduce the helper; otherwise per-site validation.
+   - **#896 rendered-output exemptions**: Enumerate MistHelper.py lines whose reflow would change rendered CLI output (banners, table columns, prompt text). These follow the `plan_wave_builder.py` / `reporting.py` precedent and MUST be hand-wrapped without altering the rendered characters.
+
+**Output**: `research.md` with all clarifications resolved, containing:
+- Fresh 2026-07-13 audit counts per suppression family (baseline for FR-015 delta tracking).
+- Per-issue fix-pattern decisions in Decision / Rationale / Alternatives format.
+- Explicit hoist / helper thresholds for #895 and #900.
+- Rendered-output exemption list for #896.
+
+## Phase 1: Design & Contracts
+
+**Prerequisite**: `research.md` complete.
+
+### 1. Extract entities → `data-model.md`
+
+The spec's Key Entities section names four operational entities. `data-model.md` records their concrete shape as it applies to this workflow:
+
+- **`__all__` list (Story 1)**: The concrete list of module-level names to export from `MistHelper.py`. `data-model.md` captures the enumerated list, grouped by source subsystem (`analytics/`, `api/`, etc.), and the validation rule that this list must be a strict superset of every name currently accessible via `from MistHelper import <name>` at the workflow start (SC-007). Record whether the list will be defined inline in `MistHelper.py` or hoisted to `src/_bootstrap.py` per the Phase 0 decision.
+- **Facade Global → Protocol mapping (Story 4)**: For each Any-typed module-level attribute in `MistHelper.py` currently exposed to callers, record the Protocol name, the exact method signatures it must cover, and the call sites in `MistHelper.py` that route through it. Validation rule: Protocol coverage MUST be exact — no unused methods, no missing methods, per Story 4 Acceptance Scenario 3.
+- **Helper extraction boundaries (Story 3)**: For each of `GlobalImportManager`, `DeviceFetchConfig`, and `main()`, enumerate the intended helper functions/methods (name, single-sentence purpose, target size ≤ 25 lines per constitution Principle I). Validation rule: public signatures of the three target symbols MUST be unchanged post-extraction (Story 3 Acceptance Scenario 2).
+- **`subprocess_runner` surface (Story 7, conditional)**: If Phase 0 triggered the helper, record its intended public entry point signature, the input-validation contract (allow-list vs. shlex.quote-equivalent), and the error-handling contract. Validation rule: coverage ≥ 90% (Story 7 Acceptance Scenario 3).
+
+State transitions: this workflow has no runtime state changes; the "state" being modified is source-code hygiene, tracked externally by the audit-count delta per FR-015.
+
+### 2. Define interface contracts → `contracts/`
+
+`MistHelper.py` exposes a public API surface to external tools (FR-007). This workflow freezes that surface but formally documents it for the first time. Contracts are captured as Markdown fragments (project convention — no OpenAPI / IDL applies to a CLI module):
+
+- `contracts/public_api.md`: The frozen public API. Enumerates every module-level name in `dir(MistHelper)` at workflow start. This document is the authoritative comparison baseline for SC-007. No PR in this workflow may reduce this set; Story 1's `__all__` MUST be a superset.
+- `contracts/misthelper_facade_protocols.md`: The Protocol contracts for `src/utils/misthelper_facade.py`. One section per Protocol class, listing method signatures with type annotations and a two-line contract note per method.
+- `contracts/subprocess_runner.md` (conditional, Story 7): Public entry point signature, input-validation rules, error-handling behavior for `src/utils/subprocess_runner.py`.
+
+### 3. Quickstart → `quickstart.md`
+
+`quickstart.md` records the verification recipe an operator or reviewer runs to confirm a given story is complete. One section per story, each containing:
+- The exact `ruff` / `pylint` / `mypy` / `bandit` / `grep` commands that MUST return zero findings.
+- The command to compare public API surface against `contracts/public_api.md` (SC-007).
+- The pytest invocation covering that story's new helpers/Protocols.
+
+### 4. Agent context update
+
+Update the plan reference block between `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` in `.github/copilot-instructions.md` to point at this plan file (`specs/1016-misthelper-suppression-cleanup/plan.md`). No other agent-context files change.
+
+**Output**: `research.md`, `data-model.md`, `contracts/public_api.md`, `contracts/misthelper_facade_protocols.md`, `contracts/subprocess_runner.md` (conditional), `quickstart.md`, updated `.github/copilot-instructions.md`.
+
+---
+
+## Phase 2: Implementation Planning (Strategy)
+
+> **Note**: `/speckit.tasks` generates `tasks.md` with per-file, per-code-site task decomposition. This section captures cross-PR strategy, ordering rationale, and the shared exit-criteria template. Individual code sites are NOT enumerated here.
+
+### Merge ordering rationale
+
+The 8 PRs land in the order `[#895, #899, #901, #898, #897, #896, #900, #902]`, chosen to minimize rework:
+
+- **#895 first** removes ~124 import suppressions. Every subsequent lint run then produces trustworthy signal, reducing the noise ratio for reviewers of PRs 2–8.
+- **#899 → #901 → #898** is a typing/complexity braid. #899's `assignment` fixes create the typed globals that #898's Protocol integration relies on; #901's helper extraction stabilizes the code shape #898 must annotate. Landing #901 between them shrinks the diff surface of #898.
+- **#897** (small `type-arg` cluster) piggybacks on the now-stable Protocol/helper types.
+- **#896** (E501 hand-wraps) lands after all typing PRs so no typing PR reflows lines already wrapped, avoiding merge conflicts.
+- **#900** (bandit) reviews subprocess call sites that #901 may have restructured; landing after complexity is settled keeps the security audit tight.
+- **#902** sweeps the residual long tail; deferring last guarantees the residual set is well-defined and not polluted by earlier PRs' side effects.
+
+### Cross-PR invariants (apply to every PR)
+
+- Public API surface of `MistHelper.py` unchanged; `diff <(python -c "import MistHelper; print('\n'.join(sorted(dir(MistHelper))))") contracts/public_api.md` produces no diff.
+- No `# noqa`, `# type: ignore`, `# nosec`, or `# pylint: disable` comments are added anywhere in the repository (FR-008). Reviewers must grep the diff.
+- `pyproject.toml` changes limited to per-file-ignore removals (FR-010).
+- Only one PR from this workflow open at a time (SC-008); serial dispatch (FR-003).
+- Delivery branches cut fresh from `main` — never from `1016-misthelper-suppression-cleanup` (FR-004).
+- Pre-push local gate: `rtk black --check .` and `rtk ruff check .` MUST be clean before push.
+
+### PR sub-phase enumeration
+
+Each sub-phase corresponds to one delivery PR. The exit criteria are identical across sub-phases; only the target issue, cluster, and expected suppression-count delta vary.
+
+**Sub-phase 1 — Story 1 / Issue #895 — Bootstrap re-exports**
+- Entry: Phase 1 artifacts (`data-model.md` `__all__` list, `contracts/public_api.md`) merged into the feature branch. Fresh audit committed to `research.md`.
+- Deliverable: `__all__ = [...]` declared in `MistHelper.py` (or hoisted to `src/_bootstrap.py` per Phase 0 decision); all `# noqa: F401` and `# pylint: disable=unused-import` comments removed from the file.
+- Exit criteria: see template below.
+
+**Sub-phase 2 — Story 2 / Issue #899 — Mypy grab-bag**
+- Entry: PR #895 merged; `main` audit refreshed.
+- Deliverable: `assignment` sites converted to `X: type[Foo] | None = None` typed declarations; per-site fixes for `misc`, `no-any-return`, `arg-type`, `operator`. All matching `# type: ignore` comments removed.
+- Exit criteria: template.
+
+**Sub-phase 3 — Story 3 / Issue #901 — Complexity extraction**
+- Entry: PR #899 merged; `main` audit refreshed.
+- Deliverable: narrow helpers extracted inside `GlobalImportManager`, `DeviceFetchConfig`, and `main()` per the boundaries in `data-model.md`. Public signatures of all three symbols unchanged. `# noqa: C901` and `# noqa: PLR0913` comments removed.
+- Exit criteria: template + Story-3-specific: each extracted helper has at least one unit test invoked from the existing test suite, and helper coverage ≥ 90%.
+
+**Sub-phase 4 — Story 4 / Issue #898 — no-untyped-call via Protocols**
+- Entry: PR #901 merged; `main` audit refreshed; `contracts/misthelper_facade_protocols.md` up to date.
+- Deliverable: `src/utils/misthelper_facade.py` contains Protocol classes per the contract; `MistHelper.py` call sites through the facade are annotated so mypy resolves them without `# type: ignore[no-untyped-call]`. All matching comments removed.
+- Exit criteria: template + Story-4-specific: Protocol coverage is exact (no unused, no missing methods).
+
+**Sub-phase 5 — Story 5 / Issue #897 — type-arg**
+- Entry: PR #898 merged; `main` audit refreshed.
+- Deliverable: concrete generic parameters (`dict[str, Any]`, `list[SomeType]`, etc.) added at the small number of `type-arg` sites. Matching `# type: ignore` comments removed.
+- Exit criteria: template.
+
+**Sub-phase 6 — Story 6 / Issue #896 — Line length**
+- Entry: PR #897 merged; `main` audit refreshed.
+- Deliverable: hand-wrapped long lines (or narrow helper extractions where clearly warranted) at every remaining `E501` site. Rendered-output-exempt lines per the Phase 0 list are wrapped without changing rendered characters. All `# noqa: E501` comments removed.
+- Exit criteria: template + Story-6-specific: `black --check MistHelper.py` reports no diffs; file diff against pre-PR HEAD contains no logic changes, only whitespace/parenthesization/narrow-helper extractions.
+
+**Sub-phase 7 — Story 7 / Issue #900 — Bandit**
+- Entry: PR #896 merged; `main` audit refreshed.
+- Deliverable: input-validation audit per subprocess call site with either (a) documented safe-usage justification (validated inputs, allow-list) and `# nosec` removed, or (b) call site routed through `src/utils/subprocess_runner.py` (introduced this PR if the Phase 0 threshold was met). `B404` addressed by encapsulating the subprocess import at the helper module. All `# nosec` comments in `MistHelper.py` removed.
+- Exit criteria: template + Story-7-specific: if `subprocess_runner` was introduced, its coverage ≥ 90%.
+
+**Sub-phase 8 — Story 8 / Issue #902 — Long tail**
+- Entry: PR #900 merged; `main` audit refreshed.
+- Deliverable: `PLC0415` late imports hoisted where safe; `E402` exemptions removed if the version-check pattern moves; residual mypy-misc / name-defined / var-annotated / `PLW0602` cleared. All remaining suppression comments in `MistHelper.py` removed.
+- Exit criteria: template + Story-8-specific (final gate): grep `MistHelper.py` for `# noqa|# type: ignore|# nosec|# pylint: disable` returns zero matches (SC-001).
+
+### Per-PR exit criteria template
+
+Every delivery PR MUST satisfy all eight criteria before merge. This template is applied uniformly across sub-phases 1–8:
+
+| # | Criterion | Verification |
+|---|-----------|-------------|
+| a | Target issue closed | PR description contains `Closes #<NNN>` referencing the sub-phase's issue; GitHub issue-linking status confirms auto-close on merge. |
+| b | Suppression count for the target category → 0 in `MistHelper.py` | Category-specific grep or lint command returns zero findings (exact command per sub-phase; see `quickstart.md`). |
+| c | Black + ruff clean | `rtk black --check .` and `rtk ruff check .` return zero findings locally AND in CI. |
+| d | mypy for `MistHelper.py` has no new errors | `mypy MistHelper.py --strict` output has zero net-new errors relative to `main` at PR-open time (baseline captured in the PR description). |
+| e | Full test suite green | `pytest -v --tb=short` passes in CI on the PR's head commit. |
+| f | Coverage ≥ 90% | Coverage report on the PR's merge commit shows `coverage.fail_under=90` satisfied. |
+| g | Pylint ≥ 9.5 | `pylint --fail-under=9.5` satisfied on the PR's merge commit. |
+| h | `mergeStateStatus=CLEAN` | `gh pr view <N> --json mergeStateStatus` returns `CLEAN` immediately before invoking merge; no `--admin` bypass under any condition. |
+
+Story-specific supplementary criteria (Stories 3, 4, 6, 7, 8) are enumerated inline in each sub-phase description above.
+
+### Merge invocation pattern
+
+Once all eight template criteria pass locally and in CI, and `mergeStateStatus=CLEAN`:
+
+```bash
+GITHUB_TOKEN= gh pr merge <PR_NUMBER> --auto --squash --delete-branch
+```
+
+Arm once, then poll `gh pr view <PR_NUMBER> --json state,mergeCommit` until state is `MERGED`. After merge, refresh the audit via `tools/refactor_analyzer/` before opening the next sub-phase's PR (FR-014 / FR-015).
+
+---
+
+## Stop-and-report
+
+Phase 0 and Phase 1 artifacts are produced by this command. `tasks.md` is intentionally NOT produced — it is the output of the separate `/speckit.tasks` step. Individual code-site enumeration lives in `tasks.md`, not here.

--- a/specs/1016-misthelper-suppression-cleanup/quickstart.md
+++ b/specs/1016-misthelper-suppression-cleanup/quickstart.md
@@ -1,0 +1,188 @@
+# Quickstart: Verification Recipes per Story
+
+**Feature**: `specs/1016-misthelper-suppression-cleanup/`
+
+**Date**: 2026-07-13
+
+## Purpose
+
+Give a reviewer or operator a one-page recipe per story to confirm the story is complete. Every recipe returns pass/fail deterministically — no judgement calls.
+
+## Pre-push local gate (applies to every story)
+
+Run before every `git push`:
+
+```bash
+rtk black --check .
+rtk ruff check .
+pytest -v --tb=short
+```
+
+All three MUST return zero findings / all-pass before the branch is pushed. This is the mandatory pre-push gate per user feedback recorded in memory (`Pre-push black + ruff gate`).
+
+## Merge gate (applies to every PR)
+
+Immediately before invoking merge:
+
+```bash
+gh pr view <PR_NUMBER> --json mergeStateStatus
+```
+
+MUST return `"mergeStateStatus": "CLEAN"`. No `--admin` bypass under any condition (FR-006 / recorded feedback `No --admin merge bypass`).
+
+Then arm auto-merge:
+
+```bash
+GITHUB_TOKEN= gh pr merge <PR_NUMBER> --auto --squash --delete-branch
+```
+
+Then poll:
+
+```bash
+gh pr view <PR_NUMBER> --json state,mergeCommit
+```
+
+Until state is `MERGED`.
+
+## Public API preservation (applies to every PR)
+
+At every PR opening AND immediately before merge:
+
+```bash
+python -c "import MistHelper; print('\n'.join(sorted(n for n in dir(MistHelper) if not n.startswith('_'))))" > /tmp/current_public_api.txt
+diff specs/1016-misthelper-suppression-cleanup/contracts/public_api_snapshot.txt /tmp/current_public_api.txt
+```
+
+The `diff` MUST produce empty output. Any diff blocks merge.
+
+---
+
+## Story 1 (#895) — Bootstrap re-exports
+
+```bash
+# Must all return zero findings:
+ruff check MistHelper.py --select F401
+pylint MistHelper.py --disable=all --enable=unused-import
+
+# Must return zero matches:
+grep -n "# noqa: F401" MistHelper.py
+grep -n "# pylint: disable=unused-import" MistHelper.py
+
+# Must succeed and print a positive integer:
+python -c "import MistHelper; print(len(MistHelper.__all__))"
+
+# Audit delta (via tools/refactor_analyzer/) must show suppression drop of ≥ 120.
+```
+
+## Story 2 (#899) — Mypy grab-bag
+
+```bash
+# Must report zero findings in these five categories on MistHelper.py:
+mypy MistHelper.py --strict
+
+# Must return zero matches:
+grep -nE "# type: ignore\[(misc|assignment|no-any-return|arg-type|operator)" MistHelper.py
+```
+
+## Story 3 (#901) — Complexity extraction
+
+```bash
+# Must return zero findings:
+ruff check MistHelper.py --select C901,PLR0913
+
+# Must return zero matches:
+grep -nE "# noqa: (C901|PLR0913)" MistHelper.py
+
+# Extracted helpers coverage ≥ 90% (project gate coverage.fail_under=90 still passes overall):
+pytest -v --tb=short --cov=MistHelper --cov-fail-under=90
+```
+
+## Story 4 (#898) — no-untyped-call via Protocols
+
+```bash
+# Must report zero no-untyped-call findings in MistHelper.py:
+mypy MistHelper.py --strict
+
+# Must return zero matches:
+grep -n "# type: ignore\[no-untyped-call" MistHelper.py
+
+# Protocol classes must exist:
+test -f src/utils/misthelper_facade.py
+python -c "from src.utils import misthelper_facade; print(dir(misthelper_facade))"
+```
+
+## Story 5 (#897) — type-arg
+
+```bash
+# Must report zero type-arg findings:
+mypy MistHelper.py --strict
+
+# Must return zero matches:
+grep -n "# type: ignore\[type-arg" MistHelper.py
+```
+
+## Story 6 (#896) — Line length
+
+```bash
+# Must return zero findings:
+ruff check MistHelper.py --select E501
+
+# Must return zero matches:
+grep -n "# noqa: E501" MistHelper.py
+
+# Must report no diffs:
+black --check MistHelper.py
+```
+
+## Story 7 (#900) — Bandit
+
+```bash
+# Must report zero findings:
+bandit -r MistHelper.py
+
+# Must return zero matches:
+grep -n "# nosec" MistHelper.py
+
+# If subprocess_runner was introduced, it must exist and its coverage must be ≥ 90%:
+test -f src/utils/subprocess_runner.py && \
+  pytest -v --tb=short --cov=src.utils.subprocess_runner --cov-fail-under=90 \
+    tests/utils/test_subprocess_runner.py
+```
+
+## Story 8 (#902) — Long tail (final sweep)
+
+```bash
+# All four lint tools must pass with zero findings AND zero suppression comments:
+ruff check MistHelper.py
+pylint MistHelper.py --fail-under=9.5
+mypy MistHelper.py --strict
+bandit -r MistHelper.py
+black --check MistHelper.py
+
+# Success criterion SC-001: exactly zero suppression comments remain:
+grep -cE "# (noqa|type: ignore|nosec|pylint: disable)" MistHelper.py
+# MUST print: 0
+
+# Config gate FR-010: pyproject.toml changes limited to per-file-ignore removals:
+git diff main -- pyproject.toml
+# Reviewer confirms visually that no rule disables or fail-under changes appear.
+```
+
+## Full-suite regression (applies to every PR)
+
+Beyond the per-story recipes above, every PR MUST pass:
+
+```bash
+pytest -v --tb=short              # all tests green
+coverage report --fail-under=90   # project coverage gate
+pylint --fail-under=9.5 .         # project pylint gate
+```
+
+## Audit refresh (between stories)
+
+After each merge, before opening the next story's PR:
+
+```bash
+python tools/refactor_analyzer/... MistHelper.py > /tmp/audit_post_story_<N>.txt
+# Attach delta (previous baseline vs. current) to the next story's PR description per FR-015.
+```

--- a/specs/1016-misthelper-suppression-cleanup/research.md
+++ b/specs/1016-misthelper-suppression-cleanup/research.md
@@ -1,0 +1,164 @@
+# Phase 0 Research: MistHelper.py Suppression Cleanup
+
+**Feature**: `specs/1016-misthelper-suppression-cleanup/`
+
+**Date**: 2026-07-13
+
+## Purpose
+
+Consolidate the three inputs required before Phase 1 design can proceed:
+
+1. The historical claims recorded in GitHub issues `#895`–`#902`.
+2. The fresh audit output from `tools/refactor_analyzer/` on `MistHelper.py` at current `main` HEAD (authoritative per FR-014).
+3. The per-cluster fix-pattern decisions with rationale and alternatives.
+
+All references to counts in issue bodies are marked stale where they disagree with the fresh audit.
+
+---
+
+## 1. Issue body review (historical claims)
+
+**Method**: `gh issue view <N>` for `N in {895..902}`. Recorded here as claimed cluster + claimed count + claimed representative locations, WITHOUT further verification. The 2026-07-13 audit (§2) is the ground truth.
+
+| Issue | Cluster theme | Historical claim (stale) |
+|-------|---------------|--------------------------|
+| #895 | Bootstrap re-exports: `F401` + `pylint:unused-import` | ~124 combined sites |
+| #896 | `E501` line length | 5–15 sites |
+| #897 | `mypy:type-arg` | ~3 sites |
+| #898 | `mypy:no-untyped-call` | 8–15 sites |
+| #899 | Mypy grab-bag: `misc`, `assignment`, `no-any-return`, `arg-type`, `operator` | 12–20 sites |
+| #900 | Bandit: `B603` dominant, some `B404` | 4–8 sites |
+| #901 | `C901` cyclomatic + `PLR0913` too-many-arguments | 3–5 sites on `GlobalImportManager`, `DeviceFetchConfig`, `main()` |
+| #902 | Long tail: `PLC0415`, `E402`, `PLW0602`, residual mypy-misc | 5–10 sites |
+
+**Staleness flag**: All numeric claims above supersede on presentation of §2's fresh audit. Reviewers must NOT gate merge decisions on the historical numbers per FR-014.
+
+---
+
+## 2. Fresh 2026-07-13 audit (authoritative)
+
+**Method**: `python tools/refactor_analyzer/... MistHelper.py` on current `main` HEAD, captured on 2026-07-13. The raw output is preserved as Appendix A. Summary counts by suppression family and by GitHub issue cluster follow.
+
+### Suppression family totals in `MistHelper.py`
+
+| Family | Count (2026-07-13) | Notes |
+|--------|--------------------:|-------|
+| `# noqa: F401` | *(to be filled by first audit run committed to this file)* | Bootstrap re-export block. |
+| `# pylint: disable=unused-import` | *(to be filled)* | Same block. |
+| `# type: ignore[assignment]` | *(to be filled)* | Module-level `X: type[Foo] = None` bootstrap globals. |
+| `# type: ignore[misc]` | *(to be filled)* | Residual mypy misc. |
+| `# type: ignore[no-any-return]` | *(to be filled)* | Bootstrap wrapper returns. |
+| `# type: ignore[arg-type]` | *(to be filled)* | Facade call sites. |
+| `# type: ignore[operator]` | *(to be filled)* | Facade call sites. |
+| `# type: ignore[no-untyped-call]` | *(to be filled)* | Facade global calls. |
+| `# type: ignore[type-arg]` | *(to be filled)* | Bare generics. |
+| `# noqa: C901` | *(to be filled)* | `GlobalImportManager`, `DeviceFetchConfig`, `main()`. |
+| `# noqa: PLR0913` | *(to be filled)* | Same three symbols. |
+| `# noqa: E501` | *(to be filled)* | Long lines. |
+| `# nosec` (`B603`, `B404`) | *(to be filled)* | Subprocess sites. |
+| `# noqa: PLC0415` | *(to be filled)* | Late imports inside functions. |
+| `# noqa: E402` | *(to be filled)* | Module-level import order (version check pattern). |
+| `# noqa: PLW0602` | *(to be filled)* | Global-variable-not-assigned. |
+| **Total suppressions in `MistHelper.py`** | *(to be filled)* | Sum of the above. Baseline for FR-015 delta tracking. |
+
+**Note**: This file is committed with placeholder cells so the audit can be attached in the PR that lands Phase 0. The Story 1 PR MUST update the totals to concrete numbers before merge, and each subsequent story PR must record the resulting delta after its merge.
+
+### Appendix A — raw analyzer output
+
+*(Attach the `tools/refactor_analyzer/` output for `MistHelper.py` here as a fenced code block. This appendix is the reproducible baseline for FR-014 and FR-015.)*
+
+---
+
+## 3. Per-cluster fix-pattern decisions
+
+Format: **Decision** / **Rationale** / **Alternatives considered**.
+
+### Cluster #895 — Bootstrap re-exports
+
+- **Decision**: Declare `__all__` explicitly in `MistHelper.py` as an inline module-level list. Do NOT hoist to `src/_bootstrap.py` unless the hoist demonstrably reduces the total suppression count in `MistHelper.py` by ≥ 20 sites beyond what the inline `__all__` alone can achieve.
+- **Rationale**: Inline `__all__` is the smallest possible diff and preserves the file as the canonical public-API surface source. The hoist adds a new module and forces external consumers to trace one extra level of indirection for no functional benefit unless the sheer number of import lines meaningfully burdens `MistHelper.py`.
+- **Alternatives considered**:
+  - *Hoist to `src/_bootstrap.py`*: Rejected as default because it grows `src/` surface area for a hygiene benefit that inline `__all__` already delivers.
+  - *Bulk-add per-file-ignore in `pyproject.toml`*: Explicitly forbidden by FR-010.
+  - *Delete the re-export block*: Rejected because FR-007 freezes the public API surface — external tools rely on these imports.
+
+### Cluster #899 — Mypy grab-bag
+
+- **Decision**: Site-by-site fix:
+  - `assignment` sites: change `X: type[Foo] = None` to `X: type[Foo] | None = None` (or `Optional[type[Foo]]` if project style already established there).
+  - `no-any-return`: add concrete return type annotations to the affected wrappers.
+  - `arg-type`, `operator`, `misc`: per-site targeted fix (typically adding a concrete annotation or narrowing a Union).
+- **Rationale**: Each mypy error category has a canonical fix in Python type-hint idiom. No shared refactor is required.
+- **Alternatives considered**:
+  - *Blanket `Any` typing*: Rejected because it reintroduces the exact laxity the suppressions currently mask.
+  - *Union types via `typing.Union[...]`*: Rejected in favor of PEP 604 `X | Y` syntax (Python 3.13 target per constitution).
+
+### Cluster #901 — Complexity
+
+- **Decision**: Extract narrow helpers inside `GlobalImportManager`, `DeviceFetchConfig`, and `main()` per the Phase 1 `data-model.md` boundaries. Public signatures of all three symbols remain unchanged. Each extracted helper stays ≤ 25 LOC per constitution Principle I.
+- **Rationale**: The three symbols currently exceed C901 / PLR0913 thresholds by carrying multiple sub-tasks that map cleanly to named helpers (e.g., separate the "resolve import target" step from the "install into global namespace" step in `GlobalImportManager`; separate positional-arg unpacking from validation in `DeviceFetchConfig`).
+- **Alternatives considered**:
+  - *Raise the ruff thresholds*: Forbidden by FR-010.
+  - *Full class re-architecture*: Explicitly out of scope per FR-011.
+
+### Cluster #898 — no-untyped-call via Protocols
+
+- **Decision**: Add Protocol classes in `src/utils/misthelper_facade.py` (creating the module if absent per FR-012). Each Protocol covers exactly the call surface used by `MistHelper.py`; `MistHelper.py` call sites are then typed to accept the Protocol, letting mypy resolve the call without suppression.
+- **Rationale**: The suppression exists because module-level "facade globals" have implicit `Any` type. Protocols are the least-invasive typing tool for duck-typed facade patterns and do not require touching the underlying implementations.
+- **Alternatives considered**:
+  - *Concrete type import*: Rejected because it couples `MistHelper.py` to specific implementations of the underlying `src/` subsystems, breaking the facade indirection.
+  - *`cast()` at every call site*: Rejected because it produces the same runtime blindness as the current suppression, just with more syntax.
+
+### Cluster #897 — type-arg
+
+- **Decision**: Add concrete generic parameters at each site (`dict[str, Any]`, `list[SomeType]`, etc.). Prefer domain-specific value types over `Any` where the underlying value type is known.
+- **Rationale**: `type-arg` findings are always resolvable with a concrete parameter; no design decision is required beyond picking the correct value type per site.
+- **Alternatives considered**:
+  - *`# type: ignore[type-arg]` continuation*: Rejected — the whole workflow is opposed to continued suppression.
+
+### Cluster #896 — Line length
+
+- **Decision**: Hand-wrap each `E501` site. Where a line's length is driven by an unavoidably long identifier chain, extract a locally-named intermediate variable. Where the line is a literal rendered string (banner, table row, prompt), wrap using implicit string concatenation inside parentheses so the rendered output character sequence is unchanged.
+- **Rationale**: Preserves runtime output byte-for-byte, satisfies black without reflowing (black respects existing wraps under the project's line-length setting), and does not require any logic edits.
+- **Alternatives considered**:
+  - *Raise the project line length*: Forbidden by FR-010.
+  - *Blanket `# noqa: E501`*: Explicitly the anti-pattern the workflow eliminates.
+- **Rendered-output exemption list**: To be enumerated during the audit rerun. Candidates include CLI banner lines, help-text formatting, and any Rich-rendered table rows in `MistHelper.py`. This list is finalized in `research.md` before Story 6 begins.
+
+### Cluster #900 — Bandit
+
+- **Decision**: For `B603` (subprocess without `shell=True` review): audit each call site, add input validation (allow-list of executable names, `shlex.quote`-equivalent for arguments where dynamic), remove the `# nosec` once validation is in place. For `B404` (subprocess module import flagged at file top): if 3+ subprocess call sites remain post-audit, introduce `src/utils/subprocess_runner.py` as a single audited entry point and route `MistHelper.py` calls through it; if fewer than 3, keep per-site validation and add module-level justification comment.
+- **Rationale**: Constitution's "Fix Over Suppress" principle explicitly forbids `# nosec` as a shortcut. Input validation is the root-cause fix for `B603`. Centralizing subprocess import at one file is the standard remediation for `B404` and also aligns with defense-in-depth.
+- **Alternatives considered**:
+  - *`shell=True`*: Rejected outright — worse than the finding it would silence.
+  - *Whitelist `# nosec B603` unconditionally*: Forbidden by constitution and FR-008.
+
+### Cluster #902 — Long tail
+
+- **Decision**: Per-site treatment:
+  - `PLC0415` (late imports inside functions): hoist to module level where the imported symbol is safe to load eagerly. Where late import is required (circular-import avoidance, optional dependency), retain the late import but restructure so the linter's rationale is satisfied (typically by moving to a narrow helper).
+  - `E402` (module-level import ordering): remove exemption if the version-check pattern that forced it moves to a helper module; otherwise keep the version-check pattern and remove `# noqa: E402` by restructuring the block to comply.
+  - `PLW0602` (global-variable-not-assigned): declare the affected globals with typed initializers so the linter is satisfied.
+  - Residual `mypy-misc` / `name-defined` / `var-annotated`: per-site fix.
+- **Rationale**: Long-tail findings share no common refactor; each site has a canonical fix.
+- **Alternatives considered**: None — the story is the final sweep after larger structural work has landed.
+
+---
+
+## 4. Cross-cluster decisions
+
+### `subprocess_runner` helper threshold
+
+- **Decision**: Introduce `src/utils/subprocess_runner.py` (Story 7) if and only if the post-audit subprocess call-site count in `MistHelper.py` is ≥ 3. Otherwise perform per-site validation and delete `# nosec` per site.
+- **Rationale**: A one-off helper module for 1–2 call sites is over-engineered. Three or more sites justify the maintenance surface of the helper and its ≥ 90% coverage requirement (Story 7 Acceptance Scenario 3).
+
+### `__all__` hoist threshold
+
+- **Decision**: Hoist `__all__` to `src/_bootstrap.py` (Story 1) if and only if doing so reduces `MistHelper.py`'s residual suppression count by ≥ 20 beyond the inline `__all__` alternative. Otherwise the `__all__` list lives inline in `MistHelper.py`.
+- **Rationale**: The hoist has real cost (new file, new import indirection). It's worth paying only if it materially advances the zero-suppression goal.
+
+---
+
+## 5. Outstanding items requiring Phase 1 attention
+
+None — all NEEDS-CLARIFICATION items from the spec were resolved during spec authoring, and the fix-pattern decisions above resolve the remaining research questions. Phase 1 design (`data-model.md`, `contracts/`) can proceed on the strength of the decisions in this document.

--- a/specs/1016-misthelper-suppression-cleanup/spec.md
+++ b/specs/1016-misthelper-suppression-cleanup/spec.md
@@ -1,0 +1,210 @@
+# Feature Specification: MistHelper.py Suppression Cleanup
+
+**Feature Branch**: `1016-misthelper-suppression-cleanup`
+
+**Created**: 2026-07-13
+
+**Status**: Draft
+
+**Input**: User description: "MistHelper.py suppression cleanup — drive to zero the 8 issue clusters #895–#902 in MistHelper.py."
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Each user story below corresponds to one GitHub issue (#895–#902) and is delivered
+  as one independent pull request. Stories are ordered by the required merge sequence:
+  bootstrap-first, type-hardening middle, cleanup last. Each story is independently
+  testable, reviewable, and revertable — landing any single story removes real
+  suppressions from MistHelper.py and closes exactly one tracked issue.
+-->
+
+### User Story 1 - Bootstrap Re-Export Suppression Removal (#895) (Priority: P1)
+
+Codebase maintainers need `MistHelper.py`'s bootstrap re-exports (the block that pulls names from `src/` modules for backward compatibility with external tools) to satisfy static-analysis import rules without per-line suppressions, so that unused-import detection produces trustworthy signal across the module.
+
+**Why this priority**: This is the largest single cluster (~124 combined `F401` + `pylint:unused-import` sites) and it blocks accurate import analysis for every subsequent story. Landing it first removes cross-talk between clusters and shrinks the review surface of later PRs.
+
+**Independent Test**: After merge, `ruff check MistHelper.py --select F401` and `pylint MistHelper.py --disable=all --enable=unused-import` both report zero findings, and `python -c "import MistHelper; print(len(MistHelper.__all__))"` succeeds. External tooling that imports names such as `from MistHelper import DeviceFetchConfig` continues to work unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper.py at HEAD of the PR branch, **When** ruff + pylint run under CI, **Then** zero `F401` and zero `unused-import` findings remain and no `# noqa: F401` or `# pylint: disable=unused-import` comments exist in the file.
+2. **Given** the merged PR, **When** an external caller runs `from MistHelper import <any previously re-exported symbol>`, **Then** the import resolves to the same object it did before the PR.
+3. **Given** the merged PR, **When** the audit script (`tools/refactor_analyzer/`) is re-run, **Then** the total count of MistHelper.py suppressions has dropped by at least 120.
+
+---
+
+### User Story 2 - Mypy Grab-Bag Suppression Removal (#899) (Priority: P2)
+
+Codebase maintainers need the mixed mypy suppression cluster (`misc`, `assignment`, `no-any-return`, `arg-type`, `operator`) in MistHelper.py eliminated so that type checking produces honest results and unblocks the downstream typing PRs.
+
+**Why this priority**: Fixing the `assignment` sites (typically `X: type[Foo] | None = None` at bootstrap-time) removes the Any-typed globals that cascade into the `no-untyped-call` findings addressed in Story 4. It must land before Story 4 to avoid re-work.
+
+**Independent Test**: After merge, `mypy MistHelper.py --strict` (or the project's current mypy configuration) reports zero findings in categories `misc`, `assignment`, `no-any-return`, `arg-type`, and `operator`, and no `# type: ignore[misc|assignment|no-any-return|arg-type|operator]` comments remain in MistHelper.py.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper.py at HEAD of the PR branch, **When** mypy runs under CI, **Then** the five targeted error categories return zero findings in MistHelper.py.
+2. **Given** the merged PR, **When** the file is grepped for `# type: ignore[misc`, `# type: ignore[assignment`, `# type: ignore[no-any-return`, `# type: ignore[arg-type`, `# type: ignore[operator`, **Then** zero matches are returned.
+3. **Given** the merged PR, **When** downstream callers of MistHelper's public API run their existing test suites, **Then** all tests pass without modification.
+
+---
+
+### User Story 3 - Complexity Cluster Reduction (#901) (Priority: P3)
+
+Codebase maintainers need the remaining `C901` (cyclomatic complexity) and `PLR0913` (too-many-arguments) findings on `GlobalImportManager`, `DeviceFetchConfig`, and `main()` removed by extracting narrow helper functions/methods, so those symbols become testable and readable without per-symbol suppressions.
+
+**Why this priority**: Reducing surface area on these three symbols shrinks the code that later stories (typing, line-length, bandit) must edit, reducing merge conflicts and rework.
+
+**Independent Test**: After merge, `ruff check MistHelper.py --select C901,PLR0913` returns zero findings, no `# noqa: C901` or `# noqa: PLR0913` comments remain, and each extracted helper has at least one unit test invoked from the existing test suite. The public signature of `GlobalImportManager`, `DeviceFetchConfig`, and `main()` is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper.py at HEAD of the PR branch, **When** ruff runs under CI, **Then** zero `C901` and zero `PLR0913` findings remain in the file.
+2. **Given** the merged PR, **When** external code calls `MistHelper.GlobalImportManager(...)`, `MistHelper.DeviceFetchConfig(...)`, or invokes `MistHelper.main()`, **Then** behavior and return values are identical to pre-PR HEAD.
+3. **Given** the merged PR, **When** pytest runs, **Then** coverage on the extracted helpers is at least 90% and the overall project coverage gate (90%) still passes.
+
+---
+
+### User Story 4 - No-Untyped-Call Suppression Removal (#898) (Priority: P4)
+
+Codebase maintainers need the `no-untyped-call` cluster removed by promoting the Any-typed facade globals in `src/utils/misthelper_facade.py` to `Protocol` classes, so mypy can resolve call sites through the facade without per-call suppressions.
+
+**Why this priority**: This depends on Story 2's assignment fixes and is best done after Story 3's complexity extractions, since the extracted helpers may participate in facade calls.
+
+**Independent Test**: After merge, `mypy MistHelper.py --strict` reports zero `no-untyped-call` findings, and no `# type: ignore[no-untyped-call]` comments remain in MistHelper.py. `src/utils/misthelper_facade.py` defines one or more `Protocol` classes covering the facade surface.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper.py at HEAD of the PR branch, **When** mypy runs under CI, **Then** zero `no-untyped-call` findings remain in the file.
+2. **Given** the merged PR, **When** external code that reads or writes to the facade attributes runs, **Then** behavior is unchanged.
+3. **Given** the merged PR, **When** the Protocol classes are inspected, **Then** they cover the exact call surface used by MistHelper.py (no unused methods, no missing methods).
+
+---
+
+### User Story 5 - Type-Arg Suppression Removal (#897) (Priority: P5)
+
+Codebase maintainers need the `mypy:type-arg` cluster removed by providing concrete generic annotations (`dict[str, Any]`, `list[SomeType]`, etc.) at the call sites, so bare-generic warnings disappear without suppression.
+
+**Why this priority**: Small, isolated cluster (3 sites). Runs after the larger typing PRs so the concrete types can reference stabilized Protocol classes and helper signatures from Stories 2–4.
+
+**Independent Test**: After merge, `mypy MistHelper.py --strict` reports zero `type-arg` findings, and no `# type: ignore[type-arg]` comments remain in MistHelper.py.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper.py at HEAD of the PR branch, **When** mypy runs under CI, **Then** zero `type-arg` findings remain in the file.
+2. **Given** the merged PR, **When** external callers pass through the newly-annotated parameters, **Then** they see no runtime behavior change.
+
+---
+
+### User Story 6 - Line-Length Suppression Removal (#896) (Priority: P6)
+
+Codebase maintainers need the `E501` line-length findings in MistHelper.py eliminated by hand-wrapping the offending lines (or, where clearly warranted, extracting a small helper), so the file conforms to the project line-length gate without suppressions.
+
+**Why this priority**: Line-wrapping frequently reflows lines that neighboring typing PRs also touch. Landing E501 after all typing/complexity PRs prevents merge conflicts and rewrites.
+
+**Independent Test**: After merge, `ruff check MistHelper.py --select E501` returns zero findings and no `# noqa: E501` comments remain in the file.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper.py at HEAD of the PR branch, **When** ruff runs under CI, **Then** zero `E501` findings remain in the file.
+2. **Given** the merged PR, **When** `black --check MistHelper.py` runs, **Then** it reports no diffs.
+3. **Given** the merged PR, **When** the file is diffed against pre-PR HEAD, **Then** no logic changes are present — only whitespace, parenthesization, and narrow helper extractions.
+
+---
+
+### User Story 7 - Bandit Suppression Removal (#900) (Priority: P7)
+
+Codebase maintainers need the `bandit` cluster (dominated by `B603` subprocess-without-shell-equals-true, plus `B404` and others) removed by performing an input-validation audit on each subprocess call site and centralizing invocation through a new `subprocess_runner` helper module where appropriate, so security suppressions are backed by verified safe usage rather than blanket `# nosec`.
+
+**Why this priority**: Bandit-related work touches subprocess call sites, some of which are inside code paths reshaped by Stories 3 (complexity) and 4 (typing). Landing this after those changes ensures the security review lands on stable code.
+
+**Independent Test**: After merge, `bandit -r MistHelper.py` reports zero findings, no `# nosec` comments remain in the file, and each affected subprocess call site is either (a) documented as safe with validated inputs or (b) refactored to route through `subprocess_runner`.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper.py at HEAD of the PR branch, **When** bandit runs under CI, **Then** zero findings remain in the file.
+2. **Given** the merged PR, **When** subprocess invocations execute end-to-end (either via existing tests or the security audit checklist), **Then** all inputs are validated at or before invocation and no new attack surface is introduced.
+3. **Given** the merged PR, **When** the `subprocess_runner` helper (if introduced) is unit tested, **Then** coverage is at least 90%.
+
+---
+
+### User Story 8 - Long-Tail Cleanup (#902) (Priority: P8)
+
+Codebase maintainers need the residual long-tail suppressions in MistHelper.py (`PLC0415` late imports, `E402` module-level import order, remaining `mypy-misc`, `PLW0602` global-variable-not-assigned, structural/pragma tags) resolved as a final sweep, so the module reaches the zero-suppression success state.
+
+**Why this priority**: This is the final sweep — it depends on all prior clusters being clean so that the residual set is well-defined and no new suppressions appear as side effects of earlier PRs.
+
+**Independent Test**: After merge, MistHelper.py contains zero occurrences of `# noqa`, `# type: ignore`, `# nosec`, and `# pylint: disable`. Full lint stack (`ruff check`, `pylint`, `mypy --strict`, `bandit -r`, `black --check`) passes on the file with no suppressions.
+
+**Acceptance Scenarios**:
+
+1. **Given** MistHelper.py at HEAD of the PR branch, **When** all four lint tools run under CI, **Then** zero findings and zero suppression comments remain.
+2. **Given** the merged PR, **When** the file is grepped for the suppression patterns listed above, **Then** the match count is exactly zero.
+3. **Given** the merged PR, **When** `pyproject.toml` is diffed against the state at the start of the workflow, **Then** the only changes are per-file-ignore removals — no rule disables, no fail-under lowering.
+
+---
+
+### Edge Cases
+
+- **Public API drift**: If a helper extraction (Story 3 or 7) is tempted to change a public class/function signature, the PR MUST be scoped down — public API is frozen by an FR below.
+- **Merge conflict from CI**: If any PR fails to merge cleanly on main (e.g., because a peer PR landed first), the branch is rebased and re-tested; no `--admin` bypass is used and no merge proceeds unless `mergeStateStatus=CLEAN`.
+- **New suppressions introduced by a PR**: The PR is rejected in review; the author must either resolve the root cause or split the change into a follow-up story. No new suppressions may be introduced anywhere in the repo.
+- **Coverage regression on an extracted helper**: If Story 3 or 7 extracts a helper that lands below 90% coverage, the PR must add tests before merge; the project coverage gate must not drop.
+- **CI stale audit**: If the audit numbers in the delivery ordering shift materially before a PR is opened (e.g., another workflow lands and touches MistHelper.py), the workflow lead refreshes the audit via `tools/refactor_analyzer/` and adjusts remaining stories.
+- **Assumption mismatch on facade Protocol coverage (Story 4)**: If the Protocol classes cannot cover a call surface without altering signatures, that call site is documented and deferred to a follow-up issue rather than suppressed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The workflow MUST deliver exactly 8 pull requests, one per GitHub issue in the set `{#895, #896, #897, #898, #899, #900, #901, #902}`, in the ordered sequence `[#895, #899, #901, #898, #897, #896, #900, #902]`.
+- **FR-002**: Each pull request MUST fully close its target GitHub issue on merge, referenced via a `Closes #NNN` trailer in the PR description or squash commit body.
+- **FR-003**: The workflow MUST use serial dispatch: pull request N+1 MUST NOT be opened until pull request N has landed cleanly on `main`.
+- **FR-004**: Each pull request MUST originate from its own short-lived branch cut from the current `main` at the moment the PR is opened; the `1016-misthelper-suppression-cleanup` feature branch is used ONLY as the coordination home for spec/plan/tasks artifacts, not as the base for the 8 delivery PRs.
+- **FR-005**: Each pull request MUST pass `black --check` and `ruff check` locally before being pushed to the remote branch.
+- **FR-006**: No pull request MUST use administrative merge bypass; each PR MUST wait for `mergeStateStatus=CLEAN` before merging.
+- **FR-007**: The public API surface of `MistHelper.py` (the set of names exported to external tools, including but not limited to those currently accessible via `from MistHelper import ...`) MUST remain unchanged across all 8 pull requests. Public API is defined by the set of module-level names accessible on the `MistHelper` module object at the start of this workflow.
+- **FR-008**: No pull request MUST introduce a new `# noqa`, `# type: ignore`, `# nosec`, or `# pylint: disable` comment anywhere in the repository. A CI check or manual review step MUST enforce this.
+- **FR-009**: The project's continuous-integration pipeline MUST remain green on every merged commit produced by this workflow.
+- **FR-010**: Modifications to `pyproject.toml` (or equivalent lint tool configuration) MUST be restricted to per-file-ignore removals; no rule disables, no fail-under threshold changes, and no bulk rule suppressions are permitted.
+- **FR-011**: The workflow MUST NOT extract further classes or functions from `MistHelper.py` beyond the narrow helper additions explicitly required to eliminate a suppression in the current story.
+- **FR-012**: The workflow MUST NOT modify files under `src/` except to (a) add Protocol classes to `src/utils/misthelper_facade.py` (Story 4) or (b) add a `subprocess_runner` helper module (Story 7), and only when those additions are load-bearing for the current story's suppression fix.
+- **FR-013**: On completion of all 8 pull requests, `MistHelper.py` MUST contain zero occurrences of `# noqa`, zero `# type: ignore`, zero `# nosec`, and zero `# pylint: disable` comments.
+- **FR-014**: The workflow MUST adopt the fresh 2026-07-13 audit numbers (rerun through `tools/refactor_analyzer/`) as ground truth for story sizing; stale projections in issue bodies MUST NOT gate merge decisions.
+- **FR-015**: Each pull request MUST include or link to an updated audit report showing the delta in suppression counts caused by that PR.
+- **FR-016**: The project's coverage threshold of 90% and pylint fail-under threshold of 9.5 MUST both continue to hold on every merged commit.
+
+### Key Entities *(include if feature involves data)*
+
+- **Suppression Comment**: An inline directive of one of four forms (`# noqa`, `# type: ignore`, `# nosec`, `# pylint: disable`) that instructs a lint or type tool to skip a specific rule at a specific site. In `MistHelper.py`, each such comment is a work item; success is measured by driving the count to zero.
+- **Issue Cluster**: A themed group of suppressions tracked by a single GitHub issue (`#895` through `#902`). Each cluster maps 1:1 to a User Story and 1:1 to a delivery pull request.
+- **Bootstrap Re-Export Block**: The section of `MistHelper.py` that re-imports names from `src/` modules for backward compatibility. Owned by Story 1; requires an `__all__` declaration (optionally hoisted into `src/_bootstrap.py`) to satisfy import rules without suppressions.
+- **Facade Global**: A module-level attribute in `MistHelper.py` (or `src/utils/misthelper_facade.py`) that currently has an implicit `Any` type, triggering `no-untyped-call` on downstream call sites. Owned by Story 4; requires a `Protocol` class describing its call surface.
+- **Public API Symbol**: A module-level name of `MistHelper.py` that is (or may be) imported by external tools. The union of these names constitutes the frozen public API surface referenced by FR-007.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After all 8 pull requests are merged, `MistHelper.py` contains exactly zero occurrences of `# noqa`, zero `# type: ignore`, zero `# nosec`, and zero `# pylint: disable` comments (verified via automated grep).
+- **SC-002**: All 8 GitHub issues in the set `{#895–#902}` are closed on the merge commit of their respective pull request, verified by GitHub's issue-linking status.
+- **SC-003**: No new suppressions are introduced anywhere in the repository during the workflow (net delta of suppression count in files outside `MistHelper.py` is zero or negative).
+- **SC-004**: CI pipeline is green on every merge commit produced by the workflow — no red builds bypassed, no `--admin` merges.
+- **SC-005**: The project coverage threshold (90%) holds on every merged commit and is at least 90.0% on the final merge commit.
+- **SC-006**: The pylint fail-under threshold (9.5) holds on every merged commit and is at least 9.5 on the final merge commit.
+- **SC-007**: The public API surface of `MistHelper.py` (module-level names) is byte-identical between the start of Story 1 and the merge commit of Story 8, verified by a diff of `dir(MistHelper)` output.
+- **SC-008**: Each of the 8 pull requests is reviewed and merged serially — no two PRs from this workflow are simultaneously open on the remote at any time.
+- **SC-009**: The end-to-end elapsed time from opening Story 1's PR to merging Story 8's PR is within the team's target of one working month (4 calendar weeks), assuming standard review cadence.
+
+## Assumptions
+
+- The fresh 2026-07-13 audit (`tools/refactor_analyzer/` output referenced in the input) is authoritative and supersedes the stale projections still cited in issue bodies of `#895–#902`.
+- The `#1014` hot-classes refactor is fully merged; no further class extractions from `MistHelper.py` are pending outside this workflow.
+- External tools that consume `MistHelper.py` continue to import via the module's current public API (i.e., no consumer is relying on private/underscore-prefixed names).
+- The project's lint stack (ruff, pylint, mypy, bandit, black) and their configured rule sets remain stable throughout the workflow; any upstream tool bump is handled outside this feature.
+- Coverage and pylint thresholds (90%, 9.5) already hold on `main` at the start of Story 1; the workflow's job is to preserve them, not raise them.
+- The `src/_bootstrap.py` module hoist mentioned as "optional" for Story 1 is genuinely optional — the `__all__` declaration alone suffices, and the hoist only happens if it materially simplifies the diff.
+- GitHub issue numbering `#895–#902` is not re-used or reassigned during the workflow; the same issue numbers referenced here remain the correct closing targets.
+- Reviewers have capacity to review 8 sequential PRs at roughly one PR per 2–3 working days, matching SC-009's target elapsed time.
+- The `tools/refactor_analyzer/` tooling remains functional and can be re-run between stories to refresh audit deltas required by FR-015.

--- a/specs/1016-misthelper-suppression-cleanup/tasks.md
+++ b/specs/1016-misthelper-suppression-cleanup/tasks.md
@@ -1,0 +1,280 @@
+# Tasks: MistHelper.py Suppression Cleanup
+
+**Input**: Design documents from `specs/1016-misthelper-suppression-cleanup/`
+
+**Prerequisites**: `plan.md` (required), `spec.md` (required for user stories), `research.md`, `data-model.md`, `contracts/public_api.md`, `contracts/misthelper_facade_protocols.md`, `contracts/subprocess_runner.md`
+
+**Tests**: Tests are ONLY required for helpers/Protocols/subprocess_runner introduced by Stories 3, 4, and 7. No new tests for pure suppression-removal PRs.
+
+**Organization**: Tasks are grouped by delivery pull request (T-01 through T-08 map to PR-1 through PR-8), plus a T-09 final workflow-level verification. Every PR is strictly sequential per FR-003 (SC-008) — PR N+1 does NOT open until PR N is merged. Within a PR, sub-tasks are strictly sequential unless marked `[P]`.
+
+## Format: `[TaskID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel with other `[P]` tasks in the same PR (different files/edits, no ordering deps)
+- **[Story]**: Which user story this task belongs to (US1–US8, one per PR)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single-project layout (per `plan.md` Project Structure). All work lands in `MistHelper.py` at repo root, plus two conditional `src/utils/` additions:
+
+- `src/utils/misthelper_facade.py` (Story 4, mandatory)
+- `src/utils/subprocess_runner.py` (Story 7, conditional per `research.md` threshold)
+
+No other `src/` files may be modified (FR-012).
+
+---
+
+## PR-1: Issue #895 — Bootstrap `__all__` + F401/unused-import removal (Priority: P1) 🎯 MVP
+
+**Goal**: Add an `__all__` declaration to `MistHelper.py` that enumerates every re-exported symbol, then delete all `# noqa: F401` and `# pylint: disable=unused-import` comments from the bootstrap import block.
+
+**Independent Test**: After merge, `ruff check MistHelper.py --select F401` and `pylint MistHelper.py --disable=all --enable=unused-import` both report zero findings; `grep -nE '# (noqa: F401|pylint: disable=unused-import)' MistHelper.py` returns zero matches; `python -c "import MistHelper; print(len(MistHelper.__all__))"` succeeds; every `from MistHelper import <name>` used by `tools/`, `tests/`, `web_portal/`, and `wsgi.py` continues to resolve.
+
+- [ ] T-01.1 [US1] Audit: run `grep -cE '# (noqa: F401|pylint: disable=unused-import)' MistHelper.py` and record the current count in the PR body; compare against the 2026-07-13 baseline in `research.md` and flag any delta.
+- [ ] T-01.2 [US1] Branch: run `git switch main && git pull && git switch -c misthelper-bootstrap-all-895` from repo root.
+- [ ] T-01.3 [US1] Implement in `MistHelper.py`: enumerate every symbol imported by external consumers by grepping the repo for `from MistHelper import` and `import MistHelper` across `tools/`, `tests/`, `web_portal/`, and `wsgi.py`; use that union set (validated against `contracts/public_api.md`) to define `__all__ = [...]` in `MistHelper.py`; remove every `# noqa: F401` and `# pylint: disable=unused-import` comment from the bootstrap re-export block. Optionally hoist the import block to `src/_bootstrap.py` ONLY if it eliminates more suppressions than it introduces (per `research.md` hoist threshold).
+- [ ] T-01.4 [US1] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest`, then `grep -cE '# (noqa: F401|pylint: disable=unused-import)' MistHelper.py` and confirm zero. Diff `python -c "import MistHelper; print('\n'.join(sorted(dir(MistHelper))))"` against `specs/1016-misthelper-suppression-cleanup/contracts/public_api.md` to confirm SC-007.
+- [ ] T-01.5 [US1] Commit + push: stage `MistHelper.py` (and `src/_bootstrap.py` if the hoist was taken); commit with a body referencing the audit delta; push the `misthelper-bootstrap-all-895` branch to remote.
+- [ ] T-01.6 [US1] Open PR with `Closes #895` trailer using `gh pr create --base main --head misthelper-bootstrap-all-895` and include the pre/post grep counts in the PR body per FR-015.
+- [ ] T-01.7 [US1] Wait for CI + `mergeStateStatus=CLEAN`: poll `gh pr view <N> --json mergeStateStatus,statusCheckRollup` until state is CLEAN and all required checks are SUCCESS.
+- [ ] T-01.8 [US1] Arm auto-merge and land: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch` (no `--admin` bypass under any circumstance per FR-006).
+- [ ] T-01.9 [US1] Confirm merged: `gh pr view <N> --json state,mergeCommit` returns `MERGED`; issue #895 is closed by GitHub auto-close; branch `misthelper-bootstrap-all-895` is deleted on remote. Refresh audit via `tools/refactor_analyzer/` and commit the refreshed numbers to the feature branch before opening PR-2.
+
+**Checkpoint**: MistHelper.py bootstrap import block is suppression-free; ~124 suppressions removed.
+
+---
+
+## PR-2: Issue #899 — Mypy grab-bag (assignment/misc/no-any-return/arg-type/operator) (Priority: P2)
+
+**Goal**: Eliminate the mixed mypy suppression cluster in `MistHelper.py`. For the 12 `assignment` sites, promote to typed declarations (`X: type[Foo] | None = None`). For the 11 `misc` sites, resolve root cause per site. For no-any-return/arg-type/operator, fix per site — no bulk pattern.
+
+**Independent Test**: After merge, `mypy MistHelper.py --strict` reports zero findings in categories `misc`, `assignment`, `no-any-return`, `arg-type`, `operator`; `grep -nE '# type: ignore\[(misc|assignment|no-any-return|arg-type|operator)' MistHelper.py` returns zero matches.
+
+- [ ] T-02.1 [US2] Audit: run `grep -cE '# type: ignore\[(misc|assignment|no-any-return|arg-type|operator)' MistHelper.py` and record the count per subcategory; compare against `research.md` 2026-07-13 baseline and flag any delta.
+- [ ] T-02.2 [US2] Branch: run `git switch main && git pull && git switch -c misthelper-mypy-grabbag-899`.
+- [ ] T-02.3 [US2] Implement in `MistHelper.py`: for each of the 12 `assignment` sites, replace `X = None  # type: ignore[assignment]` with `X: type[Foo] | None = None` (use the concrete class name — no `Any`); for each of the 11 `misc` sites, read the surrounding call context and fix the root cause (typically a legitimate `Any` narrowing, an incorrect return-type declaration, or a missing overload). For no-any-return, arg-type, and operator sites, fix per site: add explicit return annotations for no-any-return; narrow argument types for arg-type; add `__add__`/`__eq__`-style method signatures or use `typing.cast` sparingly for operator. Delete every matching `# type: ignore[...]` comment.
+- [ ] T-02.4 [US2] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest`, `mypy MistHelper.py --strict`, then `grep -cE '# type: ignore\[(misc|assignment|no-any-return|arg-type|operator)' MistHelper.py` — confirm zero. Diff `dir(MistHelper)` against `contracts/public_api.md`.
+- [ ] T-02.5 [US2] Commit + push: stage `MistHelper.py`; commit with the pre/post grep counts in the body; push the branch.
+- [ ] T-02.6 [US2] Open PR with `Closes #899` trailer via `gh pr create --base main --head misthelper-mypy-grabbag-899`; include audit delta per FR-015.
+- [ ] T-02.7 [US2] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-02.8 [US2] Arm auto-merge and land: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-02.9 [US2] Confirm merged, #899 closed, branch deleted; refresh audit via `tools/refactor_analyzer/` before PR-3.
+
+**Checkpoint**: Assignment/misc/no-any-return/arg-type/operator suppressions in MistHelper.py are zero.
+
+---
+
+## PR-3: Issue #901 — Complexity extraction (C901 + PLR0913) (Priority: P3)
+
+**Goal**: Extract narrow helper methods inside `GlobalImportManager`, split `main()` argparser + dispatch, and break `DeviceFetchConfig`'s PLR0913 signature via a small dataclass or two-phase init. Public signatures of all three symbols MUST remain unchanged.
+
+**Independent Test**: After merge, `ruff check MistHelper.py --select C901,PLR0913` returns zero findings; no `# noqa: C901` or `# noqa: PLR0913` comments remain; each extracted helper has ≥1 unit test with helper coverage ≥ 90%; overall project coverage ≥ 90%.
+
+- [ ] T-03.1 [US3] Audit: run `grep -cE '# noqa: (C901|PLR0913)' MistHelper.py` and record; compare against `research.md` baseline.
+- [ ] T-03.2 [US3] Branch: run `git switch main && git pull && git switch -c misthelper-complexity-901`.
+- [ ] T-03.3 [US3] Implement in `MistHelper.py`: (a) extract narrow helper methods inside `GlobalImportManager` per the boundaries enumerated in `data-model.md` (each helper ≤ 25 lines, single responsibility, inline-commented per constitution Principle VI); (b) split `main()` into `_build_arg_parser()` + `_dispatch_command()` helpers plus a thin `main()` orchestrator; (c) break `DeviceFetchConfig`'s PLR0913 signature by grouping args into a small dataclass or two-phase init as chosen in `data-model.md`. Delete every `# noqa: C901` and `# noqa: PLR0913` comment. Public signatures of `GlobalImportManager`, `DeviceFetchConfig`, and `main()` MUST be byte-identical to pre-PR HEAD.
+- [ ] T-03.4 [US3] Add tests: land at least one unit test per extracted helper in `tests/` (next to the closest existing test file); confirm helper coverage ≥ 90% via `pytest --cov`.
+- [ ] T-03.5 [US3] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov`, `pylint --fail-under=9.5 MistHelper.py`, then `grep -cE '# noqa: (C901|PLR0913)' MistHelper.py` — confirm zero. Diff `dir(MistHelper)` against `contracts/public_api.md`.
+- [ ] T-03.6 [US3] Commit + push: stage `MistHelper.py` and new test files; push the branch.
+- [ ] T-03.7 [US3] Open PR with `Closes #901` trailer via `gh pr create --base main --head misthelper-complexity-901`; include audit delta and coverage numbers per FR-015.
+- [ ] T-03.8 [US3] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-03.9 [US3] Arm auto-merge and land: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`; confirm #901 closed, branch deleted; refresh audit before PR-4.
+
+**Checkpoint**: `GlobalImportManager`, `DeviceFetchConfig`, and `main()` are C901/PLR0913-clean; their public signatures are unchanged.
+
+---
+
+## PR-4: Issue #898 — no-untyped-call via Protocol classes (Priority: P4)
+
+**Goal**: Read `contracts/misthelper_facade_protocols.md`, create/update `src/utils/misthelper_facade.py` with Protocol classes typing every Any-typed facade global (mistapi client, session-like objects, etc.), retype the module-level declarations in `MistHelper.py` using those Protocols, and delete every `# type: ignore[no-untyped-call]` comment.
+
+**Independent Test**: After merge, `mypy MistHelper.py --strict` reports zero `no-untyped-call` findings; no `# type: ignore[no-untyped-call]` comments remain in `MistHelper.py`; `src/utils/misthelper_facade.py` defines Protocol classes whose method coverage is exact (no unused methods, no missing methods) per Story 4 Acceptance Scenario 3.
+
+- [ ] T-04.1 [US4] Audit: run `grep -cE '# type: ignore\[no-untyped-call' MistHelper.py` and record; compare against `research.md`.
+- [ ] T-04.2 [US4] Branch: run `git switch main && git pull && git switch -c misthelper-facade-protocols-898`.
+- [ ] T-04.3 [US4] Implement Protocols in `src/utils/misthelper_facade.py`: create the Protocol classes per `contracts/misthelper_facade_protocols.md`, one class per facade surface (mistapi client, session-like objects, etc.), each with the exact method signatures the contract specifies. Inline-comment each Protocol per constitution Principle VI.
+- [ ] T-04.4 [US4] Retype declarations in `MistHelper.py`: annotate every module-level facade global with the Protocol from step T-04.3 (e.g., `mistapi_client: MistApiClientProtocol | None = None`). Delete every `# type: ignore[no-untyped-call]` comment.
+- [ ] T-04.5 [US4] Add Protocol coverage tests: land tests under `tests/` verifying the Protocol classes match the exact facade surface (structural conformance test); confirm no unused methods, no missing methods per Story 4 Acceptance Scenario 3.
+- [ ] T-04.6 [US4] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest`, `mypy MistHelper.py src/utils/misthelper_facade.py --strict`, then `grep -cE '# type: ignore\[no-untyped-call' MistHelper.py` — confirm zero. Diff `dir(MistHelper)` against `contracts/public_api.md`.
+- [ ] T-04.7 [US4] Commit + push + open PR with `Closes #898` via `gh pr create --base main --head misthelper-facade-protocols-898`; include audit delta.
+- [ ] T-04.8 [US4] Wait for CI + `mergeStateStatus=CLEAN`; arm auto-merge with `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-04.9 [US4] Confirm merged, #898 closed, branch deleted; refresh audit before PR-5.
+
+**Checkpoint**: All no-untyped-call sites in `MistHelper.py` resolve through Protocol classes.
+
+---
+
+## PR-5: Issue #897 — type-arg concrete generics (Priority: P5)
+
+**Goal**: Grep the 3 `type-arg` sites in `MistHelper.py`, add concrete generic parameters (`dict[str, Any]`, `list[SomeType]`, etc.), and delete the ignores.
+
+**Independent Test**: After merge, `mypy MistHelper.py --strict` reports zero `type-arg` findings; `grep -nE '# type: ignore\[type-arg' MistHelper.py` returns zero matches.
+
+- [ ] T-05.1 [US5] Audit: run `grep -cE '# type: ignore\[type-arg' MistHelper.py`, expect ~3 sites; compare against `research.md`.
+- [ ] T-05.2 [US5] Branch: run `git switch main && git pull && git switch -c misthelper-typearg-897`.
+- [ ] T-05.3 [US5] Implement in `MistHelper.py`: for each of the 3 `type-arg` sites, add the concrete generic parameter (`dict[str, Any]`, `list[SomeType]`, or the specific type indicated by call-site inspection — never bare `dict` or `list`); delete each `# type: ignore[type-arg]` comment.
+- [ ] T-05.4 [US5] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest`, `mypy MistHelper.py --strict`, then `grep -cE '# type: ignore\[type-arg' MistHelper.py` — confirm zero. Diff `dir(MistHelper)` against `contracts/public_api.md`.
+- [ ] T-05.5 [US5] Commit + push + open PR with `Closes #897` via `gh pr create --base main --head misthelper-typearg-897`; include audit delta.
+- [ ] T-05.6 [US5] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-05.7 [US5] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-05.8 [US5] Confirm merged, #897 closed, branch deleted; refresh audit before PR-6.
+
+**Checkpoint**: All type-arg suppressions in MistHelper.py are zero.
+
+---
+
+## PR-6: Issue #896 — E501 line-length hand-wrap (Priority: P6)
+
+**Goal**: Hand-wrap each of the 54 `E501` lines in `MistHelper.py` (or, where clearly warranted, extract a narrow helper). Constraints: never reflow literal template strings or user-facing multi-line prompts; if any line is a literal template, escalate — do not force-wrap.
+
+**Independent Test**: After merge, `ruff check MistHelper.py --select E501` returns zero findings; `grep -nE '# noqa: E501' MistHelper.py` returns zero matches; `black --check MistHelper.py` reports no diffs; file diff contains no logic changes, only whitespace/parenthesization/narrow-helper extractions.
+
+- [ ] T-06.1 [US6] Audit: run `grep -cE '# noqa: E501' MistHelper.py`, expect ~54 sites; compare against `research.md`. Cross-reference each site against the rendered-output-exempt list in `research.md` and confirm the escalation set is empty (if not, halt and escalate per Story 6 constraints).
+- [ ] T-06.2 [US6] Branch: run `git switch main && git pull && git switch -c misthelper-line-length-896`.
+- [ ] T-06.3 [US6] Implement in `MistHelper.py`: hand-wrap each of the 54 `E501` lines using black-compatible parenthesization, trailing commas, and continuation-line indentation. Where a single-line f-string clearly warrants a helper (e.g., building a multi-line log record), extract a narrow helper (≤ 10 lines) rather than force-wrap. Never reflow literal template strings or user-facing multi-line prompts; those must be hand-wrapped without changing rendered characters (per `plan_wave_builder.py` precedent). Delete every `# noqa: E501` comment.
+- [ ] T-06.4 [US6] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest`, then `grep -cE '# noqa: E501' MistHelper.py` — confirm zero. Confirm rendered CLI output is byte-identical (spot-check `python -m MistHelper --help` output against pre-PR HEAD). Diff `dir(MistHelper)` against `contracts/public_api.md`.
+- [ ] T-06.5 [US6] Commit + push + open PR with `Closes #896` via `gh pr create --base main --head misthelper-line-length-896`; include audit delta per FR-015; note in the PR body that the diff contains no logic changes.
+- [ ] T-06.6 [US6] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-06.7 [US6] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-06.8 [US6] Confirm merged, #896 closed, branch deleted; refresh audit before PR-7.
+
+**Checkpoint**: All E501 suppressions in MistHelper.py are zero.
+
+---
+
+## PR-7: Issue #900 — Bandit subprocess audit + `subprocess_runner` helper (Priority: P7)
+
+**Goal**: For 9 `B603` subprocess sites, audit input validation. Where inputs come from validated CLI args or hardcoded values, remove `nosec` after documenting the validation. Where inputs are untrusted, add explicit allow-list validation. For `B404` module-import `nosec`, create `src/utils/subprocess_runner.py` per contract; move the `subprocess` import there once; call sites use the helper's exported functions.
+
+**Independent Test**: After merge, `bandit -r MistHelper.py` reports zero findings; `grep -nE '# nosec' MistHelper.py` returns zero matches; each affected subprocess call site is either (a) documented with validated inputs in an inline comment or (b) routed through `subprocess_runner`; if `subprocess_runner.py` was introduced, its coverage ≥ 90%.
+
+- [ ] T-07.1 [US7] Audit: run `grep -cE '# nosec' MistHelper.py`, expect ~10 sites (9 B603 + 1 B404); enumerate each site with its subprocess-call context. Compare against `research.md` 2026-07-13 baseline and confirm the `subprocess_runner` threshold decision (introduce helper if ≥ 3 call sites remain post-validation; else per-site validation only).
+- [ ] T-07.2 [US7] Branch: run `git switch main && git pull && git switch -c misthelper-bandit-subprocess-900`.
+- [ ] T-07.3 [US7] [P] Implement `src/utils/subprocess_runner.py` (conditional, only if T-07.1 triggered the threshold): create the helper per `contracts/subprocess_runner.md` — one public entry point (e.g., `run_validated(cmd: list[str], *, allow_list: Sequence[str], ...)`), input-validation contract via allow-list, explicit error-handling contract, structured logging per constitution Principle VII. Move the `subprocess` import to this module so `B404` collapses to one call site. Inline-comment per constitution Principle VI.
+- [ ] T-07.4 [US7] [P] Add tests for `subprocess_runner` (if introduced): land tests under `tests/` covering happy path, allow-list rejection, and error propagation; confirm coverage ≥ 90% via `pytest --cov=src.utils.subprocess_runner`.
+- [ ] T-07.5 [US7] Retype call sites in `MistHelper.py`: for each of the 9 B603 sites, either (a) document inline validation and delete `# nosec` where inputs are validated CLI args or hardcoded, or (b) route the call through `subprocess_runner.run_validated(...)`. Delete every `# nosec` comment.
+- [ ] T-07.6 [US7] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov`, `bandit -r MistHelper.py src/utils/subprocess_runner.py`, then `grep -cE '# nosec' MistHelper.py` — confirm zero. Diff `dir(MistHelper)` against `contracts/public_api.md`.
+- [ ] T-07.7 [US7] Commit + push + open PR with `Closes #900` via `gh pr create --base main --head misthelper-bandit-subprocess-900`; include audit delta and (if applicable) `subprocess_runner` coverage numbers per FR-015.
+- [ ] T-07.8 [US7] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-07.9 [US7] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`; confirm merged, #900 closed, branch deleted; refresh audit before PR-8.
+
+**Checkpoint**: All bandit suppressions in MistHelper.py are zero; subprocess call sites are validated or routed through `subprocess_runner`.
+
+---
+
+## PR-8: Issue #902 — Long-tail sweep (PLC0415 / E402 / residual mypy-misc / etc.) (Priority: P8)
+
+**Goal**: Per-site fixes for `PLC0415` (2 late-import sites — hoist if safe), `E402` (7 sites — mostly the version-check preamble; document if unavoidable and remove exemption), and remaining `mypy-misc`/`name-defined`/`var-annotated` per site. Any sites that truly cannot be fixed require a `plan.md` update explaining why — this should not happen because spec forbids new suppressions.
+
+**Independent Test** (also serves as the final SC-001 gate): After merge, `grep -nE '# (noqa|type: ignore|nosec|pylint: disable)' MistHelper.py` returns zero matches; full lint stack (`ruff check`, `pylint`, `mypy --strict`, `bandit -r`, `black --check`) passes on the file with no suppressions.
+
+- [ ] T-08.1 [US8] Audit: run `grep -nE '# (noqa|type: ignore|nosec|pylint: disable)' MistHelper.py`; every remaining match belongs to this PR. Categorize per rule (PLC0415, E402, mypy-misc, name-defined, var-annotated, PLW0602) and compare against `research.md` baseline.
+- [ ] T-08.2 [US8] Branch: run `git switch main && git pull && git switch -c misthelper-long-tail-902`.
+- [ ] T-08.3 [US8] Implement in `MistHelper.py`: (a) for 2 `PLC0415` late-import sites, hoist to the module-level import block if safe (no circular-import risk, no lazy-load requirement); if unsafe, escalate — do NOT suppress. (b) For 7 `E402` sites, remove the exemption where the version-check preamble can move (or where the pattern can be restructured); if the version-check preamble MUST remain before imports, restructure `pyproject.toml`'s per-file-ignore only (FR-010 allows per-file-ignore removals, not additions — if the constraint is truly unresolvable, halt and update `plan.md`). (c) For each residual `mypy-misc`, `name-defined`, `var-annotated`, and `PLW0602` site, fix per site (declare missing names, add explicit annotations, resolve global-not-assigned by proper initialization). Delete every remaining `# noqa`, `# type: ignore`, `# nosec`, and `# pylint: disable` comment in `MistHelper.py`.
+- [ ] T-08.4 [US8] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest`, `mypy MistHelper.py --strict`, `pylint --fail-under=9.5 MistHelper.py`, `bandit -r MistHelper.py`, then run the final zero-suppression grep: `grep -nE '# (noqa|type: ignore|nosec|pylint: disable)' MistHelper.py` — MUST return zero output. Diff `dir(MistHelper)` against `contracts/public_api.md`.
+- [ ] T-08.5 [US8] Commit + push + open PR with `Closes #902` via `gh pr create --base main --head misthelper-long-tail-902`; include final audit delta per FR-015 and explicit confirmation that the zero-suppression grep returns nothing.
+- [ ] T-08.6 [US8] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-08.7 [US8] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-08.8 [US8] Confirm merged, #902 closed, branch deleted.
+
+**Checkpoint**: MistHelper.py has zero suppressions of any family.
+
+---
+
+## T-09: Final workflow verification (post-PR-8)
+
+**Purpose**: Confirm all 8 issues are closed, the zero-suppression state holds, and workflow-level success criteria SC-001 through SC-008 are all satisfied.
+
+- [ ] T-09.1 Run the definitive zero-suppression grep against `MistHelper.py`:
+  ```bash
+  grep -nE '# (noqa|type: ignore|nosec|pylint: disable)' MistHelper.py
+  ```
+  Expect zero output. If any match appears, halt and open a follow-up issue — do not close the workflow.
+- [ ] T-09.2 Confirm all 8 issues (#895, #896, #897, #898, #899, #900, #901, #902) are closed by running `gh issue view <NNN> --json state` for each and verifying `state=CLOSED`.
+- [ ] T-09.3 Confirm public API surface is byte-identical to workflow start: diff `python -c "import MistHelper; print('\n'.join(sorted(dir(MistHelper))))"` against `specs/1016-misthelper-suppression-cleanup/contracts/public_api.md`; the diff MUST be empty (SC-007).
+- [ ] T-09.4 Confirm project coverage ≥ 90% on the merge commit of PR-8 (SC-005) and pylint ≥ 9.5 (SC-006).
+- [ ] T-09.5 Refresh the audit via `tools/refactor_analyzer/` and commit the final report to the feature branch; note the total suppression-count delta versus the 2026-07-13 baseline (should be exactly the sum of the per-PR deltas reported in T-01.6 through T-08.5).
+- [ ] T-09.6 Close the feature branch `1016-misthelper-suppression-cleanup` (retain locally as historical reference; no PR merges into it).
+
+**Checkpoint**: Workflow complete. `MistHelper.py` contains zero suppression comments. All 8 issues closed.
+
+---
+
+## Dependencies & Execution Order
+
+### PR-to-PR Dependencies (strict)
+
+All 8 PRs are strictly sequential per FR-003 and SC-008. PR N+1 does NOT open until PR N is merged, its branch deleted, and its target issue closed. No two workflow PRs may be open simultaneously.
+
+```
+PR-1 (#895) → PR-2 (#899) → PR-3 (#901) → PR-4 (#898) → PR-5 (#897) → PR-6 (#896) → PR-7 (#900) → PR-8 (#902) → T-09
+```
+
+Rationale (from `plan.md` § Merge ordering):
+
+- PR-1 first: removes ~124 import suppressions, cleaning lint signal for all subsequent PRs.
+- PR-2 → PR-3 → PR-4: typing/complexity braid — assignment fixes create typed globals PR-4's Protocol integration relies on; PR-3's helper extraction stabilizes the code shape PR-4 must annotate.
+- PR-5: small `type-arg` cluster piggybacks on stable Protocols.
+- PR-6: `E501` after all typing/complexity PRs so no earlier PR reflows lines PR-6 wraps.
+- PR-7: bandit after subprocess-adjacent complexity is settled.
+- PR-8: long-tail sweep last — residual set is well-defined only after all earlier clusters land.
+
+### Within-PR Dependencies
+
+Each PR's sub-tasks are strictly sequential (audit → branch → implement → verify → commit → push → PR → CI wait → merge → confirm). The only in-PR parallelism appears in PR-7, where T-07.3 (`subprocess_runner` helper creation) and T-07.4 (its tests) can be authored together with the retype work — both marked `[P]` because they touch different files (`src/utils/subprocess_runner.py`, `tests/`) versus `MistHelper.py`.
+
+### Parallel Opportunities
+
+Between PRs: none (strict serial dispatch).
+
+Within PRs:
+
+- PR-7: T-07.3 and T-07.4 are `[P]` — helper module and its tests land in different files.
+- All other PRs: single-file focus on `MistHelper.py`; no in-PR parallelism.
+
+---
+
+## Implementation Strategy
+
+### MVP Scope
+
+The MVP is PR-1 (#895) alone. Landing it drops ~124 suppressions and unblocks accurate lint signal for the remaining 7 PRs. If the workflow must pause at any point, pausing after PR-1 leaves the codebase strictly better than baseline.
+
+### Incremental Delivery
+
+Each PR delivers an independently valuable and revertable increment:
+
+1. PR-1 (#895): bootstrap `__all__` — ~124 suppressions gone; import signal trustworthy.
+2. PR-2 (#899): typing grab-bag — mypy signal trustworthy for downstream PRs.
+3. PR-3 (#901): complexity extraction — three monolithic symbols become testable.
+4. PR-4 (#898): Protocol classes — facade globals typed end-to-end.
+5. PR-5 (#897): concrete generics — small isolated win.
+6. PR-6 (#896): line-length hand-wrap — file conforms to E501 gate.
+7. PR-7 (#900): bandit audit — subprocess calls validated or routed through helper.
+8. PR-8 (#902): long-tail sweep — final zero-suppression state achieved.
+
+### Serial Execution Discipline
+
+Only one workflow PR open at a time (SC-008). After each merge:
+
+1. Wait for GitHub to auto-close the target issue.
+2. Confirm the delivery branch is deleted on remote.
+3. Refresh the audit via `tools/refactor_analyzer/`.
+4. Commit the refreshed audit to the feature branch.
+5. Open the next PR's branch from the fresh `main`.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no dependencies. Rare in this workflow — most sub-tasks are strictly sequential because they all edit `MistHelper.py`.
+- `[Story]` label maps each task to its user story / PR (US1 → PR-1, ..., US8 → PR-8).
+- Every delivery PR branches from current `main` at PR-open time (FR-004) — never from `1016-misthelper-suppression-cleanup`.
+- No `--admin` bypass anywhere (FR-006). Wait for `mergeStateStatus=CLEAN`. SKIPPED conditional checks are not blocking; failing required checks are.
+- Pre-push gate: `rtk black --check .` and `rtk ruff check .` MUST be clean before every push. Never rely on CI to catch format/lint issues.
+- No new `# noqa`, `# type: ignore`, `# nosec`, or `# pylint: disable` may be introduced anywhere in the repository (FR-008). Reviewers grep the diff.
+- `pyproject.toml` edits limited to per-file-ignore removals (FR-010).
+- Public API surface of `MistHelper.py` is frozen (FR-007); verify with `dir(MistHelper)` diff against `contracts/public_api.md` on every PR.
+- Coverage ≥ 90% and pylint ≥ 9.5 hold on every merged commit (FR-016).
+- Refresh audit between PRs; PR body must include pre/post grep counts per FR-015.


### PR DESCRIPTION
## Summary

Adds SpecKit spec/plan/tasks artifacts for the 8-issue serial cleanup of suppression comments in `MistHelper.py`.

**Scope**: drive to zero all `# noqa`, `# type: ignore`, `# nosec`, and `# pylint: disable` comments in `MistHelper.py`, covering issues #895–#902.

**Ground truth**: fresh 2026-07-13 audit (post-#1014 hot-classes refactor completion). Prior migration projections in the issue bodies are stale — the hot-classes extractions moved classes into `src/` but left suppressions on the callsites.

**Delivery model**: 8 sequential PRs, one per issue, in merge order `[#895, #899, #901, #898, #897, #896, #900, #902]`. Each PR closes its target issue via `Closes #NNN` trailer. Local `black --check` + `ruff check` mandatory before push; no `--admin` merge bypass.

## Artifacts

- `specs/1016-misthelper-suppression-cleanup/spec.md` — 8 user stories, 16 functional requirements, 9 success criteria
- `specs/1016-misthelper-suppression-cleanup/plan.md` — Phase 0/1/2 with cross-PR invariants
- `specs/1016-misthelper-suppression-cleanup/tasks.md` — 77 sub-tasks (T-01..T-09)
- `specs/1016-misthelper-suppression-cleanup/contracts/` — public_api freeze, misthelper_facade Protocols, subprocess_runner helper
- `specs/1016-misthelper-suppression-cleanup/{data-model,research,quickstart}.md`

## Test plan

- [x] `rtk black --check` and `rtk ruff check` on spec dir (markdown only — no-op)
- [x] Constitution check passes (implements "Fix Over Suppress" principle)
- [x] Spec-artifact-only diff — no code changes in this PR

Next up after merge: PR-1 for issue #895 (bootstrap `__all__` re-export cleanup).