### PR TITLE
fix(1016): remove obsolete complexity noqa in MistHelper.py (PR-3, #901)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -1890,7 +1890,7 @@ class GlobalImportManager:
     def initialize_all_imports(
         self,
         skip_deps: bool = False,
-    ) -> tuple[bool, dict[str, Any]]:  # noqa: C901, PLR0912, PLR0915
+    ) -> tuple[bool, dict[str, Any]]:
         """
         Initialize all imports and dependencies upfront.
 
@@ -1904,7 +1904,7 @@ class GlobalImportManager:
 
         return ImportInitializationService.execute(self, skip_deps=skip_deps)
 
-    def _get_global_assignments(self):  # noqa: C901, PLR0912, PLR0915
+    def _get_global_assignments(self):
         """Get dictionary of global variable assignments for imported modules."""
         from src.refactors.serial_cc.global_assignments_builder import GlobalAssignmentsBuilderService
 
@@ -3003,9 +3003,7 @@ def _install_default_request_timeout(inner_session: Any) -> None:
             self.default_timeout = default_timeout  # Reused when send() gets timeout=None
             super().__init__(**kwargs)  # Real adapter setup (connection pool, retries)
 
-        def send(  # noqa: PLR0913, STRUCT-PARAMS  # external contract: requests.HTTPAdapter.send signature
-            self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None
-        ):
+        def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
             if timeout is None:  # Caller did not supply a per-call timeout -- substitute our default
                 timeout = self.default_timeout
             # Issue #431: forward args verbatim; signature must match parent for adapter contract.


### PR DESCRIPTION
## Summary

PR-3 of workflow #1016: drives complexity/arg-count `# noqa` sites in `MistHelper.py` to **zero**.

All 3 suppressions were stale — the functions they annotated are no longer complex:

| Site | Suppression | Status after removal |
|------|-------------|---------------------|
| `initialize_all_imports` (L1893) | `# noqa: C901, PLR0912, PLR0915` | Delegates to `ImportInitializationService.execute()` (3 lines, complexity 1) |
| `_get_global_assignments` (L1907) | `# noqa: C901, PLR0912, PLR0915` | Delegates to `GlobalAssignmentsBuilderService.execute()` (3 lines, complexity 1) |
| `TimeoutAdapter.send` (L3006) | `# noqa: PLR0913, STRUCT-PARAMS` | `PLR0913` not in ruff `select = [E,F,W,I,UP,B,G]` — the annotation was a no-op |

## Verification

- `ruff check MistHelper.py` → All checks passed
- `black --check MistHelper.py` → clean
- `mypy MistHelper.py --strict` → no new errors (only pre-existing L61/L81 attr-defined outside PR-3 scope, to be swept in PR-8)
- Public API surface diff → empty (229 names preserved per `contracts/public_api_snapshot.txt`)
- Post-removal grep `noqa.*(C901|PLR091)` in MistHelper.py → 0 matches

Closes #901.

## Test plan
- [x] Ruff / black / mypy strict green
- [x] Public API surface preserved
- [x] Zero residual C901/PLR091x suppressions in MistHelper.py