### PR TITLE
fix(1016): drop unnecessary global stmt for read-only names (PR-8, #902)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -3585,7 +3585,8 @@ def _build_org_ap_upgrader(**overrides: Any) -> _OrgLevelAPFirmwareUpgrader:
     ``selected_msp`` via keyword. All remaining hooks bind to canonical
     MistHelper.py collaborators.
     """
-    global msp_privileges, apisession, selected_msp  # noqa: PLW0602  # WHY: read module globals
+    # WHY: read-only references to module globals msp_privileges/apisession/selected_msp;
+    # no assignment means `global` is unnecessary (drops PLW0602 site, initiative 1016).
     kwargs: dict[str, Any] = dict(  # WHY: build DI kwargs dict for src class
         org_id=ConfigUtils.get_cached_or_prompted_org_id() or "",
         apisession=apisession,


### PR DESCRIPTION
Closes #902 — the final PR of the 8-PR serial suppression cleanup for initiative #1016.

## What changed

Single edit in `MistHelper.py` at the `_build_org_ap_upgrader` helper: the function only READS the three module-level names `msp_privileges`, `apisession`, and `selected_msp`; there is no assignment, so `global` is unnecessary and its `# noqa: PLW0602` suppression was hiding a real code smell (a needless `global` statement).

Replaced the `global` line with a WHY comment naming the three names.

## Why the remaining 11 sites stay

Per issue #902 success criteria, every remaining `# nosec` / `# noqa` in `MistHelper.py` must have a documented reason. After this PR, 11 sites remain — all architecturally required:

| Line | Suppression | Reason |
|------|-------------|--------|
| 44   | `# nosec B404` | `import subprocess` — injected into `src/bootstrap/PackageInstaller` DI seam only; all runtime calls in this module use `SubprocessRunner` (PR-7 initiative 1016). |
| 870  | `# nosec B310` | `urlopen` with 5s timeout for startup network check; timeout avoids blocking on blocked networks. |
| 1001 | `# noqa: E402, I001` | `from src.utils.tqdm_wrapper import tqdm` — Cat E canonical re-export from initiative 1015 T-14. Late import required by module-order constraints (circular imports between `MistHelper` and `src/*`). |
| 2258 | `# noqa: E402, I001` | `from src.utils.input_utils import InputUtils` — Cat E canonical re-export (1015 T-09). |
| 2312 | `# noqa: E402` | `from src.refactors.mist_site_exclude_prefix import (...)` — extracted refactor, must load after module scaffold. |
| 3120 | `# noqa: E402, I001` | `from src.data.data_processing_utils import DataProcessingUtils` — Cat E canonical re-export (1015 T-10). |
| 3130 | `# noqa: E402,F401` | `from src.export.data_exporter import DataExporter` — Cat E re-export (T-08). F401 required because the name is re-exported for backwards compat, not used in this module. |
| 3142 | `# noqa: E402,F401` | `from src.ui.prompt_utils import PromptUtils` — Cat E re-export (T-07). |
| 3458 | `# noqa: E402` | `from src.utils.rate_limiting import RateLimitingUtils` — late import for module ordering. |
| 3622 | `# noqa: PLC0415` | `import mistapi.api.v1.sites.devices as _site_devices` — runtime mistapi submodule loading requires local import (module loaded dynamically by `GlobalImportManager`). |
| 5617 | `# noqa: PLC0415` | `RunSystematicTestManager` local import inside function — lazy import keeps module startup path light. |

## Verification

- `pytest tests/unit/test_subprocess_runner.py`: 24/24 pass
- `ruff MistHelper.py src/utils/subprocess_runner.py`: All checks passed
- `black --check MistHelper.py src/utils/subprocess_runner.py`: unchanged
- `bandit -c pyproject.toml MistHelper.py`: 2 pre-existing B101 asserts (baseline unchanged, verified with `git stash` compare)
- `mypy src/`: 3 pre-existing errors in `rate_limiting.py` and `environment_utils.py` (baseline unchanged)
- Public API snapshot (`dir(MistHelper)`) identical before/after edit