### PR TITLE
docs(1017): SpecKit scaffolding for coverage-omits cleanup

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/1016-misthelper-suppression-cleanup"}
+{"feature_directory": "specs/1017-remove-coverage-omits"}

--- a/specs/1017-remove-coverage-omits/checklists/requirements.md
+++ b/specs/1017-remove-coverage-omits/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Remove Coverage Omits and Test 36 Excluded Modules
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All 8 User Stories (P1–P8) map 1:1 to themed clusters of the omit list, following the #1016 serial-PR cadence.
+- FR-013 explicitly permits story splitting into sub-PRs where fixture surface warrants (e.g., Story 4's six org exporters).
+- FR-015 provides a bounded refactor-pending escape hatch (max 2 modules across the workflow, SC-008) to prevent scope creep while acknowledging that some modules may be untestable without refactoring — which is out of scope per issue #878's non-goals.
+- Assumptions document the delta between issue #878's original 35-file list and today's actual `pyproject.toml` omit list (~41 entries), so implementation reviewers can immediately see what is in scope.
+- Two lightly technical terms appear intentionally (`pytest`, `coverage.py`, `mergeStateStatus`) because they are the standard vocabulary of the codebase's contributor-facing quality gates and cannot be paraphrased without losing testability. This is consistent with prior specs in this initiative family (see `specs/1016-*/spec.md`).

--- a/specs/1017-remove-coverage-omits/plan.md
+++ b/specs/1017-remove-coverage-omits/plan.md
@@ -1,0 +1,505 @@
+# Implementation Plan: Remove Coverage Omits and Test 36 Excluded Modules
+
+**Branch**: `1017-remove-coverage-omits` | **Date**: 2026-07-13 | **Spec**: `specs/1017-remove-coverage-omits/spec.md`
+
+**Input**: Feature specification from `specs/1017-remove-coverage-omits/spec.md`; GitHub issue [#878](https://github.com/jmorrison-juniper/MistHelper/issues/878).
+
+## Summary
+
+Drive the `[tool.coverage.run].omit` array in `pyproject.toml` from its current ~41 entries down to the six legitimately-non-source entries (`tests/*`, `venv/*`, `.venv/*`, `setup.py`, `*/site-packages/*`, `src/maps/*`) across 8 serial User-Story clusters (P1 -> P8), one or more delivery PRs per story. The technical approach is **honest test authoring, not gate manipulation**: for every module removed from the omit list, land a dedicated test file under `tests/` that exercises real code paths against mocked externals (mistapi client, SSH transport, WebSocket transport, DB connections, subprocess), reaching per-file coverage >= 90%. Ordering is smallest-and-safest first (utilities), then data-plumbing, then exporters, then state-changing device managers, then SSH/TUI, then the async WebSocket cluster last (so every mocking pattern the earlier stories build up is available before it's needed). Source modules are **not refactored** as part of this workflow (issue #878 non-goal); the FR-015 escape hatch permits up to 2 modules to retain their omit entry with a `# TODO(1017): refactor pending` comment and a tracking issue if a module is genuinely untestable without refactor. The `fail_under=90` and pylint `fail-under=9.5` gates are never lowered; every merge lands with `mergeStateStatus=CLEAN`, no `--admin` bypass.
+
+## Technical Context
+
+**Language/Version**: Python 3.13+ (per constitution Technology & Compatibility Constraints).
+
+**Primary Dependencies**: `pytest 9.0.3`, `coverage 7.13.5`, `unittest.mock` (stdlib), `pytest`'s built-in `monkeypatch` fixture, `mistapi>=0.63.1` (mocked, never live in default suite). Optional per-module: `responses` / `pytest-httpx` for HTTP mocking IF the mocking surface exceeds ~30 lines of `unittest.mock` boilerplate (see Phase 0 decision matrix). No new runtime deps.
+
+**Storage**: N/A for the workflow itself. `src/db/database_schema_utils.py` is a pure SQL DDL **string builder** (verified: only stdlib imports `inspect`, `logging`, `re`, `datetime`, `typing`); it never opens a database connection. Tests assert on the generated SQL text directly; no `sqlite3` fixture needed.
+
+**Testing**: `pytest -v --tb=short` with `coverage.fail_under=90`; `pylint --fail-under=9.5`. Per-file coverage assertion via `coverage report --fail-under=90 --skip-covered` after each merge (see verification commands below).
+
+**Target Platform**: Windows 11 dev (local venv), Linux container runtime (Podman) for CI. Tests must be OS-neutral — no hardcoded `/` or `\\` separators, always `os.path.join()` or `pathlib.Path()`.
+
+**Project Type**: Single-project CLI tool with extracted `src/` subsystems. Test suite mirrors `src/` layout under `tests/unit/<pkg>/` (existing convention — e.g., `tests/unit/ui/`, `tests/unit/analytics/`, etc.).
+
+**Performance Goals**: Unit tests must run offline with zero API credentials in under 30 seconds (per `tests/conftest.py` docstring). Any test added by this workflow that pushes total suite runtime beyond 60 seconds MUST be reviewed for over-broad fixtures.
+
+**Constraints**:
+- **No source refactor** (issue #878 non-goal; FR-010). Test-affordance changes (e.g., extracting an inner helper to make it importable) MUST be recorded in the PR body with rationale and MUST NOT be structural (no new classes, no re-partitioning of a module across files). Constitution Principle II (Class-Based Architecture) is respected — this workflow adds tests, not new classes in `src/`.
+- **FR-015 escape hatch capped at 2 modules across the entire workflow** — if more than 2 modules cannot reach 90% without refactor, the workflow pauses and scope is renegotiated via a follow-up issue rather than lowering the bar (SC-008).
+- **No live-network calls in the default CI run** (FR-012 / SC-007). Every external touch point (mistapi, paramiko SSH, websocket, subprocess to a device, sqlite file writes) is mocked or gated behind `@pytest.mark.integration`.
+- **Coverage gate frozen at 90** (FR-009); pylint fail-under frozen at 9.5 (SC-010).
+- **No `# pragma: no cover`, `# type: ignore`, or dummy `import <module>` tests** used to game the gate (SC-006).
+- **Retained omit entries frozen at 6**: `tests/*`, `venv/*`, `.venv/*`, `setup.py`, `*/site-packages/*`, `src/maps/*` (FR-011 / SC-001).
+- **Serial dispatch across stories** (FR-003): PRs for Story N+1 do not open until every PR for Story N has landed cleanly on `main`. Within a single story, sub-PRs MAY open in parallel iff they touch disjoint files.
+- **Every delivery PR branches from current `main`** at PR-open time; `1017-remove-coverage-omits` is coordination-only (FR-004).
+
+**Scale/Scope**:
+- **Working set (2026-07-13 audit)**: 41 total omit entries. 6 are retained non-source (out of scope). 35 are in-scope in-workflow (matches issue #878's "36 excluded modules" less one, adjusted per the current omit list snapshot recorded in `pyproject.toml`).
+- **Wildcard cluster**: `src/websocket/*` (Story 8) recursively covers 15 `.py` files under `src/websocket/`, `src/websocket/diagnostics/`, and `src/websocket/polling/`. Removing the wildcard un-omits every file present at merge time — the PR MUST land tests for all of them.
+- **Delta from issue body**: The 2026-07-13 audit shows 6 entries added between issue creation and today (`src/analytics/insight_metrics_utils.py`, `src/api/api_core_fetch_utils.py`, `src/cache/cache_utils.py`, `src/export/data_exporter.py`, `src/export/org_site_exporter.py`, `src/ui/prompt_utils.py`). Per FR-016, these are in scope and folded into P1/P2/P3/P4/P5/P7 clusters by module theme.
+- **Fresh audit refresh**: Between every merged PR in this workflow, the omit list in `pyproject.toml` on `main` is re-read as ground truth. Issue-body counts are stale after 2026-07-13 and MUST NOT be used to size any single PR.
+
+**Repo layout notes**:
+- `tests/` mirrors `src/` layout under `tests/unit/<pkg>/` (existing convention). New test files for a module in `src/<pkg>/<module>.py` land at `tests/unit/<pkg>/test_<module>.py`. Non-conforming placements (root-level `tests/test_*.py`) are permitted only if a peer test file already sits there — new work MUST use the mirrored layout.
+- Existing fixtures: `tests/conftest.py` (repo-wide autouse `isolate_working_directory`, `tmp_data_dir`, `tmp_jsonl_file`, plus MistHelper pre-loader), `tests/integration/conftest.py` (live-network fixtures — untouched by this workflow), `tests/unit/ui/conftest.py` (UI-specific mocks). This workflow MAY extend `tests/conftest.py` with **new shared fixtures**, but MUST NOT rewrite existing fixtures.
+- The `integration` pytest marker is already registered in `pyproject.toml`. No marker registration change needed.
+
+**Development gates (mandatory before every push)**:
+1. `rtk black --check .` — repo-wide format check; fix locally, never push and rely on CI.
+2. `rtk ruff check .` — repo-wide lint; fix locally.
+3. `pytest -v --tb=short --cov=src --cov-fail-under=90` — full suite green locally with coverage gate satisfied.
+4. `mypy --strict src/` — no new errors on files this PR touches.
+
+**PR gates (mandatory before every merge)**:
+- Wait for `mergeStateStatus=CLEAN` from `gh pr view <N> --json mergeStateStatus`. No `--admin` bypass under any condition (FR-006).
+- Merge command pattern: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch` armed once, then poll.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Status**: PASS (with explicit alignment).
+
+The MistHelper Constitution v1.4.0 exists at `.specify/memory/constitution.md`. Every principle is respected by this workflow:
+
+- **Principle I (Five-Item Rule)**: New test functions MUST stay under 25 lines each and 5 parameters each. Test fixtures use dataclass or dict factories when parameter count exceeds the limit.
+- **Principle II (Class-Based Architecture, No Wrappers)**: This workflow adds tests, not new source classes. Any test-affordance change discovered mid-work that would require a new class in `src/` MUST invoke the FR-015 escape hatch instead — no drive-by class extractions.
+- **Principle III (Safety-First, NON-NEGOTIABLE)**: State-changing modules in P6 (reboot, firmware upgrade, RADIUS reconfig, ticket create) MUST have tests that assert `safe_input()`-guarded confirmation paths are exercised with both accept and reject inputs; destructive-op tests MUST verify the `confirmation != "UPGRADE"` early-return path is hit.
+- **Principle IV (Full Deployment Pipeline, NON-NEGOTIABLE)**: Runtime behavior of `src/` modules MUST NOT change from any test-affordance edit; the deployment pipeline (build container, restart, verify) runs on every merged PR as normal.
+- **Principle V (Observability & Logging)**: Tests MUST assert ASCII-only log output where log content is checked; no unicode/emoji in test-authored log strings.
+- **Principle VI (Inline Comments, NON-NEGOTIABLE)**: Every non-trivial line in a new test file MUST carry an inline comment explaining what the assertion or setup is doing. Boilerplate lines (imports, decorators, blank lines) exempt.
+- **Principle VII (Action Logging, NON-NEGOTIABLE)**: Tests do not need to add `logging.info()` before/after (they are the observers, not the actor). BUT: if a test-affordance edit adds any executable line to a source module, that line MUST carry inline comments AND, if it wraps a meaningful action, before/after logging — matching the touched function's existing style.
+
+Secondary alignment with **"Security Findings: Fix Over Suppress (NON-NEGOTIABLE)"**: New test files MUST NOT introduce `#nosec`, `# type: ignore`, `# noqa`, or `# pylint: disable` comments to silence findings. Bandit false positives (e.g., B105 hardcoded-password-string on mock passwords) MUST use the well-known safe pattern (`"REDACTED"` sentinel) rather than annotation.
+
+No entries required in the Complexity Tracking table on the basis of constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1017-remove-coverage-omits/
+├── plan.md              # This file (/speckit.plan output)
+├── research.md          # Phase 0 output: audit + per-cluster mocking pattern decisions
+├── data-model.md        # Phase 1 output: per-module test scope + fixture inventory
+├── quickstart.md        # Phase 1 output: verification recipes per PR
+├── contracts/           # Phase 1 output: shared-fixture contracts + coverage assertion contract
+│   ├── shared_fixtures.md
+│   ├── coverage_assertion.md
+│   └── mocking_conventions.md
+├── checklists/          # Existing: requirements.md
+└── tasks.md             # NOT produced by this command — /speckit.tasks generates it
+```
+
+### Source Code (repository root)
+
+```text
+pyproject.toml                                 # Target of every PR: omit-list entries deleted.
+                                               # No other pyproject.toml changes permitted
+                                               # (no fail_under change, no marker additions,
+                                               # no new omit entries — FR-009, FR-011).
+
+src/
+├── analytics/  api/  cache/  db/  device/
+├── export/     firmware/  gateway/  input/
+├── inventory/  org/  reports/  site/  ssh/
+├── troubleshooting/  ui/  utils/  websocket/  # Existing source, untouched except for
+                                               # FR-010-guarded test-affordance edits.
+
+tests/
+├── conftest.py                                # Existing repo-wide fixtures. This workflow
+│                                              # MAY add new shared fixtures here (see
+│                                              # contracts/shared_fixtures.md).
+├── integration/  e2e/  contract/              # Existing; untouched.
+├── unit/
+│   ├── <pkg>/                                 # Mirrors src/<pkg>/ layout. New test files
+│   │                                          # land here at test_<module>.py.
+│   │   └── conftest.py                        # Optional per-package fixtures (added only
+│   │                                          # when a fixture is used by 2+ test files
+│   │                                          # within the same package).
+│   └── <existing test files>
+└── fixtures/                                  # Existing JSON/CSV fixture bundles.
+                                               # New fixture files added here per module.
+```
+
+**Structure Decision**: Option 1 (single-project) layout is unchanged. This workflow does not introduce new top-level packages, does not restructure `src/`, and does not create new `tests/` subtrees. All new test files land under the existing `tests/unit/<pkg>/` mirror layout. Per-package `conftest.py` is added inside `tests/unit/<pkg>/` **only** when a fixture is shared by 2+ test files within that package (see planning decision #1 below).
+
+## Planning Decisions
+
+The six planning decisions called out in the `/speckit.plan` invocation are recorded here as authoritative choices for the workflow. Every task in `tasks.md` and every PR body in this workflow MUST cite the applicable decision by number.
+
+### Decision 1 — Test authoring pattern
+
+**Shared fixture location** (three-tier hierarchy):
+
+1. **`tests/conftest.py` (repo-wide)** — Add a fixture here IFF it is used by 3+ test files across 2+ packages. Example candidates from this workflow:
+   - `mock_mistapi_session` — a `unittest.mock.MagicMock` shaped like `mistapi.APISession` with commonly-stubbed methods (`.mist_get`, `.mist_post`, `.mist_delete`, `.mist_put`) pre-configured to return empty dicts. Used by every P3, P4, P5 exporter test.
+   - `mock_config` — a dict-shaped config that mirrors `MistHelper`'s runtime config surface. Used by exporter and manager tests.
+2. **`tests/unit/<pkg>/conftest.py` (per-package)** — Add a fixture here IFF it is used by 2+ test files inside a single package. Example candidates:
+   - `tests/unit/export/conftest.py` — a `mock_org_snapshot` fixture with a small representative org payload, shared across all six P4 exporter tests.
+   - `tests/unit/websocket/conftest.py` — a `mock_websocket_transport` fixture with `send`, `recv`, `close` stubs, shared across all P8 tests.
+3. **In-file (per-test-file)** — Everything else lives inside the specific `test_<module>.py`, using the `@pytest.fixture` decorator. Default location; use when the fixture serves a single test file.
+
+**Mock scope conventions**:
+- Default scope is **`function`** (pytest's default) — every test gets a fresh mock, no cross-test state bleed.
+- **`module`** scope is permitted only for fixtures that build a costly in-memory object with no mutable state (e.g., loading a JSON fixture file). Never for mocks that a test might mutate.
+- **`session`** scope is prohibited for anything touching source modules in this workflow — leaves too much room for cross-test bleed and masks real bugs.
+
+**`monkeypatch` vs. `unittest.mock`** (decision tree):
+- **Use `monkeypatch`** when: (a) replacing an attribute on an imported module (`monkeypatch.setattr("src.api.api_data_fetcher.some_helper", fake)`), (b) setting environment variables (`monkeypatch.setenv`), (c) changing the working directory (already done by the repo-wide `isolate_working_directory` autouse fixture).
+- **Use `unittest.mock`** when: (a) verifying call counts and argument shapes on a returned object (`mock.assert_called_once_with(...)`), (b) stubbing out a class instance passed as a parameter, (c) building a nested mock tree for a mistapi client (attribute access chains), (d) patching decorators via `@patch("module.attribute")`.
+- **Never mix** the two on the same target — pick one per attribute. If a test needs both a state-swap and call-count verification, use `mock.patch` with an inline `MagicMock` and inspect `.call_args_list` afterwards.
+
+**Anti-patterns** (explicitly prohibited):
+- **Dummy `import module` tests** — SC-006 forbids these. If a test file only does `import src.foo.bar` and asserts nothing, it does not count as coverage even if `coverage.py` reports 100%.
+- **`# pragma: no cover` wrappers around dead branches** — SC-006 forbids these. If a branch is genuinely unreachable, the branch (not the test) is refactored — or, if refactoring is out of scope per FR-010, the FR-015 escape hatch is invoked.
+- **`unittest.mock.MagicMock()` with no `spec=` argument** for anything imported from `mistapi` or `paramiko` — always pass `spec=mistapi.APISession` (or equivalent) so typos in method names raise `AttributeError` immediately. This catches drift when the SDK version bumps.
+
+### Decision 2 — Coverage measurement approach
+
+**Local per-module verification** (run before every push):
+
+```bash
+# 1. Run the full suite with coverage measurement enabled.
+pytest -v --tb=short --cov=src --cov-report=term-missing --cov-fail-under=90
+
+# 2. Assert per-file coverage for the module(s) this PR just un-omitted.
+#    --skip-covered hides files already at 100%; --fail-under=90 asserts the floor.
+coverage report --include="src/<pkg>/<module>.py" --fail-under=90
+
+# 3. Confirm no omit-list regression on other files by producing a full report.
+coverage report --skip-covered --sort=cover | head -30
+```
+
+**CI verification**: The project's existing CI pipeline (per Assumptions in the spec) runs `pytest --cov` on every push and enforces `fail_under=90` as a hard gate. This workflow relies on that gate — removing an omit entry without landing sufficient tests causes CI failure by design. No new CI steps are required.
+
+**Per-PR coverage artifact**: Each PR body MUST include a coverage report snippet for the un-omitted modules, generated by:
+
+```bash
+coverage report --include="src/<pkg>/<module1>.py,src/<pkg>/<module2>.py" --skip-covered
+```
+
+This snippet lives in the PR description, not in a committed file — no coverage HTML/XML is added to the repo.
+
+**Gate-invariant check**: `pyproject.toml`'s `fail_under = 90` line is verified by grep at every PR-open time. Any PR that changes this line fails review immediately (FR-009).
+
+### Decision 3 — Per-PR delivery contract
+
+**Every delivery PR MUST satisfy all criteria below before merge.** This is the uniform exit template for all sub-phases in Phase 2.
+
+| # | Criterion | Verification |
+|---|-----------|-------------|
+| a | Target user story cited | PR description contains `Refs #878` and names the user story (P1–P8) plus the omit entries removed. Final PR of P8 uses `Closes #878`. |
+| b | Omit entries deleted | `grep -E "^\\s*\"src/(<pkg>/<module>)\\.py\"" pyproject.toml` returns zero matches for every module the PR claims to un-omit. |
+| c | Per-module coverage >= 90% | `coverage report --include=<un-omitted-files> --fail-under=90` passes locally and in CI. |
+| d | Test files use real assertions | `grep -E "# pragma: no cover\|# type: ignore" tests/<new files>` returns zero matches (SC-006). |
+| e | No live-network calls | New test files inspected for either (a) explicit `unittest.mock` / `monkeypatch` usage on network entry points, OR (b) `@pytest.mark.integration` marker. Verified by manual review + CI running default suite in network-isolated container per SC-007. |
+| f | Black + ruff clean | `rtk black --check .` and `rtk ruff check .` return zero findings locally AND in CI. |
+| g | mypy clean on touched files | `mypy --strict src/<pkg>/<module>.py` output has zero net-new errors relative to `main` at PR-open time. |
+| h | Full test suite green | `pytest -v --tb=short --cov=src --cov-fail-under=90` passes in CI on the PR's head commit. |
+| i | Pylint >= 9.5 | `pylint --fail-under=9.5` satisfied on the PR's merge commit. |
+| j | `mergeStateStatus=CLEAN` | `gh pr view <N> --json mergeStateStatus` returns `CLEAN` immediately before invoking merge; no `--admin` bypass under any condition. |
+| k | Coverage report snippet in PR body | PR description includes the `coverage report --include=...` output for the un-omitted modules (see Decision 2). |
+| l | If FR-015 invoked, tracking issue linked | PR body cites the tracking issue for any module retained with `# TODO(1017): refactor pending`. Escape-hatch use counted against the 2-module cap. |
+
+**Refactor-pending modules** (FR-015 handling):
+- Precondition: the module was audited, at least one attempt at test authoring against real behavior was made, and the module was found to require structural refactor to reach 90% coverage.
+- Action: leave the omit entry in `pyproject.toml`. Add a `# TODO(1017): refactor pending — see #<tracking-issue>` comment immediately above the omit entry. Open a `refactor` label tracking issue referencing #878 with a specific unblocking hypothesis (e.g., "extract inner closure from Foo.bar so branch X is directly callable").
+- Counter: track escape-hatch usage in the workflow's running tally. Cap = 2. If the count would exceed 2, the PR does NOT merge; instead the workflow pauses, a decision is escalated (SC-008), and scope is renegotiated via a follow-up issue.
+
+**Dead-code modules** (per spec Assumptions): if audit shows a module is imported nowhere in `src/`, keep its omit entry with a `# TODO(1017): dead code candidate — see #<tracking-issue>` comment and open a follow-up refactor issue. Dead-code exemptions DO NOT count against the FR-015 2-module cap because they trigger a different follow-up (deletion, not refactor).
+
+### Decision 4 — Ordering rationale for P1 -> P8 clusters
+
+The spec fixes ordering (FR-001); this decision carries the rationale forward as an implementation-facing map. Serial dispatch (FR-003) is strict — no story is reordered.
+
+| Story | Cluster theme | Rationale for slot |
+|-------|---------------|-------------------|
+| P1 | Low-level utilities (`environment_utils`, `filter_operator_engine`, `troubleshoot_utils`, `prompt_client_utils`, plus deltas per FR-016) | Smallest, purest, dependency-light. Establishes the test-authoring patterns (fixture placement, mock scope, `monkeypatch` vs. `unittest.mock` split) that every later story reuses. Removing 4+ omit entries with minimal churn signals workflow works. |
+| P2 | Export helpers (`org_export_utils`, `license_export_utils`, `const_definitions_exporter`, `gateway_test_exporter`) | Consumed by the larger exporter clusters in P3/P4/P5. Landing their tests first means downstream exporter tests exercise validated helper contracts — bugs surface in the smaller helper tests before they cascade. |
+| P3 | API + DB + analytics data path (`api_data_fetcher`, `api_fetch_utils`, `database_schema_utils`, `data_collection_manager`, plus deltas per FR-016) | Upstream of every exporter. Landing coverage here first means P4/P5 exporter tests exercise real fetch code paths rather than compensating for unproven upstream behavior. Also crystallizes the `mock_mistapi_session` shared fixture. |
+| P4 | Org-level exporters (six modules) | Largest single exporter cluster. Depends on P2's validated helpers and P3's validated fetcher. May split into up to 6 sub-PRs if any exporter's fixture surface exceeds ~150 lines (FR-013). |
+| P5 | Site-level exporters + report generators + read-only facades (ten modules; split PR-5a exporters / PR-5b reports+inventory-facade) | Parallels P4 in structure at site scope. Reuses P4's fixture patterns. Absorbs two read-only modules originally listed under spec.md P6 (`offline_device_reporter`, `org_device_inventory_summary_facade`) to keep P6 focused on state-changing code per Constitution Principle III — see tasks.md line 259 for the reshuffle rationale. |
+| P6 | State-changing device / firmware / RADIUS / ticket managers (five modules: `arp_command_manager`, `device_reboot_manager`, `firmware_manager`, `bulk_radius_wlan_config_manager`, `org_ticket_manager`) | State-changing operations (reboots, firmware upgrades, RADIUS reconfig, ticket creation). Requires the most careful mocking to prevent accidental live-device calls in CI. Landing after P3 ensures the mock fixtures the managers need are stable. Constitution Principle III (Safety-First) tests for destructive-op confirmation paths live here. |
+| P7 | SSH + TUI (`cli_shell_manager`, `tui`) | Interactive-terminal code paths. Depends on P6 for any shared SSH mock patterns. Small cluster (two modules), single PR unless one module's fixture surface pushes past the FR-013 500-line threshold. |
+| P8 | WebSocket wildcard cluster (`src/websocket/*` — 15 files) | Hardest cluster: async transport, long-lived connections, service-ping discovery, diagnostic subscriptions. Lands last so every mocking pattern (network, subprocess, SSH, TUI) is already in place. Wildcard removal un-omits every current and future file under `src/websocket/`; PR must land tests for all 15 files present at merge time. |
+
+### Decision 5 — Risk register
+
+Modules most likely to need heavy mocking or FR-015 escape-hatch treatment. Risk score is the assessment for planning purposes; actual invocation is decided per-PR based on real testability.
+
+| Module | Cluster | Risk | Mocking surface | Mitigation |
+|--------|---------|------|-----------------|------------|
+| `src/websocket/service_ping_discovery.py` (~805 LOC) | P8 | High | Injected `utility` deps; no direct websocket library import — orchestrates discovery via injected dependencies | Mock the injected `utility` deps with `MagicMock(spec=...)`; assert loop exits after at most 2 mocked iterations (per Story 8 Acceptance 3). Candidate for sub-PR split. |
+| `src/websocket/service_ping_manager.py` (~1000 LOC) | P8 | High | Async lifecycle + service registry | Same pattern as `service_ping_discovery`; share fixtures in `tests/unit/websocket/conftest.py`. |
+| `src/ssh/cli_shell_manager.py` | P7 | High | Paramiko `SSHClient`, `Channel`, `Transport` object graph + interactive prompts + I/O timeouts | Mock at `paramiko.SSHClient` class boundary; use `MagicMock(spec=paramiko.SSHClient)` for typo-safety. Interactive prompt path uses `monkeypatch` on `safe_input()`. |
+| `src/ui/tui.py` | P7 | High | Terminal rendering + blocking user input | Mock `sshkeyboard.listen_keyboard` (project uses this per requirements.txt); assert `on_press` callback firing with synthetic key events. No real terminal open. |
+| `src/firmware/firmware_manager.py` | P6 | Medium-High | State-changing API calls (upgrade) + confirmation prompts (Principle III) | Mock `mistapi` client; test BOTH accept (`"UPGRADE"`) and reject paths for the safe_input confirmation. |
+| `src/device/device_reboot_manager.py` | P6 | Medium-High | State-changing API + destructive confirmation | Same pattern as firmware_manager. |
+| `src/site/bulk_radius_wlan_config_manager.py` | P6 | Medium | Multi-step config write + rollback | Mock `mistapi`; assert rollback path is exercised via injected exception on step 2 of 3. |
+| `src/api/api_data_fetcher.py` | P3 | Medium | Pagination loop + mistapi client | Mock returns page-token-terminated responses. Assert loop exits after N pages (N=3 fixture default). |
+| `src/api/api_core_fetch_utils.py` | P3 | Medium | Cursor-based iteration | Same pattern as api_data_fetcher. |
+| `src/db/database_schema_utils.py` | P3 | Low | Pure SQL DDL string builder (no DB driver imported) | Assert on the returned DDL text directly with `assert "CREATE TABLE" in sql`, `assert "PRIMARY KEY (foo, bar)" in sql`, etc. No fixture, no mocking, no in-memory DB. |
+| Six P4 org exporters | P4 | Medium (each) | Large JSON output shapes | Fixture-based golden-file comparison OR in-memory buffer inspection (Story 4 Acceptance 3). Golden fixtures land in `tests/fixtures/`. |
+| Eight P5 site exporters + reporters | P5 | Medium (each) | Tabular output shape + column ordering | At least one test per module MUST validate column order, header text, one row of data (Story 5 Acceptance 3). |
+
+**FR-015 candidates** (advance-flagged as likely escape-hatch users, not commitments):
+- `src/websocket/service_ping_discovery.py` — if async lifecycle proves untestable without splitting the class, retain omit + open refactor issue. Counts against the 2-cap.
+- `src/ui/tui.py` — if the render loop is too coupled to `sshkeyboard` internals to mock cleanly, retain omit + open refactor issue. Counts against the 2-cap.
+
+If either candidate consumes an escape-hatch slot, the workflow proceeds with 0 or 1 slots remaining. If a third module surfaces mid-workflow requiring escape-hatch, the workflow pauses per SC-008.
+
+### Decision 6 — Verification commands for the final state
+
+**Terminal-state assertions** (run against `main` after the last PR of Story 8 merges):
+
+```bash
+# SC-001: omit list contains exactly the 6 retained non-source entries.
+python -c "
+import tomllib, sys
+with open('pyproject.toml', 'rb') as f:
+    omit = sorted(tomllib.load(f)['tool']['coverage']['run']['omit'])
+expected = sorted([
+    'tests/*', 'venv/*', '.venv/*', 'setup.py',
+    '*/site-packages/*', 'src/maps/*'
+])
+if omit != expected:
+    print('FAIL: unexpected omit entries')
+    print('  present:', omit)
+    print('  expected:', expected)
+    sys.exit(1)
+print('PASS: omit list is exactly the 6 retained non-source entries')
+"
+
+# SC-003 / SC-004: coverage passes at 90 project-wide AND per-file.
+pytest -v --tb=short --cov=src --cov-report=term-missing --cov-fail-under=90
+coverage report --fail-under=90 --skip-covered
+
+# SC-006: no gate-gaming annotations in workflow-added test files.
+git diff --name-only origin/main..HEAD -- tests/ | \
+  xargs grep -lE "# pragma: no cover|# type: ignore" || echo "PASS: zero gate-gaming annotations"
+
+# SC-007: default CI suite issues no live network calls.
+# Verified by running the suite in a network-isolated container (Podman with --network=none)
+# and observing zero external egress. See quickstart.md for the exact recipe.
+
+# SC-010: pylint gate holds.
+pylint --fail-under=9.5 src/
+
+# FR-009: fail_under is still 90.
+grep -E "^fail_under\\s*=\\s*90$" pyproject.toml || (echo "FAIL: coverage.fail_under changed"; exit 1)
+
+# FR-015 cap check: at most 2 modules retain omit entry with refactor-pending TODO.
+grep -c "TODO(1017): refactor pending" pyproject.toml
+# Value MUST be <= 2. If value == 0, workflow completed without invoking escape hatch.
+```
+
+**Per-PR verification** (run before every merge; see Decision 3 exit criteria):
+
+```bash
+# Un-omit assertion for THIS PR's modules.
+for module in <list-of-un-omitted-modules>; do
+  grep -E "^\\s*\"$module\"" pyproject.toml && echo "FAIL: $module still omitted" && exit 1
+done
+echo "PASS: all target modules removed from omit list"
+
+# Coverage floor for THIS PR's modules.
+coverage report --include="<comma-separated-module-paths>" --fail-under=90
+```
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+Constitution Check passed with explicit alignment; no violations to track. The table below repurposes the section for its analogue use in this workflow: **per-story effort estimate** to help pace serial dispatch under SC-009 (eight calendar weeks target for eight stories at ~1 PR per 2–3 working days).
+
+| Story | Cluster | In-scope module count | Est. sub-PR count | Est. effort | Ordering-dependency notes |
+|-------|---------|-----------------------|-------------------|-------------|--------------------------|
+| P1 | Low-level utilities | 4 base + up to 2 delta (FR-016) = ~6 | 1 | Day–1.5 days | Establishes fixture patterns. First PR of workflow. |
+| P2 | Export helpers | 4 | 1 | Day | Depends on P1 fixtures existing. Introduces `mock_mistapi_session` shared fixture (Decision 1). |
+| P3 | API + DB + analytics data path | 4 base + up to 2 delta = ~6 | 1–2 | 2 days | Depends on P2 mock patterns. Introduces pagination-loop mock pattern (no in-memory DB needed — `database_schema_utils` is a pure string builder). |
+| P4 | Org-level exporters | 6 base + 1 delta (`org_site_exporter`) = ~7 | 2–4 | 4–6 days | Largest cluster. Reuses P2/P3 fixtures. Golden-fixture setup pattern lands here (Decision 5). |
+| P5 | Site-level exporters + reporters + read-only inventory facade | 10 (5 exporters + 4 reporters + 1 facade; absorbs 2 read-only modules originally scoped to P6) | 2 (PR-5a exporters, PR-5b reports+facade) | 3–5 days | Parallels P4. Reuses P4 fixture patterns; tabular-output assertion pattern (Story 5 Acceptance 3) crystallizes here. |
+| P6 | State-changing device / firmware / RADIUS / ticket managers | 5 (`arp_command_manager`, `device_reboot_manager`, `firmware_manager`, `bulk_radius_wlan_config_manager`, `org_ticket_manager`) | 1 (optionally split into T-06a device/firmware + T-06b site/org per tasks.md line 261) | 4–6 days | State-changing tests + Principle III safe_input coverage (Decision 5). Highest-risk mocking. |
+| P7 | SSH + TUI | 2 | 1 | 2–4 days | Two hard modules, small count. Highest FR-015 risk (Decision 5 flag). |
+| P8 | WebSocket wildcard cluster | 15 (from wildcard expansion) | 2–4 | 5–7 days | Last story. Highest complexity per module. May consume 1 of 2 FR-015 slots. |
+
+Effort estimates assume the standard review cadence of ~1 PR per 2–3 working days (SC-009) and are advisory, not gating. Total workflow envelope: ~8 calendar weeks, ~15–25 delivery PRs across 8 stories.
+
+---
+
+## Phase 0: Outline & Research
+
+**Prerequisite**: none (spec captured all clarifications).
+
+Phase 0 for this workflow is short — the spec fixed ordering and the plan fixed patterns. The Phase 0 deliverable (`research.md`) consolidates three inputs into a single reviewable document, produced BEFORE Story 1's first PR opens:
+
+1. **Refresh the omit-list audit at current `main` HEAD**. Capture the exact set of 35 in-scope entries (per FR-016) and 6 retained non-source entries. Preserve the raw `pyproject.toml` omit-array snapshot as an appendix. Diff the current list against issue #878's original 35 and record the delta (~6 entries added post-issue) with confirmed cluster assignments (which entries go into which of P1–P8).
+
+2. **Enumerate the 15 files under `src/websocket/*`** at current `main` HEAD (per `find src/websocket -name "*.py" -type f`). Record each file's LOC and imports. This bounds Story P8's scope precisely — if a new file appears in `src/websocket/` between now and Story P8 opening, P8's PR MUST cover it.
+
+3. **Record per-cluster mocking decisions** in Decision / Rationale / Alternatives format:
+   - **P3 API pagination mocking pattern**: paginated mistapi calls (`.mist_get` returning `{"next": ...}`-shaped responses). Decision: mock at `mistapi.APISession` boundary via `unittest.mock.MagicMock(spec=mistapi.APISession)`. Rationale: matches existing fixture patterns in `tests/unit/api/`. Alternative rejected: `responses` library — heavier dep, unnecessary for stdlib-mock-adequate shape.
+   - **P4/P5 exporter output-shape assertions**: Decision — golden JSON/CSV fixtures under `tests/fixtures/` compared via `assert exported == expected_fixture`. Rationale: rewards fixture-comparable output, forces exporters to have deterministic serialization. Alternative rejected: schema-only assertions — hides drift.
+   - **P6 destructive-op confirmation coverage**: Decision — parametrize each destructive-op test with `("UPGRADE", expected_action_called), ("cancel", expected_no_action)`. Rationale: exercises the safe_input early-return path (Principle III). Alternative rejected: only-happy-path — misses the safety-critical branch.
+   - **P7 SSH mock boundary**: Decision — mock `paramiko.SSHClient` class, not `Channel` or `Transport`. Rationale: `SSHClient` is the entry point every call site touches; mocking it once suffices. Alternative rejected: mock all three — over-mocks, misses call-flow bugs.
+   - **P7 TUI mock boundary**: Decision — mock `sshkeyboard.listen_keyboard` at its import location per test file. Rationale: single entry point; predictable synthetic events. Alternative rejected: subprocess-launch TUI in headless PTY — too slow, too fragile for CI.
+   - **P8 WebSocket transport mocking**: Decision — mock `websocket.WebSocketApp` (sync `websocket-client` library, NOT the async `websockets` package) with `MagicMock(spec=websocket.WebSocketApp)`, feeding recorded frames through the reader-thread callback. Rationale: `src/websocket/manager.py` imports `websocket-client` and uses `threading` for the background reader; there is no `asyncio` in the transport path. Alternative rejected: any async-mock helper (`aioresponses`, `websockets-mock`) — the source is not async.
+
+4. **Record the fixture-migration order** for the three shared fixtures introduced by this workflow (per Decision 1): `mock_mistapi_session` (introduced in P2, promoted to `tests/conftest.py` in P3 once used by 3+ files), `mock_config` (introduced in P2), `mock_websocket_transport` (introduced in P8, stays in `tests/unit/websocket/conftest.py`).
+
+**Output**: `research.md` with all clarifications resolved, containing:
+- Fresh 2026-07-13 omit-list snapshot with cluster assignments (P1–P8) for every in-scope entry.
+- `src/websocket/*` file enumeration (bounds P8 scope).
+- Per-cluster mocking pattern decisions in Decision / Rationale / Alternatives format.
+- Fixture-migration order for the three shared fixtures.
+
+## Phase 1: Design & Contracts
+
+**Prerequisite**: `research.md` complete.
+
+### 1. Extract entities → `data-model.md`
+
+The spec's Key Entities section names five operational entities. `data-model.md` records each entity's concrete shape as it applies to this workflow:
+
+- **Omit Entry inventory (35 in-scope)**: The exact list of module paths to remove, grouped by cluster (P1–P8), with per-entry columns for `pyproject.toml` line number at workflow start, cluster assignment, and Phase 0 audit disposition (in-scope / retained / dead-code candidate / refactor-pending candidate).
+- **Un-Omitted Module test manifest**: For each of the 35 in-scope modules, record:
+  - Target test file path (mirrored `tests/unit/<pkg>/test_<module>.py`).
+  - Public-API surface to cover (list of top-level classes and functions with docstring-declared entry points).
+  - External touch points requiring mocks (mistapi calls, subprocess, SSH, WebSocket, filesystem, DB).
+  - Expected fixture bundle location (`tests/fixtures/<cluster>/<module>_fixtures.json` or in-file dataclass factories).
+- **Retained Non-Source Entry inventory**: Enumerated verbatim from FR-011: `tests/*`, `venv/*`, `.venv/*`, `setup.py`, `*/site-packages/*`, `src/maps/*`. Validation rule: `data-model.md` MUST assert this set is exactly the omit-list terminal state (SC-001).
+- **Integration-Only Path inventory**: Per-module list of code paths that CANNOT be covered without live infrastructure (e.g., a WebSocket handshake in `service_ping_manager.py` that requires a real controller). Each entry cites the decision (mock double OR `@pytest.mark.integration`) and the reason.
+- **Test Fixture Bundle registry**: Per-cluster inventory of new fixture files added to `tests/fixtures/` and per-package `conftest.py` files added to `tests/unit/<pkg>/`. Each entry records first-consumer story (P#) and shared-scope tier (Decision 1 tier 1/2/3).
+
+State transitions: this workflow's tracked "state" is the omit-list count, decrementing monotonically as PRs merge. The Phase 0 audit is the baseline count (~35); the terminal state is 0 in-scope entries (SC-001).
+
+### 2. Define interface contracts → `contracts/`
+
+This workflow doesn't touch public APIs of source modules (FR-010). Contracts here document the internal contracts the test suite relies on, captured as Markdown fragments (project convention — no OpenAPI / IDL applies to test infrastructure):
+
+- **`contracts/shared_fixtures.md`**: The contract for every shared fixture introduced by this workflow. One section per fixture, listing:
+  - Fixture name and location tier (Decision 1 tier).
+  - Return-type shape (class or dict schema with field names + types).
+  - Mock-scope decision and rationale.
+  - Consumer stories (P#) and expected consumer count.
+  - Validation rule: shared fixtures MUST NOT mutate global state; each fixture call MUST return a fresh object graph.
+
+- **`contracts/coverage_assertion.md`**: The contract for per-file coverage verification. Enumerates:
+  - The `coverage report --include=<path> --fail-under=90` invocation used per PR.
+  - The full-suite coverage assertion (`pytest --cov=src --cov-fail-under=90`).
+  - The FR-009 assertion (`fail_under=90` line unchanged in `pyproject.toml`).
+  - The FR-015 counter assertion (`grep -c "TODO(1017): refactor pending" pyproject.toml <= 2`).
+  - Validation rule: every PR body MUST include the per-file coverage snippet output.
+
+- **`contracts/mocking_conventions.md`**: The contract for how source modules are mocked. Enumerates:
+  - The `MagicMock(spec=<real class>)` convention for mistapi, paramiko, and `websocket-client` (the sync `websocket.WebSocketApp` — not the async `websockets` package) (Decision 1 anti-patterns). No in-scope module imports `sqlite3` or the async `websockets` library at runtime.
+  - The `monkeypatch` vs. `unittest.mock` decision tree (Decision 1).
+  - The `@pytest.mark.integration` gate for any code path that cannot be mocked cleanly (FR-012).
+  - The prohibition on `session`-scope mocks touching source modules (Decision 1).
+  - Validation rule: reviewers grep new test files for `MagicMock()` without `spec=` on mistapi/paramiko/`websocket-client` imports and reject PRs that violate the convention.
+
+### 3. Quickstart → `quickstart.md`
+
+`quickstart.md` records the verification recipe an operator or reviewer runs to confirm a given story's PR is complete. One section per story (P1–P8), each containing:
+
+- The exact `grep` command to assert the target omit entries are deleted from `pyproject.toml`.
+- The exact `coverage report --include=<paths> --fail-under=90` command for the un-omitted modules.
+- The exact `pytest -v tests/unit/<pkg>/` invocation for the story's new test files.
+- The `black --check` + `ruff check` + `mypy --strict src/<pkg>/` commands for the touched source files.
+- The `gh pr view <N> --json mergeStateStatus` command asserting `CLEAN` before merge.
+- For P8 specifically: the `find src/websocket -name "*.py" | xargs -I{} coverage report --include={} --fail-under=90` recursive per-file assertion covering all 15 files un-omitted by the wildcard removal (Story 8 Acceptance 2).
+- The network-isolation recipe (Podman with `--network=none`) for verifying SC-007 on each PR.
+
+### 4. Agent context update
+
+Update the plan reference block between `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` in `.github/copilot-instructions.md` to point at this plan file (`specs/1017-remove-coverage-omits/plan.md`). No other agent-context files change.
+
+**Output**: `research.md`, `data-model.md`, `contracts/shared_fixtures.md`, `contracts/coverage_assertion.md`, `contracts/mocking_conventions.md`, `quickstart.md`, updated `.github/copilot-instructions.md`.
+
+---
+
+## Phase 2: Implementation Planning (Strategy)
+
+> **Note**: `/speckit.tasks` generates `tasks.md` with per-module, per-fixture task decomposition. This section captures cross-PR strategy, ordering rationale, and the shared exit-criteria template. Individual test-file enumeration lives in `tasks.md`, not here.
+
+### Merge ordering rationale
+
+The 8 stories land in the fixed order P1 -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 (FR-001; Decision 4). Each story may split into 1–4 sub-PRs (Decision 4 estimated column) if the FR-013 threshold (~500 net lines OR ~150 fixture lines per module) is met. Within a single story, sub-PRs MAY open in parallel iff they touch disjoint files; between stories, dispatch is strict serial (FR-003).
+
+### Cross-PR invariants (apply to every PR)
+
+- Every module removed from the omit list has a dedicated test file under `tests/unit/<pkg>/test_<module>.py` with real assertions (SC-006).
+- No `# pragma: no cover`, `# type: ignore`, or dummy `import module` tests added to `tests/` (SC-006).
+- No live-network calls in the default suite (SC-007). Every `mistapi`, `paramiko`, `websocket-client`, `subprocess` touch point is mocked OR gated by `@pytest.mark.integration`.
+- `pyproject.toml` changes limited to omit-entry deletions (FR-009 forbids fail_under change; FR-011 requires retained set unchanged).
+- Only one PR from this workflow open on `main` at any moment within a single story cluster (FR-003 strict-serial across stories); intra-story parallel sub-PRs permitted iff file-disjoint.
+- Delivery branches cut fresh from `main` — never from `1017-remove-coverage-omits` (FR-004).
+- Pre-push local gate: `rtk black --check .`, `rtk ruff check .`, `pytest -v --tb=short --cov=src --cov-fail-under=90`, `mypy --strict src/` (on touched files) MUST all be clean before push.
+- FR-015 escape-hatch invocations counted against the 2-module cap; workflow pauses if a third would push count to 3 (SC-008).
+
+### PR sub-phase enumeration
+
+Each sub-phase corresponds to one User Story cluster (P1–P8). Exit criteria are identical across sub-phases per Decision 3; only the target cluster, module set, and expected omit-count delta vary. Per-story deliverable summaries:
+
+**Sub-phase 1 — Story P1 — Low-level utilities**
+- Entry: Phase 0 audit committed to `research.md`; Phase 1 artifacts merged into feature branch.
+- Deliverable: 4 base modules + up to 2 delta modules (per FR-016) removed from omit list; per-module tests under `tests/unit/utils/`, `tests/unit/troubleshooting/`, `tests/unit/input/`.
+- Fixture introductions: baseline patterns established; nothing yet lifted to `tests/conftest.py`.
+
+**Sub-phase 2 — Story P2 — Export helpers**
+- Entry: P1 merged; `main` audit refreshed.
+- Deliverable: 4 export-helper modules un-omitted; tests under `tests/unit/export/`. `mock_mistapi_session` fixture introduced at package-scope `tests/unit/export/conftest.py`.
+
+**Sub-phase 3 — Story P3 — API + DB + analytics data path**
+- Entry: P2 merged; `main` audit refreshed. `mock_mistapi_session` promoted from `tests/unit/export/conftest.py` to `tests/conftest.py` once P3 tests reference it from 3+ files across 2+ packages (Decision 1 tier promotion).
+- Deliverable: 4 base + up to 2 delta modules un-omitted; tests under `tests/unit/api/`, `tests/unit/db/`, `tests/unit/analytics/`, `tests/unit/cache/`. Pagination-loop mock pattern crystallizes here (`database_schema_utils` needs only string-assertion tests — no DB fixture).
+
+**Sub-phase 4 — Story P4 — Org-level exporters**
+- Entry: P3 merged; `main` audit refreshed. Golden-fixture setup complete under `tests/fixtures/org_exporters/`.
+- Deliverable: 6 base + 1 delta (`org_site_exporter`) exporter modules un-omitted; tests under `tests/unit/export/`. May split into up to 4 sub-PRs by exporter theme (admin, alarm, config, device_stats, template, site).
+
+**Sub-phase 5 — Story P5 — Site-level exporters + report generators**
+- Entry: P4 merged; `main` audit refreshed.
+- Deliverable: 8 modules un-omitted; tests under `tests/unit/export/` and `tests/unit/reports/`. Tabular-output column-order assertion pattern (Story 5 Acceptance 3) crystallizes here. May split into 2–3 sub-PRs.
+
+**Sub-phase 6 — Story P6 — Device / firmware / inventory managers**
+- Entry: P5 merged; `main` audit refreshed.
+- Deliverable: 7 modules un-omitted; tests under `tests/unit/device/`, `tests/unit/firmware/`, `tests/unit/inventory/`, `tests/unit/org/`, `tests/unit/site/`, `tests/unit/gateway/`. Principle III safe_input confirmation coverage lands here. May split into 2–3 sub-PRs.
+
+**Sub-phase 7 — Story P7 — SSH + TUI**
+- Entry: P6 merged; `main` audit refreshed.
+- Deliverable: 2 modules un-omitted; tests under `tests/unit/ssh/` and `tests/unit/ui/`. Paramiko-mock and sshkeyboard-mock patterns crystallize here. Single PR unless FR-013 threshold breached. Highest FR-015 escape-hatch risk (Decision 5); may consume 1 of 2 slots.
+
+**Sub-phase 8 — Story P8 — WebSocket wildcard cluster**
+- Entry: P7 merged; `main` audit refreshed; `find src/websocket -name "*.py" -type f` re-run to bound scope.
+- Deliverable: `"src/websocket/*"` wildcard removed from omit list; tests for all 15 files under `src/websocket/` (recursively including `diagnostics/` and `polling/`) landed under `tests/unit/websocket/`. `mock_websocket_transport` fixture at `tests/unit/websocket/conftest.py`. Long-running poll loops mocked to exit after ≤2 iterations (Story 8 Acceptance 3). May split into up to 4 sub-PRs. Final PR uses `Closes #878`.
+
+### Per-PR exit criteria template
+
+Every delivery PR MUST satisfy all 12 criteria enumerated in Decision 3 (rows a–l). Story-specific supplementary criteria:
+
+- **P3, P4, P5**: PR body includes a snippet from `coverage report --include=<un-omitted-files>` showing per-file coverage >= 90%.
+- **P4**: Golden-fixture files committed under `tests/fixtures/org_exporters/` are byte-for-byte deterministic (no timestamps, no non-deterministic ordering).
+- **P5**: At least one test per module validates column order, header text, and one row of data (Story 5 Acceptance 3).
+- **P6**: For every module performing state-changing operations, at least one test invokes the destructive path and asserts the safe_input confirmation branch (Principle III).
+- **P7**: PR body confirms no `paramiko.SSHClient()` or `sshkeyboard.listen_keyboard()` invocation runs without a mock (grep test files).
+- **P8**: PR body enumerates the 15 files under `src/websocket/` at merge time and shows per-file coverage >= 90% for every one (Story 8 Acceptance 2). Final P8 PR body uses `Closes #878`.
+
+### Merge invocation pattern
+
+Once all 12 exit criteria pass locally and in CI, and `mergeStateStatus=CLEAN`:
+
+```bash
+GITHUB_TOKEN= gh pr merge <PR_NUMBER> --auto --squash --delete-branch
+```
+
+Arm once, then poll `gh pr view <PR_NUMBER> --json state,mergeCommit` until state is `MERGED`. After merge, refresh the audit via `python -c "import tomllib; print(sorted(tomllib.load(open('pyproject.toml','rb'))['tool']['coverage']['run']['omit']))"` before opening the next sub-phase's PR (FR-014).
+
+---
+
+## Stop-and-report
+
+Phase 0 and Phase 1 artifacts are the deliverables of this command. `tasks.md` is intentionally NOT produced — it is the output of the separate `/speckit.tasks` step. Individual test-file and per-module task enumeration lives in `tasks.md`, not here.

--- a/specs/1017-remove-coverage-omits/spec.md
+++ b/specs/1017-remove-coverage-omits/spec.md
@@ -1,0 +1,215 @@
+# Feature Specification: Remove Coverage Omits and Test 36 Excluded Modules
+
+**Feature Branch**: `1017-remove-coverage-omits`
+
+**Created**: 2026-07-13
+
+**Status**: Draft
+
+**Input**: GitHub issue [#878](https://github.com/jmorrison-juniper/MistHelper/issues/878) — "test: remove coverage omits and add tests for 36 excluded modules"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Each user story below corresponds to a themed cluster of modules currently
+  hidden from coverage measurement by the `[tool.coverage.run].omit` list in
+  `pyproject.toml`. Stories are ordered smallest-and-safest first, riskiest
+  (async/interactive) last, mirroring the serial PR cadence used by initiative
+  #1016. Each story is independently testable, reviewable, and revertable —
+  landing any single story deletes real omit entries and lands real tests
+  without dropping the repo below its `fail_under = 90` coverage gate.
+-->
+
+### User Story 1 - Low-Level Utility Modules Un-Omitted (Priority: P1)
+
+Codebase maintainers need the small, pure-Python utility modules (`environment_utils`, `filter_operator_engine`, `troubleshoot_utils`, `prompt_client_utils`) removed from the coverage omit list and covered by real unit tests, so the safest cluster of modules stops gaming the coverage gate and establishes a working test pattern for the rest of the workflow.
+
+**Why this priority**: These modules are small, dependency-light, and mostly pure functions. They are the lowest-risk cluster to land first and produce the highest confidence signal that the workflow's test-authoring conventions (fixtures, mock scope, marker usage) are correct before the workflow tackles harder clusters. Landing this first also removes 4 omit entries with minimal churn.
+
+**Independent Test**: After merge, the four listed omit entries are absent from `pyproject.toml`, each module has at least one dedicated test file under `tests/` exercising every public entry point without `# pragma: no cover` or dummy imports, and `pytest --cov` passes with `fail_under = 90` and no drop in overall project coverage.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR branch at HEAD, **When** `grep -E "^\\s*\"src/(utils/environment_utils|utils/filter_operator_engine|troubleshooting/troubleshoot_utils|input/prompt_client_utils)\\.py\"" pyproject.toml` runs, **Then** the command returns zero matches.
+2. **Given** the PR branch at HEAD, **When** `pytest --cov=src --cov-fail-under=90` runs under CI, **Then** the run passes and per-module coverage for each of the four un-omitted modules is at least 90%.
+3. **Given** the PR branch at HEAD, **When** the four new/expanded test files are grepped for `# pragma: no cover`, **Then** zero matches are found.
+
+---
+
+### User Story 2 - Export Helper Utilities Un-Omitted (Priority: P2)
+
+Codebase maintainers need the export-helper utility modules (`org_export_utils`, `license_export_utils`, `const_definitions_exporter`, `gateway_test_exporter`) removed from the coverage omit list and covered by real unit tests, so the shared helpers underpinning the larger org/site exporter clusters are proven correct before the exporters themselves are un-omitted.
+
+**Why this priority**: These modules are consumed by the larger exporter clusters in P3–P4. Landing tests here first means the exporter tests that follow can rely on validated helper contracts, reducing rework and letting the helper tests catch bugs before exporter tests trip on them.
+
+**Independent Test**: After merge, the four listed omit entries are absent from `pyproject.toml`, each module has dedicated tests under `tests/`, and `pytest --cov` passes at `fail_under = 90`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR branch at HEAD, **When** the four omit lines are searched in `pyproject.toml`, **Then** zero matches remain.
+2. **Given** the PR branch at HEAD, **When** the coverage report is inspected, **Then** each of the four un-omitted modules reports coverage of at least 90%.
+3. **Given** the PR branch at HEAD, **When** integration-only paths (real Mist API calls) exist in these helpers, **Then** those paths are covered via `unittest.mock` doubles OR marked with the existing `integration` pytest marker — never left unexecuted.
+
+---
+
+### User Story 3 - API + Database + Analytics Data Path Un-Omitted (Priority: P3)
+
+Codebase maintainers need the data-plumbing modules (`api_data_fetcher`, `api_fetch_utils`, `database_schema_utils`, `data_collection_manager`) removed from the coverage omit list and covered by real unit tests with mocked network and DB dependencies, so the core data path stops silently under-testing and the exporter clusters that consume it can be tested with confidence.
+
+**Why this priority**: The data-fetch layer is upstream of most exporters. Landing its coverage before the exporter clusters (P4–P5) reduces the risk that an exporter test masks a bug in the fetcher. It comes after P2's helpers because the fetcher's test doubles reuse fixtures that P2 introduces.
+
+**Independent Test**: After merge, the four listed omit entries are absent from `pyproject.toml`, each module has dedicated tests under `tests/` with network and DB calls mocked (or marked `integration`), and `pytest --cov` passes at `fail_under = 90`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR branch at HEAD, **When** the four omit lines are searched in `pyproject.toml`, **Then** zero matches remain.
+2. **Given** the PR branch at HEAD, **When** the new tests execute, **Then** no real Mist API call is issued (verified by `responses` / `pytest-httpx` / `unittest.mock` inspection, or by tests being marked `integration` and skipped by default).
+3. **Given** the PR branch at HEAD, **When** the coverage report is inspected, **Then** each of the four un-omitted modules reports coverage of at least 90%.
+
+---
+
+### User Story 4 - Organization-Level Exporters Un-Omitted (Priority: P4)
+
+Codebase maintainers need the org-level exporter modules (`org_admin_exporter`, `org_alarm_event_exporter`, `org_client_security_exporter`, `org_config_exporter`, `org_device_stats_exporter`, `org_template_exporter`) removed from the coverage omit list and covered by real unit tests, so the largest exporter cluster stops hiding behind coverage exclusions and every output format the org exporters produce is validated end-to-end against fixtures.
+
+**Why this priority**: This is the largest single exporter cluster (six files). Landing it after P3 ensures the underlying data fetcher is validated first, so exporter tests exercise real code paths rather than compensating for unproven upstream behavior. Splitting into 6 sub-PRs may be warranted if any single exporter needs more than ~150 lines of test fixtures — implementation decides that, spec sets the ceiling per PR.
+
+**Independent Test**: After merge, the six listed omit entries are absent from `pyproject.toml`, each exporter has dedicated tests validating at least one happy-path output and one error-path output, and `pytest --cov` passes at `fail_under = 90`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR branch (or series of PRs) at HEAD, **When** the six omit lines are searched in `pyproject.toml`, **Then** zero matches remain.
+2. **Given** the PR branch at HEAD, **When** the coverage report is inspected, **Then** each of the six un-omitted exporters reports coverage of at least 90%.
+3. **Given** the PR branch at HEAD, **When** exporters that write files or emit CSV/JSON are tested, **Then** the tests assert against fixture-comparable output (either golden files or in-memory buffers), not just "did not raise".
+
+---
+
+### User Story 5 - Site-Level Exporters and Report Generators Un-Omitted (Priority: P5)
+
+Codebase maintainers need the site-level exporter modules (`site_anomaly_exporter`, `site_config_exporter`, `site_device_exporter`, `sites_by_ap_model_exporter`) and report generators (`global_wired_client_report_generator`, `offline_device_reporter`, `sfp_transceiver_data_processor`, `wired_client_manufacturer_report_generator`) removed from the coverage omit list and covered by real unit tests, so the site-scope reporting surface reaches the project coverage bar.
+
+**Why this priority**: These modules parallel the org-level exporters in structure but scope down to sites. Landing them after P4 lets P4's fixture patterns be reused. Each module is independently testable, so this may split into 2–3 sub-PRs if fixture surface warrants.
+
+**Independent Test**: After merge, the eight listed omit entries are absent from `pyproject.toml`, each module has dedicated tests, and `pytest --cov` passes at `fail_under = 90`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR branch (or series of PRs) at HEAD, **When** the eight omit lines are searched in `pyproject.toml`, **Then** zero matches remain.
+2. **Given** the PR branch at HEAD, **When** the coverage report is inspected, **Then** each of the eight un-omitted modules reports coverage of at least 90%.
+3. **Given** the PR branch at HEAD, **When** report generators that produce tabular output are tested, **Then** at least one test validates column order, header text, and one row of data.
+
+---
+
+### User Story 6 - Device, Firmware, and Inventory Managers Un-Omitted (Priority: P6)
+
+Codebase maintainers need the device/firmware/inventory management modules (`arp_command_manager`, `device_reboot_manager`, `firmware_manager`, `org_device_inventory_summary_facade`, `bulk_radius_wlan_config_manager`, `gateway_ha_exporter`, `org_ticket_manager`) removed from the coverage omit list and covered by real unit tests with device-side calls mocked, so state-changing operational code paths are covered by tests that assert the correct API calls are issued without hitting real infrastructure.
+
+**Why this priority**: These modules perform state-changing operations (reboots, firmware upgrades, RADIUS reconfiguration, ticket creation). They require the most careful mocking to avoid accidental live-device calls in CI. Landing them mid-workflow ensures the P2–P3 mock fixtures are stable before this cluster relies on them.
+
+**Independent Test**: After merge, the seven listed omit entries are absent from `pyproject.toml`, each module has dedicated tests with all state-changing calls mocked (or marked `integration`), and `pytest --cov` passes at `fail_under = 90`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR branch (or series of PRs) at HEAD, **When** the seven omit lines are searched in `pyproject.toml`, **Then** zero matches remain.
+2. **Given** the PR branch at HEAD, **When** the new tests execute in a network-isolated container, **Then** no test issues a real HTTP request, SSH connection, or subprocess to a device (verified by network sandboxing or mock-strict assertions).
+3. **Given** the PR branch at HEAD, **When** the coverage report is inspected, **Then** each of the seven un-omitted modules reports coverage of at least 90%.
+
+---
+
+### User Story 7 - SSH and UI Modules Un-Omitted (Priority: P7)
+
+Codebase maintainers need the SSH and TUI modules (`cli_shell_manager`, `tui`) removed from the coverage omit list and covered by real unit tests that mock the SSH transport and TUI rendering surface, so the interactive-terminal code paths stop hiding behind exclusions.
+
+**Why this priority**: SSH and TUI code paths require specialized mocking (paramiko / prompt_toolkit / textual). Landing this after P6's device managers ensures any shared SSH fixtures introduced in P6 are already in place. Small cluster (two modules) so it stays a single PR.
+
+**Independent Test**: After merge, the two listed omit entries are absent from `pyproject.toml`, each module has dedicated tests with SSH and terminal-rendering calls mocked, and `pytest --cov` passes at `fail_under = 90`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR branch at HEAD, **When** the two omit lines are searched in `pyproject.toml`, **Then** zero matches remain.
+2. **Given** the PR branch at HEAD, **When** the new SSH tests execute, **Then** no test opens a real SSH connection (verified by mocked transport assertions).
+3. **Given** the PR branch at HEAD, **When** the new TUI tests execute, **Then** no test opens a real terminal or blocks on user input.
+
+---
+
+### User Story 8 - WebSocket Cluster Un-Omitted (Priority: P8)
+
+Codebase maintainers need the `src/websocket/*` wildcard entry removed from the coverage omit list and every file under `src/websocket/` covered by real unit tests with the async transport and Mist WebSocket protocol mocked, so the async streaming surface reaches the project coverage bar.
+
+**Why this priority**: The WebSocket cluster is the hardest to test cleanly — async transport, long-lived connections, service-ping discovery, and diagnostic subscriptions all live here. Landing it last means every mocking pattern the earlier stories developed (network, subprocess, SSH, TUI) is already available, and this cluster's PR can lean on them. Because the omit line is a wildcard, removing it un-omits every current and future file under `src/websocket/`, so the PR must land tests for all files present at merge time.
+
+**Independent Test**: After merge, `"src/websocket/*"` is absent from `pyproject.toml`, every `.py` file directly under `src/websocket/` (and its subpackages `diagnostics/`, `polling/`) has dedicated tests, and `pytest --cov` passes at `fail_under = 90` with per-file coverage of at least 90% for every file the wildcard previously hid.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR branch at HEAD, **When** the wildcard omit line is searched in `pyproject.toml`, **Then** zero matches remain.
+2. **Given** the PR branch at HEAD, **When** the coverage report is inspected, **Then** every file under `src/websocket/` (recursively) reports coverage of at least 90%.
+3. **Given** the PR branch at HEAD, **When** the new WebSocket tests execute, **Then** no test opens a real WebSocket connection to `api.mist.com` or any external host (verified by `unittest.mock` strict-assert usage on the sync `websocket-client` `WebSocketApp` — the transport library imported by `src/websocket/manager.py`), and any long-running polling loop is exercised via at most two mocked iterations.
+
+---
+
+### Edge Cases
+
+- **Coverage regression on an un-omitted module**: If any un-omitted module lands below the project's 90% coverage threshold, the PR must add tests before merge. No `# pragma: no cover` or dummy `import module` tests are permitted to game the gate.
+- **Integration-only paths**: If a code path genuinely requires a live Mist API (e.g., WebSocket handshake against a real controller), it is covered via mocked doubles OR marked with the existing `integration` pytest marker. Marking with `integration` counts as tested for coverage purposes if and only if the marker keeps the code path out of the coverage denominator — otherwise the mocked-double route is used.
+- **New omit entry appears mid-workflow**: Between the writing of issue #878 (35 named files + `src/websocket/*`) and today, extra files may have been added to the omit list (e.g., `src/analytics/insight_metrics_utils.py`, `src/api/api_core_fetch_utils.py`, `src/cache/cache_utils.py`, `src/export/data_exporter.py`, `src/export/org_site_exporter.py`, `src/ui/prompt_utils.py`). The workflow MUST audit `pyproject.toml` at start and treat the current omit list (minus the six legitimately-non-source entries preserved by the issue's acceptance criteria) as the working set. Delta from the issue's original 35 entries is captured in Assumptions.
+- **Merge conflict from CI**: If any PR fails to merge cleanly on main (e.g., because a peer PR landed first), the branch is rebased and re-tested; no `--admin` bypass is used and no merge proceeds unless `mergeStateStatus=CLEAN`.
+- **Test file collision**: If a test file for an un-omitted module already exists under `tests/` but is a dummy placeholder (import-only or `pragma: no cover`-wrapped), the PR MUST replace it with real tests, not augment it silently.
+- **Refactor temptation**: If, while writing tests, a module is discovered to be untestable without refactoring, the PR MUST NOT refactor the module (per issue #878 non-goals). Instead, open a follow-up issue and defer coverage for that specific module — but retain coverage for the parts that ARE testable, and keep the omit entry removed only if the file still meets the 90% bar. Otherwise, leave the omit entry in place with a `# TODO(1017): refactor pending` comment and open a tracking issue.
+- **Stale audit numbers**: The current omit list in `pyproject.toml` differs from the issue body. The workflow refreshes the omit-list snapshot at the start of each PR and uses that as ground truth for the story's scope.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The workflow MUST deliver a series of pull requests, each closing one User Story (P1 through P8), following the ordered sequence P1 → P2 → P3 → P4 → P5 → P6 → P7 → P8. A single User Story MAY be delivered as more than one PR if scope warrants (see FR-013), but no story may be reordered.
+- **FR-002**: Each pull request MUST reference the covered User Story in its description and MUST include a `Refs #878` trailer (with `Closes #878` on the final PR of the workflow).
+- **FR-003**: The workflow MUST use serial dispatch across stories: pull request(s) for Story N+1 MUST NOT be opened until all pull requests for Story N have landed cleanly on `main`. Within a single story, sub-PRs MAY be opened in parallel if they touch disjoint files.
+- **FR-004**: Each pull request MUST originate from its own short-lived branch cut from the current `main` at the moment the PR is opened; the `1017-remove-coverage-omits` feature branch is used ONLY as the coordination home for spec/plan/tasks artifacts, not as the base for delivery PRs.
+- **FR-005**: Each pull request MUST pass `black --check` and `ruff check` locally before being pushed to the remote branch (per the "Pre-push black + ruff gate" repo convention).
+- **FR-006**: No pull request MUST use administrative merge bypass; each PR MUST wait for `mergeStateStatus=CLEAN` before merging (per the "No `--admin` merge bypass" repo convention).
+- **FR-007**: Every module removed from the omit list MUST have at least one dedicated test file under `tests/` that exercises real code paths. Dummy `import module` tests and `# pragma: no cover` wrappers MUST NOT be used to game the coverage gate.
+- **FR-008**: After every merged PR in the workflow, `pytest --cov=src --cov-fail-under=90` MUST pass on `main` without lowering `fail_under` and without adding any new omit entry.
+- **FR-009**: The workflow MUST NOT modify the fail_under threshold in `pyproject.toml` from its current value of 90.
+- **FR-010**: The workflow MUST NOT modify the modules themselves except where a non-cosmetic change is required to make them testable, in which case the change MUST be recorded in the PR body with rationale and MUST be limited to that PR (per issue #878 non-goals; also see the Refactor Temptation edge case).
+- **FR-011**: Retained omit entries (`tests/*`, `venv/*`, `.venv/*`, `setup.py`, `*/site-packages/*`, `src/maps/*`) MUST remain in the omit list at the end of the workflow — those are legitimately non-source.
+- **FR-012**: Integration-only code paths (real Mist API calls, real device SSH, real WebSocket handshakes) MUST be covered via mocked doubles OR marked with the existing `integration` pytest marker. No live-network call is permitted in the default CI test suite.
+- **FR-013**: A single User Story MAY be split into multiple pull requests if the total diff (test code + minimal test-affordance changes) exceeds ~500 net lines added or ~150 fixture lines per module. Sub-PRs of a story MUST land before the workflow advances to the next story.
+- **FR-014**: The workflow's coordination artifacts (`specs/1017-remove-coverage-omits/spec.md`, and any follow-up `plan.md` / `tasks.md`) MUST NOT be modified after the first delivery PR opens except to record deltas — no scope creep, no post-hoc story insertion.
+- **FR-015**: If a module cannot reach 90% coverage without refactoring (per the Refactor Temptation edge case), the workflow MUST retain that specific omit entry, add a `# TODO(1017): refactor pending` comment, and open a tracking issue that references #878. This exception MUST be documented in the PR body and MUST NOT be used to skip more than 2 modules across the entire workflow.
+- **FR-016**: The current omit list in `pyproject.toml` (which contains ~41 entries as of 2026-07-13, slightly more than the 35 named in issue #878) is treated as the authoritative working set. Any file present in `pyproject.toml`'s omit list at workflow start that is NOT in the "legitimately non-source" retained set (FR-011) MUST be un-omitted by the workflow. See Assumptions for the delta.
+
+### Key Entities *(include if feature involves data)*
+
+- **Omit Entry**: A single line in the `[tool.coverage.run].omit` array of `pyproject.toml` that instructs `coverage.py` to exclude a specific file (or, for `src/websocket/*`, a directory tree) from the coverage calculation. In this workflow, each such entry (except the retained non-source entries) is a work item; success is measured by driving the count to zero.
+- **Un-Omitted Module**: A Python source file that (a) previously had an omit entry, (b) has had that entry removed by a PR in this workflow, and (c) is now measured by `coverage.py`. Success for an un-omitted module is per-file coverage ≥ 90%.
+- **Retained Non-Source Entry**: An omit entry that does NOT map to first-party source under `src/` (or `src/maps/` which is generated). The retained set at workflow start is `{tests/*, venv/*, .venv/*, setup.py, */site-packages/*, src/maps/*}`. These MUST remain in the omit list per FR-011.
+- **Integration-Only Path**: A code path inside an un-omitted module that requires a live external resource (Mist API, device SSH, WebSocket handshake to controller). Per FR-012, these are covered by mocks OR marked with the existing `integration` pytest marker.
+- **Test Fixture Bundle**: The per-module test scaffolding (JSON fixture files, mock factories, `conftest.py` additions) needed to exercise an un-omitted module. Owned by the story that un-omits that module. Reusable across stories where possible (P4 exporters reuse P3 fetcher mocks, P8 WebSocket tests reuse P6 SSH mock patterns).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After all workflow PRs are merged, the `[tool.coverage.run].omit` array in `pyproject.toml` contains exactly the retained non-source entries `{tests/*, venv/*, .venv/*, setup.py, */site-packages/*, src/maps/*}` and no other entries (verified via `python -c "import tomllib; print(sorted(tomllib.load(open('pyproject.toml', 'rb'))['tool']['coverage']['run']['omit']))"`).
+- **SC-002**: GitHub issue #878 is closed by the workflow's final merge, verified by GitHub's issue-linking status on the last PR.
+- **SC-003**: `pytest --cov=src --cov-fail-under=90` passes on `main` on every merge commit produced by this workflow, without any lowering of the `fail_under` threshold and without any new omit entry.
+- **SC-004**: Every un-omitted module reports per-file coverage of at least 90% on the final merge commit (verified via `coverage report --fail-under=90 --skip-covered`).
+- **SC-005**: No pull request in this workflow uses administrative merge bypass — every merge lands with `mergeStateStatus=CLEAN`.
+- **SC-006**: No test file added by this workflow contains `# pragma: no cover`, `# type: ignore`, or dummy `import module` statements used purely to reach the 90% bar (verified by lint check on the tests/ diff of each PR).
+- **SC-007**: No test added by this workflow issues a live HTTP, WebSocket, or SSH connection during the default CI run (verified by running the suite in a network-isolated container and observing zero external egress, OR by inspecting each new test file for mock usage or `@pytest.mark.integration`).
+- **SC-008**: At most 2 modules across the entire workflow invoke the FR-015 refactor-pending escape hatch. If more than 2 modules cannot reach coverage without refactoring, the workflow pauses and the scope is renegotiated via a follow-up issue rather than lowering the bar.
+- **SC-009**: The end-to-end elapsed time from opening Story 1's first PR to merging Story 8's final PR is within the team's target of two working months (8 calendar weeks), assuming standard review cadence at approximately one PR per 2–3 working days.
+- **SC-010**: The pylint fail-under threshold (9.5) and the coverage fail_under threshold (90) both continue to hold on every merged commit — no gate is lowered anywhere in `pyproject.toml`.
+
+## Assumptions
+
+- The `[tool.coverage.run].omit` list in `pyproject.toml` at workflow start (as of 2026-07-13) contains the 35 entries named in issue #878 plus `src/websocket/*` (matching the issue title "36 excluded modules") AND the following additional entries added between issue creation and today: `src/analytics/insight_metrics_utils.py`, `src/api/api_core_fetch_utils.py`, `src/cache/cache_utils.py`, `src/export/data_exporter.py`, `src/export/org_site_exporter.py`, `src/ui/prompt_utils.py`. Per FR-016, these additional entries are also in scope; they will be folded into the P1–P8 clusters based on module theme (utilities → P1/P2, exporters → P4/P5, API → P3, UI → P7).
+- Initiative #1015 (`misthelper-refactor-final-15`) and initiative #1016 (`misthelper-suppression-cleanup`) are complete or nearing completion; no cross-initiative rebase conflicts are expected. Any overlap between a module's refactor PR (from #1015) and its coverage PR (from this workflow) is resolved by landing the refactor first.
+- The project's pytest configuration (`pyproject.toml` `[tool.pytest.ini_options]`) already defines the `integration` marker used by FR-012; no marker registration change is required by this workflow.
+- The `tests/` directory already contains a `conftest.py` with reusable fixtures for common mocks (mistapi client, sessions, config). This workflow may extend `conftest.py` but does not rewrite it.
+- The project's CI pipeline runs `pytest --cov` on every push and enforces `fail_under = 90` as a hard gate. Removing an omit entry without adding sufficient tests will fail CI, which is the desired behavior — no PR merges without honest coverage.
+- No consumer of the un-omitted modules depends on their being un-covered — i.e., no downstream code inspects `coverage.py`'s output or the omit list itself.
+- Reviewers have capacity to review PRs at roughly one PR per 2–3 working days, matching SC-009's target elapsed time of ~8 calendar weeks for 8+ stories.
+- The `tools/refactor_analyzer/` tooling and existing lint/coverage tooling remain functional throughout the workflow; no tooling upgrades are gated on this workflow.
+- Any module that turns out to be genuinely dead code (imported nowhere in `src/` after audit) will be handled by a follow-up refactor issue outside this workflow, per issue #878 non-goals. This workflow will keep its omit entry and add a `# TODO(1017): dead code candidate` comment in `pyproject.toml`, then open a tracking issue.

--- a/specs/1017-remove-coverage-omits/tasks.md
+++ b/specs/1017-remove-coverage-omits/tasks.md
@@ -1,0 +1,510 @@
+# Tasks: Remove Coverage Omit Entries for In-Scope Modules
+
+**Input**: Design documents from `specs/1017-remove-coverage-omits/`
+
+**Prerequisites**: `plan.md` (required), `spec.md` (required for user stories)
+
+**Tests**: This workflow is fundamentally a test-authoring workflow. Every PR from T-01 through T-08 lands new tests under `tests/unit/` (and optionally `tests/integration/` where a `@pytest.mark.integration` fixture is more accurate than mocks) whose sole purpose is to raise per-module coverage to ≥ 90% BEFORE the corresponding `pyproject.toml` omit entries are deleted. No production module is edited by this workflow; only tests are added and `pyproject.toml` is trimmed.
+
+**Organization**: Tasks are grouped by delivery pull request (T-01 through T-08 map to PR-1 through PR-8, with T-04 split into T-04a/T-04b and T-05 split into T-05a/T-05b to keep each PR reviewable), plus a T-Final workflow-level cleanup and verification PR. Every PR is strictly sequential per FR-003 (SC-008) — PR N+1 does NOT open until PR N is merged. Within a PR, sub-tasks are strictly sequential unless marked `[P]`.
+
+## Format: `[TaskID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel with other `[P]` tasks in the same PR (different files/edits, no ordering deps)
+- **[Story]**: Which user story this task belongs to (US1–US8, one per PR-family)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single-project layout (per `plan.md` Project Structure). All test additions land under `tests/unit/` (or `tests/integration/` where explicitly noted). The final PR (T-Final) edits `pyproject.toml` only. No production `src/` module is modified by this workflow (FR-010).
+
+Delta modules (in-scope but not enumerated in spec.md § User Stories at plan time, mapped per FR-016):
+
+- `src/analytics/insight_metrics_utils.py` → P3 (analytics/API cluster)
+- `src/api/api_core_fetch_utils.py` → P3 (API cluster)
+- `src/cache/cache_utils.py` → P3 (API-adjacent)
+- `src/export/data_exporter.py` → P2 (export helper)
+- `src/export/org_site_exporter.py` → P4 (org exporter cluster, PR-4a)
+- `src/ui/prompt_utils.py` → P7 (UI cluster)
+
+---
+
+## PR-0: Phase 0/1 Design Artifacts (Priority: P0 — prerequisite for PR-1)
+
+**Goal**: Create the six Phase 0/1 deliverables enumerated in `plan.md` § File Structure and § Phase 0/1 so PR-1 opens against a complete design record. This PR touches only `specs/1017-remove-coverage-omits/` — no `src/`, `tests/`, or `pyproject.toml` edits.
+
+**Target artifacts**:
+
+- `specs/1017-remove-coverage-omits/research.md` (Phase 0 output — omit-list audit, `src/websocket/*` file enumeration, per-cluster mocking decisions, fixture-migration order)
+- `specs/1017-remove-coverage-omits/data-model.md` (Phase 1 — per-module test manifest, retained non-source inventory, integration-only path inventory, fixture registry)
+- `specs/1017-remove-coverage-omits/contracts/shared_fixtures.md` (fixture shape + tier contracts per plan.md Decision 1)
+- `specs/1017-remove-coverage-omits/contracts/coverage_assertion.md` (per-file + full-suite coverage invocations)
+- `specs/1017-remove-coverage-omits/contracts/mocking_conventions.md` (`MagicMock(spec=…)` rules for mistapi/paramiko/`websocket-client`)
+- `specs/1017-remove-coverage-omits/quickstart.md` (per-story verification recipes P1–P8)
+
+**Estimated PR size**: docs-only; ~500–900 net lines across six new markdown files under `specs/1017-remove-coverage-omits/`. No `pyproject.toml` diff.
+
+**Independent Test**: `ls specs/1017-remove-coverage-omits/` shows `research.md`, `data-model.md`, `quickstart.md`, and a `contracts/` directory containing `shared_fixtures.md`, `coverage_assertion.md`, `mocking_conventions.md`; every file references the exact same 6-entry retained non-source omit set (SC-001) and 90% coverage threshold (SC-003); `research.md` records a snapshot of `pyproject.toml [tool.coverage.run].omit` as it exists at PR-0 branch-cut time.
+
+- [ ] T-00.1 [US0] Branch: `git switch main && git pull && git switch -c coverage-omits-p0-design-artifacts-1017`.
+- [ ] T-00.2 [US0] Author `research.md`: refresh the omit-list audit at current `main` HEAD; enumerate the 35 in-scope + 6 retained entries; enumerate every `.py` file under `src/websocket/`, `src/websocket/diagnostics/`, `src/websocket/polling/` (bounds P8); record per-cluster mocking-library choices (mistapi, `websocket-client` sync + threading, paramiko, no sqlite3); record fixture-migration order for `mock_mistapi_session`, `mock_config`, `mock_websocket_transport`.
+- [ ] T-00.3 [US0] Author `data-model.md`: for each of the 35 in-scope modules, record target test file path, external touch points, expected fixture bundle location; enumerate retained non-source entries verbatim from FR-011; enumerate integration-only paths with mock-vs-`@pytest.mark.integration` decision + reason.
+- [ ] T-00.4 [US0] Author `contracts/shared_fixtures.md`, `contracts/coverage_assertion.md`, `contracts/mocking_conventions.md` per plan.md Phase 1 § 2 (create the `contracts/` directory first). Each contract file MUST include an explicit `Validation rule:` line so reviewers can grep for it.
+- [ ] T-00.5 [US0] Author `quickstart.md`: per-story verification recipes (P1–P8) with exact `grep` + `pytest --cov=… --cov-fail-under=90` invocations; include the `podman run --network=none` recipe for SC-007 verification (per plan.md line 286).
+- [ ] T-00.6 [US0] Verify locally: `ls specs/1017-remove-coverage-omits/contracts/` shows the three contract files; `grep -l "SC-001" specs/1017-remove-coverage-omits/*.md specs/1017-remove-coverage-omits/contracts/*.md` returns every new file; no formatter/lint gates apply (docs-only PR).
+- [ ] T-00.7 [US0] Commit + push: stage the six new files; commit body cites `Refs #878` and plan.md § Phase 0 / § Phase 1; push the `coverage-omits-p0-design-artifacts-1017` branch.
+- [ ] T-00.8 [US0] Open PR with `Refs #878` trailer (intermediate PR — no code changes to gate CI failures) via `gh pr create --base main --head coverage-omits-p0-design-artifacts-1017`.
+- [ ] T-00.9 [US0] Wait for CI + `mergeStateStatus=CLEAN`; arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-00.10 [US0] Confirm merged; branch deleted. PR-1 is now unblocked.
+
+**Checkpoint**: Phase 0/1 design artifacts merged to `main`. Every downstream PR (T-01…T-Final) can cite `research.md`, `data-model.md`, and the three contract files as authoritative.
+
+---
+
+## PR-1: Issue #878 — P1 utility modules coverage (Priority: P1) 🎯 MVP
+
+**Goal**: Author tests to reach ≥ 90% coverage on the 4 P1 utility modules and delete their omit entries from `pyproject.toml`.
+
+**Target modules**:
+
+- `src/utils/environment_utils.py`
+- `src/utils/filter_operator_engine.py`
+- `src/troubleshooting/troubleshoot_utils.py`
+- `src/input/prompt_client_utils.py`
+
+**Estimated PR size**: ~4–8 new test files under `tests/unit/`, ~800–1500 net lines added. `pyproject.toml` diff: −4 lines.
+
+**Independent Test**: After merge, `pytest --cov=src/utils/environment_utils --cov=src/utils/filter_operator_engine --cov=src/troubleshooting/troubleshoot_utils --cov=src/input/prompt_client_utils --cov-report=term-missing --cov-fail-under=90` passes; the four corresponding lines are absent from `[tool.coverage.run].omit` in `pyproject.toml`; repo-wide `pytest --cov` still reports total coverage ≥ 90%.
+
+- [ ] T-01.1 [US1] Audit: run `pytest --cov=src/utils/environment_utils --cov=src/utils/filter_operator_engine --cov=src/troubleshooting/troubleshoot_utils --cov=src/input/prompt_client_utils --cov-report=term-missing --no-cov-on-fail` with the omit entries temporarily commented out locally to establish the current per-module coverage baseline; record numbers in the PR body (do NOT commit the commented pyproject).
+- [ ] T-01.2 [US1] Branch: run `git switch main && git pull && git switch -c coverage-omits-p1-utilities-878` from repo root.
+- [ ] T-01.3 [US1] Author tests under `tests/unit/utils/` and `tests/unit/troubleshooting/` and `tests/unit/input/`: create `test_environment_utils.py`, `test_filter_operator_engine.py`, `test_troubleshoot_utils.py`, and `test_prompt_client_utils.py`. Use `unittest.mock.MagicMock(spec=...)` for external SDK objects (mistapi client, filesystem), `monkeypatch` for environment variables and stdin prompts, and `@pytest.mark.integration` for any test that must call the real Mist API (guarded by `.env` credentials). Aim for ≥ 90% per-module line coverage; document any legitimately unreachable branches with `# pragma: no cover` INLINE (not by re-adding to omit).
+- [ ] T-01.4 [US1] Remove omit entries in `pyproject.toml`: delete the four lines `"src/troubleshooting/troubleshoot_utils.py"`, `"src/input/prompt_client_utils.py"`, `"src/utils/environment_utils.py"`, `"src/utils/filter_operator_engine.py"` from `[tool.coverage.run].omit`. No other pyproject edits (FR-009, FR-011).
+- [ ] T-01.5 [US1] Verify locally: run `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90`, then `mypy` on any test helpers. Confirm the four modules now appear in the coverage report and each is at ≥ 90%; confirm repo-wide total ≥ 90%. If a per-module target is below 90% and cannot be met without touching production code, halt and evaluate FR-015 escape hatch (max 2 modules total across the workflow).
+- [ ] T-01.6 [US1] Commit + push: stage `tests/unit/utils/`, `tests/unit/troubleshooting/`, `tests/unit/input/`, and `pyproject.toml`; commit with a body reporting pre/post per-module coverage numbers; push the `coverage-omits-p1-utilities-878` branch to remote.
+- [ ] T-01.7 [US1] Open PR with `Refs #878` trailer (intermediate PR — the tracking issue closes only after T-Final) using `gh pr create --base main --head coverage-omits-p1-utilities-878`; include per-module coverage numbers and the pyproject diff in the PR body per plan.md Decision 2.
+- [ ] T-01.8 [US1] Wait for CI + `mergeStateStatus=CLEAN`: poll `gh pr view <N> --json mergeStateStatus,statusCheckRollup` until state is CLEAN and all required checks are SUCCESS.
+- [ ] T-01.9 [US1] Arm auto-merge and land: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch` (no `--admin` bypass under any circumstance per FR-006).
+- [ ] T-01.10 [US1] Confirm merged: `gh pr view <N> --json state,mergeCommit` returns `MERGED`; the P1 tracking issue is closed by GitHub auto-close; branch `coverage-omits-p1-utilities-878` is deleted on remote.
+
+**Checkpoint**: 4 P1 utility modules are covered ≥ 90% and removed from the omit list.
+
+---
+
+## PR-2: Issue #TBD — P2 export helper coverage (Priority: P2)
+
+**Goal**: Author tests to reach ≥ 90% coverage on the P2 export helper modules and delete their omit entries.
+
+**Target modules**:
+
+- `src/export/org_export_utils.py`
+- `src/export/license_export_utils.py`
+- `src/export/const_definitions_exporter.py`
+- `src/export/gateway_test_exporter.py`
+- `src/export/data_exporter.py` (delta from FR-016)
+
+**Estimated PR size**: ~5–8 new test files under `tests/unit/export/`, ~1000–1800 net lines added. `pyproject.toml` diff: −5 lines.
+
+**Independent Test**: After merge, `pytest --cov=src/export/org_export_utils --cov=src/export/license_export_utils --cov=src/export/const_definitions_exporter --cov=src/export/gateway_test_exporter --cov=src/export/data_exporter --cov-report=term-missing --cov-fail-under=90` passes; the five corresponding lines are absent from `[tool.coverage.run].omit`; repo-wide coverage ≥ 90%.
+
+- [ ] T-02.1 [US2] Audit: run coverage locally with the five omit lines temporarily commented out; record per-module baseline in PR body.
+- [ ] T-02.2 [US2] Branch: run `git switch main && git pull && git switch -c coverage-omits-p2-export-helpers`.
+- [ ] T-02.3 [US2] Author tests under `tests/unit/export/`: create `test_org_export_utils.py`, `test_license_export_utils.py`, `test_const_definitions_exporter.py`, `test_gateway_test_exporter.py`, `test_data_exporter.py`. Reuse shared fixtures where the exporters share JSON/CSV writer patterns; use `tmp_path` for filesystem writes; mock `mistapi` client with `MagicMock(spec=mistapi.APISession)`. Land ≥ 90% per-module line coverage.
+- [ ] T-02.4 [US2] Remove the five omit entries from `pyproject.toml`: `"src/export/const_definitions_exporter.py"`, `"src/export/data_exporter.py"`, `"src/export/gateway_test_exporter.py"`, `"src/export/license_export_utils.py"`, `"src/export/org_export_utils.py"`.
+- [ ] T-02.5 [US2] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90`; confirm the five modules appear at ≥ 90% and repo total ≥ 90%.
+- [ ] T-02.6 [US2] Commit + push: stage `tests/unit/export/` additions and `pyproject.toml`; commit with pre/post coverage; push the branch.
+- [ ] T-02.7 [US2] Open PR with `Refs #<P2-issue>` trailer (intermediate PR) via `gh pr create --base main --head coverage-omits-p2-export-helpers`; include coverage numbers and pyproject diff per plan.md Decision 2.
+- [ ] T-02.8 [US2] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-02.9 [US2] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-02.10 [US2] Confirm merged, P2 issue closed, branch deleted.
+
+**Checkpoint**: 5 P2 export helper modules are covered ≥ 90% and removed from the omit list.
+
+---
+
+## PR-3: Issue #TBD — P3 API/DB/analytics coverage (Priority: P3)
+
+**Goal**: Author tests to reach ≥ 90% coverage on the P3 API-adjacent modules and delete their omit entries.
+
+**Target modules**:
+
+- `src/api/api_data_fetcher.py`
+- `src/api/api_fetch_utils.py`
+- `src/api/api_core_fetch_utils.py` (delta)
+- `src/cache/cache_utils.py` (delta)
+- `src/db/database_schema_utils.py`
+- `src/analytics/data_collection_manager.py`
+- `src/analytics/insight_metrics_utils.py` (delta)
+
+**Estimated PR size**: ~7–10 new test files under `tests/unit/api/`, `tests/unit/cache/`, `tests/unit/db/`, `tests/unit/analytics/`. ~1500–2500 net lines added. `pyproject.toml` diff: −7 lines. If the API cluster proves too large for a single reviewable PR, split into T-03a (`api_*`, `cache_utils`) and T-03b (`db/analytics`) — allowed by plan.md Complexity Table Row P3 (1–2 sub-PRs).
+
+**Independent Test**: After merge, `pytest --cov=src/api --cov=src/cache/cache_utils --cov=src/db/database_schema_utils --cov=src/analytics/data_collection_manager --cov=src/analytics/insight_metrics_utils --cov-fail-under=90` passes; the seven corresponding lines are absent from `[tool.coverage.run].omit`; repo-wide coverage ≥ 90%.
+
+- [ ] T-03.1 [US3] Audit: run coverage locally with the seven omit lines commented out; record per-module baseline.
+- [ ] T-03.2 [US3] Branch: `git switch main && git pull && git switch -c coverage-omits-p3-api-db-analytics`.
+- [ ] T-03.3 [US3] Author tests: create `tests/unit/api/test_api_data_fetcher.py`, `test_api_fetch_utils.py`, `test_api_core_fetch_utils.py`; `tests/unit/cache/test_cache_utils.py`; `tests/unit/db/test_database_schema_utils.py`; `tests/unit/analytics/test_data_collection_manager.py`, `test_insight_metrics_utils.py`. Mock `python-arango` and `redis` clients with `MagicMock(spec=...)`; use `pytest.fixture` for reusable mistapi session fixtures; add a shared `conftest.py` under `tests/unit/api/` for the API session mock if two or more tests need it.
+- [ ] T-03.4 [US3] Remove the seven omit entries from `pyproject.toml`: `"src/analytics/data_collection_manager.py"`, `"src/analytics/insight_metrics_utils.py"`, `"src/api/api_data_fetcher.py"`, `"src/api/api_fetch_utils.py"`, `"src/api/api_core_fetch_utils.py"`, `"src/cache/cache_utils.py"`, `"src/db/database_schema_utils.py"`.
+- [ ] T-03.5 [US3] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90`; confirm ≥ 90% per module and repo total ≥ 90%.
+- [ ] T-03.6 [US3] Commit + push: stage `tests/unit/api/`, `tests/unit/cache/`, `tests/unit/db/`, `tests/unit/analytics/` additions and `pyproject.toml`; push branch.
+- [ ] T-03.7 [US3] Open PR with `Refs #<P3-issue>` trailer (intermediate PR) via `gh pr create --base main --head coverage-omits-p3-api-db-analytics`; include coverage numbers per plan.md Decision 2. If the PR exceeds ~2500 lines, split into T-03a (branch `coverage-omits-p3a-api-cache`) and T-03b (branch `coverage-omits-p3b-db-analytics`) — merge T-03a fully (CI green + branch deleted) before opening T-03b.
+- [ ] T-03.8 [US3] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-03.9 [US3] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-03.10 [US3] Confirm merged, P3 issue closed, branch deleted.
+
+**Checkpoint**: 7 P3 API/DB/analytics modules are covered ≥ 90% and removed from the omit list.
+
+---
+
+## PR-4a: Issue #TBD — P4 org exporters (part 1: stats + templates + admin) (Priority: P4)
+
+**Goal**: Author tests for the first half of the P4 org-exporter cluster and delete those omit entries.
+
+**Target modules**:
+
+- `src/export/org_device_stats_exporter.py`
+- `src/export/org_template_exporter.py`
+- `src/export/org_admin_exporter.py`
+
+**Estimated PR size**: ~3–5 new test files under `tests/unit/export/`, ~800–1400 net lines. `pyproject.toml` diff: −3 lines.
+
+**Independent Test**: After merge, `pytest --cov=src/export/org_device_stats_exporter --cov=src/export/org_template_exporter --cov=src/export/org_admin_exporter --cov-fail-under=90` passes; the three corresponding lines are absent from `[tool.coverage.run].omit`; repo-wide coverage ≥ 90%. The remaining P4 org exporters are still omitted and will be picked up by PR-4b.
+
+- [ ] T-04a.1 [US4] Audit: run coverage locally with the three omit lines commented out; record baseline.
+- [ ] T-04a.2 [US4] Branch: `git switch main && git pull && git switch -c coverage-omits-p4a-org-stats-templates-admin`.
+- [ ] T-04a.3 [US4] Author tests under `tests/unit/export/`: `test_org_device_stats_exporter.py`, `test_org_template_exporter.py`, `test_org_admin_exporter.py`. Introduce a shared `tests/unit/export/conftest.py` fixture set for `mistapi.APISession` mock, sample org payloads, and `tmp_path` output paths — this fixture MUST be shared with PR-4b/PR-5a/PR-5b to keep future exporter tests DRY.
+- [ ] T-04a.4 [US4] Remove the three omit entries: `"src/export/org_admin_exporter.py"`, `"src/export/org_device_stats_exporter.py"`, `"src/export/org_template_exporter.py"`.
+- [ ] T-04a.5 [US4] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90`.
+- [ ] T-04a.6 [US4] Commit + push: stage `tests/unit/export/` additions (including `conftest.py`) and `pyproject.toml`; push branch.
+- [ ] T-04a.7 [US4] Open PR with `Closes #<P4a-issue>` trailer via `gh pr create --base main --head coverage-omits-p4a-org-stats-templates-admin`; note in PR body that a shared `conftest.py` was introduced and will be reused by PR-4b/PR-5a/PR-5b.
+- [ ] T-04a.8 [US4] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-04a.9 [US4] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-04a.10 [US4] Confirm merged, P4a issue closed, branch deleted.
+
+**Checkpoint**: 3 org exporters covered ≥ 90% and removed from omit list; shared `tests/unit/export/conftest.py` fixture library is in place.
+
+---
+
+## PR-4b: Issue #TBD — P4 org exporters (part 2: config + alarms + client-security + sites) (Priority: P4)
+
+**Goal**: Complete the P4 org-exporter cluster by covering the remaining four modules.
+
+**Target modules**:
+
+- `src/export/org_config_exporter.py`
+- `src/export/org_alarm_event_exporter.py`
+- `src/export/org_client_security_exporter.py`
+- `src/export/org_site_exporter.py` (delta)
+
+**Estimated PR size**: ~4–6 new test files under `tests/unit/export/`, ~1000–1600 net lines. `pyproject.toml` diff: −4 lines.
+
+**Independent Test**: After merge, `pytest --cov=src/export/org_config_exporter --cov=src/export/org_alarm_event_exporter --cov=src/export/org_client_security_exporter --cov=src/export/org_site_exporter --cov-fail-under=90` passes; the four corresponding lines are absent from `[tool.coverage.run].omit`; repo-wide coverage ≥ 90%.
+
+- [ ] T-04b.1 [US4] Audit: coverage baseline with the four omit lines commented out.
+- [ ] T-04b.2 [US4] Branch: `git switch main && git pull && git switch -c coverage-omits-p4b-org-config-alarms-security-sites`.
+- [ ] T-04b.3 [US4] Author tests: `tests/unit/export/test_org_config_exporter.py`, `test_org_alarm_event_exporter.py`, `test_org_client_security_exporter.py`, `test_org_site_exporter.py`. Reuse `tests/unit/export/conftest.py` from PR-4a for the `mistapi.APISession` mock and shared payload fixtures.
+- [ ] T-04b.4 [US4] Remove the four omit entries: `"src/export/org_alarm_event_exporter.py"`, `"src/export/org_client_security_exporter.py"`, `"src/export/org_config_exporter.py"`, `"src/export/org_site_exporter.py"`.
+- [ ] T-04b.5 [US4] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90`.
+- [ ] T-04b.6 [US4] Commit + push.
+- [ ] T-04b.7 [US4] Open PR with `Closes #<P4b-issue>` trailer via `gh pr create --base main --head coverage-omits-p4b-org-config-alarms-security-sites`.
+- [ ] T-04b.8 [US4] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-04b.9 [US4] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-04b.10 [US4] Confirm merged, P4b issue closed, branch deleted.
+
+**Checkpoint**: All 7 P4 org exporters (3 from PR-4a + 4 from PR-4b) are covered ≥ 90% and removed from the omit list.
+
+---
+
+## PR-5a: Issue #TBD — P5 site exporters (Priority: P5)
+
+**Goal**: Author tests for the site-exporter half of P5 and delete those omit entries.
+
+**Target modules**:
+
+- `src/export/site_anomaly_exporter.py`
+- `src/export/site_config_exporter.py`
+- `src/export/site_device_exporter.py`
+- `src/export/sites_by_ap_model_exporter.py`
+- `src/gateway/gateway_ha_exporter.py`
+
+**Estimated PR size**: ~5–7 new test files under `tests/unit/export/` and `tests/unit/gateway/`, ~1200–1800 net lines. `pyproject.toml` diff: −5 lines.
+
+**Independent Test**: After merge, `pytest --cov=src/export/site_anomaly_exporter --cov=src/export/site_config_exporter --cov=src/export/site_device_exporter --cov=src/export/sites_by_ap_model_exporter --cov=src/gateway/gateway_ha_exporter --cov-fail-under=90` passes; the five lines are absent from `[tool.coverage.run].omit`; repo-wide coverage ≥ 90%.
+
+- [ ] T-05a.1 [US5] Audit: coverage baseline with the five omit lines commented out.
+- [ ] T-05a.2 [US5] Branch: `git switch main && git pull && git switch -c coverage-omits-p5a-site-exporters`.
+- [ ] T-05a.3 [US5] Author tests: `tests/unit/export/test_site_anomaly_exporter.py`, `test_site_config_exporter.py`, `test_site_device_exporter.py`, `test_sites_by_ap_model_exporter.py`; `tests/unit/gateway/test_gateway_ha_exporter.py`. Reuse `tests/unit/export/conftest.py` for shared session/payload fixtures; add a `tests/unit/gateway/conftest.py` if a gateway-specific mock is needed.
+- [ ] T-05a.4 [US5] Remove the five omit entries: `"src/export/site_anomaly_exporter.py"`, `"src/export/site_config_exporter.py"`, `"src/export/site_device_exporter.py"`, `"src/export/sites_by_ap_model_exporter.py"`, `"src/gateway/gateway_ha_exporter.py"`.
+- [ ] T-05a.5 [US5] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90`.
+- [ ] T-05a.6 [US5] Commit + push.
+- [ ] T-05a.7 [US5] Open PR with `Closes #<P5a-issue>` trailer via `gh pr create --base main --head coverage-omits-p5a-site-exporters`.
+- [ ] T-05a.8 [US5] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-05a.9 [US5] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-05a.10 [US5] Confirm merged, P5a issue closed, branch deleted.
+
+**Checkpoint**: 5 site exporters (+ gateway HA exporter) covered ≥ 90% and removed from the omit list.
+
+---
+
+## PR-5b: Issue #TBD — P5 reporters + inventory facade (Priority: P5)
+
+**Goal**: Author tests for the reporter/inventory half of P5 and delete those omit entries.
+
+**Target modules**:
+
+- `src/reports/global_wired_client_report_generator.py`
+- `src/reports/offline_device_reporter.py`
+- `src/reports/sfp_transceiver_data_processor.py`
+- `src/reports/wired_client_manufacturer_report_generator.py`
+- `src/inventory/org_device_inventory_summary_facade.py`
+
+**Estimated PR size**: ~5–7 new test files under `tests/unit/reports/` and `tests/unit/inventory/`, ~1200–1800 net lines. `pyproject.toml` diff: −5 lines.
+
+**Independent Test**: After merge, `pytest --cov=src/reports/global_wired_client_report_generator --cov=src/reports/offline_device_reporter --cov=src/reports/sfp_transceiver_data_processor --cov=src/reports/wired_client_manufacturer_report_generator --cov=src/inventory/org_device_inventory_summary_facade --cov-fail-under=90` passes; the five lines are absent from `[tool.coverage.run].omit`; repo-wide coverage ≥ 90%.
+
+- [ ] T-05b.1 [US5] Audit: coverage baseline with the five omit lines commented out.
+- [ ] T-05b.2 [US5] Branch: `git switch main && git pull && git switch -c coverage-omits-p5b-reports-inventory`.
+- [ ] T-05b.3 [US5] Author tests: `tests/unit/reports/test_global_wired_client_report_generator.py`, `test_offline_device_reporter.py`, `test_sfp_transceiver_data_processor.py`, `test_wired_client_manufacturer_report_generator.py`; `tests/unit/inventory/test_org_device_inventory_summary_facade.py`. Mock `prettytable` output where needed; verify sort/filter logic with parametrized cases.
+- [ ] T-05b.4 [US5] Remove the five omit entries: `"src/reports/global_wired_client_report_generator.py"`, `"src/reports/offline_device_reporter.py"`, `"src/reports/sfp_transceiver_data_processor.py"`, `"src/reports/wired_client_manufacturer_report_generator.py"`, `"src/inventory/org_device_inventory_summary_facade.py"`.
+- [ ] T-05b.5 [US5] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90`.
+- [ ] T-05b.6 [US5] Commit + push.
+- [ ] T-05b.7 [US5] Open PR with `Closes #<P5b-issue>` trailer via `gh pr create --base main --head coverage-omits-p5b-reports-inventory`.
+- [ ] T-05b.8 [US5] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-05b.9 [US5] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-05b.10 [US5] Confirm merged, P5b issue closed, branch deleted.
+
+**Checkpoint**: 5 report generators + inventory facade covered ≥ 90% and removed from the omit list. All P5 modules are now fully covered.
+
+---
+
+## PR-6: Issue #TBD — P6 device/firmware/inventory managers (Priority: P6)
+
+**Goal**: Author tests for the P6 state-changing device managers. Because these modules perform destructive actions (reboots, firmware pushes, ARP-cache clears, ticket writes), tests MUST NOT mutate real infrastructure. Every state-changing path is exercised through `unittest.mock.MagicMock(spec=mistapi.APISession)` and asserts on outbound call arguments; any test that requires a real device must be gated with `@pytest.mark.integration` and skipped by default.
+
+**Target modules**:
+
+- `src/device/arp_command_manager.py`
+- `src/device/device_reboot_manager.py`
+- `src/firmware/firmware_manager.py`
+- `src/site/bulk_radius_wlan_config_manager.py`
+- `src/org/org_ticket_manager.py`
+
+Note: `src/reports/offline_device_reporter.py` and `src/inventory/org_device_inventory_summary_facade.py` from spec.md's P6 list are picked up by PR-5b (report/inventory cluster) to keep P6 focused on state-changing modules per Constitution Principle III.
+
+**Estimated PR size**: ~5–8 new test files under `tests/unit/device/`, `tests/unit/firmware/`, `tests/unit/site/`, `tests/unit/org/`. ~1500–2400 net lines. `pyproject.toml` diff: −5 lines. If reviewer feedback finds this PR too large, split into T-06a (device/firmware) and T-06b (site/org) — allowed by plan.md Complexity Table Row P6 (2–3 sub-PRs).
+
+**Independent Test**: After merge, `pytest --cov=src/device/arp_command_manager --cov=src/device/device_reboot_manager --cov=src/firmware/firmware_manager --cov=src/site/bulk_radius_wlan_config_manager --cov=src/org/org_ticket_manager --cov-fail-under=90` passes; the five lines are absent from `[tool.coverage.run].omit`; repo-wide coverage ≥ 90%. No test writes to a real Mist org (verified by grepping test files for `@pytest.mark.integration` and confirming every real-API test is gated).
+
+- [ ] T-06.1 [US6] Audit: coverage baseline with the five omit lines commented out. In the PR body, explicitly enumerate every outbound state-changing API call each module makes (Constitution Principle III artifact) and confirm each is mocked in the new tests.
+- [ ] T-06.2 [US6] Branch: `git switch main && git pull && git switch -c coverage-omits-p6-state-changing-managers`.
+- [ ] T-06.3 [US6] Author tests: `tests/unit/device/test_arp_command_manager.py`, `test_device_reboot_manager.py`; `tests/unit/firmware/test_firmware_manager.py`; `tests/unit/site/test_bulk_radius_wlan_config_manager.py`; `tests/unit/org/test_org_ticket_manager.py`. For each destructive method (reboot, firmware upgrade, ARP clear, ticket write, config bulk-apply), assert (a) the correct mistapi method is called with the correct arguments, (b) confirmation prompts route through a mockable dependency (never `input()` directly in the test path), (c) dry-run/simulate paths do NOT call the destructive API. Add `@pytest.mark.integration` markers for any test that requires a live device; keep default `pytest` runs skipping them.
+- [ ] T-06.4 [US6] Remove the five omit entries: `"src/device/arp_command_manager.py"`, `"src/device/device_reboot_manager.py"`, `"src/firmware/firmware_manager.py"`, `"src/site/bulk_radius_wlan_config_manager.py"`, `"src/org/org_ticket_manager.py"`.
+- [ ] T-06.5 [US6] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90` — MUST pass without needing `-m "not integration"`; run `rtk pytest -m integration` separately if `.env` credentials are set locally.
+- [ ] T-06.6 [US6] Commit + push.
+- [ ] T-06.7 [US6] Open PR with `Closes #<P6-issue>` trailer via `gh pr create --base main --head coverage-omits-p6-state-changing-managers`; include the Constitution Principle III artifact from T-06.1 in the PR body.
+- [ ] T-06.8 [US6] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-06.9 [US6] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-06.10 [US6] Confirm merged, P6 issue closed, branch deleted.
+
+**Checkpoint**: 5 P6 state-changing managers are covered ≥ 90% (unit-mocked, no live-infra mutation) and removed from the omit list.
+
+---
+
+## PR-7: Issue #TBD — P7 SSH + TUI + prompt (Priority: P7)
+
+**Goal**: Author tests to reach ≥ 90% coverage on the SSH shell/TUI/prompt cluster. Because `cli_shell_manager.py` and `tui.py` rely on interactive terminal state (pyte, sshkeyboard, tqdm), tests must mock the terminal-emulator surface via `MagicMock(spec=pyte.Screen)` and drive keystroke sequences through fixtures. If SSH shell coverage cannot reach 90% without touching production code, this module is a candidate for FR-015 escape hatch (retain omit + `# TODO(1017): refactor pending` annotation) — max 2 modules across the whole workflow.
+
+**Target modules**:
+
+- `src/ssh/cli_shell_manager.py`
+- `src/ui/tui.py`
+- `src/ui/prompt_utils.py` (delta)
+
+**Estimated PR size**: ~3–6 new test files under `tests/unit/ssh/` and `tests/unit/ui/`, ~800–1600 net lines. `pyproject.toml` diff: −3 lines (or −2 if FR-015 escape hatch is invoked on `cli_shell_manager` or `tui`).
+
+**Independent Test**: After merge, `pytest --cov=src/ssh/cli_shell_manager --cov=src/ui/tui --cov=src/ui/prompt_utils --cov-fail-under=90` passes for every module not covered by FR-015 escape hatch; the corresponding lines are absent from `[tool.coverage.run].omit` (unless retained under FR-015 with the required `# TODO(1017): refactor pending` inline comment); repo-wide coverage ≥ 90%.
+
+- [ ] T-07.1 [US7] Audit: coverage baseline with the three omit lines commented out. If a module's realistic ceiling is < 80%, document the reason and mark it as an FR-015 candidate in the PR body; consumption of the 2-module escape-hatch budget MUST be explicitly noted.
+- [ ] T-07.2 [US7] Branch: `git switch main && git pull && git switch -c coverage-omits-p7-ssh-tui-prompt`.
+- [ ] T-07.3 [US7] Author tests: `tests/unit/ssh/test_cli_shell_manager.py`; `tests/unit/ui/test_tui.py`, `test_prompt_utils.py`. Mock `pyte.Screen`, `sshkeyboard.listen_keyboard`, and `tqdm` via `MagicMock(spec=...)`; drive keystroke sequences through parametrized fixtures; use `capsys` for stdout assertions on TUI rendering. For `prompt_utils.py`, `monkeypatch.setattr('builtins.input', ...)` to inject prompt responses.
+- [ ] T-07.4 [US7] Remove the three omit entries: `"src/ssh/cli_shell_manager.py"`, `"src/ui/tui.py"`, `"src/ui/prompt_utils.py"` — unless FR-015 escape hatch was invoked on one of them (see T-07.1). In the escape-hatch case, leave that specific line in `pyproject.toml` but add a `# TODO(1017): refactor pending — see #<issue>` comment on the same line and open a follow-up refactor issue linked from the PR body.
+- [ ] T-07.5 [US7] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90`.
+- [ ] T-07.6 [US7] Commit + push.
+- [ ] T-07.7 [US7] Open PR with `Closes #<P7-issue>` trailer via `gh pr create --base main --head coverage-omits-p7-ssh-tui-prompt`; if FR-015 was invoked, include the escape-hatch justification and the follow-up refactor issue link in the PR body.
+- [ ] T-07.8 [US7] Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-07.9 [US7] Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-07.10 [US7] Confirm merged, P7 issue closed, branch deleted; if FR-015 was invoked, confirm the follow-up refactor issue is open and linked.
+
+**Checkpoint**: SSH shell + TUI + prompt modules are covered ≥ 90% (or ≤ 2 total FR-015 escape-hatch entries remain, each with a `# TODO(1017): refactor pending` marker and a follow-up refactor issue).
+
+---
+
+## PR-8: Issue #TBD — P8 websocket wildcard expansion (Priority: P8)
+
+**Goal**: Replace the `src/websocket/*` wildcard omit entry with per-file coverage for every websocket module. Because the websocket subsystem contains ~14 files organized under `src/websocket/`, `src/websocket/diagnostics/`, and `src/websocket/polling/`, this PR is the largest of the workflow and MAY split into 2–4 sub-PRs (plan.md Complexity Table Row P8 permits it). Sub-PR splits are recommended along subpackage boundaries.
+
+**Target files** (enumerated from `ls src/websocket/`):
+
+- `src/websocket/__init__.py`
+- `src/websocket/commands.py`
+- `src/websocket/context.py`
+- `src/websocket/manager.py`
+- `src/websocket/service_ping_discovery.py`
+- `src/websocket/service_ping_manager.py`
+- `src/websocket/diagnostics/__init__.py`
+- `src/websocket/diagnostics/arp_executor.py`
+- `src/websocket/diagnostics/common.py`
+- `src/websocket/diagnostics/ping_executor.py`
+- `src/websocket/polling/__init__.py`
+- `src/websocket/polling/completion_detector.py`
+- `src/websocket/polling/message_router.py`
+- `src/websocket/polling/result_collector.py`
+- `src/websocket/polling/result_combiner.py`
+
+**Estimated PR size**: If shipped as one PR: ~14 new test files under `tests/unit/websocket/`, `tests/unit/websocket/diagnostics/`, `tests/unit/websocket/polling/`; ~3000–5000 net lines. If split (recommended): PR-8a = `src/websocket/` top-level, PR-8b = `diagnostics/`, PR-8c = `polling/`. `pyproject.toml` diff: −1 wildcard line, +0 (or leave the wildcard until every module is covered, whichever is safer).
+
+**Recommended split** (from plan.md Decision 5, Risk Register — websocket is the flagship refactor candidate):
+
+- **PR-8a**: `src/websocket/` top-level (`commands.py`, `context.py`, `manager.py`, `service_ping_discovery.py`, `service_ping_manager.py`, `__init__.py`) — 6 files
+- **PR-8b**: `src/websocket/diagnostics/` (`arp_executor.py`, `common.py`, `ping_executor.py`, `__init__.py`) — 4 files
+- **PR-8c**: `src/websocket/polling/` (`completion_detector.py`, `message_router.py`, `result_collector.py`, `result_combiner.py`, `__init__.py`) — 5 files
+- **PR-8d** (only if needed): remove the `src/websocket/*` wildcard from `pyproject.toml` after all three sub-PRs land; this may fold into PR-8c's pyproject edit if all coverage is green.
+
+Each sub-PR MUST be merged fully (branch deleted, issue closed) before the next opens. Within each sub-PR, the wildcard entry stays in `pyproject.toml` until PR-8c (or PR-8d) — the omit is only removed once every websocket module is at ≥ 90%.
+
+**Independent Test**: After the final sub-PR merges, `pytest --cov=src/websocket --cov-fail-under=90` passes; the line `"src/websocket/*"` is absent from `[tool.coverage.run].omit`; repo-wide coverage ≥ 90%. If any websocket module cannot reach 90% and FR-015 escape hatch was already spent on P7, halt and refactor — do NOT re-introduce the wildcard.
+
+- [ ] T-08.1 [US8] Audit: enumerate every file under `src/websocket/` via `find src/websocket -name '*.py' -type f | sort` and record the count in the PR body (expected: 14 excluding `__init__.py` shims). Run coverage locally with the `"src/websocket/*"` line commented out to establish per-file baselines.
+- [ ] T-08.2 [US8] Branch (sub-PR-8a): `git switch main && git pull && git switch -c coverage-omits-p8a-websocket-toplevel`.
+- [ ] T-08.3 [US8] Author tests under `tests/unit/websocket/`: `test_commands.py`, `test_context.py`, `test_manager.py`, `test_service_ping_discovery.py`, `test_service_ping_manager.py`. Mock `websocket-client` (`websocket.WebSocketApp`) with `MagicMock(spec=websocket.WebSocketApp)`; drive incoming-message sequences through fixtures that invoke the reader-thread callback directly; use `threading.Event` for synchronization (the transport is sync + threaded — NO asyncio); add a `tests/unit/websocket/conftest.py` for shared connection/session mocks.
+- [ ] T-08.4 [US8] Do NOT remove the `"src/websocket/*"` line from `pyproject.toml` yet — the wildcard stays until every websocket file is covered (final sub-PR). Track per-file coverage in the PR body.
+- [ ] T-08.5 [US8] Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90` (wildcard still active — repo total ≥ 90% is achieved via the wildcard until the final sub-PR).
+- [ ] T-08.6 [US8] Commit + push + open PR-8a with `Refs #<P8-issue>` trailer (not `Closes` — the umbrella issue closes only after PR-8c/PR-8d).
+- [ ] T-08.7 [US8] Wait for CI + `mergeStateStatus=CLEAN`; arm auto-merge; confirm merged, branch deleted.
+- [ ] T-08.8 [US8] Repeat T-08.2 through T-08.7 for PR-8b (`coverage-omits-p8b-websocket-diagnostics`, targets `diagnostics/*.py`, tests land under `tests/unit/websocket/diagnostics/`).
+- [ ] T-08.9 [US8] Repeat T-08.2 through T-08.7 for PR-8c (`coverage-omits-p8c-websocket-polling`, targets `polling/*.py`, tests land under `tests/unit/websocket/polling/`). In PR-8c (or a follow-on PR-8d if the diff would be too large), remove the `"src/websocket/*"` line from `pyproject.toml` and use `Closes #<P8-issue>` in that final PR only after per-file coverage ≥ 90% is proven on every websocket module.
+- [ ] T-08.10 [US8] Confirm all P8 sub-PRs merged, P8 umbrella issue closed by the final sub-PR, all branches deleted.
+
+**Checkpoint**: Every file under `src/websocket/` is covered ≥ 90%; the `"src/websocket/*"` wildcard is removed from the omit list.
+
+---
+
+## T-Final: pyproject.toml omit-list cleanup + repo-wide verification (post-PR-8)
+
+**Purpose**: Confirm the coverage omit list contains only the 6 non-source exclusions per FR-011 and SC-001, that repo-wide coverage ≥ 90% (SC-003), and that the workflow succeeded end-to-end.
+
+**Estimated PR size**: `pyproject.toml` diff only (any leftover stale entries or comment updates); ~5–15 lines. No test additions.
+
+**Independent Test**: After merge, `[tool.coverage.run].omit` in `pyproject.toml` contains exactly `tests/*`, `venv/*`, `.venv/*`, `setup.py`, `*/site-packages/*`, and `src/maps/*` (and up to 2 FR-015 escape-hatch entries with `# TODO(1017): refactor pending` markers). Repo-wide `pytest --cov --cov-fail-under=90` passes.
+
+- [ ] T-Final.1 Run `grep -nE '^\s*"src/' pyproject.toml` scoped to the `[tool.coverage.run].omit` block; every remaining entry MUST either (a) be `src/maps/*` or (b) be one of the ≤ 2 FR-015 escape-hatch modules with an inline `# TODO(1017): refactor pending — see #<issue>` comment. If any other in-scope module remains, halt and open a follow-up issue — do NOT close the workflow.
+- [ ] T-Final.2 Branch: `git switch main && git pull && git switch -c coverage-omits-final-cleanup`.
+- [ ] T-Final.3 Edit `pyproject.toml`: delete any stale in-scope module entries that remain (should be zero if T-01 through T-08 landed correctly); confirm the FR-015 escape-hatch entries carry the `# TODO(1017): refactor pending` marker and a live follow-up issue link.
+- [ ] T-Final.4 Verify locally: `rtk black --check .`, `rtk ruff check .`, `rtk pytest --cov --cov-fail-under=90` — must be green with zero suppressions of any kind added.
+- [ ] T-Final.5 Run the definitive omit-list check:
+  ```bash
+  python -c "import tomllib; import pathlib; d = tomllib.loads(pathlib.Path('pyproject.toml').read_text()); print('\n'.join(d['tool']['coverage']['run']['omit']))"
+  ```
+  Expect exactly `tests/*`, `venv/*`, `.venv/*`, `setup.py`, `*/site-packages/*`, `src/maps/*`, plus any FR-015 escape-hatch entries. Any other line is a workflow bug.
+- [ ] T-Final.6 Commit + push: stage `pyproject.toml`; push the branch.
+- [ ] T-Final.7 Open PR with `Closes #<workflow-tracking-issue>` trailer via `gh pr create --base main --head coverage-omits-final-cleanup`; include the T-Final.5 output in the PR body per plan.md Decision 2.
+- [ ] T-Final.8 Wait for CI + `mergeStateStatus=CLEAN`.
+- [ ] T-Final.9 Arm auto-merge: `GITHUB_TOKEN= gh pr merge <N> --auto --squash --delete-branch`.
+- [ ] T-Final.10 Confirm merged, workflow issue closed, branch deleted. Confirm the FR-015 escape-hatch follow-up issue(s) (if any) remain open in the tracker.
+
+**Checkpoint**: Workflow complete. `pyproject.toml`'s coverage omit list contains only non-source exclusions plus ≤ 2 FR-015 escape-hatch entries. Repo-wide coverage ≥ 90% with the true source surface measured.
+
+---
+
+## Dependencies & Execution Order
+
+### PR-to-PR Dependencies (strict)
+
+All PRs are strictly sequential per FR-003 and SC-008. PR N+1 does NOT open until PR N is merged, its branch deleted, and its target issue closed. No two workflow PRs may be open simultaneously.
+
+```
+PR-0 (P0 design artifacts) → PR-1 (P1) → PR-2 (P2) → PR-3 (P3) → PR-4a (P4) → PR-4b (P4) → PR-5a (P5) → PR-5b (P5) → PR-6 (P6) → PR-7 (P7) → PR-8a (P8) → PR-8b (P8) → PR-8c (P8) → T-Final
+```
+
+Optional splits:
+
+- PR-3 → PR-3a + PR-3b if API cluster exceeds ~2500 lines
+- PR-6 → PR-6a + PR-6b if the state-changing cluster exceeds reviewer bandwidth
+- PR-8 → PR-8a/PR-8b/PR-8c (recommended default) or PR-8a/PR-8b/PR-8c/PR-8d if pyproject cleanup needs a dedicated final step
+
+Rationale (from `plan.md` § Decision 4 — Ordering rationale):
+
+- P1 first: pure-function utilities are lowest risk, highest test-authoring-speed; they build the fixture-authoring muscle memory needed for later clusters.
+- P2 → P3 → P4 → P5: exporter/API clusters share the `mistapi.APISession` mock pattern established by PR-2; the shared `tests/unit/export/conftest.py` introduced in PR-4a is reused by PR-4b/PR-5a/PR-5b.
+- P6 after P5: state-changing modules require the mocking discipline learned on read-only exporters; Constitution Principle III demands extra rigor.
+- P7 after P6: SSH/TUI is the first cluster where FR-015 escape hatch may be invoked; the escape-hatch budget is only spent after simpler clusters prove the workflow is on track.
+- P8 last: websocket is the largest and most likely to require refactoring; leaving it last preserves options.
+- T-Final ensures the final omit list matches SC-002 exactly.
+
+### Within-PR Dependencies
+
+Each PR's sub-tasks are strictly sequential (audit → branch → author tests → edit pyproject → verify → commit → push → PR → CI wait → merge → confirm). PR-4a and PR-4b MUST run in that order because PR-4a introduces the shared `tests/unit/export/conftest.py` reused by PR-4b/PR-5a/PR-5b. PR-8a/PR-8b/PR-8c MUST run in order because the `src/websocket/*` wildcard stays in `pyproject.toml` until the final sub-PR.
+
+### Parallel Opportunities
+
+Between PRs: none (strict serial dispatch per FR-003 and SC-008).
+
+Within PRs: sub-tasks for authoring separate `test_*.py` files under a shared `tests/unit/<cluster>/` directory are logically parallelizable during authoring — but they land as a single PR, so `[P]` markers are not used in this workflow. All sub-tasks are single-track sequential.
+
+---
+
+## Implementation Strategy
+
+### MVP Scope
+
+The MVP is PR-1 (P1 utilities) alone. Landing it removes 4 omit entries — 11% of the in-scope omit list — and validates the test-authoring pattern for the remaining 7 PR-families. If the workflow must pause at any point, pausing after PR-1 leaves the codebase strictly better than baseline.
+
+### Incremental Delivery
+
+Each PR delivers an independently valuable and revertable increment:
+
+1. PR-1 (P1): utilities — 4 omits removed; test pattern validated.
+2. PR-2 (P2): export helpers — 5 omits removed; `mistapi.APISession` mock pattern established.
+3. PR-3 (P3): API/DB/analytics — 7 omits removed; DB mocks (arango, redis) validated.
+4. PR-4a (P4): org exporters part 1 — 3 omits removed; shared `tests/unit/export/conftest.py` introduced.
+5. PR-4b (P4): org exporters part 2 — 4 omits removed; conftest reuse proven.
+6. PR-5a (P5): site exporters — 5 omits removed.
+7. PR-5b (P5): report generators + inventory facade — 5 omits removed.
+8. PR-6 (P6): state-changing device managers — 5 omits removed; Constitution Principle III artifact produced.
+9. PR-7 (P7): SSH + TUI + prompt — 2–3 omits removed (FR-015 escape hatch candidate).
+10. PR-8a/PR-8b/PR-8c (P8): websocket subpackage-by-subpackage — 1 wildcard removed once per-file coverage lands.
+11. T-Final: pyproject.toml cleanup + workflow verification.
+
+### Serial Execution Discipline
+
+Only one workflow PR open at a time (SC-008). After each merge:
+
+1. Wait for GitHub to auto-close the target issue.
+2. Confirm the delivery branch is deleted on remote.
+3. Re-run `pytest --cov --cov-fail-under=90` locally on the fresh `main` to confirm repo-wide coverage still ≥ 90%.
+4. Open the next PR's branch from the fresh `main`.
+
+### FR-015 Escape-Hatch Budget
+
+Maximum 2 modules may retain an omit entry across the workflow, each requiring:
+
+- Inline `# TODO(1017): refactor pending — see #<issue>` comment on the omit line.
+- A follow-up refactor issue open in the tracker at PR-merge time.
+- Explicit PR-body justification.
+
+Candidates (from plan.md Risk Register): `src/websocket/service_ping_manager.py`, `src/ssh/cli_shell_manager.py`, `src/ui/tui.py`. Do not spend escape-hatch budget before PR-7.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no dependencies. Not used in this workflow — every sub-task is single-track sequential.
+- `[Story]` label maps each task to its user story / PR-family (US1 → PR-1, US4 → PR-4a+PR-4b, US5 → PR-5a+PR-5b, US8 → PR-8a+PR-8b+PR-8c).
+- Every delivery PR branches from current `main` at PR-open time (FR-004) — never from `1017-remove-coverage-omits`.
+- No `--admin` bypass anywhere (FR-006). Wait for `mergeStateStatus=CLEAN`. SKIPPED conditional checks are not blocking; failing required checks are.
+- Pre-push gate: `rtk black --check .` and `rtk ruff check .` MUST be clean before every push. Never rely on CI to catch format/lint issues.
+- No new `# noqa`, `# type: ignore`, `# nosec`, or `# pylint: disable` may be introduced anywhere in the repository (SC-006). Reviewers grep the diff.
+- Production `src/` modules MUST NOT be edited by this workflow (FR-010); only tests are added and `pyproject.toml` is trimmed. If a module cannot reach 90% without a refactor, invoke FR-015 escape hatch or halt.
+- `pyproject.toml` edits are strictly limited to `[tool.coverage.run].omit` line deletions (FR-009, FR-011) plus the optional FR-015 `# TODO(1017): refactor pending` inline comment.
+- Coverage ≥ 90% and pylint ≥ 9.5 hold on every merged commit (SC-010).
+- Refresh coverage baseline between PRs; PR body must include pre/post per-module coverage numbers and the pyproject diff per plan.md Decision 2.
+- Issue numbers marked `#TBD` above must be replaced with real tracking-issue numbers before PR-open time; the P1 tracking issue is `#878` per plan.md § Decision 3 exit criterion (a).


### PR DESCRIPTION
## Summary
- Bootstraps SpecKit workflow for GH issue #878 (un-omit 36 modules from `pyproject.toml [tool.coverage.run].omit` and add real unit tests).
- Lands `specs/1017-remove-coverage-omits/spec.md` (16 FRs, 10 SCs, 8 user stories), `plan.md` (5 decisions, risk register, Phase 0/1 deliverable definitions, 12-PR sequential delivery flow), and `tasks.md` (T-00 design artifacts + T-01..T-08 per-cluster PRs + T-Final cleanup).
- Prior `/speckit.analyze` produced 7 CRITICAL + 3 HIGH findings; all remediated in-place (I1..I12); re-analyze verdict READY.

## Test plan
- [ ] CI green (docs-only PR; no code changes to gate)
- [ ] Reviewer sanity-check: FR/SC citations in `tasks.md` map to `spec.md` numbering
- [ ] Reviewer sanity-check: PR-0..T-Final flow diagram in `tasks.md` matches `plan.md` complexity table

Refs #878