### PR TITLE
docs(1017): PR-0 design artifacts for coverage-omit removal (#878)

### DIFF
--- a/specs/1017-remove-coverage-omits/contracts/coverage_assertion.md
+++ b/specs/1017-remove-coverage-omits/contracts/coverage_assertion.md
@@ -1,0 +1,110 @@
+# Contract: Coverage Assertion
+
+**Feature**: 1017-remove-coverage-omits
+**Refs**: #878
+**Applies to**: every PR from PR-1 through T-Final
+
+**Validation rule**: Each PR MUST demonstrate BOTH (a) per-file coverage ≥ 90% for every module de-omitted in that PR, AND (b) full-suite `pytest --cov --cov-fail-under=90` exits with status 0. A PR that lowers global coverage below the branch-cut baseline (measured pre-PR) fails SC-003 and MUST be rejected.
+
+## §1 Per-file assertion
+
+Invoked once per de-omitted module in the PR under review.
+
+```bash
+pytest --cov=<dotted.module.path> \
+       --cov-report=term-missing \
+       --cov-fail-under=90 \
+       tests/unit/<matching-path>/
+```
+
+**Example — PR-1 utility check**:
+```bash
+pytest --cov=src.utils.filter_operator_engine \
+       --cov-report=term-missing \
+       --cov-fail-under=90 \
+       tests/unit/utils/test_filter_operator_engine.py
+```
+
+**Exit criterion**: status 0. Any uncovered line surfaced under "Missing" MUST be either (i) reachable and tested in the same PR, or (ii) covered by an explicit `# pragma: no cover` that was pre-existing at branch-cut (new pragmas violate SC-006).
+
+## §2 Full-suite assertion
+
+Invoked once at the end of each PR before pushing.
+
+```bash
+pytest --cov --cov-fail-under=90 --cov-report=term
+```
+
+**Exit criterion**: status 0. `pyproject.toml [tool.coverage.report] fail_under = 90` is authoritative — this command reads it. Do NOT pass `--cov-fail-under=<N>` with `N != 90` in CI or local pre-push checks (FR-009).
+
+## §3 Omit-list assertion (SC-001)
+
+Invoked in T-Final. Verifies the retained omit set matches the frozen 6-entry inventory from data-model.md §1.
+
+```bash
+python -c "
+import tomllib, pathlib
+data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
+omit = data['tool']['coverage']['run']['omit']
+expected = ['tests/*', 'venv/*', '.venv/*', 'setup.py', '*/site-packages/*', 'src/maps/*']
+assert sorted(omit) == sorted(expected), f'SC-001 violated: {sorted(omit)} != {sorted(expected)}'
+print('SC-001 OK: retained omit list matches frozen inventory')
+"
+```
+
+**Exit criterion**: status 0 and stdout contains `SC-001 OK`.
+
+## §4 Escape-hatch cap assertion (FR-015)
+
+At most 2 modules may retain their omit entry with a `# TODO(1017): refactor pending` annotation. Verify:
+
+```bash
+python -c "
+import tomllib, pathlib
+data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
+omit = data['tool']['coverage']['run']['omit']
+retained = {'tests/*', 'venv/*', '.venv/*', 'setup.py', '*/site-packages/*', 'src/maps/*'}
+escape_hatches = [e for e in omit if e not in retained]
+assert len(escape_hatches) <= 2, f'FR-015 violated: {len(escape_hatches)} escape hatches > 2'
+print(f'FR-015 OK: {len(escape_hatches)} escape hatches')
+"
+```
+
+**Exit criterion**: status 0. If `len(escape_hatches) > 0`, a matching `# TODO(1017)` comment MUST appear on the same line in pyproject.toml (grep the file separately).
+
+## §5 New-suppression assertion (SC-006)
+
+No PR from PR-1 through T-Final may introduce new `# pragma: no cover`, `# type: ignore`, or `# noqa` annotations inside newly-added test files.
+
+```bash
+git diff main...HEAD -- tests/ | \
+  grep -E '^\+.*(# pragma: no cover|# type: ignore|# noqa)' && \
+  { echo 'SC-006 violated: new suppression added'; exit 1; } || \
+  echo 'SC-006 OK: no new suppressions in tests/'
+```
+
+**Exit criterion**: status 0.
+
+## §6 Baseline-drift assertion
+
+Before each PR, capture the pre-PR coverage number; after the PR, verify the number strictly rose (or stayed equal only if the PR is docs-only like PR-0).
+
+```bash
+# pre-PR
+git checkout main
+pytest --cov --cov-report=json:/tmp/baseline.json --cov-fail-under=90
+python -c "import json; print(json.load(open('/tmp/baseline.json'))['totals']['percent_covered'])" > /tmp/baseline.txt
+
+# post-PR
+git checkout <branch>
+pytest --cov --cov-report=json:/tmp/postpr.json --cov-fail-under=90
+python -c "
+import json
+baseline = float(open('/tmp/baseline.txt').read())
+postpr = json.load(open('/tmp/postpr.json'))['totals']['percent_covered']
+assert postpr >= baseline, f'Coverage regressed: {postpr} < {baseline}'
+print(f'Coverage: {baseline:.2f} -> {postpr:.2f}')
+"
+```
+
+**Exit criterion**: status 0.

--- a/specs/1017-remove-coverage-omits/contracts/mocking_conventions.md
+++ b/specs/1017-remove-coverage-omits/contracts/mocking_conventions.md
@@ -1,0 +1,146 @@
+# Contract: Mocking Conventions
+
+**Feature**: 1017-remove-coverage-omits
+**Refs**: #878
+**Applies to**: PR-1 through PR-8c (all new unit tests)
+**Success criteria**: SC-006 (no bare mocks), SC-007 (zero live network calls), SC-003 (`fail_under=90` after this convention holds). Frozen retained omit set is authoritative under SC-001 (6 non-source entries) — see contracts/coverage_assertion.md §3.
+
+**Validation rule**: Every mock of an external dependency (mistapi, paramiko, websocket-client, python-arango, redis, sshkeyboard) MUST be constructed via `MagicMock(spec=<real class>)` or `monkeypatch.setattr(<import path>, <fake>)`. Bare `Mock()` or `MagicMock()` without `spec=` is a hard rejection in code review (attribute typos escape detection and cause false-positive coverage).
+
+## §1 mistapi — sync HTTP session
+
+**Real class**: `mistapi.APISession`.
+
+```python
+from unittest.mock import MagicMock
+import mistapi
+
+session = MagicMock(spec=mistapi.APISession)
+session.mist_get.return_value = {"result": [{"id": "abc"}]}
+```
+
+**Rules**:
+- Never mock `mistapi.get_next` at module level — mock the paginator via the `mock_mistapi_paginated_response` fixture (contracts/shared_fixtures.md §3).
+- HTTP verbs (`mist_get`/`mist_post`/`mist_put`/`mist_delete`) return dicts, not `requests.Response` — mistapi already unwraps the JSON body.
+- The `SC-007` invariant (zero live network calls) is enforced by `podman run --network=none` in CI. A test that hits the network under mocks-only mode indicates missing coverage of the mistapi call site.
+
+## §2 paramiko — SSH transport
+
+**Real class**: `paramiko.SSHClient`, `paramiko.Channel`.
+
+```python
+from unittest.mock import MagicMock
+import paramiko
+
+client = MagicMock(spec=paramiko.SSHClient)
+channel = MagicMock(spec=paramiko.Channel)
+client.invoke_shell.return_value = channel
+channel.recv.side_effect = [b"prompt> ", b"output\n", b""]  # empty = EOF
+```
+
+**Rules**:
+- Never let a real `paramiko.SSHClient()` instance be constructed in a unit test — patch at the import site (`src.ssh.cli_shell_manager.SSHClient`) not the module (`paramiko.SSHClient`).
+- `set_missing_host_key_policy` MUST be exercised by every SSH test (host-key discipline).
+- Real connections belong under `@pytest.mark.integration` — excluded from default CI (SC-007).
+
+## §3 websocket-client — sync WebSocketApp + threading
+
+**Real class**: `websocket.WebSocketApp`. Project uses the **synchronous** `websocket-client` package, NOT the async `websockets` package.
+
+```python
+from unittest.mock import MagicMock
+import websocket
+
+app = MagicMock(spec=websocket.WebSocketApp)
+```
+
+**Rules**:
+- `run_forever()` MUST be configured to exit after ≤ 2 iterations. Real callbacks accept `(ws, message)` positional args — validate signatures with `spec=`.
+- Threading is real in tests — do not mock `threading.Thread`. Use `threading.Event().set()` to trigger shutdown paths.
+- Injected utility deps (config, logger, safe_input) MUST be passed via constructor and mocked by the caller. Global patching of `safe_input` is acceptable only inside interactive-prompt tests.
+
+## §4 python-arango — DB session
+
+**Real class**: `arango.database.StandardDatabase`.
+
+```python
+from unittest.mock import MagicMock
+import arango.database
+
+db = MagicMock(spec=arango.database.StandardDatabase)
+db.collection.return_value.insert.return_value = {"_key": "abc"}
+```
+
+**Rules**:
+- Never construct a real `ArangoClient` in unit tests.
+- `database_schema_utils.py` is a pure string builder — NO DB fixture required (verified in research.md §2).
+- Integration-only DB tests live under `tests/integration/db/` and require live ArangoDB reachable — excluded from default CI.
+
+## §5 redis — cache / timeseries
+
+**Real class**: `redis.Redis` (sync client used by the project).
+
+```python
+from unittest.mock import MagicMock
+import redis
+
+client = MagicMock(spec=redis.Redis)
+client.get.return_value = None
+client.set.return_value = True
+```
+
+**Alternative**: `fakeredis.FakeStrictRedis()` for tests that need round-trip fidelity on hash/list operations. Do NOT mix `MagicMock` and `fakeredis` in the same test — pick one per test.
+
+## §6 sshkeyboard — TUI key listener
+
+**Real callable**: `sshkeyboard.listen_keyboard`.
+
+```python
+def fake_listen(on_press=None, **kwargs):
+    on_press("q")  # simulate quit keypress and return
+monkeypatch.setattr("sshkeyboard.listen_keyboard", fake_listen)
+```
+
+**Rules**:
+- The real listener blocks forever — tests MUST replace it, never call it.
+- Use the `mock_sshkeyboard_listen` fixture from `tests/unit/ui/conftest.py` (contracts/shared_fixtures.md §6) rather than inline patching.
+
+## §7 stdin / interactive prompts (`safe_input`)
+
+```python
+monkeypatch.setattr("src.ui.prompt_utils.safe_input", lambda *_, **__: "UPGRADE")
+```
+
+**Rules**:
+- Patch at the **import site** where `safe_input` is called (e.g., `src.firmware.firmware_manager.safe_input`), not the definition site — otherwise the patch is invisible to the module under test.
+- Every state-changing manager (PR-6) MUST test BOTH accept AND reject responses. Constitution Principle III non-negotiable.
+
+## §8 Filesystem
+
+```python
+def test_writer(tmp_path):
+    output = tmp_path / "out.csv"
+    writer(output)
+    assert output.read_text().startswith("col1,col2")
+```
+
+**Rules**:
+- Use pytest's `tmp_path` fixture — never write to the repo working tree or system temp directly.
+- For golden-file comparisons, use the `golden_json_writer` / `golden_csv_writer` fixtures (contracts/shared_fixtures.md §4).
+
+## §9 Rejection criteria (grep-checkable in PR review)
+
+```bash
+# Reject: bare Mock without spec=
+grep -rn "= MagicMock()" tests/unit/ && exit 1
+grep -rn "= Mock()" tests/unit/ && exit 1
+
+# Reject: real network calls
+grep -rn "requests\.get\|requests\.post" tests/unit/ && exit 1
+grep -rn "paramiko\.SSHClient()" tests/unit/ && exit 1
+
+# Reject: patching the wrong site
+grep -rn 'monkeypatch\.setattr("mistapi\.' tests/unit/ && exit 1
+```
+
+Any hit above is a hard PR rejection.

--- a/specs/1017-remove-coverage-omits/contracts/shared_fixtures.md
+++ b/specs/1017-remove-coverage-omits/contracts/shared_fixtures.md
@@ -1,0 +1,100 @@
+# Contract: Shared Test Fixtures
+
+**Feature**: 1017-remove-coverage-omits
+**Refs**: #878
+**Applies to**: PR-3 through PR-8c
+**Success criteria**: SC-003 (`fail_under=90`), SC-006 (no ad-hoc mocks). Frozen omit set is defined by SC-001 (6 non-source entries) — see contracts/coverage_assertion.md §3.
+
+**Validation rule**: Every fixture listed below MUST be `@pytest.fixture`-decorated in the exact file path shown, MUST use function scope unless explicitly noted, and MUST match the return-type contract in this document. A test that imports a fixture from an unlisted path violates SC-006 (no ad-hoc mocks).
+
+## §1 `mock_mistapi_session`
+
+**Location**: `tests/conftest.py` (repo-wide) — introduced PR-3.
+**Scope**: `function`.
+**Returns**: `MagicMock(spec=mistapi.APISession)`.
+
+**Contract**:
+- Bound to the real `mistapi.APISession` symbol via `spec=` so attribute typos raise `AttributeError`.
+- No default return values on `.mist_get`, `.mist_post`, `.mist_put`, `.mist_delete` — each test configures its own responses.
+- MUST NOT be `autospec=True` (too slow for the ~200-test target); the `spec=` narrow form is sufficient.
+- Consumers: PR-3 (api/analytics), PR-4a/b (org exporters), PR-5a/b (site exporters + reports), PR-6 (state-changing managers), PR-7 (SSH/TUI).
+
+**Reference shape**:
+```python
+@pytest.fixture
+def mock_mistapi_session():
+    return MagicMock(spec=mistapi.APISession)
+```
+
+## §2 `mock_config`
+
+**Location**: `tests/conftest.py` — introduced PR-3.
+**Scope**: `function`.
+**Returns**: `dict[str, Any]` mirroring the `.env` config schema loaded by `src/utils/environment_utils.py`.
+
+**Contract**:
+- Populated with placeholder credentials (`MIST_ORG_ID="00000000-0000-0000-0000-000000000000"`, `MIST_HOST="api.mist.com"`, `MIST_TOKEN="fake-token"`).
+- Tests that mutate the dict must do so on a copy (`mock_config.copy()`) — the fixture returns a fresh dict per test.
+- Consumers: same as `mock_mistapi_session`.
+
+## §3 `mock_mistapi_paginated_response`
+
+**Location**: `tests/unit/api/conftest.py` — introduced PR-3.
+**Scope**: `function`.
+**Returns**: factory callable `(pages: list[list[dict]]) -> MagicMock` that produces a mistapi paginated iterator mock.
+
+**Contract**:
+- Each `pages[i]` element becomes one call to `mistapi.get_next(...)`.
+- Final call returns `None` to terminate the pagination loop.
+- Consumers: PR-3 (api_data_fetcher, api_core_fetch_utils), PR-4a/b, PR-5a/b (exporters that page through devices/sites).
+
+## §4 Golden-file writers: `golden_json_writer`, `golden_csv_writer`
+
+**Location**: `tests/unit/export/conftest.py` — introduced PR-4a.
+**Scope**: `function`.
+**Returns**: callable `(payload, expected_filename) -> Path`.
+
+**Contract**:
+- Writes payload to `tmp_path / expected_filename`, then re-reads and returns parsed contents for assertion against a golden fixture file under `tests/unit/export/goldens/`.
+- JSON writer uses `indent=2, sort_keys=True` for deterministic diffs.
+- CSV writer preserves column order from the exporter under test — column-order regression is a hard failure.
+- Consumers: PR-4a, PR-4b, PR-5a, PR-5b (all exporter tests).
+
+## §5 `mock_paramiko_ssh_client`
+
+**Location**: `tests/unit/ssh/conftest.py` — introduced PR-7.
+**Scope**: `function`.
+**Returns**: `MagicMock(spec=paramiko.SSHClient)` with `.invoke_shell()` returning `MagicMock(spec=paramiko.Channel)`.
+
+**Contract**:
+- `.connect()`, `.close()`, `.set_missing_host_key_policy()` are no-ops but recorded in `mock_calls` for assertion.
+- Channel `.recv(n)` returns bytes controlled per-test via `.side_effect`.
+- Consumers: PR-7 (`cli_shell_manager.py`).
+
+## §6 `mock_sshkeyboard_listen`
+
+**Location**: `tests/unit/ui/conftest.py` — extends existing conftest, introduced PR-7.
+**Scope**: `function`.
+**Returns**: `MagicMock` bound to `sshkeyboard.listen_keyboard` via `monkeypatch.setattr`.
+
+**Contract**:
+- Default behavior: immediately calls the registered `on_press` handler with a configurable keypress sequence, then returns.
+- Consumers: PR-7 (`tui.py`).
+
+## §7 `mock_websocket_transport`
+
+**Location**: `tests/unit/websocket/conftest.py` — introduced PR-8a.
+**Scope**: `function`.
+**Returns**: `MagicMock(spec=websocket.WebSocketApp)` — sync `websocket-client`, NOT `websockets` (async).
+
+**Contract**:
+- `.run_forever()` MUST exit after ≤ 2 mocked message iterations (drive by `.side_effect` on `.send`).
+- Callback registration (`on_message`, `on_error`, `on_close`) invoked synchronously by test setup, not by a real thread.
+- Threading is NOT mocked — tests use `threading.Event.set()` to signal shutdown paths.
+- Consumers: PR-8a (toplevel), PR-8b (diagnostics), PR-8c (polling).
+
+## Fixture-migration invariants
+
+- No fixture may be redefined in a nested conftest. Redefinition indicates spec drift and MUST be caught in PR review.
+- A fixture introduced in a later PR MUST NOT be back-imported into an earlier PR — enforce with `pytest --collect-only` in CI.
+- New fixtures added outside this contract require a spec amendment and a `Refs #878` sub-issue.

--- a/specs/1017-remove-coverage-omits/data-model.md
+++ b/specs/1017-remove-coverage-omits/data-model.md
@@ -1,0 +1,170 @@
+# Phase 1 Data Model: Per-Module Test Manifest
+
+**Feature**: 1017-remove-coverage-omits
+**Refs**: #878
+**Success criteria**: SC-001 (6 retained), SC-003 (fail_under=90), SC-006 (no gate gaming)
+
+## 1. Retained non-source inventory (frozen per FR-011)
+
+The following 6 entries remain in `[tool.coverage.run].omit` after T-Final. They MUST match verbatim.
+
+```
+tests/*
+venv/*
+.venv/*
+setup.py
+*/site-packages/*
+src/maps/*
+```
+
+## 2. Per-module test manifest
+
+For each of the 36 in-scope modules: target test file path, external touch points, expected fixture bundle, and per-PR mapping.
+
+### P1 — Utilities (PR-1)
+
+| Source module | Test file | External touch points | Fixtures needed |
+|--------------|-----------|----------------------|-----------------|
+| `src/utils/environment_utils.py` | `tests/unit/utils/test_environment_utils.py` | `os.environ`, `pathlib.Path` | `monkeypatch`, `tmp_path` |
+| `src/utils/filter_operator_engine.py` | `tests/unit/utils/test_filter_operator_engine.py` | none (pure logic) | none |
+| `src/troubleshooting/troubleshoot_utils.py` | `tests/unit/troubleshooting/test_troubleshoot_utils.py` | `mistapi.APISession`, stdin prompt | `MagicMock(spec=mistapi.APISession)`, `monkeypatch` |
+| `src/input/prompt_client_utils.py` | `tests/unit/input/test_prompt_client_utils.py` | stdin prompt, `mistapi.APISession` | `MagicMock(spec=mistapi.APISession)`, `monkeypatch` |
+
+### P2 — Export helpers (PR-2)
+
+| Source module | Test file | External touch points | Fixtures needed |
+|--------------|-----------|----------------------|-----------------|
+| `src/export/org_export_utils.py` | `tests/unit/export/test_org_export_utils.py` | filesystem (JSON writer) | `tmp_path`, `MagicMock(spec=mistapi.APISession)` |
+| `src/export/license_export_utils.py` | `tests/unit/export/test_license_export_utils.py` | filesystem | `tmp_path` |
+| `src/export/const_definitions_exporter.py` | `tests/unit/export/test_const_definitions_exporter.py` | filesystem | `tmp_path` |
+| `src/export/gateway_test_exporter.py` | `tests/unit/export/test_gateway_test_exporter.py` | filesystem, mistapi | `tmp_path`, `MagicMock(spec=mistapi.APISession)` |
+| `src/export/data_exporter.py` | `tests/unit/export/test_data_exporter.py` | filesystem (CSV writer) | `tmp_path` |
+
+### P3 — API / DB / analytics (PR-3)
+
+| Source module | Test file | External touch points | Fixtures needed |
+|--------------|-----------|----------------------|-----------------|
+| `src/api/api_data_fetcher.py` | `tests/unit/api/test_api_data_fetcher.py` | `mistapi.APISession` pagination | `mock_mistapi_paginated_response` (new), `MagicMock(spec=mistapi.APISession)` |
+| `src/api/api_fetch_utils.py` | `tests/unit/api/test_api_fetch_utils.py` | `mistapi.APISession` | `mock_mistapi_session` (new, repo-wide) |
+| `src/api/api_core_fetch_utils.py` | `tests/unit/api/test_api_core_fetch_utils.py` | `mistapi.APISession` cursor iteration | `mock_mistapi_paginated_response` |
+| `src/cache/cache_utils.py` | `tests/unit/cache/test_cache_utils.py` | filesystem cache | `tmp_path`, `monkeypatch` |
+| `src/db/database_schema_utils.py` | `tests/unit/db/test_database_schema_utils.py` | none (pure DDL string builder) | none |
+| `src/analytics/data_collection_manager.py` | `tests/unit/analytics/test_data_collection_manager.py` | `mistapi.APISession` | `mock_mistapi_session` |
+| `src/analytics/insight_metrics_utils.py` | `tests/unit/analytics/test_insight_metrics_utils.py` | `mistapi.APISession` | `mock_mistapi_session` |
+
+### P4a — Org exporters (stats/templates/admin) (PR-4a)
+
+| Source module | Test file | Fixtures needed |
+|--------------|-----------|-----------------|
+| `src/export/org_device_stats_exporter.py` | `tests/unit/export/test_org_device_stats_exporter.py` | `mock_mistapi_session`, `tmp_path`, `golden_json_writer` (new) |
+| `src/export/org_template_exporter.py` | `tests/unit/export/test_org_template_exporter.py` | Same as above |
+| `src/export/org_admin_exporter.py` | `tests/unit/export/test_org_admin_exporter.py` | Same as above |
+
+**PR-4a introduces** `tests/unit/export/conftest.py` housing `golden_json_writer`, `golden_csv_writer`, and org-exporter mock factories reused by PR-4b/PR-5a/PR-5b.
+
+### P4b — Org exporters (config/alarms/security/sites) (PR-4b)
+
+| Source module | Test file | Fixtures needed |
+|--------------|-----------|-----------------|
+| `src/export/org_config_exporter.py` | `tests/unit/export/test_org_config_exporter.py` | PR-4a shared fixtures |
+| `src/export/org_alarm_event_exporter.py` | `tests/unit/export/test_org_alarm_event_exporter.py` | PR-4a shared fixtures |
+| `src/export/org_client_security_exporter.py` | `tests/unit/export/test_org_client_security_exporter.py` | PR-4a shared fixtures |
+| `src/export/org_site_exporter.py` | `tests/unit/export/test_org_site_exporter.py` | PR-4a shared fixtures |
+
+### P5a — Site exporters + gateway HA (PR-5a)
+
+| Source module | Test file | Fixtures needed |
+|--------------|-----------|-----------------|
+| `src/export/site_anomaly_exporter.py` | `tests/unit/export/test_site_anomaly_exporter.py` | PR-4a shared fixtures |
+| `src/export/site_config_exporter.py` | `tests/unit/export/test_site_config_exporter.py` | PR-4a shared fixtures |
+| `src/export/site_device_exporter.py` | `tests/unit/export/test_site_device_exporter.py` | PR-4a shared fixtures |
+| `src/export/sites_by_ap_model_exporter.py` | `tests/unit/export/test_sites_by_ap_model_exporter.py` | PR-4a shared fixtures |
+| `src/gateway/gateway_ha_exporter.py` | `tests/unit/gateway/test_gateway_ha_exporter.py` | `mock_mistapi_session` |
+
+### P5b — Reports + inventory facade (PR-5b)
+
+| Source module | Test file | Fixtures needed |
+|--------------|-----------|-----------------|
+| `src/reports/global_wired_client_report_generator.py` | `tests/unit/reports/test_global_wired_client_report_generator.py` | `mock_mistapi_session`, `tmp_path` |
+| `src/reports/offline_device_reporter.py` | `tests/unit/reports/test_offline_device_reporter.py` | `mock_mistapi_session`, `tmp_path` |
+| `src/reports/sfp_transceiver_data_processor.py` | `tests/unit/reports/test_sfp_transceiver_data_processor.py` | `mock_mistapi_session` |
+| `src/reports/wired_client_manufacturer_report_generator.py` | `tests/unit/reports/test_wired_client_manufacturer_report_generator.py` | `mock_mistapi_session`, `tmp_path` |
+| `src/inventory/org_device_inventory_summary_facade.py` | `tests/unit/inventory/test_org_device_inventory_summary_facade.py` | `mock_mistapi_session` |
+
+### P6 — State-changing managers (PR-6) — Principle III
+
+| Source module | Test file | Confirmation path tested | Fixtures |
+|--------------|-----------|-------------------------|----------|
+| `src/device/arp_command_manager.py` | `tests/unit/device/test_arp_command_manager.py` | Accept + reject | `mock_mistapi_session`, `monkeypatch` on `safe_input` |
+| `src/device/device_reboot_manager.py` | `tests/unit/device/test_device_reboot_manager.py` | Accept + reject (destructive) | Same |
+| `src/firmware/firmware_manager.py` | `tests/unit/firmware/test_firmware_manager.py` | `confirmation == "UPGRADE"` + reject early-return | Same |
+| `src/site/bulk_radius_wlan_config_manager.py` | `tests/unit/site/test_bulk_radius_wlan_config_manager.py` | Rollback exercised via injected exception | Same |
+| `src/org/org_ticket_manager.py` | `tests/unit/org/test_org_ticket_manager.py` | Accept + reject | Same |
+
+### P7 — SSH / TUI / prompt (PR-7)
+
+| Source module | Test file | External touch points | Fixtures |
+|--------------|-----------|----------------------|----------|
+| `src/ssh/cli_shell_manager.py` | `tests/unit/ssh/test_cli_shell_manager.py` | `paramiko.SSHClient`, `Channel`, interactive prompt | `mock_paramiko_ssh_client` (new) |
+| `src/ui/tui.py` | `tests/unit/ui/test_tui.py` | `sshkeyboard.listen_keyboard`, terminal render | `mock_sshkeyboard_listen` (extend existing `tests/unit/ui/conftest.py`) |
+| `src/ui/prompt_utils.py` | `tests/unit/ui/test_prompt_utils.py` | stdin, `safe_input()` | `monkeypatch` |
+
+FR-015 candidates: `tui.py` and `cli_shell_manager.py` (per plan.md Decision 5). Escape hatch cap = 2.
+
+### P8 — Websocket wildcard (PR-8a/b/c)
+
+**PR-8a (toplevel, 5 files)**
+
+| Source | Test file |
+|--------|-----------|
+| `src/websocket/__init__.py` | `tests/unit/websocket/test_init.py` |
+| `src/websocket/commands.py` | `tests/unit/websocket/test_commands.py` |
+| `src/websocket/context.py` | `tests/unit/websocket/test_context.py` |
+| `src/websocket/manager.py` | `tests/unit/websocket/test_manager.py` |
+| `src/websocket/service_ping_discovery.py` + `service_ping_manager.py` | `tests/unit/websocket/test_service_ping_discovery.py`, `test_service_ping_manager.py` |
+
+**PR-8b (diagnostics, 4 files)**
+
+| Source | Test file |
+|--------|-----------|
+| `src/websocket/diagnostics/__init__.py` | `tests/unit/websocket/diagnostics/test_init.py` |
+| `src/websocket/diagnostics/arp_executor.py` | `tests/unit/websocket/diagnostics/test_arp_executor.py` |
+| `src/websocket/diagnostics/common.py` | `tests/unit/websocket/diagnostics/test_common.py` |
+| `src/websocket/diagnostics/ping_executor.py` | `tests/unit/websocket/diagnostics/test_ping_executor.py` |
+
+**PR-8c (polling, 5 files)**
+
+| Source | Test file |
+|--------|-----------|
+| `src/websocket/polling/__init__.py` | `tests/unit/websocket/polling/test_init.py` |
+| `src/websocket/polling/completion_detector.py` | `tests/unit/websocket/polling/test_completion_detector.py` |
+| `src/websocket/polling/message_router.py` | `tests/unit/websocket/polling/test_message_router.py` |
+| `src/websocket/polling/result_collector.py` | `tests/unit/websocket/polling/test_result_collector.py` |
+| `src/websocket/polling/result_combiner.py` | `tests/unit/websocket/polling/test_result_combiner.py` |
+
+All websocket tests use `mock_websocket_transport` fixture from `tests/unit/websocket/conftest.py` (introduced PR-8a).
+
+## 3. Integration-only paths (mock vs `@pytest.mark.integration`)
+
+The following code paths CANNOT be faithfully mocked and MUST use `@pytest.mark.integration` (gated by `.env` credentials — excluded from default CI run per SC-007).
+
+| Path | Reason for integration marker | Alternative considered |
+|------|------------------------------|----------------------|
+| `troubleshoot_utils.py` end-to-end Marvis query flow | Marvis response shape is model-dependent; mock cannot mimic real semantics | Rejected: shape mocks would not exercise real branch logic |
+| `firmware_manager.py` actual upgrade RPC | State-changing device call; NEVER mocked as if real | Not applicable — real test only in staged integration environment |
+| `bulk_radius_wlan_config_manager.py` multi-step rollback under real API errors | API error taxonomy is broader than any mock | Mock covers happy path + one injected exception; integration marker covers real error surface |
+
+All three integration paths remain covered by mocked unit tests for the code-under-test that lives in the module. Integration marker is additive, not a substitute.
+
+## 4. Fixture registry (source of truth)
+
+| Fixture | Location | Scope | Contract file |
+|---------|----------|-------|---------------|
+| `mock_mistapi_session` | `tests/conftest.py` | function | `contracts/shared_fixtures.md` §1 |
+| `mock_config` | `tests/conftest.py` | function | `contracts/shared_fixtures.md` §2 |
+| `mock_mistapi_paginated_response` | `tests/unit/api/conftest.py` | function | `contracts/shared_fixtures.md` §3 |
+| `golden_json_writer` | `tests/unit/export/conftest.py` | function | `contracts/shared_fixtures.md` §4 |
+| `golden_csv_writer` | `tests/unit/export/conftest.py` | function | `contracts/shared_fixtures.md` §4 |
+| `mock_paramiko_ssh_client` | `tests/unit/ssh/conftest.py` | function | `contracts/shared_fixtures.md` §5 |
+| `mock_sshkeyboard_listen` | `tests/unit/ui/conftest.py` | function | `contracts/shared_fixtures.md` §6 |
+| `mock_websocket_transport` | `tests/unit/websocket/conftest.py` | function | `contracts/shared_fixtures.md` §7 |

--- a/specs/1017-remove-coverage-omits/quickstart.md
+++ b/specs/1017-remove-coverage-omits/quickstart.md
@@ -1,0 +1,202 @@
+# Quickstart: Per-Story Verification Recipes
+
+**Feature**: 1017-remove-coverage-omits
+**Refs**: #878
+
+Run these commands to verify a given PR meets the exit criteria before requesting review. All commands assume repo root as CWD and a Python 3.13 venv activated (or `uv run` prefix).
+
+## Setup (once per shell)
+
+```bash
+python -m venv .venv && source .venv/bin/activate  # or use uv/existing .venv
+pip install -e .[dev]
+```
+
+## PR-1 — Utilities (4 modules)
+
+```bash
+# Per-file coverage
+pytest --cov=src.utils.environment_utils \
+       --cov=src.utils.filter_operator_engine \
+       --cov=src.troubleshooting.troubleshoot_utils \
+       --cov=src.input.prompt_client_utils \
+       --cov-report=term-missing \
+       --cov-fail-under=90 \
+       tests/unit/utils/ tests/unit/troubleshooting/ tests/unit/input/
+
+# Full suite still passes
+pytest --cov --cov-fail-under=90
+
+# pyproject omit removed
+grep -c "src/utils/environment_utils.py" pyproject.toml    # -> 0
+grep -c "src/utils/filter_operator_engine.py" pyproject.toml  # -> 0
+```
+
+## PR-2 — Export helpers (5 modules)
+
+```bash
+pytest --cov=src.export.org_export_utils \
+       --cov=src.export.license_export_utils \
+       --cov=src.export.const_definitions_exporter \
+       --cov=src.export.gateway_test_exporter \
+       --cov=src.export.data_exporter \
+       --cov-report=term-missing \
+       --cov-fail-under=90 \
+       tests/unit/export/
+```
+
+## PR-3 — API / DB / analytics (7 modules)
+
+```bash
+pytest --cov=src.api --cov=src.cache --cov=src.db --cov=src.analytics \
+       --cov-report=term-missing --cov-fail-under=90 \
+       tests/unit/api/ tests/unit/cache/ tests/unit/db/ tests/unit/analytics/
+
+# Verify shared fixture landed in tests/conftest.py
+grep -n "def mock_mistapi_session" tests/conftest.py
+grep -n "def mock_config" tests/conftest.py
+```
+
+## PR-4a / PR-4b — Org exporters (3 + 4 modules)
+
+```bash
+# PR-4a
+pytest --cov=src.export.org_device_stats_exporter \
+       --cov=src.export.org_template_exporter \
+       --cov=src.export.org_admin_exporter \
+       --cov-fail-under=90 tests/unit/export/
+
+# Verify golden-file conftest introduced
+grep -n "def golden_json_writer\|def golden_csv_writer" tests/unit/export/conftest.py
+
+# PR-4b
+pytest --cov=src.export.org_config_exporter \
+       --cov=src.export.org_alarm_event_exporter \
+       --cov=src.export.org_client_security_exporter \
+       --cov=src.export.org_site_exporter \
+       --cov-fail-under=90 tests/unit/export/
+```
+
+## PR-5a / PR-5b — Site exporters + reports + inventory (5 + 5 modules)
+
+```bash
+# PR-5a
+pytest --cov=src.export.site_anomaly_exporter \
+       --cov=src.export.site_config_exporter \
+       --cov=src.export.site_device_exporter \
+       --cov=src.export.sites_by_ap_model_exporter \
+       --cov=src.gateway.gateway_ha_exporter \
+       --cov-fail-under=90 tests/unit/export/ tests/unit/gateway/
+
+# PR-5b
+pytest --cov=src.reports --cov=src.inventory.org_device_inventory_summary_facade \
+       --cov-fail-under=90 tests/unit/reports/ tests/unit/inventory/
+```
+
+## PR-6 — State-changing managers (5 modules, Principle III)
+
+```bash
+pytest --cov=src.device.arp_command_manager \
+       --cov=src.device.device_reboot_manager \
+       --cov=src.firmware.firmware_manager \
+       --cov=src.site.bulk_radius_wlan_config_manager \
+       --cov=src.org.org_ticket_manager \
+       --cov-fail-under=90 \
+       tests/unit/device/ tests/unit/firmware/ tests/unit/site/ tests/unit/org/
+
+# Confirm accept AND reject paths present for every manager
+grep -rn "confirmation.*UPGRADE\|reject\|early-return\|early_return" \
+  tests/unit/device/ tests/unit/firmware/ tests/unit/site/ tests/unit/org/
+```
+
+## PR-7 — SSH / TUI / prompt (3 modules, FR-015 candidates)
+
+```bash
+pytest --cov=src.ssh.cli_shell_manager \
+       --cov=src.ui.tui \
+       --cov=src.ui.prompt_utils \
+       --cov-fail-under=90 \
+       tests/unit/ssh/ tests/unit/ui/
+
+# Verify at most 2 escape-hatch omits added (FR-015)
+python -c "
+import tomllib, pathlib
+data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
+retained = {'tests/*','venv/*','.venv/*','setup.py','*/site-packages/*','src/maps/*'}
+hatches = [e for e in data['tool']['coverage']['run']['omit'] if e not in retained]
+assert len(hatches) <= 2, f'FR-015 violated: {len(hatches)} > 2'
+print(f'FR-015 OK: {len(hatches)} escape hatches remain')
+"
+```
+
+## PR-8a / PR-8b / PR-8c — Websocket wildcard (5 + 4 + 5 files)
+
+```bash
+# PR-8a (toplevel)
+pytest --cov=src.websocket --cov-fail-under=90 tests/unit/websocket/
+grep -n "def mock_websocket_transport" tests/unit/websocket/conftest.py
+
+# PR-8b (diagnostics)
+pytest --cov=src.websocket.diagnostics --cov-fail-under=90 \
+       tests/unit/websocket/diagnostics/
+
+# PR-8c (polling)
+pytest --cov=src.websocket.polling --cov-fail-under=90 \
+       tests/unit/websocket/polling/
+```
+
+## T-Final — Verify SC-001 + final omit list
+
+```bash
+python -c "
+import tomllib, pathlib
+data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
+omit = data['tool']['coverage']['run']['omit']
+expected = ['tests/*','venv/*','.venv/*','setup.py','*/site-packages/*','src/maps/*']
+assert sorted(omit) == sorted(expected), f'SC-001 violated: {sorted(omit)}'
+print('SC-001 OK')
+"
+
+pytest --cov --cov-fail-under=90 --cov-report=term
+```
+
+## SC-007 — Zero live network calls (podman network isolation)
+
+Run the full default suite inside a container with no network access to prove all mocks are complete.
+
+```bash
+podman run --rm --network=none \
+  -v "$PWD:/app:Z" -w /app \
+  python:3.13-slim \
+  bash -c "pip install -e .[dev] --no-index --find-links=/app/wheels && \
+           pytest --cov --cov-fail-under=90 -m 'not integration'"
+```
+
+**Exit criterion**: status 0 with no `ConnectionError`, no `socket.gaierror`, no `requests.exceptions.ConnectionError`. Any network attempt raises immediately under `--network=none`.
+
+If wheels are not pre-staged, substitute with a locked venv baked into the image at build time — the key point is `--network=none` at runtime.
+
+## SC-010 — Pylint gate unchanged
+
+```bash
+pylint --fail-under=9.5 src/ MistHelper.py
+```
+
+**Exit criterion**: status 0. `fail-under=9.5` MUST match `pyproject.toml [tool.pylint.main]` line unchanged.
+
+## Cross-PR sanity: baseline coverage never regresses
+
+```bash
+# Before starting the PR
+git checkout main && pytest --cov --cov-report=json:/tmp/baseline.json -q
+python -c "import json; print(json.load(open('/tmp/baseline.json'))['totals']['percent_covered'])" > /tmp/baseline.txt
+
+# After the PR
+git checkout <pr-branch> && pytest --cov --cov-report=json:/tmp/postpr.json -q
+python -c "
+import json
+b, p = float(open('/tmp/baseline.txt').read()), json.load(open('/tmp/postpr.json'))['totals']['percent_covered']
+assert p >= b, f'Regressed: {p:.2f} < {b:.2f}'
+print(f'{b:.2f} -> {p:.2f}')
+"
+```

--- a/specs/1017-remove-coverage-omits/research.md
+++ b/specs/1017-remove-coverage-omits/research.md
@@ -1,0 +1,145 @@
+# Phase 0 Research: Coverage Omit Removal Audit
+
+**Feature**: 1017-remove-coverage-omits
+**Branch cut**: `main` @ `3044717` (2026-07-13, post-#966 merge)
+**Refs**: #878
+
+## 1. Omit-list snapshot at branch cut
+
+Read verbatim from `pyproject.toml [tool.coverage.run].omit` (lines 238-287) at HEAD `3044717`.
+
+### Retained non-source (6 entries, FR-011 / SC-001 — frozen)
+
+| # | Entry | Rationale |
+|---|-------|-----------|
+| 1 | `tests/*` | Test files themselves — coverage does not measure test code. |
+| 2 | `venv/*` | Virtualenv site-packages — third-party code. |
+| 3 | `.venv/*` | Alternate venv location. |
+| 4 | `setup.py` | Legacy build stub (project builds via `hatchling`). |
+| 5 | `*/site-packages/*` | Any third-party install path. |
+| 6 | `src/maps/*` | Vendored maps subsystem — separate lifecycle. |
+
+### In-scope for removal (35 explicit + 1 wildcard = 36 modules total)
+
+**P1 — Utilities (4)**
+- `src/troubleshooting/troubleshoot_utils.py`
+- `src/input/prompt_client_utils.py`
+- `src/utils/environment_utils.py`
+- `src/utils/filter_operator_engine.py`
+
+**P2 — Export helpers (5, incl. FR-016 delta `data_exporter.py`)**
+- `src/export/const_definitions_exporter.py`
+- `src/export/data_exporter.py`
+- `src/export/gateway_test_exporter.py`
+- `src/export/license_export_utils.py`
+- `src/export/org_export_utils.py`
+
+**P3 — API / DB / analytics (7, incl. FR-016 deltas `api_core_fetch_utils`, `cache_utils`, `insight_metrics_utils`)**
+- `src/analytics/data_collection_manager.py`
+- `src/analytics/insight_metrics_utils.py`
+- `src/api/api_data_fetcher.py`
+- `src/api/api_fetch_utils.py`
+- `src/api/api_core_fetch_utils.py`
+- `src/cache/cache_utils.py`
+- `src/db/database_schema_utils.py`
+
+**P4a — Org exporters, stats/templates/admin (3)**
+- `src/export/org_device_stats_exporter.py`
+- `src/export/org_template_exporter.py`
+- `src/export/org_admin_exporter.py`
+
+**P4b — Org exporters, config/alarms/security/sites (4, incl. FR-016 delta `org_site_exporter.py`)**
+- `src/export/org_config_exporter.py`
+- `src/export/org_alarm_event_exporter.py`
+- `src/export/org_client_security_exporter.py`
+- `src/export/org_site_exporter.py`
+
+**P5a — Site exporters + gateway HA (5)**
+- `src/export/site_anomaly_exporter.py`
+- `src/export/site_config_exporter.py`
+- `src/export/site_device_exporter.py`
+- `src/export/sites_by_ap_model_exporter.py`
+- `src/gateway/gateway_ha_exporter.py`
+
+**P5b — Reports + inventory facade (5, reshuffled from spec P6 per plan.md Decision 4)**
+- `src/reports/global_wired_client_report_generator.py`
+- `src/reports/offline_device_reporter.py`
+- `src/reports/sfp_transceiver_data_processor.py`
+- `src/reports/wired_client_manufacturer_report_generator.py`
+- `src/inventory/org_device_inventory_summary_facade.py`
+
+**P6 — State-changing managers (5, Principle III)**
+- `src/device/arp_command_manager.py`
+- `src/device/device_reboot_manager.py`
+- `src/firmware/firmware_manager.py`
+- `src/site/bulk_radius_wlan_config_manager.py`
+- `src/org/org_ticket_manager.py`
+
+**P7 — SSH + TUI + prompt (3, FR-015 candidates)**
+- `src/ssh/cli_shell_manager.py`
+- `src/ui/tui.py`
+- `src/ui/prompt_utils.py`
+
+**P8 — Websocket wildcard (`src/websocket/*` → 15 files)**
+
+Enumerated at branch cut:
+
+- `src/websocket/__init__.py`
+- `src/websocket/commands.py`
+- `src/websocket/context.py`
+- `src/websocket/manager.py`
+- `src/websocket/service_ping_discovery.py`
+- `src/websocket/service_ping_manager.py`
+- `src/websocket/diagnostics/__init__.py`
+- `src/websocket/diagnostics/arp_executor.py`
+- `src/websocket/diagnostics/common.py`
+- `src/websocket/diagnostics/ping_executor.py`
+- `src/websocket/polling/__init__.py`
+- `src/websocket/polling/completion_detector.py`
+- `src/websocket/polling/message_router.py`
+- `src/websocket/polling/result_collector.py`
+- `src/websocket/polling/result_combiner.py`
+
+Split across PR-8a (toplevel), PR-8b (diagnostics), PR-8c (polling).
+
+## 2. Per-cluster mocking decisions
+
+Per plan.md Decision 5 risk register and Technical Context.
+
+| Cluster | Primary external touchpoint | Mocking library | Rationale |
+|---------|---------------------------|-----------------|-----------|
+| P1 utilities | `os.environ`, stdin, filesystem | `monkeypatch` + `tmp_path` | pytest built-ins are sufficient; no third-party deps. |
+| P2 export helpers | filesystem (JSON/CSV write) | `tmp_path` + `unittest.mock` for `mistapi` | Golden-file comparison in-memory buffer inspection. |
+| P3 API/DB/analytics | `mistapi.APISession`, `python-arango`, `redis` | `MagicMock(spec=mistapi.APISession)`, `MagicMock(spec=arango.database.StandardDatabase)`, `fakeredis` or `MagicMock(spec=redis.Redis)` | Spec-bound mocks catch typos; no live network. `database_schema_utils` is a pure string builder — no DB fixture. |
+| P4 org exporters | `mistapi` + filesystem | `MagicMock(spec=mistapi.APISession)` + `tmp_path` | Shared fixture `mock_mistapi_session` in `tests/unit/export/conftest.py` (introduced PR-4a). |
+| P5 site exporters + reports | `mistapi` + filesystem | Same as P4 — reuses PR-4a fixtures | Column-order + header + one-row-of-data assertions. |
+| P6 state-changing managers | `mistapi` + `safe_input()` prompts | `MagicMock(spec=mistapi.APISession)` + `monkeypatch.setattr("...safe_input", lambda *_: "UPGRADE")` | Both accept AND reject paths tested (Principle III). |
+| P7 SSH / TUI | `paramiko.SSHClient`, `sshkeyboard.listen_keyboard` | `MagicMock(spec=paramiko.SSHClient)`, `monkeypatch.setattr("sshkeyboard.listen_keyboard", fake)` | Interactive prompts via `monkeypatch` on `safe_input()`. |
+| P8 websocket | `websocket.WebSocketApp` (sync `websocket-client` + threading), injected `utility` deps | `MagicMock(spec=websocket.WebSocketApp)`; for `service_ping_*` mock injected utility deps | Project uses **synchronous** `websocket-client`, NOT `websockets` (async). Assert loop exits after ≤ 2 mocked iterations. |
+
+**No `sqlite3` fixture** — `src/db/database_schema_utils.py` is a pure DDL string builder (verified: only imports `inspect`, `logging`, `re`, `datetime`, `typing`).
+
+## 3. Fixture-migration order
+
+Fixtures introduced in early PRs are reused by later PRs. Placement is deliberate.
+
+| Fixture | Introduced in | Location | Consumers |
+|---------|--------------|----------|-----------|
+| `mock_mistapi_session` | PR-3 | `tests/conftest.py` (repo-wide) | PR-3, PR-4a, PR-4b, PR-5a, PR-5b, PR-6 |
+| `mock_config` | PR-3 | `tests/conftest.py` | PR-3, PR-4a-b, PR-5a-b, PR-6 |
+| `mock_mistapi_paginated_response` | PR-3 | `tests/unit/api/conftest.py` | PR-3, PR-4a-b, PR-5a-b |
+| Golden-file writer helpers | PR-4a | `tests/unit/export/conftest.py` | PR-4a, PR-4b, PR-5a, PR-5b |
+| `mock_paramiko_ssh_client` | PR-7 | `tests/unit/ssh/conftest.py` | PR-7 |
+| `mock_sshkeyboard_listen` | PR-7 | `tests/unit/ui/conftest.py` (extend existing) | PR-7 |
+| `mock_websocket_transport` | PR-8a | `tests/unit/websocket/conftest.py` | PR-8a, PR-8b, PR-8c |
+
+## 4. Success criteria references
+
+- SC-001: exactly 6 retained non-source omits after T-Final.
+- SC-003: `pytest --cov --cov-fail-under=90` passes.
+- SC-006: no new `# pragma: no cover` / `# type: ignore` / `# noqa` in workflow-added tests.
+- SC-007: default CI suite makes zero live network calls (verify with `podman run --network=none`).
+- SC-010: pylint `fail-under=9.5` unchanged.
+- FR-009: `fail_under=90` line unchanged.
+- FR-011: retained omit set unchanged.
+- FR-015: max 2 modules retain omit + `# TODO(1017): refactor pending` comment.


### PR DESCRIPTION
## Summary
- Author six Phase 0 / Phase 1 deliverables under `specs/1017-remove-coverage-omits/` per T-00.1..T-00.10 (research.md, data-model.md, contracts/{shared_fixtures,coverage_assertion,mocking_conventions}.md, quickstart.md).
- Every artifact references SC-001 (6-entry retained omit set) and the 90% coverage threshold; every contract file carries an explicit \`Validation rule:\` line per T-00.4.
- Docs-only change: no source, test, or config files touched.

## Verification
- \`ls specs/1017-remove-coverage-omits/\` shows the 4 top-level files + \`contracts/\` dir.
- \`grep -l SC-001 specs/1017-remove-coverage-omits/*.md specs/1017-remove-coverage-omits/contracts/*.md\` returns all 6 new files (contracts reference SC-001 via cross-link to \`coverage_assertion.md §3\`).
- \`grep -c 'Validation rule' specs/1017-remove-coverage-omits/contracts/*.md\` returns 1 per file.

## Test plan
- [x] Docs-only PR — no code paths exercised. Formatter/lint/coverage gates do not apply.
- [x] All 6 files render as markdown in the PR preview.
- [x] \`Refs #878\` trailer present (spec-sanctioned linkage; sub-issues created just-in-time per PR).

Refs #878