### PR TITLE
test(1018): Wave 10 P2 coverage — +1.96pp -> 86.66%

### DIFF
--- a/tests/unit/export/test_msp_inventory_exporter.py
+++ b/tests/unit/export/test_msp_inventory_exporter.py
@@ -1,0 +1,712 @@
+"""Wave 10 P2 coverage for src/export/msp_inventory_exporter.py (initiative #1018).
+
+Covers ``MSPInventoryExporter`` static + instance methods:
+- ``_normalize_msp_orgs_response``: list/dict/None coercion.
+- ``_normalize_inventory_data``: list/dict/None coercion.
+- ``_validate_msp_info``: valid vs invalid msp_id.
+- ``_validate_org``: valid vs missing/invalid org id.
+- ``_enrich_device_context``: site_id in lookup, missing lookup entry, no site_id.
+- ``_count_device_types``: aggregate device types.
+- ``_ingest_org_devices``: enrich + append semantics.
+- ``_get_priority_fields`` + ``_order_fields`` + ``_build_sorted_rows``: field ordering.
+- ``_print_org_inventory_summary`` + ``_print_summary_errors`` + ``_print_device_breakdown``.
+- ``_finalize_export``: empty vs populated device list.
+- ``_run`` + ``_ensure_msp_privileges`` + ``_attempt_interactive_login`` + ``_execute_login_and_validate``
+  + ``_process_all_msps`` + ``_process_msp`` + ``_process_msp_orgs_inventory``
+  + ``_process_org`` + ``_fetch_msp_orgs`` + ``_fetch_org_inventory`` + ``_build_site_lookup``.
+
+Uses sys.modules injection of a fake MistHelper module (per conftest pattern) so
+``importlib.import_module('MistHelper')`` returns our stub. No live network.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions in test type hints.
+
+import sys  # WHY: mint a fake MistHelper module into sys.modules for lazy-import resolution.
+import types  # WHY: build the fake MistHelper module cheaply.
+from typing import Any  # WHY: satisfies mypy strict + ruff B010 on dynamic module attrs.
+from unittest.mock import MagicMock, patch  # WHY: mocks + patch for lazy-imported endpoint modules.
+
+import mistapi  # WHY: capture real top-level module for defensive restoration against polluter tests.
+import mistapi.api  # WHY: capture real 'api' submodule for restoration (polluters overwrite with MagicMock).
+import mistapi.api.v1  # WHY: capture real 'v1' submodule for restoration against polluter tests.
+import mistapi.api.v1.msps  # WHY: capture real 'msps' submodule for restoration against polluter tests.
+import mistapi.api.v1.msps.orgs as msp_orgs_api  # WHY: patch listMspOrgs attribute directly (mypy strict re-export).
+import mistapi.api.v1.orgs  # WHY: capture real 'orgs' submodule for restoration against polluter tests.
+import mistapi.api.v1.orgs.inventory as org_inventory_api  # WHY: patch getOrgInventory attribute directly.
+import pytest  # WHY: monkeypatch fixture + capsys for stdout capture.
+
+from src.dataclasses.msp_org_context import MspOrgContext  # WHY: dataclass passed to _enrich_device_context.
+from src.export.msp_inventory_exporter import MSPInventoryExporter  # WHY: SUT direct import.
+
+# WHY: capture real mistapi module chain at test-collection time to defend against sys.modules pollution
+# from module-scope `patch.dict(sys.modules, {"mistapi": MagicMock(), ...})` blocks in sibling test files
+# (test_bulk_ap_upgrader, test_org_ap_upgrader, test_e911_bssid, test_rate_limiting, etc.). Those blocks
+# inject MagicMock into sys.modules at their own collection time; when the SUT later executes
+# `import mistapi.api.v1.msps.orgs as msp_orgs_api` inside a method, Python's IMPORT_FROM bytecode
+# performs an attribute lookup on sys.modules['mistapi'] which resolves through the MagicMock chain,
+# NOT the real submodule we monkeypatch attributes on. Restoring the real submodules to sys.modules
+# in each affected test ensures the lazy import inside the SUT resolves to the real module we patched.
+_REAL_MISTAPI_MODULES: dict[str, Any] = {
+    "mistapi": mistapi,  # WHY: top-level module; attribute chain root.
+    "mistapi.api": mistapi.api,  # WHY: intermediate submodule; IMPORT_FROM lookup step.
+    "mistapi.api.v1": mistapi.api.v1,  # WHY: intermediate submodule; IMPORT_FROM lookup step.
+    "mistapi.api.v1.msps": mistapi.api.v1.msps,  # WHY: intermediate submodule; IMPORT_FROM lookup step.
+    "mistapi.api.v1.msps.orgs": msp_orgs_api,  # WHY: target submodule with listMspOrgs attribute.
+    "mistapi.api.v1.orgs": mistapi.api.v1.orgs,  # WHY: intermediate submodule; IMPORT_FROM lookup step.
+    "mistapi.api.v1.orgs.inventory": org_inventory_api,  # WHY: target submodule with getOrgInventory attribute.
+}
+
+
+def _restore_real_mistapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restore real mistapi submodules into sys.modules for the current test scope."""
+    for name, module in _REAL_MISTAPI_MODULES.items():  # WHY: pin each level of the chain.
+        monkeypatch.setitem(sys.modules, name, module)  # WHY: overwrite any polluter MagicMocks.
+
+
+def _install_fake_mh(monkeypatch: pytest.MonkeyPatch, *, msp_privileges: list[dict] | None = None) -> Any:
+    """Install a minimal fake MistHelper module with commonly-needed attributes."""
+    mh: Any = types.ModuleType("MistHelper")  # WHY: Any typing satisfies mypy strict on dynamic attrs.
+    mh.msp_privileges = msp_privileges if msp_privileges is not None else []  # WHY: driven by tests.
+    mh.apisession = MagicMock(spec=object)  # WHY: opaque placeholder; only pass-through.
+    mh.InputUtils = MagicMock()  # WHY: patched per-test as needed.
+    mh.APICoreFetchUtils = MagicMock()  # WHY: patched per-test as needed.
+    mh.DataExporter = MagicMock()  # WHY: write_with_format_selection assertion target.
+    monkeypatch.setitem(sys.modules, "MistHelper", mh)  # WHY: lazy import returns this stub.
+    return mh
+
+
+# =========================================================================
+# Static coercion helpers
+# =========================================================================
+
+
+def test_normalize_msp_orgs_response_returns_list_when_list() -> None:
+    """A list payload is returned unchanged (identity path)."""
+    payload = [{"id": "a"}, {"id": "b"}]  # WHY: two-org list.
+    assert MSPInventoryExporter._normalize_msp_orgs_response(payload) is payload  # WHY: passthrough.
+
+
+def test_normalize_msp_orgs_response_wraps_dict() -> None:
+    """A single dict payload is wrapped in a one-element list."""
+    payload = {"id": "a"}  # WHY: single-org dict.
+    assert MSPInventoryExporter._normalize_msp_orgs_response(payload) == [payload]  # WHY: wrap.
+
+
+def test_normalize_msp_orgs_response_returns_empty_for_none() -> None:
+    """None/falsy payloads coerce to an empty list."""
+    assert MSPInventoryExporter._normalize_msp_orgs_response(None) == []  # WHY: no data.
+
+
+def test_normalize_inventory_data_returns_list_when_list() -> None:
+    """A list inventory payload is returned unchanged."""
+    payload = [{"mac": "aa"}, {"mac": "bb"}]  # WHY: two devices.
+    assert MSPInventoryExporter._normalize_inventory_data(payload) is payload  # WHY: passthrough.
+
+
+def test_normalize_inventory_data_wraps_dict() -> None:
+    """A single dict inventory payload is wrapped into a list."""
+    payload = {"mac": "aa"}  # WHY: single device dict.
+    assert MSPInventoryExporter._normalize_inventory_data(payload) == [payload]  # WHY: wrap.
+
+
+def test_normalize_inventory_data_returns_empty_for_none() -> None:
+    """Falsy inventory payloads coerce to empty list."""
+    assert MSPInventoryExporter._normalize_inventory_data(None) == []  # WHY: no data.
+
+
+# =========================================================================
+# Validation
+# =========================================================================
+
+
+def test_validate_msp_info_returns_ids_for_valid_msp() -> None:
+    """Valid MSP dict returns (msp_id, msp_name) tuple."""
+    exporter = MSPInventoryExporter()  # WHY: exercise instance method.
+    result = exporter._validate_msp_info({"msp_id": "msp-1", "msp_name": "Acme"})  # WHY: happy path.
+    assert result == ("msp-1", "Acme")  # WHY: both fields extracted.
+
+
+def test_validate_msp_info_returns_none_when_id_missing(capsys: pytest.CaptureFixture[str]) -> None:
+    """Missing/invalid msp_id returns (None, name) and prints an X error line."""
+    exporter = MSPInventoryExporter()  # WHY: exercise instance method.
+    result = exporter._validate_msp_info({"msp_name": "Acme"})  # WHY: id absent.
+    assert result == (None, "Acme")  # WHY: fallback name preserved.
+    captured = capsys.readouterr()  # WHY: verify error banner.
+    assert "Invalid MSP ID" in captured.out  # WHY: sanity print.
+
+
+def test_validate_msp_info_returns_none_when_id_not_string(capsys: pytest.CaptureFixture[str]) -> None:
+    """Non-string msp_id (e.g., int) is rejected as invalid."""
+    exporter = MSPInventoryExporter()  # WHY: exercise instance method.
+    result = exporter._validate_msp_info({"msp_id": 42, "msp_name": "Beta"})  # WHY: type violation.
+    assert result == (None, "Beta")  # WHY: reject non-string.
+    assert "Invalid MSP ID" in capsys.readouterr().out  # WHY: user notified.
+
+
+def test_validate_org_returns_tuple_for_valid_org() -> None:
+    """Valid org dict returns (org_id, org_name) tuple."""
+    exporter = MSPInventoryExporter()  # WHY: exercise instance method.
+    assert exporter._validate_org({"id": "org-1", "name": "MyOrg"}) == ("org-1", "MyOrg")  # WHY: happy path.
+
+
+def test_validate_org_returns_none_when_id_missing(capsys: pytest.CaptureFixture[str]) -> None:
+    """Missing id yields None + printed diagnostic."""
+    exporter = MSPInventoryExporter()  # WHY: exercise instance method.
+    assert exporter._validate_org({"name": "MyOrg"}) is None  # WHY: rejected.
+    assert "Invalid org ID" in capsys.readouterr().out  # WHY: user notified.
+
+
+# =========================================================================
+# Device enrichment / counting
+# =========================================================================
+
+
+def test_enrich_device_context_stamps_all_fields() -> None:
+    """Device record gains _msp_id/_msp_name/_org_id/_org_name/_site_name."""
+    exporter = MSPInventoryExporter()  # WHY: instance for enrichment.
+    ctx = MspOrgContext(msp_id="msp-1", msp_name="Acme", org_id="org-1", org_name="Sub")  # WHY: bundled ids.
+    device: dict[str, Any] = {"site_id": "site-1", "mac": "aa"}  # WHY: minimal device.
+    exporter._enrich_device_context(device, ctx, {"site-1": "HQ"})  # WHY: lookup hit path.
+    assert device["_msp_id"] == "msp-1"  # WHY: MSP stamp.
+    assert device["_msp_name"] == "Acme"  # WHY: MSP stamp.
+    assert device["_org_id"] == "org-1"  # WHY: org stamp.
+    assert device["_org_name"] == "Sub"  # WHY: org stamp.
+    assert device["_site_name"] == "HQ"  # WHY: lookup resolved.
+
+
+def test_enrich_device_context_uses_unknown_site_when_missing_from_lookup() -> None:
+    """Unknown site_id -> _site_name = 'Unknown Site'."""
+    exporter = MSPInventoryExporter()  # WHY: instance for enrichment.
+    ctx = MspOrgContext("msp-1", "A", "org-1", "S")  # WHY: bundled ids.
+    device = {"site_id": "unknown-site"}  # WHY: id not in lookup.
+    exporter._enrich_device_context(device, ctx, {})  # WHY: empty lookup path.
+    assert device["_site_name"] == "Unknown Site"  # WHY: fallback string.
+
+
+def test_enrich_device_context_marks_unassigned_when_site_id_missing() -> None:
+    """Missing site_id key -> _site_name = 'Unassigned'."""
+    exporter = MSPInventoryExporter()  # WHY: instance for enrichment.
+    ctx = MspOrgContext("msp-1", "A", "org-1", "S")  # WHY: bundled ids.
+    device: dict[str, Any] = {}  # WHY: no site_id at all.
+    exporter._enrich_device_context(device, ctx, {"site-1": "HQ"})  # WHY: lookup irrelevant.
+    assert device["_site_name"] == "Unassigned"  # WHY: unassigned branch.
+
+
+def test_count_device_types_aggregates_and_labels_unknowns() -> None:
+    """Devices without a type key are counted under 'unknown'."""
+    exporter = MSPInventoryExporter()  # WHY: exercise counter.
+    devices = [{"type": "ap"}, {"type": "ap"}, {"type": "switch"}, {}]  # WHY: two aps, one switch, one unknown.
+    counts = exporter._count_device_types(devices)  # WHY: aggregate.
+    assert counts == {"ap": 2, "switch": 1, "unknown": 1}  # WHY: full tally.
+
+
+def test_ingest_org_devices_enriches_and_appends() -> None:
+    """Each device gets enriched and appended to all_devices."""
+    exporter = MSPInventoryExporter()  # WHY: instance carries all_devices state.
+    ctx = MspOrgContext("m", "M-name", "o", "O-name")  # WHY: bundled ids.
+    devices = [{"mac": "aa", "site_id": "s1"}, {"mac": "bb"}]  # WHY: mixed site_id presence.
+    exporter._ingest_org_devices(devices, ctx, {"s1": "HQ"})  # WHY: run ingest.
+    assert len(exporter.all_devices) == 2  # WHY: both appended.
+    assert exporter.all_devices[0]["_site_name"] == "HQ"  # WHY: first enriched with lookup.
+    assert exporter.all_devices[1]["_site_name"] == "Unassigned"  # WHY: second lacked site_id.
+
+
+# =========================================================================
+# Column ordering / row building
+# =========================================================================
+
+
+def test_get_priority_fields_includes_msp_org_site_columns() -> None:
+    """Priority list starts with _msp_name and includes core identity + device columns."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    priority = exporter._get_priority_fields()  # WHY: fetch list.
+    assert priority[0] == "_msp_name"  # WHY: MSP first for readability.
+    assert "_org_name" in priority  # WHY: org identity present.
+    assert "type" in priority and "mac" in priority  # WHY: core device columns present.
+
+
+def test_order_fields_priority_first_then_alphabetical() -> None:
+    """Ordering keeps priority order for known fields, then sorts remaining."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    all_fields = {"_msp_name", "type", "mac", "extra_z", "extra_a"}  # WHY: mixed priority + extras.
+    ordered = exporter._order_fields(all_fields, ["_msp_name", "type", "mac"])  # WHY: sanity path.
+    assert ordered[:3] == ["_msp_name", "type", "mac"]  # WHY: priority preserved.
+    assert ordered[3:] == ["extra_a", "extra_z"]  # WHY: extras sorted alphabetically.
+
+
+def test_build_sorted_rows_sorts_by_msp_org_site_type_name() -> None:
+    """Rows sort primarily by MSP name (case-insensitive), then org/site/type/name."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    flat = [  # WHY: two devices differing in MSP.
+        {"_msp_name": "Zeta", "_org_name": "o", "_site_name": "s", "type": "ap", "name": "b"},
+        {"_msp_name": "alpha", "_org_name": "o", "_site_name": "s", "type": "ap", "name": "a"},
+    ]
+    ordered_fields = ["_msp_name", "_org_name", "_site_name", "type", "name"]  # WHY: minimal ordered set.
+    rows = exporter._build_sorted_rows(flat, ordered_fields)  # WHY: sort + project.
+    assert rows[0]["_msp_name"] == "alpha"  # WHY: case-insensitive sort puts 'alpha' first.
+    assert rows[1]["_msp_name"] == "Zeta"  # WHY: 'zeta' comes second.
+
+
+# =========================================================================
+# Print helpers
+# =========================================================================
+
+
+def test_print_org_inventory_summary_formats_type_tally(capsys: pytest.CaptureFixture[str]) -> None:
+    """Summary line renders total count and per-type breakdown."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    exporter._print_org_inventory_summary("MyOrg", [{"type": "ap"}, {"type": "switch"}])  # WHY: two-type mix.
+    out = capsys.readouterr().out  # WHY: capture stdout.
+    assert "MyOrg" in out and "2 devices" in out  # WHY: counts printed.
+    assert "ap:1" in out and "switch:1" in out  # WHY: per-type tally.
+
+
+def test_print_summary_errors_no_errors_no_output(capsys: pytest.CaptureFixture[str]) -> None:
+    """No errors -> no additional output."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    exporter._print_summary_errors()  # WHY: empty errors path.
+    assert capsys.readouterr().out == ""  # WHY: silent early return.
+
+
+def test_print_summary_errors_truncates_at_five(capsys: pytest.CaptureFixture[str]) -> None:
+    """More than five errors triggers 'and N more' truncation line."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    exporter.errors = [f"err-{i}" for i in range(7)]  # WHY: seven errors triggers truncation.
+    exporter._print_summary_errors()  # WHY: exercise print.
+    out = capsys.readouterr().out  # WHY: capture output.
+    assert "and 2 more" in out  # WHY: 7 total - 5 shown = 2 remainder.
+
+
+def test_print_device_breakdown_prints_sorted_counts(capsys: pytest.CaptureFixture[str]) -> None:
+    """Device type breakdown prints in descending count order."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    exporter.all_devices = [{"type": "ap"}] * 3 + [{"type": "switch"}]  # WHY: 3 aps, 1 switch.
+    exporter._print_device_breakdown()  # WHY: exercise print.
+    out = capsys.readouterr().out  # WHY: capture output.
+    assert "Device Type Breakdown" in out  # WHY: header printed.
+    ap_pos = out.find("ap")  # WHY: 'ap' comes first (highest count).
+    switch_pos = out.find("switch")  # WHY: 'switch' comes after.
+    assert 0 <= ap_pos < switch_pos  # WHY: descending order enforced.
+
+
+def test_print_device_breakdown_empty_returns_silent(capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty device list produces no breakdown output."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    exporter._print_device_breakdown()  # WHY: empty list path.
+    assert capsys.readouterr().out == ""  # WHY: early return.
+
+
+def test_print_header_renders_banner(capsys: pytest.CaptureFixture[str]) -> None:
+    """Header banner contains title text."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    exporter._print_header()  # WHY: exercise print.
+    assert "MSP-WIDE DEVICE INVENTORY EXPORT" in capsys.readouterr().out  # WHY: banner text.
+
+
+def test_print_login_prompt_renders_expected_text(capsys: pytest.CaptureFixture[str]) -> None:
+    """Login prompt describes interactive login."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    exporter._print_login_prompt()  # WHY: exercise print.
+    out = capsys.readouterr().out  # WHY: capture output.
+    assert "MSP privileges not currently available" in out  # WHY: prompt text.
+    assert "interactive login" in out  # WHY: describes action.
+
+
+def test_print_summary_full_flow(capsys: pytest.CaptureFixture[str]) -> None:
+    """_print_summary renders MSP/org/device totals + errors + breakdown."""
+    exporter = MSPInventoryExporter()  # WHY: instance access.
+    exporter.msp_count = 2  # WHY: seed totals.
+    exporter.org_count = 3  # WHY: seed totals.
+    exporter.device_count = 5  # WHY: seed totals.
+    exporter.errors = ["boom"]  # WHY: exercise error path.
+    exporter.all_devices = [{"type": "ap"}]  # WHY: breakdown non-empty.
+    exporter._print_summary()  # WHY: full summary.
+    out = capsys.readouterr().out  # WHY: capture output.
+    assert "MSPs processed:" in out and "2" in out  # WHY: MSP count.
+    assert "Organizations scanned:" in out and "3" in out  # WHY: org count.
+    assert "Total devices exported:" in out and "5" in out  # WHY: device count.
+    assert "boom" in out  # WHY: error printed.
+
+
+# =========================================================================
+# Finalize / Run entry points
+# =========================================================================
+
+
+def test_finalize_export_no_devices_prints_no_data(capsys: pytest.CaptureFixture[str]) -> None:
+    """When all_devices is empty, finalize prints 'No devices found' banner."""
+    exporter = MSPInventoryExporter()  # WHY: exercise finalize.
+    exporter._finalize_export()  # WHY: empty branch.
+    assert "No devices found" in capsys.readouterr().out  # WHY: user notified.
+
+
+def test_finalize_export_with_devices_writes_and_summarises(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When devices exist, finalize invokes _write_results + _print_summary."""
+    exporter = MSPInventoryExporter()  # WHY: exercise finalize.
+    exporter.all_devices = [{"type": "ap", "_msp_name": "M"}]  # WHY: seed non-empty state.
+    write_mock = MagicMock()  # WHY: capture write call.
+    summary_mock = MagicMock()  # WHY: capture summary call.
+    monkeypatch.setattr(exporter, "_write_results", write_mock)  # WHY: stub side effects.
+    monkeypatch.setattr(exporter, "_print_summary", summary_mock)  # WHY: stub side effects.
+    exporter._finalize_export()  # WHY: exercise populated branch.
+    write_mock.assert_called_once()  # WHY: write invoked.
+    summary_mock.assert_called_once()  # WHY: summary invoked.
+
+
+def test_write_results_invokes_data_exporter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_write_results flattens rows and calls DataExporter.write_with_format_selection."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper for lazy import.
+    write_mock = MagicMock()  # WHY: capture write invocation.
+    mh.DataExporter = types.SimpleNamespace(write_with_format_selection=write_mock)  # WHY: attach exporter.
+
+    with patch("src.export.msp_inventory_exporter.DataProcessingUtils") as fake_dp:
+        fake_dp.flatten_nested_fields.side_effect = lambda rows: rows  # WHY: identity flatten.
+        exporter = MSPInventoryExporter()  # WHY: instance.
+        exporter.all_devices = [{"type": "ap", "_msp_name": "M", "_org_name": "O", "_site_name": "S", "name": "x"}]
+        exporter._write_results()  # WHY: run under fakes.
+
+    write_mock.assert_called_once()  # WHY: exporter invoked once.
+    args, kwargs = write_mock.call_args  # WHY: inspect payload.
+    assert "MSP_Inventory_Export.csv" in args[1]  # WHY: filename asserted.
+    assert kwargs["api_function_name"] == "mspInventoryExport"  # WHY: pass-through metadata.
+
+
+# =========================================================================
+# MSP privilege / login flow
+# =========================================================================
+
+
+def test_ensure_msp_privileges_returns_true_when_privileges_present(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When msp_privileges is non-empty, method prints banner and returns True."""
+    _install_fake_mh(monkeypatch, msp_privileges=[{"msp_id": "x", "msp_name": "n"}])  # WHY: pre-populated.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    assert exporter._ensure_msp_privileges() is True  # WHY: happy path.
+    assert "MSP privileges detected" in capsys.readouterr().out  # WHY: banner printed.
+
+
+def test_attempt_interactive_login_returns_false_when_user_declines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """User answering 'n' cancels login flow."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    mh.InputUtils = types.SimpleNamespace(safe_input=MagicMock(return_value="n"))  # WHY: decline path.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    assert exporter._attempt_interactive_login() is False  # WHY: user cancelled.
+
+
+def test_attempt_interactive_login_handles_systemexit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SystemExit during safe_input returns False cleanly."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    mh.InputUtils = types.SimpleNamespace(safe_input=MagicMock(side_effect=SystemExit()))  # WHY: EOF/abort path.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    assert exporter._attempt_interactive_login() is False  # WHY: SystemExit handled.
+
+
+def test_execute_login_and_validate_returns_false_when_login_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Login failure returns False and prints diagnostic."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    with patch("src.export.msp_inventory_exporter.MistSessionInteractiveInitializer.initialize", return_value=False):
+        exporter = MSPInventoryExporter()  # WHY: instance.
+        assert exporter._execute_login_and_validate() is False  # WHY: initialize returned False.
+    assert "Login failed" in capsys.readouterr().out  # WHY: user informed.
+
+
+def test_execute_login_and_validate_returns_false_when_no_privileges_after_login(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Successful login but no privileges obtained yields False + warning."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    with (
+        patch("src.export.msp_inventory_exporter.MistSessionInteractiveInitializer.initialize", return_value=True),
+        patch("src.export.msp_inventory_exporter.detect_msp_privileges", return_value=[]) as detect_mock,
+    ):
+        exporter = MSPInventoryExporter()  # WHY: instance.
+        assert exporter._execute_login_and_validate() is False  # WHY: no privileges post-login.
+    detect_mock.assert_called_once()  # WHY: detection ran.
+    assert mh.msp_privileges == []  # WHY: mh global updated (still empty).
+    assert "No MSP privileges" in capsys.readouterr().out  # WHY: user informed.
+
+
+def test_execute_login_and_validate_returns_true_when_privileges_detected(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Successful login and non-empty privileges list yields True."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    detected = [{"msp_id": "m", "msp_name": "Acme"}]  # WHY: single detected privilege.
+    with (
+        patch("src.export.msp_inventory_exporter.MistSessionInteractiveInitializer.initialize", return_value=True),
+        patch("src.export.msp_inventory_exporter.detect_msp_privileges", return_value=detected),
+    ):
+        exporter = MSPInventoryExporter()  # WHY: instance.
+        assert exporter._execute_login_and_validate() is True  # WHY: happy path.
+    assert mh.msp_privileges == detected  # WHY: mh global replaced.
+    assert "Continuing" in capsys.readouterr().out  # WHY: continuation banner.
+
+
+# =========================================================================
+# MSP + Org processing
+# =========================================================================
+
+
+def test_process_all_msps_iterates_privileges(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every entry in mh.msp_privileges is dispatched to _process_msp."""
+    _install_fake_mh(monkeypatch, msp_privileges=[{"msp_id": "a"}, {"msp_id": "b"}])  # WHY: two MSPs.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    dispatch_mock = MagicMock()  # WHY: capture dispatches.
+    monkeypatch.setattr(exporter, "_process_msp", dispatch_mock)  # WHY: intercept dispatch.
+    exporter._process_all_msps()  # WHY: run loop.
+    assert dispatch_mock.call_count == 2  # WHY: two iterations.
+
+
+def test_fetch_msp_orgs_returns_empty_when_no_apisession(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No apisession -> print notice + empty list."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    mh.apisession = None  # WHY: simulate missing session.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    assert exporter._fetch_msp_orgs("m", "n") == []  # WHY: short-circuit.
+    assert "API session not initialized" in capsys.readouterr().out  # WHY: user notified.
+
+
+def test_fetch_msp_orgs_returns_empty_on_failed_response(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Response without .data attribute records error and returns empty."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    _restore_real_mistapi(monkeypatch)  # WHY: undo pollution so lazy `import ... as msp_orgs_api` in SUT resolves real.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(msp_orgs_api, "listMspOrgs", MagicMock(return_value=None))  # WHY: patch actual submodule attr.
+    result = exporter._fetch_msp_orgs("m", "n")  # WHY: run under fake endpoint.
+    assert result == []  # WHY: empty on failure.
+    assert "Failed to retrieve organizations" in capsys.readouterr().out  # WHY: notice printed.
+    assert exporter.errors  # WHY: error recorded.
+
+
+def test_fetch_msp_orgs_normalises_response_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Response .data is coerced through _normalize_msp_orgs_response."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    _restore_real_mistapi(monkeypatch)  # WHY: undo sys.modules pollution from sibling module-scope patch.dict blocks.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    response = types.SimpleNamespace(data=[{"id": "org-1"}])  # WHY: normal list payload.
+    monkeypatch.setattr(msp_orgs_api, "listMspOrgs", MagicMock(return_value=response))  # WHY: patch actual submodule.
+    result = exporter._fetch_msp_orgs("m", "n")  # WHY: run.
+    assert result == [{"id": "org-1"}]  # WHY: list preserved.
+
+
+def test_process_msp_records_error_on_exception(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exception in _process_msp_orgs_inventory is caught and recorded in errors list."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(
+        exporter,
+        "_process_msp_orgs_inventory",
+        MagicMock(side_effect=RuntimeError("kaboom")),  # WHY: force error path.
+    )
+    exporter._process_msp({"msp_id": "m", "msp_name": "n"})  # WHY: exercise catch path.
+    assert exporter.msp_count == 1  # WHY: MSP still counted before error.
+    assert any("kaboom" in e for e in exporter.errors)  # WHY: error captured.
+
+
+def test_process_msp_returns_early_when_apisession_none(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Missing apisession short-circuits _process_msp after validate + banner."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    mh.apisession = None  # WHY: simulate missing.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    exporter._process_msp({"msp_id": "m", "msp_name": "n"})  # WHY: run.
+    assert "API session not initialized" in capsys.readouterr().out  # WHY: user informed.
+
+
+def test_process_msp_returns_early_on_invalid_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid msp_id short-circuits without incrementing msp_count."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    exporter._process_msp({"msp_name": "n"})  # WHY: missing msp_id.
+    assert exporter.msp_count == 0  # WHY: never counted.
+
+
+def test_process_msp_orgs_inventory_reports_no_orgs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Empty org list prints 'No organizations found' banner."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(exporter, "_fetch_msp_orgs", MagicMock(return_value=[]))  # WHY: stub API.
+    exporter._process_msp_orgs_inventory("m", "N")  # WHY: run.
+    assert "No organizations found" in capsys.readouterr().out  # WHY: banner text.
+
+
+def test_process_msp_orgs_inventory_dispatches_each_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every org from _fetch_msp_orgs is dispatched to _process_org."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(
+        exporter, "_fetch_msp_orgs", MagicMock(return_value=[{"id": "o1"}, {"id": "o2"}])
+    )  # WHY: two-org fixture.
+    process_mock = MagicMock()  # WHY: capture per-org dispatch.
+    monkeypatch.setattr(exporter, "_process_org", process_mock)  # WHY: intercept.
+    exporter._process_msp_orgs_inventory("m", "N")  # WHY: run.
+    assert process_mock.call_count == 2  # WHY: both dispatched.
+
+
+def test_fetch_org_inventory_returns_empty_without_apisession(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Missing apisession short-circuits _fetch_org_inventory with warning."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    mh.apisession = None  # WHY: simulate missing.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    assert exporter._fetch_org_inventory("org-1", "Org") == []  # WHY: short-circuit.
+    assert "API session not initialized" in capsys.readouterr().out  # WHY: user notified.
+
+
+def test_fetch_org_inventory_returns_empty_when_no_data(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Response lacking .data attribute returns empty list + notice."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    _restore_real_mistapi(
+        monkeypatch
+    )  # WHY: undo pollution so lazy `import ... as org_inventory_api` in SUT resolves real.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(org_inventory_api, "getOrgInventory", MagicMock(return_value=None))  # WHY: patch actual attr.
+    assert exporter._fetch_org_inventory("org-1", "Org") == []  # WHY: no data path.
+    assert "No inventory data" in capsys.readouterr().out  # WHY: user notified.
+
+
+def test_fetch_org_inventory_normalises_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Normal response returns coerced list of devices."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    _restore_real_mistapi(monkeypatch)  # WHY: undo sys.modules pollution from sibling module-scope patch.dict blocks.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    response = types.SimpleNamespace(data={"mac": "aa"})  # WHY: single dict to be wrapped.
+    monkeypatch.setattr(org_inventory_api, "getOrgInventory", MagicMock(return_value=response))  # WHY: patch actual.
+    assert exporter._fetch_org_inventory("org-1", "Org") == [{"mac": "aa"}]  # WHY: single-dict wrapped.
+
+
+def test_build_site_lookup_returns_id_to_name_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Site lookup builder returns a mapping of site_id to site name."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    mh.APICoreFetchUtils = types.SimpleNamespace(
+        all_sites_with_limit=MagicMock(return_value=[{"id": "s1", "name": "HQ"}, {"id": "s2", "name": "Branch"}])
+    )
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    result = exporter._build_site_lookup("org-1")  # WHY: run.
+    assert result == {"s1": "HQ", "s2": "Branch"}  # WHY: mapping built.
+
+
+def test_build_site_lookup_returns_empty_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exception building site lookup yields empty dict (tolerated)."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    mh.APICoreFetchUtils = types.SimpleNamespace(all_sites_with_limit=MagicMock(side_effect=RuntimeError("api")))
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    assert exporter._build_site_lookup("org-1") == {}  # WHY: tolerated failure.
+
+
+def test_process_org_returns_early_on_invalid_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid org dict returns early without incrementing counters."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    exporter._process_org("m", "M", {"name": "no-id"})  # WHY: no id.
+    assert exporter.org_count == 0  # WHY: never counted.
+    assert exporter.device_count == 0  # WHY: never counted.
+
+
+def test_process_org_short_circuits_when_apisession_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing apisession short-circuits after incrementing org_count."""
+    mh = _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    mh.apisession = None  # WHY: simulate missing.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    exporter._process_org("m", "M", {"id": "o1", "name": "Org1"})  # WHY: run.
+    assert exporter.org_count == 1  # WHY: counted before short-circuit.
+    assert exporter.device_count == 0  # WHY: no devices ingested.
+
+
+def test_process_org_ingests_devices_on_success(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Devices returned by _fetch_org_inventory are enriched and ingested."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(
+        exporter,
+        "_fetch_org_inventory",
+        MagicMock(return_value=[{"type": "ap", "mac": "aa", "site_id": "s1"}]),
+    )
+    monkeypatch.setattr(exporter, "_build_site_lookup", MagicMock(return_value={"s1": "HQ"}))  # WHY: seed lookup.
+    exporter._process_org("m", "M", {"id": "o1", "name": "Org1"})  # WHY: run.
+    assert exporter.org_count == 1  # WHY: counted.
+    assert exporter.device_count == 1  # WHY: one device ingested.
+    assert exporter.all_devices[0]["_site_name"] == "HQ"  # WHY: enriched with site name.
+    assert "Org1" in capsys.readouterr().out  # WHY: summary printed.
+
+
+def test_process_org_prints_zero_when_no_devices(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Empty device list produces '0 devices' line."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(exporter, "_fetch_org_inventory", MagicMock(return_value=[]))  # WHY: no devices.
+    exporter._process_org("m", "M", {"id": "o1", "name": "Org1"})  # WHY: run.
+    assert exporter.device_count == 0  # WHY: nothing ingested.
+    assert "0 devices" in capsys.readouterr().out  # WHY: banner text.
+
+
+def test_process_org_records_error_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exception during inventory fetch is caught and recorded."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(
+        exporter, "_fetch_org_inventory", MagicMock(side_effect=RuntimeError("oops"))
+    )  # WHY: force error.
+    exporter._process_org("m", "M", {"id": "o1", "name": "Org1"})  # WHY: exercise catch.
+    assert exporter.org_count == 1  # WHY: counted before error.
+    assert any("oops" in e for e in exporter.errors)  # WHY: error captured.
+
+
+# =========================================================================
+# End-to-end run entry
+# =========================================================================
+
+
+def test_run_short_circuits_without_privileges(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_run returns early when _ensure_msp_privileges is False."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(exporter, "_ensure_msp_privileges", MagicMock(return_value=False))  # WHY: block.
+    process_mock = MagicMock()  # WHY: track invocation.
+    monkeypatch.setattr(exporter, "_process_all_msps", process_mock)  # WHY: intercept.
+    exporter._run()  # WHY: run.
+    process_mock.assert_not_called()  # WHY: never reached.
+
+
+def test_run_full_flow_dispatches_expected_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_run invokes _process_all_msps and _finalize_export when privileges present."""
+    _install_fake_mh(monkeypatch)  # WHY: fake MistHelper.
+    exporter = MSPInventoryExporter()  # WHY: instance.
+    monkeypatch.setattr(exporter, "_ensure_msp_privileges", MagicMock(return_value=True))  # WHY: allow.
+    process_mock = MagicMock()  # WHY: track invocation.
+    finalize_mock = MagicMock()  # WHY: track invocation.
+    monkeypatch.setattr(exporter, "_process_all_msps", process_mock)  # WHY: intercept.
+    monkeypatch.setattr(exporter, "_finalize_export", finalize_mock)  # WHY: intercept.
+    exporter._run()  # WHY: run.
+    process_mock.assert_called_once()  # WHY: invoked.
+    finalize_mock.assert_called_once()  # WHY: invoked.
+
+
+def test_execute_class_method_wires_run() -> None:
+    """MSPInventoryExporter.execute() constructs an instance and calls _run."""
+    with patch.object(MSPInventoryExporter, "_run") as run_mock:
+        MSPInventoryExporter.execute()  # WHY: exercise classmethod.
+    run_mock.assert_called_once()  # WHY: invoked exactly once.

--- a/tests/unit/gateway/test_gateway_stats_exporter.py
+++ b/tests/unit/gateway/test_gateway_stats_exporter.py
@@ -1,11 +1,31 @@
 """Unit tests for extracted GatewayStatsExporter module."""
 
-from __future__ import annotations
+from __future__ import annotations  # WHY: forward refs for method signatures.
 
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+import csv  # WHY: build in-memory CSVs for the file-read helper tests.
+import logging  # WHY: assert log-record emission for retry/failure/success helpers.
+import time  # WHY: patch time.sleep directly (avoids mypy strict re-export on time).
+from pathlib import Path  # WHY: typed tmp_path parameter without # type: ignore.
+from types import SimpleNamespace  # WHY: lightweight dep stubs for DI wiring.
+from unittest.mock import MagicMock, patch  # WHY: side-effect stubs + attribute patching for statics.
 
-from src.gateway.gateway_stats_exporter import GatewayStatsExporter, configure_gateway_stats_exporter_dependencies
+import pytest  # WHY: fixtures + tmp_path for file helper tests.
+
+from src.gateway import gateway_stats_exporter as module  # WHY: module handle for slot replacement + patching.
+from src.gateway.gateway_stats_exporter import (  # WHY: direct symbols under test.
+    EMPTY_IP_TOKENS,
+    SAMPLE_CONFLICT_LIMIT,
+    STATS_CSV_FILENAME,
+    STATUS_FAILED,
+    GatewayStatsExporter,
+    _build_failure_record,
+    _compute_backoff,
+    _enrich_stats_record,
+    _log_attempt_success,
+    _log_retry_failure,
+    _log_terminal_failure,
+    configure_gateway_stats_exporter_dependencies,
+)
 
 
 def _configure_dependencies() -> None:
@@ -27,6 +47,9 @@ def _configure_dependencies() -> None:
         tqdm_module=MagicMock(side_effect=lambda rows, **kwargs: rows),
         gateway_export_utils_ref=SimpleNamespace(_get_devices_with_sites=MagicMock(return_value=[])),
     )
+
+
+# -------------------------- Existing coverage (preserved) --------------------------
 
 
 def test_collect_device_wan_ips_ignores_empty_and_invalid_values() -> None:
@@ -72,3 +95,440 @@ def test_build_conflict_records_creates_port_level_rows() -> None:
     assert len(records) == 2
     assert {record["port_name"] for record in records} == {"ge-0/0/0", "ge-0/0/1"}
     assert all(record["port_ip"] == "10.0.0.1" for record in records)
+
+
+# -------------------------- Module helper coverage --------------------------
+
+
+def test_enrich_stats_record_attaches_all_identifiers() -> None:
+    """Enrichment should stamp site_id/site_name/device_id/device_name into the stats dict."""
+    _configure_dependencies()
+
+    stats = {"cpu": 0.5}  # WHY: baseline stats record before enrichment.
+    device_info = ("site-1", "dev-1", "gw-name", "Site A")
+
+    enriched = _enrich_stats_record(stats, device_info)
+
+    assert enriched["site_id"] == "site-1"
+    assert enriched["site_name"] == "Site A"
+    assert enriched["device_id"] == "dev-1"
+    assert enriched["device_name"] == "gw-name"
+    assert enriched["cpu"] == 0.5  # WHY: preserves original payload keys.
+
+
+def test_build_failure_record_preserves_legacy_shape() -> None:
+    """Failure record builder should return the legacy dict with error text and failed status."""
+    _configure_dependencies()
+
+    device_info = ("site-1", "dev-1", "gw-name", "Site A")
+    record = _build_failure_record(device_info, RuntimeError("boom"))
+
+    assert record["site_id"] == "site-1"
+    assert record["device_id"] == "dev-1"
+    assert record["device_name"] == "gw-name"
+    assert record["site_name"] == "Site A"
+    assert record["error"] == "boom"
+    assert record["status"] == STATUS_FAILED
+
+
+def test_compute_backoff_fast_returns_flat_delay() -> None:
+    """Fast-mode backoff should return the base delay regardless of attempt count."""
+    _configure_dependencies()
+
+    assert _compute_backoff(attempt=0, retry_delay=0.5, fast=True) == 0.5
+    assert _compute_backoff(attempt=3, retry_delay=0.5, fast=True) == 0.5
+
+
+def test_compute_backoff_slow_uses_exponential_growth() -> None:
+    """Non-fast backoff should grow as retry_delay * 2**attempt."""
+    _configure_dependencies()
+
+    assert _compute_backoff(attempt=0, retry_delay=1.0, fast=False) == 1.0  # WHY: 1 * 2^0.
+    assert _compute_backoff(attempt=1, retry_delay=1.0, fast=False) == 2.0  # WHY: 1 * 2^1.
+    assert _compute_backoff(attempt=3, retry_delay=1.0, fast=False) == 8.0  # WHY: 1 * 2^3.
+
+
+def test_log_retry_failure_emits_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Retry-failure helper should emit a WARNING record with legacy phrasing."""
+    _configure_dependencies()
+
+    with caplog.at_level(logging.WARNING):
+        _log_retry_failure(0, ("site-1", "dev-1", "gw", "Site A"), RuntimeError("nope"))
+
+    assert any("Attempt 1 failed" in record.getMessage() for record in caplog.records)
+
+
+def test_log_terminal_failure_emits_error(caplog: pytest.LogCaptureFixture) -> None:
+    """Terminal-failure helper should emit an ERROR record with retry count in phrasing."""
+    _configure_dependencies()
+
+    with caplog.at_level(logging.ERROR):
+        _log_terminal_failure(("site-1", "dev-1", "gw", "Site A"), 3, RuntimeError("nope"))
+
+    assert any(
+        "Failed to fetch device stats" in record.getMessage() and "3 attempts" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_log_attempt_success_first_try_uses_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """First-try success should emit at DEBUG, not INFO."""
+    _configure_dependencies()
+
+    with caplog.at_level(logging.DEBUG):
+        _log_attempt_success(0, ("site-1", "dev-1", "gw", "Site A"))
+
+    debug_records = [record for record in caplog.records if record.levelno == logging.DEBUG]
+    assert any("Collected device stats" in record.getMessage() for record in debug_records)
+
+
+def test_log_attempt_success_retry_uses_info(caplog: pytest.LogCaptureFixture) -> None:
+    """Retry success should emit at INFO with retry index in phrasing."""
+    _configure_dependencies()
+
+    with caplog.at_level(logging.INFO):
+        _log_attempt_success(2, ("site-1", "dev-1", "gw", "Site A"))
+
+    info_records = [record for record in caplog.records if record.levelno == logging.INFO]
+    assert any("Retry 2 successful" in record.getMessage() for record in info_records)
+
+
+# -------------------------- _extract_wan_ip_cell edge cases --------------------------
+
+
+def test_extract_wan_ip_cell_returns_none_for_missing_key() -> None:
+    """Missing key should short-circuit to None."""
+    _configure_dependencies()
+
+    assert GatewayStatsExporter._extract_wan_ip_cell({}, "if_stat_ge-0/0/0_ips") is None
+
+
+def test_extract_wan_ip_cell_returns_none_for_sentinel_tokens() -> None:
+    """Sentinel tokens like 'nan'/'None'/'null' should map to None."""
+    _configure_dependencies()
+
+    for sentinel in EMPTY_IP_TOKENS:  # WHY: exercise each legacy sentinel value.
+        row = {"if_stat_ge-0/0/0_ips": sentinel}
+        # WHY: empty strings are falsy so short-circuit path returns None too.
+        assert GatewayStatsExporter._extract_wan_ip_cell(row, "if_stat_ge-0/0/0_ips") is None
+
+
+def test_extract_wan_ip_cell_strips_whitespace_around_valid_ip() -> None:
+    """Valid IPs should be returned stripped of surrounding whitespace."""
+    _configure_dependencies()
+
+    row = {"if_stat_ge-0/0/0_ips": "  10.0.0.1  "}
+    assert GatewayStatsExporter._extract_wan_ip_cell(row, "if_stat_ge-0/0/0_ips") == "10.0.0.1"
+
+
+# -------------------------- _flatten_stats + _log_export_summary --------------------------
+
+
+def test_flatten_stats_delegates_to_data_processing_utils() -> None:
+    """Flatten helper should call DataProcessingUtils.flatten_dict once per row."""
+    _configure_dependencies()
+
+    all_stats = [{"a": 1}, {"b": 2}]
+    result = GatewayStatsExporter._flatten_stats(all_stats)
+
+    assert result == all_stats  # WHY: default stub is identity so rows pass through.
+    assert module.DataProcessingUtils.flatten_dict.call_count == 2
+
+
+def test_log_export_summary_success_only(caplog: pytest.LogCaptureFixture) -> None:
+    """When all rows are successful, INFO 'all completed successfully' banner should emit."""
+    _configure_dependencies()
+
+    with caplog.at_level(logging.INFO):
+        GatewayStatsExporter._log_export_summary(
+            [{"status": "ok"}, {"status": "ok"}],
+            [("site-1", "dev-1", "gw", "Site A")],
+        )
+
+    assert any("All 2 requests completed successfully" in record.getMessage() for record in caplog.records)
+
+
+def test_log_export_summary_partial_failure_emits_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Partial-failure branch should emit a WARNING with failed count."""
+    _configure_dependencies()
+
+    with caplog.at_level(logging.WARNING):
+        GatewayStatsExporter._log_export_summary(
+            [{"status": "ok"}, {"status": STATUS_FAILED}],
+            [("site-1", "dev-1", "gw", "Site A")],
+        )
+
+    warns = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert any("1 requests failed out of 2" in record.getMessage() for record in warns)
+
+
+# -------------------------- _export_stats + _export_conflict_results --------------------------
+
+
+def test_export_stats_empty_short_circuits(caplog: pytest.LogCaptureFixture) -> None:
+    """Empty stats list should warn and skip persistence."""
+    _configure_dependencies()
+
+    module.DataExporter.write_with_format_selection = MagicMock()
+    with caplog.at_level(logging.WARNING):
+        GatewayStatsExporter._export_stats([], [])
+
+    module.DataExporter.write_with_format_selection.assert_not_called()
+    assert any("No gateway device statistics found" in record.getMessage() for record in caplog.records)
+
+
+def test_export_stats_populated_writes_csv() -> None:
+    """Populated stats list should be flattened and written via DataExporter."""
+    _configure_dependencies()
+
+    module.DataExporter.write_with_format_selection = MagicMock()
+    stats = [{"status": "ok", "cpu": 0.1}]
+    devices = [("site-1", "dev-1", "gw", "Site A")]
+
+    GatewayStatsExporter._export_stats(stats, devices)
+
+    module.DataExporter.write_with_format_selection.assert_called_once_with(stats, STATS_CSV_FILENAME)
+
+
+def test_export_conflict_results_empty_short_circuits(capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty conflict list should print healthy banner and skip persistence."""
+    _configure_dependencies()
+
+    module.DataExporter.write_with_format_selection = MagicMock()
+
+    GatewayStatsExporter._export_conflict_results([])
+
+    module.DataExporter.write_with_format_selection.assert_not_called()
+    captured = capsys.readouterr()
+    assert "healthy WAN port configurations" in captured.out
+
+
+def test_export_conflict_results_populated_writes_and_prints(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Populated conflicts should sort, write CSV, print summary + sample."""
+    _configure_dependencies()
+
+    module.DataExporter.write_with_format_selection = MagicMock()
+
+    conflicts = [
+        {
+            "device_name": "gw-1",
+            "site_name": "Site A",
+            "port_name": "ge-0/0/0",
+            "port_ip": "10.0.0.1",
+            "conflict_with_ports": "0/0/1",
+        },
+        {
+            "device_name": "gw-1",
+            "site_name": "Site A",
+            "port_name": "ge-0/0/1",
+            "port_ip": "10.0.0.1",
+            "conflict_with_ports": "0/0/0",
+        },
+    ]
+
+    GatewayStatsExporter._export_conflict_results(conflicts)
+
+    module.DataExporter.write_with_format_selection.assert_called_once()
+    captured = capsys.readouterr()
+    assert "1 gateways with IP conflicts" in captured.out
+    assert "Sample WAN Port IP Conflicts" in captured.out
+
+
+# -------------------------- _display_conflict_samples truncation --------------------------
+
+
+def test_display_conflict_samples_short_list_no_trailer(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fewer than SAMPLE_CONFLICT_LIMIT items should not print trailing 'and N more'."""
+    _configure_dependencies()
+
+    conflicts = [
+        {"device_name": f"gw-{idx}", "site_name": "S", "port_name": "ge-0/0/0", "port_ip": "1.1.1.1"}
+        for idx in range(3)
+    ]
+
+    GatewayStatsExporter._display_conflict_samples(conflicts)
+
+    captured = capsys.readouterr()
+    assert "more conflicted ports" not in captured.out
+
+
+def test_display_conflict_samples_long_list_emits_trailer(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Lists exceeding SAMPLE_CONFLICT_LIMIT should emit trailer with remaining count."""
+    _configure_dependencies()
+
+    total = SAMPLE_CONFLICT_LIMIT + 3
+    conflicts = [
+        {"device_name": f"gw-{idx}", "site_name": "S", "port_name": "ge-0/0/0", "port_ip": "1.1.1.1"}
+        for idx in range(total)
+    ]
+
+    GatewayStatsExporter._display_conflict_samples(conflicts)
+
+    captured = capsys.readouterr()
+    assert f"and {total - SAMPLE_CONFLICT_LIMIT} more conflicted ports" in captured.out
+
+
+# -------------------------- _analyze_device_ip_conflicts + _analyze_all_gateway_conflicts --------------------------
+
+
+def test_analyze_device_ip_conflicts_returns_records_for_duplicates() -> None:
+    """Row with same IP on two ports should produce two conflict records."""
+    _configure_dependencies()
+
+    row = {
+        "device_name": "gw-1",
+        "site_name": "Site A",
+        "if_stat_ge-0/0/0_ips": "10.0.0.1",
+        "if_stat_ge-0/0/1_ips": "10.0.0.1",
+        "if_stat_ge-0/0/2_ips": "10.0.0.2",
+    }
+
+    records = GatewayStatsExporter._analyze_device_ip_conflicts(row, index=0)
+
+    assert len(records) == 2
+    assert {record["port_name"] for record in records} == {"ge-0/0/0", "ge-0/0/1"}
+    assert all(record["port_ip"] == "10.0.0.1" for record in records)
+
+
+def test_analyze_device_ip_conflicts_uses_fallback_name_when_missing() -> None:
+    """Missing device_name/name should fall back to 'Device_<index>'."""
+    _configure_dependencies()
+
+    row = {
+        "if_stat_ge-0/0/0_ips": "10.0.0.1",
+        "if_stat_ge-0/0/1_ips": "10.0.0.1",
+    }
+
+    records = GatewayStatsExporter._analyze_device_ip_conflicts(row, index=7)
+
+    assert all(record["device_name"] == "Device_7" for record in records)
+
+
+def test_analyze_all_gateway_conflicts_aggregates_per_row() -> None:
+    """Multi-row scanner should return the union of per-row conflict records."""
+    _configure_dependencies()
+
+    rows = [
+        {
+            "device_name": "gw-1",
+            "if_stat_ge-0/0/0_ips": "10.0.0.1",
+            "if_stat_ge-0/0/1_ips": "10.0.0.1",
+        },
+        {
+            "device_name": "gw-2",
+            "if_stat_ge-0/0/0_ips": "10.0.0.2",
+        },
+    ]
+
+    conflicts = GatewayStatsExporter._analyze_all_gateway_conflicts(rows)
+
+    assert len(conflicts) == 2
+    assert {record["device_name"] for record in conflicts} == {"gw-1"}  # only gw-1 has duplicate ports
+
+
+# -------------------------- _load_gateway_stats_for_conflicts --------------------------
+
+
+def test_load_gateway_stats_reads_csv_rows(tmp_path: Path) -> None:
+    """CSV reader should return list of dict rows on success."""
+    _configure_dependencies()
+
+    csv_file = tmp_path / "stats.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["device_name", "if_stat_ge-0/0/0_ips"])
+        writer.writeheader()
+        writer.writerow({"device_name": "gw-1", "if_stat_ge-0/0/0_ips": "10.0.0.1"})
+
+    module.FilePathUtils = SimpleNamespace(get_csv_path=MagicMock(return_value=str(csv_file)))
+    module.CacheUtils = SimpleNamespace(check_and_generate_csv=MagicMock(return_value=True))
+
+    rows = GatewayStatsExporter._load_gateway_stats_for_conflicts()
+
+    assert rows == [{"device_name": "gw-1", "if_stat_ge-0/0/0_ips": "10.0.0.1"}]
+
+
+def test_load_gateway_stats_returns_none_on_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing/unreadable file should return None and print an error banner."""
+    _configure_dependencies()
+
+    module.FilePathUtils = SimpleNamespace(get_csv_path=MagicMock(return_value="/no/such/path/nowhere.csv"))
+    module.CacheUtils = SimpleNamespace(check_and_generate_csv=MagicMock(return_value=False))
+
+    result = GatewayStatsExporter._load_gateway_stats_for_conflicts()
+
+    assert result is None
+    captured = capsys.readouterr()
+    assert "Failed to load" in captured.out
+
+
+# -------------------------- _fetch_one_device_stats retry loop --------------------------
+
+
+def test_fetch_one_device_stats_success_first_try() -> None:
+    """First attempt success should return enriched stats without sleeping."""
+    _configure_dependencies()
+
+    with (
+        patch.object(module, "_attempt_fetch_stats", return_value={"cpu": 0.1}),
+        patch.object(time, "sleep") as sleep_mock,
+    ):
+        result = GatewayStatsExporter._fetch_one_device_stats(("site-1", "dev-1", "gw", "Site A"), fast=True)
+
+    assert result == {"cpu": 0.1}
+    sleep_mock.assert_not_called()
+
+
+def test_fetch_one_device_stats_retry_then_success() -> None:
+    """Transient error should trigger retry then return success on second attempt."""
+    _configure_dependencies()
+
+    attempts = MagicMock(side_effect=[RuntimeError("boom"), {"cpu": 0.2}])
+    with patch.object(module, "_attempt_fetch_stats", attempts), patch.object(time, "sleep") as sleep_mock:
+        result = GatewayStatsExporter._fetch_one_device_stats(("site-1", "dev-1", "gw", "Site A"), fast=True)
+
+    assert result == {"cpu": 0.2}
+    sleep_mock.assert_called_once()  # WHY: exactly one backoff between attempts.
+
+
+def test_fetch_one_device_stats_terminal_failure_returns_failure_record() -> None:
+    """Exhausted retries should return legacy failure record with status='failed'."""
+    _configure_dependencies()
+
+    with (
+        patch.object(module, "_attempt_fetch_stats", side_effect=RuntimeError("boom")),
+        patch.object(time, "sleep"),
+    ):
+        result = GatewayStatsExporter._fetch_one_device_stats(("site-1", "dev-1", "gw", "Site A"), fast=True)
+
+    assert result["status"] == STATUS_FAILED
+    assert result["error"] == "boom"
+
+
+# -------------------------- _process_devices_sequential --------------------------
+
+
+def test_process_devices_sequential_collects_successful_rows() -> None:
+    """Sequential loop should call fetch once per device and skip empty results."""
+    _configure_dependencies()
+
+    devices = [
+        ("site-1", "dev-1", "gw-1", "Site A"),
+        ("site-2", "dev-2", "gw-2", "Site B"),
+    ]
+
+    fetch_mock = MagicMock(side_effect=[{"cpu": 0.1}, None])  # WHY: second call returns falsy.
+    with patch.object(GatewayStatsExporter, "_fetch_one_device_stats", fetch_mock):
+        result = GatewayStatsExporter._process_devices_sequential(devices, fast=False)
+
+    assert result == [{"cpu": 0.1}]  # WHY: None result is filtered.
+    assert fetch_mock.call_count == 2

--- a/tests/unit/inventory/test_org_device_inventory_msp.py
+++ b/tests/unit/inventory/test_org_device_inventory_msp.py
@@ -3,22 +3,31 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any  # WHY: type mixed-value dicts for mypy strict.
 from unittest.mock import MagicMock
+
+import pytest
 
 from src.inventory.org_device_inventory_msp import (
     OrgDeviceInventoryMSPOrchestrator,
+    _flatten_model_rows,
+    _flatten_version_rows,
+    _normalise_orgs_payload,
+    _OrgProcessedResult,
+    _sanitize_msp_name,
+    _to_org_result,
     configure_org_device_inventory_msp_dependencies,
 )
 
 
 def _configure_msp(*, privileges: list[dict] | None = None, safe_input_return: str = "1") -> MagicMock:
     """Configure MSP module dependencies and return exporter mock."""
-    exporter = MagicMock()
+    exporter = MagicMock()  # WHY: capture writer calls for assertions
     configure_org_device_inventory_msp_dependencies(
-        apisession_dependency=object(),
-        input_utils=SimpleNamespace(safe_input=MagicMock(return_value=safe_input_return)),
-        data_exporter=SimpleNamespace(write_with_format_selection=exporter),
-        msp_privileges_value=privileges or [],
+        apisession_dependency=object(),  # WHY: opaque non-None object satisfies apisession check
+        input_utils=SimpleNamespace(safe_input=MagicMock(return_value=safe_input_return)),  # WHY: stub input
+        data_exporter=SimpleNamespace(write_with_format_selection=exporter),  # WHY: capture exporter side effect
+        msp_privileges_value=privileges or [],  # WHY: default to empty MSP privilege list
     )
     return exporter
 
@@ -37,7 +46,39 @@ def test_resolve_active_msp_autoselects_single_privilege() -> None:
     assert selected["msp_id"] == "m1"
 
 
-def test_dispatch_routes_to_selected_mode(monkeypatch) -> None:
+def test_resolve_active_msp_prompts_when_multiple_privileges() -> None:
+    """MSP resolver should call prompt helper when multiple privileges exist."""
+    privs = [
+        {"msp_id": "m1", "msp_name": "One", "role": "admin"},
+        {"msp_id": "m2", "msp_name": "Two", "role": "admin"},
+    ]
+    _configure_msp(privileges=privs, safe_input_return="2")
+    selected = OrgDeviceInventoryMSPOrchestrator._resolve_active_msp()
+    assert selected is not None
+    assert selected["msp_id"] == "m2"
+
+
+def test_resolve_active_msp_returns_none_on_bad_input() -> None:
+    """MSP resolver should return None when operator provides out-of-range selection."""
+    privs = [
+        {"msp_id": "m1", "msp_name": "One", "role": "admin"},
+        {"msp_id": "m2", "msp_name": "Two", "role": "admin"},
+    ]
+    _configure_msp(privileges=privs, safe_input_return="99")
+    assert OrgDeviceInventoryMSPOrchestrator._resolve_active_msp() is None
+
+
+def test_resolve_active_msp_returns_none_on_parse_error() -> None:
+    """MSP resolver should return None when operator input cannot be parsed."""
+    privs = [
+        {"msp_id": "m1", "msp_name": "One", "role": "admin"},
+        {"msp_id": "m2", "msp_name": "Two", "role": "admin"},
+    ]
+    _configure_msp(privileges=privs, safe_input_return="not-a-number")
+    assert OrgDeviceInventoryMSPOrchestrator._resolve_active_msp() is None
+
+
+def test_dispatch_routes_to_selected_mode() -> None:
     """Dispatcher should call the correct callback for mode selections."""
     _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "One MSP", "role": "admin"}], safe_input_return="3")
     single_mock = MagicMock()
@@ -55,7 +96,43 @@ def test_dispatch_routes_to_selected_mode(monkeypatch) -> None:
     select_mock.assert_not_called()
 
 
-def test_execute_msp_builds_combined_reports_for_multiple_orgs(monkeypatch) -> None:
+def test_dispatch_mode_2_calls_select() -> None:
+    """Dispatcher mode 2 should route to select_org_fn."""
+    _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "One MSP", "role": "admin"}], safe_input_return="2")
+    single_mock, select_mock, batch_mock = MagicMock(), MagicMock(), MagicMock()
+    OrgDeviceInventoryMSPOrchestrator.dispatch(
+        single_org_fn=single_mock, select_org_fn=select_mock, batch_fn=batch_mock
+    )
+    select_mock.assert_called_once()
+    single_mock.assert_not_called()
+    batch_mock.assert_not_called()
+
+
+def test_dispatch_mode_1_calls_single() -> None:
+    """Dispatcher mode 1 or unknown should route to single_org_fn."""
+    _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "One MSP", "role": "admin"}], safe_input_return="1")
+    single_mock, select_mock, batch_mock = MagicMock(), MagicMock(), MagicMock()
+    OrgDeviceInventoryMSPOrchestrator.dispatch(
+        single_org_fn=single_mock, select_org_fn=select_mock, batch_fn=batch_mock
+    )
+    single_mock.assert_called_once()
+    select_mock.assert_not_called()
+    batch_mock.assert_not_called()
+
+
+def test_dispatch_without_privileges_calls_single_directly() -> None:
+    """Dispatcher without any MSP privileges should skip the menu and call single_org_fn."""
+    _configure_msp(privileges=[])
+    single_mock, select_mock, batch_mock = MagicMock(), MagicMock(), MagicMock()
+    OrgDeviceInventoryMSPOrchestrator.dispatch(
+        single_org_fn=single_mock, select_org_fn=select_mock, batch_fn=batch_mock
+    )
+    single_mock.assert_called_once()
+    select_mock.assert_not_called()
+    batch_mock.assert_not_called()
+
+
+def test_execute_msp_builds_combined_reports_for_multiple_orgs(monkeypatch: pytest.MonkeyPatch) -> None:
     """MSP batch should build combined reports when at least two orgs are processed."""
     _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "MSP Name", "role": "admin"}])
     monkeypatch.setattr(
@@ -82,3 +159,384 @@ def test_execute_msp_builds_combined_reports_for_multiple_orgs(monkeypatch) -> N
     OrgDeviceInventoryMSPOrchestrator.execute_msp(_run_for_org)
 
     combined_mock.assert_called_once()
+
+
+def test_execute_msp_skips_combined_reports_for_single_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MSP batch should skip combined reports when fewer than 2 orgs processed."""
+    _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "One", "role": "admin"}])
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator,
+        "_resolve_active_msp",
+        staticmethod(lambda: {"msp_id": "m1", "msp_name": "One", "role": "admin"}),
+    )
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator,
+        "_fetch_org_list",
+        staticmethod(lambda active_msp: [{"id": "org-1", "name": "Solo"}]),
+    )
+    combined_mock = MagicMock()
+    monkeypatch.setattr(OrgDeviceInventoryMSPOrchestrator, "_build_combined_reports", staticmethod(combined_mock))
+
+    def _run(org_id: str) -> tuple[list[dict], list[dict], list[dict], str]:
+        return ([], [], [], org_id)
+
+    OrgDeviceInventoryMSPOrchestrator.execute_msp(_run)
+    combined_mock.assert_not_called()
+
+
+def test_execute_msp_short_circuits_when_no_msp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """execute_msp should return early when resolve_active_msp yields None."""
+    _configure_msp(privileges=[])
+    monkeypatch.setattr(OrgDeviceInventoryMSPOrchestrator, "_resolve_active_msp", staticmethod(lambda: None))
+    OrgDeviceInventoryMSPOrchestrator.execute_msp(lambda org_id: ([], [], [], org_id))
+
+
+def test_execute_msp_short_circuits_when_no_orgs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """execute_msp should print no-orgs message and return when org list is empty."""
+    _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "M", "role": "admin"}])
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator,
+        "_resolve_active_msp",
+        staticmethod(lambda: {"msp_id": "m1", "msp_name": "M", "role": "admin"}),
+    )
+    monkeypatch.setattr(OrgDeviceInventoryMSPOrchestrator, "_fetch_org_list", staticmethod(lambda active_msp: []))
+    OrgDeviceInventoryMSPOrchestrator.execute_msp(lambda org_id: ([], [], [], org_id))
+
+
+def test_normalise_orgs_payload_returns_list_when_list() -> None:
+    """List payloads should pass through unchanged."""
+    payload = [{"id": "o1"}, {"id": "o2"}]
+    assert _normalise_orgs_payload(payload) == payload
+
+
+def test_normalise_orgs_payload_wraps_dict() -> None:
+    """Single dict payload should be wrapped in a one-element list."""
+    payload = {"id": "solo"}
+    assert _normalise_orgs_payload(payload) == [payload]
+
+
+def test_normalise_orgs_payload_returns_empty_for_none() -> None:
+    """None/falsy payloads should normalise to an empty list."""
+    assert _normalise_orgs_payload(None) == []
+    assert _normalise_orgs_payload(0) == []
+
+
+def test_sanitize_msp_name_replaces_non_alnum() -> None:
+    """Special characters outside alnum/-/_ should be replaced with underscore."""
+    assert _sanitize_msp_name("Acme Corp / West") == "Acme_Corp___West"
+
+
+def test_sanitize_msp_name_keeps_allowed_chars() -> None:
+    """Alphanumeric plus dash/underscore should pass through unchanged."""
+    assert _sanitize_msp_name("Acme-Corp_2024") == "Acme-Corp_2024"
+
+
+def test_flatten_model_rows_produces_tagged_rows() -> None:
+    """Model rows should be flattened with Org tag column added."""
+    collected = [
+        _OrgProcessedResult(
+            safe_org="OrgA",
+            model_rows=[{"device_type": "ap", "model": "M1", "count": 3}],
+            version_rows=[],
+            ver_per_model=[],
+        )
+    ]
+    flat = _flatten_model_rows(collected)
+    assert flat == [{"Org": "OrgA", "Device Type": "ap", "Model": "M1", "Count": 3}]
+
+
+def test_flatten_model_rows_uses_defaults_for_missing_fields() -> None:
+    """Missing model/count fields should default to '' and 0 respectively."""
+    collected = [
+        _OrgProcessedResult(
+            safe_org="OrgB",
+            model_rows=[{"device_type": "switch"}],
+            version_rows=[],
+            ver_per_model=[],
+        )
+    ]
+    flat = _flatten_model_rows(collected)
+    assert flat == [{"Org": "OrgB", "Device Type": "switch", "Model": "", "Count": 0}]
+
+
+def test_flatten_version_rows_produces_tagged_rows() -> None:
+    """Version rows should be flattened with Org tag column added."""
+    collected = [
+        _OrgProcessedResult(
+            safe_org="OrgA",
+            model_rows=[],
+            version_rows=[{"device_type": "ap", "version": "1.0", "count": 2}],
+            ver_per_model=[],
+        )
+    ]
+    flat = _flatten_version_rows(collected)
+    assert flat == [{"Org": "OrgA", "Device Type": "ap", "Version": "1.0", "Count": 2}]
+
+
+def test_to_org_result_converts_dict_to_dataclass() -> None:
+    """_to_org_result should build a frozen _OrgProcessedResult from a plain dict."""
+    entry = {
+        "safe_org": "OrgX",
+        "model_rows": [{"a": 1}],
+        "version_rows": [{"b": 2}],
+        "ver_per_model": [{"c": 3}],
+    }
+    result = _to_org_result(entry)
+    assert isinstance(result, _OrgProcessedResult)
+    assert result.safe_org == "OrgX"
+    assert result.model_rows == [{"a": 1}]
+    assert result.version_rows == [{"b": 2}]
+    assert result.ver_per_model == [{"c": 3}]
+
+
+def test_flatten_msp_version_rows_tags_and_merges() -> None:
+    """MSP version flattener should tag each row with the owning org name."""
+    data = [
+        ("OrgA", [{"model": "M1", "version": "1", "count": 1, "device_type": "ap"}]),
+        ("OrgB", [{"model": "M2", "version": "2", "count": 5, "device_type": "switch"}]),
+    ]
+    flat = OrgDeviceInventoryMSPOrchestrator._flatten_msp_version_rows(data)
+    assert len(flat) == 2
+    assert flat[0]["org"] == "OrgA"
+    assert flat[1]["org"] == "OrgB"
+
+
+def test_build_msp_version_pivot_builds_ordered_columns() -> None:
+    """Version pivot builder should return sorted versions and (org, model) keyed pivot."""
+    flat = [
+        {"org": "A", "model": "M1", "version": "1.1", "count": 3, "device_type": "ap"},
+        {"org": "A", "model": "M1", "version": "1.0", "count": 2, "device_type": "ap"},
+    ]
+    versions, pivot = OrgDeviceInventoryMSPOrchestrator._build_msp_version_pivot(flat)
+    assert versions == ["1.0", "1.1"]
+    assert pivot[("A", "M1")]["1.0"] == 2
+    assert pivot[("A", "M1")]["1.1"] == 3
+    assert pivot[("A", "M1")]["device_type"] == "ap"
+
+
+def test_make_export_row_populates_all_versions_with_defaults() -> None:
+    """Export row should fill every requested version, defaulting missing to zero."""
+    row = OrgDeviceInventoryMSPOrchestrator._make_export_row(
+        safe_org="OrgA",
+        model="M1",
+        ver_counts={"device_type": "ap", "1.0": 5},
+        versions=["1.0", "2.0"],
+        row_total=5,
+    )
+    assert row == {"Org": "OrgA", "Model": "M1", "Device Type": "ap", "1.0": 5, "2.0": 0, "Total": 5}
+
+
+def test_build_msp_pivot_table_and_rows_produces_totals() -> None:
+    """Pivot builder should include a TOTAL row and column totals."""
+    versions = ["1.0", "2.0"]
+    pivot = {
+        ("OrgA", "M1"): {"device_type": "ap", "1.0": 3, "2.0": 5},
+        ("OrgB", "M2"): {"device_type": "switch", "1.0": 1, "2.0": 0},
+    }
+    table, export_rows, col_totals, grand_total = OrgDeviceInventoryMSPOrchestrator._build_msp_pivot_table_and_rows(
+        versions, pivot
+    )
+    assert len(export_rows) == 2  # WHY: one row per (org, model) key
+    assert col_totals == {"1.0": 4, "2.0": 5}
+    assert grand_total == 9
+    assert table is not None
+
+
+def test_display_combined_pivot_empty_short_circuits() -> None:
+    """Combined pivot displayer should short-circuit when no data present."""
+    exporter = _configure_msp()
+    OrgDeviceInventoryMSPOrchestrator._display_combined_pivot_and_export([], "prefix")
+    exporter.assert_not_called()  # WHY: no data -> no export
+
+
+def test_display_combined_pivot_populated_calls_exporter() -> None:
+    """Combined pivot displayer should call the exporter when rows exist."""
+    exporter = _configure_msp()
+    data = [("OrgA", [{"model": "M1", "version": "1.0", "count": 2, "device_type": "ap"}])]
+    OrgDeviceInventoryMSPOrchestrator._display_combined_pivot_and_export(data, "prefix")
+    exporter.assert_called_once()
+
+
+def test_emit_combined_model_calls_exporter() -> None:
+    """emit_combined_model should delegate to DataExporter.write_with_format_selection."""
+    exporter = _configure_msp()
+    collected = [
+        _OrgProcessedResult(
+            safe_org="OrgA",
+            model_rows=[{"device_type": "ap", "model": "M1", "count": 1}],
+            version_rows=[],
+            ver_per_model=[],
+        )
+    ]
+    OrgDeviceInventoryMSPOrchestrator._emit_combined_model("MSP_TEST", collected)
+    exporter.assert_called_once()
+    args, kwargs = exporter.call_args
+    assert args[1] == "MSP_TEST_CombinedDeviceModelCounts"
+
+
+def test_emit_combined_version_calls_exporter() -> None:
+    """emit_combined_version should delegate to DataExporter.write_with_format_selection."""
+    exporter = _configure_msp()
+    collected = [
+        _OrgProcessedResult(
+            safe_org="OrgA",
+            model_rows=[],
+            version_rows=[{"device_type": "ap", "version": "1.0", "count": 1}],
+            ver_per_model=[],
+        )
+    ]
+    OrgDeviceInventoryMSPOrchestrator._emit_combined_version("MSP_TEST", collected)
+    exporter.assert_called_once()
+    args, kwargs = exporter.call_args
+    assert args[1] == "MSP_TEST_CombinedDeviceFirmwareSummary"
+
+
+def test_build_combined_reports_emits_all_three_reports(monkeypatch: pytest.MonkeyPatch) -> None:
+    """build_combined_reports should invoke model, version, and pivot emitters in sequence."""
+    _configure_msp()
+    model_mock = MagicMock()
+    version_mock = MagicMock()
+    pivot_mock = MagicMock()
+    monkeypatch.setattr(OrgDeviceInventoryMSPOrchestrator, "_emit_combined_model", staticmethod(model_mock))
+    monkeypatch.setattr(OrgDeviceInventoryMSPOrchestrator, "_emit_combined_version", staticmethod(version_mock))
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator, "_display_combined_pivot_and_export", staticmethod(pivot_mock)
+    )
+    collected = [
+        {"safe_org": "OrgA", "model_rows": [], "version_rows": [], "ver_per_model": []},
+    ]
+    OrgDeviceInventoryMSPOrchestrator._build_combined_reports("MSP_TEST", collected)
+    model_mock.assert_called_once()
+    version_mock.assert_called_once()
+    pivot_mock.assert_called_once()
+
+
+def test_process_org_skips_record_without_id() -> None:
+    """_process_org should skip records without an id and log a warning."""
+    _configure_msp()
+    collected: list[dict] = []
+    OrgDeviceInventoryMSPOrchestrator._process_org(
+        {"name": "no-id-org"}, 1, 1, lambda oid: ([], [], [], oid), collected
+    )
+    assert collected == []
+
+
+def test_process_org_invokes_runner_on_valid_record() -> None:
+    """_process_org should invoke runner and append result on valid record."""
+    _configure_msp()
+    collected: list[dict] = []
+
+    def _runner(oid: str) -> tuple[list[dict], list[dict], list[dict], str]:
+        return ([{"a": 1}], [{"b": 2}], [{"c": 3}], oid)
+
+    OrgDeviceInventoryMSPOrchestrator._process_org({"id": "org-1", "name": "Org One"}, 1, 1, _runner, collected)
+    assert len(collected) == 1
+    assert collected[0]["safe_org"] == "org-1"
+
+
+def test_run_org_and_collect_appends_on_success() -> None:
+    """_run_org_and_collect should append normalised dict on successful runner call."""
+    _configure_msp()
+    collected: list[dict[str, Any]] = []  # WHY: mypy strict — Any values (mixed shapes per collection call).
+    OrgDeviceInventoryMSPOrchestrator._run_org_and_collect(
+        "org-1", "Org One", lambda oid: ([{"m": 1}], [{"v": 2}], [{"vpm": 3}], "safe-org"), collected
+    )
+    assert collected == [
+        {"safe_org": "safe-org", "model_rows": [{"m": 1}], "version_rows": [{"v": 2}], "ver_per_model": [{"vpm": 3}]}
+    ]
+
+
+def test_run_org_and_collect_tolerates_runner_exception() -> None:
+    """_run_org_and_collect should swallow per-org runner exceptions and continue."""
+    _configure_msp()
+    collected: list[dict] = []
+
+    def _boom(oid: str) -> tuple[list[dict], list[dict], list[dict], str]:
+        raise RuntimeError("boom")
+
+    OrgDeviceInventoryMSPOrchestrator._run_org_and_collect("org-1", "Org One", _boom, collected)
+    assert collected == []  # WHY: exception path must not append
+
+
+def test_process_orgs_batch_iterates_all_orgs() -> None:
+    """_process_orgs_batch should invoke the runner for every valid org."""
+    _configure_msp()
+
+    def _runner(oid: str) -> tuple[list[dict], list[dict], list[dict], str]:
+        return ([], [], [], oid)
+
+    orgs = [{"id": "o1", "name": "One"}, {"id": "o2", "name": "Two"}]
+    collected = OrgDeviceInventoryMSPOrchestrator._process_orgs_batch(orgs, _runner)
+    assert len(collected) == 2
+    assert [c["safe_org"] for c in collected] == ["o1", "o2"]
+
+
+def test_run_single_msp_org_short_circuits_without_msp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_single_msp_org should short-circuit when resolve returns None."""
+    _configure_msp()
+    monkeypatch.setattr(OrgDeviceInventoryMSPOrchestrator, "_resolve_active_msp", staticmethod(lambda: None))
+    run_mock = MagicMock()
+    OrgDeviceInventoryMSPOrchestrator.run_single_msp_org(run_mock)
+    run_mock.assert_not_called()
+
+
+def test_run_single_msp_org_short_circuits_without_orgs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_single_msp_org should short-circuit when org list is empty."""
+    _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "M", "role": "admin"}])
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator,
+        "_resolve_active_msp",
+        staticmethod(lambda: {"msp_id": "m1", "msp_name": "M", "role": "admin"}),
+    )
+    monkeypatch.setattr(OrgDeviceInventoryMSPOrchestrator, "_fetch_org_list", staticmethod(lambda active_msp: []))
+    run_mock = MagicMock()
+    OrgDeviceInventoryMSPOrchestrator.run_single_msp_org(run_mock)
+    run_mock.assert_not_called()
+
+
+def test_run_single_msp_org_invokes_runner_on_valid_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_single_msp_org should invoke the runner when a valid org is chosen."""
+    _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "M", "role": "admin"}], safe_input_return="1")
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator,
+        "_resolve_active_msp",
+        staticmethod(lambda: {"msp_id": "m1", "msp_name": "M", "role": "admin"}),
+    )
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator,
+        "_fetch_org_list",
+        staticmethod(lambda active_msp: [{"id": "org-1", "name": "Org One"}]),
+    )
+    run_mock = MagicMock()
+    OrgDeviceInventoryMSPOrchestrator.run_single_msp_org(run_mock)
+    run_mock.assert_called_once_with("org-1")
+
+
+def test_run_single_msp_org_rejects_org_without_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_single_msp_org should not invoke runner when selected org lacks an id."""
+    _configure_msp(privileges=[{"msp_id": "m1", "msp_name": "M", "role": "admin"}], safe_input_return="1")
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator,
+        "_resolve_active_msp",
+        staticmethod(lambda: {"msp_id": "m1", "msp_name": "M", "role": "admin"}),
+    )
+    monkeypatch.setattr(
+        OrgDeviceInventoryMSPOrchestrator,
+        "_fetch_org_list",
+        staticmethod(lambda active_msp: [{"name": "no-id"}]),
+    )
+    run_mock = MagicMock()
+    OrgDeviceInventoryMSPOrchestrator.run_single_msp_org(run_mock)
+    run_mock.assert_not_called()
+
+
+def test_fetch_org_list_returns_empty_without_apisession() -> None:
+    """_fetch_org_list should return empty list when apisession is not configured."""
+    configure_org_device_inventory_msp_dependencies(
+        apisession_dependency=None,  # WHY: force session-missing branch
+        input_utils=SimpleNamespace(safe_input=MagicMock(return_value="")),
+        data_exporter=SimpleNamespace(write_with_format_selection=MagicMock()),
+        msp_privileges_value=[],
+    )
+    result = OrgDeviceInventoryMSPOrchestrator._fetch_org_list({"msp_id": "m1", "msp_name": "M"})
+    assert result == []

--- a/tests/unit/refactors/test_wanprobe_config_manager.py
+++ b/tests/unit/refactors/test_wanprobe_config_manager.py
@@ -1,0 +1,961 @@
+"""Unit tests for WANProbeConfigManager (Menu #166 WAN probe overrides).
+
+Wave 10 P2 coverage lift (initiative 1018). Tests patch the module-level
+``_MH`` proxy singleton via ``monkeypatch.setattr(module, "_MH", ...)`` so
+call-time attribute access resolves to a controlled fake, without importing
+the real MistHelper module.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions on Python 3.9+.
+
+import csv  # WHY: build CSV fixtures for _load_data tests.
+import logging  # WHY: assert on log-record output.
+from types import SimpleNamespace  # WHY: build stand-in namespaces for injected deps.
+from typing import Any  # WHY: loose typing for dict fixtures.
+from unittest.mock import MagicMock  # WHY: stub callables that record invocation.
+
+import mistapi.api.v1.orgs.gatewaytemplates as gwt_api  # WHY: patch API endpoint directly (mypy strict re-export).
+import pytest  # WHY: fixtures, monkeypatch, capsys, caplog.
+
+from src.refactors import wanprobe_config_manager as module  # WHY: SUT module handle.
+from src.refactors.wanprobe_config_manager import WANProbeConfigManager  # WHY: class under test.
+
+
+def _install_fake_mh(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    org_id: str | None = "org-1",
+    templates_csv_path: str = "OrgGatewayTemplates.csv",
+    sites_csv_path: str = "SiteList.csv",
+    safe_input_value: str = "1",
+    apisession: Any | None = None,
+) -> SimpleNamespace:
+    """Install a fake ``_MH`` proxy on the module under test and return it for further tweaking."""
+    fake_mh = SimpleNamespace(  # WHY: build all attributes accessed via _MH.<name>.
+        ConfigUtils=SimpleNamespace(get_cached_or_prompted_org_id=MagicMock(return_value=org_id)),
+        CacheUtils=SimpleNamespace(check_and_generate_csv=MagicMock()),
+        GatewayExportUtils=SimpleNamespace(templates=MagicMock()),
+        OrgSiteExporter=SimpleNamespace(sites=MagicMock()),
+        FilePathUtils=SimpleNamespace(
+            get_csv_path=MagicMock(side_effect=[templates_csv_path, sites_csv_path]),
+        ),
+        InputUtils=SimpleNamespace(safe_input=MagicMock(return_value=safe_input_value)),
+        DataExporter=SimpleNamespace(write_with_format_selection=MagicMock()),
+        apisession=apisession if apisession is not None else object(),  # WHY: mistapi calls receive this.
+    )
+    monkeypatch.setattr(module, "_MH", fake_mh)  # WHY: swap proxy singleton in place.
+    return fake_mh  # WHY: return for per-test tweaks.
+
+
+# ---------------------------------------------------------------------------
+# __init__ and DEFAULT_* class attributes
+# ---------------------------------------------------------------------------
+
+
+def test_init_state_defaults() -> None:
+    """Constructor should copy class-level default IPs/profile onto instance."""
+    manager = WANProbeConfigManager()  # WHY: fresh instance.
+    assert manager.org_id is None  # WHY: unresolved.
+    assert manager.templates == []  # WHY: empty list.
+    assert manager.sites == []  # WHY: empty list.
+    assert manager.template_site_counts == {}  # WHY: empty dict.
+    assert manager.probe_ips == WANProbeConfigManager.DEFAULT_PROBE_IPS  # WHY: copy.
+    assert manager.probe_ips is not WANProbeConfigManager.DEFAULT_PROBE_IPS  # WHY: not shared alias.
+    assert manager.probe_profile == WANProbeConfigManager.DEFAULT_PROBE_PROFILE  # WHY: default.
+
+
+# ---------------------------------------------------------------------------
+# _initialize / _load_data / _build_template_site_counts
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_initialize returns True and stores org_id when ConfigUtils resolves one."""
+    _install_fake_mh(monkeypatch, org_id="org-abc")
+    manager = WANProbeConfigManager()  # WHY: instance under test.
+    assert manager._initialize() is True  # WHY: resolution succeeded.
+    assert manager.org_id == "org-abc"  # WHY: stored on instance.
+
+
+def test_initialize_failure(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """_initialize returns False when the org lookup returns falsy."""
+    _install_fake_mh(monkeypatch, org_id=None)
+    manager = WANProbeConfigManager()
+    assert manager._initialize() is False  # WHY: no org -> abort.
+    assert "Failed to get organization ID" in capsys.readouterr().out  # WHY: user notice.
+
+
+def test_build_template_site_counts_tallies_and_skips_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Site tally skips names starting with MIST_SITE_EXCLUDE_PREFIX and skips blank template ids."""
+    # WHY: patch the imported symbol on the module the SUT reads it from.
+    monkeypatch.setattr(
+        "src.refactors.mist_site_exclude_prefix.MIST_SITE_EXCLUDE_PREFIX",
+        "SKIP-",
+    )
+    manager = WANProbeConfigManager()
+    manager.sites = [
+        {"name": "Alpha", "gatewaytemplate_id": "tpl-1"},  # WHY: count.
+        {"name": "Beta", "gatewaytemplate_id": "tpl-1"},  # WHY: count again.
+        {"name": "SKIP-Excluded", "gatewaytemplate_id": "tpl-2"},  # WHY: excluded.
+        {"name": "Gamma", "gatewaytemplate_id": ""},  # WHY: blank id skipped.
+        {"name": "Delta", "gatewaytemplate_id": "tpl-3"},  # WHY: unique.
+    ]
+    manager._build_template_site_counts()
+    assert manager.template_site_counts == {"tpl-1": 2, "tpl-3": 1}  # WHY: excluded/blank filtered out.
+
+
+def test_load_data_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """_load_data reads both CSVs and populates templates + sites + counts."""
+    templates_csv = tmp_path / "OrgGatewayTemplates.csv"
+    sites_csv = tmp_path / "SiteList.csv"
+    with open(templates_csv, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["id", "name"])
+        writer.writeheader()
+        writer.writerow({"id": "tpl-1", "name": "T1"})
+    with open(sites_csv, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["name", "gatewaytemplate_id"])
+        writer.writeheader()
+        writer.writerow({"name": "Site1", "gatewaytemplate_id": "tpl-1"})
+
+    _install_fake_mh(
+        monkeypatch,
+        templates_csv_path=str(templates_csv),
+        sites_csv_path=str(sites_csv),
+    )
+    manager = WANProbeConfigManager()
+    assert manager._load_data() is True  # WHY: both CSVs read.
+    assert manager.templates == [{"id": "tpl-1", "name": "T1"}]  # WHY: templates loaded.
+    assert manager.sites == [{"name": "Site1", "gatewaytemplate_id": "tpl-1"}]  # WHY: sites loaded.
+    assert manager.template_site_counts == {"tpl-1": 1}  # WHY: site tally built.
+
+
+def test_load_data_no_templates(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """_load_data returns False and warns when the templates CSV is empty."""
+    templates_csv = tmp_path / "OrgGatewayTemplates.csv"
+    templates_csv.write_text("id,name\n", encoding="utf-8")
+    sites_csv = tmp_path / "SiteList.csv"
+    sites_csv.write_text("name,gatewaytemplate_id\n", encoding="utf-8")
+
+    _install_fake_mh(
+        monkeypatch,
+        templates_csv_path=str(templates_csv),
+        sites_csv_path=str(sites_csv),
+    )
+    manager = WANProbeConfigManager()
+    assert manager._load_data() is False  # WHY: no templates -> abort.
+
+
+# ---------------------------------------------------------------------------
+# _resolve_template_indices / _parse_template_selection
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_template_indices_valid() -> None:
+    """Static helper maps 1-based comma-separated indices to matching rows."""
+    template_list = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    result = WANProbeConfigManager._resolve_template_indices("1,3", template_list)
+    assert result == [{"id": "a"}, {"id": "c"}]  # WHY: 1-based -> 0-based index.
+
+
+def test_resolve_template_indices_drops_out_of_range() -> None:
+    """Static helper silently drops indices outside the template range."""
+    template_list = [{"id": "a"}, {"id": "b"}]
+    result = WANProbeConfigManager._resolve_template_indices("1,99", template_list)
+    assert result == [{"id": "a"}]  # WHY: out-of-range 99 dropped.
+
+
+def test_resolve_template_indices_bad_input_raises() -> None:
+    """Static helper propagates ValueError on non-numeric input."""
+    with pytest.raises(ValueError):
+        WANProbeConfigManager._resolve_template_indices("foo", [{"id": "a"}])  # WHY: int() barfs.
+
+
+def test_parse_template_selection_cancel() -> None:
+    """'cancel' selection returns an empty list."""
+    manager = WANProbeConfigManager()
+    assert manager._parse_template_selection("cancel", [{"id": "a"}]) == []
+
+
+def test_parse_template_selection_all() -> None:
+    """'all' selection returns the full template list as-is."""
+    manager = WANProbeConfigManager()
+    template_list = [{"id": "a"}, {"id": "b"}]
+    assert manager._parse_template_selection("all", template_list) == template_list
+
+
+def test_parse_template_selection_invalid_input_caught() -> None:
+    """Malformed numeric input returns empty list without raising."""
+    manager = WANProbeConfigManager()
+    assert manager._parse_template_selection("foo", [{"id": "a"}]) == []
+
+
+def test_parse_template_selection_out_of_range_only() -> None:
+    """When all indices are out-of-range the helper returns empty."""
+    manager = WANProbeConfigManager()
+    assert manager._parse_template_selection("99", [{"id": "a"}]) == []
+
+
+def test_parse_template_selection_delegates_to_resolver() -> None:
+    """Valid numeric selection routes through _resolve_template_indices."""
+    manager = WANProbeConfigManager()
+    template_list = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    result = manager._parse_template_selection("2", template_list)
+    assert result == [{"id": "b"}]  # WHY: 1-based index 2 -> row index 1.
+
+
+# ---------------------------------------------------------------------------
+# _extract_wan_interfaces / _build_wan_interface
+# ---------------------------------------------------------------------------
+
+
+def test_extract_wan_interfaces_non_dict_returns_empty() -> None:
+    """Non-dict port_config returns an empty list."""
+    manager = WANProbeConfigManager()
+    assert manager._extract_wan_interfaces(None) == []
+    assert manager._extract_wan_interfaces("not-a-dict") == []
+    assert manager._extract_wan_interfaces(["also", "wrong"]) == []
+
+
+def test_extract_wan_interfaces_filters_non_wan() -> None:
+    """Only ports with usage == 'wan' are collected."""
+    manager = WANProbeConfigManager()
+    port_config = {
+        "ge-0/0/0": {"usage": "wan", "wan_probe_override": {"ips": ["1.1.1.1"], "probe_profile": "lte"}},
+        "ge-0/0/1": {"usage": "lan"},
+        "ge-0/0/2": {"usage": "wan"},  # WHY: no override present.
+        "ge-0/0/3": "not-a-dict",  # WHY: non-dict skipped.
+    }
+    result = manager._extract_wan_interfaces(port_config)
+    port_names = sorted(r["port_name"] for r in result)
+    assert port_names == ["ge-0/0/0", "ge-0/0/2"]  # WHY: only WAN entries.
+
+
+def test_build_wan_interface_with_override() -> None:
+    """Existing override values populate current_ips / current_profile."""
+    manager = WANProbeConfigManager()
+    result = manager._build_wan_interface(
+        "ge-0/0/0",
+        {"usage": "wan", "wan_probe_override": {"ips": ["1.1.1.1"], "probe_profile": "lte"}},
+    )
+    assert result == {
+        "port_name": "ge-0/0/0",
+        "current_ips": ["1.1.1.1"],
+        "current_profile": "lte",
+    }
+
+
+def test_build_wan_interface_without_override() -> None:
+    """Missing override yields empty ips/profile defaults."""
+    manager = WANProbeConfigManager()
+    result = manager._build_wan_interface("ge-0/0/1", {"usage": "wan"})
+    assert result == {"port_name": "ge-0/0/1", "current_ips": [], "current_profile": ""}
+
+
+def test_build_wan_interface_non_dict_override() -> None:
+    """Non-dict override falls back to empty values via isinstance guard."""
+    manager = WANProbeConfigManager()
+    result = manager._build_wan_interface("ge-0/0/2", {"usage": "wan", "wan_probe_override": "bad"})
+    assert result == {"port_name": "ge-0/0/2", "current_ips": [], "current_profile": ""}
+
+
+# ---------------------------------------------------------------------------
+# _blank_template_result / _build_report_row / _compute_report_totals
+# ---------------------------------------------------------------------------
+
+
+def test_blank_template_result_skeleton() -> None:
+    """Skeleton fills identity fields and leaves status/error/updates empty."""
+    template = {"id": "tpl-1", "name": "T1", "site_count": 5}
+    result = WANProbeConfigManager._blank_template_result(template)
+    assert result == {
+        "template_name": "T1",
+        "template_id": "tpl-1",
+        "site_count": 5,
+        "interfaces_updated": [],
+        "status": "",
+        "error": "",
+    }
+
+
+def test_build_report_row_populated() -> None:
+    """Report row joins interface names and stamps current probe config."""
+    manager = WANProbeConfigManager()
+    manager.probe_ips = ["1.1.1.1", "2.2.2.2"]
+    manager.probe_profile = "lte"
+    row = manager._build_report_row(
+        {
+            "template_name": "T1",
+            "template_id": "tpl-1",
+            "site_count": 3,
+            "interfaces_updated": ["ge-0/0/0", "ge-0/0/1"],
+            "status": "SUCCESS",
+            "error": "",
+        }
+    )
+    assert row["interfaces_updated"] == "ge-0/0/0, ge-0/0/1"  # WHY: joined name string.
+    assert row["interface_count"] == 2  # WHY: count of updates.
+    assert row["new_probe_ips"] == "1.1.1.1, 2.2.2.2"  # WHY: joined ip string.
+    assert row["new_probe_profile"] == "lte"  # WHY: current profile stamp.
+
+
+def test_build_report_row_empty_updates() -> None:
+    """Empty interface list renders as empty string, not literal 'None'."""
+    manager = WANProbeConfigManager()
+    row = manager._build_report_row(
+        {
+            "template_name": "T",
+            "template_id": "i",
+            "site_count": 0,
+            "interfaces_updated": [],
+            "status": "SKIPPED",
+            "error": "no wan",
+        }
+    )
+    assert row["interfaces_updated"] == ""  # WHY: empty list -> empty string.
+    assert row["interface_count"] == 0  # WHY: no updates.
+
+
+def test_compute_report_totals_sums_by_status() -> None:
+    """Total sites only counts SUCCESS + DRY-RUN rows; interfaces sums all."""
+    manager = WANProbeConfigManager()
+    results = [
+        {"interfaces_updated": ["a"], "site_count": 5, "status": "SUCCESS"},
+        {"interfaces_updated": ["b", "c"], "site_count": 10, "status": "FAILED"},
+        {"interfaces_updated": [], "site_count": 7, "status": "DRY-RUN"},
+    ]
+    total_interfaces, total_sites = manager._compute_report_totals(results)
+    assert total_interfaces == 3  # WHY: 1 + 2 + 0.
+    assert total_sites == 12  # WHY: SUCCESS(5) + DRY-RUN(7); FAILED skipped.
+
+
+# ---------------------------------------------------------------------------
+# _apply_wan_probe_overrides
+# ---------------------------------------------------------------------------
+
+
+def test_apply_wan_probe_overrides_sets_config_on_matching_ports() -> None:
+    """Ports in wan_interfaces AND port_config get probe overrides applied."""
+    manager = WANProbeConfigManager()
+    manager.probe_ips = ["1.1.1.1"]
+    manager.probe_profile = "lte"
+    port_config: dict[str, dict[str, Any]] = {  # WHY: values are Any-valued dicts (usage str + override dict).
+        "ge-0/0/0": {"usage": "wan"},
+        "ge-0/0/1": {"usage": "wan"},
+    }
+    template = {
+        "name": "T1",
+        "wan_interfaces": [
+            {"port_name": "ge-0/0/0", "current_ips": [], "current_profile": ""},
+            {"port_name": "ge-0/0/1", "current_ips": [], "current_profile": ""},
+        ],
+    }
+    modified = manager._apply_wan_probe_overrides(template, port_config)
+    assert sorted(modified) == ["ge-0/0/0", "ge-0/0/1"]
+    assert port_config["ge-0/0/0"]["wan_probe_override"] == {"ips": ["1.1.1.1"], "probe_profile": "lte"}
+    assert port_config["ge-0/0/1"]["wan_probe_override"] == {"ips": ["1.1.1.1"], "probe_profile": "lte"}
+
+
+def test_apply_wan_probe_overrides_skips_missing_ports() -> None:
+    """Ports absent from port_config are skipped without KeyError."""
+    manager = WANProbeConfigManager()
+    port_config = {"ge-0/0/0": {"usage": "wan"}}
+    template = {
+        "name": "T1",
+        "wan_interfaces": [
+            {"port_name": "ge-0/0/0"},
+            {"port_name": "ge-0/0/missing"},  # WHY: not in port_config.
+        ],
+    }
+    modified = manager._apply_wan_probe_overrides(template, port_config)
+    assert modified == ["ge-0/0/0"]
+
+
+# ---------------------------------------------------------------------------
+# _persist_template_update
+# ---------------------------------------------------------------------------
+
+
+def test_persist_template_update_dry_run() -> None:
+    """Dry-run path returns ('DRY-RUN', '') and does not call the API."""
+    manager = WANProbeConfigManager()
+    status, error = manager._persist_template_update(
+        {"id": "tpl-1", "name": "T"}, {"config": True}, dry_run=True, interfaces_modified=["ge-0/0/0"]
+    )
+    assert status == "DRY-RUN"
+    assert error == ""
+
+
+def test_persist_template_update_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful API response returns ('SUCCESS', '')."""
+    _install_fake_mh(monkeypatch)
+    update_resp = SimpleNamespace(status_code=200)  # WHY: emulate mistapi response.
+    update_mock = MagicMock(return_value=update_resp)
+    monkeypatch.setattr(
+        gwt_api,
+        "updateOrgGatewayTemplate",
+        update_mock,
+    )
+    manager = WANProbeConfigManager()
+    manager.org_id = "org-1"
+    status, error = manager._persist_template_update(
+        {"id": "tpl-1", "name": "T"}, {"cfg": True}, dry_run=False, interfaces_modified=["ge-0/0/0"]
+    )
+    assert status == "SUCCESS"
+    assert error == ""
+    update_mock.assert_called_once()
+
+
+def test_persist_template_update_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-200 API response returns ('FAILED', 'API returned status ...')."""
+    _install_fake_mh(monkeypatch)
+    update_resp = SimpleNamespace(status_code=500)
+    update_mock = MagicMock(return_value=update_resp)
+    monkeypatch.setattr(
+        gwt_api,
+        "updateOrgGatewayTemplate",
+        update_mock,
+    )
+    manager = WANProbeConfigManager()
+    manager.org_id = "org-1"
+    status, error = manager._persist_template_update(
+        {"id": "tpl-1", "name": "T"}, {"cfg": True}, dry_run=False, interfaces_modified=["ge-0/0/0"]
+    )
+    assert status == "FAILED"
+    assert "500" in error
+
+
+# ---------------------------------------------------------------------------
+# print / preview helpers (capsys)
+# ---------------------------------------------------------------------------
+
+
+def test_print_wan_interface_change_populated(capsys: pytest.CaptureFixture[str]) -> None:
+    """Populated port renders current and new lines with actual values."""
+    manager = WANProbeConfigManager()
+    manager.probe_ips = ["9.9.9.9"]
+    manager.probe_profile = "starlink"
+    manager._print_wan_interface_change({"port_name": "ge-0/0/0", "current_ips": ["1.1.1.1"], "current_profile": "lte"})
+    output = capsys.readouterr().out
+    assert "ge-0/0/0" in output
+    assert "1.1.1.1" in output
+    assert "9.9.9.9" in output
+    assert "starlink" in output
+
+
+def test_print_wan_interface_change_empty(capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty current values render '(none)' literals."""
+    manager = WANProbeConfigManager()
+    manager._print_wan_interface_change({"port_name": "ge-0/0/0", "current_ips": [], "current_profile": ""})
+    output = capsys.readouterr().out
+    assert "(none)" in output  # WHY: substitution for empty values.
+
+
+def test_show_preview_prints_totals_and_ports(capsys: pytest.CaptureFixture[str]) -> None:
+    """Preview prints template count, interface count, site count, and per-port block."""
+    manager = WANProbeConfigManager()
+    templates = [
+        {
+            "name": "T1",
+            "site_count": 3,
+            "wan_interfaces": [
+                {"port_name": "ge-0/0/0", "current_ips": [], "current_profile": ""},
+                {"port_name": "ge-0/0/1", "current_ips": ["1.1.1.1"], "current_profile": "lte"},
+            ],
+        },
+        {
+            "name": "T2",
+            "site_count": 2,
+            "wan_interfaces": [
+                {"port_name": "ge-0/0/0", "current_ips": [], "current_profile": ""},
+            ],
+        },
+    ]
+    manager._show_preview(templates, dry_run=False)
+    output = capsys.readouterr().out
+    assert "2 templates with 3 WAN interfaces" in output  # WHY: totals line.
+    assert "Affecting 5 sites" in output  # WHY: sum site_count.
+    assert "T1" in output  # WHY: template subheader.
+    assert "T2" in output
+
+
+def test_display_header_dry_run(capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
+    """Dry-run header prints DRY-RUN MODE banner and logs a warning."""
+    manager = WANProbeConfigManager()
+    with caplog.at_level(logging.WARNING):
+        manager._display_header(dry_run=True)
+    output = capsys.readouterr().out
+    assert "DRY-RUN MODE" in output
+    assert "Menu #166 DESTRUCTIVE" in caplog.text  # WHY: warning-level log emitted.
+
+
+def test_display_header_live_run(capsys: pytest.CaptureFixture[str]) -> None:
+    """Live-run header prints destructive warning."""
+    manager = WANProbeConfigManager()
+    manager._display_header(dry_run=False)
+    output = capsys.readouterr().out
+    assert "WARNING" in output
+    assert "modifies gateway templates" in output
+
+
+def test_announce_no_wan_interfaces(capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
+    """No-interfaces announcement prints message and logs info line."""
+    manager = WANProbeConfigManager()
+    with caplog.at_level(logging.INFO):
+        manager._announce_no_wan_interfaces()
+    output = capsys.readouterr().out
+    assert "No WAN interfaces" in output
+    assert "No WAN interfaces" in caplog.text  # WHY: same message logged.
+
+
+# ---------------------------------------------------------------------------
+# _emit_dry_run_summary / _emit_live_run_summary / _log_destructive_completion
+# ---------------------------------------------------------------------------
+
+
+def test_emit_dry_run_summary_prints_counts(capsys: pytest.CaptureFixture[str]) -> None:
+    """Dry-run summary reports templates analyzed and would-update counts."""
+    manager = WANProbeConfigManager()
+    results = [
+        {"status": "DRY-RUN"},
+        {"status": "DRY-RUN"},
+        {"status": "SKIPPED"},
+    ]
+    manager._emit_dry_run_summary(results, total_interfaces=5, total_sites=10)
+    output = capsys.readouterr().out
+    assert "Templates Analyzed: 3" in output
+    assert "Would Update: 2" in output
+    assert "WAN Interfaces: 5" in output
+    assert "Sites Affected: 10" in output
+
+
+def test_emit_live_run_summary_success_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """Live-run summary lists success + failure counts and skips failure line when none."""
+    manager = WANProbeConfigManager()
+    manager.probe_ips = ["1.1.1.1"]
+    manager.probe_profile = "lte"
+    results = [{"status": "SUCCESS"}, {"status": "SUCCESS"}]
+    manager._emit_live_run_summary(results, total_interfaces=4, total_sites=8)
+    output = capsys.readouterr().out
+    assert "Templates Updated: 2" in output
+    assert "Templates Failed: 0" in output
+    assert "Configuration Applied" in output  # WHY: success block present.
+    assert "templates failed - check audit report" not in output  # WHY: no failure line.
+
+
+def test_emit_live_run_summary_with_failures(capsys: pytest.CaptureFixture[str]) -> None:
+    """Live-run summary prints failure count and audit-report line when there are failures."""
+    manager = WANProbeConfigManager()
+    results = [{"status": "SUCCESS"}, {"status": "FAILED"}]
+    manager._emit_live_run_summary(results, total_interfaces=3, total_sites=6)
+    output = capsys.readouterr().out
+    assert "Templates Updated: 1" in output
+    assert "Templates Failed: 1" in output
+    assert "1 templates failed - check audit report" in output
+
+
+def test_log_destructive_completion(caplog: pytest.LogCaptureFixture) -> None:
+    """Completion logger emits a warning-level record counting successes."""
+    manager = WANProbeConfigManager()
+    results = [{"status": "SUCCESS"}, {"status": "SUCCESS"}, {"status": "FAILED"}]
+    with caplog.at_level(logging.WARNING):
+        manager._log_destructive_completion(results)
+    assert "2 templates updated" in caplog.text  # WHY: success count only.
+
+
+# ---------------------------------------------------------------------------
+# _confirm_operation
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_operation_apply(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Typing 'APPLY' returns True."""
+    _install_fake_mh(monkeypatch, safe_input_value="APPLY")
+    manager = WANProbeConfigManager()
+    assert manager._confirm_operation(3) is True
+
+
+def test_confirm_operation_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Any other input cancels the operation."""
+    _install_fake_mh(monkeypatch, safe_input_value="no")
+    manager = WANProbeConfigManager()
+    assert manager._confirm_operation(3) is False
+
+
+# ---------------------------------------------------------------------------
+# _render_template_list / _select_templates
+# ---------------------------------------------------------------------------
+
+
+def test_render_template_list_returns_rows_and_prints(capsys: pytest.CaptureFixture[str]) -> None:
+    """Template list renders rows with site counts populated from template_site_counts."""
+    manager = WANProbeConfigManager()
+    manager.template_site_counts = {"tpl-1": 4, "tpl-2": 0}
+    rows = manager._render_template_list(
+        [
+            {"id": "tpl-1", "name": "T1"},
+            {"id": "tpl-2", "name": "T2"},
+        ]
+    )
+    assert rows == [
+        {"id": "tpl-1", "name": "T1", "site_count": 4},
+        {"id": "tpl-2", "name": "T2", "site_count": 0},
+    ]
+    output = capsys.readouterr().out
+    assert "T1" in output
+    assert "T2" in output
+
+
+def test_select_templates_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When user types 'all', _select_templates returns every rendered row."""
+    _install_fake_mh(monkeypatch, safe_input_value="all")
+    manager = WANProbeConfigManager()
+    manager.templates = [
+        {"id": "tpl-1", "name": "T1"},
+        {"id": "tpl-2", "name": "T2"},
+    ]
+    manager.template_site_counts = {"tpl-1": 1, "tpl-2": 2}
+    result = manager._select_templates()
+    assert len(result) == 2  # WHY: both templates.
+    assert {row["id"] for row in result} == {"tpl-1", "tpl-2"}
+
+
+def test_select_templates_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Numeric selection returns just the matching rendered rows."""
+    _install_fake_mh(monkeypatch, safe_input_value="2")
+    manager = WANProbeConfigManager()
+    manager.templates = [
+        {"id": "tpl-1", "name": "T1"},
+        {"id": "tpl-2", "name": "T2"},
+    ]
+    manager.template_site_counts = {"tpl-1": 0, "tpl-2": 0}
+    result = manager._select_templates()
+    assert len(result) == 1
+    assert result[0]["id"] == "tpl-2"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_template_config / _analyze_template
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_template_config_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful fetch returns the config dict from response.data."""
+    _install_fake_mh(monkeypatch)
+    fetch_mock = MagicMock(return_value=SimpleNamespace(data={"port_config": {"ge-0/0/0": {"usage": "wan"}}}))
+    monkeypatch.setattr(
+        gwt_api,
+        "getOrgGatewayTemplate",
+        fetch_mock,
+    )
+    manager = WANProbeConfigManager()
+    manager.org_id = "org-1"
+    config = manager._fetch_template_config({"id": "tpl-1", "name": "T1"})
+    assert config == {"port_config": {"ge-0/0/0": {"usage": "wan"}}}
+
+
+def test_fetch_template_config_invalid_structure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-dict data returns None."""
+    _install_fake_mh(monkeypatch)
+    fetch_mock = MagicMock(return_value=SimpleNamespace(data="bad"))
+    monkeypatch.setattr(
+        gwt_api,
+        "getOrgGatewayTemplate",
+        fetch_mock,
+    )
+    manager = WANProbeConfigManager()
+    manager.org_id = "org-1"
+    assert manager._fetch_template_config({"id": "tpl-1", "name": "T1"}) is None
+
+
+def test_fetch_template_config_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exception during fetch is caught; helper returns None."""
+    _install_fake_mh(monkeypatch)
+    fetch_mock = MagicMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(
+        gwt_api,
+        "getOrgGatewayTemplate",
+        fetch_mock,
+    )
+    manager = WANProbeConfigManager()
+    manager.org_id = "org-1"
+    assert manager._fetch_template_config({"id": "tpl-1", "name": "T1"}) is None
+
+
+def test_analyze_template_no_wan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_analyze_template returns None when a template has no WAN interfaces."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(
+        WANProbeConfigManager,
+        "_fetch_template_config",
+        lambda self, tinfo: {"port_config": {"ge-0/0/0": {"usage": "lan"}}},
+    )
+    manager = WANProbeConfigManager()
+    assert manager._analyze_template({"id": "tpl-1", "name": "T1", "site_count": 1}) is None
+
+
+def test_analyze_template_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_analyze_template returns a change record when WAN interfaces are present."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(
+        WANProbeConfigManager,
+        "_fetch_template_config",
+        lambda self, tinfo: {"port_config": {"ge-0/0/0": {"usage": "wan"}}},
+    )
+    manager = WANProbeConfigManager()
+    result = manager._analyze_template({"id": "tpl-1", "name": "T1", "site_count": 3})
+    assert result is not None
+    assert result["id"] == "tpl-1"
+    assert len(result["wan_interfaces"]) == 1
+    assert result["wan_interfaces"][0]["port_name"] == "ge-0/0/0"
+
+
+def test_analyze_template_fetch_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When _fetch_template_config returns None, _analyze_template returns None."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(
+        WANProbeConfigManager,
+        "_fetch_template_config",
+        lambda self, tinfo: None,
+    )
+    manager = WANProbeConfigManager()
+    assert manager._analyze_template({"id": "tpl-1", "name": "T1", "site_count": 1}) is None
+
+
+# ---------------------------------------------------------------------------
+# _update_single_template
+# ---------------------------------------------------------------------------
+
+
+def test_update_single_template_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dry-run path records DRY-RUN status and updated interfaces."""
+    _install_fake_mh(monkeypatch)
+    manager = WANProbeConfigManager()
+    template = {
+        "id": "tpl-1",
+        "name": "T1",
+        "site_count": 3,
+        "config": {"port_config": {"ge-0/0/0": {"usage": "wan"}}},
+        "wan_interfaces": [{"port_name": "ge-0/0/0"}],
+    }
+    result = manager._update_single_template(template, dry_run=True)
+    assert result["status"] == "DRY-RUN"
+    assert result["interfaces_updated"] == ["ge-0/0/0"]
+
+
+def test_update_single_template_no_interfaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no interfaces match port_config the result is SKIPPED."""
+    _install_fake_mh(monkeypatch)
+    manager = WANProbeConfigManager()
+    template = {
+        "id": "tpl-1",
+        "name": "T1",
+        "site_count": 2,
+        "config": {"port_config": {}},
+        "wan_interfaces": [{"port_name": "ge-0/0/missing"}],
+    }
+    result = manager._update_single_template(template, dry_run=True)
+    assert result["status"] == "SKIPPED"
+    assert result["interfaces_updated"] == []
+
+
+def test_update_single_template_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exception during update is caught and reported as ERROR status."""
+    _install_fake_mh(monkeypatch)
+    manager = WANProbeConfigManager()
+    template = {
+        "id": "tpl-1",
+        "name": "T1",
+        "site_count": 1,
+        "config": None,  # WHY: .get('port_config') will fail on None.
+        "wan_interfaces": [{"port_name": "ge-0/0/0"}],
+    }
+    result = manager._update_single_template(template, dry_run=True)
+    assert result["status"] == "ERROR"
+    assert result["error"]  # WHY: some error string recorded.
+
+
+# ---------------------------------------------------------------------------
+# _apply_changes / _generate_report
+# ---------------------------------------------------------------------------
+
+
+def test_apply_changes_delegates_per_template(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_apply_changes iterates through templates and returns all update results."""
+    _install_fake_mh(monkeypatch)
+    manager = WANProbeConfigManager()
+    call_count = {"n": 0}
+
+    def _fake_update(
+        self: WANProbeConfigManager, template: dict[str, Any], dry_run: bool
+    ) -> dict[str, Any]:  # WHY: replace real update.
+        call_count["n"] += 1
+        return {"status": "DRY-RUN", "template_name": template["name"]}
+
+    monkeypatch.setattr(WANProbeConfigManager, "_update_single_template", _fake_update)
+    templates = [
+        {"name": "T1", "id": "1", "site_count": 0, "config": {}, "wan_interfaces": []},
+        {"name": "T2", "id": "2", "site_count": 0, "config": {}, "wan_interfaces": []},
+    ]
+    results = manager._apply_changes(templates, dry_run=True)
+    assert call_count["n"] == 2  # WHY: dispatched twice.
+    assert [r["template_name"] for r in results] == ["T1", "T2"]  # WHY: preserves order.
+
+
+def test_generate_report_dry_run(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Dry-run report writes CSV via DataExporter and prints the dry-run summary."""
+    fake_mh = _install_fake_mh(monkeypatch)
+    manager = WANProbeConfigManager()
+    results = [
+        {
+            "template_name": "T1",
+            "template_id": "tpl-1",
+            "site_count": 3,
+            "interfaces_updated": ["ge-0/0/0"],
+            "status": "DRY-RUN",
+            "error": "",
+        }
+    ]
+    manager._generate_report(results, dry_run=True)
+    fake_mh.DataExporter.write_with_format_selection.assert_called_once()  # WHY: CSV written.
+    output = capsys.readouterr().out
+    assert "DRY-RUN Complete" in output
+    assert "Would Update: 1" in output
+
+
+def test_generate_report_live_run(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Live-run report writes CSV and prints the live summary."""
+    fake_mh = _install_fake_mh(monkeypatch)
+    manager = WANProbeConfigManager()
+    results = [
+        {
+            "template_name": "T1",
+            "template_id": "tpl-1",
+            "site_count": 3,
+            "interfaces_updated": ["ge-0/0/0"],
+            "status": "SUCCESS",
+            "error": "",
+        }
+    ]
+    manager._generate_report(results, dry_run=False)
+    fake_mh.DataExporter.write_with_format_selection.assert_called_once()
+    output = capsys.readouterr().out
+    assert "WAN Probe Configuration Complete" in output
+    assert "Templates Updated: 1" in output
+
+
+# ---------------------------------------------------------------------------
+# _prepare_templates_with_changes / _execute / configure classmethod
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_templates_with_changes_init_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prep helper returns None when _initialize fails."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(WANProbeConfigManager, "_initialize", lambda self: False)
+    manager = WANProbeConfigManager()
+    assert manager._prepare_templates_with_changes() is None
+
+
+def test_prepare_templates_with_changes_load_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prep helper returns None when _load_data fails after successful init."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(WANProbeConfigManager, "_initialize", lambda self: True)
+    monkeypatch.setattr(WANProbeConfigManager, "_load_data", lambda self: False)
+    manager = WANProbeConfigManager()
+    assert manager._prepare_templates_with_changes() is None
+
+
+def test_prepare_templates_with_changes_no_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prep helper returns None when the operator picks no templates."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(WANProbeConfigManager, "_initialize", lambda self: True)
+    monkeypatch.setattr(WANProbeConfigManager, "_load_data", lambda self: True)
+    monkeypatch.setattr(WANProbeConfigManager, "_select_templates", lambda self: [])
+    manager = WANProbeConfigManager()
+    assert manager._prepare_templates_with_changes() is None
+
+
+def test_prepare_templates_with_changes_no_wan(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Prep helper returns None and announces when analysis yields no changes."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(WANProbeConfigManager, "_initialize", lambda self: True)
+    monkeypatch.setattr(WANProbeConfigManager, "_load_data", lambda self: True)
+    monkeypatch.setattr(WANProbeConfigManager, "_select_templates", lambda self: [{"id": "tpl-1"}])
+    monkeypatch.setattr(WANProbeConfigManager, "_analyze_templates", lambda self, x: [])
+    manager = WANProbeConfigManager()
+    assert manager._prepare_templates_with_changes() is None
+    assert "No WAN interfaces" in capsys.readouterr().out
+
+
+def test_prepare_templates_with_changes_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prep helper returns the analyzed list when every step succeeds."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(WANProbeConfigManager, "_initialize", lambda self: True)
+    monkeypatch.setattr(WANProbeConfigManager, "_load_data", lambda self: True)
+    monkeypatch.setattr(WANProbeConfigManager, "_select_templates", lambda self: [{"id": "tpl-1"}])
+    expected = [{"id": "tpl-1", "wan_interfaces": [{"port_name": "ge-0/0/0"}]}]
+    monkeypatch.setattr(WANProbeConfigManager, "_analyze_templates", lambda self, x: expected)
+    manager = WANProbeConfigManager()
+    assert manager._prepare_templates_with_changes() == expected
+
+
+def test_execute_short_circuits_on_prep_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_execute returns early when _prepare_templates_with_changes yields None."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(WANProbeConfigManager, "_display_header", lambda self, dr: None)
+    monkeypatch.setattr(WANProbeConfigManager, "_prepare_templates_with_changes", lambda self: None)
+    apply_mock = MagicMock()
+    monkeypatch.setattr(WANProbeConfigManager, "_apply_changes", apply_mock)
+    manager = WANProbeConfigManager()
+    manager._execute(dry_run=False)
+    apply_mock.assert_not_called()  # WHY: prep aborted; apply must be skipped.
+
+
+def test_execute_full_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_execute in dry-run mode calls preview, apply, and report (skips confirmation)."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(WANProbeConfigManager, "_display_header", lambda self, dr: None)
+    monkeypatch.setattr(
+        WANProbeConfigManager,
+        "_prepare_templates_with_changes",
+        lambda self: [{"id": "tpl-1", "name": "T", "site_count": 1, "wan_interfaces": []}],
+    )
+    preview_mock = MagicMock()
+    apply_mock = MagicMock(return_value=[{"status": "DRY-RUN"}])
+    report_mock = MagicMock()
+    monkeypatch.setattr(WANProbeConfigManager, "_show_preview", preview_mock)
+    monkeypatch.setattr(WANProbeConfigManager, "_apply_changes", apply_mock)
+    monkeypatch.setattr(WANProbeConfigManager, "_generate_report", report_mock)
+    manager = WANProbeConfigManager()
+    manager._execute(dry_run=True)
+    preview_mock.assert_called_once()
+    apply_mock.assert_called_once()
+    report_mock.assert_called_once()
+
+
+def test_execute_live_run_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Live-run _execute returns early when confirmation fails."""
+    _install_fake_mh(monkeypatch)
+    monkeypatch.setattr(WANProbeConfigManager, "_display_header", lambda self, dr: None)
+    monkeypatch.setattr(
+        WANProbeConfigManager,
+        "_prepare_templates_with_changes",
+        lambda self: [{"id": "tpl-1", "name": "T", "site_count": 1, "wan_interfaces": []}],
+    )
+    monkeypatch.setattr(WANProbeConfigManager, "_show_preview", lambda self, t, dr: None)
+    monkeypatch.setattr(WANProbeConfigManager, "_confirm_operation", lambda self, n: False)
+    apply_mock = MagicMock()
+    monkeypatch.setattr(WANProbeConfigManager, "_apply_changes", apply_mock)
+    manager = WANProbeConfigManager()
+    manager._execute(dry_run=False)
+    apply_mock.assert_not_called()  # WHY: cancelled; no writes.
+
+
+def test_configure_classmethod_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """configure() builds an instance and dispatches to _execute with the dry_run flag."""
+    execute_mock = MagicMock()
+    monkeypatch.setattr(WANProbeConfigManager, "_execute", execute_mock)
+    WANProbeConfigManager.configure(dry_run=True)
+    execute_mock.assert_called_once_with(True)


### PR DESCRIPTION
## Summary
- Wave 10 of initiative #1018 P2 coverage lift toward the 90% aspirational target.
- Coverage: 84.70% -> 86.66% (**+1.96pp**, ~742 statements newly covered).
- All gates GREEN: black clean, ruff clean, mypy --strict clean, 5537 tests passing (0 failed, 19 skipped, 5 xfailed, 1 xpassed).
- Zero new suppressions (# type: ignore, # noqa, # pragma: no cover, #nosec).
- Zero live network in unit tests. WHY comments per Principle VI.

## Modules covered
- **src/export/msp_inventory_exporter.py** — 58 new tests exercising static coercion helpers, MSP/org validation, device enrichment, field ordering + row sorting, and full `_run` / `_process_msp` / `_process_org` / `_fetch_*` pipelines including interactive-login MSP-privilege escalation. Defensive mistapi sys.modules restoration guards against collection-time pollution from sibling test files that inject `MagicMock` into `sys.modules` at module scope (`test_bulk_ap_upgrader`, `test_org_ap_upgrader`, `test_e911_bssid`, `test_rate_limiting`, `test_ssid_template_consolidation`, `test_virtual_chassis`).
- **src/refactors/wanprobe_config_manager.py** — new test file covering the `_MH` proxy lazy-import contract plus configuration-manager execution paths.
- **src/gateway/gateway_stats_exporter.py** — expanded tests exercising the variadic `configure_gateway_stats_dependencies` DI seam and downstream row shaping.
- **src/inventory/org_device_inventory_msp.py** — expanded tests exercising the keyword-only `configure_org_device_inventory_msp_dependencies` DI seam and MSP enrichment fan-out.

## Notable finding: import-from-submodule vs sys.modules pollution
Python's `IMPORT_FROM` bytecode for `import x.y.z as A` uses attribute lookup on `sys.modules['x']`, NOT direct `sys.modules['x.y.z']`. When another test file uses module-scope `patch.dict(sys.modules, {"mistapi": MagicMock(), ...})`, cumulative pollution during collection leaks a `MagicMock` into the top-level slot, causing the SUT's lazy `import mistapi.api.v1.msps.orgs as msp_orgs_api` inside method bodies to resolve to the MagicMock chain rather than the module we `monkeypatch.setattr`. Fix: capture real mistapi submodules at collection time and `monkeypatch.setitem` them back into `sys.modules` at the top of each affected test before applying the endpoint attribute patch. See `_REAL_MISTAPI_MODULES` and `_restore_real_mistapi` in `tests/unit/export/test_msp_inventory_exporter.py`.

## Test plan
- [x] `black tests/` — 276 files clean
- [x] `ruff check tests/` — no issues
- [x] `mypy --strict tests/` — no issues
- [x] `pytest tests/ --cov=src/ --cov-report=term` — 5537 passed, 86.66% coverage
- [x] Verified the 4 previously flaky msp_inventory tests pass under full-suite collection (not just isolated)
- [x] No files modified outside `tests/**` (respects #1019 parallel-agent guardrails)