### PR TITLE
test(1018): Wave 11 P2 coverage — login_orchestrator/gateway_export_utils (+0.67 pp -> 86.18%)

### DIFF
--- a/tests/unit/auth/interactive/test_login_orchestrator.py
+++ b/tests/unit/auth/interactive/test_login_orchestrator.py
@@ -1,0 +1,672 @@
+"""Wave 11 P2 coverage for src/auth/interactive/login_orchestrator.py (initiative #1018).
+
+Covers every branch of ``LoginOrchestrator`` including:
+- ``execute`` early-abort paths (mistapi missing, cloud cancelled, credentials cancelled) + success.
+- ``_resolve_mistapi`` state cache hit, fallback import success, and ImportError.
+- ``_collect_credentials`` email-None and password-None short-circuits.
+- ``_authenticate`` exception dispatch to Connection / Value / generic handlers + happy path.
+- ``_run_login_pipeline`` full sequence, apisession-None guard, 2FA prompt-cancel, auth-fail.
+- ``_log_login_inputs``, ``_create_api_session`` (with None guard), ``_clear_pre_existing_token``.
+- ``_initial_login``, ``_needs_two_factor`` (all 3 shapes), ``_handle_two_factor`` (None + success).
+- ``_is_authenticated``, ``_report_auth_failure`` (dict error + string error + None response).
+- ``_finalize_session``, ``_configure_session_timeout`` (success + swallowed error).
+- ``_announce_msp_privileges`` (with grants + without grants).
+- ``_handle_connection_error``, ``_handle_value_error`` (token+401 branch + generic branch).
+- ``_handle_generic_error``, ``_print_generic_error_message`` (credential/2FA/401/fallback branches).
+- ``_is_credential_error``, ``_is_two_factor_error`` substring guards.
+
+No live network, no MistHelper import touched. MagicMock(spec=...) mandatory on stubs.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions in test type hints.
+
+import logging  # WHY: caplog verification of structured warning/info/debug lines.
+from collections.abc import Callable  # WHY: Callable typing for injected fake callbacks.
+from typing import Any, cast  # WHY: dict[str, Any] annotations + cast(Any, x) for dynamic attr writes.
+from unittest.mock import MagicMock, patch  # WHY: mandatory spec= mocks + patch decorators.
+
+import pytest  # WHY: fixtures + parametrize.
+
+from src.auth.interactive.clouds import CloudSelector  # WHY: shared class object for patch.object.
+from src.auth.interactive.credential_prompter import CredentialPrompter  # WHY: shared class for patch.object.
+from src.auth.interactive.login_orchestrator import LoginOrchestrator  # WHY: SUT direct import.
+
+
+def _make_orchestrator(
+    state: dict[str, Any] | None = None,
+    safe_input: Callable[..., str] | None = None,
+    detect_msp_privileges: Callable[[], list[dict[str, Any]]] | None = None,
+) -> LoginOrchestrator:
+    """Build a LoginOrchestrator with minimal stub collaborators for unit tests."""
+    return LoginOrchestrator(
+        state=state if state is not None else {},  # WHY: fresh mutable state per test.
+        safe_input=safe_input or MagicMock(spec=Callable, return_value=""),  # WHY: default no-op input.
+        detect_msp_privileges=detect_msp_privileges or MagicMock(spec=Callable, return_value=[]),
+    )
+
+
+class TestExecute:
+    """``execute`` orchestrates the full login flow with 3 early-exit branches."""
+
+    def test_returns_false_when_mistapi_unavailable(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When _resolve_mistapi returns None, execute short-circuits with False."""
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with (
+            patch.object(LoginOrchestrator, "_resolve_mistapi", return_value=None),
+            caplog.at_level(logging.DEBUG),
+        ):
+            assert orch.execute() is False  # WHY: SUT contract: propagate failure.
+        assert "aborted: mistapi unavailable" in caplog.text  # WHY: legacy debug log.
+
+    def test_returns_false_when_cloud_cancelled(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When CloudSelector.prompt returns None, execute short-circuits with False."""
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with (
+            patch.object(LoginOrchestrator, "_resolve_mistapi", return_value=MagicMock(spec=object)),
+            patch.object(CloudSelector, "prompt", return_value=None),
+            caplog.at_level(logging.DEBUG),
+        ):
+            assert orch.execute() is False  # WHY: SUT contract: propagate failure.
+        assert "cloud selection cancelled" in caplog.text  # WHY: legacy debug log.
+
+    def test_returns_false_when_credentials_cancelled(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When _collect_credentials returns None, execute short-circuits with False."""
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with (
+            patch.object(LoginOrchestrator, "_resolve_mistapi", return_value=MagicMock(spec=object)),
+            patch.object(CloudSelector, "prompt", return_value=("Global 01", "api.mist.com")),
+            patch.object(LoginOrchestrator, "_collect_credentials", return_value=None),
+            caplog.at_level(logging.DEBUG),
+        ):
+            assert orch.execute() is False  # WHY: SUT contract: propagate failure.
+        assert "credential collection cancelled" in caplog.text  # WHY: legacy debug log.
+
+    def test_success_delegates_to_authenticate(self) -> None:
+        """Happy path: unpacks cloud + credentials and calls _authenticate with them."""
+        fake_sdk = MagicMock(spec=object)  # WHY: opaque SDK reference passed through.
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with (
+            patch.object(LoginOrchestrator, "_resolve_mistapi", return_value=fake_sdk),
+            patch.object(CloudSelector, "prompt", return_value=("Global 02", "api.gc1.mist.com")),
+            patch.object(LoginOrchestrator, "_collect_credentials", return_value=("u@e.com", "pw")),
+            patch.object(LoginOrchestrator, "_authenticate", return_value=True) as fake_auth,
+        ):
+            assert orch.execute() is True  # WHY: SUT returns _authenticate's return.
+        fake_auth.assert_called_once_with(fake_sdk, "Global 02", "api.gc1.mist.com", "u@e.com", "pw")
+
+
+class TestResolveMistapi:
+    """``_resolve_mistapi`` prefers state, else fallback-imports, and handles ImportError."""
+
+    def test_returns_state_reference_when_present(self) -> None:
+        """State already has mistapi → use it and skip the import."""
+        stub_sdk = MagicMock(spec=object)  # WHY: opaque SDK reference sitting in state.
+        orch = _make_orchestrator(state={"mistapi": stub_sdk})
+        assert orch._resolve_mistapi() is stub_sdk  # WHY: fast-path returns state value.
+
+    def test_fallback_import_succeeds_and_caches_in_state(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When state has no mistapi, the fallback import path caches the SDK in state."""
+        orch = _make_orchestrator()  # WHY: empty state triggers fallback branch.
+        with caplog.at_level(logging.DEBUG):
+            resolved = orch._resolve_mistapi()
+        # We do not assert the exact module identity (fallback imports the real mistapi package)
+        # but we assert it is not None and was cached back to state.
+        assert resolved is not None  # WHY: SUT returned the SDK reference.
+        assert orch.state["mistapi"] is resolved  # WHY: cache-back contract.
+        assert "Resolving mistapi SDK via fallback import" in caplog.text  # WHY: pre-action info log.
+
+    def test_fallback_import_error_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When mistapi cannot be imported, log error, print banner, return None."""
+        import builtins  # WHY: patch built-in __import__ to inject the ImportError.
+
+        real_import = builtins.__import__  # WHY: cache real import to preserve unrelated imports.
+
+        def _fail_only_mistapi(
+            name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0
+        ) -> Any:
+            if name == "mistapi":  # WHY: narrow the failure to the SUT's target.
+                raise ImportError("boom")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _fail_only_mistapi)
+        orch = _make_orchestrator()  # WHY: empty state triggers fallback branch.
+        with caplog.at_level(logging.ERROR):
+            assert orch._resolve_mistapi() is None  # WHY: SUT returns None on ImportError.
+        captured = capsys.readouterr()
+        assert "X Failed to import mistapi library" in captured.out  # WHY: legacy console message.
+        assert "Cannot import mistapi: boom" in caplog.text  # WHY: legacy error log preserved.
+
+
+class TestCollectCredentials:
+    """``_collect_credentials`` short-circuits on email None or password None."""
+
+    def test_returns_none_when_email_none(self) -> None:
+        """Email None → return None without prompting for password."""
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with patch.object(CredentialPrompter, "prompt_email", return_value=None):
+            with patch.object(CredentialPrompter, "prompt_password") as fake_pw:
+                assert orch._collect_credentials() is None  # WHY: SUT contract.
+                fake_pw.assert_not_called()  # WHY: guard clause skips password prompt.
+
+    def test_returns_none_when_password_none(self) -> None:
+        """Password None → return None even though email was captured."""
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with (
+            patch.object(CredentialPrompter, "prompt_email", return_value="u@e.com"),
+            patch.object(CredentialPrompter, "prompt_password", return_value=None),
+        ):
+            assert orch._collect_credentials() is None  # WHY: SUT contract.
+
+    def test_returns_credentials_tuple_on_success(self) -> None:
+        """Both prompts succeed → tuple returned."""
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with (
+            patch.object(CredentialPrompter, "prompt_email", return_value="u@e.com"),
+            patch.object(CredentialPrompter, "prompt_password", return_value="pw"),
+        ):
+            assert orch._collect_credentials() == ("u@e.com", "pw")  # WHY: SUT contract.
+
+
+class TestAuthenticate:
+    """``_authenticate`` dispatches exceptions to the matching handler."""
+
+    def test_happy_path_delegates_to_pipeline(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """No exception → returns whatever _run_login_pipeline returned."""
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with patch.object(LoginOrchestrator, "_run_login_pipeline", return_value=True) as fake_pipe:
+            result = orch._authenticate(MagicMock(spec=object), "Global 01", "api.mist.com", "u@e.com", "pw")
+        assert result is True  # WHY: SUT contract.
+        fake_pipe.assert_called_once()  # WHY: exactly one delegation call.
+        assert "Authenticating..." in capsys.readouterr().out  # WHY: legacy console banner.
+
+    def test_connection_error_dispatched(self) -> None:
+        """ConnectionError → routed to _handle_connection_error and returns False."""
+        exc = ConnectionError("no route")  # WHY: reference kept to assert delegation arg.
+        orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
+        with (
+            patch.object(LoginOrchestrator, "_run_login_pipeline", side_effect=exc),
+            patch.object(LoginOrchestrator, "_handle_connection_error", return_value=False) as fake_conn,
+        ):
+            assert orch._authenticate(MagicMock(spec=object), "c", "h", "e", "p") is False
+        fake_conn.assert_called_once_with(exc)  # WHY: dispatch preserves the exception object.
+
+    def test_value_error_dispatched(self) -> None:
+        """ValueError → routed to _handle_value_error and returns False."""
+        exc = ValueError("bad token")
+        orch = _make_orchestrator()
+        with (
+            patch.object(LoginOrchestrator, "_run_login_pipeline", side_effect=exc),
+            patch.object(LoginOrchestrator, "_handle_value_error", return_value=False) as fake_ve,
+        ):
+            assert orch._authenticate(MagicMock(spec=object), "c", "h", "e", "p") is False
+        fake_ve.assert_called_once_with(exc)  # WHY: dispatch preserves the exception object.
+
+    def test_generic_error_dispatched(self) -> None:
+        """Any other Exception → routed to _handle_generic_error and returns False."""
+        exc = RuntimeError("boom")
+        orch = _make_orchestrator()
+        with (
+            patch.object(LoginOrchestrator, "_run_login_pipeline", side_effect=exc),
+            patch.object(LoginOrchestrator, "_handle_generic_error", return_value=False) as fake_gen,
+        ):
+            assert orch._authenticate(MagicMock(spec=object), "c", "h", "e", "p") is False
+        fake_gen.assert_called_once_with(exc)  # WHY: dispatch preserves the exception object.
+
+
+class TestRunLoginPipeline:
+    """``_run_login_pipeline`` walks create-session / login / 2FA / finalize sequence."""
+
+    def test_returns_false_when_apisession_is_none(self) -> None:
+        """APISession constructor returned None → propagate False without touching login."""
+        orch = _make_orchestrator()
+        with (
+            patch.object(LoginOrchestrator, "_log_login_inputs"),
+            patch.object(LoginOrchestrator, "_create_api_session", return_value=None),
+            patch.object(LoginOrchestrator, "_initial_login") as fake_initial,
+        ):
+            assert orch._run_login_pipeline(MagicMock(spec=object), "h", "e", "p") is False
+        fake_initial.assert_not_called()  # WHY: guard skips downstream calls.
+
+    def test_returns_false_when_two_factor_cancelled(self) -> None:
+        """2FA prompt cancelled → _handle_two_factor returned None → False."""
+        orch = _make_orchestrator()
+        fake_session = MagicMock(spec=object)
+        with (
+            patch.object(LoginOrchestrator, "_log_login_inputs"),
+            patch.object(LoginOrchestrator, "_create_api_session", return_value=fake_session),
+            patch.object(LoginOrchestrator, "_initial_login", return_value={"error": {"two_factor_required": True}}),
+            patch.object(LoginOrchestrator, "_handle_two_factor", return_value=None),
+            patch.object(LoginOrchestrator, "_finalize_session") as fake_final,
+        ):
+            assert orch._run_login_pipeline(MagicMock(spec=object), "h", "e", "p") is False
+        fake_final.assert_not_called()  # WHY: 2FA cancellation skips finalize.
+
+    def test_returns_false_when_not_authenticated(self) -> None:
+        """Login result not authenticated → _report_auth_failure invoked and False returned."""
+        orch = _make_orchestrator()
+        fake_session = MagicMock(spec=object)
+        login_result = {"authenticated": False, "error": "bad creds"}  # WHY: post-2FA failure surface.
+        with (
+            patch.object(LoginOrchestrator, "_log_login_inputs"),
+            patch.object(LoginOrchestrator, "_create_api_session", return_value=fake_session),
+            patch.object(LoginOrchestrator, "_initial_login", return_value=login_result),
+            patch.object(LoginOrchestrator, "_report_auth_failure") as fake_report,
+            patch.object(LoginOrchestrator, "_finalize_session") as fake_final,
+        ):
+            assert orch._run_login_pipeline(MagicMock(spec=object), "h", "e", "p") is False
+        fake_report.assert_called_once_with(login_result)  # WHY: legacy contract.
+        fake_final.assert_not_called()  # WHY: no finalize on auth failure.
+
+    def test_returns_true_on_full_happy_path(self) -> None:
+        """Login authenticated → _finalize_session invoked and True returned."""
+        orch = _make_orchestrator()
+        fake_session = MagicMock(spec=object)
+        login_result = {"authenticated": True}
+        with (
+            patch.object(LoginOrchestrator, "_log_login_inputs"),
+            patch.object(LoginOrchestrator, "_create_api_session", return_value=fake_session),
+            patch.object(LoginOrchestrator, "_initial_login", return_value=login_result),
+            patch.object(LoginOrchestrator, "_finalize_session") as fake_final,
+        ):
+            assert orch._run_login_pipeline(MagicMock(spec=object), "h", "e-mail", "p") is True
+        fake_final.assert_called_once_with(fake_session, "e-mail", "h")  # WHY: legacy contract.
+
+
+class TestLogLoginInputs:
+    """``_log_login_inputs`` emits three legacy debug lines."""
+
+    def test_emits_three_debug_lines(self, caplog: pytest.LogCaptureFixture) -> None:
+        """host, email and password length are debug-logged separately."""
+        with caplog.at_level(logging.DEBUG):
+            LoginOrchestrator._log_login_inputs("api.mist.com", "u@e.com", "hunter2")
+        assert "host: api.mist.com" in caplog.text  # WHY: legacy line 1.
+        assert "email: u@e.com" in caplog.text  # WHY: legacy line 2.
+        assert "password length: 7" in caplog.text  # WHY: legacy line 3.
+
+    def test_empty_password_logs_length_zero(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Empty password logs length 0 (short-circuit protects len())."""
+        with caplog.at_level(logging.DEBUG):
+            LoginOrchestrator._log_login_inputs("h", "e", "")
+        assert "password length: 0" in caplog.text  # WHY: SUT ternary contract.
+
+
+class TestCreateApiSession:
+    """``_create_api_session`` constructs SDK session and clears the pre-existing token."""
+
+    def test_none_session_returns_none_and_warns(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When APISession returns None, log error, print banner, return None."""
+        fake_sdk = MagicMock()  # WHY: unspec'd because we swap the constructor attribute.
+        fake_sdk.APISession = MagicMock(return_value=None)  # WHY: soft-failure surface.
+        with caplog.at_level(logging.ERROR):
+            result = LoginOrchestrator._create_api_session(fake_sdk, "h", "e", "p")
+        assert result is None  # WHY: SUT contract.
+        assert "X Failed to create API session" in capsys.readouterr().out  # WHY: legacy console.
+        assert "APISession constructor returned None" in caplog.text  # WHY: legacy error log.
+
+    def test_returns_session_and_clears_token(self) -> None:
+        """Successful construction returns the session and clears any cached token."""
+        fake_session = MagicMock()  # WHY: attributes _apitoken + _apitoken_index accessed in helper.
+        fake_session._apitoken = ["tok1"]  # WHY: force the clear branch in _clear_pre_existing_token.
+        fake_session._apitoken_index = 0
+        fake_sdk = MagicMock()
+        fake_sdk.APISession = MagicMock(return_value=fake_session)
+        with patch.object(LoginOrchestrator, "_clear_pre_existing_token") as fake_clear:
+            result = LoginOrchestrator._create_api_session(fake_sdk, "h", "e", "p")
+        assert result is fake_session  # WHY: session handed back to caller.
+        fake_clear.assert_called_once_with(fake_session)  # WHY: token clear helper invoked.
+        fake_sdk.APISession.assert_called_once_with(
+            email="e", password="p", host="h", console_log_level=20, show_cli_notif=False
+        )  # WHY: SUT kwargs must match legacy signature verbatim.
+
+
+class TestClearPreExistingToken:
+    """``_clear_pre_existing_token`` fast-exits on empty token, clears otherwise."""
+
+    def test_no_token_is_noop(self) -> None:
+        """Empty apisession._apitoken skips the clear branch."""
+        fake_session = MagicMock()  # WHY: unspec'd to allow arbitrary attribute reads.
+        fake_session._apitoken = []  # WHY: empty list means no token to clear.
+        LoginOrchestrator._clear_pre_existing_token(fake_session)  # SUT should return without touching state.
+        assert fake_session._apitoken == []  # WHY: unchanged.
+
+    def test_clears_token_and_resets_index(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Non-empty token → cleared to [] and index reset to -1."""
+        fake_session = MagicMock()
+        fake_session._apitoken = ["tok1", "tok2"]  # WHY: two tokens forces len()==2 in the log line.
+        fake_session._apitoken_index = 1
+        with caplog.at_level(logging.DEBUG):
+            LoginOrchestrator._clear_pre_existing_token(fake_session)
+        assert fake_session._apitoken == []  # WHY: SUT resets token cache.
+        assert fake_session._apitoken_index == -1  # WHY: SUT resets cursor.
+        assert "Clearing API token to force email/password login (had 2 token(s))" in caplog.text
+
+
+class TestInitialLogin:
+    """``_initial_login`` invokes login_with_return() and returns the raw result."""
+
+    def test_returns_apisession_result(self, caplog: pytest.LogCaptureFixture) -> None:
+        """SDK response flows back verbatim; debug log records authentication flag."""
+        fake_session = MagicMock()
+        fake_session.login_with_return = MagicMock(return_value={"authenticated": True})
+        with caplog.at_level(logging.DEBUG):
+            result = LoginOrchestrator._initial_login(fake_session)
+        assert result == {"authenticated": True}  # WHY: verbatim passthrough.
+        assert "Initial login returned authenticated=True" in caplog.text  # WHY: legacy debug log.
+
+
+class TestNeedsTwoFactor:
+    """``_needs_two_factor`` handles three shapes: standard dict, legacy top-level, None."""
+
+    def test_none_result_returns_false(self) -> None:
+        """None login result → not required."""
+        assert LoginOrchestrator._needs_two_factor(None) is False
+
+    def test_empty_dict_returns_false(self) -> None:
+        """Empty dict → not required."""
+        assert LoginOrchestrator._needs_two_factor({}) is False
+
+    def test_standard_shape_error_dict_returns_true(self) -> None:
+        """{'error': {'two_factor_required': True}} → True."""
+        assert LoginOrchestrator._needs_two_factor({"error": {"two_factor_required": True}}) is True
+
+    def test_legacy_top_level_shape_returns_true(self) -> None:
+        """{'two_factor_required': True} → True (legacy fallback)."""
+        assert LoginOrchestrator._needs_two_factor({"two_factor_required": True}) is True
+
+    def test_non_dict_error_field_falls_through_to_top_level(self) -> None:
+        """error field that is not a dict falls through to the top-level check."""
+        assert LoginOrchestrator._needs_two_factor({"error": "some string", "two_factor_required": True}) is True
+
+
+class TestHandleTwoFactor:
+    """``_handle_two_factor`` prompts for 2FA and replays the login."""
+
+    def test_none_when_user_aborts(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """CredentialPrompter returns None → state cleared and None propagated."""
+        orch = _make_orchestrator()
+        orch.state["apisession"] = "stale"  # WHY: pre-existing partial session must be cleared.
+        fake_session = MagicMock()
+        with patch.object(CredentialPrompter, "prompt_two_factor", return_value=None):
+            result = orch._handle_two_factor(fake_session)
+        assert result is None  # WHY: SUT contract.
+        assert orch.state["apisession"] is None  # WHY: partial session cleared.
+        assert "Two-factor authentication required." in capsys.readouterr().out  # WHY: legacy banner.
+
+    def test_success_calls_login_with_return_with_two_factor(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Prompt returns a code → login_with_return replayed with two_factor kwarg."""
+        orch = _make_orchestrator()
+        fake_session = MagicMock()
+        fake_session.login_with_return = MagicMock(return_value={"authenticated": True})
+        with patch.object(CredentialPrompter, "prompt_two_factor", return_value="123456"):
+            with caplog.at_level(logging.DEBUG):
+                result = orch._handle_two_factor(fake_session)
+        assert result == {"authenticated": True}  # WHY: SUT contract.
+        fake_session.login_with_return.assert_called_once_with(two_factor="123456")  # WHY: kwargs shape.
+        assert "2FA login returned authenticated=True" in caplog.text  # WHY: legacy debug log.
+
+
+class TestIsAuthenticated:
+    """``_is_authenticated`` returns bool based on 'authenticated' key."""
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (None, False),  # WHY: None response → False.
+            ({}, False),  # WHY: missing key → False.
+            ({"authenticated": False}, False),  # WHY: explicit False → False.
+            ({"authenticated": True}, True),  # WHY: explicit True → True.
+        ],
+    )
+    def test_authenticated_branch(self, payload: dict[str, Any] | None, expected: bool) -> None:
+        """The 4-way truth table for the SUT contract."""
+        assert LoginOrchestrator._is_authenticated(payload) is expected
+
+
+class TestReportAuthFailure:
+    """``_report_auth_failure`` prints legacy message and clears state."""
+
+    def test_none_response_uses_no_response_default(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """None login result → 'No response' is printed and logged."""
+        orch = _make_orchestrator()
+        with caplog.at_level(logging.ERROR):
+            orch._report_auth_failure(None)
+        assert "X Authentication failed: No response" in capsys.readouterr().out  # WHY: legacy.
+        assert "Interactive login failed: No response" in caplog.text  # WHY: legacy.
+        assert orch.state["apisession"] is None  # WHY: state cleanup.
+
+    def test_dict_error_uses_detail_field(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Error dict → the 'detail' field is preferred."""
+        orch = _make_orchestrator()
+        orch._report_auth_failure({"error": {"detail": "bad token"}})
+        assert "X Authentication failed: bad token" in capsys.readouterr().out  # WHY: detail wins.
+
+    def test_dict_error_without_detail_uses_string(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Error dict without 'detail' → falls back to str(dict)."""
+        orch = _make_orchestrator()
+        orch._report_auth_failure({"error": {"code": 401}})
+        out = capsys.readouterr().out
+        assert "X Authentication failed:" in out  # WHY: prefix preserved.
+        assert "401" in out  # WHY: dict-string contains the code.
+
+    def test_string_error_used_verbatim(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Non-dict error field is used verbatim (coerced to str)."""
+        orch = _make_orchestrator()
+        orch._report_auth_failure({"error": "bad creds"})
+        assert "X Authentication failed: bad creds" in capsys.readouterr().out  # WHY: verbatim.
+
+    def test_missing_error_field_uses_unknown_default(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Missing 'error' key → 'Unknown error' default."""
+        orch = _make_orchestrator()
+        orch._report_auth_failure({"authenticated": False})
+        assert "X Authentication failed: Unknown error" in capsys.readouterr().out  # WHY: legacy default.
+
+
+class TestFinalizeSession:
+    """``_finalize_session`` caches session, configures timeout, announces MSPs."""
+
+    def test_full_finalize_sequence(self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
+        """State cached, timeout configured, MSP privileges announced."""
+        orch = _make_orchestrator()
+        fake_session = MagicMock(spec=object)
+        with (
+            patch.object(LoginOrchestrator, "_configure_session_timeout") as fake_timeout,
+            patch.object(LoginOrchestrator, "_announce_msp_privileges") as fake_msp,
+            caplog.at_level(logging.INFO),
+        ):
+            orch._finalize_session(fake_session, "u@e.com", "api.mist.com")
+        assert orch.state["apisession"] is fake_session  # WHY: state cache-back.
+        fake_timeout.assert_called_once_with(fake_session)  # WHY: timeout helper invoked.
+        fake_msp.assert_called_once()  # WHY: MSP announcement invoked.
+        assert "+ Login successful!" in capsys.readouterr().out  # WHY: legacy console.
+        assert "Interactive login successful for u@e.com to api.mist.com" in caplog.text  # WHY: legacy log.
+
+
+class TestConfigureSessionTimeout:
+    """``_configure_session_timeout`` best-effort delegation to session_timeout helper."""
+
+    def test_success_delegates_to_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Import succeeds → helper called with the session."""
+        import sys  # WHY: inject a fake module into sys.modules for deferred import.
+        import types  # WHY: build a ModuleType stub for the deferred import target.
+
+        fake_module = types.ModuleType("src.auth.session_timeout")  # WHY: real module type for import machinery.
+        fake_helper = MagicMock()  # WHY: replaced helper we can assert on.
+        cast(Any, fake_module).configure_session_timeout = fake_helper  # WHY: cast(Any) satisfies mypy + ruff.
+        monkeypatch.setitem(sys.modules, "src.auth.session_timeout", fake_module)
+        fake_session = MagicMock(spec=object)
+        LoginOrchestrator._configure_session_timeout(fake_session)
+        fake_helper.assert_called_once_with(fake_session)  # WHY: delegation contract.
+
+    def test_swallowed_exception_does_not_propagate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Helper raises → SUT swallows silently (legacy contract)."""
+        import sys  # WHY: inject fake module for the deferred import.
+        import types  # WHY: build a ModuleType stub.
+
+        fake_module = types.ModuleType("src.auth.session_timeout")
+
+        def _boom(_session: Any) -> None:
+            raise RuntimeError("timeout wiring broken")  # WHY: reach the except Exception branch.
+
+        cast(Any, fake_module).configure_session_timeout = _boom  # WHY: cast(Any) satisfies mypy + ruff.
+        monkeypatch.setitem(sys.modules, "src.auth.session_timeout", fake_module)
+        LoginOrchestrator._configure_session_timeout(MagicMock(spec=object))  # SUT should not raise.
+
+    def test_missing_module_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When the deferred import fails, the SUT swallows the ImportError silently."""
+        import sys  # WHY: force ImportError by ensuring the target key is not in sys.modules.
+
+        monkeypatch.delitem(sys.modules, "src.auth.session_timeout", raising=False)
+        LoginOrchestrator._configure_session_timeout(MagicMock(spec=object))  # SUT should not raise.
+
+
+class TestAnnounceMspPrivileges:
+    """``_announce_msp_privileges`` echoes MSP grants or the empty-list banner."""
+
+    def test_with_grants_populates_state_and_echoes_each(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Non-empty grants → state cached and each grant printed."""
+        grants = [
+            {"msp_name": "MSP-A", "role": "admin"},  # WHY: two grants exercises the loop.
+            {"msp_name": "MSP-B", "role": "viewer"},
+        ]
+        detect_fn = MagicMock(spec=Callable, return_value=grants)
+        orch = _make_orchestrator(detect_msp_privileges=detect_fn)
+        orch._announce_msp_privileges()
+        out = capsys.readouterr().out
+        assert orch.state["msp_privileges"] == grants  # WHY: cache-back.
+        assert "MSP access detected: 2 MSP(s) available" in out  # WHY: legacy banner.
+        assert "- MSP-A (role: admin)" in out  # WHY: per-grant line.
+        assert "- MSP-B (role: viewer)" in out  # WHY: per-grant line.
+
+    def test_no_grants_prints_org_level_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Empty grants list → org-level banner printed and state untouched."""
+        detect_fn = MagicMock(spec=Callable, return_value=[])
+        orch = _make_orchestrator(detect_msp_privileges=detect_fn)
+        orch._announce_msp_privileges()
+        out = capsys.readouterr().out
+        assert "No MSP privileges detected (org-level access only)" in out  # WHY: legacy banner.
+        assert "msp_privileges" not in orch.state  # WHY: state left untouched.
+
+
+class TestHandleConnectionError:
+    """``_handle_connection_error`` prints legacy line + logs + clears state."""
+
+    def test_prints_and_logs_and_clears_state(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        orch = _make_orchestrator()
+        orch.state["apisession"] = "partial"  # WHY: verify cleanup runs.
+        exc = ConnectionError("network down")
+        with caplog.at_level(logging.ERROR):
+            assert orch._handle_connection_error(exc) is False  # WHY: contract.
+        assert "X Connection failed: network down" in capsys.readouterr().out  # WHY: legacy console.
+        assert "Interactive login connection error: network down" in caplog.text  # WHY: legacy log.
+        assert orch.state["apisession"] is None  # WHY: state cleared.
+
+
+class TestHandleValueError:
+    """``_handle_value_error`` branches on 'token'/'401' substrings."""
+
+    def test_token_branch_uses_generic_line(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """'token' substring → 'Invalid API token or credentials' line."""
+        orch = _make_orchestrator()
+        exc = ValueError("bad token payload")
+        with caplog.at_level(logging.ERROR):
+            assert orch._handle_value_error(exc) is False
+        assert "X Invalid API token or credentials" in capsys.readouterr().out  # WHY: specific branch.
+        assert "Interactive login value error: bad token payload" in caplog.text  # WHY: legacy log.
+        assert orch.state["apisession"] is None  # WHY: state cleared.
+
+    def test_401_branch_uses_generic_line(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """'401' substring → same 'Invalid API token or credentials' line."""
+        orch = _make_orchestrator()
+        exc = ValueError("HTTP 401 returned")
+        orch._handle_value_error(exc)
+        assert "X Invalid API token or credentials" in capsys.readouterr().out  # WHY: specific branch.
+
+    def test_generic_branch_uses_error_verbatim(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """No token / 401 substring → verbatim 'Authentication error: ...' line."""
+        orch = _make_orchestrator()
+        exc = ValueError("some random validation")
+        orch._handle_value_error(exc)
+        assert "X Authentication error: some random validation" in capsys.readouterr().out
+
+
+class TestHandleGenericError:
+    """``_handle_generic_error`` prints via helper + logs + clears state."""
+
+    def test_delegates_and_clears_state(self, caplog: pytest.LogCaptureFixture) -> None:
+        orch = _make_orchestrator()
+        orch.state["apisession"] = "partial"
+        exc = RuntimeError("kaboom")
+        with (
+            patch.object(LoginOrchestrator, "_print_generic_error_message") as fake_print,
+            caplog.at_level(logging.ERROR),
+        ):
+            assert orch._handle_generic_error(exc) is False  # WHY: contract.
+        fake_print.assert_called_once_with(exc, "kaboom", "kaboom")  # WHY: helper receives 3 args.
+        assert "Interactive login failed: kaboom" in caplog.text  # WHY: legacy log.
+        assert orch.state["apisession"] is None  # WHY: state cleared.
+
+
+class TestPrintGenericErrorMessage:
+    """``_print_generic_error_message`` branches: credential / 2FA / 401 / fallback."""
+
+    def test_credential_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """'invalid' substring → credential message."""
+        LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "invalid whatever", "invalid whatever")
+        assert "X Invalid email or password" in capsys.readouterr().out
+
+    def test_two_factor_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """'2fa' substring → 2FA message."""
+        LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "2fa broken", "2fa broken")
+        assert "X Two-factor authentication failed" in capsys.readouterr().out
+
+    def test_401_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """'401' substring in the original error message → auth-failure message."""
+        LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "HTTP 401", "http 401")
+        assert "X Invalid email or password (authentication failed)" in capsys.readouterr().out
+
+    def test_fallback_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """No matching substring → generic 'X Login failed: <exc>' line."""
+        exc = RuntimeError("mystery")  # WHY: __str__ used in the fallback line.
+        LoginOrchestrator._print_generic_error_message(exc, "mystery", "mystery")
+        assert "X Login failed: mystery" in capsys.readouterr().out
+
+
+class TestIsCredentialError:
+    """``_is_credential_error`` short substring guard."""
+
+    @pytest.mark.parametrize(
+        ("lower_message", "expected"),
+        [
+            ("invalid credentials", True),  # WHY: both substrings.
+            ("invalid input", True),  # WHY: 'invalid' only.
+            ("bad credential value", True),  # WHY: 'credential' only.
+            ("unrelated", False),  # WHY: neither.
+        ],
+    )
+    def test_substring_guard(self, lower_message: str, expected: bool) -> None:
+        assert LoginOrchestrator._is_credential_error(lower_message) is expected
+
+
+class TestIsTwoFactorError:
+    """``_is_two_factor_error`` short substring guard."""
+
+    @pytest.mark.parametrize(
+        ("lower_message", "expected"),
+        [
+            ("two_factor required", True),  # WHY: 'two_factor' snake form.
+            ("2fa code", True),  # WHY: '2fa' short form.
+            ("unrelated failure", False),  # WHY: neither.
+        ],
+    )
+    def test_substring_guard(self, lower_message: str, expected: bool) -> None:
+        assert LoginOrchestrator._is_two_factor_error(lower_message) is expected

--- a/tests/unit/gateway/test_gateway_export_utils_extended.py
+++ b/tests/unit/gateway/test_gateway_export_utils_extended.py
@@ -1,0 +1,808 @@
+"""Wave 11 P2 coverage for src/gateway/gateway_export_utils.py (initiative #1018).
+
+Covers the module-level helper functions and the ``GatewayExportUtils`` static methods that
+are not exercised by the existing test_gateway_export_utils.py smoke tests. All external
+collaborators (mistapi, CSV I/O helpers, cache utilities, exporters) are injected as
+MagicMock(spec=...) fakes via the configure_gateway_export_utils_dependencies() DI hook.
+
+No live network calls are made and no MistHelper import is touched.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 union syntax used in helper type hints.
+
+import csv  # WHY: build deterministic CSV fixtures for helper reads.
+import logging  # WHY: caplog verification for structured log lines.
+from pathlib import Path  # WHY: pathlib fixtures for tmp_path CSV round-trips.
+from types import ModuleType, SimpleNamespace  # WHY: opaque namespaces stand in for injected modules.
+from typing import Any, cast  # WHY: Any annotations mirror the SUT; cast(Any, x) for dynamic attr writes.
+from unittest.mock import MagicMock, patch  # WHY: mandatory spec= mocks + patch.object for method injection.
+
+import pytest  # WHY: fixtures + caplog for behaviour assertions.
+
+from src.gateway.gateway_export_utils import (  # WHY: SUT direct import for helpers + class.
+    EMPTY_CELL_MARKERS,
+    MGMT_IP_MISSING_LABEL,
+    NO_TEMPLATE_LABEL,
+    STATUS_OFFLINE,
+    STATUS_ONLINE,
+    STATUS_UNKNOWN,
+    TEMPLATE_ID_MISSING_LABEL,
+    UNKNOWN_GATEWAY,
+    UNKNOWN_SITE,
+    GatewayExportUtils,
+    _build_management_ip_row,
+    _classify_connected_status,
+    _fetch_site_name_lookup_from_api,
+    _is_wan_port_column,
+    _load_gateways_from_inventory_csv,
+    _load_site_name_lookup_from_csv,
+    _log_management_ip_row,
+    _project_api_gateway_devices,
+    _project_gateway_devices,
+    _project_row_to_columns,
+    _read_csv_rows,
+    _resolve_template_name,
+    _row_has_port_data,
+    _select_wan_port_columns,
+    _write_empty_filtered_port_marker,
+    configure_gateway_export_utils_dependencies,
+)
+
+# WHY: capture pristine GatewayExportUtils methods at IMPORT TIME (before any test file
+# mutates the class). The neighbouring test_gateway_export_utils.py reassigns
+# GatewayExportUtils._get_devices_from_cache = MagicMock(...) without restoring it, so
+# by the time our tests run the class attribute is polluted. Snapshotting here — while the
+# class is still pristine — lets us reset it via the autouse fixture below.
+_PRISTINE_GET_DEVICES_FROM_CACHE = staticmethod(GatewayExportUtils._get_devices_from_cache)
+_PRISTINE_GET_DEVICES_FROM_API = staticmethod(GatewayExportUtils._get_devices_from_api)
+
+
+@pytest.fixture(autouse=True)
+def _restore_pristine_gateway_methods() -> None:
+    """Restore pristine GatewayExportUtils methods before every test in this module."""
+    cast(Any, GatewayExportUtils)._get_devices_from_cache = _PRISTINE_GET_DEVICES_FROM_CACHE  # WHY: undo pollution.
+    cast(Any, GatewayExportUtils)._get_devices_from_api = _PRISTINE_GET_DEVICES_FROM_API  # WHY: undo pollution.
+
+
+# -- Shared DI configuration helper -------------------------------------------------------
+
+
+def _build_dependency_bundle(  # WHY: single-source keyword bundle for every configure() call.
+    tmp_path: Path,
+    *,
+    apisession: Any = None,
+    mistapi_dependency: Any = None,
+    api_fetch_utils: Any = None,
+    api_core_fetch_utils: Any = None,
+    org_inventory_exporter: Any = None,
+    org_site_exporter: Any = None,
+    data_exporter: Any = None,
+    data_processing_utils: Any = None,
+    input_utils: Any = None,
+    config_utils: Any = None,
+) -> dict[str, Any]:
+    """Return a minimal-but-complete dependency bundle for configure_gateway_export_utils_dependencies."""
+    return {
+        "apisession_dependency": apisession or object(),  # WHY: opaque object stand-in for the SDK session.
+        "mistapi_dependency": mistapi_dependency or SimpleNamespace(),  # WHY: overridden per-test if needed.
+        "config_utils": config_utils or SimpleNamespace(get_cached_or_prompted_org_id=MagicMock(return_value="org-1")),
+        "cache_utils": SimpleNamespace(check_and_generate_csv=MagicMock()),  # WHY: no-op cache refresh.
+        "file_path_utils": SimpleNamespace(get_csv_path=lambda name: str(tmp_path / name)),  # WHY: tmp fixture.
+        "data_exporter": data_exporter or SimpleNamespace(write_with_format_selection=MagicMock()),
+        "data_processing_utils": data_processing_utils
+        or SimpleNamespace(
+            flatten_nested_fields=MagicMock(side_effect=lambda rows: rows),
+            escape_multiline=MagicMock(side_effect=lambda rows: rows),
+        ),
+        "api_fetch_utils": api_fetch_utils or SimpleNamespace(gateway_device_configs=MagicMock(return_value=[])),
+        "api_core_fetch_utils": api_core_fetch_utils
+        or SimpleNamespace(all_inventory_with_limit=MagicMock(return_value=[])),
+        "org_inventory_exporter": org_inventory_exporter
+        or SimpleNamespace(inventory=MagicMock(), gateways_with_site_info=MagicMock()),
+        "org_site_exporter": org_site_exporter or SimpleNamespace(sites=MagicMock(), sites_list_api=MagicMock()),
+        "input_utils": input_utils or SimpleNamespace(safe_input=MagicMock(return_value="yes")),
+        "execute_fn": MagicMock(return_value=([], [])),
+        "validation_utils": SimpleNamespace(validate_site_id=MagicMock(), validate_device_id=MagicMock()),
+        "rate_limiting_utils": SimpleNamespace(get_rate_limited_delay=MagicMock(return_value=(None, 0))),
+        "mist_wan_target_ports": ["ge-0/0/1", "ge-0/0/2"],
+        "mist_site_exclude_prefix": "",
+        "fast_mode_max_retries": 2,
+        "fast_mode_retry_delay": 0.01,
+        "api_usage_cache": {},
+        "tqdm_module": lambda iterable, **_: iterable,
+    }
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, Any]]) -> None:
+    """Write a CSV fixture with a stable header order."""
+    with path.open("w", newline="", encoding="utf-8") as fh:  # WHY: newline='' per csv module docs.
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)  # WHY: dict-based writer for readability.
+        writer.writeheader()  # WHY: emit header row for DictReader consumers.
+        writer.writerows(rows)  # WHY: emit deterministic data rows.
+
+
+# -- _classify_connected_status --------------------------------------------------------------
+
+
+class TestClassifyConnectedStatus:
+    """Legacy Online/Offline/Unknown mapping for the connected CSV cell."""
+
+    @pytest.mark.parametrize("token", ["true", "TRUE", "1", "yes", "  Yes  "])
+    def test_truthy_tokens_map_to_online(self, token: str) -> None:
+        """All truthy tokens (any case, whitespace) map to Online."""
+        assert _classify_connected_status(token) == STATUS_ONLINE  # WHY: legacy Online string preserved.
+
+    @pytest.mark.parametrize("token", ["false", "FALSE", "0", "no"])
+    def test_falsy_tokens_map_to_offline(self, token: str) -> None:
+        """All falsy tokens map to Offline."""
+        assert _classify_connected_status(token) == STATUS_OFFLINE  # WHY: legacy Offline string preserved.
+
+    @pytest.mark.parametrize("token", ["", "maybe", "nan"])
+    def test_unrecognised_tokens_map_to_unknown(self, token: str) -> None:
+        """Anything else falls back to Unknown (legacy behaviour)."""
+        assert _classify_connected_status(token) == STATUS_UNKNOWN  # WHY: legacy fallback preserved.
+
+
+# -- _read_csv_rows -------------------------------------------------------------------------
+
+
+class TestReadCsvRows:
+    """Cache-name-driven CSV reader used by every management-IP correlation path."""
+
+    def test_reads_rows_via_file_path_utils(self, tmp_path: Path) -> None:
+        """Rows are returned as dict list; file path resolved via FilePathUtils.get_csv_path."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: wire DI.
+        target = tmp_path / "SiteList.csv"  # WHY: pick one of the fixed input names.
+        _write_csv(
+            target,
+            ["id", "name"],
+            [{"id": "s1", "name": "Site 1"}, {"id": "s2", "name": "Site 2"}],
+        )
+        rows = _read_csv_rows("SiteList.csv")  # WHY: helper resolves and reads by logical name.
+        assert rows == [{"id": "s1", "name": "Site 1"}, {"id": "s2", "name": "Site 2"}]
+
+
+# -- _log_management_ip_row -----------------------------------------------------------------
+
+
+class TestLogManagementIpRow:
+    """Per-device debug logs preserve the two legacy phrasings."""
+
+    def test_with_ip_uses_mgmt_ip_phrase(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When an IP is present the log includes the IP."""
+        caplog.set_level(logging.DEBUG)  # WHY: helper emits at DEBUG level.
+        _log_management_ip_row("gw1", "10.1.1.1", STATUS_ONLINE, "TplA")
+        assert any("Management IP 10.1.1.1" in rec.getMessage() for rec in caplog.records)
+
+    def test_without_ip_uses_no_management_ip_phrase(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When no IP is present the log uses the legacy 'no management IP configured' phrase."""
+        caplog.set_level(logging.DEBUG)  # WHY: helper emits at DEBUG level.
+        _log_management_ip_row("gw1", "", STATUS_OFFLINE, "TplA")
+        assert any("No management IP configured" in rec.getMessage() for rec in caplog.records)
+
+
+# -- _resolve_template_name -----------------------------------------------------------------
+
+
+class TestResolveTemplateName:
+    """Legacy 'No Template' fallback rules for the template lookup."""
+
+    def test_empty_id_returns_no_template_label(self) -> None:
+        """Empty template_id yields the legacy 'No Template' label."""
+        assert _resolve_template_name({"t1": "TemplateA"}, "") == NO_TEMPLATE_LABEL
+
+    def test_known_id_returns_template_name(self) -> None:
+        """Known template_id returns the mapped display name."""
+        assert _resolve_template_name({"t1": "TemplateA"}, "t1") == "TemplateA"
+
+    def test_unknown_id_returns_no_template_label(self) -> None:
+        """Unknown template_id falls back to the legacy label."""
+        assert _resolve_template_name({"t1": "TemplateA"}, "t9") == NO_TEMPLATE_LABEL
+
+
+# -- _build_management_ip_row ---------------------------------------------------------------
+
+
+class TestBuildManagementIpRow:
+    """Row-builder correlates device + lookups into the final management-IP row shape."""
+
+    def test_full_correlation_populates_all_fields(self) -> None:
+        """Every field is populated when device+lookups are complete."""
+        device = {
+            "name": "gw1",
+            "site_id": "s1",
+            "site_name": "Site One",
+            "connected": "true",
+        }
+        lookups: dict[str, dict[Any, Any]] = {
+            "site": {"s1": {"gatewaytemplate_id": "t1"}},
+            "template": {"t1": "TplA"},
+            "mgmt_ip": {"gw1": "10.0.0.1"},
+        }
+        row, mgmt_ip = _build_management_ip_row(device, lookups)  # WHY: exercise full correlation path.
+        assert row["gateway_name"] == "gw1"  # WHY: preserves device name.
+        assert row["management_ip"] == "10.0.0.1"  # WHY: uses looked-up mgmt IP.
+        assert row["status"] == STATUS_ONLINE  # WHY: 'true' maps to Online.
+        assert row["site_name"] == "Site One"  # WHY: preserves device site_name.
+        assert row["gateway_template"] == "TplA"  # WHY: resolves via template lookup.
+        assert row["template_id"] == "t1"  # WHY: preserves resolved template_id.
+        assert mgmt_ip == "10.0.0.1"  # WHY: returned tuple includes raw mgmt_ip.
+
+    def test_missing_mgmt_ip_uses_legacy_fallback_label(self) -> None:
+        """Empty mgmt_ip yields legacy 'Not Configured' label; template_id fallback used."""
+        device = {"name": "gw2", "site_id": "s1", "site_name": "Site Two", "connected": "false"}
+        lookups: dict[str, dict[Any, Any]] = {"site": {}, "template": {}, "mgmt_ip": {}}  # WHY: no matches.
+        row, mgmt_ip = _build_management_ip_row(device, lookups)
+        assert row["management_ip"] == MGMT_IP_MISSING_LABEL  # WHY: legacy label.
+        assert row["template_id"] == TEMPLATE_ID_MISSING_LABEL  # WHY: legacy 'None' fallback.
+        assert row["gateway_template"] == NO_TEMPLATE_LABEL  # WHY: legacy template fallback.
+        assert row["status"] == STATUS_OFFLINE  # WHY: 'false' maps to Offline.
+        assert mgmt_ip == ""  # WHY: helper still returns the raw empty string.
+
+    def test_missing_device_name_defaults_to_unknown_gateway(self) -> None:
+        """Missing 'name' key falls back to 'Unknown Gateway'."""
+        device: dict[str, Any] = {"connected": "yes"}  # WHY: no name/site_id/site_name.
+        lookups: dict[str, dict[Any, Any]] = {"site": {}, "template": {}, "mgmt_ip": {}}  # WHY: no matches.
+        row, _ = _build_management_ip_row(device, lookups)
+        assert row["gateway_name"] == UNKNOWN_GATEWAY  # WHY: legacy fallback text.
+        assert row["site_name"] == UNKNOWN_SITE  # WHY: legacy fallback text.
+
+
+# -- _select_wan_port_columns / _project_row_to_columns / _is_wan_port_column ---------------
+
+
+class TestPortColumnHelpers:
+    """WAN column filter, per-row projection and predicate helpers."""
+
+    def test_select_wan_port_columns_matches_regex_only(self) -> None:
+        """Only ge-0/0/N port_config columns without _vpn_paths_ noise pass the filter."""
+        row = {
+            "mac": "aa",
+            "port_config_ge-0/0/1_speed": "1G",  # WHY: matches WAN pattern.
+            "port_config_ge-0/0/1_vpn_paths_index": "0",  # WHY: excluded by _vpn_paths_ guard.
+            "port_config_ge-0/0/2_duplex": "full",  # WHY: matches WAN pattern.
+            "some_other_field": "x",  # WHY: excluded by regex.
+        }
+        selected = _select_wan_port_columns(row)  # WHY: exercise the pure filter helper.
+        assert "port_config_ge-0/0/1_speed" in selected  # WHY: expected WAN column.
+        assert "port_config_ge-0/0/2_duplex" in selected  # WHY: expected WAN column.
+        assert "port_config_ge-0/0/1_vpn_paths_index" not in selected  # WHY: VPN column excluded.
+        assert "mac" not in selected  # WHY: non-WAN column excluded.
+
+    def test_project_row_to_columns_uses_empty_string_fallback(self) -> None:
+        """Missing keys are projected as empty strings to preserve downstream shape."""
+        row = {"a": "1", "b": "2"}
+        projected = _project_row_to_columns(row, ["a", "b", "c"])
+        assert projected == {"a": "1", "b": "2", "c": ""}  # WHY: 'c' fallback preserved.
+
+    @pytest.mark.parametrize(
+        "column,expected",
+        [
+            ("port_config_ge-0/0/0_speed", True),  # WHY: matches WAN pattern.
+            ("port_config_ge-0/0/0_vpn_paths_x", False),  # WHY: VPN column filtered.
+            ("random_col", False),  # WHY: non-matching column.
+            ("port_config_xe-0/0/1", False),  # WHY: not ge- prefix.
+        ],
+    )
+    def test_is_wan_port_column_predicate_matrix(self, column: str, expected: bool) -> None:
+        """Predicate returns True only for WAN port_config columns without VPN noise."""
+        assert _is_wan_port_column(column) is expected  # WHY: verify boolean matrix.
+
+    def test_row_has_port_data_returns_true_when_any_value_present(self) -> None:
+        """Predicate returns True as long as at least one requested column has non-empty value."""
+        row = {"p1": "", "p2": None, "p3": "42"}  # WHY: only p3 has real data.
+        assert _row_has_port_data(row, ["p1", "p2", "p3"]) is True  # WHY: p3 counts.
+
+    def test_row_has_port_data_returns_false_when_all_markers(self) -> None:
+        """Predicate returns False when every requested column is in EMPTY_CELL_MARKERS."""
+        row: dict[str, Any] = {
+            marker_key: marker for marker_key, marker in zip(["a", "b", "c"], EMPTY_CELL_MARKERS, strict=False)
+        }
+        assert _row_has_port_data(row, ["a", "b", "c"]) is False  # WHY: all values are markers.
+
+
+# -- _write_empty_filtered_port_marker -----------------------------------------------------
+
+
+class TestEmptyFilteredPortMarker:
+    """Empty-projection fallback writes the legacy marker file to disk."""
+
+    def test_marker_file_contains_legacy_no_matching_data_message(self, tmp_path: Path) -> None:
+        """Marker file exists and contains the legacy phrase 'No matching data found.'"""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        _write_empty_filtered_port_marker()  # WHY: exercise the marker write path.
+        marker_path = tmp_path / "FilteredGatewayPortConfigs.csv"
+        assert marker_path.exists()  # WHY: file must be created.
+        assert "No matching data found." in marker_path.read_text(encoding="utf-8")
+
+
+# -- _load_gateways_from_inventory_csv + _load_site_name_lookup_from_csv --------------------
+
+
+class TestInventoryCsvLoaders:
+    """CSV loaders back the fast-mode gateway device projection."""
+
+    def test_load_gateways_filters_non_gateway_and_missing_ids(self, tmp_path: Path) -> None:
+        """Only gateway rows with populated site_id + id are returned."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        _write_csv(
+            tmp_path / "OrgInventory.csv",
+            ["type", "site_id", "id", "name"],
+            [
+                {"type": "gateway", "site_id": "s1", "id": "d1", "name": "n1"},  # WHY: kept.
+                {"type": "switch", "site_id": "s1", "id": "d2", "name": "n2"},  # WHY: filtered.
+                {"type": "gateway", "site_id": "", "id": "d3", "name": "n3"},  # WHY: filtered.
+                {"type": "gateway", "site_id": "s2", "id": "", "name": "n4"},  # WHY: filtered.
+            ],
+        )
+        rows = _load_gateways_from_inventory_csv()
+        assert len(rows) == 1  # WHY: only the first row passes all guards.
+        assert rows[0]["id"] == "d1"  # WHY: verify the surviving row.
+
+    def test_load_site_name_lookup_preserves_unknown_fallback(self, tmp_path: Path) -> None:
+        """Missing name column yields the legacy 'Unknown Site' fallback."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        _write_csv(
+            tmp_path / "SiteList.csv",
+            ["id", "name"],
+            [{"id": "s1", "name": "Alpha"}, {"id": "s2", "name": ""}],  # WHY: blank name for fallback.
+        )
+        lookup = _load_site_name_lookup_from_csv()
+        assert lookup["s1"] == "Alpha"  # WHY: verify normal path.
+        assert lookup["s2"] == ""  # WHY: DictReader emits '' when column present but blank.
+
+
+# -- _project_gateway_devices ---------------------------------------------------------------
+
+
+class TestProjectGatewayDevices:
+    """Tuple-projection helper for cached inventory rows."""
+
+    def test_projects_rows_with_lookup_fallback(self) -> None:
+        """Missing site names default to 'Unknown Site'; missing fields default to ''."""
+        gateways = [
+            {"site_id": "s1", "id": "d1", "name": "n1"},
+            {"site_id": "s-missing", "id": "d2", "name": "n2"},
+            {},  # WHY: fully empty row exercises every fallback branch.
+        ]
+        site_name_lookup = {"s1": "Alpha"}
+        projected = _project_gateway_devices(gateways, site_name_lookup)
+        assert projected[0] == ("s1", "d1", "n1", "Alpha")  # WHY: normal path.
+        assert projected[1] == ("s-missing", "d2", "n2", UNKNOWN_SITE)  # WHY: legacy fallback.
+        assert projected[2] == ("", "", "", UNKNOWN_SITE)  # WHY: empty-row fallback.
+
+
+# -- _fetch_site_name_lookup_from_api + _project_api_gateway_devices ------------------------
+
+
+class TestApiDrivenProjections:
+    """API-path helpers use the injected mistapi + APICoreFetchUtils facades."""
+
+    def test_fetch_site_name_lookup_uses_mistapi_and_get_all(self, tmp_path: Path) -> None:
+        """Delegates to mistapi.get_all and returns id->name mapping."""
+        list_org_sites = MagicMock(return_value=SimpleNamespace(data=[]))  # WHY: first-page response stub.
+        mistapi_module = ModuleType("mistapi_stub")  # WHY: real ModuleType so nested attr chain works.
+        cast(Any, mistapi_module).api = SimpleNamespace(
+            v1=SimpleNamespace(
+                orgs=SimpleNamespace(
+                    sites=SimpleNamespace(listOrgSites=list_org_sites),
+                ),
+            ),
+        )
+        get_all_mock = MagicMock(  # WHY: exhaust-all-pages helper stubbed to fixed sites list.
+            return_value=[{"id": "s1", "name": "Site A"}, {"id": "s2"}]  # WHY: 2nd site lacks name.
+        )
+        cast(Any, mistapi_module).get_all = get_all_mock  # WHY: cast(Any) satisfies mypy + ruff.
+        bundle = _build_dependency_bundle(tmp_path, mistapi_dependency=mistapi_module)  # WHY: wire stub.
+        configure_gateway_export_utils_dependencies(**bundle)
+        lookup = _fetch_site_name_lookup_from_api("org-1")
+        assert lookup["s1"] == "Site A"  # WHY: normal path.
+        assert lookup["s2"] == UNKNOWN_SITE  # WHY: legacy fallback when name absent.
+        list_org_sites.assert_called_once()  # WHY: first-page call invoked exactly once.
+        get_all_mock.assert_called_once()  # WHY: pagination helper invoked exactly once.
+
+    def test_project_api_gateway_devices_filters_and_shapes_tuples(self) -> None:
+        """API projection applies the same gateway-only + site/id guards as cache path."""
+        devices = [
+            {"type": "gateway", "site_id": "s1", "id": "d1", "name": "n1"},  # WHY: kept.
+            {"type": "switch", "site_id": "s1", "id": "d2", "name": "n2"},  # WHY: filtered by type.
+            {"type": "gateway", "site_id": "", "id": "d3"},  # WHY: filtered by empty site_id.
+            {"type": "gateway", "site_id": "s2", "id": "d4", "name": "n4"},  # WHY: kept (Unknown site).
+        ]
+        site_name_lookup = {"s1": "Alpha"}
+        result = _project_api_gateway_devices(devices, site_name_lookup)
+        assert result == [
+            ("s1", "d1", "n1", "Alpha"),
+            ("s2", "d4", "n4", UNKNOWN_SITE),
+        ]
+
+
+# -- GatewayExportUtils static methods ------------------------------------------------------
+
+
+class TestGatewayExportUtilsStaticMethods:
+    """Static methods orchestrate the DI-wired helpers we tested above."""
+
+    def test_with_site_info_delegates_to_org_inventory_exporter(self, tmp_path: Path) -> None:
+        """Single-line delegate forwards to OrgInventoryExporter.gateways_with_site_info."""
+        exporter = SimpleNamespace(inventory=MagicMock(), gateways_with_site_info=MagicMock())
+        bundle = _build_dependency_bundle(tmp_path, org_inventory_exporter=exporter)  # WHY: capture call.
+        configure_gateway_export_utils_dependencies(**bundle)
+        GatewayExportUtils._with_site_info()
+        exporter.gateways_with_site_info.assert_called_once()  # WHY: verify delegation.
+
+    def test_load_management_ip_csv_inputs_returns_none_when_file_missing(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """FileNotFoundError path returns None and logs the legacy error message."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        caplog.set_level(logging.ERROR)  # WHY: error log path exercised here.
+        assert GatewayExportUtils._load_management_ip_csv_inputs() is None  # WHY: no CSVs = None.
+        assert any("Required CSV file not found" in rec.getMessage() for rec in caplog.records)
+
+    def test_load_management_ip_csv_inputs_returns_all_four_tables(self, tmp_path: Path) -> None:
+        """Happy path returns a 4-tuple of tables in the fixed order."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        for name in (
+            "SiteList.csv",
+            "OrgGatewayTemplates.csv",
+            "GatewaysWithSiteInfo.csv",
+            "AllSiteGatewayConfigs.csv",
+        ):
+            _write_csv(tmp_path / name, ["id"], [{"id": name}])  # WHY: single-row deterministic content.
+        result = GatewayExportUtils._load_management_ip_csv_inputs()
+        assert result is not None  # WHY: happy path must not be None.
+        sites, templates, devices, configs = result
+        assert sites == [{"id": "SiteList.csv"}]  # WHY: verify order.
+        assert configs == [{"id": "AllSiteGatewayConfigs.csv"}]  # WHY: fourth slot preserved.
+
+    def test_build_management_ip_lookups_shapes_three_maps(self, tmp_path: Path) -> None:
+        """Lookups builder returns (site_lookup, template_lookup, mgmt_ip_lookup)."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        sites = [{"id": "s1", "name": "Site 1"}, {"id": "s2"}]  # WHY: two sites for lookup.
+        templates = [{"id": "t1", "name": "T1"}, {"id": "t2"}]  # WHY: legacy 'Unknown Template' fallback.
+        configs = [
+            {"name": "gw1", "gateway_mgmt_overlay_ip_ip": "10.1.1.1"},
+            {"name": "gw2"},  # WHY: missing mgmt IP yields empty string in lookup.
+        ]
+        site_lookup, template_lookup, mgmt_ip_lookup = GatewayExportUtils._build_management_ip_lookups(
+            sites, templates, configs
+        )
+        assert site_lookup["s1"] == {"id": "s1", "name": "Site 1"}  # WHY: full site preserved.
+        assert template_lookup["t1"] == "T1"  # WHY: id -> name mapping.
+        assert template_lookup["t2"] == "Unknown Template"  # WHY: legacy fallback for missing name.
+        assert mgmt_ip_lookup == {"gw1": "10.1.1.1", "gw2": ""}  # WHY: verify shape.
+
+    def test_build_management_ip_rows_counts_with_and_without_mgmt_ip(self, tmp_path: Path) -> None:
+        """Row builder returns (rows, total_count, with_mgmt_ip_count)."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        devices = [
+            {"name": "gw1", "site_id": "s1", "site_name": "S1", "connected": "true"},
+            {"name": "gw2", "site_id": "s2", "site_name": "S2", "connected": "false"},
+            {"name": "gw3", "site_id": "s3", "site_name": "S3", "connected": ""},
+        ]
+        site_lookup = {"s1": {"gatewaytemplate_id": "t1"}, "s2": {}, "s3": {}}
+        template_lookup = {"t1": "TplA"}
+        mgmt_ip_lookup = {"gw1": "10.0.0.1"}  # WHY: only gw1 has a mgmt IP.
+        rows, total, with_ip = GatewayExportUtils._build_management_ip_rows(
+            devices, site_lookup, template_lookup, mgmt_ip_lookup
+        )
+        assert total == 3  # WHY: three devices processed.
+        assert with_ip == 1  # WHY: only gw1 counted.
+        assert len(rows) == 3  # WHY: every device produces a row.
+
+    def test_prime_management_ip_caches_calls_check_and_generate_csv_four_times(self, tmp_path: Path) -> None:
+        """Cache-priming step refreshes all four CSVs via CacheUtils."""
+        cache_calls: list[str] = []  # WHY: capture names in call order.
+        bundle = _build_dependency_bundle(tmp_path)
+        bundle["cache_utils"] = SimpleNamespace(
+            check_and_generate_csv=MagicMock(side_effect=lambda name, fn: cache_calls.append(name))
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        GatewayExportUtils._prime_management_ip_caches(fast=False)
+        assert cache_calls == [
+            "SiteList.csv",
+            "OrgGatewayTemplates.csv",
+            "GatewaysWithSiteInfo.csv",
+            "AllSiteGatewayConfigs.csv",
+        ]
+
+    def test_finalise_management_ip_output_sorts_rows_and_writes_via_exporter(self, tmp_path: Path) -> None:
+        """Output rows are sorted then renamed and forwarded to DataExporter."""
+        writer = MagicMock()
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            data_exporter=SimpleNamespace(write_with_format_selection=writer),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        rows = [
+            {
+                "gateway_name": "gwB",
+                "gateway_template": "TplB",
+                "management_ip": "1.1.1.1",
+                "status": STATUS_ONLINE,
+                "site_name": "Site B",
+            },
+            {
+                "gateway_name": "gwA",
+                "gateway_template": "TplA",
+                "management_ip": "2.2.2.2",
+                "status": STATUS_OFFLINE,
+                "site_name": "Site A",
+            },
+        ]
+        GatewayExportUtils._finalise_management_ip_output(rows)
+        writer.assert_called_once()  # WHY: single write invocation.
+        renamed, filename = writer.call_args.args
+        assert filename == "GatewayManagementIPs.csv"  # WHY: legacy output filename.
+        assert renamed[0]["Gateway Template"] == "TplA"  # WHY: sorted by (template, name) ascending.
+        assert renamed[1]["Gateway Name"] == "gwB"  # WHY: TplB entry sorts second.
+
+    def test_emit_management_ip_summary_writes_completion_lines(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Summary emits legacy console lines and audit log entry."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        caplog.set_level(logging.INFO)  # WHY: audit line emitted at INFO.
+        GatewayExportUtils._emit_management_ip_summary(gateways_processed=5, gateways_with_mgmt_ip=3)
+        captured = capsys.readouterr().out  # WHY: assert on console output.
+        assert "Gateway management IP export completed" in captured  # WHY: banner headline.
+        assert "Total gateways processed: 5" in captured  # WHY: total line.
+        assert "Gateways without management IPs: 2" in captured  # WHY: derived arithmetic.
+        assert any("Gateway management IP export completed" in rec.getMessage() for rec in caplog.records)
+
+    def test_management_ips_returns_early_when_load_fails(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When _load_management_ip_csv_inputs returns None the outer flow exits without writing."""
+        writer = MagicMock()
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            data_exporter=SimpleNamespace(write_with_format_selection=writer),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        caplog.set_level(logging.ERROR)  # WHY: file-missing error surfaces at ERROR.
+        # NOTE: CSVs are deliberately not created so the loader returns None.
+        GatewayExportUtils.management_ips(fast=False)
+        writer.assert_not_called()  # WHY: no writes on early exit.
+
+    def test_management_ips_happy_path_writes_output(self, tmp_path: Path) -> None:
+        """End-to-end management_ips writes the final CSV via the DataExporter."""
+        writer = MagicMock()
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            data_exporter=SimpleNamespace(write_with_format_selection=writer),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        _write_csv(
+            tmp_path / "SiteList.csv",
+            ["id", "gatewaytemplate_id"],
+            [{"id": "s1", "gatewaytemplate_id": "t1"}],
+        )
+        _write_csv(tmp_path / "OrgGatewayTemplates.csv", ["id", "name"], [{"id": "t1", "name": "T1"}])
+        _write_csv(
+            tmp_path / "GatewaysWithSiteInfo.csv",
+            ["name", "site_id", "site_name", "connected"],
+            [{"name": "gw1", "site_id": "s1", "site_name": "S1", "connected": "true"}],
+        )
+        _write_csv(
+            tmp_path / "AllSiteGatewayConfigs.csv",
+            ["name", "gateway_mgmt_overlay_ip_ip"],
+            [{"name": "gw1", "gateway_mgmt_overlay_ip_ip": "10.9.9.9"}],
+        )
+        GatewayExportUtils.management_ips(fast=False)
+        writer.assert_called_once()  # WHY: single output write.
+        rows, filename = writer.call_args.args
+        assert filename == "GatewayManagementIPs.csv"  # WHY: legacy filename.
+        assert rows[0]["Gateway Name"] == "gw1"  # WHY: single gateway processed.
+        assert rows[0]["Management IP"] == "10.9.9.9"  # WHY: mgmt IP correlated.
+
+    def test_build_filtered_port_rows_projects_wan_columns(self, tmp_path: Path) -> None:
+        """Only rows with non-empty WAN ports are projected onto base + WAN column names."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        sanitized = [
+            {"mac": "aa", "name": "gw1", "port_config_ge-0/0/1_speed": "1G"},
+            {"mac": "bb", "name": "gw2", "port_config_ge-0/0/1_speed": ""},  # WHY: filtered out.
+        ]
+        rows = GatewayExportUtils._build_filtered_port_rows(sanitized)
+        assert len(rows) == 1  # WHY: only gw1 survives filter.
+        assert rows[0]["name"] == "gw1"  # WHY: base column preserved.
+        assert rows[0]["port_config_ge-0/0/1_speed"] == "1G"  # WHY: WAN column preserved.
+
+    def test_save_filtered_port_configs_writes_marker_when_empty(self, tmp_path: Path) -> None:
+        """Empty projection triggers the legacy marker file write path."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        GatewayExportUtils._save_filtered_port_configs([], debug=False)
+        marker = tmp_path / "FilteredGatewayPortConfigs.csv"
+        assert marker.exists()  # WHY: marker file must be created.
+
+    def test_save_filtered_port_configs_writes_via_data_exporter(self, tmp_path: Path) -> None:
+        """Non-empty projection forwards rows to DataExporter.write_with_format_selection."""
+        writer = MagicMock()
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            data_exporter=SimpleNamespace(write_with_format_selection=writer),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        rows = [{"name": "gw1", "port_config_ge-0/0/1_speed": "1G"}]  # WHY: non-empty set.
+        GatewayExportUtils._save_filtered_port_configs(rows, debug=True)  # WHY: also triggers sample log.
+        writer.assert_called_once_with(rows, "FilteredGatewayPortConfigs.csv")  # WHY: verify args.
+
+    def test_device_configs_returns_early_when_api_returns_nothing(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No data from API leaves DataExporter untouched and logs the legacy warning."""
+        writer = MagicMock()
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            api_fetch_utils=SimpleNamespace(gateway_device_configs=MagicMock(return_value=[])),
+            data_exporter=SimpleNamespace(write_with_format_selection=writer),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        caplog.set_level(logging.WARNING)  # WHY: no-data path emits a warning.
+        GatewayExportUtils.device_configs(debug=False, fast=False)
+        writer.assert_not_called()  # WHY: no writes on empty API response.
+
+    def test_device_configs_writes_full_and_filtered_when_data_present(self, tmp_path: Path) -> None:
+        """Happy path writes both AllSiteGatewayConfigs.csv and FilteredGatewayPortConfigs.csv."""
+        writer = MagicMock()
+        data = [{"mac": "aa", "name": "gw1", "port_config_ge-0/0/1_speed": "1G"}]  # WHY: 1 usable row.
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            api_fetch_utils=SimpleNamespace(gateway_device_configs=MagicMock(return_value=data)),
+            data_exporter=SimpleNamespace(write_with_format_selection=writer),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        GatewayExportUtils.device_configs(debug=False, fast=False)
+        assert writer.call_count == 2  # WHY: full + filtered writes.
+        first_args = writer.call_args_list[0].args
+        second_args = writer.call_args_list[1].args
+        assert first_args[1] == "AllSiteGatewayConfigs.csv"  # WHY: full write filename.
+        assert second_args[1] == "FilteredGatewayPortConfigs.csv"  # WHY: filtered write filename.
+
+    def test_templates_returns_early_when_no_templates(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Empty template list yields legacy warning log + operator message and no write."""
+        writer = MagicMock()
+        list_templates = MagicMock(return_value=SimpleNamespace(data=[]))
+        mistapi_module = ModuleType("mistapi_stub")
+        cast(Any, mistapi_module).api = SimpleNamespace(
+            v1=SimpleNamespace(
+                orgs=SimpleNamespace(gatewaytemplates=SimpleNamespace(listOrgGatewayTemplates=list_templates))
+            )
+        )
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            mistapi_dependency=mistapi_module,
+            data_exporter=SimpleNamespace(write_with_format_selection=writer),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        caplog.set_level(logging.WARNING)  # WHY: warn logged on empty template set.
+        GatewayExportUtils.templates()
+        writer.assert_not_called()  # WHY: no export when there are no templates.
+        captured = capsys.readouterr().out
+        assert "No gateway templates found" in captured  # WHY: legacy operator message.
+
+    def test_templates_writes_export_when_templates_present(self, tmp_path: Path) -> None:
+        """Happy path forwards flattened+escaped templates to DataExporter."""
+        writer = MagicMock()
+        templates_data = [{"id": "t1", "name": "TplA"}]  # WHY: 1 template.
+        list_templates = MagicMock(return_value=SimpleNamespace(data=templates_data))
+        mistapi_module = ModuleType("mistapi_stub")
+        cast(Any, mistapi_module).api = SimpleNamespace(
+            v1=SimpleNamespace(
+                orgs=SimpleNamespace(gatewaytemplates=SimpleNamespace(listOrgGatewayTemplates=list_templates))
+            )
+        )
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            mistapi_dependency=mistapi_module,
+            data_exporter=SimpleNamespace(write_with_format_selection=writer),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        GatewayExportUtils.templates()
+        writer.assert_called_once()  # WHY: single write.
+        _, filename = writer.call_args.args
+        assert filename == "OrgGatewayTemplates.csv"  # WHY: legacy filename preserved.
+
+    def test_get_devices_with_sites_uses_api_when_fast_false(self, tmp_path: Path) -> None:
+        """Non-fast path calls _get_devices_from_api and returns its output."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        expected = [("s1", "d1", "n1", "Alpha")]
+        with patch.object(GatewayExportUtils, "_get_devices_from_api", return_value=expected):
+            result = GatewayExportUtils._get_devices_with_sites("org-1", fast=False)
+        assert result == expected  # WHY: pass-through of API-path result.
+
+    def test_get_devices_from_api_uses_injected_fetchers(self, tmp_path: Path) -> None:
+        """API-path aggregates APICoreFetchUtils inventory + mistapi site lookup."""
+        inventory = [
+            {"type": "gateway", "site_id": "s1", "id": "d1", "name": "gw1"},
+            {"type": "switch", "site_id": "s1", "id": "d2"},  # WHY: filtered.
+        ]
+        list_org_sites = MagicMock(return_value=SimpleNamespace(data=[]))  # WHY: first-page response stub.
+        mistapi_module = ModuleType("mistapi_stub")
+        cast(Any, mistapi_module).api = SimpleNamespace(
+            v1=SimpleNamespace(orgs=SimpleNamespace(sites=SimpleNamespace(listOrgSites=list_org_sites)))
+        )
+        cast(Any, mistapi_module).get_all = MagicMock(return_value=[{"id": "s1", "name": "SiteA"}])
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            mistapi_dependency=mistapi_module,
+            api_core_fetch_utils=SimpleNamespace(all_inventory_with_limit=MagicMock(return_value=inventory)),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        result = GatewayExportUtils._get_devices_from_api("org-1")
+        assert result == [("s1", "d1", "gw1", "SiteA")]  # WHY: only the gateway row survives + resolved name.
+
+    def test_get_devices_from_cache_falls_back_to_api_on_missing_csv(self, tmp_path: Path) -> None:
+        """Missing cache CSVs trigger the except path which delegates to _get_devices_from_api."""
+        # WHY: no CSV files exist in tmp_path so open() will raise FileNotFoundError.
+        expected = [("s2", "d2", "gw2", "Beta")]
+        bundle = _build_dependency_bundle(tmp_path)
+        configure_gateway_export_utils_dependencies(**bundle)
+        with patch.object(GatewayExportUtils, "_get_devices_from_api", return_value=expected) as api_stub:
+            result = GatewayExportUtils._get_devices_from_cache()
+        assert result == expected  # WHY: fallback result propagated.
+        api_stub.assert_called_once_with("org-1")  # WHY: called with resolved org id.
+
+    def test_get_devices_from_cache_happy_path(self, tmp_path: Path) -> None:
+        """Present CSVs yield cache-driven projection with the injected exception guard bypassed."""
+        _write_csv(
+            tmp_path / "OrgInventory.csv",
+            ["type", "site_id", "id", "name"],
+            [{"type": "gateway", "site_id": "s1", "id": "d1", "name": "gw1"}],
+        )
+        _write_csv(tmp_path / "SiteList.csv", ["id", "name"], [{"id": "s1", "name": "Alpha"}])
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))
+        result = GatewayExportUtils._get_devices_from_cache()
+        assert result == [("s1", "d1", "gw1", "Alpha")]  # WHY: cache-driven projection succeeds.
+
+    def test_get_site_ids_with_devices_dedupes_gateway_sites(self, tmp_path: Path) -> None:
+        """Only distinct non-empty gateway site IDs are returned."""
+        inventory = [
+            {"type": "gateway", "site_id": "s1"},
+            {"type": "gateway", "site_id": "s1"},  # WHY: dedupe target.
+            {"type": "switch", "site_id": "s2"},  # WHY: filtered by type.
+            {"type": "gateway", "site_id": ""},  # WHY: filtered by empty.
+            {"type": "gateway", "site_id": "s3"},
+        ]
+        bundle = _build_dependency_bundle(
+            tmp_path,
+            api_core_fetch_utils=SimpleNamespace(all_inventory_with_limit=MagicMock(return_value=inventory)),
+        )
+        configure_gateway_export_utils_dependencies(**bundle)
+        result = GatewayExportUtils._get_site_ids_with_devices("org-1")
+        assert sorted(result) == ["s1", "s3"]  # WHY: dedupe + filter applied.
+
+    def test_with_wan_overrides_delegates_to_walker(self, tmp_path: Path) -> None:
+        """Static entry-point calls WanOverrideWalker.walk with the fast flag."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        from src.gateway.overrides import WanOverrideWalker  # WHY: explicit re-import from its true home.
+
+        with patch.object(WanOverrideWalker, "walk") as stub:
+            GatewayExportUtils.with_wan_overrides(fast=True)
+        stub.assert_called_once_with(fast=True)  # WHY: verify delegation + fast flag.
+
+    def test_wan2_variable_migration_invokes_migrator_execute(self, tmp_path: Path) -> None:
+        """Entry-point wires deps into GatewayWan2VariableMigrator and calls execute()."""
+        configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
+        import src.gateway.wan2_variable as wan2_module  # WHY: local import to allow patching.
+
+        captured: dict[str, Any] = {}
+
+        class _StubMigrator:
+            """Test double capturing constructor + execute() invocations."""
+
+            def __init__(self, deps: Any) -> None:
+                captured["deps"] = deps  # WHY: verify deps forwarded verbatim.
+
+            def execute(self, *, fast: bool, dry_run: bool) -> None:
+                captured["fast"] = fast  # WHY: verify fast flag pass-through.
+                captured["dry_run"] = dry_run  # WHY: verify dry_run flag pass-through.
+
+        with patch.object(wan2_module, "GatewayWan2VariableMigrator", _StubMigrator):
+            GatewayExportUtils.wan2_variable_migration(fast=True, dry_run=True)
+        assert captured["fast"] is True  # WHY: flag forwarded to migrator.
+        assert captured["dry_run"] is True  # WHY: flag forwarded to migrator.
+        assert captured["deps"].org_id == "org-1"  # WHY: config utils returned 'org-1' in bundle.


### PR DESCRIPTION
## Summary

Wave 11 of initiative #1018 lifts P2 coverage by adding branch-complete unit tests for two orchestrator modules in the 100-400 stmt sweet spot.

- **src/auth/interactive/login_orchestrator.py**: full coverage of `LoginOrchestrator` including all `execute` branches, `_resolve_mistapi` fallback paths, `_authenticate` exception dispatch, 2FA handling, session timeout wiring, MSP privilege announcement, and every error-classification helper.
- **src/gateway/gateway_export_utils.py**: full coverage of `GatewayExportUtils` static orchestrator methods, management-IP pipeline, WAN port filtering, template exports, cache/API device fetching, and `WanOverrideWalker` delegation.

## Delta

- Baseline (without new tests): **85.51%**
- Final (with new tests):       **86.18%**
- **Delta: +0.67 pp** (exceeds +0.50 pp target)

## Quality Gates

- ruff check: clean
- mypy --strict: clean (no new suppressions)
- pytest: 5199 passed (122 new tests)
- MistHelper.py: untouched
- pyproject.toml: untouched
- No new suppressions

## Test plan

- [x] All 122 new tests pass locally
- [x] Full unit suite (5199 tests) passes
- [x] ruff/mypy strict green on both new files
- [x] Coverage delta measured against branch baseline