### PR TITLE
test(878): Wave 4 - un-omit wired_client_manufacturer_report_generator.py + 21 tests (100% cov)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,7 +280,6 @@ omit = [
     "src/reports/global_wired_client_report_generator.py",
     "src/reports/offline_device_reporter.py",
     "src/reports/sfp_transceiver_data_processor.py",
-    "src/reports/wired_client_manufacturer_report_generator.py",
     "src/site/bulk_radius_wlan_config_manager.py",
     "src/ssh/cli_shell_manager.py",
     "src/ui/prompt_utils.py",

--- a/tests/unit/reports/test_wired_client_manufacturer_report_generator.py
+++ b/tests/unit/reports/test_wired_client_manufacturer_report_generator.py
@@ -1,0 +1,320 @@
+"""Unit tests for WiredClientManufacturerReportGenerator (issue #878 tranche 4 -- un-omit).
+
+Covers all nine static methods on ``src.reports.wired_client_manufacturer_report_generator``:
+``execute`` (three flow branches: no records, records but no selection, records +
+selection), ``_fetch_all_clients`` (happy path + exception path),
+``_build_manufacturer_summary`` (counting, "Unknown" fallback, alphabetical
+sort), ``_print_manufacturer_table``, ``_parse_manufacturer_choice`` (empty /
+non-numeric / in-range / out-of-range), ``_prompt_selection``,
+``_filter_by_manufacturer`` (empty filter + match + case-insensitive),
+``_build_filename`` (ALL slug + slugified manufacturer + truncation), and
+``_write_outputs`` (empty vs non-empty pipeline).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.reports.wired_client_manufacturer_report_generator import (
+    WiredClientManufacturerReportGenerator as R,
+)
+
+
+def _make_mh(**extra):
+    """Assemble a stub MistHelper module with the attributes each method touches."""
+    defaults = {
+        "ConfigUtils": MagicMock(name="ConfigUtils"),
+        "InputUtils": MagicMock(name="InputUtils"),
+        "DataExporter": MagicMock(name="DataExporter"),
+        "apisession": MagicMock(name="apisession"),
+    }
+    defaults.update(extra)
+    return SimpleNamespace(**defaults)
+
+
+# ---------- execute ----------
+
+
+def test_execute_aborts_when_no_records(capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty fetch -> warning + user notice, no exports invoked."""
+    fake_mh = _make_mh()
+    fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-uuid"
+    with (
+        patch(
+            "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+            return_value=fake_mh,
+        ),
+        patch.object(R, "_fetch_all_clients", return_value=[]),
+        patch.object(R, "_write_outputs") as write_outputs,
+    ):
+        R.execute()
+    write_outputs.assert_not_called()
+    assert "No wired clients found" in capsys.readouterr().out
+
+
+def test_execute_writes_all_only_when_selection_skipped() -> None:
+    """When user skips the picker only the ALL export runs."""
+    fake_mh = _make_mh()
+    fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-uuid"
+    records = [{"manufacture": "Cisco"}]
+    with (
+        patch(
+            "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+            return_value=fake_mh,
+        ),
+        patch.object(R, "_fetch_all_clients", return_value=records),
+        patch.object(R, "_prompt_selection", return_value=None),
+        patch.object(R, "_write_outputs") as write_outputs,
+    ):
+        R.execute()
+    write_outputs.assert_called_once_with(records, "")
+
+
+def test_execute_writes_all_and_filtered_when_manufacturer_selected() -> None:
+    """When user picks a manufacturer both ALL and filtered exports run."""
+    fake_mh = _make_mh()
+    fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-uuid"
+    records = [{"manufacture": "Cisco"}, {"manufacture": "Juniper"}]
+    filtered = [{"manufacture": "Cisco"}]
+    with (
+        patch(
+            "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+            return_value=fake_mh,
+        ),
+        patch.object(R, "_fetch_all_clients", return_value=records),
+        patch.object(R, "_prompt_selection", return_value="Cisco"),
+        patch.object(R, "_filter_by_manufacturer", return_value=filtered) as filter_call,
+        patch.object(R, "_write_outputs") as write_outputs,
+    ):
+        R.execute()
+    filter_call.assert_called_once_with(records, "Cisco")
+    assert write_outputs.call_args_list[0].args == (records, "")
+    assert write_outputs.call_args_list[1].args == (filtered, "Cisco")
+
+
+# ---------- _fetch_all_clients ----------
+
+
+def test_fetch_all_clients_returns_paginated_records() -> None:
+    """Happy path: searchOrgWiredClients + get_all return the paginated list."""
+    fake_mh = _make_mh()
+    fake_response = MagicMock(name="searchResp")
+    fake_mistapi = MagicMock(name="mistapi")
+    fake_mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients.return_value = fake_response
+    fake_mistapi.get_all.return_value = [{"mac": "aa"}]
+    with (
+        patch("src.reports.wired_client_manufacturer_report_generator.mistapi", fake_mistapi),
+        patch(
+            "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+            return_value=fake_mh,
+        ),
+    ):
+        result = R._fetch_all_clients("org-uuid")
+    fake_mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients.assert_called_once_with(
+        fake_mh.apisession, "org-uuid", limit=1000
+    )
+    fake_mistapi.get_all.assert_called_once_with(response=fake_response, mist_session=fake_mh.apisession)
+    assert result == [{"mac": "aa"}]
+
+
+def test_fetch_all_clients_defaults_none_pagination_to_empty_list() -> None:
+    """get_all returning None (no pages) must yield an empty list."""
+    fake_mh = _make_mh()
+    fake_mistapi = MagicMock(name="mistapi")
+    fake_mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients.return_value = MagicMock()
+    fake_mistapi.get_all.return_value = None
+    with (
+        patch("src.reports.wired_client_manufacturer_report_generator.mistapi", fake_mistapi),
+        patch(
+            "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+            return_value=fake_mh,
+        ),
+    ):
+        assert R._fetch_all_clients("org-uuid") == []
+
+
+def test_fetch_all_clients_returns_empty_on_api_exception(capsys: pytest.CaptureFixture[str]) -> None:
+    """API failure logs + prints and returns an empty list (no re-raise)."""
+    fake_mh = _make_mh()
+    fake_mistapi = MagicMock(name="mistapi")
+    fake_mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients.side_effect = RuntimeError("boom")
+    with (
+        patch("src.reports.wired_client_manufacturer_report_generator.mistapi", fake_mistapi),
+        patch(
+            "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+            return_value=fake_mh,
+        ),
+    ):
+        assert R._fetch_all_clients("org-uuid") == []
+    assert "Error retrieving wired clients" in capsys.readouterr().out
+
+
+# ---------- _build_manufacturer_summary ----------
+
+
+def test_build_manufacturer_summary_counts_and_sorts_alphabetically() -> None:
+    """Records are grouped, counted, and returned sorted case-insensitively."""
+    records = [
+        {"manufacture": "Cisco"},
+        {"manufacture": "Juniper"},
+        {"manufacture": "Cisco"},
+        {"manufacture": "arista"},
+    ]
+    summary = R._build_manufacturer_summary(records)
+    assert summary == [("arista", 1), ("Cisco", 2), ("Juniper", 1)]
+
+
+def test_build_manufacturer_summary_uses_unknown_for_missing_or_empty() -> None:
+    """Missing/None/empty manufacturer values collapse into 'Unknown'."""
+    records = [
+        {"manufacture": None},
+        {"manufacture": ""},
+        {},
+    ]
+    assert R._build_manufacturer_summary(records) == [("Unknown", 3)]
+
+
+# ---------- _print_manufacturer_table ----------
+
+
+def test_print_manufacturer_table_renders_totals_and_rows(capsys: pytest.CaptureFixture[str]) -> None:
+    """Header shows totals; rows list each manufacturer with count."""
+    R._print_manufacturer_table([("Cisco", 3), ("Juniper", 1)])
+    output = capsys.readouterr().out
+    assert "Found 4 clients from 2 manufacturers" in output
+    assert "Cisco" in output
+    assert "Juniper" in output
+
+
+def test_print_manufacturer_table_truncates_long_names(capsys: pytest.CaptureFixture[str]) -> None:
+    """Names longer than 44 characters are truncated for column alignment."""
+    long_name = "X" * 60
+    R._print_manufacturer_table([(long_name, 1)])
+    output = capsys.readouterr().out
+    assert "X" * 44 in output
+    assert "X" * 45 not in output
+
+
+# ---------- _parse_manufacturer_choice ----------
+
+
+def test_parse_manufacturer_choice_returns_none_for_empty_input() -> None:
+    """Empty input maps to None (no filter)."""
+    assert R._parse_manufacturer_choice("", [("Cisco", 1)]) is None
+
+
+def test_parse_manufacturer_choice_returns_none_for_non_numeric(capsys: pytest.CaptureFixture[str]) -> None:
+    """Non-numeric input prints an error and returns None."""
+    assert R._parse_manufacturer_choice("abc", [("Cisco", 1)]) is None
+    assert "Invalid selection" in capsys.readouterr().out
+
+
+def test_parse_manufacturer_choice_returns_selected_name_for_valid_index() -> None:
+    """A 1-based index within range returns the manufacturer name."""
+    summary = [("Cisco", 1), ("Juniper", 2)]
+    assert R._parse_manufacturer_choice("2", summary) == "Juniper"
+
+
+def test_parse_manufacturer_choice_returns_none_when_out_of_range(capsys: pytest.CaptureFixture[str]) -> None:
+    """Out-of-range indexes print an error and return None."""
+    assert R._parse_manufacturer_choice("99", [("Cisco", 1)]) is None
+    assert "out of range" in capsys.readouterr().out
+
+
+# ---------- _prompt_selection ----------
+
+
+def test_prompt_selection_delegates_to_input_utils_and_parses_choice() -> None:
+    """Prompt invokes InputUtils.safe_input then routes the choice through the parser."""
+    fake_mh = _make_mh()
+    fake_mh.InputUtils.safe_input.return_value = "1"
+    summary = [("Cisco", 1)]
+    with patch(
+        "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+        return_value=fake_mh,
+    ):
+        assert R._prompt_selection(summary) == "Cisco"
+    fake_mh.InputUtils.safe_input.assert_called_once()
+
+
+# ---------- _filter_by_manufacturer ----------
+
+
+def test_filter_by_manufacturer_returns_all_when_manufacturer_is_empty() -> None:
+    """An empty selection means 'no filter': the original list is returned."""
+    records = [{"manufacture": "Cisco"}, {"manufacture": "Juniper"}]
+    assert R._filter_by_manufacturer(records, "") is records
+
+
+def test_filter_by_manufacturer_matches_case_insensitively() -> None:
+    """Comparison is case-insensitive on the normalized manufacture field."""
+    records = [
+        {"manufacture": "Cisco"},
+        {"manufacture": "CISCO"},
+        {"manufacture": "Juniper"},
+        {"manufacture": None},
+    ]
+    assert R._filter_by_manufacturer(records, "cisco") == [
+        {"manufacture": "Cisco"},
+        {"manufacture": "CISCO"},
+    ]
+
+
+# ---------- _build_filename ----------
+
+
+def test_build_filename_uses_all_slug_when_no_manufacturer() -> None:
+    """Empty manufacturer -> 'ALL' slug."""
+    assert R._build_filename("") == "WiredClientManufacturerReport_ALL"
+
+
+def test_build_filename_slugifies_and_truncates_manufacturer() -> None:
+    """Non-word characters collapse to underscores; slug truncates at 40 chars."""
+    name = "Cisco Systems, Inc. " + ("X" * 60)
+    filename = R._build_filename(name)
+    assert filename.startswith("WiredClientManufacturerReport_Cisco_Systems_Inc_")
+    slug = filename.removeprefix("WiredClientManufacturerReport_")
+    assert len(slug) <= 40
+
+
+# ---------- _write_outputs ----------
+
+
+def test_write_outputs_writes_empty_list_when_no_records() -> None:
+    """Empty filtered list skips the flatten/escape pipeline but still writes."""
+    fake_mh = _make_mh()
+    with (
+        patch("src.reports.wired_client_manufacturer_report_generator.DataProcessingUtils") as fake_dpu,
+        patch(
+            "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+            return_value=fake_mh,
+        ),
+    ):
+        R._write_outputs([], "Cisco")
+    fake_dpu.flatten_nested_fields.assert_not_called()
+    fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(
+        [], "WiredClientManufacturerReport_Cisco", api_function_name="wiredClientManufacturerReport"
+    )
+
+
+def test_write_outputs_runs_pipeline_and_writes_when_records_present() -> None:
+    """Non-empty list flows through flatten -> escape_multiline -> write."""
+    fake_mh = _make_mh()
+    with (
+        patch("src.reports.wired_client_manufacturer_report_generator.DataProcessingUtils") as fake_dpu,
+        patch(
+            "src.reports.wired_client_manufacturer_report_generator.importlib.import_module",
+            return_value=fake_mh,
+        ),
+    ):
+        fake_dpu.flatten_nested_fields.return_value = [{"flat": True}]
+        fake_dpu.escape_multiline.return_value = [{"safe": True}]
+        R._write_outputs([{"mac": "aa"}], "")
+    fake_dpu.flatten_nested_fields.assert_called_once_with([{"mac": "aa"}])
+    fake_dpu.escape_multiline.assert_called_once_with([{"flat": True}])
+    fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(
+        [{"safe": True}], "WiredClientManufacturerReport_ALL", api_function_name="wiredClientManufacturerReport"
+    )


### PR DESCRIPTION
## Summary

Tranche 4 of #878. Removes `src/reports/wired_client_manufacturer_report_generator.py` from `[tool.coverage.run].omit` and lands 21 unit tests achieving 100% coverage (102/102 statements).

## Coverage delta
- Module: `src/reports/wired_client_manufacturer_report_generator.py`
- Before: excluded via `omit`
- After: 100% (21 tests, all nine static methods and every conditional branch)

## Tests added
Nine static methods, all branches:
- `execute` - no-records / no-selection / manufacturer-selected
- `_fetch_all_clients` - happy path / None-defaults-to-empty / exception
- `_build_manufacturer_summary` - count+sort / Unknown fallback for None/empty/missing
- `_print_manufacturer_table` - totals+rows / 44-char truncation
- `_parse_manufacturer_choice` - empty / non-numeric / valid / out-of-range
- `_prompt_selection` - safe_input + parse
- `_filter_by_manufacturer` - empty=no filter / case-insensitive match
- `_build_filename` - ALL slug / slugify+truncate
- `_write_outputs` - empty skip pipeline / non-empty full pipeline

## Test plan
- [x] `pytest tests/unit/reports/test_wired_client_manufacturer_report_generator.py --cov=src.reports.wired_client_manufacturer_report_generator` -> 21 passed, 100% coverage
- [x] `ruff check` clean
- [x] `black --check` clean

Relates to #878.