### PR TITLE
test(878): un-omit src/websocket/context.py + __init__ modules (100% cov)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,17 @@ omit = [
     "*/site-packages/*",
     "src/maps/*",
     "src/firmware/firmware_manager.py",
-    "src/websocket/*"
+    "src/websocket/commands.py",
+    "src/websocket/manager.py",
+    "src/websocket/service_ping_discovery.py",
+    "src/websocket/service_ping_manager.py",
+    "src/websocket/diagnostics/arp_executor.py",
+    "src/websocket/diagnostics/common.py",
+    "src/websocket/diagnostics/ping_executor.py",
+    "src/websocket/polling/completion_detector.py",
+    "src/websocket/polling/message_router.py",
+    "src/websocket/polling/result_collector.py",
+    "src/websocket/polling/result_combiner.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary
- Replace the `src/websocket/*` wildcard in `[tool.coverage.run].omit` with an explicit list of the remaining uncovered files
- Result: `src/websocket/context.py` (dataclass-only container) and the empty subpackage `__init__` modules become measured and are already at 100% line + branch coverage on mere import — no new tests needed

Part of #878.

## Test plan
- [x] `pytest tests/ --cov=src.websocket.context --cov-branch` → 100% cov (12/12 stmts, 0 branches)
- [x] Full test suite still passes (7616 passed)