### PR TITLE
test(878): un-omit firmware/firmware_manager.py + 678 tests (100% cov)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,7 +251,6 @@ omit = [
     "setup.py",
     "*/site-packages/*",
     "src/maps/*",
-    "src/firmware/firmware_manager.py",
 ]
 
 [tool.coverage.report]

--- a/tests/unit/firmware/__init__.py
+++ b/tests/unit/firmware/__init__.py
@@ -1,0 +1,8 @@
+"""Unit tests for the ``src.firmware`` package.
+
+Why:
+    Groups all firmware-manager coverage tests (issue #878 tranche 38).
+    Split into per-topic modules so no single file exceeds the 1500-line
+    project soft-cap and each concern (config, version, MSP, SSR,
+    status-checker, etc.) can be exercised independently.
+"""

--- a/tests/unit/firmware/test_firmware_manager_ap_msp.py
+++ b/tests/unit/firmware/test_firmware_manager_ap_msp.py
@@ -1,0 +1,1433 @@
+"""AP mode dispatch + MSP multi-org upgrade unit tests.
+
+Why:
+    The MSP orchestrator is the largest branchy surface in the module and
+    the only place where module-global ``msp_privileges``/``apisession``/
+    ``org_id`` get mutated mid-flow. If the MSP guard regresses, single-org
+    upgrade menus can silently offer an inaccessible "MSP" option; if
+    selection parsing regresses, an operator's ``1,3,5-7`` picker string
+    can silently drop indices. Every helper on the MSP path therefore has
+    to stay pinned with an executable spec.
+"""
+
+from __future__ import annotations
+
+import logging
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.firmware.firmware_manager as fm_mod
+from src.firmware.firmware_manager import FirmwareManager, FirmwareManagerConfig
+
+# ---------------------------------------------------------------------------
+# Shared factory + snapshot helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(**overrides: Any) -> FirmwareManager:
+    """Build a ``FirmwareManager`` with a valid minimum config.
+
+    Why:
+        Every test needs a live manager; centralising the factory removes
+        boilerplate and lets each test body focus on the branch it drives.
+
+    Args:
+        **overrides: Any config field to override on the underlying
+            ``FirmwareManagerConfig``.
+
+    Returns:
+        A live ``FirmwareManager`` bound to the current module state.
+    """
+    defaults: dict[str, Any] = {"apisession": object(), "org_id": "org-test"}
+    defaults.update(overrides)
+    return FirmwareManager(FirmwareManagerConfig(**defaults))
+
+
+def _snapshot_msp() -> list[Any]:
+    """Snapshot module-global ``msp_privileges`` for later restore.
+
+    Why:
+        MSP helpers read the module global directly; tests must not leak
+        state across test functions or ``_is_msp_mode_available`` etc. will
+        misbehave for the next test.
+
+    Returns:
+        Deep-enough copy of the current ``msp_privileges`` list.
+    """
+    return list(fm_mod.msp_privileges)
+
+
+def _restore_msp(snap: list[Any]) -> None:
+    """Restore module-global ``msp_privileges`` from a prior snapshot.
+
+    Args:
+        snap: Value returned by :func:`_snapshot_msp`.
+    """
+    fm_mod.msp_privileges = snap
+
+
+def _snapshot_session() -> tuple[Any, str]:
+    """Snapshot module-global ``apisession`` and ``org_id`` together.
+
+    Why:
+        MSP execution mutates the module ``org_id`` mid-flow; forgetting
+        to restore leaks between tests and breaks other suites that read
+        it later.
+
+    Returns:
+        Tuple of (apisession, org_id).
+    """
+    return fm_mod.apisession, fm_mod.org_id
+
+
+def _restore_session(snap: tuple[Any, str]) -> None:
+    """Restore module-global session/org state from a prior snapshot.
+
+    Args:
+        snap: Value returned by :func:`_snapshot_session`.
+    """
+    fm_mod.apisession, fm_mod.org_id = snap
+
+
+# ---------------------------------------------------------------------------
+# AP mode dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestIsMspModeAvailable:
+    """``_is_msp_mode_available`` reads module-global cache.
+
+    Why:
+        The AP mode menu conditionally renders option 3 based on this
+        flag; a false negative silently hides the MSP branch from
+        operators with valid privileges.
+    """
+
+    def test_empty_msp_list_returns_false(self) -> None:
+        mgr = _make_manager()  # WHY: construct first — init rebinds globals
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = []
+            assert mgr._is_msp_mode_available() is False
+        finally:
+            _restore_msp(snap)
+
+    def test_populated_list_returns_true(self) -> None:
+        mgr = _make_manager()  # WHY: construct first — init rebinds globals
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "m1", "msp_name": "One"}]
+            assert mgr._is_msp_mode_available() is True
+        finally:
+            _restore_msp(snap)
+
+
+class TestPrintApUpgradeBanner:
+    """``_print_ap_upgrade_banner`` renders title + underline."""
+
+    def test_prints_title_and_underline(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ap_upgrade_banner()
+        out = capsys.readouterr().out
+        assert "Advanced AP Firmware Upgrade" in out
+        assert "=" * 60 in out
+
+
+class TestRenderApModeMenu:
+    """``_render_ap_mode_menu`` returns choices tuple based on MSP flag."""
+
+    def test_two_option_menu_no_msp(self, capsys: pytest.CaptureFixture[str]) -> None:
+        choices, prompt = _make_manager()._render_ap_mode_menu(msp_mode_available=False)
+        assert choices == ["1", "2"]
+        assert "1-2" in prompt
+        out = capsys.readouterr().out
+        assert "By Site" in out
+        assert "By Gateway Template" in out
+        assert "MSP Multi-Org" not in out
+
+    def test_three_option_menu_with_msp(self, capsys: pytest.CaptureFixture[str]) -> None:
+        choices, prompt = _make_manager()._render_ap_mode_menu(msp_mode_available=True)
+        assert choices == ["1", "2", "3"]
+        assert "1-3" in prompt
+        assert "MSP Multi-Org" in capsys.readouterr().out
+
+
+class TestPromptApUpgradeMode:
+    """``_prompt_ap_upgrade_mode`` retries invalid tokens; None on Ctrl-C."""
+
+    def test_returns_valid_choice_first_try(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "2")
+        assert mgr._prompt_ap_upgrade_mode("? ", ["1", "2"]) == "2"
+
+    def test_retries_until_valid(self, capsys: pytest.CaptureFixture[str]) -> None:
+        answers = iter(["9", "abc", "1"])
+
+        def fake_input(*_a: Any, **_k: Any) -> str:
+            return next(answers)
+
+        mgr = _make_manager(safe_input_fn=fake_input)
+        assert mgr._prompt_ap_upgrade_mode("? ", ["1", "2"]) == "1"
+        out = capsys.readouterr().out
+        assert out.count("Invalid selection") == 2
+
+    def test_keyboard_interrupt_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        def raise_kbint(*_a: Any, **_k: Any) -> str:
+            raise KeyboardInterrupt
+
+        mgr = _make_manager(safe_input_fn=raise_kbint)
+        assert mgr._prompt_ap_upgrade_mode("? ", ["1", "2"]) is None
+        assert "cancelled by user" in capsys.readouterr().out
+
+
+class TestDispatchApUpgradeMode:
+    """``_dispatch_ap_upgrade_mode`` routes 1/2/3 to correct flows."""
+
+    def test_mode_1_calls_bulk_upgrade(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_bulk_upgrade_ap_firmware_by_site", called)
+        assert mgr._dispatch_ap_upgrade_mode("1") is None
+        called.assert_called_once_with()
+
+    def test_mode_2_calls_template_flow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_upgrade_ap_firmware_by_gateway_template", called)
+        assert mgr._dispatch_ap_upgrade_mode("2") is None
+        called.assert_called_once_with()
+
+    def test_mode_3_calls_msp_orchestrator(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        expected = [{"org": "x"}]
+        monkeypatch.setattr(mgr, "_execute_msp_multi_org_upgrade", lambda: expected)
+        assert mgr._dispatch_ap_upgrade_mode("3") is expected
+
+
+# ---------------------------------------------------------------------------
+# Selection input parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseRangeBounds:
+    """``_parse_range_bounds`` normalises range tokens to 0-based (start,end)."""
+
+    def test_valid_ascending(self) -> None:
+        assert _make_manager()._parse_range_bounds("1-5") == (0, 4)
+
+    def test_valid_reversed(self) -> None:
+        # Reversed bounds must swap to normalise order.
+        assert _make_manager()._parse_range_bounds("5-1") == (0, 4)
+
+    def test_whitespace_tolerated(self) -> None:
+        assert _make_manager()._parse_range_bounds(" 2 - 4 ") == (1, 3)
+
+    def test_too_many_parts_returns_none(self) -> None:
+        assert _make_manager()._parse_range_bounds("1-2-3") is None
+
+    def test_non_numeric_returns_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.WARNING, logger="root")
+        assert _make_manager()._parse_range_bounds("a-b") is None
+        assert any("Invalid range format" in r.message for r in caplog.records)
+
+
+class TestAppendIndexIfValid:
+    """``_append_index_if_valid`` bounds/dedupe gate."""
+
+    def test_valid_index_appended(self) -> None:
+        acc: list[int] = []
+        _make_manager()._append_index_if_valid(3, 10, acc)
+        assert acc == [3]
+
+    def test_duplicate_not_appended(self) -> None:
+        acc = [3]
+        _make_manager()._append_index_if_valid(3, 10, acc)
+        assert acc == [3]
+
+    def test_negative_ignored_silently(self, capsys: pytest.CaptureFixture[str]) -> None:
+        acc: list[int] = []
+        _make_manager()._append_index_if_valid(-1, 10, acc)
+        assert acc == []
+        # Negative branch neither appends nor warns.
+        assert capsys.readouterr().out == ""
+
+    def test_overflow_prints_hint(self, capsys: pytest.CaptureFixture[str]) -> None:
+        acc: list[int] = []
+        _make_manager()._append_index_if_valid(11, 10, acc)
+        assert acc == []
+        assert "out of range" in capsys.readouterr().out
+
+
+class TestParseRangeToken:
+    """``_parse_range_token`` expands a range into indices."""
+
+    def test_expands_inclusive_range(self) -> None:
+        acc: list[int] = []
+        _make_manager()._parse_range_token("2-4", 10, acc)
+        assert acc == [1, 2, 3]
+
+    def test_invalid_bounds_no_op(self) -> None:
+        acc: list[int] = []
+        _make_manager()._parse_range_token("x-y", 10, acc)
+        assert acc == []
+
+
+class TestParseSingleToken:
+    """``_parse_single_token`` appends valid single index."""
+
+    def test_valid_index(self) -> None:
+        acc: list[int] = []
+        _make_manager()._parse_single_token("3", 10, acc)
+        assert acc == [2]
+
+    def test_invalid_index_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.WARNING, logger="root")
+        acc: list[int] = []
+        _make_manager()._parse_single_token("abc", 10, acc)
+        assert acc == []
+        assert any("Invalid index" in r.message for r in caplog.records)
+
+
+class TestParseSelectionInput:
+    """Integration: ``_parse_selection_input`` handles combined tokens."""
+
+    def test_single_index(self) -> None:
+        assert _make_manager()._parse_selection_input("3", 10) == [2]
+
+    def test_csv_indices(self) -> None:
+        assert _make_manager()._parse_selection_input("1,3,5", 10) == [0, 2, 4]
+
+    def test_dash_range(self) -> None:
+        assert _make_manager()._parse_selection_input("2-4", 10) == [1, 2, 3]
+
+    def test_through_range(self) -> None:
+        assert _make_manager()._parse_selection_input("2 through 4", 10) == [1, 2, 3]
+
+    def test_mixed_csv_and_range(self) -> None:
+        assert _make_manager()._parse_selection_input("1,3-5,8", 10) == [0, 2, 3, 4, 7]
+
+    def test_sorted_and_deduped(self) -> None:
+        assert _make_manager()._parse_selection_input("5,1,3,1", 10) == [0, 2, 4]
+
+    def test_out_of_range_dropped(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert _make_manager()._parse_selection_input("15", 10) == []
+        assert "out of range" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# MSP selection prompt path
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSelectSingleMsp:
+    """``_auto_select_single_msp`` returns sole MSP and previews."""
+
+    def test_returns_and_previews(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "m1", "msp_name": "Acme"}]
+            result = mgr._auto_select_single_msp()
+            assert result[0]["msp_id"] == "m1"
+            assert "Single MSP available: Acme" in capsys.readouterr().out
+        finally:
+            _restore_msp(snap)
+
+
+class TestDisplayMspsForSelection:
+    """``_display_msps_for_selection`` renders numbered MSP list + help."""
+
+    def test_lists_msps_and_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [
+                {"msp_name": "One", "role": "admin"},
+                {"msp_name": "Two", "role": "read"},
+            ]
+            mgr._display_msps_for_selection()
+            out = capsys.readouterr().out
+            assert "Available MSPs" in out
+            assert "One (role: admin)" in out
+            assert "Two (role: read)" in out
+            assert "Selection options" in out
+        finally:
+            _restore_msp(snap)
+
+    def test_missing_fields_use_defaults(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{}]
+            mgr._display_msps_for_selection()
+            out = capsys.readouterr().out
+            assert "Unknown (role: unknown)" in out
+        finally:
+            _restore_msp(snap)
+
+
+class TestPromptMspSelectionInput:
+    """``_prompt_msp_selection_input`` normalises operator tokens."""
+
+    def test_returns_lowercased_stripped(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "  1,3  ")
+        assert mgr._prompt_msp_selection_input() == "1,3"
+
+    def test_q_returns_none(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "Q")
+        assert mgr._prompt_msp_selection_input() is None
+
+    def test_empty_returns_none(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "")
+        assert mgr._prompt_msp_selection_input() is None
+
+    def test_system_exit_returns_none(self) -> None:
+        def raise_sysexit(*_a: Any, **_k: Any) -> str:
+            raise SystemExit
+
+        mgr = _make_manager(safe_input_fn=raise_sysexit)
+        assert mgr._prompt_msp_selection_input() is None
+
+
+class TestResolveMspSelection:
+    """``_resolve_msp_selection`` maps tokens to MSP dicts."""
+
+    def test_all_returns_full_list(self) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "a"}, {"msp_id": "b"}]
+            result = mgr._resolve_msp_selection("all")
+            assert result == [{"msp_id": "a"}, {"msp_id": "b"}]
+        finally:
+            _restore_msp(snap)
+
+    def test_indices_return_picks(self) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "a"}, {"msp_id": "b"}, {"msp_id": "c"}]
+            result = mgr._resolve_msp_selection("1,3")
+            assert result == [{"msp_id": "a"}, {"msp_id": "c"}]
+        finally:
+            _restore_msp(snap)
+
+    def test_invalid_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "a"}]
+            assert mgr._resolve_msp_selection("nope") is None
+            assert "Invalid selection" in capsys.readouterr().out
+        finally:
+            _restore_msp(snap)
+
+
+class TestSelectMspsForUpgrade:
+    """``_select_msps_for_upgrade`` orchestrates the picker path."""
+
+    def test_no_msps_returns_none(self) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = []
+            assert mgr._select_msps_for_upgrade() is None
+        finally:
+            _restore_msp(snap)
+
+    def test_single_msp_auto_selected(self) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "one", "msp_name": "Only"}]
+            result = mgr._select_msps_for_upgrade()
+            assert result is not None
+            assert result[0]["msp_id"] == "one"
+        finally:
+            _restore_msp(snap)
+
+    def test_cancelled_prompt_returns_none(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "q")
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "a"}, {"msp_id": "b"}]
+            assert mgr._select_msps_for_upgrade() is None
+        finally:
+            _restore_msp(snap)
+
+    def test_multi_select_returns_picks(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "2")
+        snap = _snapshot_msp()
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "a"}, {"msp_id": "b"}]
+            result = mgr._select_msps_for_upgrade()
+            assert result == [{"msp_id": "b"}]
+        finally:
+            _restore_msp(snap)
+
+
+class TestSelectMspForUpgradeDeprecated:
+    """Deprecated single-MSP shim ``_select_msp_for_upgrade``."""
+
+    def test_returns_first_msp_dict_when_singleton(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_msps_for_upgrade", lambda: [{"msp_id": "only"}])
+        assert mgr._select_msp_for_upgrade() == {"msp_id": "only"}
+
+    def test_returns_none_when_multiple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_msps_for_upgrade", lambda: [{"msp_id": "a"}, {"msp_id": "b"}])
+        assert mgr._select_msp_for_upgrade() is None
+
+    def test_returns_none_on_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_msps_for_upgrade", lambda: None)
+        assert mgr._select_msp_for_upgrade() is None
+
+
+# ---------------------------------------------------------------------------
+# API response coercion + MSP org fetch
+# ---------------------------------------------------------------------------
+
+
+class TestExtractResponseList:
+    """``_extract_response_list`` coerces API responses to list or None."""
+
+    def test_none_response(self) -> None:
+        assert _make_manager()._extract_response_list(None) is None
+
+    def test_empty_data(self) -> None:
+        resp = types.SimpleNamespace(data=[])
+        assert _make_manager()._extract_response_list(resp) is None
+
+    def test_missing_data_attr(self) -> None:
+        assert _make_manager()._extract_response_list(object()) is None
+
+    def test_list_data_passthrough(self) -> None:
+        resp = types.SimpleNamespace(data=[{"a": 1}])
+        assert _make_manager()._extract_response_list(resp) == [{"a": 1}]
+
+    def test_single_dict_wrapped_in_list(self) -> None:
+        resp = types.SimpleNamespace(data={"a": 1})
+        assert _make_manager()._extract_response_list(resp) == [{"a": 1}]
+
+
+class TestFetchMspOrgList:
+    """``_fetch_msp_org_list`` sorts orgs case-insensitively; None on empty."""
+
+    def test_returns_sorted_orgs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.msps.orgs as real_api  # noqa: PLC0415
+
+        response = types.SimpleNamespace(data=[{"name": "Zeta"}, {"name": "alpha"}])
+        monkeypatch.setattr(real_api, "listMspOrgs", lambda _s, _m: response)
+        result = _make_manager()._fetch_msp_org_list("m1")
+        assert result == [{"name": "alpha"}, {"name": "Zeta"}]
+
+    def test_returns_none_when_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.msps.orgs as real_api  # noqa: PLC0415
+
+        response = types.SimpleNamespace(data=[])
+        monkeypatch.setattr(real_api, "listMspOrgs", lambda _s, _m: response)
+        assert _make_manager()._fetch_msp_org_list("m1") is None
+
+
+class TestFetchOrgsForSelection:
+    """``_fetch_orgs_for_selection`` wraps fetch with UX + error handling."""
+
+    def test_no_session_returns_none(self) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_session()
+        try:
+            fm_mod.apisession = None
+            assert mgr._fetch_orgs_for_selection("m1", "MSP-One") is None
+        finally:
+            _restore_session(snap)
+
+    def test_api_error_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+
+        def blow_up(_msp_id: str) -> list[dict[str, Any]] | None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(mgr, "_fetch_msp_org_list", blow_up)
+        snap = _snapshot_session()
+        try:
+            fm_mod.apisession = object()
+            assert mgr._fetch_orgs_for_selection("m1", "MSP-One") is None
+            assert "Error fetching organizations" in capsys.readouterr().out
+        finally:
+            _restore_session(snap)
+
+    def test_empty_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_msp_org_list", lambda _m: None)
+        snap = _snapshot_session()
+        try:
+            fm_mod.apisession = object()
+            assert mgr._fetch_orgs_for_selection("m1", "MSP-One") is None
+            assert "Failed to retrieve organizations" in capsys.readouterr().out
+        finally:
+            _restore_session(snap)
+
+    def test_valid_returns_data(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        data = [{"id": "o1", "name": "Org1"}]
+        monkeypatch.setattr(mgr, "_fetch_msp_org_list", lambda _m: data)
+        snap = _snapshot_session()
+        try:
+            fm_mod.apisession = object()
+            assert mgr._fetch_orgs_for_selection("m1", "MSP-One") == data
+        finally:
+            _restore_session(snap)
+
+
+class TestDisplayOrgsForSelection:
+    """``_display_orgs_for_selection`` renders numbered org table."""
+
+    def test_renders_orgs_with_id_preview(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        mgr._display_orgs_for_selection([{"id": "abcdefgh1234", "name": "Org1"}])
+        out = capsys.readouterr().out
+        assert "Found 1 organization" in out
+        assert "Org1 (abcdefgh...)" in out
+        assert "Selection:" in out
+
+
+class TestPromptOrgSelectionInput:
+    """``_prompt_org_selection_input`` normalises input tokens."""
+
+    def test_returns_normalized(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "  ALL  ")
+        assert mgr._prompt_org_selection_input() == "all"
+
+    def test_q_returns_none(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "q")
+        assert mgr._prompt_org_selection_input() is None
+
+    def test_empty_returns_none(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "")
+        assert mgr._prompt_org_selection_input() is None
+
+    def test_system_exit_returns_none(self) -> None:
+        def raise_sysexit(*_a: Any, **_k: Any) -> str:
+            raise SystemExit
+
+        mgr = _make_manager(safe_input_fn=raise_sysexit)
+        assert mgr._prompt_org_selection_input() is None
+
+
+class TestResolveOrgSelection:
+    """``_resolve_org_selection`` maps token to org list."""
+
+    def test_all_returns_full(self) -> None:
+        mgr = _make_manager()
+        orgs = [{"id": "a"}, {"id": "b"}]
+        assert mgr._resolve_org_selection("all", orgs) == orgs
+
+    def test_indices(self) -> None:
+        mgr = _make_manager()
+        orgs = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        assert mgr._resolve_org_selection("1,3", orgs) == [{"id": "a"}, {"id": "c"}]
+
+    def test_invalid_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        assert mgr._resolve_org_selection("nope", [{"id": "a"}]) is None
+        assert "Invalid selection" in capsys.readouterr().out
+
+
+class TestSelectOrgsForUpgrade:
+    """``_select_orgs_for_upgrade`` end-to-end MSP -> orgs picker."""
+
+    def test_no_orgs_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_orgs_for_selection", lambda *_a, **_k: None)
+        assert mgr._select_orgs_for_upgrade("m1", "MSP-One") is None
+
+    def test_cancelled_prompt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_orgs_for_selection", lambda *_a, **_k: [{"id": "a"}])
+        monkeypatch.setattr(mgr, "_prompt_org_selection_input", lambda: None)
+        assert mgr._select_orgs_for_upgrade("m1", "MSP-One") is None
+
+    def test_valid_selection(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        orgs = [{"id": "a"}, {"id": "b"}]
+        monkeypatch.setattr(mgr, "_fetch_orgs_for_selection", lambda *_a, **_k: orgs)
+        monkeypatch.setattr(mgr, "_prompt_org_selection_input", lambda: "all")
+        assert mgr._select_orgs_for_upgrade("m1", "MSP-One") == orgs
+
+
+# ---------------------------------------------------------------------------
+# Site fetch + paginated site picker
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAndValidateOrgSites:
+    """``_fetch_and_validate_org_sites`` sorts sites and returns None on empty."""
+
+    def test_returns_sorted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.sites as real_api  # noqa: PLC0415
+
+        response = types.SimpleNamespace(data=[{"name": "B"}, {"name": "a"}])
+        monkeypatch.setattr(real_api, "listOrgSites", lambda _s, _o: response)
+        assert _make_manager()._fetch_and_validate_org_sites("o1") == [{"name": "a"}, {"name": "B"}]
+
+    def test_empty_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.sites as real_api  # noqa: PLC0415
+
+        response = types.SimpleNamespace(data=[])
+        monkeypatch.setattr(real_api, "listOrgSites", lambda _s, _o: response)
+        assert _make_manager()._fetch_and_validate_org_sites("o1") is None
+
+
+class TestSafeFetchSitesForOrg:
+    """``_safe_fetch_sites_for_org`` wraps fetch with error handling."""
+
+    def test_exception_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+
+        def blow_up(_o: str) -> None:
+            raise RuntimeError("net-fail")
+
+        monkeypatch.setattr(mgr, "_fetch_and_validate_org_sites", blow_up)
+        assert mgr._safe_fetch_sites_for_org("o1") is None
+        assert "Error fetching sites" in capsys.readouterr().out
+
+    def test_empty_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_and_validate_org_sites", lambda _o: None)
+        assert mgr._safe_fetch_sites_for_org("o1") is None
+        assert "Failed to retrieve sites" in capsys.readouterr().out
+
+    def test_valid_returns_data(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        data = [{"id": "s1"}]
+        monkeypatch.setattr(mgr, "_fetch_and_validate_org_sites", lambda _o: data)
+        assert mgr._safe_fetch_sites_for_org("o1") == data
+
+
+class TestDisplaySitesPage:
+    """``_display_sites_page`` prints one page and pagination footer."""
+
+    def test_prints_indices(self, capsys: pytest.CaptureFixture[str]) -> None:
+        sites = [{"name": f"s{i}"} for i in range(3)]
+        _make_manager()._display_sites_page(sites, 0, 3, 0, 1)
+        out = capsys.readouterr().out
+        assert "s0" in out and "s1" in out and "s2" in out
+        # Only one page -> no navigation footer.
+        assert "Page 1/1" not in out
+
+    def test_multi_page_prints_navigation(self, capsys: pytest.CaptureFixture[str]) -> None:
+        sites = [{"name": f"s{i}"} for i in range(5)]
+        _make_manager()._display_sites_page(sites, 0, 2, 0, 3)
+        out = capsys.readouterr().out
+        assert "Page 1/3" in out
+        assert "[n]ext page" in out
+
+
+class TestResolveSitePageNavigation:
+    """``_resolve_site_page_navigation`` handles n/p only when in bounds."""
+
+    def test_next_when_allowed(self) -> None:
+        assert _make_manager()._resolve_site_page_navigation("n", 0, 2) == ("next", 1)
+
+    def test_next_at_last_page_returns_none(self) -> None:
+        assert _make_manager()._resolve_site_page_navigation("n", 1, 2) is None
+
+    def test_prev_when_allowed(self) -> None:
+        assert _make_manager()._resolve_site_page_navigation("p", 2, 3) == ("prev", 1)
+
+    def test_prev_at_first_page_returns_none(self) -> None:
+        assert _make_manager()._resolve_site_page_navigation("p", 0, 3) is None
+
+    def test_non_nav_returns_none(self) -> None:
+        assert _make_manager()._resolve_site_page_navigation("1,2", 0, 3) is None
+
+
+class TestHandleSitePageInput:
+    """``_handle_site_page_input`` classifies each token."""
+
+    def test_q_is_quit(self) -> None:
+        assert _make_manager()._handle_site_page_input("q", 0, 2) == ("quit", None)
+
+    def test_empty_is_quit(self) -> None:
+        assert _make_manager()._handle_site_page_input("", 0, 2) == ("quit", None)
+
+    def test_all(self) -> None:
+        assert _make_manager()._handle_site_page_input("all", 0, 2) == ("all", None)
+
+    def test_next(self) -> None:
+        assert _make_manager()._handle_site_page_input("n", 0, 2) == ("next", 1)
+
+    def test_prev(self) -> None:
+        assert _make_manager()._handle_site_page_input("p", 1, 2) == ("prev", 0)
+
+    def test_select_default(self) -> None:
+        assert _make_manager()._handle_site_page_input("1,3", 0, 2) == ("select", "1,3")
+
+
+class TestHandleSimplePageAction:
+    """``_handle_simple_page_action`` maps quit/all/nav to outcome tuple."""
+
+    def test_quit(self) -> None:
+        assert _make_manager()._handle_simple_page_action("quit", None, [{"id": "a"}]) == (
+            "commit",
+            None,
+        )
+
+    def test_all_returns_full(self) -> None:
+        sites = [{"id": "a"}]
+        assert _make_manager()._handle_simple_page_action("all", None, sites) == ("commit", sites)
+
+    def test_next_navigate(self) -> None:
+        assert _make_manager()._handle_simple_page_action("next", 2, [{"id": "a"}]) == ("navigate", 2)
+
+    def test_select_returns_none(self) -> None:
+        # 'select' actions aren't simple — should return None to signal fallback.
+        assert _make_manager()._handle_simple_page_action("select", "1", [{"id": "a"}]) is None
+
+
+class TestApplySiteSelectionAction:
+    """``_apply_site_selection_action`` dispatches to commit or navigate."""
+
+    def test_quit_commits_none(self) -> None:
+        mgr = _make_manager()
+        result = mgr._apply_site_selection_action("q", 0, 1, [{"id": "a"}])
+        assert result == ("commit", None)
+
+    def test_all_commits_full(self) -> None:
+        mgr = _make_manager()
+        sites = [{"id": "a"}]
+        assert mgr._apply_site_selection_action("all", 0, 1, sites) == ("commit", sites)
+
+    def test_valid_index_commits_pick(self) -> None:
+        mgr = _make_manager()
+        sites = [{"id": "a"}, {"id": "b"}]
+        assert mgr._apply_site_selection_action("2", 0, 1, sites) == ("commit", [{"id": "b"}])
+
+    def test_invalid_index_navigates_same_page(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        sites = [{"id": "a"}]
+        assert mgr._apply_site_selection_action("99", 0, 1, sites) == ("navigate", 0)
+        assert "Invalid selection" in capsys.readouterr().out
+
+
+class TestPromptSitePageSelection:
+    """``_prompt_site_page_selection`` renders + reads one token."""
+
+    def test_returns_normalised_token(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "  ALL  ")
+        sites = [{"name": f"s{i}"} for i in range(3)]
+        assert mgr._prompt_site_page_selection(sites, 0, 25, 1) == "all"
+
+    def test_system_exit_returns_none(self) -> None:
+        def raise_sysexit(*_a: Any, **_k: Any) -> str:
+            raise SystemExit
+
+        mgr = _make_manager(safe_input_fn=raise_sysexit)
+        assert mgr._prompt_site_page_selection([{"name": "s1"}], 0, 25, 1) is None
+
+
+class TestRunSiteSelectionLoop:
+    """``_run_site_selection_loop`` walks pagination and commits result."""
+
+    def test_cancel_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prompt_site_page_selection", lambda *_a, **_k: None)
+        assert mgr._run_site_selection_loop([{"name": "s1"}]) is None
+
+    def test_all_returns_full(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        sites = [{"name": "s1"}, {"name": "s2"}]
+        monkeypatch.setattr(mgr, "_prompt_site_page_selection", lambda *_a, **_k: "all")
+        assert mgr._run_site_selection_loop(sites) == sites
+
+    def test_navigate_then_commit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        sites = [{"name": f"s{i}"} for i in range(30)]  # WHY: two pages @ 25/page
+        answers = iter(["n", "all"])
+        monkeypatch.setattr(mgr, "_prompt_site_page_selection", lambda *_a, **_k: next(answers))
+        assert mgr._run_site_selection_loop(sites) == sites
+
+
+class TestSelectSitesForOrgUpgrade:
+    """End-to-end ``_select_sites_for_org_upgrade``."""
+
+    def test_no_session_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_session()
+        try:
+            fm_mod.apisession = None
+            assert mgr._select_sites_for_org_upgrade("o1", "Org1") is None
+            assert "API session not initialized" in capsys.readouterr().out
+        finally:
+            _restore_session(snap)
+
+    def test_no_sites_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_safe_fetch_sites_for_org", lambda _o: None)
+        snap = _snapshot_session()
+        try:
+            fm_mod.apisession = object()
+            assert mgr._select_sites_for_org_upgrade("o1", "Org1") is None
+        finally:
+            _restore_session(snap)
+
+    def test_sites_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        sites = [{"id": "s1", "name": "S1"}]
+        monkeypatch.setattr(mgr, "_safe_fetch_sites_for_org", lambda _o: sites)
+        monkeypatch.setattr(mgr, "_run_site_selection_loop", lambda _d: sites)
+        snap = _snapshot_session()
+        try:
+            fm_mod.apisession = object()
+            assert mgr._select_sites_for_org_upgrade("o1", "Org1") == sites
+        finally:
+            _restore_session(snap)
+
+
+# ---------------------------------------------------------------------------
+# Upgrade plan construction + display + confirmation
+# ---------------------------------------------------------------------------
+
+
+class TestAddOrgToUpgradePlan:
+    """``_add_org_to_upgrade_plan`` appends non-empty selections."""
+
+    def test_appends_when_sites_selected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_sites_for_org_upgrade", lambda *_a, **_k: [{"id": "s1"}])
+        plan: list[dict[str, Any]] = []
+        mgr._add_org_to_upgrade_plan(plan, "m1", "MSP1", {"id": "o1", "name": "Org1"})
+        assert plan == [
+            {"msp_id": "m1", "msp_name": "MSP1", "org_id": "o1", "org_name": "Org1", "sites": [{"id": "s1"}]}
+        ]
+
+    def test_skips_when_no_sites(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_sites_for_org_upgrade", lambda *_a, **_k: None)
+        plan: list[dict[str, Any]] = []
+        mgr._add_org_to_upgrade_plan(plan, "m1", "MSP1", {"id": "o1", "name": "Org1"})
+        assert plan == []
+        assert "no sites selected" in capsys.readouterr().out
+
+
+class TestBuildMspUpgradePlan:
+    """``_build_msp_upgrade_plan`` iterates MSPs and their orgs."""
+
+    def test_skips_msp_with_no_orgs(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_orgs_for_upgrade", lambda *_a, **_k: None)
+        result = mgr._build_msp_upgrade_plan([{"msp_id": "m1", "msp_name": "MSP1"}])
+        assert result == []
+        assert "no organizations selected" in capsys.readouterr().out
+
+    def test_expands_orgs_into_plan_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_orgs_for_upgrade", lambda *_a, **_k: [{"id": "o1", "name": "Org1"}])
+        monkeypatch.setattr(mgr, "_select_sites_for_org_upgrade", lambda *_a, **_k: [{"id": "s1", "name": "S1"}])
+        result = mgr._build_msp_upgrade_plan([{"msp_id": "m1", "msp_name": "MSP1"}])
+        assert len(result) == 1
+        assert result[0]["org_id"] == "o1"
+        assert result[0]["sites"] == [{"id": "s1", "name": "S1"}]
+
+
+class TestConfirmMspUpgrade:
+    """``_confirm_msp_upgrade`` requires literal 'UPGRADE' token."""
+
+    def _plan(self) -> list[dict[str, Any]]:
+        return [{"org_id": "o1", "sites": [{"id": "s1"}, {"id": "s2"}]}]
+
+    def test_confirms_on_exact_token(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "UPGRADE")
+        assert mgr._confirm_msp_upgrade(self._plan()) is True
+
+    def test_rejects_wrong_token(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "yes")
+        assert mgr._confirm_msp_upgrade(self._plan()) is False
+        assert "cancelled" in capsys.readouterr().out.lower()
+
+    def test_lowercase_rejected(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "upgrade")
+        assert mgr._confirm_msp_upgrade(self._plan()) is False
+
+    def test_system_exit_returns_false(self) -> None:
+        def raise_sysexit(*_a: Any, **_k: Any) -> str:
+            raise SystemExit
+
+        mgr = _make_manager(safe_input_fn=raise_sysexit)
+        assert mgr._confirm_msp_upgrade(self._plan()) is False
+
+
+class TestAwaitMspUpgradeConfirmation:
+    """``_await_msp_upgrade_confirmation`` dry-run auto-confirms."""
+
+    def test_dry_run_auto_confirms(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "no")
+        assert mgr._await_msp_upgrade_confirmation([{"sites": []}], dry_run=True) is True
+        assert "DRY-RUN" in capsys.readouterr().out
+
+    def test_non_dry_delegates_to_confirm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_confirm_msp_upgrade", lambda _p: True)
+        assert mgr._await_msp_upgrade_confirmation([{"sites": []}], dry_run=False) is True
+
+
+class TestPrintMspMultiOrgBanner:
+    """``_print_msp_multi_org_banner`` prints banner + warning."""
+
+    def test_no_dry_run(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_msp_multi_org_banner(dry_run=False)
+        out = capsys.readouterr().out
+        assert "MSP MULTI-ORGANIZATION FIRMWARE UPGRADE" in out
+        assert "DRY-RUN" not in out
+        assert "WARNING" in out
+
+    def test_dry_run_banner(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_msp_multi_org_banner(dry_run=True)
+        out = capsys.readouterr().out
+        assert "DRY-RUN MODE ENABLED" in out
+
+
+class TestDisplayUpgradePlanSummary:
+    """``_display_upgrade_plan_summary`` renders plan + totals."""
+
+    def test_renders_multiple_orgs(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        plan = [
+            {
+                "msp_id": "m1",
+                "msp_name": "MSP1",
+                "org_id": "o1",
+                "org_name": "Org1",
+                "sites": [{"name": f"s{i}"} for i in range(3)],
+            },
+            {
+                "msp_id": "m1",
+                "msp_name": "MSP1",
+                "org_id": "o2",
+                "org_name": "Org2",
+                "sites": [{"name": f"t{i}"} for i in range(7)],  # WHY: >5 triggers elision
+            },
+        ]
+        mgr._display_upgrade_plan_summary(plan, dry_run=False)
+        out = capsys.readouterr().out
+        assert "UPGRADE PLAN SUMMARY" in out
+        assert "MSP1" in out
+        assert "Org1" in out
+        assert "and 2 more" in out
+        assert "MSPs: 1" in out
+        assert "Organizations: 2" in out
+        assert "Sites: 10" in out
+
+    def test_dry_run_title(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        mgr._display_upgrade_plan_summary(
+            [{"msp_id": "m1", "msp_name": "M1", "org_id": "o1", "org_name": "Org", "sites": []}],
+            dry_run=True,
+        )
+        assert "(DRY-RUN)" in capsys.readouterr().out
+
+
+class TestPrintUpgradePlanEntry:
+    """``_print_upgrade_plan_entry`` handles site elision correctly."""
+
+    def test_small_list_no_elision(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        sites = [{"name": "s1"}, {"name": "s2"}]
+        mgr._print_upgrade_plan_entry({"msp_name": "M", "org_name": "O"}, sites)
+        out = capsys.readouterr().out
+        assert "and" not in out or "more" not in out
+
+
+class TestCollectMspUpgradePlan:
+    """``_collect_msp_upgrade_plan`` drives MSP + org + site selection."""
+
+    def test_no_msps_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_msps_for_upgrade", lambda: None)
+        assert mgr._collect_msp_upgrade_plan() is None
+        assert "Cancelled" in capsys.readouterr().out
+
+    def test_msps_expanded_to_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_msps_for_upgrade", lambda: [{"msp_id": "m1"}])
+        monkeypatch.setattr(
+            mgr,
+            "_build_msp_upgrade_plan",
+            lambda _msps: [{"msp_id": "m1", "org_id": "o1", "sites": []}],
+        )
+        assert mgr._collect_msp_upgrade_plan() == [{"msp_id": "m1", "org_id": "o1", "sites": []}]
+
+
+# ---------------------------------------------------------------------------
+# Upgrade plan execution: loop + per-org + summary
+# ---------------------------------------------------------------------------
+
+
+class TestPresentMspPlanHeader:
+    """``_present_msp_plan_header`` renders per-org banner."""
+
+    def test_prints_org_and_msp_names(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._present_msp_plan_header(
+            1, 3, {"org_name": "Org1", "msp_name": "MSP1", "org_id": "o1", "sites": [{"id": "s1"}]}
+        )
+        out = capsys.readouterr().out
+        assert "[1/3]" in out
+        assert "Org1" in out
+        assert "MSP1" in out
+        assert "Organization ID: o1" in out
+        assert "Sites to upgrade: 1" in out
+
+
+class TestMakeMspRecord:
+    """``_make_msp_record`` builds status record dict."""
+
+    def _plan(self) -> dict[str, Any]:
+        return {"msp_name": "M1", "org_id": "o1", "org_name": "Org1", "sites": [{"id": "s1"}]}
+
+    def test_completed_no_error(self) -> None:
+        rec = _make_manager()._make_msp_record(self._plan(), "completed", dry_run=False)
+        assert rec["status"] == "completed"
+        assert rec["dry_run"] is False
+        assert rec["sites_count"] == 1
+        assert "error" not in rec
+
+    def test_failed_with_error(self) -> None:
+        rec = _make_manager()._make_msp_record(self._plan(), "failed", dry_run=True, error="boom")
+        assert rec["error"] == "boom"
+        assert rec["dry_run"] is True
+
+
+class TestSplitResultsByStatus:
+    """``_split_results_by_status`` fanout by status key."""
+
+    def test_splits_all_three(self) -> None:
+        results = [
+            {"status": "completed", "org_name": "A"},
+            {"status": "failed", "org_name": "B"},
+            {"status": "interrupted", "org_name": "C"},
+            {"status": "completed", "org_name": "D"},
+        ]
+        completed, failed, interrupted = _make_manager()._split_results_by_status(results)
+        assert [c["org_name"] for c in completed] == ["A", "D"]
+        assert [f["org_name"] for f in failed] == ["B"]
+        assert [i["org_name"] for i in interrupted] == ["C"]
+
+    def test_empty_returns_empty_buckets(self) -> None:
+        completed, failed, interrupted = _make_manager()._split_results_by_status([])
+        assert completed == [] and failed == [] and interrupted == []
+
+    def test_unknown_status_bucket_created(self) -> None:
+        # Unknown status buckets are created via setdefault but never
+        # returned — verify unknown statuses don't crash the split.
+        completed, failed, interrupted = _make_manager()._split_results_by_status([{"status": "weird"}])
+        assert completed == [] and failed == [] and interrupted == []
+
+
+class TestPrintOrgsDetail:
+    """Print helpers for completed / failed / interrupted org details."""
+
+    def test_completed_no_op_when_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_completed_orgs_detail([])
+        assert capsys.readouterr().out == ""
+
+    def test_completed_prefixes_dry_run(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_completed_orgs_detail([{"org_name": "A", "sites_count": 2, "dry_run": True}])
+        out = capsys.readouterr().out
+        assert "(DRY-RUN)" in out
+        assert "A (2 sites)" in out
+
+    def test_failed_prints_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_failed_orgs_detail([{"org_name": "X", "error": "bad"}])
+        assert "X: bad" in capsys.readouterr().out
+
+    def test_failed_default_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_failed_orgs_detail([{"org_name": "X"}])
+        assert "Unknown error" in capsys.readouterr().out
+
+    def test_interrupted(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_interrupted_orgs_detail([{"org_name": "Z"}])
+        assert "Z" in capsys.readouterr().out
+
+
+class TestPrintMspUpgradeSummary:
+    """``_print_msp_upgrade_summary`` prints full summary block."""
+
+    def test_summary_renders_totals_and_sections(self, capsys: pytest.CaptureFixture[str]) -> None:
+        results = [
+            {"status": "completed", "org_name": "A", "sites_count": 2, "dry_run": False},
+            {"status": "failed", "org_name": "B", "sites_count": 1, "error": "boom"},
+        ]
+        _make_manager()._print_msp_upgrade_summary(results, dry_run=False)
+        out = capsys.readouterr().out
+        assert "MSP UPGRADE SUMMARY" in out
+        assert "Completed: 1" in out
+        assert "Failed: 1" in out
+        assert "Interrupted: 0" in out
+
+    def test_summary_dry_run_flag_appears(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_msp_upgrade_summary([], dry_run=True)
+        assert "(DRY-RUN)" in capsys.readouterr().out
+
+    def test_log_msp_summary_totals_emits_info(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger="root")
+        _make_manager()._log_msp_summary_totals(
+            dry_run=True, completed=[1], failed=[], interrupted=[]  # type: ignore[list-item]
+        )
+        assert any("DRY-RUN" in r.message for r in caplog.records)
+
+
+class TestRunMspBulkUpgrader:
+    """``_run_msp_bulk_upgrader`` normalises sites and dispatches."""
+
+    def test_dispatches_normalised_sites(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        seen: dict[str, Any] = {}
+
+        def fake_dispatch(oid: str, sites: list[dict[str, Any]], dry_run: bool) -> None:
+            seen["oid"] = oid
+            seen["sites"] = sites
+            seen["dry_run"] = dry_run
+
+        monkeypatch.setattr(mgr, "_dispatch_bulk_ap_upgrade", fake_dispatch)
+        mgr._run_msp_bulk_upgrader("o1", [{"id": "s1", "name": "S1", "extra": "x"}], dry_run=True)
+        assert seen["oid"] == "o1"
+        assert seen["sites"] == [{"id": "s1", "name": "S1"}]  # extra field dropped
+        assert seen["dry_run"] is True
+
+    def test_missing_site_name_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        seen: dict[str, list[dict[str, Any]]] = {}
+
+        def fake_dispatch(_o: str, sites: list[dict[str, Any]], _d: bool) -> None:
+            seen["sites"] = sites
+
+        monkeypatch.setattr(mgr, "_dispatch_bulk_ap_upgrade", fake_dispatch)
+        mgr._run_msp_bulk_upgrader("o1", [{"id": "s1"}], dry_run=False)
+        assert seen["sites"] == [{"id": "s1", "name": "Unknown"}]
+
+
+class TestHandleMspInterrupt:
+    """``_handle_msp_interrupt`` handles Ctrl-C policy prompts."""
+
+    def _plan(self) -> dict[str, Any]:
+        return {"msp_name": "M", "org_id": "o1", "org_name": "Org1", "sites": [{"id": "s1"}]}
+
+    def test_y_continues(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "y")
+        out = mgr._handle_msp_interrupt(self._plan(), "Org1", dry_run=False)
+        assert out["stop"] is False
+        assert out["record"]["status"] == "interrupted"
+
+    def test_n_stops(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "n")
+        out = mgr._handle_msp_interrupt(self._plan(), "Org1", dry_run=False)
+        assert out["stop"] is True
+        assert "Stopping" in capsys.readouterr().out
+
+    def test_system_exit_stops(self) -> None:
+        def raise_sysexit(*_a: Any, **_k: Any) -> str:
+            raise SystemExit
+
+        mgr = _make_manager(safe_input_fn=raise_sysexit)
+        out = mgr._handle_msp_interrupt(self._plan(), "Org1", dry_run=False)
+        assert out["stop"] is True
+
+
+class TestHandleMspFailure:
+    """``_handle_msp_failure`` converts exception to failure record."""
+
+    def test_failure_record(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        plan = {"msp_name": "M", "org_id": "o1", "org_name": "Org1", "sites": [{"id": "s1"}]}
+        result = mgr._handle_msp_failure(plan, "Org1", RuntimeError("boom"), dry_run=False)
+        assert result["stop"] is False
+        assert result["record"]["status"] == "failed"
+        assert result["record"]["error"] == "boom"
+        assert "boom" in capsys.readouterr().out
+
+
+class TestExecuteMspSingleOrg:
+    """``_execute_msp_single_org`` classifies success/interrupt/failure."""
+
+    def _plan(self) -> dict[str, Any]:
+        return {"msp_name": "M", "org_id": "o1", "org_name": "Org1", "sites": [{"id": "s1"}]}
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_session()
+        try:
+            monkeypatch.setattr(mgr, "_run_msp_bulk_upgrader", lambda *_a, **_k: None)
+            out = mgr._execute_msp_single_org(self._plan(), dry_run=False)
+            assert out["stop"] is False
+            assert out["record"]["status"] == "completed"
+        finally:
+            _restore_session(snap)
+
+    def test_kbint_delegates_to_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_session()
+        try:
+
+            def raise_kbint(*_a: Any, **_k: Any) -> None:
+                raise KeyboardInterrupt
+
+            monkeypatch.setattr(mgr, "_run_msp_bulk_upgrader", raise_kbint)
+            monkeypatch.setattr(mgr, "_handle_msp_interrupt", lambda *_a, **_k: {"record": {}, "stop": True})
+            out = mgr._execute_msp_single_org(self._plan(), dry_run=False)
+            assert out["stop"] is True
+        finally:
+            _restore_session(snap)
+
+    def test_exception_delegates_to_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_session()
+        try:
+
+            def blow_up(*_a: Any, **_k: Any) -> None:
+                raise RuntimeError("boom")
+
+            monkeypatch.setattr(mgr, "_run_msp_bulk_upgrader", blow_up)
+            monkeypatch.setattr(
+                mgr,
+                "_handle_msp_failure",
+                lambda *_a, **_k: {"record": {"status": "failed"}, "stop": False},
+            )
+            out = mgr._execute_msp_single_org(self._plan(), dry_run=False)
+            assert out["record"]["status"] == "failed"
+        finally:
+            _restore_session(snap)
+
+
+class TestRunMspUpgradeLoop:
+    """``_run_msp_upgrade_loop`` iterates plan and honours stop signal."""
+
+    def test_normal_completion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        outcomes = iter(
+            [
+                {"record": {"status": "completed"}, "stop": False},
+                {"record": {"status": "completed"}, "stop": False},
+            ]
+        )
+        monkeypatch.setattr(mgr, "_execute_msp_single_org", lambda *_a, **_k: next(outcomes))
+        results: list[dict[str, Any]] = []
+        stopped = mgr._run_msp_upgrade_loop(
+            [
+                {"msp_name": "M", "org_name": "A", "org_id": "o1", "sites": []},
+                {"msp_name": "M", "org_name": "B", "org_id": "o2", "sites": []},
+            ],
+            False,
+            results,
+        )
+        assert stopped is False
+        assert len(results) == 2
+
+    def test_stop_signal_short_circuits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(
+            mgr,
+            "_execute_msp_single_org",
+            lambda *_a, **_k: {"record": {"status": "interrupted"}, "stop": True},
+        )
+        results: list[dict[str, Any]] = []
+        stopped = mgr._run_msp_upgrade_loop(
+            [
+                {"msp_name": "M", "org_name": "A", "org_id": "o1", "sites": []},
+                {"msp_name": "M", "org_name": "B", "org_id": "o2", "sites": []},
+            ],
+            False,
+            results,
+        )
+        assert stopped is True
+        assert len(results) == 1  # WHY: loop bailed after first entry
+
+
+class TestExecuteMspUpgradePlan:
+    """``_execute_msp_upgrade_plan`` restores org_id after loop."""
+
+    def test_restores_org_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        snap = _snapshot_session()
+        try:
+            fm_mod.org_id = "before"
+            monkeypatch.setattr(
+                mgr,
+                "_run_msp_upgrade_loop",
+                lambda *_a, **_k: False,
+            )
+            result = mgr._execute_msp_upgrade_plan([], dry_run=False)
+            assert fm_mod.org_id == "before"
+            assert result == []
+        finally:
+            _restore_session(snap)
+
+
+class TestFinalizeMspUpgrade:
+    """``_finalize_msp_upgrade`` runs preview + confirm + execute + summary."""
+
+    def test_confirmation_declined_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_display_upgrade_plan_summary", lambda *_a, **_k: None)
+        monkeypatch.setattr(mgr, "_await_msp_upgrade_confirmation", lambda *_a, **_k: False)
+        assert mgr._finalize_msp_upgrade([{"sites": []}], dry_run=False) is None
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_display_upgrade_plan_summary", lambda *_a, **_k: None)
+        monkeypatch.setattr(mgr, "_await_msp_upgrade_confirmation", lambda *_a, **_k: True)
+        monkeypatch.setattr(
+            mgr,
+            "_execute_msp_upgrade_plan",
+            lambda *_a, **_k: [{"status": "completed"}],
+        )
+        printed: dict[str, Any] = {}
+        monkeypatch.setattr(
+            mgr,
+            "_print_msp_upgrade_summary",
+            lambda results, dry_run: printed.setdefault("r", results),
+        )
+        out = mgr._finalize_msp_upgrade([{"sites": []}], dry_run=False)
+        assert out == [{"status": "completed"}]
+        assert printed["r"] == [{"status": "completed"}]
+
+
+class TestExecuteMspMultiOrgUpgrade:
+    """Top-level ``_execute_msp_multi_org_upgrade`` orchestration."""
+
+    def test_cancel_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_collect_msp_upgrade_plan", lambda: None)
+        assert mgr._execute_msp_multi_org_upgrade() is None
+
+    def test_empty_plan_prints_and_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_collect_msp_upgrade_plan", lambda: [])
+        assert mgr._execute_msp_multi_org_upgrade() is None
+        assert "No upgrade targets" in capsys.readouterr().out
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_collect_msp_upgrade_plan", lambda: [{"org_id": "o1"}])
+        monkeypatch.setattr(mgr, "_finalize_msp_upgrade", lambda plan, dry_run: [{"status": "ok"}])
+        assert mgr._execute_msp_multi_org_upgrade() == [{"status": "ok"}]
+
+    def test_honours_dry_run_from_globals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        # Install a fake args namespace with dry_run=True in the module globals.
+        fake_args = types.SimpleNamespace(dry_run=True)
+        monkeypatch.setitem(fm_mod.__dict__, "args", fake_args)
+        seen: dict[str, bool] = {}
+
+        def fake_finalize(_plan: list[Any], dry_run: bool) -> list[dict[str, Any]] | None:
+            seen["dry_run"] = dry_run
+            return []
+
+        monkeypatch.setattr(mgr, "_collect_msp_upgrade_plan", lambda: [{"org_id": "o1"}])
+        monkeypatch.setattr(mgr, "_finalize_msp_upgrade", fake_finalize)
+        mgr._execute_msp_multi_org_upgrade()
+        assert seen["dry_run"] is True

--- a/tests/unit/firmware/test_firmware_manager_config.py
+++ b/tests/unit/firmware/test_firmware_manager_config.py
@@ -1,0 +1,318 @@
+"""Unit tests for ``src.firmware.firmware_manager`` config surface.
+
+Why:
+    ``FirmwareManagerConfig`` is the frozen value object every downstream
+    helper depends on. Its ``__post_init__`` validation is the only guard
+    against silent None-propagation into the HTTP layer, so every branch
+    must be pinned. ``_MistHelperProxy`` and ``_bind_module_globals``
+    likewise carry hidden module-scope side effects that break in subtle
+    ways if refactored without a test net.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from typing import Any
+
+import pytest
+
+import src.firmware.firmware_manager as fm_mod
+from src.firmware.firmware_manager import (
+    FirmwareManager,
+    FirmwareManagerConfig,
+    _bind_module_globals,
+    _MistHelperProxy,
+)
+
+
+def _make_config(**overrides: Any) -> FirmwareManagerConfig:
+    """Build a valid ``FirmwareManagerConfig`` with test defaults.
+
+    Why:
+        Every test needs a fresh config; centralising the constructor
+        lets each test body focus on the branch it exercises rather than
+        restating the required identity fields.
+
+    Args:
+        **overrides: Any dataclass field to override.
+
+    Returns:
+        Fully populated ``FirmwareManagerConfig`` ready for use.
+    """
+    defaults: dict[str, Any] = {
+        "apisession": object(),
+        "org_id": "org-test",
+    }
+    defaults.update(overrides)
+    return FirmwareManagerConfig(**defaults)
+
+
+class TestFirmwareManagerConfigValidation:
+    """``FirmwareManagerConfig.__post_init__`` fail-fast contract.
+
+    Why:
+        Downstream helpers assume both identity fields are already valid;
+        letting an invalid config through would surface as a much later
+        (and much noisier) HTTP or AttributeError.
+    """
+
+    def test_valid_minimal_config_constructs(self) -> None:
+        cfg = _make_config()
+        assert cfg.apisession is not None
+        assert cfg.org_id == "org-test"
+
+    def test_none_apisession_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="apisession is required"):
+            FirmwareManagerConfig(apisession=None, org_id="org-x")
+
+    def test_empty_org_id_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="org_id must be a non-empty string"):
+            FirmwareManagerConfig(apisession=object(), org_id="")
+
+    def test_non_string_org_id_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="org_id must be a non-empty string"):
+            FirmwareManagerConfig(apisession=object(), org_id=123)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "hook_name",
+        [
+            "safe_input_fn",
+            "select_site_fn",
+            "check_cache_fn",
+            "get_csv_path_fn",
+            "gateway_templates_fn",
+            "sites_fn",
+        ],
+    )
+    def test_non_callable_hook_raises_type_error(self, hook_name: str) -> None:
+        with pytest.raises(TypeError, match=f"{hook_name} must be callable or None"):
+            _make_config(**{hook_name: "not-callable"})
+
+    def test_all_none_hooks_accepted(self) -> None:
+        cfg = _make_config(
+            safe_input_fn=None,
+            select_site_fn=None,
+            check_cache_fn=None,
+            get_csv_path_fn=None,
+            gateway_templates_fn=None,
+            sites_fn=None,
+        )
+        assert cfg.safe_input_fn is None
+
+    def test_callable_hooks_accepted(self) -> None:
+        cfg = _make_config(
+            safe_input_fn=lambda *_a, **_k: "",
+            select_site_fn=lambda: None,
+            check_cache_fn=lambda *_a, **_k: None,
+            get_csv_path_fn=lambda _n: "/tmp/x.csv",
+            gateway_templates_fn=lambda *_a, **_k: None,
+            sites_fn=lambda *_a, **_k: None,
+        )
+        assert callable(cfg.safe_input_fn)
+        assert callable(cfg.sites_fn)
+
+
+class TestFirmwareManagerConfigImmutability:
+    """Frozen + slots guarantees.
+
+    Why:
+        Helpers assume the bundle cannot mutate mid-flight. If either
+        guarantee regresses, subtle cross-flow state leaks become
+        possible when a single config is reused between flows.
+    """
+
+    def test_frozen_disallows_mutation(self) -> None:
+        cfg = _make_config()
+        with pytest.raises((AttributeError, Exception)):
+            cfg.org_id = "other"  # type: ignore[misc]
+
+    def test_slots_disallow_new_attributes(self) -> None:
+        cfg = _make_config()
+        with pytest.raises((AttributeError, TypeError)):
+            cfg.new_field = "nope"  # type: ignore[attr-defined]
+
+
+class TestMistHelperProxy:
+    """``_MistHelperProxy`` late-binding attribute forwarding.
+
+    Why:
+        Direct import of ``MistHelper`` at module load creates a cycle;
+        the proxy exists to defer resolution until call time so tests
+        can swap the module out via monkey-patching.
+    """
+
+    def test_forwards_to_import_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_module = types.SimpleNamespace(SomeSingleton="live-value")
+
+        def fake_import(name: str) -> Any:
+            assert name == "MistHelper"
+            return fake_module
+
+        monkeypatch.setattr(fm_mod.importlib, "import_module", fake_import)
+        proxy = _MistHelperProxy()
+        assert proxy.SomeSingleton == "live-value"
+
+    def test_forwarding_is_late_bound(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        counter = {"n": 0}
+        fake_module = types.SimpleNamespace(dynamic_value="a")
+
+        def fake_import(_name: str) -> Any:
+            counter["n"] += 1
+            return fake_module
+
+        monkeypatch.setattr(fm_mod.importlib, "import_module", fake_import)
+        proxy = _MistHelperProxy()
+        _ = proxy.dynamic_value
+        fake_module.dynamic_value = "b"  # mutate after first access
+        assert proxy.dynamic_value == "b"
+        assert counter["n"] == 2  # both lookups hit importlib
+
+    def test_missing_attr_raises_attribute_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_module = types.SimpleNamespace()
+        monkeypatch.setattr(fm_mod.importlib, "import_module", lambda _n: fake_module)
+        proxy = _MistHelperProxy()
+        with pytest.raises(AttributeError):
+            _ = proxy.definitely_absent
+
+
+class TestBindModuleGlobals:
+    """``_bind_module_globals`` module-scope side effects.
+
+    Why:
+        Legacy helpers read module-scope ``apisession``/``org_id``/
+        ``msp_privileges``/``PROGRESS_EMITTER`` via ``global`` statements.
+        Missing the rebind step causes silent cross-org data leakage.
+    """
+
+    def _snapshot_globals(self) -> tuple[Any, str, list[Any], Any]:
+        return fm_mod.apisession, fm_mod.org_id, list(fm_mod.msp_privileges), fm_mod.PROGRESS_EMITTER
+
+    def _restore_globals(self, snap: tuple[Any, str, list[Any], Any]) -> None:
+        fm_mod.apisession, fm_mod.org_id = snap[0], snap[1]
+        fm_mod.msp_privileges = snap[2]
+        fm_mod.PROGRESS_EMITTER = snap[3]
+
+    def test_binds_identity_fields(self) -> None:
+        snap = self._snapshot_globals()
+        try:
+            session_marker = object()
+            cfg = _make_config(apisession=session_marker, org_id="ORG-42")
+            _bind_module_globals(cfg)
+            assert fm_mod.apisession is session_marker
+            assert fm_mod.org_id == "ORG-42"
+        finally:
+            self._restore_globals(snap)
+
+    def test_pulls_from_main_module_when_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        snap = self._snapshot_globals()
+        try:
+            fake_main = types.SimpleNamespace(msp_privileges=["priv-a"], PROGRESS_EMITTER="emit-sentinel")
+            monkeypatch.setitem(sys.modules, "__main__", fake_main)
+            cfg = _make_config()
+            _bind_module_globals(cfg)
+            assert fm_mod.msp_privileges == ["priv-a"]
+            assert fm_mod.PROGRESS_EMITTER == "emit-sentinel"
+        finally:
+            self._restore_globals(snap)
+
+    def test_falls_back_to_misthelper_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        snap = self._snapshot_globals()
+        try:
+            fake_mh = types.SimpleNamespace(msp_privileges=["fallback"], PROGRESS_EMITTER=None)
+            # Remove __main__ so the fallback branch runs (real sys.modules key is __main__).
+            monkeypatch.setitem(sys.modules, "__main__", types.SimpleNamespace())
+            monkeypatch.setitem(sys.modules, "MistHelper", fake_mh)
+            # Also strip attributes from fake main so getattr fallback triggers
+            # when both modules are present.
+            cfg = _make_config()
+            _bind_module_globals(cfg)
+            # __main__ present but lacks attrs -> defaults from getattr are used.
+            assert fm_mod.msp_privileges == []
+            assert fm_mod.PROGRESS_EMITTER is None
+        finally:
+            self._restore_globals(snap)
+
+    def test_no_main_or_misthelper_leaves_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        snap = self._snapshot_globals()
+        try:
+            # Simulate no host module present.
+            monkeypatch.delitem(sys.modules, "__main__", raising=False)
+            monkeypatch.delitem(sys.modules, "MistHelper", raising=False)
+            fm_mod.msp_privileges = ["untouched"]
+            fm_mod.PROGRESS_EMITTER = "untouched"
+            cfg = _make_config()
+            _bind_module_globals(cfg)
+            # Globals stay because the outer if guard prevented the rebind.
+            assert fm_mod.msp_privileges == ["untouched"]
+            assert fm_mod.PROGRESS_EMITTER == "untouched"
+        finally:
+            self._restore_globals(snap)
+
+    def test_emits_info_and_debug_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        snap = self._snapshot_globals()
+        try:
+            caplog.set_level(logging.DEBUG, logger="root")
+            cfg = _make_config(org_id="ORG-LOG")
+            _bind_module_globals(cfg)
+            messages = [r.message for r in caplog.records]
+            assert any("Rebinding firmware_manager module globals for org ORG-LOG" in m for m in messages)
+            assert any("firmware_manager module globals rebound for org ORG-LOG" in m for m in messages)
+        finally:
+            self._restore_globals(snap)
+
+
+class TestFirmwareManagerInit:
+    """``FirmwareManager.__init__`` attribute wiring.
+
+    Why:
+        Every downstream helper reads either ``self._config``, one of the
+        back-compat attributes (``apisession``/``org_id``), or a bound
+        DI hook. This test locks the wiring so any regression breaks here
+        (and not deep inside a menu flow).
+    """
+
+    def test_stores_config_and_backcompat_attrs(self) -> None:
+        session = object()
+        cfg = _make_config(apisession=session, org_id="ORG-BC")
+        mgr = FirmwareManager(cfg)
+        assert mgr._config is cfg
+        assert mgr.apisession is session
+        assert mgr.org_id == "ORG-BC"
+
+    def test_defaults_safe_input_to_builtin(self) -> None:
+        cfg = _make_config(safe_input_fn=None)
+        mgr = FirmwareManager(cfg)
+        assert mgr._safe_input_fn is input
+
+    def test_preserves_all_optional_hooks(self) -> None:
+        safe_input = lambda *_a, **_k: "x"  # noqa: E731
+        select_site = lambda: {"id": "S"}  # noqa: E731
+        check_cache = lambda *_a, **_k: None  # noqa: E731
+        get_csv_path = lambda _n: "/x.csv"  # noqa: E731
+        gateway_templates = lambda *_a, **_k: iter([])  # noqa: E731
+        sites = lambda *_a, **_k: iter([])  # noqa: E731
+        cfg = _make_config(
+            safe_input_fn=safe_input,
+            select_site_fn=select_site,
+            check_cache_fn=check_cache,
+            get_csv_path_fn=get_csv_path,
+            gateway_templates_fn=gateway_templates,
+            sites_fn=sites,
+        )
+        mgr = FirmwareManager(cfg)
+        assert mgr._safe_input_fn is safe_input
+        assert mgr._select_site_fn is select_site
+        assert mgr._check_cache_fn is check_cache
+        assert mgr._get_csv_path_fn is get_csv_path
+        assert mgr._gateway_templates_fn is gateway_templates
+        assert mgr._sites_fn is sites
+
+    def test_emits_init_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG, logger="root")
+        cfg = _make_config(org_id="ORG-INIT")
+        FirmwareManager(cfg)
+        messages = [r.message for r in caplog.records]
+        assert any("Initializing FirmwareManager for org ORG-INIT" in m for m in messages)
+        assert any("FirmwareManager init complete for org ORG-INIT" in m for m in messages)

--- a/tests/unit/firmware/test_firmware_manager_monitoring.py
+++ b/tests/unit/firmware/test_firmware_manager_monitoring.py
@@ -1,0 +1,610 @@
+"""Unit tests for continuous monitoring + org-level upgrade jobs display.
+
+Why:
+    Monitoring is the operator's live-view into fleet firmware rollouts;
+    any regression in the poll-print-sleep loop, the "active upgrade"
+    classifier, or the org-jobs detail rendering surfaces immediately in
+    an operator-visible way. Every branch of these helpers must be pinned
+    against silent refactor drift so field-ops tooling and grep-based
+    dashboards keep working.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.firmware.firmware_manager as fm_mod
+from src.firmware.firmware_manager import FirmwareManager, FirmwareManagerConfig
+
+
+def _make_manager(**overrides: Any) -> FirmwareManager:
+    """Build a live ``FirmwareManager`` with the smallest valid config.
+
+    Why:
+        Monitoring/org-jobs helpers need a real instance to bind
+        ``self.apisession`` and ``self.org_id`` for API calls, but they
+        never touch the MSP privilege chain or the DI hooks. Keeping the
+        constructor in one place lets each test focus on the branch it
+        exercises.
+
+    Args:
+        **overrides: Any ``FirmwareManagerConfig`` field to override.
+
+    Returns:
+        A fully wired ``FirmwareManager`` ready to exercise helpers.
+    """
+    defaults: dict[str, Any] = {"apisession": object(), "org_id": "org-mon"}
+    defaults.update(overrides)
+    return FirmwareManager(FirmwareManagerConfig(**defaults))
+
+
+class TestPresentMonitoringHeader:
+    """``_present_monitoring_header`` banner block.
+
+    Why:
+        Operators read the fixed banner to confirm they're in continuous
+        mode and to see the 7-second cadence disclosure. Reformatting or
+        dropping any line would silently mislead operators, so all six
+        content lines and the two dividers are pinned.
+    """
+
+    def test_prints_all_expected_banner_lines(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO, logger="root")
+        _make_manager()._present_monitoring_header()
+        out = capsys.readouterr().out
+        assert "Continuous Monitoring Mode" in out
+        assert "Monitoring active firmware upgrades..." in out
+        assert "Press Ctrl+C to exit at any time" in out
+        assert "Auto-refreshing every 7 seconds" in out
+        assert "NOTE: Each refresh scans ALL devices for active upgrades" in out
+        assert out.count("=" * 70) == 2  # WHY: opening + closing dividers
+        assert any("Starting continuous monitoring mode" in r.message for r in caplog.records)
+
+
+class TestPresentMonitoringIterationHeader:
+    """``_present_monitoring_iteration_header`` per-refresh banner."""
+
+    def test_uses_iteration_number(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._present_monitoring_iteration_header(42)
+        out = capsys.readouterr().out
+        assert "Firmware Upgrade Monitoring - Live View" in out
+        assert "Refresh #42 | Press Ctrl+C to exit" in out
+        assert "Scanning all devices for active upgrades..." in out
+
+
+class TestClearMonitoringScreen:
+    """``_clear_monitoring_screen`` platform dispatch.
+
+    Why:
+        The wrong screen-clear command is silently ignored on the other
+        platform, leaving stale text on screen. Both branches must be
+        exercised with a mocked ``os.system`` so tests never fork a
+        subprocess.
+    """
+
+    def test_windows_calls_cls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import os
+        import platform
+
+        calls: list[str] = []
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.setattr(os, "system", lambda cmd: calls.append(cmd) or 0)
+        _make_manager()._clear_monitoring_screen()
+        assert calls == ["cls"]
+
+    def test_posix_calls_clear(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import os
+        import platform
+
+        calls: list[str] = []
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(os, "system", lambda cmd: calls.append(cmd) or 0)
+        _make_manager()._clear_monitoring_screen()
+        assert calls == ["clear"]
+
+
+class TestHandleMonitoringResult:
+    """``_handle_monitoring_result`` three-way branch.
+
+    Why:
+        The return value drives loop exit: ``True`` means done, ``False``
+        means "keep polling". Confusing these two returns silently wedges
+        the monitoring loop or exits it early.
+    """
+
+    def test_none_result_prints_retry_and_continues(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="root")
+        assert _make_manager()._handle_monitoring_result(None, 3) is False
+        out = capsys.readouterr().out
+        assert "Error fetching upgrade status. Retrying..." in out
+        assert any("Monitoring iteration 3 failed" in r.message for r in caplog.records)
+
+    def test_zero_result_signals_completion(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO, logger="root")
+        assert _make_manager()._handle_monitoring_result(0, 5) is True
+        out = capsys.readouterr().out
+        assert "All upgrades completed!" in out
+        assert "No active firmware upgrades detected." in out
+        assert "Exiting monitoring mode." in out
+        assert any("Monitoring mode exiting" in r.message for r in caplog.records)
+
+    def test_positive_result_prints_progress_and_continues(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert _make_manager()._handle_monitoring_result(4, 2) is False
+        out = capsys.readouterr().out
+        assert "Found 4 device(s) actively upgrading" in out
+        assert "Next refresh in 7 seconds..." in out
+
+
+class TestRunMonitoringLoop:
+    """``_run_monitoring_loop`` drive-through with mocked collaborators."""
+
+    def test_exits_when_handler_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_clear_monitoring_screen", lambda: None)
+        monkeypatch.setattr(mgr, "_present_monitoring_iteration_header", lambda _i: None)
+        monkeypatch.setattr(mgr, "_execute_monitoring_check", lambda _sf: 0)
+        # If time.sleep were reached the test would hang; force the loop to exit first.
+        monkeypatch.setattr(fm_mod.time, "sleep", lambda _s: (_ for _ in ()).throw(AssertionError("slept")))
+        mgr._run_monitoring_loop("site-x")
+
+    def test_loops_until_zero_upgrades(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        iterations = {"n": 0}
+
+        def fake_check(_sf: str | None) -> int:
+            iterations["n"] += 1
+            return 2 if iterations["n"] < 3 else 0  # WHY: emulate two "still upgrading" then done
+
+        monkeypatch.setattr(mgr, "_clear_monitoring_screen", lambda: None)
+        monkeypatch.setattr(mgr, "_present_monitoring_iteration_header", lambda _i: None)
+        monkeypatch.setattr(mgr, "_execute_monitoring_check", fake_check)
+        monkeypatch.setattr(fm_mod.time, "sleep", lambda _s: None)  # WHY: no real sleep
+        mgr._run_monitoring_loop(None)
+        assert iterations["n"] == 3
+
+
+class TestContinuousMonitoringMode:
+    """``_continuous_monitoring_mode`` outer wrapper w/ KeyboardInterrupt."""
+
+    def test_normal_exit_calls_run_loop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        header = MagicMock()
+        loop = MagicMock()
+        monkeypatch.setattr(mgr, "_present_monitoring_header", header)
+        monkeypatch.setattr(mgr, "_run_monitoring_loop", loop)
+        mgr._continuous_monitoring_mode("site-a")
+        header.assert_called_once_with()
+        loop.assert_called_once_with("site-a")
+
+    def test_keyboard_interrupt_prints_cancel_banner(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_present_monitoring_header", lambda: None)
+
+        def raise_kb(_sf: str | None) -> None:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(mgr, "_run_monitoring_loop", raise_kb)
+        mgr._continuous_monitoring_mode(None)
+        assert "Monitoring mode cancelled by user." in capsys.readouterr().out
+
+
+class TestPrintUpgradeJobTimingInfo:
+    """``_print_upgrade_job_timing_info`` epoch formatting + fallback."""
+
+    def test_prints_formatted_times(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_upgrade_job_timing_info({"start_time": 1_700_000_000, "reboot_at": 1_700_003_600})
+        out = capsys.readouterr().out
+        assert "Start Time:" in out
+        assert "Reboot Time:" in out
+
+    def test_missing_fields_render_nothing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_upgrade_job_timing_info({})
+        assert capsys.readouterr().out == ""
+
+    def test_bad_epoch_falls_back_to_raw(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # Very large epoch triggers OverflowError inside fromtimestamp on some platforms;
+        # a string value forces the except branch cleanly.
+        _make_manager()._print_upgrade_job_timing_info({"start_time": "bad", "reboot_at": "bad"})
+        out = capsys.readouterr().out
+        assert "Start Time: bad (epoch)" in out
+        assert "Reboot Time: bad (epoch)" in out
+
+
+class TestPrintUpgradeJobP2pConfig:
+    """``_print_upgrade_job_p2p_config`` conditional block behavior."""
+
+    def test_p2p_disabled_only_prints_flag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_upgrade_job_p2p_config({"enable_p2p": False})
+        out = capsys.readouterr().out
+        assert "P2P Enabled: False" in out
+        assert "Cluster Size" not in out
+
+    def test_p2p_enabled_prints_cluster_and_parallelism(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_upgrade_job_p2p_config({"enable_p2p": True, "p2p_cluster_size": 4, "p2p_parallelism": 2})
+        out = capsys.readouterr().out
+        assert "P2P Enabled: True" in out
+        assert "P2P Cluster Size: 4" in out
+        assert "P2P Parallelism: 2" in out
+
+    def test_optional_fields_render_when_present(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_upgrade_job_p2p_config(
+            {"canary_phases": [1, 2], "max_failure_percentage": 0, "current_phase": 0}
+        )
+        out = capsys.readouterr().out
+        assert "Canary Phases: [1, 2]" in out
+        assert "Max Failure %: 0" in out  # WHY: 0 is a legitimate value
+        assert "Current Phase: 0" in out  # WHY: 0 is a legitimate value
+
+
+class TestPrintUpgradeJobProgressSummary:
+    """``_print_upgrade_job_progress_summary`` progress + sites lines."""
+
+    def test_prints_progress_line(self, capsys: pytest.CaptureFixture[str]) -> None:
+        details = {
+            "targets": {
+                "total": 10,
+                "upgraded": ["d1", "d2"],
+                "downloaded": ["d3"],
+                "download_requested": ["d4", "d5", "d6"],
+            }
+        }
+        _make_manager()._print_upgrade_job_progress_summary(details)
+        out = capsys.readouterr().out
+        assert "Progress: 2/10 upgraded, 1 downloaded, 3 downloading" in out
+
+    def test_prints_sites_when_present(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_upgrade_job_progress_summary({"upgrades": [{"a": 1}, {"b": 2}]})
+        assert "Sites: 2 site upgrade(s)" in capsys.readouterr().out
+
+    def test_empty_details_prints_nothing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_upgrade_job_progress_summary({})
+        assert capsys.readouterr().out == ""
+
+
+class TestPrintUpgradeJobDetailBlock:
+    """``_print_upgrade_job_detail_block`` orchestrator + error path."""
+
+    def test_prints_all_sections_on_success(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        api = MagicMock()
+        api.getOrgDeviceUpgrade.return_value = types.SimpleNamespace(
+            data={"status": "inprogress", "target_version": "6.3.5", "strategy": "rolling"}
+        )
+        called: list[str] = []
+        monkeypatch.setattr(mgr, "_print_upgrade_job_timing_info", lambda _d: called.append("timing"))
+        monkeypatch.setattr(mgr, "_print_upgrade_job_p2p_config", lambda _d: called.append("p2p"))
+        monkeypatch.setattr(mgr, "_print_upgrade_job_progress_summary", lambda _d: called.append("prog"))
+        mgr._print_upgrade_job_detail_block(api, "job-1")
+        out = capsys.readouterr().out
+        assert "Status: inprogress" in out
+        assert "Target Version: 6.3.5" in out
+        assert "Strategy: rolling" in out
+        assert called == ["timing", "p2p", "prog"]
+
+    def test_missing_data_short_circuits(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        api = MagicMock()
+        api.getOrgDeviceUpgrade.return_value = None
+        mgr._print_upgrade_job_detail_block(api, "job-2")
+        # Nothing should be printed and no exception raised.
+        assert capsys.readouterr().out == ""
+
+    def test_non_dict_data_uses_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        api = MagicMock()
+        api.getOrgDeviceUpgrade.return_value = types.SimpleNamespace(data=["not-a-dict"])
+        monkeypatch.setattr(mgr, "_print_upgrade_job_timing_info", lambda _d: None)
+        monkeypatch.setattr(mgr, "_print_upgrade_job_p2p_config", lambda _d: None)
+        monkeypatch.setattr(mgr, "_print_upgrade_job_progress_summary", lambda _d: None)
+        mgr._print_upgrade_job_detail_block(api, "job-3")
+        out = capsys.readouterr().out
+        assert "Status: Unknown" in out
+
+    def test_error_path_prints_and_logs(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mgr = _make_manager()
+        api = MagicMock()
+        api.getOrgDeviceUpgrade.side_effect = RuntimeError("boom")
+        caplog.set_level(logging.ERROR, logger="root")
+        mgr._print_upgrade_job_detail_block(api, "job-err")
+        assert "Error fetching details: boom" in capsys.readouterr().out
+        assert any("Error fetching upgrade job job-err" in r.message for r in caplog.records)
+
+
+class TestFetchOrgUpgradeJobs:
+    """``_fetch_org_upgrade_jobs`` API-wrapper contract.
+
+    Why:
+        The lazy ``import mistapi.api.v1.orgs.devices as org_devices_api``
+        resolves via attribute-walk from the ``mistapi`` package, so
+        overriding ``sys.modules`` alone is not enough — we replace the
+        function attribute on the real submodule so the import returns a
+        module whose ``listOrgDeviceUpgrades`` is our fake.
+    """
+
+    def test_returns_normalized_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.devices as real_api
+
+        monkeypatch.setattr(
+            real_api,
+            "listOrgDeviceUpgrades",
+            lambda _s, _o: types.SimpleNamespace(data=[{"id": "j1"}, {"id": "j2"}]),
+        )
+        api, jobs = _make_manager()._fetch_org_upgrade_jobs()
+        assert api is real_api
+        assert jobs == [{"id": "j1"}, {"id": "j2"}]
+
+    def test_missing_data_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.devices as real_api
+
+        monkeypatch.setattr(real_api, "listOrgDeviceUpgrades", lambda _s, _o: None)
+        api, jobs = _make_manager()._fetch_org_upgrade_jobs()
+        assert api is real_api
+        assert jobs == []
+
+    def test_non_list_data_normalized_to_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.devices as real_api
+
+        monkeypatch.setattr(
+            real_api,
+            "listOrgDeviceUpgrades",
+            lambda _s, _o: types.SimpleNamespace(data={"not": "a list"}),
+        )
+        _api, jobs = _make_manager()._fetch_org_upgrade_jobs()
+        assert jobs == []
+
+
+class TestRenderOrgUpgradeJobs:
+    """``_render_org_upgrade_jobs`` per-job iteration."""
+
+    def test_calls_detail_block_for_each_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        seen: list[str] = []
+        monkeypatch.setattr(mgr, "_print_upgrade_job_detail_block", lambda _api, jid: seen.append(jid))
+        mgr._render_org_upgrade_jobs(MagicMock(), [{"id": "a"}, {"id": "b"}])
+        assert seen == ["a", "b"]
+
+    def test_skips_records_without_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        seen: list[str] = []
+        monkeypatch.setattr(mgr, "_print_upgrade_job_detail_block", lambda _api, jid: seen.append(jid))
+        mgr._render_org_upgrade_jobs(MagicMock(), [{"other": "x"}, {"id": None}, {"id": "keep"}])
+        assert seen == ["keep"]
+
+    def test_supports_object_style_jobs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        seen: list[str] = []
+        monkeypatch.setattr(mgr, "_print_upgrade_job_detail_block", lambda _api, jid: seen.append(jid))
+        obj = types.SimpleNamespace(id="objid")
+        mgr._render_org_upgrade_jobs(MagicMock(), [obj])
+        assert seen == ["objid"]
+
+
+class TestShowOrgLevelUpgradeJobs:
+    """``_show_org_level_upgrade_jobs`` end-to-end orchestrator."""
+
+    def test_empty_list_prints_none_found(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_org_upgrade_jobs", lambda: (MagicMock(), []))
+        render = MagicMock()
+        monkeypatch.setattr(mgr, "_render_org_upgrade_jobs", render)
+        mgr._show_org_level_upgrade_jobs()
+        out = capsys.readouterr().out
+        assert "No org-level upgrade jobs found." in out
+        render.assert_not_called()
+
+    def test_non_empty_list_renders_and_finalizes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        api = MagicMock()
+        monkeypatch.setattr(mgr, "_fetch_org_upgrade_jobs", lambda: (api, [{"id": "j"}]))
+        render = MagicMock()
+        monkeypatch.setattr(mgr, "_render_org_upgrade_jobs", render)
+        mgr._show_org_level_upgrade_jobs()
+        out = capsys.readouterr().out
+        assert "Found 1 org-level upgrade job(s)" in out
+        assert "Org-level upgrade job details complete." in out
+        render.assert_called_once_with(api, [{"id": "j"}])
+
+    def test_exception_prints_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mgr = _make_manager()
+
+        def blow(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(mgr, "_fetch_org_upgrade_jobs", blow)
+        caplog.set_level(logging.ERROR, logger="root")
+        mgr._show_org_level_upgrade_jobs()
+        assert "Error fetching org-level upgrades: boom" in capsys.readouterr().out
+        assert any("Error in _show_org_level_upgrade_jobs" in r.message for r in caplog.records)
+
+
+class TestFetchDeviceStatsForMonitoring:
+    """``_fetch_device_stats_for_monitoring`` branch selection."""
+
+    def test_site_filter_uses_site_stats(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: dict[str, Any] = {}
+
+        def site_stats(_ses: Any, site_id: str, **kw: Any) -> str:
+            seen["site"] = (site_id, kw)
+            return "site-resp"
+
+        fake_mistapi = types.SimpleNamespace(
+            api=types.SimpleNamespace(
+                v1=types.SimpleNamespace(
+                    sites=types.SimpleNamespace(stats=types.SimpleNamespace(listSiteDevicesStats=site_stats)),
+                    orgs=types.SimpleNamespace(stats=types.SimpleNamespace(listOrgDevicesStats=None)),
+                )
+            ),
+            get_all=lambda response, mist_session: f"all-of-{response}",
+        )
+        monkeypatch.setattr(fm_mod, "mistapi", fake_mistapi)
+        got = _make_manager()._fetch_device_stats_for_monitoring("site-1")
+        assert got == "all-of-site-resp"
+        assert seen["site"][0] == "site-1"
+        assert seen["site"][1]["type"] == "all"
+        assert seen["site"][1]["limit"] == 1000
+
+    def test_no_site_filter_uses_org_stats(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: dict[str, Any] = {}
+
+        def org_stats(_ses: Any, org_id: str, **kw: Any) -> str:
+            seen["org"] = (org_id, kw)
+            return "org-resp"
+
+        fake_mistapi = types.SimpleNamespace(
+            api=types.SimpleNamespace(
+                v1=types.SimpleNamespace(
+                    sites=types.SimpleNamespace(stats=types.SimpleNamespace(listSiteDevicesStats=None)),
+                    orgs=types.SimpleNamespace(stats=types.SimpleNamespace(listOrgDevicesStats=org_stats)),
+                )
+            ),
+            get_all=lambda response, mist_session: f"all-of-{response}",
+        )
+        monkeypatch.setattr(fm_mod, "mistapi", fake_mistapi)
+        got = _make_manager(org_id="ORG-Z")._fetch_device_stats_for_monitoring(None)
+        assert got == "all-of-org-resp"
+        assert seen["org"][0] == "ORG-Z"
+        assert seen["org"][1]["fields"] == "*"
+
+
+class TestIsActiveFwUpdate:
+    """``_is_active_fw_update`` classifier + stale 100% guard."""
+
+    def test_non_active_status_is_false(self) -> None:
+        assert _make_manager()._is_active_fw_update({"status": "success", "progress": 100}) is False
+
+    @pytest.mark.parametrize("verb", ["inprogress", "upgrading", "downloading"])
+    def test_active_status_true(self, verb: str) -> None:
+        assert _make_manager()._is_active_fw_update({"status": verb, "progress": 50}) is True
+
+    def test_fresh_100_percent_is_active(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        now = 1_700_000_000
+        monkeypatch.setattr(fm_mod.time, "time", lambda: now)
+        rec = {"status": "inprogress", "progress": 100, "timestamp": now - 60}
+        assert _make_manager()._is_active_fw_update(rec) is True
+
+    def test_stale_100_percent_is_inactive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        now = 1_700_000_000
+        monkeypatch.setattr(fm_mod.time, "time", lambda: now)
+        # 2 hours old -> stale beyond 1-hour cutoff.
+        rec = {"status": "inprogress", "progress": 100, "timestamp": now - 7200}
+        assert _make_manager()._is_active_fw_update(rec) is False
+
+    def test_bad_timestamp_leaves_active_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A string epoch triggers TypeError in the subtraction -> except keeps active True.
+        rec = {"status": "inprogress", "progress": 100, "timestamp": "bad"}
+        assert _make_manager()._is_active_fw_update(rec) is True
+
+
+class TestGetActiveUpgradesFromStats:
+    """``_get_active_upgrades_from_stats`` filter + projection."""
+
+    def test_filters_out_inactive_and_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        stats = [
+            {"name": "a", "type": "ap", "model": "AP32", "fwupdate": {"status": "inprogress", "progress": 42}},
+            {"name": "b", "type": "ap", "model": "AP32"},  # WHY: no fwupdate -> skip
+            {
+                "name": "c",
+                "type": "switch",
+                "model": "EX4400",
+                "fwupdate": {"status": "success", "progress": 100},  # WHY: not active
+            },
+        ]
+        result = mgr._get_active_upgrades_from_stats(stats)
+        assert result == [{"name": "a", "type": "ap", "model": "AP32", "progress": 42, "status": "inprogress"}]
+
+    def test_projection_defaults_when_fields_missing(self) -> None:
+        stats = [{"fwupdate": {"status": "upgrading"}}]
+        result = _make_manager()._get_active_upgrades_from_stats(stats)
+        assert result == [
+            {
+                "name": "Unnamed",
+                "type": "unknown",
+                "model": "Unknown",
+                "progress": 0,
+                "status": "upgrading",
+            }
+        ]
+
+
+class TestPrintActiveUpgradesTable:
+    """``_print_active_upgrades_table`` header + DisplayUtils fallback."""
+
+    def test_empty_list_returns_silently(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_active_upgrades_table([])
+        assert capsys.readouterr().out == ""
+
+    def test_no_main_module_uses_blank_progress(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Remove both main + MistHelper from sys.modules so _main_d is None.
+        monkeypatch.delitem(sys.modules, "__main__", raising=False)
+        monkeypatch.delitem(sys.modules, "MistHelper", raising=False)
+        rec = [{"name": "sw1", "type": "switch", "model": "EX4400", "progress": 30, "status": "upgrading"}]
+        _make_manager()._print_active_upgrades_table(rec)
+        out = capsys.readouterr().out
+        assert "Devices Currently Upgrading:" in out
+        assert "Device Name" in out and "Progress" in out
+        assert "sw1" in out and "switch" in out and "EX4400" in out and "upgrading" in out
+
+    def test_with_display_utils_renders_progress_bar(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        fake_main = types.SimpleNamespace(
+            DisplayUtils=types.SimpleNamespace(create_progress_bar=lambda pct, bar_length: f"[BAR-{pct}]")
+        )
+        monkeypatch.setitem(sys.modules, "__main__", fake_main)
+        rec = [{"name": "ap1", "type": "ap", "model": "AP32", "progress": 55, "status": "upgrading"}]
+        _make_manager()._print_active_upgrades_table(rec)
+        out = capsys.readouterr().out
+        assert "[BAR-55]" in out
+
+
+class TestExecuteMonitoringCheck:
+    """``_execute_monitoring_check`` orchestrator + error-safety."""
+
+    def test_returns_active_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_device_stats_for_monitoring", lambda _sf: ["stat1", "stat2"])
+        monkeypatch.setattr(mgr, "_get_active_upgrades_from_stats", lambda _s: [{"name": "a"}, {"name": "b"}])
+        monkeypatch.setattr(mgr, "_print_active_upgrades_table", lambda _r: None)
+        assert mgr._execute_monitoring_check("site-x") == 2
+
+    def test_returns_none_on_exception(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        mgr = _make_manager()
+
+        def blow(_sf: str | None) -> None:
+            raise RuntimeError("fetch fail")
+
+        monkeypatch.setattr(mgr, "_fetch_device_stats_for_monitoring", blow)
+        caplog.set_level(logging.ERROR, logger="root")
+        assert mgr._execute_monitoring_check(None) is None
+        assert any("Error in monitoring check" in r.message for r in caplog.records)

--- a/tests/unit/firmware/test_firmware_manager_ssr.py
+++ b/tests/unit/firmware/test_firmware_manager_ssr.py
@@ -1,0 +1,2027 @@
+"""Switch-mode + full SSR firmware upgrade flow unit tests.
+
+Why:
+    The SSR upgrade path is the most destructive operation in the whole
+    tool — it reboots WAN routers and can drop branch offices offline.
+    Every branch of the input validation, verdict classification, error
+    interpretation and dispatch orchestration must be pinned or a
+    silent regression could turn a controlled maintenance window into
+    an outage. The switch mode-selection helpers share the same
+    ``_safe_input_fn`` retry contract so they are covered here too.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.firmware.firmware_manager as fm_mod
+from src.firmware.firmware_manager import FirmwareManager, FirmwareManagerConfig
+
+
+def _make_manager(**overrides: Any) -> FirmwareManager:
+    """Build a ``FirmwareManager`` with a valid minimum config.
+
+    Why:
+        Every helper under test needs a live manager but only reads
+        ``self.apisession`` / ``self.org_id`` (or one of the DI hooks).
+        Centralising construction keeps each test focused on the
+        branch it exercises.
+
+    Args:
+        **overrides: Any config field to override.
+
+    Returns:
+        A live ``FirmwareManager`` ready for helper invocation.
+    """
+    defaults: dict[str, Any] = {"apisession": object(), "org_id": "org-test"}
+    defaults.update(overrides)
+    return FirmwareManager(FirmwareManagerConfig(**defaults))
+
+
+def _snapshot_session() -> tuple[Any, str]:
+    """Snapshot ``(apisession, org_id)`` module globals.
+
+    Why:
+        ``FirmwareManager.__init__`` rebinds these; tests that depend
+        on the pre-existing values must restore them to avoid leaking
+        state into the next test.
+
+    Returns:
+        A pair of ``(apisession, org_id)`` values.
+    """
+    return fm_mod.apisession, fm_mod.org_id
+
+
+def _restore_session(snap: tuple[Any, str]) -> None:
+    """Restore the module-scope session captured by ``_snapshot_session``.
+
+    Args:
+        snap: The pair captured by ``_snapshot_session``.
+    """
+    fm_mod.apisession, fm_mod.org_id = snap
+
+
+class _FakeResponse:
+    """Minimal mistapi response stand-in.
+
+    Why:
+        Every SSR helper reads ``status_code`` + ``data`` off the
+        response object; some also fall through to ``text``/``content``.
+        A hand-rolled stand-in avoids importing ``requests`` just to
+        wire up a test.
+    """
+
+    def __init__(
+        self,
+        status_code: int = 200,
+        data: Any = None,
+        text: str | None = None,
+        content: bytes | None = None,
+    ) -> None:
+        """Store the pieces the SSR helpers read.
+
+        Args:
+            status_code: Response status.
+            data: Parsed JSON payload.
+            text: Optional textual body.
+            content: Optional raw bytes body.
+        """
+        self.status_code = status_code
+        self.data = data
+        if text is not None:
+            self.text = text
+        if content is not None:
+            self.content = content
+
+
+# ==============================================================================
+# SWITCH MODE SELECTION HELPERS
+# ==============================================================================
+
+
+class TestPrintSwitchUpgradeBanner:
+    """``_print_switch_upgrade_banner`` operator hazard header."""
+
+    def test_prints_expected_banner_lines(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_switch_upgrade_banner()
+        out = capsys.readouterr().out
+        assert "Advanced Switch Firmware Upgrade" in out
+        assert "DESTRUCTIVE OPERATION WARNING" in out
+        assert "Reboot switches during upgrade process" in out
+        assert "Require recovery snapshots for Junos devices" in out
+
+
+class TestPrintSwitchModeMenu:
+    """``_print_switch_mode_menu`` shows the 1/2 menu."""
+
+    def test_menu_lines_emitted(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_switch_mode_menu()
+        out = capsys.readouterr().out
+        assert "Select upgrade mode" in out
+        assert "[1] By Site" in out
+        assert "[2] By Gateway Template" in out
+
+
+class TestPromptSwitchUpgradeMode:
+    """Loop until 1|2; EOF/interrupt returns None."""
+
+    @pytest.mark.parametrize("choice", ["1", "2"])
+    def test_returns_valid_choice(self, choice: str) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: choice)
+        assert mgr._prompt_switch_upgrade_mode() == choice
+
+    def test_retries_on_invalid(self, capsys: pytest.CaptureFixture[str]) -> None:
+        answers = iter(["x", "0", "1"])
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: next(answers))
+        assert mgr._prompt_switch_upgrade_mode() == "1"
+        assert "Invalid selection. Please choose 1 or 2." in capsys.readouterr().out
+
+    @pytest.mark.parametrize("exc", [EOFError, KeyboardInterrupt])
+    def test_returns_none_on_interrupt(self, capsys: pytest.CaptureFixture[str], exc: type[BaseException]) -> None:
+        def raise_exc(*_a: Any, **_k: Any) -> str:
+            raise exc()
+
+        mgr = _make_manager(safe_input_fn=raise_exc)
+        assert mgr._prompt_switch_upgrade_mode() is None
+        assert "Operation cancelled by user" in capsys.readouterr().out
+
+
+class TestDispatchSwitchUpgradeMode:
+    """Route validated 1|2 to site or template flow."""
+
+    def test_mode_1_calls_site_flow(self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_bulk_upgrade_switch_firmware_by_site", called)
+        mgr._dispatch_switch_upgrade_mode("1")
+        called.assert_called_once_with()
+        assert "Site-based switch upgrade mode selected" in capsys.readouterr().out
+
+    def test_mode_2_calls_template_flow(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_upgrade_switch_firmware_by_gateway_template", called)
+        mgr._dispatch_switch_upgrade_mode("2")
+        called.assert_called_once_with()
+        assert "Template-based switch upgrade mode selected" in capsys.readouterr().out
+
+
+class TestExecuteSwitchFirmwareUpgradeWithModeSelection:
+    """Full switch upgrade orchestrator wiring."""
+
+    def test_early_return_on_none_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_switch_upgrade_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_print_switch_mode_menu", lambda: None)
+        monkeypatch.setattr(mgr, "_prompt_switch_upgrade_mode", lambda: None)
+        dispatch = MagicMock()
+        monkeypatch.setattr(mgr, "_dispatch_switch_upgrade_mode", dispatch)
+        assert mgr.execute_switch_firmware_upgrade_with_mode_selection() is None
+        dispatch.assert_not_called()
+
+    def test_happy_path_dispatches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_switch_upgrade_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_print_switch_mode_menu", lambda: None)
+        monkeypatch.setattr(mgr, "_prompt_switch_upgrade_mode", lambda: "1")
+        dispatch = MagicMock()
+        monkeypatch.setattr(mgr, "_dispatch_switch_upgrade_mode", dispatch)
+        mgr.execute_switch_firmware_upgrade_with_mode_selection()
+        dispatch.assert_called_once_with("1")
+
+
+class TestBulkUpgradeSwitchFirmwareBySite:
+    """Lazy import + delegate to ``BulkSwitchFirmwareUpgrader``."""
+
+    def test_delegates_to_bulk_switch_upgrader(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        import src.firmware.bulk_switch_upgrader as bsu
+
+        captured: dict[str, Any] = {}
+
+        class FakeImpl:
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+            def execute(self) -> None:
+                captured["executed"] = True
+
+        monkeypatch.setattr(bsu, "BulkSwitchFirmwareUpgrader", FakeImpl)
+        mgr._bulk_upgrade_switch_firmware_by_site(sites_to_upgrade_override=[{"id": "s1"}])
+        assert captured["org_id"] == "org-test"
+        assert captured["executed"] is True
+        assert captured["sites_override"] == [{"id": "s1"}]
+
+
+class TestUpgradeSwitchFirmwareByGatewayTemplate:
+    """Template flow: banner + prepare + select + execute."""
+
+    def test_returns_none_when_prepare_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_switch_template_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_prepare_template_upgrade", lambda _k: None)
+        exec_mock = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_switch_upgrade", exec_mock)
+        assert mgr._upgrade_switch_firmware_by_gateway_template() is None
+        exec_mock.assert_not_called()
+
+    def test_returns_none_when_selection_declined(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_switch_template_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_prepare_template_upgrade", lambda _k: ({}, {}))
+        monkeypatch.setattr(mgr, "_select_template_and_sites", lambda *_a: None)
+        exec_mock = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_switch_upgrade", exec_mock)
+        assert mgr._upgrade_switch_firmware_by_gateway_template() is None
+        exec_mock.assert_not_called()
+
+    def test_happy_path_dispatches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_switch_template_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_prepare_template_upgrade", lambda _k: ({"t": "1"}, {"1": [{"id": "s1"}]}))
+        monkeypatch.setattr(mgr, "_select_template_and_sites", lambda *_a: ("tpl", [{"id": "s1"}]))
+        exec_mock = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_switch_upgrade", exec_mock)
+        mgr._upgrade_switch_firmware_by_gateway_template()
+        exec_mock.assert_called_once_with([{"id": "s1"}], "tpl")
+
+
+class TestPrintSwitchTemplateBanner:
+    """``_print_switch_template_banner`` operator title."""
+
+    def test_prints_banner(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_switch_template_banner()
+        out = capsys.readouterr().out
+        assert "Advanced Switch Firmware Upgrade by Gateway Template" in out
+        assert "=" * 70 in out
+
+
+class TestExecuteTemplateBasedSwitchUpgrade:
+    """Template-driven switch upgrade prints headers + delegates."""
+
+    def test_calls_bulk_switch_with_override(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_bulk_upgrade_switch_firmware_by_site", called)
+        sites = [{"id": "s1"}, {"id": "s2"}]
+        mgr._execute_template_based_switch_upgrade(sites, "TMPL")
+        called.assert_called_once_with(sites)
+        out = capsys.readouterr().out
+        assert "template: TMPL" in out
+        assert "Target sites: 2" in out
+
+
+# ==============================================================================
+# SSR MODE ENTRY + WARNING HELPERS
+# ==============================================================================
+
+
+class TestPrintSSRHazardsBlock:
+    """SSR hazards banner content."""
+
+    def test_prints_hazards(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_hazards_block()
+        out = capsys.readouterr().out
+        assert "Advanced SSR Firmware Upgrade" in out
+        assert "CRITICAL ROUTING INFRASTRUCTURE WARNING" in out
+        assert "Reboot Session Smart Routers" in out
+        assert "Impact tunnel establishment and failover" in out
+
+
+class TestPrintSSRPrecautionsBlock:
+    """SSR precautions + mode-selector banner."""
+
+    def test_prints_precautions_and_menu(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_precautions_block()
+        out = capsys.readouterr().out
+        assert "RECOMMENDED PRECAUTIONS" in out
+        assert "Schedule maintenance windows" in out
+        assert "Select upgrade mode" in out
+        assert "[1] By Site" in out
+        assert "[2] By Gateway Template" in out
+
+
+class TestPresentSSRUpgradeWarning:
+    """Combined banner + precautions dispatch."""
+
+    def test_calls_both_blocks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        h = MagicMock()
+        p = MagicMock()
+        monkeypatch.setattr(mgr, "_print_ssr_hazards_block", h)
+        monkeypatch.setattr(mgr, "_print_ssr_precautions_block", p)
+        mgr._present_ssr_upgrade_warning()
+        h.assert_called_once_with()
+        p.assert_called_once_with()
+
+
+class TestPromptSSRModeSelection:
+    """Mode prompt loop and cancel semantics."""
+
+    @pytest.mark.parametrize("choice", ["1", "2"])
+    def test_returns_valid_choice(self, choice: str) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: choice)
+        assert mgr._prompt_ssr_mode_selection() == choice
+
+    def test_retries_on_invalid(self, capsys: pytest.CaptureFixture[str]) -> None:
+        answers = iter(["", "x", "2"])
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: next(answers))
+        assert mgr._prompt_ssr_mode_selection() == "2"
+        assert "Invalid selection" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("exc", [EOFError, KeyboardInterrupt])
+    def test_returns_none_on_interrupt(self, capsys: pytest.CaptureFixture[str], exc: type[BaseException]) -> None:
+        def raise_exc(*_a: Any, **_k: Any) -> str:
+            raise exc()
+
+        mgr = _make_manager(safe_input_fn=raise_exc)
+        assert mgr._prompt_ssr_mode_selection() is None
+        assert "Operation cancelled by user" in capsys.readouterr().out
+
+
+class TestDispatchSSRUpgradeMode:
+    """Route validated mode to site or template flow."""
+
+    def test_mode_1_returns_site_result(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_bulk_upgrade_ssr_firmware_by_site", lambda: {"upgraded": 3})
+        result = mgr._dispatch_ssr_upgrade_mode("1")
+        assert result == {"upgraded": 3}
+        assert "Site-based SSR upgrade mode selected" in capsys.readouterr().out
+
+    def test_mode_2_returns_none(self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_upgrade_ssr_firmware_by_gateway_template", called)
+        assert mgr._dispatch_ssr_upgrade_mode("2") is None
+        called.assert_called_once_with()
+        assert "Template-based SSR upgrade mode selected" in capsys.readouterr().out
+
+
+class TestExecuteSSRFirmwareUpgradeWithModeSelection:
+    """Orchestrator: warning + prompt + dispatch."""
+
+    def test_returns_none_on_prompt_cancel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_present_ssr_upgrade_warning", lambda: None)
+        monkeypatch.setattr(mgr, "_prompt_ssr_mode_selection", lambda: None)
+        dispatch = MagicMock()
+        monkeypatch.setattr(mgr, "_dispatch_ssr_upgrade_mode", dispatch)
+        assert mgr.execute_ssr_firmware_upgrade_with_mode_selection() is None
+        dispatch.assert_not_called()
+
+    def test_returns_dispatch_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_present_ssr_upgrade_warning", lambda: None)
+        monkeypatch.setattr(mgr, "_prompt_ssr_mode_selection", lambda: "1")
+        monkeypatch.setattr(mgr, "_dispatch_ssr_upgrade_mode", lambda _c: {"x": 1})
+        assert mgr.execute_ssr_firmware_upgrade_with_mode_selection() == {"x": 1}
+
+
+# ==============================================================================
+# ORG VALIDATION
+# ==============================================================================
+
+
+class TestValidateOrgForSSRUpgrade:
+    """``_validate_org_for_ssr_upgrade`` handles success/error/exception."""
+
+    def test_success_returns_org_name(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import mistapi.api.v1.orgs.orgs as real_orgs
+
+        monkeypatch.setattr(
+            real_orgs,
+            "getOrg",
+            lambda _s, _o: _FakeResponse(200, {"name": "MyOrg"}),
+        )
+        mgr = _make_manager()
+        name, err = mgr._validate_org_for_ssr_upgrade()
+        assert name == "MyOrg"
+        assert err is None
+        assert "MyOrg" in capsys.readouterr().out
+
+    def test_non_200_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.orgs as real_orgs
+
+        monkeypatch.setattr(real_orgs, "getOrg", lambda _s, _o: _FakeResponse(500, {}))
+        mgr = _make_manager()
+        name, err = mgr._validate_org_for_ssr_upgrade()
+        assert name == ""
+        assert err == {"error": "Organization access failed"}
+
+    def test_exception_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.orgs as real_orgs
+
+        def raise_exc(*_a: Any, **_k: Any) -> Any:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(real_orgs, "getOrg", raise_exc)
+        mgr = _make_manager()
+        name, err = mgr._validate_org_for_ssr_upgrade()
+        assert name == ""
+        assert err is not None and "Organization validation error" in err["error"]
+
+
+# ==============================================================================
+# SITE SELECTION HELPERS
+# ==============================================================================
+
+
+class TestPromptSSRSiteSelection:
+    """A/S/C site selection menu."""
+
+    def test_choice_a_returns_all(self, capsys: pytest.CaptureFixture[str]) -> None:
+        sites = [{"id": "s1", "name": "S1"}, {"id": "s2", "name": "S2"}]
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "A")
+        selected, err = mgr._prompt_ssr_site_selection(sites)
+        assert selected == sites
+        assert err is None
+        assert "Selected all 2 sites" in capsys.readouterr().out
+
+    def test_choice_a_case_insensitive(self) -> None:
+        sites = [{"id": "s1"}]
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "a")
+        selected, err = mgr._prompt_ssr_site_selection(sites)
+        assert selected == sites and err is None
+
+    def test_choice_c_cancels(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "C")
+        selected, err = mgr._prompt_ssr_site_selection([{"id": "s1"}])
+        assert selected == []
+        assert err == {"cancelled": True}
+        assert "Operation cancelled by user" in capsys.readouterr().out
+
+    def test_choice_s_delegates_to_parser(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "S")
+        sites = [{"id": "s1"}]
+        monkeypatch.setattr(mgr, "_parse_ssr_site_selection", lambda s: (s, None))
+        selected, err = mgr._prompt_ssr_site_selection(sites)
+        assert selected == sites and err is None
+
+    def test_invalid_choice_returns_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "Q")
+        selected, err = mgr._prompt_ssr_site_selection([{"id": "s1"}])
+        assert selected == []
+        assert err == {"error": "Invalid selection"}
+        assert "Invalid selection" in capsys.readouterr().out
+
+
+class TestParseSSRSiteSelection:
+    """Site index/range parser: valid tokens vs exception path."""
+
+    def test_valid_range_selection(self, capsys: pytest.CaptureFixture[str]) -> None:
+        sites = [{"id": f"s{i}"} for i in range(5)]
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "1-3")
+        selected, err = mgr._parse_ssr_site_selection(sites)
+        assert len(selected) == 3
+        assert err is None
+        assert "Selected 3 sites" in capsys.readouterr().out
+
+    def test_invalid_input_returns_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "abc")
+        selected, err = mgr._parse_ssr_site_selection([{"id": "s1"}])
+        assert selected == []
+        assert err == {"error": "Invalid site selection"}
+        assert "Invalid site selection" in capsys.readouterr().out
+
+
+class TestResolveSSRSiteTokens:
+    """Comma-separated site token resolver."""
+
+    def test_single_index(self) -> None:
+        sites = [{"id": f"s{i}"} for i in range(5)]
+        result = _make_manager()._resolve_ssr_site_tokens("2", sites)
+        assert result == [{"id": "s1"}]
+
+    def test_range(self) -> None:
+        sites = [{"id": f"s{i}"} for i in range(5)]
+        result = _make_manager()._resolve_ssr_site_tokens("1-3", sites)
+        assert result == [{"id": "s0"}, {"id": "s1"}, {"id": "s2"}]
+
+    def test_mixed_tokens_and_blanks(self) -> None:
+        sites = [{"id": f"s{i}"} for i in range(5)]
+        result = _make_manager()._resolve_ssr_site_tokens("1, ,3", sites)
+        assert result == [{"id": "s0"}, {"id": "s2"}]
+
+    def test_out_of_range_ignored(self) -> None:
+        sites = [{"id": f"s{i}"} for i in range(3)]
+        result = _make_manager()._resolve_ssr_site_tokens("99", sites)
+        assert result == []
+
+
+class TestExtendSitesFromToken:
+    """``_extend_sites_from_token`` per-token appender."""
+
+    def test_single_valid(self) -> None:
+        sites = [{"id": f"s{i}"} for i in range(5)]
+        buffer: list[dict[str, Any]] = []
+        _make_manager()._extend_sites_from_token("3", sites, buffer)
+        assert buffer == [{"id": "s2"}]
+
+    def test_single_out_of_range(self) -> None:
+        sites = [{"id": "s0"}]
+        buffer: list[dict[str, Any]] = []
+        _make_manager()._extend_sites_from_token("99", sites, buffer)
+        assert buffer == []
+
+    def test_range_inclusive(self) -> None:
+        sites = [{"id": f"s{i}"} for i in range(5)]
+        buffer: list[dict[str, Any]] = []
+        _make_manager()._extend_sites_from_token("2-4", sites, buffer)
+        assert buffer == [{"id": "s1"}, {"id": "s2"}, {"id": "s3"}]
+
+
+class TestSelectSSRSitesForUpgrade:
+    """Site selection driver: override / discover / error."""
+
+    def test_override_short_circuits(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        override = [{"id": "s1"}, {"id": "s2"}]
+        selected, err = mgr._select_ssr_sites_for_upgrade(override)
+        assert selected == override and err is None
+        assert "Using provided site list: 2 sites" in capsys.readouterr().out
+
+    def test_discovery_success_delegates_to_prompt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_sites = fm_mod.mistapi.api.v1.orgs.sites
+
+        monkeypatch.setattr(
+            real_sites,
+            "listOrgSites",
+            lambda _s, _o: _FakeResponse(200, [{"id": "s1", "name": "S1"}]),
+        )
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prompt_ssr_site_selection", lambda sites: (sites, None))
+        selected, err = mgr._select_ssr_sites_for_upgrade(None)
+        assert selected == [{"id": "s1", "name": "S1"}] and err is None
+
+    def test_discovery_non_200_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_sites = fm_mod.mistapi.api.v1.orgs.sites
+
+        monkeypatch.setattr(real_sites, "listOrgSites", lambda _s, _o: _FakeResponse(500, []))
+        mgr = _make_manager()
+        selected, err = mgr._select_ssr_sites_for_upgrade(None)
+        assert selected == []
+        assert err == {"error": "Failed to retrieve sites"}
+
+    def test_exception_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_sites = fm_mod.mistapi.api.v1.orgs.sites
+
+        def boom(*_a: Any, **_k: Any) -> Any:
+            raise RuntimeError("net-down")
+
+        monkeypatch.setattr(real_sites, "listOrgSites", boom)
+        mgr = _make_manager()
+        selected, err = mgr._select_ssr_sites_for_upgrade(None)
+        assert selected == []
+        assert err is not None and "Site discovery error" in err["error"]
+
+
+# ==============================================================================
+# UPGRADE PARAMETER SELECTION
+# ==============================================================================
+
+
+class TestSelectSSRUpgradeStrategy:
+    """Serial vs big-bang strategy prompt."""
+
+    def test_serial(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "1")
+        assert mgr._select_ssr_upgrade_strategy() == "serial"
+
+    def test_big_bang(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "2")
+        assert mgr._select_ssr_upgrade_strategy() == "big_bang"
+        assert "Big bang" in capsys.readouterr().out
+
+    def test_retries_on_bad_input(self) -> None:
+        answers = iter(["9", "", "1"])
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: next(answers))
+        assert mgr._select_ssr_upgrade_strategy() == "serial"
+
+
+class TestSelectSSRRebootTiming:
+    """Auto vs manual reboot flag."""
+
+    def test_auto(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "1")
+        assert mgr._select_ssr_reboot_timing() is True
+
+    def test_manual(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "2")
+        assert mgr._select_ssr_reboot_timing() is False
+        assert "manual reboot" in capsys.readouterr().out.lower()
+
+    def test_retries_on_bad_input(self) -> None:
+        answers = iter(["x", "1"])
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: next(answers))
+        assert mgr._select_ssr_reboot_timing() is True
+
+
+class TestSelectSSRFirmwareChannel:
+    """Stable/beta/alpha channel selection."""
+
+    @pytest.mark.parametrize("choice,expected", [("1", "stable"), ("2", "beta"), ("3", "alpha")])
+    def test_channel_choices(self, choice: str, expected: str) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: choice)
+        assert mgr._select_ssr_firmware_channel() == expected
+
+    def test_alpha_warning_printed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "3")
+        mgr._select_ssr_firmware_channel()
+        assert "alpha channel contains development" in capsys.readouterr().out
+
+    def test_retries_on_bad_input(self) -> None:
+        answers = iter(["", "4", "2"])
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: next(answers))
+        assert mgr._select_ssr_firmware_channel() == "beta"
+
+
+class TestSetupSSRUpgradeParams:
+    """Assemble strategy + reboot + channel into a bundle."""
+
+    def test_returns_bundle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_ssr_upgrade_strategy", lambda: "serial")
+        monkeypatch.setattr(mgr, "_select_ssr_reboot_timing", lambda: True)
+        monkeypatch.setattr(mgr, "_select_ssr_firmware_channel", lambda: "stable")
+        params = mgr._setup_ssr_upgrade_params()
+        assert params == {"strategy": "serial", "auto_reboot": True, "channel": "stable"}
+
+    def test_returns_none_when_strategy_cancelled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Cancel path: strategy prompt returns None -> reboot/channel are
+        # never called and the caller receives None so it can abort cleanly
+        # instead of firing a partial-config upgrade.
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_ssr_upgrade_strategy", lambda: None)
+        reboot_calls: list[int] = []
+        channel_calls: list[int] = []
+        monkeypatch.setattr(mgr, "_select_ssr_reboot_timing", lambda: reboot_calls.append(1) or True)
+        monkeypatch.setattr(mgr, "_select_ssr_firmware_channel", lambda: channel_calls.append(1) or "stable")
+        assert mgr._setup_ssr_upgrade_params() is None
+        assert reboot_calls == []
+        assert channel_calls == []
+
+
+# ==============================================================================
+# VERSION FETCH / NORMALIZE / SUMMARY
+# ==============================================================================
+
+
+class TestFetchSSRVersionRows:
+    """Raw version rows: success / non-200 / empty data."""
+
+    def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.ssr as real_ssr
+
+        monkeypatch.setattr(
+            real_ssr,
+            "listOrgAvailableSsrVersions",
+            lambda _s, _o, channel=None: _FakeResponse(200, [{"version": "6.3.5"}]),
+        )
+        mgr = _make_manager()
+        rows = mgr._fetch_ssr_version_rows("stable")
+        assert rows == [{"version": "6.3.5"}]
+
+    def test_non_200_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        import mistapi.api.v1.orgs.ssr as real_ssr
+
+        monkeypatch.setattr(
+            real_ssr,
+            "listOrgAvailableSsrVersions",
+            lambda _s, _o, channel=None: _FakeResponse(503, None),
+        )
+        mgr = _make_manager()
+        assert mgr._fetch_ssr_version_rows("stable") is None
+        assert "Error retrieving SSR firmware versions" in capsys.readouterr().out
+
+    def test_none_data_becomes_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.ssr as real_ssr
+
+        monkeypatch.setattr(
+            real_ssr,
+            "listOrgAvailableSsrVersions",
+            lambda _s, _o, channel=None: _FakeResponse(200, None),
+        )
+        mgr = _make_manager()
+        assert mgr._fetch_ssr_version_rows("stable") == []
+
+
+class TestParseSingleSSRVersionRow:
+    """Dict / string / other row shapes."""
+
+    def test_dict_with_all_fields(self) -> None:
+        row = {"version": "6.3.5", "package": "pkgX", "default": True}
+        assert _make_manager()._parse_single_ssr_version_row(row) == row
+
+    def test_dict_missing_fields_defaults(self) -> None:
+        result = _make_manager()._parse_single_ssr_version_row({"version": "6.3"})
+        assert result == {"version": "6.3", "package": "SSR", "default": False}
+
+    def test_dict_missing_version_returns_none(self) -> None:
+        # empty/missing "version" is falsy so returns None
+        assert _make_manager()._parse_single_ssr_version_row({}) is None
+
+    def test_string_row_minimal_shape(self) -> None:
+        assert _make_manager()._parse_single_ssr_version_row("6.3.5") == {
+            "version": "6.3.5",
+            "package": "SSR",
+            "default": False,
+        }
+
+    def test_unrecognized_returns_none(self) -> None:
+        assert _make_manager()._parse_single_ssr_version_row(42) is None
+
+
+class TestNormalizeSSRVersionRows:
+    """Normalize raw list into a uniform list of dicts."""
+
+    def test_mixed_rows_filter_bad(self) -> None:
+        rows: list[Any] = [
+            {"version": "6.3.5"},
+            "6.3.4",
+            None,
+            42,
+            {"missing": "version"},
+        ]
+        result = _make_manager()._normalize_ssr_version_rows(rows)
+        assert result == [
+            {"version": "6.3.5", "package": "SSR", "default": False},
+            {"version": "6.3.4", "package": "SSR", "default": False},
+        ]
+
+
+class TestPrintSSRVersionSummary:
+    """Version summary shows count or empty warning."""
+
+    def test_empty_warns(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_version_summary([], "stable")
+        assert "No SSR firmware versions" in capsys.readouterr().out
+
+    def test_count_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_version_summary([{"version": "1"}, {"version": "2"}], "stable")
+        out = capsys.readouterr().out
+        assert "Found 2" in out and "stable" in out
+
+
+class TestGetSSRAvailableVersions:
+    """End-to-end version discovery orchestrator."""
+
+    def test_returns_empty_on_fetch_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_ssr_version_rows", lambda _c: None)
+        assert mgr._get_ssr_available_versions("stable") == []
+
+    def test_returns_normalized_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_ssr_version_rows", lambda _c: [{"version": "6.3.5"}])
+        result = mgr._get_ssr_available_versions("stable")
+        assert result == [{"version": "6.3.5", "package": "SSR", "default": False}]
+
+
+# ==============================================================================
+# INVENTORY COLLECTION
+# ==============================================================================
+
+
+class TestIsSSRInventoryRow:
+    """Predicate: type/model based SSR detection."""
+
+    def test_type_ssr_matches(self) -> None:
+        assert _make_manager()._is_ssr_inventory_row({"type": "ssr"}) is True
+
+    def test_model_ssr_matches(self) -> None:
+        assert _make_manager()._is_ssr_inventory_row({"model": "SSR-100"}) is True
+
+    def test_model_128t_matches(self) -> None:
+        assert _make_manager()._is_ssr_inventory_row({"model": "128T-Router"}) is True
+
+    def test_nothing_matches(self) -> None:
+        assert _make_manager()._is_ssr_inventory_row({"type": "ap"}) is False
+
+
+class TestCollectSSRRowMetadata:
+    """Populate model/version sets from a row."""
+
+    def test_populates_both_sets(self) -> None:
+        models: set[str] = set()
+        versions: set[str] = set()
+        _make_manager()._collect_ssr_row_metadata({"model": "SSR-100", "version": "6.3.5"}, models, versions)
+        assert models == {"SSR-100"}
+        assert versions == {"6.3.5"}
+
+    def test_empty_fields_skipped(self) -> None:
+        models: set[str] = set()
+        versions: set[str] = set()
+        _make_manager()._collect_ssr_row_metadata({}, models, versions)
+        assert not models and not versions
+
+
+class TestCollectSSRInventoryData:
+    """Aggregate count/models/versions across rows."""
+
+    def test_mixed_rows(self) -> None:
+        gws = [
+            {"type": "ssr", "model": "SSR-100", "version": "6.3.5"},
+            {"type": "gateway", "model": "SSR-200", "version": "6.3.4"},
+            {"type": "ap", "model": "AP41"},
+            {"type": "gateway", "model": "SRX", "version": "20"},
+        ]
+        count, models, versions = _make_manager()._collect_ssr_inventory_data(gws)
+        assert count == 2
+        assert models == {"SSR-100", "SSR-200"}
+        assert versions == {"6.3.5", "6.3.4"}
+
+
+class TestDisplaySSRInventoryStats:
+    """Stats printer skips empty counts."""
+
+    def test_zero_count_skipped(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._display_ssr_inventory_stats(0, set(), set())
+        assert capsys.readouterr().out == ""
+
+    def test_positive_count_prints(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._display_ssr_inventory_stats(2, {"M"}, {"1", "2"})
+        out = capsys.readouterr().out
+        assert "Found 2 SSR" in out
+        assert "Models: M" in out
+        assert "Current versions: 1, 2" in out
+
+
+class TestDisplaySSRInventoryInfo:
+    """Wrapper around ``getOrgInventory`` — silently swallows all errors."""
+
+    def test_success_calls_stats(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.inventory as real_inv
+
+        monkeypatch.setattr(
+            real_inv,
+            "getOrgInventory",
+            lambda _s, _o, type=None: _FakeResponse(200, [{"type": "ssr", "model": "M"}]),
+        )
+        mgr = _make_manager()
+        stats = MagicMock()
+        monkeypatch.setattr(mgr, "_display_ssr_inventory_stats", stats)
+        mgr._display_ssr_inventory_info()
+        stats.assert_called_once()
+
+    def test_non_200_no_stats(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.inventory as real_inv
+
+        monkeypatch.setattr(real_inv, "getOrgInventory", lambda _s, _o, type=None: _FakeResponse(500))
+        mgr = _make_manager()
+        stats = MagicMock()
+        monkeypatch.setattr(mgr, "_display_ssr_inventory_stats", stats)
+        mgr._display_ssr_inventory_info()
+        stats.assert_not_called()
+
+    def test_exception_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.inventory as real_inv
+
+        def boom(*_a: Any, **_k: Any) -> Any:
+            raise RuntimeError("net-down")
+
+        monkeypatch.setattr(real_inv, "getOrgInventory", boom)
+        # Should not raise; wrapper swallows.
+        _make_manager()._display_ssr_inventory_info()
+
+
+# ==============================================================================
+# VERSION SELECTION UI
+# ==============================================================================
+
+
+class TestRenderSSRVersionMenu:
+    """Numbered menu with default marker."""
+
+    def test_marks_default(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._render_ssr_version_menu(
+            [
+                {"version": "6.3.5", "package": "SSR", "default": True},
+                {"version": "6.3.4", "package": "SSR", "default": False},
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "6.3.5" in out and "(default)" in out
+        assert "6.3.4" in out
+
+
+class TestResolveSSRVersionChoice:
+    """Choice → version string, or None to retry."""
+
+    def test_empty_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert _make_manager()._resolve_ssr_version_choice("", [{"version": "1"}]) is None
+        assert "Please enter a selection" in capsys.readouterr().out
+
+    def test_non_numeric_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert _make_manager()._resolve_ssr_version_choice("abc", [{"version": "1"}]) is None
+        assert "valid number" in capsys.readouterr().out
+
+    def test_out_of_range_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert _make_manager()._resolve_ssr_version_choice("99", [{"version": "1"}]) is None
+        assert "between 1 and 1" in capsys.readouterr().out
+
+    def test_valid_returns_version(self) -> None:
+        result = _make_manager()._resolve_ssr_version_choice("2", [{"version": "6.3.4"}, {"version": "6.3.5"}])
+        assert result == "6.3.5"
+
+
+class TestLoopSSRVersionInput:
+    """Loop until a valid selection returns."""
+
+    def test_retries_then_accepts(self, capsys: pytest.CaptureFixture[str]) -> None:
+        answers = iter(["", "abc", "1"])
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: next(answers))
+        assert mgr._loop_ssr_version_input([{"version": "6.3.5"}]) == "6.3.5"
+        assert "Selected firmware version: 6.3.5" in capsys.readouterr().out
+
+
+class TestSelectSSRVersionFromList:
+    """End-to-end version selection UI."""
+
+    def test_returns_selected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_render_ssr_version_menu", lambda _v: None)
+        monkeypatch.setattr(mgr, "_loop_ssr_version_input", lambda _v: "6.3.5")
+        assert mgr._select_ssr_version_from_list([{"version": "6.3.5"}]) == "6.3.5"
+
+
+class TestFetchAndSelectSSRVersion:
+    """Fetch → display inventory → select version."""
+
+    def test_empty_versions_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_get_ssr_available_versions", lambda _c: [])
+        version, err = mgr._fetch_and_select_ssr_version("stable")
+        assert version == ""
+        assert err is not None and "No SSR firmware versions" in err["error"]
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_get_ssr_available_versions", lambda _c: [{"version": "6.3.5"}])
+        monkeypatch.setattr(mgr, "_display_ssr_inventory_info", lambda: None)
+        monkeypatch.setattr(mgr, "_select_ssr_version_from_list", lambda _v: "6.3.5")
+        version, err = mgr._fetch_and_select_ssr_version("stable")
+        assert version == "6.3.5" and err is None
+
+    def test_exception_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+
+        def boom(*_a: Any, **_k: Any) -> Any:
+            raise RuntimeError("api-down")
+
+        monkeypatch.setattr(mgr, "_get_ssr_available_versions", boom)
+        version, err = mgr._fetch_and_select_ssr_version("stable")
+        assert version == ""
+        assert err is not None and "SSR firmware discovery error" in err["error"]
+
+
+# ==============================================================================
+# CONFIRMATION FLOW
+# ==============================================================================
+
+
+class TestPrintSSRUpgradeSummary:
+    """Print upgrade summary block."""
+
+    def test_prints_all_fields(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(org_id="ORGX")
+        mgr._print_ssr_upgrade_summary(
+            "OrgName",
+            [{"id": "s1"}, {"id": "s2"}],
+            "6.3.5",
+            {"channel": "stable", "strategy": "serial", "auto_reboot": True},
+        )
+        out = capsys.readouterr().out
+        assert "ORGX" in out
+        assert "OrgName" in out
+        assert "Sites to upgrade: 2" in out
+        assert "Target firmware: 6.3.5" in out
+        assert "channel: stable" in out.lower()
+        assert "Auto reboot: Yes" in out
+
+    def test_auto_reboot_no(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_upgrade_summary(
+            "O", [], "v", {"channel": "c", "strategy": "s", "auto_reboot": False}
+        )
+        assert "Auto reboot: No" in capsys.readouterr().out
+
+
+class TestPrintSSRUpgradeWarning:
+    """Print critical routing warning."""
+
+    def test_prints_warning(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_upgrade_warning()
+        out = capsys.readouterr().out
+        assert "CRITICAL ROUTING INFRASTRUCTURE" in out
+        assert "type: UPGRADE" in out
+
+
+class TestReadSSRUpgradeConfirmation:
+    """UPGRADE token strict match; SystemExit -> False."""
+
+    def test_correct_token_true(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "UPGRADE")
+        assert mgr._read_ssr_upgrade_confirmation() is True
+
+    def test_wrong_token_false(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "no")
+        assert mgr._read_ssr_upgrade_confirmation() is False
+        assert "incorrect confirmation" in capsys.readouterr().out
+
+    def test_systemexit_returns_false(self, capsys: pytest.CaptureFixture[str]) -> None:
+        def raise_exit(*_a: Any, **_k: Any) -> str:
+            raise SystemExit(1)
+
+        mgr = _make_manager(safe_input_fn=raise_exit)
+        assert mgr._read_ssr_upgrade_confirmation() is False
+        assert "Operation cancelled" in capsys.readouterr().out
+
+
+class TestConfirmSSRUpgrade:
+    """Combined summary + warning + read."""
+
+    def test_delegates_to_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_ssr_upgrade_summary", lambda *_a: None)
+        monkeypatch.setattr(mgr, "_print_ssr_upgrade_warning", lambda: None)
+        monkeypatch.setattr(mgr, "_read_ssr_upgrade_confirmation", lambda: True)
+        assert mgr._confirm_ssr_upgrade("Org", [], "v", {}) is True
+
+
+# ==============================================================================
+# RESULTS ENVELOPE
+# ==============================================================================
+
+
+class TestBuildSSRUpgradeResults:
+    """Initialize the upgrade results dict shape."""
+
+    def test_shape(self) -> None:
+        result = _make_manager()._build_ssr_upgrade_results(
+            "6.3.5",
+            {"strategy": "serial", "channel": "stable", "auto_reboot": True},
+        )
+        assert result["target_version"] == "6.3.5"
+        assert result["strategy"] == "serial"
+        assert result["channel"] == "stable"
+        assert result["reboot"] is True
+        assert result["sites_processed"] == 0
+        assert result["ssrs_upgraded"] == 0
+        assert result["errors"] == []
+        assert result["site_results"] == []
+        assert "start_time" in result
+        assert result["operation_id"].startswith("ssr_upgrade_")
+
+
+# ==============================================================================
+# ORG INVENTORY LOADING
+# ==============================================================================
+
+
+class TestIsSSRGatewayRow:
+    """Type/model discriminator for SSR gateway."""
+
+    def test_type_ssr_true(self) -> None:
+        assert _make_manager()._is_ssr_gateway_row("ssr", "") is True
+
+    def test_model_ssr_true(self) -> None:
+        assert _make_manager()._is_ssr_gateway_row("gateway", "SSR-100") is True
+
+    def test_model_128t_true(self) -> None:
+        assert _make_manager()._is_ssr_gateway_row("gateway", "128T") is True
+
+    def test_neither_false(self) -> None:
+        assert _make_manager()._is_ssr_gateway_row("ap", "AP41") is False
+
+
+class TestSSREntryFromGateway:
+    """Return (id, info) tuple for SSR row or None."""
+
+    def test_ssr_gateway_returns_tuple(self) -> None:
+        gw = {"type": "ssr", "model": "SSR-100", "id": "id-1", "version": "6.3.5", "site_id": "s"}
+        result = _make_manager()._ssr_entry_from_gateway(gw)
+        assert result is not None
+        gid, info = result
+        assert gid == "id-1"
+        assert info == {"model": "SSR-100", "type": "ssr", "version": "6.3.5", "site_id": "s"}
+
+    def test_non_ssr_returns_none(self) -> None:
+        assert _make_manager()._ssr_entry_from_gateway({"type": "ap", "id": "x"}) is None
+
+    def test_missing_id_returns_none(self) -> None:
+        assert _make_manager()._ssr_entry_from_gateway({"type": "ssr"}) is None
+
+    def test_non_string_id_returns_none(self) -> None:
+        assert _make_manager()._ssr_entry_from_gateway({"type": "ssr", "id": 42}) is None
+
+
+class TestExtractSSRDevicesFromGateways:
+    """Filter gateway list down to SSR-keyed dict."""
+
+    def test_mixed_list(self) -> None:
+        gws = [
+            {"type": "ssr", "id": "s1", "model": "SSR-100"},
+            {"type": "ap", "id": "a1"},
+            {"type": "gateway", "model": "SRX", "id": "g1"},
+            {"type": "gateway", "model": "128T", "id": "g2"},
+        ]
+        result = _make_manager()._extract_ssr_devices_from_gateways(gws)
+        assert set(result.keys()) == {"s1", "g2"}
+
+
+class TestFetchOrgGatewayInventory:
+    """Fetch gateway inventory: success/error/exception."""
+
+    def test_success_returns_data(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.inventory as real_inv
+
+        monkeypatch.setattr(
+            real_inv,
+            "getOrgInventory",
+            lambda _s, _o, type=None: _FakeResponse(200, [{"id": "g1"}]),
+        )
+        assert _make_manager()._fetch_org_gateway_inventory() == [{"id": "g1"}]
+
+    def test_exception_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        import mistapi.api.v1.orgs.inventory as real_inv
+
+        def boom(*_a: Any, **_k: Any) -> Any:
+            raise RuntimeError("bad")
+
+        monkeypatch.setattr(real_inv, "getOrgInventory", boom)
+        assert _make_manager()._fetch_org_gateway_inventory() is None
+        assert "Error validating SSR inventory" in capsys.readouterr().out
+
+    def test_non_200_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        import mistapi.api.v1.orgs.inventory as real_inv
+
+        monkeypatch.setattr(
+            real_inv,
+            "getOrgInventory",
+            lambda _s, _o, type=None: _FakeResponse(500),
+        )
+        assert _make_manager()._fetch_org_gateway_inventory() is None
+        assert "Failed to validate SSR inventory" in capsys.readouterr().out
+
+    def test_none_data_becomes_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.inventory as real_inv
+
+        monkeypatch.setattr(
+            real_inv,
+            "getOrgInventory",
+            lambda _s, _o, type=None: _FakeResponse(200, None),
+        )
+        assert _make_manager()._fetch_org_gateway_inventory() == []
+
+
+class TestLoadOrgSSRInventory:
+    """Load full org SSR inventory map."""
+
+    def test_returns_empty_on_fetch_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_org_gateway_inventory", lambda: None)
+        assert mgr._load_org_ssr_inventory() == {}
+
+    def test_success_returns_filtered_map(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(
+            mgr,
+            "_fetch_org_gateway_inventory",
+            lambda: [{"type": "ssr", "id": "s1", "model": "SSR-100"}],
+        )
+        result = mgr._load_org_ssr_inventory()
+        assert list(result.keys()) == ["s1"]
+
+
+# ==============================================================================
+# SITE SSR DISCOVERY
+# ==============================================================================
+
+
+class TestIsSSRGateway:
+    """Gateway-type + model pattern check."""
+
+    def test_non_gateway_type_false(self) -> None:
+        assert _make_manager()._is_ssr_gateway({"type": "ap", "model": "SSR-100"}, []) is False
+
+    def test_ssr_in_model_true(self) -> None:
+        assert _make_manager()._is_ssr_gateway({"type": "gateway", "model": "SSR-100"}, []) is True
+
+    def test_pattern_match_true(self) -> None:
+        assert _make_manager()._is_ssr_gateway({"type": "gateway", "model": "128T-x"}, ["128T"]) is True
+
+    def test_no_match_false(self) -> None:
+        assert _make_manager()._is_ssr_gateway({"type": "gateway", "model": "SRX"}, ["SSR", "128T"]) is False
+
+
+class TestFetchSiteGatewayDevices:
+    """Per-site device fetch."""
+
+    def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.sites.devices as real_devs
+
+        monkeypatch.setattr(
+            real_devs,
+            "listSiteDevices",
+            lambda _s, _sid, type=None: _FakeResponse(200, [{"id": "d1"}]),
+        )
+        result = _make_manager()._fetch_site_gateway_devices("s1", "S1")
+        assert result == [{"id": "d1"}]
+
+    def test_non_200_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.sites.devices as real_devs
+
+        monkeypatch.setattr(
+            real_devs,
+            "listSiteDevices",
+            lambda _s, _sid, type=None: _FakeResponse(500),
+        )
+        assert _make_manager()._fetch_site_gateway_devices("s1", "S1") is None
+
+    def test_none_data_becomes_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.sites.devices as real_devs
+
+        monkeypatch.setattr(
+            real_devs,
+            "listSiteDevices",
+            lambda _s, _sid, type=None: _FakeResponse(200, None),
+        )
+        assert _make_manager()._fetch_site_gateway_devices("s1", "S1") == []
+
+
+class TestFilterDevicesBySSRModel:
+    """Filter devices to SSR matches."""
+
+    def test_mixed_list(self, capsys: pytest.CaptureFixture[str]) -> None:
+        devices = [
+            {"type": "gateway", "model": "SSR-100", "id": "d1"},
+            {"type": "ap", "model": "SSR-x", "id": "d2"},
+            {"type": "gateway", "model": "SRX", "id": "d3"},
+        ]
+        result = _make_manager()._filter_devices_by_ssr_model(devices, ["SSR"])
+        assert [d["id"] for d in result] == ["d1"]
+        assert "Identified SSR" in capsys.readouterr().out
+
+
+class TestDiscoverSiteSSRDevices:
+    """Site SSR discovery driver."""
+
+    def test_fetch_none_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_fetch_site_gateway_devices", lambda _sid, _sn: None)
+        assert mgr._discover_site_ssr_devices({"id": "s1", "name": "S1"}, ["SSR"]) == []
+
+    def test_delegates_to_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(
+            mgr,
+            "_fetch_site_gateway_devices",
+            lambda _sid, _sn: [{"id": "d1", "type": "gateway", "model": "SSR-100"}],
+        )
+        result = mgr._discover_site_ssr_devices({"id": "s1", "name": "S1"}, ["SSR"])
+        assert [d["id"] for d in result] == ["d1"]
+
+
+# ==============================================================================
+# VALIDATE + CLASSIFY DEVICE
+# ==============================================================================
+
+
+class TestClassifySSRDeviceForUpgrade:
+    """Four verdicts: missing / current / downgrade / upgrade."""
+
+    def test_missing_verdict(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        result = mgr._classify_ssr_device_for_upgrade("missing-id", {}, "6.3.5")
+        assert result == "missing"
+        assert "not in SSR inventory" in capsys.readouterr().out
+
+    def test_current_verdict(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        inv = {"d1": {"model": "SSR-100", "version": "6.3.5"}}
+        result = mgr._classify_ssr_device_for_upgrade("d1", inv, "6.3.5")
+        assert result == "current"
+        assert "already at version" in capsys.readouterr().out
+
+    def test_downgrade_verdict(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        inv = {"d1": {"model": "SSR-100", "version": "6.3.5"}}
+        result = mgr._classify_ssr_device_for_upgrade("d1", inv, "6.3.4")
+        assert result == "downgrade"
+        assert "Downgrade detected" in capsys.readouterr().out
+
+    def test_upgrade_verdict(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        inv = {"d1": {"model": "SSR-100", "version": "6.3.4"}}
+        result = mgr._classify_ssr_device_for_upgrade("d1", inv, "6.3.5")
+        assert result == "upgrade"
+        assert "Upgrade needed" in capsys.readouterr().out
+
+
+class TestValidateSSRDevicesForVersion:
+    """Split ids into validated vs skipped lists."""
+
+    def test_splits_by_verdict(self) -> None:
+        mgr = _make_manager()
+        inv = {
+            "u": {"model": "M", "version": "6.3.4"},  # upgrade
+            "c": {"model": "M", "version": "6.3.5"},  # current
+        }
+        validated, skipped = mgr._validate_ssr_devices_for_version(["u", "c", "missing"], inv, "6.3.5")
+        assert validated == ["u"]
+        assert set(skipped) == {"c", "missing"}
+
+
+# ==============================================================================
+# ERROR RESPONSE HANDLING
+# ==============================================================================
+
+
+class TestExtractSSRErrorText:
+    """Priority: data > text > content > status code."""
+
+    def test_data_wins(self) -> None:
+        r = _FakeResponse(500, data={"detail": "bad"})
+        assert _make_manager()._extract_ssr_error_text(r) == "{'detail': 'bad'}"
+
+    def test_text_wins_when_no_data(self) -> None:
+        r = _FakeResponse(500, data=None, text="oops")
+        assert _make_manager()._extract_ssr_error_text(r) == "oops"
+
+    def test_content_decoded_when_no_data_or_text(self) -> None:
+        r = _FakeResponse(500, data=None, text="", content=b"payload")
+        assert _make_manager()._extract_ssr_error_text(r) == "payload"
+
+    def test_status_fallback(self) -> None:
+        r = _FakeResponse(503)
+        assert _make_manager()._extract_ssr_error_text(r) == "Status: 503"
+
+
+class TestClassifySSRErrorText:
+    """Route error text into skip_reason or error."""
+
+    def test_already_at_version(self, capsys: pytest.CaptureFixture[str]) -> None:
+        result: dict[str, Any] = {}
+        _make_manager()._classify_ssr_error_text(
+            "SSRs already at the requested fw version", "site-1", _FakeResponse(400), result
+        )
+        assert result == {"skip_reason": "already_at_version"}
+        assert "already at target version" in capsys.readouterr().out
+
+    def test_downgrade_not_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        result: dict[str, Any] = {}
+        _make_manager()._classify_ssr_error_text(
+            "Downgrade fw version not allowed", "site-1", _FakeResponse(400), result
+        )
+        assert result == {"skip_reason": "downgrade_not_allowed"}
+        assert "downgrade not allowed" in capsys.readouterr().out.lower()
+
+    def test_case_insensitive_match(self) -> None:
+        result: dict[str, Any] = {}
+        _make_manager()._classify_ssr_error_text("ALREADY AT THE REQUESTED FW VERSION", "s", _FakeResponse(400), result)
+        assert result.get("skip_reason") == "already_at_version"
+
+    def test_generic_error_records_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        result: dict[str, Any] = {}
+        _make_manager()._classify_ssr_error_text("some other error", "site-1", _FakeResponse(500), result)
+        assert result["error"] == "Upgrade initiation failed for site-1: 500"
+        assert "some other error" in capsys.readouterr().out
+
+
+class TestHandleSSRUpgradeErrorResponse:
+    """Wraps extract + classify."""
+
+    def test_delegates_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_extract_ssr_error_text", lambda _r: "text")
+
+        def stub_classify(text: str, site: str, response: Any, result: dict[str, Any]) -> None:
+            result["skip_reason"] = "already_at_version"
+
+        monkeypatch.setattr(mgr, "_classify_ssr_error_text", stub_classify)
+        site_result: dict[str, Any] = {}
+        result = mgr._handle_ssr_upgrade_error_response("site-1", _FakeResponse(400), site_result)
+        assert result["skip_reason"] == "already_at_version"
+
+    def test_extract_exception_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+
+        def boom(_r: Any) -> str:
+            raise RuntimeError("decode-fail")
+
+        monkeypatch.setattr(mgr, "_extract_ssr_error_text", boom)
+        site_result: dict[str, Any] = {}
+        result = mgr._handle_ssr_upgrade_error_response("site-1", _FakeResponse(500), site_result)
+        assert "Upgrade initiation failed for site-1: 500" in result["error"]
+
+
+# ==============================================================================
+# CALL API + BUILD BODY
+# ==============================================================================
+
+
+class TestBuildSSRUpgradeBody:
+    """Body includes reboot_at=-1 only when not auto_reboot."""
+
+    def test_auto_reboot_omits_reboot_at(self) -> None:
+        body = _make_manager()._build_ssr_upgrade_body(
+            ["d1", "d2"],
+            "6.3.5",
+            {"channel": "stable", "strategy": "serial", "auto_reboot": True},
+        )
+        assert body == {
+            "device_ids": ["d1", "d2"],
+            "channel": "stable",
+            "version": "6.3.5",
+            "strategy": "serial",
+        }
+
+    def test_manual_reboot_adds_sentinel(self) -> None:
+        body = _make_manager()._build_ssr_upgrade_body(
+            ["d1"],
+            "6.3.5",
+            {"channel": "stable", "strategy": "serial", "auto_reboot": False},
+        )
+        assert body["reboot_at"] == -1
+
+
+class TestLogSSRUpgradeRequest:
+    """Log + operator visible print of body summary."""
+
+    def test_prints_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._log_ssr_upgrade_request(
+            {"device_ids": ["d1"], "channel": "stable", "version": "v", "strategy": "serial"},
+            ["d1"],
+            "v",
+            {"channel": "stable", "strategy": "serial"},
+        )
+        out = capsys.readouterr().out
+        assert "channel='stable'" in out
+        assert "version='v'" in out
+        assert "strategy='serial'" in out
+        assert "['d1']" in out
+
+
+class TestInterpretSSRUpgradeResponse:
+    """Success codes vs delegated error."""
+
+    @pytest.mark.parametrize("code", [200, 202])
+    def test_success_codes(self, code: int) -> None:
+        mgr = _make_manager()
+        result = mgr._interpret_ssr_upgrade_response(
+            _FakeResponse(code), "site-1", ["d1"], {"upgrade_initiated": False}
+        )
+        assert result["upgrade_initiated"] is True
+
+    def test_failure_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        handler = MagicMock(return_value={"error": "e"})
+        monkeypatch.setattr(mgr, "_handle_ssr_upgrade_error_response", handler)
+        r = _FakeResponse(500)
+        site_result: dict[str, Any] = {"upgrade_initiated": False}
+        result = mgr._interpret_ssr_upgrade_response(r, "site-1", ["d1"], site_result)
+        handler.assert_called_once_with("site-1", r, site_result)
+        assert result == {"error": "e"}
+
+
+class TestCallSSRUpgradeAPI:
+    """Full upgrade API call: builds body, logs, interprets."""
+
+    def test_success_flow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.orgs.ssr as real_ssr
+
+        monkeypatch.setattr(real_ssr, "upgradeOrgSsrs", lambda _s, _o, body=None: _FakeResponse(200))
+        mgr = _make_manager()
+        result = mgr._call_ssr_upgrade_api(
+            "site-1",
+            ["d1"],
+            "6.3.5",
+            {"channel": "stable", "strategy": "serial", "auto_reboot": True},
+        )
+        assert result["upgrade_initiated"] is True
+
+
+# ==============================================================================
+# SITE PROCESSING ORCHESTRATION
+# ==============================================================================
+
+
+class TestInitSSRSiteResult:
+    """Zeroed per-site result shape."""
+
+    def test_shape(self) -> None:
+        result = _make_manager()._init_ssr_site_result({"id": "s1", "name": "S1"})
+        assert result == {
+            "site_id": "s1",
+            "site_name": "S1",
+            "ssrs_found": 0,
+            "upgrade_initiated": False,
+            "error": None,
+        }
+
+    def test_defaults_name_to_unknown(self) -> None:
+        result = _make_manager()._init_ssr_site_result({})
+        assert result["site_name"] == "Unknown"
+
+
+class TestTallySSRSiteUpgradeResult:
+    """Fold per-site outcome into global counters."""
+
+    def test_upgrade_initiated_bumps_count(self) -> None:
+        results = {"ssrs_upgraded": 0, "errors": []}
+        _make_manager()._tally_ssr_site_upgrade_result({"upgrade_initiated": True}, ["d1", "d2"], results)
+        assert results["ssrs_upgraded"] == 2
+        assert results["errors"] == []
+
+    def test_error_appended(self) -> None:
+        results: dict[str, Any] = {"ssrs_upgraded": 0, "errors": []}
+        _make_manager()._tally_ssr_site_upgrade_result({"upgrade_initiated": False, "error": "boom"}, [], results)
+        assert results["errors"] == ["boom"]
+
+
+class TestRunSSRSiteUpgradeFlow:
+    """Discover + validate + call API + tally."""
+
+    def test_no_ssrs_returns_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_discover_site_ssr_devices", lambda *_a: [])
+        site_result: dict[str, Any] = {"upgrade_initiated": False}
+        results: dict[str, Any] = {"errors": [], "ssrs_upgraded": 0}
+        mgr._run_ssr_site_upgrade_flow(
+            {"id": "s1", "name": "S1"},
+            site_result,
+            {"inventory": {}, "version": "v"},
+            results,
+        )
+        assert site_result["ssrs_found"] == 0
+
+    def test_no_validated_returns_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(
+            mgr,
+            "_discover_site_ssr_devices",
+            lambda *_a: [{"id": "d1"}],
+        )
+        monkeypatch.setattr(
+            mgr,
+            "_validate_ssr_devices_for_version",
+            lambda *_a: ([], ["d1"]),
+        )
+        api_mock = MagicMock()
+        monkeypatch.setattr(mgr, "_call_ssr_upgrade_api", api_mock)
+        site_result: dict[str, Any] = {"upgrade_initiated": False, "site_name": "S1"}
+        mgr._run_ssr_site_upgrade_flow(
+            {"id": "s1", "name": "S1"},
+            site_result,
+            {"inventory": {}, "version": "v"},
+            {"errors": [], "ssrs_upgraded": 0},
+        )
+        api_mock.assert_not_called()
+
+    def test_happy_path_calls_api_and_tallies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_discover_site_ssr_devices", lambda *_a: [{"id": "d1"}])
+        monkeypatch.setattr(mgr, "_validate_ssr_devices_for_version", lambda *_a: (["d1"], []))
+        monkeypatch.setattr(
+            mgr,
+            "_call_ssr_upgrade_api",
+            lambda *_a: {"upgrade_initiated": True},
+        )
+        site_result: dict[str, Any] = {"upgrade_initiated": False, "site_name": "S1"}
+        results: dict[str, Any] = {"errors": [], "ssrs_upgraded": 0}
+        mgr._run_ssr_site_upgrade_flow(
+            {"id": "s1", "name": "S1"},
+            site_result,
+            {"inventory": {}, "version": "v"},
+            results,
+        )
+        assert results["ssrs_upgraded"] == 1
+        assert site_result["upgrade_initiated"] is True
+
+
+class TestRecordSSRSiteError:
+    """Uniform error recording."""
+
+    def test_records_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        site_result: dict[str, Any] = {}
+        results: dict[str, Any] = {"errors": []}
+        _make_manager()._record_ssr_site_error("S1", RuntimeError("boom"), site_result, results)
+        assert "Error processing site S1" in site_result["error"]
+        assert len(results["errors"]) == 1
+        assert "boom" in capsys.readouterr().out
+
+
+class TestProcessSSRSiteUpgrade:
+    """Full per-site orchestrator: init, run, tally, record."""
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+
+        def fake_run(_site: Any, site_result: dict[str, Any], *_a: Any) -> None:
+            site_result["upgrade_initiated"] = True
+
+        monkeypatch.setattr(mgr, "_run_ssr_site_upgrade_flow", fake_run)
+        results: dict[str, Any] = {"sites_processed": 0, "site_results": [], "errors": []}
+        mgr._process_ssr_site_upgrade({"id": "s1", "name": "S1"}, 1, 3, {}, results)
+        assert results["sites_processed"] == 1
+        assert len(results["site_results"]) == 1
+
+    def test_exception_recorded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+
+        def blow(*_a: Any) -> None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(mgr, "_run_ssr_site_upgrade_flow", blow)
+        results: dict[str, Any] = {"sites_processed": 0, "site_results": [], "errors": []}
+        mgr._process_ssr_site_upgrade({"id": "s1", "name": "S1"}, 1, 3, {}, results)
+        assert results["sites_processed"] == 1
+        assert "Error processing site S1" in results["errors"][0]
+
+
+class TestPrintSSRUpgradeCompletion:
+    """Completion banner + error list."""
+
+    def test_no_errors(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_upgrade_completion(
+            {
+                "operation_id": "op-1",
+                "sites_processed": 3,
+                "ssrs_upgraded": 5,
+                "errors": [],
+            }
+        )
+        out = capsys.readouterr().out
+        assert "OPERATION COMPLETED" in out
+        assert "op-1" in out
+        assert "Sites processed: 3" in out
+        assert "SSRs upgraded: 5" in out
+
+    def test_with_errors(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_upgrade_completion(
+            {
+                "operation_id": "op-1",
+                "sites_processed": 3,
+                "ssrs_upgraded": 5,
+                "errors": ["err1", "err2"],
+            }
+        )
+        out = capsys.readouterr().out
+        assert "Errors encountered: 2" in out
+        assert "err1" in out and "err2" in out
+
+
+class TestIterateSSRSiteUpgrades:
+    """Iterate selected sites for per-site processing."""
+
+    def test_calls_process_for_each(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        calls: list[tuple[Any, int, int]] = []
+
+        def fake_process(site: Any, idx: int, total: int, _cfg: Any, _res: Any) -> None:
+            calls.append((site["id"], idx, total))
+
+        monkeypatch.setattr(mgr, "_process_ssr_site_upgrade", fake_process)
+        mgr._iterate_ssr_site_upgrades([{"id": "s1"}, {"id": "s2"}, {"id": "s3"}], {}, {})
+        assert calls == [("s1", 1, 3), ("s2", 2, 3), ("s3", 3, 3)]
+
+
+class TestRunSSRSiteUpgrades:
+    """End-to-end upgrade runner."""
+
+    def test_happy_path_populates_end_time(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_load_org_ssr_inventory", lambda: {})
+        monkeypatch.setattr(mgr, "_iterate_ssr_site_upgrades", lambda *_a: None)
+        monkeypatch.setattr(mgr, "_print_ssr_upgrade_completion", lambda _r: None)
+        result = mgr._run_ssr_site_upgrades(
+            [{"id": "s1"}],
+            "6.3.5",
+            {"strategy": "serial", "channel": "stable", "auto_reboot": True},
+        )
+        assert "end_time" in result
+        assert result["target_version"] == "6.3.5"
+
+    def test_exception_recorded(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_load_org_ssr_inventory", lambda: {})
+
+        def blow(*_a: Any) -> None:
+            raise RuntimeError("critical")
+
+        monkeypatch.setattr(mgr, "_iterate_ssr_site_upgrades", blow)
+        result = mgr._run_ssr_site_upgrades(
+            [{"id": "s1"}],
+            "6.3.5",
+            {"strategy": "serial", "channel": "stable", "auto_reboot": True},
+        )
+        assert result["error"] == "critical"
+        assert "Critical error in SSR firmware upgrade" in capsys.readouterr().out
+
+
+# ==============================================================================
+# BULK ENTRYPOINT + PREPARATION HELPERS
+# ==============================================================================
+
+
+class TestResolveSSRSitesOrError:
+    """Wrap select_ssr_sites into standardised error/empty guard."""
+
+    def test_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_ssr_sites_for_upgrade", lambda _o: ([], {"error": "boom"}))
+        sites, err = mgr._resolve_ssr_sites_or_error(None)
+        assert sites is None
+        assert err == {"error": "boom"}
+
+    def test_empty_selection_becomes_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_select_ssr_sites_for_upgrade", lambda _o: ([], None))
+        sites, err = mgr._resolve_ssr_sites_or_error(None)
+        assert sites is None
+        assert err == {"error": "No sites selected"}
+        assert "No sites selected" in capsys.readouterr().out
+
+    def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        picked = [{"id": "s1"}]
+        monkeypatch.setattr(mgr, "_select_ssr_sites_for_upgrade", lambda _o: (picked, None))
+        sites, err = mgr._resolve_ssr_sites_or_error(None)
+        assert sites == picked
+        assert err is None
+
+
+class TestResolveSSROrgAndSites:
+    """Chain org validate + site select."""
+
+    def test_org_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_validate_org_for_ssr_upgrade", lambda: ("", {"error": "org"}))
+        result, err = mgr._resolve_ssr_org_and_sites(None)
+        assert result is None and err == {"error": "org"}
+
+    def test_sites_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_validate_org_for_ssr_upgrade", lambda: ("Org", None))
+        monkeypatch.setattr(mgr, "_resolve_ssr_sites_or_error", lambda _o: (None, {"error": "sites"}))
+        result, err = mgr._resolve_ssr_org_and_sites(None)
+        assert result is None and err == {"error": "sites"}
+
+    def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_validate_org_for_ssr_upgrade", lambda: ("Org", None))
+        monkeypatch.setattr(mgr, "_resolve_ssr_sites_or_error", lambda _o: ([{"id": "s1"}], None))
+        result, err = mgr._resolve_ssr_org_and_sites(None)
+        assert result == ("Org", [{"id": "s1"}])
+        assert err is None
+
+
+class TestResolveSSRConfigAndVersion:
+    """Chain param setup + version selection."""
+
+    def test_setup_cancel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_setup_ssr_upgrade_params", lambda: None)
+        result, err = mgr._resolve_ssr_config_and_version()
+        assert result is None
+        assert err == {"cancelled": True}
+
+    def test_version_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(
+            mgr,
+            "_setup_ssr_upgrade_params",
+            lambda: {"channel": "stable", "strategy": "serial", "auto_reboot": True},
+        )
+        monkeypatch.setattr(mgr, "_fetch_and_select_ssr_version", lambda _c: ("", {"error": "vfail"}))
+        result, err = mgr._resolve_ssr_config_and_version()
+        assert result is None and err == {"error": "vfail"}
+
+    def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        cfg = {"channel": "stable", "strategy": "serial", "auto_reboot": True}
+        monkeypatch.setattr(mgr, "_setup_ssr_upgrade_params", lambda: cfg)
+        monkeypatch.setattr(mgr, "_fetch_and_select_ssr_version", lambda _c: ("6.3.5", None))
+        result, err = mgr._resolve_ssr_config_and_version()
+        assert result == (cfg, "6.3.5")
+        assert err is None
+
+
+class TestPrepareSSRBulkUpgrade:
+    """Bulk prep: org error / cfg error / success."""
+
+    def test_org_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_resolve_ssr_org_and_sites", lambda _o: (None, {"error": "e"}))
+        result, err = mgr._prepare_ssr_bulk_upgrade(None)
+        assert result is None and err == {"error": "e"}
+
+    def test_config_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_resolve_ssr_org_and_sites", lambda _o: (("Org", [{"id": "s1"}]), None))
+        monkeypatch.setattr(mgr, "_resolve_ssr_config_and_version", lambda: (None, {"cancelled": True}))
+        result, err = mgr._prepare_ssr_bulk_upgrade(None)
+        assert result is None and err == {"cancelled": True}
+
+    def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        cfg = {"channel": "stable", "strategy": "serial", "auto_reboot": True}
+        monkeypatch.setattr(mgr, "_resolve_ssr_org_and_sites", lambda _o: (("Org", [{"id": "s1"}]), None))
+        monkeypatch.setattr(mgr, "_resolve_ssr_config_and_version", lambda: ((cfg, "6.3.5"), None))
+        result, err = mgr._prepare_ssr_bulk_upgrade(None)
+        assert result == ("Org", [{"id": "s1"}], cfg, "6.3.5")
+        assert err is None
+
+
+class TestBulkUpgradeSSRFirmwareBySite:
+    """SSR bulk entrypoint: prep error / confirm decline / happy path."""
+
+    def test_prep_error_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prepare_ssr_bulk_upgrade", lambda _o: (None, {"error": "e"}))
+        assert mgr._bulk_upgrade_ssr_firmware_by_site() == {"error": "e"}
+
+    def test_confirm_decline_returns_cancel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        cfg = {"channel": "stable", "strategy": "serial", "auto_reboot": True}
+        monkeypatch.setattr(
+            mgr,
+            "_prepare_ssr_bulk_upgrade",
+            lambda _o: (("Org", [{"id": "s1"}], cfg, "6.3.5"), None),
+        )
+        monkeypatch.setattr(mgr, "_confirm_ssr_upgrade", lambda *_a: False)
+        assert mgr._bulk_upgrade_ssr_firmware_by_site() == {"cancelled": True}
+
+    def test_happy_path_runs_upgrades(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        cfg = {"channel": "stable", "strategy": "serial", "auto_reboot": True}
+        monkeypatch.setattr(
+            mgr,
+            "_prepare_ssr_bulk_upgrade",
+            lambda _o: (("Org", [{"id": "s1"}], cfg, "6.3.5"), None),
+        )
+        monkeypatch.setattr(mgr, "_confirm_ssr_upgrade", lambda *_a: True)
+        monkeypatch.setattr(mgr, "_run_ssr_site_upgrades", lambda *_a: {"ssrs_upgraded": 2})
+        assert mgr._bulk_upgrade_ssr_firmware_by_site() == {"ssrs_upgraded": 2}
+
+
+# ==============================================================================
+# SSR TEMPLATE FLOW
+# ==============================================================================
+
+
+class TestPrintSSRTemplateBanner:
+    """Template banner content."""
+
+    def test_prints_banner(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager()._print_ssr_template_banner()
+        out = capsys.readouterr().out
+        assert "Advanced SSR Firmware Upgrade by Gateway Template" in out
+
+
+class TestExecuteTemplateBasedSSRUpgrade:
+    """Template-driven SSR upgrade delegates to site bulk."""
+
+    def test_delegates(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_bulk_upgrade_ssr_firmware_by_site", lambda sites: {"handled": len(sites)})
+        result = mgr._execute_template_based_ssr_upgrade([{"id": "s1"}, {"id": "s2"}], "TMPL")
+        assert result == {"handled": 2}
+        out = capsys.readouterr().out
+        assert "template: TMPL" in out
+        assert "Target sites: 2" in out
+
+
+class TestUpgradeSSRFirmwareByGatewayTemplate:
+    """SSR template flow orchestrator."""
+
+    def test_prep_none_returns_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_ssr_template_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_prepare_template_upgrade", lambda _k: None)
+        exec_mock = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_ssr_upgrade", exec_mock)
+        assert mgr._upgrade_ssr_firmware_by_gateway_template() is None
+        exec_mock.assert_not_called()
+
+    def test_selection_none_returns_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_ssr_template_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_prepare_template_upgrade", lambda _k: ({}, {}))
+        monkeypatch.setattr(mgr, "_select_template_and_sites", lambda *_a: None)
+        exec_mock = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_ssr_upgrade", exec_mock)
+        assert mgr._upgrade_ssr_firmware_by_gateway_template() is None
+        exec_mock.assert_not_called()
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_print_ssr_template_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_prepare_template_upgrade", lambda _k: ({"t": "1"}, {"1": [{"id": "s1"}]}))
+        monkeypatch.setattr(mgr, "_select_template_and_sites", lambda *_a: ("TPL", [{"id": "s1"}]))
+        exec_mock = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_ssr_upgrade", exec_mock)
+        mgr._upgrade_ssr_firmware_by_gateway_template()
+        exec_mock.assert_called_once_with([{"id": "s1"}], "TPL")
+
+
+class TestPrepareTemplateUpgrade:
+    """``_prepare_template_upgrade`` freshens CSV then loads the mapping.
+
+    Why:
+        The helper is the join between the CSV cache-refresh step and the
+        template->sites mapping load. Both halves are audit-logged and
+        the early return on an empty mapping is what stops the SSR
+        (destructive!) flow when there are no assigned sites.
+    """
+
+    def test_returns_none_when_mapping_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        mgr = _make_manager()
+        fresh_calls: list[int] = []
+        monkeypatch.setattr(mgr, "_ensure_template_csv_freshness", lambda: fresh_calls.append(1))
+        # Empty mapping -> operator diagnostic + audit warning + None return.
+        monkeypatch.setattr(mgr, "_load_template_sites_mapping", lambda: ({}, {}))
+        caplog.set_level(logging.WARNING, logger="root")
+        assert mgr._prepare_template_upgrade("SSR") is None
+        assert fresh_calls == [1]
+        out = capsys.readouterr().out
+        assert "No Gateway Templates with assigned sites found." in out
+        assert "Make sure sites are assigned to Gateway Templates" in out
+        assert any("No Gateway Templates with site assignments found" in r.message for r in caplog.records)
+
+    def test_returns_tuple_on_success(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_ensure_template_csv_freshness", lambda: None)
+        name_to_id = {"tpl-a": "id-a"}
+        sites_mapping = {"id-a": [{"id": "site-1"}, {"id": "site-2"}]}
+        monkeypatch.setattr(mgr, "_load_template_sites_mapping", lambda: (name_to_id, sites_mapping))
+        caplog.set_level(logging.DEBUG, logger="root")
+        result = mgr._prepare_template_upgrade("SSR")
+        assert result == (name_to_id, sites_mapping)
+        # Both audit lines fired: entry (info) + exit (debug).
+        messages = [r.message for r in caplog.records]
+        assert any("Preparing SSR template upgrade" in m for m in messages)
+        assert any("Template mapping loaded" in m for m in messages)
+
+
+class TestSelectTemplateAndSites:
+    """``_select_template_and_sites`` picks a template and returns its sites.
+
+    Why:
+        The picker is the last human gate before a bulk SSR upgrade
+        fires. Both the decline path (must return None cleanly) and the
+        happy path (must forward the exact site list from the mapping)
+        need to be pinned.
+    """
+
+    def test_returns_none_when_operator_declines(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prompt_template_selection", lambda *_a: ("", None))
+        assert mgr._select_template_and_sites({"t": "id-1"}, {"id-1": [{"id": "s"}]}) is None
+        assert "No template selected. Exiting." in capsys.readouterr().out
+
+    def test_returns_none_when_id_is_empty_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Guard both halves of the "declined" predicate: empty id string.
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prompt_template_selection", lambda *_a: ("", "some-name"))
+        assert mgr._select_template_and_sites({}, {}) is None
+
+    def test_returns_name_and_sites_on_success(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prompt_template_selection", lambda *_a: ("id-x", "TPL-X"))
+        sites_mapping = {"id-x": [{"id": "s1"}, {"id": "s2"}]}
+        result = mgr._select_template_and_sites({"TPL-X": "id-x"}, sites_mapping)
+        assert result == ("TPL-X", [{"id": "s1"}, {"id": "s2"}])
+        out = capsys.readouterr().out
+        assert "Template 'TPL-X' includes 2 sites" in out
+
+    def test_returns_empty_sites_when_id_not_in_mapping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Defensive branch: picker returned an id that is somehow absent
+        # from the mapping -> resolves to [] via dict.get default.
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prompt_template_selection", lambda *_a: ("orphan-id", "orphan"))
+        result = mgr._select_template_and_sites({"orphan": "orphan-id"}, {})
+        assert result == ("orphan", [])

--- a/tests/unit/firmware/test_firmware_manager_template.py
+++ b/tests/unit/firmware/test_firmware_manager_template.py
@@ -1,0 +1,677 @@
+"""Template-based AP upgrade + AP mode-selection unit tests.
+
+Why:
+    The template flow reads two CSVs and joins them; a silent malformed
+    row or missing DI hook must not crash the whole menu. AP mode
+    selection is the operator's single gateway into every AP-upgrade
+    branch (site / template / MSP), so its routing table has to be
+    pinned against silent regressions.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.firmware.firmware_manager as fm_mod
+from src.firmware.firmware_manager import FirmwareManager, FirmwareManagerConfig
+
+
+def _make_manager(**overrides: Any) -> FirmwareManager:
+    """Build a ``FirmwareManager`` with a valid minimum config.
+
+    Why:
+        Every template/mode-selection test needs a live manager. Keeping
+        construction in one helper lets each test focus on the branch it
+        exercises rather than restating the required identity fields.
+
+    Args:
+        **overrides: Any config field to override.
+
+    Returns:
+        A live ``FirmwareManager`` ready to exercise helpers.
+    """
+    defaults: dict[str, Any] = {"apisession": object(), "org_id": "org-tpl"}
+    defaults.update(overrides)
+    return FirmwareManager(FirmwareManagerConfig(**defaults))
+
+
+def _write_templates_csv(path: str, rows: list[dict[str, str]]) -> None:
+    """Write an OrgGatewayTemplates.csv fixture.
+
+    Why:
+        Template-mapping tests need a real CSV file on disk because the
+        loader opens the file directly rather than accepting a stream.
+
+    Args:
+        path: Absolute path to write the CSV to.
+        rows: Row dicts with ``id`` and ``name`` columns.
+    """
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "name"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _write_sites_csv(path: str, rows: list[dict[str, str]]) -> None:
+    """Write a SiteList.csv fixture.
+
+    Why:
+        The template-to-site join reads the SiteList CSV from disk to
+        associate ``gatewaytemplate_id`` back into template groupings.
+
+    Args:
+        path: Absolute path to write the CSV to.
+        rows: Row dicts with ``id``, ``name``, ``gatewaytemplate_id``.
+    """
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "name", "gatewaytemplate_id"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+class TestPrepareTemplateCache:
+    """``_prepare_template_cache`` warms both CSVs when a cache fn is wired."""
+
+    def test_no_cache_fn_is_noop(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(check_cache_fn=None)
+        mgr._prepare_template_cache()
+        assert "Preparing template and site data" in capsys.readouterr().out
+
+    def test_invokes_cache_fn_for_both_csvs(self) -> None:
+        calls: list[tuple[str, Any]] = []
+
+        def cache(name: str, fn: Any) -> None:
+            calls.append((name, fn))
+
+        gw_fn = lambda *_a, **_k: None  # noqa: E731
+        sites_fn = lambda *_a, **_k: None  # noqa: E731
+        mgr = _make_manager(check_cache_fn=cache, gateway_templates_fn=gw_fn, sites_fn=sites_fn)
+        mgr._prepare_template_cache()
+        assert ("OrgGatewayTemplates.csv", gw_fn) in calls
+        assert ("SiteList.csv", sites_fn) in calls
+
+
+class TestEnsureTemplateCsvFreshness:
+    """``_ensure_template_csv_freshness`` duplicate wrapper of prepare_cache."""
+
+    def test_no_cache_fn_is_noop(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _make_manager(check_cache_fn=None)._ensure_template_csv_freshness()
+        assert "Preparing template and site data" in capsys.readouterr().out
+
+    def test_invokes_cache_fn_when_set(self) -> None:
+        calls: list[str] = []
+        mgr = _make_manager(check_cache_fn=lambda name, _fn: calls.append(name))
+        mgr._ensure_template_csv_freshness()
+        assert "OrgGatewayTemplates.csv" in calls
+        assert "SiteList.csv" in calls
+
+
+class TestReadGatewayTemplatesCsv:
+    """CSV parsing for OrgGatewayTemplates.csv."""
+
+    def test_no_path_fn_returns_empty(self, caplog: pytest.LogCaptureFixture) -> None:
+        mgr = _make_manager(get_csv_path_fn=None)
+        caplog.set_level(logging.WARNING, logger="root")
+        name_to_id, sites_map = mgr._read_gateway_templates_csv()
+        assert name_to_id == {}
+        assert sites_map == {}
+        assert any("get_csv_path_fn not configured" in r.message for r in caplog.records)
+
+    def test_reads_populated_csv(self, tmp_path: Any) -> None:
+        csv_path = tmp_path / "OrgGatewayTemplates.csv"
+        _write_templates_csv(
+            str(csv_path),
+            [{"id": "t1", "name": "Alpha"}, {"id": "t2", "name": "Beta"}],
+        )
+        mgr = _make_manager(get_csv_path_fn=lambda _n: str(csv_path))
+        name_to_id, sites_map = mgr._read_gateway_templates_csv()
+        assert name_to_id == {"Alpha": "t1", "Beta": "t2"}
+        assert sites_map == {"t1": [], "t2": []}
+
+    def test_skips_rows_missing_name_or_id(self, tmp_path: Any) -> None:
+        csv_path = tmp_path / "OrgGatewayTemplates.csv"
+        _write_templates_csv(
+            str(csv_path),
+            [
+                {"id": "", "name": "NoID"},
+                {"id": "t1", "name": ""},
+                {"id": "t2", "name": "Good"},
+            ],
+        )
+        mgr = _make_manager(get_csv_path_fn=lambda _n: str(csv_path))
+        name_to_id, sites_map = mgr._read_gateway_templates_csv()
+        assert name_to_id == {"Good": "t2"}
+        assert sites_map == {"t2": []}
+
+
+class TestMapSitesToTemplate:
+    """``_map_sites_to_template`` joins sites into the template mapping."""
+
+    def test_joins_matching_sites(self, tmp_path: Any) -> None:
+        site_path = tmp_path / "SiteList.csv"
+        _write_sites_csv(
+            str(site_path),
+            [
+                {"id": "s1", "name": "S1", "gatewaytemplate_id": "t1"},
+                {"id": "s2", "name": "S2", "gatewaytemplate_id": "t2"},
+                {"id": "s3", "name": "S3", "gatewaytemplate_id": "t1"},
+            ],
+        )
+        mapping: dict[str, list[dict[str, Any]]] = {"t1": [], "t2": []}
+        _make_manager()._map_sites_to_template(mapping, str(site_path))
+        assert len(mapping["t1"]) == 2
+        assert len(mapping["t2"]) == 1
+
+    def test_skips_missing_fields(self, tmp_path: Any) -> None:
+        site_path = tmp_path / "SiteList.csv"
+        _write_sites_csv(
+            str(site_path),
+            [
+                {"id": "", "name": "S1", "gatewaytemplate_id": "t1"},
+                {"id": "s2", "name": "", "gatewaytemplate_id": "t1"},
+                {"id": "s3", "name": "S3", "gatewaytemplate_id": "unknown"},
+            ],
+        )
+        mapping: dict[str, list[dict[str, Any]]] = {"t1": []}
+        _make_manager()._map_sites_to_template(mapping, str(site_path))
+        assert mapping["t1"] == []
+
+
+class TestLoadTemplateSitesMapping:
+    """``_load_template_sites_mapping`` composes read + join + stats."""
+
+    def test_no_path_fn_returns_empty_pair(self) -> None:
+        assert _make_manager(get_csv_path_fn=None)._load_template_sites_mapping() == ({}, {})
+
+    def test_happy_path_loads_both(self, tmp_path: Any) -> None:
+        tpl_path = tmp_path / "OrgGatewayTemplates.csv"
+        site_path = tmp_path / "SiteList.csv"
+        _write_templates_csv(str(tpl_path), [{"id": "t1", "name": "Alpha"}])
+        _write_sites_csv(str(site_path), [{"id": "s1", "name": "S1", "gatewaytemplate_id": "t1"}])
+
+        def path_fn(name: str) -> str:
+            return str(tpl_path if "Gateway" in name else site_path)
+
+        mgr = _make_manager(get_csv_path_fn=path_fn)
+        name_to_id, sites_map = mgr._load_template_sites_mapping()
+        assert name_to_id == {"Alpha": "t1"}
+        assert sites_map["t1"][0]["id"] == "s1"
+
+    def test_exception_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager(get_csv_path_fn=lambda _n: "/does/not/exist.csv")
+        caplog.set_level(logging.ERROR, logger="root")
+        # _read_gateway_templates_csv will raise FileNotFoundError.
+        assert mgr._load_template_sites_mapping() == ({}, {})
+        out = capsys.readouterr().out
+        assert "Failed to load template and site data" in out
+        assert any("Failed to load template-sites mapping" in r.message for r in caplog.records)
+
+
+class TestRenderTemplateSelectionMenu:
+    """``_render_template_selection_menu`` prints table + returns index map."""
+
+    def test_returns_index_map(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        idx_map = mgr._render_template_selection_menu(
+            [("Alpha", "t1"), ("Beta", "t2")], {"t1": [{"id": "s1", "name": "S1"}], "t2": []}
+        )
+        assert idx_map == {"1": ("t1", "Alpha"), "2": ("t2", "Beta")}
+        out = capsys.readouterr().out
+        assert "Available Gateway Templates" in out
+        assert "Alpha" in out
+        assert "Beta" in out
+
+
+class TestResolveTemplateSelection:
+    """Index-then-name resolution."""
+
+    def test_by_index(self) -> None:
+        mgr = _make_manager()
+        result = mgr._resolve_template_selection("1", {"1": ("t1", "Alpha")}, {"Alpha": "t1"})
+        assert result == ("t1", "Alpha")
+
+    def test_by_exact_name(self) -> None:
+        mgr = _make_manager()
+        result = mgr._resolve_template_selection("Alpha", {"1": ("t1", "Alpha")}, {"Alpha": "t1"})
+        assert result == ("t1", "Alpha")
+
+    def test_no_match(self) -> None:
+        assert _make_manager()._resolve_template_selection("zzz", {"1": ("t1", "A")}, {"A": "t1"}) is None
+
+
+class TestLoopTemplateSelectionInput:
+    """Loop reads until index/name match or cancel."""
+
+    def test_keyboard_interrupt_cancels(self, capsys: pytest.CaptureFixture[str]) -> None:
+        def raise_kb(*_a: Any, **_k: Any) -> str:
+            raise KeyboardInterrupt
+
+        mgr = _make_manager(safe_input_fn=raise_kb)
+        result = mgr._loop_template_selection_input({"1": ("t1", "A")}, {"A": "t1"}, 1)
+        assert result == (None, None)
+        assert "cancelled" in capsys.readouterr().out.lower()
+
+    def test_blank_cancels(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "")
+        assert mgr._loop_template_selection_input({"1": ("t1", "A")}, {"A": "t1"}, 1) == (None, None)
+
+    def test_invalid_then_valid(self, capsys: pytest.CaptureFixture[str]) -> None:
+        answers = iter(["zzz", "1"])
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: next(answers))
+        assert mgr._loop_template_selection_input({"1": ("t1", "A")}, {"A": "t1"}, 1) == ("t1", "A")
+        assert "Invalid selection" in capsys.readouterr().out
+
+
+class TestPromptTemplateSelection:
+    """End-to-end prompt: menu render + input loop."""
+
+    def test_returns_selection(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "1")
+        result = mgr._prompt_template_selection({"Alpha": "t1"}, {"t1": []})
+        assert result == ("t1", "Alpha")
+
+
+class TestSelectTemplateForUpgrade:
+    """``_select_template_for_upgrade`` composes load + prompt."""
+
+    def test_no_templates_returns_none_pair(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_load_template_sites_mapping", lambda: ({}, {}))
+        assert mgr._select_template_for_upgrade() == (None, None)
+        assert "No gateway templates found" in capsys.readouterr().out
+
+    def test_cancel_returns_none_pair(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_load_template_sites_mapping", lambda: ({"A": "t1"}, {"t1": []}))
+        monkeypatch.setattr(mgr, "_prompt_template_selection", lambda *_a, **_k: (None, None))
+        assert mgr._select_template_for_upgrade() == (None, None)
+        assert "No template selected" in capsys.readouterr().out
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_load_template_sites_mapping", lambda: ({"A": "t1"}, {"t1": []}))
+        monkeypatch.setattr(mgr, "_prompt_template_selection", lambda *_a, **_k: ("t1", "A"))
+        assert mgr._select_template_for_upgrade() == ("t1", "A")
+
+
+class TestResolveTemplateSites:
+    """``_resolve_template_sites`` warns + returns [] when empty."""
+
+    def test_empty_warns(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_load_template_sites_mapping", lambda: ({}, {"t1": []}))
+        assert mgr._resolve_template_sites("t1", "TplA") == []
+        assert "No sites found using template" in capsys.readouterr().out
+
+    def test_returns_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        sites = [{"id": "s1", "name": "S1"}]
+        monkeypatch.setattr(mgr, "_load_template_sites_mapping", lambda: ({}, {"t1": sites}))
+        assert mgr._resolve_template_sites("t1", "TplA") == sites
+
+
+class TestPresentTemplateSummary:
+    """Summary printer + per-site debug log."""
+
+    def test_prints_summary(self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG, logger="root")
+        mgr = _make_manager()
+        mgr._present_template_summary("t1", "Alpha", [{"id": "s1", "name": "S1"}])
+        out = capsys.readouterr().out
+        assert "Selected Template: Alpha" in out
+        assert "Template ID: t1" in out
+        assert "Sites in Template: 1" in out
+        assert any("Site: S1" in r.message for r in caplog.records)
+
+
+class TestPrintTemplateUpgradeBanner:
+    """Banner + table for template-based upgrades."""
+
+    def test_prints_all_rows(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager()
+        mgr._print_template_upgrade_banner("Alpha", [{"id": "s1", "name": "S1"}, {"id": "s2", "name": "S2"}])
+        out = capsys.readouterr().out
+        assert "Template-Based Upgrade Execution" in out
+        assert "Template: Alpha" in out
+        assert "Sites to process: 2" in out
+        assert "S1" in out
+        assert "S2" in out
+
+
+class TestExecuteTemplateBasedUpgrade:
+    """Delegates to ``_bulk_upgrade_ap_firmware_by_site`` with override list."""
+
+    def test_delegates_with_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_bulk_upgrade_ap_firmware_by_site", called)
+        sites = [{"id": "s1", "name": "S1"}]
+        mgr._execute_template_based_upgrade(sites, "Alpha")
+        called.assert_called_once_with(sites_to_upgrade_override=sites)
+
+
+class TestUpgradeApFirmwareByGatewayTemplate:
+    """End-to-end orchestrator: cancel + empty-site + happy paths."""
+
+    def test_cancelled_at_template_selection(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prepare_template_cache", lambda: None)
+        monkeypatch.setattr(mgr, "_select_template_for_upgrade", lambda: (None, None))
+        exec_hook = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_upgrade", exec_hook)
+        assert mgr._upgrade_ap_firmware_by_gateway_template() is None
+        exec_hook.assert_not_called()
+
+    def test_empty_sites_returns_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prepare_template_cache", lambda: None)
+        monkeypatch.setattr(mgr, "_select_template_for_upgrade", lambda: ("t1", "A"))
+        monkeypatch.setattr(mgr, "_resolve_template_sites", lambda _tid, _tn: [])
+        exec_hook = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_upgrade", exec_hook)
+        assert mgr._upgrade_ap_firmware_by_gateway_template() is None
+        exec_hook.assert_not_called()
+
+    def test_happy_path_dispatches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prepare_template_cache", lambda: None)
+        monkeypatch.setattr(mgr, "_select_template_for_upgrade", lambda: ("t1", "Alpha"))
+        sites = [{"id": "s1", "name": "S1"}]
+        monkeypatch.setattr(mgr, "_resolve_template_sites", lambda _tid, _tn: sites)
+        monkeypatch.setattr(mgr, "_present_template_summary", lambda *_a, **_k: None)
+        exec_hook = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_template_based_upgrade", exec_hook)
+        mgr._upgrade_ap_firmware_by_gateway_template()
+        exec_hook.assert_called_once_with(sites, "Alpha")
+
+
+class TestEmitApUpgradeProgressStart:
+    """Progress-emitter fires only when the module-global is set."""
+
+    def test_no_emitter_is_noop(self) -> None:
+        mgr = _make_manager()  # WHY: construct first — init rebinds globals
+        original = fm_mod.PROGRESS_EMITTER
+        try:
+            fm_mod.PROGRESS_EMITTER = None
+            mgr._emit_ap_upgrade_progress_start()  # should not raise
+        finally:
+            fm_mod.PROGRESS_EMITTER = original
+
+    def test_emitter_fires_progress_start(self) -> None:
+        mgr = _make_manager()  # WHY: construct first — init rebinds globals
+        original = fm_mod.PROGRESS_EMITTER
+        try:
+            emitter = MagicMock()
+            fm_mod.PROGRESS_EMITTER = emitter
+            mgr._emit_ap_upgrade_progress_start()
+            emitter.emit_progress_start.assert_called_once_with("90", "firmware_upgrade", 1)
+        finally:
+            fm_mod.PROGRESS_EMITTER = original
+
+
+class TestIsMspModeAvailable:
+    """Module-global MSP privileges gate."""
+
+    def test_empty_list_returns_false(self) -> None:
+        mgr = _make_manager()  # WHY: construct first — init rebinds globals
+        original = list(fm_mod.msp_privileges)
+        try:
+            fm_mod.msp_privileges = []
+            assert mgr._is_msp_mode_available() is False
+        finally:
+            fm_mod.msp_privileges = original
+
+    def test_populated_list_returns_true(self) -> None:
+        mgr = _make_manager()  # WHY: construct first — init rebinds globals
+        original = list(fm_mod.msp_privileges)
+        try:
+            fm_mod.msp_privileges = [{"msp_id": "m1", "msp_name": "MSP1"}]
+            assert mgr._is_msp_mode_available() is True
+        finally:
+            fm_mod.msp_privileges = original
+
+
+class TestRenderApModeMenu:
+    """Menu prints + returns choice/prompt tuple."""
+
+    def test_without_msp(self, capsys: pytest.CaptureFixture[str]) -> None:
+        choices, prompt = _make_manager()._render_ap_mode_menu(False)
+        assert choices == ["1", "2"]
+        assert "1-2" in prompt
+        out = capsys.readouterr().out
+        assert "Select upgrade mode" in out
+        assert "MSP Multi-Org" not in out
+
+    def test_with_msp(self, capsys: pytest.CaptureFixture[str]) -> None:
+        choices, prompt = _make_manager()._render_ap_mode_menu(True)
+        assert choices == ["1", "2", "3"]
+        assert "1-3" in prompt
+        assert "MSP Multi-Org" in capsys.readouterr().out
+
+
+class TestPromptApUpgradeMode:
+    """Retries invalid input; KeyboardInterrupt cancels."""
+
+    def test_valid_returns_choice(self) -> None:
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: "2")
+        assert mgr._prompt_ap_upgrade_mode("> ", ["1", "2"]) == "2"
+
+    def test_invalid_then_valid(self, capsys: pytest.CaptureFixture[str]) -> None:
+        answers = iter(["9", "1"])
+        mgr = _make_manager(safe_input_fn=lambda *_a, **_k: next(answers))
+        assert mgr._prompt_ap_upgrade_mode("> ", ["1", "2"]) == "1"
+        assert "Invalid selection" in capsys.readouterr().out
+
+    def test_keyboard_interrupt_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        def raise_kb(*_a: Any, **_k: Any) -> str:
+            raise KeyboardInterrupt
+
+        mgr = _make_manager(safe_input_fn=raise_kb)
+        assert mgr._prompt_ap_upgrade_mode("> ", ["1", "2"]) is None
+        assert "cancelled" in capsys.readouterr().out.lower()
+
+
+class TestDispatchApUpgradeMode:
+    """Routing table: 1 -> site, 2 -> template, 3 -> MSP orchestrator."""
+
+    def test_mode_1_calls_bulk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_bulk_upgrade_ap_firmware_by_site", called)
+        assert mgr._dispatch_ap_upgrade_mode("1") is None
+        called.assert_called_once_with()
+
+    def test_mode_2_calls_template(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_upgrade_ap_firmware_by_gateway_template", called)
+        assert mgr._dispatch_ap_upgrade_mode("2") is None
+        called.assert_called_once_with()
+
+    def test_mode_3_calls_msp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        msp_result = [{"org_id": "o1", "status": "completed"}]
+        monkeypatch.setattr(mgr, "_execute_msp_multi_org_upgrade", lambda: msp_result)
+        assert mgr._dispatch_ap_upgrade_mode("3") == msp_result
+
+
+class TestExecuteFirmwareUpgradeWithModeSelection:
+    """End-to-end AP-upgrade entry point."""
+
+    def test_cancelled_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_emit_ap_upgrade_progress_start", lambda: None)
+        monkeypatch.setattr(mgr, "_is_msp_mode_available", lambda: False)
+        monkeypatch.setattr(mgr, "_print_ap_upgrade_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_render_ap_mode_menu", lambda _msp: (["1", "2"], "> "))
+        monkeypatch.setattr(mgr, "_prompt_ap_upgrade_mode", lambda _p, _c: None)
+        dispatch = MagicMock()
+        monkeypatch.setattr(mgr, "_dispatch_ap_upgrade_mode", dispatch)
+        assert mgr.execute_firmware_upgrade_with_mode_selection() is None
+        dispatch.assert_not_called()
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_emit_ap_upgrade_progress_start", lambda: None)
+        monkeypatch.setattr(mgr, "_is_msp_mode_available", lambda: True)
+        monkeypatch.setattr(mgr, "_print_ap_upgrade_banner", lambda: None)
+        monkeypatch.setattr(mgr, "_render_ap_mode_menu", lambda _msp: (["1", "2", "3"], "> "))
+        monkeypatch.setattr(mgr, "_prompt_ap_upgrade_mode", lambda _p, _c: "1")
+        dispatch = MagicMock(return_value=None)
+        monkeypatch.setattr(mgr, "_dispatch_ap_upgrade_mode", dispatch)
+        assert mgr.execute_firmware_upgrade_with_mode_selection() is None
+        dispatch.assert_called_once_with("1")
+
+
+class TestBulkUpgradeApFirmwareBySite:
+    """``_bulk_upgrade_ap_firmware_by_site`` save/restore of module apisession.
+
+    Why:
+        Legacy helpers read the bare ``apisession`` module global.
+        Missing the save/restore step would silently leak the previous
+        caller's session into the next flow.
+    """
+
+    def test_wraps_execute_and_restores_module_apisession(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        instance_session = object()
+        mgr = _make_manager(apisession=instance_session)
+        # Set the sentinel AFTER __init__ rebinds the module global; the
+        # save/restore under test only holds if we trap the *current* value
+        # of ``fm_mod.apisession`` at call time.
+        sentinel_prev = object()
+        monkeypatch.setattr(fm_mod, "apisession", sentinel_prev)
+        seen: dict[str, Any] = {}
+
+        def fake_execute(override: Any) -> None:
+            seen["override"] = override
+            seen["during"] = fm_mod.apisession
+
+        monkeypatch.setattr(mgr, "_execute_bulk_upgrade", fake_execute)
+        mgr._bulk_upgrade_ap_firmware_by_site([{"id": "s"}])
+        # apisession swapped in during the call, restored after.
+        assert seen["during"] is instance_session
+        assert seen["override"] == [{"id": "s"}]
+        assert fm_mod.apisession is sentinel_prev
+
+    def test_restores_apisession_even_on_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager(apisession=object())
+        # Set sentinel after __init__ rebound the module global.
+        sentinel_prev = object()
+        monkeypatch.setattr(fm_mod, "apisession", sentinel_prev)
+
+        def boom(_o: Any) -> None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(mgr, "_execute_bulk_upgrade", boom)
+        with pytest.raises(RuntimeError):
+            mgr._bulk_upgrade_ap_firmware_by_site(None)
+        assert fm_mod.apisession is sentinel_prev
+
+
+class TestExecuteBulkUpgrade:
+    """``_execute_bulk_upgrade`` reads dry_run and delegates."""
+
+    def test_dispatches_with_dry_run_from_mh_args(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import types
+
+        mgr = _make_manager()
+        # _MH is a proxy; give it an args namespace with dry_run flipped on.
+        fake_mh = types.SimpleNamespace(args=types.SimpleNamespace(dry_run=True))
+        monkeypatch.setattr(fm_mod, "_MH", fake_mh)
+        seen: dict[str, Any] = {}
+
+        def fake_dispatch(oid: str, override: Any, dry_run: bool) -> None:
+            seen["oid"] = oid
+            seen["override"] = override
+            seen["dry_run"] = dry_run
+
+        monkeypatch.setattr(mgr, "_dispatch_bulk_ap_upgrade", fake_dispatch)
+        mgr._execute_bulk_upgrade([{"id": "s"}])
+        assert seen["oid"] == "org-tpl"
+        assert seen["override"] == [{"id": "s"}]
+        assert seen["dry_run"] is True
+
+    def test_defaults_dry_run_false_when_args_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import types
+
+        mgr = _make_manager()
+        # _MH proxy without args attribute -> getattr default None; getattr
+        # dry_run default False.
+        monkeypatch.setattr(fm_mod, "_MH", types.SimpleNamespace())
+        seen: dict[str, bool] = {}
+
+        def fake_dispatch(_o: str, _s: Any, dry_run: bool) -> None:
+            seen["dry_run"] = dry_run
+
+        monkeypatch.setattr(mgr, "_dispatch_bulk_ap_upgrade", fake_dispatch)
+        mgr._execute_bulk_upgrade(None)
+        assert seen["dry_run"] is False
+
+
+class TestBuildBulkAPConfig:
+    """``_build_bulk_ap_config`` lazily builds an immutable upgrader config."""
+
+    def test_returns_config_with_wired_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import types
+
+        # Stub the _MH proxy with the attributes the builder reads.
+        fake_mh = types.SimpleNamespace(
+            apisession="AMBIENT",
+            InputUtils=types.SimpleNamespace(safe_input=lambda *_a, **_k: ""),
+            ConfigUtils=types.SimpleNamespace(
+                check_stop_signal=lambda *_a, **_k: False,
+                get_cached_or_prompted_org_id=lambda: "org-tpl",
+            ),
+            APICoreFetchUtils=types.SimpleNamespace(all_sites_with_limit=lambda *_a, **_k: []),
+            FilePathUtils=types.SimpleNamespace(get_csv_path=lambda _n: "/tmp/x.csv"),
+            _build_firmware_manager=lambda _s, _o: types.SimpleNamespace(check_firmware_upgrade_status=lambda: None),
+        )
+        monkeypatch.setattr(fm_mod, "_MH", fake_mh)
+        mgr = _make_manager()
+        cfg = mgr._build_bulk_ap_config("org-tpl", [{"id": "s"}], dry_run=True)
+        # Sanity: config is the frozen BulkAPUpgraderConfig with our fields.
+        assert cfg.org_id == "org-tpl"
+        assert cfg.apisession == "AMBIENT"
+        assert cfg.sites_override == [{"id": "s"}]
+        assert cfg.dry_run is True
+        assert callable(cfg.safe_input_fn)
+        # Lazy status factory returns a live-looking object with the method wired.
+        assert cfg.check_firmware_status_fn() is None
+
+
+class TestDispatchBulkAPUpgrade:
+    """``_dispatch_bulk_ap_upgrade`` builds config + drives the upgrader."""
+
+    def test_builds_config_and_calls_execute(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import src.firmware.bulk_ap_upgrader as bau
+
+        mgr = _make_manager()
+        built_cfg = object()
+        monkeypatch.setattr(mgr, "_build_bulk_ap_config", lambda *_a, **_k: built_cfg)
+
+        seen: dict[str, Any] = {}
+
+        class _FakeUpgrader:
+            def __init__(self, cfg: Any) -> None:
+                seen["cfg"] = cfg
+
+            def execute(self) -> None:
+                seen["executed"] = True
+
+        monkeypatch.setattr(bau, "BulkAPFirmwareUpgrader", _FakeUpgrader)
+        mgr._dispatch_bulk_ap_upgrade("org-tpl", [{"id": "s"}], dry_run=False)
+        assert seen["cfg"] is built_cfg
+        assert seen["executed"] is True

--- a/tests/unit/firmware/test_firmware_manager_version.py
+++ b/tests/unit/firmware/test_firmware_manager_version.py
@@ -1,0 +1,374 @@
+"""Version comparison + scope prompt/dispatch unit tests.
+
+Why:
+    Version comparison is safety-critical: mis-classifying an upgrade as
+    a downgrade would silently block operators from rolling firmware
+    forward. Scope prompt and dispatch route the whole ``check_firmware_
+    upgrade_status`` entry point, so every branch of the router has to
+    stay pinned.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.firmware.firmware_manager import FirmwareManager, FirmwareManagerConfig
+
+
+def _make_manager(**overrides: Any) -> FirmwareManager:
+    """Build a ``FirmwareManager`` with a valid minimum config.
+
+    Why:
+        Version helpers and scope prompt only need a live manager
+        instance — no real API session, no MSP privileges, no template
+        cache. Keeping construction in one place avoids re-stating the
+        identity fields in every test.
+
+    Args:
+        **overrides: Any config field to override.
+
+    Returns:
+        A live ``FirmwareManager`` ready to exercise helpers.
+    """
+    defaults: dict[str, Any] = {"apisession": object(), "org_id": "org-test"}
+    defaults.update(overrides)
+    return FirmwareManager(FirmwareManagerConfig(**defaults))
+
+
+class TestNormalizeVersionParts:
+    """``_normalize_version_parts`` pads and splits version strings.
+
+    Why:
+        The zero-pad step is what makes ``6.3`` and ``6.3.5`` comparable
+        instead of triggering a spurious IndexError downstream.
+    """
+
+    def test_equal_length_versions_unpadded(self) -> None:
+        mgr = _make_manager()
+        left, right = mgr._normalize_version_parts("1.2.3", "1.2.4")
+        assert left == ["1", "2", "3"]
+        assert right == ["1", "2", "4"]
+
+    def test_shorter_current_is_zero_padded(self) -> None:
+        mgr = _make_manager()
+        left, right = mgr._normalize_version_parts("1.2", "1.2.3.4")
+        assert left == ["1", "2", "0", "0"]
+        assert right == ["1", "2", "3", "4"]
+
+    def test_shorter_target_is_zero_padded(self) -> None:
+        mgr = _make_manager()
+        left, right = mgr._normalize_version_parts("1.2.3.4", "1.2")
+        assert left == ["1", "2", "3", "4"]
+        assert right == ["1", "2", "0", "0"]
+
+    def test_suffix_after_dash_is_dropped(self) -> None:
+        mgr = _make_manager()
+        left, right = mgr._normalize_version_parts("6.3.4-7.r2", "6.3.5-37.sts")
+        assert left == ["6", "3", "4"]
+        assert right == ["6", "3", "5"]
+
+
+class TestCompareScalarPair:
+    """``_compare_scalar_pair`` three-way comparison."""
+
+    def test_target_less_is_downgrade(self) -> None:
+        assert _make_manager()._compare_scalar_pair(1, 2) is True
+
+    def test_target_greater_is_upgrade(self) -> None:
+        assert _make_manager()._compare_scalar_pair(3, 2) is False
+
+    def test_target_equal_returns_none(self) -> None:
+        assert _make_manager()._compare_scalar_pair(2, 2) is None
+
+    def test_string_comparison_supported(self) -> None:
+        # Lexical fallback path — used when int cast fails.
+        assert _make_manager()._compare_scalar_pair("a", "b") is True
+        assert _make_manager()._compare_scalar_pair("b", "a") is False
+
+
+class TestCompareSingleVersionPair:
+    """``_compare_single_version_pair`` numeric-with-lexical-fallback."""
+
+    def test_numeric_downgrade(self) -> None:
+        assert _make_manager()._compare_single_version_pair("5", "3") is True
+
+    def test_numeric_upgrade(self) -> None:
+        assert _make_manager()._compare_single_version_pair("3", "5") is False
+
+    def test_numeric_equal(self) -> None:
+        assert _make_manager()._compare_single_version_pair("3", "3") is None
+
+    def test_lexical_fallback_when_non_numeric(self) -> None:
+        # "abc" and "abd" trigger the ValueError fallback.
+        mgr = _make_manager()
+        assert mgr._compare_single_version_pair("abd", "abc") is True
+        assert mgr._compare_single_version_pair("abc", "abd") is False
+
+
+class TestCompareVersionParts:
+    """``_compare_version_parts`` iterates until a verdict is reached."""
+
+    def test_all_equal_returns_false(self) -> None:
+        assert _make_manager()._compare_version_parts(["1", "2", "3"], ["1", "2", "3"]) is False
+
+    def test_stops_at_first_definitive(self) -> None:
+        # Middle segment decides: 2 < 3 -> current has greater middle -> downgrade.
+        assert _make_manager()._compare_version_parts(["1", "3", "5"], ["1", "2", "9"]) is True
+
+    def test_upgrade_verdict(self) -> None:
+        assert _make_manager()._compare_version_parts(["1", "2", "3"], ["1", "3", "0"]) is False
+
+
+class TestIsFirmwareDowngrade:
+    """Public downgrade classifier — wires normalise+compare together."""
+
+    def test_empty_current_returns_false(self) -> None:
+        assert _make_manager()._is_firmware_downgrade("", "1.0") is False
+
+    def test_empty_target_returns_false(self) -> None:
+        assert _make_manager()._is_firmware_downgrade("1.0", "") is False
+
+    def test_true_downgrade(self) -> None:
+        assert _make_manager()._is_firmware_downgrade("6.3.5", "6.3.4") is True
+
+    def test_upgrade_returns_false(self) -> None:
+        assert _make_manager()._is_firmware_downgrade("6.3.5", "6.3.6") is False
+
+    def test_equal_versions_return_false(self) -> None:
+        assert _make_manager()._is_firmware_downgrade("6.3.5", "6.3.5") is False
+
+    def test_ssr_style_suffix_ignored(self) -> None:
+        # 6.3.5 vs 6.3.4 (with -N.sts suffixes) — downgrade.
+        assert _make_manager()._is_firmware_downgrade("6.3.5-37.sts", "6.3.4-7.r2") is True
+
+    def test_exception_path_returns_false_and_logs(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mgr = _make_manager()
+
+        def blow_up(*_a: Any, **_k: Any) -> tuple[list[str], list[str]]:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(mgr, "_normalize_version_parts", blow_up)
+        caplog.set_level(logging.WARNING, logger="root")
+        assert mgr._is_firmware_downgrade("1.0", "2.0") is False
+        assert any("Could not compare versions" in r.message for r in caplog.records)
+
+
+class TestPromptScopeSelection:
+    """Scope prompt loop: valid range, retry, KeyboardInterrupt cancel."""
+
+    @pytest.mark.parametrize("choice", ["1", "2", "3", "4", "5", "6"])
+    def test_returns_valid_choice(self, capsys: pytest.CaptureFixture[str], choice: str) -> None:
+        prompts: list[str] = []
+
+        def fake_input(prompt: str, context: str = "") -> str:
+            prompts.append(prompt)
+            return choice
+
+        mgr = _make_manager(safe_input_fn=fake_input)
+        assert mgr._prompt_scope_selection() == choice
+        out = capsys.readouterr().out
+        assert "Select status check scope" in out
+        assert prompts and "Select scope" in prompts[0]
+
+    def test_retries_on_invalid_then_accepts(self, capsys: pytest.CaptureFixture[str]) -> None:
+        answers = iter(["7", "0", "3"])
+
+        def fake_input(_prompt: str, context: str = "") -> str:
+            return next(answers)
+
+        mgr = _make_manager(safe_input_fn=fake_input)
+        assert mgr._prompt_scope_selection() == "3"
+        out = capsys.readouterr().out
+        assert out.count("Invalid selection. Please choose 1-6.") == 2
+
+    def test_keyboard_interrupt_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        def fake_input(*_a: Any, **_k: Any) -> str:
+            raise KeyboardInterrupt
+
+        mgr = _make_manager(safe_input_fn=fake_input)
+        assert mgr._prompt_scope_selection() is None
+        assert "Operation cancelled by user" in capsys.readouterr().out
+
+
+class TestResolveScopeChoice:
+    """``_resolve_scope_choice`` passthrough vs prompt."""
+
+    def test_passthrough_when_provided(self) -> None:
+        mgr = _make_manager()
+        assert mgr._resolve_scope_choice("1") == "1"
+
+    def test_prompts_when_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_prompt_scope_selection", lambda: "4")
+        assert mgr._resolve_scope_choice(None) == "4"
+
+
+class TestResolveSiteFilterForStatus:
+    """``_resolve_site_filter_for_status`` prompts only when scope=2."""
+
+    def test_non_scope_2_passthrough(self) -> None:
+        mgr = _make_manager()
+        assert mgr._resolve_site_filter_for_status("1", None) is None
+        assert mgr._resolve_site_filter_for_status("3", "sf") == "sf"
+
+    def test_scope_2_with_existing_filter_passthrough(self) -> None:
+        mgr = _make_manager()
+        assert mgr._resolve_site_filter_for_status("2", "already-set") == "already-set"
+
+    def test_scope_2_no_hook_returns_none_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        mgr = _make_manager(select_site_fn=None)
+        caplog.set_level(logging.ERROR, logger="root")
+        assert mgr._resolve_site_filter_for_status("2", None) is None
+        assert any("select_site_fn not configured" in r.message for r in caplog.records)
+
+    def test_scope_2_empty_selection_returns_none(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mgr = _make_manager(select_site_fn=lambda: None)
+        assert mgr._resolve_site_filter_for_status("2", None) is None
+        assert "No site selected" in capsys.readouterr().out
+
+    def test_scope_2_valid_selection_returned(self) -> None:
+        mgr = _make_manager(select_site_fn=lambda: "site-abc")
+        assert mgr._resolve_site_filter_for_status("2", None) == "site-abc"
+
+
+class TestDispatchStatusScope:
+    """Route from scope choice to correct handler."""
+
+    def test_scope_5_calls_monitoring_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_continuous_monitoring_mode", called)
+        mgr._dispatch_status_scope("5", "site-x")
+        called.assert_called_once_with("site-x")
+
+    def test_scope_6_calls_show_org_jobs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_show_org_level_upgrade_jobs", called)
+        mgr._dispatch_status_scope("6", None)
+        called.assert_called_once_with()
+
+    def test_default_calls_execute_status_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        called = MagicMock()
+        monkeypatch.setattr(mgr, "_execute_status_check", called)
+        mgr._dispatch_status_scope("1", "sf")
+        called.assert_called_once_with("1", "sf")
+
+
+class TestCheckFirmwareUpgradeStatus:
+    """End-to-end orchestrator with fully mocked collaborators."""
+
+    def test_cancelled_scope_returns_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_resolve_scope_choice", lambda _s: None)
+        dispatch = MagicMock()
+        monkeypatch.setattr(mgr, "_dispatch_status_scope", dispatch)
+        assert mgr.check_firmware_upgrade_status() is None
+        dispatch.assert_not_called()
+
+    def test_scope_2_cancelled_returns_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_resolve_scope_choice", lambda _s: "2")
+        monkeypatch.setattr(mgr, "_resolve_site_filter_for_status", lambda _s, _f: None)
+        dispatch = MagicMock()
+        monkeypatch.setattr(mgr, "_dispatch_status_scope", dispatch)
+        assert mgr.check_firmware_upgrade_status() is None
+        dispatch.assert_not_called()
+
+    def test_happy_path_dispatches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_resolve_scope_choice", lambda _s: "1")
+        monkeypatch.setattr(mgr, "_resolve_site_filter_for_status", lambda _s, _f: None)
+        dispatch = MagicMock()
+        monkeypatch.setattr(mgr, "_dispatch_status_scope", dispatch)
+        mgr.check_firmware_upgrade_status()
+        dispatch.assert_called_once_with("1", None)
+
+
+class TestExecuteStatusCheck:
+    """``_execute_status_check`` save/restore module apisession + runs checker.
+
+    Why:
+        The co-located FirmwareUpgradeStatusChecker reads the bare
+        ``apisession`` module global. Missing the save/restore around it
+        would leak the previous caller's session and (worse) skew audit
+        logs. The try/finally block is safety-critical.
+    """
+
+    def test_runs_checker_with_bound_session_and_restores(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import src.firmware.firmware_manager as fm_mod
+
+        instance_session = object()
+        mgr = _make_manager(apisession=instance_session)
+        # Set the sentinel AFTER construction — __init__ rebinds the module
+        # global to the instance session, so we must override it here to
+        # verify the save/restore contract of _execute_status_check itself.
+        sentinel_prev = object()
+        monkeypatch.setattr(fm_mod, "apisession", sentinel_prev)
+
+        observed: dict[str, Any] = {}
+
+        class _FakeChecker:
+            def __init__(self, scope: str, site: str | None) -> None:
+                observed["scope"] = scope
+                observed["site"] = site
+                observed["session_during_init"] = fm_mod.apisession
+
+            def check(self) -> None:
+                observed["ran"] = True
+
+        monkeypatch.setattr(fm_mod, "FirmwareUpgradeStatusChecker", _FakeChecker)
+        mgr._execute_status_check("3", "sf")
+        assert observed == {
+            "scope": "3",
+            "site": "sf",
+            "session_during_init": instance_session,
+            "ran": True,
+        }
+        assert fm_mod.apisession is sentinel_prev
+
+    def test_restores_apisession_even_on_checker_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import src.firmware.firmware_manager as fm_mod
+
+        mgr = _make_manager(apisession=object())
+        # Reset the module global AFTER __init__ rebound it.
+        sentinel_prev = object()
+        monkeypatch.setattr(fm_mod, "apisession", sentinel_prev)
+
+        class _BadChecker:
+            def __init__(self, _s: str, _f: str | None) -> None:
+                pass
+
+            def check(self) -> None:
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(fm_mod, "FirmwareUpgradeStatusChecker", _BadChecker)
+        with pytest.raises(RuntimeError):
+            mgr._execute_status_check("1", None)
+        assert fm_mod.apisession is sentinel_prev
+
+    def test_emits_audit_logs(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        import src.firmware.firmware_manager as fm_mod
+
+        mgr = _make_manager()
+
+        class _NoopChecker:
+            def __init__(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def check(self) -> None:
+                pass
+
+        monkeypatch.setattr(fm_mod, "FirmwareUpgradeStatusChecker", _NoopChecker)
+        caplog.set_level(logging.DEBUG, logger="root")
+        mgr._execute_status_check("2", "site-x")
+        messages = [r.message for r in caplog.records]
+        assert any("Dispatching status check (scope=2, site_filter=site-x)" in m for m in messages)
+        assert any("Status check dispatch complete" in m for m in messages)

--- a/tests/unit/firmware/test_firmware_upgrade_status_checker.py
+++ b/tests/unit/firmware/test_firmware_upgrade_status_checker.py
@@ -1,0 +1,1481 @@
+"""Unit tests for the co-located ``FirmwareUpgradeStatusChecker`` class.
+
+Why:
+    The status checker is a long procedural report generator that reads
+    ``apisession`` at module scope and touches five separate mistapi
+    endpoints. Each helper is small but the surface area is huge; without
+    per-helper coverage a single silent regression (wrong status glyph,
+    missing histogram bucket, swapped ``upgrade_id`` field) ships to
+    operators unnoticed.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.firmware.firmware_manager as fm_mod
+from src.firmware.firmware_manager import FirmwareUpgradeStatusChecker
+
+
+class _FakeResponse:
+    """Stand-in for a ``requests.Response`` used by mistapi helpers.
+
+    Why:
+        The status checker only inspects ``status_code`` and ``data`` on
+        the responses it receives; the fake avoids constructing a real
+        response object with headers, cookies, etc.
+    """
+
+    def __init__(self, status_code: int = 200, data: Any = None, has_data_attr: bool = True) -> None:
+        """Store canned status + payload; drop ``data`` attribute if requested.
+
+        Args:
+            status_code: HTTP status code to expose.
+            data: Payload to return via ``.data``.
+            has_data_attr: If False, the ``data`` attribute is not set,
+                simulating an API shape that lacks the field.
+        """
+        self.status_code = status_code
+        if has_data_attr:
+            self.data = data
+
+
+def _install_mh_proxy(monkeypatch: pytest.MonkeyPatch, org_id: str = "org-test") -> MagicMock:
+    """Replace ``fm_mod._MH`` with a MagicMock for the duration of the test.
+
+    Why:
+        The real ``_MH`` proxy forwards attribute lookups to the
+        ``MistHelper`` module (which is a heavy import). Every checker
+        helper touches it (``ConfigUtils``, ``DisplayUtils``, ``DataExporter``,
+        ``APICoreFetchUtils``, ``PromptUtils``). A MagicMock with the org id
+        wired in is enough to satisfy every call site.
+
+    Args:
+        monkeypatch: The active ``pytest.MonkeyPatch`` fixture.
+        org_id: Org id to return from ``get_cached_or_prompted_org_id``.
+
+    Returns:
+        The MagicMock installed as ``fm_mod._MH`` (so tests can assert on it).
+    """
+    mh = MagicMock()
+    mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = org_id
+    mh.DisplayUtils.create_progress_bar.side_effect = lambda p, bar_length=20: f"[bar {p}]"
+    monkeypatch.setattr(fm_mod, "_MH", mh)
+    return mh
+
+
+def _make_checker(
+    monkeypatch: pytest.MonkeyPatch,
+    scope_choice: str | None = None,
+    site_filter: str | None = None,
+    org_id: str = "org-test",
+) -> FirmwareUpgradeStatusChecker:
+    """Instantiate a checker with the _MH proxy stubbed.
+
+    Args:
+        monkeypatch: Test fixture used to install the mock proxy.
+        scope_choice: Optional scope selector to forward.
+        site_filter: Optional site id filter to forward.
+        org_id: Org id the mocked ConfigUtils returns.
+
+    Returns:
+        Fresh ``FirmwareUpgradeStatusChecker`` ready for use.
+    """
+    _install_mh_proxy(monkeypatch, org_id=org_id)
+    return FirmwareUpgradeStatusChecker(scope_choice=scope_choice, site_filter=site_filter)
+
+
+class TestInit:
+    """Init wiring + summary shape.
+
+    Why:
+        Every other helper reads ``self.summary`` and ``self.org_id``, so
+        a regression in the constructor's default state cascades into all
+        downstream displays.
+    """
+
+    def test_stores_scope_and_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="2", site_filter="site-x")
+        assert chk.scope_choice == "2"
+        assert chk.site_filter == "site-x"
+        assert chk.org_id == "org-test"
+
+    def test_org_id_pulled_from_configutils(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mh = _install_mh_proxy(monkeypatch, org_id="ORG-42")
+        chk = FirmwareUpgradeStatusChecker()
+        assert chk.org_id == "ORG-42"
+        mh.ConfigUtils.get_cached_or_prompted_org_id.assert_called_once()
+
+    def test_summary_keys_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        expected_keys = {
+            "total_devices",
+            "devices_with_fwupdate",
+            "upgrade_in_progress",
+            "upgrade_failed",
+            "upgrade_completed",
+            "upgrade_unknown",
+            "devices_by_status",
+            "devices_by_version",
+            "devices_by_model",
+            "devices_by_type",
+            "progress_total",
+            "progress_count",
+            "devices_upgrading",
+        }
+        assert expected_keys.issubset(chk.summary.keys())
+        assert chk.summary["total_devices"] == 0
+        assert chk.summary["devices_upgrading"] == []
+
+    def test_empty_collections_initialized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk.all_device_stats == []
+        assert chk.upgrade_results == []
+        assert chk.active_upgrades == []
+        assert chk.site_lookup == {}
+
+
+class TestResolveSiteFilter:
+    """``_resolve_site_filter`` prompt/passthrough gate."""
+
+    def test_scope_not_2_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="3")
+        assert chk._resolve_site_filter() is True
+
+    def test_scope_2_with_existing_filter_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="2", site_filter="pre-set")
+        assert chk._resolve_site_filter() is True
+
+    def test_scope_2_selects_via_promptutils(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mh = _install_mh_proxy(monkeypatch)
+        mh.PromptUtils.select_site.return_value = "chosen-site"
+        chk = FirmwareUpgradeStatusChecker(scope_choice="2")
+        assert chk._resolve_site_filter() is True
+        assert chk.site_filter == "chosen-site"
+
+    def test_scope_2_no_selection_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mh = _install_mh_proxy(monkeypatch)
+        mh.PromptUtils.select_site.return_value = None
+        chk = FirmwareUpgradeStatusChecker(scope_choice="2")
+        assert chk._resolve_site_filter() is False
+        assert "No site selected" in capsys.readouterr().out
+
+
+class TestFetchDeviceStats:
+    """``_fetch_device_stats`` dispatch + exception guard."""
+
+    def test_delegates_to_site_when_filter_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="2", site_filter="site-a")
+        monkeypatch.setattr(chk, "_fetch_site_stats", lambda: True)
+        monkeypatch.setattr(chk, "_fetch_org_stats", lambda: pytest.fail("wrong branch"))
+        assert chk._fetch_device_stats() is True
+
+    def test_delegates_to_org_when_no_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_fetch_site_stats", lambda: pytest.fail("wrong branch"))
+        monkeypatch.setattr(chk, "_fetch_org_stats", lambda: True)
+        assert chk._fetch_device_stats() is True
+
+    def test_exception_returns_false(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+
+        def blow_up() -> bool:
+            raise RuntimeError("api-down")
+
+        monkeypatch.setattr(chk, "_fetch_org_stats", blow_up)
+        assert chk._fetch_device_stats() is False
+        assert "Failed to fetch device statistics" in capsys.readouterr().out
+
+
+class TestFetchSiteAndOrgStats:
+    """Site + org fetch helpers hit mistapi + accumulate results."""
+
+    def _install_pagination(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        page1: list[dict[str, Any]],
+        endpoint_path: tuple[str, ...],
+    ) -> None:
+        """Wire ``mistapi.get_all`` + a specific endpoint to canned data.
+
+        Why:
+            Patch through ``fm_mod.mistapi`` (the same module reference
+            firmware_manager already resolved) so a sibling test that
+            replaces ``sys.modules['mistapi']`` cannot desync our shim.
+        """
+        mistapi = fm_mod.mistapi
+
+        monkeypatch.setattr(mistapi, "get_all", lambda response, mist_session: response.data)
+        module = mistapi
+        for part in endpoint_path[:-1]:
+            module = getattr(module, part)
+        monkeypatch.setattr(module, endpoint_path[-1], lambda *_a, **_k: _FakeResponse(200, page1))
+
+    def test_site_stats_accumulates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, site_filter="site-x")
+        self._install_pagination(
+            monkeypatch,
+            [{"id": "d1"}, {"id": "d2"}],
+            ("api", "v1", "sites", "stats", "listSiteDevicesStats"),
+        )
+        assert chk._fetch_site_stats() is True
+        assert len(chk.all_device_stats) == 2
+
+    def test_site_stats_empty_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, site_filter="site-x")
+        self._install_pagination(monkeypatch, [], ("api", "v1", "sites", "stats", "listSiteDevicesStats"))
+        assert chk._fetch_site_stats() is False
+
+    def test_org_stats_accumulates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        self._install_pagination(
+            monkeypatch,
+            [{"id": "d1"}],
+            ("api", "v1", "orgs", "stats", "listOrgDevicesStats"),
+        )
+        assert chk._fetch_org_stats() is True
+        assert chk.all_device_stats == [{"id": "d1"}]
+
+    def test_org_stats_empty_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        self._install_pagination(monkeypatch, [], ("api", "v1", "orgs", "stats", "listOrgDevicesStats"))
+        assert chk._fetch_org_stats() is False
+        assert "No device statistics found" in capsys.readouterr().out
+
+
+class TestFetchSiteLookup:
+    """``_fetch_site_lookup`` builds site_id -> site_name map, tolerates errors."""
+
+    def test_populates_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mh = _install_mh_proxy(monkeypatch)
+        mh.APICoreFetchUtils.all_sites_with_limit.return_value = [
+            {"id": "s1", "name": "Site 1"},
+            {"id": "s2", "name": "Site 2"},
+            {"id": None, "name": "Skip"},
+        ]
+        chk = FirmwareUpgradeStatusChecker()
+        chk._fetch_site_lookup()
+        assert chk.site_lookup == {"s1": "Site 1", "s2": "Site 2"}
+
+    def test_exception_clears_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mh = _install_mh_proxy(monkeypatch)
+        mh.APICoreFetchUtils.all_sites_with_limit.side_effect = RuntimeError("boom")
+        chk = FirmwareUpgradeStatusChecker()
+        chk.site_lookup["stale"] = "must-clear"
+        chk._fetch_site_lookup()
+        assert chk.site_lookup == {}
+
+
+class TestExtractDeviceInfo:
+    """``_extract_device_info`` normalises the raw stats row."""
+
+    def test_fields_pulled_and_defaulted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.site_lookup["s1"] = "Site 1"
+        row = chk._extract_device_info(
+            {
+                "id": "d1",
+                "name": "n1",
+                "mac": "aabbcc",
+                "model": "m1",
+                "type": "ap",
+                "version": "6.3.5",
+                "site_id": "s1",
+                "last_seen": 100,
+            }
+        )
+        assert row["device_id"] == "d1"
+        assert row["device_name"] == "n1"
+        assert row["device_mac"] == "aabbcc"
+        assert row["site_name"] == "Site 1"
+
+    def test_unknown_site_yields_fallback_label(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        row = chk._extract_device_info({"site_id": "unknown-site"})
+        assert row["site_name"] == "Unknown Site"
+        assert row["device_id"] == "Unknown"
+
+
+class TestProcessFwupdateAndSubHelpers:
+    """``_process_fwupdate`` + ``_parse_fwupdate_data`` + ``_categorize_status``."""
+
+    def _base_info(self, last_seen: int = 0) -> dict[str, Any]:
+        return {
+            "device_id": "d1",
+            "device_name": "n1",
+            "device_mac": "aabbcc",
+            "device_model": "m1",
+            "device_type": "ap",
+            "device_version": "6.3.5",
+            "site_id": "s1",
+            "site_name": "Site 1",
+            "last_seen": last_seen,
+        }
+
+    def test_empty_fwupdate_returns_no_upgrade_info(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        fw = chk._process_fwupdate({}, self._base_info())
+        assert fw["fw_status"] == "no_upgrade_info"
+        assert chk.summary["devices_with_fwupdate"] == 0
+
+    def test_populated_fwupdate_increments_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        fw = chk._process_fwupdate(
+            {"fwupdate": {"status": "upgraded", "progress": 100}},
+            self._base_info(),
+        )
+        assert fw["fw_status"] == "upgraded"
+        assert chk.summary["devices_with_fwupdate"] == 1
+
+    @pytest.mark.parametrize(
+        "status,progress,expected_key",
+        [
+            ("failed", 0, "upgrade_failed"),
+            ("upgraded", 100, "upgrade_completed"),
+            ("success", 100, "upgrade_completed"),
+            ("mystery", 0, "upgrade_unknown"),
+        ],
+    )
+    def test_categorize_terminal_states(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        status: str,
+        progress: int,
+        expected_key: str,
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._categorize_status(status, progress, 0, self._base_info())
+        assert chk.summary[expected_key] == 1
+
+    def test_categorize_active_upgrade_tracks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._categorize_status("inprogress", 50, 0, self._base_info())
+        assert chk.summary["upgrade_in_progress"] == 1
+        assert chk.summary["devices_upgrading"][0]["progress"] == 50
+
+    def test_categorize_active_stale_marks_complete(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_is_stale_upgrade", lambda _p, _t: True)
+        chk._categorize_status("upgrading", 100, 12345, self._base_info())
+        assert chk.summary["upgrade_completed"] == 1
+
+
+class TestStaleUpgrade:
+    """``_is_stale_upgrade`` + ``_is_valid_upgrade_timestamp``."""
+
+    def test_non_100_progress_not_stale(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._is_stale_upgrade(50, 12345) is False
+
+    def test_invalid_timestamp_not_stale(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._is_stale_upgrade(100, 0) is False
+        assert chk._is_stale_upgrade(100, "abc") is False
+
+    def test_old_upgrade_is_stale(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        # 2 hours ago, threshold 1
+        monkeypatch.setattr(fm_mod.time, "time", lambda: 3600 * 5)
+        assert chk._is_stale_upgrade(100, 3600 * 2) is True
+
+    def test_fresh_upgrade_not_stale(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        # 1 minute ago
+        monkeypatch.setattr(fm_mod.time, "time", lambda: 3660)
+        assert chk._is_stale_upgrade(100, 3600) is False
+
+    def test_math_exception_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+
+        def bad_time() -> float:
+            raise ValueError("nope")
+
+        monkeypatch.setattr(fm_mod.time, "time", bad_time)
+        assert chk._is_stale_upgrade(100, 1) is False
+
+    @pytest.mark.parametrize("value,expected", [(1, True), (1.5, True), (0, False), (-5, False), ("x", False)])
+    def test_valid_timestamp(self, value: Any, expected: bool) -> None:
+        assert FirmwareUpgradeStatusChecker._is_valid_upgrade_timestamp(value) is expected
+
+
+class TestTrackActiveUpgrade:
+    """``_track_active_upgrade`` progress accounting."""
+
+    def test_numeric_progress_updates_average(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        info = {
+            "device_name": "n1",
+            "device_mac": "aabbcc",
+            "device_type": "ap",
+            "device_model": "m1",
+            "site_name": "Site 1",
+            "device_version": "6.3.5",
+        }
+        chk._track_active_upgrade(30, 1000, info)
+        assert chk.summary["progress_total"] == 30
+        assert chk.summary["progress_count"] == 1
+        assert chk.summary["devices_upgrading"][0]["progress"] == 30
+
+    def test_none_progress_records_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        info = {
+            "device_name": "n1",
+            "device_mac": "aabbcc",
+            "device_type": "ap",
+            "device_model": "m1",
+            "site_name": "Site 1",
+            "device_version": "6.3.5",
+        }
+        chk._track_active_upgrade(None, 1000, info)
+        assert chk.summary["progress_count"] == 0
+        assert chk.summary["devices_upgrading"][0]["progress"] == 0
+
+
+class TestFormatTimestamp:
+    """``_format_timestamp`` fallbacks + happy path."""
+
+    def test_valid_timestamp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        out = chk._format_timestamp(1700000000)
+        assert len(out) == 19  # YYYY-MM-DD HH:MM:SS
+
+    @pytest.mark.parametrize("bad", [0, -1, None, "abc"])
+    def test_invalid_returns_unknown(self, monkeypatch: pytest.MonkeyPatch, bad: Any) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._format_timestamp(bad) == "Unknown"
+
+    def test_exception_returns_invalid_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+
+        class _Dt:
+            @staticmethod
+            def fromtimestamp(_ts: float) -> Any:
+                raise ValueError("bad epoch")
+
+        monkeypatch.setattr(fm_mod, "datetime", _Dt)
+        assert chk._format_timestamp(123).startswith("Invalid:")
+
+
+class TestUpdateSummaryCounters:
+    """``_update_summary_counters`` histogram maintenance."""
+
+    def test_all_three_histograms_increment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        info = {"device_version": "6.3.5", "device_model": "AP41", "device_type": "ap"}
+        chk._update_summary_counters(info, {})
+        chk._update_summary_counters(info, {})
+        assert chk.summary["devices_by_version"]["6.3.5"] == 2
+        assert chk.summary["devices_by_model"]["AP41"] == 2
+        assert chk.summary["devices_by_type"]["ap"] == 2
+        assert chk.summary["total_devices"] == 2
+
+
+class TestBuildUpgradeResultRow:
+    """``_build_upgrade_result_row`` CSV row shape."""
+
+    def test_all_columns_present(self) -> None:
+        row = FirmwareUpgradeStatusChecker._build_upgrade_result_row(
+            {
+                "site_id": "s1",
+                "site_name": "Site 1",
+                "device_id": "d1",
+                "device_name": "n1",
+                "device_mac": "aabbcc",
+                "device_model": "m1",
+                "device_type": "ap",
+                "device_version": "6.3.5",
+            },
+            {
+                "last_seen_str": "2024-01-01 00:00:00",
+                "fw_status": "upgraded",
+                "fw_progress": 100,
+                "fw_status_id": 5,
+                "fw_will_retry": False,
+                "fw_time_str": "2024-01-01 00:01:00",
+            },
+            "[bar 100]",
+        )
+        assert row["Site ID"] == "s1"
+        assert row["FW Progress Display"] == "[bar 100]"
+        assert "Timestamp" in row
+
+
+class TestMaybeAddToResults:
+    """``_maybe_add_to_results`` scope gate + row append."""
+
+    def test_scope_3_active_appends(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="3")
+        chk._maybe_add_to_results(
+            {
+                "site_id": "s1",
+                "site_name": "Site 1",
+                "device_id": "d1",
+                "device_name": "n1",
+                "device_mac": "aabbcc",
+                "device_model": "m1",
+                "device_type": "ap",
+                "device_version": "6.3.5",
+            },
+            {
+                "fw_status": "inprogress",
+                "fw_progress": 50,
+                "fw_timestamp": 0,
+                "fw_status_id": 0,
+                "fw_will_retry": False,
+                "fw_time_str": "-",
+                "last_seen_str": "-",
+            },
+        )
+        assert len(chk.upgrade_results) == 1
+
+    def test_out_of_scope_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="4")
+        chk._maybe_add_to_results(
+            {
+                "site_id": "s1",
+                "site_name": "Site 1",
+                "device_id": "d1",
+                "device_name": "n1",
+                "device_mac": "aabbcc",
+                "device_model": "m1",
+                "device_type": "ap",
+                "device_version": "6.3.5",
+            },
+            {
+                "fw_status": "upgraded",
+                "fw_progress": 100,
+                "fw_timestamp": 0,
+                "fw_status_id": 0,
+                "fw_will_retry": False,
+                "fw_time_str": "-",
+                "last_seen_str": "-",
+            },
+        )
+        assert chk.upgrade_results == []
+
+
+class TestShouldIncludeDevice:
+    """``_should_include_device`` scope gate branches."""
+
+    @pytest.mark.parametrize("status", ["inprogress", "upgrading", "downloading"])
+    def test_scope_3_active_included(self, monkeypatch: pytest.MonkeyPatch, status: str) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="3")
+        assert chk._should_include_device({"fw_status": status, "fw_progress": 50, "fw_timestamp": 0}) is True
+
+    def test_scope_3_stale_excluded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="3")
+        monkeypatch.setattr(chk, "_is_stale_upgrade", lambda _p, _t: True)
+        assert chk._should_include_device({"fw_status": "inprogress", "fw_progress": 100, "fw_timestamp": 1}) is False
+
+    def test_scope_3_non_active_excluded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="3")
+        assert chk._should_include_device({"fw_status": "upgraded", "fw_progress": 100, "fw_timestamp": 0}) is False
+
+    def test_scope_4_failed_included(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="4")
+        assert chk._should_include_device({"fw_status": "failed", "fw_progress": 0, "fw_timestamp": 0}) is True
+
+    def test_scope_4_non_failed_excluded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice="4")
+        assert chk._should_include_device({"fw_status": "upgraded", "fw_progress": 100, "fw_timestamp": 0}) is False
+
+    def test_default_includes_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, scope_choice=None)
+        assert chk._should_include_device({"fw_status": "whatever", "fw_progress": 0, "fw_timestamp": 0}) is True
+
+
+class TestRenderActiveProgress:
+    """``_render_active_progress`` branch coverage."""
+
+    def test_stale_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_is_stale_upgrade", lambda _p, _t: True)
+        assert "Stale" in chk._render_active_progress(100, 0)
+
+    def test_progress_renders_bar(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_is_stale_upgrade", lambda _p, _t: False)
+        assert chk._render_active_progress(50, 0) == "[bar 50]"
+
+    def test_no_progress_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_is_stale_upgrade", lambda _p, _t: False)
+        assert chk._render_active_progress(None, 0) == "N/A"
+
+
+class TestCreateProgressDisplay:
+    """``_create_progress_display`` per-status rendering."""
+
+    @pytest.mark.parametrize("status", ["inprogress", "upgrading", "downloading"])
+    def test_active_delegates_to_render(self, monkeypatch: pytest.MonkeyPatch, status: str) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_render_active_progress", lambda _p, _t: "RENDERED")
+        assert chk._create_progress_display({"fw_status": status, "fw_progress": 40, "fw_timestamp": 0}) == "RENDERED"
+
+    @pytest.mark.parametrize("status", ["upgraded", "success"])
+    def test_completed_display(self, monkeypatch: pytest.MonkeyPatch, status: str) -> None:
+        chk = _make_checker(monkeypatch)
+        assert "Complete" in chk._create_progress_display({"fw_status": status, "fw_progress": 100, "fw_timestamp": 0})
+
+    def test_failed_display(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert "FAILED" in chk._create_progress_display({"fw_status": "failed", "fw_progress": 0, "fw_timestamp": 0})
+
+    def test_unknown_display(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._create_progress_display({"fw_status": "mystery", "fw_progress": 0, "fw_timestamp": 0}) == "N/A"
+
+
+class TestDisplaySummary:
+    """``_display_summary`` + distribution helpers."""
+
+    def test_summary_prints_totals(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.summary["total_devices"] = 3
+        chk._display_summary()
+        out = capsys.readouterr().out
+        assert "Firmware Status Summary" in out
+        assert "Total devices analyzed: 3" in out
+
+    def test_display_average_progress_when_zero_count(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._display_average_progress()
+        assert "Average" not in capsys.readouterr().out
+
+    def test_display_average_progress_prints(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.summary["progress_total"] = 100
+        chk.summary["progress_count"] = 2
+        chk._display_average_progress()
+        assert "Average upgrade progress" in capsys.readouterr().out
+
+    def test_status_distribution_empty(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._display_status_distribution()
+        assert "Status Distribution" not in capsys.readouterr().out
+
+    def test_status_distribution_populated(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.summary["devices_by_status"] = {"upgraded": 3, "failed": 1}
+        chk._display_status_distribution()
+        out = capsys.readouterr().out
+        assert "upgraded: 3" in out
+        assert "failed: 1" in out
+
+    def test_type_distribution_empty_shows_message(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._display_type_distribution()
+        assert "No device type information" in capsys.readouterr().out
+
+    def test_type_distribution_uses_friendly_names(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.summary["devices_by_type"] = {"ap": 2, "switch": 1, "custom": 4}
+        chk._display_type_distribution()
+        out = capsys.readouterr().out
+        assert "Access Points" in out
+        assert "Switches" in out
+        assert "CUSTOM" in out
+
+    def test_version_distribution(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.summary["devices_by_version"] = {"6.3.5": 2, "6.3.4": 1}
+        chk._display_version_distribution()
+        assert "6.3.5: 2" in capsys.readouterr().out
+
+    def test_model_distribution(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.summary["devices_by_model"] = {"AP41": 5}
+        chk._display_model_distribution()
+        assert "AP41: 5" in capsys.readouterr().out
+
+
+class TestDisplayUpgradingDevices:
+    """``_display_upgrading_devices`` + progress distribution."""
+
+    def test_empty_short_circuits(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._display_upgrading_devices()
+        assert capsys.readouterr().out == ""
+
+    def test_populated_renders_table(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.summary["devices_upgrading"] = [
+            {
+                "device_name": "n1",
+                "device_type": "ap",
+                "device_mac": "aabbcc",
+                "device_model": "m1",
+                "site_name": "Site 1",
+                "current_version": "6.3.5",
+                "progress": 60,
+                "fw_timestamp": 0,
+            }
+        ]
+        chk._display_upgrading_devices()
+        out = capsys.readouterr().out
+        assert "Currently Upgrading" in out
+        assert "n1" in out
+
+    def test_print_upgrading_device_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._print_upgrading_device(
+            {
+                "device_name": "",
+                "device_type": "",
+                "device_mac": "",
+                "device_model": "",
+                "site_name": "",
+                "current_version": "",
+                "progress": 25,
+                "fw_timestamp": 0,
+            }
+        )
+        out = capsys.readouterr().out
+        assert "Unnamed" in out
+        assert "Unknown" in out
+
+    @pytest.mark.parametrize(
+        "progress,bucket",
+        [
+            (0, "0-25%"),
+            (25, "0-25%"),
+            (26, "26-50%"),
+            (50, "26-50%"),
+            (51, "51-75%"),
+            (75, "51-75%"),
+            (76, "76-99%"),
+            (99, "76-99%"),
+            (100, "100%"),
+        ],
+    )
+    def test_classify_progress_bucket(self, progress: int, bucket: str) -> None:
+        assert FirmwareUpgradeStatusChecker._classify_progress_bucket(progress) == bucket
+
+    def test_display_progress_distribution(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._display_progress_distribution(
+            [
+                {"progress": 10},
+                {"progress": 60},
+                {"progress": 100},
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "0-25%" in out
+        assert "51-75%" in out
+        assert "100%" in out
+
+
+class TestFetchSsrUpgradesPayload:
+    """``_fetch_ssr_upgrades_payload`` HTTP-shape guard."""
+
+    def test_non_200_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        import mistapi.api.v1.orgs.ssr as real_ssr
+
+        monkeypatch.setattr(real_ssr, "listOrgSsrUpgrades", lambda *_a, **_k: _FakeResponse(500, None))
+        assert chk._fetch_ssr_upgrades_payload() is None
+
+    def test_missing_data_attr_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        import mistapi.api.v1.orgs.ssr as real_ssr
+
+        monkeypatch.setattr(
+            real_ssr,
+            "listOrgSsrUpgrades",
+            lambda *_a, **_k: _FakeResponse(200, None, has_data_attr=False),
+        )
+        assert chk._fetch_ssr_upgrades_payload() is None
+
+    def test_empty_data_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        import mistapi.api.v1.orgs.ssr as real_ssr
+
+        monkeypatch.setattr(real_ssr, "listOrgSsrUpgrades", lambda *_a, **_k: _FakeResponse(200, None))
+        assert chk._fetch_ssr_upgrades_payload() == []
+
+    def test_populated_returns_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        import mistapi.api.v1.orgs.ssr as real_ssr
+
+        monkeypatch.setattr(
+            real_ssr,
+            "listOrgSsrUpgrades",
+            lambda *_a, **_k: _FakeResponse(200, [{"id": "u1"}]),
+        )
+        assert chk._fetch_ssr_upgrades_payload() == [{"id": "u1"}]
+
+
+class TestCheckSsrUpgrades:
+    """``_check_ssr_upgrades`` full-flow branches."""
+
+    def test_none_payload_short_circuits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_fetch_ssr_upgrades_payload", lambda: None)
+        chk._check_ssr_upgrades()
+        assert chk.active_upgrades == []
+
+    def test_empty_payload_prints_message(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_fetch_ssr_upgrades_payload", lambda: [])
+        chk._check_ssr_upgrades()
+        assert "No active SSR upgrade" in capsys.readouterr().out
+
+    def test_populated_processes_each(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_fetch_ssr_upgrades_payload", lambda: [{"id": "u1"}, {"id": "u2"}])
+        called = []
+        monkeypatch.setattr(chk, "_process_ssr_upgrade", lambda u: called.append(u))
+        chk._check_ssr_upgrades()
+        assert len(called) == 2
+
+    def test_exception_prints_warning(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(
+            chk,
+            "_fetch_ssr_upgrades_payload",
+            lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        chk._check_ssr_upgrades()
+        assert "Error checking SSR upgrade" in capsys.readouterr().out
+
+
+class TestProcessSsrUpgrade:
+    """``_process_ssr_upgrade`` + helpers."""
+
+    def test_appends_record(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._process_ssr_upgrade(
+            {
+                "id": "abcdefgh-longer",
+                "status": "upgrading",
+                "strategy": "big_bang",
+                "counts": {"upgrading": 2, "success": 1, "failed": 0, "queued": 3},
+                "versions": {"router-a": "6.3.5"},
+                "channel": "stable",
+            }
+        )
+        assert len(chk.active_upgrades) == 1
+        rec = chk.active_upgrades[0]
+        assert rec["upgrade_id"] == "abcdefgh-longer"
+        assert rec["total_devices"] == 6
+        assert rec["site_id"] == "N/A (Org-level)"
+
+    def test_build_ssr_status_parts_all_buckets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        parts = chk._build_ssr_status_parts({"upgrading": 1, "success": 2, "failed": 3, "queued": 4})
+        assert parts == ["1 upgrading", "2 completed", "3 failed", "4 queued"]
+
+    def test_build_ssr_status_parts_all_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._build_ssr_status_parts({"upgrading": 0}) == []
+
+    def test_build_version_info_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._build_version_info({}) == "Multiple versions"
+
+    def test_build_version_info_single(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._build_version_info({"a": "6.3.5"}) == "-> 6.3.5"
+
+    def test_build_version_info_multiple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert "Multiple versions" in chk._build_version_info({"a": "6.3.5", "b": "6.3.6"})
+
+
+class TestLoadOrgUpgradesFromFile:
+    """``_load_org_upgrades_from_file`` json + filter."""
+
+    def test_read_error_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(builtins, "open", MagicMock(side_effect=OSError("nope")))
+        assert chk._load_org_upgrades_from_file("missing.json") is None
+        assert "Failed to read" in capsys.readouterr().out
+
+    def test_filters_by_org_id(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+        chk = _make_checker(monkeypatch, org_id="me")
+        file = tmp_path / "upgrades.json"
+        file.write_text(json.dumps([{"org_id": "me"}, {"org_id": "other"}]))
+        assert chk._load_org_upgrades_from_file(str(file)) == [{"org_id": "me"}]
+
+
+class TestCheckStoredUpgrades:
+    """``_check_stored_upgrades`` decision tree."""
+
+    def test_no_file(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda _p: False)
+        chk._check_stored_upgrades()
+        assert "No site-level upgrade tracking file" in capsys.readouterr().out
+
+    def test_load_error_returns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda _p: True)
+        monkeypatch.setattr(chk, "_load_org_upgrades_from_file", lambda _p: None)
+        chk._check_stored_upgrades()
+
+    def test_empty_after_filter(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda _p: True)
+        monkeypatch.setattr(chk, "_load_org_upgrades_from_file", lambda _p: [])
+        chk._check_stored_upgrades()
+        assert "No stored upgrades match" in capsys.readouterr().out
+
+    def test_delegates_per_record(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda _p: True)
+        monkeypatch.setattr(chk, "_load_org_upgrades_from_file", lambda _p: [{"a": 1}, {"a": 2}])
+        called: list[dict[str, Any]] = []
+        monkeypatch.setattr(chk, "_check_stored_upgrade", lambda rec: called.append(rec))
+        chk._check_stored_upgrades()
+        assert len(called) == 2
+
+
+class TestSafeGetSiteUpgradeData:
+    """``_safe_get_site_upgrade_data`` API-call error tolerance."""
+
+    def test_exception_returns_none(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        import mistapi.api.v1.sites.devices as real_dev
+
+        def blow(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(real_dev, "getSiteDeviceUpgrade", blow)
+        assert FirmwareUpgradeStatusChecker._safe_get_site_upgrade_data("u1", "s1", "Site 1") is None
+        assert "Failed to check upgrade" in capsys.readouterr().out
+
+    def test_empty_data_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.sites.devices as real_dev
+
+        monkeypatch.setattr(real_dev, "getSiteDeviceUpgrade", lambda *_a, **_k: _FakeResponse(200, None))
+        assert FirmwareUpgradeStatusChecker._safe_get_site_upgrade_data("u1", "s1", "Site 1") is None
+
+    def test_populated_returns_data(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mistapi.api.v1.sites.devices as real_dev
+
+        monkeypatch.setattr(
+            real_dev,
+            "getSiteDeviceUpgrade",
+            lambda *_a, **_k: _FakeResponse(200, {"status": "upgrading"}),
+        )
+        assert FirmwareUpgradeStatusChecker._safe_get_site_upgrade_data("u1", "s1", "Site 1") == {"status": "upgrading"}
+
+
+class TestCheckStoredUpgrade:
+    """``_check_stored_upgrade`` single-record probe."""
+
+    def test_missing_fields_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._check_stored_upgrade({"upgrade_id": None, "site_id": "s1"})
+        assert chk.active_upgrades == []
+
+    def test_present_data_records(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(
+            type(chk),
+            "_safe_get_site_upgrade_data",
+            staticmethod(lambda *a, **kw: {"status": "up"}),
+        )
+        chk._check_stored_upgrade({"upgrade_id": "u12345678", "site_id": "s1", "site_name": "n"})
+        assert len(chk.active_upgrades) == 1
+        assert chk.active_upgrades[0]["upgrade_id"] == "u12345678"
+
+    def test_empty_data_prints_no_longer_active(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(
+            type(chk),
+            "_safe_get_site_upgrade_data",
+            staticmethod(lambda *a, **kw: None),
+        )
+        chk._check_stored_upgrade({"upgrade_id": "u12345678", "site_id": "s1", "site_name": "n"})
+        assert "No longer active" in capsys.readouterr().out
+
+
+class TestAuditLogs:
+    """``_fetch_audit_logs_24h`` + ``_check_audit_logs`` + helpers."""
+
+    def test_is_upgrade_event_matches_keywords(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._is_upgrade_event({"message": "Firmware upgrade started"}) is True
+        assert chk._is_upgrade_event({"message": "regular login"}) is False
+
+    def test_filter_upgrade_events(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        events = chk._filter_upgrade_events([{"message": "upgrade"}, {"message": "hello"}])
+        assert len(events) == 1
+
+    def test_check_audit_logs_no_logs(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_fetch_audit_logs_24h", lambda: [])
+        chk._check_audit_logs()
+        assert "No audit logs available" in capsys.readouterr().out
+
+    def test_check_audit_logs_no_upgrade_events(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_fetch_audit_logs_24h", lambda: [{"message": "login"}])
+        chk._check_audit_logs()
+        assert "No upgrade-related events" in capsys.readouterr().out
+
+    def test_check_audit_logs_ok(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(
+            chk,
+            "_fetch_audit_logs_24h",
+            lambda: [{"message": "firmware upgrade", "timestamp": 1700000000, "admin_name": "op", "site_name": "s"}],
+        )
+        chk._check_audit_logs()
+        assert "1 upgrade-related audit event" in capsys.readouterr().out
+
+    def test_check_audit_logs_exception(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+
+        def blow() -> list[dict[str, Any]]:
+            raise RuntimeError("api")
+
+        monkeypatch.setattr(chk, "_fetch_audit_logs_24h", blow)
+        chk._check_audit_logs()
+        assert "Error checking audit logs" in capsys.readouterr().out
+
+    def test_fetch_audit_logs_calls_api(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        mistapi = fm_mod.mistapi
+        real_logs = mistapi.api.v1.orgs.logs
+
+        monkeypatch.setattr(
+            real_logs,
+            "listOrgAuditLogs",
+            lambda *_a, **_k: _FakeResponse(200, [{"message": "upgrade"}]),
+        )
+        monkeypatch.setattr(mistapi, "get_all", lambda response, mist_session: response.data)
+        assert chk._fetch_audit_logs_24h() == [{"message": "upgrade"}]
+
+    def test_display_audit_events(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._display_audit_events(
+            [
+                {"timestamp": 1700000001, "admin_name": "op1", "message": "m1", "site_name": "s1"},
+                {"timestamp": 1700000000, "admin_name": "op2", "message": "m2", "site_name": "s2"},
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "op1" in out and "op2" in out
+
+
+class TestDeviceEvents:
+    """``_check_device_events`` + display helper."""
+
+    def test_no_events(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_fetch_device_upgrade_events_24h", lambda: [])
+        chk._check_device_events()
+        assert "No device upgrade events" in capsys.readouterr().out
+
+    def test_populated(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(
+            chk,
+            "_fetch_device_upgrade_events_24h",
+            lambda: [
+                {"type": "SYSTEM_UPGRADE_STARTED"},
+                {"type": "SYSTEM_UPGRADE_STARTED"},
+                {"type": "SYSTEM_UPGRADE_FAILED"},
+            ],
+        )
+        chk._check_device_events()
+        out = capsys.readouterr().out
+        assert "Started: 2" in out
+        assert "Failed: 1" in out
+
+    def test_exception(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+
+        def blow() -> list[dict[str, Any]]:
+            raise RuntimeError("api")
+
+        monkeypatch.setattr(chk, "_fetch_device_upgrade_events_24h", blow)
+        chk._check_device_events()
+        assert "Error checking device events" in capsys.readouterr().out
+
+    def test_fetch_device_events_calls_api(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        mistapi = fm_mod.mistapi
+        real_dev = mistapi.api.v1.orgs.devices
+
+        monkeypatch.setattr(
+            real_dev,
+            "searchOrgDeviceEvents",
+            lambda *_a, **_k: _FakeResponse(200, [{"type": "SYSTEM_UPGRADE_STARTED"}]),
+        )
+        monkeypatch.setattr(mistapi, "get_all", lambda response, mist_session: response.data)
+        assert chk._fetch_device_upgrade_events_24h() == [{"type": "SYSTEM_UPGRADE_STARTED"}]
+
+
+class TestSiteUpgrades:
+    """``_check_site_upgrades`` + single-site probe + reporting."""
+
+    def test_report_sites_without_upgrades_skips_when_filter(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch, site_filter="site-x")
+        chk._report_sites_without_upgrades(3, 1)
+        assert capsys.readouterr().out == ""
+
+    def test_report_sites_without_upgrades_prints_diff(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._report_sites_without_upgrades(3, 1)
+        assert "2 site(s) have no active" in capsys.readouterr().out
+
+    def test_report_sites_without_upgrades_zero_diff_silent(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._report_sites_without_upgrades(3, 3)
+        assert capsys.readouterr().out == ""
+
+    def test_check_site_upgrades_with_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch, site_filter="site-x")
+        monkeypatch.setattr(chk, "_check_single_site_upgrades", lambda _s: True)
+        chk._check_site_upgrades()
+
+    def test_check_site_upgrades_no_filter_uses_first_5(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.site_lookup = {f"s{i}": f"Name {i}" for i in range(10)}
+        called: list[str] = []
+        monkeypatch.setattr(chk, "_check_single_site_upgrades", lambda s: (called.append(s), False)[1])
+        chk._check_site_upgrades()
+        assert len(called) == 5
+
+    def test_check_single_site_no_upgrades(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        mistapi = fm_mod.mistapi
+        real_dev = mistapi.api.v1.sites.devices
+
+        monkeypatch.setattr(real_dev, "listSiteDeviceUpgrades", lambda *_a, **_k: _FakeResponse(200, []))
+        monkeypatch.setattr(mistapi, "get_all", lambda response, mist_session: response.data)
+        assert chk._check_single_site_upgrades("s1") is False
+
+    def test_check_single_site_populated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        mistapi = fm_mod.mistapi
+        real_dev = mistapi.api.v1.sites.devices
+
+        monkeypatch.setattr(
+            real_dev,
+            "listSiteDeviceUpgrades",
+            lambda *_a, **_k: _FakeResponse(200, [{"id": "u1"}]),
+        )
+        monkeypatch.setattr(mistapi, "get_all", lambda response, mist_session: response.data)
+        called: list[dict[str, Any]] = []
+        monkeypatch.setattr(chk, "_process_site_upgrade", lambda u, s, n: called.append(u))
+        assert chk._check_single_site_upgrades("s1") is True
+        assert len(called) == 1
+
+    def test_check_single_site_exception(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        import mistapi.api.v1.sites.devices as real_dev
+
+        def blow(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("api")
+
+        monkeypatch.setattr(real_dev, "listSiteDeviceUpgrades", blow)
+        assert chk._check_single_site_upgrades("s1") is False
+        assert "Error checking upgrades" in capsys.readouterr().out
+
+
+class TestProcessSiteUpgrade:
+    """``_process_site_upgrade`` + progress helper."""
+
+    def test_appends_full_record(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._process_site_upgrade(
+            {
+                "id": "u12345678xxxx",
+                "status": "created",
+                "strategy": "big_bang",
+                "target_version": "6.3.5",
+                "counts": {"total": 3, "downloaded": 2, "rebooted": 1, "failed": 0},
+                "start_time": 1700000000,
+            },
+            "site-a",
+            "Site A",
+        )
+        assert len(chk.active_upgrades) == 1
+        row = chk.active_upgrades[0]
+        assert row["target_version"] == "6.3.5"
+        assert row["site_id"] == "site-a"
+        assert row["total"] == 3
+
+    def test_build_site_upgrade_progress_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        parts = chk._build_site_upgrade_progress({"total": 5, "downloaded": 3, "rebooted": 2, "failed": 1})
+        assert "3/5 downloaded" in parts
+        assert "2/5 rebooted" in parts
+        assert "1 failed" in parts
+
+    def test_build_site_upgrade_progress_no_total(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._build_site_upgrade_progress({"total": 0}) == []
+
+
+class TestExports:
+    """CSV export helpers."""
+
+    def test_export_device_status_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._export_device_status("ts")  # no-op, no exceptions
+        assert True
+
+    def test_export_device_status_calls_writer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mh = _install_mh_proxy(monkeypatch)
+        chk = FirmwareUpgradeStatusChecker()
+        chk.upgrade_results = [{"row": 1}]
+        chk._export_device_status("ts")
+        mh.DataExporter.write_with_format_selection.assert_called_once()
+
+    def test_export_device_status_write_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mh = _install_mh_proxy(monkeypatch)
+        mh.DataExporter.write_with_format_selection.side_effect = RuntimeError("io")
+        chk = FirmwareUpgradeStatusChecker()
+        chk.upgrade_results = [{"row": 1}]
+        chk._export_device_status("ts")
+        assert "Failed to export device status" in capsys.readouterr().out
+
+    def test_export_active_operations_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._export_active_operations("ts")
+
+    def test_export_active_operations_writes_csv(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.active_upgrades = [
+            {
+                "site_id": "s1",
+                "site_name": "Site 1",
+                "upgrade_id": "u1",
+                "status": "ok",
+                "strategy": "big_bang",
+                "target_version": "6.3.5",
+                "source": "site_lookup",
+                "details": {"counts": {"total": 3}},
+            }
+        ]
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data").mkdir()
+        chk._export_active_operations("ts-42")
+        csv_files = list((tmp_path / "data").glob("ActiveUpgradeOperations_*.csv"))
+        assert len(csv_files) == 1
+
+    def test_export_active_operations_write_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.active_upgrades = [{"source": "x"}]
+        monkeypatch.setattr(builtins, "open", MagicMock(side_effect=OSError("io")))
+        chk._export_active_operations("ts")
+        assert "Failed to export upgrade operations" in capsys.readouterr().out
+
+    def test_export_results_calls_both(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        called: list[str] = []
+        monkeypatch.setattr(chk, "_export_device_status", lambda ts: called.append(f"dev-{ts}"))
+        monkeypatch.setattr(chk, "_export_active_operations", lambda ts: called.append(f"act-{ts}"))
+        chk._export_results()
+        assert len(called) == 2
+
+
+class TestMapUpgradeForExport:
+    """``_map_upgrade_for_export`` + resolve helpers."""
+
+    def test_maps_all_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        mapped = chk._map_upgrade_for_export(
+            {
+                "site_id": "s1",
+                "site_name": "n1",
+                "upgrade_id": "u1",
+                "status": "ok",
+                "strategy": "big_bang",
+                "target_version": "6.3.5",
+                "start_time": 1700000000,
+                "enable_p2p": True,
+                "total_devices": 3,
+                "source": "x",
+                "timestamp": "2024-01-01T00:00:00+00:00",
+                "details": {"counts": {"total": 3, "downloaded": 2}},
+            }
+        )
+        assert mapped["site_id"] == "s1"
+        assert mapped["total_devices"] == 3
+        assert mapped["downloaded"] == 2
+        assert "start_time" in mapped
+
+    def test_falls_back_to_details(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        mapped = chk._map_upgrade_for_export(
+            {"source": "x", "details": {"counts": {"downloaded": 5}, "enable_p2p": False}}
+        )
+        assert mapped["downloaded"] == 5
+
+    def test_resolve_start_time_formats_epoch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        out = chk._resolve_upgrade_start_time({"start_time": 1700000000}, {})
+        assert len(out) == 19
+
+    def test_resolve_start_time_passthrough_when_not_epoch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        assert chk._resolve_upgrade_start_time({"start_time": "text"}, {}) == "text"
+
+    def test_resolve_counts_prefers_top_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        counts = chk._resolve_upgrade_counts({"total_devices": 7}, {"total": 3})
+        assert counts["total_devices"] == 7
+
+
+class TestDisplayRecommendations:
+    """``_display_recommendations`` branch coverage."""
+
+    def test_no_activity(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._display_recommendations()
+        out = capsys.readouterr().out
+        assert "No active upgrade operations" in out
+        assert "Status check complete" in out
+
+    def test_all_branches(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.summary["upgrade_failed"] = 2
+        chk.summary["upgrade_in_progress"] = 3
+        chk.summary["devices_by_version"] = {"a": 1, "b": 1, "c": 1, "d": 1}
+        chk.active_upgrades = [{"a": 1}]
+        chk._display_recommendations()
+        out = capsys.readouterr().out
+        assert "2 devices have failed upgrades" in out
+        assert "3 devices currently upgrading" in out
+        assert "Multiple firmware versions detected" in out
+        assert "1 active upgrade operations" in out
+
+
+class TestCheckOrchestrator:
+    """``check`` end-to-end orchestration + ``_check_active_operations`` fanout."""
+
+    def test_early_exit_on_no_site(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_resolve_site_filter", lambda: False)
+        chk.check()  # no exception
+
+    def test_early_exit_on_no_stats(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_resolve_site_filter", lambda: True)
+        monkeypatch.setattr(chk, "_fetch_device_stats", lambda: False)
+        chk.check()
+
+    def test_happy_path_calls_all_stages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        monkeypatch.setattr(chk, "_resolve_site_filter", lambda: True)
+        monkeypatch.setattr(chk, "_fetch_device_stats", lambda: True)
+        stages: list[str] = []
+        for name in [
+            "_fetch_site_lookup",
+            "_process_all_devices",
+            "_display_summary",
+            "_display_upgrading_devices",
+            "_check_active_operations",
+            "_export_results",
+            "_display_recommendations",
+        ]:
+            monkeypatch.setattr(chk, name, lambda n=name: stages.append(n))
+        chk.check()
+        assert len(stages) == 7
+
+    def test_check_active_operations_fanout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        called: list[str] = []
+        for name in [
+            "_check_ssr_upgrades",
+            "_check_stored_upgrades",
+            "_check_audit_logs",
+            "_check_device_events",
+            "_check_site_upgrades",
+        ]:
+            monkeypatch.setattr(chk, name, lambda n=name: called.append(n))
+        chk._check_active_operations()
+        assert len(called) == 5
+
+
+class TestProcessAllDevices:
+    """``_process_all_devices`` iteration wiring."""
+
+    def test_iterates_and_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk.all_device_stats = [{"id": "d1"}, {"id": "d2"}]
+        seen: list[Any] = []
+        monkeypatch.setattr(chk, "_extract_device_info", lambda d: {"device_id": d["id"]})
+        monkeypatch.setattr(
+            chk,
+            "_process_fwupdate",
+            lambda d, i: seen.append(("fw", i)) or {"fw_status": "no_upgrade_info"},
+        )
+        monkeypatch.setattr(chk, "_update_summary_counters", lambda i, f: seen.append(("counter", i)))
+        monkeypatch.setattr(chk, "_maybe_add_to_results", lambda i, f: seen.append(("results", i)))
+        chk._process_all_devices()
+        assert len([entry for entry in seen if entry[0] == "fw"]) == 2
+        assert len([entry for entry in seen if entry[0] == "counter"]) == 2
+
+
+class TestRecordHelpers:
+    """Small ``_record_*`` helpers append correctly shaped rows."""
+
+    def test_record_ssr_upgrade(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._record_ssr_upgrade("u1", "queued", "big_bang", 5, {"raw": True})
+        assert chk.active_upgrades[0]["source"] == "ssr_api"
+        assert chk.active_upgrades[0]["total_devices"] == 5
+
+    def test_record_stored_upgrade(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        chk = _make_checker(monkeypatch)
+        chk._record_stored_upgrade("u12345678", "s1", "Site 1", {"status": "up"})
+        assert chk.active_upgrades[0]["source"] == "stored_tracking"
+        assert "Site 1" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Removes `src/firmware/firmware_manager.py` from `[tool.coverage.run].omit` in `pyproject.toml`
- Adds 678 tests across 7 files under `tests/unit/firmware/` achieving **100%** file coverage (2473 stmts, 0 miss)
- Closes the last remaining un-omit for issue #878

## Coverage
- `src/firmware/firmware_manager.py`: **100%** (was 13% baseline before this PR)
- Project overall: **93.37%** — well above `fail_under = 90` gate

## Test files
| File | Lines |
| --- | --- |
| `test_firmware_manager_config.py` | 318 |
| `test_firmware_manager_version.py` | 374 |
| `test_firmware_manager_monitoring.py` | 610 |
| `test_firmware_manager_template.py` | 677 |
| `test_firmware_manager_ap_msp.py` | 1,433 |
| `test_firmware_upgrade_status_checker.py` | 1,481 |
| `test_firmware_manager_ssr.py` | 2,027 |

## Test plan
- [x] `pytest tests/unit/firmware/` — 678 passed
- [x] `pytest --cov=src.firmware.firmware_manager` — 100%
- [x] `pytest --cov=src` overall — 93.37%
- [x] `ruff check tests/unit/firmware/` — clean
- [x] `black --check tests/unit/firmware/` — clean

## Notes / backlog
mypy/pylint on `tests/**` is deliberately relaxed (`strict=false`) per the existing pyproject override; the new test files rely on that. A future sweep can tighten strict compliance on `tests/unit/firmware/` if desired — non-blocking, not tracked as a separate issue here.

Closes #878 (final tranche).