### PR TITLE
refactor(#880): drop i/e/f from pylint good-names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,7 @@ max-line-length = 120
 disable = ["C0114", "C0115", "C0116", "W1203", "W0613", "W0718"]
 
 [tool.pylint.basic]
-good-names = ["i", "e", "f", "db", "ok"]
+good-names = ["db", "ok"]
 
 # --- pydocstyle ---
 [tool.pydocstyle]


### PR DESCRIPTION
## Summary

Removes single-letter entries `i`, `e`, `f` from `[tool.pylint.basic]`
`good-names` in `pyproject.toml`. These entries were redundant: pylint's
default naming rules already exempt short loop variables and
exception-handler names from `C0103` (invalid-name), so removing them
produces zero new violations and requires no renames.

## Verification

Ran the CI-equivalent pylint invocation locally:

```
pylint src/ --fail-under=9.5 --ignore=maps,ssh,ui
Your code has been rated at 9.53/10 (previous run: 9.34/10, +0.19)
```

Above the 9.5 gate. The +0.19 delta is unrelated churn from a prior
baseline; the removal itself is a no-op for the score because pylint
never flagged these names to begin with.

## Backlog (not filed — EMU 403 blocks `issue_write`)

- Test-file mypy/pylint sweep — tests are excluded from the strict
  overrides today; a follow-up should tighten them incrementally.
- Ruff-format alignment sweep — ~60 files under `src/` have residual
  ruff-format drift (discovered while working #879).

Closes #880