### PR TITLE
sec: bring mist-ops-platform + ops-portal under bandit (#881)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,9 +212,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install bandit
+      - run: pip install 'bandit[toml]'
       - name: Run Bandit
-        run: bandit -r ${{ env.SRC_PATH }} -ll
+        # -c pyproject.toml picks up [tool.bandit] targets/exclude_dirs (issue #881)
+        # -ll gates on MEDIUM+ severity (LOW findings surface in logs but don't fail)
+        run: bandit -c pyproject.toml -r . -ll
 
   pip_audit:
     name: "pip-audit (CVE scan)"

--- a/mist-ops-platform/src/worker/tasks/audit_tasks.py
+++ b/mist-ops-platform/src/worker/tasks/audit_tasks.py
@@ -250,7 +250,9 @@ def _purge_table(db: Session, table: str, days: int) -> int:
     from sqlalchemy import text
 
     ts_col = _timestamp_column(table)
-    sql = text(f"DELETE FROM {table} " f"WHERE {ts_col} < NOW() - INTERVAL ':days days'")
+    # `table` and `ts_col` are sourced from module-local dicts (_RETENTION_DAYS,
+    # _timestamp_column mapping) — never from user input. Only `days` is bound.
+    sql = text(f"DELETE FROM {table} WHERE {ts_col} < NOW() - INTERVAL ':days days'")  # nosec B608
     result = db.execute(sql, {"days": days})
     return result.rowcount
 

--- a/mist-ops-platform/src/worker/tasks/sync_tasks.py
+++ b/mist-ops-platform/src/worker/tasks/sync_tasks.py
@@ -190,7 +190,9 @@ def _export_table_backup(
 
     try:
         with Session(engine) as db:
-            rows = db.execute(text(f"SELECT * FROM {table_name} LIMIT 50000"))
+            # `table_name` is drawn from the hardcoded tuple above (line 170),
+            # never from user input. LIMIT is a literal integer.
+            rows = db.execute(text(f"SELECT * FROM {table_name} LIMIT 50000"))  # nosec B608
             data = [dict(row._mapping) for row in rows]
             logger.info(
                 "Backup %s: %d rows at %s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,8 +228,11 @@ warn_unused_ignores = false
 ignore_errors = true
 
 [tool.bandit]
-targets = ["MistHelper.py", "maps_manager.py", "wsgi.py", "web_portal", "src"]
-exclude_dirs = ["tests", ".venv", "node_modules", "mist-ops-platform", "ops-portal", "scripts", "specs"]
+targets = ["MistHelper.py", "maps_manager.py", "wsgi.py", "web_portal", "mist-ops-platform", "ops-portal", "src"]
+# tools/test_quality_analyzer/fixtures: deliberately-bad code used as test
+# material by the analyzer — mirrors the ruff per-file-ignore for the same tree
+# (see [tool.ruff.lint.per-file-ignores] at "tools/test_quality_analyzer/fixtures/bad/**").
+exclude_dirs = ["tests", ".venv", "node_modules", "scripts", "specs", "tools/test_quality_analyzer/fixtures"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/tools/test_quality_analyzer/fixtures/bad/test_missing_failure_mode_bad.py
+++ b/tools/test_quality_analyzer/fixtures/bad/test_missing_failure_mode_bad.py
@@ -24,7 +24,7 @@ import requests  # Imported so the detector recognizes this as an HTTP-testing m
 
 def call_api() -> dict:  # Trivial SUT that would issue a real HTTP call.
     """Return the JSON body of a GET request to a URL."""
-    response = requests.get("https://example.com/api")  # Real HTTP call in production.
+    response = requests.get("https://example.com/api")  # nosec B113 -- fixture SUT; no real HTTP call in tests
     return response.json()  # Return the parsed JSON body.
 
 

--- a/tools/test_quality_analyzer/fixtures/good/test_missing_failure_mode_good.py
+++ b/tools/test_quality_analyzer/fixtures/good/test_missing_failure_mode_good.py
@@ -27,7 +27,7 @@ import requests  # Imported so the detector recognizes this as an HTTP module.
 
 def call_api() -> dict:  # SUT wrapper around requests.
     """Return the JSON body of a GET request to a URL."""
-    response = requests.get("https://example.com/api")  # SUT under test.
+    response = requests.get("https://example.com/api")  # nosec B113 -- fixture SUT; no real HTTP call in tests
     return response.json()  # Return parsed JSON body.
 
 


### PR DESCRIPTION
Closes #881.

## Summary
- Move `mist-ops-platform` and `ops-portal` subtrees from bandit's ignore list into `[tool.bandit] targets`.
- Fix CI: previous invocation hard-coded targets on the CLI and completely ignored `[tool.bandit]`. Switched to `bandit -c pyproject.toml -r . -ll`.
- 2 MEDIUM B608 (SQL f-string) findings suppressed with justified inline `# nosec` (values sourced from hardcoded module-local mappings, not user input).
- 2 MEDIUM B113 (requests without timeout) findings suppressed in `tools/test_quality_analyzer/fixtures` — fixtures are analyzer test material, not real HTTP calls (SUT is fully mocked).

## Final gate
```
bandit -c pyproject.toml -r . -ll
Total issues (by severity): Undefined: 0, Low: 92, Medium: 0, High: 0
```

## Test plan
- [x] `bandit -c pyproject.toml -r . -ll` locally → 0 MEDIUM, 0 HIGH.
- [ ] CI bandit job passes with the new invocation.

## Backlog (unfilable — EMU 403 on issue_write)
- `[tool.bandit] targets` still lists `maps_manager.py` which no longer exists at repo root; bandit prints a non-fatal skip. Trim in a follow-up.
- `src/` has ~60 files with ruff-format drift; separate sweep needed.
- Test-file mypy/pylint strictness sweep is out-of-scope here.