### PR TITLE
feat(901): add menu 198 - searchSiteWanUsage exporter (#1409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Menu 198: Search Site WAN Usages (spec 901 / issue #1409)
+
+- **New menu 198 (Added)**: `SiteWanUsageExporter.wan_usages()` wraps the previously
+  unreachable Mist API `searchSiteWanUsage` operation
+  (`GET /api/v1/sites/{site_id}/wan_usages/search`). Operator picks a site (shared
+  `SiteDeviceExporter._resolve_site_for_stats` helper), the exporter pages all rows via
+  `mistapi.get_all`, flattens + escapes them with `DataProcessingUtils`, then persists
+  through `DataExporter.write_with_format_selection` so CSV / SQLite / ArangoDB backends
+  all work. Empty responses surface a friendly "no WAN usage data" notice instead of
+  failing. `ENDPOINT_PRIMARY_KEY_STRATEGIES` already defined a composite PK on
+  `(mac, port_id, peer_mac)` for this operationId, and `arango_writer` already routed it
+  to the `wan_usage` collection -- no schema changes required.
+
 ### Menu 197: Client Packet Capture Downloader (issue #421)
 
 - **New menu 197 (Added)**: `ClientPacketCaptureDownloader` guides the operator through

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -442,6 +442,9 @@ from src.export.site_insights.device_metric_operation import (
 from src.export.site_insights.site_metric_operation import (
     SiteMetricOperation,
 )  # Decomposed Menu 74 entry point
+from src.export.site_wan_usage_exporter import (
+    SiteWanUsageExporter,  # Spec 901 / issue #1409 -- searchSiteWanUsage menu 198
+)
 from src.export.sites_by_ap_model_exporter import (
     SitesByAPModelExporter,  # Cat B (1013 SC-001 position 28) -- re-export
 )
@@ -3864,6 +3867,10 @@ menu_actions: "dict[str, tuple[Callable[..., Any], str]]" = {
     "197": (
         lambda: ClientPacketCaptureDownloader(apisession).run(),
         "Download client packet captures grouped by VLAN (site -> client -> VLAN -> data/packet_captures/)",
+    ),
+    "198": (
+        SiteWanUsageExporter.wan_usages,
+        "Search Site WAN Usages (searchSiteWanUsage) - Export per-site WAN usage records to SiteWanUsages.csv",
     ),
     "44": (OrgConfigExporter.psks, "Export PSK (Pre-Shared Key) information for the organization"),
     "45": (OrgConfigExporter.webhooks, "Export webhook configuration for the organization"),

--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ For quick category guidance, see the Wiki Menu Reference page linked above.
 
 - New in this branch: Menu `196` exports org async license-claim status summary and optional per-device detail rows.
 - New in this branch: Menu `197` interactively downloads client packet captures grouped by VLAN (site -> client -> VLAN -> `data/packet_captures/<mac>/vlan_<id>/`).
+- New in this branch: Menu `198` searches site WAN usage records (`searchSiteWanUsage`) and exports them to `SiteWanUsages_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 ## Security & Safety
 
 | Area | Practice |

--- a/src/export/site_wan_usage_exporter.py
+++ b/src/export/site_wan_usage_exporter.py
@@ -1,0 +1,103 @@
+"""SiteWanUsageExporter -- site-level WAN usage search export.
+
+Added for spec 901 / issue #1409.  Wraps the Mist API
+``searchSiteWanUsage`` (``GET /api/v1/sites/{site_id}/wan_usages/search``)
+so operators can retrieve per-site WAN usage records through the standard
+MistHelper menu + DataExporter pipeline (CSV/SQLite/ArangoDB).
+
+Why:
+    The endpoint was absent from MistHelper's menu, forcing users to write
+    custom code to reach WAN usage records.  This exporter closes that gap
+    while reusing the shared site-resolution + persistence scaffolding
+    established by ``SiteClientExporter.clients()`` and
+    ``SiteDeviceExporter._resolve_site_for_stats()``.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+ toolchains.
+
+import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
+import logging  # WHY: structured trace for export lifecycle events.
+from typing import Any  # WHY: raw WAN usage rows are duck-typed dicts from mistapi.
+
+import mistapi  # WHY: direct SDK access for searchSiteWanUsage + get_all pagination.
+
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+
+
+class SiteWanUsageExporter:
+    """Site WAN Usage search exporter.
+
+    Why:
+        Provides the sole MistHelper entry point for the
+        ``searchSiteWanUsage`` operationId.  Static methods only -- no
+        per-instance state, matching the pattern used by
+        ``SiteClientExporter`` / ``SiteDeviceExporter``.
+    """
+
+    @staticmethod
+    def _persist_site_wan_usages(rawdata: list[Any], site_name: str) -> None:
+        """Flatten + persist WAN usage rows to a per-site file (or tell the user when empty).
+
+        Why:
+            Empty responses are legitimate (a site with no WAN telemetry in
+            the query window); we surface a friendly message rather than
+            failing so scheduled runs stay quiet in that case.
+
+        Args:
+            rawdata: Raw list returned by ``mistapi.get_all`` for the WAN
+                usage search response.  May be empty.
+            site_name: Human-readable site name used to name the output
+                file (falls back to site_id when name lookup failed).
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
+        if not rawdata:  # No WAN usage rows for this site -- inform the operator and return.
+            print("! No WAN usage data found for this site")  # ASCII-only user notice.
+            return
+        flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
+        sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe multiline escape.
+        filename = f"SiteWanUsages_{site_name.replace(' ', '_')}.csv"  # Per-site filename, spaces to underscores.
+        mh.DataExporter.write_with_format_selection(  # Persist through CSV/SQLite/Arango backend selector.
+            sanitized_data, filename, api_function_name="searchSiteWanUsage"
+        )
+        logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
+            "searchSiteWanUsage persisted %d rows to %s", len(rawdata), filename
+        )
+        print(f"! {len(rawdata)} WAN usage records exported to {filename}")  # User notice with count.
+
+    @staticmethod
+    def wan_usages() -> None:
+        """Search WAN usages for a site and export to SiteWanUsages.csv.
+
+        Why:
+            Interactive menu entry point (menu 198).  Delegates site
+            resolution to the shared helper so behavior stays consistent
+            with peer site-scoped exports.  Errors are logged and surfaced
+            to the user rather than crashing the menu loop.
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
+        print("Site WAN Usage Search:")  # Menu header echoed to operator.
+        logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
+            "Starting searchSiteWanUsage export..."
+        )
+        resolved = mh.SiteDeviceExporter._resolve_site_for_stats(  # Prompt + org/site resolution (shared).
+            "WAN usage search"
+        )
+        if resolved is None:  # Operator declined selection or org unresolved -- shared helper already logged.
+            return
+        site_id, site_name = resolved  # Unpack resolved identifiers for the API call.
+        try:
+            logging.info(  # INFO trace immediately before the SDK call (with site context).
+                "Calling searchSiteWanUsage for site_id=%s (%s)", site_id, site_name
+            )
+            response = mistapi.api.v1.sites.wan_usages.searchSiteWanUsage(  # SDK call -- defaults for filters.
+                mh.apisession, site_id
+            )
+            rawdata = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page all rows.
+            SiteWanUsageExporter._persist_site_wan_usages(rawdata, site_name)  # Persist or notify empty.
+        except Exception as e:  # noqa: BLE001 -- surface any SDK/network error to the user instead of crashing.
+            logging.error(  # ERROR trace with site context for post-mortem correlation.
+                "Error fetching WAN usage for site %s: %s", site_name, e
+            )
+            print(f"! Error fetching WAN usage data: {e}")  # ASCII-only user notice.

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -262,6 +262,7 @@ class OperationRegistry:
         "25": {"category": "safe"},
         "196": {"category": "safe"},
         "197": {"category": "interactive_safe", "skip_reason": "Requires site + client + VLAN selection"},
+        "198": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "186": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Deletes all generated cache CSV files"},
         "58": {"category": "safe"},
         "187": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Creates config objects in destination org"},


### PR DESCRIPTION
## Summary

Closes #1409 (spec 901). Adds MistHelper menu **198** wrapping the previously-unreachable Mist API `searchSiteWanUsage` operation (`GET /api/v1/sites/{site_id}/wan_usages/search`) so operators can retrieve per-site WAN usage records through the standard menu + DataExporter pipeline (CSV / SQLite / ArangoDB).

## Changes

- `src/export/site_wan_usage_exporter.py` **(new)** — `SiteWanUsageExporter` with `wan_usages()` menu entry point + `_persist_site_wan_usages()` helper. Modeled on `SiteClientExporter.clients()`; reuses `SiteDeviceExporter._resolve_site_for_stats()` for site resolution and `mistapi.get_all()` for pagination.
- `MistHelper.py` — import + `menu_actions["198"]` registration.
- `README.md` + `CHANGELOG.md` — menu documentation.
- **No schema changes**: `ENDPOINT_PRIMARY_KEY_STRATEGIES` already defines a composite PK on `(mac, port_id, peer_mac)` and `arango_writer` already routes `searchSiteWanUsage` to the `wan_usage` collection.

## Constitution conformance

- Inline comments on every executable line (Principle VI).
- Full Google-style docstrings with Why sections (DOCS.md).
- INFO before / DEBUG after the API call (Principle VII, ASCII-only).
- Empty-response friendly notice; broad-except surfaces SDK errors as user notices instead of crashing the menu loop.
- 5-Item Rule respected (methods <=25 lines / <=5 params / <=5 nesting).

## Test plan

- [x] `python -m py_compile MistHelper.py src/export/site_wan_usage_exporter.py`
- [x] `python -m ruff check src/export/site_wan_usage_exporter.py MistHelper.py`
- [x] `python -m black --check src/export/site_wan_usage_exporter.py MistHelper.py`
- [ ] CI: Bandit, Radon, Vulture, pydocstyle, Interrogate, mypy, pip-audit, pytest, Pylint, E2E, CodeQL

## Backlog (carried in PR body — EMU blocks `issue_write`)

- Stale `maps_manager.py` reference in `[tool.bandit] targets`.
- src/ ruff-format drift (~60 files).
- Test-file mypy/pylint strictness sweep.
- Branch cleanup issues #1435-1442.