### PR TITLE
feat(889): add menu 200 SiteGuestAuthorizationExporter for searchSiteGuestAuthorization (#1397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Menu 200: Search Site Guest Authorization (spec 889 / issue #1397)
+
+- **New menu 200 (Added)**: `SiteGuestAuthorizationExporter.guest_authorizations()` wraps
+  the previously unreachable Mist API `searchSiteGuestAuthorization` operation
+  (`GET /api/v1/sites/{site_id}/guests/search`). Operator picks a site (shared
+  `SiteDeviceExporter._resolve_site_for_stats` helper), the exporter pages all authorized
+  guest rows via `mistapi.get_all`, flattens + escapes them with `DataProcessingUtils`,
+  then persists through `DataExporter.write_with_format_selection` so CSV / SQLite /
+  ArangoDB backends all work. Empty responses surface a friendly "no guest authorization
+  data" notice instead of failing. `ENDPOINT_PRIMARY_KEY_STRATEGIES` already defined a PK
+  for this operationId -- no schema changes required. Registered as `interactive_safe` in
+  `OperationRegistry` (requires site selection).
+
 ### Menu 199: Search Site Webhook Deliveries (spec 902 / issue #1410)
 
 - **New menu 199 (Added)**: `SiteWebhookDeliveriesExporter.deliveries()` wraps the

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -436,6 +436,9 @@ from src.export.site_device_exporter import (
 from src.export.site_export_utils import (  # Cat A canonical (1014 P16)
     SiteExportUtils,
 )
+from src.export.site_guest_authorization_exporter import (
+    SiteGuestAuthorizationExporter,  # Spec 889 / issue #1397 -- searchSiteGuestAuthorization menu 200
+)
 from src.export.site_insights.device_metric_operation import (
     DeviceMetricOperation,
 )  # Decomposed Menu 76 entry point
@@ -3878,6 +3881,10 @@ menu_actions: "dict[str, tuple[Callable[..., Any], str]]" = {
     "199": (
         SiteWebhookDeliveriesExporter.deliveries,
         "Search Site Webhook Deliveries (searchSiteWebhooksDeliveries) - Per site+webhook delivery audit CSV",
+    ),
+    "200": (
+        SiteGuestAuthorizationExporter.guest_authorizations,
+        "Search Site Guest Authorization (searchSiteGuestAuthorization) - Per-site authorized guest CSV",
     ),
     "44": (OrgConfigExporter.psks, "Export PSK (Pre-Shared Key) information for the organization"),
     "45": (OrgConfigExporter.webhooks, "Export webhook configuration for the organization"),

--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ For quick category guidance, see the Wiki Menu Reference page linked above.
 - New in this branch: Menu `197` interactively downloads client packet captures grouped by VLAN (site -> client -> VLAN -> `data/packet_captures/<mac>/vlan_<id>/`).
 - New in this branch: Menu `198` searches site WAN usage records (`searchSiteWanUsage`) and exports them to `SiteWanUsages_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 - New in this branch: Menu `199` searches site webhook delivery attempts (`searchSiteWebhooksDeliveries`) and exports them to `SiteWebhookDeliveries_<site>_<webhook>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
+- New in this branch: Menu `200` searches site guest authorization records (`searchSiteGuestAuthorization`) and exports them to `SiteGuestAuthorizations_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 ## Security & Safety
 
 | Area | Practice |

--- a/src/export/site_guest_authorization_exporter.py
+++ b/src/export/site_guest_authorization_exporter.py
@@ -1,0 +1,105 @@
+"""SiteGuestAuthorizationExporter -- site-level guest authorization search export.
+
+Added for spec 889 / issue #1397.  Wraps the Mist API
+``searchSiteGuestAuthorization`` (``GET /api/v1/sites/{site_id}/guests/search``)
+so operators can retrieve per-site authorized guest records through the
+standard MistHelper menu + DataExporter pipeline (CSV/SQLite/ArangoDB).
+
+Why:
+    The endpoint was absent from MistHelper's menu, forcing users to write
+    custom code to reach guest authorization records.  This exporter closes
+    that gap while reusing the shared site-resolution + persistence
+    scaffolding established by ``SiteWanUsageExporter.wan_usages()`` and
+    ``SiteDeviceExporter._resolve_site_for_stats()``.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+ toolchains.
+
+import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
+import logging  # WHY: structured trace for export lifecycle events.
+from typing import Any  # WHY: raw guest authorization rows are duck-typed dicts from mistapi.
+
+import mistapi  # WHY: direct SDK access for searchSiteGuestAuthorization + get_all pagination.
+
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+
+
+class SiteGuestAuthorizationExporter:
+    """Site Guest Authorization search exporter.
+
+    Why:
+        Provides the sole MistHelper entry point for the
+        ``searchSiteGuestAuthorization`` operationId.  Static methods only --
+        no per-instance state, matching the pattern used by
+        ``SiteWanUsageExporter`` / ``SiteDeviceExporter``.
+    """
+
+    @staticmethod
+    def _persist_site_guest_authorizations(rawdata: list[Any], site_name: str) -> None:
+        """Flatten + persist guest authorization rows to a per-site file (or tell the user when empty).
+
+        Why:
+            Empty responses are legitimate (a site with no authorized guests
+            in the query window); we surface a friendly message rather than
+            failing so scheduled runs stay quiet in that case.
+
+        Args:
+            rawdata: Raw list returned by ``mistapi.get_all`` for the guest
+                authorization search response.  May be empty.
+            site_name: Human-readable site name used to name the output
+                file (falls back to site_id when name lookup failed).
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
+        if not rawdata:  # No guest authorization rows for this site -- inform the operator and return.
+            print("! No guest authorization data found for this site")  # ASCII-only user notice.
+            return
+        flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
+        sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe multiline escape.
+        filename = f"SiteGuestAuthorizations_{site_name.replace(' ', '_')}.csv"  # Per-site filename.
+        mh.DataExporter.write_with_format_selection(  # Persist through CSV/SQLite/Arango backend selector.
+            sanitized_data, filename, api_function_name="searchSiteGuestAuthorization"
+        )
+        logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
+            "searchSiteGuestAuthorization persisted %d rows to %s", len(rawdata), filename
+        )
+        print(f"! {len(rawdata)} guest authorization records exported to {filename}")  # User notice with count.
+
+    @staticmethod
+    def guest_authorizations() -> None:
+        """Search guest authorizations for a site and export to SiteGuestAuthorizations.csv.
+
+        Why:
+            Interactive menu entry point (menu 200).  Delegates site
+            resolution to the shared helper so behavior stays consistent
+            with peer site-scoped exports.  Errors are logged and surfaced
+            to the user rather than crashing the menu loop.
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
+        print("Site Guest Authorization Search:")  # Menu header echoed to operator.
+        logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
+            "Starting searchSiteGuestAuthorization export..."
+        )
+        resolved = mh.SiteDeviceExporter._resolve_site_for_stats(  # Prompt + org/site resolution (shared).
+            "guest authorization search"
+        )
+        if resolved is None:  # Operator declined selection or org unresolved -- shared helper already logged.
+            return
+        site_id, site_name = resolved  # Unpack resolved identifiers for the API call.
+        try:
+            logging.info(  # INFO trace immediately before the SDK call (with site context).
+                "Calling searchSiteGuestAuthorization for site_id=%s (%s)", site_id, site_name
+            )
+            response = mistapi.api.v1.sites.guests.searchSiteGuestAuthorization(  # SDK call -- defaults for filters.
+                mh.apisession, site_id
+            )
+            rawdata = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page all rows.
+            SiteGuestAuthorizationExporter._persist_site_guest_authorizations(  # Persist or notify empty.
+                rawdata, site_name
+            )
+        except Exception as e:  # noqa: BLE001 -- surface any SDK/network error to the user instead of crashing.
+            logging.error(  # ERROR trace with site context for post-mortem correlation.
+                "Error fetching guest authorization for site %s: %s", site_name, e
+            )
+            print(f"! Error fetching guest authorization data: {e}")  # ASCII-only user notice.

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -264,6 +264,7 @@ class OperationRegistry:
         "197": {"category": "interactive_safe", "skip_reason": "Requires site + client + VLAN selection"},
         "198": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "199": {"category": "interactive_safe", "skip_reason": "Requires site + webhook selection"},
+        "200": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "186": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Deletes all generated cache CSV files"},
         "58": {"category": "safe"},
         "187": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Creates config objects in destination org"},


### PR DESCRIPTION
Closes #1397 (spec 889).

## Summary
- New `SiteGuestAuthorizationExporter.guest_authorizations()` wraps `searchSiteGuestAuthorization` (`GET /api/v1/sites/{site_id}/guests/search`)
- Menu 200 registered as `interactive_safe` in `OperationRegistry`
- Pages all rows via `mistapi.get_all`, flattens + escapes via `DataProcessingUtils`, writes through `DataExporter.write_with_format_selection` (CSV / SQLite / ArangoDB)
- `ENDPOINT_PRIMARY_KEY_STRATEGIES` already had this operationId registered -- no schema changes
- README + CHANGELOG updated

## Test plan
- [x] `python -m py_compile MistHelper.py src/export/site_guest_authorization_exporter.py`
- [x] `python -m ruff check` (clean)
- [x] `python -m black --check` (clean)
- [x] `pytest tests/guardrails/test_operation_registry_menu_coverage.py tests/unit/test_operation_registry_fail_closed.py` (10 passed)

## Backlog (carry across PRs, EMU-blocks issue writes)
- Stale `maps_manager.py` reference in `[tool.bandit] targets`
- src/ ruff-format drift sweep
- test-file mypy/pylint strictness sweep
- Branch cleanup issues #1435-1442