### PR TITLE
feat(890): add menu 201 SiteMistEdgeEventsExporter (#1398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Menu 201: Search Site Mist Edge Events (spec 890 / issue #1398)
+
+- **New menu 201 (Added)**: `SiteMistEdgeEventsExporter.mist_edge_events()` wraps
+  the previously unreachable Mist API `searchSiteMistEdgeEvents` operation
+  (`GET /api/v1/sites/{site_id}/mxedges/events/search`). Operator picks a site (shared
+  `SiteDeviceExporter._resolve_site_for_stats` helper), the exporter pages all Mist Edge
+  event rows via `mistapi.get_all`, flattens + escapes them with `DataProcessingUtils`,
+  then persists through `DataExporter.write_with_format_selection` so CSV / SQLite /
+  ArangoDB backends all work. Empty responses surface a friendly "no Mist Edge event
+  data" notice instead of failing. `ENDPOINT_PRIMARY_KEY_STRATEGIES` already defined a PK
+  for this operationId -- no schema changes required. Registered as `interactive_safe` in
+  `OperationRegistry` (requires site selection).
+
 ### Menu 200: Search Site Guest Authorization (spec 889 / issue #1397)
 
 - **New menu 200 (Added)**: `SiteGuestAuthorizationExporter.guest_authorizations()` wraps

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -445,6 +445,9 @@ from src.export.site_insights.device_metric_operation import (
 from src.export.site_insights.site_metric_operation import (
     SiteMetricOperation,
 )  # Decomposed Menu 74 entry point
+from src.export.site_mist_edge_events_exporter import (
+    SiteMistEdgeEventsExporter,  # Spec 890 / issue #1398 -- searchSiteMistEdgeEvents menu 201
+)
 from src.export.site_wan_usage_exporter import (
     SiteWanUsageExporter,  # Spec 901 / issue #1409 -- searchSiteWanUsage menu 198
 )
@@ -3885,6 +3888,10 @@ menu_actions: "dict[str, tuple[Callable[..., Any], str]]" = {
     "200": (
         SiteGuestAuthorizationExporter.guest_authorizations,
         "Search Site Guest Authorization (searchSiteGuestAuthorization) - Per-site authorized guest CSV",
+    ),
+    "201": (
+        SiteMistEdgeEventsExporter.mist_edge_events,
+        "Search Site Mist Edge Events (searchSiteMistEdgeEvents) - Per-site Mist Edge event CSV",
     ),
     "44": (OrgConfigExporter.psks, "Export PSK (Pre-Shared Key) information for the organization"),
     "45": (OrgConfigExporter.webhooks, "Export webhook configuration for the organization"),

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ For quick category guidance, see the Wiki Menu Reference page linked above.
 - New in this branch: Menu `198` searches site WAN usage records (`searchSiteWanUsage`) and exports them to `SiteWanUsages_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 - New in this branch: Menu `199` searches site webhook delivery attempts (`searchSiteWebhooksDeliveries`) and exports them to `SiteWebhookDeliveries_<site>_<webhook>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 - New in this branch: Menu `200` searches site guest authorization records (`searchSiteGuestAuthorization`) and exports them to `SiteGuestAuthorizations_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
+- New in this branch: Menu `201` searches site Mist Edge events (`searchSiteMistEdgeEvents`) and exports them to `SiteMistEdgeEvents_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 ## Security & Safety
 
 | Area | Practice |

--- a/src/export/site_mist_edge_events_exporter.py
+++ b/src/export/site_mist_edge_events_exporter.py
@@ -1,0 +1,103 @@
+"""SiteMistEdgeEventsExporter -- site-level Mist Edge event search export.
+
+Added for spec 890 / issue #1398.  Wraps the Mist API
+``searchSiteMistEdgeEvents`` (``GET /api/v1/sites/{site_id}/mxedges/events/search``)
+so operators can retrieve per-site Mist Edge event records through the
+standard MistHelper menu + DataExporter pipeline (CSV/SQLite/ArangoDB).
+
+Why:
+    The endpoint was absent from MistHelper's menu, forcing users to write
+    custom code to reach Mist Edge event history.  This exporter closes
+    that gap while reusing the shared site-resolution + persistence
+    scaffolding established by ``SiteGuestAuthorizationExporter`` and
+    ``SiteDeviceExporter._resolve_site_for_stats()``.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+ toolchains.
+
+import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
+import logging  # WHY: structured trace for export lifecycle events.
+from typing import Any  # WHY: raw event rows are duck-typed dicts from mistapi.
+
+import mistapi  # WHY: direct SDK access for searchSiteMistEdgeEvents + get_all pagination.
+
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+
+
+class SiteMistEdgeEventsExporter:
+    """Site Mist Edge Events search exporter.
+
+    Why:
+        Provides the sole MistHelper entry point for the
+        ``searchSiteMistEdgeEvents`` operationId.  Static methods only --
+        no per-instance state, matching the pattern used by
+        ``SiteGuestAuthorizationExporter`` / ``SiteDeviceExporter``.
+    """
+
+    @staticmethod
+    def _persist_site_mist_edge_events(rawdata: list[Any], site_name: str) -> None:
+        """Flatten + persist Mist Edge event rows to a per-site file (or tell the user when empty).
+
+        Why:
+            Empty responses are legitimate (a site with no Mist Edge events
+            in the query window); we surface a friendly message rather than
+            failing so scheduled runs stay quiet in that case.
+
+        Args:
+            rawdata: Raw list returned by ``mistapi.get_all`` for the Mist Edge
+                events search response.  May be empty.
+            site_name: Human-readable site name used to name the output
+                file (falls back to site_id when name lookup failed).
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
+        if not rawdata:  # No Mist Edge event rows for this site -- inform the operator and return.
+            print("! No Mist Edge event data found for this site")  # ASCII-only user notice.
+            return
+        flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
+        sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe multiline escape.
+        filename = f"SiteMistEdgeEvents_{site_name.replace(' ', '_')}.csv"  # Per-site filename.
+        mh.DataExporter.write_with_format_selection(  # Persist through CSV/SQLite/Arango backend selector.
+            sanitized_data, filename, api_function_name="searchSiteMistEdgeEvents"
+        )
+        logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
+            "searchSiteMistEdgeEvents persisted %d rows to %s", len(rawdata), filename
+        )
+        print(f"! {len(rawdata)} Mist Edge event records exported to {filename}")  # User notice with count.
+
+    @staticmethod
+    def mist_edge_events() -> None:
+        """Search Mist Edge events for a site and export to SiteMistEdgeEvents_<site>.csv.
+
+        Why:
+            Interactive menu entry point (menu 201).  Delegates site
+            resolution to the shared helper so behavior stays consistent
+            with peer site-scoped exports.  Errors are logged and surfaced
+            to the user rather than crashing the menu loop.
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
+        print("Site Mist Edge Events Search:")  # Menu header echoed to operator.
+        logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
+            "Starting searchSiteMistEdgeEvents export..."
+        )
+        resolved = mh.SiteDeviceExporter._resolve_site_for_stats(  # Prompt + org/site resolution (shared).
+            "Mist Edge events search"
+        )
+        if resolved is None:  # Operator declined selection or org unresolved -- shared helper already logged.
+            return
+        site_id, site_name = resolved  # Unpack resolved identifiers for the API call.
+        try:
+            logging.info(  # INFO trace immediately before the SDK call (with site context).
+                "Calling searchSiteMistEdgeEvents for site_id=%s (%s)", site_id, site_name
+            )
+            response = mistapi.api.v1.sites.mxedges.searchSiteMistEdgeEvents(  # SDK call -- defaults for filters.
+                mh.apisession, site_id
+            )
+            rawdata = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page all rows.
+            SiteMistEdgeEventsExporter._persist_site_mist_edge_events(rawdata, site_name)  # Persist or notify empty.
+        except Exception as e:  # noqa: BLE001 -- surface any SDK/network error to the user instead of crashing.
+            logging.error(  # ERROR trace with site context for post-mortem correlation.
+                "Error fetching Mist Edge events for site %s: %s", site_name, e
+            )
+            print(f"! Error fetching Mist Edge event data: {e}")  # ASCII-only user notice.

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -265,6 +265,7 @@ class OperationRegistry:
         "198": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "199": {"category": "interactive_safe", "skip_reason": "Requires site + webhook selection"},
         "200": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
+        "201": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "186": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Deletes all generated cache CSV files"},
         "58": {"category": "safe"},
         "187": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Creates config objects in destination org"},


### PR DESCRIPTION
## Summary
- New menu 201 wraps `searchSiteMistEdgeEvents` (`GET /api/v1/sites/{site_id}/mxedges/events/search`)
- `SiteMistEdgeEventsExporter.mist_edge_events()` uses shared site resolution, `mistapi.get_all` pagination, and `DataExporter.write_with_format_selection` for CSV/SQLite/ArangoDB output
- Registered in `OperationRegistry` as `interactive_safe`; PK strategy already present in `ENDPOINT_PRIMARY_KEY_STRATEGIES`
- README + CHANGELOG updated

## Test plan
- [x] `python -m py_compile MistHelper.py src/export/site_mist_edge_events_exporter.py`
- [x] `python -m ruff check` (clean)
- [x] `python -m black --check` (clean)
- [ ] CI green (pytest, mypy, pylint, bandit, interrogate, pydocstyle, radon, vulture, CodeQL, e2e smoke)

Closes #1398

## Backlog (carry-forward, EMU-blocked from opening from this session)
- stale `maps_manager.py` reference in `[tool.bandit] targets`
- src/ ruff-format drift sweep
- test-file mypy/pylint strictness sweep
- branch cleanup issues #1435-1442