### PR TITLE
feat(891): add searchSiteNacClientEvents export as menu 202 (#1399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Menu 202: Search Site NAC Client Events (spec 891 / issue #1399)
+
+- **New menu 202 (Added)**: `SiteNacClientEventsExporter.nac_client_events()` wraps
+  the previously unreachable Mist API `searchSiteNacClientEvents` operation
+  (`GET /api/v1/sites/{site_id}/nac_clients/events/search`). Operator picks a site
+  (shared `SiteDeviceExporter._resolve_site_for_stats` helper), the exporter pages all
+  NAC client event rows via `mistapi.get_all`, flattens + escapes them with
+  `DataProcessingUtils`, then persists through `DataExporter.write_with_format_selection`
+  so CSV / SQLite / ArangoDB backends all work. Empty responses surface a friendly
+  "no NAC client event data" notice instead of failing. `ENDPOINT_PRIMARY_KEY_STRATEGIES`
+  already defined a composite PK (`id`, `mac`, `timestamp`) for this operationId -- no
+  schema changes required. Registered as `interactive_safe` in `OperationRegistry`
+  (requires site selection).
+
 ### Menu 201: Search Site Mist Edge Events (spec 890 / issue #1398)
 
 - **New menu 201 (Added)**: `SiteMistEdgeEventsExporter.mist_edge_events()` wraps

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -448,6 +448,9 @@ from src.export.site_insights.site_metric_operation import (
 from src.export.site_mist_edge_events_exporter import (
     SiteMistEdgeEventsExporter,  # Spec 890 / issue #1398 -- searchSiteMistEdgeEvents menu 201
 )
+from src.export.site_nac_client_events_exporter import (
+    SiteNacClientEventsExporter,  # Spec 891 / issue #1399 -- searchSiteNacClientEvents menu 202
+)
 from src.export.site_wan_usage_exporter import (
     SiteWanUsageExporter,  # Spec 901 / issue #1409 -- searchSiteWanUsage menu 198
 )
@@ -3892,6 +3895,10 @@ menu_actions: "dict[str, tuple[Callable[..., Any], str]]" = {
     "201": (
         SiteMistEdgeEventsExporter.mist_edge_events,
         "Search Site Mist Edge Events (searchSiteMistEdgeEvents) - Per-site Mist Edge event CSV",
+    ),
+    "202": (
+        SiteNacClientEventsExporter.nac_client_events,
+        "Search Site NAC Client Events (searchSiteNacClientEvents) - Per-site NAC client event CSV",
     ),
     "44": (OrgConfigExporter.psks, "Export PSK (Pre-Shared Key) information for the organization"),
     "45": (OrgConfigExporter.webhooks, "Export webhook configuration for the organization"),

--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ For quick category guidance, see the Wiki Menu Reference page linked above.
 - New in this branch: Menu `199` searches site webhook delivery attempts (`searchSiteWebhooksDeliveries`) and exports them to `SiteWebhookDeliveries_<site>_<webhook>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 - New in this branch: Menu `200` searches site guest authorization records (`searchSiteGuestAuthorization`) and exports them to `SiteGuestAuthorizations_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 - New in this branch: Menu `201` searches site Mist Edge events (`searchSiteMistEdgeEvents`) and exports them to `SiteMistEdgeEvents_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
+- New in this branch: Menu `202` searches site NAC client events (`searchSiteNacClientEvents`) and exports them to `SiteNacClientEvents_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 ## Security & Safety
 
 | Area | Practice |

--- a/src/export/site_nac_client_events_exporter.py
+++ b/src/export/site_nac_client_events_exporter.py
@@ -1,0 +1,103 @@
+"""SiteNacClientEventsExporter -- site-level NAC client event search export.
+
+Added for spec 891 / issue #1399.  Wraps the Mist API
+``searchSiteNacClientEvents`` (``GET /api/v1/sites/{site_id}/nac_clients/events/search``)
+so operators can retrieve per-site NAC client event records through the
+standard MistHelper menu + DataExporter pipeline (CSV/SQLite/ArangoDB).
+
+Why:
+    The endpoint was absent from MistHelper's menu, forcing users to write
+    custom code to reach NAC client event history.  This exporter closes
+    that gap while reusing the shared site-resolution + persistence
+    scaffolding established by ``SiteMistEdgeEventsExporter`` and
+    ``SiteDeviceExporter._resolve_site_for_stats()``.
+"""
+
+from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+ toolchains.
+
+import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
+import logging  # WHY: structured trace for export lifecycle events.
+from typing import Any  # WHY: raw event rows are duck-typed dicts from mistapi.
+
+import mistapi  # WHY: direct SDK access for searchSiteNacClientEvents + get_all pagination.
+
+from src.data.data_processing_utils import (
+    DataProcessingUtils,
+)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+
+
+class SiteNacClientEventsExporter:
+    """Site NAC Client Events search exporter.
+
+    Why:
+        Provides the sole MistHelper entry point for the
+        ``searchSiteNacClientEvents`` operationId.  Static methods only --
+        no per-instance state, matching the pattern used by
+        ``SiteMistEdgeEventsExporter`` / ``SiteDeviceExporter``.
+    """
+
+    @staticmethod
+    def _persist_site_nac_client_events(rawdata: list[Any], site_name: str) -> None:
+        """Flatten + persist NAC client event rows to a per-site file (or tell the user when empty).
+
+        Why:
+            Empty responses are legitimate (a site with no NAC client events
+            in the query window); we surface a friendly message rather than
+            failing so scheduled runs stay quiet in that case.
+
+        Args:
+            rawdata: Raw list returned by ``mistapi.get_all`` for the NAC
+                client events search response.  May be empty.
+            site_name: Human-readable site name used to name the output
+                file (falls back to site_id when name lookup failed).
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
+        if not rawdata:  # No NAC client event rows for this site -- inform the operator and return.
+            print("! No NAC client event data found for this site")  # ASCII-only user notice.
+            return
+        flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
+        sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe multiline escape.
+        filename = f"SiteNacClientEvents_{site_name.replace(' ', '_')}.csv"  # Per-site filename.
+        mh.DataExporter.write_with_format_selection(  # Persist through CSV/SQLite/Arango backend selector.
+            sanitized_data, filename, api_function_name="searchSiteNacClientEvents"
+        )
+        logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
+            "searchSiteNacClientEvents persisted %d rows to %s", len(rawdata), filename
+        )
+        print(f"! {len(rawdata)} NAC client event records exported to {filename}")  # User notice with count.
+
+    @staticmethod
+    def nac_client_events() -> None:
+        """Search NAC client events for a site and export to SiteNacClientEvents_<site>.csv.
+
+        Why:
+            Interactive menu entry point (menu 202).  Delegates site
+            resolution to the shared helper so behavior stays consistent
+            with peer site-scoped exports.  Errors are logged and surfaced
+            to the user rather than crashing the menu loop.
+        """
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
+        print("Site NAC Client Events Search:")  # Menu header echoed to operator.
+        logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
+            "Starting searchSiteNacClientEvents export..."
+        )
+        resolved = mh.SiteDeviceExporter._resolve_site_for_stats(  # Prompt + org/site resolution (shared).
+            "NAC client events search"
+        )
+        if resolved is None:  # Operator declined selection or org unresolved -- shared helper already logged.
+            return
+        site_id, site_name = resolved  # Unpack resolved identifiers for the API call.
+        try:
+            logging.info(  # INFO trace immediately before the SDK call (with site context).
+                "Calling searchSiteNacClientEvents for site_id=%s (%s)", site_id, site_name
+            )
+            response = mistapi.api.v1.sites.nac_clients.searchSiteNacClientEvents(  # SDK call -- defaults for filters.
+                mh.apisession, site_id
+            )
+            rawdata = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page all rows.
+            SiteNacClientEventsExporter._persist_site_nac_client_events(rawdata, site_name)  # Persist or notify empty.
+        except Exception as e:  # noqa: BLE001 -- surface any SDK/network error to the user instead of crashing.
+            logging.error(  # ERROR trace with site context for post-mortem correlation.
+                "Error fetching NAC client events for site %s: %s", site_name, e
+            )
+            print(f"! Error fetching NAC client event data: {e}")  # ASCII-only user notice.

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -266,6 +266,7 @@ class OperationRegistry:
         "199": {"category": "interactive_safe", "skip_reason": "Requires site + webhook selection"},
         "200": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "201": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
+        "202": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "186": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Deletes all generated cache CSV files"},
         "58": {"category": "safe"},
         "187": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Creates config objects in destination org"},


### PR DESCRIPTION
## Summary

- Adds Menu 202 for the previously unreachable Mist API `searchSiteNacClientEvents` (GET /api/v1/sites/{site_id}/nac_clients/events/search).
- New `SiteNacClientEventsExporter` modeled on the peer `SiteMistEdgeEventsExporter`; uses the shared `SiteDeviceExporter._resolve_site_for_stats` helper for site prompt, pages all rows via `mistapi.get_all`, flattens/escapes via `DataProcessingUtils`, then persists through `DataExporter.write_with_format_selection` for CSV/SQLite/ArangoDB.
- PK strategy already registered (`searchSiteNacClientEvents` → composite `id, mac, timestamp`), no schema change. Registered as `interactive_safe` in `OperationRegistry`. README + CHANGELOG updated.

Closes #1399

## Test plan

- [ ] `python -m py_compile MistHelper.py src/export/site_nac_client_events_exporter.py src/utils/operation_registry.py` (green locally)
- [ ] `python -m black --check` on touched files (green locally)
- [ ] `python -m ruff check` on touched files (green locally)
- [ ] CI: pytest coverage gate, Pylint score gate, mypy, Bandit, CodeQL, E2E smoke
- [ ] Post-merge: verify menu 202 launches, prompts for site, and produces `SiteNacClientEvents_<site>.csv`

## Backlog (out-of-scope, carried forward)

- stale `maps_manager.py` reference in `[tool.bandit] targets`
- src/ ruff-format drift sweep
- test-file mypy/pylint strictness sweep
- branch cleanup issues #1435-#1442