### PR TITLE
chore(882): drop mypy ignore_errors=true; graduate 4 Wave-2 modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,12 +197,28 @@ strict = false
 [[tool.mypy.overrides]]
 # Wave 2 extracted modules: legacy code extracted as-is from MistHelper.py monolith.
 # Uses module-level dependency injection (Any-typed globals) and mixin patterns that
-# produce attr-defined errors. Relax strict checks; tighten after type annotations are
-# added in a dedicated refactoring pass.
+# produce attr-defined errors. Relax strict checks per module with narrower per-flag
+# opt-outs (no blanket ignore_errors); graduate individual modules off the override
+# once type annotations are added and mypy passes at strict mode.
+#
+# Graduated (removed from list) — pass strict mypy as of issue #882:
+#   src.cache.*                    (0 errs pre-graduation)
+#   src.ssh.ssh_runner             (0 errs pre-graduation)
+#   src.ssh.cli_shell_manager      (1 err  fixed pre-graduation: no-any-return cast)
+#   src.ssh.ssh_runner_manager     (2 errs fixed pre-graduation: no-any-return cast + ignore code)
+#
+# Remaining (still overridden) — error counts at strict mypy captured 2026-07-19,
+# tracked for follow-up under issue #882 comments (module list to graduate next):
+#   src.analytics.*     ( 15 errs)  src.api.*           ( 23 errs)
+#   src.device.*        ( 36 errs)  src.export.*        (189 errs)
+#   src.gateway.*       ( 92 errs)  src.input.*         ( 14 errs)
+#   src.inventory.*     ( 94 errs)  src.org.*           ( 55 errs)
+#   src.reports.*       (  7 errs)  src.site.*          ( 17 errs)
+#   src.troubleshooting.* ( 7 errs) src.ui.*            ( 12 errs)
+#   src.websocket.*     ( 79 errs)
 module = [
     "src.analytics.*",
     "src.api.*",
-    "src.cache.*",
     "src.export.*",
     "src.gateway.*",
     "src.input.*",
@@ -214,18 +230,37 @@ module = [
     "src.troubleshooting.*",
     "src.ui.*",
     "src.websocket.*",
-    "src.ssh.ssh_runner",
-    "src.ssh.ssh_runner_manager",
-    "src.ssh.cli_shell_manager",
 ]
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-disallow_untyped_calls = false
-disallow_any_generics = false
-warn_return_any = false
-check_untyped_defs = false
-warn_unused_ignores = false
-ignore_errors = true
+# WHY (per-flag opt-outs): each flag below is relaxed for a specific documented
+# reason -- collectively they replace the blanket `ignore_errors = true`, so mypy
+# still runs and catches regressions in these subtrees; only the specific patterns
+# below are permitted.
+disallow_untyped_defs = false      # Wave-2 legacy functions lack annotations; add over time.
+disallow_incomplete_defs = false   # Same reason as disallow_untyped_defs.
+disallow_untyped_calls = false     # Many callees are still Any-typed (deps.* mixins).
+disallow_any_generics = false      # Legacy uses bare list/dict; graduate as we add generics.
+warn_return_any = false            # Any-typed helper chains propagate; tighten with casts later.
+check_untyped_defs = false         # Untyped legacy defs would otherwise flood errors.
+warn_unused_ignores = false        # Existing type: ignore comments predate current mypy version.
+# WHY (per-code disables): each code below is disabled for a specific documented
+# Wave-2 pattern -- collectively narrower than `ignore_errors = true` (which the
+# AC forbids), so mypy still catches every OTHER category of error in these
+# subtrees. Graduate individual modules off the override as annotations land.
+# Error counts captured 2026-07-19 across the 13 modules in `module` above.
+disable_error_code = [
+    "attr-defined",   # 60 errs: Wave-2 mixin pattern (e.g. ServicePingDiscoveryMixin
+                      # references self.site_id / self._debug_print supplied by the
+                      # host class that mixes it in). Real fix = ABC + Protocol.
+    "arg-type",       # 5 errs: Any-typed helper results flow into typed callees.
+    "index",          # 5 errs: legacy code indexes Any-typed dicts (e.g. deps.state[...]).
+    "return-value",   # 4 errs: Wave-2 helpers return Any where callers annotate a type.
+    "call-overload",  # 3 errs: int()/str() called on Any-typed values from deps.*.
+    "assignment",     # 2 errs: Any values assigned into typed slots.
+    "union-attr",     # 1 err : Any-typed vars treated as unions in legacy branches.
+    "var-annotated",  # 1 err : bare `foo = {}` needs annotation; add during graduation.
+    "misc",           # 4 errs: mypy "miscellaneous" bucket (mixin base-class subclass
+                      # detection, method-assign in test fixtures, etc.).
+]
 
 [tool.bandit]
 targets = ["MistHelper.py", "maps_manager.py", "wsgi.py", "web_portal", "mist-ops-platform", "ops-portal", "src"]

--- a/src/ssh/cli_shell_manager.py
+++ b/src/ssh/cli_shell_manager.py
@@ -117,7 +117,8 @@ class CLIShellManager:
         if debug:  # Verbose troubleshooting output is enabled.
             print(f"[DEBUG] Raw recv: {repr(data)}")  # Show the raw received payload.
         if data and isinstance(data, str):  # We have a non-empty text frame to render.
-            return data  # Renderable text.
+            # WHY: cast narrows Any->str for mypy strict (no-any-return); runtime check above ensures str.
+            return str(data)  # Renderable text.
         return None  # Nothing to render for this frame.
 
     @staticmethod

--- a/src/ssh/ssh_runner_manager.py
+++ b/src/ssh/ssh_runner_manager.py
@@ -234,7 +234,8 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _prompt_username(deps: SSHRunnerManagerDeps) -> str | None:  # WHY: username-only prompt path.
         """Prompt operator for SSH username; return value or None on cancel."""
-        username = deps.input_utils.safe_input("Enter SSH username: ", context="ssh_runner_username").strip()
+        # WHY: safe_input is Any-typed via deps; cast to str for mypy strict (no-any-return).
+        username: str = str(deps.input_utils.safe_input("Enter SSH username: ", context="ssh_runner_username")).strip()
         if not username:  # WHY: cancel path.
             print("X  SSH username is required")
             logging.info("Exiting SSHRunnerManager._collect_missing_data: cancelled (no username provided)")
@@ -297,7 +298,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             _ = env_file  # WHY: retained for signature parity with the real loader.
             return {"hosts": hosts, "username": username, "password": password, "commands": commands}
 
-        EnvSshConfigLoader.load = mock_load  # type: ignore[method-assign]  # WHY: inject mocked loader.
+        EnvSshConfigLoader.load = mock_load  # type: ignore[assignment,method-assign]  # WHY: inject mocked loader.
 
     @staticmethod
     def _execute_multi_host(hosts: Any, username: Any, password: Any, commands: Any) -> bool:  # WHY: fan-out path.


### PR DESCRIPTION
Closes #882.

## Summary
- Replaces blanket `ignore_errors = true` on the Wave-2 mypy override with narrower per-flag opt-outs plus per-code disables — mypy still runs and catches regressions on the remaining subtrees.
- Graduates 4 modules off the override entirely (they pass strict mypy after 3 small fixes).

## Graduated modules (removed from override)
| Module | Pre-graduation errs | Notes |
|---|---:|---|
| `src.cache.*` | 0 | Already clean |
| `src.ssh.ssh_runner` | 0 | Already clean |
| `src.ssh.cli_shell_manager` | 1 | Fixed: `no-any-return` cast in `_shell_decode_frame` |
| `src.ssh.ssh_runner_manager` | 2 | Fixed: `no-any-return` cast in `_prompt_username`; `assignment,method-assign` ignore on `EnvSshConfigLoader.load` mock injection |

## Remaining Wave-2 modules (still overridden)
Strict-mypy error counts captured 2026-07-19 — documented inline in `pyproject.toml`:

```
analytics 15 | api 23 | device 36 | export 189 | gateway 92 | input 14
inventory 94 | org 55 | reports 7 | site 17 | troubleshooting 7 | ui 12 | websocket 79
```

## Why per-code disables instead of `ignore_errors = true`
The AC forbids `ignore_errors = true` because it bypasses everything. Instead:
- Per-flag opt-outs (`disallow_untyped_defs = false`, etc.) — each documented with a WHY comment.
- Per-code disables — 9 codes, dominated by `attr-defined` (60/85, Wave-2 mixin pattern like `ServicePingDiscoveryMixin` referencing attributes supplied by the host class that mixes it in). Every OTHER mypy category still fires on these modules.

Real fix for the mixin pattern (ABC + Protocol) is deferred to the per-module graduation follow-ups.

## Test plan
- [x] `mypy src/` returns 0 errors (was 85 with just per-flag opt-outs).
- [x] `black --check` clean on touched files.
- [x] `ruff check` clean on touched files.
- [x] SSH tests: 363 passed (`tests/unit/ssh/`, `tests/unit/test_ssh_runner.py`, `tests/unit/test_ssh_host_key_tofu.py`).
- [ ] Full CI green.