### PR TITLE
chore(883): narrow mypy follow_imports override; fix stale lazy import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,12 +162,28 @@ module = ["dash", "dash.*"]
 follow_imports = "skip"
 
 [[tool.mypy.overrides]]
-# Skip type-checking for imported modules that are not part of the CI target (MistHelper.py).
-# maps_manager: large module with its own type issues — Phase 2 target
-# web_portal: Flask app with its own type issues — Phase 2 target
-# Others: third-party or legacy code not under active development
-module = ["MistHelper", "MistHelper.*", "maps_manager", "maps_manager.*", "src.maps", "src.maps.*", "mist-ops-platform.*", "ops-portal.*", "web_portal.*", "scripts.*", "specs.*"]
-follow_imports = "skip"
+# Non-CI-target modules: MistHelper.py (monolith being refactored), src.maps.*
+# (matplotlib/plotly viewer subtree — its own Phase-2 target), and web_portal.*
+# (Flask app — needs types-flask + per-view annotations). Using `follow_imports = "silent"`
+# means mypy still follows imports to resolve real types at call sites but suppresses
+# error reporting from these files themselves. This is deliberately narrower than
+# `follow_imports = "skip"` (the old blanket setting, forbidden by issue #883 AC), which
+# treated every symbol imported from these modules as `Any` and hid cross-module bugs
+# like the one caught in src/capture/packet_capture.py (a `PromptNetworkDeviceUtils`
+# reference that no longer existed after issue #33xx extracted it out of MistHelper).
+#
+# Graduated in this PR (issue #883):
+#   maps_manager, maps_manager.*      -- root module never existed; only src.maps.maps_manager
+#   mist-ops-platform.*, ops-portal.* -- hyphenated names are not valid Python modules;
+#                                         patterns never matched anything
+#   scripts.*, specs.*                -- dev tooling and planning artifacts; not imported
+#                                         by src/, so no follow_imports effect
+#   MistHelper.*                      -- MistHelper.py is a single module, no submodules
+#
+# Follow-ups: as MistHelper monolith classes graduate, the `MistHelper` entry shrinks;
+# src.maps.* and web_portal.* need their own dedicated typing sweeps (out of scope here).
+module = ["MistHelper", "src.maps.*", "web_portal.*"]
+follow_imports = "silent"
 
 [[tool.mypy.overrides]]
 # src.db: polyglot database modules use python-arango and redis SDKs which have

--- a/src/capture/packet_capture.py
+++ b/src/capture/packet_capture.py
@@ -56,9 +56,11 @@ def _get_prompt_client_utils() -> Any:  # WHY: module-level factory for deferred
 
 def _get_prompt_network_device_utils() -> Any:  # WHY: module-level factory for deferred PromptNetworkDeviceUtils access
     """Lazy import PromptNetworkDeviceUtils to avoid circular imports."""
-    import MistHelper as _mh  # pylint: disable=import-outside-toplevel  # WHY: deferred to break capture<->MistHelper cycle
+    from src.device.prompt_utils import (
+        PromptNetworkDeviceUtils,
+    )  # pylint: disable=import-outside-toplevel  # WHY: extracted from MistHelper monolith under issue #33xx
 
-    return _mh.PromptNetworkDeviceUtils  # WHY: caller invokes device/port selection prompts
+    return PromptNetworkDeviceUtils  # WHY: caller invokes device/port selection prompts
 
 
 def _get_data_exporter() -> Any:  # WHY: module-level factory for deferred DataExporter access


### PR DESCRIPTION
Closes #883.

## Summary
- Replace blanket `follow_imports = "skip"` with narrower `follow_imports = "silent"` on 3 modules (`MistHelper`, `src.maps.*`, `web_portal.*`).
- `silent` still resolves real types at call sites and only suppresses errors from the imported files themselves — cross-module bugs are no longer invisible.
- Graduate 8 dead/redundant entries off the override (see commit body for the full list and rationale).
- Fix `src/capture/packet_capture.py` deferred import that pointed at `MistHelper.PromptNetworkDeviceUtils`, which was extracted to `src/device/prompt_utils.py` in a prior refactor. `follow_imports = skip` had been hiding this by silently treating the attribute as `Any`.

## Why this matters
Issue #883's acceptance criterion forbids blanket `follow_imports = "skip"` because it treats every symbol imported from the covered modules as `Any`, which hides real bugs at every call site. Narrowing to `silent` preserves the "don't nag about errors inside legacy files" behavior while restoring cross-module type checking. The packet_capture fix is the concrete proof: `mypy src/` now finds bugs it previously masked.

## Test plan
- [x] `mypy src/ --config-file pyproject.toml` — 0 errors, 324 files
- [x] `black` — reformatted packet_capture.py, clean
- [x] `ruff check` — clean
- [x] `pytest tests/unit/capture/` — 45 passed