### PR TITLE
lint: drop dead tests/** B011 ignore; audit ruff per-file-ignores (#885)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,15 +113,18 @@ ignore = ["E402"]
 known-first-party = ["src"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["B011"]
 # Issue #433 Phase A swept G003/G004/G201 from src/, tools/, web_portal/,
 # starlink_dashboard.py, wsgi.py, and maps_manager.py (#429 had previously
 # cleaned up MistHelper.py). Only the codemod synthetic input fixture
 # retains G violations on purpose -- they are the test material.
+# Both #429 and #433 are CLOSED; the fixture is still exercised by
+# tests/test_issue_429_codemod_idempotent.py (verified live under #885).
 "tests/fixtures/issue_429_codemod_synthetic_input.py" = ["G"]
 # plan_wave_builder.py embeds a literal multi-line prompt template that is
 # rendered verbatim into subagent task payloads; reflowing the lines would
-# change the prompt content sent to the model.
+# change the prompt content sent to the model. Externalizing the prompt
+# to a .txt fixture is possible but is a behavioral refactor tracked
+# separately -- see #885 discussion.
 "tools/plan_wave_builder.py" = ["E501"]
 # refactor_analyzer/reporting.py emits literal markdown strings for the
 # refactor_candidates.md report; reflowing the lines would break the rendered


### PR DESCRIPTION
## Summary
- Delete `"tests/**" = ["B011"]` per-file-ignore — grep shows zero `assert False` occurrences under `tests/`, so the ignore was dead.
- Refresh justification comments on the two remaining survivors (`issue_429_codemod_synthetic_input.py` for `G`, `plan_wave_builder.py` for `E501`) with the AC's verification results.

## Verification
- `rg -n "assert False" tests/` → no matches (B011 ignore was inert).
- `rg -n "issue_429_codemod_synthetic_input" tests/` → hit in `tests/test_issue_429_codemod_idempotent.py` (fixture is live).
- Issues #429 and #433 confirmed CLOSED via `gh issue view`.
- `python -m ruff check .` → All checks passed.

## Non-goals
- Externalizing `plan_wave_builder.py` prompt to a `.txt` fixture is a behavioral refactor; noted in the ignore comment as a separate follow-up.
- Not touching top-level `ignore = ["E402"]` (#886 scope).
- Not touching the other three ignore blocks whose inline justifications were already sufficient.

Closes #885