### PR TITLE
feat(865): add menu 204 for searchOrgJsiAssetsAndContracts (#1373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Menu 204: Search Org JSI Assets and Contracts (spec 865 / issue #1373)
+
+- **New menu 204 (Added)**: `OrgExportUtils.jsi_assets()` wraps the previously
+  unreachable Mist API `searchOrgJsiAssetsAndContracts` operation
+  (`GET /api/v1/orgs/{org_id}/jsi/inventory/search`). Delegates to the shared
+  `OrgExportUtils.export_data` scaffold used by sibling `jsi_pbn` / `jsi_sirt`
+  entrypoints: prompts for org (via `ConfigUtils.get_cached_or_prompted_org_id`),
+  pages all rows through `APIDataFetcher` / `mistapi.get_all`, and persists via
+  `DataExporter.write_with_format_selection` so CSV / SQLite / ArangoDB backends
+  all work uniformly. `ENDPOINT_PRIMARY_KEY_STRATEGIES` already registered the
+  endpoint as `auto_increment_with_unique` with indexes on `org_id` and `serial`
+  -- no schema changes required. Sort order stabilised on `serial` to match the
+  PK index. Fulfills spec 865.
+
 ### Menu 203: Search Site WAN Client Events (spec 899 / issue #1407)
 
 - **New menu 203 (Added)**: `WanClientEventsExporter` (delegated from

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -4474,6 +4474,9 @@ menu_actions: "dict[str, tuple[Callable[..., Any], str]]" = {
     "5": (OrgExportUtils.e911_report, "Export E911 report for the organization"),
     "56": (OrgExportUtils.jsi_pbn, "Export JSI PBN (Product Bulletin Notifications) data"),
     "57": (OrgExportUtils.jsi_sirt, "Export JSI SIRT (Security Incident Response) advisories"),
+    # Spec 865 / issue #1373 -- surfaces mistapi.api.v1.orgs.jsi.searchOrgJsiAssetsAndContracts
+    # alongside the existing PBN/SIRT reports so operators can pull JSI inventory + contracts.
+    "204": (OrgExportUtils.jsi_assets, "Export JSI assets and contract search results"),
     "55": (OrgExportUtils.ospf_stats, "Export OSPF adjacency statistics for the organization"),
     "70": (
         lambda: SiteExportUtils(

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ For quick category guidance, see the Wiki Menu Reference page linked above.
 - New in this branch: Menu `201` searches site Mist Edge events (`searchSiteMistEdgeEvents`) and exports them to `SiteMistEdgeEvents_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 - New in this branch: Menu `202` searches site NAC client events (`searchSiteNacClientEvents`) and exports them to `SiteNacClientEvents_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 - New in this branch: Menu `203` searches WAN client events for a selected site via `searchSiteWanClientEvents` (spec 899 / issue #1407) and persists paginated results to `SiteWanClientEvents.CSV` (or the configured SQLite/ArangoDB backend).
+- New in this branch: Menu `204` searches org JSI assets and contract coverage via `searchOrgJsiAssetsAndContracts` (spec 865 / issue #1373) and exports the paginated results to `OrgJsiAssets.CSV` (CSV/SQLite/ArangoDB via `DataExporter`).
 ## Security & Safety
 
 | Area | Practice |

--- a/src/export/org_export_utils.py
+++ b/src/export/org_export_utils.py
@@ -594,6 +594,25 @@ class OrgExportUtils:
         )
 
     @staticmethod
+    def jsi_assets():  # Export JSI Assets and Contracts.
+        """Export JSI assets & contract search results to OrgJsiAssets.csv.
+
+        Why:
+            Spec 865 / issue #1373 registers the ``searchOrgJsiAssetsAndContracts``
+            endpoint so operators can pull the JSI inventory (assets plus their
+            contract coverage) alongside the existing ``jsi_pbn`` / ``jsi_sirt``
+            reports.  Delegating to :meth:`export_data` keeps this consistent with
+            the sibling JSI exports (prompt for org, paginate, multi-backend write)
+            and lets the pre-registered primary-key strategy for
+            ``searchOrgJsiAssetsAndContracts`` drive downstream dedup / SQL loads.
+        """
+        OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.orgs.jsi.searchOrgJsiAssetsAndContracts,
+            data_type="jsi assets",  # Drives the export filename -> OrgJsiAssets.csv.
+            sort_key="serial",  # Matches the PK strategy index on `serial` for stable ordering.
+        )
+
+    @staticmethod
     def ospf_stats():  # Export OSPF stats.
         """Export OSPF adjacency statistics for the organization to OrgOspfStats.csv."""
         OrgExportUtils.export_data(  # type: ignore[no-untyped-call]

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -345,6 +345,7 @@ class OperationRegistry:
         "55": {"category": "safe"},  # OrgExportUtils.ospf_stats - read-only export.
         "56": {"category": "safe"},  # OrgExportUtils.jsi_pbn - read-only export.
         "57": {"category": "safe"},  # OrgExportUtils.jsi_sirt - read-only export.
+        "204": {"category": "safe"},  # OrgExportUtils.jsi_assets - read-only export (spec 865 / #1373).
         "188": {"category": "safe"},  # OrgTicketManager.list_tickets - read-only ticket list export (no selection).
         "193": {"category": "safe"},  # OrgTicketManager.export_ticket_details - read-only (exports all, no selection).
         "195": {"category": "safe"},  # Site address audit - self-described READ-ONLY report.


### PR DESCRIPTION
## Summary
- Adds `OrgExportUtils.jsi_assets()` static method wrapping `mistapi.api.v1.orgs.jsi.searchOrgJsiAssetsAndContracts`, delegating to the shared `OrgExportUtils.export_data` scaffold used by sibling `jsi_pbn` / `jsi_sirt` entrypoints.
- Wires new menu entry `204` under the `MISTAPI 0.62.0 NEW ENDPOINTS` section in `MistHelper.py`.
- Documents the new operation in `CHANGELOG.md` (Unreleased) and `README.md` (new-in-this-branch bullet).

## Details
- Endpoint: `GET /api/v1/orgs/{org_id}/jsi/inventory/search`
- Filename: `OrgJsiAssets.csv` (derived from `data_type="jsi assets"`)
- Sort key: `serial` (matches the `ENDPOINT_PRIMARY_KEY_STRATEGIES` index)
- Primary key strategy: already registered as `auto_increment_with_unique` with indexes on `org_id` and `serial` — no schema change required.
- Persistence: `DataExporter.write_with_format_selection` — CSV / SQLite / ArangoDB backends all work.

Closes #1373.

## Test plan
- [x] `python -m py_compile src/export/org_export_utils.py MistHelper.py`
- [x] `ruff check src/export/org_export_utils.py MistHelper.py` — clean
- [x] `black --check src/export/org_export_utils.py MistHelper.py` — clean
- [x] `pytest tests/unit/export/test_org_export_utils.py -x -q` — 85 passed
- [x] `from src.export.org_export_utils import OrgExportUtils; OrgExportUtils.jsi_assets` resolves