### PR TITLE
feat(866): add searchOrgMistEdgeEvents menu 205 (#1374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Menu 205: Search Org Mist Edge Events (spec 866 / issue #1374)
+
+- **New menu 205 (Added)**: `OrgExportUtils.mist_edge_events()` wraps the
+  previously unreachable Mist API `searchOrgMistEdgeEvents` operation
+  (`GET /api/v1/orgs/{org_id}/mxedges/events/search`). Provides the org-scope
+  peer of the site-scoped `SiteMistEdgeEventsExporter` (menu 201) so operators
+  can pull Mist Edge event history across every mxedge in the org in one shot
+  rather than iterating sites. Delegates to the shared
+  `OrgExportUtils.export_data` scaffold used by sibling `jsi_*` entrypoints:
+  prompts for org (via `ConfigUtils.get_cached_or_prompted_org_id`), pages all
+  rows through `APIDataFetcher` / `mistapi.get_all`, and persists via
+  `DataExporter.write_with_format_selection` so CSV / SQLite / ArangoDB
+  backends all work uniformly. `ENDPOINT_PRIMARY_KEY_STRATEGIES` already
+  registers the endpoint as `composite_pk` on `(id, mxedge_id, timestamp)` with
+  indexes on `org_id` and `type` -- no schema changes required. Sort order
+  stabilised on `timestamp` to align with the composite PK and yield newest-
+  first output. Fulfills spec 866.
+
 ### Menu 204: Search Org JSI Assets and Contracts (spec 865 / issue #1373)
 
 - **New menu 204 (Added)**: `OrgExportUtils.jsi_assets()` wraps the previously

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -4477,6 +4477,9 @@ menu_actions: "dict[str, tuple[Callable[..., Any], str]]" = {
     # Spec 865 / issue #1373 -- surfaces mistapi.api.v1.orgs.jsi.searchOrgJsiAssetsAndContracts
     # alongside the existing PBN/SIRT reports so operators can pull JSI inventory + contracts.
     "204": (OrgExportUtils.jsi_assets, "Export JSI assets and contract search results"),
+    # Spec 866 / issue #1374 -- surfaces mistapi.api.v1.orgs.mxedges.searchOrgMistEdgeEvents
+    # (org-scope peer of the site-scoped SiteMistEdgeEventsExporter registered on menu 201).
+    "205": (OrgExportUtils.mist_edge_events, "Export Org Mist Edge event search results"),
     "55": (OrgExportUtils.ospf_stats, "Export OSPF adjacency statistics for the organization"),
     "70": (
         lambda: SiteExportUtils(

--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ For quick category guidance, see the Wiki Menu Reference page linked above.
 - New in this branch: Menu `202` searches site NAC client events (`searchSiteNacClientEvents`) and exports them to `SiteNacClientEvents_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
 - New in this branch: Menu `203` searches WAN client events for a selected site via `searchSiteWanClientEvents` (spec 899 / issue #1407) and persists paginated results to `SiteWanClientEvents.CSV` (or the configured SQLite/ArangoDB backend).
 - New in this branch: Menu `204` searches org JSI assets and contract coverage via `searchOrgJsiAssetsAndContracts` (spec 865 / issue #1373) and exports the paginated results to `OrgJsiAssets.CSV` (CSV/SQLite/ArangoDB via `DataExporter`).
+- New in this branch: Menu `205` searches org-wide Mist Edge events via `searchOrgMistEdgeEvents` (spec 866 / issue #1374) -- org-scope peer of the site-scoped Menu `201` -- and persists paginated results to `OrgMistEdgeEvents.CSV` (CSV/SQLite/ArangoDB via `DataExporter`).
 ## Security & Safety
 
 | Area | Practice |

--- a/src/export/org_export_utils.py
+++ b/src/export/org_export_utils.py
@@ -613,6 +613,26 @@ class OrgExportUtils:
         )
 
     @staticmethod
+    def mist_edge_events():  # Export Org Mist Edge Events.
+        """Export Org Mist Edge Events search results to OrgMistEdgeEvents.csv.
+
+        Why:
+            Spec 866 / issue #1374 registers the ``searchOrgMistEdgeEvents``
+            endpoint so operators can pull org-wide Mist Edge event history
+            alongside the sibling per-site ``SiteMistEdgeEventsExporter``
+            (menu 201).  Delegating to :meth:`export_data` reuses the shared
+            prompt-for-org + paginate + multi-backend write scaffold, and
+            lets the pre-registered composite PK strategy for
+            ``searchOrgMistEdgeEvents`` (id + mxedge_id + timestamp) drive
+            downstream dedup / SQL loads without duplicates.
+        """
+        OrgExportUtils.export_data(  # type: ignore[no-untyped-call]
+            api_call=mistapi.api.v1.orgs.mxedges.searchOrgMistEdgeEvents,
+            data_type="mist edge events",  # Drives the export filename -> OrgMistEdgeEvents.csv.
+            sort_key="timestamp",  # Matches the composite PK ordering (newest events sort naturally).
+        )
+
+    @staticmethod
     def ospf_stats():  # Export OSPF stats.
         """Export OSPF adjacency statistics for the organization to OrgOspfStats.csv."""
         OrgExportUtils.export_data(  # type: ignore[no-untyped-call]

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -346,6 +346,7 @@ class OperationRegistry:
         "56": {"category": "safe"},  # OrgExportUtils.jsi_pbn - read-only export.
         "57": {"category": "safe"},  # OrgExportUtils.jsi_sirt - read-only export.
         "204": {"category": "safe"},  # OrgExportUtils.jsi_assets - read-only export (spec 865 / #1373).
+        "205": {"category": "safe"},  # OrgExportUtils.mist_edge_events - read-only export (spec 866 / #1374).
         "188": {"category": "safe"},  # OrgTicketManager.list_tickets - read-only ticket list export (no selection).
         "193": {"category": "safe"},  # OrgTicketManager.export_ticket_details - read-only (exports all, no selection).
         "195": {"category": "safe"},  # Site address audit - self-described READ-ONLY report.


### PR DESCRIPTION
Closes #1374 (spec 866).

## Summary
- Adds `OrgExportUtils.mist_edge_events()` wrapping `mistapi.api.v1.orgs.mxedges.searchOrgMistEdgeEvents`
- Registers menu **205** as the org-scope peer of the site-scoped menu 201 (`SiteMistEdgeEventsExporter`)
- Delegates to `OrgExportUtils.export_data` for pagination, rate-limit retry, and multi-backend (CSV/SQLite/ArangoDB) writes
- Composite PK strategy `(id, mxedge_id, timestamp)` is already pre-registered in `ENDPOINT_PRIMARY_KEY_STRATEGIES` (line 1252)
- Classifies menu 205 as `safe` in `src/utils/operation_registry.py` (guardrail test passes locally)

## Test plan
- [x] `python -m black --check` clean on all 3 code files
- [x] `python -m ruff check` clean on all 3 code files
- [x] `tests/guardrails/test_operation_registry_menu_coverage.py` -- 5/5 pass locally
- [ ] CI green