### PR TITLE
chore(logging): migrate src/utils/ print() to logger.warning (#886 slice 1/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 1/N: retire `print()` in `src/utils/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`
+  calls in `src/utils/` with `logging.warning(...)` so the print-avoidance rule
+  (T20 selector target of #886) can eventually be enabled repo-wide. Touched
+  `src/utils/input_utils.py` (`_handle_eof` / `_handle_interrupt`) and
+  `src/utils/filter_operator_engine.py` (`validate_operator_value`). Collapsed
+  the previous `print(...)` + `logging.info(...)` pairs into a single WARNING
+  line each so operators still see the notice on the default root-logger
+  configuration (INFO is suppressed by default; WARNING is not). Companion
+  unit tests in `tests/unit/utils/test_input_utils_wave9.py` and
+  `tests/unit/utils/test_filter_operator_engine.py` were updated to assert
+  against `caplog.text` instead of `capsys.readouterr().out`. First of ~20+
+  per-subdirectory slices of #886; T20 selector flip and E402 audit will land
+  after all `src/` subdirs are print-free.
+
 ### Menu 205: Search Org Mist Edge Events (spec 866 / issue #1374)
 
 - **New menu 205 (Added)**: `OrgExportUtils.mist_edge_events()` wraps the

--- a/src/utils/filter_operator_engine.py
+++ b/src/utils/filter_operator_engine.py
@@ -82,8 +82,9 @@ class FilterOperatorEngine:  # Filter operator evaluation engine.
         """Validate that value-required operators have non-empty normalized values."""
         if operator in FilterOperatorEngine.VALUE_REQUIRED_OPERATORS:  # Value-required operator?
             if not value or not value.strip():  # Missing value.
-                logging.warning("Operator '%s' for %s requires a non-empty value", operator, field_name)
-                print(f"\n  Operator '{operator}' requires a value for {field_name}. Please try again.")
+                logging.warning(
+                    "Operator '%s' for %s requires a non-empty value. Please try again.", operator, field_name
+                )  # Single WARNING (retired duplicate print() per #886 Phase 2) surfaces on operator terminal.
                 return False  # Invalid.
         return True  # Valid.
 

--- a/src/utils/input_utils.py
+++ b/src/utils/input_utils.py
@@ -90,13 +90,17 @@ class InputUtils:
 
     @staticmethod
     def _handle_eof(context: str, default_value: str) -> str:
-        """Handle a closed input stream by degrading to ``default_value``."""
-        # WHY: extracted to keep safe_input CC<=5 and length<=25 lines.
-        print(  # Notify operator at the terminal before degrading gracefully.
-            f"\n[EOF] Input stream closed during {context}. " f"Using default value: '{default_value}'"
-        )
-        logging.info(  # Action-log the disconnect with the substituted default.
-            "EOF encountered on input during %s - returning default: '%s'",
+        """Handle a closed input stream by degrading to ``default_value``.
+
+        Why:
+            Extracted from ``safe_input`` to keep it CC<=5 and length<=25.
+            Emits at WARNING (not INFO) so the operator sees the disconnect
+            notice on the default root-logger config -- previously we relied
+            on a raw ``print()``, which #886 Phase 2 (T20) is retiring in
+            favour of logger calls across ``src/``.
+        """
+        logging.warning(  # WARNING surfaces on the operator terminal under the default root-logger level.
+            "[EOF] Input stream closed during %s. Using default value: '%s'",
             context,
             default_value,
         )
@@ -104,8 +108,15 @@ class InputUtils:
 
     @staticmethod
     def _handle_interrupt(context: str) -> str:
-        """Handle a Ctrl+C interrupt by returning an empty sentinel."""
-        # WHY: extracted to keep safe_input CC<=5 and length<=25 lines.
-        print(f"\n[INTERRUPT] User interrupted {context}. Canceling...")  # Acknowledge cancellation.
-        logging.info("KeyboardInterrupt encountered during %s", context)  # Action-log the interrupt.
+        """Handle a Ctrl+C interrupt by returning an empty sentinel.
+
+        Why:
+            Extracted from ``safe_input`` to keep it CC<=5 and length<=25.
+            Uses WARNING so the operator sees the acknowledgement without
+            needing INFO enabled -- part of the #886 Phase 2 print-to-logger
+            migration for ``src/utils/``.
+        """
+        logging.warning(
+            "[INTERRUPT] User interrupted %s. Canceling...", context
+        )  # Surface at WARNING so operator sees it.
         return ""  # Return empty so the caller can detect the abort.

--- a/tests/unit/utils/test_filter_operator_engine.py
+++ b/tests/unit/utils/test_filter_operator_engine.py
@@ -67,12 +67,12 @@ class TestNormalizeText:
 
 
 class TestValidateOperatorValue:
-    def test_value_required_with_empty_warns_and_returns_false(self, caplog, capsys):
+    def test_value_required_with_empty_warns_and_returns_false(self, caplog):
         caplog.set_level(logging.WARNING)
         assert FilterOperatorEngine.validate_operator_value("is", "", "hostname") is False
+        # WHY (#886 Phase 2): print() consolidated into single WARNING log line.
         assert "requires a non-empty value" in caplog.text
-        captured = capsys.readouterr()
-        assert "requires a value for hostname" in captured.out
+        assert "Please try again." in caplog.text
 
     def test_value_required_with_whitespace_only_returns_false(self):
         assert FilterOperatorEngine.validate_operator_value("contains", "   ", "mac") is False

--- a/tests/unit/utils/test_input_utils_wave9.py
+++ b/tests/unit/utils/test_input_utils_wave9.py
@@ -105,33 +105,33 @@ class TestSafeInputEmptyBranches:
 class TestSafeInputExceptionBranches:
     """Cover the EOF and KeyboardInterrupt exception branches."""
 
-    def test_eof_returns_default_and_prints_notice(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    def test_eof_returns_default_and_logs_notice(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        # WHY: EOFError -> degrade to default_value + print [EOF] notice
+        # WHY: EOFError -> degrade to default_value + WARNING log notice (#886 Phase 2 print->logger)
         def _raise_eof(_prompt: str) -> str:  # WHY: patched input raises EOFError
-            logging.info("Simulating EOFError from input")  # WHY: pre-action trace
             raise EOFError("stream closed")  # WHY: hit the except EOFError branch
 
         monkeypatch.setattr("builtins.input", _raise_eof)  # WHY: patched input
-        result = InputUtils.safe_input(
-            "Enter: ", default_value="fallback", context="testctx"
-        )  # WHY: exercise EOF branch
+        with caplog.at_level(logging.WARNING):  # WHY: capture warning surface
+            result = InputUtils.safe_input(
+                "Enter: ", default_value="fallback", context="testctx"
+            )  # WHY: exercise EOF branch
         assert result == "fallback"  # WHY: default substituted
-        assert "[EOF]" in capsys.readouterr().out  # WHY: user-facing notice surfaced
+        assert "[EOF]" in caplog.text  # WHY: operator notice surfaced via logger
 
-    def test_keyboard_interrupt_returns_empty_and_prints_notice(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    def test_keyboard_interrupt_returns_empty_and_logs_notice(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        # WHY: KeyboardInterrupt -> return "" + print [INTERRUPT] notice
+        # WHY: KeyboardInterrupt -> return "" + WARNING log notice (#886 Phase 2 print->logger)
         def _raise_interrupt(_prompt: str) -> str:  # WHY: patched input raises KeyboardInterrupt
-            logging.info("Simulating KeyboardInterrupt from input")  # WHY: pre-action trace
             raise KeyboardInterrupt()  # WHY: hit the except KeyboardInterrupt branch
 
         monkeypatch.setattr("builtins.input", _raise_interrupt)  # WHY: patched input
-        result = InputUtils.safe_input("Enter: ", context="testctx")  # WHY: exercise interrupt branch
+        with caplog.at_level(logging.WARNING):  # WHY: capture warning surface
+            result = InputUtils.safe_input("Enter: ", context="testctx")  # WHY: exercise interrupt branch
         assert result == ""  # WHY: interrupt returns empty sentinel
-        assert "[INTERRUPT]" in capsys.readouterr().out  # WHY: user-facing notice surfaced
+        assert "[INTERRUPT]" in caplog.text  # WHY: operator notice surfaced via logger
 
 
 class TestPrivateHelpersDirect:
@@ -154,17 +154,19 @@ class TestPrivateHelpersDirect:
         assert result == ""  # WHY: sentinel empty returned
         assert any("not allowed" in rec.message for rec in caplog.records)  # WHY: warning logged
 
-    def test_handle_eof_returns_default(self, capsys: pytest.CaptureFixture[str]) -> None:
-        # WHY: EOF handler returns the default and prints a notice
-        result = InputUtils._handle_eof("ctx", "def")  # WHY: direct call
+    def test_handle_eof_returns_default(self, caplog: pytest.LogCaptureFixture) -> None:
+        # WHY: EOF handler returns the default and logs a WARNING notice (#886 Phase 2)
+        with caplog.at_level(logging.WARNING):  # WHY: capture warning surface
+            result = InputUtils._handle_eof("ctx", "def")  # WHY: direct call
         assert result == "def"  # WHY: default returned
-        assert "[EOF]" in capsys.readouterr().out  # WHY: notice surfaced
+        assert "[EOF]" in caplog.text  # WHY: operator notice surfaced via logger
 
-    def test_handle_interrupt_returns_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
-        # WHY: interrupt handler returns "" and prints a notice
-        result = InputUtils._handle_interrupt("ctx")  # WHY: direct call
+    def test_handle_interrupt_returns_empty(self, caplog: pytest.LogCaptureFixture) -> None:
+        # WHY: interrupt handler returns "" and logs a WARNING notice (#886 Phase 2)
+        with caplog.at_level(logging.WARNING):  # WHY: capture warning surface
+            result = InputUtils._handle_interrupt("ctx")  # WHY: direct call
         assert result == ""  # WHY: sentinel empty returned
-        assert "[INTERRUPT]" in capsys.readouterr().out  # WHY: notice surfaced
+        assert "[INTERRUPT]" in caplog.text  # WHY: operator notice surfaced via logger
 
 
 class TestSafeInputDefaultArguments:


### PR DESCRIPTION
## Summary
- First slice of the #886 print-avoidance rollout (targeting T20 selector flip repo-wide once all `src/` subdirs are print-free)
- Retires the 3 `print()` calls in `src/utils/` (`input_utils._handle_eof`, `input_utils._handle_interrupt`, `filter_operator_engine.validate_operator_value`)
- Collapses each `print()` + `logging.info()` pair into a single `logging.warning(...)` so operators still see the notice under the default root-logger config (INFO is suppressed by default; WARNING is not)
- Updates 3 companion unit tests to assert against `caplog.text` instead of `capsys.readouterr().out`

## Scope note
- This is slice 1 of ~20+. Follow-up slices (one per `src/` subdirectory, oldest-first by print count) will land as independent PRs referencing #886. The T20 ruff selector flip and the E402 audit land after all `src/` subdirs are print-free.

## Test plan
- [x] `pytest tests/unit/utils/` — 101 passed
- [x] `pytest tests/guardrails/test_operation_registry_menu_coverage.py` — 5 passed
- [x] `black --check src/utils/ tests/unit/utils/` — clean
- [x] `ruff check src/utils/ tests/unit/utils/` — clean
- [ ] CI green on this PR

Refs #886