### PR TITLE
chore(logging): migrate src/config/ print() to logger (#886 slice 3/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 3/N: retire `print()` in `src/config/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 7 remaining `print()`
+  calls in `src/config/config_utils.py` with `logging.error(...)` /
+  `logging.warning(...)` so the print-avoidance rule (T20 selector target of
+  #886) can eventually be enabled repo-wide. Touched
+  `_resolve_org_id_via_prompt` (three `--test`/`--testinteractive`
+  fail-closed messages, no-session guard, no-orgs-returned guard) and
+  `check_stop_signal` (stop-signal detection notice). ERROR level chosen for
+  the fatal-abort paths and WARNING for the operator-visible stop notice so
+  both surface on the default root-logger configuration (INFO is suppressed by
+  default). The `check_stop_signal` `print(...)` + `logging.info(...)` pair
+  was collapsed into a single WARNING line. Companion unit test
+  `tests/unit/test_config_utils_org_id_preflight.py::test_test_mode_fails_closed_without_calling_select_org`
+  was updated to assert against `caplog.text` instead of
+  `capsys.readouterr().out`. Third of ~20+ per-subdirectory slices of #886;
+  T20 selector flip and E402 audit will land after all `src/` subdirs are
+  print-free.
+
 ### #886 Phase 2 slice 2/N: retire `print()` in `src/audit/` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`

--- a/src/config/config_utils.py
+++ b/src/config/config_utils.py
@@ -105,23 +105,27 @@ class ConfigUtils:
         # actionable message naming the real variable (org_id, not MIST_ORG_ID) before any network call.
         if "--test" in sys.argv or "--testinteractive" in sys.argv:  # Non-interactive systematic test mode.
             logging.error("Cannot resolve org_id non-interactively for --test/--testinteractive: none configured.")
-            print("[ERROR] No organization id configured for --test/--testinteractive.")
-            print("[ERROR] Set 'org_id' (or 'ORG_ID') in your environment, or add an 'org_id=' line to .env.")
-            print(
-                "[ERROR] Copy deploy/.env.example to .env for the full variable list (note: org_id, "
+            # WHY (#886 Phase 2): retiring print() in favor of logging.error so operators still see the
+            # actionable guidance on the default root-logger config (ERROR is always emitted).
+            logging.error("No organization id configured for --test/--testinteractive.")
+            logging.error("Set 'org_id' (or 'ORG_ID') in your environment, or add an 'org_id=' line to .env.")
+            logging.error(
+                "Copy deploy/.env.example to .env for the full variable list (note: org_id, "
                 "not MIST_ORG_ID, is read by this path)."
             )
             sys.exit(1)  # Fail closed before mistapi.cli.select_org() can issue a malformed-URL request.
         logging.info("* No org_id found in .env or CLI. Prompting user...")  # Prompt the user as last resort.
         if cls._apisession is None:  # No session was ever injected.
             logging.error("Cannot prompt for org selection: no mistapi session injected via set_apisession().")
-            print("[ERROR] Cannot select an organization without an authenticated API session.")
+            # WHY (#886 Phase 2): retire print() in favor of logging.error (surfaces on default root-logger).
+            logging.error("Cannot select an organization without an authenticated API session.")
             sys.exit(1)  # Abort: prompt path is unreachable without a session.
         org_id_list = mistapi.cli.select_org(cls._apisession)  # Interactive org selection using injected session.
         if not org_id_list:  # Selection returned nothing.
             logging.error("Failed to retrieve org list. Check your API token and authentication.")
-            print("[ERROR] Unable to retrieve organizations. Your API token may be invalid or expired.")
-            print("[ERROR] Please update MIST_API_TOKEN in your .env file and try again.")
+            # WHY (#886 Phase 2): retire print() in favor of logging.error (surfaces on default root-logger).
+            logging.error("Unable to retrieve organizations. Your API token may be invalid or expired.")
+            logging.error("Please update MIST_API_TOKEN in your .env file and try again.")
             sys.exit(1)  # Abort: no org to proceed with.
         return str(org_id_list[0])  # Use the first selected org (explicit str cast: mistapi returns Any).
 
@@ -167,7 +171,8 @@ class ConfigUtils:
                 os.remove("stop_loop.txt")  # Consume the sentinel once.
             except OSError:  # Ignore removal races.
                 pass  # Best-effort cleanup only.
-            print(" Stop signal detected. Ending operation early.")  # Notify the user of early stop.
-            logging.info("Stop signal (stop_loop.txt) detected - operation stopped by user.")  # Log user stop.
+            # WHY (#886 Phase 2): consolidate print+info into single WARNING so operator sees stop
+            # notification on the default root-logger config (INFO is suppressed by default).
+            logging.warning("Stop signal (stop_loop.txt) detected - operation stopped by user.")
             return True  # Signal callers to stop.
         return False  # No stop requested.

--- a/tests/unit/test_config_utils_org_id_preflight.py
+++ b/tests/unit/test_config_utils_org_id_preflight.py
@@ -10,6 +10,7 @@ behavior is unchanged. Zero network, zero real credentials.
 
 from __future__ import annotations
 
+import logging  # WHY (#886 Phase 2): assert against caplog after print()->logging.error migration.
 from unittest.mock import MagicMock
 
 import pytest
@@ -42,7 +43,7 @@ class TestConfigUtilsOrgIdPreflight:
     """Fail-closed org-id resolution in systematic test modes; unchanged interactive behavior."""
 
     @pytest.mark.parametrize("flag", ["--test", "--testinteractive"])
-    def test_test_mode_fails_closed_without_calling_select_org(self, monkeypatch, capsys, flag):
+    def test_test_mode_fails_closed_without_calling_select_org(self, monkeypatch, caplog, flag):
         """Test mode + no org id anywhere -> exit with actionable message; select_org never called."""
         _reset_config_state(monkeypatch)
         monkeypatch.setattr("sys.argv", ["MistHelper.py", flag])  # WHY: simulate the systematic test invocation.
@@ -50,12 +51,14 @@ class TestConfigUtilsOrgIdPreflight:
             monkeypatch
         )  # WHY: prove the guarded path never reaches SDK selection.
 
-        with pytest.raises(SystemExit) as exc_info:
-            ConfigUtils.get_cached_or_prompted_org_id()
+        # WHY (#886 Phase 2): print() replaced with logging.error; assert against caplog not capsys.
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exc_info:
+                ConfigUtils.get_cached_or_prompted_org_id()
 
         assert exc_info.value.code == 1
         select_org_spy.assert_not_called()  # WHY: the whole point - no malformed-URL request is issued.
-        out = capsys.readouterr().out
+        out = caplog.text
         assert "org_id" in out and "ORG_ID" in out, "must name the exact env vars the code reads"
         assert "deploy/.env.example" in out, "must reference the template file to copy"
         assert "to .env" in out, "must direct operators to the root .env file ConfigUtils reads"


### PR DESCRIPTION
## Summary

Slice 3 of ~20+ per-subdirectory slices retiring `print()` in favor of `logging` (parent issue #886). Migrates the 7 remaining `print()` calls in `src/config/config_utils.py` so the T20 selector can eventually be flipped repo-wide.

## What changed

- `_resolve_org_id_via_prompt`:
  - 3 `--test`/`--testinteractive` fail-closed messages → `logging.error`
  - No-session guard message → `logging.error`
  - No-orgs-returned messages → `logging.error`
- `check_stop_signal`: consolidated `print(...) + logging.info(...)` pair into a single `logging.warning(...)` (WARNING surfaces on the default root-logger config; INFO is suppressed).

## Why

ERROR is always emitted on the default root logger, so operators still see the actionable "set `org_id` in .env / copy `deploy/.env.example`" guidance when the fail-closed path fires. WARNING is likewise always visible, so the stop-signal notice is unaffected. This mirrors the pattern used in slices 1 and 2.

## Test plan

- [x] `pytest tests/unit/test_config_utils_org_id_preflight.py -v` — 3 passed
- [x] `pytest tests/unit/test_config_utils*.py` — 21 passed
- [x] `black --check src/config/ tests/unit/test_config_utils_org_id_preflight.py` — clean
- [x] `ruff check src/config/ tests/unit/test_config_utils_org_id_preflight.py` — clean
- [x] No remaining `print(` calls in `src/config/`

Refs #886.