### PR TITLE
chore(logging): migrate src/cache/ print() to logger (#886 slice 4/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 4/N: retire `print()` in `src/cache/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 9 remaining `print()`
+  calls in `src/cache/cache_utils.py` with `logging.warning(...)` /
+  `logging.error(...)` so the print-avoidance rule (T20 selector target of
+  #886) can eventually be enabled repo-wide. Touched `clear_cache` (empty
+  state, discovered-files banner, per-file list, cleared-summary), `_scan_cache_candidates`
+  (I/O error path), `_delete_cache_files` (per-file OSError path),
+  `create_address_parse_failures_csv` (success and failure notices), and
+  `fast_cache_hit` (cache-hit notice). WARNING level chosen for operator-visible
+  summaries so they surface on the default root-logger configuration (INFO is
+  suppressed by default); ERROR level for the two failure paths. Existing
+  `print(...)` + `logging.info(...)` pairs were collapsed into single WARNING
+  lines to avoid double-emission. Companion unit tests in
+  `tests/unit/cache/test_cache_utils.py` were updated to assert against
+  `caplog.text` instead of `capsys.readouterr().out`. Fourth of ~20+
+  per-subdirectory slices of #886; T20 selector flip and E402 audit will
+  land after all `src/` subdirs are print-free.
+
 ### #886 Phase 2 slice 3/N: retire `print()` in `src/config/` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 7 remaining `print()`

--- a/src/cache/cache_utils.py
+++ b/src/cache/cache_utils.py
@@ -208,15 +208,18 @@ class CacheUtils:
         if candidates is None:  # Directory could not be listed (already reported by the scanner)
             return  # Abort -- nothing to delete if we can't list the directory
         if not candidates:  # Nothing to delete -- inform operator and return early
-            print("! No generated cache CSV files found to delete.")  # User-friendly empty state message
-            logging.info("No generated cache CSVs found in %s", data_dir)  # Log empty result
+            # WHY (#886 Phase 2): consolidate print+info into single WARNING so operator sees notice
+            # on the default root-logger config (INFO is suppressed by default).
+            logging.warning("No generated cache CSV files found to delete.")
             return  # Early return -- nothing to do
-        print(f"Found {len(candidates)} generated cache CSV file(s) to delete:")  # Show operator what will be removed
+        logging.warning(
+            "Found %d generated cache CSV file(s) to delete:", len(candidates)
+        )  # Show operator what will be removed (WARNING surfaces on default root-logger)
         for name in sorted(candidates):  # Sort for readable output
-            print(f"  {name}")  # List each file so operator knows exactly what is affected
+            logging.warning("  %s", name)  # List each file so operator knows exactly what is affected
         deleted, errors = CacheUtils._delete_cache_files(data_dir, candidates)  # Delete each file, counting outcomes
-        print(f"! Cache cleared: {deleted} file(s) deleted, {errors} error(s).")  # Summary line for operator
-        logging.info("Cache clear complete: %d deleted, %d errors", deleted, errors)  # Log summary for post-run review
+        # WHY (#886 Phase 2): consolidate print+info into single WARNING for post-run operator summary.
+        logging.warning("Cache cleared: %d file(s) deleted, %d error(s).", deleted, errors)
 
     @staticmethod
     def _scan_cache_candidates(data_dir: str) -> list[str] | None:  # List generated cache files, or None on error
@@ -228,7 +231,8 @@ class CacheUtils:
             ]  # Keep only MistHelper-generated cache files (safe to delete)
         except OSError as scan_error:  # Permission or missing-directory error
             logging.error("Failed to list data directory %s: %s", data_dir, scan_error)  # Log I/O failure with context
-            print(f"! Error scanning data directory: {scan_error}")  # Surface error to operator
+            # WHY (#886 Phase 2): retire print() in favor of logging.error (surfaces on default root-logger).
+            logging.error("Error scanning data directory: %s", scan_error)
             return None  # Signal the caller to abort
 
     @staticmethod
@@ -245,7 +249,8 @@ class CacheUtils:
                 deleted += 1  # Increment success counter
             except OSError as delete_error:  # Handle individual file deletion failures
                 logging.error("Failed to delete %s: %s", full_path, delete_error)  # Log failure with path and reason
-                print(f"  ! Could not delete {name}: {delete_error}")  # Surface individual failure to operator
+                # WHY (#886 Phase 2): retire print() in favor of logging.error (surfaces on default root-logger).
+                logging.error("  Could not delete %s: %s", name, delete_error)
                 errors += 1  # Increment error counter
         return deleted, errors  # Report totals to the caller
 
@@ -266,10 +271,13 @@ class CacheUtils:
                 for failure in parse_failures:
                     writer.writerow(failure)  # One row per failure record
             logging.info("Address parsing failures documented in: %s (%s records)", filename, len(parse_failures))
-            print(f"! Address parsing failures documented in: {filename} ({len(parse_failures)} records)")
+            # WHY (#886 Phase 2): consolidate print+info into single WARNING so operator sees notice
+            # on the default root-logger config (INFO is suppressed by default).
+            logging.warning("Address parsing failures documented in: %s (%d records)", filename, len(parse_failures))
         except Exception as e:
             logging.error("Failed to create address parse failures CSV: %s", e)
-            print(f"! Failed to create address parse failures CSV: {e}")
+            # WHY (#886 Phase 2): retire print() in favor of logging.error (surfaces on default root-logger).
+            logging.error("Failed to create address parse failures CSV: %s", e)
 
     @staticmethod
     def fast_cache_hit(filename: str, max_age_minutes: int = 60) -> bool:  # Check if cached output file is fresh
@@ -284,8 +292,9 @@ class CacheUtils:
             age_seconds = time.time() - os.path.getmtime(full_path)  # Seconds since last modification
             age_minutes = age_seconds / 60.0  # Convert to minutes for readable comparison
             if age_minutes <= max_age_minutes:  # File is within the freshness window
-                logging.info("fast_cache_hit HIT: %s (%.1f min old)", filename, age_minutes)  # Log cache hit
-                print(f"! Using cached {filename} ({age_minutes:.0f} min old) -- skipping re-generation.")
+                # WHY (#886 Phase 2): consolidate print+info into single WARNING so operator sees
+                # the cache-hit notice on the default root-logger config (INFO is suppressed).
+                logging.warning("Using cached %s (%.0f min old) -- skipping re-generation.", filename, age_minutes)
                 return True  # Cache hit -- caller can skip expensive work
             logging.debug("fast_cache_hit MISS: %s is stale (%.1f min old)", filename, age_minutes)  # Log stale
             return False  # File is too old -- cache miss

--- a/tests/unit/cache/test_cache_utils.py
+++ b/tests/unit/cache/test_cache_utils.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import csv
 import importlib
+import logging  # WHY (#886 Phase 2): assert against caplog after print()->logging migration.
 import os
 import time
 from datetime import datetime, timedelta
@@ -323,31 +324,36 @@ class TestDeleteCacheFiles:
 class TestClearCache:
     """End-to-end orchestration for the Menu 175 clear-cache path."""
 
-    def test_clears_generated_files(self, tmp_path, monkeypatch, capsys):
+    def test_clears_generated_files(self, tmp_path, monkeypatch, caplog):
         """Discovers, prints, and deletes matching files, then reports totals."""
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         (data_dir / "SiteList.csv").write_text("x", encoding="utf-8")
         (data_dir / "unrelated.txt").write_text("x", encoding="utf-8")
         monkeypatch.chdir(tmp_path)
-        CacheUtils.clear_cache()
+        # WHY (#886 Phase 2): operator-visible summary is now WARNING-level via logging, not print().
+        with caplog.at_level(logging.WARNING):
+            CacheUtils.clear_cache()
         assert not (data_dir / "SiteList.csv").exists()
         assert (data_dir / "unrelated.txt").exists()
-        out = capsys.readouterr().out
-        assert "Cache cleared" in out
+        assert "Cache cleared" in caplog.text
 
-    def test_no_files_message_when_empty(self, tmp_path, monkeypatch, capsys):
+    def test_no_files_message_when_empty(self, tmp_path, monkeypatch, caplog):
         """Empty data dir prints the empty-state message without errors."""
         (tmp_path / "data").mkdir()
         monkeypatch.chdir(tmp_path)
-        CacheUtils.clear_cache()
-        assert "No generated cache CSV files found to delete." in capsys.readouterr().out
+        # WHY (#886 Phase 2): empty-state notice now WARNING via logging (see cache_utils.clear_cache).
+        with caplog.at_level(logging.WARNING):
+            CacheUtils.clear_cache()
+        assert "No generated cache CSV files found to delete." in caplog.text
 
-    def test_aborts_when_scan_fails(self, monkeypatch, capsys):
+    def test_aborts_when_scan_fails(self, monkeypatch, caplog):
         """Scan failure (None) short-circuits clear_cache without printing summary."""
         monkeypatch.setattr(CacheUtils, "_scan_cache_candidates", staticmethod(lambda _: None))
-        CacheUtils.clear_cache()
-        assert "Cache cleared" not in capsys.readouterr().out
+        # WHY (#886 Phase 2): summary line is now WARNING via logging; capture it to assert absence.
+        with caplog.at_level(logging.WARNING):
+            CacheUtils.clear_cache()
+        assert "Cache cleared" not in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -363,7 +369,7 @@ class TestCreateAddressParseFailuresCsv:
         CacheUtils.create_address_parse_failures_csv([])
         assert not (tmp_path / "AddressParseFailures.csv").exists()
 
-    def test_writes_expected_rows(self, fake_mh, tmp_path, capsys):
+    def test_writes_expected_rows(self, fake_mh, tmp_path, caplog):
         """One row per failure record is written under FilePathUtils path."""
         failures = [
             {
@@ -378,21 +384,25 @@ class TestCreateAddressParseFailuresCsv:
                 "timestamp": "2026-01-01",
             }
         ]
-        CacheUtils.create_address_parse_failures_csv(failures, "custom.csv")
+        # WHY (#886 Phase 2): operator-visible "documented in" notice is now WARNING via logging, not print().
+        with caplog.at_level(logging.WARNING):
+            CacheUtils.create_address_parse_failures_csv(failures, "custom.csv")
         content = (tmp_path / "custom.csv").read_text(encoding="utf-8").splitlines()
         assert content[0].startswith("site_id,")
         assert "123 Main" in content[1]
-        assert "documented in" in capsys.readouterr().out
+        assert "documented in" in caplog.text
 
-    def test_swallows_write_exception(self, fake_mh, monkeypatch, capsys):
-        """OSError during write is logged and printed but does not raise."""
+    def test_swallows_write_exception(self, fake_mh, monkeypatch, caplog):
+        """OSError during write is logged but does not raise."""
 
         def _bad_open(*_a, **_kw):
             raise OSError("disk full")
 
         monkeypatch.setattr("src.cache.cache_utils.open", _bad_open, raising=False)
-        CacheUtils.create_address_parse_failures_csv([{"site_id": "x"}])
-        assert "Failed to create address parse failures CSV" in capsys.readouterr().out
+        # WHY (#886 Phase 2): failure notice migrated from print() to logging.error; capture via caplog.
+        with caplog.at_level(logging.ERROR):
+            CacheUtils.create_address_parse_failures_csv([{"site_id": "x"}])
+        assert "Failed to create address parse failures CSV" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -407,11 +417,13 @@ class TestFastCacheHit:
         """Missing file is a cache miss."""
         assert CacheUtils.fast_cache_hit("nope.csv") is False
 
-    def test_returns_true_when_fresh(self, fake_mh, tmp_path, capsys):
-        """Fresh file returns True and prints the operator-facing message."""
+    def test_returns_true_when_fresh(self, fake_mh, tmp_path, caplog):
+        """Fresh file returns True and emits the operator-facing message."""
         (tmp_path / "fresh.csv").write_text("x", encoding="utf-8")
-        assert CacheUtils.fast_cache_hit("fresh.csv", max_age_minutes=60) is True
-        assert "Using cached fresh.csv" in capsys.readouterr().out
+        # WHY (#886 Phase 2): cache-hit notice migrated from print() to logging.warning.
+        with caplog.at_level(logging.WARNING):
+            assert CacheUtils.fast_cache_hit("fresh.csv", max_age_minutes=60) is True
+        assert "Using cached fresh.csv" in caplog.text
 
     def test_returns_false_when_stale(self, fake_mh, tmp_path):
         """Stale file returns False so caller regenerates."""


### PR DESCRIPTION
## Summary

- Replace the 9 remaining `print()` calls in `src/cache/cache_utils.py` with `logging.warning()` / `logging.error()`.
- Collapse existing `print(...)` + `logging.info(...)` pairs into single WARNING emissions so operators still see the notices under the default root-logger configuration (INFO suppressed by default).
- Update companion pytest cases in `tests/unit/cache/test_cache_utils.py` to assert against `caplog.text` instead of `capsys.readouterr().out`.

Fourth of ~20+ per-subdirectory slices toward enabling T20 in `pyproject.toml`. T20 selector flip and E402 audit land after all `src/` subdirs are print-free.

Refs #886

## Test plan

- [x] `pytest tests/unit/cache/test_cache_utils.py -v` → 33 passed
- [x] `black --check src/cache/ tests/unit/cache/test_cache_utils.py`
- [x] `ruff check src/cache/ tests/unit/cache/test_cache_utils.py`
- [ ] CI green on PR