### PR TITLE
chore(logging): migrate src/api/ print() to logger (#886 slice 5/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 5/N: retire `print()` in `src/api/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 14 remaining `print()`
+  calls in `src/api/api_data_fetcher.py` with `logging.warning(...)` /
+  `logging.error(...)` so the print-avoidance rule (T20 selector target of
+  #886) can eventually be enabled repo-wide. Touched `_log_entry` (fetch-start
+  banner), `_log_retry_attempt` (retry backoff notice), `_save_recovered_data`
+  (unexpected-structure + recovered-rows notices), `_handle_no_recovery`
+  (unrecoverable-data notice), `_handle_rate_limit` (partial-save notice),
+  `_emergency_save_and_raise` (emergency-save notice), `_handle_outer_exception`
+  (no-data-collected notice), `_save_partial_data_on_error` (five-line summary
+  block + save-failure error), and `_export_and_display_data` (records-exported
+  notice). WARNING level chosen for operator-visible summaries so they surface
+  on the default root-logger configuration (INFO is suppressed by default);
+  ERROR level for the two failure paths (`_handle_no_recovery`,
+  `_save_partial_data_on_error` write failure). Existing `print(...)` +
+  `logging.info(...)` pairs were collapsed into single WARNING lines and the
+  redundant error-path `print(...)` in `_handle_api_exception` was retired.
+  Companion unit tests in `tests/unit/api/test_api_data_fetcher.py` (12 tests)
+  were updated to assert against `caplog.text` under
+  `caplog.at_level(logging.WARNING/ERROR)` instead of
+  `capsys.readouterr().out`. Fifth of ~20+ per-subdirectory slices of #886;
+  T20 selector flip and E402 audit will land after all `src/` subdirs are
+  print-free.
+
 ### #886 Phase 2 slice 4/N: retire `print()` in `src/cache/` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 9 remaining `print()`

--- a/src/api/api_data_fetcher.py
+++ b/src/api/api_data_fetcher.py
@@ -90,8 +90,9 @@ class APIDataFetcher:
             self.sort_key,
             self.kwargs,
         )
-        logging.info("Starting data fetch: %s", self.title)  # Log fetch start.
-        print(self.title)  # Show the title.
+        # WHY (#886 Phase 2): consolidated print()+logging.info into a single WARNING so the title
+        # remains operator-visible without duplicating notices on the terminal.
+        logging.warning("Starting data fetch: %s", self.title)  # Fetch-start notice (operator-visible).
 
     # =========================================================================
     # API CALL METHODS
@@ -138,14 +139,15 @@ class APIDataFetcher:
         """Log a warning, print user-visible retry notice, and sleep for the backoff window."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of retry-ceiling constant.
         max_retries = mh.API_REQUEST_MAX_RETRIES  # Retry ceiling.
-        logging.warning(  # Warn and back off.
+        # WHY (#886 Phase 2): retired duplicate print(); logging.warning below already reaches the
+        # operator terminal via the WARNING-level default handler.
+        logging.warning(  # Warn and back off (operator-visible).
             "API call %s failed (attempt %s/%s) - retrying in %.0fs",
             api_name,
             attempt + 1,
             max_retries + 1,
             delay,
         )
-        print(f"! API call timed out - retrying in {delay:.0f}s (attempt {attempt + 2}/{max_retries + 1})")
         time.sleep(delay)  # Wait before retry.
 
     @staticmethod
@@ -230,22 +232,27 @@ class APIDataFetcher:
     def _save_recovered_data(self) -> None:  # Persist recovered rows.
         """Save recovered data and notify user."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
-        print(f"! API returned unexpected structure. Recovered {len(self.rawdata)} records.")  # Tell the user.
+        # WHY (#886 Phase 2): promoted print() + logging.info to WARNING so the recovery notice
+        # remains operator-visible without duplicate terminal output.
+        logging.warning("API returned unexpected structure. Recovered %s records.", len(self.rawdata))
         api_name = self.api_call.__name__  # API callable name.
         mh.DataExporter.write_with_format_selection(self.rawdata, self.filename, api_function_name=api_name)
-        logging.info("Recovered data saved to %s (%s rows)", self.filename, len(self.rawdata))  # log saved.
+        logging.warning("Recovered data saved to %s (%s rows)", self.filename, len(self.rawdata))
 
     def _handle_no_recovery(self) -> None:  # Report unrecoverable response.
         """Handle case where no data could be recovered."""
-        print("! API response missing expected 'results' key. No data could be recovered.")  # Tell the user.
+        # WHY (#886 Phase 2): print() replaced with logging.error so the failure notice stays
+        # operator-visible via the ERROR-level default handler.
+        logging.error("API response missing expected 'results' key. No data could be recovered.")
         logging.error("Unable to recover any data from malformed response for %s", self.title)  # log no recovery.
         logging.debug("EXIT: APIDataFetcher - structure error, no recovery")  # Trace exit.
 
     def _handle_api_exception(self, error: Exception) -> None:  # Handle a fetch exception.
         """Handle exceptions during API data retrieval."""
+        # WHY (#886 Phase 2): retired duplicate print(); the logging.error calls below already
+        # surface the failure via the ERROR-level default handler.
         logging.error("Exception occurred during API data retrieval: %s", error)  # log exception.
         logging.error("Exception type: %s", type(error).__name__)  # log type.
-        print(f"! Exception occurred during API call: {error}")  # Tell the user.
 
         if self._is_rate_limit_error(error):  # Rate limited?
             self._handle_rate_limit()  # Save partial and stop.
@@ -266,8 +273,9 @@ class APIDataFetcher:
         if self.rawdata:  # Have partial data?
             api_name = self.api_call.__name__  # API callable name.
             mh.DataExporter.write_with_format_selection(self.rawdata, self.filename, api_function_name=api_name)
-            logging.info("Partial results saved to %s (%s rows)", self.filename, len(self.rawdata))  # log partial.
-            print(f"* Partial data saved: {len(self.rawdata)} records written to {self.filename}")  # Tell the user.
+            # WHY (#886 Phase 2): consolidated print()+logging.info into a single WARNING so the
+            # partial-save notice stays operator-visible without duplicate terminal output.
+            logging.warning("Partial data saved: %s records written to %s", len(self.rawdata), self.filename)
 
         logging.debug("EXIT: APIDataFetcher - rate limited")  # Trace exit.
 
@@ -278,8 +286,9 @@ class APIDataFetcher:
             try:
                 api_name = self.api_call.__name__  # API callable name.
                 mh.DataExporter.write_with_format_selection(self.rawdata, self.filename, api_function_name=api_name)
-                logging.info("Emergency save: %s partial records saved before error exit", len(self.rawdata))
-                print(f"* Emergency save: {len(self.rawdata)} partial records written to {self.filename}")
+                # WHY (#886 Phase 2): consolidated print()+logging.info into a single WARNING so
+                # the emergency-save notice remains operator-visible via the default handler.
+                logging.warning("Emergency save: %s partial records written to %s", len(self.rawdata), self.filename)
             except Exception as save_error:  # Save failed.
                 logging.error("Failed to save partial data during error handling: %s", save_error)  # log save fail.
 
@@ -294,7 +303,9 @@ class APIDataFetcher:
         if self.rawdata:  # Have partial data?
             self._save_partial_data_on_error(error)  # Save what we have.
         else:
-            print("! No data was collected before the error occurred")  # Tell the user none saved.
+            # WHY (#886 Phase 2): print() replaced with logging.warning so operator terminal
+            # still surfaces the "nothing collected" notice via the default WARNING handler.
+            logging.warning("No data was collected before the error occurred")
 
         logging.debug("EXIT: APIDataFetcher - error")  # Trace exit.
 
@@ -304,15 +315,22 @@ class APIDataFetcher:
         try:
             api_name = self.api_call.__name__  # API callable name.
             mh.DataExporter.write_with_format_selection(self.rawdata, self.filename, api_function_name=api_name)
-            logging.info("Partial results saved to %s (%s rows)", self.filename, len(self.rawdata))  # log partial.
-
-            print("\n!! PARTIAL DATA SAVED !!")  # Notify the user.
-            print(f"   * Despite the error, {len(self.rawdata)} records were successfully saved to {self.filename}")
-            print(f"   * Error: {str(error)}")  # Show the error.
-            print("   * You can retry the operation later to get remaining data")  # Suggest a retry.
+            # WHY (#886 Phase 2): consolidated logging.info + 4 print() calls into WARNING lines
+            # so the "partial data saved" banner remains operator-visible without duplicates.
+            logging.warning("Partial results saved to %s (%s rows)", self.filename, len(self.rawdata))
+            logging.warning("PARTIAL DATA SAVED")
+            logging.warning(
+                "Despite the error, %s records were successfully saved to %s",
+                len(self.rawdata),
+                self.filename,
+            )
+            logging.warning("Error: %s", str(error))
+            logging.warning("You can retry the operation later to get remaining data")
         except Exception as save_error:  # Save failed.
-            logging.error("Failed to save partial data in outer exception handler: %s", save_error)  # log save fail.
-            print(f"! Critical: Could not save partial data. Error: {save_error}")  # Tell the user.
+            # WHY (#886 Phase 2): consolidated print() with logging.error so the critical failure
+            # surfaces once through the ERROR-level default handler.
+            logging.error("Failed to save partial data in outer exception handler: %s", save_error)
+            logging.error("Critical: Could not save partial data. Error: %s", save_error)
 
     # =========================================================================
     # DATA PROCESSING AND DISPLAY METHODS
@@ -327,7 +345,9 @@ class APIDataFetcher:
         mh.DataExporter.export_with_processing(
             self.rawdata, self.filename, sort_key=self.sort_key, api_function_name=api_name
         )
-        print(f"! {len(self.rawdata)} records exported to {self.filename}")  # Tell the user.
+        # WHY (#886 Phase 2): print() replaced with logging.warning so the export-count notice
+        # remains operator-visible via the WARNING-level default handler.
+        logging.warning("%s records exported to %s", len(self.rawdata), self.filename)
 
         self._display_table()  # Render the table.
 

--- a/tests/unit/api/test_api_data_fetcher.py
+++ b/tests/unit/api/test_api_data_fetcher.py
@@ -223,19 +223,19 @@ class TestLogRetryAttempt:
         self,
         fake_mh: _FakeMH,
         caplog: pytest.LogCaptureFixture,
-        capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Method must warn, print, and sleep for the exact backoff window.
+        """Method must warn and sleep for the exact backoff window.
 
         Why:
-            All three side-effects are user-visible (log stream, stdout, real
-            wall-clock time) so any regression there hides retry timing bugs.
+            Both side-effects are user-visible (log stream, real wall-clock
+            time) so any regression there hides retry timing bugs. Per #886
+            Phase 2 the duplicate print() was retired; the WARNING log now
+            carries the "retrying in" notice.
         """
         with caplog.at_level(logging.WARNING):
             APIDataFetcher._log_retry_attempt("listOrgSites", attempt=0, delay=2.0)
         assert "listOrgSites" in caplog.text
-        out = capsys.readouterr().out
-        assert "retrying in 2s" in out or "retrying in 2s" in out
+        assert "retrying in 2s" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -453,63 +453,78 @@ class TestSaveHelpers:
         self,
         fake_mh: _FakeMH,
         api_call: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Recovered data must flow through ``DataExporter.write_with_format_selection``."""
+        """Recovered data must flow through ``DataExporter.write_with_format_selection``.
+
+        Why:
+            Per #886 Phase 2, the recovery notices moved from print() to
+            ``logging.warning``; the assertion reads ``caplog.text`` so the
+            operator-visible surface is still verified.
+        """
         fetcher = _make_fetcher(api_call)
         fetcher.rawdata = [{"id": 1}]
-        fetcher._save_recovered_data()
+        with caplog.at_level(logging.WARNING):
+            fetcher._save_recovered_data()
         fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(
             [{"id": 1}], "sites.csv", api_function_name="listOrgSites"
         )
-        assert "Recovered 1" in capsys.readouterr().out
+        assert "Recovered 1" in caplog.text
 
     def test_handle_no_recovery_prints_and_logs(
         self,
         fake_mh: _FakeMH,
         api_call: MagicMock,
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """No-recovery branch must inform both user and logs.
 
         Why:
-            Users need CLI feedback that no rows survived; ops need a log
-            entry so post-mortems can find the run.
+            Ops need a log entry so post-mortems can find the run. Per #886
+            Phase 2 the redundant print() was retired; both the user-facing
+            notice and the ERROR log now flow through ``caplog``.
         """
         fetcher = _make_fetcher(api_call)
         with caplog.at_level(logging.ERROR):
             fetcher._handle_no_recovery()
-        assert "No data could be recovered" in capsys.readouterr().out
+        assert "No data could be recovered" in caplog.text
         assert "Unable to recover" in caplog.text
 
     def test_save_partial_data_on_error_success(
-        self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]
+        self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Happy path must write partial rows and print the summary block."""
+        """Happy path must write partial rows and emit the summary block.
+
+        Why:
+            Per #886 Phase 2 the summary block moved to WARNING logs so a
+            single stream carries the notice; ``caplog`` replaces the retired
+            capsys assertion.
+        """
         fetcher = _make_fetcher(api_call)
         fetcher.rawdata = [{"id": 1}]
-        fetcher._save_partial_data_on_error(RuntimeError("boom"))
+        with caplog.at_level(logging.WARNING):
+            fetcher._save_partial_data_on_error(RuntimeError("boom"))
         fake_mh.DataExporter.write_with_format_selection.assert_called_once()
-        out = capsys.readouterr().out
-        assert "PARTIAL DATA SAVED" in out
-        assert "boom" in out
+        assert "PARTIAL DATA SAVED" in caplog.text
+        assert "boom" in caplog.text
 
     def test_save_partial_data_on_error_write_failure(
-        self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]
+        self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """DataExporter failures inside the save must be caught and reported.
 
         Why:
             The outer error handler already re-raises the original exception;
             swallowing the save error is intentional so we don't mask the
-            root cause with a secondary failure.
+            root cause with a secondary failure. Per #886 Phase 2 the notice
+            now flows through ``logging.error``.
         """
         fake_mh.DataExporter.write_with_format_selection.side_effect = OSError("disk full")
         fetcher = _make_fetcher(api_call)
         fetcher.rawdata = [{"id": 1}]
-        fetcher._save_partial_data_on_error(RuntimeError("boom"))
-        assert "Could not save partial data" in capsys.readouterr().out
+        with caplog.at_level(logging.ERROR):
+            fetcher._save_partial_data_on_error(RuntimeError("boom"))
+        assert "Could not save partial data" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -537,14 +552,20 @@ class TestRateLimitHelpers:
         assert fetcher._is_rate_limit_error(e2) is False
 
     def test_handle_rate_limit_saves_partial_when_data_present(
-        self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]
+        self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Partial rows must be flushed to disk on 429."""
+        """Partial rows must be flushed to disk on 429.
+
+        Why:
+            Per #886 Phase 2 the "Partial data saved" notice moved to
+            ``logging.warning``; ``caplog`` replaces the retired capsys check.
+        """
         fetcher = _make_fetcher(api_call)
         fetcher.rawdata = [{"id": 1}, {"id": 2}]
-        fetcher._handle_rate_limit()
+        with caplog.at_level(logging.WARNING):
+            fetcher._handle_rate_limit()
         fake_mh.DataExporter.write_with_format_selection.assert_called_once()
-        assert "Partial data saved: 2 records" in capsys.readouterr().out
+        assert "Partial data saved: 2 records" in caplog.text
 
     def test_handle_rate_limit_skips_save_when_no_data(self, fake_mh: _FakeMH, api_call: MagicMock) -> None:
         """Empty raw data on 429 must not invoke DataExporter."""
@@ -554,15 +575,20 @@ class TestRateLimitHelpers:
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
 
     def test_emergency_save_and_raise_saves_and_reraises(
-        self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]
+        self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Emergency path must persist partial rows before re-raising."""
+        """Emergency path must persist partial rows before re-raising.
+
+        Why:
+            Per #886 Phase 2 the "Emergency save" notice moved to
+            ``logging.warning``; ``caplog`` replaces the retired capsys check.
+        """
         fetcher = _make_fetcher(api_call)
         fetcher.rawdata = [{"id": 1}]
-        with pytest.raises(RuntimeError, match="kaboom"):
+        with caplog.at_level(logging.WARNING), pytest.raises(RuntimeError, match="kaboom"):
             fetcher._emergency_save_and_raise(RuntimeError("kaboom"))
         fake_mh.DataExporter.write_with_format_selection.assert_called_once()
-        assert "Emergency save: 1 partial" in capsys.readouterr().out
+        assert "Emergency save: 1 partial" in caplog.text
 
     def test_emergency_save_swallows_secondary_save_error(
         self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
@@ -626,18 +652,24 @@ class TestHandleKeyError:
         fake_mh.DataExporter.write_with_format_selection.assert_called_once()
 
     def test_reports_when_recovery_fails(
-        self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]
+        self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Unrecoverable payload must fall through to the no-recovery path."""
+        """Unrecoverable payload must fall through to the no-recovery path.
+
+        Why:
+            Per #886 Phase 2 the no-recovery notice moved to
+            ``logging.error``; ``caplog`` replaces the retired capsys check.
+        """
 
         class NoData:
             pass
 
         fetcher = _make_fetcher(api_call)
-        fetcher._handle_key_error(NoData(), KeyError("results"))
+        with caplog.at_level(logging.ERROR):
+            fetcher._handle_key_error(NoData(), KeyError("results"))
         assert fetcher.rawdata == []
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
-        assert "No data could be recovered" in capsys.readouterr().out
+        assert "No data could be recovered" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -656,12 +688,18 @@ class TestHandleOuterException:
         fake_mh.DataExporter.write_with_format_selection.assert_called_once()
 
     def test_reports_no_data_when_rawdata_empty(
-        self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]
+        self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Empty rawdata must inform the user without invoking DataExporter."""
+        """Empty rawdata must inform the user without invoking DataExporter.
+
+        Why:
+            Per #886 Phase 2 the "No data was collected" notice moved to
+            ``logging.warning``; ``caplog`` replaces the retired capsys check.
+        """
         fetcher = _make_fetcher(api_call)
-        fetcher._handle_outer_exception(RuntimeError("outer"))
-        assert "No data was collected" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            fetcher._handle_outer_exception(RuntimeError("outer"))
+        assert "No data was collected" in caplog.text
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
 
 
@@ -806,9 +844,14 @@ class TestExportAndDisplayData:
     """Coverage for :meth:`_export_and_display_data`."""
 
     def test_calls_exporter_and_display(
-        self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]
+        self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Method must invoke DataExporter with correct args and render a table."""
+        """Method must invoke DataExporter with correct args and render a table.
+
+        Why:
+            Per #886 Phase 2 the "N records exported" notice moved to
+            ``logging.warning``; ``caplog`` replaces the retired capsys check.
+        """
         fetcher = _make_fetcher(api_call, sort_key="id")
         fetcher.rawdata = [{"id": 1}]
         with (
@@ -824,12 +867,13 @@ class TestExportAndDisplayData:
                 "src.api.api_data_fetcher.DataProcessingUtils.get_unique_keys",
                 return_value=["id"],
             ),
+            caplog.at_level(logging.WARNING),
         ):
             fetcher._export_and_display_data()
         fake_mh.DataExporter.export_with_processing.assert_called_once_with(
             [{"id": 1}], "sites.csv", sort_key="id", api_function_name="listOrgSites"
         )
-        assert "1 records exported" in capsys.readouterr().out
+        assert "1 records exported" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -840,8 +884,14 @@ class TestExportAndDisplayData:
 class TestExecute:
     """End-to-end coverage of :meth:`execute`."""
 
-    def test_success_path(self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
-        """Happy path must resolve org, fetch, export, and display."""
+    def test_success_path(self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture) -> None:
+        """Happy path must resolve org, fetch, export, and display.
+
+        Why:
+            Per #886 Phase 2 the "Starting data fetch"/"N records exported"
+            notices moved to ``logging.warning``; ``caplog`` replaces the
+            retired capsys check.
+        """
         api_call.return_value = MagicMock(status_code=200)
         fetcher = _make_fetcher(api_call)
         with (
@@ -858,13 +908,13 @@ class TestExecute:
                 "src.api.api_data_fetcher.DataProcessingUtils.get_unique_keys",
                 return_value=["id"],
             ),
+            caplog.at_level(logging.WARNING),
         ):
             fetcher.execute()
         assert fetcher.org_id == "org-123"
         fake_mh.DataExporter.export_with_processing.assert_called_once()
-        out = capsys.readouterr().out
-        assert "Sites" in out
-        assert "1 records exported" in out
+        assert "Sites" in caplog.text
+        assert "1 records exported" in caplog.text
 
     def test_returns_early_when_no_data(
         self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
@@ -894,9 +944,15 @@ class TestExecute:
         assert "No data returned" in caplog.text
 
     def test_outer_exception_logs_and_reraises(
-        self, fake_mh: _FakeMH, api_call: MagicMock, capsys: pytest.CaptureFixture[str]
+        self, fake_mh: _FakeMH, api_call: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A raised exception must go through the outer handler and re-raise."""
+        """A raised exception must go through the outer handler and re-raise.
+
+        Why:
+            Per #886 Phase 2 the "PARTIAL DATA SAVED"/"Emergency save"
+            notices moved to ``logging.warning``; ``caplog`` replaces the
+            retired capsys check.
+        """
         api_call.return_value = MagicMock(status_code=200)
         fetcher = _make_fetcher(api_call)
         fetcher.rawdata = [{"id": 99}]  # simulate partial fetch before failure
@@ -905,11 +961,11 @@ class TestExecute:
                 "src.api.api_data_fetcher.mistapi.get_all",
                 side_effect=RuntimeError("boom"),
             ),
+            caplog.at_level(logging.WARNING),
             pytest.raises(RuntimeError, match="boom"),
         ):
             fetcher.execute()
         # emergency save happened *inside* _handle_api_exception,
         # then outer handler ran again on the re-raise
         assert fake_mh.DataExporter.write_with_format_selection.call_count >= 1
-        out = capsys.readouterr().out
-        assert "PARTIAL DATA SAVED" in out or "Emergency save" in out
+        assert "PARTIAL DATA SAVED" in caplog.text or "Emergency save" in caplog.text


### PR DESCRIPTION
## Summary

Slice 5/N of #886 Phase 2: retire the 14 remaining `print()` calls in `src/api/api_data_fetcher.py`, replacing them with `logging.warning(...)` / `logging.error(...)` per severity. Companion tests migrated from `capsys` to `caplog`.

- Source: `src/api/api_data_fetcher.py` — 14 `print()` → logger calls (WARNING for user-visible notices, ERROR for failure paths).
- Tests: `tests/unit/api/test_api_data_fetcher.py` — 12 tests re-wired from `capsys.readouterr().out` to `caplog.text` under `caplog.at_level(...)`.
- Ruff T20 selector still off globally — flip lands with the final #886 PR after all subdirectory slices merge.

Refs: #886

## Test plan

- [x] `pytest tests/unit/api/` — 87 passed locally
- [x] `black --check src/api/ tests/unit/api/` — clean
- [x] `ruff check src/api/ tests/unit/api/` — clean
- [ ] CI green on this PR