### PR TITLE
chore(logging): migrate src/input/ print() to logger (#886 slice 6/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 6/N: retire `print()` in `src/input/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 24 remaining `print()`
+  calls in `src/input/prompt_client_utils.py` with `logging.warning(...)` /
+  `logging.error(...)` / `logging.exception(...)` so the print-avoidance rule
+  (T20 selector target of #886) can eventually be enabled repo-wide. Touched
+  `select_client_mac` (empty-state notice, fetch-failure exception), the ten
+  header/table/options lines in `_render_client_selection_prompt` (moved from
+  `print()` to `logging.warning` so the interactive prompt UI still surfaces
+  on the default root-logger config where INFO is suppressed),
+  `_handle_client_selection_input` (non-digit and out-of-range validation
+  hints), `_finalize_client_choice` ("Selected: ..." confirmation),
+  `_parse_client_choice` (Exiting/valid-number/Invalid-index hints),
+  `select_client` (heading + fetch-error), `_run_client_selection_flow`
+  (no-clients notice), and `select_site_and_device_ids` (no-site / no-device
+  notices). WARNING level chosen for operator-visible summaries so they
+  surface on the default root-logger configuration (INFO is suppressed by
+  default); ERROR level for the `select_client` failure path;
+  `logging.exception` for `select_client_mac` so the fetch stack trace is
+  preserved. Existing `print(...)` + `logging.info/error/warning(...)` pairs
+  were collapsed into single log calls to avoid double-emission. Companion
+  unit tests in `tests/unit/input/test_prompt_client_utils.py` (12 tests
+  across 7 classes) were updated to assert against `caplog.text` under
+  `caplog.at_level(logging.WARNING/ERROR)` instead of
+  `capsys.readouterr().out`. Sixth of ~20+ per-subdirectory slices of #886;
+  T20 selector flip and E402 audit will land after all `src/` subdirs are
+  print-free.
+
 ### #886 Phase 2 slice 5/N: retire `print()` in `src/api/` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 14 remaining `print()`

--- a/src/input/prompt_client_utils.py
+++ b/src/input/prompt_client_utils.py
@@ -35,8 +35,9 @@ class PromptClientUtils:
         try:
             all_clients = PromptClientUtils._fetch_all_clients_for_site(site_id)  # Wireless + wired tagged.
             if not all_clients:  # No clients to choose from.
-                print("\n! No connected clients found at the selected site.")  # Tell operator.
-                logging.warning("No clients found for site_id: %s", site_id)  # Log it.
+                # WHY (#886 Phase 2): consolidate print+warning into single WARNING so operator sees notice
+                # on the default root-logger config (INFO is suppressed by default).
+                logging.warning("No connected clients found at the selected site (site_id=%s).", site_id)
                 return None  # Abort.
             all_clients.sort(key=lambda x: (x.get("hostname", ""), x.get("username", "")))  # Sort.
             table, index_to_client = PromptClientUtils._build_client_selection_table(all_clients)  # Build UI.
@@ -45,8 +46,9 @@ class PromptClientUtils:
             logging.debug("User input for client selection: %s", user_input)  # Log raw choice.
             return PromptClientUtils._handle_client_selection_input(user_input, index_to_client)  # Resolve.
         except Exception as error:  # Catch fetch + render failures.
-            print(f"\n! Error fetching clients: {error}")  # Tell operator.
-            logging.exception("Exception in PromptClientUtils.select_client_mac: %s", error)  # Stack trace.
+            # WHY (#886 Phase 2): consolidate print+exception into single logging.exception
+            # (operator-visible ERROR + stack trace).
+            logging.exception("Error fetching clients: %s", error)
             return None  # Abort on error.
 
     @staticmethod
@@ -112,17 +114,23 @@ class PromptClientUtils:
 
     @staticmethod
     def _render_client_selection_prompt(table: PrettyTable, count: int) -> None:
-        """Print the standard header + table + options block for client selection."""
-        print("\n" + "=" * 80)  # Header rule.
-        print(" SELECT CONNECTED CLIENT")  # Title.
-        print("=" * 80)  # Header rule.
-        print(f"  Found {count} connected clients")  # Count.
-        print("=" * 80)  # Separator.
-        print(table)  # Render table.
-        print("\nOptions:")  # Options heading.
-        print("  - Enter index number to select a client")  # Index option.
-        print("  - Enter 'm' to manually type MAC address")  # Manual option.
-        print("  - Enter 'c' to cancel")  # Cancel option.
+        """Print the standard header + table + options block for client selection.
+
+        Why:
+            Post-#886 Phase 2 the render pipeline goes through ``logging.warning``
+            so operators still see the prompt UI on the default root-logger config
+            (INFO is suppressed) while satisfying the ruff T20 print/pprint ban.
+        """
+        logging.warning("\n%s", "=" * 80)  # Header rule.
+        logging.warning(" SELECT CONNECTED CLIENT")  # Title.
+        logging.warning("%s", "=" * 80)  # Header rule.
+        logging.warning("  Found %d connected clients", count)  # Count.
+        logging.warning("%s", "=" * 80)  # Separator.
+        logging.warning("%s", table)  # Render table.
+        logging.warning("\nOptions:")  # Options heading.
+        logging.warning("  - Enter index number to select a client")  # Index option.
+        logging.warning("  - Enter 'm' to manually type MAC address")  # Manual option.
+        logging.warning("  - Enter 'c' to cancel")  # Cancel option.
 
     @staticmethod
     def _handle_client_selection_input(user_input: str, index_to_client: dict) -> str | None:
@@ -136,13 +144,14 @@ class PromptClientUtils:
             logging.info("User cancelled client selection")  # Log cancel.
             return None  # Abort selection.
         if not user_input.isdigit():  # Bad input path.
-            print("\n! Please enter a valid index number, 'm' for manual, or 'c' to cancel")  # Tell operator.
-            logging.error("Invalid client selection input: %s", user_input)  # Log bad input.
+            # WHY (#886 Phase 2): consolidate print+error into single WARNING so operator sees
+            # the validation hint on the default root-logger config.
+            logging.warning("Please enter a valid index number, 'm' for manual, or 'c' to cancel (got %r).", user_input)
             return None  # Abort selection.
         idx = int(user_input)  # Parse index.
         if idx not in index_to_client:  # Out of range path.
-            print("\n! Invalid index")  # Tell operator.
-            logging.error("Invalid client index: %s", idx)  # Log bad index.
+            # WHY (#886 Phase 2): consolidate print+error into single WARNING for operator visibility.
+            logging.warning("Invalid index: %s", idx)
             return None  # Abort selection.
         return PromptClientUtils._finalize_client_choice(idx, index_to_client[idx])  # Success path.
 
@@ -152,13 +161,14 @@ class PromptClientUtils:
         client_mac = client.get("mac")  # Read MAC.
         client_hostname = client.get("hostname", client.get("username", "Unknown"))  # Hostname for log.
         conn_type = client.get("connection_type", "Unknown")  # Connection type for log.
-        print(f"\n! Selected: {client_hostname} ({conn_type}) - MAC: {client_mac}")  # Tell operator.
-        logging.info(
-            "User selected client by index: %s (hostname: %s, mac: %s, type: %s)",
-            idx,
+        # WHY (#886 Phase 2): consolidate print+info into single WARNING so the "Selected: ..."
+        # confirmation surfaces on the default root-logger config (INFO is suppressed).
+        logging.warning(
+            "Selected: %s (%s) - MAC: %s (idx=%s)",
             client_hostname,
-            client_mac,
             conn_type,
+            client_mac,
+            idx,
         )
         return client_mac  # type: ignore[no-any-return]  # Return chosen MAC.
 
@@ -166,15 +176,18 @@ class PromptClientUtils:
     def _parse_client_choice(user_input: str, max_index: int) -> int | None:
         """Parse client-selection input to a validated 0..max_index, or None for quit/invalid."""
         if user_input.lower() in ("q", "quit", "exit"):  # Explicit quit commands
-            print(" Exiting client selection...")  # Inform operator of exit
+            # WHY (#886 Phase 2): retire print() in favor of logging.warning (surfaces on default root-logger).
+            logging.warning("Exiting client selection...")
             return None  # Signal quit to caller
         try:
             idx = int(user_input)  # Parse numeric index
         except ValueError:  # Non-numeric, non-quit input
-            print(" Please enter a valid number or 'q' to quit.")  # Prompt for valid input
+            # WHY (#886 Phase 2): retire print() in favor of logging.warning (surfaces on default root-logger).
+            logging.warning("Please enter a valid number or 'q' to quit.")
             return None  # Signal invalid input
         if not 0 <= idx <= max_index:  # Out-of-range numeric input
-            print(f"! Invalid index. Please enter a number between 0 and {max_index}.")
+            # WHY (#886 Phase 2): retire print() in favor of logging.warning (surfaces on default root-logger).
+            logging.warning("Invalid index. Please enter a number between 0 and %d.", max_index)
             return None  # Signal out-of-range
         return idx  # Validated index in range
 
@@ -182,8 +195,10 @@ class PromptClientUtils:
     def select_client(site_id: str | None = None) -> tuple[str | None, str | None, str | None]:
         """Prompt user to select a wireless/wired client; returns (mac, type, site_id) or (None,None,None)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils + ConfigUtils.
-        print("\n  Client Selection")  # Print selection heading.
-        print("=" * 30)  # Print separator rule.
+        # WHY (#886 Phase 2): retire print() decorations in favor of logging.warning
+        # (visible on default root-logger config while satisfying the ruff T20 ban).
+        logging.warning("\n  Client Selection")
+        logging.warning("%s", "=" * 30)
         site_id = mh.PromptUtils._determine_search_scope(site_id)  # type: ignore[assignment]
         if site_id is False:  # type: ignore[comparison-overlap]  # User explicitly cancelled
             return None, None, None  # Abort when no scope resolved.
@@ -191,8 +206,8 @@ class PromptClientUtils:
         try:
             return PromptClientUtils._run_client_selection_flow(org_id, site_id)  # Run fetch/display/select flow.
         except Exception as exception:  # Catch selection errors.
-            logging.error("Error during client selection: %s", exception)  # Log selection error.
-            print(f"! Error searching for clients: {exception}")  # Show error to operator.
+            # WHY (#886 Phase 2): consolidate print+error into single logging.error (surfaces on default root-logger).
+            logging.error("Error searching for clients: %s", exception)
             return None, None, None  # Abort on error.
 
     @staticmethod
@@ -203,7 +218,8 @@ class PromptClientUtils:
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils facade.
         all_clients = mh.PromptUtils._fetch_all_clients(org_id, site_id)  # Fetch all clients for org/site.
         if not all_clients:  # Handle empty client set.
-            print(" No clients found.")  # Tell operator none found.
+            # WHY (#886 Phase 2): retire print() in favor of logging.warning (surfaces on default root-logger).
+            logging.warning("No clients found.")
             return None, None, None  # Abort with empty result.
         sites_cache = mh.PromptUtils._load_sites_cache(org_id)  # Load sites cache for names.
         mh.PromptUtils._display_client_table(all_clients, sites_cache)  # Display the client table.
@@ -224,13 +240,15 @@ class PromptClientUtils:
         if not site_id:  # Resolve site when not supplied.
             site_id = mh.PromptUtils.select_site_id_from_csv()  # Prompt site from CSV.
             if not site_id:  # Handle no-site selection.
-                print(" No site selected.")  # Tell operator none selected.
+                # WHY (#886 Phase 2): retire print() in favor of logging.warning (surfaces on default root-logger).
+                logging.warning("No site selected.")
                 return None, None  # Abort with no ids.
 
         if not device_id:  # Resolve device when not supplied.
             device_id = mh.PromptUtils.select_device_id_from_inventory(site_id, device_type="all")
             if not device_id:  # Handle no-device selection.
-                print(" No device selected.")  # Tell operator none selected.
+                # WHY (#886 Phase 2): retire print() in favor of logging.warning (surfaces on default root-logger).
+                logging.warning("No device selected.")
                 return None, None  # Abort with no ids.
 
         return site_id, device_id  # Return resolved id pair.

--- a/tests/unit/input/test_prompt_client_utils.py
+++ b/tests/unit/input/test_prompt_client_utils.py
@@ -124,11 +124,18 @@ class TestBuildClientSelectionTable:
 
 
 class TestRenderClientSelectionPrompt:
-    def test_prints_header_and_options(self, capsys):
+    def test_prints_header_and_options(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Header, count, and options must be emitted through logging.warning.
+
+        Why:
+            Per #886 Phase 2 the render UI moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
         clients = [{"connection_type": "Wireless", "hostname": "h", "mac": "m", "ip": "i"}]
         table, _ = PromptClientUtils._build_client_selection_table(clients)
-        PromptClientUtils._render_client_selection_prompt(table, 1)
-        out = capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            PromptClientUtils._render_client_selection_prompt(table, 1)
+        out = caplog.text
         assert "SELECT CONNECTED CLIENT" in out
         assert "Found 1 connected clients" in out
         assert "'m'" in out
@@ -144,13 +151,27 @@ class TestHandleClientSelectionInput:
     def test_cancel_returns_none(self, mh_mocks):
         assert PromptClientUtils._handle_client_selection_input("c", {}) is None
 
-    def test_non_digit_returns_none(self, mh_mocks, capsys):
-        assert PromptClientUtils._handle_client_selection_input("xyz", {}) is None
-        assert "valid index" in capsys.readouterr().out
+    def test_non_digit_returns_none(self, mh_mocks, caplog: pytest.LogCaptureFixture) -> None:
+        """Non-digit input logs the validation hint via WARNING.
 
-    def test_out_of_range_returns_none(self, mh_mocks, capsys):
-        assert PromptClientUtils._handle_client_selection_input("99", {0: {"mac": "a"}}) is None
-        assert "Invalid index" in capsys.readouterr().out
+        Why:
+            Per #886 Phase 2 the operator hint moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils._handle_client_selection_input("xyz", {}) is None
+        assert "valid index" in caplog.text
+
+    def test_out_of_range_returns_none(self, mh_mocks, caplog: pytest.LogCaptureFixture) -> None:
+        """Out-of-range index logs the "Invalid index" WARNING.
+
+        Why:
+            Per #886 Phase 2 the operator hint moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils._handle_client_selection_input("99", {0: {"mac": "a"}}) is None
+        assert "Invalid index" in caplog.text
 
     def test_valid_index_returns_mac(self, mh_mocks):
         idx_map = {0: {"mac": "aa:bb", "hostname": "h", "connection_type": "Wireless"}}
@@ -158,30 +179,66 @@ class TestHandleClientSelectionInput:
 
 
 class TestFinalizeClientChoice:
-    def test_prints_and_returns_mac(self, capsys):
-        client = {"mac": "AA", "hostname": "host", "connection_type": "Wireless"}
-        assert PromptClientUtils._finalize_client_choice(0, client) == "AA"
-        assert "Selected: host" in capsys.readouterr().out
+    def test_prints_and_returns_mac(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Selection confirmation is emitted via logging.warning.
 
-    def test_uses_username_fallback(self, capsys):
+        Why:
+            Per #886 Phase 2 the "Selected: ..." confirmation moved from
+            ``print()`` to ``logging.warning`` so the assertion reads
+            ``caplog.text``.
+        """
+        client = {"mac": "AA", "hostname": "host", "connection_type": "Wireless"}
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils._finalize_client_choice(0, client) == "AA"
+        assert "Selected: host" in caplog.text
+
+    def test_uses_username_fallback(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Username fallback still surfaces in the WARNING record.
+
+        Why:
+            Per #886 Phase 2 the confirmation moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
         client = {"mac": "AA", "username": "userX", "connection_type": "Wired"}
-        PromptClientUtils._finalize_client_choice(1, client)
-        assert "userX" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            PromptClientUtils._finalize_client_choice(1, client)
+        assert "userX" in caplog.text
 
 
 class TestParseClientChoice:
     @pytest.mark.parametrize("quit_word", ["q", "quit", "exit", "QUIT"])
-    def test_quit_returns_none(self, quit_word, capsys):
-        assert PromptClientUtils._parse_client_choice(quit_word, 5) is None
-        assert "Exiting client selection" in capsys.readouterr().out
+    def test_quit_returns_none(self, quit_word, caplog: pytest.LogCaptureFixture) -> None:
+        """Quit keywords emit "Exiting client selection..." via WARNING.
 
-    def test_non_numeric_returns_none(self, capsys):
-        assert PromptClientUtils._parse_client_choice("abc", 5) is None
-        assert "valid number" in capsys.readouterr().out
+        Why:
+            Per #886 Phase 2 the quit notice moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils._parse_client_choice(quit_word, 5) is None
+        assert "Exiting client selection" in caplog.text
 
-    def test_out_of_range_returns_none(self, capsys):
-        assert PromptClientUtils._parse_client_choice("10", 5) is None
-        assert "Invalid index" in capsys.readouterr().out
+    def test_non_numeric_returns_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Non-numeric input emits the WARNING hint.
+
+        Why:
+            Per #886 Phase 2 the validation hint moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils._parse_client_choice("abc", 5) is None
+        assert "valid number" in caplog.text
+
+    def test_out_of_range_returns_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Out-of-range numeric input emits the WARNING hint.
+
+        Why:
+            Per #886 Phase 2 the validation hint moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils._parse_client_choice("10", 5) is None
+        assert "Invalid index" in caplog.text
 
     def test_valid_index(self):
         assert PromptClientUtils._parse_client_choice("3", 5) == 3
@@ -191,10 +248,17 @@ class TestParseClientChoice:
 
 
 class TestSelectClientMac:
-    def test_no_clients_returns_none(self, mh_mocks, monkeypatch, capsys):
+    def test_no_clients_returns_none(self, mh_mocks, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
+        """Empty client list surfaces "No connected clients found" via WARNING.
+
+        Why:
+            Per #886 Phase 2 the empty-state notice moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
         monkeypatch.setattr(PromptClientUtils, "_fetch_all_clients_for_site", staticmethod(lambda _s: []))
-        assert PromptClientUtils.select_client_mac("site-1") is None
-        assert "No connected clients found" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils.select_client_mac("site-1") is None
+        assert "No connected clients found" in caplog.text
 
     def test_happy_path_returns_selected_mac(self, mh_mocks, monkeypatch):
         clients = [{"mac": "aa", "hostname": "h", "connection_type": "Wireless"}]
@@ -202,13 +266,21 @@ class TestSelectClientMac:
         mh_mocks["InputUtils"].safe_input.return_value = "0"
         assert PromptClientUtils.select_client_mac("site-1") == "aa"
 
-    def test_exception_returns_none(self, mh_mocks, monkeypatch, capsys):
+    def test_exception_returns_none(self, mh_mocks, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
+        """Fetch exceptions surface via logging.exception (ERROR-level).
+
+        Why:
+            Per #886 Phase 2 the fetch-failure message moved from ``print()``
+            to ``logging.exception`` so the assertion reads ``caplog.text``.
+        """
+
         def raise_err(_s):
             raise RuntimeError("boom")
 
         monkeypatch.setattr(PromptClientUtils, "_fetch_all_clients_for_site", staticmethod(raise_err))
-        assert PromptClientUtils.select_client_mac("site-1") is None
-        assert "Error fetching clients" in capsys.readouterr().out
+        with caplog.at_level(logging.ERROR):
+            assert PromptClientUtils.select_client_mac("site-1") is None
+        assert "Error fetching clients" in caplog.text
 
 
 class TestSelectClient:
@@ -225,22 +297,36 @@ class TestSelectClient:
         )
         assert PromptClientUtils.select_client("site-1") == ("mac", "type", "site")
 
-    def test_exception_returns_none_tuple(self, mh_mocks, monkeypatch, capsys):
+    def test_exception_returns_none_tuple(self, mh_mocks, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
+        """Selection-flow exceptions surface via logging.error.
+
+        Why:
+            Per #886 Phase 2 the operator-visible error moved from ``print()``
+            to ``logging.error`` so the assertion reads ``caplog.text``.
+        """
         mh_mocks["PromptUtils"]._determine_search_scope.return_value = "site-1"
 
         def raise_err(_o, _s):
             raise RuntimeError("boom")
 
         monkeypatch.setattr(PromptClientUtils, "_run_client_selection_flow", staticmethod(raise_err))
-        assert PromptClientUtils.select_client("site-1") == (None, None, None)
-        assert "Error searching for clients" in capsys.readouterr().out
+        with caplog.at_level(logging.ERROR):
+            assert PromptClientUtils.select_client("site-1") == (None, None, None)
+        assert "Error searching for clients" in caplog.text
 
 
 class TestRunClientSelectionFlow:
-    def test_empty_clients_returns_none_tuple(self, mh_mocks, capsys):
+    def test_empty_clients_returns_none_tuple(self, mh_mocks, caplog: pytest.LogCaptureFixture) -> None:
+        """Empty-client-set surfaces "No clients found." via WARNING.
+
+        Why:
+            Per #886 Phase 2 the empty-state notice moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
         mh_mocks["PromptUtils"]._fetch_all_clients.return_value = []
-        assert PromptClientUtils._run_client_selection_flow("org-1", "site-1") == (None, None, None)
-        assert "No clients found" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils._run_client_selection_flow("org-1", "site-1") == (None, None, None)
+        assert "No clients found" in caplog.text
 
     def test_populated_flow_delegates_to_prompt_utils(self, mh_mocks):
         mh_mocks["PromptUtils"]._fetch_all_clients.return_value = [{"mac": "aa"}]
@@ -260,12 +346,26 @@ class TestSelectSiteAndDeviceIds:
         mh_mocks["PromptUtils"].select_device_id_from_inventory.return_value = "d2"
         assert PromptClientUtils.select_site_and_device_ids(None, None) == ("s2", "d2")
 
-    def test_no_site_returns_none_pair(self, mh_mocks, capsys):
-        mh_mocks["PromptUtils"].select_site_id_from_csv.return_value = None
-        assert PromptClientUtils.select_site_and_device_ids(None, None) == (None, None)
-        assert "No site selected" in capsys.readouterr().out
+    def test_no_site_returns_none_pair(self, mh_mocks, caplog: pytest.LogCaptureFixture) -> None:
+        """Missing-site path emits "No site selected." via WARNING.
 
-    def test_no_device_returns_none_pair(self, mh_mocks, capsys):
+        Why:
+            Per #886 Phase 2 the notice moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
+        mh_mocks["PromptUtils"].select_site_id_from_csv.return_value = None
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils.select_site_and_device_ids(None, None) == (None, None)
+        assert "No site selected" in caplog.text
+
+    def test_no_device_returns_none_pair(self, mh_mocks, caplog: pytest.LogCaptureFixture) -> None:
+        """Missing-device path emits "No device selected." via WARNING.
+
+        Why:
+            Per #886 Phase 2 the notice moved from ``print()`` to
+            ``logging.warning`` so the assertion reads ``caplog.text``.
+        """
         mh_mocks["PromptUtils"].select_device_id_from_inventory.return_value = None
-        assert PromptClientUtils.select_site_and_device_ids("s", None) == (None, None)
-        assert "No device selected" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            assert PromptClientUtils.select_site_and_device_ids("s", None) == (None, None)
+        assert "No device selected" in caplog.text


### PR DESCRIPTION
## Summary

Slice 6 of the #886 Phase 2 print-to-logger migration. Replaces the 24 remaining `print()` calls in `src/input/prompt_client_utils.py` with `logging.warning` / `logging.error` / `logging.exception` so the T20 selector target of #886 can eventually be enabled repo-wide.

Touched helpers:
- `select_client_mac` — empty-state WARNING; fetch-failure `logging.exception`
- `_render_client_selection_prompt` — 10 header/table/options lines moved to `logging.warning` so the interactive UI still surfaces on the default root-logger config (INFO is suppressed by default)
- `_handle_client_selection_input` — validation hints (non-digit, out-of-range)
- `_finalize_client_choice` — "Selected: ..." confirmation
- `_parse_client_choice` — Exiting / valid-number / Invalid-index hints
- `select_client` — heading + fetch-error
- `_run_client_selection_flow` — no-clients notice
- `select_site_and_device_ids` — no-site / no-device notices

Existing `print(...)` + `logging.info/error/warning(...)` pairs were collapsed into single log calls to avoid double-emission.

Companion unit tests in `tests/unit/input/test_prompt_client_utils.py` (12 tests across 7 classes) were migrated from `capsys.readouterr().out` to `caplog.text` under `caplog.at_level(logging.WARNING/ERROR)`.

Sixth of ~20+ per-subdirectory slices. T20 selector flip and E402 audit land after all `src/` subdirs are print-free.

Refs #886

## Test plan

- [x] `pytest tests/unit/input/test_prompt_client_utils.py` — 41 pass
- [x] `black src/input/ tests/unit/input/` clean
- [x] `ruff check src/input/ tests/unit/input/` clean
- [ ] CI green on this branch