### PR TITLE
chore(logging): migrate src/ui/ print() to logger (#886 slice 7/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 7/N: retire `print()` in `src/ui/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the remaining `print()`
+  calls in `src/ui/prompt_utils.py`, `src/ui/tui.py`,
+  `src/ui/runtime/tui_runner.py`, and `src/ui/interactive_display_utils.py`
+  with `logging.warning(...)` / `logging.error(...)` / `logging.exception(...)`
+  so the print-avoidance rule (T20 selector target of #886) can eventually be
+  enabled repo-wide. Existing paired `print(...)` + `logging.info/error/warning(...)`
+  emit sites were collapsed into single log calls to avoid double-emission
+  (notably the Rich-missing fatal in `MistHelperTUI._init_rich` and the
+  TUI exit banner in `TuiRunner.run`). WARNING level chosen for operator-visible
+  interactive UI surfaces (site/device selection headers, "Loading site
+  information", "Found N clients", legend/summary lines, per-selection
+  "Site: ..." confirmations, "Invalid site index", "No devices ..." notices,
+  "site" vs "organization" fetch scope hints, "No site selected", and the TUI
+  "\[EXIT] ... closed" banner) so they surface on the default root-logger
+  configuration (INFO is suppressed by default); ERROR level retained for the
+  Rich-import fatal in `MistHelperTUI._init_rich`. Companion unit tests in
+  `tests/unit/ui/test_prompt_utils.py` (~13 tests across the site-selection,
+  device-inventory, client-fetch, sites-cache, client-summary, client-table,
+  and extract-selected-client suites) and
+  `tests/unit/ui/test_tui.py::TestInitRich::test_import_error_triggers_sys_exit`
+  were updated to assert against `caplog.text` under
+  `caplog.at_level(logging.WARNING/ERROR)` instead of `capsys.readouterr().out`;
+  the Rich-missing assertion string was updated from `"Rich library required"`
+  to `"Rich library not available"` to match the collapsed
+  `logging.error(...)` message. Seventh of ~20+ per-subdirectory slices of #886;
+  T20 selector flip and E402 audit will land after all `src/` subdirs are
+  print-free.
+
 ### #886 Phase 2 slice 6/N: retire `print()` in `src/input/` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 24 remaining `print()`

--- a/src/ui/execution/item_executor.py
+++ b/src/ui/execution/item_executor.py
@@ -34,11 +34,11 @@ _PREVIEW_ITEM_REPR_CAP = 100  # WHY: char cap for per-item repr in sequence prev
 
 _MSG_NOT_CALLABLE = "Selected item is not callable"  # WHY: user-facing error stored on tui.last_error
 _MSG_SESSION_ERROR = "API session not initialized"  # WHY: user-facing error when tui.apisession is None
-_MSG_SESSION_PRINT = "[ERROR] API session not available"  # WHY: printed banner when tui.apisession is None
-_MSG_CANCEL_BANNER = "\n[CANCELLED] Execution cancelled by user"  # WHY: printed banner on KeyboardInterrupt
-_MSG_EXECUTING = "\nExecuting API call..."  # WHY: printed status line before the API call
-_MSG_SUCCESS = "\n[SUCCESS]"  # WHY: printed success banner after the API call
-_MSG_PRESS_KEY = "\nPress any key to return to explorer..."  # WHY: printed cue before wait-and-restore
+_MSG_SESSION_PRINT = "[ERROR] API session not available"  # WHY: logged banner when tui.apisession is None
+_MSG_CANCEL_BANNER = "\n[CANCELLED] Execution cancelled by user"  # WHY: logged banner on KeyboardInterrupt
+_MSG_EXECUTING = "\nExecuting API call..."  # WHY: logged status line before the API call
+_MSG_SUCCESS = "\n[SUCCESS]"  # WHY: logged success banner after the API call
+_MSG_PRESS_KEY = "\nPress any key to return to explorer..."  # WHY: logged cue before wait-and-restore
 
 _LOG_START = "TUI: prompt-exec start for %s"  # WHY: log format for pre-run breadcrumb
 _LOG_DONE = "TUI: prompt-exec done for %s"  # WHY: log format for post-run breadcrumb
@@ -116,13 +116,16 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
 
     def _on_cancel(self, func_name: str) -> None:  # WHY: KeyboardInterrupt path
         """Print the cancel banner and log the cancelled run."""
-        print(_MSG_CANCEL_BANNER)  # WHY: user-visible banner
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so the cancel banner
+        # reaches the operator on the default root-logger config (INFO is suppressed by default).
+        logging.warning(_MSG_CANCEL_BANNER)  # User-visible banner
         logging.info(_LOG_CANCEL, func_name)  # WHY: action-log the cancellation
 
     def _on_error(self, func_name: str, error: BaseException) -> None:  # WHY: generic exception path
         """Capture the error on the TUI, print a banner, and log with traceback."""
         self._tui.last_error = str(error)  # WHY: expose to caller for render
-        print(f"\n[ERROR] {error}")  # WHY: user-visible banner
+        # WHY (#886 Phase 2): retire print() in favor of logging.exception which already emits the
+        # error string plus traceback via the shared handler chain (banner + triage in one call).
         logging.exception(_LOG_FAIL, func_name, error)  # WHY: include traceback for triage
 
     def _validated_selection(self) -> dict[str, Any] | None:  # WHY: bounds + type guard
@@ -150,8 +153,10 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
         """Walk the signature, prompting for each param; ``None`` on hard error."""
         sig = inspect.signature(func)  # WHY: signature for introspection
         params: dict[str, Any] = {}  # WHY: accumulator for collected values
-        print(f"\n[Executing] {func_name}")  # WHY: banner before prompts
-        print(f"Signature: {func_name}{sig}\n")  # WHY: show signature for user context
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so the pre-prompt banners
+        # reach the operator on the default root-logger config (INFO is suppressed by default).
+        logging.warning("\n[Executing] %s", func_name)  # Banner before prompts
+        logging.warning("Signature: %s%s\n", func_name, sig)  # Show signature for user context
         for param_name, param in sig.parameters.items():  # WHY: walk each parameter
             if param_name == "self":  # WHY: skip implicit self
                 continue
@@ -186,7 +191,9 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
         if not env_value:  # WHY: no env value - defer to prompt
             return None
         params[param_name] = env_value  # WHY: store env value on accumulator
-        print(f"  {param_name}: [from .env] {env_value}")  # WHY: show autofill provenance to user
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so the autofill provenance
+        # reaches the operator on the default root-logger config (INFO is suppressed by default).
+        logging.warning("  %s: [from .env] %s", param_name, env_value)  # Show autofill provenance to user
         return _OUTCOME_OK
 
     def _prompt_outcome(
@@ -196,7 +203,9 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
         has_default = param.default != inspect.Parameter.empty  # WHY: required-vs-optional flag
         value = self._prompt_for_value(param_name, param.default, has_default)  # WHY: EOF-safe stdin read
         if not value and not has_default:  # WHY: required-but-empty - hard error
-            print(f"[ERROR] {param_name} is required")  # WHY: user-visible error banner
+            # WHY (#886 Phase 2): retire print() in favor of logging.error so the required-param
+            # banner reaches the operator on the default root-logger config.
+            logging.error("[ERROR] %s is required", param_name)  # User-visible error banner
             self._tui.last_error = f"Missing required parameter: {param_name}"  # WHY: expose to caller for render
             return _OUTCOME_ABORT
         if value:  # WHY: store user-provided value only when supplied
@@ -209,7 +218,9 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
             return False
         tui = self._tui  # WHY: local alias
         if getattr(tui, "apisession", None) is None:  # WHY: guard - no session available
-            print(_MSG_SESSION_PRINT)  # WHY: user-visible banner
+            # WHY (#886 Phase 2): retire print() in favor of logging.error so the missing-session
+            # banner reaches the operator on the default root-logger config.
+            logging.error(_MSG_SESSION_PRINT)  # User-visible banner
             tui.last_error = _MSG_SESSION_ERROR  # WHY: expose to caller for render
             return False
         params[param_name] = tui.apisession  # WHY: inject the session reference
@@ -230,11 +241,13 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
         tui = self._tui  # WHY: local alias
         redacted = {k: _redact(k, v) for k, v in params.items()}  # WHY: redact secrets before logging
         logging.info(_LOG_CALL, func_name, redacted)  # WHY: log the redacted call site
-        print(_MSG_EXECUTING)  # WHY: status line for user
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so the executing/success/
+        # preview banners reach the operator on the default root-logger config.
+        logging.warning(_MSG_EXECUTING)  # Status line for user
         result = func(**params)  # WHY: the actual API call
         tui.last_result = result  # WHY: stash for caller / details panel
-        print(_MSG_SUCCESS)  # WHY: success banner
-        print(f"\n{_ResultPreview.build(result)}")  # WHY: smart preview (no full repr)
+        logging.warning(_MSG_SUCCESS)  # Success banner
+        logging.warning("\n%s", _ResultPreview.build(result))  # Smart preview (no full repr)
         self._maybe_print_export_hint(result)  # WHY: hint when result is large enough
         logging.info(_LOG_SUCCESS, func_name)  # WHY: action-log after success
 
@@ -245,15 +258,19 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
             return
         if len(result) <= _LARGE_RESULT_HINT_THRESHOLD:  # WHY: only large enough to warrant the tip
             return
-        print(  # WHY: user-visible tip banner
-            f"\n[TIP] Result has {len(result)} items. Consider using main menu options "
-            "to save full data to CSV/SQLite."
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so the export tip reaches
+        # the operator on the default root-logger config (INFO is suppressed by default).
+        logging.warning(  # User-visible tip banner
+            "\n[TIP] Result has %d items. Consider using main menu options " "to save full data to CSV/SQLite.",
+            len(result),
         )
 
     def _wait_and_restore_raw(self) -> None:  # WHY: wait-for-key + restore raw mode
         """Block on a single keypress, then restore Unix raw mode for the TUI."""
         tui = self._tui  # WHY: local alias
-        print(_MSG_PRESS_KEY)  # WHY: user cue
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so the press-key cue
+        # reaches the operator on the default root-logger config.
+        logging.warning(_MSG_PRESS_KEY)  # User cue
         self._read_single_keypress(tui)  # WHY: platform-specific single-char read
         if not tui.IS_WINDOWS:  # WHY: restore raw mode for the TUI on Unix
             tui.tty.setcbreak(sys.stdin.fileno())

--- a/src/ui/interactive_display_utils.py
+++ b/src/ui/interactive_display_utils.py
@@ -30,7 +30,9 @@ class InteractiveDisplayUtils:
         """Prompt the user to select a site and display its device inventory."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils + SiteDeviceExporter.
         logging.info("Prompting user to select a site for device inventory view...")  # Log the prompt.
-        print("Select a Site to View Device Inventory:")  # Header.
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+        # header on the default root-logger config (INFO is suppressed by default).
+        logging.warning("Select a Site to View Device Inventory:")  # Header.
         site_id = mh.PromptUtils.select_site_id_from_csv()  # Select a site.
         if site_id:  # Site selected.
             logging.info("User selected site_id: %s for inventory display.", site_id)  # Log the selection.

--- a/src/ui/prompt_utils.py
+++ b/src/ui/prompt_utils.py
@@ -45,7 +45,10 @@ class PromptUtils:  # General prompt helpers.
         if not inventory:  # Nothing matched the requested filter.
             return None  # Abort selection.
         table, index_to_device, name_to_device = PromptUtils._export_and_index_inventory(inventory, csv_filename)
-        print(table)  # Render the device table.
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+        # table on the default root-logger config (INFO is suppressed by default). Lazy %-format
+        # keeps ruff clean and renders PrettyTable via its __str__.
+        logging.warning("%s", table)  # Render the device table.
         logging.info("Displayed device selection table to user.")  # Log table display.
         user_input = InputUtils.safe_input(  # Read operator device choice.
             "Enter the index or name of the device to view device: ",
@@ -68,12 +71,14 @@ class PromptUtils:  # General prompt helpers.
         mh = importlib.import_module("MistHelper")
         rawdata = mistapi.api.v1.sites.devices.listSiteDevices(mh.apisession, site_id, type="all").data  # Fetch
         if not rawdata:  # Empty inventory path
-            print("No devices found for the selected site.")
+            # WHY (#886 Phase 2): collapse paired print+logger into a single logging.warning so
+            # the "no devices" banner reaches the operator via the same handler chain as the log.
             logging.warning("No devices found for site_id: %s", site_id)
             return None
         filtered = PromptUtils._filter_inventory_by_type(rawdata, device_type)  # Apply type filter
         if not filtered:  # Filter produced empty set
-            print(f"No devices of type '{device_type}' found at the selected site.")
+            # WHY (#886 Phase 2): collapse paired print+logger into a single logging.warning so
+            # the "no devices of type" banner reaches the operator via the same handler chain.
             logging.warning("No devices of type '%s' found for site_id: %s", device_type, site_id)
             return None
         return filtered
@@ -124,9 +129,11 @@ class PromptUtils:  # General prompt helpers.
         mh = importlib.import_module("MistHelper")
         CacheUtils.check_and_generate_csv(csv_file, OrgSiteExporter.sites)  # Ensure site CSV exists/fresh.
         index_to_site, name_to_site = PromptUtils._load_site_csv_maps(csv_file)  # Read CSV into index/name maps.
-        print("\nAvailable Sites:")  # Print available sites heading.
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+        # heading + per-site rows on the default root-logger config (INFO is suppressed by default).
+        logging.warning("\nAvailable Sites:")  # Log available sites heading.
         for idx, row in index_to_site.items():  # Enumerate site rows.
-            print(f"[{idx}] {row.get('name', 'Unnamed')}")  # Print each site option.
+            logging.warning("[%s] %s", idx, row.get("name", "Unnamed"))  # Log each site option.
         user_input = InputUtils.safe_input("\nEnter site index or name: ", context="site_selection").strip()
         logging.debug("User input for site selection: %s", user_input)  # Log raw site input.
         if user_input.isdigit():  # Branch: numeric index choice.
@@ -138,7 +145,8 @@ class PromptUtils:  # General prompt helpers.
             site_id = PromptUtils._pick_site_by_name(user_input, name_to_site)  # Resolve by name.
             mh.LAST_SELECTED_SITE_ID = site_id  # Remember last selected site (module attr assignment).
             return site_id  # Return resolved id.
-        print(" Site not found by name or index.")  # Report not-found site.
+        # WHY (#886 Phase 2): collapse paired print+logger into a single logging.warning so the
+        # site-not-found banner reaches the operator via the same handler chain as the log.
         logging.warning("Site not found by name or index: %s", user_input)  # Log not-found site.
         return None  # Abort on not found.
 
@@ -156,11 +164,14 @@ class PromptUtils:  # General prompt helpers.
     def _pick_site_by_index(idx: int, index_to_site: dict[int, dict]) -> str | None:  # type: ignore[type-arg]
         """Resolve a numeric site index to a site_id; print/log selection or invalid-index message."""
         if idx not in index_to_site:  # Validate index exists.
-            print(" Invalid index.")  # Reject out-of-range index.
+            # WHY (#886 Phase 2): collapse paired print+logger into a single logging.warning so
+            # the invalid-index banner reaches the operator via the same handler chain.
             logging.warning("Invalid site index entered: %s", idx)  # Log invalid index.
             return None  # Abort on invalid index.
         site_id = index_to_site[idx].get("id")  # Read selected site id.
-        print(f"! Selected site: {index_to_site[idx].get('name')} (ID: {site_id})")  # Confirm site selection.
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+        # confirmation banner on the default root-logger config (INFO is suppressed by default).
+        logging.warning("! Selected site: %s (ID: %s)", index_to_site[idx].get("name"), site_id)
         logging.info("User selected site by index: %s (site_id: %s)", idx, site_id)  # Log index selection.
         return site_id  # Return selected site id.
 
@@ -168,7 +179,9 @@ class PromptUtils:  # General prompt helpers.
     def _pick_site_by_name(name: str, name_to_site: dict[str, dict]) -> str | None:  # type: ignore[type-arg]
         """Resolve a site name to a site_id; print/log the selection."""
         site_id = name_to_site[name].get("id")  # Read site id by name.
-        print(f"! Selected site: {name} (ID: {site_id})")  # Confirm site selection.
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+        # confirmation banner on the default root-logger config (INFO is suppressed by default).
+        logging.warning("! Selected site: %s (ID: %s)", name, site_id)
         logging.info("User selected site by name: %s (site_id: %s)", name, site_id)  # Log name selection.
         return site_id  # Return selected site id.
 
@@ -218,7 +231,9 @@ class PromptUtils:  # General prompt helpers.
         if scope_choice == "s":  # Branch: single-site scope.
             selected_site = PromptUtils.select_site()  # Prompt to pick a site.
             if not selected_site:  # Handle no-site selection.
-                print(" No site selected.")  # Tell operator none selected.
+                # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees
+                # the "no site" banner on the default root-logger config (INFO is suppressed).
+                logging.warning(" No site selected.")  # Log none selected.
                 return False  # Signal scope failure.
             return selected_site  # Return chosen site scope.
         return None  # Org-wide search
@@ -233,11 +248,15 @@ class PromptUtils:  # General prompt helpers.
         all_clients = []  # Combined client accumulator.
 
         if site_id:  # Branch: site-scoped search.
-            print("! Searching for clients in selected site...")  # Inform operator of site search.
+            # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+            # search-scope banner on the default root-logger config (INFO is suppressed by default).
+            logging.warning("! Searching for clients in selected site...")
             wireless = PromptUtils._fetch_site_wireless_clients(site_id)  # Fetch site wireless clients.
             wired = PromptUtils._fetch_site_wired_clients(site_id)  # Fetch site wired clients.
         else:
-            print("! Searching for clients across organization...")  # Inform operator of org search.
+            # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+            # search-scope banner on the default root-logger config (INFO is suppressed by default).
+            logging.warning("! Searching for clients across organization...")
             wireless = PromptUtils._fetch_org_wireless_clients(org_id)  # Fetch org wireless clients.
             wired = PromptUtils._fetch_org_wired_clients(org_id)  # Fetch org wired clients.
 
@@ -312,7 +331,9 @@ class PromptUtils:  # General prompt helpers.
     def _load_sites_cache(org_id: str) -> dict[str, str]:  # Load site id-to-name cache.
         """Loads site ID to name mapping for display purposes."""
         try:
-            print(" Loading site information...")  # Inform operator of load.
+            # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+            # load banner on the default root-logger config (INFO is suppressed by default).
+            logging.warning(" Loading site information...")
             sites = APICoreFetchUtils.all_sites_with_limit(org_id)  # Fetch all sites for org.
             cache = {site["id"]: site["name"] for site in sites}  # Build id-to-name map.
             logging.info("Cached %s sites for client display", len(cache))  # Log cached site count.
@@ -326,9 +347,11 @@ class PromptUtils:  # General prompt helpers.
         """Print the wireless/wired count line and status legend for the client selection table."""
         wireless_count = sum(1 for c in all_clients if c.get("client_type") == "wireless")  # Count wireless
         wired_count = sum(1 for c in all_clients if c.get("client_type") == "wired")  # Count wired
-        print(f"\n  Summary: {wireless_count} wireless, {wired_count} wired clients")
-        print("\n  [+] = Online  [~] = Recently seen  [-] = Offline")
-        print("---" * 20)
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+        # summary + legend + separator on the default root-logger config (INFO is suppressed).
+        logging.warning("\n  Summary: %s wireless, %s wired clients", wireless_count, wired_count)
+        logging.warning("\n  [+] = Online  [~] = Recently seen  [-] = Offline")
+        logging.warning("%s", "---" * 20)
 
     @staticmethod
     def _display_client_table(all_clients: list[dict], sites_cache: dict[str, str]) -> dict[int, dict]:  # type: ignore[type-arg]
@@ -337,8 +360,11 @@ class PromptUtils:  # General prompt helpers.
         for idx, client in enumerate(all_clients):  # Enumerate clients for rows
             row = PromptUtils._format_client_row(idx, client, sites_cache)  # Format a client row
             table.add_row(row)
-        print(f"\n  Found {len(all_clients)} clients:")
-        print(table)
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+        # "Found N clients" banner + table on the default root-logger config (INFO is suppressed).
+        # Lazy %-format renders PrettyTable via its __str__ while keeping ruff clean.
+        logging.warning("\n  Found %d clients:", len(all_clients))
+        logging.warning("%s", table)
         PromptUtils._print_client_type_summary(all_clients)  # Type counts + legend
         return dict(enumerate(all_clients))  # Index-to-client map for caller
 
@@ -462,12 +488,14 @@ class PromptUtils:  # General prompt helpers.
         client_site_id = client.get("site_id", default_site_id) or ""  # Resolve client site id.
         hostname = client.get("hostname", client.get("name", "Unknown"))  # Read hostname/name.
 
-        print("\n Selected client:")  # Print selection heading.
-        print(f"   Name: {hostname}")  # Show client name.
-        print(f"   MAC: {client_mac}")  # Show client MAC.
-        print(f"   Type: {client_type}")  # Show client type.
+        # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
+        # selection heading + fields on the default root-logger config (INFO is suppressed).
+        logging.warning("\n Selected client:")
+        logging.warning("   Name: %s", hostname)
+        logging.warning("   MAC: %s", client_mac)
+        logging.warning("   Type: %s", client_type)
         if client_site_id and client_site_id in sites_cache:  # Branch: known site.
-            print(f"   Site: {sites_cache[client_site_id]}")  # Show resolved site name.
+            logging.warning("   Site: %s", sites_cache[client_site_id])  # Show resolved site name.
 
         logging.info("User selected client: MAC=%s, type=%s, site=%s", client_mac, client_type, client_site_id)
         return client_mac, client_type, client_site_id  # Return client id triple.

--- a/src/ui/runtime/tui_runner.py
+++ b/src/ui/runtime/tui_runner.py
@@ -36,7 +36,9 @@ class TuiRunner:  # WHY: extracted from MistHelperTUI.run (was CC=33)
         finally:
             self._teardown_terminal()  # Restore terminal even on error
             logging.info("TUI: Explorer exited cleanly")  # Action log after teardown
-            print("\n[EXIT] MistHelper TUI - Hierarchical API Explorer closed")  # WHY: user-visible exit banner
+            # WHY (#886 Phase 2): retire print() in favor of logging.warning so the exit banner
+            # reaches the operator on the default root-logger config (INFO is suppressed by default).
+            logging.warning("\n[EXIT] MistHelper TUI - Hierarchical API Explorer closed")  # User-visible exit banner
 
     def _setup_terminal(self) -> None:  # WHY: enter cbreak so keys read w/o Enter
         """Put the Unix terminal into raw (cbreak) mode for keypress capture."""

--- a/src/ui/tui.py
+++ b/src/ui/tui.py
@@ -72,8 +72,11 @@ class MistHelperTUI:  # WHY: public TUI entrypoint composing all collaborators
             from rich.syntax import Syntax  # Code syntax highlighter
             from rich.table import Table  # Table primitive for grids
         except ImportError:  # Rich missing -> fatal in TUI mode
-            logging.error("TUI_MODE: Rich library not available - cannot start TUI mode")  # Diagnose fatal
-            print("[ERROR] Rich library required for TUI mode. Install with: pip install rich")  # User hint
+            # WHY (#886 Phase 2): collapse paired logger+print into a single logging.error so the
+            # install hint reaches the operator via the same handler chain as the diagnostic line.
+            logging.error(
+                "TUI_MODE: Rich library not available - cannot start TUI mode. " "Install with: pip install rich"
+            )  # Diagnose fatal + surface install hint
             sys.exit(1)  # Cannot render without Rich
         self.Console = Console  # Public attrs reused by collaborators
         self.Live = Live  # Cached class for TuiRunner

--- a/tests/unit/ui/test_prompt_utils.py
+++ b/tests/unit/ui/test_prompt_utils.py
@@ -12,6 +12,8 @@ Why:
 
 from __future__ import annotations
 
+# WHY (#886 Phase 2): PromptUtils now emits via logging.warning instead of print, so tests capture via caplog.
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -76,8 +78,8 @@ def test_filter_inventory_by_type_missing_type_key() -> None:
 # ---------- _fetch_and_filter_devices ----------
 
 
-def test_fetch_and_filter_devices_empty_rawdata(capsys: pytest.CaptureFixture[str]) -> None:
-    """Empty API response prints + logs and returns None."""
+def test_fetch_and_filter_devices_empty_rawdata(caplog: pytest.LogCaptureFixture) -> None:
+    """Empty API response logs a warning and returns None."""
     fake_mh = _make_mh()
     fake_response = SimpleNamespace(data=[])
     with (
@@ -86,14 +88,15 @@ def test_fetch_and_filter_devices_empty_rawdata(capsys: pytest.CaptureFixture[st
             return_value=fake_response,
         ),
         patch("src.ui.prompt_utils.importlib.import_module", return_value=fake_mh),
+        caplog.at_level(logging.WARNING),
     ):
         result = PromptUtils._fetch_and_filter_devices("site-1", "all")
     assert result is None
-    assert "No devices found" in capsys.readouterr().out
+    assert "No devices found" in caplog.text
 
 
-def test_fetch_and_filter_devices_empty_after_filter(capsys: pytest.CaptureFixture[str]) -> None:
-    """Empty post-filter set prints + logs and returns None."""
+def test_fetch_and_filter_devices_empty_after_filter(caplog: pytest.LogCaptureFixture) -> None:
+    """Empty post-filter set logs a warning and returns None."""
     fake_mh = _make_mh()
     fake_response = SimpleNamespace(data=[{"type": "ap"}])
     with (
@@ -102,10 +105,11 @@ def test_fetch_and_filter_devices_empty_after_filter(capsys: pytest.CaptureFixtu
             return_value=fake_response,
         ),
         patch("src.ui.prompt_utils.importlib.import_module", return_value=fake_mh),
+        caplog.at_level(logging.WARNING),
     ):
         result = PromptUtils._fetch_and_filter_devices("site-1", "gateway")
     assert result is None
-    assert "No devices of type 'gateway'" in capsys.readouterr().out
+    assert "No devices of type 'gateway'" in caplog.text
 
 
 def test_fetch_and_filter_devices_happy_path() -> None:
@@ -187,7 +191,7 @@ def test_select_device_id_from_inventory_nothing_matched_aborts() -> None:
         assert PromptUtils.select_device_id_from_inventory("site-1") is None
 
 
-def test_select_device_id_from_inventory_happy_path(capsys: pytest.CaptureFixture[str]) -> None:
+def test_select_device_id_from_inventory_happy_path(caplog: pytest.LogCaptureFixture) -> None:
     """End-to-end: fetch, export, prompt, resolve returns device id."""
     fake_table = MagicMock(name="table")
     with (
@@ -199,10 +203,11 @@ def test_select_device_id_from_inventory_happy_path(capsys: pytest.CaptureFixtur
         ),
         patch("src.ui.prompt_utils.InputUtils.safe_input", return_value="0  "),
         patch.object(PromptUtils, "_resolve_device_selection", return_value="d1"),
+        caplog.at_level(logging.WARNING),
     ):
         assert PromptUtils.select_device_id_from_inventory("site-1") == "d1"
-    # Ensures ``print(table)`` executed the render path.
-    assert capsys.readouterr().out  # Non-empty stdout captured.
+    # Ensures the table render path emitted at least one log record.
+    assert caplog.records  # Non-empty log captured.
 
 
 # ---------- _load_site_csv_maps ----------
@@ -232,30 +237,33 @@ def test_load_site_csv_maps_skips_rows_without_name(tmp_path) -> None:
 # ---------- _pick_site_by_index / _pick_site_by_name ----------
 
 
-def test_pick_site_by_index_invalid(capsys: pytest.CaptureFixture[str]) -> None:
-    """Out-of-range index prints ``Invalid index`` and returns None."""
-    assert PromptUtils._pick_site_by_index(9, {0: {"id": "x"}}) is None
-    assert "Invalid index" in capsys.readouterr().out
+def test_pick_site_by_index_invalid(caplog: pytest.LogCaptureFixture) -> None:
+    """Out-of-range index logs ``Invalid index`` and returns None."""
+    with caplog.at_level(logging.WARNING):
+        assert PromptUtils._pick_site_by_index(9, {0: {"id": "x"}}) is None
+    assert "Invalid site index" in caplog.text
 
 
-def test_pick_site_by_index_valid(capsys: pytest.CaptureFixture[str]) -> None:
+def test_pick_site_by_index_valid(caplog: pytest.LogCaptureFixture) -> None:
     """Valid index returns the site id."""
-    result = PromptUtils._pick_site_by_index(0, {0: {"id": "id-1", "name": "Alpha"}})
+    with caplog.at_level(logging.WARNING):
+        result = PromptUtils._pick_site_by_index(0, {0: {"id": "id-1", "name": "Alpha"}})
     assert result == "id-1"
-    assert "Selected site: Alpha" in capsys.readouterr().out
+    assert "Selected site: Alpha" in caplog.text
 
 
-def test_pick_site_by_name(capsys: pytest.CaptureFixture[str]) -> None:
-    """Name lookup returns site id and prints confirmation."""
-    result = PromptUtils._pick_site_by_name("Alpha", {"Alpha": {"id": "id-1"}})
+def test_pick_site_by_name(caplog: pytest.LogCaptureFixture) -> None:
+    """Name lookup returns site id and logs confirmation."""
+    with caplog.at_level(logging.WARNING):
+        result = PromptUtils._pick_site_by_name("Alpha", {"Alpha": {"id": "id-1"}})
     assert result == "id-1"
-    assert "Selected site: Alpha" in capsys.readouterr().out
+    assert "Selected site: Alpha" in caplog.text
 
 
 # ---------- select_site_id_from_csv ----------
 
 
-def test_select_site_id_from_csv_by_index(capsys: pytest.CaptureFixture[str]) -> None:
+def test_select_site_id_from_csv_by_index(caplog: pytest.LogCaptureFixture) -> None:
     """Digit input picks site by index and caches to ``mh.LAST_SELECTED_SITE_ID``."""
     fake_mh = _make_mh()
     with (
@@ -267,11 +275,12 @@ def test_select_site_id_from_csv_by_index(capsys: pytest.CaptureFixture[str]) ->
         ),
         patch("src.ui.prompt_utils.InputUtils.safe_input", return_value="0"),
         patch("src.ui.prompt_utils.importlib.import_module", return_value=fake_mh),
+        caplog.at_level(logging.WARNING),
     ):
         result = PromptUtils.select_site_id_from_csv()
     assert result == "s0"
     assert fake_mh.LAST_SELECTED_SITE_ID == "s0"
-    assert "Available Sites" in capsys.readouterr().out
+    assert "Available Sites" in caplog.text
 
 
 def test_select_site_id_from_csv_index_invalid_keeps_last_selected_unset() -> None:
@@ -310,8 +319,8 @@ def test_select_site_id_from_csv_by_name() -> None:
     assert fake_mh.LAST_SELECTED_SITE_ID == "s0"
 
 
-def test_select_site_id_from_csv_not_found(capsys: pytest.CaptureFixture[str]) -> None:
-    """Unmatched input prints ``Site not found`` and returns None."""
+def test_select_site_id_from_csv_not_found(caplog: pytest.LogCaptureFixture) -> None:
+    """Unmatched input logs ``Site not found`` and returns None."""
     fake_mh = _make_mh()
     with (
         patch("src.ui.prompt_utils.CacheUtils.check_and_generate_csv"),
@@ -322,10 +331,11 @@ def test_select_site_id_from_csv_not_found(capsys: pytest.CaptureFixture[str]) -
         ),
         patch("src.ui.prompt_utils.InputUtils.safe_input", return_value="Zed"),
         patch("src.ui.prompt_utils.importlib.import_module", return_value=fake_mh),
+        caplog.at_level(logging.WARNING),
     ):
         result = PromptUtils.select_site_id_from_csv()
     assert result is None
-    assert "Site not found" in capsys.readouterr().out
+    assert "Site not found" in caplog.text
 
 
 # ---------- select_site / select_site_with_logging ----------
@@ -371,14 +381,15 @@ def test_determine_search_scope_site_selected() -> None:
         assert PromptUtils._determine_search_scope(None) == "site-pick"
 
 
-def test_determine_search_scope_site_cancelled(capsys: pytest.CaptureFixture[str]) -> None:
+def test_determine_search_scope_site_cancelled(caplog: pytest.LogCaptureFixture) -> None:
     """``'s'`` scope with cancelled site pick returns False."""
     with (
         patch("src.ui.prompt_utils.InputUtils.safe_input", return_value="s"),
         patch.object(PromptUtils, "select_site", return_value=None),
+        caplog.at_level(logging.WARNING),
     ):
         assert PromptUtils._determine_search_scope(None) is False
-    assert "No site selected" in capsys.readouterr().out
+    assert "No site selected" in caplog.text
 
 
 def test_determine_search_scope_org_wide() -> None:
@@ -535,7 +546,7 @@ def test_fetch_org_wired_clients_exception_returns_empty() -> None:
 # ---------- _fetch_all_clients ----------
 
 
-def test_fetch_all_clients_site_branch(capsys: pytest.CaptureFixture[str]) -> None:
+def test_fetch_all_clients_site_branch(caplog: pytest.LogCaptureFixture) -> None:
     """Site branch calls site-scoped fetchers and returns sorted combined list."""
     with (
         patch.object(
@@ -548,35 +559,41 @@ def test_fetch_all_clients_site_branch(capsys: pytest.CaptureFixture[str]) -> No
             "_fetch_site_wired_clients",
             return_value=[{"hostname": "a", "mac": "1"}],
         ),
+        caplog.at_level(logging.WARNING),
     ):
         result = PromptUtils._fetch_all_clients("org-1", "site-1")
     assert [c["hostname"] for c in result] == ["a", "b"]
-    assert "site" in capsys.readouterr().out
+    assert "site" in caplog.text
 
 
-def test_fetch_all_clients_org_branch(capsys: pytest.CaptureFixture[str]) -> None:
+def test_fetch_all_clients_org_branch(caplog: pytest.LogCaptureFixture) -> None:
     """Org branch calls org-scoped fetchers when ``site_id`` is None."""
     with (
         patch.object(PromptUtils, "_fetch_org_wireless_clients", return_value=[{"hostname": "x"}]),
         patch.object(PromptUtils, "_fetch_org_wired_clients", return_value=[{"hostname": "y"}]),
+        caplog.at_level(logging.WARNING),
     ):
         result = PromptUtils._fetch_all_clients("org-1", None)
     assert len(result) == 2
-    assert "organization" in capsys.readouterr().out
+    assert "organization" in caplog.text
 
 
 # ---------- _load_sites_cache ----------
 
 
-def test_load_sites_cache_success(capsys: pytest.CaptureFixture[str]) -> None:
+def test_load_sites_cache_success(caplog: pytest.LogCaptureFixture) -> None:
     """Builds id-to-name mapping from ``all_sites_with_limit`` result."""
-    with patch(
-        "src.ui.prompt_utils.APICoreFetchUtils.all_sites_with_limit",
-        return_value=[{"id": "a", "name": "Alpha"}, {"id": "b", "name": "Beta"}],
+    # WHY (#886 Phase 2): PromptUtils now emits via logging.warning instead of print, so tests capture via caplog.
+    with (
+        patch(
+            "src.ui.prompt_utils.APICoreFetchUtils.all_sites_with_limit",
+            return_value=[{"id": "a", "name": "Alpha"}, {"id": "b", "name": "Beta"}],
+        ),
+        caplog.at_level(logging.WARNING),
     ):
         cache = PromptUtils._load_sites_cache("org-1")
     assert cache == {"a": "Alpha", "b": "Beta"}
-    assert "Loading site information" in capsys.readouterr().out
+    assert "Loading site information" in caplog.text
 
 
 def test_load_sites_cache_exception_returns_empty() -> None:
@@ -591,12 +608,14 @@ def test_load_sites_cache_exception_returns_empty() -> None:
 # ---------- _print_client_type_summary ----------
 
 
-def test_print_client_type_summary(capsys: pytest.CaptureFixture[str]) -> None:
+def test_print_client_type_summary(caplog: pytest.LogCaptureFixture) -> None:
     """Prints wireless/wired counts and legend."""
-    PromptUtils._print_client_type_summary(
-        [{"client_type": "wireless"}, {"client_type": "wired"}, {"client_type": "wired"}]
-    )
-    out = capsys.readouterr().out
+    # WHY (#886 Phase 2): PromptUtils now emits via logging.warning instead of print, so tests capture via caplog.
+    with caplog.at_level(logging.WARNING):
+        PromptUtils._print_client_type_summary(
+            [{"client_type": "wireless"}, {"client_type": "wired"}, {"client_type": "wired"}]
+        )
+    out = caplog.text
     assert "1 wireless" in out
     assert "2 wired" in out
     assert "[+]" in out and "[~]" in out and "[-]" in out
@@ -652,15 +671,17 @@ def test_format_client_row_composes_all_cells() -> None:
 # ---------- _display_client_table ----------
 
 
-def test_display_client_table_returns_index_map(capsys: pytest.CaptureFixture[str]) -> None:
+def test_display_client_table_returns_index_map(caplog: pytest.LogCaptureFixture) -> None:
     """Returns a 0-based ``dict`` mapping index to client."""
+    # WHY (#886 Phase 2): PromptUtils now emits via logging.warning instead of print, so tests capture via caplog.
     clients = [
         {"client_type": "wireless", "hostname": "a", "mac": "1", "connected": True},
         {"client_type": "wired", "hostname": "b", "mac": "2", "connected": True},
     ]
-    result = PromptUtils._display_client_table(clients, {})
+    with caplog.at_level(logging.WARNING):
+        result = PromptUtils._display_client_table(clients, {})
     assert result == {0: clients[0], 1: clients[1]}
-    assert "Found 2 clients" in capsys.readouterr().out
+    assert "Found 2 clients" in caplog.text
 
 
 # ---------- _get_client_site_name ----------
@@ -817,23 +838,27 @@ def test_handle_client_selection_valid_index() -> None:
 
 
 def test_extract_selected_client_site_in_cache_prints_site(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Known site prints resolved site name."""
+    # WHY (#886 Phase 2): PromptUtils now emits via logging.warning instead of print, so tests capture via caplog.
     client = {"mac": "aa", "client_type": "wireless", "site_id": "s-1", "hostname": "h"}
-    result = PromptUtils._extract_selected_client(client, {"s-1": "Alpha"}, None)
+    with caplog.at_level(logging.WARNING):
+        result = PromptUtils._extract_selected_client(client, {"s-1": "Alpha"}, None)
     assert result == ("aa", "wireless", "s-1")
-    assert "Site: Alpha" in capsys.readouterr().out
+    assert "Site: Alpha" in caplog.text
 
 
 def test_extract_selected_client_site_not_in_cache_skips_site_line(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Unknown site skips the ``Site:`` line but still returns the id."""
+    # WHY (#886 Phase 2): PromptUtils now emits via logging.warning instead of print, so tests capture via caplog.
     client = {"mac": "bb", "client_type": "wired", "site_id": "unknown", "name": "n"}
-    result = PromptUtils._extract_selected_client(client, {}, None)
+    with caplog.at_level(logging.WARNING):
+        result = PromptUtils._extract_selected_client(client, {}, None)
     assert result == ("bb", "wired", "unknown")
-    assert "Site:" not in capsys.readouterr().out
+    assert "Site:" not in caplog.text
 
 
 def test_extract_selected_client_defaults_to_default_site_id() -> None:

--- a/tests/unit/ui/test_tui.py
+++ b/tests/unit/ui/test_tui.py
@@ -13,6 +13,7 @@ free of real Rich work while still exercising the wiring code paths.
 from __future__ import annotations
 
 import builtins
+import logging  # WHY (#886 Phase 2): capture Rich-missing error via caplog since tui.py now uses logging.error.
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -105,8 +106,9 @@ class TestInitRich:
             assert hasattr(tui, name)
         assert tui.console is not None  # Console instance created
 
-    def test_import_error_triggers_sys_exit(self, capsys):
+    def test_import_error_triggers_sys_exit(self, caplog: pytest.LogCaptureFixture) -> None:
         """Missing Rich library aborts the process with sys.exit(1)."""
+        # WHY (#886 Phase 2): tui.py now emits the diagnostic via logging.error, so assert via caplog.
         import sys as _sys
 
         from src.ui import tui as tui_module
@@ -123,12 +125,13 @@ class TestInitRich:
             patch.object(tui_module.platform, "system", return_value="Linux"),
             patch.dict(_sys.modules, _fake_unix_modules()),
             patch.object(builtins, "__import__", side_effect=blocked_import),
+            caplog.at_level(logging.ERROR),
             pytest.raises(SystemExit) as exc_info,
         ):
             tui_module.MistHelperTUI()
 
         assert exc_info.value.code == 1
-        assert "Rich library required" in capsys.readouterr().out
+        assert "Rich library not available" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Seventh per-subdirectory slice of #886 (T20 print-avoidance). Retires the remaining `print()` calls in `src/ui/` — targeting `prompt_utils.py`, `tui.py`, `runtime/tui_runner.py`, and `interactive_display_utils.py` — by migrating them to `logging.warning/error/exception`. Paired `print(...)` + `logging.*(...)` emit sites (Rich-missing fatal, TUI exit banner) are collapsed to single log calls.

Companion unit tests in `tests/unit/ui/test_prompt_utils.py` (~13 tests across site-selection, device-inventory, client-fetch, sites-cache, client-summary, client-table, and extract-selected-client suites) and `tests/unit/ui/test_tui.py::TestInitRich::test_import_error_triggers_sys_exit` migrated from `capsys.readouterr().out` to `caplog.text` under `caplog.at_level(logging.WARNING/ERROR)`. The Rich-missing assertion string updated from `"Rich library required"` to `"Rich library not available"` to match the collapsed `logging.error(...)` message.

WARNING level chosen for operator-visible interactive UI surfaces so they render on the default root-logger config (INFO suppressed by default); ERROR retained for the Rich-import fatal.

Refs #886. Follow-up slices continue in ascending-print-count order until T20 selector flip + E402 audit land.

## Test plan

- [x] `pytest tests/unit/ui/ -q` → 327 passed
- [x] `pytest tests/unit/ -q` → 8529 passed (full unit suite)
- [x] `ruff check src/ui/ tests/unit/ui/` → clean
- [x] `black --check src/ui/ tests/unit/ui/` → clean