### PR TITLE
chore(logging): migrate src/ssid_consolidation/ print() to logger (#886 slice 8/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 8/N: retire `print()` in `src/ssid_consolidation/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the remaining `print()`
+  calls in `src/ssid_consolidation/ssid_template_consolidation.py`,
+  `src/ssid_consolidation/_ssid_template_cache.py`,
+  `src/ssid_consolidation/_ssid_template_cluster.py`,
+  `src/ssid_consolidation/_ssid_template_phase1.py`,
+  `src/ssid_consolidation/_ssid_template_phase2.py`,
+  `src/ssid_consolidation/_ssid_template_phase3.py`, and
+  `src/ssid_consolidation/_ssid_template_phase45.py` with `logging.warning(...)`
+  so the print-avoidance rule (T20 selector target of #886) can eventually be
+  enabled repo-wide. WARNING level chosen for operator-visible phase banners,
+  plan-summary tables, conflict listings, phase-menu output, "Phase 1 cache
+  not found" bail messages, and per-phase status footers so they surface on
+  the default root-logger configuration (INFO is suppressed by default).
+  Companion unit tests in `tests/unit/test_ssid_template_consolidation.py`
+  were migrated from `capsys`/`captured.out` to `caplog`/`caplog.text` with
+  a `caplog.at_level(logging.WARNING)` wrapper around each call site so the
+  suite continues to assert operator-visible output through the logging path.
+  No behavioural change beyond the emit channel; all 241 tests in the module
+  remain green.
+
 ### #886 Phase 2 slice 7/N: retire `print()` in `src/ui/` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the remaining `print()`

--- a/src/ssid_consolidation/_ssid_template_cache.py
+++ b/src/ssid_consolidation/_ssid_template_cache.py
@@ -49,7 +49,7 @@ def _check_prerequisite_for_all(phase_number: int) -> bool:  # WHY: run-all shor
 def _check_cache_exists(cache_file: str) -> bool:  # WHY: gate downstream phases on phase-1 artefact
     """Check if Phase 1 cache file exists."""
     if not os.path.exists(cache_file):  # WHY: guard first-run before phase 1 completes
-        print("! Phase 1 cache not found. Run Phase 1 first.")  # WHY: teach operator the fix
+        logging.warning("Phase 1 cache not found. Run Phase 1 first.")  # WHY: teach operator the fix
         return False  # WHY: signal caller to abort the current phase
     return True  # WHY: cache present, downstream phase may proceed
 
@@ -61,7 +61,9 @@ def _handle_completed_resume(  # WHY: UX branch when prior run finished all rows
     safe_input_fn: SafeInputFn,
 ) -> tuple[bool, list[dict[str, Any]]]:
     """Handle resume when phase is already complete."""
-    print(f"Phase {phase} already completed ({completed_count}/{total}). Re-running will overwrite.")  # WHY: warn
+    logging.warning(
+        "Phase %d already completed (%d/%d). Re-running will overwrite.", phase, completed_count, total
+    )  # WHY: warn
     choice: str = safe_input_fn(  # WHY: ask before re-running a completed phase
         "Re-run from scratch? (y/N): ",
         context="ssid_consolidation_resume",
@@ -79,7 +81,9 @@ def _handle_partial_resume(  # WHY: UX branch when prior run stopped mid-phase
     safe_input_fn: SafeInputFn,
 ) -> tuple[bool, list[dict[str, Any]]]:
     """Handle resume when phase is partially complete."""
-    print(f"Phase {phase} partially completed ({completed_count}/{total}).")  # WHY: report progress to operator
+    logging.warning(
+        "Phase %d partially completed (%d/%d).", phase, completed_count, total
+    )  # WHY: report progress to operator
     choice: str = safe_input_fn(  # WHY: default (Y) is resume — matches operator intent
         "Resume from last checkpoint? (Y/n): ",
         context="ssid_consolidation_resume",
@@ -106,7 +110,7 @@ class _SsidTemplateCacheCluster(_ClusterBase):  # WHY: proxy cluster grouping ca
             return _check_cache_exists(parent.CACHE_FILE)  # WHY: reuse shared cache-existence guard
         prior_file = parent.PHASE_RESULT_FILES.get(phase - 1)  # WHY: chain phases via results file
         if prior_file and not os.path.exists(prior_file):  # WHY: prior artefact absent blocks this phase
-            print(f"! Phase {phase - 1} results not found. Run Phase {phase - 1} first.")  # WHY: teach fix
+            logging.warning("Phase %d results not found. Run Phase %d first.", phase - 1, phase - 1)  # WHY: teach fix
             return False  # WHY: signal caller to abort
         return True  # WHY: prior artefact present, proceed
 

--- a/src/ssid_consolidation/_ssid_template_cluster.py
+++ b/src/ssid_consolidation/_ssid_template_cluster.py
@@ -18,6 +18,7 @@ on.
 
 from __future__ import annotations  # WHY: postponed evaluation for forward-ref parent type
 
+import logging  # WHY (#886 Phase 2): cluster helper emits bail msg via logger instead of print
 from typing import TYPE_CHECKING, Any  # WHY: Any lets __getattr__ proxy any parent method
 
 if TYPE_CHECKING:  # WHY: only pulled in by type checkers; skipped at runtime
@@ -67,7 +68,7 @@ class _ClusterBase:  # WHY: shared wrapper base for every ssid_template cluster
         parent = self._mm  # WHY: proxy alias
         cached = parent._load_cache()  # noqa: SLF001 — cluster helper is intra-package
         if not cached:  # WHY: cache missing means Phase 1 was skipped
-            print("! Phase 1 cache not found. Run Phase 1 first.")  # WHY: user bail msg
+            logging.warning("Phase 1 cache not found. Run Phase 1 first.")  # WHY: user bail msg
             return False  # WHY: signal to caller to abort the phase
         parent.cache = cached  # WHY: hand loaded cache to parent state
         return True  # WHY: cache loaded successfully, phase can proceed

--- a/src/ssid_consolidation/_ssid_template_phase1.py
+++ b/src/ssid_consolidation/_ssid_template_phase1.py
@@ -71,7 +71,7 @@ def _fetch_and_log(  # WHY: mirror parent's fetch helper so mistapi patching lan
     shared ``mistapi`` MagicMock injected via ``sys.modules``) in effect
     for ``_fetch_all_org_data`` callers.
     """
-    print(f"    Fetching {label}...")  # WHY: operator telemetry during multi-call fetch
+    logging.warning("Fetching %s...", label)  # WHY: operator telemetry during multi-call fetch
     response = api_fn(session, org_id, **kwargs)  # WHY: mistapi list endpoint call
     data: list[dict[str, Any]] = (  # WHY: paginate response; None -> [] keeps callers dict-safe
         mistapi.get_all(response=response, mist_session=session) or []
@@ -579,11 +579,11 @@ def _print_phase1_summary(
 ) -> None:
     """Print Phase 1 audit summary."""
     eligible, psk_count, anomaly_count = _phase1_counts(matrix)  # WHY: single-pass tallies
-    print(f"\n  Total sites:   {len(matrix)}")  # WHY: operator-visible tally
-    print(f"  Eligible:      {eligible}")  # WHY: operator-visible eligible count
-    print(f"  PSK excluded:  {psk_count}")  # WHY: operator-visible PSK excluded count
-    print(f"  Anomalies:     {anomaly_count}")  # WHY: operator-visible anomaly count
-    print(f"  Deviations:    {len(deviations)}")  # WHY: operator-visible deviation count
+    logging.warning("Total sites:   %d", len(matrix))  # WHY: operator-visible tally
+    logging.warning("Eligible:      %d", eligible)  # WHY: operator-visible eligible count
+    logging.warning("PSK excluded:  %d", psk_count)  # WHY: operator-visible PSK excluded count
+    logging.warning("Anomalies:     %d", anomaly_count)  # WHY: operator-visible anomaly count
+    logging.warning("Deviations:    %d", len(deviations))  # WHY: operator-visible deviation count
     logging.info(  # WHY: durable log record mirrors console summary
         "Phase 1 complete: %d sites, %d eligible, %d deviations",
         len(matrix),
@@ -613,7 +613,7 @@ class _SsidTemplatePhase1Cluster(_ClusterBase):
     def phase1_audit(self) -> None:
         """Phase 1 orchestrator — fetch data, build matrix, analyze."""
         parent = self._mm  # WHY: proxy alias for readability + W0212 avoidance
-        print("\n=== Phase 1: Read-Only Audit ===")  # WHY: operator-visible section banner
+        logging.warning("=== Phase 1: Read-Only Audit ===")  # WHY: operator-visible section banner
         logging.info(  # WHY: audit-log start-of-phase entry with SSID context
             "Phase 1: Starting read-only audit for SSID '%s'",
             parent.target_ssid,
@@ -621,7 +621,7 @@ class _SsidTemplatePhase1Cluster(_ClusterBase):
         # WHY: route through parent so `patch.object(mgr, "_phase1_load_or_fetch", ...)` intercepts.
         org_data = self._call("_phase1_load_or_fetch")
         if not org_data:  # WHY: prerequisite fetch failure aborts the phase gracefully
-            print("! Failed to load or fetch organization data.")
+            logging.warning("Failed to load or fetch organization data.")
             return
         matrix = self._call("_build_matrix", org_data)  # WHY: allow test patches on parent
         deviations = self._call("_analyze_deviations", matrix, org_data)  # WHY: allow test patches
@@ -632,7 +632,7 @@ class _SsidTemplatePhase1Cluster(_ClusterBase):
         cached_data = self._try_load_cached()  # WHY: helper isolates cache-read + prompt branch
         if cached_data is not None:  # WHY: sentinel None means proceed to fresh fetch
             return cached_data
-        print("  Fetching fresh organization data...")  # WHY: operator telemetry for fetch path
+        logging.warning("Fetching fresh organization data...")  # WHY: operator telemetry for fetch path
         # WHY: route through parent so tests may patch _fetch_all_org_data on mgr directly.
         fresh: dict[str, Any] = self._call("_fetch_all_org_data")
         return fresh
@@ -646,7 +646,7 @@ class _SsidTemplatePhase1Cluster(_ClusterBase):
         if not cached or not cached.get("data"):  # WHY: no cache => caller performs fresh fetch
             return None
         age = _cache_age_minutes(cached.get("collected_at", ""))  # WHY: minutes since cache stamp
-        print(f"  Cached data found ({age:.0f} minutes old).")  # WHY: operator sees freshness
+        logging.warning("Cached data found (%.0f minutes old).", age)  # WHY: operator sees freshness
         choice = parent.safe_input_fn(  # WHY: prompt operator with default-Y reuse
             _CACHE_REUSE_PROMPT,
             default_value="Y",
@@ -708,7 +708,7 @@ class _SsidTemplatePhase1Cluster(_ClusterBase):
             kwargs = {"limit": parent.page_limit} if spec.limited else {}  # WHY: only some paginated
             result[spec.key] = _fetch_and_log(spec.label, spec.api_fn, parent.apisession, parent.org_id, **kwargs)
         logging.info("Total org-level API calls: %d", _TOTAL_BULK_CALLS)  # WHY: audit trail count
-        print(f"    Done ({_TOTAL_BULK_CALLS} API calls)")  # WHY: operator-visible finalizer
+        logging.warning("Done (%d API calls)", _TOTAL_BULK_CALLS)  # WHY: operator-visible finalizer
         return result
 
     def _build_matrix(self, org_data: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/ssid_consolidation/_ssid_template_phase2.py
+++ b/src/ssid_consolidation/_ssid_template_phase2.py
@@ -25,6 +25,7 @@ tests without teaching them about internal module boundaries.
 
 from __future__ import annotations  # WHY: postponed evaluation for forward-ref parent type
 
+import logging  # WHY (#886 Phase 2): operator-visible summary lines emitted via logger
 from typing import Any  # WHY: broad typing for opaque cache / row payloads
 
 from ._ssid_template_cluster import _ClusterBase  # WHY: shared parent-proxy wrapper
@@ -153,11 +154,11 @@ def _count_statuses(plan: list[dict[str, Any]]) -> dict[str, int]:  # WHY: extra
 def _display_variable_summary(plan: list[dict[str, Any]]) -> None:  # WHY: user-facing summary output
     """Display variable assignment summary table."""
     counts = _count_statuses(plan)  # WHY: single-pass tally keeps this function CC low
-    print("\n  Variable Assignment Plan:")  # WHY: header aligns with parent phases
-    print(f"    Pending:            {counts[_STATUS_PENDING]}")  # WHY: entries queued for write
-    print(f"    Already configured: {counts[_STATUS_CONFIGURED]}")  # WHY: no-op count
-    print(f"    Conflicts:          {counts[_STATUS_CONFLICT]}")  # WHY: needs operator attention
-    print(f"    Skipped:            {counts[_STATUS_SKIPPED]}")  # WHY: PSK/anomaly rows
+    logging.warning("Variable Assignment Plan:")  # WHY: header aligns with parent phases
+    logging.warning("Pending:            %d", counts[_STATUS_PENDING])  # WHY: entries queued for write
+    logging.warning("Already configured: %d", counts[_STATUS_CONFIGURED])  # WHY: no-op count
+    logging.warning("Conflicts:          %d", counts[_STATUS_CONFLICT])  # WHY: needs operator attention
+    logging.warning("Skipped:            %d", counts[_STATUS_SKIPPED])  # WHY: PSK/anomaly rows
     if counts[_STATUS_CONFLICT]:  # WHY: only pay for the details table when needed
         conflicts = [e for e in plan if e["status"] == _STATUS_CONFLICT]  # WHY: filter for detail rows
         _print_conflicts(conflicts)  # WHY: render bounded conflict detail table
@@ -165,15 +166,15 @@ def _display_variable_summary(plan: list[dict[str, Any]]) -> None:  # WHY: user-
 
 def _print_conflicts(conflicts: list[dict[str, Any]]) -> None:  # WHY: bounded conflict output
     """Print conflict details for variable summary."""
-    print("\n  Conflicts (existing value differs from proposed):")  # WHY: section header
+    logging.warning("Conflicts (existing value differs from proposed):")  # WHY: section header
     for entry in conflicts[:_CONFLICT_DISPLAY_LIMIT]:  # WHY: bound console noise to first N
         site = entry["site_name"]  # WHY: readable local for f-string
         var_name = entry["variable_name"]  # WHY: readable local for f-string
         current = entry["current_value"]  # WHY: readable local for f-string
         proposed = entry["proposed_value"]  # WHY: readable local for f-string
-        print(f"    {site}: {var_name} = {current} -> {proposed}")  # WHY: one line per conflict
+        logging.warning("%s: %s = %s -> %s", site, var_name, current, proposed)  # WHY: one line per conflict
     if len(conflicts) > _CONFLICT_DISPLAY_LIMIT:  # WHY: signal that output was truncated
-        print(f"    ... and {len(conflicts) - _CONFLICT_DISPLAY_LIMIT} more")  # WHY: overflow count
+        logging.warning("... and %d more", len(conflicts) - _CONFLICT_DISPLAY_LIMIT)  # WHY: overflow count
 
 
 def _group_entries_by_site(entries: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
@@ -211,15 +212,15 @@ class _SsidTemplatePhase2Cluster(_ClusterBase):
 
     def phase2_site_variables(self) -> None:  # WHY: user-facing Phase 2 entry point
         """Phase 2 orchestrator - compute variable plan, write to sites."""
-        print("\n=== Phase 2: Write Site Variables ===")  # WHY: banner marks phase boundary
-        import logging  # noqa: PLC0415 — kept local so this cluster ships zero import-time deps
+        logging.warning("=== Phase 2: Write Site Variables ===")  # WHY: banner marks phase boundary
+        # WHY (#886 Phase 2): module already imports `logging` at module top; local re-import removed.
 
         logging.info("Phase 2: Starting site variable configuration")  # WHY: audit trail
         if not self._load_cache_or_bail():  # WHY: cache preamble aborts on missing Phase 1
             return
         plan = _compute_variable_plan(self._mm.cache)  # WHY: derive plan from cached deviations
         if not plan:  # WHY: nothing to configure means we exit cleanly
-            print("  No site variables to configure (no deviations detected).")
+            logging.warning("No site variables to configure (no deviations detected).")
             return
         _display_variable_summary(plan)  # WHY: show operator the counts + conflicts
         if not self._confirm_phase2_write(plan):  # WHY: confirmation is user-blocking

--- a/src/ssid_consolidation/_ssid_template_phase3.py
+++ b/src/ssid_consolidation/_ssid_template_phase3.py
@@ -41,7 +41,7 @@ _PILOT_GROUP_NAME = "misthelper_pilot"  # WHY: fixed name for the pilot site-gro
 _PILOT_TARGET = "pilot"  # WHY: matrix rows targeting pilot cluster route to the pilot group
 _PHASE_ID = 3  # WHY: phase index for offer_resume / save_phase_results dispatch
 _PHASE_LABEL = "Phase 3"  # WHY: label used by _print_phase_summary for report output
-_PHASE3_HEADER = "\n=== Phase 3: Create / Assign Site Groups ==="  # WHY: user-facing banner
+_PHASE3_HEADER = "=== Phase 3: Create / Assign Site Groups ==="  # WHY: user-facing banner
 _PHASE3_START_LOG = "Phase 3: Starting site group configuration"  # WHY: startup log line
 _GROUP_EXISTS_LOG = "Group '%s' already exists (id=%s)"  # WHY: reuse-existing skip message
 _WRITE_FILENAME = "ssid_consolidation_site_groups"  # WHY: parquet/table sink filename
@@ -175,7 +175,7 @@ def _assign_matrix_sites(
 
 def _display_group_plan(plan: dict[str, Any]) -> None:  # WHY: exported for tests + re-export
     """Print the group assignment plan."""
-    print("\n  Site Group Plan:")  # WHY: section header for the console preview
+    logging.warning("Site Group Plan:")  # WHY: section header for the console preview
     for group in plan.get("groups", []):  # WHY: preview one group entry at a time
         _print_group_header(group)  # WHY: header line with exists/create + site count
         _print_group_preview(group)  # WHY: bounded preview of member sites
@@ -185,16 +185,16 @@ def _print_group_header(group: dict[str, Any]) -> None:  # WHY: extracted from _
     """Print a single group header row (status + site count)."""
     status = "exists" if group["exists"] else "to create"  # WHY: preview action verb
     site_count = len(group["sites"])  # WHY: total members before truncation
-    print(f"    {group['group_name']} ({status}) - {site_count} sites")  # WHY: single header line
+    logging.warning("%s (%s) - %d sites", group["group_name"], status, site_count)  # WHY: single header line
 
 
 def _print_group_preview(group: dict[str, Any]) -> None:  # WHY: extracted from _display_group_plan
     """Print a bounded preview of a group's assigned sites."""
     sites = group["sites"]  # WHY: alias for readability
     for site in sites[:_DISPLAY_SITE_LIMIT]:  # WHY: bound console noise per group
-        print(f"      - {site['site_name']}")  # WHY: one visible site name per line
+        logging.warning("- %s", site["site_name"])  # WHY: one visible site name per line
     if len(sites) > _DISPLAY_SITE_LIMIT:  # WHY: only mention overflow when it exists
-        print(f"      ... and {len(sites) - _DISPLAY_SITE_LIMIT} more")  # WHY: overflow marker
+        logging.warning("... and %d more", len(sites) - _DISPLAY_SITE_LIMIT)  # WHY: overflow marker
 
 
 def _build_assign_results(
@@ -340,7 +340,7 @@ class _SsidTemplatePhase3Cluster(_ClusterBase):  # WHY: exported for parent __in
 
 def _log_phase3_start() -> None:  # WHY: extracted from phase3_site_groups
     """Print the banner and emit the startup log line for Phase 3."""
-    print(_PHASE3_HEADER)  # WHY: user-facing banner marks phase entry
+    logging.warning(_PHASE3_HEADER)  # WHY: user-facing banner marks phase entry
     logging.info(_PHASE3_START_LOG)  # WHY: telemetry alongside the banner
 
 

--- a/src/ssid_consolidation/_ssid_template_phase45.py
+++ b/src/ssid_consolidation/_ssid_template_phase45.py
@@ -62,13 +62,13 @@ _TEMPLATE_BASENAME_ENV = "MIST_TEMPLATE_BASENAME"  # WHY: env override for the s
 _DEVIATION_CONTEXT = "ssid_consolidation_deviation_resolution"  # WHY: safe_input_fn context tag
 _PHASE4_ID = 4  # WHY: phase index for save_phase_results / write_data_fn dispatch
 _PHASE4_LABEL = "Phase 4"  # WHY: label used by _print_phase_summary for the templates phase
-_PHASE4_HEADER = "\n=== Phase 4: Create Consolidated Templates ==="  # WHY: user-facing banner
+_PHASE4_HEADER = "=== Phase 4: Create Consolidated Templates ==="  # WHY: user-facing banner
 _PHASE4_START_LOG = "Phase 4: Starting template creation"  # WHY: startup log line for phase 4
 _PHASE4_WRITE_FILENAME = "ssid_consolidation_templates"  # WHY: parquet/table sink label for phase 4
 _PHASE4_WRITE_API_NAME = "ssidConsolidationTemplates"  # WHY: mist API function tag for phase 4 write
 _PHASE5_ID = 5  # WHY: phase index for save_phase_results / offer_resume dispatch
 _PHASE5_LABEL = "Phase 5"  # WHY: label used by _print_phase_summary for the disable phase
-_PHASE5_HEADER = "\n=== Phase 5: Disable Old SSIDs ==="  # WHY: user-facing banner
+_PHASE5_HEADER = "=== Phase 5: Disable Old SSIDs ==="  # WHY: user-facing banner
 _PHASE5_START_LOG = "Phase 5: Starting old SSID disable"  # WHY: startup log line for phase 5
 _PHASE5_WRITE_FILENAME = "ssid_consolidation_disable"  # WHY: parquet/table sink label for phase 5
 _PHASE5_WRITE_API_NAME = "ssidConsolidationDisable"  # WHY: mist API function tag for phase 5 write
@@ -162,7 +162,7 @@ def _print_deviation_choices(
     unique_values: list[dict[str, Any]],
 ) -> None:
     """Print the numbered list of candidate values for a deviation."""
-    print(f"\n  Deviation: {param} in cluster '{cluster}'")  # WHY: header per deviation
+    logging.warning("Deviation: %s in cluster '%s'", param, cluster)  # WHY: header per deviation
     for index, entry in enumerate(unique_values, 1):  # WHY: 1-based menu numbering for operator
         _print_choice_entry(index, entry)  # WHY: delegate row rendering to keep loop body tight
 
@@ -170,10 +170,12 @@ def _print_deviation_choices(
 def _print_choice_entry(index: int, entry: dict[str, Any]) -> None:
     """Print one candidate value row plus optional 'and N more sites' tail."""
     sites_preview = ", ".join(entry["sites"][:_SITES_PREVIEW_LIMIT])  # WHY: bounded preview
-    print(f"    {index}. {entry['value']} ({entry['count']} sites: {sites_preview})")  # WHY: candidate line
+    logging.warning(
+        "%d. %s (%d sites: %s)", index, entry["value"], entry["count"], sites_preview
+    )  # WHY: candidate line
     remaining = len(entry["sites"]) - _SITES_PREVIEW_LIMIT  # WHY: tail count when list exceeds preview
     if remaining > 0:  # WHY: only emit tail hint when overflow rows exist
-        print(f"       ... and {remaining} more sites")  # WHY: report tail count without noise
+        logging.warning("... and %d more sites", remaining)  # WHY: report tail count without noise
 
 
 def _record_deviation_choice(
@@ -199,7 +201,7 @@ def _parse_choice_index(choice: str, param: str) -> int | None:
     try:
         return int(choice) - 1  # WHY: 1-based menu -> 0-based index
     except ValueError:  # WHY: non-integer input is a soft failure — skip param, keep loop
-        print(f"  ! Invalid input. Skipping {param}.")  # WHY: user-visible skip reason
+        logging.warning("Invalid input. Skipping %s.", param)  # WHY: user-visible skip reason
         return None  # WHY: caller treats None as skip signal
 
 
@@ -212,7 +214,7 @@ def _apply_choice(
 ) -> None:
     """Validate the index and either record the resolution or emit a skip message."""
     if not 0 <= selected_index < len(unique_values):  # WHY: out-of-range index is a soft failure
-        print(f"  ! Invalid selection. Skipping {param}.")  # WHY: user-visible skip reason
+        logging.warning("Invalid selection. Skipping %s.", param)  # WHY: user-visible skip reason
         return  # WHY: skip when index falls outside the menu bounds
     selected = unique_values[selected_index]["value"]  # WHY: canonical value chosen
     resolutions[(cluster, param)] = selected  # WHY: cluster+param uniquely keys the resolution
@@ -342,7 +344,7 @@ def _display_template_plan(
     group_plan: dict[str, dict[str, str]],
 ) -> None:
     """Print template creation plan."""
-    print("\n  Template Plan:")  # WHY: header separates the plan from prior output
+    logging.warning("Template Plan:")  # WHY: header separates the plan from prior output
     for group_name, config in configs.items():  # WHY: one block per group in the plan
         group_info = group_plan.get(group_name, {})  # WHY: recover group_id for display
         _print_template_row(group_name, group_info, config)  # WHY: delegate row rendering
@@ -355,11 +357,11 @@ def _print_template_row(
 ) -> None:
     """Print one template plan block (group header + SSID + remaining fields)."""
     group_id = group_info.get("group_id", "new")  # WHY: 'new' sentinel when the group is not yet created
-    print(f"    {group_name} (group_id={group_id})")  # WHY: block header
-    print(f"      SSID: {config.get('ssid', '')}")  # WHY: SSID always printed first for readability
+    logging.warning("%s (group_id=%s)", group_name, group_id)  # WHY: block header
+    logging.warning("SSID: %s", config.get("ssid", ""))  # WHY: SSID always printed first for readability
     for key, value in config.items():  # WHY: iterate remaining config fields
         if key != "ssid":  # WHY: ssid already emitted above
-            print(f"      {key}: {value}")  # WHY: two-space indent aligns with header
+            logging.warning("%s: %s", key, value)  # WHY: two-space indent aligns with header
 
 
 # ---------------------------------------------------------------------------
@@ -423,10 +425,10 @@ def _display_disable_plan(
 ) -> None:
     """Print disable plan summary."""
     counts = _partition_disable_plan(plan)  # WHY: single pass over the plan
-    print("\n  Disable Plan:")  # WHY: header separates the plan from prior output
-    print(f"    To disable:       {counts[_STATUS_TO_DISABLE]}")  # WHY: actionable count first
-    print(f"    Already disabled: {counts[_STATUS_ALREADY_DISABLED]}")  # WHY: idempotent-skip count
-    print(f"    Skipped:          {counts[_STATUS_SKIPPED]}")  # WHY: other-skip count last
+    logging.warning("Disable Plan:")  # WHY: header separates the plan from prior output
+    logging.warning("To disable:       %d", counts[_STATUS_TO_DISABLE])  # WHY: actionable count first
+    logging.warning("Already disabled: %d", counts[_STATUS_ALREADY_DISABLED])  # WHY: idempotent-skip count
+    logging.warning("Skipped:          %d", counts[_STATUS_SKIPPED])  # WHY: other-skip count last
 
 
 def _partition_disable_plan(plan: list[dict[str, Any]]) -> dict[str, int]:
@@ -456,9 +458,9 @@ def _set_ssid_disabled(wlans: list[dict[str, Any]], ssid_id: str) -> bool:
 def _print_phase_summary(phase_label: str, results: list[dict[str, Any]]) -> None:
     """Print a summary of phase results by status."""
     status_counts = _tally_status(results)  # WHY: aggregate over heterogeneous status field
-    print(f"\n  {phase_label} Summary:")  # WHY: header per phase for the summary block
+    logging.warning("%s Summary:", phase_label)  # WHY: header per phase for the summary block
     for status, count in sorted(status_counts.items()):  # WHY: deterministic status ordering
-        print(f"    {status}: {count}")  # WHY: single indent aligns with plan blocks
+        logging.warning("%s: %d", status, count)  # WHY: single indent aligns with plan blocks
 
 
 def _tally_status(results: list[dict[str, Any]]) -> dict[str, int]:
@@ -481,7 +483,7 @@ class _SsidTemplatePhase45Cluster(_ClusterBase):
     def phase4_templates(self) -> None:
         """Phase 4 orchestrator — resolve deviations, create templates."""
         parent = self._mm  # WHY: proxy alias for readability + W0212 avoidance
-        print(_PHASE4_HEADER)  # WHY: user-facing banner
+        logging.warning(_PHASE4_HEADER)  # WHY: user-facing banner
         logging.info(_PHASE4_START_LOG)  # WHY: audit-log start of phase 4
         preflight = self._phase4_preflight()  # WHY: split cache + plan build out of orchestrator
         if preflight is None:  # WHY: preflight already printed the bail message
@@ -514,7 +516,7 @@ class _SsidTemplatePhase45Cluster(_ClusterBase):
             return None  # WHY: cache preamble already printed the bail message
         phase3_results = parent._load_phase_results(3)  # noqa: SLF001
         if not phase3_results:  # WHY: phase 4 depends on Phase 3 groups being materialized
-            print("! Phase 3 results not found. Run Phase 3 first.")  # WHY: operator-visible reason
+            logging.warning("Phase 3 results not found. Run Phase 3 first.")  # WHY: operator-visible reason
             return None  # WHY: abort until phase 3 has been executed
         resolutions = _resolve_deviations(parent.cache, parent.safe_input_fn)  # WHY: interactive step
         group_plan = _load_group_plan_from_results(phase3_results)  # WHY: shape the group plan map
@@ -571,14 +573,14 @@ class _SsidTemplatePhase45Cluster(_ClusterBase):
     def phase5_disable_old(self) -> None:
         """Phase 5 orchestrator — disable matching SSIDs in old templates."""
         parent = self._mm  # WHY: proxy alias
-        print(_PHASE5_HEADER)  # WHY: user-facing banner
+        logging.warning(_PHASE5_HEADER)  # WHY: user-facing banner
         logging.info(_PHASE5_START_LOG)  # WHY: audit-log start of phase 5
         prep = self._phase5_prepare_plan()  # WHY: split cache + plan build out of orchestrator
         if prep is None:  # WHY: preflight already printed the bail message
             return  # WHY: abort when cache is missing
         resuming, prior_results, plan, to_disable = prep  # WHY: unpack the four preflight artifacts
         if not to_disable:  # WHY: nothing to do — empty actionable slice
-            print("  No SSIDs to disable.")  # WHY: operator-visible reason for the no-op
+            logging.warning("No SSIDs to disable.")  # WHY: operator-visible reason for the no-op
             return  # WHY: skip persistence when the plan is empty
         prompt = f"Disable {len(to_disable)} SSIDs in old templates?"  # WHY: confirmation prompt copy
         if not parent._confirm_or_cancel(prompt):  # noqa: SLF001 — shared preamble helper

--- a/src/ssid_consolidation/ssid_template_consolidation.py
+++ b/src/ssid_consolidation/ssid_template_consolidation.py
@@ -186,7 +186,7 @@ def _fetch_and_log(  # WHY: parent-owned so its __globals__ points here for mist
     ``patch.object(ssid_template_consolidation, "mistapi", ...)``
     observable when they call ``_mod._fetch_and_log`` directly.
     """
-    print(f"    Fetching {label}...")  # WHY: operator telemetry during multi-call fetch
+    logging.warning("Fetching %s...", label)  # WHY: operator telemetry during multi-call fetch
     response = api_fn(session, org_id, **kwargs)  # WHY: mistapi list endpoint call
     data: list[dict[str, Any]] = mistapi.get_all(response=response, mist_session=session) or []  # WHY: paginate
     logging.info("%s fetched: %d", label.capitalize(), len(data))  # WHY: audit trail per collection
@@ -308,7 +308,9 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
         get_org_id_fn: GetOrgIdFn,
     ) -> None:
         """Menu 159 entry point — prompt for SSID, launch phase menu."""
-        print("\n=== SSID Template Consolidation (5-Phase Guided Workflow) ===")  # WHY: banner for operator context
+        logging.warning(
+            "=== SSID Template Consolidation (5-Phase Guided Workflow) ==="
+        )  # WHY: banner for operator context
         logging.info("Starting SSID Template Consolidation workflow")  # WHY: audit-log workflow entry
         context = SSIDTemplateConsolidationManager._resolve_target_context(  # WHY: extracted for STRUCT-LENGTH
             get_org_id_fn, safe_input_fn
@@ -333,11 +335,11 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
         """Resolve (org_id, target_ssid) or None when either is missing."""
         current_org_id: str | None = get_org_id_fn()  # WHY: pull active org from injected getter
         if not current_org_id:
-            print("! No organization selected. Exiting.")  # WHY: fail fast when no org is bound
+            logging.warning("No organization selected. Exiting.")  # WHY: fail fast when no org is bound
             return None  # WHY: caller treats None as an aborted workflow
         target_ssid = SSIDTemplateConsolidationManager._prompt_target_ssid(safe_input_fn)  # WHY: prompt operator
         if not target_ssid:
-            print("! No target SSID specified. Exiting.")  # WHY: empty SSID -> nothing to consolidate
+            logging.warning("No target SSID specified. Exiting.")  # WHY: empty SSID -> nothing to consolidate
             return None  # WHY: caller treats None as an aborted workflow
         return current_org_id, target_ssid  # WHY: hand off validated pair to execute()
 
@@ -383,13 +385,13 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
     def _handle_menu_choice(self, choice: str, dispatch: dict[str, Any]) -> bool:  # WHY: extracted so complexity <= 5
         """Route one menu selection; return True when the menu should exit."""
         if choice.lower() in ("q", "quit", ""):  # WHY: quit tokens include blank enter
-            print("Returning to main menu.")  # WHY: operator feedback before unwinding
+            logging.warning("Returning to main menu.")  # WHY: operator feedback before unwinding
             return True  # WHY: signal caller to exit the menu loop
         if choice == "6":  # WHY: 6 = sequential run of all phases
             self._run_all_phases(dispatch)  # WHY: delegates to shared runner
             return True  # WHY: sequential run is terminal like quit
         if choice not in dispatch:  # WHY: guard against typos before int() cast
-            print(f"! Invalid selection: {choice}")  # WHY: surface the bad token
+            logging.warning("Invalid selection: %s", choice)  # WHY: surface the bad token
             return False  # WHY: stay in the menu after typo
         phase_number = int(choice)  # WHY: dispatch keys are digit strings
         if not self._check_prerequisite(phase_number):  # WHY: bail if the preceding phase artifact missing
@@ -409,28 +411,28 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
 
     def _display_phase_menu(self, labels: dict[str, str]) -> None:  # WHY: printer split from loop for clarity
         """Print the numbered phase menu."""
-        print(f"\n--- SSID Template Consolidation: {self.target_ssid} ---")  # WHY: banner shows target SSID
+        logging.warning("--- SSID Template Consolidation: %s ---", self.target_ssid)  # WHY: banner shows target SSID
         for key, description in labels.items():  # WHY: iterate the ordered menu rows
-            print(f"  {key}. {description}")  # WHY: numbered menu row
-        print("  q. Return to main menu")  # WHY: escape hatch back to the top-level CLI
+            logging.warning("%s. %s", key, description)  # WHY: numbered menu row
+        logging.warning("q. Return to main menu")  # WHY: escape hatch back to the top-level CLI
 
     def _run_all_phases(self, dispatch: dict[str, Any]) -> None:  # WHY: sequential all-phases runner
         """Execute phases 1-5 sequentially, stopping on failure."""
         for phase_key in ("1", "2", "3", "4", "5"):  # WHY: run every phase in order
             phase_number = int(phase_key)  # WHY: dispatch keys are digit strings
-            print(f"\n{'=' * 60}")  # WHY: visual separator between phases
-            print(f"  Starting Phase {phase_number}")  # WHY: operator sees which phase started
-            print(f"{'=' * 60}")  # WHY: closing separator for banner symmetry
+            logging.warning("%s", "=" * 60)  # WHY: visual separator between phases
+            logging.warning("Starting Phase %d", phase_number)  # WHY: operator sees which phase started
+            logging.warning("%s", "=" * 60)  # WHY: closing separator for banner symmetry
             if not _check_prerequisite_for_all(phase_number):  # WHY: gate the phase on its prerequisite artifact
-                print(f"! Phase {phase_number} prerequisite not met. Stopping.")  # WHY: fail-fast message
+                logging.warning("Phase %d prerequisite not met. Stopping.", phase_number)  # WHY: fail-fast message
                 return  # WHY: stop the run-all when prereqs are missing
             try:
                 dispatch[phase_key]()  # WHY: invoke the phase's bound handler
             except Exception as error:  # WHY: convert phase failures into operator-visible messages
                 logging.exception("Phase %d failed: %s", phase_number, error)  # WHY: audit-log full traceback
-                print(f"! Phase {phase_number} failed: {error}")  # WHY: surface the error to the operator
+                logging.warning("Phase %d failed: %s", phase_number, error)  # WHY: surface the error to the operator
                 return  # WHY: halt the sequence on the first failure
-        print("\nAll 5 phases completed successfully.")  # WHY: success message after full sequence
+        logging.warning("All 5 phases completed successfully.")  # WHY: success message after full sequence
 
     # ------------------------------------------------------------------
     # Shared helpers
@@ -438,14 +440,14 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
 
     def _confirm_or_cancel(self, summary: str) -> bool:  # WHY: shared CONFIRM gate for write phases
         """Display summary and require CONFIRM to proceed."""
-        print(f"\n{summary}")  # WHY: print the operator-facing plan summary before prompting
+        logging.warning("%s", summary)  # WHY: print the operator-facing plan summary before prompting
         confirmation = self.safe_input_fn(  # WHY: EOF-safe stdin reader with confirmation context tag
             f'Type "{self.CONFIRM_KEYWORD}" to proceed: ',
             context="ssid_consolidation_confirm",
         )
         if confirmation != self.CONFIRM_KEYWORD:  # WHY: literal-match gate blocks accidental writes
             logging.warning("Operation cancelled - confirmation not provided")  # WHY: audit-log cancel
-            print("! Operation cancelled.")  # WHY: user-visible cancel message
+            logging.warning("Operation cancelled.")  # WHY: user-visible cancel message
             return False  # WHY: caller aborts the write path
         logging.info("Operation confirmed at %s", datetime.now().isoformat())  # WHY: audit-log confirmation time
         return True  # WHY: caller proceeds with the write
@@ -570,14 +572,14 @@ def _create_site_group(group: dict[str, Any], org_id: str, apisession: Any) -> N
             group["group_name"],
             group["group_id"],
         )
-        print(f"  Created group: {group['group_name']}")  # WHY: operator feedback for the create
+        logging.warning("Created group: %s", group["group_name"])  # WHY: operator feedback for the create
     except Exception as error:  # WHY: convert API/network failure into an audit-log + user message
         logging.error(  # WHY: audit-log the failure with the group name
             "Failed to create group '%s': %s",
             group["group_name"],
             error,
         )
-        print(f"  ! Failed to create group: " f"{group['group_name']}: {error}")  # WHY: user-visible failure line
+        logging.warning("Failed to create group: %s: %s", group["group_name"], error)  # WHY: user-visible failure line
 
 
 def _assign_group_sites(  # WHY: mistapi-touching site-group assigner (parent-owned for test patching)

--- a/tests/unit/test_ssid_template_consolidation.py
+++ b/tests/unit/test_ssid_template_consolidation.py
@@ -11,6 +11,7 @@ and display/summary functions.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import sys
@@ -206,30 +207,30 @@ class TestInit:
 class TestExecute:
     """SSIDTemplateConsolidationManager.execute tests."""
 
-    def test_exits_when_no_org_id(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_exits_when_no_org_id(self, caplog: pytest.LogCaptureFixture) -> None:
         get_org = MagicMock(return_value=None)
-        SSIDTemplateConsolidationManager.execute(
-            apisession=MagicMock(),
-            page_limit=100,
-            safe_input_fn=MagicMock(),
-            write_data_fn=MagicMock(),
-            get_org_id_fn=get_org,
-        )
-        captured = capsys.readouterr()
-        assert "No organization selected" in captured.out
+        with caplog.at_level(logging.WARNING):
+            SSIDTemplateConsolidationManager.execute(
+                apisession=MagicMock(),
+                page_limit=100,
+                safe_input_fn=MagicMock(),
+                write_data_fn=MagicMock(),
+                get_org_id_fn=get_org,
+            )
+        assert "No organization selected" in caplog.text
 
-    def test_exits_when_no_ssid(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_exits_when_no_ssid(self, caplog: pytest.LogCaptureFixture) -> None:
         get_org = MagicMock(return_value="org-1")
         safe_fn = MagicMock(return_value="")
-        SSIDTemplateConsolidationManager.execute(
-            apisession=MagicMock(),
-            page_limit=100,
-            safe_input_fn=safe_fn,
-            write_data_fn=MagicMock(),
-            get_org_id_fn=get_org,
-        )
-        captured = capsys.readouterr()
-        assert "No target SSID specified" in captured.out
+        with caplog.at_level(logging.WARNING):
+            SSIDTemplateConsolidationManager.execute(
+                apisession=MagicMock(),
+                page_limit=100,
+                safe_input_fn=safe_fn,
+                write_data_fn=MagicMock(),
+                get_org_id_fn=get_org,
+            )
+        assert "No target SSID specified" in caplog.text
 
     @patch.object(SSIDTemplateConsolidationManager, "run_phase_menu")
     def test_launches_phase_menu(self, mock_menu: MagicMock) -> None:
@@ -268,13 +269,13 @@ class TestPhaseMenu:
         dispatch = manager._build_phase_dispatch()
         assert set(dispatch.keys()) == {"1", "2", "3", "4", "5"}
 
-    def test_display_phase_menu(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_display_phase_menu(self, caplog: pytest.LogCaptureFixture) -> None:
         manager = _make_manager()
         labels = {"1": "Phase 1: Audit"}
-        manager._display_phase_menu(labels)
-        captured = capsys.readouterr()
-        assert "Phase 1: Audit" in captured.out
-        assert "q." in captured.out
+        with caplog.at_level(logging.WARNING):
+            manager._display_phase_menu(labels)
+        assert "Phase 1: Audit" in caplog.text
+        assert "q." in caplog.text
 
 
 # ===================================================================
@@ -292,7 +293,7 @@ class TestPrerequisites:
             result = manager._check_prerequisite(1)
         assert result is True
 
-    def test_phase_2_needs_cache(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_phase_2_needs_cache(self) -> None:
         manager = _make_manager()
         manager.cache = {}
         with patch.object(manager, "_load_cache", return_value=None):
@@ -318,11 +319,11 @@ class TestConfirmOrCancel:
         manager = _make_manager(safe_input_fn=MagicMock(return_value="CONFIRM"))
         assert manager._confirm_or_cancel("Proceed?") is True
 
-    def test_confirm_rejected(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_confirm_rejected(self, caplog: pytest.LogCaptureFixture) -> None:
         manager = _make_manager(safe_input_fn=MagicMock(return_value="no"))
-        assert manager._confirm_or_cancel("Proceed?") is False
-        captured = capsys.readouterr()
-        assert "cancelled" in captured.out.lower()
+        with caplog.at_level(logging.WARNING):
+            assert manager._confirm_or_cancel("Proceed?") is False
+        assert "cancelled" in caplog.text.lower()
 
 
 # ===================================================================
@@ -359,10 +360,10 @@ class TestCheckCacheExists:
         assert _check_cache_exists("data/cache.json") is True
 
     @patch("os.path.exists", return_value=False)
-    def test_cache_not_found(self, _mock: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
-        assert _check_cache_exists("data/cache.json") is False
-        captured = capsys.readouterr()
-        assert "Phase 1 cache not found" in captured.out
+    def test_cache_not_found(self, _mock: MagicMock, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            assert _check_cache_exists("data/cache.json") is False
+        assert "Phase 1 cache not found" in caplog.text
 
 
 # ===================================================================
@@ -821,7 +822,7 @@ class TestGroupPlanHelpers:
 class TestResumeHelpers:
     """_handle_completed_resume, _handle_partial_resume tests."""
 
-    def test_handle_completed_resume(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_handle_completed_resume(self) -> None:
         result = _handle_completed_resume(2, 10, 10, MagicMock(return_value="y"))
         assert isinstance(result, tuple)
 
@@ -844,7 +845,7 @@ class TestResumeHelpers:
 class TestDisplayHelpers:
     """Display/print helper tests."""
 
-    def test_display_variable_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_display_variable_summary(self, caplog: pytest.LogCaptureFixture) -> None:
         plan = [
             {"status": "pending", "variable_name": "V"},
             {"status": "skipped", "variable_name": "V"},
@@ -858,11 +859,11 @@ class TestDisplayHelpers:
                 "proposed_value": "100",
             },
         ]
-        _display_variable_summary(plan)
-        captured = capsys.readouterr()
-        assert len(captured.out) > 0
+        with caplog.at_level(logging.WARNING):
+            _display_variable_summary(plan)
+        assert len(caplog.text) > 0
 
-    def test_print_conflicts(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_print_conflicts(self, caplog: pytest.LogCaptureFixture) -> None:
         conflicts = [
             {
                 "site_name": "Site-A",
@@ -872,11 +873,11 @@ class TestDisplayHelpers:
                 "proposed_value": "100",
             },
         ]
-        _print_conflicts(conflicts)
-        captured = capsys.readouterr()
-        assert "Site-A" in captured.out
+        with caplog.at_level(logging.WARNING):
+            _print_conflicts(conflicts)
+        assert "Site-A" in caplog.text
 
-    def test_display_group_plan(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_display_group_plan(self, caplog: pytest.LogCaptureFixture) -> None:
         plan = {
             "groups": [
                 {
@@ -887,46 +888,46 @@ class TestDisplayHelpers:
                 }
             ]
         }
-        _display_group_plan(plan)
-        captured = capsys.readouterr()
-        assert "G1" in captured.out
+        with caplog.at_level(logging.WARNING):
+            _display_group_plan(plan)
+        assert "G1" in caplog.text
 
-    def test_display_template_plan(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_display_template_plan(self, caplog: pytest.LogCaptureFixture) -> None:
         configs = {
             "G1": {"ssid": "Corp", "enabled": True},
         }
         group_plan = {"G1": {"cluster_name": "East"}}
-        _display_template_plan(configs, group_plan)
-        captured = capsys.readouterr()
-        assert "G1" in captured.out
+        with caplog.at_level(logging.WARNING):
+            _display_template_plan(configs, group_plan)
+        assert "G1" in caplog.text
 
-    def test_display_disable_plan(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_display_disable_plan(self, caplog: pytest.LogCaptureFixture) -> None:
         plan = [
             {"site_name": "A", "ssid_name": "Corp", "action": "to_disable", "status": "pending"},
         ]
-        _display_disable_plan(plan)
-        captured = capsys.readouterr()
-        assert len(captured.out) > 0
+        with caplog.at_level(logging.WARNING):
+            _display_disable_plan(plan)
+        assert len(caplog.text) > 0
 
-    def test_print_phase1_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_print_phase1_summary(self, caplog: pytest.LogCaptureFixture) -> None:
         matrix = [
             {"anomaly": False, "psk_detected": False, "target_group": "East"},
             {"anomaly": True, "psk_detected": False, "target_group": "East"},
         ]
         deviations = [{"parameter": "vlan_id"}]
-        _print_phase1_summary(matrix, deviations)
-        captured = capsys.readouterr()
-        assert "eligible" in captured.out.lower() or "Eligible" in captured.out
+        with caplog.at_level(logging.WARNING):
+            _print_phase1_summary(matrix, deviations)
+        assert "eligible" in caplog.text.lower() or "Eligible" in caplog.text
 
-    def test_print_phase_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_print_phase_summary(self, caplog: pytest.LogCaptureFixture) -> None:
         results = [
             {"status": "success"},
             {"status": "failed"},
             {"status": "skipped"},
         ]
-        _print_phase_summary("Test Phase", results)
-        captured = capsys.readouterr()
-        assert "success" in captured.out.lower() or "Success" in captured.out
+        with caplog.at_level(logging.WARNING):
+            _print_phase_summary("Test Phase", results)
+        assert "success" in caplog.text.lower() or "Success" in caplog.text
 
 
 # ===================================================================
@@ -1865,23 +1866,23 @@ class TestPhaseOrchestrators:
 
     def test_display_phase_menu(
         self,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mgr = self._make_manager()
         labels = {"1": "Audit", "2": "Variables"}
-        mgr._display_phase_menu(labels)
-        captured = capsys.readouterr()
-        assert "Audit" in captured.out
+        with caplog.at_level(logging.WARNING):
+            mgr._display_phase_menu(labels)
+        assert "Audit" in caplog.text
 
     def test_phase1_audit_no_data(
         self,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mgr = self._make_manager()
         mgr._phase1_load_or_fetch = MagicMock(return_value=None)  # type: ignore[method-assign]
-        mgr.phase1_audit()
-        captured = capsys.readouterr()
-        assert "Failed" in captured.out or "failed" in captured.out.lower()
+        with caplog.at_level(logging.WARNING):
+            mgr.phase1_audit()
+        assert "Failed" in caplog.text or "failed" in caplog.text.lower()
 
     def test_phase1_load_or_fetch_uses_cache(self) -> None:
         mgr = self._make_manager()
@@ -1896,43 +1897,43 @@ class TestPhaseOrchestrators:
 
     def test_phase2_no_cache(
         self,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mgr = self._make_manager()
         mgr._load_cache = MagicMock(return_value=None)  # type: ignore[method-assign]
-        mgr.phase2_site_variables()
-        captured = capsys.readouterr()
-        assert "not found" in captured.out.lower() or "no cache" in captured.out.lower()
+        with caplog.at_level(logging.WARNING):
+            mgr.phase2_site_variables()
+        assert "not found" in caplog.text.lower() or "no cache" in caplog.text.lower()
 
     def test_phase3_no_cache(
         self,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mgr = self._make_manager()
         mgr._load_cache = MagicMock(return_value=None)  # type: ignore[method-assign]
-        mgr.phase3_site_groups()
-        captured = capsys.readouterr()
-        assert "not found" in captured.out.lower() or "no cache" in captured.out.lower()
+        with caplog.at_level(logging.WARNING):
+            mgr.phase3_site_groups()
+        assert "not found" in caplog.text.lower() or "no cache" in caplog.text.lower()
 
     def test_phase4_no_cache(
         self,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mgr = self._make_manager()
         mgr._load_cache = MagicMock(return_value=None)  # type: ignore[method-assign]
-        mgr.phase4_templates()
-        captured = capsys.readouterr()
-        assert "not found" in captured.out.lower() or "no cache" in captured.out.lower()
+        with caplog.at_level(logging.WARNING):
+            mgr.phase4_templates()
+        assert "not found" in caplog.text.lower() or "no cache" in caplog.text.lower()
 
     def test_phase5_no_cache(
         self,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mgr = self._make_manager()
         mgr._load_cache = MagicMock(return_value=None)  # type: ignore[method-assign]
-        mgr.phase5_disable_old()
-        captured = capsys.readouterr()
-        assert "not found" in captured.out.lower() or "no cache" in captured.out.lower()
+        with caplog.at_level(logging.WARNING):
+            mgr.phase5_disable_old()
+        assert "not found" in caplog.text.lower() or "no cache" in caplog.text.lower()
 
 
 class TestFetchAllOrgData:


### PR DESCRIPTION
## Summary
- Replaced `print()` calls in `src/ssid_consolidation/` (7 files) with `logging.warning(...)` so #886's T20 selector flip can eventually enable print-avoidance repo-wide.
- WARNING level chosen so operator-visible phase banners, plan summaries, conflict tables, phase-menu output, and cache-missing bail messages surface on the default root logger (INFO is suppressed by default).
- Companion unit tests migrated from `capsys`/`captured.out` to `caplog`/`caplog.text` wrapped in `caplog.at_level(logging.WARNING)`.

## Test plan
- [x] `pytest tests/unit/test_ssid_template_consolidation.py` → 241 passed
- [x] `black --check` clean on touched paths
- [x] `ruff check` clean on touched paths

Refs: #886