### PR TITLE
chore(logging): migrate src/auth/ print() to logger (#886 slice 9/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 9/N: retire `print()` in `src/auth/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the remaining `print()`
+  calls in `src/auth/interactive/clouds.py`,
+  `src/auth/interactive/credential_prompter.py`,
+  `src/auth/interactive/login_orchestrator.py`, and
+  `src/auth/interactive/msp_org_selector.py` with `logging.warning(...)` /
+  `logging.error(...)` / `logging.info(...)` / `logging.debug(...)` so the
+  print-avoidance rule (T20 selector target of #886) can eventually be
+  enabled repo-wide. WARNING level chosen for operator-visible cloud/MSP/org
+  menu banners, credential-validation banners, auth-failure messages, 2FA
+  prompts, and paginated-picker status output so they surface on the default
+  root-logger configuration (INFO is suppressed by default). Companion unit
+  tests in `tests/unit/auth/interactive/test_credential_prompter.py`,
+  `tests/unit/auth/interactive/test_login_orchestrator.py`, and
+  `tests/unit/auth/interactive/test_msp_org_selector.py` were migrated from
+  `capsys`/`captured.out` to `caplog`/`caplog.text` with a
+  `caplog.at_level(logging.WARNING)` wrapper around each call site so the
+  suite continues to assert operator-visible output through the logging path.
+  No behavioural change beyond the emit channel; all 96 tests under
+  `tests/unit/auth/` remain green.
+
 ### #886 Phase 2 slice 8/N: retire `print()` in `src/ssid_consolidation/` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the remaining `print()`

--- a/src/auth/interactive/clouds.py
+++ b/src/auth/interactive/clouds.py
@@ -50,23 +50,27 @@ class CloudSelector:
         if cloud_choice == "" or cloud_choice not in MIST_CLOUDS:  # Default to Global 01
             cloud_choice = "1"  # Preserve legacy default behaviour
         cloud_name, host = MIST_CLOUDS[cloud_choice]  # Resolve label + host from catalog
-        print(f"  Using cloud: {cloud_name} ({host})")  # Legacy console echo preserved verbatim
-        print("")  # Blank spacer matches the original output exactly
+        logging.warning("  Using cloud: %s (%s)", cloud_name, host)  # Legacy console echo routed via logger
+        logging.warning("")  # Blank spacer matches the original output exactly
         logging.debug("Cloud selected: %s (%s)", cloud_name, host)  # Trace selection result
         return (cloud_name, host)  # Hand off to the login orchestrator
 
     @staticmethod
     def _render_menu() -> None:
         """Print the interactive cloud menu using the legacy formatting."""
-        print("")  # Leading blank line matches the original banner spacing
-        print("=" * 60)  # Top divider preserved verbatim
-        print("  INTERACTIVE MIST API LOGIN")  # Banner heading preserved verbatim
-        print("=" * 60)  # Bottom divider preserved verbatim
-        print("")  # Blank spacer matches original output
-        print("  This authentication method uses session/cookie-based login,")  # Legacy explainer preserved
-        print("  which can access MSP-level APIs (unlike org-scoped API tokens).")  # Legacy explainer preserved
-        print("")  # Blank spacer matches original output
-        print("  Available Mist Clouds:")  # Legacy header preserved verbatim
+        logging.warning("")  # Leading blank line matches the original banner spacing
+        logging.warning("=" * 60)  # Top divider routed via logger
+        logging.warning("  INTERACTIVE MIST API LOGIN")  # Banner heading routed via logger
+        logging.warning("=" * 60)  # Bottom divider routed via logger
+        logging.warning("")  # Blank spacer matches original output
+        logging.warning(
+            "  This authentication method uses session/cookie-based login,"
+        )  # Legacy explainer routed via logger
+        logging.warning(
+            "  which can access MSP-level APIs (unlike org-scoped API tokens)."
+        )  # Legacy explainer routed via logger
+        logging.warning("")  # Blank spacer matches original output
+        logging.warning("  Available Mist Clouds:")  # Legacy header routed via logger
         for key, (name, host) in MIST_CLOUDS.items():  # Iterate catalog in insertion order
-            print(f"    {key:>2}. {name:<12} ({host})")  # Legacy format string preserved exactly
-        print("")  # Blank spacer matches original output
+            logging.warning("    %2s. %-12s (%s)", key, name, host)  # Legacy format string preserved exactly
+        logging.warning("")  # Blank spacer matches original output

--- a/src/auth/interactive/credential_prompter.py
+++ b/src/auth/interactive/credential_prompter.py
@@ -23,7 +23,7 @@ class CredentialPrompter:
             logging.info("Email prompt aborted via EOF")  # Trace abort path
             return None  # Signal caller to cancel the login flow
         if not email:  # Treat blank as a hard validation failure
-            print("X Email is required")  # Legacy console message preserved verbatim
+            logging.warning("X Email is required")  # Legacy console message routed via logger
             logging.debug("Email prompt returned empty string")  # Trace validation failure
             return None  # Caller will short-circuit the login
         logging.debug("Email prompt accepted")  # Trace acceptance without leaking the value
@@ -39,10 +39,10 @@ class CredentialPrompter:
             return None  # Signal caller to cancel the login flow
         except Exception as password_error:  # Any other terminal failure (e.g., closed stdin)
             logging.error("Failed to read password: %s", password_error)  # Legacy error log preserved
-            print(f"X Failed to read password: {password_error}")  # Legacy console message preserved
+            logging.warning("X Failed to read password: %s", password_error)  # Legacy console message routed via logger
             return None  # Caller will short-circuit the login
         if not password:  # Treat blank password as validation failure
-            print("X Password is required")  # Legacy console message preserved verbatim
+            logging.warning("X Password is required")  # Legacy console message routed via logger
             logging.debug("Password prompt returned empty string")  # Trace validation failure
             return None  # Caller will short-circuit the login
         logging.debug("Password prompt accepted (length=%d)", len(password))  # Trace length only
@@ -57,7 +57,7 @@ class CredentialPrompter:
             logging.info("2FA prompt aborted via EOF")  # Trace abort path
             return None  # Signal caller to cancel the login flow
         if not code:  # Empty 2FA code is treated as a hard failure by the legacy flow
-            print("  X 2FA code is required")  # Legacy console message preserved verbatim
+            logging.warning("  X 2FA code is required")  # Legacy console message routed via logger
             logging.debug("2FA prompt returned empty string")  # Trace validation failure
             return None  # Caller will short-circuit the login
         logging.debug("2FA prompt accepted")  # Trace acceptance without leaking the value

--- a/src/auth/interactive/login_orchestrator.py
+++ b/src/auth/interactive/login_orchestrator.py
@@ -53,7 +53,7 @@ class LoginOrchestrator:
             import mistapi as mistapi_fallback  # Deferred import keeps module load cheap
         except ImportError as import_error:  # SDK missing is a hard failure
             logging.error("Cannot import mistapi: %s", import_error)  # Legacy error log preserved
-            print("X Failed to import mistapi library")  # Legacy console message preserved
+            logging.warning("X Failed to import mistapi library")  # Legacy console message routed via logger
             return None  # Caller will short-circuit the login
         self.state["mistapi"] = mistapi_fallback  # Cache the SDK reference in shared state
         logging.debug("mistapi SDK resolved via fallback import")  # Trace successful import
@@ -80,8 +80,8 @@ class LoginOrchestrator:
     ) -> bool:
         """Perform the network login and dispatch exceptions to their handlers."""
         logging.info("Authenticating to %s as %s on cloud %s", host, email, cloud_name)  # Trace
-        print("")  # Blank spacer matches legacy output exactly
-        print("  Authenticating...")  # Legacy console message preserved verbatim
+        logging.warning("")  # Blank spacer matches legacy output exactly
+        logging.warning("  Authenticating...")  # Legacy console message routed via logger
         try:
             return self._run_login_pipeline(mistapi_module, host, email, password)  # Main path
         except ConnectionError as connection_error:  # Network failure surface
@@ -131,7 +131,7 @@ class LoginOrchestrator:
         password: str,
     ) -> Any | None:
         """Build the APISession object and clear any cached API token."""
-        print("  Creating API session...")  # Legacy console message preserved verbatim
+        logging.warning("  Creating API session...")  # Legacy console message routed via logger
         logging.info("Creating mistapi APISession for %s", host)  # Trace before SDK call
         apisession = mistapi_module.APISession(  # Construct the SDK session with legacy kwargs
             email=email,
@@ -142,7 +142,7 @@ class LoginOrchestrator:
         )
         if apisession is None:  # SDK contract allows None as a soft failure
             logging.error("APISession constructor returned None")  # Legacy error log preserved
-            print("  X Failed to create API session")  # Legacy console message preserved verbatim
+            logging.warning("  X Failed to create API session")  # Legacy console message routed via logger
             return None  # Caller will short-circuit the login
         LoginOrchestrator._clear_pre_existing_token(apisession)  # Force email/password path
         logging.debug("APISession created successfully")  # Trace successful construction
@@ -164,7 +164,7 @@ class LoginOrchestrator:
     @staticmethod
     def _initial_login(apisession: Any) -> dict[str, Any] | None:
         """Issue the first login_with_return() call (no 2FA token)."""
-        print("  Sending login request...")  # Legacy console message preserved verbatim
+        logging.warning("  Sending login request...")  # Legacy console message routed via logger
         logging.info("Sending initial login_with_return() request")  # Trace before SDK call
         result: dict[str, Any] | None = apisession.login_with_return()  # Initial login attempt without 2FA
         logging.debug("Initial login returned authenticated=%s", bool(result and result.get("authenticated")))
@@ -182,13 +182,13 @@ class LoginOrchestrator:
 
     def _handle_two_factor(self, apisession: Any) -> dict[str, Any] | None:
         """Prompt for 2FA and replay the login with the code attached."""
-        print("")  # Blank spacer matches legacy output exactly
-        print("  Two-factor authentication required.")  # Legacy console message preserved verbatim
+        logging.warning("")  # Blank spacer matches legacy output exactly
+        logging.warning("  Two-factor authentication required.")  # Legacy console message routed via logger
         code = CredentialPrompter(self.safe_input).prompt_two_factor()  # EOF-safe 2FA prompt
         if code is None:  # User aborted at the 2FA prompt
             self.state["apisession"] = None  # Clear any partially established session
             return None  # Propagate failure to the caller
-        print("  Sending 2FA verification...")  # Legacy console message preserved verbatim
+        logging.warning("  Sending 2FA verification...")  # Legacy console message routed via logger
         logging.info("Resubmitting login_with_return() with 2FA code")  # Trace before SDK call
         result: dict[str, Any] | None = apisession.login_with_return(two_factor=code)  # Replay with 2FA
         logging.debug("2FA login returned authenticated=%s", bool(result and result.get("authenticated")))
@@ -209,15 +209,15 @@ class LoginOrchestrator:
             error_message = error_field.get("detail", str(error_field))  # Prefer the detail string
         else:
             error_message = str(error_field)  # Coerce primitives/strings to string
-        print(f"  X Authentication failed: {error_message}")  # Legacy console message preserved
+        logging.warning("  X Authentication failed: %s", error_message)  # Legacy console message routed via logger
         logging.error("Interactive login failed: %s", error_message)  # Legacy error log preserved
         self.state["apisession"] = None  # Drop any partially established session reference
 
     def _finalize_session(self, apisession: Any, email: str, host: str) -> None:
         """Persist the session, configure timeout, and announce MSP privileges."""
         self.state["apisession"] = apisession  # Cache the live session for the rest of the app
-        print("")  # Blank spacer matches legacy output exactly
-        print("  + Login successful!")  # Legacy console message preserved verbatim
+        logging.warning("")  # Blank spacer matches legacy output exactly
+        logging.warning("  + Login successful!")  # Legacy console message routed via logger
         logging.info("Interactive login successful for %s to %s", email, host)  # Legacy info log
         self._configure_session_timeout(apisession)  # Best-effort timeout configuration
         self._announce_msp_privileges()  # Detect and print MSP grants
@@ -235,22 +235,26 @@ class LoginOrchestrator:
 
     def _announce_msp_privileges(self) -> None:
         """Detect MSP privileges via the injected callback and echo the result."""
-        print("  Checking for MSP privileges...")  # Legacy console message preserved verbatim
+        logging.warning("  Checking for MSP privileges...")  # Legacy console message routed via logger
         logging.info("Running detect_msp_privileges callback")  # Trace before callback
         detected = self.detect_msp_privileges()  # Invoke the injected detection callback
         logging.debug("detect_msp_privileges returned %d entries", len(detected) if detected else 0)
         if detected:  # Operator has at least one MSP grant available
             self.state["msp_privileges"] = detected  # Cache the MSP grants for later selection
-            print(f"  + MSP access detected: {len(detected)} MSP(s) available")  # Legacy message
+            logging.warning(
+                "  + MSP access detected: %d MSP(s) available", len(detected)
+            )  # Legacy message routed via logger
             for msp in detected:  # Echo each MSP grant on its own line
-                print(f"    - {msp['msp_name']} (role: {msp['role']})")  # Legacy format preserved
+                logging.warning("    - %s (role: %s)", msp["msp_name"], msp["role"])  # Legacy format routed via logger
         else:
-            print("  - No MSP privileges detected (org-level access only)")  # Legacy message preserved
-        print("")  # Blank spacer matches legacy output exactly
+            logging.warning(
+                "  - No MSP privileges detected (org-level access only)"
+            )  # Legacy message routed via logger
+        logging.warning("")  # Blank spacer matches legacy output exactly
 
     def _handle_connection_error(self, connection_error: ConnectionError) -> bool:
         """Map a ConnectionError to the legacy console + log output."""
-        print(f"  X Connection failed: {connection_error}")  # Legacy console message preserved
+        logging.warning("  X Connection failed: %s", connection_error)  # Legacy console message routed via logger
         logging.error("Interactive login connection error: %s", connection_error)  # Legacy error log
         self.state["apisession"] = None  # Drop any partially established session reference
         return False  # Propagate failure to the caller
@@ -259,9 +263,9 @@ class LoginOrchestrator:
         """Map a ValueError to the legacy console + log output."""
         error_message = str(value_error).lower()  # Lowercase once for the substring guards
         if "token" in error_message or "401" in error_message:  # Token/auth surface
-            print("  X Invalid API token or credentials")  # Legacy console message preserved
+            logging.warning("  X Invalid API token or credentials")  # Legacy console message routed via logger
         else:
-            print(f"  X Authentication error: {value_error}")  # Legacy console message preserved
+            logging.warning("  X Authentication error: %s", value_error)  # Legacy console message routed via logger
         logging.error("Interactive login value error: %s", value_error)  # Legacy error log preserved
         self.state["apisession"] = None  # Drop any partially established session reference
         return False  # Propagate failure to the caller
@@ -283,15 +287,15 @@ class LoginOrchestrator:
     ) -> None:
         """Print the legacy 'X ...' message for a generic login error."""
         if LoginOrchestrator._is_credential_error(lower_message):  # Credential surface
-            print("  X Invalid email or password")  # Legacy console message preserved verbatim
+            logging.warning("  X Invalid email or password")  # Legacy console message routed via logger
             return  # Guard clause keeps CC at 4
         if LoginOrchestrator._is_two_factor_error(lower_message):  # 2FA failure surface
-            print("  X Two-factor authentication failed")  # Legacy console message preserved
+            logging.warning("  X Two-factor authentication failed")  # Legacy console message routed via logger
             return  # Guard clause keeps CC at 4
         if "401" in error_message:  # HTTP 401 in the original message string
-            print("  X Invalid email or password (authentication failed)")  # Legacy message preserved
+            logging.warning("  X Invalid email or password (authentication failed)")  # Legacy message routed via logger
             return  # Guard clause keeps CC at 4
-        print(f"  X Login failed: {login_error}")  # Legacy fallback message preserved verbatim
+        logging.warning("  X Login failed: %s", login_error)  # Legacy fallback message routed via logger
 
     @staticmethod
     def _is_credential_error(lower_message: str) -> bool:

--- a/src/auth/interactive/msp_org_selector.py
+++ b/src/auth/interactive/msp_org_selector.py
@@ -40,17 +40,19 @@ class MspOrgSelector:
     @staticmethod
     def _print_banner() -> None:
         """Print the legacy 'SELECT MSP AND ORGANIZATION' banner verbatim."""
-        print("")  # Blank spacer matches legacy output exactly
-        print("=" * 60)  # Top divider preserved verbatim
-        print("  SELECT MSP AND ORGANIZATION")  # Banner heading preserved verbatim
-        print("=" * 60)  # Bottom divider preserved verbatim
-        print("")  # Blank spacer matches legacy output exactly
+        logging.warning("")  # Blank spacer matches legacy output exactly
+        logging.warning("=" * 60)  # Top divider routed via logger
+        logging.warning("  SELECT MSP AND ORGANIZATION")  # Banner heading routed via logger
+        logging.warning("=" * 60)  # Bottom divider routed via logger
+        logging.warning("")  # Blank spacer matches legacy output exactly
 
     def _choose_msp(self, msps: list[dict[str, Any]]) -> dict[str, Any] | None:
         """Return the chosen MSP dict, auto-selecting when only one is available."""
         if len(msps) == 1:  # Auto-pick path preserves the legacy convenience behaviour
             only = msps[0]  # Single MSP available
-            print(f"  Using MSP: {only['msp_name']} (only one available)")  # Legacy message preserved
+            logging.warning(
+                "  Using MSP: %s (only one available)", only["msp_name"]
+            )  # Legacy message routed via logger
             logging.debug("Auto-selected the only available MSP: %s", only.get("msp_id"))  # Trace
             return only  # Caller will proceed straight to org selection
         return self._prompt_msp(msps)  # Multi-MSP case requires an interactive prompt
@@ -64,18 +66,18 @@ class MspOrgSelector:
                 "  Select MSP (number, or Enter to skip): ", context="msp_select"
             ).strip()
         except (ValueError, SystemExit):  # Preserve legacy combined exception handling
-            print("  X Invalid input - skipping MSP selection")  # Legacy console message preserved
+            logging.warning("  X Invalid input - skipping MSP selection")  # Legacy console message routed via logger
             return None  # Caller will fall back to direct org selection
         if choice == "":  # Blank input means "skip MSP selection" in the legacy flow
-            print("  Skipping MSP selection - using direct org access")  # Legacy message preserved
+            logging.warning("  Skipping MSP selection - using direct org access")  # Legacy message routed via logger
             return None  # Caller will fall back to direct org selection
         try:
             index = int(choice) - 1  # Convert 1-based selection to 0-based list index
         except ValueError:  # Non-numeric input falls into the legacy invalid path
-            print("  X Invalid selection - skipping MSP selection")  # Legacy message preserved
+            logging.warning("  X Invalid selection - skipping MSP selection")  # Legacy message routed via logger
             return None  # Caller will fall back to direct org selection
         if not (0 <= index < len(msps)):  # Out-of-range index falls into the legacy invalid path
-            print("  X Invalid selection - skipping MSP selection")  # Legacy message preserved
+            logging.warning("  X Invalid selection - skipping MSP selection")  # Legacy message routed via logger
             return None  # Caller will fall back to direct org selection
         logging.debug("MSP selected at index %d", index)  # Trace the picked index
         return msps[index]  # Hand the chosen MSP dict back to the caller
@@ -83,29 +85,29 @@ class MspOrgSelector:
     @staticmethod
     def _render_msp_menu(msps: list[dict[str, Any]]) -> None:
         """Print the numbered MSP menu using the legacy formatting."""
-        print("  Available MSPs:")  # Legacy header preserved verbatim
+        logging.warning("  Available MSPs:")  # Legacy header routed via logger
         for index, msp in enumerate(msps, start=1):  # 1-based numbering matches legacy UI
             msp_name = msp.get("msp_name", "Unknown")  # Preserve legacy fallback label
             msp_role = msp.get("role", "unknown")  # Preserve legacy fallback role
-            print(f"    {index}. {msp_name} (role: {msp_role})")  # Legacy format preserved verbatim
-        print("")  # Blank spacer matches legacy output exactly
+            logging.warning("    %d. %s (role: %s)", index, msp_name, msp_role)  # Legacy format routed via logger
+        logging.warning("")  # Blank spacer matches legacy output exactly
 
     def _select_org_under_msp(self, msp: dict[str, Any]) -> None:
         """Fetch orgs under the chosen MSP and persist the operator's pick to state."""
         self.state["selected_msp"] = msp  # Cache the chosen MSP regardless of org outcome
         msp_id = msp["msp_id"]  # Required field per the MSP detection contract
         msp_name = msp.get("msp_name", "Unknown")  # Preserve legacy fallback label
-        print(f"  + Selected MSP: {msp_name}")  # Legacy console message preserved verbatim
-        print(f"  Fetching organizations under {msp_name}...")  # Legacy console message preserved
+        logging.warning("  + Selected MSP: %s", msp_name)  # Legacy console message routed via logger
+        logging.warning("  Fetching organizations under %s...", msp_name)  # Legacy console message routed via logger
         apisession = self.state.get("apisession")  # Pull the live session from shared state
         if apisession is None:  # Defensive guard preserved from the legacy code path
-            print("  X API session not initialized")  # Legacy console message preserved verbatim
+            logging.warning("  X API session not initialized")  # Legacy console message routed via logger
             logging.error("API session not initialized when selecting MSP org")  # Legacy error log
             return  # Cannot continue without a session
         try:
             orgs = self._fetch_msp_orgs(apisession, msp_id)  # Sorted list of org dicts (or None)
         except Exception as org_error:  # noqa: BLE001  Preserve legacy catch-all surface
-            print(f"  X Error fetching MSP organizations: {org_error}")  # Legacy message preserved
+            logging.warning("  X Error fetching MSP organizations: %s", org_error)  # Legacy message routed via logger
             logging.error("Failed to fetch MSP organizations: %s", org_error)  # Legacy error log
             return  # Bail out without mutating org_id
         if not orgs:  # Empty list or None means "no orgs to choose from"
@@ -121,19 +123,19 @@ class MspOrgSelector:
         logging.info("Calling listMspOrgs for msp_id=%s", msp_id)  # Trace before SDK call
         response = mistapi_module.api.v1.msps.orgs.listMspOrgs(apisession, msp_id)  # SDK call
         if not response or not hasattr(response, "data"):  # Legacy guard for empty/invalid response
-            print("  X Failed to retrieve MSP organizations")  # Legacy console message preserved
+            logging.warning("  X Failed to retrieve MSP organizations")  # Legacy console message routed via logger
             logging.debug("listMspOrgs returned an empty or invalid response")  # Trace bad response
             return None  # Caller will treat as "no orgs"
         orgs_data = response.data  # SDK response payload (list or dict)
         if not isinstance(orgs_data, list):  # Normalize single-object responses to a list
             orgs_data = [orgs_data] if orgs_data else []  # Empty falsy values become empty list
         if not orgs_data:  # Empty list short-circuits to the legacy "no orgs" message
-            print("  No organizations found under this MSP")  # Legacy console message preserved
+            logging.warning("  No organizations found under this MSP")  # Legacy console message routed via logger
             logging.debug("listMspOrgs returned an empty org list")  # Trace empty list
             return []  # Caller will short-circuit on empty list
         orgs_data = sorted(orgs_data, key=lambda org: org.get("name", "").lower())  # Stable sort
-        print(f"  Found {len(orgs_data)} organization(s):")  # Legacy console message preserved
-        print("")  # Blank spacer matches legacy output exactly
+        logging.warning("  Found %d organization(s):", len(orgs_data))  # Legacy console message routed via logger
+        logging.warning("")  # Blank spacer matches legacy output exactly
         logging.debug("listMspOrgs returned %d orgs (sorted by name)", len(orgs_data))  # Trace
         return orgs_data  # Hand the sorted list back to the picker
 
@@ -180,13 +182,17 @@ class MspOrgSelector:
             org = orgs[org_index]  # Current org dict
             org_name = org.get("name", "Unknown")  # Preserve legacy fallback label
             org_id_preview = org.get("id", "N/A")[:8]  # Preserve legacy 8-char id preview
-            print(f"    {org_index + 1:>3}. {org_name} ({org_id_preview}...)")  # Legacy format preserved
-        print("")  # Blank spacer matches legacy output exactly
+            logging.warning(
+                "    %3d. %s (%s...)", org_index + 1, org_name, org_id_preview
+            )  # Legacy format routed via logger
+        logging.warning("")  # Blank spacer matches legacy output exactly
         if total_pages > 1:  # Multi-page mode prints the page counter + nav hint
-            print(f"  Page {current_page + 1}/{total_pages}")  # Legacy page indicator preserved
-            print("  Enter number to select, 'n' for next page, 'p' for previous, 'q' to skip")  # Legacy hint
+            logging.warning("  Page %d/%d", current_page + 1, total_pages)  # Legacy page indicator routed via logger
+            logging.warning(
+                "  Enter number to select, 'n' for next page, 'p' for previous, 'q' to skip"
+            )  # Legacy hint routed via logger
         else:
-            print("  Enter number to select, or 'q' to skip")  # Legacy single-page hint preserved
+            logging.warning("  Enter number to select, or 'q' to skip")  # Legacy single-page hint routed via logger
 
     @staticmethod
     def _interpret_choice(
@@ -197,7 +203,7 @@ class MspOrgSelector:
     ) -> tuple[str, int, dict[str, Any] | None]:
         """Decode the operator's choice into (action, next_page, picked_org)."""
         if choice in {"", "q"}:  # Blank or 'q' both mean "skip" in the legacy flow
-            print("  Skipping org selection")  # Legacy console message preserved verbatim
+            logging.warning("  Skipping org selection")  # Legacy console message routed via logger
             return ("quit", current_page, None)  # Loop caller will exit with None
         if choice == "n" and current_page < total_pages - 1:  # Next-page navigation
             return ("nav", current_page + 1, None)  # Loop caller will re-render the next page
@@ -206,11 +212,11 @@ class MspOrgSelector:
         try:
             index = int(choice) - 1  # Convert 1-based selection to 0-based list index
         except ValueError:  # Non-numeric input falls into the legacy invalid-input path
-            print("  X Invalid input - try again")  # Legacy console message preserved verbatim
+            logging.warning("  X Invalid input - try again")  # Legacy console message routed via logger
             return ("nav", current_page, None)  # Stay on the same page and loop again
         if 0 <= index < len(orgs):  # Index is in range: this is a valid selection
             return ("select", current_page, orgs[index])  # Hand the picked org back via loop caller
-        print("  X Invalid number - try again")  # Out-of-range index falls into the legacy path
+        logging.warning("  X Invalid number - try again")  # Out-of-range index routed via logger
         return ("nav", current_page, None)  # Stay on the same page and loop again
 
     def _record_org_selection(self, msp_name: str, org: dict[str, Any]) -> None:
@@ -218,9 +224,9 @@ class MspOrgSelector:
         selected_org_id = org.get("id")  # Pull the org UUID from the chosen entry
         selected_org_name = org.get("name", "Unknown")  # Preserve legacy fallback label
         self.state["org_id"] = selected_org_id  # Update shared state with the new org id
-        print("")  # Blank spacer matches legacy output exactly
-        print(f"  + Selected organization: {selected_org_name}")  # Legacy console message preserved
-        print(f"  + Organization ID: {selected_org_id}")  # Legacy console message preserved verbatim
+        logging.warning("")  # Blank spacer matches legacy output exactly
+        logging.warning("  + Selected organization: %s", selected_org_name)  # Legacy console message routed via logger
+        logging.warning("  + Organization ID: %s", selected_org_id)  # Legacy console message routed via logger
         logging.info(  # Legacy info log preserved verbatim
             "User selected org: %s (%s) under MSP: %s",
             selected_org_name,

--- a/tests/unit/auth/interactive/test_credential_prompter.py
+++ b/tests/unit/auth/interactive/test_credential_prompter.py
@@ -8,7 +8,10 @@ safe_input/getpass that returns Optional[str]. Cover every branch
 
 from __future__ import annotations  # WHY: enable PEP 604 unions on older type checkers
 
+import logging  # WHY: caplog level control for legacy warning-level messages
 from unittest.mock import MagicMock  # WHY: MagicMock spec + patch for getpass
+
+import pytest  # WHY: LogCaptureFixture type for caplog assertions
 
 from src.auth.interactive.credential_prompter import CredentialPrompter  # WHY: subject under test
 
@@ -43,12 +46,13 @@ def test_prompt_email_returns_none_on_eof() -> None:
     assert prompter.prompt_email() is None  # WHY: EOF must cancel the flow
 
 
-def test_prompt_email_returns_none_on_blank(capsys) -> None:
+def test_prompt_email_returns_none_on_blank(caplog: pytest.LogCaptureFixture) -> None:
     """Blank email prints the legacy validation banner and returns None."""
     stub = _SafeInputStub(return_value="")  # WHY: blank input is a hard validation failure
     prompter = CredentialPrompter(safe_input=stub)
-    assert prompter.prompt_email() is None
-    assert "X Email is required" in capsys.readouterr().out  # WHY: legacy console message preserved
+    with caplog.at_level(logging.WARNING):
+        assert prompter.prompt_email() is None
+    assert "X Email is required" in caplog.text  # WHY: legacy console message preserved
 
 
 def test_prompt_password_returns_value(monkeypatch) -> None:
@@ -71,26 +75,28 @@ def test_prompt_password_returns_none_on_eof(monkeypatch) -> None:
     assert prompter.prompt_password() is None
 
 
-def test_prompt_password_returns_none_on_terminal_error(monkeypatch, capsys) -> None:
+def test_prompt_password_returns_none_on_terminal_error(monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
     """Non-EOF exceptions from getpass are logged and returned as None."""
     monkeypatch.setattr(
         "src.auth.interactive.credential_prompter.getpass.getpass",
         MagicMock(side_effect=OSError("closed stdin")),
     )
     prompter = CredentialPrompter(safe_input=_SafeInputStub())
-    assert prompter.prompt_password() is None
-    assert "Failed to read password" in capsys.readouterr().out  # WHY: legacy console banner
+    with caplog.at_level(logging.WARNING):
+        assert prompter.prompt_password() is None
+    assert "Failed to read password" in caplog.text  # WHY: legacy console banner
 
 
-def test_prompt_password_returns_none_on_blank(monkeypatch, capsys) -> None:
+def test_prompt_password_returns_none_on_blank(monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
     """Blank password prints validation banner and returns None."""
     monkeypatch.setattr(
         "src.auth.interactive.credential_prompter.getpass.getpass",
         MagicMock(return_value=""),
     )
     prompter = CredentialPrompter(safe_input=_SafeInputStub())
-    assert prompter.prompt_password() is None
-    assert "X Password is required" in capsys.readouterr().out
+    with caplog.at_level(logging.WARNING):
+        assert prompter.prompt_password() is None
+    assert "X Password is required" in caplog.text
 
 
 def test_prompt_two_factor_returns_trimmed_value() -> None:
@@ -108,9 +114,10 @@ def test_prompt_two_factor_returns_none_on_eof() -> None:
     assert prompter.prompt_two_factor() is None
 
 
-def test_prompt_two_factor_returns_none_on_blank(capsys) -> None:
+def test_prompt_two_factor_returns_none_on_blank(caplog: pytest.LogCaptureFixture) -> None:
     """Blank 2FA prints legacy banner and returns None."""
     stub = _SafeInputStub(return_value="   ")  # WHY: whitespace-only trims to empty
     prompter = CredentialPrompter(safe_input=stub)
-    assert prompter.prompt_two_factor() is None
-    assert "X 2FA code is required" in capsys.readouterr().out
+    with caplog.at_level(logging.WARNING):
+        assert prompter.prompt_two_factor() is None
+    assert "X 2FA code is required" in caplog.text

--- a/tests/unit/auth/interactive/test_login_orchestrator.py
+++ b/tests/unit/auth/interactive/test_login_orchestrator.py
@@ -116,7 +116,7 @@ class TestResolveMistapi:
         assert "Resolving mistapi SDK via fallback import" in caplog.text  # WHY: pre-action info log.
 
     def test_fallback_import_error_returns_none(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
         """When mistapi cannot be imported, log error, print banner, return None."""
         import builtins  # WHY: patch built-in __import__ to inject the ImportError.
@@ -132,10 +132,9 @@ class TestResolveMistapi:
 
         monkeypatch.setattr(builtins, "__import__", _fail_only_mistapi)
         orch = _make_orchestrator()  # WHY: empty state triggers fallback branch.
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.DEBUG):
             assert orch._resolve_mistapi() is None  # WHY: SUT returns None on ImportError.
-        captured = capsys.readouterr()
-        assert "X Failed to import mistapi library" in captured.out  # WHY: legacy console message.
+        assert "X Failed to import mistapi library" in caplog.text  # WHY: legacy console message.
         assert "Cannot import mistapi: boom" in caplog.text  # WHY: legacy error log preserved.
 
 
@@ -172,14 +171,15 @@ class TestCollectCredentials:
 class TestAuthenticate:
     """``_authenticate`` dispatches exceptions to the matching handler."""
 
-    def test_happy_path_delegates_to_pipeline(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_happy_path_delegates_to_pipeline(self, caplog: pytest.LogCaptureFixture) -> None:
         """No exception → returns whatever _run_login_pipeline returned."""
         orch = _make_orchestrator()  # WHY: default orchestrator with empty state.
         with patch.object(LoginOrchestrator, "_run_login_pipeline", return_value=True) as fake_pipe:
-            result = orch._authenticate(MagicMock(spec=object), "Global 01", "api.mist.com", "u@e.com", "pw")
+            with caplog.at_level(logging.WARNING):
+                result = orch._authenticate(MagicMock(spec=object), "Global 01", "api.mist.com", "u@e.com", "pw")
         assert result is True  # WHY: SUT contract.
         fake_pipe.assert_called_once()  # WHY: exactly one delegation call.
-        assert "Authenticating..." in capsys.readouterr().out  # WHY: legacy console banner.
+        assert "Authenticating..." in caplog.text  # WHY: legacy console banner routed via logger.
 
     def test_connection_error_dispatched(self) -> None:
         """ConnectionError → routed to _handle_connection_error and returns False."""
@@ -295,16 +295,14 @@ class TestLogLoginInputs:
 class TestCreateApiSession:
     """``_create_api_session`` constructs SDK session and clears the pre-existing token."""
 
-    def test_none_session_returns_none_and_warns(
-        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_none_session_returns_none_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
         """When APISession returns None, log error, print banner, return None."""
         fake_sdk = MagicMock()  # WHY: unspec'd because we swap the constructor attribute.
         fake_sdk.APISession = MagicMock(return_value=None)  # WHY: soft-failure surface.
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.WARNING):
             result = LoginOrchestrator._create_api_session(fake_sdk, "h", "e", "p")
         assert result is None  # WHY: SUT contract.
-        assert "X Failed to create API session" in capsys.readouterr().out  # WHY: legacy console.
+        assert "X Failed to create API session" in caplog.text  # WHY: legacy console routed via logger.
         assert "APISession constructor returned None" in caplog.text  # WHY: legacy error log.
 
     def test_returns_session_and_clears_token(self) -> None:
@@ -385,16 +383,17 @@ class TestNeedsTwoFactor:
 class TestHandleTwoFactor:
     """``_handle_two_factor`` prompts for 2FA and replays the login."""
 
-    def test_none_when_user_aborts(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_none_when_user_aborts(self, caplog: pytest.LogCaptureFixture) -> None:
         """CredentialPrompter returns None → state cleared and None propagated."""
         orch = _make_orchestrator()
         orch.state["apisession"] = "stale"  # WHY: pre-existing partial session must be cleared.
         fake_session = MagicMock()
         with patch.object(CredentialPrompter, "prompt_two_factor", return_value=None):
-            result = orch._handle_two_factor(fake_session)
+            with caplog.at_level(logging.WARNING):
+                result = orch._handle_two_factor(fake_session)
         assert result is None  # WHY: SUT contract.
         assert orch.state["apisession"] is None  # WHY: partial session cleared.
-        assert "Two-factor authentication required." in capsys.readouterr().out  # WHY: legacy banner.
+        assert "Two-factor authentication required." in caplog.text  # WHY: legacy banner routed via logger.
 
     def test_success_calls_login_with_return_with_two_factor(self, caplog: pytest.LogCaptureFixture) -> None:
         """Prompt returns a code → login_with_return replayed with two_factor kwarg."""
@@ -429,48 +428,49 @@ class TestIsAuthenticated:
 class TestReportAuthFailure:
     """``_report_auth_failure`` prints legacy message and clears state."""
 
-    def test_none_response_uses_no_response_default(
-        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_none_response_uses_no_response_default(self, caplog: pytest.LogCaptureFixture) -> None:
         """None login result → 'No response' is printed and logged."""
         orch = _make_orchestrator()
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.WARNING):
             orch._report_auth_failure(None)
-        assert "X Authentication failed: No response" in capsys.readouterr().out  # WHY: legacy.
+        assert "X Authentication failed: No response" in caplog.text  # WHY: legacy banner routed via logger.
         assert "Interactive login failed: No response" in caplog.text  # WHY: legacy.
         assert orch.state["apisession"] is None  # WHY: state cleanup.
 
-    def test_dict_error_uses_detail_field(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_dict_error_uses_detail_field(self, caplog: pytest.LogCaptureFixture) -> None:
         """Error dict → the 'detail' field is preferred."""
         orch = _make_orchestrator()
-        orch._report_auth_failure({"error": {"detail": "bad token"}})
-        assert "X Authentication failed: bad token" in capsys.readouterr().out  # WHY: detail wins.
+        with caplog.at_level(logging.WARNING):
+            orch._report_auth_failure({"error": {"detail": "bad token"}})
+        assert "X Authentication failed: bad token" in caplog.text  # WHY: detail wins.
 
-    def test_dict_error_without_detail_uses_string(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_dict_error_without_detail_uses_string(self, caplog: pytest.LogCaptureFixture) -> None:
         """Error dict without 'detail' → falls back to str(dict)."""
         orch = _make_orchestrator()
-        orch._report_auth_failure({"error": {"code": 401}})
-        out = capsys.readouterr().out
-        assert "X Authentication failed:" in out  # WHY: prefix preserved.
-        assert "401" in out  # WHY: dict-string contains the code.
+        with caplog.at_level(logging.WARNING):
+            orch._report_auth_failure({"error": {"code": 401}})
+        assert "X Authentication failed:" in caplog.text  # WHY: prefix preserved.
+        assert "401" in caplog.text  # WHY: dict-string contains the code.
 
-    def test_string_error_used_verbatim(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_string_error_used_verbatim(self, caplog: pytest.LogCaptureFixture) -> None:
         """Non-dict error field is used verbatim (coerced to str)."""
         orch = _make_orchestrator()
-        orch._report_auth_failure({"error": "bad creds"})
-        assert "X Authentication failed: bad creds" in capsys.readouterr().out  # WHY: verbatim.
+        with caplog.at_level(logging.WARNING):
+            orch._report_auth_failure({"error": "bad creds"})
+        assert "X Authentication failed: bad creds" in caplog.text  # WHY: verbatim.
 
-    def test_missing_error_field_uses_unknown_default(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_missing_error_field_uses_unknown_default(self, caplog: pytest.LogCaptureFixture) -> None:
         """Missing 'error' key → 'Unknown error' default."""
         orch = _make_orchestrator()
-        orch._report_auth_failure({"authenticated": False})
-        assert "X Authentication failed: Unknown error" in capsys.readouterr().out  # WHY: legacy default.
+        with caplog.at_level(logging.WARNING):
+            orch._report_auth_failure({"authenticated": False})
+        assert "X Authentication failed: Unknown error" in caplog.text  # WHY: legacy default.
 
 
 class TestFinalizeSession:
     """``_finalize_session`` caches session, configures timeout, announces MSPs."""
 
-    def test_full_finalize_sequence(self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
+    def test_full_finalize_sequence(self, caplog: pytest.LogCaptureFixture) -> None:
         """State cached, timeout configured, MSP privileges announced."""
         orch = _make_orchestrator()
         fake_session = MagicMock(spec=object)
@@ -483,7 +483,7 @@ class TestFinalizeSession:
         assert orch.state["apisession"] is fake_session  # WHY: state cache-back.
         fake_timeout.assert_called_once_with(fake_session)  # WHY: timeout helper invoked.
         fake_msp.assert_called_once()  # WHY: MSP announcement invoked.
-        assert "+ Login successful!" in capsys.readouterr().out  # WHY: legacy console.
+        assert "+ Login successful!" in caplog.text  # WHY: legacy console routed via logger.
         assert "Interactive login successful for u@e.com to api.mist.com" in caplog.text  # WHY: legacy log.
 
 
@@ -528,7 +528,7 @@ class TestConfigureSessionTimeout:
 class TestAnnounceMspPrivileges:
     """``_announce_msp_privileges`` echoes MSP grants or the empty-list banner."""
 
-    def test_with_grants_populates_state_and_echoes_each(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_with_grants_populates_state_and_echoes_each(self, caplog: pytest.LogCaptureFixture) -> None:
         """Non-empty grants → state cached and each grant printed."""
         grants = [
             {"msp_name": "MSP-A", "role": "admin"},  # WHY: two grants exercises the loop.
@@ -536,35 +536,34 @@ class TestAnnounceMspPrivileges:
         ]
         detect_fn = MagicMock(spec=Callable, return_value=grants)
         orch = _make_orchestrator(detect_msp_privileges=detect_fn)
-        orch._announce_msp_privileges()
-        out = capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            orch._announce_msp_privileges()
         assert orch.state["msp_privileges"] == grants  # WHY: cache-back.
-        assert "MSP access detected: 2 MSP(s) available" in out  # WHY: legacy banner.
-        assert "- MSP-A (role: admin)" in out  # WHY: per-grant line.
-        assert "- MSP-B (role: viewer)" in out  # WHY: per-grant line.
+        assert "MSP access detected: 2 MSP(s) available" in caplog.text  # WHY: legacy banner routed via logger.
+        assert "- MSP-A (role: admin)" in caplog.text  # WHY: per-grant line.
+        assert "- MSP-B (role: viewer)" in caplog.text  # WHY: per-grant line.
 
-    def test_no_grants_prints_org_level_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_no_grants_prints_org_level_message(self, caplog: pytest.LogCaptureFixture) -> None:
         """Empty grants list → org-level banner printed and state untouched."""
         detect_fn = MagicMock(spec=Callable, return_value=[])
         orch = _make_orchestrator(detect_msp_privileges=detect_fn)
-        orch._announce_msp_privileges()
-        out = capsys.readouterr().out
-        assert "No MSP privileges detected (org-level access only)" in out  # WHY: legacy banner.
+        with caplog.at_level(logging.WARNING):
+            orch._announce_msp_privileges()
+        assert "No MSP privileges detected (org-level access only)" in caplog.text  # WHY: legacy banner.
         assert "msp_privileges" not in orch.state  # WHY: state left untouched.
 
 
 class TestHandleConnectionError:
     """``_handle_connection_error`` prints legacy line + logs + clears state."""
 
-    def test_prints_and_logs_and_clears_state(
-        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_prints_and_logs_and_clears_state(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Print + log + state clear on ConnectionError."""
         orch = _make_orchestrator()
         orch.state["apisession"] = "partial"  # WHY: verify cleanup runs.
         exc = ConnectionError("network down")
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.WARNING):
             assert orch._handle_connection_error(exc) is False  # WHY: contract.
-        assert "X Connection failed: network down" in capsys.readouterr().out  # WHY: legacy console.
+        assert "X Connection failed: network down" in caplog.text  # WHY: legacy console routed via logger.
         assert "Interactive login connection error: network down" in caplog.text  # WHY: legacy log.
         assert orch.state["apisession"] is None  # WHY: state cleared.
 
@@ -572,31 +571,31 @@ class TestHandleConnectionError:
 class TestHandleValueError:
     """``_handle_value_error`` branches on 'token'/'401' substrings."""
 
-    def test_token_branch_uses_generic_line(
-        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_token_branch_uses_generic_line(self, caplog: pytest.LogCaptureFixture) -> None:
         """'token' substring → 'Invalid API token or credentials' line."""
         orch = _make_orchestrator()
         exc = ValueError("bad token payload")
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.WARNING):
             assert orch._handle_value_error(exc) is False
-        assert "X Invalid API token or credentials" in capsys.readouterr().out  # WHY: specific branch.
+        assert "X Invalid API token or credentials" in caplog.text  # WHY: specific branch routed via logger.
         assert "Interactive login value error: bad token payload" in caplog.text  # WHY: legacy log.
         assert orch.state["apisession"] is None  # WHY: state cleared.
 
-    def test_401_branch_uses_generic_line(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_401_branch_uses_generic_line(self, caplog: pytest.LogCaptureFixture) -> None:
         """'401' substring → same 'Invalid API token or credentials' line."""
         orch = _make_orchestrator()
         exc = ValueError("HTTP 401 returned")
-        orch._handle_value_error(exc)
-        assert "X Invalid API token or credentials" in capsys.readouterr().out  # WHY: specific branch.
+        with caplog.at_level(logging.WARNING):
+            orch._handle_value_error(exc)
+        assert "X Invalid API token or credentials" in caplog.text  # WHY: specific branch routed via logger.
 
-    def test_generic_branch_uses_error_verbatim(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_generic_branch_uses_error_verbatim(self, caplog: pytest.LogCaptureFixture) -> None:
         """No token / 401 substring → verbatim 'Authentication error: ...' line."""
         orch = _make_orchestrator()
         exc = ValueError("some random validation")
-        orch._handle_value_error(exc)
-        assert "X Authentication error: some random validation" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            orch._handle_value_error(exc)
+        assert "X Authentication error: some random validation" in caplog.text
 
 
 class TestHandleGenericError:
@@ -619,26 +618,30 @@ class TestHandleGenericError:
 class TestPrintGenericErrorMessage:
     """``_print_generic_error_message`` branches: credential / 2FA / 401 / fallback."""
 
-    def test_credential_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_credential_branch(self, caplog: pytest.LogCaptureFixture) -> None:
         """'invalid' substring → credential message."""
-        LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "invalid whatever", "invalid whatever")
-        assert "X Invalid email or password" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "invalid whatever", "invalid whatever")
+        assert "X Invalid email or password" in caplog.text
 
-    def test_two_factor_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_two_factor_branch(self, caplog: pytest.LogCaptureFixture) -> None:
         """'2fa' substring → 2FA message."""
-        LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "2fa broken", "2fa broken")
-        assert "X Two-factor authentication failed" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "2fa broken", "2fa broken")
+        assert "X Two-factor authentication failed" in caplog.text
 
-    def test_401_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_401_branch(self, caplog: pytest.LogCaptureFixture) -> None:
         """'401' substring in the original error message → auth-failure message."""
-        LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "HTTP 401", "http 401")
-        assert "X Invalid email or password (authentication failed)" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            LoginOrchestrator._print_generic_error_message(RuntimeError("x"), "HTTP 401", "http 401")
+        assert "X Invalid email or password (authentication failed)" in caplog.text
 
-    def test_fallback_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_fallback_branch(self, caplog: pytest.LogCaptureFixture) -> None:
         """No matching substring → generic 'X Login failed: <exc>' line."""
         exc = RuntimeError("mystery")  # WHY: __str__ used in the fallback line.
-        LoginOrchestrator._print_generic_error_message(exc, "mystery", "mystery")
-        assert "X Login failed: mystery" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING):
+            LoginOrchestrator._print_generic_error_message(exc, "mystery", "mystery")
+        assert "X Login failed: mystery" in caplog.text
 
 
 class TestIsCredentialError:

--- a/tests/unit/auth/interactive/test_msp_org_selector.py
+++ b/tests/unit/auth/interactive/test_msp_org_selector.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging  # WHY: caplog level control after #886 print->logger migration
 from types import SimpleNamespace  # WHY: lightweight stand-in for mistapi/SDK responses
 from typing import Any  # WHY: matches Selector's state bag typing
 from unittest.mock import MagicMock  # WHY: MagicMock(spec=Callable) is mandatory per project standard
 
-import pytest  # WHY: capsys/monkeypatch fixtures for output + state assertions
+import pytest  # WHY: caplog/monkeypatch fixtures for log + state assertions
 
 from src.auth.interactive.msp_org_selector import MspOrgSelector  # WHY: SUT under test
 
@@ -46,7 +47,7 @@ def test_select_no_msp_delegates_to_fallback() -> None:
 
 
 def test_select_single_msp_autopicks_and_selects_org(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """One MSP auto-picks; then selector prompts for an org and records the pick."""
     apisession = MagicMock()  # WHY: sentinel session passed through to SDK
@@ -74,11 +75,12 @@ def test_select_single_msp_autopicks_and_selects_org(
         "mistapi": mistapi_stub,  # WHY: avoids the fallback import path
     }
     selector, fallback = _make_selector(state=state, answers=["1"])  # WHY: pick org #1 in the picker
-    selector.select()  # WHY: run full workflow
+    with caplog.at_level(logging.WARNING):
+        selector.select()  # WHY: run full workflow
     fallback.assert_not_called()  # WHY: single-MSP path never uses the fallback
     assert state["selected_msp"]["msp_id"] == "m1"  # WHY: MSP recorded
     assert state["org_id"] == "org-A"  # WHY: sorted-first org selected via "1"
-    assert "Selected organization: Alpha" in capsys.readouterr().out  # WHY: user confirmation printed
+    assert "Selected organization: Alpha" in caplog.text  # WHY: user confirmation logged
 
 
 def test_prompt_msp_blank_input_skips() -> None:
@@ -138,18 +140,19 @@ def test_prompt_msp_valueerror_from_safe_input_falls_back() -> None:
     fallback.assert_called_once_with()  # WHY: fallback triggered by exception handler
 
 
-def test_msp_org_selector_missing_apisession(capsys: pytest.CaptureFixture[str]) -> None:
+def test_msp_org_selector_missing_apisession(caplog: pytest.LogCaptureFixture) -> None:
     """Missing apisession in state prints an error and returns without selecting an org."""
     state = {
         "msp_privileges": [{"msp_id": "m1", "msp_name": "MSP One", "role": "admin"}],  # WHY: single MSP
     }  # WHY: apisession intentionally missing
     selector, fallback = _make_selector(state=state)  # WHY: no scripted input needed; fallback not used
-    selector.select()  # WHY: run and hit the missing-session guard
-    assert "API session not initialized" in capsys.readouterr().out  # WHY: legacy error preserved
+    with caplog.at_level(logging.WARNING):
+        selector.select()  # WHY: run and hit the missing-session guard
+    assert "API session not initialized" in caplog.text  # WHY: legacy error preserved
     assert "org_id" not in state  # WHY: no org selection performed
 
 
-def test_msp_org_selector_fetch_exception(capsys: pytest.CaptureFixture[str]) -> None:
+def test_msp_org_selector_fetch_exception(caplog: pytest.LogCaptureFixture) -> None:
     """Exception during listMspOrgs is caught and printed; no org is selected."""
     apisession = MagicMock()  # WHY: passed through to the SDK
     mistapi_stub = SimpleNamespace(
@@ -169,12 +172,13 @@ def test_msp_org_selector_fetch_exception(capsys: pytest.CaptureFixture[str]) ->
         "mistapi": mistapi_stub,
     }
     selector, _ = _make_selector(state=state)  # WHY: exception path needs no scripted answer
-    selector.select()  # WHY: run the failing SDK call
-    assert "Error fetching MSP organizations" in capsys.readouterr().out  # WHY: legacy error message
+    with caplog.at_level(logging.WARNING):
+        selector.select()  # WHY: run the failing SDK call
+    assert "Error fetching MSP organizations" in caplog.text  # WHY: legacy error message
     assert "org_id" not in state  # WHY: no selection recorded
 
 
-def test_fetch_msp_orgs_invalid_response(capsys: pytest.CaptureFixture[str]) -> None:
+def test_fetch_msp_orgs_invalid_response(caplog: pytest.LogCaptureFixture) -> None:
     """Response without .data returns None and prints the legacy error message."""
     mistapi_stub = SimpleNamespace(
         api=SimpleNamespace(
@@ -187,12 +191,13 @@ def test_fetch_msp_orgs_invalid_response(capsys: pytest.CaptureFixture[str]) -> 
     )
     state: dict[str, Any] = {"mistapi": mistapi_stub}  # WHY: SDK stub is enough for this path
     selector, _ = _make_selector(state=state)  # WHY: no user input needed
-    result = selector._fetch_msp_orgs(MagicMock(), "m1")  # WHY: direct method to isolate branch
+    with caplog.at_level(logging.WARNING):
+        result = selector._fetch_msp_orgs(MagicMock(), "m1")  # WHY: direct method to isolate branch
     assert result is None  # WHY: falsy-response guard returns None
-    assert "Failed to retrieve MSP organizations" in capsys.readouterr().out  # WHY: legacy warning
+    assert "Failed to retrieve MSP organizations" in caplog.text  # WHY: legacy warning
 
 
-def test_fetch_msp_orgs_empty_data_returns_empty(capsys: pytest.CaptureFixture[str]) -> None:
+def test_fetch_msp_orgs_empty_data_returns_empty(caplog: pytest.LogCaptureFixture) -> None:
     """Empty MSP org list prints the 'no organizations' message and returns []."""
     mistapi_stub = SimpleNamespace(
         api=SimpleNamespace(
@@ -207,9 +212,10 @@ def test_fetch_msp_orgs_empty_data_returns_empty(capsys: pytest.CaptureFixture[s
     )
     state: dict[str, Any] = {"mistapi": mistapi_stub}  # WHY: minimal state
     selector, _ = _make_selector(state=state)  # WHY: no input needed
-    result = selector._fetch_msp_orgs(MagicMock(), "m1")  # WHY: exercise empty-list branch
+    with caplog.at_level(logging.WARNING):
+        result = selector._fetch_msp_orgs(MagicMock(), "m1")  # WHY: exercise empty-list branch
     assert result == []  # WHY: empty branch returns []
-    assert "No organizations found under this MSP" in capsys.readouterr().out  # WHY: legacy message
+    assert "No organizations found under this MSP" in caplog.text  # WHY: legacy message
 
 
 def test_fetch_msp_orgs_single_org_normalizes_to_list() -> None:
@@ -242,13 +248,14 @@ def test_resolve_mistapi_fallback_import() -> None:
     assert state["mistapi"] is module  # WHY: cached in state for later reuse
 
 
-def test_paginated_pick_quit_shortcut(capsys: pytest.CaptureFixture[str]) -> None:
+def test_paginated_pick_quit_shortcut(caplog: pytest.LogCaptureFixture) -> None:
     """Entering 'q' in the org picker returns None and prints the skip message."""
     orgs = [{"id": "org-1", "name": "Alpha"}]  # WHY: any non-empty org list satisfies the picker
     selector, _ = _make_selector(answers=["q"])  # WHY: scripted 'q' triggers quit path
-    result = selector._paginated_pick(orgs)  # WHY: exercise the quit branch directly
+    with caplog.at_level(logging.WARNING):
+        result = selector._paginated_pick(orgs)  # WHY: exercise the quit branch directly
     assert result is None  # WHY: quit returns None
-    assert "Skipping org selection" in capsys.readouterr().out  # WHY: legacy skip message printed
+    assert "Skipping org selection" in caplog.text  # WHY: legacy skip message logged
 
 
 def test_paginated_pick_eof_returns_none() -> None:
@@ -260,25 +267,27 @@ def test_paginated_pick_eof_returns_none() -> None:
     assert result is None  # WHY: EOF returns None silently
 
 
-def test_paginated_pick_invalid_then_valid(capsys: pytest.CaptureFixture[str]) -> None:
+def test_paginated_pick_invalid_then_valid(caplog: pytest.LogCaptureFixture) -> None:
     """Non-numeric input reprompts; a valid numeric selection returns the picked org."""
     orgs = [
         {"id": "org-A", "name": "Alpha"},
         {"id": "org-B", "name": "Beta"},
     ]  # WHY: two orgs so index 2 is valid
     selector, _ = _make_selector(answers=["not-a-number", "2"])  # WHY: first invalid, then valid
-    result = selector._paginated_pick(orgs)  # WHY: exercise the invalid+retry branches
+    with caplog.at_level(logging.WARNING):
+        result = selector._paginated_pick(orgs)  # WHY: exercise the invalid+retry branches
     assert result == orgs[1]  # WHY: index "2" maps to orgs[1]
-    assert "Invalid input" in capsys.readouterr().out  # WHY: legacy invalid-input message printed
+    assert "Invalid input" in caplog.text  # WHY: legacy invalid-input message logged
 
 
-def test_paginated_pick_out_of_range_then_valid(capsys: pytest.CaptureFixture[str]) -> None:
+def test_paginated_pick_out_of_range_then_valid(caplog: pytest.LogCaptureFixture) -> None:
     """Out-of-range index reprompts; the next valid index returns the picked org."""
     orgs = [{"id": "org-A", "name": "Alpha"}]  # WHY: single org so "5" is out of range
     selector, _ = _make_selector(answers=["5", "1"])  # WHY: out-of-range then valid
-    result = selector._paginated_pick(orgs)  # WHY: exercise the range-guard branch
+    with caplog.at_level(logging.WARNING):
+        result = selector._paginated_pick(orgs)  # WHY: exercise the range-guard branch
     assert result == orgs[0]  # WHY: index "1" maps to orgs[0]
-    assert "Invalid number" in capsys.readouterr().out  # WHY: legacy range-error message printed
+    assert "Invalid number" in caplog.text  # WHY: legacy range-error message logged
 
 
 def test_interpret_choice_navigation() -> None:
@@ -290,22 +299,24 @@ def test_interpret_choice_navigation() -> None:
     assert (action, next_page, picked) == ("nav", 1, None)  # WHY: paged backward
 
 
-def test_render_msp_menu_prints_all_msps(capsys: pytest.CaptureFixture[str]) -> None:
+def test_render_msp_menu_prints_all_msps(caplog: pytest.LogCaptureFixture) -> None:
     """_render_msp_menu prints one line per MSP with role annotation."""
-    MspOrgSelector._render_msp_menu(
-        [
-            {"msp_name": "MSP One", "role": "admin"},  # WHY: full-shape row
-            {},  # WHY: missing fields exercises the fallback labels
-        ]
-    )  # WHY: static method call — no instance state required
-    out = capsys.readouterr().out  # WHY: capture printed menu
+    with caplog.at_level(logging.WARNING):
+        MspOrgSelector._render_msp_menu(
+            [
+                {"msp_name": "MSP One", "role": "admin"},  # WHY: full-shape row
+                {},  # WHY: missing fields exercises the fallback labels
+            ]
+        )  # WHY: static method call — no instance state required
+    out = caplog.text  # WHY: capture logged menu
     assert "MSP One" in out  # WHY: named MSP surfaced
     assert "Unknown" in out  # WHY: fallback name label used for the empty dict
     assert "unknown" in out  # WHY: fallback role label used for the empty dict
 
 
-def test_render_page_shows_multi_page_hint(capsys: pytest.CaptureFixture[str]) -> None:
+def test_render_page_shows_multi_page_hint(caplog: pytest.LogCaptureFixture) -> None:
     """When total_pages > 1 the multi-page hint is printed."""
     selector, _ = _make_selector()  # WHY: build a bare selector to reach the instance method
-    selector._render_page([{"id": "org-A", "name": "A"}], 0, 2)  # WHY: total_pages=2 triggers hint
-    assert "Page 1/2" in capsys.readouterr().out  # WHY: multi-page hint surfaced
+    with caplog.at_level(logging.WARNING):
+        selector._render_page([{"id": "org-A", "name": "A"}], 0, 2)  # WHY: total_pages=2 triggers hint
+    assert "Page 1/2" in caplog.text  # WHY: multi-page hint surfaced


### PR DESCRIPTION
## Summary

Slice 9/N of #886 (ruff T20 enablement).

Replace `print()` with `logging.warning/error/info/debug` across the
interactive auth module (`clouds`, `credential_prompter`,
`login_orchestrator`, `msp_org_selector`) so ruff T20 can be enabled
repo-wide.

Companion tests migrated `capsys` -> `caplog` with
`caplog.at_level(logging.WARNING)` around each call site.

Refs #886

## Test plan

- [x] `python -m ruff check src/auth tests/unit/auth` — all checks passed
- [x] `python -m pytest tests/unit/auth -q` — 96 passed
- [x] black formatting applied