### PR TITLE
chore(logging): migrate src/reports/ print() to logger (#886 slice 10/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 10/N: retire `print()` in `src/reports/` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the remaining `print()`
+  calls in `src/reports/e911_bssid.py`,
+  `src/reports/global_wired_client_report_generator.py`,
+  `src/reports/offline_device_reporter.py`,
+  `src/reports/sfp_transceiver_data_processor.py`, and
+  `src/reports/wired_client_manufacturer_report_generator.py` with
+  `logging.warning(...)` / `logging.info(...)` / `logging.error(...)` so
+  the print-avoidance rule (T20 selector target of #886) can eventually be
+  enabled repo-wide. WARNING level chosen for operator-visible report
+  headers, threshold prompts, per-type/per-site breakdowns, CSV-write
+  confirmations, and all-clear/no-devices notices so they surface on the
+  default root-logger configuration (INFO is suppressed by default).
+  Companion unit tests in
+  `tests/unit/reports/test_global_wired_client_report_generator.py`,
+  `tests/unit/reports/test_offline_device_reporter.py`,
+  `tests/unit/reports/test_sfp_transceiver_data_processor.py`,
+  `tests/unit/reports/test_wired_client_manufacturer_report_generator.py`,
+  and `tests/unit/test_e911_bssid.py` were migrated from
+  `capsys`/`captured.out` to `caplog`/`caplog.text` with a
+  `caplog.set_level(logging.WARNING)` prefix so the suite continues to
+  assert operator-visible output through the logging path. No behavioural
+  change beyond the emit channel; all 203 tests under
+  `tests/unit/reports/` + `tests/unit/test_e911_bssid.py` remain green.
+
 ### #886 Phase 2 slice 9/N: retire `print()` in `src/auth/` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the remaining `print()`

--- a/src/reports/e911_bssid.py
+++ b/src/reports/e911_bssid.py
@@ -103,7 +103,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         These are the expensive bulk queries that only need to run once.
         Results are cached in the checkpoint file so they survive a 429.
         """
-        print("  Phase 1: Fetching org-level bulk data...")  # WHY: operator sees progress at each phase
+        logging.warning("  Phase 1: Fetching org-level bulk data...")  # Legacy console echo routed via logger.
         sites_data = E911BSSIDReportGenerator._fetch_site_and_ap_bulk(apisession, org_id, page_limit)  # WHY: sites+APs
         wlan_data = E911BSSIDReportGenerator._fetch_wlan_bulk(  # WHY: bulk WLAN + templates fetch
             apisession, org_id, page_limit, sites_data["sites"]
@@ -129,11 +129,11 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
 
         WHY: extracted from `_fetch_org_bulk_data` to keep parent ≤25 lines.
         """
-        print("    Fetching site information...")  # WHY: user visibility during long org queries
+        logging.warning("    Fetching site information...")  # Legacy console echo routed via logger.
         all_sites = E911BSSIDReportGenerator._fetch_all_sites(apisession, org_id, page_limit)  # WHY: paginated list
         site_lookup = E911BSSIDReportGenerator._build_site_lookup(all_sites)  # WHY: dict for O(1) lookup by id
         logging.info("Sites fetched: %d", len(site_lookup))  # WHY: telemetry for run-size auditing
-        print("    Fetching AP inventory stats...")  # WHY: operator progress cue
+        logging.warning("    Fetching AP inventory stats...")  # Legacy console echo routed via logger.
         ap_lookup = E911BSSIDReportGenerator._fetch_ap_stats(apisession, org_id, page_limit)  # WHY: MAC-indexed AP data
         logging.info("AP device stats fetched: %d", len(ap_lookup))  # WHY: audit AP inventory size
         return {"sites": site_lookup, "aps": ap_lookup}  # WHY: bundled return keeps caller signature small
@@ -149,11 +149,11 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
 
         WHY: extracted so `_fetch_org_bulk_data` stays under the 25-line ceiling.
         """
-        print("    Fetching org WLAN templates and org WLANs...")  # WHY: operator sees API phase
+        logging.warning("    Fetching org WLAN templates and org WLANs...")  # Legacy console echo routed via logger.
         wlan_templates, org_wlans = E911BSSIDReportGenerator._fetch_wlan_sources(  # WHY: pair template+wlan fetch
             apisession, org_id, page_limit
         )
-        print("    Pre-fetching unique site template WLANs...")  # WHY: warn about additional per-template calls
+        logging.warning("    Pre-fetching unique site template WLANs...")  # Legacy console echo routed via logger.
         cache = E911BSSIDReportGenerator._prefetch_site_templates(  # WHY: cache SSIDs per template
             apisession, org_id, site_lookup
         )
@@ -190,13 +190,13 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         """
         import mistapi  # noqa: E402  # WHY: lazy import so non-report menus start fast
 
-        print("    Fetching AP radio MACs...")  # WHY: operator visibility for this API call
+        logging.warning("    Fetching AP radio MACs...")  # Legacy console echo routed via logger.
         radio_response = mistapi.api.v1.orgs.devices.listOrgApsMacs(apisession, org_id, limit=page_limit)  # WHY: page 1
         radio_macs_data: list[dict[str, Any]] = mistapi.get_all(  # WHY: fetch all remaining pages
             response=radio_response, mist_session=apisession
         )
         logging.info("Radio MAC records fetched: %d", len(radio_macs_data))  # WHY: audit radio-record count
-        print("    Inferring radio bands from MAC positions...")  # WHY: highlight local inference (no API call)
+        logging.warning("    Inferring radio bands from MAC positions...")  # Legacy console echo routed via logger.
         radio_band_lookup = E911BSSIDReportGenerator._infer_radio_bands(radio_macs_data)  # WHY: position -> band
         logging.info("Radio bands inferred: %d broadcast radios", len(radio_band_lookup))  # WHY: audit inference
         return {"radio_macs": radio_macs_data, "radio_bands": radio_band_lookup}  # WHY: bundle for parent
@@ -765,16 +765,22 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         compliance_gaps: list[dict[str, str]],
     ) -> None:
         """Display E911 report summary with compliance gap detection."""
-        print("\n--- E911 BSSID Report Summary ---")  # WHY: visual delimiter for CLI output
-        print(f"  Sites processed: {total_sites:,}")  # WHY: thousands separators for large orgs
-        print(f"  APs processed: {total_aps:,}")  # WHY: audit AP volume
-        print(f"  BSSIDs generated: {total_bssids:,}")  # WHY: total rows in CSV
+        logging.warning("\n--- E911 BSSID Report Summary ---")  # Legacy console echo routed via logger.
+        logging.warning("  Sites processed: %s", f"{total_sites:,}")  # Legacy console echo routed via logger.
+        logging.warning("  APs processed: %s", f"{total_aps:,}")  # Legacy console echo routed via logger.
+        logging.warning("  BSSIDs generated: %s", f"{total_bssids:,}")  # Legacy console echo routed via logger.
         if not compliance_gaps:  # WHY: happy-path exits with a positive message
-            print("\n  No compliance gaps detected -- all APs are assigned to floor plans.")
+            logging.warning(
+                "\n  No compliance gaps detected -- all APs are assigned to floor plans."
+            )  # Legacy console echo routed via logger.
             return  # WHY: nothing more to print
-        print(f"\n  Compliance Gaps: {len(compliance_gaps)} AP(s) require attention")  # WHY: header for gap list
+        logging.warning(
+            "\n  Compliance Gaps: %s AP(s) require attention", len(compliance_gaps)
+        )  # Legacy console echo routed via logger.
         for gap in compliance_gaps:  # WHY: enumerate each gap with reason
-            print(f"    - {gap['ap_name']} ({gap['ap_mac']}): {gap['reason']}")  # WHY: consistent format for triage
+            logging.warning(
+                "    - %s (%s): %s", gap["ap_name"], gap["ap_mac"], gap["reason"]
+            )  # Legacy console echo routed via logger.
 
     @staticmethod
     def _process_sites(
@@ -793,9 +799,14 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
             org_data, completed_sites
         )
         if not remaining:  # WHY: everything cached from a prior run
-            print(f"  All {total_sites} sites already cached.")  # WHY: operator confirmation
+            logging.warning("  All %s sites already cached.", total_sites)  # Legacy console echo routed via logger.
             return True  # WHY: nothing to do
-        print(f"  Phase 2: Processing {len(remaining)} sites ({len(completed_sites)} cached, {total_sites} total)...")
+        logging.warning(
+            "  Phase 2: Processing %s sites (%s cached, %s total)...",
+            len(remaining),
+            len(completed_sites),
+            total_sites,
+        )  # Legacy console echo routed via logger.
         batch = E911BSSIDReportGenerator._build_batch_context(org_id, org_data, site_state, total_sites)  # WHY: bundle
         return E911BSSIDReportGenerator._process_site_batch(apisession, page_limit, remaining, batch)
 
@@ -870,8 +881,12 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
                 E911BSSIDReportGenerator._save_checkpoint(
                     batch.org_id, batch.org_data, batch.completed_sites, batch.map_lookup, batch.wlan_band_lookup
                 )
-                print(f"    Progress: {len(batch.completed_sites)}/{batch.total_sites} sites")  # WHY: operator cue
-        print(f"    Done: {len(batch.completed_sites)}/{batch.total_sites} sites enriched.")  # WHY: completion cue
+                logging.warning(
+                    "    Progress: %s/%s sites", len(batch.completed_sites), batch.total_sites
+                )  # Legacy console echo routed via logger.
+        logging.warning(
+            "    Done: %s/%s sites enriched.", len(batch.completed_sites), batch.total_sites
+        )  # Legacy console echo routed via logger.
         return True  # WHY: caller writes the report
 
     @staticmethod
@@ -907,13 +922,19 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         index: int,
     ) -> bool:
         """Handle HTTP 429 rate limit by saving checkpoint."""
-        print(f"\n  ! Rate limited (HTTP 429) after {index} sites this run.")  # WHY: prominent operator alert
+        logging.warning(
+            "\n  ! Rate limited (HTTP 429) after %s sites this run.", index
+        )  # Legacy console echo routed via logger.
         E911BSSIDReportGenerator._save_checkpoint(
             batch.org_id, batch.org_data, batch.completed_sites, batch.map_lookup, batch.wlan_band_lookup
         )
         next_hour = datetime.now().replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)  # WHY: rate reset
-        print(f"    Checkpoint saved: {len(batch.completed_sites)}/{batch.total_sites} sites.")  # WHY: progress
-        print(f"    Run Menu 160 again after {next_hour.strftime('%H:%M')} to resume.")  # WHY: guide user
+        logging.warning(
+            "    Checkpoint saved: %s/%s sites.", len(batch.completed_sites), batch.total_sites
+        )  # Legacy console echo routed via logger.
+        logging.warning(
+            "    Run Menu 160 again after %s to resume.", next_hour.strftime("%H:%M")
+        )  # Legacy console echo routed via logger.
         return False  # WHY: caller uses False to abort the run cleanly
 
     @staticmethod
@@ -929,7 +950,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         Supports checkpoint/resume for large orgs that exceed the
         5000 API calls per clock-hour rate limit.
         """
-        print("\n=== E911 BSSID Compliance Report ===")  # WHY: visual header for the CLI menu action
+        logging.warning("\n=== E911 BSSID Compliance Report ===")  # Legacy console echo routed via logger.
         logging.info("Starting E911 BSSID compliance report generation...")  # WHY: audit trail entry
         start_time = time.time()  # WHY: elapsed-time telemetry at the end
         site_state = E911BSSIDReportGenerator._restore_or_init(org_id, safe_input_fn)  # WHY: resume or fresh state
@@ -950,7 +971,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         """
         radio_macs_data: list[dict[str, Any]] = org_data["radio_macs"]  # WHY: primary iteration payload
         if not radio_macs_data:  # WHY: nothing to report -> operator feedback + audit trail
-            print("No APs found in this organization.")  # WHY: operator feedback
+            logging.warning("No APs found in this organization.")  # Legacy console echo routed via logger.
             logging.info("No APs found - skipping E911 report generation")  # WHY: audit trail
         return radio_macs_data  # WHY: caller uses truthiness to short-circuit
 
@@ -1007,12 +1028,14 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         """
         done = len(checkpoint.get("completed_sites", []))  # WHY: for progress display
         total = checkpoint.get("total_sites", "?")  # WHY: total may be missing on very old checkpoints
-        print(f"  Found checkpoint: {done}/{total} sites completed.")  # WHY: operator visibility
+        logging.warning(
+            "  Found checkpoint: %s/%s sites completed.", done, total
+        )  # Legacy console echo routed via logger.
         resume = safe_input_fn("  Resume from checkpoint? (y/n): ", context="e911_resume")  # WHY: user consent
         if resume.lower() != "y":  # WHY: any answer besides 'y' discards checkpoint
             E911BSSIDReportGenerator._clear_checkpoint()  # WHY: remove stale file
             return E911BSSIDReportGenerator._blank_state()  # WHY: start fresh
-        print("  Restored org data from checkpoint.")  # WHY: confirm reuse to user
+        logging.warning("  Restored org data from checkpoint.")  # Legacy console echo routed via logger.
         return {  # WHY: restored state is what `execute` feeds into `_process_sites`
             "org_data": checkpoint["org_data"],
             "maps": checkpoint.get("map_lookup", {}),
@@ -1032,13 +1055,15 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         lookups = E911BSSIDReportGenerator._build_report_lookups(org_data, radio_macs_data, site_state)  # WHY: unified
         rows, compliance_gaps = E911BSSIDReportGenerator._build_bssid_rows(radio_macs_data, lookups)  # WHY: E911 rows
         filename = E911BSSIDReportGenerator._write_csv(rows, write_data_fn)  # WHY: file naming isolated
-        print(f"\nCSV saved: data/{filename} ({len(rows):,} BSSIDs)")  # WHY: confirm to operator
+        logging.warning(
+            "\nCSV saved: data/%s (%s BSSIDs)", filename, f"{len(rows):,}"
+        )  # Legacy console echo routed via logger.
         unique_sites = {row["Site Name"] for row in rows} - {"Unassigned"}  # WHY: unique real sites in output
         E911BSSIDReportGenerator._display_summary(len(unique_sites), len(radio_macs_data), len(rows), compliance_gaps)
         E911BSSIDReportGenerator._clear_checkpoint()  # WHY: successful run -> no checkpoint needed
         elapsed = time.time() - start_time  # WHY: telemetry for report duration
         logging.info("E911 BSSID report completed in %.1f seconds", elapsed)  # WHY: audit trail
-        print(f"\nReport completed in {elapsed:.1f} seconds")  # WHY: operator visibility
+        logging.warning("\nReport completed in %.1f seconds", elapsed)  # Legacy console echo routed via logger.
 
     @staticmethod
     def _build_report_lookups(

--- a/src/reports/global_wired_client_report_generator.py
+++ b/src/reports/global_wired_client_report_generator.py
@@ -44,7 +44,7 @@ class GlobalWiredClientReportGenerator:
         records, remote_used = GlobalWiredClientReportGenerator._fetch_clients(org_id, criteria)
         if not records:  # No records.
             logging.warning("No wired clients retrieved from API")  # Warn none retrieved.
-            print("\n  No wired clients found in the organization.")  # Tell the user.
+            logging.warning("\n  No wired clients found in the organization.")  # Legacy console echo routed via logger.
             return  # Abort.
         matched, metadata = GlobalWiredClientReportGenerator._apply_filters(records, criteria, remote_used)
         GlobalWiredClientReportGenerator._write_outputs(matched, metadata)  # Write the outputs.
@@ -52,8 +52,8 @@ class GlobalWiredClientReportGenerator:
     @staticmethod
     def _prompt_filter_criteria() -> dict[str, str] | Literal[False] | None:  # False = user cancelled, never True
         """Collect optional MAC and manufacturer filter criteria from user."""
-        print("\n--- Global Wired Client Report ---")  # Header.
-        print("Optional filters (press Enter to skip):\n")  # Explain skipping.
+        logging.warning("\n--- Global Wired Client Report ---")  # Legacy console echo routed via logger.
+        logging.warning("Optional filters (press Enter to skip):\n")  # Legacy console echo routed via logger.
         criteria: dict[str, str] = {}  # Collect criteria.
         mac_result = GlobalWiredClientReportGenerator._collect_single_filter("MAC address", "mac", criteria)
         if mac_result is False:  # User cancelled.
@@ -93,17 +93,19 @@ class GlobalWiredClientReportGenerator:
                 return selected  # type: ignore[no-any-return]
         except ValueError:  # Non-numeric input -> treat as invalid
             pass
-        print(f"  Invalid selection. No {field_name} filter will be applied.")  # Operator notice on invalid
+        logging.warning(
+            "  Invalid selection. No %s filter will be applied.", field_name
+        )  # Legacy console echo routed via logger.
         return None
 
     @staticmethod
     def _prompt_operator(field_name: str) -> str | None:  # Prompt an operator choice.
         """Display operator selection menu and return chosen operator or None."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FilterOperatorEngine + InputUtils.
-        print(f"  {field_name} filter operator:")  # Label the field
-        print("    0. No filter (skip)")  # No-filter option
+        logging.warning("  %s filter operator:", field_name)  # Legacy console echo routed via logger.
+        logging.warning("    0. No filter (skip)")  # Legacy console echo routed via logger.
         for index, operator in enumerate(mh.FilterOperatorEngine.OPERATOR_CATALOG, 1):  # List operators
-            print(f"    {index}. {operator}")  # Print each option
+            logging.warning("    %s. %s", index, operator)  # Legacy console echo routed via logger.
         choice = mh.InputUtils.safe_input(  # Read the choice
             f"  Select {field_name} operator (0-12, default 0): ",
             default_value="0",
@@ -121,7 +123,9 @@ class GlobalWiredClientReportGenerator:
             remote_used = GlobalWiredClientReportGenerator._build_remote_params(criteria, remote_params)
         try:
             logging.info("Fetching organization wired clients...")  # Log the fetch.
-            print("\n  Retrieving wired clients from organization...")  # Tell the user.
+            logging.warning(
+                "\n  Retrieving wired clients from organization..."
+            )  # Legacy console echo routed via logger.
             response = mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients(  # Call the API.
                 mh.apisession,
                 org_id,
@@ -129,11 +133,15 @@ class GlobalWiredClientReportGenerator:
             )
             records = mistapi.get_all(response=response, mist_session=mh.apisession) or []  # Page all; default empty.
             logging.info("Retrieved %s wired client records", len(records))  # Log the count.
-            print(f"  Retrieved {len(records)} wired client records")  # Tell the user.
+            logging.warning(
+                "  Retrieved %s wired client records", len(records)
+            )  # Legacy console echo routed via logger.
             return records, remote_used  # Return records and flag.
         except Exception as exception:  # Fetch failed.
             logging.exception("Failed to fetch wired clients: %s", exception)  # Log the exception.
-            print(f"\n  Error retrieving wired clients: {exception}")  # Tell the user.
+            logging.warning(
+                "\n  Error retrieving wired clients: %s", exception
+            )  # Legacy console echo routed via logger.
             return [], False  # Return empty.
 
     @staticmethod
@@ -250,10 +258,12 @@ class GlobalWiredClientReportGenerator:
         """Write matched records to both local report artifact and standard export."""
         matched_count = metadata["records_matched"]  # Matched count.
         retrieved_count = metadata["records_retrieved"]  # Retrieved count.
-        print(f"\n  Matched {matched_count} of {retrieved_count} wired client records")  # Tell the user.
+        logging.warning(
+            "\n  Matched %s of %s wired client records", matched_count, retrieved_count
+        )  # Legacy console echo routed via logger.
         if matched_count == 0:  # Nothing matched.
             logging.info("Zero records matched filters -- producing empty outputs")  # Log empty result.
-            print("  No records matched the specified filters.")  # Tell the user.
+            logging.warning("  No records matched the specified filters.")  # Legacy console echo routed via logger.
         GlobalWiredClientReportGenerator._write_standard_export(matched)  # Write the CSV export.
         GlobalWiredClientReportGenerator._write_local_report(matched, metadata)  # Write the JSON summary.
 
@@ -285,7 +295,9 @@ class GlobalWiredClientReportGenerator:
             with open(report_path, "w", encoding="utf-8") as report_file:  # Open the report file.
                 json.dump(report_payload, report_file, indent=2, default=str)  # Dump JSON.
             logging.info("Local report artifact written to %s", report_path)  # Log the write.
-            print(f"  Report summary written to {report_path}")  # Tell the user.
+            logging.warning("  Report summary written to %s", report_path)  # Legacy console echo routed via logger.
         except OSError as error:  # Write failed.
             logging.error("Failed to write local report artifact: %s", error)  # Log the error.
-            print(f"  Warning: Could not write report summary to {report_path}")  # Warn the user.
+            logging.warning(
+                "  Warning: Could not write report summary to %s", report_path
+            )  # Legacy console echo routed via logger.

--- a/src/reports/offline_device_reporter.py
+++ b/src/reports/offline_device_reporter.py
@@ -52,9 +52,11 @@ class OfflineDeviceReporter:  # Offline device inventory report.
             max_h = OfflineDeviceReporter.MAX_THRESHOLD_HOURS  # Local alias for line length.
             if min_h <= hours <= max_h:
                 return hours  # Valid -- accept.
-            print(f"! Threshold must be between {min_h} and {max_h} hours.")  # Out-of-range.
+            logging.warning(
+                "! Threshold must be between %s and %s hours.", min_h, max_h
+            )  # Out-of-range echo via logger.
         except ValueError:
-            print(f"! Invalid input '{raw}'. Please enter a number.")  # Bad type.
+            logging.warning("! Invalid input '%s'. Please enter a number.", raw)  # Bad-type echo via logger.
         return None
 
     @staticmethod
@@ -75,9 +77,11 @@ class OfflineDeviceReporter:  # Offline device inventory report.
                 return parsed
             remaining = OfflineDeviceReporter.MAX_INPUT_RETRIES - attempt - 1  # Attempts left.
             if remaining > 0:
-                print(f"  ({remaining} attempt(s) remaining)")  # Tell user.
+                logging.warning("  (%s attempt(s) remaining)", remaining)  # Legacy console echo routed via logger.
         logging.warning("Max retries exceeded for threshold input, using default 48 hours")  # Log fallback.
-        print(f"  Using default threshold: {OfflineDeviceReporter.DEFAULT_THRESHOLD_HOURS} hours")  # Tell user.
+        logging.warning(
+            "  Using default threshold: %s hours", OfflineDeviceReporter.DEFAULT_THRESHOLD_HOURS
+        )  # Legacy console echo routed via logger.
         return OfflineDeviceReporter.DEFAULT_THRESHOLD_HOURS
 
     @staticmethod
@@ -85,7 +89,7 @@ class OfflineDeviceReporter:  # Offline device inventory report.
         """Fetch site lookup and device stats from Mist API."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of APICoreFetchUtils/mistapi/apisession.
         logging.info("Fetching site information for offline device report...")
-        print("  Fetching site information...")
+        logging.warning("  Fetching site information...")  # Legacy console echo routed via logger.
         all_sites = mh.APICoreFetchUtils.all_sites_with_limit(current_org_id)
         site_lookup: dict[str, str] = {}
         for site in all_sites:
@@ -94,13 +98,13 @@ class OfflineDeviceReporter:  # Offline device inventory report.
                 site_lookup[site_id] = site.get("name", "Unknown Site")
 
         logging.info("Fetching device stats for offline device report...")
-        print("  Fetching device statistics...")
+        logging.warning("  Fetching device statistics...")  # Legacy console echo routed via logger.
         stats_resp = mh.mistapi.api.v1.orgs.stats.listOrgDevicesStats(
             mh.apisession, current_org_id, type="all", status="all", fields="*", limit=1000
         )
         all_devices: list[dict[str, Any]] = mh.mistapi.get_all(response=stats_resp, mist_session=mh.apisession)
         logging.info("Retrieved stats for %s devices", len(all_devices))
-        print(f"  Retrieved {len(all_devices)} devices from API")
+        logging.warning("  Retrieved %s devices from API", len(all_devices))  # Legacy console echo routed via logger.
         return site_lookup, all_devices
 
     @staticmethod
@@ -186,16 +190,18 @@ class OfflineDeviceReporter:  # Offline device inventory report.
     @staticmethod
     def _render_offline_breakdowns(type_counts: dict[str, int], site_counts: dict[str, int]) -> None:
         """Print 'By Type' and 'Top 5 Sites' breakdowns from precomputed counts."""
-        print("\nBy Type:")  # Header for type breakdown.
+        logging.warning("\nBy Type:")  # Legacy console echo routed via logger.
         for device_type in ["AP", "Switch", "Gateway"]:  # Stable display order.
             count = type_counts.get(device_type, 0)  # Lookup count.
             if count > 0:  # Suppress zeros.
-                print(f"  {device_type}s: {count}")
+                logging.warning("  %ss: %s", device_type, count)  # Legacy console echo routed via logger.
         sorted_sites = sorted(site_counts.items(), key=lambda item: item[1], reverse=True)[:5]  # Top 5 by count.
         if sorted_sites:
-            print("\nTop 5 Sites:")  # Header for the leaderboard.
+            logging.warning("\nTop 5 Sites:")  # Legacy console echo routed via logger.
             for rank, (site_name, count) in enumerate(sorted_sites, 1):  # Rank each top site.
-                print(f"  {rank}. {site_name}: {count} offline")  # Print rank and count.
+                logging.warning(
+                    "  %s. %s: %s offline", rank, site_name, count
+                )  # Legacy console echo routed via logger.
 
     @staticmethod
     def _display_summary(
@@ -204,9 +210,11 @@ class OfflineDeviceReporter:  # Offline device inventory report.
         threshold_hours: int,
     ) -> None:
         """Display summary statistics before the detail table."""
-        print("\n--- Summary ---")  # Section header.
-        print(f"Total devices in org: {total_device_count:,}")  # Total count.
-        print(f"Devices offline > {threshold_hours} hours: {len(offline_records)}")  # Offline count.
+        logging.warning("\n--- Summary ---")  # Legacy console echo routed via logger.
+        logging.warning("Total devices in org: %s", f"{total_device_count:,}")  # Legacy console echo routed via logger.
+        logging.warning(
+            "Devices offline > %s hours: %s", threshold_hours, len(offline_records)
+        )  # Legacy console echo routed via logger.
         type_counts: dict[str, int] = {}  # Per-type tally.
         site_counts: dict[str, int] = {}  # Per-site tally.
         for record in offline_records:  # Walk each offline record once.
@@ -238,7 +246,9 @@ class OfflineDeviceReporter:  # Offline device inventory report.
             data=csv_records, filename_or_table=filename, api_function_name="listOrgDevicesStats"
         )  # Persist.
         logging.info("CSV saved: data/%s (%s devices)", filename, total_count)  # Log save.
-        print(f"\nCSV saved: data/{filename} ({total_count} devices)")  # Operator-facing.
+        logging.warning(
+            "\nCSV saved: data/%s (%s devices)", filename, total_count
+        )  # Legacy console echo routed via logger.
 
     @staticmethod
     def _present_results(offline_records: list[dict[str, str]]) -> None:  # Render and save offline results.
@@ -246,12 +256,14 @@ class OfflineDeviceReporter:  # Offline device inventory report.
         fields = OfflineDeviceReporter._OFFLINE_DISPLAY_FIELDS  # Column order.
         total_count = len(offline_records)  # Total rows.
         show_count = min(total_count, OfflineDeviceReporter.MAX_DISPLAY_ROWS)  # Cap display.
-        print(f"\n--- Offline Devices (showing {show_count} of {total_count}) ---")  # Header.
+        logging.warning(
+            "\n--- Offline Devices (showing %s of %s) ---", show_count, total_count
+        )  # Legacy console echo routed via logger.
         table = PrettyTable()  # Build display table.
         table.field_names = list(fields)  # Set columns.
         for record in offline_records[:show_count]:  # Show capped rows.
             table.add_row([record.get(f, "") for f in fields])  # Add each row.
-        print(table)  # Print table.
+        logging.warning("%s", table)  # Legacy console echo routed via logger.
         OfflineDeviceReporter._save_offline_csv(offline_records, total_count)  # Persist CSV + log.
 
     @staticmethod
@@ -260,10 +272,10 @@ class OfflineDeviceReporter:  # Offline device inventory report.
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils.
         current_org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.
         if not current_org_id:  # No org selected.
-            print("! No organization selected. Exiting.")  # Tell the user.
+            logging.warning("! No organization selected. Exiting.")  # Legacy console echo routed via logger.
             return None, 0  # Caller must abort.
         threshold_hours = OfflineDeviceReporter._prompt_threshold()  # Prompt threshold.
-        print(f"Threshold: {threshold_hours} hours\n")  # Echo selection.
+        logging.warning("Threshold: %s hours\n", threshold_hours)  # Legacy console echo routed via logger.
         return current_org_id, threshold_hours
 
     @staticmethod
@@ -275,12 +287,12 @@ class OfflineDeviceReporter:  # Offline device inventory report.
         OfflineDeviceReporter._present_results(offline_records)  # Detail table + CSV.
         elapsed = time.time() - start_time  # Elapsed wall time.
         logging.info("Offline device report completed in %.1f seconds", elapsed)  # Log duration.
-        print(f"\nReport completed in {elapsed:.1f} seconds")  # Tell user.
+        logging.warning("\nReport completed in %.1f seconds", elapsed)  # Legacy console echo routed via logger.
 
     @staticmethod
     def execute() -> None:  # Run the offline report.
         """Main entry point for offline device report (Menu 158)."""
-        print("\n=== Offline Device Report ===")  # Header.
+        logging.warning("\n=== Offline Device Report ===")  # Legacy console echo routed via logger.
         logging.info("Starting offline device report...")  # Log start.
         start_time = time.time()  # Start timer.
         current_org_id, threshold_hours = OfflineDeviceReporter._gather_offline_inputs()  # Org + threshold.
@@ -290,15 +302,19 @@ class OfflineDeviceReporter:  # Offline device inventory report.
             site_lookup, all_devices = OfflineDeviceReporter._fetch_data(current_org_id)  # Fetch sites + devices.
         except Exception as error:  # Fetch failed.
             logging.error("Failed to fetch data from Mist API: %s", error)  # Log error.
-            print("! Failed to fetch data. Please check your API credentials and network connection.")  # Tell user.
+            logging.warning(
+                "! Failed to fetch data. Please check your API credentials and network connection."
+            )  # Legacy console echo routed via logger.
             return
         if not all_devices:  # No devices in org.
             logging.info("No devices found in organization")  # Log it.
-            print("No devices found in this organization.")  # Tell user.
+            logging.warning("No devices found in this organization.")  # Legacy console echo routed via logger.
             return
         offline_records = OfflineDeviceReporter._process_devices(all_devices, site_lookup, threshold_hours)  # Filter.
         if not offline_records:  # Nothing offline.
-            print(f"No devices found offline for more than {threshold_hours} hours. All clear!")  # All-clear.
+            logging.warning(
+                "No devices found offline for more than %s hours. All clear!", threshold_hours
+            )  # Legacy console echo routed via logger.
             logging.info("No devices offline beyond %sh threshold", threshold_hours)  # Log all-clear.
             return
         OfflineDeviceReporter._finalize_offline_report(len(all_devices), offline_records, threshold_hours, start_time)

--- a/src/reports/sfp_transceiver_data_processor.py
+++ b/src/reports/sfp_transceiver_data_processor.py
@@ -45,13 +45,17 @@ class SFPTransceiverDataProcessor:
             devices_with_site_info_path,
         )  # Trace entry with both target paths
         if not os.path.exists(org_port_stats_path):  # Port-stats CSV missing -> regenerate it
-            print("* OrgDevicePortStats.csv not found. Generating it now...")  # User-facing notice
+            logging.warning(
+                "* OrgDevicePortStats.csv not found. Generating it now..."
+            )  # Legacy console echo routed via logger
             logging.info(
                 "OrgDevicePortStats.csv missing; invoking OrgDeviceStatsExporter.device_port_stats()"
             )  # Action log before generating port-stats CSV
             mh.OrgDeviceStatsExporter.device_port_stats()  # Generate the port-stats CSV
         if not os.path.exists(devices_with_site_info_path):  # Devices+site CSV missing -> regenerate it
-            print("* AllDevicesWithSiteInfo.csv not found. Generating it now...")  # User-facing notice
+            logging.warning(
+                "* AllDevicesWithSiteInfo.csv not found. Generating it now..."
+            )  # Legacy console echo routed via logger
             logging.info(
                 "AllDevicesWithSiteInfo.csv missing; invoking OrgInventoryExporter.devices_with_site_info()"
             )  # Action log before generating devices+site CSV
@@ -162,9 +166,9 @@ class SFPTransceiverDataProcessor:
         logging.info(
             "Wrote %s rows to %s", len(merged_data), SFPTransceiverDataProcessor.OUTPUT_FILENAME
         )  # Log the row count written
-        print(
-            f"! Merged data written to {SFPTransceiverDataProcessor.OUTPUT_FILENAME}"
-        )  # Tell the user where the file landed
+        logging.warning(
+            "! Merged data written to %s", SFPTransceiverDataProcessor.OUTPUT_FILENAME
+        )  # Legacy console echo routed via logger
         logging.debug("EXIT: SFPTransceiverDataProcessor.merge_transceiver_data - success")  # Trace successful exit
 
     @staticmethod

--- a/src/reports/wired_client_manufacturer_report_generator.py
+++ b/src/reports/wired_client_manufacturer_report_generator.py
@@ -33,7 +33,7 @@ class WiredClientManufacturerReportGenerator:
         records = WiredClientManufacturerReportGenerator._fetch_all_clients(org_id)  # Fetch all clients.
         if not records:  # No records.
             logging.warning("No wired clients retrieved from API")  # Warn none retrieved.
-            print("\n  No wired clients found in the organization.")  # Tell the user.
+            logging.warning("\n  No wired clients found in the organization.")  # Legacy console echo routed via logger.
             return  # Abort.
         WiredClientManufacturerReportGenerator._write_outputs(records, "")  # Write the full export.
         summary = WiredClientManufacturerReportGenerator._build_manufacturer_summary(records)
@@ -49,7 +49,9 @@ class WiredClientManufacturerReportGenerator:
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession global.
         try:
             logging.info("Fetching all organization wired clients for manufacturer report...")  # Log the fetch.
-            print("\n  Retrieving all wired clients from organization...")  # Tell the user.
+            logging.warning(
+                "\n  Retrieving all wired clients from organization..."
+            )  # Legacy console echo routed via logger.
             response = mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients(  # Call the API.
                 mh.apisession,
                 org_id,
@@ -57,11 +59,15 @@ class WiredClientManufacturerReportGenerator:
             )
             records = mistapi.get_all(response=response, mist_session=mh.apisession) or []  # Page all; default empty.
             logging.info("Retrieved %s wired client records", len(records))  # Log the count.
-            print(f"  Retrieved {len(records)} wired client records")  # Tell the user.
+            logging.warning(
+                "  Retrieved %s wired client records", len(records)
+            )  # Legacy console echo routed via logger.
             return records  # Return records.
         except Exception as exception:  # Fetch failed.
             logging.exception("Failed to fetch wired clients: %s", exception)  # Log the exception.
-            print(f"\n  Error retrieving wired clients: {exception}")  # Tell the user.
+            logging.warning(
+                "\n  Error retrieving wired clients: %s", exception
+            )  # Legacy console echo routed via logger.
             return []  # Return empty.
 
     @staticmethod
@@ -78,12 +84,14 @@ class WiredClientManufacturerReportGenerator:
     def _print_manufacturer_table(summary: list[tuple[str, int]]) -> None:
         """Render the manufacturer/count picker table to stdout."""
         total_clients = sum(count for _, count in summary)  # Aggregate total client count for header line.
-        print(f"\n  Found {total_clients} clients from {len(summary)} manufacturers\n")  # Tell the user totals.
-        print(f"  {'#':<5} {'Manufacturer':<45} {'Count':>8}")  # Column header.
-        print(f"  {'-' * 5} {'-' * 45} {'-' * 8}")  # Separator row.
+        logging.warning(
+            "\n  Found %s clients from %s manufacturers\n", total_clients, len(summary)
+        )  # Legacy totals echo.
+        logging.warning("  %-5s %-45s %8s", "#", "Manufacturer", "Count")  # Column header.
+        logging.warning("  %s %s %s", "-" * 5, "-" * 45, "-" * 8)  # Separator row.
         for index, (manufacturer, count) in enumerate(summary, 1):  # List each manufacturer.
             display_name = manufacturer[:44]  # Truncate long names so column stays aligned.
-            print(f"  {index:<5} {display_name:<45} {count:>8}")  # Print the row.
+            logging.warning("  %-5s %-45s %8s", index, display_name, count)  # Legacy row echo routed via logger.
 
     @staticmethod
     def _parse_manufacturer_choice(choice: str, summary: list[tuple[str, int]]) -> str | None:
@@ -93,13 +101,13 @@ class WiredClientManufacturerReportGenerator:
         try:
             selection_index = int(choice)  # Parse the numeric selection.
         except ValueError:  # Non-numeric input.
-            print("  Invalid selection.")  # Tell the user.
+            logging.warning("  Invalid selection.")  # Legacy console echo routed via logger.
             return None  # Abort.
         if 1 <= selection_index <= len(summary):  # In valid range.
             selected_manufacturer = summary[selection_index - 1][0]  # Pick the manufacturer name.
             logging.info("User selected manufacturer: %s", selected_manufacturer)  # Log the choice.
             return selected_manufacturer  # Return chosen manufacturer.
-        print("  Selection out of range.")  # Out-of-range selection.
+        logging.warning("  Selection out of range.")  # Legacy console echo routed via logger.
         return None  # Abort.
 
     @staticmethod
@@ -144,7 +152,9 @@ class WiredClientManufacturerReportGenerator:
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter helpers.
         label = manufacturer if manufacturer else "ALL manufacturers"  # Label for messages.
         filename = WiredClientManufacturerReportGenerator._build_filename(manufacturer)  # Build the filename.
-        print(f"\n  Exporting {len(filtered)} records for: {label}")  # Tell the user.
+        logging.warning(
+            "\n  Exporting %s records for: %s", len(filtered), label
+        )  # Legacy console echo routed via logger.
         if filtered:  # Have records.
             flattened = DataProcessingUtils.flatten_nested_fields(filtered)  # Flatten nested fields.
             sanitized = DataProcessingUtils.escape_multiline(flattened)
@@ -155,5 +165,5 @@ class WiredClientManufacturerReportGenerator:
             filename,
             api_function_name="wiredClientManufacturerReport",
         )
-        print(f"  Exported to: data/{filename}.csv")  # Tell the user.
+        logging.warning("  Exported to: data/%s.csv", filename)  # Legacy console echo routed via logger.
         logging.info("Manufacturer report exported: %s records for %s -> %s", len(sanitized), label, filename)

--- a/tests/unit/reports/test_global_wired_client_report_generator.py
+++ b/tests/unit/reports/test_global_wired_client_report_generator.py
@@ -18,6 +18,7 @@ matches, OSError branch).
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -84,8 +85,9 @@ def test_execute_returns_when_user_cancels_filter_prompt() -> None:
     fetch.assert_not_called()
 
 
-def test_execute_returns_when_no_records(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_returns_when_no_records(caplog: pytest.LogCaptureFixture) -> None:
     """Empty fetch prints notice and skips write."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-uuid"
     with (
@@ -96,7 +98,7 @@ def test_execute_returns_when_no_records(capsys: pytest.CaptureFixture[str]) -> 
     ):
         R.execute()
     write_outputs.assert_not_called()
-    assert "No wired clients found" in capsys.readouterr().out
+    assert "No wired clients found" in caplog.text
 
 
 def test_execute_happy_path_invokes_write_outputs() -> None:
@@ -223,31 +225,34 @@ def test_resolve_operator_choice_returns_catalog_entry_for_valid_index() -> None
         assert R._resolve_operator_choice("3", "MAC") == "contains"
 
 
-def test_resolve_operator_choice_returns_none_when_out_of_range(capsys: pytest.CaptureFixture[str]) -> None:
+def test_resolve_operator_choice_returns_none_when_out_of_range(caplog: pytest.LogCaptureFixture) -> None:
     """Index outside catalog -> None + warning."""
+    caplog.set_level(logging.WARNING)
     with _patch_mh(_make_mh()):
         assert R._resolve_operator_choice("99", "MAC") is None
-    assert "Invalid selection" in capsys.readouterr().out
+    assert "Invalid selection" in caplog.text
 
 
-def test_resolve_operator_choice_returns_none_for_non_numeric(capsys: pytest.CaptureFixture[str]) -> None:
+def test_resolve_operator_choice_returns_none_for_non_numeric(caplog: pytest.LogCaptureFixture) -> None:
     """Non-numeric input -> None + warning."""
+    caplog.set_level(logging.WARNING)
     with _patch_mh(_make_mh()):
         assert R._resolve_operator_choice("abc", "MAC") is None
-    assert "Invalid selection" in capsys.readouterr().out
+    assert "Invalid selection" in caplog.text
 
 
 # ---------- _prompt_operator ----------
 
 
-def test_prompt_operator_delegates_to_resolve(capsys: pytest.CaptureFixture[str]) -> None:
+def test_prompt_operator_delegates_to_resolve(caplog: pytest.LogCaptureFixture) -> None:
     """Prompt shows menu, reads input, then delegates parsing."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mh.InputUtils.safe_input.return_value = "1"
     with _patch_mh(fake_mh):
         result = R._prompt_operator("MAC")
     assert result == "equals"
-    out = capsys.readouterr().out
+    out = caplog.text
     assert "MAC filter operator" in out
     assert "No filter" in out
     fake_mh.InputUtils.safe_input.assert_called_once()
@@ -292,8 +297,9 @@ def test_fetch_clients_success_with_pushable_criteria() -> None:
     assert kwargs["mac"] == "aa"
 
 
-def test_fetch_clients_returns_empty_on_exception(capsys: pytest.CaptureFixture[str]) -> None:
+def test_fetch_clients_returns_empty_on_exception(caplog: pytest.LogCaptureFixture) -> None:
     """API failure returns ([], False) and prints error."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mistapi = MagicMock(name="mistapi")
     fake_mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients.side_effect = RuntimeError("boom")
@@ -304,7 +310,7 @@ def test_fetch_clients_returns_empty_on_exception(capsys: pytest.CaptureFixture[
         records, remote_used = R._fetch_clients("org-uuid", None)
     assert records == []
     assert remote_used is False
-    assert "Error retrieving wired clients" in capsys.readouterr().out
+    assert "Error retrieving wired clients" in caplog.text
 
 
 # ---------- _build_remote_params ----------
@@ -476,8 +482,9 @@ def test_build_metadata_with_both_filters() -> None:
 # ---------- _write_outputs / _write_standard_export / _write_local_report ----------
 
 
-def test_write_outputs_prints_zero_match_message(capsys: pytest.CaptureFixture[str]) -> None:
+def test_write_outputs_prints_zero_match_message(caplog: pytest.LogCaptureFixture) -> None:
     """Zero matched records prints the no-matches notice."""
+    caplog.set_level(logging.WARNING)
     metadata = {"records_matched": 0, "records_retrieved": 5}
     with (
         patch.object(R, "_write_standard_export") as write_export,
@@ -486,11 +493,12 @@ def test_write_outputs_prints_zero_match_message(capsys: pytest.CaptureFixture[s
         R._write_outputs([], metadata)
     write_export.assert_called_once_with([])
     write_report.assert_called_once_with([], metadata)
-    assert "No records matched" in capsys.readouterr().out
+    assert "No records matched" in caplog.text
 
 
-def test_write_outputs_with_matches_skips_no_match_notice(capsys: pytest.CaptureFixture[str]) -> None:
+def test_write_outputs_with_matches_skips_no_match_notice(caplog: pytest.LogCaptureFixture) -> None:
     """When records match, only summary is printed; no zero-match notice."""
+    caplog.set_level(logging.WARNING)
     metadata = {"records_matched": 1, "records_retrieved": 5}
     matched = [{"mac": "aa"}]
     with (
@@ -498,7 +506,7 @@ def test_write_outputs_with_matches_skips_no_match_notice(capsys: pytest.Capture
         patch.object(R, "_write_local_report"),
     ):
         R._write_outputs(matched, metadata)
-    out = capsys.readouterr().out
+    out = caplog.text
     assert "Matched 1 of 5" in out
     assert "No records matched" not in out
 
@@ -534,23 +542,25 @@ def test_write_standard_export_runs_pipeline_when_populated() -> None:
     )
 
 
-def test_write_local_report_writes_summary_json(tmp_path, monkeypatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_write_local_report_writes_summary_json(tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
     """Writes JSON summary file to the data/ directory."""
+    caplog.set_level(logging.WARNING)
     monkeypatch.chdir(tmp_path)
     (tmp_path / "data").mkdir()
     metadata = {"records_matched": 1, "records_retrieved": 5}
     R._write_local_report([{"mac": "aa"}], metadata)
     written = (tmp_path / "data" / "GlobalWiredClientReport_summary.json").read_text(encoding="utf-8")
     assert "records_matched" in written
-    assert "Report summary written" in capsys.readouterr().out
+    assert "Report summary written" in caplog.text
 
 
-def test_write_local_report_handles_os_error(capsys: pytest.CaptureFixture[str]) -> None:
+def test_write_local_report_handles_os_error(caplog: pytest.LogCaptureFixture) -> None:
     """OSError during write logs + warns without raising."""
+    caplog.set_level(logging.WARNING)
     metadata = {"records_matched": 0, "records_retrieved": 0}
     with patch(
         "src.reports.global_wired_client_report_generator.open",
         side_effect=OSError("disk full"),
     ):
         R._write_local_report([], metadata)
-    assert "Could not write report summary" in capsys.readouterr().out
+    assert "Could not write report summary" in caplog.text

--- a/tests/unit/reports/test_offline_device_reporter.py
+++ b/tests/unit/reports/test_offline_device_reporter.py
@@ -23,6 +23,7 @@ no-offline, happy path).
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -54,22 +55,25 @@ def test_parse_threshold_attempt_returns_int_when_in_range() -> None:
     assert R._parse_threshold_attempt("48") == 48
 
 
-def test_parse_threshold_attempt_returns_none_when_below_min(capsys: pytest.CaptureFixture[str]) -> None:
+def test_parse_threshold_attempt_returns_none_when_below_min(caplog: pytest.LogCaptureFixture) -> None:
     """Zero is below MIN_THRESHOLD_HOURS: returns None with range message."""
+    caplog.set_level(logging.WARNING)
     assert R._parse_threshold_attempt("0") is None
-    assert "must be between" in capsys.readouterr().out
+    assert "must be between" in caplog.text
 
 
-def test_parse_threshold_attempt_returns_none_when_above_max(capsys: pytest.CaptureFixture[str]) -> None:
+def test_parse_threshold_attempt_returns_none_when_above_max(caplog: pytest.LogCaptureFixture) -> None:
     """Above MAX_THRESHOLD_HOURS: returns None with range message."""
+    caplog.set_level(logging.WARNING)
     assert R._parse_threshold_attempt("99999") is None
-    assert "must be between" in capsys.readouterr().out
+    assert "must be between" in caplog.text
 
 
-def test_parse_threshold_attempt_returns_none_on_value_error(capsys: pytest.CaptureFixture[str]) -> None:
+def test_parse_threshold_attempt_returns_none_on_value_error(caplog: pytest.LogCaptureFixture) -> None:
     """Non-numeric input triggers ValueError branch and prints invalid message."""
+    caplog.set_level(logging.WARNING)
     assert R._parse_threshold_attempt("abc") is None
-    assert "Invalid input" in capsys.readouterr().out
+    assert "Invalid input" in caplog.text
 
 
 # ---------- _prompt_threshold ----------
@@ -96,8 +100,9 @@ def test_prompt_threshold_returns_first_valid_attempt() -> None:
         assert R._prompt_threshold() == 24
 
 
-def test_prompt_threshold_retries_then_succeeds(capsys: pytest.CaptureFixture[str]) -> None:
+def test_prompt_threshold_retries_then_succeeds(caplog: pytest.LogCaptureFixture) -> None:
     """Bad input on first attempt: retry counter decrements and second attempt wins."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mh.InputUtils.safe_input.side_effect = ["bad", "72"]
     with patch(
@@ -105,11 +110,12 @@ def test_prompt_threshold_retries_then_succeeds(capsys: pytest.CaptureFixture[st
         return_value=fake_mh,
     ):
         assert R._prompt_threshold() == 72
-    assert "attempt(s) remaining" in capsys.readouterr().out
+    assert "attempt(s) remaining" in caplog.text
 
 
-def test_prompt_threshold_falls_back_when_max_retries_exceeded(capsys: pytest.CaptureFixture[str]) -> None:
+def test_prompt_threshold_falls_back_when_max_retries_exceeded(caplog: pytest.LogCaptureFixture) -> None:
     """All MAX_INPUT_RETRIES attempts fail -> DEFAULT_THRESHOLD_HOURS."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mh.InputUtils.safe_input.side_effect = ["bad"] * R.MAX_INPUT_RETRIES
     with patch(
@@ -117,7 +123,7 @@ def test_prompt_threshold_falls_back_when_max_retries_exceeded(capsys: pytest.Ca
         return_value=fake_mh,
     ):
         assert R._prompt_threshold() == R.DEFAULT_THRESHOLD_HOURS
-    assert "Using default threshold" in capsys.readouterr().out
+    assert "Using default threshold" in caplog.text
 
 
 # ---------- _fetch_data ----------
@@ -275,13 +281,14 @@ def test_process_devices_sorts_offline_records_by_duration_desc() -> None:
 
 
 def test_render_offline_breakdowns_hides_zero_type_and_lists_top_sites(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Zero counts are suppressed; sites render sorted descending, capped at 5."""
+    caplog.set_level(logging.WARNING)
     type_counts = {"AP": 3, "Switch": 0, "Gateway": 1}
     site_counts = {f"site-{i}": i for i in range(1, 8)}
     R._render_offline_breakdowns(type_counts, site_counts)
-    output = capsys.readouterr().out
+    output = caplog.text
     assert "APs: 3" in output
     assert "Switches:" not in output  # zero-suppressed
     assert "Gateways: 1" in output
@@ -290,26 +297,28 @@ def test_render_offline_breakdowns_hides_zero_type_and_lists_top_sites(
 
 
 def test_render_offline_breakdowns_skips_top_sites_when_empty(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Empty site_counts hides the Top 5 leaderboard entirely."""
+    caplog.set_level(logging.WARNING)
     R._render_offline_breakdowns({"AP": 1}, {})
-    output = capsys.readouterr().out
+    output = caplog.text
     assert "Top 5 Sites" not in output
 
 
 # ---------- _display_summary ----------
 
 
-def test_display_summary_prints_counts_and_calls_breakdown(capsys: pytest.CaptureFixture[str]) -> None:
+def test_display_summary_prints_counts_and_calls_breakdown(caplog: pytest.LogCaptureFixture) -> None:
     """Header + totals print; per-type/per-site counts render via helper."""
+    caplog.set_level(logging.WARNING)
     offline_records = [
         {"Device Type": "AP", "Site Name": "HQ"},
         {"Device Type": "AP", "Site Name": "HQ"},
         {"Device Type": "Switch", "Site Name": "Branch"},
     ]
     R._display_summary(100, offline_records, 48)
-    output = capsys.readouterr().out
+    output = caplog.text
     assert "Total devices in org: 100" in output
     assert "Devices offline > 48 hours: 3" in output
     assert "APs: 2" in output
@@ -319,8 +328,9 @@ def test_display_summary_prints_counts_and_calls_breakdown(capsys: pytest.Captur
 # ---------- _save_offline_csv ----------
 
 
-def test_save_offline_csv_strips_helper_keys_and_writes(capsys: pytest.CaptureFixture[str]) -> None:
+def test_save_offline_csv_strips_helper_keys_and_writes(caplog: pytest.LogCaptureFixture) -> None:
     """Helper keys (_sort_key) are stripped; DataExporter is called with expected filename."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     records = [
         {
@@ -346,14 +356,15 @@ def test_save_offline_csv_strips_helper_keys_and_writes(capsys: pytest.CaptureFi
     assert "_sort_key" not in csv_records[0]
     filename = written.kwargs["filename_or_table"]
     assert filename.startswith("OfflineDeviceReport_") and filename.endswith(".csv")
-    assert "CSV saved" in capsys.readouterr().out
+    assert "CSV saved" in caplog.text
 
 
 # ---------- _present_results ----------
 
 
-def test_present_results_caps_display_rows_and_calls_save(capsys: pytest.CaptureFixture[str]) -> None:
+def test_present_results_caps_display_rows_and_calls_save(caplog: pytest.LogCaptureFixture) -> None:
     """Table display honors MAX_DISPLAY_ROWS; _save_offline_csv gets the full list."""
+    caplog.set_level(logging.WARNING)
     records = [
         {
             "Device Name": f"d{i}",
@@ -371,15 +382,16 @@ def test_present_results_caps_display_rows_and_calls_save(capsys: pytest.Capture
     with patch.object(R, "_save_offline_csv") as save:
         R._present_results(records)
     save.assert_called_once_with(records, R.MAX_DISPLAY_ROWS + 5)
-    output = capsys.readouterr().out
+    output = caplog.text
     assert f"showing {R.MAX_DISPLAY_ROWS} of {R.MAX_DISPLAY_ROWS + 5}" in output
 
 
 # ---------- _gather_offline_inputs ----------
 
 
-def test_gather_offline_inputs_aborts_when_no_org(capsys: pytest.CaptureFixture[str]) -> None:
+def test_gather_offline_inputs_aborts_when_no_org(caplog: pytest.LogCaptureFixture) -> None:
     """Missing org -> (None, 0)."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = ""
     with patch(
@@ -387,11 +399,12 @@ def test_gather_offline_inputs_aborts_when_no_org(capsys: pytest.CaptureFixture[
         return_value=fake_mh,
     ):
         assert R._gather_offline_inputs() == (None, 0)
-    assert "No organization selected" in capsys.readouterr().out
+    assert "No organization selected" in caplog.text
 
 
-def test_gather_offline_inputs_returns_org_and_threshold(capsys: pytest.CaptureFixture[str]) -> None:
+def test_gather_offline_inputs_returns_org_and_threshold(caplog: pytest.LogCaptureFixture) -> None:
     """Happy path resolves org + prompts threshold + echoes."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-x"
     with (
@@ -402,16 +415,17 @@ def test_gather_offline_inputs_returns_org_and_threshold(capsys: pytest.CaptureF
         ),
     ):
         assert R._gather_offline_inputs() == ("org-x", 24)
-    assert "Threshold: 24 hours" in capsys.readouterr().out
+    assert "Threshold: 24 hours" in caplog.text
 
 
 # ---------- _finalize_offline_report ----------
 
 
 def test_finalize_offline_report_runs_summary_present_and_elapsed(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Finalize walks summary -> present -> elapsed."""
+    caplog.set_level(logging.WARNING)
     with (
         patch.object(R, "_display_summary") as summary,
         patch.object(R, "_present_results") as present,
@@ -420,7 +434,7 @@ def test_finalize_offline_report_runs_summary_present_and_elapsed(
         R._finalize_offline_report(10, [{"x": 1}], 48, 990.0)
     summary.assert_called_once_with(10, [{"x": 1}], 48)
     present.assert_called_once_with([{"x": 1}])
-    assert "Report completed in 10.0 seconds" in capsys.readouterr().out
+    assert "Report completed in 10.0 seconds" in caplog.text
 
 
 # ---------- execute ----------
@@ -436,8 +450,9 @@ def test_execute_returns_early_when_no_org() -> None:
     fetch.assert_not_called()
 
 
-def test_execute_handles_fetch_exception(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_handles_fetch_exception(caplog: pytest.LogCaptureFixture) -> None:
     """_fetch_data exception -> user-facing error + no processing."""
+    caplog.set_level(logging.WARNING)
     with (
         patch.object(R, "_gather_offline_inputs", return_value=("org", 48)),
         patch.object(R, "_fetch_data", side_effect=RuntimeError("boom")),
@@ -445,11 +460,12 @@ def test_execute_handles_fetch_exception(capsys: pytest.CaptureFixture[str]) -> 
     ):
         R.execute()
     proc.assert_not_called()
-    assert "Failed to fetch data" in capsys.readouterr().out
+    assert "Failed to fetch data" in caplog.text
 
 
-def test_execute_prints_notice_when_no_devices(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_prints_notice_when_no_devices(caplog: pytest.LogCaptureFixture) -> None:
     """Empty device list -> "No devices found" notice + early return."""
+    caplog.set_level(logging.WARNING)
     with (
         patch.object(R, "_gather_offline_inputs", return_value=("org", 48)),
         patch.object(R, "_fetch_data", return_value=({}, [])),
@@ -457,11 +473,12 @@ def test_execute_prints_notice_when_no_devices(capsys: pytest.CaptureFixture[str
     ):
         R.execute()
     proc.assert_not_called()
-    assert "No devices found in this organization" in capsys.readouterr().out
+    assert "No devices found in this organization" in caplog.text
 
 
-def test_execute_prints_all_clear_when_none_offline(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_prints_all_clear_when_none_offline(caplog: pytest.LogCaptureFixture) -> None:
     """Devices exist but none offline beyond threshold -> all-clear message."""
+    caplog.set_level(logging.WARNING)
     with (
         patch.object(R, "_gather_offline_inputs", return_value=("org", 48)),
         patch.object(R, "_fetch_data", return_value=({}, [{"mac": "aa"}])),
@@ -470,7 +487,7 @@ def test_execute_prints_all_clear_when_none_offline(capsys: pytest.CaptureFixtur
     ):
         R.execute()
     finalize.assert_not_called()
-    assert "All clear" in capsys.readouterr().out
+    assert "All clear" in caplog.text
 
 
 def test_execute_finalizes_when_offline_records_present() -> None:

--- a/tests/unit/reports/test_sfp_transceiver_data_processor.py
+++ b/tests/unit/reports/test_sfp_transceiver_data_processor.py
@@ -15,6 +15,7 @@ resolves paths and delegates to helpers).
 from __future__ import annotations
 
 import csv
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -52,13 +53,14 @@ def test_ensure_prereq_csvs_does_nothing_when_both_exist() -> None:
     inv_exporter.devices_with_site_info.assert_not_called()
 
 
-def test_ensure_prereq_csvs_generates_port_stats_when_missing(capsys: pytest.CaptureFixture[str]) -> None:
+def test_ensure_prereq_csvs_generates_port_stats_when_missing(caplog: pytest.LogCaptureFixture) -> None:
     """When only the port-stats CSV is missing OrgDeviceStatsExporter is invoked."""
     fake_mh = _make_mh()
 
     def exists(path: str) -> bool:
         return path != "port.csv"
 
+    caplog.set_level(logging.WARNING)
     with (
         patch("src.reports.sfp_transceiver_data_processor.OrgInventoryExporter") as inv_exporter,
         patch("src.reports.sfp_transceiver_data_processor.os.path.exists", side_effect=exists),
@@ -67,16 +69,17 @@ def test_ensure_prereq_csvs_generates_port_stats_when_missing(capsys: pytest.Cap
         P._ensure_prerequisite_csvs("port.csv", "devices.csv")
     fake_mh.OrgDeviceStatsExporter.device_port_stats.assert_called_once_with()
     inv_exporter.devices_with_site_info.assert_not_called()
-    assert "OrgDevicePortStats.csv not found" in capsys.readouterr().out
+    assert "OrgDevicePortStats.csv not found" in caplog.text
 
 
-def test_ensure_prereq_csvs_generates_devices_when_missing(capsys: pytest.CaptureFixture[str]) -> None:
+def test_ensure_prereq_csvs_generates_devices_when_missing(caplog: pytest.LogCaptureFixture) -> None:
     """When only the devices CSV is missing OrgInventoryExporter is invoked."""
     fake_mh = _make_mh()
 
     def exists(path: str) -> bool:
         return path != "devices.csv"
 
+    caplog.set_level(logging.WARNING)
     with (
         patch("src.reports.sfp_transceiver_data_processor.OrgInventoryExporter") as inv_exporter,
         patch("src.reports.sfp_transceiver_data_processor.os.path.exists", side_effect=exists),
@@ -85,7 +88,7 @@ def test_ensure_prereq_csvs_generates_devices_when_missing(capsys: pytest.Captur
         P._ensure_prerequisite_csvs("port.csv", "devices.csv")
     fake_mh.OrgDeviceStatsExporter.device_port_stats.assert_not_called()
     inv_exporter.devices_with_site_info.assert_called_once_with()
-    assert "AllDevicesWithSiteInfo.csv not found" in capsys.readouterr().out
+    assert "AllDevicesWithSiteInfo.csv not found" in caplog.text
 
 
 def test_ensure_prereq_csvs_generates_both_when_missing() -> None:
@@ -209,15 +212,16 @@ def test_log_merge_summary_emits_success_message(caplog: pytest.LogCaptureFixtur
 
 
 def test_finalize_merge_output_writes_via_backend_and_notifies_user(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Writes via DataExporter and prints the user-facing filename notice."""
     fake_mh = _make_mh()
     rows = [{"site_name": "HQ"}]
+    caplog.set_level(logging.WARNING)
     with patch("src.reports.sfp_transceiver_data_processor.importlib.import_module", return_value=fake_mh):
         P._finalize_merge_output(rows)
     fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(rows, "MergedTransceiverData.csv")
-    assert "Merged data written to MergedTransceiverData.csv" in capsys.readouterr().out
+    assert "Merged data written to MergedTransceiverData.csv" in caplog.text
 
 
 # ---------- _run_merge_pipeline ----------

--- a/tests/unit/reports/test_wired_client_manufacturer_report_generator.py
+++ b/tests/unit/reports/test_wired_client_manufacturer_report_generator.py
@@ -13,6 +13,7 @@ non-numeric / in-range / out-of-range), ``_prompt_selection``,
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -38,8 +39,9 @@ def _make_mh(**extra):
 # ---------- execute ----------
 
 
-def test_execute_aborts_when_no_records(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_aborts_when_no_records(caplog: pytest.LogCaptureFixture) -> None:
     """Empty fetch -> warning + user notice, no exports invoked."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-uuid"
     with (
@@ -52,7 +54,7 @@ def test_execute_aborts_when_no_records(capsys: pytest.CaptureFixture[str]) -> N
     ):
         R.execute()
     write_outputs.assert_not_called()
-    assert "No wired clients found" in capsys.readouterr().out
+    assert "No wired clients found" in caplog.text
 
 
 def test_execute_writes_all_only_when_selection_skipped() -> None:
@@ -136,8 +138,9 @@ def test_fetch_all_clients_defaults_none_pagination_to_empty_list() -> None:
         assert R._fetch_all_clients("org-uuid") == []
 
 
-def test_fetch_all_clients_returns_empty_on_api_exception(capsys: pytest.CaptureFixture[str]) -> None:
+def test_fetch_all_clients_returns_empty_on_api_exception(caplog: pytest.LogCaptureFixture) -> None:
     """API failure logs + prints and returns an empty list (no re-raise)."""
+    caplog.set_level(logging.WARNING)
     fake_mh = _make_mh()
     fake_mistapi = MagicMock(name="mistapi")
     fake_mistapi.api.v1.orgs.wired_clients.searchOrgWiredClients.side_effect = RuntimeError("boom")
@@ -149,7 +152,7 @@ def test_fetch_all_clients_returns_empty_on_api_exception(capsys: pytest.Capture
         ),
     ):
         assert R._fetch_all_clients("org-uuid") == []
-    assert "Error retrieving wired clients" in capsys.readouterr().out
+    assert "Error retrieving wired clients" in caplog.text
 
 
 # ---------- _build_manufacturer_summary ----------
@@ -180,20 +183,22 @@ def test_build_manufacturer_summary_uses_unknown_for_missing_or_empty() -> None:
 # ---------- _print_manufacturer_table ----------
 
 
-def test_print_manufacturer_table_renders_totals_and_rows(capsys: pytest.CaptureFixture[str]) -> None:
+def test_print_manufacturer_table_renders_totals_and_rows(caplog: pytest.LogCaptureFixture) -> None:
     """Header shows totals; rows list each manufacturer with count."""
+    caplog.set_level(logging.WARNING)
     R._print_manufacturer_table([("Cisco", 3), ("Juniper", 1)])
-    output = capsys.readouterr().out
+    output = caplog.text
     assert "Found 4 clients from 2 manufacturers" in output
     assert "Cisco" in output
     assert "Juniper" in output
 
 
-def test_print_manufacturer_table_truncates_long_names(capsys: pytest.CaptureFixture[str]) -> None:
+def test_print_manufacturer_table_truncates_long_names(caplog: pytest.LogCaptureFixture) -> None:
     """Names longer than 44 characters are truncated for column alignment."""
+    caplog.set_level(logging.WARNING)
     long_name = "X" * 60
     R._print_manufacturer_table([(long_name, 1)])
-    output = capsys.readouterr().out
+    output = caplog.text
     assert "X" * 44 in output
     assert "X" * 45 not in output
 
@@ -206,10 +211,11 @@ def test_parse_manufacturer_choice_returns_none_for_empty_input() -> None:
     assert R._parse_manufacturer_choice("", [("Cisco", 1)]) is None
 
 
-def test_parse_manufacturer_choice_returns_none_for_non_numeric(capsys: pytest.CaptureFixture[str]) -> None:
+def test_parse_manufacturer_choice_returns_none_for_non_numeric(caplog: pytest.LogCaptureFixture) -> None:
     """Non-numeric input prints an error and returns None."""
+    caplog.set_level(logging.WARNING)
     assert R._parse_manufacturer_choice("abc", [("Cisco", 1)]) is None
-    assert "Invalid selection" in capsys.readouterr().out
+    assert "Invalid selection" in caplog.text
 
 
 def test_parse_manufacturer_choice_returns_selected_name_for_valid_index() -> None:
@@ -218,10 +224,11 @@ def test_parse_manufacturer_choice_returns_selected_name_for_valid_index() -> No
     assert R._parse_manufacturer_choice("2", summary) == "Juniper"
 
 
-def test_parse_manufacturer_choice_returns_none_when_out_of_range(capsys: pytest.CaptureFixture[str]) -> None:
+def test_parse_manufacturer_choice_returns_none_when_out_of_range(caplog: pytest.LogCaptureFixture) -> None:
     """Out-of-range indexes print an error and return None."""
+    caplog.set_level(logging.WARNING)
     assert R._parse_manufacturer_choice("99", [("Cisco", 1)]) is None
-    assert "out of range" in capsys.readouterr().out
+    assert "out of range" in caplog.text
 
 
 # ---------- _prompt_selection ----------

--- a/tests/unit/test_e911_bssid.py
+++ b/tests/unit/test_e911_bssid.py
@@ -1,5 +1,6 @@
 """Unit tests for E911BSSIDReportGenerator in src/reports/e911_bssid.py."""
 
+import logging
 import os
 import sys
 import time
@@ -450,18 +451,20 @@ class TestBuildBssidRows:
 class TestDisplaySummary:
     """Tests for report summary output."""
 
-    def test_no_gaps(self, capsys):
+    def test_no_gaps(self, caplog: pytest.LogCaptureFixture):
         """Summary without gaps shows clean message."""
+        caplog.set_level(logging.WARNING)
         E911BSSIDReportGenerator._display_summary(5, 20, 320, [])
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "Sites processed: 5" in output
         assert "No compliance gaps" in output
 
-    def test_with_gaps(self, capsys):
+    def test_with_gaps(self, caplog: pytest.LogCaptureFixture):
         """Summary with gaps lists each one."""
+        caplog.set_level(logging.WARNING)
         gaps = [{"ap_name": "AP-1", "ap_mac": "aa:bb", "reason": "No map"}]
         E911BSSIDReportGenerator._display_summary(5, 20, 320, gaps)
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "Compliance Gaps: 1" in output
         assert "AP-1" in output
 
@@ -553,8 +556,9 @@ class TestRestoreOrInit:
 class TestHandleRateLimit:
     """Tests for rate limit handling."""
 
-    def test_saves_checkpoint_and_returns_false(self, capsys):
+    def test_saves_checkpoint_and_returns_false(self, caplog: pytest.LogCaptureFixture):
         """Rate limit handler saves state and returns False."""
+        caplog.set_level(logging.WARNING)
         org_data = {"sites": {}}
         batch = SiteBatchContext(
             org_id="org-1",
@@ -568,7 +572,7 @@ class TestHandleRateLimit:
         result = E911BSSIDReportGenerator._handle_rate_limit(batch, 5)
         assert result is False
         assert os.path.exists(E911BSSIDReportGenerator.CHECKPOINT_FILE)
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "Rate limited" in output
 
 
@@ -578,7 +582,7 @@ class TestHandleRateLimit:
 class TestWriteReport:
     """Tests for report writing and cleanup."""
 
-    def test_calls_write_fn(self, lookups, capsys):
+    def test_calls_write_fn(self, lookups):
         """Write function is called with rows and filename."""
         write_fn = MagicMock()
         radio_data = [
@@ -665,8 +669,9 @@ class TestAppendApRows:
 class TestExecute:
     """Integration tests for the top-level execute method."""
 
-    def test_no_aps_exits_early(self, capsys):
+    def test_no_aps_exits_early(self, caplog: pytest.LogCaptureFixture):
         """If no APs found, report exits with message."""
+        caplog.set_level(logging.WARNING)
         mock_api = MagicMock()
 
         def fake_fetch_bulk(*args, **kwargs):
@@ -692,7 +697,7 @@ class TestExecute:
                 safe_input_fn=lambda *a, **kw: "n",
                 write_data_fn=MagicMock(),
             )
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "No APs found" in output
 
     def test_full_run_writes_report(self, lookups):
@@ -743,7 +748,7 @@ class TestExecute:
             )
         write_fn.assert_called_once()
 
-    def test_rate_limited_run_stops_early(self, lookups, capsys):
+    def test_rate_limited_run_stops_early(self, lookups):
         """Execution stops when rate-limited, doesn't call write."""
         mock_api = MagicMock()
         write_fn = MagicMock()
@@ -1069,8 +1074,9 @@ class TestResolveSiteSsids:
 class TestProcessSites:
     """Tests for _process_sites with mocked API methods."""
 
-    def test_all_cached_returns_true(self, capsys):
+    def test_all_cached_returns_true(self, caplog: pytest.LogCaptureFixture):
         """When all sites are already cached, returns True immediately."""
+        caplog.set_level(logging.WARNING)
         org_data = {
             "aps": {"aa": {"site_id": "s1"}},
             "sites": {"s1": {}},
@@ -1091,7 +1097,7 @@ class TestProcessSites:
             site_state,
         )
         assert result is True
-        assert "already cached" in capsys.readouterr().out
+        assert "already cached" in caplog.text
 
     def test_processes_remaining_sites(self):
         """Processes remaining sites and returns True when complete."""


### PR DESCRIPTION
## Summary

Slice 10 of #886. Retires all `print()` in `src/reports/` (5 files) in favor of `logging.warning/info/error`, and migrates the companion tests from `capsys` to `caplog`.

Files:
- `src/reports/e911_bssid.py`
- `src/reports/global_wired_client_report_generator.py`
- `src/reports/offline_device_reporter.py`
- `src/reports/sfp_transceiver_data_processor.py`
- `src/reports/wired_client_manufacturer_report_generator.py`

WARNING level chosen so operator-visible output surfaces under the default root-logger config (INFO is suppressed by default).

No behavioural change beyond emit channel. Final T20 selector flip lands in the closing #886 PR.

## Test plan
- [x] `black src/reports tests/unit/reports tests/unit/test_e911_bssid.py` clean
- [x] `ruff check src/reports tests/unit/reports tests/unit/test_e911_bssid.py` clean
- [x] `pytest tests/unit/reports tests/unit/test_e911_bssid.py -q` → 203 passed