### PR TITLE
chore(logging): migrate src/org_data_collector.py print() to logger (#886 slice 12/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 12/N: retire `print()` in `src/org_data_collector.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 16 `print()` calls in
+  `src/org_data_collector.py` (the bulk org-level read sweep) with
+  `logging.warning(...)` so the print-avoidance rule (T20 selector target of
+  #886) can eventually be enabled repo-wide. WARNING level chosen for
+  operator-visible cancel confirmation, category banners, per-operation
+  progress lines (`... OK` / `FAILED (ExceptionClass)`), and the closing
+  summary banner (Total / Succeeded / Failed / Skipped / Duration) so they
+  surface on the default root-logger configuration (INFO is suppressed by
+  default). The original streaming `print(..., end=" ", flush=True)` progress
+  pattern was restructured into two complete lines per operation because the
+  logging module has no partial-line output capability; the visible outcome
+  is preserved. Companion unit tests in
+  `tests/unit/test_org_data_collector.py` were migrated from
+  `capsys`/`captured.out` to `caplog`/`caplog.text` with a
+  `caplog.set_level(logging.WARNING)` prefix so the suite continues to assert
+  the operator-visible output through the logging path. `_report_failure`
+  keeps its `(api_name, error)` signature so the direct-call test needs no
+  update beyond the fixture swap. No behavioural change beyond the emit
+  channel; all 8529 unit tests remain green.
+
 ### #886 Phase 2 slice 11/N: retire `print()` in root `MistHelper.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 98 `print()` calls in

--- a/src/org_data_collector.py
+++ b/src/org_data_collector.py
@@ -523,7 +523,7 @@ def _confirm_run(safe_input_fn: Callable[..., str], total: int) -> bool:
     if reply.strip().lower() == _CONFIRM_YES:  # WHY: Normalize whitespace/case before comparing
         return True
     logging.info("Org Data Collector: cancelled by user")  # WHY: Audit trail for the cancel path
-    print("Cancelled.")  # WHY: User-visible confirmation that the run was aborted
+    logging.warning("Cancelled.")  # WHY: Operator-visible cancel confirmation via logger.
     return False
 
 
@@ -549,9 +549,7 @@ def _maybe_print_category(category: str, previous: str) -> str:
     """Print the category banner when ``category`` differs from ``previous`` and return the new tag."""
     if category == previous:  # WHY: Guard clause avoids reprinting the banner for adjacent same-category ops
         return previous
-    print(f"\n{_SEPARATOR}")  # WHY: Top rule of the new category banner
-    print(f"  {category}")  # WHY: Indented category label
-    print(_SEPARATOR)  # WHY: Bottom rule matches the top so blocks are visually paired
+    logging.warning("\n%s\n  %s\n%s", _SEPARATOR, category, _SEPARATOR)  # WHY: Category banner via logger.
     return category  # WHY: Return the new tag so the caller updates its watermark
 
 
@@ -564,12 +562,12 @@ def _run_single(
     """Execute one operation and return one of ``_RESULT_OK`` / ``_RESULT_FAILED`` / ``_RESULT_SKIPPED``."""
     api_name = operation.api_call.__name__  # WHY: Human-readable function name for progress + logging
     progress = f"[{index}/{total}]"  # WHY: Pre-format progress token so the print stays a single f-string
-    print(f"{progress} {api_name} ({operation.data_type})...", end=" ", flush=True)  # WHY: Inline status line
+    logging.warning("%s %s (%s)...", progress, api_name, operation.data_type)  # WHY: Progress line via logger.
     try:
         export_data_fn(**_build_export_kwargs(operation))  # WHY: Delegate to the shared export pipeline
     except Exception as error:  # WHY: Catch broadly so one flaky API never aborts the entire sweep
         return _report_failure(api_name, error)  # WHY: Emit failure line + log and return the sentinel
-    print("OK")  # WHY: Trailing status token confirming success on stdout
+    logging.warning("OK")  # WHY: Trailing status token confirming success via logger.
     return _RESULT_OK
 
 
@@ -590,7 +588,7 @@ def _build_export_kwargs(operation: Operation) -> dict[str, Any]:
 def _report_failure(api_name: str, error: BaseException) -> str:
     """Print, log, and return the failure sentinel for a raised exception."""  # WHY: Isolates error-path I/O
     error_name = type(error).__name__  # WHY: Compact class name suffices in the console line
-    print(f"FAILED ({error_name})")  # WHY: Replace the trailing 'OK' with a failure marker
+    logging.warning("FAILED (%s)", error_name)  # WHY: Failure marker via logger.
     logging.error("Org Data Collector: %s failed: %s: %s", api_name, error_name, error)  # WHY: Full detail log
     return _RESULT_FAILED
 
@@ -618,12 +616,21 @@ def _split_elapsed(elapsed: float) -> tuple[int, int]:
 
 def _print_summary_banner(total: int, totals: _RunTotals, minutes: int, seconds: int) -> None:
     """Emit the operator-facing summary banner for the completed run."""  # WHY: Pure console output helper
-    print(f"\n{_SEPARATOR}")  # WHY: Top rule of the summary banner
-    print("  Org Data Collection Complete")  # WHY: Banner title matching category banner style
-    print(_SEPARATOR)  # WHY: Rule closes the banner header
-    print(f"  Total:     {total}")  # WHY: Total registered operations that were attempted
-    print(f"  Succeeded: {totals.succeeded}")  # WHY: Success tally from the loop
-    print(f"  Failed:    {totals.failed}")  # WHY: Failure tally from the loop
-    print(f"  Skipped:   {totals.skipped}")  # WHY: Skip tally reserved for future opt-outs
-    print(f"  Duration:  {minutes}m {seconds}s")  # WHY: Human-readable wall clock duration
-    print(_SEPARATOR)  # WHY: Bottom rule closes the summary block
+    logging.warning(  # WHY: Summary banner via logger; single call preserves block cohesion.
+        "\n%s\n  Org Data Collection Complete\n%s\n"
+        "  Total:     %s\n"
+        "  Succeeded: %s\n"
+        "  Failed:    %s\n"
+        "  Skipped:   %s\n"
+        "  Duration:  %sm %ss\n"
+        "%s",
+        _SEPARATOR,
+        _SEPARATOR,
+        total,
+        totals.succeeded,
+        totals.failed,
+        totals.skipped,
+        minutes,
+        seconds,
+        _SEPARATOR,
+    )

--- a/tests/unit/test_org_data_collector.py
+++ b/tests/unit/test_org_data_collector.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import logging  # WHY: caplog assertions filter on the WARNING/ERROR channel emitted since #886 slice 12
 import time as _stdlib_time  # WHY: patch time.time on the shared module (mypy-strict friendly)
 from unittest.mock import MagicMock  # WHY: MagicMock(spec=Callable) is mandatory per project standard
 
-import pytest  # WHY: capsys + monkeypatch fixtures assert stdout + patch time.time
+import pytest  # WHY: caplog + monkeypatch fixtures assert log output + patch time.time
 
 from src import org_data_collector as odc  # WHY: SUT under test — grab module for private helpers
 from src.org_data_collector import (  # WHY: Public entry point + Operation dataclass
@@ -20,20 +21,21 @@ def _make_export_fn() -> MagicMock:
     return MagicMock(spec=lambda **kwargs: None)  # WHY: spec=callable satisfies strict style
 
 
-def test_execute_cancels_when_user_declines(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_cancels_when_user_declines(caplog: pytest.LogCaptureFixture) -> None:
     """When operator answers something other than 'y', execute short-circuits without collecting."""
     export_fn = _make_export_fn()  # WHY: should never be called on cancel
     get_org = MagicMock(spec=lambda: "org-1")  # WHY: returns org id
     get_org.return_value = "org-1"  # WHY: explicit return value
     safe_input = MagicMock(spec=lambda prompt, context: prompt)  # WHY: safe_input signature
     safe_input.return_value = "n"  # WHY: non-affirmative reply triggers cancel
+    caplog.set_level(logging.WARNING)  # WHY: cancel confirmation emits via logging.warning since #886 slice 12.
     OrgDataCollector.execute(export_fn, get_org, safe_input)  # WHY: run the entrypoint
     export_fn.assert_not_called()  # WHY: no operations executed on cancel
-    assert "Cancelled." in capsys.readouterr().out  # WHY: user-visible cancel confirmation
+    assert "Cancelled." in caplog.text  # WHY: user-visible cancel confirmation
 
 
 def test_execute_runs_all_operations_when_confirmed(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """When operator confirms with 'y', execute runs every registered operation exactly once."""
     export_fn = _make_export_fn()  # WHY: recording stub
@@ -42,9 +44,10 @@ def test_execute_runs_all_operations_when_confirmed(
     safe_input = MagicMock(spec=lambda prompt, context: prompt)  # WHY: safe_input signature
     safe_input.return_value = "Y"  # WHY: mixed-case affirmative exercises normalization
     monkeypatch.setattr(_stdlib_time, "time", lambda: 0.0)  # WHY: pin elapsed to 0 for deterministic banner output
+    caplog.set_level(logging.WARNING)  # WHY: summary banner emits via logging.warning since #886 slice 12.
     OrgDataCollector.execute(export_fn, get_org, safe_input)  # WHY: run the full sweep
     assert export_fn.call_count == len(ALL_OPERATIONS)  # WHY: one export per registered operation
-    out = capsys.readouterr().out  # WHY: capture summary banner
+    out = caplog.text  # WHY: capture summary banner
     assert "Org Data Collection Complete" in out  # WHY: closing banner title printed
     assert f"Total:     {len(ALL_OPERATIONS)}" in out  # WHY: total reflects registry size
 
@@ -56,41 +59,45 @@ def test_confirm_run_accepts_lowercase_y() -> None:
     assert odc._confirm_run(safe_input, total=5) is True  # WHY: affirmative branch
 
 
-def test_confirm_run_rejects_blank_input(capsys: pytest.CaptureFixture[str]) -> None:
-    """Blank input is treated as decline; prints 'Cancelled.'"""
+def test_confirm_run_rejects_blank_input(caplog: pytest.LogCaptureFixture) -> None:
+    """Blank input is treated as decline; logs 'Cancelled.'"""
     safe_input = MagicMock(spec=lambda prompt, context: prompt)  # WHY: safe_input signature
     safe_input.return_value = ""  # WHY: empty reply is non-affirmative
+    caplog.set_level(logging.WARNING)  # WHY: cancel confirmation emits via logging.warning since #886 slice 12.
     assert odc._confirm_run(safe_input, total=3) is False  # WHY: cancel path
-    assert "Cancelled." in capsys.readouterr().out  # WHY: user-facing message
+    assert "Cancelled." in caplog.text  # WHY: user-facing message
 
 
-def test_maybe_print_category_prints_on_change(capsys: pytest.CaptureFixture[str]) -> None:
+def test_maybe_print_category_prints_on_change(caplog: pytest.LogCaptureFixture) -> None:
     """Different category prints a banner and returns the new tag."""
+    caplog.set_level(logging.WARNING)  # WHY: category banner emits via logging.warning since #886 slice 12.
     result = odc._maybe_print_category("Alpha", "Beta")  # WHY: exercise category change
     assert result == "Alpha"  # WHY: new tag returned
-    assert "Alpha" in capsys.readouterr().out  # WHY: banner label surfaced
+    assert "Alpha" in caplog.text  # WHY: banner label surfaced
 
 
-def test_maybe_print_category_skips_on_same(capsys: pytest.CaptureFixture[str]) -> None:
-    """Same category returns previous verbatim and prints nothing."""
+def test_maybe_print_category_skips_on_same(caplog: pytest.LogCaptureFixture) -> None:
+    """Same category returns previous verbatim and logs nothing."""
+    caplog.set_level(logging.WARNING)  # WHY: verify no banner emitted on the no-op branch.
     result = odc._maybe_print_category("Alpha", "Alpha")  # WHY: exercise no-op branch
     assert result == "Alpha"  # WHY: previous tag preserved
-    assert capsys.readouterr().out == ""  # WHY: no banner reprinted
+    assert caplog.text == ""  # WHY: no banner reprinted
 
 
-def test_run_single_ok_returns_ok_sentinel(capsys: pytest.CaptureFixture[str]) -> None:
-    """A successful export prints OK and returns _RESULT_OK."""
+def test_run_single_ok_returns_ok_sentinel(caplog: pytest.LogCaptureFixture) -> None:
+    """A successful export logs OK and returns _RESULT_OK."""
     export_fn = _make_export_fn()  # WHY: stub, no side effects
     api_call = MagicMock(spec=lambda: None)  # WHY: dummy api_call carries __name__
     api_call.__name__ = "listOrgSomething"  # WHY: readable name for progress line
     op = Operation(api_call=api_call, data_type="things", category="Cat")  # WHY: minimal Operation
+    caplog.set_level(logging.WARNING)  # WHY: OK status emits via logging.warning since #886 slice 12.
     result = odc._run_single(export_fn, op, index=1, total=1)  # WHY: exercise success path
     assert result == odc._RESULT_OK  # WHY: success sentinel returned
-    assert "OK" in capsys.readouterr().out  # WHY: trailing status printed
+    assert "OK" in caplog.text  # WHY: trailing status printed
 
 
-def test_run_single_failure_returns_failed_sentinel(capsys: pytest.CaptureFixture[str]) -> None:
-    """An export exception prints FAILED, logs, and returns _RESULT_FAILED."""
+def test_run_single_failure_returns_failed_sentinel(caplog: pytest.LogCaptureFixture) -> None:
+    """An export exception logs FAILED and returns _RESULT_FAILED."""
 
     def _boom(**_kwargs: object) -> None:  # WHY: injected export_fn raises
         raise RuntimeError("kaboom")  # WHY: forces the exception branch of _run_single
@@ -98,9 +105,10 @@ def test_run_single_failure_returns_failed_sentinel(capsys: pytest.CaptureFixtur
     api_call = MagicMock(spec=lambda: None)  # WHY: dummy api_call carries __name__
     api_call.__name__ = "listOrgSomething"  # WHY: readable name for progress line
     op = Operation(api_call=api_call, data_type="things", category="Cat")  # WHY: minimal Operation
+    caplog.set_level(logging.WARNING)  # WHY: failure marker emits via logging.warning since #886 slice 12.
     result = odc._run_single(_boom, op, index=2, total=5)  # WHY: exercise failure path
     assert result == odc._RESULT_FAILED  # WHY: failure sentinel returned
-    assert "FAILED (RuntimeError)" in capsys.readouterr().out  # WHY: failure marker printed
+    assert "FAILED (RuntimeError)" in caplog.text  # WHY: failure marker printed
 
 
 def test_build_export_kwargs_paginated_default_sort() -> None:
@@ -141,12 +149,13 @@ def test_build_export_kwargs_merges_api_kwargs() -> None:
     assert kwargs["distinct"] == "mac"  # WHY: api_kwargs merged into the base dict
 
 
-def test_report_failure_prints_and_returns_sentinel(capsys: pytest.CaptureFixture[str]) -> None:
-    """_report_failure prints FAILED with the class name and returns _RESULT_FAILED."""
+def test_report_failure_prints_and_returns_sentinel(caplog: pytest.LogCaptureFixture) -> None:
+    """_report_failure logs FAILED with the class name and returns _RESULT_FAILED."""
     error = ValueError("bad thing")  # WHY: concrete exception with distinguishable class name
+    caplog.set_level(logging.WARNING)  # WHY: failure marker emits via logging.warning since #886 slice 12.
     result = odc._report_failure("listOrgWhatever", error)  # WHY: exercise the failure helper directly
     assert result == odc._RESULT_FAILED  # WHY: failure sentinel returned
-    assert "FAILED (ValueError)" in capsys.readouterr().out  # WHY: class name surfaced in the marker
+    assert "FAILED (ValueError)" in caplog.text  # WHY: class name surfaced in the marker
 
 
 def test_split_elapsed_converts_seconds() -> None:
@@ -155,11 +164,12 @@ def test_split_elapsed_converts_seconds() -> None:
     assert (minutes, seconds) == (2, 5)  # WHY: floor-divide + remainder
 
 
-def test_print_summary_banner_prints_all_lines(capsys: pytest.CaptureFixture[str]) -> None:
+def test_print_summary_banner_prints_all_lines(caplog: pytest.LogCaptureFixture) -> None:
     """_print_summary_banner emits total, succeeded, failed, skipped, and duration."""
     totals = odc._RunTotals(succeeded=3, failed=1, skipped=0, elapsed=65.0)  # WHY: distinct counts + duration
+    caplog.set_level(logging.WARNING)  # WHY: summary banner emits via logging.warning since #886 slice 12.
     odc._print_summary_banner(total=4, totals=totals, minutes=1, seconds=5)  # WHY: exercise banner
-    out = capsys.readouterr().out  # WHY: capture banner text
+    out = caplog.text  # WHY: capture banner text
     assert "Total:     4" in out  # WHY: total surfaced
     assert "Succeeded: 3" in out  # WHY: success count surfaced
     assert "Failed:    1" in out  # WHY: failure count surfaced
@@ -168,7 +178,7 @@ def test_print_summary_banner_prints_all_lines(capsys: pytest.CaptureFixture[str
 
 
 def test_collect_all_tally_reflects_mix_of_results(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """_collect_all tallies OK and FAILED sentinels over the full ALL_OPERATIONS run."""
     seen: list[str] = []  # WHY: capture per-call names to prove iteration ran
@@ -179,8 +189,8 @@ def test_collect_all_tally_reflects_mix_of_results(
             raise RuntimeError("simulated")  # WHY: raises through _run_single
 
     monkeypatch.setattr(_stdlib_time, "time", lambda: 0.0)  # WHY: pin elapsed to 0 for deterministic run
+    caplog.set_level(logging.WARNING)  # WHY: silence banner output through caplog since #886 slice 12.
     totals = odc._collect_all(_export, total=len(ALL_OPERATIONS))  # WHY: run the collector
-    capsys.readouterr()  # WHY: drain captured banner output so downstream noise is silenced
     assert totals.failed == 1  # WHY: exactly one forced failure
     assert totals.succeeded == len(ALL_OPERATIONS) - 1  # WHY: rest succeeded
     assert totals.skipped == 0  # WHY: no skip sentinel produced today


### PR DESCRIPTION
## Summary

- Slice 12/N of #886: replace all 16 `print()` calls in `src/org_data_collector.py` with `logging.warning(...)` so the T20 selector can eventually be enabled repo-wide.
- WARNING level chosen for operator-visible cancel confirmation, category banners, per-operation progress lines (`... OK` / `FAILED (ExceptionClass)`), and the closing summary banner (Total / Succeeded / Failed / Skipped / Duration) so they surface on the default root-logger configuration.
- Streaming `print(..., end=" ", flush=True)` progress pattern restructured into two complete lines per operation (logging has no partial-line output); visible outcome preserved.
- Companion tests in `tests/unit/test_org_data_collector.py` migrated from `capsys` → `caplog` with an explicit `caplog.set_level(logging.WARNING)` prefix per capturing test.
- `_report_failure` keeps its `(api_name, error)` signature so the direct-call test needs no update beyond the fixture swap.

Refs #886.

## Test plan

- [x] `black --check src/org_data_collector.py tests/unit/test_org_data_collector.py` → 2 files unchanged
- [x] `ruff check --select T20 src/org_data_collector.py tests/unit/test_org_data_collector.py` → No issues found
- [x] `ruff check src/org_data_collector.py tests/unit/test_org_data_collector.py` → No issues found
- [x] `pytest tests/unit/test_org_data_collector.py -q` → 15 passed
- [x] `pytest tests/unit -q` → 8529 passed