### PR TITLE
chore(logging): migrate src/wan_hub_group_manager.py print() to logger (#886 slice 13/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 13/N: retire `print()` in `src/wan_hub_group_manager.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 30 `print()` calls in
+  `src/wan_hub_group_manager.py` (the WAN Hub Group Number Manager backing
+  Menu 163) with `logging.warning(...)` for operator-visible output
+  (banners, profile list rows, action menu, selection echoes, pod-value
+  validation errors, cancel acks, no-op reasons, mixed-pod warnings, final
+  update summary) and `logging.error(...)` for API-failure paths
+  (`_MSG_ERR_PROFILES`, `_MSG_ERR_VPNS`, per-VPN `updateOrgVpn` failure).
+  WARNING/ERROR are the two levels visible under the default root-logger
+  configuration, preserving the pre-migration UX. The six-line action-menu
+  banner (`_display_action_menu`) was consolidated into a single multi-line
+  `logging.warning` with embedded `\n` because logging emits one record per
+  call and per-line emission would fragment the output visually. The blank
+  separator `print()` between the profile list header and the numbered
+  entries became `logging.warning("")` for the same reason. All f-string
+  formatting was converted to %-style deferred args per the print-avoidance
+  rule (T20 selector target of #886). Companion unit tests in
+  `tests/unit/test_wan_hub_group_manager.py` were migrated from
+  `capsys`/`captured.out` to `caplog`/`caplog.text` with a
+  `caplog.set_level(logging.WARNING)` (or `logging.ERROR` for the two
+  API-failure assertions) prefix so the suite continues to assert the
+  operator-visible output through the logging path. No behavioural change
+  beyond the emit channel; all 8529 unit tests remain green.
+
 ### #886 Phase 2 slice 12/N: retire `print()` in `src/org_data_collector.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 16 `print()` calls in

--- a/src/wan_hub_group_manager.py
+++ b/src/wan_hub_group_manager.py
@@ -100,7 +100,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         """Static entry point called by menu_actions lambda."""
         org_id = get_org_id_func()  # WHY: resolves org lazily so menu can share cached value.
         if not org_id:  # WHY: guard clause - no org means nothing to manage.
-            print(_MSG_NO_ORG)  # WHY: surface the exit reason to the operator.
+            logging.warning(_MSG_NO_ORG)  # WHY: operator-visible exit reason via logger.
             return  # WHY: bail before constructing a useless manager.
         manager = WanHubGroupNumberManager(apisession, org_id, safe_input_func)  # WHY: build with resolved org.
         manager.run()  # WHY: delegate to the interactive workflow.
@@ -111,12 +111,12 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
 
     def run(self) -> None:  # WHY: top-level workflow orchestrator called from execute().
         """Main workflow: fetch, display, select, act."""
-        print(_HEADER)  # WHY: banner establishes menu context for the operator.
+        logging.warning(_HEADER)  # WHY: operator-visible menu banner via logger.
         logging.info(_MSG_START)  # WHY: emit start marker before any API traffic.
 
         profiles = self._fetch_profiles()  # WHY: source-of-truth list to display and index against.
         if not profiles:  # WHY: guard clause - no profiles means nothing to configure.
-            print(_MSG_NO_PROFILES)  # WHY: explain the empty-list exit.
+            logging.warning(_MSG_NO_PROFILES)  # WHY: operator-visible empty-list exit via logger.
             return  # WHY: no further work possible.
 
         vpns, all_vpns = self._fetch_hub_spoke_vpns()  # WHY: need hub_spoke overlays that carry pods.
@@ -151,7 +151,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
             return profiles  # WHY: caller drives display and match building.
         except Exception:  # WHY: broad catch - any API/network fault must not raise into menu loop.
             logging.exception("Failed to fetch device profiles")  # WHY: full traceback for triage.
-            print(_MSG_ERR_PROFILES)  # WHY: user-visible hint to check connectivity.
+            logging.error(_MSG_ERR_PROFILES)  # WHY: operator-visible connectivity hint via logger.
             return []  # WHY: empty list flows into no-profiles guard clause.
 
     def _fetch_hub_spoke_vpns(
@@ -171,14 +171,14 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
             return hub_spoke, all_vpns  # WHY: caller distinguishes 'no VPNs' from 'no hub-spoke VPNs'.
         except Exception:  # WHY: same broad-catch degradation as _fetch_profiles.
             logging.exception("Failed to fetch org VPNs")  # WHY: full traceback for triage.
-            print(_MSG_ERR_VPNS)  # WHY: user-visible connectivity hint.
+            logging.error(_MSG_ERR_VPNS)  # WHY: operator-visible connectivity hint via logger.
             return [], []  # WHY: signal both lists empty to caller.
 
     @staticmethod
     def _report_no_hub_spoke(all_vpns: list[dict[str, Any]]) -> None:  # WHY: helper for empty-hub-spoke UX branch.
         """Tell the user what VPN types were found instead of hub_spoke."""
         if not all_vpns:  # WHY: guard clause - distinguish 'zero VPNs' from 'no hub-spoke'.
-            print(_MSG_NO_VPNS)  # WHY: unambiguous message for empty inventory.
+            logging.warning(_MSG_NO_VPNS)  # WHY: operator-visible empty-inventory msg via logger.
             return  # WHY: nothing further to summarize.
         type_counts: dict[str, int] = {}  # WHY: histogram of type -> count for operator context.
         for vpn in all_vpns:  # WHY: single-pass tally keeps helper cheap.
@@ -187,9 +187,11 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         summary = ", ".join(
             f"{count} {vtype}" for vtype, count in sorted(type_counts.items())
         )  # WHY: deterministic sorted summary aids log diff review.
-        print(
-            f"! No hub-spoke VPN definitions found. Found {len(all_vpns)} VPN(s): {summary}."
-        )  # WHY: guides operator toward creating a hub_spoke overlay.
+        logging.warning(
+            "! No hub-spoke VPN definitions found. Found %d VPN(s): %s.",
+            len(all_vpns),
+            summary,
+        )  # WHY: operator-visible guidance toward creating a hub_spoke overlay via logger.
 
     # ------------------------------------------------------------------
     # Path matching
@@ -238,13 +240,13 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         vpn_data: dict[str, list[tuple[str, str, str, int]]],
     ) -> None:  # WHY: pure I/O helper - no state mutation, just formatted print.
         """Print numbered, alphabetized profile list with pod values."""
-        print(_MSG_HEADING_PROFILES)  # WHY: heading above the numbered list.
+        logging.warning(_MSG_HEADING_PROFILES)  # WHY: operator-visible list heading via logger.
         for index, profile in enumerate(profiles, start=1):  # WHY: 1-based numbering matches prompt.
             name = profile.get("name", "")  # WHY: default matches _build_vpn_data key.
             matches = vpn_data.get(name, [])  # WHY: precomputed match cache lookup.
             pod_display = self._format_pod_display(matches)  # WHY: uniform pod summary.
-            print(f"   {index}. {name:<30s} {pod_display}")  # WHY: 30-char pad keeps columns aligned.
-        print()  # WHY: trailing blank line separates list from prompt.
+            logging.warning("   %d. %-30s %s", index, name, pod_display)  # WHY: aligned row via logger.
+        logging.warning("")  # WHY: trailing blank line separates list from prompt via logger.
 
     @staticmethod
     def _format_pod_display(
@@ -277,12 +279,12 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
                 context=_CTX_PROFILE_SELECT,
             )  # WHY: EOF-safe input with structured context tag.
             if choice.lower() == _QUIT_CHAR:  # WHY: case-insensitive cancel handling.
-                print(_MSG_CANCELLED)  # WHY: acknowledge cancel to operator.
+                logging.warning(_MSG_CANCELLED)  # WHY: operator-visible cancel ack via logger.
                 return None  # WHY: sentinel drives run() to exit workflow.
             selected = self._resolve_choice_index(choice, profiles, count)  # WHY: pure parse + range check.
             if selected is not None:  # WHY: valid index found, return match.
                 return selected  # WHY: caller uses this profile for subsequent action.
-            print(f"  Please enter a number between 1 and {count}.")  # WHY: guide operator on retry.
+            logging.warning("  Please enter a number between 1 and %d.", count)  # WHY: retry hint via logger.
 
     @staticmethod
     def _resolve_choice_index(
@@ -298,7 +300,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         if not (1 <= index <= count):  # WHY: out-of-range index also drives retry.
             return None  # WHY: keep loop responsibility in caller.
         selected = profiles[index - 1]  # WHY: display list is 1-based, list is 0-based.
-        print(f"  Selected: {selected.get('name', '')}")  # WHY: echo selection for operator confidence.
+        logging.warning("  Selected: %s", selected.get("name", ""))  # WHY: selection echo via logger.
         return selected  # WHY: signal success to caller.
 
     def _prompt_action(
@@ -310,7 +312,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         name = profile.get("name", "")  # WHY: canonical name used for lookup + messages.
         matches = vpn_data.get(name, [])  # WHY: precomputed match cache for the profile.
         if not matches:  # WHY: guard clause - nothing to update for this profile.
-            print(f"  No VPN paths found for profile '{name}'.")  # WHY: explicit exit reason.
+            logging.warning("  No VPN paths found for profile '%s'.", name)  # WHY: exit reason via logger.
             return  # WHY: bail before any prompts.
         self._log_inconsistent_pods(name, matches)  # WHY: warn operator on drift before choice.
         self._display_action_menu(name, matches)  # WHY: render menu after any inconsistency warning.
@@ -324,12 +326,16 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
     ) -> None:  # WHY: extracted from _prompt_action so it stays under STRUCT-LENGTH.
         """Print the profile header and set/clear/cancel labels."""
         pod_display = self._format_pod_display(matches)  # WHY: reuse formatter for consistent display.
-        print(f"\n  Profile: {name}")  # WHY: header pins the operator to selected profile.
-        print(f"  Current {pod_display}  ({len(matches)} VPN paths)")  # WHY: show current pod + path count.
-        print(_MSG_HEADING_ACTIONS)  # WHY: heading above the numbered menu.
-        print(_MSG_ACTION_SET)  # WHY: action 1 label.
-        print(_MSG_ACTION_CLEAR)  # WHY: action 2 label.
-        print(_MSG_ACTION_CANCEL)  # WHY: action 3 label.
+        logging.warning(
+            "\n  Profile: %s\n  Current %s  (%d VPN paths)\n%s\n%s\n%s\n%s",
+            name,
+            pod_display,
+            len(matches),
+            _MSG_HEADING_ACTIONS,
+            _MSG_ACTION_SET,
+            _MSG_ACTION_CLEAR,
+            _MSG_ACTION_CANCEL,
+        )  # WHY: consolidated action-menu banner via logger.
 
     def _dispatch_action(
         self,
@@ -345,7 +351,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         }
         handler = handlers.get(choice)  # WHY: unknown / '3' falls through to cancel branch.
         if handler is None:  # WHY: '3' or garbage input is the cancel path.
-            print(_MSG_CANCELLED)  # WHY: single canonical cancel message.
+            logging.warning(_MSG_CANCELLED)  # WHY: canonical cancel message via logger.
             return  # WHY: no state change.
         handler(profile, vpn_data)  # WHY: invoke selected handler with the profile + cached matches.
 
@@ -360,7 +366,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
             return  # WHY: caller loop is unchanged.
         confirm_prompt = f"  Update all matching paths to pod {new_pod}? (y/N): "  # WHY: build prompt once.
         if not self._confirm(confirm_prompt, _CTX_CONFIRM_SET):  # WHY: explicit y required to proceed.
-            print(_MSG_CANCELLED)  # WHY: acknowledge cancel to operator.
+            logging.warning(_MSG_CANCELLED)  # WHY: cancel ack via logger.
             return  # WHY: skip API call when operator declines.
         self.set_pod(profile, vpn_data, new_pod)  # WHY: proceed with the batched update.
 
@@ -373,10 +379,14 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         try:  # WHY: any non-numeric input is a normal validation failure.
             new_pod = int(raw)  # WHY: pod is stored as integer in Mist API.
         except ValueError:  # WHY: friendlier than raising to menu.
-            print(f"  Pod value must be between {self.POD_MIN} and {self.POD_MAX}.")  # WHY: rejection hint.
+            logging.warning(
+                "  Pod value must be between %d and %d.", self.POD_MIN, self.POD_MAX
+            )  # WHY: rejection hint via logger.
             return None  # WHY: sentinel drives caller cancel path.
         if not (self.POD_MIN <= new_pod <= self.POD_MAX):  # WHY: enforce API-accepted range.
-            print(f"  Pod value must be between {self.POD_MIN} and {self.POD_MAX}.")  # WHY: same message.
+            logging.warning(
+                "  Pod value must be between %d and %d.", self.POD_MIN, self.POD_MAX
+            )  # WHY: same rejection hint via logger.
             return None  # WHY: consistent None sentinel for both failure modes.
         return new_pod  # WHY: valid integer returned to caller.
 
@@ -399,7 +409,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         name = profile.get("name", "")  # WHY: index into precomputed cache.
         matches = vpn_data.get(name, [])  # WHY: cached matches from _build_vpn_data.
         if not matches:  # WHY: guard clause - nothing to update.
-            print(f"  No VPN paths found for profile '{name}'.")  # WHY: explicit no-op reason.
+            logging.warning("  No VPN paths found for profile '%s'.", name)  # WHY: no-op reason via logger.
             return  # WHY: no API call needed.
         vpn_updates = self._group_by_vpn(matches, new_pod)  # WHY: batch by VPN id for fewer API calls.
         self._apply_vpn_updates(vpn_updates, name, new_pod)  # WHY: perform grouped update.
@@ -414,13 +424,15 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         matches = vpn_data.get(name, [])  # WHY: cached matches from _build_vpn_data.
         pod_values = {pod for (_, _, _, pod) in matches}  # WHY: dedupe pods to short-circuit no-ops.
         if pod_values == {self.POD_DEFAULT}:  # WHY: already at default = no-op.
-            print(f"  Pod for '{name}' is already at default (1). No action needed.")  # WHY: explain no-op.
+            logging.warning(
+                "  Pod for '%s' is already at default (1). No action needed.", name
+            )  # WHY: no-op explanation via logger.
             return  # WHY: skip API call and prompt.
         if not self._confirm(
             f"  Reset pod to default (1) on {len(matches)} paths? (y/N): ",
             _CTX_CONFIRM_CLEAR,
         ):  # WHY: destructive reset requires explicit y.
-            print(_MSG_CANCELLED)  # WHY: acknowledge cancel to operator.
+            logging.warning(_MSG_CANCELLED)  # WHY: cancel ack via logger.
             return  # WHY: skip API call.
         self.set_pod(profile, vpn_data, self.POD_DEFAULT)  # WHY: delegate to set_pod with default value.
 
@@ -455,9 +467,12 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
             if updated is None:  # WHY: None signals failure - abort remaining VPNs.
                 return  # WHY: preserve partial-success state for triage.
             total_updated += updated  # WHY: accumulate successful mutation count.
-        print(
-            f"  Updated {total_updated} paths for '{profile_name}' to pod {new_pod}."
-        )  # WHY: final success summary line.
+        logging.warning(
+            "  Updated %d paths for '%s' to pod %d.",
+            total_updated,
+            profile_name,
+            new_pod,
+        )  # WHY: final success summary via logger.
 
     def _apply_one_vpn(
         self,
@@ -479,7 +494,9 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
             return updated  # WHY: caller aggregates counts across VPNs.
         except Exception:  # WHY: broad catch - preserves partial-success reporting.
             logging.exception("Failed to update VPN '%s'", vpn_name)  # WHY: full traceback for triage.
-            print(f"  Error updating VPN '{vpn_name}'. Check logs for details.")  # WHY: user hint.
+            logging.error(
+                "  Error updating VPN '%s'. Check logs for details.", vpn_name
+            )  # WHY: operator-visible failure hint via logger.
             return None  # WHY: sentinel telling caller to abort remaining VPNs.
 
     def _update_single_vpn(
@@ -522,11 +539,11 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         logging.warning(
             "Paths for %s have mixed pod values: %s", name, sorted_pods
         )  # WHY: raise operations attention to drift.
-        print(
-            f"  Warning: Paths for {name} have mixed pod values "
-            f"({', '.join(str(p) for p in sorted_pods)}). "
-            "All will be updated to the new value."
-        )  # WHY: operator-facing warning mirrors the log message.
+        logging.warning(
+            "  Warning: Paths for %s have mixed pod values (%s). " "All will be updated to the new value.",
+            name,
+            ", ".join(str(p) for p in sorted_pods),
+        )  # WHY: operator-facing warning mirrors the log message via logger.
 
     @staticmethod
     def _fallback_input(prompt: str, **_kwargs: Any) -> str:

--- a/tests/unit/test_wan_hub_group_manager.py
+++ b/tests/unit/test_wan_hub_group_manager.py
@@ -7,6 +7,7 @@ Tests cover all user stories:
 - US4: Module import and instantiation
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -138,22 +139,22 @@ class TestFetchHubSpokeVpns:
 class TestReportNoHubSpoke:
     """Test _report_no_hub_spoke output messages."""
 
-    def test_empty_vpns_reports_none(self, capsys):
+    def test_empty_vpns_reports_none(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         WanHubGroupNumberManager._report_no_hub_spoke([])
-        output = capsys.readouterr().out
-        assert "No VPN definitions found" in output
+        assert "No VPN definitions found" in caplog.text
 
-    def test_reports_found_types(self, capsys):
+    def test_reports_found_types(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         all_vpns = [
             {"name": "V1", "type": "mesh"},
             {"name": "V2", "type": "mesh"},
             {"name": "V3", "type": None},
         ]
         WanHubGroupNumberManager._report_no_hub_spoke(all_vpns)
-        output = capsys.readouterr().out
-        assert "No hub-spoke" in output
-        assert "3 VPN(s)" in output
-        assert "mesh" in output
+        assert "No hub-spoke" in caplog.text
+        assert "3 VPN(s)" in caplog.text
+        assert "mesh" in caplog.text
 
 
 class TestFindMatchingPaths:
@@ -293,37 +294,37 @@ class TestSetPod:
 class TestPromptSetPod:
     """Test pod value input prompt and validation."""
 
-    def test_non_numeric_rejected(self, manager, sample_vpns, capsys):
+    def test_non_numeric_rejected(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profile = {"id": "uuid-alpha", "name": "ALPHA"}
         vpn_data = manager._build_vpn_data([profile], sample_vpns)
         manager._safe_input = MagicMock(return_value="abc")
         manager._prompt_set_pod(profile, vpn_data)
-        output = capsys.readouterr().out
-        assert "must be between" in output
+        assert "must be between" in caplog.text
 
-    def test_zero_rejected(self, manager, sample_vpns, capsys):
+    def test_zero_rejected(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profile = {"id": "uuid-alpha", "name": "ALPHA"}
         vpn_data = manager._build_vpn_data([profile], sample_vpns)
         manager._safe_input = MagicMock(return_value="0")
         manager._prompt_set_pod(profile, vpn_data)
-        output = capsys.readouterr().out
-        assert "must be between" in output
+        assert "must be between" in caplog.text
 
-    def test_over_128_rejected(self, manager, sample_vpns, capsys):
+    def test_over_128_rejected(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profile = {"id": "uuid-alpha", "name": "ALPHA"}
         vpn_data = manager._build_vpn_data([profile], sample_vpns)
         manager._safe_input = MagicMock(return_value="129")
         manager._prompt_set_pod(profile, vpn_data)
-        output = capsys.readouterr().out
-        assert "must be between" in output
+        assert "must be between" in caplog.text
 
-    def test_negative_rejected(self, manager, sample_vpns, capsys):
+    def test_negative_rejected(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profile = {"id": "uuid-alpha", "name": "ALPHA"}
         vpn_data = manager._build_vpn_data([profile], sample_vpns)
         manager._safe_input = MagicMock(return_value="-5")
         manager._prompt_set_pod(profile, vpn_data)
-        output = capsys.readouterr().out
-        assert "must be between" in output
+        assert "must be between" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -334,12 +335,12 @@ class TestPromptSetPod:
 class TestClearPod:
     """Test clear_pod reset logic."""
 
-    def test_already_default_no_action(self, manager, sample_vpns, capsys):
+    def test_already_default_no_action(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profile = {"id": "uuid-bravo", "name": "BRAVO"}
         vpn_data = manager._build_vpn_data([profile], sample_vpns)
         manager.clear_pod(profile, vpn_data)
-        output = capsys.readouterr().out
-        assert "already at default" in output
+        assert "already at default" in caplog.text
 
     @patch.object(WanHubGroupNumberManager, "set_pod")
     def test_delegates_to_set_pod(self, mock_set, manager, sample_vpns):
@@ -383,12 +384,12 @@ class TestModuleArchitecture:
             WanHubGroupNumberManager.execute(mock_session, mock_get_org, mock_input)
             mock_run.assert_called_once()
 
-    def test_execute_exits_on_no_org(self, mock_session, capsys):
+    def test_execute_exits_on_no_org(self, mock_session, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         mock_get_org = MagicMock(return_value=None)
         mock_input = MagicMock()
         WanHubGroupNumberManager.execute(mock_session, mock_get_org, mock_input)
-        output = capsys.readouterr().out
-        assert "No organization" in output
+        assert "No organization" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -399,19 +400,19 @@ class TestModuleArchitecture:
 class TestLogInconsistentPods:
     """Test warning for mixed pod values."""
 
-    def test_warns_on_mixed_pods(self, manager, mixed_pod_vpns, capsys):
+    def test_warns_on_mixed_pods(self, manager, mixed_pod_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         matches = manager._find_matching_paths("MIXED", mixed_pod_vpns)
         manager._log_inconsistent_pods("MIXED", matches)
-        output = capsys.readouterr().out
-        assert "mixed pod values" in output
-        assert "5" in output
-        assert "10" in output
+        assert "mixed pod values" in caplog.text
+        assert "5" in caplog.text
+        assert "10" in caplog.text
 
-    def test_no_warning_on_consistent_pods(self, manager, sample_vpns, capsys):
+    def test_no_warning_on_consistent_pods(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         matches = manager._find_matching_paths("ALPHA", sample_vpns)
         manager._log_inconsistent_pods("ALPHA", matches)
-        output = capsys.readouterr().out
-        assert "mixed" not in output.lower()
+        assert "mixed" not in caplog.text.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -423,11 +424,11 @@ class TestRunWorkflow:
     """Test the main run() orchestration method."""
 
     @patch.object(WanHubGroupNumberManager, "_fetch_profiles")
-    def test_no_profiles_exits(self, mock_fetch, manager, capsys):
+    def test_no_profiles_exits(self, mock_fetch, manager, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         mock_fetch.return_value = []
         manager.run()
-        output = capsys.readouterr().out
-        assert "No WAN Hub Profiles" in output
+        assert "No WAN Hub Profiles" in caplog.text
 
     @patch.object(WanHubGroupNumberManager, "_prompt_action")
     @patch.object(WanHubGroupNumberManager, "_prompt_profile_selection")
@@ -435,8 +436,16 @@ class TestRunWorkflow:
     @patch.object(WanHubGroupNumberManager, "_fetch_hub_spoke_vpns")
     @patch.object(WanHubGroupNumberManager, "_fetch_profiles")
     def test_no_hub_spoke_vpns_exits(
-        self, mock_profiles, mock_vpns, mock_display, mock_select, mock_action, manager, capsys
+        self,
+        mock_profiles,
+        mock_vpns,
+        mock_display,
+        mock_select,
+        mock_action,
+        manager,
+        caplog: pytest.LogCaptureFixture,
     ):
+        caplog.set_level(logging.WARNING)
         mock_profiles.return_value = [{"name": "P1"}]
         mock_vpns.return_value = ([], [{"type": "mesh"}])
         manager.run()
@@ -480,13 +489,13 @@ class TestFetchHubSpokeVpnsError:
     """Test _fetch_hub_spoke_vpns error handling."""
 
     @patch("src.wan_hub_group_manager.mistapi.api.v1.orgs.vpns.listOrgVpns")
-    def test_api_error_returns_empty(self, mock_list, manager, capsys):
+    def test_api_error_returns_empty(self, mock_list, manager, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.ERROR)
         mock_list.side_effect = Exception("Connection failed")
         hub_spoke, all_vpns = manager._fetch_hub_spoke_vpns()
         assert hub_spoke == []
         assert all_vpns == []
-        output = capsys.readouterr().out
-        assert "Error retrieving VPN" in output
+        assert "Error retrieving VPN" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -497,18 +506,18 @@ class TestFetchHubSpokeVpnsError:
 class TestDisplayProfileList:
     """Test profile list display rendering."""
 
-    def test_renders_profile_names(self, manager, sample_vpns, capsys):
+    def test_renders_profile_names(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profiles = [
             {"name": "ALPHA"},
             {"name": "BRAVO"},
         ]
         vpn_data = manager._build_vpn_data(profiles, sample_vpns)
         manager._display_profile_list(profiles, vpn_data)
-        output = capsys.readouterr().out
-        assert "1." in output
-        assert "ALPHA" in output
-        assert "2." in output
-        assert "BRAVO" in output
+        assert "1." in caplog.text
+        assert "ALPHA" in caplog.text
+        assert "2." in caplog.text
+        assert "BRAVO" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -519,12 +528,12 @@ class TestDisplayProfileList:
 class TestPromptAction:
     """Test the set/clear/cancel action menu."""
 
-    def test_no_matches_exits(self, manager, capsys):
+    def test_no_matches_exits(self, manager, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profile = {"name": "EMPTY"}
         vpn_data = {"EMPTY": []}
         manager._prompt_action(profile, vpn_data)
-        output = capsys.readouterr().out
-        assert "No VPN paths found" in output
+        assert "No VPN paths found" in caplog.text
 
     @patch.object(WanHubGroupNumberManager, "_prompt_set_pod")
     def test_action_1_calls_set_pod(self, mock_set, manager, sample_vpns):
@@ -542,13 +551,13 @@ class TestPromptAction:
         manager._prompt_action(profile, vpn_data)
         mock_clear.assert_called_once()
 
-    def test_action_3_cancels(self, manager, sample_vpns, capsys):
+    def test_action_3_cancels(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profile = {"name": "ALPHA"}
         vpn_data = manager._build_vpn_data([profile], sample_vpns)
         manager._safe_input = MagicMock(return_value="3")
         manager._prompt_action(profile, vpn_data)
-        output = capsys.readouterr().out
-        assert "Cancelled" in output
+        assert "Cancelled" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -567,13 +576,13 @@ class TestPromptSetPodConfirmation:
         manager._prompt_set_pod(profile, vpn_data)
         mock_set.assert_called_once_with(profile, vpn_data, 42)
 
-    def test_declined_cancels(self, manager, sample_vpns, capsys):
+    def test_declined_cancels(self, manager, sample_vpns, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
         profile = {"name": "ALPHA"}
         vpn_data = manager._build_vpn_data([profile], sample_vpns)
         manager._safe_input = MagicMock(side_effect=["42", "n"])
         manager._prompt_set_pod(profile, vpn_data)
-        output = capsys.readouterr().out
-        assert "Cancelled" in output
+        assert "Cancelled" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -585,12 +594,12 @@ class TestApplyVpnUpdatesError:
     """Test _apply_vpn_updates error handling."""
 
     @patch("src.wan_hub_group_manager.mistapi.api.v1.orgs.vpns.getOrgVpn")
-    def test_api_error_prints_message(self, mock_get, manager, capsys):
+    def test_api_error_prints_message(self, mock_get, manager, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.ERROR)
         mock_get.side_effect = Exception("Network error")
         vpn_updates = {"vpn-1": {"name": "OrgOverlay", "paths": ["ALPHA-WAN1"]}}
         manager._apply_vpn_updates(vpn_updates, "ALPHA", 99)
-        output = capsys.readouterr().out
-        assert "Error updating VPN" in output
+        assert "Error updating VPN" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 13/N of #886: replace all 30 `print()` calls in `src/wan_hub_group_manager.py` (WAN Hub Group Number Manager backing Menu 163) with `logging.warning(...)` for operator-visible output and `logging.error(...)` for API-failure paths.

- Consolidated the six-line action-menu banner into a single multi-line `logging.warning` with embedded `\n` (logging emits one record per call).
- Empty separator `print()` between the profile list header and numbered entries becomes `logging.warning("")`.
- All f-strings converted to %-style deferred args per the T20 selector target.
- Companion `tests/unit/test_wan_hub_group_manager.py` migrated `capsys` → `caplog` with `caplog.set_level(logging.WARNING)` (or `logging.ERROR` for the two API-failure assertions).

## Test plan

- [x] `ruff check --select T20 src/wan_hub_group_manager.py` — clean
- [x] `ruff check .` — clean
- [x] `black --check src/wan_hub_group_manager.py tests/unit/test_wan_hub_group_manager.py` — clean
- [x] `pytest tests/unit/test_wan_hub_group_manager.py` — 51 passed
- [x] `pytest tests/unit` — 8529 passed