### PR TITLE
chore(logging): migrate src/wan_vpn_builder.py print() to logger (#886 slice 14/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 14/N: retire `print()` in `src/wan_vpn_builder.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 40 `print()` calls in
+  `src/wan_vpn_builder.py` (the WAN Hub-Spoke VPN Builder backing Menu 164)
+  with `logging.warning(...)` for operator-visible output (headers, existing-
+  VPN table, profile list, VPN preview, path-keys preview, role legend,
+  cancellation / no-op acks, per-profile update summary) and
+  `logging.error(...)` for API-failure paths (missing org, VPN create
+  failures, profile update failures). Multi-line table headers
+  (`_display_existing_vpns` and `_display_profile_list` three-line preambles;
+  the four-line `_display_vpn_preview` header + threshold warning) were
+  consolidated into single `logging.warning` records with embedded `\n` to
+  keep header output atomic under logging's one-record-per-call model. Blank
+  separator `print()`s became `logging.warning("")` for the same reason. All
+  f-string formatting was converted to %-style deferred args per the
+  print-avoidance rule (T20 selector target of #886). Companion unit tests
+  in `tests/unit/test_wan_vpn_builder.py` were migrated from
+  `capsys`/`captured.out` to `caplog`/`caplog.text` with
+  `caplog.set_level(logging.WARNING)` on all five affected tests. Full unit
+  suite still passes (8529/8529). No behavior change; only the emission
+  channel moves from `stdout` to the root logger's WARNING/ERROR streams.
+
 ### #886 Phase 2 slice 13/N: retire `print()` in `src/wan_hub_group_manager.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 30 `print()` calls in

--- a/src/wan_vpn_builder.py
+++ b/src/wan_vpn_builder.py
@@ -84,7 +84,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         """Static entry point called by menu_actions lambda."""
         org_id = get_org_id_func()  # WHY: resolve org lazily so caching prompt happens only when needed.
         if not org_id:  # WHY: no org selected -> abort with a user-visible reason instead of raising.
-            print("! No organization selected. Exiting.")  # WHY: single-line operator hint before returning.
+            logging.error("! No organization selected. Exiting.")  # WHY: single-line operator hint before returning.
             return  # WHY: nothing more to do without an org context.
         builder = WanVpnBuilder(apisession, org_id, safe_input_func)  # WHY: bind session/org/input for this run.
         builder.run()  # WHY: hand off to the interactive workflow.
@@ -95,7 +95,9 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
 
     def run(self) -> None:  # WHY: top-level orchestrator; kept small by delegating to focused helpers.
         """Main workflow: fetch, display, build, preview, create."""
-        print("\n=== WAN Hub-Spoke VPN Builder ===")  # WHY: banner delimits this menu action in the operator log.
+        logging.warning(
+            "\n=== WAN Hub-Spoke VPN Builder ==="
+        )  # WHY: banner delimits this menu action in the operator log.
         logging.info("Starting WAN Hub-Spoke VPN Builder")  # WHY: capture entry timestamp for troubleshooting.
 
         profiles = self._load_profiles_or_none()  # WHY: fetch profiles and short-circuit on empty inventory.
@@ -112,7 +114,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
 
         vpn_body = self._build_vpn_body(vpn_name, assignments)  # WHY: assemble API payload from validated inputs.
         if not self._display_preview(vpn_name, vpn_body):  # WHY: require explicit CREATE token before mutating org.
-            print("  VPN creation cancelled.")  # WHY: operator-visible confirmation of cancellation.
+            logging.warning("  VPN creation cancelled.")  # WHY: operator-visible confirmation of cancellation.
             return  # WHY: honor the operator's decision not to proceed.
 
         self._create_and_optionally_update(vpn_name, vpn_body, assignments)  # WHY: perform side-effects together.
@@ -121,7 +123,9 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         """Fetch gateway profiles; return None and warn if inventory is empty."""
         profiles = self._fetch_profiles()  # WHY: API call is isolated for test-time monkeypatch.
         if not profiles:  # WHY: empty list means org has no gateway profiles -> abort with hint.
-            print("! No gateway device profiles found in this organization.")  # WHY: actionable operator hint.
+            logging.warning(
+                "! No gateway device profiles found in this organization."
+            )  # WHY: actionable operator hint.
             return None  # WHY: sentinel triggers early return in run().
         return profiles  # WHY: hand the fetched list to the workflow.
 
@@ -155,7 +159,9 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         if created_vpn is None:  # WHY: creation failed -> do not attempt profile updates.
             return  # WHY: caller already saw an error message from _create_vpn.
         vpn_id = created_vpn.get("id", "")  # WHY: id is required for downstream vpn_paths refs.
-        print(f"  VPN '{vpn_name}' created successfully. ID: {vpn_id}")  # WHY: operator confirmation of success.
+        logging.warning(
+            "  VPN '%s' created successfully. ID: %s", vpn_name, vpn_id
+        )  # WHY: operator confirmation of success.
         logging.info("VPN '%s' created with ID %s", vpn_name, vpn_id)  # WHY: audit trail of created id.
         self._prompt_profile_updates(vpn_id, vpn_name, assignments)  # WHY: optional US2 profile linkage.
 
@@ -330,7 +336,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             return profiles  # WHY: sorted list surfaces to run() for display.
         except Exception:  # WHY: single-branch guard so we return [] on any error.
             logging.exception("Failed to fetch device profiles")  # WHY: capture traceback for post-mortem.
-            print("! Error retrieving gateway device profiles. Check API connectivity.")  # WHY: operator hint.
+            logging.error("! Error retrieving gateway device profiles. Check API connectivity.")  # WHY: operator hint.
             return []  # WHY: empty result triggers the graceful abort branch in run().
 
     def _fetch_existing_vpns(self) -> list[Any]:  # WHY: separate fetch keeps API responsibilities clear.
@@ -342,7 +348,9 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             return vpns  # WHY: caller uses for display + uniqueness check.
         except Exception:  # WHY: keep the workflow going even if the VPN list can't be fetched.
             logging.exception("Failed to fetch org VPNs")  # WHY: preserve traceback for operator log review.
-            print("! Error retrieving VPN definitions. Check API connectivity.")  # WHY: operator-visible warning.
+            logging.error(
+                "! Error retrieving VPN definitions. Check API connectivity."
+            )  # WHY: operator-visible warning.
             return []  # WHY: empty list keeps display/name-uniqueness code paths well-defined.
 
     def _create_vpn(self, vpn_body: dict[str, Any]) -> dict[str, Any] | None:  # WHY: isolated for tests.
@@ -354,7 +362,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             return created  # WHY: caller extracts the new vpn id for profile updates.
         except Exception:  # WHY: single-branch guard: any exception -> operator warning + None.
             logging.exception("Failed to create VPN")  # WHY: capture full traceback in operator log.
-            print("! Error creating VPN. Check API connectivity and input.")  # WHY: user-actionable feedback.
+            logging.error("! Error creating VPN. Check API connectivity and input.")  # WHY: user-actionable feedback.
             return None  # WHY: caller treats None as "abort without further side-effects".
 
     # ------------------------------------------------------------------
@@ -364,23 +372,43 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     def _display_existing_vpns(self, vpns: list[Any]) -> None:  # WHY: read-only display step before naming.
         """Display summary table of existing VPNs."""
         if not vpns:  # WHY: no rows to render -> print a friendly placeholder instead of an empty table.
-            print("\n  No existing VPN definitions in this organization.")  # WHY: prevent confusing blank output.
+            logging.warning(
+                "\n  No existing VPN definitions in this organization."
+            )  # WHY: prevent confusing blank output.
             return  # WHY: early return keeps the empty case simple.
-        print(f"\n  Existing VPN Definitions ({len(vpns)}):")  # WHY: header includes count for quick scan.
-        print(f"  {'#':<4} {'Name':<30} {'Type':<12} {'Paths':>6}")  # WHY: fixed-width columns for readability.
-        print(f"  {'-'*4} {'-'*30} {'-'*12} {'-'*6}")  # WHY: separator row matches column widths.
+        logging.warning(  # WHY: consolidated header lines emit as a single logging record for atomic output.
+            "\n  Existing VPN Definitions (%d):\n  %-4s %-30s %-12s %6s\n  %s %s %s %s",
+            len(vpns),
+            "#",
+            "Name",
+            "Type",
+            "Paths",
+            "-" * 4,
+            "-" * 30,
+            "-" * 12,
+            "-" * 6,
+        )
         for index, vpn in enumerate(vpns, start=1):  # WHY: 1-based numbering matches operator expectations.
             name = vpn.get("name", "")  # WHY: default empty avoids KeyError on partial API rows.
             vpn_type = vpn.get("type", "unknown")  # WHY: default keeps column populated on partial API data.
             path_count = len(vpn.get("paths", {}))  # WHY: quick visual signal of VPN size.
-            print(f"  {index:<4} {name:<30} {vpn_type:<12} {path_count:>6}")  # WHY: aligned row output.
-        print()  # WHY: blank line separates table from the next prompt.
+            logging.warning("  %-4d %-30s %-12s %6d", index, name, vpn_type, path_count)  # WHY: aligned row output.
+        logging.warning("")  # WHY: blank line separates table from the next prompt.
 
     def _display_profile_list(self, profiles: list[Any]) -> None:  # WHY: shows inventory prior to role prompt.
         """Show numbered profile list with WAN/LAN interface counts."""
-        print(f"\n  Gateway Device Profiles ({len(profiles)}):")  # WHY: header includes count for quick scan.
-        print(f"  {'#':<4} {'Profile Name':<30} {'WAN':>4} {'LAN':>4}")  # WHY: fixed-width columns for readability.
-        print(f"  {'-'*4} {'-'*30} {'-'*4} {'-'*4}")  # WHY: separator row matches column widths.
+        logging.warning(  # WHY: consolidated header lines emit as a single logging record.
+            "\n  Gateway Device Profiles (%d):\n  %-4s %-30s %4s %4s\n  %s %s %s %s",
+            len(profiles),
+            "#",
+            "Profile Name",
+            "WAN",
+            "LAN",
+            "-" * 4,
+            "-" * 30,
+            "-" * 4,
+            "-" * 4,
+        )
         for index, profile in enumerate(profiles, start=1):  # WHY: 1-based indexing consistent with prompts.
             name = profile.get("name", "")  # WHY: default empty avoids KeyError on partial rows.
             port_config = profile.get("port_config", {})  # WHY: default empty dict for missing key.
@@ -388,8 +416,10 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             wan_count = len(wan_list)  # WHY: displayed for operator context.
             lan_count = len(lan_list)  # WHY: displayed for operator context.
             warning = " (!) No WAN interfaces" if wan_count == 0 else ""  # WHY: flag profiles that can't be hub.
-            print(f"  {index:<4} {name:<30} {wan_count:>4} {lan_count:>4}{warning}")  # WHY: aligned row output.
-        print()  # WHY: blank line separates table from the next prompt.
+            logging.warning(
+                "  %-4d %-30s %4d %4d%s", index, name, wan_count, lan_count, warning
+            )  # WHY: aligned row output.
+        logging.warning("")  # WHY: blank line separates table from the next prompt.
 
     def _display_preview(self, vpn_name: str, vpn_body: dict[str, Any]) -> bool:  # WHY: last chance to bail.
         """Display VPN preview and prompt for CREATE confirmation."""
@@ -406,25 +436,28 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         self, vpn_name: str, vpn_body: dict[str, Any], path_count: int
     ) -> None:
         """Print the VPN preview header block and optional path-count warning."""
-        print("\n  === VPN Preview ===")  # WHY: banner separates preview from prior tables.
-        print(f"  Name: {vpn_name}")  # WHY: echo chosen name so operator sees it before committing.
-        print(f"  Type: {vpn_body.get('type', '')}")  # WHY: reinforce the topology being created.
-        print(f"  Path Selection: {vpn_body.get('path_selection', {})}")  # WHY: show final path_selection strategy.
-        print(f"  Total Paths: {path_count}")  # WHY: total count helps spot obvious mistakes.
+        logging.warning(  # WHY: consolidated preview header emits as a single logging record.
+            "\n  === VPN Preview ===\n  Name: %s\n  Type: %s\n  Path Selection: %s\n  Total Paths: %d",
+            vpn_name,
+            vpn_body.get("type", ""),
+            vpn_body.get("path_selection", {}),
+            path_count,
+        )
         if path_count > self.PATH_WARN_THRESHOLD:  # WHY: flag likely misconfiguration before it hits the API.
-            print(  # WHY: multi-line warning is easier to scan than one long line.
-                f"  WARNING: Path count ({path_count}) exceeds {self.PATH_WARN_THRESHOLD}. "
-                "This may indicate an unusually large configuration."
+            logging.warning(  # WHY: multi-line warning is easier to scan than one long line.
+                "  WARNING: Path count (%d) exceeds %d. This may indicate an unusually large configuration.",
+                path_count,
+                self.PATH_WARN_THRESHOLD,
             )
 
     @staticmethod
     def _print_preview_paths(paths: dict[str, Any]) -> None:  # WHY: pure printer for the path list.
         """Print the sorted list of generated path keys with pod annotations."""
-        print("\n  Path Keys:")  # WHY: header labels the list that follows.
+        logging.warning("\n  Path Keys:")  # WHY: header labels the list that follows.
         for key in sorted(paths.keys()):  # WHY: sorted output is easier to eyeball during review.
             pod = paths[key].get("pod", "")  # WHY: default empty string keeps output stable for edge shapes.
-            print(f"    {key} (pod: {pod})")  # WHY: indent + annotation aids visual scanning.
-        print()  # WHY: blank line separates list from the next prompt.
+            logging.warning("    %s (pod: %s)", key, pod)  # WHY: indent + annotation aids visual scanning.
+        logging.warning("")  # WHY: blank line separates list from the next prompt.
 
     # ------------------------------------------------------------------
     # User interaction — prompts (US1)
@@ -440,13 +473,13 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             ).strip()  # WHY: trim leading/trailing whitespace before validation.
             outcome = self._classify_name(name, lower_names)  # WHY: pure classifier keeps this loop tiny.
             if outcome == "cancel":  # WHY: user typed the cancellation sentinel.
-                print("  Cancelled.")  # WHY: audible confirmation of cancellation.
+                logging.warning("  Cancelled.")  # WHY: audible confirmation of cancellation.
                 return None  # WHY: signal caller to abort the workflow.
             if outcome == "empty":  # WHY: reject blank so we always send a real value to the API.
-                print("  VPN name cannot be empty.")  # WHY: guide operator to retype.
+                logging.warning("  VPN name cannot be empty.")  # WHY: guide operator to retype.
                 continue  # WHY: re-prompt without leaving the loop.
             if outcome == "duplicate":  # WHY: prevent silent collision with an existing overlay.
-                print(f"  VPN name '{name}' already exists. Choose a different name.")  # WHY: actionable.
+                logging.warning("  VPN name '%s' already exists. Choose a different name.", name)  # WHY: actionable.
                 continue  # WHY: re-prompt with the same existing_names set.
             return name  # WHY: outcome == 'ok' -> validated name to return.
 
@@ -471,7 +504,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         profiles: list[Any],
     ) -> list[dict[str, Any]] | None:
         """Prompt user to assign Hub/Spoke/Skip to each profile."""
-        print("  Assign roles to each profile (H=Hub, S=Spoke, K=Skip):")  # WHY: prompt legend for operators.
+        logging.warning("  Assign roles to each profile (H=Hub, S=Spoke, K=Skip):")  # WHY: prompt legend for operators.
         assignments = [  # WHY: list comprehension pairs each profile with a role decision.
             self._prompt_role_for_profile(index, profile)  # WHY: per-profile prompt lives in its own helper.
             for index, profile in enumerate(profiles, start=1)
@@ -498,7 +531,9 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             if role is not None:  # WHY: parser returns None only for invalid inputs.
                 pod = 0 if role == ROLE_SKIP else self.POD_DEFAULT  # WHY: skips carry no pod value.
                 return {"profile": profile, "role": role, "pod": pod}  # WHY: assignment shape used everywhere.
-            print("    Please enter H (Hub), S (Spoke), or K (Skip).")  # WHY: guide operator on invalid input.
+            logging.warning(
+                "    Please enter H (Hub), S (Spoke), or K (Skip)."
+            )  # WHY: guide operator on invalid input.
 
     @staticmethod
     def _parse_role_choice(choice: str) -> str | None:  # WHY: pure parser -- easy to unit test.
@@ -520,13 +555,13 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         self, profiles: list[Any]
     ) -> list[dict[str, Any]] | None:
         """Ask operator to retry role assignment when every profile was skipped."""
-        print("  All profiles skipped. At least one must be Hub or Spoke.")  # WHY: explain why we retry.
+        logging.warning("  All profiles skipped. At least one must be Hub or Spoke.")  # WHY: explain why we retry.
         retry = (  # WHY: normalized y/N answer determines whether we loop.
             self._safe_input("  Try again? (y/N): ", context=CTX_RETRY_ROLES).strip().lower()
         )
         if retry == RETRY_YES:  # WHY: recurse to give the operator another chance.
             return self._prompt_role_assignments(profiles)  # WHY: same profiles, fresh set of role decisions.
-        print("  Cancelled.")  # WHY: operator-visible confirmation of cancel decision.
+        logging.warning("  Cancelled.")  # WHY: operator-visible confirmation of cancel decision.
         return None  # WHY: caller treats None as full workflow cancellation.
 
     def _prompt_pod_values(  # WHY: second phase of assignment collection -- assigns pods to non-skip roles.
@@ -562,10 +597,14 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         try:  # WHY: guard int() against non-numeric input.
             value = int(raw)  # WHY: allow only integer pod ids.
         except ValueError:  # WHY: non-integer input triggers a re-prompt.
-            print(f"    Pod must be an integer ({self.POD_MIN}-{self.POD_MAX}).")  # WHY: actionable guidance.
+            logging.warning(
+                "    Pod must be an integer (%d-%d).", self.POD_MIN, self.POD_MAX
+            )  # WHY: actionable guidance.
             return None  # WHY: caller sees None and re-prompts.
         if not (self.POD_MIN <= value <= self.POD_MAX):  # WHY: enforce documented pod range.
-            print(f"    Pod must be between {self.POD_MIN} and {self.POD_MAX}.")  # WHY: actionable guidance.
+            logging.warning(
+                "    Pod must be between %d and %d.", self.POD_MIN, self.POD_MAX
+            )  # WHY: actionable guidance.
             return None  # WHY: caller sees None and re-prompts.
         return value  # WHY: valid pod integer returned to caller.
 
@@ -618,7 +657,9 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             return True  # WHY: caller counts True as one success.
         except Exception:  # WHY: catch-all so a per-profile error does not abort other profiles.
             logging.exception("Failed to update profile '%s'", profile_name)  # WHY: keep traceback for support.
-            print(f"  ! Error updating profile '{profile_name}'. Check logs.")  # WHY: operator-visible feedback.
+            logging.error(
+                "  ! Error updating profile '%s'. Check logs.", profile_name
+            )  # WHY: operator-visible feedback.
             return False  # WHY: caller counts False as one failure.
 
     def _fetch_fresh_profile(self, profile_id: str) -> dict[str, Any]:  # WHY: isolated GET for patchability.
@@ -686,7 +727,9 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         if not self._prompt_confirm_profile_updates():  # WHY: honor operator decision before touching profiles.
             return  # WHY: honor a no answer without further prompts.
         success_count, fail_count = self._run_profile_updates(vpn_name, non_skip)  # WHY: helper isolates loop.
-        print(f"  Profile updates: {success_count} succeeded, {fail_count} failed.")  # WHY: summary for operator.
+        logging.warning(
+            "  Profile updates: %d succeeded, %d failed.", success_count, fail_count
+        )  # WHY: summary for operator.
 
     def _prompt_confirm_profile_updates(self) -> bool:  # WHY: y/N confirmation before mutating profiles.
         """Return True when operator answers 'y' to the profile-update prompt."""
@@ -699,7 +742,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             .lower()
         )
         if choice != RETRY_YES:  # WHY: default (N) is safer -- don't mutate profiles unless explicitly asked.
-            print("  Skipping profile updates.")  # WHY: operator-visible confirmation of the skip.
+            logging.warning("  Skipping profile updates.")  # WHY: operator-visible confirmation of the skip.
             return False  # WHY: caller returns without touching profiles.
         return True  # WHY: explicit y -> proceed with the profile-update loop.
 

--- a/tests/unit/test_wan_vpn_builder.py
+++ b/tests/unit/test_wan_vpn_builder.py
@@ -8,6 +8,7 @@ Tests cover all user stories:
 Task coverage: T006, T011, T022, T027, T029
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -539,21 +540,24 @@ class TestPromptProfileUpdates:
 class TestDisplayExistingVpns:
     """Test _display_existing_vpns output."""
 
-    def test_with_vpns(self, builder, sample_vpns, capsys):
+    def test_with_vpns(self, builder, sample_vpns, caplog):
+        caplog.set_level(logging.WARNING)
         builder._display_existing_vpns(sample_vpns)
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "OrgOverlay" in output
         assert "BackupVPN" in output
         assert "hub_spoke" in output
 
-    def test_no_vpns(self, builder, capsys):
+    def test_no_vpns(self, builder, caplog):
+        caplog.set_level(logging.WARNING)
         builder._display_existing_vpns([])
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "No existing VPN definitions" in output
 
-    def test_shows_path_count(self, builder, sample_vpns, capsys):
+    def test_shows_path_count(self, builder, sample_vpns, caplog):
+        caplog.set_level(logging.WARNING)
         builder._display_existing_vpns(sample_vpns)
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "2" in output
         assert "1" in output
 
@@ -561,14 +565,16 @@ class TestDisplayExistingVpns:
 class TestDisplayProfileList:
     """Test _display_profile_list output."""
 
-    def test_shows_wan_lan_counts(self, builder, sample_profiles, capsys):
+    def test_shows_wan_lan_counts(self, builder, sample_profiles, caplog):
+        caplog.set_level(logging.WARNING)
         builder._display_profile_list(sample_profiles)
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "VREPOL69" in output
         assert "SPOKE01" in output
 
-    def test_warns_no_wan(self, builder, capsys):
+    def test_warns_no_wan(self, builder, caplog):
+        caplog.set_level(logging.WARNING)
         profiles = [{"name": "LAN_ONLY", "port_config": {"LAN1": {"usage": "lan"}}}]
         builder._display_profile_list(profiles)
-        output = capsys.readouterr().out
+        output = caplog.text
         assert "No WAN interfaces" in output


### PR DESCRIPTION
## Summary
- Replaces all 40 `print()` calls in `src/wan_vpn_builder.py` (Menu 164 WAN Hub-Spoke VPN Builder) with `logging.warning` / `logging.error` using %-style deferred formatting.
- Multi-line table headers (`_display_existing_vpns`, `_display_profile_list`) and the VPN preview block (`_display_vpn_preview`) consolidated into single `logging.warning` records with embedded `\n` to keep output atomic.
- Blank separator `print()`s become `logging.warning("")`.
- Companion unit tests migrated from `capsys`/`captured.out` to `caplog`/`caplog.text` with `caplog.set_level(logging.WARNING)` on all five affected tests.

Part of #886 (retire `print()` in favor of `logging`, enable ruff T20).

## Test plan
- [x] `ruff check --select T20 src/wan_vpn_builder.py` → clean
- [x] `ruff check src/wan_vpn_builder.py tests/unit/test_wan_vpn_builder.py` → clean
- [x] `black --check` → clean
- [x] `pytest tests/unit/test_wan_vpn_builder.py` → 61 passed
- [x] `pytest tests/unit` → 8529 passed