### PR TITLE
chore(logging): migrate src/org/org_ticket_manager.py print() to logger (#886 slice 16/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 16/N: retire `print()` in `src/org/org_ticket_manager.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 45 `print()` calls in
+  `src/org/org_ticket_manager.py` (Menus 188-193: list/create/comment/update/
+  view/export org support tickets) with `logging.warning(...)` for the
+  operator-visible ticket list table, ticket detail block, per-comment
+  rendering, cancellation/help banners, and `logging.error(...)` for API
+  failures (fetch errors, invalid selections, retrieval failures). Multi-line
+  UI blocks were consolidated into single `logging.warning` records with
+  embedded `\n` to preserve atomic log-record boundaries: 3-line list header +
+  separator (3 → 1), 6-row ticket metadata block with top/bottom bars (8 → 1),
+  and per-comment header + body (2 → 1). WHY-comments preserved on migrated
+  lines.
+- **Tests (Changed)**: migrated `tests/unit/test_org_ticket_manager.py` (63
+  `capsys` refs) and `tests/test_ticket_manager.py` (20 `capsys` refs) to
+  `caplog`, gated by a per-file autouse `caplog.set_level(logging.WARNING)`
+  fixture so the tests deterministically observe the new WARNING/ERROR
+  records across CI runners regardless of default logger propagation. No
+  production behavior change; the visible surface (subject text, cancellation
+  banner text, "no tickets" message text, ticket metadata) is identical to
+  the pre-migration output.
+- **Verification**: `ruff check --select T20 src/org/org_ticket_manager.py`
+  → 0 issues; `grep -c "print(" src/org/org_ticket_manager.py` → 0; full
+  worktree `ruff check .` clean; full pytest 8949 passed / 0 failed.
+
 ### #886 Phase 2 slice 15/N: retire `print()` in `src/org/org_config_migration_manager.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 44 `print()` calls in

--- a/src/org/org_ticket_manager.py
+++ b/src/org/org_ticket_manager.py
@@ -69,7 +69,7 @@ class OrgTicketManager:  # Support ticket operations.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org from cache or user prompt
         subject = OrgTicketManager._prompt_subject()  # Prompt user for ticket subject line
         if not subject:  # User left subject blank -- abort
-            print("  Ticket creation cancelled -- subject is required.")  # Inform user
+            logging.warning("  Ticket creation cancelled -- subject is required.")  # Inform user
             logging.info("Ticket creation cancelled: blank subject")  # Log cancellation
             return  # Early exit
         ticket_type = OrgTicketManager._prompt_ticket_type()  # Prompt user to select ticket type
@@ -93,12 +93,12 @@ class OrgTicketManager:  # Support ticket operations.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org from cache or user prompt
         ticket_id = OrgTicketManager._select_ticket(org_id)  # Show ticket list for user selection
         if not ticket_id:  # User cancelled selection -- abort
-            print("  Operation cancelled -- no ticket selected.")  # Inform user
+            logging.warning("  Operation cancelled -- no ticket selected.")  # Inform user
             logging.info("Add comment cancelled: no ticket selected")  # Log the cancellation
             return  # Early exit without adding comment
         comment_text, file_path = OrgTicketManager._prompt_comment_and_file()  # Gather inputs together
         if not comment_text and not file_path:  # Neither comment nor file provided -- abort
-            print("  Operation cancelled -- provide a comment or file.")  # Inform user
+            logging.warning("  Operation cancelled -- provide a comment or file.")  # Inform user
             logging.info("Add comment cancelled: no comment or file provided")  # Log cancellation
             return  # Early exit
         OrgTicketManager._submit_comment(  # Submit comment to API
@@ -117,12 +117,12 @@ class OrgTicketManager:  # Support ticket operations.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org from cache or user prompt
         ticket_id = OrgTicketManager._select_ticket(org_id)  # Show ticket list for user selection
         if not ticket_id:  # User cancelled selection -- abort
-            print("  Operation cancelled -- no ticket selected.")  # Inform user
+            logging.warning("  Operation cancelled -- no ticket selected.")  # Inform user
             logging.info("Ticket update cancelled: no ticket selected")  # Log the cancellation
             return  # Early exit
         body = OrgTicketManager._build_update_body()  # Collect changed fields from user
         if not body:  # No fields were changed -- abort
-            print("  No changes specified -- update cancelled.")  # Inform user
+            logging.warning("  No changes specified -- update cancelled.")  # Inform user
             logging.info("Ticket update cancelled: no fields changed")  # Log cancellation
             return  # Early exit
         OrgTicketManager._update_via_api(org_id, ticket_id, body)  # Send update + report results
@@ -146,9 +146,9 @@ class OrgTicketManager:  # Support ticket operations.
     def _prompt_ticket_type() -> str:  # Prompt for ticket type.
         """Prompt user to select a ticket type from valid options."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of InputUtils.
-        print("\n  Ticket types:")  # Section header for type selection
+        logging.warning("\n  Ticket types:")  # Section header for type selection
         for index, ticket_type in enumerate(OrgTicketManager.TICKET_TYPES, 1):  # Number each type for selection
-            print(f"    {index}. {ticket_type}")  # Display numbered option
+            logging.warning("    %d. %s", index, ticket_type)  # Display numbered option
         choice = mh.InputUtils.safe_input(  # Prompt user to pick a type number
             "  Select type [1]: ",  # Default to first option (question)
             default_value="1",  # Default selection is 'question'
@@ -179,11 +179,13 @@ class OrgTicketManager:  # Support ticket operations.
         """Print + log the newly created ticket summary."""
         ticket_id = ticket_data.get("id", "unknown")  # Get new ticket UUID from response
         logging.debug("Ticket created: id=%s, status=%s", ticket_id, ticket_data.get("status"))  # Log result
-        print("\n  Ticket created successfully!")  # Confirm to user
-        print(f"  ID:      {ticket_id}")  # Display ticket ID for reference
-        print(f"  Subject: {subject}")  # Echo subject back to user
-        print(f"  Type:    {ticket_type}")  # Echo type back to user
-        print(f"  Status:  {ticket_data.get('status', 'open')}")  # Show initial status
+        logging.warning(
+            "\n  Ticket created successfully!" "\n  ID:      %s" "\n  Subject: %s" "\n  Type:    %s" "\n  Status:  %s",
+            ticket_id,
+            subject,
+            ticket_type,
+            ticket_data.get("status", "open"),
+        )
         logging.info("Menu 189: Ticket creation complete, id=%s", ticket_id)  # Log success
 
     @staticmethod
@@ -196,7 +198,7 @@ class OrgTicketManager:  # Support ticket operations.
             OrgTicketManager._print_ticket_created_summary(getattr(response, "data", {}), subject, ticket_type)
         except Exception as error:  # Catch API errors during ticket creation
             logging.error("Failed to create ticket: %s", error)  # Log error with context
-            print(f"\n  Error creating ticket: {error}")  # Show error to user
+            logging.error("\n  Error creating ticket: %s", error)  # Show error to user
             raise  # Re-raise for upstream error handling
 
     @staticmethod
@@ -237,13 +239,13 @@ class OrgTicketManager:  # Support ticket operations.
                 body,  # Pass session, org, ticket ID, body
             )
             logging.debug("Ticket updated: %s", getattr(response, "data", {}))  # Log full response
-            print(f"\n  Ticket {ticket_id} updated successfully!")  # Confirm to user
+            logging.warning("\n  Ticket %s updated successfully!", ticket_id)  # Confirm to user
             for field, value in body.items():  # Show each changed field to user
-                print(f"  {field}: {value}")  # Display field name and new value
+                logging.warning("  %s: %s", field, value)  # Display field name and new value
             logging.info("Menu 191: Ticket update complete for %s", ticket_id)  # Log success
         except Exception as error:  # Catch API errors during ticket update
             logging.error("Failed to update ticket %s: %s", ticket_id, error)  # Log error with context
-            print(f"\n  Error updating ticket: {error}")  # Show error to user
+            logging.error("\n  Error updating ticket: %s", error)  # Show error to user
             raise  # Re-raise for upstream error handling
 
     @staticmethod
@@ -280,12 +282,12 @@ class OrgTicketManager:  # Support ticket operations.
                 file=file_path,  # Path to file for upload
             )
             logging.debug("Comment with file submitted to ticket %s", ticket_id)  # Log after API call
-            print(f"\n  Comment with attachment added to ticket {ticket_id}")  # Confirm to user
+            logging.warning("\n  Comment with attachment added to ticket %s", ticket_id)  # Confirm to user
         elif file_path:  # User specified a path but file doesn't exist
             logging.warning(  # Warn about missing file path
                 "File not found: %s -- adding comment without attachment", file_path
             )
-            print(f"  Warning: File not found at '{file_path}' -- adding comment only.")  # Alert user
+            logging.warning("  Warning: File not found at '%s' -- adding comment only.", file_path)  # Alert user
             OrgTicketManager._submit_text_comment(org_id, ticket_id, comment_text)  # Fall back to text-only
         else:  # No file specified -- text-only comment
             OrgTicketManager._submit_text_comment(org_id, ticket_id, comment_text)  # Submit text comment
@@ -303,7 +305,7 @@ class OrgTicketManager:  # Support ticket operations.
             body,  # Session, org, ticket ID, and comment body
         )
         logging.debug("Text comment submitted to ticket %s", ticket_id)  # Log after API call
-        print(f"\n  Comment added to ticket {ticket_id}")  # Confirm to user
+        logging.warning("\n  Comment added to ticket %s", ticket_id)  # Confirm to user
 
     # ------------------------------------------------------------------
     # Public entry points -- ticket viewing and export (Menu 192-193)
@@ -319,13 +321,13 @@ class OrgTicketManager:  # Support ticket operations.
 
         ticket_id = OrgTicketManager._select_ticket(org_id)  # Show ticket list for user selection
         if not ticket_id:  # User cancelled selection -- abort
-            print("  Operation cancelled -- no ticket selected.")  # Inform user
+            logging.warning("  Operation cancelled -- no ticket selected.")  # Inform user
             logging.info("View ticket cancelled: no ticket selected")  # Log the cancellation
             return  # Early exit
 
         ticket_data = OrgTicketManager._fetch_ticket_detail(org_id, ticket_id)  # Fetch full ticket+comments
         if not ticket_data:  # API returned empty or failed
-            print("  Could not retrieve ticket details.")  # Inform user of failure
+            logging.error("  Could not retrieve ticket details.")  # Inform user of failure
             return  # Early exit
 
         OrgTicketManager._display_ticket_detail(ticket_data)  # Format and print to screen
@@ -340,7 +342,7 @@ class OrgTicketManager:  # Support ticket operations.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org from cache or user prompt
         tickets = OrgTicketManager._fetch_all_ticket_summaries(org_id)  # API list summaries
         if not tickets:  # No tickets found in the org
-            print("\n  No tickets found in this organization.")  # Inform user
+            logging.warning("\n  No tickets found in this organization.")  # Inform user
             return  # Nothing to export
         all_details = OrgTicketManager._collect_ticket_details(org_id, tickets)  # Per-ticket detail fetch
         if all_details:  # Export if we have any ticket details
@@ -352,7 +354,7 @@ class OrgTicketManager:  # Support ticket operations.
             )
             logging.info("Menu 193: Full ticket detail export complete")  # Log success
         else:  # No details were retrieved
-            print("\n  No ticket details could be retrieved.")  # Inform user
+            logging.warning("\n  No ticket details could be retrieved.")  # Inform user
 
     # ------------------------------------------------------------------
     # Private helpers -- ticket selection and detail display
@@ -366,7 +368,7 @@ class OrgTicketManager:  # Support ticket operations.
         if not tickets:  # No tickets or fetch error
             return ""  # Signal cancellation to caller
         OrgTicketManager._render_ticket_list_table(tickets)  # Display numbered ticket table
-        print(f"\n  Enter a number (1-{len(tickets)}) to select, or 'm' to enter ID manually.")
+        logging.warning("\n  Enter a number (1-%d) to select, or 'm' to enter ID manually.", len(tickets))
         choice = mh.InputUtils.safe_input(  # Prompt user for selection input
             "  Selection: ",
             default_value="",
@@ -394,23 +396,27 @@ class OrgTicketManager:  # Support ticket operations.
             logging.debug("Retrieved %d tickets for selection", len(tickets))  # Log count
         except Exception as error:  # Catch API failures
             logging.error("Failed to fetch tickets for selection: %s", error)  # Log error
-            print(f"  Error fetching tickets: {error}")  # Show error to user
+            logging.error("  Error fetching tickets: %s", error)  # Show error to user
             return []  # Signal failure with empty list
         if not tickets:  # API returned no tickets
-            print("\n  No tickets found in this organization.")  # Inform user
+            logging.warning("\n  No tickets found in this organization.")  # Inform user
         return tickets  # Return list (possibly empty)
 
     @staticmethod
     def _render_ticket_list_table(tickets: list) -> None:
         """Print a numbered table of ticket #/status/type/subject for selection."""
-        print("\n  Organization Support Tickets:")  # Section header
-        print(f"  {'#':<4} {'Status':<10} {'Type':<18} {'Subject'}")  # Column headers
-        print(f"  {'-' * 4} {'-' * 10} {'-' * 18} {'-' * 40}")  # Separator line
+        header_line = f"  {'#':<4} {'Status':<10} {'Type':<18} {'Subject'}"  # Column header row
+        separator = f"  {'-' * 4} {'-' * 10} {'-' * 18} {'-' * 40}"  # Separator row
+        logging.warning(
+            "\n  Organization Support Tickets:\n%s\n%s",
+            header_line,
+            separator,
+        )  # Section header + column headers + separator in one record
         for index, ticket in enumerate(tickets, 1):  # Display numbered rows
             status = ticket.get("status", "unknown")  # Ticket status field
             ttype = ticket.get("type", "unknown")  # Ticket type field
             subject = ticket.get("subject", "(no subject)")  # Ticket subject field
-            print(f"  {index:<4} {status:<10} {ttype:<18} {subject}")  # Print formatted row
+            logging.warning("  %-4d %-10s %-18s %s", index, status, ttype, subject)  # Print formatted row
 
     @staticmethod
     def _resolve_ticket_choice(choice: str, tickets: list) -> str:
@@ -418,14 +424,14 @@ class OrgTicketManager:  # Support ticket operations.
         try:
             idx = int(choice) - 1  # Convert 1-based to 0-based index
         except ValueError:  # Non-numeric input that wasn't 'm'
-            print(f"  Invalid selection: {choice}")  # Inform user of bad input
+            logging.error("  Invalid selection: %s", choice)  # Inform user of bad input
             return ""  # Signal cancellation
         if not 0 <= idx < len(tickets):  # Index out of range
-            print(f"  Invalid selection: {choice}")  # Inform user of bad input
+            logging.error("  Invalid selection: %s", choice)  # Inform user of bad input
             return ""  # Signal cancellation
         selected_id = tickets[idx].get("id", "")  # Extract ticket ID
         selected_subj = tickets[idx].get("subject", "(no subject)")  # Extract subject for confirmation
-        print(f"  Selected: {selected_subj}")  # Confirm selection to user
+        logging.warning("  Selected: %s", selected_subj)  # Confirm selection to user
         logging.info("User selected ticket %s (%s)", selected_id, selected_subj)  # Log selection
         return selected_id  # Return chosen ticket ID
 
@@ -446,7 +452,7 @@ class OrgTicketManager:  # Support ticket operations.
             return ticket_data  # Return the full ticket dict with comments
         except Exception as error:  # Catch API failures
             logging.error("Failed to fetch ticket %s: %s", ticket_id, error)  # Log error
-            print(f"  Error fetching ticket {ticket_id}: {error}")  # Show error to user
+            logging.error("  Error fetching ticket %s: %s", ticket_id, error)  # Show error to user
             return {}  # Return empty dict to signal failure
 
     @staticmethod
@@ -465,14 +471,14 @@ class OrgTicketManager:  # Support ticket operations.
             return tickets  # Return summary list to caller
         except Exception as error:  # Catch API failures on ticket list
             logging.error("Failed to fetch ticket list: %s", error)  # Log the failure
-            print(f"\n  Error fetching tickets: {error}")  # Show error to user
+            logging.error("\n  Error fetching tickets: %s", error)  # Show error to user
             raise  # Re-raise for upstream handling
 
     @staticmethod
     def _collect_ticket_details(org_id: str, tickets: list) -> list:
         """For each summary in tickets, fetch + flatten its full detail. Returns list of flat dicts."""
         all_details = []  # Accumulate flattened ticket+comment records
-        print(f"\n  Fetching details for {len(tickets)} tickets...")  # Progress indicator
+        logging.warning("\n  Fetching details for %d tickets...", len(tickets))  # Progress indicator
         for index, ticket in enumerate(tickets, 1):  # Iterate each ticket summary
             tid = ticket.get("id", "")  # Extract ticket ID from summary
             if not tid:  # Skip tickets without valid IDs
@@ -487,7 +493,6 @@ class OrgTicketManager:  # Support ticket operations.
     @staticmethod
     def _display_ticket_detail(ticket_data: dict) -> None:  # Display ticket detail.
         """Format and display a ticket with its full comment history."""
-        print("\n  " + "=" * 60)  # Top separator bar
         meta_fields = (  # (label, key, default) for the metadata block
             ("Ticket", "subject", "(no subject)"),
             ("ID    ", "id", "unknown"),
@@ -496,25 +501,30 @@ class OrgTicketManager:  # Support ticket operations.
             ("Created", "created_at", "unknown"),
             ("Updated", "updated_at", "unknown"),
         )
-        for label, key, default in meta_fields:  # Render header rows
-            print(f"  {label}: {ticket_data.get(key, default)}")  # Display ticket metadata row
-        print("  " + "-" * 60)  # Section separator
+        top_bar = "  " + "=" * 60  # Top separator bar
+        rows = "\n".join(  # Metadata rows built off meta_fields
+            f"  {label}: {ticket_data.get(key, default)}" for label, key, default in meta_fields
+        )
+        section_sep = "  " + "-" * 60  # Section separator between metadata and comments
+        logging.warning("\n%s\n%s\n%s", top_bar, rows, section_sep)  # Render header block atomically
         OrgTicketManager._render_comments_block(ticket_data.get("comments", []))  # Render comments
 
     @staticmethod
     def _render_comments_block(comments: list) -> None:
         """Render the comments section: header + one block per comment + attachments."""
         if not comments:  # No comments on this ticket
-            print("  No comments on this ticket.")  # Inform user
+            logging.warning("  No comments on this ticket.")  # Inform user
             return  # Nothing else to render
-        print(f"  Comments ({len(comments)}):")  # Comment section header with count
+        logging.warning("  Comments (%d):", len(comments))  # Comment section header with count
         for idx, comment in enumerate(comments, 1):  # Iterate each comment
             author = comment.get("author", "unknown")  # Get comment author name
             created = comment.get("created_at", "unknown")  # Get comment timestamp
             text = comment.get("comment", "(no text)")  # Get comment body text
-            print(f"\n  [{idx}] {author} -- {created}")  # Comment header with author+date
-            print(f"      {text}")  # Comment body text indented
+            logging.warning("\n  [%d] %s -- %s\n      %s", idx, author, created, text)  # Header + body atomically
             for att in comment.get("attachments", []) or []:  # Iterate attachments (may be empty)
-                print(f"      Attachment: {att.get('name', att.get('content_url', 'file'))}")
+                logging.warning(
+                    "      Attachment: %s",
+                    att.get("name", att.get("content_url", "file")),
+                )
 
-        print("  " + "=" * 60)  # Bottom separator bar
+        logging.warning("  %s", "=" * 60)  # Bottom separator bar

--- a/tests/test_ticket_manager.py
+++ b/tests/test_ticket_manager.py
@@ -7,6 +7,7 @@ ticket selector, and edge cases (blank subject, blank ticket ID, no changes).
 """
 
 import csv
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,6 +16,21 @@ import MistHelper
 from src.refactors.endpoint_primary_key_strategies import (
     ENDPOINT_PRIMARY_KEY_STRATEGIES,  # Direct import: no MistHelper re-export shim (initiative 1015 T-04)
 )
+
+
+@pytest.fixture(autouse=True)
+def _capture_warnings(caplog):
+    """Ensure caplog captures WARNING+ records for every test in this module.
+
+    Why:
+        After #886 slice 16/N, OrgTicketManager emits user-visible messages via
+        ``logging.warning`` / ``logging.error`` rather than ``print()``. Tests
+        assert on those strings via ``caplog.text``; setting the level here
+        keeps the behavior deterministic across CI runners regardless of the
+        default logger propagation state.
+    """
+    caplog.set_level(logging.WARNING)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -155,7 +171,7 @@ class TestCreateTicket:
         assert captured["body"]["type"] == "problem"  # Verify type selection (2 = problem)
         assert captured["body"]["comment"] == "Happens every morning"  # Verify comment was included
 
-    def test_create_ticket_blank_subject_cancels(self, monkeypatch, capsys):
+    def test_create_ticket_blank_subject_cancels(self, monkeypatch, caplog):
         """Verify create_ticket aborts when subject is blank."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -175,7 +191,7 @@ class TestCreateTicket:
         MistHelper.OrgTicketManager.create_ticket()  # Execute with blank subject
 
         fake_create.assert_not_called()  # API should not be called when subject is blank
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "cancelled" in output.lower()  # User should see cancellation message
 
 
@@ -274,7 +290,7 @@ class TestAddComment:
         assert captured["comment"] == "See attached screenshot"  # Verify comment text passed
         assert captured["file"] == str(test_file)  # Verify file path passed
 
-    def test_add_comment_blank_ticket_id_cancels(self, monkeypatch, capsys):
+    def test_add_comment_blank_ticket_id_cancels(self, monkeypatch, caplog):
         """Verify add_comment aborts when no ticket is selected."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -294,10 +310,10 @@ class TestAddComment:
         MistHelper.OrgTicketManager.add_comment()  # Execute with blank ID
 
         fake_api.assert_not_called()  # API should not be called
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "cancelled" in output.lower()  # User should see cancellation message
 
-    def test_add_comment_no_content_cancels(self, monkeypatch, capsys):
+    def test_add_comment_no_content_cancels(self, monkeypatch, caplog):
         """Verify add_comment aborts when neither comment nor file is provided."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -329,10 +345,10 @@ class TestAddComment:
         MistHelper.OrgTicketManager.add_comment()  # Execute with no content
 
         fake_api.assert_not_called()  # API should not be called
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "cancelled" in output.lower()  # User should see cancellation message
 
-    def test_add_comment_missing_file_falls_back(self, monkeypatch, capsys):
+    def test_add_comment_missing_file_falls_back(self, monkeypatch, caplog):
         """Verify add_comment falls back to text-only when file path doesn't exist."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -372,7 +388,7 @@ class TestAddComment:
 
         assert captured["ticket_id"] == "ticket-uuid-abc"  # Should fall back to text comment
         assert captured["body"]["comment"] == "Here is my comment"  # Comment text preserved
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "not found" in output.lower()  # User should see warning about missing file
 
 
@@ -428,7 +444,7 @@ class TestUpdateTicket:
         assert captured["body"]["status"] == "closed"  # Verify status change
         assert "type" not in captured["body"]  # Type was skipped (blank input)
 
-    def test_update_ticket_blank_id_cancels(self, monkeypatch, capsys):
+    def test_update_ticket_blank_id_cancels(self, monkeypatch, caplog):
         """Verify update_ticket aborts when no ticket is selected."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -448,10 +464,10 @@ class TestUpdateTicket:
         MistHelper.OrgTicketManager.update_ticket()  # Execute with cancelled selection
 
         fake_update.assert_not_called()  # API should not be called
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "cancelled" in output.lower()  # User should see cancellation message
 
-    def test_update_ticket_no_changes_cancels(self, monkeypatch, capsys):
+    def test_update_ticket_no_changes_cancels(self, monkeypatch, caplog):
         """Verify update_ticket aborts when all fields are left blank."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -484,7 +500,7 @@ class TestUpdateTicket:
         MistHelper.OrgTicketManager.update_ticket()  # Execute with no changes
 
         fake_update.assert_not_called()  # API should not be called
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "cancelled" in output.lower() or "no changes" in output.lower()  # User should see message
 
 
@@ -550,7 +566,7 @@ class TestMenuRegistration:
 class TestViewTicket:
     """Tests for OrgTicketManager.view_ticket (Menu 192)."""
 
-    def test_view_ticket_displays_detail(self, monkeypatch, capsys):
+    def test_view_ticket_displays_detail(self, monkeypatch, caplog):
         """Verify view_ticket fetches and displays ticket with comments."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -581,13 +597,13 @@ class TestViewTicket:
 
         MistHelper.OrgTicketManager.view_ticket()  # Execute the menu operation
 
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "AP keeps dropping clients" in output  # Subject should be displayed
         assert "jmorrison" in output  # First comment author should appear
         assert "Started investigation" in output  # First comment text should appear
         assert "Collecting logs" in output  # Second comment text should appear
 
-    def test_view_ticket_cancelled(self, monkeypatch, capsys):
+    def test_view_ticket_cancelled(self, monkeypatch, caplog):
         """Verify view_ticket aborts when no ticket is selected."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -599,7 +615,7 @@ class TestViewTicket:
 
         MistHelper.OrgTicketManager.view_ticket()  # Execute with cancelled selection
 
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "cancelled" in output.lower()  # User should see cancellation message
 
 
@@ -657,7 +673,7 @@ class TestExportTicketDetails:
 
         assert len(rows) == 2  # Should have 2 ticket detail rows
 
-    def test_export_details_no_tickets(self, monkeypatch, capsys):
+    def test_export_details_no_tickets(self, monkeypatch, caplog):
         """Verify export_ticket_details handles empty ticket list."""
         _stub_org_id(monkeypatch)  # Fix org_id to avoid prompt
 
@@ -673,7 +689,7 @@ class TestExportTicketDetails:
 
         MistHelper.OrgTicketManager.export_ticket_details()  # Execute with no tickets
 
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "no tickets" in output.lower()  # User should see empty message
 
 
@@ -736,7 +752,7 @@ class TestSelectTicket:
 
         assert result == ""  # Should return empty string for cancellation
 
-    def test_select_no_tickets(self, monkeypatch, capsys):
+    def test_select_no_tickets(self, monkeypatch, caplog):
         """Verify _select_ticket returns empty when no tickets exist."""
 
         def fake_list(session, org_id, **kwargs):
@@ -752,5 +768,5 @@ class TestSelectTicket:
         result = MistHelper.OrgTicketManager._select_ticket("org-test-1")  # Execute selector
 
         assert result == ""  # Should return empty string
-        output = capsys.readouterr().out  # Capture printed output
+        output = caplog.text  # Capture printed output
         assert "no tickets" in output.lower()  # User should see empty message

--- a/tests/unit/test_org_ticket_manager.py
+++ b/tests/unit/test_org_ticket_manager.py
@@ -5,16 +5,34 @@ Why:
     update, view, export-details) plus all 15 private helpers. Every
     ``importlib.import_module("MistHelper")`` call is patched with a
     ``SimpleNamespace`` fake so no real MistHelper live-globals load.
+    User-facing output migrated from print() to logging.warning/error under
+    issue #886, so tests use ``caplog`` at WARNING level rather than ``capsys``.
 """
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.org.org_ticket_manager import OrgTicketManager
+
+
+@pytest.fixture(autouse=True)
+def _capture_warnings(caplog):
+    """Capture WARNING+ records for every test so caplog.text is populated.
+
+    Why:
+        After #886 slice 16/N, user-visible strings are emitted via
+        ``logging.warning`` / ``logging.error`` on the root logger. Tests
+        assert on these strings by inspecting ``caplog.text``; without an
+        explicit level, pytest's default capture threshold (WARNING) is fine,
+        but propagate=True on the module logger is not always the default in
+        CI environments. Setting it here keeps the tests deterministic.
+    """
+    caplog.set_level(logging.WARNING)
 
 
 def _make_mh(**extra):
@@ -78,14 +96,14 @@ def test_list_tickets_reraises_on_error(caplog):
 # ---------- create_ticket ----------
 
 
-def test_create_ticket_blank_subject_cancels(capsys):
+def test_create_ticket_blank_subject_cancels(caplog):
     """create_ticket aborts when subject is blank."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
     fake_mh.InputUtils.safe_input.return_value = ""
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.create_ticket()
-    assert "subject is required" in capsys.readouterr().out
+    assert "subject is required" in caplog.text
 
 
 def test_create_ticket_full_flow_with_comment():
@@ -119,17 +137,17 @@ def test_create_ticket_flow_without_comment():
 # ---------- add_comment ----------
 
 
-def test_add_comment_cancels_when_no_ticket_selected(capsys):
+def test_add_comment_cancels_when_no_ticket_selected(caplog):
     """add_comment prints cancellation when no ticket is chosen."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
     fake_mh.mistapi.api.v1.orgs.tickets.listOrgTickets.return_value = SimpleNamespace(data=[])
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.add_comment()
-    assert "no ticket selected" in capsys.readouterr().out
+    assert "no ticket selected" in caplog.text
 
 
-def test_add_comment_cancels_when_no_comment_or_file(capsys):
+def test_add_comment_cancels_when_no_comment_or_file(caplog):
     """add_comment aborts if user gives neither comment nor file path."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
@@ -140,7 +158,7 @@ def test_add_comment_cancels_when_no_comment_or_file(capsys):
     fake_mh.InputUtils.safe_input.side_effect = ["1", "", ""]
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.add_comment()
-    assert "provide a comment or file" in capsys.readouterr().out
+    assert "provide a comment or file" in caplog.text
 
 
 def test_add_comment_success_text_only(tmp_path):
@@ -159,17 +177,17 @@ def test_add_comment_success_text_only(tmp_path):
 # ---------- update_ticket ----------
 
 
-def test_update_ticket_cancels_when_no_ticket_selected(capsys):
+def test_update_ticket_cancels_when_no_ticket_selected(caplog):
     """update_ticket prints cancellation on no selection."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
     fake_mh.mistapi.api.v1.orgs.tickets.listOrgTickets.return_value = SimpleNamespace(data=[])
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.update_ticket()
-    assert "no ticket selected" in capsys.readouterr().out
+    assert "no ticket selected" in caplog.text
 
 
-def test_update_ticket_cancels_when_no_fields_changed(capsys):
+def test_update_ticket_cancels_when_no_fields_changed(caplog):
     """update_ticket aborts if user provides no updates."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
@@ -180,10 +198,10 @@ def test_update_ticket_cancels_when_no_fields_changed(capsys):
     fake_mh.InputUtils.safe_input.side_effect = ["1", "", "", ""]
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.update_ticket()
-    assert "No changes specified" in capsys.readouterr().out
+    assert "No changes specified" in caplog.text
 
 
-def test_update_ticket_success_updates_selected_fields(capsys):
+def test_update_ticket_success_updates_selected_fields(caplog):
     """update_ticket calls updateOrgTicket with only user-provided fields."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
@@ -244,35 +262,35 @@ def test_prompt_ticket_id_returns_input_value():
 # ---------- _print_ticket_created_summary ----------
 
 
-def test_print_ticket_created_summary(capsys):
+def test_print_ticket_created_summary(caplog):
     """_print_ticket_created_summary prints ID, subject, type and status."""
     OrgTicketManager._print_ticket_created_summary({"id": "t-1", "status": "open"}, "subj", "problem")
-    out = capsys.readouterr().out
-    assert "t-1" in out
-    assert "subj" in out
-    assert "problem" in out
-    assert "open" in out
+    text = caplog.text
+    assert "t-1" in text
+    assert "subj" in text
+    assert "problem" in text
+    assert "open" in text
 
 
-def test_print_ticket_created_summary_missing_id_status(capsys):
+def test_print_ticket_created_summary_missing_id_status(caplog):
     """_print_ticket_created_summary tolerates missing id/status."""
     OrgTicketManager._print_ticket_created_summary({}, "subj", "question")
-    out = capsys.readouterr().out
-    assert "unknown" in out
-    assert "open" in out
+    text = caplog.text
+    assert "unknown" in text
+    assert "open" in text
 
 
 # ---------- _submit_create_ticket ----------
 
 
-def test_submit_create_ticket_reraises_on_api_error(capsys):
+def test_submit_create_ticket_reraises_on_api_error(caplog):
     """_submit_create_ticket logs, prints and re-raises API errors."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.createOrgTicket.side_effect = RuntimeError("api down")
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         with pytest.raises(RuntimeError, match="api down"):
             OrgTicketManager._submit_create_ticket("org-1", {"subject": "s"}, "s", "problem")
-    assert "Error creating ticket" in capsys.readouterr().out
+    assert "Error creating ticket" in caplog.text
 
 
 # ---------- _build_update_body ----------
@@ -290,25 +308,25 @@ def test_build_update_body_returns_only_provided_fields():
 # ---------- _update_via_api ----------
 
 
-def test_update_via_api_success_prints_changes(capsys):
+def test_update_via_api_success_prints_changes(caplog):
     """_update_via_api prints each changed field."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.updateOrgTicket.return_value = SimpleNamespace(data={"ok": True})
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager._update_via_api("org-1", "t-1", {"subject": "x"})
-    out = capsys.readouterr().out
-    assert "updated successfully" in out
-    assert "subject: x" in out
+    text = caplog.text
+    assert "updated successfully" in text
+    assert "subject: x" in text
 
 
-def test_update_via_api_reraises_on_error(capsys):
+def test_update_via_api_reraises_on_error(caplog):
     """_update_via_api logs, prints, and re-raises API errors."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.updateOrgTicket.side_effect = RuntimeError("x")
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         with pytest.raises(RuntimeError):
             OrgTicketManager._update_via_api("org-1", "t-1", {"subject": "x"})
-    assert "Error updating ticket" in capsys.readouterr().out
+    assert "Error updating ticket" in caplog.text
 
 
 # ---------- _prompt_comment_and_file ----------
@@ -325,7 +343,7 @@ def test_prompt_comment_and_file_returns_tuple():
 # ---------- _submit_comment ----------
 
 
-def test_submit_comment_with_valid_file_uses_multipart(tmp_path, capsys):
+def test_submit_comment_with_valid_file_uses_multipart(tmp_path, caplog):
     """_submit_comment picks addOrgTicketCommentFile when file exists."""
     fake_mh = _make_mh()
     file_path = tmp_path / "attach.txt"
@@ -333,10 +351,10 @@ def test_submit_comment_with_valid_file_uses_multipart(tmp_path, capsys):
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager._submit_comment("org-1", "t-1", "hello", str(file_path))
     fake_mh.mistapi.api.v1.orgs.tickets.addOrgTicketCommentFile.assert_called_once()
-    assert "with attachment" in capsys.readouterr().out
+    assert "with attachment" in caplog.text
 
 
-def test_submit_comment_with_missing_file_falls_back_to_text(capsys):
+def test_submit_comment_with_missing_file_falls_back_to_text(caplog):
     """_submit_comment warns and submits text-only when path is missing."""
     fake_mh = _make_mh()
     with (
@@ -344,8 +362,7 @@ def test_submit_comment_with_missing_file_falls_back_to_text(capsys):
         patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh),
     ):
         OrgTicketManager._submit_comment("org-1", "t-1", "hello", "/nope/x")
-    out = capsys.readouterr().out
-    assert "File not found" in out
+    assert "File not found" in caplog.text
     fake_mh.mistapi.api.v1.orgs.tickets.addOrgTicketComment.assert_called_once()
 
 
@@ -371,30 +388,30 @@ def test_submit_comment_with_file_and_no_text_passes_none(tmp_path):
 # ---------- _submit_text_comment ----------
 
 
-def test_submit_text_comment_calls_api(capsys):
+def test_submit_text_comment_calls_api(caplog):
     """_submit_text_comment sends addOrgTicketComment with body dict."""
     fake_mh = _make_mh()
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager._submit_text_comment("org-1", "t-1", "hi")
     args = fake_mh.mistapi.api.v1.orgs.tickets.addOrgTicketComment.call_args.args
     assert args[3] == {"comment": "hi"}
-    assert "Comment added" in capsys.readouterr().out
+    assert "Comment added" in caplog.text
 
 
 # ---------- view_ticket ----------
 
 
-def test_view_ticket_cancels_when_no_ticket_selected(capsys):
+def test_view_ticket_cancels_when_no_ticket_selected(caplog):
     """view_ticket prints cancellation when no ticket chosen."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
     fake_mh.mistapi.api.v1.orgs.tickets.listOrgTickets.return_value = SimpleNamespace(data=[])
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.view_ticket()
-    assert "no ticket selected" in capsys.readouterr().out
+    assert "no ticket selected" in caplog.text
 
 
-def test_view_ticket_prints_details_on_success(capsys):
+def test_view_ticket_prints_details_on_success(caplog):
     """view_ticket calls fetch + display when ticket found."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
@@ -407,10 +424,10 @@ def test_view_ticket_prints_details_on_success(capsys):
     fake_mh.InputUtils.safe_input.return_value = "1"
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.view_ticket()
-    assert "Ticket" in capsys.readouterr().out
+    assert "Ticket" in caplog.text
 
 
-def test_view_ticket_empty_detail_prints_message(capsys):
+def test_view_ticket_empty_detail_prints_message(caplog):
     """view_ticket prints 'Could not retrieve' when detail is empty."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
@@ -421,20 +438,20 @@ def test_view_ticket_empty_detail_prints_message(capsys):
     fake_mh.InputUtils.safe_input.return_value = "1"
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.view_ticket()
-    assert "Could not retrieve" in capsys.readouterr().out
+    assert "Could not retrieve" in caplog.text
 
 
 # ---------- export_ticket_details ----------
 
 
-def test_export_ticket_details_no_tickets(capsys):
+def test_export_ticket_details_no_tickets(caplog):
     """export_ticket_details prints 'No tickets' when list is empty."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
     fake_mh.mistapi.api.v1.orgs.tickets.listOrgTickets.return_value = SimpleNamespace(data=[])
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.export_ticket_details()
-    assert "No tickets found" in capsys.readouterr().out
+    assert "No tickets found" in caplog.text
 
 
 def test_export_ticket_details_writes_when_details_exist():
@@ -448,7 +465,7 @@ def test_export_ticket_details_writes_when_details_exist():
     fake_mh.DataExporter.write_with_format_selection.assert_called_once()
 
 
-def test_export_ticket_details_no_details_retrieved(capsys):
+def test_export_ticket_details_no_details_retrieved(caplog):
     """export_ticket_details prints message when no details are collected."""
     fake_mh = _make_mh()
     fake_mh.ConfigUtils.get_cached_or_prompted_org_id.return_value = "org-1"
@@ -456,7 +473,7 @@ def test_export_ticket_details_no_details_retrieved(capsys):
     fake_mh.mistapi.api.v1.orgs.tickets.getOrgTicket.side_effect = RuntimeError("nope")
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         OrgTicketManager.export_ticket_details()
-    assert "No ticket details could be retrieved" in capsys.readouterr().out
+    assert "No ticket details could be retrieved" in caplog.text
 
 
 # ---------- _select_ticket ----------
@@ -506,28 +523,28 @@ def test_select_ticket_blank_input_cancels():
 # ---------- _fetch_tickets_for_selection ----------
 
 
-def test_fetch_tickets_for_selection_prints_when_empty(capsys):
+def test_fetch_tickets_for_selection_prints_when_empty(caplog):
     """_fetch_tickets_for_selection prints message when API returns []."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.listOrgTickets.return_value = SimpleNamespace(data=[])
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         assert OrgTicketManager._fetch_tickets_for_selection("org-1") == []
-    assert "No tickets found" in capsys.readouterr().out
+    assert "No tickets found" in caplog.text
 
 
-def test_fetch_tickets_for_selection_handles_api_error(capsys):
+def test_fetch_tickets_for_selection_handles_api_error(caplog):
     """_fetch_tickets_for_selection returns [] and prints error on exception."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.listOrgTickets.side_effect = RuntimeError("x")
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         assert OrgTicketManager._fetch_tickets_for_selection("org-1") == []
-    assert "Error fetching tickets" in capsys.readouterr().out
+    assert "Error fetching tickets" in caplog.text
 
 
 # ---------- _render_ticket_list_table ----------
 
 
-def test_render_ticket_list_table_prints_rows(capsys):
+def test_render_ticket_list_table_prints_rows(caplog):
     """_render_ticket_list_table prints one row per ticket."""
     OrgTicketManager._render_ticket_list_table(
         [
@@ -535,37 +552,37 @@ def test_render_ticket_list_table_prints_rows(capsys):
             {},
         ]
     )
-    out = capsys.readouterr().out
-    assert "open" in out
-    assert "problem" in out
-    assert "abc" in out
-    assert "(no subject)" in out
-    assert "unknown" in out
+    text = caplog.text
+    assert "open" in text
+    assert "problem" in text
+    assert "abc" in text
+    assert "(no subject)" in text
+    assert "unknown" in text
 
 
 # ---------- _resolve_ticket_choice ----------
 
 
-def test_resolve_ticket_choice_valid_returns_id(capsys):
+def test_resolve_ticket_choice_valid_returns_id(caplog):
     """_resolve_ticket_choice returns id and prints subject on valid pick."""
     result = OrgTicketManager._resolve_ticket_choice(
         "1",
         [{"id": "t-1", "subject": "s"}],
     )
     assert result == "t-1"
-    assert "Selected" in capsys.readouterr().out
+    assert "Selected" in caplog.text
 
 
-def test_resolve_ticket_choice_non_numeric(capsys):
+def test_resolve_ticket_choice_non_numeric(caplog):
     """_resolve_ticket_choice returns '' on non-numeric input."""
     assert OrgTicketManager._resolve_ticket_choice("abc", [{"id": "t-1"}]) == ""
-    assert "Invalid selection" in capsys.readouterr().out
+    assert "Invalid selection" in caplog.text
 
 
-def test_resolve_ticket_choice_out_of_range(capsys):
+def test_resolve_ticket_choice_out_of_range(caplog):
     """_resolve_ticket_choice returns '' on out-of-range index."""
     assert OrgTicketManager._resolve_ticket_choice("5", [{"id": "t-1"}]) == ""
-    assert "Invalid selection" in capsys.readouterr().out
+    assert "Invalid selection" in caplog.text
 
 
 # ---------- _fetch_ticket_detail ----------
@@ -579,13 +596,13 @@ def test_fetch_ticket_detail_returns_data():
         assert OrgTicketManager._fetch_ticket_detail("org-1", "t-1") == {"id": "t-1"}
 
 
-def test_fetch_ticket_detail_returns_empty_dict_on_error(capsys):
+def test_fetch_ticket_detail_returns_empty_dict_on_error(caplog):
     """_fetch_ticket_detail returns {} and prints on failure."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.getOrgTicket.side_effect = RuntimeError("x")
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         assert OrgTicketManager._fetch_ticket_detail("org-1", "t-1") == {}
-    assert "Error fetching ticket" in capsys.readouterr().out
+    assert "Error fetching ticket" in caplog.text
 
 
 def test_fetch_ticket_detail_returns_empty_when_data_none():
@@ -607,14 +624,14 @@ def test_fetch_all_ticket_summaries_returns_list():
         assert OrgTicketManager._fetch_all_ticket_summaries("org-1") == [{"id": "t-1"}]
 
 
-def test_fetch_all_ticket_summaries_reraises_on_error(capsys):
+def test_fetch_all_ticket_summaries_reraises_on_error(caplog):
     """_fetch_all_ticket_summaries re-raises API error after logging."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.listOrgTickets.side_effect = RuntimeError("x")
     with patch("src.org.org_ticket_manager.importlib.import_module", return_value=fake_mh):
         with pytest.raises(RuntimeError):
             OrgTicketManager._fetch_all_ticket_summaries("org-1")
-    assert "Error fetching tickets" in capsys.readouterr().out
+    assert "Error fetching tickets" in caplog.text
 
 
 def test_fetch_all_ticket_summaries_none_data_returns_empty():
@@ -628,7 +645,7 @@ def test_fetch_all_ticket_summaries_none_data_returns_empty():
 # ---------- _collect_ticket_details ----------
 
 
-def test_collect_ticket_details_skips_ticket_without_id(capsys):
+def test_collect_ticket_details_skips_ticket_without_id(caplog):
     """_collect_ticket_details skips tickets that have no id."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.getOrgTicket.return_value = SimpleNamespace(data={"id": "t-1", "subject": "s"})
@@ -637,7 +654,7 @@ def test_collect_ticket_details_skips_ticket_without_id(capsys):
     assert len(details) == 1
 
 
-def test_collect_ticket_details_returns_empty_for_all_failed(capsys):
+def test_collect_ticket_details_returns_empty_for_all_failed(caplog):
     """_collect_ticket_details returns [] when every fetch fails."""
     fake_mh = _make_mh()
     fake_mh.mistapi.api.v1.orgs.tickets.getOrgTicket.side_effect = RuntimeError("x")
@@ -648,7 +665,7 @@ def test_collect_ticket_details_returns_empty_for_all_failed(capsys):
 # ---------- _display_ticket_detail ----------
 
 
-def test_display_ticket_detail_prints_metadata_and_comments(capsys):
+def test_display_ticket_detail_prints_metadata_and_comments(caplog):
     """_display_ticket_detail prints subject, id, comments."""
     OrgTicketManager._display_ticket_detail(
         {
@@ -666,23 +683,23 @@ def test_display_ticket_detail_prints_metadata_and_comments(capsys):
             ],
         }
     )
-    out = capsys.readouterr().out
-    assert "s" in out
-    assert "t-1" in out
-    assert "hi" in out
-    assert "Attachment" in out
+    text = caplog.text
+    assert "s" in text
+    assert "t-1" in text
+    assert "hi" in text
+    assert "Attachment" in text
 
 
 # ---------- _render_comments_block ----------
 
 
-def test_render_comments_block_no_comments(capsys):
+def test_render_comments_block_no_comments(caplog):
     """_render_comments_block prints 'No comments' when list is empty."""
     OrgTicketManager._render_comments_block([])
-    assert "No comments" in capsys.readouterr().out
+    assert "No comments" in caplog.text
 
 
-def test_render_comments_block_prints_each_comment(capsys):
+def test_render_comments_block_prints_each_comment(caplog):
     """_render_comments_block prints author, timestamp, body, attachments."""
     OrgTicketManager._render_comments_block(
         [
@@ -695,14 +712,14 @@ def test_render_comments_block_prints_each_comment(capsys):
             {"attachments": None},
         ]
     )
-    out = capsys.readouterr().out
-    assert "hello" in out
-    assert "x.txt" in out
-    assert "unknown" in out
-    assert "(no text)" in out
+    text = caplog.text
+    assert "hello" in text
+    assert "x.txt" in text
+    assert "unknown" in text
+    assert "(no text)" in text
 
 
-def test_render_comments_block_uses_content_url_when_no_name(capsys):
+def test_render_comments_block_uses_content_url_when_no_name(caplog):
     """_render_comments_block falls back to content_url when name missing."""
     OrgTicketManager._render_comments_block(
         [
@@ -714,6 +731,6 @@ def test_render_comments_block_uses_content_url_when_no_name(capsys):
             }
         ]
     )
-    out = capsys.readouterr().out
-    assert "http://x" in out
-    assert "file" in out
+    text = caplog.text
+    assert "http://x" in text
+    assert "file" in text


### PR DESCRIPTION
## Summary

Slice 16/N of the #886 T20 rollout. Retires the last 45 `print()` calls in `src/org/org_ticket_manager.py` (Menus 188-193: list / create / comment / update / view / export org support tickets) in favor of `logging.warning(...)` for operator-visible UI and `logging.error(...)` for API failures and invalid selections.

Multi-line UI blocks were consolidated into single `logging.warning` records with embedded `\n` to preserve atomic log-record boundaries: list header + separator (3 -> 1), ticket metadata block (8 -> 1), per-comment header + body (2 -> 1).

Companion tests in `tests/unit/test_org_ticket_manager.py` (63 `capsys` refs) and `tests/test_ticket_manager.py` (20 `capsys` refs) migrated to `caplog`, gated by a per-file autouse `caplog.set_level(logging.WARNING)` fixture. No production behavior change; the visible surface is identical to pre-migration output.

## Test plan

- [x] `ruff check --select T20 src/org/org_ticket_manager.py` -> 0 issues
- [x] `grep -c 'print(' src/org/org_ticket_manager.py` -> 0
- [x] `ruff check .` -> All checks passed
- [x] `pytest` full suite -> 8949 passed / 0 failed
- [x] `pytest tests/unit/test_org_ticket_manager.py` -> 56 passed
- [x] `pytest tests/test_ticket_manager.py` -> 30 passed