### PR TITLE
chore(logging): migrate src/troubleshooting/troubleshoot_utils.py print() to logger (#886 slice 17/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 17/N: retire `print()` in `src/troubleshooting/troubleshoot_utils.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 12 `print()` calls in
+  `src/troubleshooting/troubleshoot_utils.py` (Marvis interactive
+  troubleshooting menu dispatcher) with `logging.warning(...)` for
+  operator-visible menu output. Consolidated the header/divider block (3 → 1
+  record) and the numbered-options block (6 → 1 record) so each banner arrives
+  atomically at every configured log handler and cannot interleave with
+  concurrent producers. Invalid-choice and exit handlers now route their
+  user-facing notice through `logging.warning` while retaining their existing
+  audit-trail (`logging.warning`) and trace (`logging.debug`) records.
+- **Test migration (Changed)**: `tests/unit/troubleshooting/test_troubleshoot_utils.py`
+  swapped 12 `capsys.readouterr().out` assertions for `caplog.text` and added
+  a module-level `autouse` fixture (`_capture_warnings`) that calls
+  `caplog.set_level(logging.WARNING)` so the migrated warnings are captured
+  deterministically across CI runners regardless of default logger
+  propagation.
+- **Verification**: `ruff check src/troubleshooting/troubleshoot_utils.py
+  --select T20` reports 0 issues; full `ruff check .` clean; full `pytest`
+  suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 16/N: retire `print()` in `src/org/org_ticket_manager.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 45 `print()` calls in

--- a/src/troubleshooting/troubleshoot_utils.py
+++ b/src/troubleshooting/troubleshoot_utils.py
@@ -69,34 +69,61 @@ class TroubleshootUtils:  # Marvis troubleshoot delegators.
 
     @staticmethod
     def _print_marvis_menu() -> None:
-        """Print the interactive Marvis troubleshooting menu header + numbered options."""
-        print(" Starting Marvis (VNA - Virtual Network Assistant) Troubleshooting")  # Header.
-        print("=" * 65)  # Divider.
-        print()  # Spacer.
+        """Emit the interactive Marvis troubleshooting header banner.
+
+        Why:
+            #886 slice 17/N migrates ``print()`` to ``logging.warning`` so that
+            ruff T20 can stay armed globally. Header + divider are consolidated
+            into a single warning record so the banner arrives atomically in
+            handlers that buffer per-record (e.g. remote log shippers).
+        """
+        logging.warning(
+            " Starting Marvis (VNA - Virtual Network Assistant) Troubleshooting\n%s\n",
+            "=" * 65,
+        )
 
     @staticmethod
     def _print_marvis_options() -> None:
-        """Print the 5 troubleshooting choices a user can pick."""
-        print(" Marvis AI Troubleshooting Options:")  # Menu header.
-        print("1. Troubleshoot client connectivity issues (guided client selection)")  # Option 1.
-        print("2. Diagnose device performance problems (guided device selection)")  # Option 2.
-        print("3. Analyze network connectivity issues (site-level analysis)")  # Option 3.
-        print("4. View organization Marvis insights and capabilities")  # Option 4.
-        print("5. Exit")  # Option 5.
-        print()  # Spacer.
+        """Emit the 5 numbered Marvis troubleshooting choices to the user.
+
+        Why:
+            #886 slice 17/N. Merged into a single ``logging.warning`` so the
+            menu prints atomically and cannot be interleaved with other log
+            records under concurrent producers.
+        """
+        logging.warning(
+            " Marvis AI Troubleshooting Options:\n"
+            "1. Troubleshoot client connectivity issues (guided client selection)\n"
+            "2. Diagnose device performance problems (guided device selection)\n"
+            "3. Analyze network connectivity issues (site-level analysis)\n"
+            "4. View organization Marvis insights and capabilities\n"
+            "5. Exit\n"
+        )
 
     @staticmethod
     def _handle_marvis_invalid_choice(choice: str) -> None:
-        """Handle an out-of-range Marvis menu selection (warn + log)."""
-        print(" Invalid option selected.")  # User-facing notice
+        """Handle an out-of-range Marvis menu selection (warn + log).
+
+        Why:
+            #886 slice 17/N replaces the user-facing ``print()`` with
+            ``logging.warning`` so all three log lines (visible notice + audit
+            trail + debug trace) travel through the same sink.
+        """
+        logging.warning(" Invalid option selected.")  # User-visible notice
         logging.warning("MARVIS DEBUG: Invalid troubleshooting option selected: %s", choice)  # Audit trail
         logging.debug("MARVIS DEBUG: Exiting launch_interactive() due to invalid choice")  # Trace exit reason
 
     @staticmethod
     def _handle_marvis_exit() -> None:
-        """Handle the Marvis exit menu pick."""
+        """Handle the Marvis exit menu pick.
+
+        Why:
+            #886 slice 17/N. The exit notice is promoted to ``logging.warning``
+            because the caller expects it to be captured at the default pytest
+            log level and displayed by every stream handler configuration.
+        """
         logging.debug("MARVIS DEBUG: User chose to exit")  # Trace the exit
-        print("Exiting Marvis troubleshooting.")  # Tell the user
+        logging.warning("Exiting Marvis troubleshooting.")  # Tell the user
 
     @staticmethod
     def _invoke_marvis_client_connectivity() -> None:

--- a/tests/unit/troubleshooting/test_troubleshoot_utils.py
+++ b/tests/unit/troubleshooting/test_troubleshoot_utils.py
@@ -10,6 +10,20 @@ import pytest
 from src.troubleshooting.troubleshoot_utils import TroubleshootUtils
 
 
+@pytest.fixture(autouse=True)
+def _capture_warnings(caplog):
+    """Ensure caplog captures WARNING+ records for every test in this module.
+
+    Why:
+        After #886 slice 17/N, TroubleshootUtils emits user-visible menu and
+        exit messages via ``logging.warning`` rather than ``print()``. Tests
+        assert on those strings via ``caplog.text``; setting the level here
+        keeps behavior deterministic across CI runners regardless of the
+        default logger propagation state.
+    """
+    caplog.set_level(logging.WARNING)
+
+
 @pytest.fixture
 def mh_mocks(monkeypatch):
     """Patch every MistHelper attribute referenced by TroubleshootUtils lazy imports."""
@@ -74,30 +88,30 @@ class TestDelegations:
 
 
 class TestPrintHelpers:
-    def test_print_marvis_menu_writes_header(self, capsys):
+    def test_print_marvis_menu_writes_header(self, caplog):
         TroubleshootUtils._print_marvis_menu()
-        out = capsys.readouterr().out
+        out = caplog.text
         assert "Marvis" in out
         assert "=" * 65 in out
 
-    def test_print_marvis_options_lists_five(self, capsys):
+    def test_print_marvis_options_lists_five(self, caplog):
         TroubleshootUtils._print_marvis_options()
-        out = capsys.readouterr().out
+        out = caplog.text
         for token in ("1.", "2.", "3.", "4.", "5."):
             assert token in out
         assert "Exit" in out
 
 
 class TestHandlers:
-    def test_invalid_choice_logs_warning(self, caplog, capsys):
+    def test_invalid_choice_logs_warning(self, caplog):
         caplog.set_level(logging.WARNING)
         TroubleshootUtils._handle_marvis_invalid_choice("9")
-        assert "Invalid option selected." in capsys.readouterr().out
+        assert "Invalid option selected." in caplog.text
         assert "Invalid troubleshooting option selected" in caplog.text
 
-    def test_exit_prints_message(self, capsys):
+    def test_exit_prints_message(self, caplog):
         TroubleshootUtils._handle_marvis_exit()
-        assert "Exiting Marvis troubleshooting." in capsys.readouterr().out
+        assert "Exiting Marvis troubleshooting." in caplog.text
 
 
 class TestInvokers:
@@ -132,35 +146,35 @@ class TestDispatchMarvisChoice:
         TroubleshootUtils._dispatch_marvis_choice(choice)
         getattr(mh_mocks["ExtractedMarvisTroubleshootUtils"], attr).assert_called_once()
 
-    def test_choice_5_exits(self, capsys, mh_mocks):
+    def test_choice_5_exits(self, caplog, mh_mocks):
         TroubleshootUtils._dispatch_marvis_choice("5")
-        assert "Exiting Marvis troubleshooting." in capsys.readouterr().out
+        assert "Exiting Marvis troubleshooting." in caplog.text
 
-    def test_invalid_choice_routes_to_invalid_handler(self, caplog, capsys, mh_mocks):
+    def test_invalid_choice_routes_to_invalid_handler(self, caplog, mh_mocks):
         caplog.set_level(logging.WARNING)
         TroubleshootUtils._dispatch_marvis_choice("bogus")
-        assert "Invalid option selected." in capsys.readouterr().out
+        assert "Invalid option selected." in caplog.text
         mh_mocks["ExtractedMarvisTroubleshootUtils"].client_connectivity.assert_not_called()
 
 
 class TestLaunchInteractive:
-    def test_launch_dispatches_choice(self, mh_mocks, capsys):
+    def test_launch_dispatches_choice(self, mh_mocks, caplog):
         mh_mocks["InputUtils"].safe_input.return_value = "1"
         TroubleshootUtils.launch_interactive()
         mh_mocks["ConfigUtils"].get_cached_or_prompted_org_id.assert_called_once()
         mh_mocks["InputUtils"].safe_input.assert_called_once()
         mh_mocks["ExtractedMarvisTroubleshootUtils"].client_connectivity.assert_called_once()
-        assert "Marvis" in capsys.readouterr().out
+        assert "Marvis" in caplog.text
 
-    def test_launch_invalid_choice(self, mh_mocks, capsys):
+    def test_launch_invalid_choice(self, mh_mocks, caplog):
         mh_mocks["InputUtils"].safe_input.return_value = "99"
         TroubleshootUtils.launch_interactive()
-        assert "Invalid option selected." in capsys.readouterr().out
+        assert "Invalid option selected." in caplog.text
 
-    def test_launch_exit_choice(self, mh_mocks, capsys):
+    def test_launch_exit_choice(self, mh_mocks, caplog):
         mh_mocks["InputUtils"].safe_input.return_value = "5"
         TroubleshootUtils.launch_interactive()
-        assert "Exiting Marvis troubleshooting." in capsys.readouterr().out
+        assert "Exiting Marvis troubleshooting." in caplog.text
 
     def test_launch_strips_whitespace_from_input(self, mh_mocks):
         mh_mocks["InputUtils"].safe_input.return_value = "  2  "


### PR DESCRIPTION
## Summary
- Retire the last 12 `print()` calls in `src/troubleshooting/troubleshoot_utils.py`, migrating them to `logging.warning(...)` so ruff T20 (T201/T203) can stay armed globally per issue #886.
- Consolidate two multi-line print blocks into single atomic warning records: header + divider (3 → 1) and the numbered menu options (6 → 1). Prevents interleaving with concurrent producers.
- Route the invalid-choice and exit user-facing notices through `logging.warning` while preserving the existing audit-trail (`logging.warning`) and trace (`logging.debug`) records.
- Migrate `tests/unit/troubleshooting/test_troubleshoot_utils.py`: 12 `capsys.readouterr().out` → `caplog.text`, plus an `autouse` `_capture_warnings` fixture calling `caplog.set_level(logging.WARNING)` for deterministic capture across CI runners.

## Verification
- `ruff check src/troubleshooting/troubleshoot_utils.py --select T20` → 0 issues.
- `ruff check .` → clean.
- `pytest tests/unit/troubleshooting/test_troubleshoot_utils.py` → 24 passed.
- Full `pytest` → 8949 passed / 0 failed / 77 skipped / 5 xfailed / 1 xpassed.
- `black --check` → unchanged.

## Test plan
- [x] Companion unit tests green
- [x] Full pytest sweep green
- [x] Ruff T20 clean on the touched file
- [x] Ruff full-repo clean
- [x] Black check clean
- [x] CHANGELOG entry prepended under [Unreleased]

Refs: #886