### PR TITLE
chore(logging): migrate src/troubleshooting/interactive_test_runner.py print() to logger (#886 slice 18/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 18/N: retire `print()` in `src/troubleshooting/interactive_test_runner.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 35 `print()` calls in
+  `src/troubleshooting/interactive_test_runner.py` (interactive-safe
+  systematic test suite runner) with `logging.warning(...)` for
+  operator-visible banners and `logging.error(...)` for site-resolution
+  failures. Multi-line UI blocks were consolidated into single
+  `logging.warning` records so banners arrive atomically at every configured
+  log handler and cannot interleave with concurrent producers:
+  `_print_suite_header` (4 → 1 record for the header/note/timestamp/divider),
+  `_print_summary_stats` (10 → 1 record covering the entire summary block),
+  and `_print_option_listings` (2 static header lines → 1 record). Dynamic
+  lists (`_print_tested_options`, `_print_skipped_options`) use the
+  `logging.warning("%s", "\n".join(lines))` pattern to guard against
+  format-string surprises from option descriptions or skip reasons. Dropped
+  cosmetic blank-line `print()` spacers rather than emitting empty log
+  records that would clutter handler output. `_log_selector_miss` combined
+  its 2 diagnostic records into a single warning so the selector-miss
+  notification stays atomic.
+- **Test migration (Changed)**:
+  `tests/unit/troubleshooting/test_interactive_test_runner.py` swapped
+  `capsys.readouterr().out` assertions for `caplog.text` across the 5
+  affected tests (`_log_selector_miss`, `_lookup_selector_site`,
+  `_resolve_site_or_close` no-site, `_resolve_site_or_close` exception,
+  `_print_skipped_options`, `_print_summary_verdict`) and added a
+  module-level `autouse` fixture (`_capture_warnings`) that calls
+  `caplog.set_level(logging.WARNING)` so migrated warnings are captured
+  deterministically across CI runners. `_resolve_site_or_close` assertions
+  were tightened with `caplog.at_level("ERROR")` because that path now
+  routes via `logging.error`.
+- **Verification**: `ruff check src/troubleshooting/interactive_test_runner.py
+  tests/unit/troubleshooting/test_interactive_test_runner.py` reports 0
+  issues; `black --check` clean; full `pytest` suite green (8949 passed, 0
+  failed, 77 skipped, 5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 17/N: retire `print()` in `src/troubleshooting/troubleshoot_utils.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 12 `print()` calls in

--- a/src/troubleshooting/interactive_test_runner.py
+++ b/src/troubleshooting/interactive_test_runner.py
@@ -78,15 +78,19 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
 
     @staticmethod
     def _log_selector_miss(site_selector: str) -> None:
-        """Log selector-miss and print legacy warning banner."""
-        print(
-            f"   Warning: MIST_INTERACTIVE_TEST_SITE='{site_selector}' not found; "
-            "falling back to first available site."
-        )  # WHY: preserve legacy operator-facing warning banner.
+        """Log selector-miss warning banner via ``logging.warning``.
+
+        Why:
+            #886 slice 18/N migrates ``print()`` to ``logging.warning`` so
+            ruff T20 can stay armed globally. Legacy operator banner and
+            diagnostic log are consolidated into a single warning record so
+            the miss notification arrives atomically in handlers that buffer
+            per-record.
+        """
         logging.warning(
-            "INTERACTIVE_TEST: MIST_INTERACTIVE_TEST_SITE '%s' not found; using first available site.",
+            "INTERACTIVE_TEST: MIST_INTERACTIVE_TEST_SITE '%s' not found; " "falling back to first available site.",
             site_selector,
-        )  # WHY: log fallback path for operations diagnostics.
+        )  # WHY: consolidated operator banner + diagnostic log.
 
     def _lookup_selector_site(self, org_id: str, site_selector: str) -> tuple[str | None, str]:
         """Return site matching the environment selector by UUID or case-insensitive name."""
@@ -99,9 +103,11 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
             return None, "Unknown"  # WHY: signal caller to attempt fallback lookup.
         site_id = matching_site["id"]  # WHY: capture matched site id for downstream operations.
         site_name = matching_site.get("name", "Unknown")  # WHY: capture matched site name for context.
-        print(
-            f"   Using test site from MIST_INTERACTIVE_TEST_SITE: {site_name} ({site_id})"
-        )  # WHY: preserve legacy explicit selector-success message.
+        logging.warning(
+            "   Using test site from MIST_INTERACTIVE_TEST_SITE: %s (%s)",
+            site_name,
+            site_id,
+        )  # WHY: #886 slice 18/N — legacy selector-success message via logging.warning.
         logging.debug(
             "Selector matched site_id=%s site_name=%s", site_id, site_name
         )  # WHY: log selector match details for traceability.
@@ -121,9 +127,11 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         site_name = sites_response.data[0].get(
             "name", "Unknown"
         )  # WHY: capture fallback site name for user-visible context.
-        print(
-            f"   Using first available test site: {site_name} ({site_id})"
-        )  # WHY: preserve legacy fallback message output.
+        logging.warning(
+            "   Using first available test site: %s (%s)",
+            site_name,
+            site_id,
+        )  # WHY: #886 slice 18/N — legacy fallback message via logging.warning.
         return site_id, site_name  # WHY: return resolved fallback context to orchestrator.
 
     def _resolve_test_site(self, org_id: str) -> tuple[str | None, str]:
@@ -151,15 +159,21 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         return site_id, site_name  # WHY: return resolved site context used by execute() workflow.
 
     def _print_suite_header(self) -> None:
-        """Print suite banner preserved verbatim from legacy execute() output."""
-        print(" Starting interactive test of MistHelper menu options...")  # WHY: preserve legacy header text.
-        print(
-            "  Note: This tests read-only operations requiring site/device/client selection"
-        )  # WHY: preserve legacy operator note.
-        print(
-            f"! Test started at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
-        )  # WHY: preserve legacy start-time line.
-        print("=" * 80)  # WHY: preserve legacy visual divider.
+        """Emit the interactive-test suite banner as a single ``logging.warning``.
+
+        Why:
+            #886 slice 18/N. Header, note, timestamp, and divider are
+            consolidated into one atomic warning so the banner cannot be
+            interleaved with other records under concurrent log producers.
+        """
+        logging.warning(
+            " Starting interactive test of MistHelper menu options...\n"
+            "  Note: This tests read-only operations requiring site/device/client selection\n"
+            "! Test started at: %s\n"
+            "%s",
+            datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "=" * 80,
+        )
 
     def _build_option_lists(self) -> tuple[list[str], list[str], list[str]]:
         """Return (all_options, interactive_options, skip_list) using stable legacy ordering."""
@@ -179,31 +193,50 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         return all_options, interactive_options, skip_list  # WHY: return triple consumed by execute().
 
     def _print_tested_options(self, interactive_options: list[str]) -> None:
-        """Print the tested-options listing verbatim from legacy output."""
-        print(" Testing interactive read-only operations:")  # WHY: preserve tested section header.
+        """Emit the tested-options listing via a single ``logging.warning``.
+
+        Why:
+            #886 slice 18/N. Consolidated into one warning record so the
+            listing arrives atomically and cannot be interleaved with other
+            log output under concurrent producers.
+        """
+        lines = [" Testing interactive read-only operations:"]
         for option in interactive_options:
             if option in self.menu_actions:
                 _, description = self.menu_actions[option]  # WHY: resolve description for option listing.
-                print(f"   {option:>3}: {description}")  # WHY: preserve per-option tested listing.
+                lines.append(f"   {option:>3}: {description}")  # WHY: preserve per-option tested listing.
+        logging.warning("%s", "\n".join(lines))
 
     def _print_skipped_options(self, skip_list: list[str]) -> None:
-        """Print the skipped-options listing verbatim from legacy output."""
-        print(" Skipping non-interactive-safe operations:")  # WHY: preserve skipped section header.
+        """Emit the skipped-options listing via a single ``logging.warning``.
+
+        Why:
+            #886 slice 18/N. Consolidated so the skip listing prints as one
+            atomic record, matching the tested-listing helper.
+        """
+        lines = [" Skipping non-interactive-safe operations:"]
         for option in skip_list:
             if option in self.menu_actions:
                 reason = self.operation_registry.skip_reason(option)  # WHY: resolve registry skip reason.
                 if reason:
-                    print(f"   {option:>3}: {reason}")  # WHY: preserve per-option skip-reason listing.
+                    lines.append(f"   {option:>3}: {reason}")  # WHY: preserve per-option skip-reason listing.
+        logging.warning("%s", "\n".join(lines))
 
     def _print_option_listings(self, interactive_options: list[str], skip_list: list[str]) -> None:
-        """Print the tested-and-skipped option listings preserving legacy formatting."""
-        print(f"! Found {len(interactive_options)} interactive read-only options to test")  # WHY: preserve count line.
-        print(f"! {len(skip_list)} options will be skipped")  # WHY: preserve skip-count line.
-        print()  # WHY: preserve blank-line spacing before tested listing.
-        self._print_tested_options(interactive_options)  # WHY: delegate tested-listing print to helper.
-        print()  # WHY: preserve spacing between sections.
-        self._print_skipped_options(skip_list)  # WHY: delegate skipped-listing print to helper.
-        print()  # WHY: preserve spacing before telemetry setup.
+        """Emit the tested-and-skipped option listings via ``logging.warning``.
+
+        Why:
+            #886 slice 18/N. Counts and blank-line separators are folded into
+            a single warning record; delegated tested/skipped listings each
+            emit one further warning to preserve section boundaries.
+        """
+        logging.warning(
+            "! Found %d interactive read-only options to test\n! %d options will be skipped",
+            len(interactive_options),
+            len(skip_list),
+        )  # WHY: preserve count lines as one atomic warning.
+        self._print_tested_options(interactive_options)  # WHY: delegate tested-listing emission.
+        self._print_skipped_options(skip_list)  # WHY: delegate skipped-listing emission.
 
     def _create_emitter(self) -> tuple[Any, Any]:
         """Initialize telemetry emitter; return (emitter, path) tuple."""
@@ -244,19 +277,19 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
     def _resolve_site_or_close(self, org_id: str, emitter: Any) -> tuple[str | None, str]:
         """Resolve test site context; close emitter and return (None, '') on failure paths."""
         try:
-            print("   Fetching test site for interactive operations...")  # WHY: preserve legacy cue.
+            logging.warning("   Fetching test site for interactive operations...")  # WHY: #886 s18 legacy cue.
             test_site_id, test_site_name = self._resolve_test_site(org_id)  # WHY: resolve test site.
             if test_site_id:
                 logging.info(
                     "INTERACTIVE_TEST: Using test site_id=%s name=%s", test_site_id, test_site_name
                 )  # WHY: log selected site context.
                 return test_site_id, test_site_name  # WHY: return resolved context on success.
-            print(
+            logging.error(
                 "[ERROR] No sites found in organization - cannot run interactive tests"
-            )  # WHY: preserve legacy no-site error message.
+            )  # WHY: #886 slice 18/N — legacy no-site error via logging.error.
             logging.error("INTERACTIVE_TEST: No sites available for testing")  # WHY: log no-site terminal condition.
         except Exception as error:
-            print(f"[ERROR] Failed to fetch test site: {error}")  # WHY: preserve fetch-failure message.
+            logging.error("[ERROR] Failed to fetch test site: %s", error)  # WHY: #886 s18 fetch-failure msg.
             logging.error("INTERACTIVE_TEST: Failed to fetch test site: %s", error)  # WHY: log exception context.
         logging.info("Closing telemetry emitter after site-resolution failure")  # WHY: log before close on failure.
         emitter.close()  # WHY: close emitter to flush events on failure path.
@@ -277,7 +310,7 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
 
     def _emit_option_pass(self, option: str, description: str, duration: float, emitter: Any) -> bool:
         """Emit telemetry pass event and preserve legacy success output for an option."""
-        print(f"   [SUCCESS] Option {option} completed successfully")  # WHY: preserve success message.
+        logging.warning("   [SUCCESS] Option %s completed successfully", option)  # WHY: #886 s18 success msg.
         logging.info("Emitting telemetry pass event for option %s", option)  # WHY: log before pass emission.
         emitter.emit_test_pass(option, description, duration, "interactive")  # WHY: emit pass event.
         logging.debug("Telemetry pass event emitted for option %s", option)  # WHY: log pass completion.
@@ -288,9 +321,9 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
 
     def _emit_option_fail(self, option: str, description: str, duration: float, error: Exception, emitter: Any) -> bool:
         """Emit telemetry fail event and preserve legacy failure output for an option."""
-        print(
-            f"   [FAILED]  Option {option} failed: {str(error)[:100]}..."
-        )  # WHY: preserve failure message with legacy truncation.
+        logging.warning(
+            "   [FAILED]  Option %s failed: %s...", option, str(error)[:100]
+        )  # WHY: #886 slice 18/N — failure message via logging.warning with legacy truncation.
         logging.info("Emitting telemetry fail event for option %s", option)  # WHY: log before fail emission.
         emitter.emit_test_fail(
             option, description, duration, error, "interactive"
@@ -302,9 +335,9 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
     def _run_single_option(self, index: int, total: int, option: str, test_site_id: str | None, emitter: Any) -> bool:
         """Run a single interactive option, emit telemetry, and return True on success."""
         _function, description = self.menu_actions[option]  # WHY: resolve description for progress output.
-        print(
-            f"   [{index:2}/{total}] Testing option {option:>3}: {description[:60]}..."
-        )  # WHY: preserve per-option progress line.
+        logging.warning(
+            "   [%2d/%d] Testing option %3s: %s...", index, total, option, description[:60]
+        )  # WHY: #886 slice 18/N — per-option progress line via logging.warning.
         logging.info("Emitting telemetry start event for option %s", option)  # WHY: log before start emission.
         emitter.emit_test_start(option, description, "interactive")  # WHY: emit start event.
         logging.debug("Telemetry start event emitted for option %s", option)  # WHY: log start emission completion.
@@ -361,35 +394,47 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         logging.debug("Telemetry retention policy enforcement completed")  # WHY: log retention completion.
 
     def _print_summary_stats(self, tallies: SuiteTallies, interactive_total: int, telemetry_path: Any) -> None:
-        """Print the legacy stats block preserving exact formatting and message text."""
-        print()  # WHY: preserve blank line before summary.
-        print("=" * 80)  # WHY: preserve summary separator line.
-        print(" Interactive Test Summary:")  # WHY: preserve summary title.
-        print(f"   Successful operations: {tallies.success_count}")  # WHY: preserve success count line.
-        print(f"   Failed operations: {tallies.error_count}")  # WHY: preserve failure count line.
-        print(f"   Skipped operations: {tallies.skip_count}")  # WHY: preserve skip count line.
+        """Emit the legacy stats block as one atomic ``logging.warning``.
+
+        Why:
+            #886 slice 18/N. The 10-line summary block was 10 separate
+            ``print()`` calls; consolidating into one warning record
+            guarantees the block arrives contiguously in any handler.
+        """
         coverage_pct = tallies.success_count / interactive_total * 100  # WHY: precompute coverage %.
-        print(
-            f"   Total interactive read-only coverage: {tallies.success_count}/{interactive_total} "
-            f"({coverage_pct:.1f}%)"
-        )  # WHY: preserve coverage formatting.
-        print(f"   Total execution time: {tallies.total_time:.2f} seconds")  # WHY: preserve duration line.
-        print(f"   Telemetry written to: {telemetry_path}")  # WHY: preserve telemetry-path line.
-        print("   Detailed logs in: script.log")  # WHY: preserve log-guidance line.
+        logging.warning(
+            "\n%s\n Interactive Test Summary:\n"
+            "   Successful operations: %d\n"
+            "   Failed operations: %d\n"
+            "   Skipped operations: %d\n"
+            "   Total interactive read-only coverage: %d/%d (%.1f%%)\n"
+            "   Total execution time: %.2f seconds\n"
+            "   Telemetry written to: %s\n"
+            "   Detailed logs in: script.log",
+            "=" * 80,
+            tallies.success_count,
+            tallies.error_count,
+            tallies.skip_count,
+            tallies.success_count,
+            interactive_total,
+            coverage_pct,
+            tallies.total_time,
+            telemetry_path,
+        )
 
     def _print_summary_verdict(self, tallies: SuiteTallies, interactive_total: int) -> bool:
         """Print final verdict banner and return suite pass/fail status."""
         if tallies.error_count == 0:
-            print("   All tested interactive operations completed successfully!")  # WHY: preserve all-pass banner.
+            logging.warning("   All tested interactive operations completed successfully!")  # WHY: #886 s18.
             logging.info(
                 "INTERACTIVE_TEST: All %s tested operations completed successfully in %.2fs",
                 tallies.success_count,
                 tallies.total_time,
             )  # WHY: log all-pass suite outcome.
             return True  # WHY: return pass status.
-        print(
-            f"   {tallies.error_count} operations failed - check logs for details"
-        )  # WHY: preserve failure summary line.
+        logging.warning(
+            "   %d operations failed - check logs for details", tallies.error_count
+        )  # WHY: #886 slice 18/N — failure summary line via logging.warning.
         logging.warning(
             "INTERACTIVE_TEST: %s operations failed out of %s tested",
             tallies.error_count,
@@ -404,7 +449,6 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
 
     def _run_and_finalize(self, ctx: SuiteContext) -> bool:
         """Run per-option loop, finalize telemetry, and print the summary block."""
-        print()  # WHY: preserve spacing before per-option execution loop.
         success_count, error_count = self._run_option_loop(
             ctx.interactive_options, ctx.test_site_id, ctx.emitter
         )  # WHY: execute option loop.

--- a/tests/unit/troubleshooting/test_interactive_test_runner.py
+++ b/tests/unit/troubleshooting/test_interactive_test_runner.py
@@ -7,6 +7,7 @@ failure branches, and option-loop failure telemetry.
 
 from __future__ import annotations
 
+import logging  # WHY: #886 slice 18/N — caplog level control for logger-based output
 from unittest.mock import MagicMock
 
 import pytest  # WHY: pytest monkeypatch fixture for os.environ selector control
@@ -17,6 +18,21 @@ from src.troubleshooting.interactive_test_runner import (
     SuiteContext,
     SuiteTallies,
 )
+
+
+@pytest.fixture(autouse=True)
+def _capture_warnings(caplog: pytest.LogCaptureFixture) -> None:
+    """Capture WARNING+ logger output for every test in this module.
+
+    Why:
+        #886 slice 18/N migrated operator-facing ``print()`` calls in
+        ``interactive_test_runner.py`` to ``logging.warning`` /
+        ``logging.error``. Setting the caplog level at WARNING makes all
+        migrated banners visible via ``caplog.text`` without per-test
+        boilerplate, keeping the assertion shape identical to the legacy
+        ``capsys`` pattern.
+    """
+    caplog.set_level(logging.WARNING)
 
 
 class _TelemetryStub:
@@ -158,17 +174,16 @@ def test_find_selector_match_returns_none_when_missing() -> None:
     assert InteractiveTestRunner._find_selector_match(sites, "gamma") is None
 
 
-def test_log_selector_miss_prints_and_logs(capsys, caplog) -> None:
-    """_log_selector_miss emits the legacy warning banner and a warning log."""
+def test_log_selector_miss_prints_and_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """_log_selector_miss emits the consolidated selector-miss warning record."""
     with caplog.at_level("WARNING"):
         InteractiveTestRunner._log_selector_miss("selector-xyz")
-    captured = capsys.readouterr()
-    assert "selector-xyz" in captured.out  # WHY: legacy operator-facing banner
-    assert any("not found" in rec.message for rec in caplog.records)  # WHY: warning log preserved
+    assert "selector-xyz" in caplog.text  # WHY: operator-facing selector id preserved in the record
+    assert any("not found" in rec.message for rec in caplog.records)  # WHY: diagnostic wording preserved
 
 
-def test_lookup_selector_site_returns_match(capsys) -> None:
-    """_lookup_selector_site returns the matched site tuple and prints the legacy success line."""
+def test_lookup_selector_site_returns_match(caplog: pytest.LogCaptureFixture) -> None:
+    """_lookup_selector_site returns the matched site tuple and logs the legacy success line."""
     mistapi_module = MagicMock()
     site_response = MagicMock()
     mistapi_module.api.v1.orgs.sites.listOrgSites.return_value = site_response
@@ -176,7 +191,7 @@ def test_lookup_selector_site_returns_match(capsys) -> None:
     runner = _make_runner(mistapi_module=mistapi_module)
     site_id, site_name = runner._lookup_selector_site("org-1", "site-a")
     assert (site_id, site_name) == ("site-a", "Alpha")
-    assert "Alpha" in capsys.readouterr().out  # WHY: legacy success message printed
+    assert "Alpha" in caplog.text  # WHY: legacy success message routed through the logger
 
 
 def test_lookup_selector_site_miss_returns_none() -> None:
@@ -190,7 +205,7 @@ def test_lookup_selector_site_miss_returns_none() -> None:
     assert site_name == "Unknown"
 
 
-def test_lookup_first_available_site_returns_none_when_empty(capsys) -> None:
+def test_lookup_first_available_site_returns_none_when_empty() -> None:
     """_lookup_first_available_site returns (None, 'Unknown') when the org has no sites."""
     mistapi_module = MagicMock()
     site_response = MagicMock()
@@ -233,35 +248,37 @@ def test_ensure_org_id_resolves_when_cache_empty() -> None:
     assert stored["org_id"] == "resolved-org"  # WHY: setter persisted the id
 
 
-def test_resolve_site_or_close_returns_none_when_no_sites(capsys) -> None:
-    """_resolve_site_or_close closes the emitter and prints the no-site banner when nothing is found."""
+def test_resolve_site_or_close_returns_none_when_no_sites(caplog: pytest.LogCaptureFixture) -> None:
+    """_resolve_site_or_close closes the emitter and logs the no-site banner when nothing is found."""
     mistapi_module = MagicMock()
     site_response = MagicMock()
     site_response.data = []  # WHY: no sites -> abort path
     mistapi_module.api.v1.orgs.sites.listOrgSites.return_value = site_response
     runner = _make_runner(mistapi_module=mistapi_module)
     emitter = _TelemetryStub("data/x.jsonl")
-    site_id, site_name = runner._resolve_site_or_close("org-1", emitter)
+    with caplog.at_level("ERROR"):  # WHY: no-site path now uses logging.error
+        site_id, site_name = runner._resolve_site_or_close("org-1", emitter)
     assert site_id is None
     assert site_name == ""
     assert emitter.closed is True  # WHY: emitter flushed on failure
-    assert "No sites found" in capsys.readouterr().out  # WHY: legacy error banner
+    assert "No sites found" in caplog.text  # WHY: legacy error banner now routed through the logger
 
 
-def test_resolve_site_or_close_handles_exception(capsys) -> None:
+def test_resolve_site_or_close_handles_exception(caplog: pytest.LogCaptureFixture) -> None:
     """_resolve_site_or_close catches exceptions from _resolve_test_site and closes the emitter."""
     mistapi_module = MagicMock()
     mistapi_module.api.v1.orgs.sites.listOrgSites.side_effect = RuntimeError("api boom")
     runner = _make_runner(mistapi_module=mistapi_module)
     emitter = _TelemetryStub("data/x.jsonl")
-    site_id, site_name = runner._resolve_site_or_close("org-1", emitter)
+    with caplog.at_level("ERROR"):  # WHY: failure path now uses logging.error
+        site_id, site_name = runner._resolve_site_or_close("org-1", emitter)
     assert site_id is None
     assert site_name == ""
     assert emitter.closed is True  # WHY: emitter flushed on failure
-    assert "Failed to fetch test site" in capsys.readouterr().out  # WHY: legacy failure banner
+    assert "Failed to fetch test site" in caplog.text  # WHY: legacy failure banner now via logger
 
 
-def test_emit_skip_events_records_skip_per_option(capsys) -> None:
+def test_emit_skip_events_records_skip_per_option() -> None:
     """_emit_skip_events emits telemetry for each option present in menu_actions."""
 
     def _noop_with_site(site_id: str | None = None) -> None:  # WHY: named callable so mypy can type-check
@@ -281,7 +298,7 @@ def test_emit_skip_events_records_skip_per_option(capsys) -> None:
     assert emitter.events[0][0] == "skip"  # WHY: skip event emitted first
 
 
-def test_print_skipped_options_writes_reason_lines(capsys) -> None:
+def test_print_skipped_options_writes_reason_lines(caplog: pytest.LogCaptureFixture) -> None:
     """_print_skipped_options renders one reason line per skipped option present in menu_actions."""
 
     def _noop_with_site(site_id: str | None = None) -> None:  # WHY: named callable so mypy can type-check
@@ -296,20 +313,18 @@ def test_print_skipped_options_writes_reason_lines(capsys) -> None:
     }
     runner = _make_runner(menu_actions=menu_actions, registry=_RegistryWithSkip)
     runner._print_skipped_options(["2"])
-    output = capsys.readouterr().out
-    assert "not-safe-in-tests" in output  # WHY: skip reason surfaces in output
-    assert "2" in output  # WHY: option id present
+    assert "not-safe-in-tests" in caplog.text  # WHY: skip reason surfaces in the log record
+    assert "2" in caplog.text  # WHY: option id present in the log record
 
 
-def test_print_summary_verdict_returns_false_when_failures(capsys, caplog) -> None:
+def test_print_summary_verdict_returns_false_when_failures(caplog: pytest.LogCaptureFixture) -> None:
     """_print_summary_verdict returns False and logs a warning when there are failures."""
     runner = _make_runner()
     tallies = SuiteTallies(success_count=1, error_count=2, skip_count=0, total_time=1.5)
     with caplog.at_level("WARNING"):
         result = runner._print_summary_verdict(tallies, interactive_total=3)
     assert result is False
-    assert "2 operations failed" in capsys.readouterr().out  # WHY: legacy failure banner
-    assert any("2 operations failed" in rec.message for rec in caplog.records)  # WHY: warning log
+    assert "2 operations failed" in caplog.text  # WHY: legacy failure banner routed through the logger
 
 
 def test_run_option_loop_records_failure_via_telemetry() -> None:


### PR DESCRIPTION
## Summary
- #886 slice 18/N: migrate all 35 `print()` sites in `src/troubleshooting/interactive_test_runner.py` to `logging.warning`/`logging.error` with %-style deferred formatting.
- Consolidate multi-line banners into single atomic log records (header 4→1, summary 10→1, listings 2→1, selector-miss 2→1); use `"\n".join(lines)` for dynamic lists via a single `%s` placeholder.
- Drop cosmetic blank-line `print()` calls rather than emitting empty log records.
- Migrate companion tests to `caplog` with a module-level autouse fixture at WARNING; add `caplog.at_level("ERROR")` on the two `_resolve_site_or_close` paths.

## Test plan
- [x] `ruff check` clean
- [x] `black --check` clean
- [x] Targeted `pytest tests/unit/troubleshooting/test_interactive_test_runner.py` — 46 passed
- [x] Full suite — 8949 passed / 0 failed / 77 skipped / 5 xfailed / 1 xpassed