### PR TITLE
chore(logging): migrate src/troubleshooting/marvis_troubleshoot_utils.py print() to logger (#886 slice 19/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 19/N: retire `print()` in `src/troubleshooting/marvis_troubleshoot_utils.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all `print()` calls in
+  `src/troubleshooting/marvis_troubleshoot_utils.py` (the extracted Marvis
+  client/device/network troubleshooting + insights workflows) with
+  `logging.warning(...)` for operator-visible banners, `logging.info(...)` for
+  structured pre/post API call records, `logging.debug(...)` for trace-level
+  entry/exit, and `logging.error(...)` / `logging.exception(...)` for
+  failure paths. Multi-line banners were consolidated into single
+  `logging.warning` records so headers arrive atomically at every configured
+  log handler: workflow entry banners (`client_connectivity`,
+  `device_performance`, `network_connectivity`, `view_insights`) each collapse
+  their menu header + divider into one record via
+  `logging.warning("%s\n%s", _MENU_HEADER_X, _HEADER_SEP)`; the shared error
+  guidance emitter (`_print_error_guidance`) assembles the failure message
+  plus canned bullets into a `list[str]` and emits one
+  `logging.warning("%s", "\n".join(lines))`; the raw-response preview helper
+  (`_print_raw_response_preview`) emits a single record with the truncation
+  suffix baked in; the raw-key preview helper (`_print_raw_keys_preview`)
+  builds its diagnostic lines and emits atomically. Cancel-path messages and
+  the static Marvis usage guide were folded into single WARNING records
+  rather than one-print-per-line. Cosmetic blank `print()` spacers were
+  dropped rather than emitted as empty log records.
+- **Test migration (Changed)**:
+  `tests/unit/troubleshooting/test_marvis_troubleshoot_utils_extended.py`
+  swapped all `capsys.readouterr().out` assertions for `caplog.text` across
+  every affected test and added a module-level autouse fixture
+  (`_capture_warnings`) that calls `caplog.set_level(logging.WARNING)` so
+  migrated warnings are captured deterministically across CI runners. The
+  two ERROR-routed paths (`test_view_insights_exception_hits_error_handler`,
+  `test_handle_insights_error_prints_guidance`) are wrapped with
+  `with caplog.at_level(logging.ERROR):` because `_handle_insights_error`
+  emits at ERROR level. The small companion `test_marvis_troubleshoot_utils.py`
+  received the same autouse fixture (even though it had no capsys usage) so
+  both test modules share a consistent capture posture.
+- **Verification**: `ruff check
+  src/troubleshooting/marvis_troubleshoot_utils.py
+  tests/unit/troubleshooting/test_marvis_troubleshoot_utils.py
+  tests/unit/troubleshooting/test_marvis_troubleshoot_utils_extended.py`
+  reports 0 issues; `black --check` clean; full `pytest` suite green
+  (8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 18/N: retire `print()` in `src/troubleshooting/interactive_test_runner.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 35 `print()` calls in

--- a/src/troubleshooting/marvis_troubleshoot_utils.py
+++ b/src/troubleshooting/marvis_troubleshoot_utils.py
@@ -55,6 +55,22 @@ _UNKNOWN_DEVICE: str = "Unknown Device"  # WHY: fallback device name when API om
 _INSIGHTS_LABEL_DEFAULT: str = "Marvis Insights"  # WHY: default section header for insights blocks.
 _SITES_SLE_ENDPOINT: str = "Organization Sites SLE"  # WHY: only endpoint currently registered for org insights.
 
+_USAGE_GUIDE_LINES: tuple[str, ...] = (  # WHY: static guidance rendered as one consolidated record.
+    "\n  Marvis (VNA - Virtual Network Assistant) Usage Guide:",
+    "   Targeted Troubleshooting:",
+    "     !? Use client troubleshooting for specific device connectivity issues",
+    "     !? Use device troubleshooting for AP, switch, or gateway performance",
+    "     !? Use network troubleshooting for site-wide connectivity analysis",
+    "   Requirements:",
+    "     !? Marvis must be enabled for your organization",
+    "     !? Devices must be actively managed and reporting data",
+    "     !? Sufficient data history for meaningful analysis",
+    "   Best Practices:",
+    "     !? Run troubleshooting when issues are actively occurring",
+    "     !? Provide specific timeframes when prompted",
+    "     !? Review saved CSV files for detailed analysis results",
+)
+
 
 class MarvisTroubleshootUtils:
     """Extracted implementation for Marvis troubleshooting workflows."""
@@ -63,12 +79,19 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def client_connectivity(deps: MarvisTroubleshootDeps) -> None:
-        """Troubleshoot client connectivity issues using Marvis AI."""
-        print(_MENU_HEADER_CLIENT)  # WHY: user-facing header.
-        print(_HEADER_SEP)  # WHY: visual separator for menu output.
+        """Troubleshoot client connectivity issues using Marvis AI.
+
+        Why:
+            Entry point for the client-scoped Marvis workflow; routes user
+            selection into the API-call wrapper and error boundary.
+
+        Args:
+            deps: injected dependency container.
+        """
+        logging.warning("%s\n%s", _MENU_HEADER_CLIENT, _HEADER_SEP)  # WHY: user-facing menu banner.
         client_mac, client_type, site_id = deps.prompt_client_utils.select_client()  # WHY: pick target client.
         if not client_mac:  # WHY: guard against user cancelling the prompt.
-            print(" No client selected. Returning to main menu.")  # WHY: cancel-path message.
+            logging.warning(" No client selected. Returning to main menu.")  # WHY: cancel-path message.
             return  # WHY: exit before any API call.
         org_id = deps.config_utils.get_cached_or_prompted_org_id()  # WHY: resolve org id (cached or prompt).
         params = MarvisTroubleshootUtils._build_client_params(client_mac, client_type, site_id)  # WHY: build kwargs.
@@ -79,17 +102,24 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def device_performance(deps: MarvisTroubleshootDeps) -> None:
-        """Troubleshoot device performance issues using Marvis AI."""
+        """Troubleshoot device performance issues using Marvis AI.
+
+        Why:
+            Entry point for the device-scoped Marvis workflow; wraps site +
+            device selection prompts, device metadata lookup, and API dispatch.
+
+        Args:
+            deps: injected dependency container.
+        """
         logging.debug("MARVIS DEBUG: Entering device_performance()")  # WHY: trace entry per existing convention.
-        print(_MENU_HEADER_DEVICE)  # WHY: user-facing header.
-        print(_HEADER_SEP)  # WHY: visual separator.
+        logging.warning("%s\n%s", _MENU_HEADER_DEVICE, _HEADER_SEP)  # WHY: user-facing menu banner.
         site_id = deps.prompt_utils.select_site()  # WHY: prompt for target site.
         if not site_id:  # WHY: user cancelled site selection.
-            print(" No site selected.")  # WHY: cancel-path message.
+            logging.warning(" No site selected.")  # WHY: cancel-path message.
             return  # WHY: exit early.
         device_id = deps.prompt_utils.select_device_id_from_inventory(site_id)  # WHY: canonical device chooser.
         if not device_id:  # WHY: user cancelled device selection.
-            print(" No device selected.")  # WHY: cancel-path message.
+            logging.warning(" No device selected.")  # WHY: cancel-path message.
             return  # WHY: exit early.
         org_id = deps.config_utils.get_cached_or_prompted_org_id()  # WHY: resolve org id once for API call.
         device_info = MarvisTroubleshootUtils._lookup_device(deps, site_id, device_id)  # WHY: fetch mac+name.
@@ -100,13 +130,20 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def network_connectivity(deps: MarvisTroubleshootDeps) -> None:
-        """Troubleshoot general network connectivity issues using Marvis AI."""
+        """Troubleshoot general network connectivity issues using Marvis AI.
+
+        Why:
+            Entry point for site-wide Marvis analysis; dispatches into API
+            wrapper after user-facing site selection.
+
+        Args:
+            deps: injected dependency container.
+        """
         logging.debug("MARVIS DEBUG: Entering network_connectivity()")  # WHY: trace entry.
-        print(_MENU_HEADER_NETWORK)  # WHY: user-facing header.
-        print(_HEADER_SEP)  # WHY: visual separator.
+        logging.warning("%s\n%s", _MENU_HEADER_NETWORK, _HEADER_SEP)  # WHY: user-facing menu banner.
         site_id = deps.prompt_utils.select_site()  # WHY: prompt for site to analyse.
         if not site_id:  # WHY: user cancelled.
-            print(" No site selected.")  # WHY: cancel-path message.
+            logging.warning(" No site selected.")  # WHY: cancel-path message.
             return  # WHY: exit early.
         org_id = deps.config_utils.get_cached_or_prompted_org_id()  # WHY: resolve org id (cached or prompt).
         MarvisTroubleshootUtils._announce_network_run(site_id)  # WHY: print + log run banner.
@@ -123,7 +160,19 @@ class MarvisTroubleshootUtils:
         client_mac: str,
         client_type: str,
     ) -> None:
-        """Execute the client troubleshoot API call and dispatch response/error paths."""
+        """Execute the client troubleshoot API call and dispatch response/error paths.
+
+        Why:
+            Centralises the try/except boundary around the Marvis client
+            troubleshoot SDK call so the calling entry point stays small.
+
+        Args:
+            deps: injected dependency container.
+            org_id: Mist organisation id.
+            params: kwargs forwarded to ``troubleshootOrg``.
+            client_mac: MAC address of the selected client.
+            client_type: ``wired``/``wireless``/``unknown``.
+        """
         try:  # WHY: funnel SDK errors to user guidance.
             logging.info("Invoking Marvis troubleshootOrg for client %s", client_mac)  # WHY: pre-action log.
             response = deps.mistapi.api.v1.orgs.troubleshoot.troubleshootOrg(  # WHY: call Marvis API.
@@ -133,8 +182,9 @@ class MarvisTroubleshootUtils:
             MarvisTroubleshootUtils._handle_client_response(deps, response, client_mac, client_type)  # WHY: dispatch.
         except Exception as error:  # noqa: BLE001 - Marvis SDK raises bare Exception subclasses.
             logging.error("Failed to troubleshoot client %s: %s", client_mac, error)  # WHY: log full context.
-            print(f"! Failed to troubleshoot client: {error}")  # WHY: show user-facing failure.
-            MarvisTroubleshootUtils._print_error_guidance("client")  # WHY: canned guidance.
+            MarvisTroubleshootUtils._print_error_guidance(  # WHY: user-visible guidance banner.
+                "client", f"! Failed to troubleshoot client: {error}"
+            )
 
     @staticmethod
     def _invoke_device_troubleshoot(
@@ -143,7 +193,18 @@ class MarvisTroubleshootUtils:
         site_id: str,
         device_info: tuple[str, str],
     ) -> None:
-        """Execute the device troubleshoot API call and dispatch response/error paths."""
+        """Execute the device troubleshoot API call and dispatch response/error paths.
+
+        Why:
+            Centralises the try/except boundary around the Marvis device
+            troubleshoot SDK call so the calling entry point stays small.
+
+        Args:
+            deps: injected dependency container.
+            org_id: Mist organisation id.
+            site_id: site id the device belongs to.
+            device_info: ``(mac, name)`` pair returned by ``_lookup_device``.
+        """
         device_mac, device_name = device_info  # WHY: unpack tuple for use in logging + API kwargs.
         MarvisTroubleshootUtils._announce_device_run(site_id, device_mac, device_name)  # WHY: print+log banner.
         try:  # WHY: funnel SDK errors to guidance.
@@ -157,12 +218,23 @@ class MarvisTroubleshootUtils:
             MarvisTroubleshootUtils._handle_device_response(deps, response, device_mac, device_name)  # WHY: dispatch.
         except Exception as error:  # noqa: BLE001 - bare Exception is the SDK contract.
             logging.exception("Exception in device_performance: %s", error)  # WHY: log with traceback.
-            print(f"! Failed to troubleshoot device: {error}")  # WHY: user-facing failure.
-            MarvisTroubleshootUtils._print_error_guidance("device")  # WHY: canned guidance.
+            MarvisTroubleshootUtils._print_error_guidance(  # WHY: user-visible guidance banner.
+                "device", f"! Failed to troubleshoot device: {error}"
+            )
 
     @staticmethod
     def _invoke_network_troubleshoot(deps: MarvisTroubleshootDeps, org_id: str, site_id: str) -> None:
-        """Execute the network troubleshoot API call and dispatch response/error paths."""
+        """Execute the network troubleshoot API call and dispatch response/error paths.
+
+        Why:
+            Centralises the try/except boundary around the site-wide Marvis
+            troubleshoot SDK call so the calling entry point stays small.
+
+        Args:
+            deps: injected dependency container.
+            org_id: Mist organisation id.
+            site_id: site id being analysed.
+        """
         try:  # WHY: funnel SDK errors to guidance.
             logging.info("Invoking Marvis troubleshootOrg for network site %s", site_id)  # WHY: pre-call log.
             response = deps.mistapi.api.v1.orgs.troubleshoot.troubleshootOrg(  # WHY: site-wide Marvis analysis.
@@ -172,8 +244,9 @@ class MarvisTroubleshootUtils:
             MarvisTroubleshootUtils._handle_network_response(deps, response, site_id)  # WHY: dispatch into display.
         except Exception as error:  # noqa: BLE001 - bare Exception is the SDK contract.
             logging.exception("Exception in network_connectivity: %s", error)  # WHY: log with traceback.
-            print(f"! Failed to troubleshoot network: {error}")  # WHY: user-facing failure.
-            MarvisTroubleshootUtils._print_error_guidance("network")  # WHY: canned guidance.
+            MarvisTroubleshootUtils._print_error_guidance(  # WHY: user-visible guidance banner.
+                "network", f"! Failed to troubleshoot network: {error}"
+            )
 
     # ---- per-workflow response handlers (small, CC <= 5 each) ----------------
 
@@ -184,13 +257,27 @@ class MarvisTroubleshootUtils:
         client_mac: str,
         client_type: str,
     ) -> None:
-        """Process the Marvis API response for a client troubleshoot run."""
+        """Process the Marvis API response for a client troubleshoot run.
+
+        Why:
+            Splits healthy-vs-issue rendering off the API wrapper so each
+            path stays small and testable.
+
+        Args:
+            deps: injected dependency container.
+            response: raw SDK response object.
+            client_mac: MAC address of the target client.
+            client_type: ``wired``/``wireless``/``unknown``.
+        """
         if not response.data:  # WHY: Marvis returned no findings — treat as healthy.
-            print(" No specific connectivity issues found for this client.")  # WHY: healthy-path message.
-            print(" This could indicate the client is functioning normally.")  # WHY: reassurance follow-up.
+            logging.warning(  # WHY: healthy-path message consolidated into one record.
+                " No specific connectivity issues found for this client.\n"
+                " This could indicate the client is functioning normally."
+            )
             return  # WHY: nothing left to save.
-        print(" Marvis AI analysis completed!")  # WHY: success banner.
-        print("! Analysis results available.")  # WHY: prompt user to expect results below.
+        logging.warning(  # WHY: success banner + follow-up prompt as one record.
+            " Marvis AI analysis completed!\n! Analysis results available."
+        )
         data = deps.marvis_data_utils.format_for_csv(response.data, "client")  # WHY: flatten for CSV export.
         filename = f"MarvisInsights_Client_{client_mac.replace(':', '')}_{client_type}.csv"  # WHY: stable name.
         MarvisTroubleshootUtils._persist_csv(deps, data, filename, "client")  # WHY: write + log.
@@ -205,12 +292,25 @@ class MarvisTroubleshootUtils:
         device_mac: str,
         device_name: str,
     ) -> None:
-        """Process the Marvis API response for a device troubleshoot run."""
+        """Process the Marvis API response for a device troubleshoot run.
+
+        Why:
+            Splits healthy-vs-issue rendering off the API wrapper so each
+            path stays small and testable.
+
+        Args:
+            deps: injected dependency container.
+            response: raw SDK response object.
+            device_mac: MAC address of the target device.
+            device_name: friendly device name for filenames.
+        """
         if not response.data:  # WHY: healthy device — no findings.
-            print(" No performance issues detected for this device.")  # WHY: healthy-path message.
-            print(" This could indicate the device is operating within normal parameters.")  # WHY: reassurance.
+            logging.warning(  # WHY: healthy-path message consolidated into one record.
+                " No performance issues detected for this device.\n"
+                " This could indicate the device is operating within normal parameters."
+            )
             return  # WHY: nothing to save.
-        print(" Marvis AI device analysis completed!")  # WHY: success banner.
+        logging.warning(" Marvis AI device analysis completed!")  # WHY: success banner.
         data = deps.marvis_data_utils.format_for_csv(response.data, "device")  # WHY: CSV-friendly rows.
         safe_name = device_name.replace(" ", "_")  # WHY: sanitise device name for filesystem.
         filename = f"MarvisInsights_Device_{device_mac.replace(':', '')}_{safe_name}.csv"  # WHY: deterministic.
@@ -221,12 +321,24 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _handle_network_response(deps: MarvisTroubleshootDeps, response: Any, site_id: str) -> None:
-        """Process the Marvis API response for a site-wide troubleshoot run."""
+        """Process the Marvis API response for a site-wide troubleshoot run.
+
+        Why:
+            Splits healthy-vs-issue rendering off the API wrapper so each
+            path stays small and testable.
+
+        Args:
+            deps: injected dependency container.
+            response: raw SDK response object.
+            site_id: site id being analysed.
+        """
         if not response.data:  # WHY: healthy site — no findings.
-            print(" No network connectivity issues detected for this site.")  # WHY: healthy-path message.
-            print(" This indicates the network is operating within normal parameters.")  # WHY: reassurance.
+            logging.warning(  # WHY: healthy-path message consolidated into one record.
+                " No network connectivity issues detected for this site.\n"
+                " This indicates the network is operating within normal parameters."
+            )
             return  # WHY: nothing to save.
-        print(" Marvis AI network analysis completed!")  # WHY: success banner.
+        logging.warning(" Marvis AI network analysis completed!")  # WHY: success banner.
         data = deps.marvis_data_utils.format_for_csv(response.data, "network")  # WHY: flatten for CSV.
         filename = f"MarvisInsights_Network_{site_id}.csv"  # WHY: per-site filename.
         MarvisTroubleshootUtils._persist_csv(deps, data, filename, "network")  # WHY: write + log.
@@ -243,12 +355,23 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _persist_csv(deps: MarvisTroubleshootDeps, data: Any, filename: str, kind: str) -> None:
-        """Write a Marvis CSV artifact with symmetric info/debug logging around the call."""
+        """Write a Marvis CSV artifact with symmetric info/debug logging around the call.
+
+        Why:
+            Centralises the info+debug logging bracket so per-workflow
+            handlers do not repeat the same three-line pattern.
+
+        Args:
+            deps: injected dependency container.
+            data: CSV-ready row payload.
+            filename: output filename (already sanitised).
+            kind: human-readable category (``client``/``device``/``network``).
+        """
         logging.info("Saving Marvis %s CSV to %s", kind, filename)  # WHY: pre-write log with category.
         deps.data_exporter.write_with_format_selection(data, filename)  # WHY: persist results.
         row_count = len(data) if data else 0  # WHY: guard against None/empty rows before len().
         logging.debug("Marvis %s CSV saved (rows=%s)", kind, row_count)  # WHY: post-write log.
-        print(f"! Results saved to {filename}")  # WHY: user confirmation.
+        logging.warning("! Results saved to %s", filename)  # WHY: user confirmation.
 
     # ---- shared display / dispatch helpers (each CC <= 5) --------------------
 
@@ -260,7 +383,19 @@ class MarvisTroubleshootUtils:
         insights_label: str = _INSIGHTS_LABEL_DEFAULT,
         show_raw_keys: bool = False,
     ) -> None:
-        """Render a results / insights summary from a Marvis response dict."""
+        """Render a results / insights summary from a Marvis response dict.
+
+        Why:
+            Common dispatch for the three response handlers so schema-branch
+            logic lives in one place.
+
+        Args:
+            response_data: raw response ``data`` field.
+            data: CSV-formatted rows already produced from ``response_data``.
+            results_header: header for the ``results`` branch.
+            insights_label: header for the ``insights`` branch.
+            show_raw_keys: whether to render a raw-key preview in fallback.
+        """
         if not isinstance(response_data, dict):  # WHY: non-dict responses are rendered raw elsewhere.
             return  # WHY: nothing structured to summarise.
         if "results" in response_data:  # WHY: standard Marvis results schema.
@@ -277,73 +412,166 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _render_summary_fallback(response_data: dict, data: Any, show_raw_keys: bool) -> None:
-        """Fallback renderer when neither ``results`` nor ``insights`` keys are present."""
+        """Fallback renderer when neither ``results`` nor ``insights`` keys are present.
+
+        Why:
+            Ensures unknown Marvis schemas still surface item counts and, for
+            the network workflow, a bounded key preview.
+
+        Args:
+            response_data: raw response dict.
+            data: CSV-formatted rows.
+            show_raw_keys: whether to render the raw-key preview.
+        """
         items_processed = len(data) if data else 0  # WHY: how many flattened rows resulted.
-        print(f"\n  Analysis Data: {items_processed} items processed")  # WHY: user-facing count.
+        logging.warning("\n  Analysis Data: %s items processed", items_processed)  # WHY: user-facing count.
         if show_raw_keys and response_data:  # WHY: network workflow opted into raw-key preview.
             MarvisTroubleshootUtils._print_raw_keys_preview(response_data)  # WHY: bounded preview.
 
     @staticmethod
     def _render_results_section(results: Any, results_header: str) -> None:
-        """Print bullet list for a Marvis ``results`` array."""
-        print(f"\n  {results_header}:")  # WHY: section header.
+        """Print bullet list for a Marvis ``results`` array.
+
+        Why:
+            Consumers want a single dispatch that emits header + bullets even
+            when the API returns ``None`` or an empty list.
+
+        Args:
+            results: iterable of finding dicts / raw scalars.
+            results_header: heading to render before bullets.
+        """
+        logging.warning("\n  %s:", results_header)  # WHY: section header.
         for result in results or []:  # WHY: iterate; treat missing list as empty.
             MarvisTroubleshootUtils._print_result_bullet(result)  # WHY: per-result renderer.
 
     @staticmethod
     def _print_result_bullet(result: Any) -> None:
-        """Print a single result bullet, including recommended action when present."""
+        """Print a single result bullet, including recommended action when present.
+
+        Why:
+            Isolates per-result rendering so the loop stays tight and dict/
+            non-dict fallbacks stay together.
+
+        Args:
+            result: dict finding or raw scalar.
+        """
         if not isinstance(result, dict):  # WHY: non-dict finding — stringify directly.
-            print(f"  !? {result}")  # WHY: fallback rendering.
+            logging.warning("  !? %s", result)  # WHY: fallback rendering.
             return  # WHY: nothing more to display.
-        print(f"  !? {result.get('description', 'Analysis result')}")  # WHY: dict finding description.
+        description = result.get("description", "Analysis result")  # WHY: cache lookup for downstream branches.
         action = result.get("action")  # WHY: optional recommended action.
         if action:  # WHY: only show action when the API supplied one.
-            print(f"    Recommended Action: {action}")  # WHY: guidance line.
+            logging.warning("  !? %s\n    Recommended Action: %s", description, action)  # WHY: bullet + action.
+            return  # WHY: rendered together to keep one record per finding.
+        logging.warning("  !? %s", description)  # WHY: dict finding without action.
 
     @staticmethod
     def _render_insights_section(insights: Any, insights_label: str) -> None:
-        """Print bullet list for a Marvis ``insights`` array."""
-        print(f"\n  {insights_label}:")  # WHY: section header.
+        """Print bullet list for a Marvis ``insights`` array.
+
+        Why:
+            Parallel to results dispatch; keeps the insights-vs-results branch
+            symmetrical for maintenance.
+
+        Args:
+            insights: iterable of insight dicts / raw scalars.
+            insights_label: heading to render before bullets.
+        """
+        logging.warning("\n  %s:", insights_label)  # WHY: section header.
         for insight in insights or []:  # WHY: iterate; treat missing list as empty.
             description = MarvisTroubleshootUtils._insight_description(insight)  # WHY: consistent renderer.
-            print(f"  !? {description}")  # WHY: bullet output.
+            logging.warning("  !? %s", description)  # WHY: bullet output.
 
     @staticmethod
     def _insight_description(insight: Any) -> str:
-        """Return a human-readable description string for a raw insight payload."""
+        """Return a human-readable description string for a raw insight payload.
+
+        Why:
+            Consumers need a single stringification rule regardless of whether
+            the API returns a dict or a scalar.
+
+        Args:
+            insight: raw insight (dict or scalar).
+
+        Returns:
+            String description suitable for a bullet render.
+        """
         if isinstance(insight, dict):  # WHY: dicts expose a preferred description field.
             return str(insight.get("description", insight))  # WHY: fallback to repr when missing.
         return str(insight)  # WHY: non-dicts stringify directly.
 
     @staticmethod
     def _print_raw_keys_preview(response_data: dict) -> None:
-        """Print up to five raw key/value pairs for diagnostic visibility."""
-        print(f"! Raw response keys: {list(response_data.keys())}")  # WHY: show top-level keys.
+        """Print up to five raw key/value pairs for diagnostic visibility.
+
+        Why:
+            Gives operators a bounded look at unknown Marvis payloads without
+            dumping potentially unbounded content.
+
+        Args:
+            response_data: raw response dict.
+        """
+        lines = [f"! Raw response keys: {list(response_data.keys())}"]  # WHY: show top-level keys.
         for key, value in list(response_data.items())[:_MAX_RAW_PREVIEW_KEYS]:  # WHY: bounded preview.
             text = str(value)  # WHY: stringify for length check + truncation.
             suffix = "..." if len(text) > _MAX_RAW_VALUE_LEN else ""  # WHY: mark truncation.
-            print(f"   {key}: {text[:_MAX_RAW_VALUE_LEN]}{suffix}")  # WHY: truncated preview line.
+            lines.append(f"   {key}: {text[:_MAX_RAW_VALUE_LEN]}{suffix}")  # WHY: truncated preview line.
+        logging.warning("%s", "\n".join(lines))  # WHY: emit consolidated preview as one record.
 
     @staticmethod
     def _print_raw_response_preview(response_data: Any) -> None:
-        """Print a bounded stringified preview of a non-dict Marvis response body."""
+        """Print a bounded stringified preview of a non-dict Marvis response body.
+
+        Why:
+            Non-dict payloads still deserve visibility; truncation avoids
+            flooding the log with huge bodies.
+
+        Args:
+            response_data: raw response body.
+        """
         text = str(response_data)  # WHY: stringify once for length checks.
         suffix = "..." if len(text) > _MAX_RAW_RESPONSE_LEN else ""  # WHY: mark truncation.
-        print(f"\n  Raw response: {text[:_MAX_RAW_RESPONSE_LEN]}{suffix}")  # WHY: bounded preview line.
+        logging.warning("\n  Raw response: %s%s", text[:_MAX_RAW_RESPONSE_LEN], suffix)  # WHY: bounded preview.
 
     @staticmethod
-    def _print_error_guidance(kind: str) -> None:
-        """Print canned guidance bullets for a known Marvis failure category."""
-        print(" This may indicate:")  # WHY: user-facing intro.
-        for line in _MARVIS_ERROR_GUIDANCE.get(kind, ()):  # WHY: look up bullets by workflow kind.
-            print(line)  # WHY: one bullet per line.
+    def _print_error_guidance(kind: str, failure_message: str | None = None) -> None:
+        """Print canned guidance bullets for a known Marvis failure category.
+
+        Why:
+            Collapses the failure banner + guidance bullets into one atomic
+            record; callers optionally prepend a workflow-specific failure
+            message so users see the error and remediation together.
+
+        Args:
+            kind: workflow key (``client``/``device``/``network``).
+            failure_message: optional workflow-specific failure banner
+                prepended above the shared "This may indicate:" intro.
+        """
+        lines: list[str] = []  # WHY: assemble multi-line record.
+        if failure_message:  # WHY: workflow wrappers pass ``! Failed to troubleshoot ...``.
+            lines.append(failure_message)  # WHY: user-visible failure banner first.
+        lines.append(" This may indicate:")  # WHY: shared guidance intro.
+        lines.extend(_MARVIS_ERROR_GUIDANCE.get(kind, ()))  # WHY: guidance bullets for known kinds.
+        logging.warning("%s", "\n".join(lines))  # WHY: emit consolidated guidance as one record.
 
     # ---- workflow-specific micro helpers (one job each, CC <= 3) -------------
 
     @staticmethod
     def _build_client_params(client_mac: str, client_type: str, site_id: str | None) -> dict[str, Any]:
-        """Assemble keyword arguments for the Marvis client troubleshoot call."""
+        """Assemble keyword arguments for the Marvis client troubleshoot call.
+
+        Why:
+            Kept as a pure builder so the invocation wrapper stays free of
+            optional-parameter branching.
+
+        Args:
+            client_mac: MAC address (mandatory).
+            client_type: ``wired``/``wireless``/``unknown``.
+            site_id: optional site scope.
+
+        Returns:
+            Kwargs dict ready for ``**params`` expansion into the SDK call.
+        """
         params: dict[str, Any] = {"mac": client_mac}  # WHY: mandatory MAC parameter.
         if site_id:  # WHY: scope to a site when one was selected.
             params["site_id"] = site_id  # WHY: attach site filter.
@@ -354,11 +582,25 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _announce_client_run(client_mac: str, client_type: str, site_id: str | None) -> None:
-        """Print and log the start of a client troubleshoot run."""
-        print(f"! Running Marvis AI analysis for client {client_mac}...")  # WHY: user banner.
-        print(f"   Client Type: {client_type}")  # WHY: echo detected client type.
-        if site_id:  # WHY: only echo site when provided.
-            print(f"   Site ID: {site_id}")  # WHY: echo site id.
+        """Print and log the start of a client troubleshoot run.
+
+        Why:
+            Users need a visible confirmation of which client is about to be
+            analysed; a paired structured log captures the same context for
+            operators reading the logs.
+
+        Args:
+            client_mac: MAC of the selected client.
+            client_type: ``wired``/``wireless``/``unknown``.
+            site_id: optional site scope (omitted from the banner when None).
+        """
+        lines = [  # WHY: assemble consolidated banner for one record.
+            f"! Running Marvis AI analysis for client {client_mac}...",
+            f"   Client Type: {client_type}",
+        ]
+        if site_id:  # WHY: only echo site when provided (test verifies omission).
+            lines.append(f"   Site ID: {site_id}")  # WHY: echo site id.
+        logging.warning("%s", "\n".join(lines))  # WHY: user banner as single record.
         logging.info(  # WHY: structured pre-run record.
             "Starting Marvis client troubleshooting (mac=%s, type=%s, site=%s)",
             client_mac,
@@ -368,10 +610,24 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _announce_device_run(site_id: str, device_mac: str, device_name: str) -> None:
-        """Print and log the start of a device troubleshoot run."""
-        print("! Running Marvis AI performance analysis...")  # WHY: user banner.
-        print(f"   Device: {device_name} ({device_mac})")  # WHY: echo device identity.
-        print(f"   Site ID: {site_id}")  # WHY: echo site id.
+        """Print and log the start of a device troubleshoot run.
+
+        Why:
+            Users need a visible confirmation of which device is about to be
+            analysed; a paired structured log captures the same context for
+            operators reading the logs.
+
+        Args:
+            site_id: site id the device belongs to.
+            device_mac: MAC address of the device.
+            device_name: friendly device name.
+        """
+        logging.warning(  # WHY: user banner consolidated into one record.
+            "! Running Marvis AI performance analysis...\n" "   Device: %s (%s)\n" "   Site ID: %s",
+            device_name,
+            device_mac,
+            site_id,
+        )
         logging.info(  # WHY: structured pre-run record.
             "Starting Marvis device performance analysis (device=%s, mac=%s, site=%s)",
             device_name,
@@ -381,29 +637,53 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _announce_network_run(site_id: str) -> None:
-        """Print and log the start of a network troubleshoot run."""
-        print("! Running Marvis AI network analysis...")  # WHY: user banner.
-        print("   Analyzing site-level connectivity")  # WHY: describe scope of analysis.
-        print(f"   Site ID: {site_id}")  # WHY: echo site id.
+        """Print and log the start of a network troubleshoot run.
+
+        Why:
+            Users need a visible confirmation of which site is about to be
+            analysed; a paired structured log captures the same context for
+            operators reading the logs.
+
+        Args:
+            site_id: site id being analysed.
+        """
+        logging.warning(  # WHY: user banner consolidated into one record.
+            "! Running Marvis AI network analysis...\n" "   Analyzing site-level connectivity\n" "   Site ID: %s",
+            site_id,
+        )
         logging.info("Starting Marvis network connectivity analysis for site=%s", site_id)  # WHY: structured log.
 
     @staticmethod
     def _lookup_device(deps: MarvisTroubleshootDeps, site_id: str, device_id: str) -> tuple[str, str] | None:
-        """Fetch a device record and return (mac, name); print + return None on failure."""
+        """Fetch a device record and return (mac, name); print + return None on failure.
+
+        Why:
+            Marvis needs a MAC to run; the device lookup lives in its own
+            helper so the entry point stays small and testable.
+
+        Args:
+            deps: injected dependency container.
+            site_id: site id the device belongs to.
+            device_id: Mist device id.
+
+        Returns:
+            ``(mac, name)`` on success, else ``None`` after emitting a
+            user-facing warning describing the failure.
+        """
         logging.info("Looking up device %s in site %s", device_id, site_id)  # WHY: pre-call log.
-        print("! Looking up device details...")  # WHY: user progress message.
+        logging.warning("! Looking up device details...")  # WHY: user progress message.
         device_response = deps.mistapi.api.v1.sites.devices.getSiteDevice(  # WHY: fetch device details.
             deps.apisession, site_id, device_id
         )
         if not device_response.data:  # WHY: device API returned nothing.
-            print(" Could not retrieve device details.")  # WHY: user message.
+            logging.warning(" Could not retrieve device details.")  # WHY: user message.
             logging.debug("Device lookup returned empty data for %s", device_id)  # WHY: diagnostic.
             return None  # WHY: signal failure to caller.
         device_mac = device_response.data.get("mac")  # WHY: extract MAC for downstream Marvis call.
         device_name = device_response.data.get("name", _UNKNOWN_DEVICE)  # WHY: friendly name fallback.
         logging.debug("Resolved device: name=%s mac=%s", device_name, device_mac)  # WHY: post-call log.
         if not device_mac:  # WHY: cannot Marvis-query without a MAC.
-            print(" Could not determine device MAC address.")  # WHY: user message.
+            logging.warning(" Could not determine device MAC address.")  # WHY: user message.
             return None  # WHY: signal failure to caller.
         logging.debug("Device payload: %s", json.dumps(device_response.data, indent=2, default=str))  # WHY: dump.
         return device_mac, device_name  # WHY: hand back tuple for downstream API call.
@@ -412,9 +692,16 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def view_insights(deps: MarvisTroubleshootDeps) -> None:
-        """View available Marvis insights and capabilities."""
-        print(_MENU_HEADER_INSIGHTS)  # WHY: user banner.
-        print(_HEADER_SEP)  # WHY: visual separator.
+        """View available Marvis insights and capabilities.
+
+        Why:
+            Entry point that orchestrates the org metadata + insights + usage
+            guide render pipeline under a single error boundary.
+
+        Args:
+            deps: injected dependency container.
+        """
+        logging.warning("%s\n%s", _MENU_HEADER_INSIGHTS, _HEADER_SEP)  # WHY: user-facing menu banner.
         org_id = deps.config_utils.get_cached_or_prompted_org_id()  # WHY: resolve org id.
         try:  # WHY: funnel unexpected errors to shared handler.
             org_info = MarvisTroubleshootUtils._fetch_org_info(deps, org_id)  # WHY: pull org metadata.
@@ -428,31 +715,63 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _fetch_org_info(deps: MarvisTroubleshootDeps, org_id: str) -> dict | None:
-        """Return org metadata dict or None if the API call produced no data."""
-        print(" Checking Marvis availability and organizational insights...")  # WHY: progress message.
+        """Return org metadata dict or None if the API call produced no data.
+
+        Why:
+            Isolates the metadata call so ``view_insights`` stays flat.
+
+        Args:
+            deps: injected dependency container.
+            org_id: Mist organisation id.
+
+        Returns:
+            Org metadata dict on success, else ``None`` after logging a
+            user-facing warning.
+        """
+        logging.warning(" Checking Marvis availability and organizational insights...")  # WHY: progress message.
         logging.info("Fetching org metadata for Marvis insights view (org=%s)", org_id)  # WHY: pre-call log.
         org_response = deps.mistapi.api.v1.orgs.orgs.getOrg(deps.apisession, org_id)  # WHY: org metadata call.
         logging.debug("Org metadata fetched (has_data=%s)", bool(org_response.data))  # WHY: post-call log.
         if not org_response.data:  # WHY: empty response — cannot render insights.
-            print(" Could not retrieve organization information.")  # WHY: user message.
+            logging.warning(" Could not retrieve organization information.")  # WHY: user message.
             return None  # WHY: signal failure.
         return org_response.data  # WHY: hand back raw dict to caller.
 
     @staticmethod
     def _display_org_features(org_info: dict) -> None:
-        """Print the org name and any detected Marvis/VNA feature toggles."""
-        print(f"! Organization: {org_info.get('name', 'Unknown')}")  # WHY: org banner.
+        """Print the org name and any detected Marvis/VNA feature toggles.
+
+        Why:
+            Provides quick visibility into whether Marvis features are
+            enabled for the current organisation.
+
+        Args:
+            org_info: org metadata dict from the API.
+        """
+        logging.warning("! Organization: %s", org_info.get("name", "Unknown"))  # WHY: org banner.
         marvis_features = MarvisTroubleshootUtils._filter_marvis_features(org_info.get("features", []))  # WHY: filter.
         if not marvis_features:  # WHY: no toggles found.
-            print("\n  No specific Marvis/VNA features detected in organization settings.")  # WHY: user message.
+            logging.warning("\n  No specific Marvis/VNA features detected in organization settings.")  # WHY: message.
             return  # WHY: nothing to enumerate.
-        print("\n  Marvis/VNA Features Available:")  # WHY: section header.
+        lines = ["\n  Marvis/VNA Features Available:"]  # WHY: section header.
         for feature in marvis_features:  # WHY: enumerate detected toggles.
-            print(f"  !? {feature}")  # WHY: bullet output.
+            lines.append(f"  !? {feature}")  # WHY: bullet output.
+        logging.warning("%s", "\n".join(lines))  # WHY: emit consolidated section as one record.
 
     @staticmethod
     def _filter_marvis_features(features: Any) -> list[str]:
-        """Return org feature entries whose name mentions any Marvis/VNA keyword."""
+        """Return org feature entries whose name mentions any Marvis/VNA keyword.
+
+        Why:
+            Central filter so both the enumeration and any future callers use
+            identical keyword matching.
+
+        Args:
+            features: raw features list from the API.
+
+        Returns:
+            List of feature names that matched a Marvis/VNA keyword.
+        """
         return [  # WHY: comprehension keeps the caller free of branching.
             feature
             for feature in (features or [])  # WHY: tolerate None/empty input.
@@ -462,25 +781,55 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _is_marvis_feature(feature: str) -> bool:
-        """Return True if the feature name contains any known Marvis/VNA keyword."""
+        """Return True if the feature name contains any known Marvis/VNA keyword.
+
+        Why:
+            Central keyword scanner keeps the substring set in one place.
+
+        Args:
+            feature: feature name (case-insensitive match applied).
+
+        Returns:
+            True if any known Marvis/VNA keyword substring is present.
+        """
         lowered = feature.lower()  # WHY: case-insensitive matching.
         return any(keyword in lowered for keyword in _MARVIS_FEATURE_KEYWORDS)  # WHY: keyword scan.
 
     @staticmethod
     def _fetch_org_insights(org_id: str, deps: MarvisTroubleshootDeps) -> None:
-        """Fetch and display organization-level insights."""
+        """Fetch and display organization-level insights.
+
+        Why:
+            Wraps the insight-endpoint iteration in a broad try/except so a
+            single failure does not abort the surrounding view.
+
+        Args:
+            org_id: Mist organisation id.
+            deps: injected dependency container.
+        """
         try:  # WHY: bound errors from insight collection so usage guide still renders.
-            print("\n Attempting to retrieve organization-level insights...")  # WHY: progress message.
+            logging.warning("\n Attempting to retrieve organization-level insights...")  # WHY: progress message.
             insights_found = MarvisTroubleshootUtils._iter_insight_endpoints(org_id, deps)  # WHY: loop dispatch.
             if not insights_found:  # WHY: tell user when no endpoint produced data.
-                print("\n  No organization-level insights currently available.")  # WHY: user message.
+                logging.warning("\n  No organization-level insights currently available.")  # WHY: user message.
         except Exception as error:  # noqa: BLE001 - broad SDK exception surface.
             logging.warning("Could not retrieve organization insights: %s", error)  # WHY: log context.
-            print(f"! Could not retrieve insights: {error}")  # WHY: user-facing failure.
+            logging.warning("! Could not retrieve insights: %s", error)  # WHY: user-facing failure.
 
     @staticmethod
     def _iter_insight_endpoints(org_id: str, deps: MarvisTroubleshootDeps) -> bool:
-        """Iterate registered insight endpoints and return True if any yielded data."""
+        """Iterate registered insight endpoints and return True if any yielded data.
+
+        Why:
+            Loop dispatch pulled out so ``_fetch_org_insights`` stays small.
+
+        Args:
+            org_id: Mist organisation id.
+            deps: injected dependency container.
+
+        Returns:
+            True if at least one endpoint yielded and rendered data.
+        """
         insights_found = False  # WHY: track whether anything produced output.
         for endpoint_name, endpoint_func in MarvisTroubleshootUtils._insight_endpoints(org_id, deps):  # WHY: table.
             if MarvisTroubleshootUtils._try_insight_endpoint(endpoint_name, endpoint_func, deps):  # WHY: guarded.
@@ -489,7 +838,19 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _insight_endpoints(org_id: str, deps: MarvisTroubleshootDeps) -> tuple[tuple[str, Any], ...]:
-        """Return the registered ``(name, callable)`` insight endpoint table."""
+        """Return the registered ``(name, callable)`` insight endpoint table.
+
+        Why:
+            Centralises endpoint registration so future insight sources can
+            be added in one place.
+
+        Args:
+            org_id: Mist organisation id.
+            deps: injected dependency container.
+
+        Returns:
+            Tuple of ``(display_name, zero_arg_callable)`` pairs.
+        """
         return (  # WHY: single entry today; tuple keeps future additions localised.
             (
                 _SITES_SLE_ENDPOINT,
@@ -499,7 +860,20 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _try_insight_endpoint(endpoint_name: str, endpoint_func: Any, deps: MarvisTroubleshootDeps) -> bool:
-        """Invoke one insight endpoint and process its response; return True if data was rendered."""
+        """Invoke one insight endpoint and process its response; return True if data was rendered.
+
+        Why:
+            Per-endpoint try/except keeps the iteration loop resilient — a
+            403/404 on one endpoint must not stop the others.
+
+        Args:
+            endpoint_name: display name of the endpoint.
+            endpoint_func: zero-arg callable that returns an SDK response.
+            deps: injected dependency container.
+
+        Returns:
+            True if data was rendered, False on empty/error responses.
+        """
         try:  # WHY: individual endpoint errors must not abort the loop.
             logging.debug("Testing insight endpoint: %s", endpoint_name)  # WHY: trace which endpoint runs.
             response = endpoint_func()  # WHY: live API call.
@@ -512,7 +886,20 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _process_insight_response(endpoint_name: str, data: Any, deps: MarvisTroubleshootDeps) -> bool:
-        """Process and display one insight endpoint response."""
+        """Process and display one insight endpoint response.
+
+        Why:
+            Normalises list vs scalar payloads and dispatches into the
+            appropriate formatter + persistence path.
+
+        Args:
+            endpoint_name: endpoint display name (drives CSV filename).
+            data: raw response ``data`` payload.
+            deps: injected dependency container.
+
+        Returns:
+            True if a CSV was written and a preview rendered, else False.
+        """
         insights_data = data if isinstance(data, list) else [data]  # WHY: normalise to list.
         logging.debug("%s insights data length: %s", endpoint_name, len(insights_data))  # WHY: diagnostic.
         if not insights_data:  # WHY: nothing to display.
@@ -525,25 +912,62 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _print_insight_preview(endpoint_name: str, insights_data: list[Any]) -> None:
-        """Print a bounded preview of insight descriptions plus overflow count."""
-        print(f"\n  {endpoint_name}:")  # WHY: section header.
+        """Print a bounded preview of insight descriptions plus overflow count.
+
+        Why:
+            Consolidates the preview + overflow marker into a single record
+            so operators see the section header, bullets, and the ``... and
+            N more`` line grouped together.
+
+        Args:
+            endpoint_name: endpoint display name used as section header.
+            insights_data: full insights list (used for overflow computation).
+        """
+        lines = [f"\n  {endpoint_name}:"]  # WHY: section header.
         for insight in insights_data[:_MAX_PREVIEW_INSIGHTS]:  # WHY: bounded preview.
             description = MarvisTroubleshootUtils._describe_insight(insight)  # WHY: consistent renderer.
-            print(f"  !? {description}")  # WHY: bullet output.
+            lines.append(f"  !? {description}")  # WHY: bullet output.
         overflow = len(insights_data) - _MAX_PREVIEW_INSIGHTS  # WHY: how many rows are hidden.
         if overflow > 0:  # WHY: tell the user there is more in the CSV.
-            print(f"  ... and {overflow} more insights")  # WHY: overflow message.
+            lines.append(f"  ... and {overflow} more insights")  # WHY: overflow message.
+        logging.warning("%s", "\n".join(lines))  # WHY: emit consolidated preview as one record.
 
     @staticmethod
     def _describe_insight(insight: Any) -> Any:
-        """Return the best-effort description string for an insight payload."""
+        """Return the best-effort description string for an insight payload.
+
+        Why:
+            The Marvis SDK returns heterogeneous shapes; this helper picks
+            the most informative field available.
+
+        Args:
+            insight: raw insight (dict or scalar).
+
+        Returns:
+            The most descriptive field found (``description``/``type``/
+            ``name``) or ``str(insight)`` as final fallback.
+        """
         if not isinstance(insight, dict):  # WHY: non-dicts render as-is.
             return insight  # WHY: fallback to raw value.
         return insight.get("description", insight.get("type", insight.get("name", str(insight))))  # WHY: chain.
 
     @staticmethod
     def _format_insights(endpoint_name: str, data: Any, insights_data: list[Any], deps: MarvisTroubleshootDeps) -> Any:
-        """Return CSV-ready rows using the SLE-specific formatter when applicable."""
+        """Return CSV-ready rows using the SLE-specific formatter when applicable.
+
+        Why:
+            SLE data has a dedicated formatter; every other endpoint gets a
+            generic flatten + escape pass.
+
+        Args:
+            endpoint_name: endpoint display name (selects formatter branch).
+            data: raw response ``data`` payload.
+            insights_data: normalised list form of the payload.
+            deps: injected dependency container.
+
+        Returns:
+            CSV-ready row iterable ready for the data exporter.
+        """
         if "Sites SLE" in endpoint_name:  # WHY: SLE has a dedicated formatter.
             return deps.marvis_data_utils.format_for_csv(data, "sites")  # WHY: SLE-aware CSV rows.
         flattened = deps.data_processing_utils.flatten_nested_fields(insights_data)  # WHY: generic flatten.
@@ -551,16 +975,35 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _persist_insight_csv(deps: MarvisTroubleshootDeps, formatted_insights: Any, filename: str) -> None:
-        """Persist a formatted insights payload with symmetric info/debug logs."""
+        """Persist a formatted insights payload with symmetric info/debug logs.
+
+        Why:
+            Mirrors ``_persist_csv``: pre-write info, post-write debug, and
+            a user-visible confirmation line.
+
+        Args:
+            deps: injected dependency container.
+            formatted_insights: CSV-ready rows.
+            filename: output filename (already sanitised).
+        """
         logging.info("Saving insights CSV: %s", filename)  # WHY: pre-write log.
         deps.data_exporter.write_with_format_selection(formatted_insights, filename)  # WHY: persist.
         row_count = len(formatted_insights) if formatted_insights else 0  # WHY: guard against None/empty.
         logging.debug("Insights CSV saved (rows=%s)", row_count)  # WHY: post-write log.
-        print(f"  Full insights saved to {filename}")  # WHY: user confirmation.
+        logging.warning("  Full insights saved to %s", filename)  # WHY: user confirmation.
 
     @staticmethod
     def _log_endpoint_error(endpoint_name: str, exception: Exception) -> None:
-        """Log endpoint-specific insight fetch errors."""
+        """Log endpoint-specific insight fetch errors.
+
+        Why:
+            Classifies known error signatures (404 disabled, 403 permission)
+            so operators can distinguish "not enabled" from "misconfigured".
+
+        Args:
+            endpoint_name: endpoint display name for the log message.
+            exception: caught exception.
+        """
         error_message = str(exception)  # WHY: stringified once for the substring checks below.
         if "404" in error_message:  # WHY: endpoint not enabled for this org.
             logging.debug("Endpoint %s not available for this organization (404): %s", endpoint_name, exception)
@@ -571,29 +1014,34 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _display_usage_guide() -> None:
-        """Display Marvis usage guidance."""
-        print("\n  Marvis (VNA - Virtual Network Assistant) Usage Guide:")  # WHY: guide header.
-        print("   Targeted Troubleshooting:")  # WHY: subsection header.
-        print("     !? Use client troubleshooting for specific device connectivity issues")  # WHY: guidance.
-        print("     !? Use device troubleshooting for AP, switch, or gateway performance")  # WHY: guidance.
-        print("     !? Use network troubleshooting for site-wide connectivity analysis")  # WHY: guidance.
-        print()  # WHY: blank line separator.
-        print("   Requirements:")  # WHY: subsection header.
-        print("     !? Marvis must be enabled for your organization")  # WHY: prerequisite.
-        print("     !? Devices must be actively managed and reporting data")  # WHY: prerequisite.
-        print("     !? Sufficient data history for meaningful analysis")  # WHY: prerequisite.
-        print()  # WHY: blank line separator.
-        print("   Best Practices:")  # WHY: subsection header.
-        print("     !? Run troubleshooting when issues are actively occurring")  # WHY: tip.
-        print("     !? Provide specific timeframes when prompted")  # WHY: tip.
-        print("     !? Review saved CSV files for detailed analysis results")  # WHY: tip.
+        """Display Marvis usage guidance.
+
+        Why:
+            Emits the entire static guide as one consolidated log record so
+            operators see a single atomic block rather than 14 fragmented
+            print lines.
+        """
+        logging.warning("%s", "\n".join(_USAGE_GUIDE_LINES))  # WHY: single consolidated record.
 
     @staticmethod
     def _handle_insights_error(exception: Exception) -> None:
-        """Handle and display insights retrieval errors."""
-        logging.error("Failed to get Marvis insights: %s", exception)  # WHY: log full context.
-        print(f"! Failed to get Marvis insights: {exception}")  # WHY: user-facing failure.
-        print(" This may indicate:")  # WHY: guidance intro.
-        print("   - Marvis (VNA) is not enabled for your organization")  # WHY: guidance bullet.
-        print("   - Insufficient permissions to view organization details")  # WHY: guidance bullet.
-        print("   - API connectivity issues")  # WHY: guidance bullet.
+        """Handle and display insights retrieval errors.
+
+        Why:
+            Consolidates the error banner + guidance bullets into a single
+            ``logging.error`` record so downstream log aggregation groups
+            them as one event.
+
+        Args:
+            exception: raised exception surfaced by ``view_insights``.
+        """
+        logging.error(  # WHY: single consolidated error record with banner + guidance.
+            "Failed to get Marvis insights: %s\n"
+            "! Failed to get Marvis insights: %s\n"
+            " This may indicate:\n"
+            "   - Marvis (VNA) is not enabled for your organization\n"
+            "   - Insufficient permissions to view organization details\n"
+            "   - API connectivity issues",
+            exception,
+            exception,
+        )

--- a/tests/unit/troubleshooting/test_marvis_troubleshoot_utils.py
+++ b/tests/unit/troubleshooting/test_marvis_troubleshoot_utils.py
@@ -2,10 +2,27 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from src.troubleshooting.marvis_troubleshoot_utils import MarvisTroubleshootDeps, MarvisTroubleshootUtils
+
+
+@pytest.fixture(autouse=True)
+def _capture_warnings(caplog: Any) -> None:
+    """Autouse fixture ensuring caplog captures WARNING-level records module-wide.
+
+    Why:
+        User-visible output was migrated from print() to logging.warning under #886;
+        pytest's caplog defaults to WARNING for the root logger only when explicitly
+        set. Applying it via an autouse fixture avoids repeating caplog.set_level in
+        every test body and keeps this module aligned with the extended test file.
+    """
+    caplog.set_level(logging.WARNING)
 
 
 def _make_deps() -> MarvisTroubleshootDeps:

--- a/tests/unit/troubleshooting/test_marvis_troubleshoot_utils_extended.py
+++ b/tests/unit/troubleshooting/test_marvis_troubleshoot_utils_extended.py
@@ -2,14 +2,30 @@
 
 from __future__ import annotations  # WHY: postpone annotation evaluation for forward-refs.
 
+import logging  # WHY: needed to set caplog level for logging-based user output capture.
 from types import SimpleNamespace  # WHY: lightweight stand-ins for injected collaborators.
 from typing import Any  # WHY: loose typing for opaque mistapi response shapes.
 from unittest.mock import MagicMock  # WHY: explicit call tracking for interaction-based assertions.
+
+import pytest  # WHY: autouse fixture registration for caplog level.
 
 from src.troubleshooting.marvis_troubleshoot_utils import (  # WHY: import target class + dep container.
     MarvisTroubleshootDeps,
     MarvisTroubleshootUtils,
 )
+
+
+@pytest.fixture(autouse=True)
+def _capture_warnings(caplog: Any) -> None:
+    """Autouse fixture ensuring caplog captures WARNING-level records module-wide.
+
+    Why:
+        User-visible output was migrated from print() to logging.warning under #886;
+        pytest's caplog defaults to WARNING for the root logger only when explicitly
+        set. Applying it via an autouse fixture avoids repeating caplog.set_level in
+        every test body.
+    """
+    caplog.set_level(logging.WARNING)  # WHY: capture all WARNING+ records emitted by the module under test.
 
 
 def _make_deps(**overrides: Any) -> MarvisTroubleshootDeps:
@@ -74,52 +90,52 @@ def test_build_client_params_includes_site_and_type() -> None:
 # ---------- _announce_* -------------------------------------------------------------------------
 
 
-def test_announce_client_run_prints_all_lines(capsys: Any) -> None:
+def test_announce_client_run_prints_all_lines(caplog: Any) -> None:
     """Client-run announcement prints identity, type, and site when present."""
     MarvisTroubleshootUtils._announce_client_run("aa:bb", "wireless", "site-1")  # WHY: exercise print path.
-    output = capsys.readouterr().out  # WHY: capture stdout to assert user-visible text.
+    output = caplog.text  # WHY: capture logged WARNING/ERROR records as user-visible text.
     assert "aa:bb" in output  # WHY: mac echoed.
     assert "wireless" in output  # WHY: type echoed.
     assert "site-1" in output  # WHY: site id echoed.
 
 
-def test_announce_client_run_skips_site_when_absent(capsys: Any) -> None:
+def test_announce_client_run_skips_site_when_absent(caplog: Any) -> None:
     """Client-run announcement omits the site line when site_id is None."""
     MarvisTroubleshootUtils._announce_client_run("aa:bb", "wired", None)  # WHY: absent site path.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Site ID" not in output  # WHY: site line skipped.
 
 
-def test_announce_device_run_prints_identity(capsys: Any) -> None:
+def test_announce_device_run_prints_identity(caplog: Any) -> None:
     """Device-run announcement echoes name, mac, and site."""
     MarvisTroubleshootUtils._announce_device_run("site-1", "aa:bb", "ap-1")  # WHY: exercise device banner.
-    output = capsys.readouterr().out  # WHY: capture.
+    output = caplog.text  # WHY: capture logged records.
     assert "ap-1" in output  # WHY: name echoed.
     assert "aa:bb" in output  # WHY: mac echoed.
     assert "site-1" in output  # WHY: site id echoed.
 
 
-def test_announce_network_run_prints_site(capsys: Any) -> None:
+def test_announce_network_run_prints_site(caplog: Any) -> None:
     """Network-run announcement echoes site id."""
     MarvisTroubleshootUtils._announce_network_run("site-1")  # WHY: exercise network banner.
-    output = capsys.readouterr().out  # WHY: capture.
+    output = caplog.text  # WHY: capture logged records.
     assert "site-1" in output  # WHY: site id echoed.
 
 
 # ---------- _print_error_guidance ---------------------------------------------------------------
 
 
-def test_print_error_guidance_prints_bullets_for_known_kind(capsys: Any) -> None:
+def test_print_error_guidance_prints_bullets_for_known_kind(caplog: Any) -> None:
     """Client guidance prints multiple bullet lines."""
     MarvisTroubleshootUtils._print_error_guidance("client")  # WHY: exercise known kind.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Marvis (VNA) is not enabled" in output  # WHY: guidance content included.
 
 
-def test_print_error_guidance_unknown_kind_only_prints_intro(capsys: Any) -> None:
+def test_print_error_guidance_unknown_kind_only_prints_intro(caplog: Any) -> None:
     """Unknown kind still prints the intro line but no bullets."""
     MarvisTroubleshootUtils._print_error_guidance("unknown-kind")  # WHY: exercise dict-miss path.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "This may indicate:" in output  # WHY: intro line printed.
     assert output.count("\n") == 1  # WHY: no bullet lines followed.
 
@@ -127,41 +143,41 @@ def test_print_error_guidance_unknown_kind_only_prints_intro(capsys: Any) -> Non
 # ---------- render/dispatch helpers -------------------------------------------------------------
 
 
-def test_render_results_section_dispatches_bullets(capsys: Any) -> None:
+def test_render_results_section_dispatches_bullets(caplog: Any) -> None:
     """Results section prints one bullet per result."""
     MarvisTroubleshootUtils._render_results_section(  # WHY: exercise render loop.
         [{"description": "issue-1", "action": "reboot"}, "raw-item"],
         "Header",
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Header" in output  # WHY: header printed.
     assert "issue-1" in output  # WHY: dict finding rendered.
     assert "Recommended Action: reboot" in output  # WHY: action line rendered.
     assert "raw-item" in output  # WHY: non-dict finding rendered.
 
 
-def test_render_results_section_none_yields_only_header(capsys: Any) -> None:
+def test_render_results_section_none_yields_only_header(caplog: Any) -> None:
     """None results list still prints the header and iterates safely."""
     MarvisTroubleshootUtils._render_results_section(None, "Header")  # WHY: exercise None-or-[] branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Header" in output  # WHY: header printed.
 
 
-def test_print_result_bullet_skips_action_when_missing(capsys: Any) -> None:
+def test_print_result_bullet_skips_action_when_missing(caplog: Any) -> None:
     """Dict result without action prints only the description."""
     MarvisTroubleshootUtils._print_result_bullet({"description": "only-desc"})  # WHY: exercise action-missing.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "only-desc" in output  # WHY: description printed.
     assert "Recommended Action" not in output  # WHY: action line skipped.
 
 
-def test_render_insights_section_iterates_and_labels(capsys: Any) -> None:
+def test_render_insights_section_iterates_and_labels(caplog: Any) -> None:
     """Insights section prints label and per-insight bullet descriptions."""
     MarvisTroubleshootUtils._render_insights_section(  # WHY: exercise render loop.
         [{"description": "insight-1"}, "raw-insight"],
         "Insights",
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Insights" in output  # WHY: label rendered.
     assert "insight-1" in output  # WHY: dict insight rendered.
     assert "raw-insight" in output  # WHY: non-dict insight rendered.
@@ -178,34 +194,34 @@ def test_insight_description_stringifies_scalars() -> None:
     assert MarvisTroubleshootUtils._insight_description(42) == "42"  # WHY: verify scalar handling.
 
 
-def test_print_raw_keys_preview_truncates_long_values(capsys: Any) -> None:
+def test_print_raw_keys_preview_truncates_long_values(caplog: Any) -> None:
     """Raw-key preview truncates values exceeding the max length."""
     long_value = "x" * 200  # WHY: value longer than truncation threshold.
     MarvisTroubleshootUtils._print_raw_keys_preview({"k": long_value})  # WHY: exercise truncation branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "..." in output  # WHY: truncation suffix appended.
 
 
-def test_print_raw_keys_preview_no_suffix_when_short(capsys: Any) -> None:
+def test_print_raw_keys_preview_no_suffix_when_short(caplog: Any) -> None:
     """Short values do not receive a truncation suffix."""
     MarvisTroubleshootUtils._print_raw_keys_preview({"k": "short"})  # WHY: exercise no-truncation path.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "short" in output  # WHY: value printed.
     # WHY: only ellipsis check would false-positive; check '...' absent when key/value is short.
     assert "..." not in output  # WHY: no truncation applied.
 
 
-def test_print_raw_response_preview_truncates_long_body(capsys: Any) -> None:
+def test_print_raw_response_preview_truncates_long_body(caplog: Any) -> None:
     """Raw response preview truncates bodies exceeding max length."""
     MarvisTroubleshootUtils._print_raw_response_preview("x" * 500)  # WHY: exceed truncation threshold.
-    output = capsys.readouterr().out  # WHY: capture.
+    output = caplog.text  # WHY: capture logged records.
     assert "..." in output  # WHY: truncation suffix present.
 
 
-def test_print_raw_response_preview_short_body_no_suffix(capsys: Any) -> None:
+def test_print_raw_response_preview_short_body_no_suffix(caplog: Any) -> None:
     """Short response body prints without truncation suffix."""
     MarvisTroubleshootUtils._print_raw_response_preview("small")  # WHY: below threshold.
-    output = capsys.readouterr().out  # WHY: capture.
+    output = caplog.text  # WHY: capture logged records.
     assert "..." not in output  # WHY: no truncation.
     assert "small" in output  # WHY: value printed.
 
@@ -213,65 +229,65 @@ def test_print_raw_response_preview_short_body_no_suffix(capsys: Any) -> None:
 # ---------- _display_response_summary dispatch --------------------------------------------------
 
 
-def test_display_response_summary_non_dict_returns_early(capsys: Any) -> None:
+def test_display_response_summary_non_dict_returns_early(caplog: Any) -> None:
     """Non-dict payload triggers early return with no output."""
     MarvisTroubleshootUtils._display_response_summary(  # WHY: exercise non-dict early-return.
         [1, 2, 3], [{"row": 1}], "Header"
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert output == ""  # WHY: no rendering happened.
 
 
-def test_display_response_summary_dispatches_to_results(capsys: Any) -> None:
+def test_display_response_summary_dispatches_to_results(caplog: Any) -> None:
     """Presence of 'results' key routes to the results renderer."""
     MarvisTroubleshootUtils._display_response_summary(  # WHY: exercise results branch.
         {"results": [{"description": "d"}]}, [{"row": 1}], "Header"
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Header" in output  # WHY: header rendered by results branch.
 
 
-def test_display_response_summary_dispatches_to_insights(capsys: Any) -> None:
+def test_display_response_summary_dispatches_to_insights(caplog: Any) -> None:
     """Presence of 'insights' key routes to the insights renderer."""
     MarvisTroubleshootUtils._display_response_summary(  # WHY: exercise insights branch.
         {"insights": [{"description": "i"}]}, [{"row": 1}], "Header", insights_label="MyLabel"
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "MyLabel" in output  # WHY: insights label rendered.
 
 
-def test_display_response_summary_fallback_shows_raw_keys(capsys: Any) -> None:
+def test_display_response_summary_fallback_shows_raw_keys(caplog: Any) -> None:
     """Absence of results/insights + show_raw_keys renders fallback preview."""
     MarvisTroubleshootUtils._display_response_summary(  # WHY: exercise fallback branch.
         {"other": "value"}, [{"row": 1}], "Header", show_raw_keys=True
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Analysis Data" in output  # WHY: fallback header printed.
     assert "Raw response keys" in output  # WHY: raw-keys preview rendered.
 
 
-def test_render_summary_fallback_no_raw_keys_when_flag_false(capsys: Any) -> None:
+def test_render_summary_fallback_no_raw_keys_when_flag_false(caplog: Any) -> None:
     """Fallback renderer suppresses raw-key preview when flag is False."""
     MarvisTroubleshootUtils._render_summary_fallback(  # WHY: direct call for negative flag.
         {"other": "value"}, [{"row": 1}], show_raw_keys=False
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Raw response keys" not in output  # WHY: skipped.
 
 
 # ---------- _persist_csv ------------------------------------------------------------------------
 
 
-def test_persist_csv_writes_and_prints(capsys: Any) -> None:
+def test_persist_csv_writes_and_prints(caplog: Any) -> None:
     """CSV persistence delegates to data_exporter and prints a confirmation."""
     deps = _make_deps()  # WHY: fresh deps for interaction assertions.
     MarvisTroubleshootUtils._persist_csv(deps, [{"row": 1}], "file.csv", "client")  # WHY: exercise happy path.
     deps.data_exporter.write_with_format_selection.assert_called_once_with([{"row": 1}], "file.csv")
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "file.csv" in output  # WHY: user confirmation includes filename.
 
 
-def test_persist_csv_handles_none_rows(capsys: Any) -> None:
+def test_persist_csv_handles_none_rows(caplog: Any) -> None:
     """CSV persistence tolerates None rows (len() guard exercised)."""
     deps = _make_deps()  # WHY: fresh deps.
     MarvisTroubleshootUtils._persist_csv(deps, None, "file.csv", "device")  # WHY: exercise None-guard branch.
@@ -281,17 +297,17 @@ def test_persist_csv_handles_none_rows(capsys: Any) -> None:
 # ---------- _handle_client_response -------------------------------------------------------------
 
 
-def test_handle_client_response_empty_data_returns_early(capsys: Any) -> None:
+def test_handle_client_response_empty_data_returns_early(caplog: Any) -> None:
     """Empty client response prints healthy path and skips persistence."""
     deps = _make_deps()  # WHY: track that exporter is not called.
     response = SimpleNamespace(data=None)  # WHY: empty response object.
     MarvisTroubleshootUtils._handle_client_response(deps, response, "aa:bb", "wireless")  # WHY: exercise branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "No specific connectivity" in output  # WHY: healthy message printed.
     deps.data_exporter.write_with_format_selection.assert_not_called()  # WHY: no CSV written.
 
 
-def test_handle_client_response_writes_csv_and_summary(capsys: Any) -> None:
+def test_handle_client_response_writes_csv_and_summary(caplog: Any) -> None:
     """Non-empty response triggers CSV write and results-summary render."""
     deps = _make_deps()  # WHY: fresh deps.
     response = SimpleNamespace(data={"results": [{"description": "issue-x"}]})  # WHY: results schema.
@@ -299,24 +315,24 @@ def test_handle_client_response_writes_csv_and_summary(capsys: Any) -> None:
     deps.data_exporter.write_with_format_selection.assert_called_once()
     args = deps.data_exporter.write_with_format_selection.call_args[0]  # WHY: capture call args.
     assert args[1] == "MarvisInsights_Client_aabb_wireless.csv"  # WHY: filename encodes mac+type.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "issue-x" in output  # WHY: summary rendered.
 
 
 # ---------- _handle_device_response -------------------------------------------------------------
 
 
-def test_handle_device_response_empty_data_returns_early(capsys: Any) -> None:
+def test_handle_device_response_empty_data_returns_early(caplog: Any) -> None:
     """Empty device response prints healthy path and skips persistence."""
     deps = _make_deps()  # WHY: fresh deps.
     response = SimpleNamespace(data=None)  # WHY: empty response object.
     MarvisTroubleshootUtils._handle_device_response(deps, response, "aa:bb", "AP One")  # WHY: exercise branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "No performance issues" in output  # WHY: healthy message.
     deps.data_exporter.write_with_format_selection.assert_not_called()  # WHY: no CSV written.
 
 
-def test_handle_device_response_writes_csv_with_sanitized_name(capsys: Any) -> None:
+def test_handle_device_response_writes_csv_with_sanitized_name(caplog: Any) -> None:
     """Non-empty device response writes CSV using sanitized name in filename."""
     deps = _make_deps()  # WHY: fresh deps.
     response = SimpleNamespace(data={"results": []})  # WHY: dict payload triggers write path.
@@ -328,39 +344,39 @@ def test_handle_device_response_writes_csv_with_sanitized_name(capsys: Any) -> N
 # ---------- _handle_network_response ------------------------------------------------------------
 
 
-def test_handle_network_response_empty_data_returns_early(capsys: Any) -> None:
+def test_handle_network_response_empty_data_returns_early(caplog: Any) -> None:
     """Empty network response prints healthy path and skips persistence."""
     deps = _make_deps()  # WHY: fresh deps.
     response = SimpleNamespace(data=None)  # WHY: empty response.
     MarvisTroubleshootUtils._handle_network_response(deps, response, "site-1")  # WHY: exercise branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "No network connectivity issues" in output  # WHY: healthy message printed.
     deps.data_exporter.write_with_format_selection.assert_not_called()  # WHY: no CSV written.
 
 
-def test_handle_network_response_non_dict_prints_raw_preview(capsys: Any) -> None:
+def test_handle_network_response_non_dict_prints_raw_preview(caplog: Any) -> None:
     """Non-dict data still writes CSV then prints raw preview."""
     deps = _make_deps()  # WHY: fresh deps.
     response = SimpleNamespace(data=["item-a", "item-b"])  # WHY: non-dict truthy payload.
     MarvisTroubleshootUtils._handle_network_response(deps, response, "site-1")  # WHY: exercise raw-preview branch.
     deps.data_exporter.write_with_format_selection.assert_called_once()
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Raw response" in output  # WHY: raw preview printed.
 
 
-def test_handle_network_response_dict_renders_full_summary(capsys: Any) -> None:
+def test_handle_network_response_dict_renders_full_summary(caplog: Any) -> None:
     """Dict data invokes structured display summary with network labels."""
     deps = _make_deps()  # WHY: fresh deps.
     response = SimpleNamespace(data={"results": [{"description": "site-issue"}]})  # WHY: results schema.
     MarvisTroubleshootUtils._handle_network_response(deps, response, "site-1")  # WHY: exercise dict branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "site-issue" in output  # WHY: summary rendered.
 
 
 # ---------- _invoke_* wrappers ------------------------------------------------------------------
 
 
-def test_invoke_client_troubleshoot_success_dispatches(capsys: Any) -> None:
+def test_invoke_client_troubleshoot_success_dispatches(caplog: Any) -> None:
     """Successful API call invokes response handler with returned data."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.troubleshoot.troubleshootOrg.return_value = SimpleNamespace(  # WHY: stub.
@@ -372,19 +388,19 @@ def test_invoke_client_troubleshoot_success_dispatches(capsys: Any) -> None:
     deps.data_exporter.write_with_format_selection.assert_called_once()  # WHY: response handler ran.
 
 
-def test_invoke_client_troubleshoot_exception_prints_guidance(capsys: Any) -> None:
+def test_invoke_client_troubleshoot_exception_prints_guidance(caplog: Any) -> None:
     """API exceptions trigger user-facing error and canned guidance."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.troubleshoot.troubleshootOrg.side_effect = RuntimeError("boom")  # WHY: force error.
     MarvisTroubleshootUtils._invoke_client_troubleshoot(  # WHY: exercise except branch.
         deps, "org-1", {"mac": "aa:bb"}, "aa:bb", "wireless"
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "boom" in output  # WHY: error surfaced.
     assert "Marvis (VNA)" in output  # WHY: guidance printed.
 
 
-def test_invoke_device_troubleshoot_success(capsys: Any) -> None:
+def test_invoke_device_troubleshoot_success(caplog: Any) -> None:
     """Device wrapper announces run, calls API, and dispatches response."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.troubleshoot.troubleshootOrg.return_value = SimpleNamespace(  # WHY: stub.
@@ -396,14 +412,14 @@ def test_invoke_device_troubleshoot_success(capsys: Any) -> None:
     deps.data_exporter.write_with_format_selection.assert_called_once()  # WHY: handler ran.
 
 
-def test_invoke_device_troubleshoot_exception(capsys: Any) -> None:
+def test_invoke_device_troubleshoot_exception(caplog: Any) -> None:
     """Device wrapper exception path prints guidance."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.troubleshoot.troubleshootOrg.side_effect = RuntimeError("device-fail")  # WHY: error.
     MarvisTroubleshootUtils._invoke_device_troubleshoot(  # WHY: exercise except branch.
         deps, "org-1", "site-1", ("aa:bb", "AP One")
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "device-fail" in output  # WHY: error surfaced.
     assert "device is not found" in output  # WHY: device guidance printed.
 
@@ -418,12 +434,12 @@ def test_invoke_network_troubleshoot_success() -> None:
     deps.data_exporter.write_with_format_selection.assert_called_once()  # WHY: handler ran.
 
 
-def test_invoke_network_troubleshoot_exception(capsys: Any) -> None:
+def test_invoke_network_troubleshoot_exception(caplog: Any) -> None:
     """Network wrapper exception path prints guidance."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.troubleshoot.troubleshootOrg.side_effect = RuntimeError("net-fail")  # WHY: error.
     MarvisTroubleshootUtils._invoke_network_troubleshoot(deps, "org-1", "site-1")  # WHY: except path.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "net-fail" in output  # WHY: error surfaced.
     assert "site has no devices" in output  # WHY: network guidance printed.
 
@@ -510,17 +526,17 @@ def test_network_connectivity_full_flow() -> None:
 # ---------- _lookup_device ----------------------------------------------------------------------
 
 
-def test_lookup_device_empty_response_returns_none(capsys: Any) -> None:
+def test_lookup_device_empty_response_returns_none(caplog: Any) -> None:
     """Device lookup returns None when API response has empty data."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.sites.devices.getSiteDevice.return_value = SimpleNamespace(data=None)  # WHY: empty.
     result = MarvisTroubleshootUtils._lookup_device(deps, "site-1", "dev-1")  # WHY: exercise empty path.
     assert result is None  # WHY: expected None return.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Could not retrieve" in output  # WHY: user message printed.
 
 
-def test_lookup_device_missing_mac_returns_none(capsys: Any) -> None:
+def test_lookup_device_missing_mac_returns_none(caplog: Any) -> None:
     """Device lookup returns None when MAC is missing from response payload."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.sites.devices.getSiteDevice.return_value = SimpleNamespace(  # WHY: no mac.
@@ -528,7 +544,7 @@ def test_lookup_device_missing_mac_returns_none(capsys: Any) -> None:
     )
     result = MarvisTroubleshootUtils._lookup_device(deps, "site-1", "dev-1")  # WHY: exercise no-mac path.
     assert result is None  # WHY: expected None return.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Could not determine" in output  # WHY: user message printed.
 
 
@@ -553,30 +569,31 @@ def test_view_insights_org_none_returns_early() -> None:
     deps.mistapi.api.v1.orgs.insights.getOrgSitesSle.assert_not_called()  # WHY: skipped downstream.
 
 
-def test_view_insights_exception_hits_error_handler(capsys: Any) -> None:
+def test_view_insights_exception_hits_error_handler(caplog: Any) -> None:
     """view_insights surfaces exceptions via the shared error handler."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.orgs.getOrg.side_effect = RuntimeError("org-fail")  # WHY: force error.
-    MarvisTroubleshootUtils.view_insights(deps)  # WHY: exercise except path.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    with caplog.at_level(logging.ERROR):  # WHY: error handler emits at ERROR level, above default WARNING capture.
+        MarvisTroubleshootUtils.view_insights(deps)  # WHY: exercise except path.
+    output = caplog.text  # WHY: capture logged records.
     assert "org-fail" in output  # WHY: error surfaced.
     assert "Marvis (VNA) is not enabled" in output  # WHY: guidance printed.
 
 
-def test_display_org_features_no_features(capsys: Any) -> None:
+def test_display_org_features_no_features(caplog: Any) -> None:
     """Empty features list still prints the org header and 'no features' message."""
     MarvisTroubleshootUtils._display_org_features({"name": "Org", "features": []})  # WHY: exercise no-features.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Organization: Org" in output  # WHY: header printed.
     assert "No specific Marvis/VNA features" in output  # WHY: fallback message printed.
 
 
-def test_display_org_features_lists_marvis_features(capsys: Any) -> None:
+def test_display_org_features_lists_marvis_features(caplog: Any) -> None:
     """Detected Marvis features are enumerated as bullets."""
     MarvisTroubleshootUtils._display_org_features(  # WHY: exercise features path.
         {"name": "Org", "features": ["marvis", "vna-insights", "unrelated"]}
     )
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Marvis/VNA Features Available" in output  # WHY: header rendered.
     assert "marvis" in output  # WHY: feature rendered.
 
@@ -603,16 +620,16 @@ def test_is_marvis_feature_true_and_false() -> None:
 # ---------- insights fetch / iteration ----------------------------------------------------------
 
 
-def test_fetch_org_insights_empty_prints_no_message(capsys: Any) -> None:
+def test_fetch_org_insights_empty_prints_no_message(caplog: Any) -> None:
     """No insights across all endpoints prints the 'no insights' message."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.insights.getOrgSitesSle.return_value = SimpleNamespace(data=None)  # WHY: empty.
     MarvisTroubleshootUtils._fetch_org_insights("org-1", deps)  # WHY: exercise empty-result branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "No organization-level insights" in output  # WHY: user-facing message printed.
 
 
-def test_fetch_org_insights_exception_prints_warning(capsys: Any) -> None:
+def test_fetch_org_insights_exception_prints_warning(caplog: Any) -> None:
     """Iterator-level exceptions render a user-facing warning."""
     deps = _make_deps()  # WHY: fresh deps.
     # WHY: force _iter_insight_endpoints to raise by making mistapi attribute access explode.
@@ -644,7 +661,7 @@ def test_try_insight_endpoint_exception_returns_false() -> None:
     assert result is False  # WHY: no data.
 
 
-def test_try_insight_endpoint_delegates_to_process_and_returns_true(capsys: Any) -> None:
+def test_try_insight_endpoint_delegates_to_process_and_returns_true(caplog: Any) -> None:
     """Endpoint with data invokes _process_insight_response and returns True."""
     deps = _make_deps()  # WHY: fresh deps.
 
@@ -675,19 +692,19 @@ def test_process_insight_response_empty_normalised_returns_false() -> None:
     assert result is False  # WHY: nothing to render.
 
 
-def test_print_insight_preview_shows_overflow(capsys: Any) -> None:
+def test_print_insight_preview_shows_overflow(caplog: Any) -> None:
     """Insight preview appends overflow line when list exceeds preview limit."""
     insights = [{"description": f"row-{i}"} for i in range(10)]  # WHY: exceed preview limit of 5.
     MarvisTroubleshootUtils._print_insight_preview("Endpoint", insights)  # WHY: exercise overflow branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "and 5 more insights" in output  # WHY: overflow message.
 
 
-def test_print_insight_preview_no_overflow(capsys: Any) -> None:
+def test_print_insight_preview_no_overflow(caplog: Any) -> None:
     """Insight preview skips overflow line when list is small."""
     insights = [{"description": "row-1"}]  # WHY: below preview limit.
     MarvisTroubleshootUtils._print_insight_preview("Endpoint", insights)  # WHY: exercise no-overflow branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "more insights" not in output  # WHY: overflow message skipped.
 
 
@@ -705,12 +722,12 @@ def test_describe_insight_dict_chains_fallbacks() -> None:
     assert "other" in MarvisTroubleshootUtils._describe_insight({"other": 1})
 
 
-def test_persist_insight_csv_writes_and_prints(capsys: Any) -> None:
+def test_persist_insight_csv_writes_and_prints(caplog: Any) -> None:
     """Insight CSV persistence delegates to data_exporter and prints confirmation."""
     deps = _make_deps()  # WHY: fresh deps.
     MarvisTroubleshootUtils._persist_insight_csv(deps, [{"row": 1}], "file.csv")  # WHY: exercise happy path.
     deps.data_exporter.write_with_format_selection.assert_called_once_with([{"row": 1}], "file.csv")
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "file.csv" in output  # WHY: filename echoed.
 
 
@@ -729,25 +746,26 @@ def test_log_endpoint_error_classifies_404_403_generic() -> None:
     MarvisTroubleshootUtils._log_endpoint_error("E", Exception("some other error"))
 
 
-def test_display_usage_guide_prints_all_sections(capsys: Any) -> None:
+def test_display_usage_guide_prints_all_sections(caplog: Any) -> None:
     """Usage guide prints the three main sections."""
     MarvisTroubleshootUtils._display_usage_guide()  # WHY: exercise all-print branch.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Targeted Troubleshooting" in output  # WHY: section 1 header.
     assert "Requirements" in output  # WHY: section 2 header.
     assert "Best Practices" in output  # WHY: section 3 header.
 
 
-def test_handle_insights_error_prints_guidance(capsys: Any) -> None:
+def test_handle_insights_error_prints_guidance(caplog: Any) -> None:
     """Insights error handler prints error + canned bullets."""
-    MarvisTroubleshootUtils._handle_insights_error(RuntimeError("insights-error"))  # WHY: exercise handler.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    with caplog.at_level(logging.ERROR):  # WHY: handler emits at ERROR level; ensure caplog captures it.
+        MarvisTroubleshootUtils._handle_insights_error(RuntimeError("insights-error"))  # WHY: exercise handler.
+    output = caplog.text  # WHY: capture logged records.
     assert "insights-error" in output  # WHY: error surfaced.
     assert "Marvis (VNA) is not enabled" in output  # WHY: guidance printed.
     assert "API connectivity" in output  # WHY: full guidance printed.
 
 
-def test_iter_insight_endpoints_returns_true_on_any_success(capsys: Any) -> None:
+def test_iter_insight_endpoints_returns_true_on_any_success(caplog: Any) -> None:
     """Iterator returns True if any endpoint yields data even if others fail."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.insights.getOrgSitesSle.return_value = SimpleNamespace(  # WHY: happy.
@@ -757,7 +775,7 @@ def test_iter_insight_endpoints_returns_true_on_any_success(capsys: Any) -> None
     assert result is True  # WHY: at least one endpoint yielded.
 
 
-def test_view_insights_full_happy_path(capsys: Any) -> None:
+def test_view_insights_full_happy_path(caplog: Any) -> None:
     """view_insights runs through org info + insights + usage guide when all succeed."""
     deps = _make_deps()  # WHY: fresh deps.
     deps.mistapi.api.v1.orgs.orgs.getOrg.return_value = SimpleNamespace(  # WHY: org data.
@@ -767,6 +785,6 @@ def test_view_insights_full_happy_path(capsys: Any) -> None:
         data=[{"description": "insight-a"}]
     )
     MarvisTroubleshootUtils.view_insights(deps)  # WHY: exercise full flow.
-    output = capsys.readouterr().out  # WHY: capture stdout.
+    output = caplog.text  # WHY: capture logged records.
     assert "Organization: Org" in output  # WHY: org header rendered.
     assert "Best Practices" in output  # WHY: usage guide rendered.


### PR DESCRIPTION
## Summary

Slice 19/N of #886. Retires all `print()` calls in
`src/troubleshooting/marvis_troubleshoot_utils.py` (the extracted Marvis
client/device/network troubleshooting + insights workflows) in favor of
the `logging` module.

- Workflow banners (`client_connectivity`, `device_performance`,
  `network_connectivity`, `view_insights`) consolidate header + divider into
  one `logging.warning("%s\n%s", header, sep)` record so menus arrive
  atomically at every handler.
- Shared error guidance emitter (`_print_error_guidance`) assembles the
  failure message plus canned bullets into a `list[str]` and emits one
  `logging.warning("%s", "\n".join(lines))` record.
- Structured pre/post API call records use `logging.info`, trace entries
  use `logging.debug`, and failure paths use `logging.error` /
  `logging.exception` per severity.
- Test migration: `tests/unit/troubleshooting/test_marvis_troubleshoot_utils_extended.py`
  swaps `capsys.readouterr().out` for `caplog.text` across the affected
  tests and adds a module-level autouse `_capture_warnings(caplog)` fixture
  at WARNING level. The two ERROR-routed tests wrap with
  `with caplog.at_level(logging.ERROR):`. Companion `test_marvis_troubleshoot_utils.py`
  receives the same autouse fixture for consistency.

## Test plan

- [x] `ruff check` — 0 issues on the migrated files.
- [x] `black --check` — clean.
- [x] Targeted `pytest tests/unit/troubleshooting/test_marvis_troubleshoot_utils*.py` — 76 passed.
- [x] Full `pytest` — 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed.

Refs #886.