### PR TITLE
chore(logging): migrate src/ssh/ssh_runner.py print() to logger (#886 slice 20/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 20/N: retire `print()` in `src/ssh/ssh_runner.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`
+  calls in `src/ssh/ssh_runner.py` with `logging.warning(...)`. The
+  per-host command-completion banner (`_read_and_log_outputs`) now emits
+  `logging.warning("- [%s] Command completed with exit status: %s", hostname,
+  exit_status)` so operator-visible status arrives through the same handler
+  chain as the rest of the SSH runner's structured logs. The disconnect
+  banner (`_disconnect`) now emits `logging.warning(">> SSH connection
+  closed")` for the same reason. Both records are WARNING level (not INFO)
+  to preserve their default visibility on CLI runs where the root logger is
+  typically configured to filter INFO.
+- **Test posture**: no test changes required — the existing tests in
+  `tests/unit/test_ssh_runner.py` and `tests/unit/ssh/test_ssh_runner_manager*.py`
+  do not assert on either migrated banner, and neither uses
+  `capsys.readouterr()` against those emission sites.
+- **Verification**: `ruff check src/ssh/ssh_runner.py` reports 0 issues;
+  `black --check` clean; targeted `pytest tests/unit/test_ssh_runner.py
+  tests/unit/ssh/` runs 359 passed; full `pytest` suite green
+  (8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 19/N: retire `print()` in `src/troubleshooting/marvis_troubleshoot_utils.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all `print()` calls in

--- a/src/ssh/ssh_runner.py
+++ b/src/ssh/ssh_runner.py
@@ -406,7 +406,9 @@ class EnhancedSSHRunner:
         exit_status = stdout.channel.recv_exit_status()  # type: ignore[attr-defined]  # WHY: paramiko exit code
         elapsed = time.time() - start_time  # WHY: measure wall-clock time spent on the exec
         self._log_exec_details(stdout_output, stderr_output, exit_status, elapsed, with_pty)  # WHY: bounded log
-        print(f"- [{hostname}] Command completed with exit status: {exit_status}")  # WHY: keep CLI UX unchanged
+        logging.warning(  # WHY: user-visible per-host completion banner (previously print()).
+            "- [%s] Command completed with exit status: %s", hostname, exit_status
+        )
         return exit_status == 0, stdout_output, stderr_output  # WHY: legacy success/stdout/stderr tuple shape
 
     def _log_exec_details(
@@ -445,7 +447,7 @@ class EnhancedSSHRunner:
             self.logger.debug("Closing SSH connection")  # WHY: trace so users can confirm clean teardown
             self.client.close()  # WHY: releases paramiko file descriptors and server-side session
             self.client = None  # WHY: reset so subsequent _execute_command calls fail fast with a clear message
-            print(">> SSH connection closed")  # WHY: keep CLI UX identical to legacy
+            logging.warning(">> SSH connection closed")  # WHY: user-visible teardown banner (previously print()).
         else:
             self.logger.debug("No SSH connection to close")  # WHY: helpful trace during teardown of failed connect
 


### PR DESCRIPTION
## Summary

Slice 20/N of #886 — replaces the 2 remaining `print()` calls in `src/ssh/ssh_runner.py` with `logging.warning(...)` using `%`-style deferred formatting.

- `_read_and_log_outputs`: `logging.warning("- [%s] Command completed with exit status: %s", hostname, exit_status)`
- `_disconnect`: `logging.warning(">> SSH connection closed")`

Both banners retain prior user-visible semantics via WARNING level (routed through the existing root logger config).

## Test plan

- [x] `ruff check src/ssh/ssh_runner.py` — 0 issues
- [x] `black --check src/ssh/ssh_runner.py` — clean
- [x] `pytest tests/unit/test_ssh_runner.py tests/unit/ssh/` — 359 passed
- [x] Full `pytest` — 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed
- [x] `grep -c '^\s*print\(' src/ssh/ssh_runner.py` — 0 remaining

Refs #886.