### PR TITLE
chore(logging): migrate src/ssh/ssh_runner_manager.py print() to logger (#886 slice 22/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 22/N: retire `print()` in `src/ssh/ssh_runner_manager.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 40 remaining `print()`
+  calls in `src/ssh/ssh_runner_manager.py` with `logging.warning(...)` for
+  user-visible banners covering the full SSH-runner setup flow: prompt
+  headers, missing-data notices, gateway-template listing and selection
+  errors, online-gateway target listing, cancellation notices, credential
+  and command validation errors, and post-execution success/failure counts.
+  All migrated call sites use `%`-style deferred formatting so record args
+  stay unrendered when the level is filtered out. `import logging` was
+  already present at module scope.
+- **Test posture**: `tests/unit/ssh/test_ssh_runner_manager_extended.py`
+  gains an autouse `_capture_all_log_levels` fixture that pins
+  `caplog.set_level(logging.DEBUG)` for parity with earlier SSH slices, and
+  all 26 `capsys.readouterr().out` assertions against migrated banners were
+  rewritten to read `caplog.text`. Assertion substrings and their case
+  sensitivity were preserved verbatim so behavioral coverage is unchanged.
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining `print(` matches in `src/ssh/ssh_runner_manager.py`; targeted
+  `pytest tests/unit/ssh/test_ssh_runner_manager.py
+  tests/unit/ssh/test_ssh_runner_manager_extended.py` runs 70 passed; full
+  `pytest` suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed).
+
 ### #886 Phase 2 slice 21/N: retire `print()` in `src/ssh/cli_shell_manager.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 11 remaining `print()`

--- a/src/ssh/ssh_runner_manager.py
+++ b/src/ssh/ssh_runner_manager.py
@@ -64,11 +64,11 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             SSHRunnerManager._emit_completion(emitter, op_start, cancelled=not success)  # WHY: telemetry.
             return success  # WHY: propagate workflow success/failure back to menu dispatcher.
         except KeyboardInterrupt:  # WHY: user pressed Ctrl-C during the run.
-            print("\n[INTERRUPT] Operation cancelled by user")  # WHY: user-visible interrupt notice.
+            logging.warning("\n[INTERRUPT] Operation cancelled by user")  # WHY: user-visible interrupt notice.
             SSHRunnerManager._emit_completion(emitter, op_start, cancelled=True)  # WHY: mark run as cancelled.
             return False  # WHY: cancellation surfaces as failure to caller.
         except Exception as error:  # noqa: BLE001  # WHY: surface any fatal error to operator.
-            print(f"[ERROR] Fatal error: {error}")  # WHY: user-visible fatal error banner.
+            logging.warning("[ERROR] Fatal error: %s", error)  # WHY: user-visible fatal error banner.
             logging.exception("SSH Runner error: %s", error)  # WHY: full traceback captured to logs.
             SSHRunnerManager._emit_completion(emitter, op_start, cancelled=False)  # WHY: telemetry after crash.
             return False  # WHY: fatal error surfaces as failure to caller.
@@ -76,8 +76,8 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _print_banner() -> None:  # WHY: extracted banner keeps interactive() below 25 lines.
         """Print the SSH runner banner and emit the pre-action info log."""
-        print("\n>> Enhanced SSH Command Runner")  # WHY: user-facing banner.
-        print("=" * 60)  # WHY: visual divider matches other menu screens.
+        logging.warning("\n>> Enhanced SSH Command Runner")  # WHY: user-facing banner.
+        logging.warning("=" * 60)  # WHY: visual divider matches other menu screens.
         logging.info("Starting interactive SSH runner workflow")  # WHY: pre-action log.
 
     @staticmethod
@@ -107,9 +107,9 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _echo_plan(hosts: Any, username: Any, commands: Any) -> None:  # WHY: extracted echo keeps caller ≤ 25 lines.
         """Echo the resolved execution plan back to the operator."""
-        print(f"!? Target hosts: {', '.join(hosts)}")  # WHY: echo back what we are about to do.
-        print(f"!? Username: {username}")  # WHY: user-visible username echo.
-        print(f"!? Commands: {len(commands) if commands else 0} command(s)")  # WHY: echo command count to operator.
+        logging.warning("!? Target hosts: %s", ", ".join(hosts))  # WHY: echo back what we are about to do.
+        logging.warning("!? Username: %s", username)  # WHY: user-visible username echo.
+        logging.warning("!? Commands: %s command(s)", len(commands) if commands else 0)  # WHY: echo count.
 
     @staticmethod
     def _emit_completion(emitter: Any, op_start: float, cancelled: bool) -> None:  # WHY: telemetry helper.
@@ -142,13 +142,13 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     def _print_by_template_banner() -> None:  # WHY: extracted banner block for by_gateway_template().
         """Print the gateway-template SSH runner banner."""
         logging.info("Starting SSH runner targeting gateways by template...")  # WHY: pre-action log.
-        print("SSH Runner - Gateway Template Targeting:")  # WHY: user-facing banner.
-        print("=" * 60)  # WHY: visual divider.
+        logging.warning("SSH Runner - Gateway Template Targeting:")  # WHY: user-facing banner.
+        logging.warning("=" * 60)  # WHY: visual divider.
 
     @staticmethod
     def _refresh_gateway_export(deps: SSHRunnerManagerDeps, fast: bool) -> None:  # WHY: keep cache logic isolated.
         """Ensure GatewayManagementIPs.csv is present/current before selection."""
-        print("  1. Ensuring gateway management IP data is current...")  # WHY: user-facing status.
+        logging.warning("  1. Ensuring gateway management IP data is current...")  # WHY: user-facing status.
         deps.cache_utils.check_and_generate_csv(  # WHY: regenerate on first-run/stale cache.
             "GatewayManagementIPs.csv",
             lambda: deps.gateway_export_utils.management_ips(fast=fast),
@@ -167,7 +167,8 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             return None  # WHY: propagate cancel to caller.
         filtered = SSHRunnerManager._filter_gateways(gateways, selected_template)  # WHY: apply status filter.
         if not filtered:  # WHY: no online gateways with valid IPs.
-            print(f"! No online gateways with management IPs found for '{selected_template}'")  # WHY: user notice.
+            # WHY: notice operator that filtering produced no valid targets.
+            logging.warning("! No online gateways with management IPs found for '%s'", selected_template)
             return None  # WHY: nothing to run without any targets.
         return selected_template, filtered  # WHY: pass both back so caller does not re-derive them.
 
@@ -226,7 +227,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             context="ssh_runner_hosts",
         ).strip()
         if not host_input:  # WHY: empty response → user is cancelling.
-            print("X  SSH host is required")  # WHY: user-visible cancel notice.
+            logging.warning("X  SSH host is required")  # WHY: user-visible cancel notice.
             logging.info("Exiting SSHRunnerManager._collect_missing_data: cancelled (no hosts provided)")  # WHY: log.
             return None  # WHY: signal cancel to caller.
         return [host.strip() for host in host_input.split(",") if host.strip()]  # WHY: split, trim, drop empties.
@@ -237,7 +238,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         # WHY: safe_input is Any-typed via deps; cast to str for mypy strict (no-any-return).
         username: str = str(deps.input_utils.safe_input("Enter SSH username: ", context="ssh_runner_username")).strip()
         if not username:  # WHY: cancel path.
-            print("X  SSH username is required")
+            logging.warning("X  SSH username is required")
             logging.info("Exiting SSHRunnerManager._collect_missing_data: cancelled (no username provided)")
             return None
         return username
@@ -248,11 +249,11 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         try:
             password = getpass.getpass("Enter SSH password: ")  # WHY: hide input so password is not echoed.
         except (EOFError, KeyboardInterrupt):  # WHY: treat EOF / Ctrl-C as cancellation.
-            print("\n[CANCELLED] Operation cancelled")
+            logging.warning("\n[CANCELLED] Operation cancelled")
             logging.info("Exiting SSHRunnerManager._collect_missing_data: cancelled (EOF/interrupt on password prompt)")
             return None
         if not password:  # WHY: empty password → cancel.
-            print("X  SSH password is required")
+            logging.warning("X  SSH password is required")
             logging.info("Exiting SSHRunnerManager._collect_missing_data: cancelled (no password provided)")
             return None
         return password
@@ -260,7 +261,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _prompt_commands(deps: SSHRunnerManagerDeps) -> list[str]:  # WHY: optional one-shot command prompt.
         """Prompt operator for an optional one-shot command; return list (may be empty)."""
-        print("\nNo commands configured. Enter command or press Enter for CSV fallback:")
+        logging.warning("\nNo commands configured. Enter command or press Enter for CSV fallback:")
         choice = deps.input_utils.safe_input("Command: ", context="ssh_runner_command_prompt").strip()
         return [choice] if choice else []  # WHY: empty list lets the caller fall back to CSV-loaded commands.
 
@@ -303,7 +304,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _execute_multi_host(hosts: Any, username: Any, password: Any, commands: Any) -> bool:  # WHY: fan-out path.
         """Execute the multi-host / multi-command SSH fan-out path via MultiHostRunner."""
-        print(f"\n!? Executing {len(commands)} command(s) on {len(hosts)} host(s)")
+        logging.warning("\n!? Executing %s command(s) on %s host(s)", len(commands), len(hosts))
         summary = MultiHostRunner.run(  # WHY: T013c/T039 direct call via immutable request bundle.
             MultiHostRunRequest(
                 hosts=tuple(hosts),  # WHY: convert list to tuple for frozen dataclass storage.
@@ -319,7 +320,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         successful = sum(  # WHY: count entries with truthy success flag.
             1 for result in summary.values() if isinstance(result, dict) and result.get("success", False)
         )
-        print(f"\n!? Execution Summary: {successful}/{len(summary)} hosts successful")
+        logging.warning("\n!? Execution Summary: %s/%s hosts successful", successful, len(summary))
         return successful > 0
 
     @staticmethod
@@ -357,11 +358,11 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             ) as file_handle:
                 gateways = list(csv.DictReader(file_handle))  # WHY: DictReader gives row dicts keyed by header.
             if not gateways:  # WHY: empty CSV → nothing to show.
-                print("! No gateway data found.")
+                logging.warning("! No gateway data found.")
                 return None
             return gateways
         except FileNotFoundError:  # WHY: missing CSV → user-facing error, safe abort.
-            print("! Error: Gateway management IP data not found.")
+            logging.warning("! Error: Gateway management IP data not found.")
             return None
 
     @staticmethod
@@ -369,7 +370,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         """Display templates and get user selection."""
         templates = SSHRunnerManager._collect_template_names(gateways)  # WHY: dedup + sort template names.
         if not templates:  # WHY: nothing to choose from.
-            print("! No gateway templates found.")
+            logging.warning("! No gateway templates found.")
             return None
         SSHRunnerManager._print_template_menu(templates, gateways)  # WHY: show numbered menu with counts.
         selection = deps.input_utils.safe_input(  # WHY: capture operator's choice (number or name fragment).
@@ -377,7 +378,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             context="ssh_runner_template_selection",
         ).strip()
         if not selection:  # WHY: empty input → cancel.
-            print("\n! Operation cancelled.")
+            logging.warning("\n! Operation cancelled.")
             logging.info("Template selection cancelled (empty/EOF/interrupt) - SSH/container safe exit")
             return None
         return SSHRunnerManager._resolve_template_selection(selection, templates)  # WHY: numeric or fuzzy lookup.
@@ -396,10 +397,10 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _print_template_menu(templates: list[str], gateways: Any) -> None:  # WHY: menu rendering.
         """Print the numbered template menu with per-template total/online counts."""
-        print("\n  2. Available gateway templates:")  # WHY: section header (preserves prior numbering).
+        logging.warning("\n  2. Available gateway templates:")  # WHY: section header (preserves prior numbering).
         for index, name in enumerate(templates, 1):  # WHY: 1-based numbering for user input parity.
             total, online = SSHRunnerManager._count_template_gateways(name, gateways)  # WHY: helper for counts.
-            print(f"     {index:2}. {name} ({total} total, {online} online)")
+            logging.warning("     %2d. %s (%s total, %s online)", index, name, total, online)
 
     @staticmethod
     def _count_template_gateways(template_name: str, gateways: Any) -> tuple[int, int]:  # WHY: keeps menu CC low.
@@ -417,7 +418,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             return SSHRunnerManager._resolve_template_by_substring(selection, templates)  # WHY: fallback text match.
         if 0 <= idx < len(templates):  # WHY: valid numeric index.
             return templates[idx]
-        print("! Invalid selection.")  # WHY: out of range.
+        logging.warning("! Invalid selection.")  # WHY: out of range.
         return None
 
     @staticmethod
@@ -427,9 +428,9 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         if len(matches) == 1:  # WHY: unambiguous → accept.
             return matches[0]
         if len(matches) > 1:  # WHY: ambiguous → list candidates.
-            print(f"! Ambiguous: {', '.join(matches)}")
+            logging.warning("! Ambiguous: %s", ", ".join(matches))
         else:  # WHY: no match at all.
-            print(f"! Template '{selection}' not found.")
+            logging.warning("! Template '%s' not found.", selection)
         return None
 
     @staticmethod
@@ -452,12 +453,13 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _display_filtered_gateways(gateways: Any) -> None:  # WHY: renders confirmed target set.
         """Display filtered gateway information."""
-        print(f"\n  3. Found {len(gateways)} online gateways with management IPs:")  # WHY: user-facing header.
+        # WHY: user-facing header.
+        logging.warning("\n  3. Found %s online gateways with management IPs:", len(gateways))
         for gateway in gateways:  # WHY: iterate rows so operator can eyeball the target list before confirming.
             name = gateway.get("Gateway Name", _UNKNOWN_TEMPLATE)  # WHY: fall back to sentinel for display.
             ip_address = gateway.get(_MANAGEMENT_IP_KEY)  # WHY: IP was validated earlier by the filter.
             site = gateway.get("Site Name", _UNKNOWN_TEMPLATE)  # WHY: fall back to sentinel when unknown.
-            print(f"     - {name:15} | {ip_address:15} | {site}")
+            logging.warning("     - %-15s | %-15s | %s", name, ip_address, site)
 
     @staticmethod
     def _confirm_execution(deps: SSHRunnerManagerDeps, count: int) -> bool:  # WHY: guarded consent gate.
@@ -475,7 +477,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             .lower()
         )
         if not confirm:  # WHY: empty input → treat as cancel per historical semantics.
-            print("\n! Operation cancelled.")
+            logging.warning("\n! Operation cancelled.")
             logging.info("SSH execution confirmation cancelled (empty/EOF/interrupt) - SSH/container safe exit")
             logging.info("Exiting SSHRunnerManager._confirm_execution: result=cancelled")
             return False
@@ -491,7 +493,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     ) -> None:
         """Execute SSH commands on filtered gateways."""
         _ = deps  # WHY: retained for signature parity with earlier deps-based helpers.
-        print("\n  4. Loading SSH configuration...")  # WHY: user-facing status step marker.
+        logging.warning("\n  4. Loading SSH configuration...")  # WHY: user-facing status step marker.
         try:
             resolved = SSHRunnerManager._resolve_by_template_config()  # WHY: encapsulate config resolution.
             if resolved is None:  # WHY: any missing piece → skip execution (message already printed).
@@ -503,7 +505,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             )
             SSHRunnerManager._report_by_template_results(template_name, management_ips, results)  # WHY: print stats.
         except Exception as error:  # noqa: BLE001  # WHY: preserve historical "surface any error" contract.
-            print(f"! Error: {error}")
+            logging.warning("! Error: %s", error)
             logging.exception("SSH by template error: %s", error)
 
     @staticmethod
@@ -511,19 +513,19 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         """Load SSH creds + commands (from .env + CSV fallback); return None on missing data."""
         ssh_config = EnvSshConfigLoader().load()  # WHY: T013a extracted .env loader.
         if not ssh_config.get("username") or not ssh_config.get("password"):  # WHY: mandatory fields missing.
-            print("! SSH credentials not found in .env file.")
+            logging.warning("! SSH credentials not found in .env file.")
             return None
         commands = ssh_config.get("commands", []) or CommandCsvLoader().load()  # WHY: env first, CSV fallback.
         if not commands:  # WHY: no commands anywhere → nothing to execute.
-            print("! No SSH commands found.")
+            logging.warning("! No SSH commands found.")
             return None
         return ssh_config["username"], ssh_config["password"], commands  # WHY: return resolved trio.
 
     @staticmethod
     def _echo_by_template_plan(management_ips: Any, commands: Any) -> None:  # WHY: extracted echo keeps caller lean.
         """Echo the by-template execution plan to the operator."""
-        print(f"  - Target hosts: {len(management_ips)} gateways")  # WHY: user-facing summary.
-        print(f"  - Commands: {len(commands)}")
+        logging.warning("  - Target hosts: %s gateways", len(management_ips))  # WHY: user-facing summary.
+        logging.warning("  - Commands: %s", len(commands))
 
     @staticmethod
     def _run_by_template_batch(  # WHY: builds request bundle and delegates to MultiHostRunner.
@@ -554,10 +556,10 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     ) -> None:
         """Print the summary of the by-template SSH run and emit an info log."""
         successful = results.get("successful", 0)  # WHY: default 0 when runner did not populate the key.
-        print("\n! SSH execution completed:")  # WHY: user-facing summary header.
-        print(f"  - Template: {template_name}")  # WHY: echo target template for the record.
-        print(f"  - Successful: {successful}")  # WHY: echo success count.
-        print(f"  - Failed: {results.get('failed', 0)}")  # WHY: echo failure count.
+        logging.warning("\n! SSH execution completed:")  # WHY: user-facing summary header.
+        logging.warning("  - Template: %s", template_name)  # WHY: echo target template for the record.
+        logging.warning("  - Successful: %s", successful)  # WHY: echo success count.
+        logging.warning("  - Failed: %s", results.get("failed", 0))  # WHY: echo failure count.
         logging.info(  # WHY: audit log for post-hoc reporting.
             "SSH by template: %s, %s/%s successful",
             template_name,

--- a/tests/unit/ssh/test_ssh_runner_manager_extended.py
+++ b/tests/unit/ssh/test_ssh_runner_manager_extended.py
@@ -10,13 +10,26 @@ config resolver, and report emitter.
 from __future__ import annotations
 
 import getpass  # WHY: needed to monkeypatch getpass.getpass in password prompt tests.
+import logging  # WHY: caplog.set_level(logging.DEBUG) so logger output is captured.
 from pathlib import Path  # WHY: type annotation for tmp_path fixture.
 from types import SimpleNamespace  # WHY: cheap attribute bag for mock injection.
 from unittest.mock import MagicMock, patch  # WHY: standard mocking primitives.
 
-import pytest  # WHY: capsys fixture + parametrize.
+import pytest  # WHY: caplog fixture + parametrize.
 
 from src.ssh.ssh_runner_manager import SSHRunnerManager, SSHRunnerManagerDeps
+
+
+@pytest.fixture(autouse=True)
+def _capture_all_log_levels(caplog: pytest.LogCaptureFixture) -> None:
+    """Capture all log levels so warning/info/debug records show up in caplog.text.
+
+    Why:
+        The source module was migrated from ``print()`` to ``logging.warning``/``info``
+        in #886. Root-logger propagation is the default, but caplog's own handler
+        starts at WARNING — DEBUG assertions would silently fail without this hook.
+    """
+    caplog.set_level(logging.DEBUG)
 
 
 class _Args:
@@ -48,27 +61,25 @@ def _make_deps(*, no_env: bool = True, safe_input_return: str | list[str] = "") 
 # ---------------------------------------------------------------------------
 
 
-def test_print_banner_emits_expected_output(capsys: pytest.CaptureFixture[str]) -> None:
-    """Banner prints title + divider."""
+def test_print_banner_emits_expected_output(caplog: pytest.LogCaptureFixture) -> None:
+    """Banner logs title + divider."""
     SSHRunnerManager._print_banner()
-    captured = capsys.readouterr()
-    assert "Enhanced SSH Command Runner" in captured.out
-    assert "=" * 60 in captured.out
+    assert "Enhanced SSH Command Runner" in caplog.text
+    assert "=" * 60 in caplog.text
 
 
-def test_echo_plan_prints_hosts_username_commands(capsys: pytest.CaptureFixture[str]) -> None:
-    """Echo helper prints resolved plan."""
+def test_echo_plan_prints_hosts_username_commands(caplog: pytest.LogCaptureFixture) -> None:
+    """Echo helper logs resolved plan."""
     SSHRunnerManager._echo_plan(["h1", "h2"], "admin", ["cmd"])
-    output = capsys.readouterr().out
-    assert "h1, h2" in output
-    assert "admin" in output
-    assert "1 command" in output
+    assert "h1, h2" in caplog.text
+    assert "admin" in caplog.text
+    assert "1 command" in caplog.text
 
 
-def test_echo_plan_handles_none_commands(capsys: pytest.CaptureFixture[str]) -> None:
+def test_echo_plan_handles_none_commands(caplog: pytest.LogCaptureFixture) -> None:
     """Echo helper handles None command list with a zero count."""
     SSHRunnerManager._echo_plan(["h1"], "u", None)
-    assert "0 command" in capsys.readouterr().out
+    assert "0 command" in caplog.text
 
 
 def test_emit_completion_noop_when_emitter_none() -> None:
@@ -120,11 +131,11 @@ def test_prompt_hosts_returns_split_list() -> None:
     assert SSHRunnerManager._prompt_hosts(deps) == ["h1", "h2", "h3"]
 
 
-def test_prompt_hosts_returns_none_on_empty(capsys: pytest.CaptureFixture[str]) -> None:
-    """Empty input returns None and prints error notice."""
+def test_prompt_hosts_returns_none_on_empty(caplog: pytest.LogCaptureFixture) -> None:
+    """Empty input returns None and logs error notice."""
     deps = _make_deps(safe_input_return="")
     assert SSHRunnerManager._prompt_hosts(deps) is None
-    assert "SSH host is required" in capsys.readouterr().out
+    assert "SSH host is required" in caplog.text
 
 
 def test_prompt_username_returns_value() -> None:
@@ -133,11 +144,11 @@ def test_prompt_username_returns_value() -> None:
     assert SSHRunnerManager._prompt_username(deps) == "admin"
 
 
-def test_prompt_username_returns_none_on_empty(capsys: pytest.CaptureFixture[str]) -> None:
+def test_prompt_username_returns_none_on_empty(caplog: pytest.LogCaptureFixture) -> None:
     """Empty username returns None with error notice."""
     deps = _make_deps(safe_input_return="")
     assert SSHRunnerManager._prompt_username(deps) is None
-    assert "SSH username is required" in capsys.readouterr().out
+    assert "SSH username is required" in caplog.text
 
 
 def test_prompt_password_returns_value(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -146,9 +157,7 @@ def test_prompt_password_returns_value(monkeypatch: pytest.MonkeyPatch) -> None:
     assert SSHRunnerManager._prompt_password() == "secret"
 
 
-def test_prompt_password_returns_none_on_eof(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_prompt_password_returns_none_on_eof(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     """EOFError treated as cancellation."""
 
     def raise_eof(_prompt: str) -> str:
@@ -156,11 +165,11 @@ def test_prompt_password_returns_none_on_eof(
 
     monkeypatch.setattr(getpass, "getpass", raise_eof)
     assert SSHRunnerManager._prompt_password() is None
-    assert "CANCELLED" in capsys.readouterr().out
+    assert "CANCELLED" in caplog.text
 
 
 def test_prompt_password_returns_none_on_keyboard_interrupt(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """KeyboardInterrupt treated as cancellation."""
 
@@ -169,16 +178,16 @@ def test_prompt_password_returns_none_on_keyboard_interrupt(
 
     monkeypatch.setattr(getpass, "getpass", raise_kb)
     assert SSHRunnerManager._prompt_password() is None
-    assert "CANCELLED" in capsys.readouterr().out
+    assert "CANCELLED" in caplog.text
 
 
 def test_prompt_password_returns_none_on_empty(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Empty password treated as cancellation."""
     monkeypatch.setattr(getpass, "getpass", lambda _prompt: "")
     assert SSHRunnerManager._prompt_password() is None
-    assert "SSH password is required" in capsys.readouterr().out
+    assert "SSH password is required" in caplog.text
 
 
 def test_prompt_commands_returns_list_with_value() -> None:
@@ -243,22 +252,22 @@ def test_load_gateway_data_returns_parsed_rows(tmp_path: Path) -> None:
     assert rows == [{"Gateway Template": "A", "Online Status": "Online", "Management IP": "10.0.0.1"}]
 
 
-def test_load_gateway_data_returns_none_when_empty(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    """Empty CSV returns None and prints notice."""
+def test_load_gateway_data_returns_none_when_empty(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Empty CSV returns None and logs notice."""
     csv_path = tmp_path / "empty.csv"
     csv_path.write_text("Gateway Template,Online Status,Management IP\n")
     deps = _make_deps()
     deps.file_path_utils.get_csv_path = MagicMock(return_value=str(csv_path))
     assert SSHRunnerManager._load_gateway_data(deps) is None
-    assert "No gateway data" in capsys.readouterr().out
+    assert "No gateway data" in caplog.text
 
 
-def test_load_gateway_data_returns_none_on_missing_file(capsys: pytest.CaptureFixture[str]) -> None:
-    """Missing file returns None and prints error."""
+def test_load_gateway_data_returns_none_on_missing_file(caplog: pytest.LogCaptureFixture) -> None:
+    """Missing file returns None and logs error."""
     deps = _make_deps()
     deps.file_path_utils.get_csv_path = MagicMock(return_value="_nonexistent_.csv")
     assert SSHRunnerManager._load_gateway_data(deps) is None
-    assert "not found" in capsys.readouterr().out
+    assert "not found" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -266,19 +275,19 @@ def test_load_gateway_data_returns_none_on_missing_file(capsys: pytest.CaptureFi
 # ---------------------------------------------------------------------------
 
 
-def test_select_gateway_template_no_templates(capsys: pytest.CaptureFixture[str]) -> None:
+def test_select_gateway_template_no_templates(caplog: pytest.LogCaptureFixture) -> None:
     """No template names → None and notice."""
     deps = _make_deps()
     assert SSHRunnerManager._select_gateway_template(deps, [{"Gateway Template": "Unknown"}]) is None
-    assert "No gateway templates" in capsys.readouterr().out
+    assert "No gateway templates" in caplog.text
 
 
-def test_select_gateway_template_cancel_on_empty_input(capsys: pytest.CaptureFixture[str]) -> None:
+def test_select_gateway_template_cancel_on_empty_input(caplog: pytest.LogCaptureFixture) -> None:
     """Empty selection returns None and cancels."""
     deps = _make_deps(safe_input_return="")
     gateways = [{"Gateway Template": "T1", "Online Status": "Online"}]
     assert SSHRunnerManager._select_gateway_template(deps, gateways) is None
-    assert "cancelled" in capsys.readouterr().out.lower()
+    assert "cancelled" in caplog.text.lower()
 
 
 def test_select_gateway_template_numeric_selection() -> None:
@@ -307,17 +316,16 @@ def test_collect_template_names_dedup_and_sort() -> None:
     assert SSHRunnerManager._collect_template_names(gateways) == ["A", "B"]
 
 
-def test_print_template_menu_prints_counts(capsys: pytest.CaptureFixture[str]) -> None:
-    """Menu prints numbered template lines with total/online counts."""
+def test_print_template_menu_prints_counts(caplog: pytest.LogCaptureFixture) -> None:
+    """Menu logs numbered template lines with total/online counts."""
     gateways = [
         {"Gateway Template": "A", "Online Status": "Online"},
         {"Gateway Template": "A", "Online Status": "Offline"},
         {"Gateway Template": "B", "Online Status": "Online"},
     ]
     SSHRunnerManager._print_template_menu(["A", "B"], gateways)
-    output = capsys.readouterr().out
-    assert "1. A (2 total, 1 online)" in output
-    assert "2. B (1 total, 1 online)" in output
+    assert "1. A (2 total, 1 online)" in caplog.text
+    assert "2. B (1 total, 1 online)" in caplog.text
 
 
 def test_count_template_gateways_returns_expected_counts() -> None:
@@ -336,10 +344,10 @@ def test_resolve_template_selection_valid_number() -> None:
     assert SSHRunnerManager._resolve_template_selection("2", ["A", "B", "C"]) == "B"
 
 
-def test_resolve_template_selection_out_of_range(capsys: pytest.CaptureFixture[str]) -> None:
-    """Out-of-range numeric index prints error and returns None."""
+def test_resolve_template_selection_out_of_range(caplog: pytest.LogCaptureFixture) -> None:
+    """Out-of-range numeric index logs error and returns None."""
     assert SSHRunnerManager._resolve_template_selection("99", ["A"]) is None
-    assert "Invalid selection" in capsys.readouterr().out
+    assert "Invalid selection" in caplog.text
 
 
 def test_resolve_template_selection_delegates_to_substring() -> None:
@@ -353,16 +361,16 @@ def test_resolve_template_by_substring_single_match() -> None:
     assert SSHRunnerManager._resolve_template_by_substring("alp", ["Alpha", "Beta"]) == "Alpha"
 
 
-def test_resolve_template_by_substring_ambiguous(capsys: pytest.CaptureFixture[str]) -> None:
-    """Multiple substring matches print ambiguity notice and return None."""
+def test_resolve_template_by_substring_ambiguous(caplog: pytest.LogCaptureFixture) -> None:
+    """Multiple substring matches log ambiguity notice and return None."""
     assert SSHRunnerManager._resolve_template_by_substring("a", ["Alpha", "Aztec"]) is None
-    assert "Ambiguous" in capsys.readouterr().out
+    assert "Ambiguous" in caplog.text
 
 
-def test_resolve_template_by_substring_no_match(capsys: pytest.CaptureFixture[str]) -> None:
-    """No substring match prints not-found notice and returns None."""
+def test_resolve_template_by_substring_no_match(caplog: pytest.LogCaptureFixture) -> None:
+    """No substring match logs not-found notice and returns None."""
     assert SSHRunnerManager._resolve_template_by_substring("zzz", ["Alpha", "Beta"]) is None
-    assert "not found" in capsys.readouterr().out
+    assert "not found" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -370,15 +378,14 @@ def test_resolve_template_by_substring_no_match(capsys: pytest.CaptureFixture[st
 # ---------------------------------------------------------------------------
 
 
-def test_display_filtered_gateways_prints_rows(capsys: pytest.CaptureFixture[str]) -> None:
-    """Each filtered row printed with name/ip/site."""
+def test_display_filtered_gateways_prints_rows(caplog: pytest.LogCaptureFixture) -> None:
+    """Each filtered row logged with name/ip/site."""
     SSHRunnerManager._display_filtered_gateways(
         [{"Gateway Name": "gw1", "Management IP": "10.0.0.1", "Site Name": "SiteA"}]
     )
-    output = capsys.readouterr().out
-    assert "gw1" in output
-    assert "10.0.0.1" in output
-    assert "SiteA" in output
+    assert "gw1" in caplog.text
+    assert "10.0.0.1" in caplog.text
+    assert "SiteA" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -386,11 +393,11 @@ def test_display_filtered_gateways_prints_rows(capsys: pytest.CaptureFixture[str
 # ---------------------------------------------------------------------------
 
 
-def test_confirm_execution_cancels_on_empty(capsys: pytest.CaptureFixture[str]) -> None:
-    """Empty input returns False + prints cancel notice."""
+def test_confirm_execution_cancels_on_empty(caplog: pytest.LogCaptureFixture) -> None:
+    """Empty input returns False + logs cancel notice."""
     deps = _make_deps(safe_input_return="")
     assert SSHRunnerManager._confirm_execution(deps, 3) is False
-    assert "cancelled" in capsys.readouterr().out.lower()
+    assert "cancelled" in caplog.text.lower()
 
 
 def test_confirm_execution_rejects_non_yes() -> None:
@@ -425,7 +432,7 @@ def test_install_mock_env_loader_replaces_loader_and_returns_selection() -> None
 # ---------------------------------------------------------------------------
 
 
-def test_by_gateway_template_returns_early_when_no_data(capsys: pytest.CaptureFixture[str]) -> None:
+def test_by_gateway_template_returns_early_when_no_data(caplog: pytest.LogCaptureFixture) -> None:
     """No gateway data → early return without executing SSH batch."""
     deps = _make_deps()
     with (
@@ -464,7 +471,7 @@ def test_by_gateway_template_executes_when_confirmed() -> None:
     executor.assert_called_once()
 
 
-def test_prepare_gateway_selection_returns_none_when_filter_empty(capsys: pytest.CaptureFixture[str]) -> None:
+def test_prepare_gateway_selection_returns_none_when_filter_empty(caplog: pytest.LogCaptureFixture) -> None:
     """Selected template with no online rows → None + notice."""
     deps = _make_deps()
     gateways = [{"Gateway Template": "A", "Online Status": "Offline", "Management IP": "10.0.0.1"}]
@@ -473,7 +480,7 @@ def test_prepare_gateway_selection_returns_none_when_filter_empty(capsys: pytest
         patch.object(SSHRunnerManager, "_select_gateway_template", return_value="A"),
     ):
         assert SSHRunnerManager._prepare_gateway_selection(deps) is None
-    assert "No online gateways" in capsys.readouterr().out
+    assert "No online gateways" in caplog.text
 
 
 def test_prepare_gateway_selection_cancel_when_no_template() -> None:
@@ -496,10 +503,10 @@ def test_refresh_gateway_export_invokes_cache_utils() -> None:
     assert args[0] == "GatewayManagementIPs.csv"
 
 
-def test_print_by_template_banner(capsys: pytest.CaptureFixture[str]) -> None:
-    """Banner prints title + divider."""
+def test_print_by_template_banner(caplog: pytest.LogCaptureFixture) -> None:
+    """Banner logs title + divider."""
     SSHRunnerManager._print_by_template_banner()
-    assert "Gateway Template Targeting" in capsys.readouterr().out
+    assert "Gateway Template Targeting" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -508,17 +515,17 @@ def test_print_by_template_banner(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_resolve_by_template_config_returns_none_when_creds_missing(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Missing username/password → None + notice."""
     with patch("src.ssh.ssh_runner_manager.EnvSshConfigLoader") as loader:
         loader.return_value.load.return_value = {"username": "", "password": ""}
         assert SSHRunnerManager._resolve_by_template_config() is None
-    assert "SSH credentials not found" in capsys.readouterr().out
+    assert "SSH credentials not found" in caplog.text
 
 
 def test_resolve_by_template_config_returns_none_when_no_commands(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Missing commands (env + CSV fallback both empty) → None + notice."""
     with (
@@ -528,7 +535,7 @@ def test_resolve_by_template_config_returns_none_when_no_commands(
         loader.return_value.load.return_value = {"username": "u", "password": "p", "commands": []}
         csv_loader.return_value.load.return_value = []
         assert SSHRunnerManager._resolve_by_template_config() is None
-    assert "No SSH commands" in capsys.readouterr().out
+    assert "No SSH commands" in caplog.text
 
 
 def test_resolve_by_template_config_returns_resolved_trio() -> None:
@@ -553,21 +560,19 @@ def test_resolve_by_template_config_uses_csv_fallback() -> None:
         assert SSHRunnerManager._resolve_by_template_config() == ("u", "p", ["cmd1"])
 
 
-def test_echo_by_template_plan(capsys: pytest.CaptureFixture[str]) -> None:
-    """Echo prints host + command counts."""
+def test_echo_by_template_plan(caplog: pytest.LogCaptureFixture) -> None:
+    """Echo logs host + command counts."""
     SSHRunnerManager._echo_by_template_plan(["10.0.0.1", "10.0.0.2"], ["c1", "c2"])
-    output = capsys.readouterr().out
-    assert "2 gateways" in output
-    assert "Commands: 2" in output
+    assert "2 gateways" in caplog.text
+    assert "Commands: 2" in caplog.text
 
 
-def test_report_by_template_results(capsys: pytest.CaptureFixture[str]) -> None:
-    """Report prints template + success/failure counts."""
+def test_report_by_template_results(caplog: pytest.LogCaptureFixture) -> None:
+    """Report logs template + success/failure counts."""
     SSHRunnerManager._report_by_template_results("TplA", ["10.0.0.1"], {"successful": 1, "failed": 0, "total": 1})
-    output = capsys.readouterr().out
-    assert "TplA" in output
-    assert "Successful: 1" in output
-    assert "Failed: 0" in output
+    assert "TplA" in caplog.text
+    assert "Successful: 1" in caplog.text
+    assert "Failed: 0" in caplog.text
 
 
 def test_run_by_template_batch_delegates_to_multihostrunner() -> None:
@@ -606,12 +611,12 @@ def test_execute_by_template_happy_path() -> None:
     reporter.assert_called_once()
 
 
-def test_execute_by_template_swallows_exception(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_by_template_swallows_exception(caplog: pytest.LogCaptureFixture) -> None:
     """Any exception surfaces as user-visible '! Error:' notice."""
     deps = _make_deps()
     with patch.object(SSHRunnerManager, "_resolve_by_template_config", side_effect=RuntimeError("boom")):
         SSHRunnerManager._execute_by_template(deps, ["10.0.0.1"], "TplA")
-    assert "boom" in capsys.readouterr().out
+    assert "boom" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -637,20 +642,20 @@ def test_interactive_returns_false_when_workflow_fails() -> None:
         assert SSHRunnerManager.interactive(deps) is False
 
 
-def test_interactive_handles_keyboard_interrupt(capsys: pytest.CaptureFixture[str]) -> None:
+def test_interactive_handles_keyboard_interrupt(caplog: pytest.LogCaptureFixture) -> None:
     """KeyboardInterrupt from workflow yields False + cancel notice."""
     deps = _make_deps()
     with patch.object(SSHRunnerManager, "_run_interactive_workflow", side_effect=KeyboardInterrupt):
         assert SSHRunnerManager.interactive(deps) is False
-    assert "cancelled" in capsys.readouterr().out.lower()
+    assert "cancelled" in caplog.text.lower()
 
 
-def test_interactive_handles_exception(capsys: pytest.CaptureFixture[str]) -> None:
+def test_interactive_handles_exception(caplog: pytest.LogCaptureFixture) -> None:
     """Unhandled exception yields False + fatal error notice."""
     deps = _make_deps()
     with patch.object(SSHRunnerManager, "_run_interactive_workflow", side_effect=RuntimeError("boom")):
         assert SSHRunnerManager.interactive(deps) is False
-    assert "Fatal error" in capsys.readouterr().out
+    assert "Fatal error" in caplog.text
 
 
 def test_run_interactive_workflow_aborts_when_missing_fields() -> None:


### PR DESCRIPTION
## Summary

Slice 22/N of #886 — replace the 40 remaining `print()` calls in
`src/ssh/ssh_runner_manager.py` with `logging.warning(...)` using
`%`-style deferred formatting. Covers prompt headers, missing-data
notices, gateway-template listing/selection, online-gateway target
listing, cancellation banners, credential/command validation errors,
and post-execution success/failure counts.

Tests in `tests/unit/ssh/test_ssh_runner_manager_extended.py` now use
`caplog.text` in place of `capsys.readouterr().out` across all 26
assertion sites, plus an autouse `_capture_all_log_levels` fixture
pinning `caplog.set_level(logging.DEBUG)` for parity with earlier SSH
slices.

## Test plan

- [x] `ruff check src/ssh/ssh_runner_manager.py tests/unit/ssh/test_ssh_runner_manager*.py` — clean
- [x] `black --check src/ssh/ssh_runner_manager.py tests/unit/ssh/test_ssh_runner_manager*.py` — clean
- [x] 0 remaining `print(` matches in `src/ssh/ssh_runner_manager.py`
- [x] Targeted `pytest tests/unit/ssh/test_ssh_runner_manager.py tests/unit/ssh/test_ssh_runner_manager_extended.py` — 70 passed
- [x] Full `pytest` — 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed