### PR TITLE
chore(logging): migrate src/export/data_exporter.py print() to logger (#886 slice 23/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 23/N: retire `print()` in `src/export/data_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`
+  call in `src/export/data_exporter.py` with `logging.warning(...)` using
+  `%`-style deferred formatting. The `PermissionError` branch of
+  `_write_csv_with_exception_handling` now emits
+  `logging.warning("! Cannot write to %s. Is it open in another program?",
+  csv_file_path)` so the operator-visible hint arrives through the same
+  handler chain as the accompanying `logging.error(...)` record.
+  `import logging` was already present at module scope.
+- **Test posture**: `tests/unit/export/test_data_exporter.py::
+  TestWriteCsvWithExceptionHandling::test_permission_error_reraises` was
+  rewritten from `capsys.readouterr().out` to `caplog.text`. Pytest's
+  default WARNING-level caplog capture is sufficient here (no autouse
+  DEBUG fixture required); the assertion substring `"another program"`
+  is preserved verbatim.
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining T201 matches in `src/export/data_exporter.py`; targeted
+  `pytest tests/unit/export/test_data_exporter.py` runs 68 passed; full
+  `pytest` suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed).
+
 ### #886 Phase 2 slice 22/N: retire `print()` in `src/ssh/ssh_runner_manager.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 40 remaining `print()`

--- a/src/export/data_exporter.py
+++ b/src/export/data_exporter.py
@@ -318,7 +318,7 @@ class DataExporter:  # Multi-backend export facade.
             DataExporter._write_csv_open_and_emit(csv_file_path, escaped_data, fields)  # Open + emit
         except PermissionError as perm_error:  # File locked or write denied
             logging.error("File I/O: Permission denied when writing to %s: %s", csv_file_path, perm_error)
-            print(f"! Cannot write to {csv_file_path}. Is it open in another program?")  # User-facing hint
+            logging.warning("! Cannot write to %s. Is it open in another program?", csv_file_path)  # User-facing hint
             logging.debug("EXIT: DataExporter.write_to_csv - permission error")  # Trace exit on perm denial
             raise  # Propagate to the caller
         except OSError as os_error:  # OS-level write failure (disk full, path invalid, etc.)

--- a/tests/unit/export/test_data_exporter.py
+++ b/tests/unit/export/test_data_exporter.py
@@ -494,12 +494,11 @@ class TestWriteCsvWithExceptionHandling:
             DataExporter._write_csv_with_exception_handling("p", [{"a": 1}], ["a"])
         inner.assert_called_once()
 
-    def test_permission_error_reraises(self, capsys):
+    def test_permission_error_reraises(self, caplog):
         with patch.object(DataExporter, "_write_csv_open_and_emit", side_effect=PermissionError("locked")):
             with pytest.raises(PermissionError):
                 DataExporter._write_csv_with_exception_handling("p", [{"a": 1}], ["a"])
-        captured = capsys.readouterr()
-        assert "another program" in captured.out
+        assert "another program" in caplog.text
 
     def test_os_error_reraises(self):
         with patch.object(DataExporter, "_write_csv_open_and_emit", side_effect=OSError("disk full")):


### PR DESCRIPTION
## Summary

Slice 23/N of #886 — replace the 1 remaining `print()` call in
`src/export/data_exporter.py._write_csv_with_exception_handling` with
`logging.warning(...)` using `%`-style deferred formatting. The
`PermissionError` branch's operator-visible hint now flows through the
same handler chain as the accompanying `logging.error(...)` record.

`tests/unit/export/test_data_exporter.py::
TestWriteCsvWithExceptionHandling::test_permission_error_reraises` now
reads `caplog.text` in place of `capsys.readouterr().out`; pytest's
default WARNING-level capture is sufficient (no autouse DEBUG fixture
required).

## Test plan

- [x] `ruff check` clean
- [x] `black --check` clean
- [x] 0 remaining T201 in `src/export/data_exporter.py`
- [x] Targeted `pytest tests/unit/export/test_data_exporter.py` — 68 passed
- [x] Full `pytest` — 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed