### PR TITLE
chore(logging): migrate src/export/org_admin_exporter.py print() to logger (#886 slice 24/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 24/N: retire `print()` in `src/export/org_admin_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`
+  call in `src/export/org_admin_exporter.py` with `logging.warning(...)`. The
+  completion banner at the tail of `OrgAdminExporter.usage()` now emits
+  `logging.warning(" License usage data exported to OrgUsage")` so the
+  operator-visible confirmation flows through the same handler chain as the
+  pre-existing `logging.info(...)` companion record. `import logging` was
+  already present at module scope.
+- **Test posture**: `tests/unit/export/test_org_admin_exporter.py::
+  test_usage_delegates_to_apidata_fetcher_execute` was rewritten from
+  `capsys.readouterr().out` to `caplog.text`. Pytest's default WARNING-level
+  caplog capture is sufficient here (no autouse DEBUG fixture required); the
+  assertion substring `"License usage data exported to OrgUsage"` is preserved
+  verbatim.
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining T201 matches in `src/export/org_admin_exporter.py`; targeted
+  `pytest tests/unit/export/test_org_admin_exporter.py` runs 14 passed; full
+  `pytest` suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed).
+
 ### #886 Phase 2 slice 23/N: retire `print()` in `src/export/data_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`

--- a/src/export/org_admin_exporter.py
+++ b/src/export/org_admin_exporter.py
@@ -121,4 +121,5 @@ class OrgAdminExporter:
             sort_key="site_id",
         ).execute()
         logging.info(" License usage data exported to OrgUsage")  # Log completion.
-        print(" License usage data exported to OrgUsage")  # Tell the user.
+        # WHY: user-visible completion banner (replaces prior print()).
+        logging.warning(" License usage data exported to OrgUsage")

--- a/tests/unit/export/test_org_admin_exporter.py
+++ b/tests/unit/export/test_org_admin_exporter.py
@@ -224,12 +224,12 @@ def test_licenses_swallows_secondary_write_failure() -> None:
 # ---------- usage ----------
 
 
-def test_usage_delegates_to_apidata_fetcher_execute(capsys: pytest.CaptureFixture[str]) -> None:
-    """usage must run APIDataFetcher for the by-site usage endpoint and print completion."""
+def test_usage_delegates_to_apidata_fetcher_execute(caplog: pytest.LogCaptureFixture) -> None:
+    """usage must run APIDataFetcher for the by-site usage endpoint and log completion."""
     fake_mh = _make_mh()
     with patch("src.export.org_admin_exporter.importlib.import_module", return_value=fake_mh):
         OrgAdminExporter.usage()
     kwargs = fake_mh.APIDataFetcher.call_args.kwargs
     assert kwargs["filename"] == "OrgUsage"
     fake_mh.APIDataFetcher.return_value.execute.assert_called_once_with()
-    assert "License usage data exported to OrgUsage" in capsys.readouterr().out
+    assert "License usage data exported to OrgUsage" in caplog.text


### PR DESCRIPTION
## Summary

- Retire the 1 remaining `print()` in `src/export/org_admin_exporter.py` (issue #886).
- `OrgAdminExporter.usage()` completion banner is now `logging.warning(" License usage data exported to OrgUsage")`, keeping the operator-visible confirmation while routing it through the same handler chain as the accompanying `logging.info(...)` record.
- `test_usage_delegates_to_apidata_fetcher_execute` migrated from `capsys.readouterr().out` to `caplog.text`. Pytest's default WARNING-level caplog capture is sufficient — no autouse DEBUG fixture needed.

## Verification

- `ruff check --select T201,T203 src/export/org_admin_exporter.py` → 0 findings.
- `ruff check` and `black --check` clean across the two edited files.
- Targeted: `pytest tests/unit/export/test_org_admin_exporter.py` → 14 passed.
- Full suite: `pytest` → 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed.

## Test plan

- [x] `ruff check --select T201,T203 src/export/org_admin_exporter.py`
- [x] `ruff check src/export/org_admin_exporter.py tests/unit/export/test_org_admin_exporter.py`
- [x] `black --check src/export/org_admin_exporter.py tests/unit/export/test_org_admin_exporter.py`
- [x] `pytest tests/unit/export/test_org_admin_exporter.py`
- [x] `pytest` (full suite)