### PR TITLE
chore(logging): migrate src/export/org_alarm_event_exporter.py print() to logger (#886 slice 25/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 25/N: retire `print()` in `src/export/org_alarm_event_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`
+  call in `src/export/org_alarm_event_exporter.py` with `logging.warning(...)`
+  using `%`-style deferred formatting. The `OrgAlarmEventExporter.device_events()`
+  operator-visible export banner now emits
+  `logging.warning("! %s device events exported to OrgDeviceEvents.csv", len(events))`
+  so the confirmation reaches the same handler chain as the surrounding
+  `logging.info(...)` records. `import logging` was already present at module
+  scope.
+- **Test posture**: `tests/unit/export/test_org_alarm_event_exporter.py::
+  TestDeviceEvents::test_with_events_logs_sample` was rewritten from
+  `capsys.readouterr().out` to `caplog.text`. Pytest's default WARNING-level
+  caplog capture is sufficient here (no autouse DEBUG fixture required); the
+  assertion substring `"3 device events exported"` is preserved verbatim.
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining T201 matches in `src/export/org_alarm_event_exporter.py`;
+  targeted `pytest tests/unit/export/test_org_alarm_event_exporter.py` runs
+  10 passed; full `pytest` suite green (8949 passed, 0 failed, 77 skipped,
+  5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 24/N: retire `print()` in `src/export/org_admin_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`

--- a/src/export/org_alarm_event_exporter.py
+++ b/src/export/org_alarm_event_exporter.py
@@ -123,7 +123,8 @@ class OrgAlarmEventExporter:
         )
         mh.DataExporter.write_with_format_selection(events, "OrgDeviceEvents.csv")  # Persist events.
         logging.info("Device events written to OrgDeviceEvents.csv (%s rows).", len(events))
-        print(f"! {len(events)} device events exported to OrgDeviceEvents.csv")  # Confirm export to operator.
+        # WHY: operator-visible export confirmation (replaces prior print()).
+        logging.warning("! %s device events exported to OrgDeviceEvents.csv", len(events))
         logging.info("Menu #21: Device events export completed - %s events", len(events))
         if events:  # Branch: events present.
             logging.debug("Sample device events: %s", json.dumps(events[:3], indent=2))  # Debug-dump sample events.

--- a/tests/unit/export/test_org_alarm_event_exporter.py
+++ b/tests/unit/export/test_org_alarm_event_exporter.py
@@ -142,7 +142,7 @@ class TestEvents:
 
 
 class TestDeviceEvents:
-    def test_with_events_logs_sample(self, fake_mh: ModuleType, capsys: pytest.CaptureFixture) -> None:
+    def test_with_events_logs_sample(self, fake_mh: ModuleType, caplog: pytest.LogCaptureFixture) -> None:
         events = [{"id": 1}, {"id": 2}, {"id": 3}]
         with (
             patch.object(oaee.TimeUtils, "get_dynamic_lookback_hours", return_value=24),
@@ -153,7 +153,7 @@ class TestDeviceEvents:
             mistapi_mock.get_all.return_value = events
             OrgAlarmEventExporter.device_events()
         fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(events, "OrgDeviceEvents.csv")  # type: ignore[attr-defined]
-        assert "3 device events exported" in capsys.readouterr().out
+        assert "3 device events exported" in caplog.text
 
     def test_without_events_skips_sample_block(self, fake_mh: ModuleType) -> None:
         with (


### PR DESCRIPTION
## Summary

- Retire the 1 remaining `print()` in `src/export/org_alarm_event_exporter.py` (issue #886).
- `OrgAlarmEventExporter.device_events()` operator-visible confirmation is now `logging.warning("! %s device events exported to OrgDeviceEvents.csv", len(events))`, routing through the same handler chain as the surrounding `logging.info(...)` records with `%`-style deferred formatting.
- `TestDeviceEvents::test_with_events_logs_sample` migrated from `capsys.readouterr().out` to `caplog.text`. Pytest's default WARNING-level caplog capture is sufficient — no autouse DEBUG fixture needed.

## Verification

- `ruff check --select T201,T203 src/export/org_alarm_event_exporter.py` → 0 findings.
- `ruff check` and `black --check` clean across the two edited files.
- Targeted: `pytest tests/unit/export/test_org_alarm_event_exporter.py` → 10 passed.
- Full suite: `pytest` → 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed.

## Test plan

- [x] `ruff check --select T201,T203 src/export/org_alarm_event_exporter.py`
- [x] `ruff check src/export/org_alarm_event_exporter.py tests/unit/export/test_org_alarm_event_exporter.py`
- [x] `black --check src/export/org_alarm_event_exporter.py tests/unit/export/test_org_alarm_event_exporter.py`
- [x] `pytest tests/unit/export/test_org_alarm_event_exporter.py`
- [x] `pytest` (full suite)