### PR TITLE
chore(logging): migrate src/refactors/service_ping_launcher.py print() to logger (#886 slice 26/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 26/N: retire `print()` in `src/refactors/service_ping_launcher.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`
+  call in `src/refactors/service_ping_launcher.py` with `logging.warning(...)`
+  using `%`-style deferred formatting. `ServicePingLauncher._handle_fatal_error`
+  now surfaces the user-visible error banner via
+  `logging.warning("ERROR: %s", error)` so the operator-facing message flows
+  through the same handler chain as the paired
+  `logging.error("Error running Service Ping: %s", error, exc_info=True)`
+  record. `import logging` was already present at module scope.
+- **Test posture**: `tests/unit/refactors/test_service_ping_launcher.py` had
+  three tests (`TestLaunchFatalError::test_launch_wire_failure_logs_and_prints`,
+  `TestLaunchFatalError::test_launch_execute_failure_logs_and_prints`, and
+  `TestHandleFatalError::test_prints_and_logs`) rewritten from
+  `capsys.readouterr().out` to `caplog.text`. Each `caplog.at_level(logging.ERROR)`
+  context was widened to `logging.WARNING` so the new banner emission is
+  captured alongside the pre-existing ERROR log entry. Assertion substrings
+  (`"ERROR: wire boom"`, `"ERROR: execute boom"`, `"ERROR: boom-direct"`) are
+  preserved verbatim. The `capsys` parameter and the docstring header comment
+  mentioning `capsys` were removed.
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining T201 matches in `src/refactors/service_ping_launcher.py`;
+  targeted `pytest tests/unit/refactors/test_service_ping_launcher.py` runs
+  8 passed; full `pytest` suite green (8949 passed, 0 failed, 77 skipped,
+  5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 25/N: retire `print()` in `src/export/org_alarm_event_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`

--- a/src/refactors/service_ping_launcher.py
+++ b/src/refactors/service_ping_launcher.py
@@ -109,4 +109,5 @@ class ServicePingLauncher:
     def _handle_fatal_error(self, error: Exception) -> None:
         """Log and display fatal error message."""
         logging.error("Error running Service Ping: %s", error, exc_info=True)  # Log with traceback for postmortem
-        print(f"\nERROR: {error}")  # Surface error to user without stack details
+        # WHY: operator-visible error surface (replaces prior print()).
+        logging.warning("ERROR: %s", error)

--- a/tests/unit/refactors/test_service_ping_launcher.py
+++ b/tests/unit/refactors/test_service_ping_launcher.py
@@ -14,7 +14,7 @@ import logging  # WHY: verify structured logs emitted at launch/wire/build stage
 from typing import Any  # WHY: dict-of-mocks return-type annotation.
 from unittest.mock import MagicMock  # WHY: FR-008 mandates MagicMock(spec=...) doubles.
 
-import pytest  # WHY: monkeypatch/capsys/caplog fixtures.
+import pytest  # WHY: monkeypatch/caplog fixtures.
 
 from src.refactors.service_ping_launcher import (  # WHY: SUT + helper direct imports.
     ServicePingLauncher,
@@ -144,16 +144,14 @@ class TestLaunchFatalError:
     def test_launch_wire_failure_logs_and_prints(
         self,
         wired_deps: dict[str, Any],
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """When configure_service_ping_manager_dependencies raises, error is logged + printed, no crash."""
+        """When configure_service_ping_manager_dependencies raises, error is logged, no crash."""
         wired_deps["configure"].side_effect = RuntimeError("wire boom")  # WHY: raise during wire step.
         launcher = ServicePingLauncher()  # WHY: build launcher.
-        with caplog.at_level(logging.ERROR):  # WHY: fatal path logs at ERROR.
+        with caplog.at_level(logging.WARNING):  # WHY: fatal path logs at WARNING + ERROR.
             launcher.launch()  # WHY: exercise exception branch; must not re-raise.
-        captured = capsys.readouterr()  # WHY: read printed error.
-        assert "ERROR: wire boom" in captured.out  # WHY: user-visible error printed.
+        assert "ERROR: wire boom" in caplog.text  # WHY: user-visible warning banner emitted.
         assert "Error running Service Ping" in caplog.text  # WHY: structured error log emitted.
         assert wired_deps["manager_class"].call_count == 0  # WHY: manager never built when wire fails.
         assert wired_deps["manager_instance"].execute.call_count == 0  # WHY: execute never reached.
@@ -161,28 +159,25 @@ class TestLaunchFatalError:
     def test_launch_execute_failure_logs_and_prints(
         self,
         wired_deps: dict[str, Any],
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """When manager.execute() raises, the error surfaces via _handle_fatal_error."""
         wired_deps["manager_instance"].execute.side_effect = RuntimeError("execute boom")  # WHY: raise on execute.
         launcher = ServicePingLauncher()  # WHY: build launcher.
-        with caplog.at_level(logging.ERROR):  # WHY: capture the ERROR log.
+        with caplog.at_level(logging.WARNING):  # WHY: capture both WARNING banner and ERROR log.
             launcher.launch()  # WHY: exercise post-build exception branch.
-        captured = capsys.readouterr()  # WHY: capture printed banner.
-        assert "ERROR: execute boom" in captured.out  # WHY: user-visible error present.
+        assert "ERROR: execute boom" in caplog.text  # WHY: user-visible warning banner emitted.
         assert "Error running Service Ping" in caplog.text  # WHY: structured error log emitted.
 
 
 class TestHandleFatalError:
-    """`_handle_fatal_error` prints and logs directly (unit level)."""
+    """`_handle_fatal_error` logs at WARNING + ERROR directly (unit level)."""
 
-    def test_prints_and_logs(self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
-        """Direct call prints and logs without invoking sys.exit."""
+    def test_prints_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Direct call logs banner + error without invoking sys.exit."""
         launcher = ServicePingLauncher()  # WHY: build instance to reach the method.
         error = ValueError("boom-direct")  # WHY: sentinel error we can grep for.
-        with caplog.at_level(logging.ERROR):  # WHY: assert on the ERROR log entry.
+        with caplog.at_level(logging.WARNING):  # WHY: assert on both WARNING banner and ERROR log entry.
             launcher._handle_fatal_error(error)  # WHY: direct-call exercises the branch.
-        captured = capsys.readouterr()  # WHY: capture the print output.
-        assert "ERROR: boom-direct" in captured.out  # WHY: printed banner content.
+        assert "ERROR: boom-direct" in caplog.text  # WHY: warning banner content.
         assert "Error running Service Ping" in caplog.text  # WHY: log entry present.


### PR DESCRIPTION
## Summary

- Retires the 1 remaining `print()` call in `src/refactors/service_ping_launcher.py`, replacing it with `logging.warning("ERROR: %s", error)` in `ServicePingLauncher._handle_fatal_error`. `%`-style deferred formatting keeps the fatal-error banner flowing through the same handler chain as the paired `logging.error(..., exc_info=True)` record. `import logging` was already present at module scope.
- Rewrites three tests in `tests/unit/refactors/test_service_ping_launcher.py` (`TestLaunchFatalError::test_launch_wire_failure_logs_and_prints`, `TestLaunchFatalError::test_launch_execute_failure_logs_and_prints`, and `TestHandleFatalError::test_prints_and_logs`) from `capsys.readouterr().out` to `caplog.text`. Each `caplog.at_level(logging.ERROR)` context is widened to `logging.WARNING` so the new banner is captured alongside the pre-existing ERROR log entry; assertion substrings preserved verbatim.
- Slice 26/N of the #886 file-by-file print()→logging retirement.

## Test plan

- [x] `ruff check --select T201,T203 src/refactors/service_ping_launcher.py` — no issues
- [x] `ruff check src/refactors/service_ping_launcher.py tests/unit/refactors/test_service_ping_launcher.py` — no issues
- [x] `black --check src/refactors/service_ping_launcher.py tests/unit/refactors/test_service_ping_launcher.py` — clean
- [x] `pytest tests/unit/refactors/test_service_ping_launcher.py` — 8 passed
- [x] Full `pytest` suite — 8949 passed, 77 skipped, 5 xfailed, 1 xpassed

Refs: #886