### PR TITLE
chore(logging): migrate src/refactors/wan2_migration_launcher.py print() to logger (#886 slice 27/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 27/N: retire `print()` in `src/refactors/wan2_migration_launcher.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`
+  call in `src/refactors/wan2_migration_launcher.py` with `logging.warning(...)`
+  using `%`-style deferred formatting. `WAN2MigrationLauncher._handle_fatal_error`
+  now surfaces the user-visible error banner via
+  `logging.warning("ERROR: %s", error)` so the operator-facing message flows
+  through the same handler chain as the paired
+  `logging.error("Error running WAN2 Migration: %s", error, exc_info=True)`
+  record. `import logging` was already present at module scope.
+- **Test posture**: `tests/unit/refactors/test_wan2_migration_launcher.py` had
+  three tests (`TestLaunchFatalError::test_launch_wire_failure_logs_and_prints`,
+  `TestLaunchFatalError::test_launch_execute_failure_logs_and_prints`, and
+  `TestHandleFatalError::test_prints_and_logs`) rewritten from
+  `capsys.readouterr().out` to `caplog.text`. Each `caplog.at_level(logging.ERROR)`
+  context was widened to `logging.WARNING` so the new banner emission is
+  captured alongside the pre-existing ERROR log entry. Assertion substrings
+  (`"ERROR: wire boom"`, `"ERROR: flow boom"`, `"ERROR: boom-direct"`) are
+  preserved verbatim. The `capsys` parameter and the header comment
+  mentioning `capsys` were removed.
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining T201 matches in `src/refactors/wan2_migration_launcher.py`;
+  targeted `pytest tests/unit/refactors/test_wan2_migration_launcher.py` runs
+  8 passed; full `pytest` suite green (8949 passed, 0 failed, 77 skipped,
+  5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 26/N: retire `print()` in `src/refactors/service_ping_launcher.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`

--- a/src/refactors/wan2_migration_launcher.py
+++ b/src/refactors/wan2_migration_launcher.py
@@ -119,4 +119,5 @@ class WAN2MigrationLauncher:
     def _handle_fatal_error(self, error: Exception) -> None:
         """Log and display fatal error message."""
         logging.error("Error running WAN2 Migration: %s", error, exc_info=True)  # Log with traceback for postmortem
-        print(f"\nERROR: {error}")  # Surface error to user without stack details
+        # WHY: operator-visible error surface (replaces prior print()).
+        logging.warning("ERROR: %s", error)

--- a/tests/unit/refactors/test_wan2_migration_launcher.py
+++ b/tests/unit/refactors/test_wan2_migration_launcher.py
@@ -14,7 +14,7 @@ import logging  # WHY: verify structured logs emitted at launch/wire/build stage
 from typing import Any  # WHY: dict-of-mocks return-type annotation.
 from unittest.mock import MagicMock  # WHY: FR-008 mandates MagicMock(spec=...) doubles.
 
-import pytest  # WHY: monkeypatch/capsys/caplog fixtures.
+import pytest  # WHY: monkeypatch/caplog fixtures.
 
 from src.refactors.wan2_migration_launcher import (  # WHY: SUT + helper direct imports.
     WAN2MigrationLauncher,
@@ -156,23 +156,20 @@ class TestLaunchFatalError:
     def test_launch_wire_failure_logs_and_prints(
         self,
         wired_deps: dict[str, Any],
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """When configure_wan2_migration_dependencies raises, error is logged + printed, no crash."""
+        """When configure_wan2_migration_dependencies raises, error is logged, no crash."""
         wired_deps["configure"].side_effect = RuntimeError("wire boom")  # WHY: raise during wire step.
         launcher = WAN2MigrationLauncher()  # WHY: build launcher.
-        with caplog.at_level(logging.ERROR):  # WHY: fatal path logs at ERROR.
+        with caplog.at_level(logging.WARNING):  # WHY: fatal path logs WARNING banner + ERROR record.
             launcher.launch()  # WHY: exercise exception branch; must not re-raise.
-        captured = capsys.readouterr()  # WHY: read printed error.
-        assert "ERROR: wire boom" in captured.out  # WHY: user-visible error printed.
+        assert "ERROR: wire boom" in caplog.text  # WHY: user-visible warning banner emitted.
         assert "Error running WAN2 Migration" in caplog.text  # WHY: structured error log emitted.
         assert wired_deps["manager_class"].call_count == 0  # WHY: manager never built when wire fails.
 
     def test_launch_execute_failure_logs_and_prints(
         self,
         wired_deps: dict[str, Any],
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """When manager.set_site_variable() raises, the error surfaces via _handle_fatal_error."""
@@ -180,22 +177,20 @@ class TestLaunchFatalError:
             "flow boom"
         )  # WHY: raise on execute.
         launcher = WAN2MigrationLauncher()  # WHY: build launcher.
-        with caplog.at_level(logging.ERROR):  # WHY: capture the ERROR log.
+        with caplog.at_level(logging.WARNING):  # WHY: capture both WARNING banner and ERROR log.
             launcher.launch()  # WHY: exercise post-build exception branch.
-        captured = capsys.readouterr()  # WHY: capture printed banner.
-        assert "ERROR: flow boom" in captured.out  # WHY: user-visible error present.
+        assert "ERROR: flow boom" in caplog.text  # WHY: user-visible warning banner emitted.
         assert "Error running WAN2 Migration" in caplog.text  # WHY: structured error log emitted.
 
 
 class TestHandleFatalError:
-    """`_handle_fatal_error` prints and logs directly (unit level)."""
+    """`_handle_fatal_error` logs at WARNING + ERROR directly (unit level)."""
 
-    def test_prints_and_logs(self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
-        """Direct call prints and logs without invoking sys.exit."""
+    def test_prints_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Direct call logs banner + error without invoking sys.exit."""
         launcher = WAN2MigrationLauncher()  # WHY: build instance to reach the method.
         error = ValueError("boom-direct")  # WHY: sentinel error we can grep for.
-        with caplog.at_level(logging.ERROR):  # WHY: assert on the ERROR log entry.
+        with caplog.at_level(logging.WARNING):  # WHY: assert on both WARNING banner and ERROR log entry.
             launcher._handle_fatal_error(error)  # WHY: direct-call exercises the branch.
-        captured = capsys.readouterr()  # WHY: capture print output.
-        assert "ERROR: boom-direct" in captured.out  # WHY: printed banner content.
+        assert "ERROR: boom-direct" in caplog.text  # WHY: warning banner content.
         assert "Error running WAN2 Migration" in caplog.text  # WHY: log entry present.


### PR DESCRIPTION
## Summary

Slice 27/N of issue #886 (retire `print()` globally). Migrates the single remaining `print()` call in `src/refactors/wan2_migration_launcher.py` to `logging.warning(...)` with `%`-style deferred formatting so operator-visible error output flows through the standard handler chain.

`WAN2MigrationLauncher._handle_fatal_error` previously emitted `print(f"\nERROR: {error}")` immediately after `logging.error("Error running WAN2 Migration: %s", error, exc_info=True)`. The print is now `logging.warning("ERROR: %s", error)`, preserving the user-facing substring `"ERROR: <message>"` for downstream text-based assertions.

## Test changes

`tests/unit/refactors/test_wan2_migration_launcher.py` — three fatal-error tests rewritten:

- `TestLaunchFatalError::test_launch_wire_failure_logs_and_prints`
- `TestLaunchFatalError::test_launch_execute_failure_logs_and_prints`
- `TestHandleFatalError::test_prints_and_logs`

Each dropped the `capsys` fixture parameter, widened `caplog.at_level(logging.ERROR)` → `logging.WARNING` (WARNING=30 < ERROR=40, so the level threshold had to widen to catch the new banner), and swapped `capsys.readouterr().out` for `caplog.text`. Assertion substrings (`"ERROR: wire boom"`, `"ERROR: flow boom"`, `"ERROR: boom-direct"`) are preserved verbatim. Header comment updated to drop stale `capsys` reference.

## Verification

- `ruff check --select T201,T203 src/refactors/wan2_migration_launcher.py` → 0 issues
- `ruff check` + `black --check` on both changed files → clean
- `pytest tests/unit/refactors/test_wan2_migration_launcher.py` → 8 passed
- Full `pytest` suite → 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed (baseline held)

## Test plan

- [x] Ruff T20 selector reports 0 violations in target file
- [x] Ruff full check clean on both files
- [x] Black --check clean on both files
- [x] Targeted pytest green
- [x] Full pytest matches baseline (8949 passed / 77 skipped / 5 xfailed / 1 xpassed)