### PR TITLE
chore(logging): migrate src/ssh/command/command_runner.py print() to logger (#886 slice 28/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 28/N: retire `print()` in `src/ssh/command/command_runner.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`
+  call in `src/ssh/command/command_runner.py` with `logger.info(...)` using
+  `%`-style deferred formatting. `SingleCommandRunner._setup_host_log` now
+  emits the per-host log-file status line via
+  `logger.info("- [%s] Logging to: %s", request.hostname, host_log_file)`
+  through the injected `ssh_runner_v2` logger, so the user-facing message
+  flows through the same handler chain as the surrounding runner lifecycle
+  logs. `import logging` was already present at module scope.
+- **Test posture**: no existing test asserted on the `"- [<host>] Logging
+  to: <path>"` stdout substring (verified by ripgrep across
+  `tests/unit/ssh/`); no test edits required. Existing
+  `tests/unit/ssh/test_command_runner.py` suite remains green as-is (5
+  passed).
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining T201 matches in `src/ssh/command/command_runner.py`;
+  targeted `pytest tests/unit/ssh/test_command_runner.py` runs 5 passed;
+  full `pytest` suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed).
+
 ### #886 Phase 2 slice 27/N: retire `print()` in `src/refactors/wan2_migration_launcher.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`

--- a/src/ssh/command/command_runner.py
+++ b/src/ssh/command/command_runner.py
@@ -178,7 +178,9 @@ class SingleCommandRunner:
 
         runner = EnhancedSSHRunner(timeout=request.timeout, logger=logger)  # WHY: owns timeout + client.
         host_log_file, write_to_host_log = runner._create_secure_log_file(request.hostname)  # WHY: existing helper.
-        print(f"- [{request.hostname}] Logging to: {host_log_file}")  # WHY: verbatim user-facing status line.
+        logger.info(  # WHY: user-facing status via logger (replaces prior print()).
+            "- [%s] Logging to: %s", request.hostname, host_log_file
+        )
         header = SingleCommandRunner._build_header(request.hostname, request.command)  # WHY: verbatim header.
         write_to_host_log(header)  # WHY: persist the header to the per-host log file.
         return _LogContext(runner=runner, writer=write_to_host_log, log_file=host_log_file)  # WHY: bundle.


### PR DESCRIPTION
## Summary

Slice 28/N of issue #886 (retire `print()` globally). Migrates the single remaining `print()` call in `src/ssh/command/command_runner.py` to `logger.info(...)` with `%`-style deferred formatting so the per-host \"Logging to: <path>\" status line flows through the injected `ssh_runner_v2` logger's handler chain rather than raw stdout.

`SingleCommandRunner._setup_host_log` previously emitted `print(f\"- [{request.hostname}] Logging to: {host_log_file}\")`. It is now `logger.info(\"- [%s] Logging to: %s\", request.hostname, host_log_file)`, using the logger already threaded through the request.

## Test changes

None required — no existing test asserted on the pre-migration stdout substring (verified via ripgrep across `tests/unit/ssh/`). `tests/unit/ssh/test_command_runner.py` (5 tests) remains untouched and passes as-is.

## Verification

- `ruff check --select T201,T203 src/ssh/command/command_runner.py` → 0 issues
- `ruff check` + `black --check` on target file → clean
- `pytest tests/unit/ssh/test_command_runner.py` → 5 passed
- Full `pytest` suite → 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed (baseline held)

## Test plan

- [x] Ruff T20 selector reports 0 violations in target file
- [x] Ruff full check clean
- [x] Black --check clean
- [x] Targeted pytest green
- [x] Full pytest matches baseline (8949 passed / 77 skipped / 5 xfailed / 1 xpassed)