### PR TITLE
chore(logging): migrate tools/_rebuild_backlog_tsv.py print() to logger (#886 slice 29/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 29/N: retire `print()` in `tools/_rebuild_backlog_tsv.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`
+  call in `tools/_rebuild_backlog_tsv.py` with `logger.info(...)` using
+  `%`-style deferred formatting. The `main()` completion status line now
+  emits via `logger.info("wrote %s sub-A rows -> %s", len(rows), OUT)` so the
+  CLI utility's end-of-run summary flows through the standard logging
+  handler chain rather than raw stdout. `import logging` was added at
+  module scope and a module-level `logger = logging.getLogger(__name__)`
+  was introduced (the file previously had no logger wiring).
+- **Test posture**: no existing test references
+  `tools/_rebuild_backlog_tsv.py` (verified by ripgrep across `tests/`);
+  no test edits required.
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining T201 matches in `tools/_rebuild_backlog_tsv.py`; full
+  `pytest` suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed).
+
 ### #886 Phase 2 slice 28/N: retire `print()` in `src/ssh/command/command_runner.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`

--- a/tools/_rebuild_backlog_tsv.py
+++ b/tools/_rebuild_backlog_tsv.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 REPORT = Path("data/full_repo_compliance_current.md")
 OUT = Path("data/compliance_backlog.tsv")
@@ -27,7 +30,7 @@ def main() -> None:
         fh.write("rank\ttotal\tcritical\thigh\tmedium\tlow\tscore\tgrade\tpath\n")
         for idx, (total, score, crit, high, med, low, grade, path) in enumerate(rows, 1):
             fh.write(f"{idx}\t{total}\t{crit}\t{high}\t{med}\t{low}\t{score}\t{grade}\t{path}\n")
-    print(f"wrote {len(rows)} sub-A rows -> {OUT}")
+    logger.info("wrote %s sub-A rows -> %s", len(rows), OUT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Slice 29/N of the #886 `print()` → `logging` migration. Retires the single
remaining `print()` in `tools/_rebuild_backlog_tsv.py` and adds proper
logger wiring (module-level `logger = logging.getLogger(__name__)`), which
the file previously lacked.

## Changes

- `tools/_rebuild_backlog_tsv.py`:
  - Added `import logging` and `logger = logging.getLogger(__name__)`.
  - Replaced the `main()` end-of-run `print(f"wrote {len(rows)} sub-A rows -> {OUT}")`
    with `logger.info("wrote %s sub-A rows -> %s", len(rows), OUT)`
    (deferred `%`-style formatting).
- `CHANGELOG.md`: prepended slice 29/N entry under `[Unreleased]`.

## Test plan

- [x] `ruff check --select T201,T203 tools/_rebuild_backlog_tsv.py` — no issues
- [x] `ruff check tools/_rebuild_backlog_tsv.py` — no issues
- [x] `black --check tools/_rebuild_backlog_tsv.py` — clean
- [x] No tests reference this tool (verified via ripgrep across `tests/`); no test edits required
- [x] Full `pytest` suite: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed (baseline held)

Refs #886