### PR TITLE
chore(logging): migrate tools/plan_wave_builder.py print() to logger (#886 slice 30/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 30/N: retire `print()` in `tools/plan_wave_builder.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`
+  calls in `tools/plan_wave_builder.py` with `logger.info(...)` using
+  `%`-style deferred formatting. `main()` now emits the wave-summary line via
+  `logger.info("Wrote %s prompt files + wave_manifest.json", len(manifest))`
+  and each per-entry manifest line via
+  `logger.info("  %s %s -> %s", entry["spec_num"], entry["operation_id"], entry["agent_id"])`,
+  so the CLI utility's per-wave progress trace flows through the standard
+  logging handler chain rather than raw stdout. `import logging` was added
+  at module scope and a module-level `logger = logging.getLogger(__name__)`
+  was introduced (the file previously had no logger wiring).
+- **Test posture**: no existing test references `tools/plan_wave_builder.py`
+  (verified by ripgrep across `tests/`); no test edits required.
+- **Verification**: `ruff check` reports 0 issues; `black --check` clean;
+  0 remaining T201 matches in `tools/plan_wave_builder.py`; full `pytest`
+  suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 29/N: retire `print()` in `tools/_rebuild_backlog_tsv.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 1 remaining `print()`

--- a/tools/plan_wave_builder.py
+++ b/tools/plan_wave_builder.py
@@ -1,11 +1,14 @@
 """Build per-spec metadata + prompt files for the next plan-agent wave."""
 
 import json
+import logging
 import os
 import re
 import sqlite3
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 DB = Path(os.path.expandvars(r"%USERPROFILE%\.copilot\session-state\270b3bdf-8f07-470a-9757-690a1d246ec2\session.db"))
 REPO = Path(__file__).resolve().parents[1]
@@ -157,9 +160,9 @@ def main() -> int:
         json.dumps(manifest, indent=2),
         encoding="utf-8",
     )
-    print(f"Wrote {len(manifest)} prompt files + wave_manifest.json")
+    logger.info("Wrote %s prompt files + wave_manifest.json", len(manifest))
     for entry in manifest:
-        print(f"  {entry['spec_num']} {entry['operation_id']} -> {entry['agent_id']}")
+        logger.info("  %s %s -> %s", entry["spec_num"], entry["operation_id"], entry["agent_id"])
     return 0
 
 


### PR DESCRIPTION
## Summary

Slice 30/N of the #886 `print()` → `logging` migration. Retires the 2
remaining `print()` calls in `tools/plan_wave_builder.py` and adds proper
logger wiring (module-level `logger = logging.getLogger(__name__)`),
which the file previously lacked.

## Changes

- `tools/plan_wave_builder.py`:
  - Added `import logging` and `logger = logging.getLogger(__name__)`.
  - Replaced `print(f"Wrote {len(manifest)} prompt files + wave_manifest.json")`
    with `logger.info("Wrote %s prompt files + wave_manifest.json", len(manifest))`.
  - Replaced the per-entry `print(f"  {entry['spec_num']} ...")` with
    `logger.info("  %s %s -> %s", ...)` (deferred `%`-style formatting).
- `CHANGELOG.md`: prepended slice 30/N entry under `[Unreleased]`.

## Test plan

- [x] `ruff check --select T201,T203 tools/plan_wave_builder.py` — no issues
- [x] `ruff check tools/plan_wave_builder.py` — no issues
- [x] `black --check tools/plan_wave_builder.py` — clean
- [x] No tests reference this tool (verified via ripgrep across `tests/`); no test edits required
- [x] Full `pytest` suite: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed (baseline held)

Refs #886