### PR TITLE
chore(logging): migrate src/export/gateway_test_exporter.py print() to logger (#886 slice 31/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 31/N: retire `print()` in `src/export/gateway_test_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`
+  calls in `src/export/gateway_test_exporter.py` with module-level
+  `logging.warning(...)` / `logging.info(...)` using `%`-style deferred
+  formatting. `_export_synthetic_results` now emits the empty-results banner
+  via `logging.warning("! No synthetic test results found. CSV not created.")`
+  and the export-success line via
+  `logging.info("! %s gateway synthetic test results exported to %s", len(all_stats), filename)`,
+  matching the file's pre-existing `logging.info(...)` / `logging.warning(...)`
+  convention (no module `logger` binding is used elsewhere in this module).
+  `import logging` was already present at module scope.
+- **Test posture**: two tests in
+  `tests/unit/export/test_gateway_test_exporter.py`
+  (`TestExportSyntheticResults.test_no_stats_warns_and_returns` and
+  `test_writes_csv_via_dataexporter`) were migrated from the `capsys`
+  fixture to `caplog`; both assert on `caplog.text` under
+  `caplog.at_level(logging.WARNING)` / `caplog.at_level(logging.INFO)`
+  respectively. `import logging` was added to the test module.
+- **Verification**: `ruff check` reports 0 issues on both source and test
+  files; `black --check` clean; 0 remaining T201 matches in
+  `src/export/gateway_test_exporter.py`; targeted pytest for the module
+  (`tests/unit/export/test_gateway_test_exporter.py` +
+  `tests/unit/export/test_gateway_test_exporter_runtime_wiring.py`) = 32
+  passed; full `pytest` suite green (8949 passed, 0 failed, 77 skipped,
+  5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 30/N: retire `print()` in `tools/plan_wave_builder.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`

--- a/src/export/gateway_test_exporter.py
+++ b/src/export/gateway_test_exporter.py
@@ -303,13 +303,13 @@ class GatewayTestExporter:
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if not all_stats:  # No results.
             logging.warning(" No synthetic test results found. CSV not created.")  # Warn.
-            print("! No synthetic test results found. CSV not created.")  # Tell the user.
+            logging.warning("! No synthetic test results found. CSV not created.")  # Tell the user.
             return  # Nothing to write.
         filename = "AllGatewaySyntheticTests.csv"  # Build the CSV name.
         flattened = DataProcessingUtils.flatten_nested_fields(all_stats)  # Flatten nested fields.
         sanitized = DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(sanitized, filename)  # type: ignore[no-untyped-call]
-        print(f"! {len(all_stats)} gateway synthetic test results exported to {filename}")  # Tell user.
+        logging.info("! %s gateway synthetic test results exported to %s", len(all_stats), filename)  # Tell user.
         logging.info("! Synthetic test results saved to %s (%s records).", filename, len(all_stats))
         logging.info(  # Log the optimization summary.
             "! API Optimization: Saved %s listSiteDevices calls by using cached inventory",

--- a/tests/unit/export/test_gateway_test_exporter.py
+++ b/tests/unit/export/test_gateway_test_exporter.py
@@ -10,6 +10,7 @@ Why:
 
 from __future__ import annotations
 
+import logging
 import sys
 from concurrent.futures import Future
 from types import ModuleType, SimpleNamespace
@@ -379,19 +380,20 @@ class TestRunSyntheticSequentialPath:
 
 
 class TestExportSyntheticResults:
-    def test_no_stats_warns_and_returns(self, fake_mh: ModuleType, capsys: pytest.CaptureFixture) -> None:
-        GatewayTestExporter._export_synthetic_results([], [])
-        out = capsys.readouterr().out
-        assert "No synthetic test results" in out
+    def test_no_stats_warns_and_returns(self, fake_mh: ModuleType, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            GatewayTestExporter._export_synthetic_results([], [])
+        assert "No synthetic test results" in caplog.text
 
-    def test_writes_csv_via_dataexporter(self, fake_mh: ModuleType, capsys: pytest.CaptureFixture) -> None:
+    def test_writes_csv_via_dataexporter(self, fake_mh: ModuleType, caplog: pytest.LogCaptureFixture) -> None:
         rows = [{"a": 1}]
         with patch("src.export.gateway_test_exporter.DataProcessingUtils") as dp:
             dp.flatten_nested_fields.return_value = rows
             dp.escape_multiline.return_value = rows
-            GatewayTestExporter._export_synthetic_results(rows, [("s", "d", "dn", "sn")])
+            with caplog.at_level(logging.INFO):
+                GatewayTestExporter._export_synthetic_results(rows, [("s", "d", "dn", "sn")])
         fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(rows, "AllGatewaySyntheticTests.csv")  # type: ignore[attr-defined]
-        assert "exported to AllGatewaySyntheticTests.csv" in capsys.readouterr().out
+        assert "exported to AllGatewaySyntheticTests.csv" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- #886 Phase 2 slice 31/N: retire the 2 remaining `print()` calls in `src/export/gateway_test_exporter.py`.
- `_export_synthetic_results` now emits its empty-results banner via `logging.warning(...)` and its export-success line via `logging.info(...)` with `%`-style deferred formatting, matching the file's pre-existing `logging.warning(...)` / `logging.info(...)` convention (no module `logger` binding is used elsewhere in this module).
- Migrated the two corresponding tests in `tests/unit/export/test_gateway_test_exporter.py` (`TestExportSyntheticResults.test_no_stats_warns_and_returns` and `test_writes_csv_via_dataexporter`) from `capsys` to `caplog`, and added `import logging` to the test module.

## Test plan

- [x] `ruff check src/export/gateway_test_exporter.py tests/unit/export/test_gateway_test_exporter.py` — 0 issues
- [x] `black --check src/export/gateway_test_exporter.py tests/unit/export/test_gateway_test_exporter.py` — clean
- [x] `ruff check --select T201,T203 src/export/gateway_test_exporter.py` — 0 matches
- [x] Targeted pytest (`tests/unit/export/test_gateway_test_exporter.py` + `tests/unit/export/test_gateway_test_exporter_runtime_wiring.py`) — 32 passed
- [x] Full pytest — baseline held (8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed)

Refs: #886