### PR TITLE
chore(logging): migrate src/gateway/overrides/wan_override_walker.py print() to logger (#886 slice 32/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 32/N: retire `print()` in `src/gateway/overrides/wan_override_walker.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`
+  calls in `src/gateway/overrides/wan_override_walker.py` with module-level
+  `logging.info(...)` / `logging.warning(...)`, matching the file's
+  pre-existing convention (no module `logger` binding is used elsewhere in
+  this module). `WanOverrideWalker.walk` now emits the legacy compliance
+  header via `logging.info("Gateway Ports Overridden from Template (Compliance Outliers):")`
+  and the `MIST_WAN_TARGET_PORTS`-missing operator banner via
+  `logging.warning(" MIST_WAN_TARGET_PORTS not configured in .env - skipping port override analysis")`,
+  sitting next to the existing
+  `logging.warning("MIST_WAN_TARGET_PORTS environment variable not set")`
+  operator-hint pair. `import logging` was already present at module scope.
+- **Test posture**: `test_walk_early_exits_when_no_target_ports_configured`
+  in `tests/unit/gateway/test_wan_override_walker_extended.py` was migrated
+  off the `capsys` fixture; the assertion now reads `caplog.text` under
+  `caplog.at_level("WARNING")` (which the test already declared) to verify
+  the migrated operator banner. The unused `capsys` parameter was removed.
+- **Verification**: `ruff check --select T201,T203 src/gateway/overrides/wan_override_walker.py`
+  reports 0 issues; `ruff check` and `black --check` clean on both source
+  and test files; targeted pytest for
+  `tests/unit/gateway/test_wan_override_walker.py` +
+  `tests/unit/gateway/test_wan_override_walker_extended.py` = 16 passed;
+  full `pytest` suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed).
+
 ### #886 Phase 2 slice 31/N: retire `print()` in `src/export/gateway_test_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`

--- a/src/gateway/overrides/wan_override_walker.py
+++ b/src/gateway/overrides/wan_override_walker.py
@@ -19,13 +19,15 @@ class WanOverrideWalker:
     def walk(fast: bool = False) -> None:
         """Generate the GatewayOverriddenPorts.csv compliance report end-to-end."""
         logging.info("WAN override walker starting (fast=%s)", fast)  # Trace entry for operator timeline
-        print("Gateway Ports Overridden from Template (Compliance Outliers):")  # Legacy header preserved
+        logging.info("Gateway Ports Overridden from Template (Compliance Outliers):")  # Legacy header preserved
         logging.info(  # Legacy info line preserved verbatim for downstream log parsers
             " Identifying gateway ports with template overrides (outliers for compliance correction)..."
         )
         target_ports = _deps.MIST_WAN_TARGET_PORTS  # Read from configured module-level dependency
         if not target_ports:  # Early exit when operator has not configured WAN ports to audit
-            print(" MIST_WAN_TARGET_PORTS not configured in .env - skipping port override analysis")  # legacy
+            logging.warning(  # legacy operator banner preserved verbatim for downstream log parsers
+                " MIST_WAN_TARGET_PORTS not configured in .env - skipping port override analysis"
+            )
             logging.warning("MIST_WAN_TARGET_PORTS environment variable not set")  # operator hint in logs
             return  # No work possible without target ports; abort the walker
         WanOverrideWalker._run_pipeline(fast=fast, target_ports=target_ports)  # Delegate the full pipeline

--- a/tests/unit/gateway/test_wan_override_walker_extended.py
+++ b/tests/unit/gateway/test_wan_override_walker_extended.py
@@ -60,7 +60,7 @@ def _configure_default_deps(tmp_path: Path) -> _PathResolver:
     return resolver  # Caller may use it to compose additional fixture paths
 
 
-def test_walk_early_exits_when_no_target_ports_configured(tmp_path: Path, capsys, caplog) -> None:
+def test_walk_early_exits_when_no_target_ports_configured(tmp_path: Path, caplog) -> None:
     """walk() must short-circuit with a warning when MIST_WAN_TARGET_PORTS is empty."""
     _configure_default_deps(tmp_path)  # Wire dependencies with a non-empty default
     override_deps.MIST_WAN_TARGET_PORTS = []  # Force the early-exit branch under test
@@ -68,8 +68,7 @@ def test_walk_early_exits_when_no_target_ports_configured(tmp_path: Path, capsys
     with caplog.at_level("WARNING"):  # Capture the operator-visible warning
         WanOverrideWalker.walk(fast=False)  # Should return without touching CSVs
 
-    stdout = capsys.readouterr().out  # Capture the legacy console message emitted before return
-    assert "MIST_WAN_TARGET_PORTS not configured" in stdout  # Legacy console line preserved
+    assert "MIST_WAN_TARGET_PORTS not configured" in caplog.text  # Legacy operator banner preserved as WARNING
     assert any(  # The warning is what operators grep for; verify it fires
         "MIST_WAN_TARGET_PORTS" in record.message for record in caplog.records
     )


### PR DESCRIPTION
## Summary
- Slice 32/N of #886 (T20 print-retirement). Replaces the 2 remaining `print()` calls in `src/gateway/overrides/wan_override_walker.py` with module-level `logging.info(...)` / `logging.warning(...)`, matching the file's pre-existing convention (no module `logger` binding exists in this module).
- Compliance-outliers header now emits via `logging.info("Gateway Ports Overridden from Template (Compliance Outliers):")`.
- Missing-`MIST_WAN_TARGET_PORTS` operator banner now emits via `logging.warning(" MIST_WAN_TARGET_PORTS not configured in .env - skipping port override analysis")`, sitting alongside the existing `logging.warning("MIST_WAN_TARGET_PORTS environment variable not set")` operator-hint pair.
- Migrated `test_walk_early_exits_when_no_target_ports_configured` off `capsys`; the assertion now reads `caplog.text` under `caplog.at_level("WARNING")` (which the test already declared). Removed the unused `capsys` parameter.

## Test plan
- [x] `ruff check --select T201,T203 src/gateway/overrides/wan_override_walker.py` — 0 issues
- [x] `ruff check src/gateway/overrides/wan_override_walker.py tests/unit/gateway/test_wan_override_walker_extended.py` — 0 issues
- [x] `black --check` on both files — clean
- [x] Targeted pytest for `tests/unit/gateway/test_wan_override_walker.py` + `tests/unit/gateway/test_wan_override_walker_extended.py` — 16 passed
- [x] Full `pytest` suite — 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed (baseline held)

Refs: #886