### PR TITLE
chore(logging): migrate src/refactors/serial_cc/switch_vc_stats.py print() to logger (#886 slice 34/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 34/N: retire `print()` in `src/refactors/serial_cc/switch_vc_stats.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`
+  calls in `src/refactors/serial_cc/switch_vc_stats.py` (both inside
+  `SwitchVcStatsService.execute`) with module-level `logging.info(...)` using
+  `%`-style deferred formatting, matching the file's pre-existing
+  `logging.info(...)` / `logging.warning(...)` / `logging.debug(...)`
+  convention (no module `logger` binding is used elsewhere in this module).
+  The operator banner `print("Switch Virtual Chassis Statistics:")` becomes
+  `logging.info("Switch Virtual Chassis Statistics:")`, sitting next to the
+  existing `logging.info("Exporting all switch virtual chassis stats...")`.
+  The f-string
+  `print(f"! {len(all_vc_stats)} switch VC stats exported to OrgSwitchVCStats.csv")`
+  becomes
+  `logging.info("! %d switch VC stats exported to OrgSwitchVCStats.csv", len(all_vc_stats))`,
+  which produces a near-duplicate of the immediately following
+  `logging.info("! Switch VC stats exported to OrgSwitchVCStats.csv (%d records).", ...)`
+  line; the duplication is intentional to preserve the original operator UX
+  under the migration (same conservative pattern used in slices 32/33).
+  `import logging` was already present at module scope.
+- **Test posture**: no existing test asserts on the two migrated banners
+  (verified via ripgrep against `tests/`), so the test suite is unchanged.
+- **Verification**: `ruff check --select T201,T203 src/refactors/serial_cc/switch_vc_stats.py`
+  reports 0 issues; `ruff check` and `black --check` clean on the source
+  file; targeted `pytest tests/unit/refactors/` = 294 passed; full `pytest`
+  suite green (8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed).
+
 ### #886 Phase 2 slice 33/N: retire `print()` in `src/gateway/wan2_variable.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`

--- a/src/refactors/serial_cc/switch_vc_stats.py
+++ b/src/refactors/serial_cc/switch_vc_stats.py
@@ -169,7 +169,7 @@ class SwitchVcStatsService:
     def execute(cls) -> None:
         """Run switch VC stats export workflow and write OrgSwitchVCStats.csv."""
         deps = _resolve_runtime_dependencies()  # Resolve all runtime collaborators from MistHelper
-        print("Switch Virtual Chassis Statistics:")  # User-facing operation banner
+        logging.info("Switch Virtual Chassis Statistics:")  # User-facing operation banner
         logging.info("Exporting all switch virtual chassis stats...")  # Log workflow start for operators
 
         switches = cls._load_switches(deps)  # Load VC-eligible switch rows from cached OrgInventory.csv
@@ -182,7 +182,8 @@ class SwitchVcStatsService:
         all_vc_stats = deps.DataProcessingUtils.flatten_nested_fields(all_vc_stats)  # Flatten nested fields for CSV
         all_vc_stats = deps.DataProcessingUtils.escape_multiline(all_vc_stats)  # Sanitize multiline fields
         deps.DataExporter.write_with_format_selection(all_vc_stats, "OrgSwitchVCStats.csv")  # Persist VC stats
-        print(f"! {len(all_vc_stats)} switch VC stats exported to OrgSwitchVCStats.csv")  # User-facing result count
+        # User-facing result count
+        logging.info("! %d switch VC stats exported to OrgSwitchVCStats.csv", len(all_vc_stats))
         logging.info(
             "! Switch VC stats exported to OrgSwitchVCStats.csv (%d records).", len(all_vc_stats)
         )  # Log success


### PR DESCRIPTION
## Summary

- Migrate the 2 remaining `print()` calls in `src/refactors/serial_cc/switch_vc_stats.py` to `logging.info(...)` with `%`-style deferred formatting.
- Matches the file's existing `logging.info/warning/debug` convention (no module `logger` binding).
- Slice 34/N of issue #886 (retire `print()` in favor of `logging`).

## Test plan

- [x] `ruff check --select T201,T203 src/refactors/serial_cc/switch_vc_stats.py` = 0 issues
- [x] `ruff check` + `black --check` clean on the source file
- [x] Targeted `pytest tests/unit/refactors/` = 294 passed
- [x] Full `pytest` suite = 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed (baseline holds)

Refs #886.