### PR TITLE
chore(logging): migrate src/export/org_client_security_exporter.py print() to logger (#886 slice 35/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 35/N: retire `print()` in `src/export/org_client_security_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`
+  calls in `src/export/org_client_security_exporter.py` with module-level
+  `logging.info(...)` using `%`-style deferred formatting. Two of the calls
+  live in `OrgClientSecurityExporter._export_rogues` (the export-count banner
+  and the empty-result banner) and one in
+  `OrgClientSecurityExporter._check_csv_cache_fresh` (the fast-mode cache-hit
+  banner). Each print's inline `# User-facing ... banner.` comment was moved
+  one line above the migrated `logging.info(...)` call to keep the source
+  under the 120-char E501 gate. `import logging` was already present at module
+  scope.
+- **Test posture (Changed)**: three tests in
+  `tests/unit/export/test_org_client_security_exporter.py`
+  (`TestCheckCsvCacheFresh.test_returns_true_when_fresh`,
+  `TestExportRogues.test_writes_when_rogues_present`,
+  `TestExportRogues.test_empty_rogues_logs_only`) previously asserted on
+  `capsys.readouterr().out` for the removed `print()` output; they now use
+  `caplog.at_level("INFO")` and assert on `caplog.text`, with the fixture
+  signature switched from `capsys: pytest.CaptureFixture` to
+  `caplog: pytest.LogCaptureFixture`. No behavior asserted by the tests
+  changed — same substrings (`"Fast mode"`, `"2 rogue APs exported"`,
+  `"No rogue APs detected"`) are verified against the new log stream.
+- **Verification**: `ruff check --select T201,T203 src/export/org_client_security_exporter.py`
+  reports zero remaining print/pprint violations against the migrated file.
+  `ruff check` and `black --check` are clean on both changed files.
+  Targeted `pytest tests/unit/export/test_org_client_security_exporter.py
+  tests/integration/serial_cc/test_security_events_integration.py -q` →
+  26 passed, 0 failed, 1 skipped. Full-suite baseline holds:
+  **8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed**.
+- **Follow-up**: 111-ish files still contain `print()` calls (per the
+  `.tmp_census.py` T20 aggregation of `ruff check --select T201,T203 src`).
+  Each subsequent slice continues to attack the smallest-remaining files
+  first. Once the last `src/**/*.py` `print()` is gone the final #886 PR
+  flips the T20 selector on in `pyproject.toml` (add `"T20"` to the `select`
+  list, drop the "Phase 2 goal" comment) and closes the issue.
+
 ### #886 Phase 2 slice 34/N: retire `print()` in `src/refactors/serial_cc/switch_vc_stats.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 2 remaining `print()`

--- a/src/export/org_client_security_exporter.py
+++ b/src/export/org_client_security_exporter.py
@@ -129,7 +129,8 @@ class OrgClientSecurityExporter:
             logging.info(
                 "Fast mode cache hit: %s is fresh (%.1fm); skipping fetch.", output_file, age_minutes
             )  # Log the cache hit
-            print(f"* Fast mode: Using cached {output_file} (age {age_minutes:.1f}m)")  # Inform user
+            # User-facing fast-mode cache hit banner.
+            logging.info("* Fast mode: Using cached %s (age %.1fm)", output_file, age_minutes)
             return True  # Cache hit short-circuits the orchestrator
         except Exception as cache_error:  # Inspecting the cache failed
             logging.debug("Fast mode freshness check failed for %s: %s", output_file, cache_error)  # Trace
@@ -201,7 +202,9 @@ class OrgClientSecurityExporter:
             sanitized = DataProcessingUtils.escape_multiline(flattened)
             mh.DataExporter.write_with_format_selection(sanitized, csv_basename)
             logging.info("! %s %s exported to %s", len(rogues), label, csv_basename)  # Log the export
-            print(f"! {len(rogues)} {label} exported to {csv_basename}")  # Report the count to the user
+            # User-facing export count banner.
+            logging.info("! %d %s exported to %s", len(rogues), label, csv_basename)
         else:  # No rogues found anywhere
             logging.info("No %s found across all sites", label)  # Log the empty result
-            print(f" No {label} detected across all sites")  # Inform the user
+            # User-facing empty-result banner.
+            logging.info(" No %s detected across all sites", label)

--- a/tests/unit/export/test_org_client_security_exporter.py
+++ b/tests/unit/export/test_org_client_security_exporter.py
@@ -110,15 +110,16 @@ class TestCheckCsvCacheFresh:
         ):
             assert OrgClientSecurityExporter._check_csv_cache_fresh("Foo.csv", fast=True) is False
 
-    def test_returns_true_when_fresh(self, fake_mh: ModuleType, capsys: pytest.CaptureFixture) -> None:
+    def test_returns_true_when_fresh(self, fake_mh: ModuleType, caplog: pytest.LogCaptureFixture) -> None:
         fake_mh.FilePathUtils.get_csv_path.return_value = "/tmp/fresh.csv"  # type: ignore[attr-defined]
         with (
             patch.object(ocse.os.path, "exists", return_value=True),
             patch.object(ocse.os.path, "getmtime", return_value=1000),
             patch.object(ocse.time, "time", return_value=1000 + 30),
+            caplog.at_level("INFO"),
         ):
             assert OrgClientSecurityExporter._check_csv_cache_fresh("Foo.csv", fast=True) is True
-        assert "Fast mode" in capsys.readouterr().out
+        assert "Fast mode" in caplog.text
 
     def test_returns_false_on_exception(self, fake_mh: ModuleType) -> None:
         fake_mh.FilePathUtils.get_csv_path.side_effect = RuntimeError("boom")  # type: ignore[attr-defined]
@@ -227,22 +228,24 @@ class TestCollectRoguesAcrossSites:
 
 
 class TestExportRogues:
-    def test_writes_when_rogues_present(self, fake_mh: ModuleType, capsys: pytest.CaptureFixture) -> None:
+    def test_writes_when_rogues_present(self, fake_mh: ModuleType, caplog: pytest.LogCaptureFixture) -> None:
         rogues = [{"bssid": "aa"}, {"bssid": "bb"}]
         with (
             patch.object(ocse.DataProcessingUtils, "flatten_nested_fields", return_value=rogues) as flat,
             patch.object(ocse.DataProcessingUtils, "escape_multiline", return_value=rogues) as esc,
+            caplog.at_level("INFO"),
         ):
             OrgClientSecurityExporter._export_rogues(rogues, "OrgRogueAPs", "rogue APs")
         flat.assert_called_once_with(rogues)
         esc.assert_called_once_with(rogues)
         fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(rogues, "OrgRogueAPs")  # type: ignore[attr-defined]
-        assert "2 rogue APs exported" in capsys.readouterr().out
+        assert "2 rogue APs exported" in caplog.text
 
-    def test_empty_rogues_logs_only(self, fake_mh: ModuleType, capsys: pytest.CaptureFixture) -> None:
-        OrgClientSecurityExporter._export_rogues([], "OrgRogueAPs", "rogue APs")
+    def test_empty_rogues_logs_only(self, fake_mh: ModuleType, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("INFO"):
+            OrgClientSecurityExporter._export_rogues([], "OrgRogueAPs", "rogue APs")
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()  # type: ignore[attr-defined]
-        assert "No rogue APs detected" in capsys.readouterr().out
+        assert "No rogue APs detected" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 35/N of the #886 print-to-logger migration.

- Replace 3 remaining `print()` calls in `src/export/org_client_security_exporter.py` with `logging.info(...)` using `%`-style deferred formatting.
  - `_check_csv_cache_fresh`: fast-mode cache-hit banner
  - `_export_rogues`: export-count + empty-result banners
- Move inline `# User-facing ... banner.` comments one line above the migrated call site to keep source under the 120-char E501 gate.
- Migrate 3 tests in `tests/unit/export/test_org_client_security_exporter.py` from `capsys.readouterr().out` to `caplog.text` with `caplog.at_level("INFO")` (fixture switched from `capsys: pytest.CaptureFixture` to `caplog: pytest.LogCaptureFixture`).

`import logging` was already present at module scope; no new imports.

## Test plan

- [x] `ruff check --select T201,T203 src/export/org_client_security_exporter.py` → No issues
- [x] `ruff check` + `black --check` clean on both changed files
- [x] Targeted `pytest tests/unit/export/test_org_client_security_exporter.py tests/integration/serial_cc/test_security_events_integration.py -q` → 26 passed, 0 failed, 1 skipped
- [x] Full suite baseline holds: **8949 passed / 0 failed / 77 skipped / 5 xfailed / 1 xpassed**