### PR TITLE
chore(logging): migrate src/refactors/maps_manager_launcher.py print() to logger (#886 slice 36/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 36/N: retire `print()` in `src/refactors/maps_manager_launcher.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`
+  calls in `src/refactors/maps_manager_launcher.py` with module-level
+  `logging.info(...)` using `%`-style deferred formatting. Two of the calls
+  live in `MapsManagerLauncher._handle_import_error` (the "Could not load
+  Maps Manager module." failure banner and the "Ensure src/maps/maps_manager.py
+  exists" remediation hint) and one in `MapsManagerLauncher._handle_fatal_error`
+  (the user-visible `ERROR: <error>` banner). Each print's inline
+  `# User-facing ... banner.` comment was moved one line above the migrated
+  `logging.info(...)` call to keep the source under the 120-char E501 gate.
+  `import logging` was already present at module scope.
+- **Test posture (Changed)**: six tests in
+  `tests/unit/refactors/test_maps_manager_launcher.py`
+  (`TestLaunchImportFailure.test_import_failure_prints_and_aborts`,
+  `TestLaunchImportFailure.test_import_failure_direct_call`,
+  `TestLaunchOrgIdFailure.test_get_org_id_raises`,
+  `TestRunInteractiveMenuFailures.test_external_class_unset_raises_and_handled`,
+  `TestRunInteractiveMenuFailures.test_run_interactive_menu_raises`,
+  `TestHandleFatalError.test_prints_and_logs`) previously asserted on
+  `capsys.readouterr().out` for the removed `print()` output; they now use
+  `caplog.at_level(logging.INFO)` and assert on `caplog.text`, with the
+  fixture signature switched from `capsys: pytest.CaptureFixture` to
+  `caplog: pytest.LogCaptureFixture`. No behavior asserted by the tests
+  changed - only the capture mechanism moved from stdout to the logging
+  system. The module-import `import pytest` comment updated from
+  `capsys/caplog` to `caplog` fixtures.
+- **Verification**: `ruff check --select T201,T203 src/refactors/maps_manager_launcher.py`
+  → No issues (0 T20 violations remaining in this file). `ruff check` + `black --check`
+  clean on both changed files. Targeted `pytest tests/unit/refactors/test_maps_manager_launcher.py`
+  → **13 passed, 0 failed, 0 skipped**. Full-suite `pytest` → **8949 passed,
+  0 failed, 77 skipped, 5 xfailed, 1 xpassed** — matches the pre-slice baseline exactly.
+
 ### #886 Phase 2 slice 35/N: retire `print()` in `src/export/org_client_security_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`

--- a/src/refactors/maps_manager_launcher.py
+++ b/src/refactors/maps_manager_launcher.py
@@ -84,8 +84,10 @@ class MapsManagerLauncher:
     def _handle_import_error(self, error: ImportError) -> None:
         """Log and display import failure message."""
         logging.error("Failed to import MapsManager from src/maps/maps_manager.py: %s", error)  # Log the error
-        print("\nERROR: Could not load Maps Manager module.")  # User-visible failure banner
-        print("Ensure src/maps/maps_manager.py exists")  # Suggest the fix
+        # User-visible failure banner
+        logging.info("\nERROR: Could not load Maps Manager module.")
+        # Suggest the fix
+        logging.info("Ensure src/maps/maps_manager.py exists")
 
     def _get_org_id(self) -> bool:
         """Get organization ID from cache or prompt."""
@@ -113,4 +115,5 @@ class MapsManagerLauncher:
     def _handle_fatal_error(self, error: Exception) -> None:
         """Log and display fatal error message."""
         logging.error("Error running Maps Manager: %s", error, exc_info=True)  # Log with traceback for postmortem
-        print(f"\nERROR: {error}")  # Surface error to user without stack details
+        # Surface error to user without stack details
+        logging.info("\nERROR: %s", error)

--- a/tests/unit/refactors/test_maps_manager_launcher.py
+++ b/tests/unit/refactors/test_maps_manager_launcher.py
@@ -21,7 +21,7 @@ import types  # WHY: build a minimal fake module for src.maps.maps_manager.
 from typing import Any  # WHY: dict-of-mocks return-type annotation.
 from unittest.mock import MagicMock  # WHY: FR-008 mandates MagicMock(spec=...) doubles.
 
-import pytest  # WHY: monkeypatch/capsys/caplog fixtures.
+import pytest  # WHY: monkeypatch/caplog fixtures.
 
 from src.refactors.maps_manager_launcher import (  # WHY: SUT + helper direct imports.
     MapsManagerLauncher,
@@ -128,10 +128,9 @@ class TestLaunchImportFailure:
     def test_import_failure_prints_and_aborts(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """When `from src.maps.maps_manager import MapsManager` raises, launch prints guidance and returns."""
+        """When `from src.maps.maps_manager import MapsManager` raises, launch logs guidance and returns."""
         # WHY: install a module whose MapsManager attribute access raises ImportError.
         broken_module = types.ModuleType("src.maps.maps_manager")  # WHY: stand-in for the target module.
 
@@ -147,25 +146,22 @@ class TestLaunchImportFailure:
         monkeypatch.setitem(sys.modules, "src.maps.maps_manager", broken_module)  # WHY: intercept import.
 
         launcher = MapsManagerLauncher()  # WHY: build launcher post-install.
-        with caplog.at_level(logging.ERROR):  # WHY: import failure logs at ERROR.
+        with caplog.at_level(logging.INFO):  # WHY: import failure logs error + info banners.
             launcher.launch()  # WHY: exercise import-failure branch; should return cleanly.
-        captured = capsys.readouterr()  # WHY: read printed guidance.
 
-        assert "Could not load Maps Manager module" in captured.out  # WHY: user-visible failure banner.
-        assert "Ensure src/maps/maps_manager.py exists" in captured.out  # WHY: remediation shown.
+        assert "Could not load Maps Manager module" in caplog.text  # WHY: user-visible failure banner.
+        assert "Ensure src/maps/maps_manager.py exists" in caplog.text  # WHY: remediation shown.
         assert "Failed to import MapsManager" in caplog.text  # WHY: error log emitted.
 
     def test_import_failure_direct_call(
         self,
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Direct call to `_handle_import_error` logs + prints without needing full launch."""
+        """Direct call to `_handle_import_error` logs the banner without needing full launch."""
         launcher = MapsManagerLauncher()  # WHY: build instance.
-        with caplog.at_level(logging.ERROR):  # WHY: assert on the ERROR log entry.
+        with caplog.at_level(logging.INFO):  # WHY: assert on both ERROR + INFO log entries.
             launcher._handle_import_error(ImportError("direct-boom"))  # WHY: exercise helper directly.
-        captured = capsys.readouterr()  # WHY: capture the print output.
-        assert "Could not load Maps Manager module" in captured.out  # WHY: banner present.
+        assert "Could not load Maps Manager module" in caplog.text  # WHY: banner present.
         assert "Failed to import MapsManager" in caplog.text  # WHY: log entry present.
 
 
@@ -175,7 +171,6 @@ class TestLaunchOrgIdFailure:
     def test_get_org_id_raises(
         self,
         wired_deps: dict[str, Any],
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """When ConfigUtils.get_cached_or_prompted_org_id raises, launch surfaces the error and aborts."""
@@ -183,10 +178,9 @@ class TestLaunchOrgIdFailure:
             "config boom"
         )  # WHY: force fatal-error branch inside _get_org_id.
         launcher = MapsManagerLauncher()  # WHY: build launcher.
-        with caplog.at_level(logging.ERROR):  # WHY: fatal-error branch logs at ERROR.
+        with caplog.at_level(logging.INFO):  # WHY: capture ERROR log + INFO banner.
             launcher.launch()  # WHY: exercise the exception branch inside _get_org_id.
-        captured = capsys.readouterr()  # WHY: read printed banner.
-        assert "ERROR: config boom" in captured.out  # WHY: user-visible error emitted.
+        assert "ERROR: config boom" in caplog.text  # WHY: user-visible error emitted.
         assert "Error running Maps Manager" in caplog.text  # WHY: structured error log emitted.
         assert wired_deps["MapsManager_class"].call_count == 0  # WHY: interactive menu never entered.
 
@@ -204,22 +198,19 @@ class TestRunInteractiveMenuFailures:
     def test_external_class_unset_raises_and_handled(
         self,
         wired_deps: dict[str, Any],
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Direct call with `_external_class` unset triggers RuntimeError → _handle_fatal_error."""
         launcher = MapsManagerLauncher()  # WHY: fresh instance; _external_class defaults to None.
         assert launcher._external_class is None  # WHY: precondition sanity check.
-        with caplog.at_level(logging.ERROR):  # WHY: fatal-error branch logs at ERROR.
+        with caplog.at_level(logging.INFO):  # WHY: capture ERROR log + INFO banner.
             launcher._run_interactive_menu()  # WHY: exercise defensive branch directly.
-        captured = capsys.readouterr()  # WHY: read printed banner.
-        assert "ERROR: MapsManagerLauncher._external_class not initialized" in captured.out  # WHY: banner content.
+        assert "ERROR: MapsManagerLauncher._external_class not initialized" in caplog.text  # WHY: banner content.
         assert "Error running Maps Manager" in caplog.text  # WHY: structured log emitted.
 
     def test_run_interactive_menu_raises(
         self,
         wired_deps: dict[str, Any],
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """When run_interactive_menu raises, error is funneled through _handle_fatal_error."""
@@ -227,22 +218,20 @@ class TestRunInteractiveMenuFailures:
             "menu boom"
         )  # WHY: simulate crash inside interactive loop.
         launcher = MapsManagerLauncher()  # WHY: build launcher.
-        with caplog.at_level(logging.ERROR):  # WHY: fatal-error branch logs at ERROR.
+        with caplog.at_level(logging.INFO):  # WHY: capture ERROR log + INFO banner.
             launcher.launch()  # WHY: full flow; failure occurs in interactive menu step.
-        captured = capsys.readouterr()  # WHY: read printed banner.
-        assert "ERROR: menu boom" in captured.out  # WHY: user-visible error emitted.
+        assert "ERROR: menu boom" in caplog.text  # WHY: user-visible error emitted.
         assert "Error running Maps Manager" in caplog.text  # WHY: structured error log emitted.
 
 
 class TestHandleFatalError:
-    """`_handle_fatal_error` prints and logs directly (unit level)."""
+    """`_handle_fatal_error` logs directly (unit level)."""
 
-    def test_prints_and_logs(self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
-        """Direct call prints and logs the error message."""
+    def test_prints_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Direct call logs the error message at both ERROR and INFO levels."""
         launcher = MapsManagerLauncher()  # WHY: build instance to reach the method.
         error = ValueError("boom-direct")  # WHY: sentinel error we can grep for.
-        with caplog.at_level(logging.ERROR):  # WHY: assert on the ERROR log entry.
+        with caplog.at_level(logging.INFO):  # WHY: assert on both ERROR + INFO log entries.
             launcher._handle_fatal_error(error)  # WHY: direct-call exercises the branch.
-        captured = capsys.readouterr()  # WHY: capture print output.
-        assert "ERROR: boom-direct" in captured.out  # WHY: printed banner content.
+        assert "ERROR: boom-direct" in caplog.text  # WHY: banner content emitted at INFO.
         assert "Error running Maps Manager" in caplog.text  # WHY: log entry present.


### PR DESCRIPTION
## Summary

- Replace 3 `print()` calls in `src/refactors/maps_manager_launcher.py` with `logging.info(...)` using `%`-style deferred formatting.
- Two prints live in `MapsManagerLauncher._handle_import_error` (failure banner + remediation hint); one in `MapsManagerLauncher._handle_fatal_error` (user-visible `ERROR: <error>` banner).
- Migrate 6 tests in `tests/unit/refactors/test_maps_manager_launcher.py` from `capsys.readouterr().out` to `caplog.text` with `caplog.at_level(logging.INFO)`.
- Refs #886.

## Verification

- `ruff check --select T201,T203 src/refactors/maps_manager_launcher.py` → **No issues**.
- `ruff check` + `black --check` clean on both changed files.
- Targeted `pytest tests/unit/refactors/test_maps_manager_launcher.py` → **13 passed / 0 failed / 0 skipped**.
- Full-suite `pytest` → **8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed** — matches pre-slice baseline exactly.

## Test plan

- [x] `ruff check --select T201,T203` clean on the file
- [x] `ruff check` + `black --check` clean on the file and its tests
- [x] Targeted pytest passes
- [x] Full-suite pytest baseline (8949/0/77/5/1) holds