### PR TITLE
chore(logging): migrate src/refactors/serial_cc/test_results_by_site.py print() to logger (#886 slice 37/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 37/N: retire `print()` in `src/refactors/serial_cc/test_results_by_site.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`
+  calls in `src/refactors/serial_cc/test_results_by_site.py` with module-level
+  `logging.info(...)` using `%`-style deferred formatting. One call lives in
+  `GatewayTestResultsService._export_results` for the empty-result branch
+  ("No gateway test results found. CSV not created.") and one for the export
+  count summary ("<N> gateway test results exported to <file>"); the third is
+  the "Gateway Synthetic Test Results:" operation banner in
+  `GatewayTestResultsService.execute`. Each print's inline `# User-facing ...`
+  comment was moved one line above the migrated `logging.info(...)` call to
+  keep the source under the 120-char E501 gate. `import logging` was already
+  present at module scope.
+- **Test posture**: no `capsys.readouterr()` assertions in
+  `tests/unit/serial_cc/test_test_results_by_site.py` or
+  `tests/integration/serial_cc/test_test_results_by_site_integration.py`
+  targeted the removed prints, so no test migration was required for this
+  slice.
+- **Verification**:
+  - `ruff check --select T201,T203 src/refactors/serial_cc/test_results_by_site.py` — no issues.
+  - `ruff check src/refactors/serial_cc/test_results_by_site.py` — no issues.
+  - `black --check src/refactors/serial_cc/test_results_by_site.py` — clean.
+  - Targeted pytest for the file's unit + integration modules: 6 passed, 0 failed, 2 skipped.
+  - Full-suite pytest baseline held: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed.
+- **Scope guardrail**: T20 stays scoped to migrated files; the global selector
+  flip in `pyproject.toml` is deferred to the final wrap-up PR after every
+  remaining offender has been migrated file-by-file.
+
 ### #886 Phase 2 slice 36/N: retire `print()` in `src/refactors/maps_manager_launcher.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`

--- a/src/refactors/serial_cc/test_results_by_site.py
+++ b/src/refactors/serial_cc/test_results_by_site.py
@@ -148,7 +148,8 @@ class GatewayTestResultsService:
         """Flatten, sanitise, and persist results; emit user-facing summary."""
         if not all_results:  # No results found across all sites
             logging.warning("No test results found; CSV not created")  # Warn so operator can investigate
-            print("! No gateway test results found. CSV not created.")  # User-facing empty-result message
+            # User-facing empty-result message
+            logging.info("! No gateway test results found. CSV not created.")
             return  # Exit early — nothing to write
         filename = "AllGatewayTestResults.csv"  # Canonical output file name (contract with callers)
         logging.info("Exporting %d gateway test results to %s", len(all_results), filename)  # Log before export
@@ -156,7 +157,8 @@ class GatewayTestResultsService:
         sanitized = deps.DataProcessingUtils.escape_multiline(flattened)  # Sanitise multiline CSV fields
         deps.DataExporter.write_with_format_selection(sanitized, filename)  # Write to configured output backend
         logging.debug("Exported %d records to %s", len(sanitized), filename)  # Log after successful write
-        print(f"! {len(all_results)} gateway test results exported to {filename}")  # User-facing count
+        # User-facing count
+        logging.info("! %d gateway test results exported to %s", len(all_results), filename)
         logging.info("All test results saved to %s (%d records)", filename, len(all_results))  # Trace final count
         if fast:  # Only log the fast-mode optimisation note when relevant
             logging.info(
@@ -168,7 +170,8 @@ class GatewayTestResultsService:
         """Export all synthetic test results for sites with gateways."""
         logging.info("Starting GatewayTestResultsService export (fast=%s)", fast)  # Log before workflow
         deps = _resolve_runtime_dependencies()  # Resolve all collaborators from MistHelper at call time
-        print("Gateway Synthetic Test Results:")  # User-facing operation banner
+        # User-facing operation banner
+        logging.info("Gateway Synthetic Test Results:")
         logging.info(
             "Searching all test results (including speed tests) for sites with gateways"
         )  # Trace workflow intent


### PR DESCRIPTION
## Summary

Slice 37/N of the #886 print → logging migration. Retires the last 3 `print()` calls in `src/refactors/serial_cc/test_results_by_site.py`:

- `GatewayTestResultsService._export_results` — empty-result banner ("No gateway test results found. CSV not created.")
- `GatewayTestResultsService._export_results` — export-count banner ("<N> gateway test results exported to <file>")
- `GatewayTestResultsService.execute` — operation banner ("Gateway Synthetic Test Results:")

Each call moves to module-level `logging.info(...)` with `%`-style deferred formatting (avoids G004). Inline `# User-facing ...` comments moved one line above the call to stay under the 120-char E501 gate. `import logging` was already present at module scope.

No `capsys.readouterr()` assertions targeted the removed prints in `tests/unit/serial_cc/test_test_results_by_site.py` or `tests/integration/serial_cc/test_test_results_by_site_integration.py`, so no test-file migration was required.

T20 selector stays scoped per-file; the global flip in `pyproject.toml` is deferred to the final wrap-up PR after every remaining offender has been migrated.

## Test plan

- [x] `ruff check --select T201,T203 src/refactors/serial_cc/test_results_by_site.py` — no issues
- [x] `ruff check src/refactors/serial_cc/test_results_by_site.py` — no issues
- [x] `black --check src/refactors/serial_cc/test_results_by_site.py` — clean
- [x] Targeted pytest (`tests/unit/serial_cc/test_test_results_by_site.py` + `tests/integration/serial_cc/test_test_results_by_site_integration.py`): 6 passed, 0 failed, 2 skipped
- [x] Full-suite pytest baseline held: **8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed**

Refs: #886