### PR TITLE
chore(logging): migrate src/ssh/batch/batch_executor.py print() to logger (#886 slice 38/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 38/N: retire `print()` in `src/ssh/batch/batch_executor.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`
+  calls in `src/ssh/batch/batch_executor.py` with module-level
+  `logging.info(...)` using `%`-style deferred formatting. The migrated
+  callsites are (1) `BatchExecutor._setup_host_log` "Logging to: …" per-host
+  destination banner, (2) `BatchExecutor._write_command_header` per-command
+  "Executing command: …" console line, and (3) `BatchExecutor._handle_interrupt`
+  "Ctrl+C detected!" interrupt notice. Each inline `# WHY: …` comment was
+  moved one line above the migrated call so the source stays under the
+  120-char E501 gate. `import logging` was already present at module scope.
+- **Test posture**: no `capsys.readouterr()` assertions targeted the removed
+  prints (the `capsys` hits in `tests/unit/test_ssh_runner.py` cover unrelated
+  host-validation flows), so no test migration was required for this slice.
+- **Verification**:
+  - `ruff check --select T201,T203 src/ssh/batch/batch_executor.py` — no issues.
+  - `ruff check src/ssh/batch/batch_executor.py` — no issues.
+  - `black --check src/ssh/batch/batch_executor.py` — clean.
+  - Targeted pytest (`tests/unit/test_ssh_runner.py` + `tests/unit/ssh/batch/test_interactive_batch_executor_scrubbing.py`): 173 passed, 0 failed.
+  - Full-suite pytest baseline held: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed.
+- **Scope guardrail**: T20 stays scoped to migrated files; the global selector
+  flip in `pyproject.toml` is deferred to the final wrap-up PR after every
+  remaining offender has been migrated file-by-file.
+
 ### #886 Phase 2 slice 37/N: retire `print()` in `src/refactors/serial_cc/test_results_by_site.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`

--- a/src/ssh/batch/batch_executor.py
+++ b/src/ssh/batch/batch_executor.py
@@ -176,7 +176,8 @@ class BatchExecutor:
 
         runner = EnhancedSSHRunner(timeout=request.timeout, logger=logger)  # WHY: owns timeout + client.
         host_log_file, write_to_host_log = runner._create_secure_log_file(request.hostname)  # WHY: existing helper.
-        print(f"- [{request.hostname}] Logging to: {host_log_file}")  # WHY: verbatim user-facing status line.
+        # WHY: verbatim user-facing status line surfacing the per-host log destination.
+        logging.info("- [%s] Logging to: %s", request.hostname, host_log_file)
         header = BatchExecutor._build_header(request.hostname, len(request.commands))  # WHY: verbatim header.
         write_to_host_log(header)  # WHY: persist the header to the per-host log file.
         return _LogContext(runner=runner, writer=write_to_host_log, log_file=host_log_file)  # WHY: bundle.
@@ -302,7 +303,8 @@ class BatchExecutor:
         writer(f"\n{_COMMAND_BAR}")  # WHY: verbatim visual separator between commands.
         writer(f"X  Command {ctx.index}/{ctx.total}: {ctx.command}")  # WHY: verbatim command header line.
         writer(_COMMAND_BAR)  # WHY: verbatim trailing separator that closes the header block.
-        print(f"!? [{ctx.hostname}] Executing command: {ctx.command}")  # WHY: verbatim console status line.
+        # WHY: verbatim console status line announcing the current command.
+        logging.info("!? [%s] Executing command: %s", ctx.hostname, ctx.command)
 
     @staticmethod
     def _write_command_output(
@@ -342,7 +344,8 @@ class BatchExecutor:
         logger: logging.Logger,
     ) -> None:
         """Print + log the Ctrl+C interrupt block (verbatim text)."""
-        print(f"\nX  [{ctx.hostname}] Ctrl+C detected! Skipping remaining commands...")  # WHY: verbatim.
+        # WHY: verbatim console notice for the Ctrl+C interrupt.
+        logging.info("\nX  [%s] Ctrl+C detected! Skipping remaining commands...", ctx.hostname)
         interrupt_msg = (  # WHY: verbatim two-line interrupt block written to the log.
             f"\n[ERROR] Command {ctx.index} interrupted by user (Ctrl+C)\n"
             f"[SKIP] Skipping remaining {ctx.total - ctx.index} commands"


### PR DESCRIPTION
## Summary

Slice 38/N of issue #886 (retire `print()` in favor of `logging`, smallest-first, one file per PR).

Replaces the 3 remaining `print()` calls in `src/ssh/batch/batch_executor.py` with module-level `logging.info(...)` using `%`-style deferred formatting.

Migrated callsites:

1. `BatchExecutor._setup_host_log` — per-host "Logging to: `<path>`" destination banner
2. `BatchExecutor._write_command_header` — per-command "Executing command: `<cmd>`" console line
3. `BatchExecutor._handle_interrupt` — "Ctrl+C detected!" interrupt notice

Each print's inline `# WHY: …` comment was moved one line above the migrated call so the source stays under the 120-char E501 gate. `import logging` was already present at module scope.

## Test plan

- [x] `ruff check --select T201,T203 src/ssh/batch/batch_executor.py` — clean
- [x] `ruff check src/ssh/batch/batch_executor.py` — clean
- [x] `black --check src/ssh/batch/batch_executor.py` — clean
- [x] Targeted pytest (`tests/unit/test_ssh_runner.py` + `tests/unit/ssh/batch/test_interactive_batch_executor_scrubbing.py`): 173 passed, 0 failed
- [x] Full-suite pytest baseline held: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed
- [x] Scope guardrail: T20 stays scoped to migrated files; the global selector flip in `pyproject.toml` is deferred to the final wrap-up PR after every remaining offender has been migrated file-by-file

Refs #886