### PR TITLE
chore(logging): migrate src/ssh/batch/interactive_batch_executor.py print() to logger (#886 slice 39/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 39/N: retire `print()` in `src/ssh/batch/interactive_batch_executor.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`
+  calls in `src/ssh/batch/interactive_batch_executor.py` with module-level
+  `logging.info(...)` using `%`-style deferred formatting. The migrated
+  callsites are (1) `InteractiveBatchExecutor._setup_log_context` per-host
+  "Logging to: …" destination banner, (2) `InteractiveBatchExecutor._handle_step_interrupt`
+  "[INTERRUPT] … Ctrl+C detected!" notice, and (3) `InteractiveBatchExecutor._write_step_header`
+  per-step "Executing step N: …" redacted console line. Each `# WHY: …`
+  comment was moved one line above the migrated call so the source stays
+  under the 120-char E501 gate. `import logging` was already present at
+  module scope.
+- **Test posture**: no `capsys.readouterr()` assertions in the interactive
+  batch executor test module targeted the removed prints (existing `capsys`
+  hits under `tests/unit/test_ssh_runner.py` cover unrelated host-validation
+  flows), so no test migration was required for this slice.
+- **Verification**:
+  - `ruff check --select T201,T203 src/ssh/batch/interactive_batch_executor.py` — no issues.
+  - `ruff check src/ssh/batch/interactive_batch_executor.py` — no issues.
+  - `black --check src/ssh/batch/interactive_batch_executor.py` — clean.
+  - Targeted pytest (`tests/unit/ssh/batch/` + `tests/unit/test_ssh_runner.py`): 173 passed, 0 failed.
+  - Full-suite pytest baseline held: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed.
+- **Scope guardrail**: T20 stays scoped to migrated files; the global selector
+  flip in `pyproject.toml` is deferred to the final wrap-up PR after every
+  remaining offender has been migrated file-by-file.
+
 ### #886 Phase 2 slice 38/N: retire `print()` in `src/ssh/batch/batch_executor.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 3 remaining `print()`

--- a/src/ssh/batch/interactive_batch_executor.py
+++ b/src/ssh/batch/interactive_batch_executor.py
@@ -325,7 +325,8 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
 
         runner = EnhancedSSHRunner(timeout=request.timeout, logger=logger)  # WHY: owns client lifecycle.
         host_log_file = InteractiveBatchExecutor._build_log_path(request.hostname, logger)  # WHY: sanitised path.
-        print(f"** [{request.hostname}] Logging to: {host_log_file}")  # WHY: verbatim console status line.
+        # WHY: verbatim console status line.
+        logging.info("** [%s] Logging to: %s", request.hostname, host_log_file)
         raw_writer = InteractiveBatchExecutor._make_log_writer(host_log_file, logger)  # WHY: ANSI-cleaning writer.
         writer = InteractiveBatchExecutor._build_scrubbing_writer(raw_writer, request.password)  # WHY: scrub creds.
         writer(_build_header(request.hostname, len(request.commands)))  # WHY: persist header verbatim.
@@ -538,8 +539,10 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         logger: logging.Logger,
     ) -> None:
         """Emit the verbatim Ctrl+C interrupt lines (console + logger + per-host log)."""
-        print(  # WHY: verbatim console interrupt line.
-            f"\n[INTERRUPT] [{step_ctx.hostname}] Ctrl+C detected! Stopping interactive session..."
+        # WHY: verbatim console interrupt line.
+        logging.info(
+            "\n[INTERRUPT] [%s] Ctrl+C detected! Stopping interactive session...",
+            step_ctx.hostname,
         )
         logger.warning(  # WHY: log parity for interrupt event.
             "Interactive session interrupted by user at step %d", step_ctx.step_num
@@ -597,7 +600,13 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         writer(f"[STEP] Step {step_ctx.step_num}/{step_ctx.total}: {step_ctx.command}")  # WHY: verbatim.
         writer(_STEP_BAR)  # WHY: closing bar (verbatim).
         display_item = InteractiveBatchExecutor._redact_for_display(step_ctx.command)  # WHY: mask pwd.
-        print(f"* [{step_ctx.hostname}] Executing step {step_ctx.step_num}: {display_item}")  # WHY: parity.
+        # WHY: parity.
+        logging.info(
+            "* [%s] Executing step %d: %s",
+            step_ctx.hostname,
+            step_ctx.step_num,
+            display_item,
+        )
         logger.debug("[%s] Sending: %s", step_ctx.hostname, step_ctx.command)  # WHY: debug diag line.
 
     @staticmethod


### PR DESCRIPTION
## Summary

Slice 39/N of issue #886 (retire `print()` in favor of `logging`, smallest-first, one file per PR).

Replaces the 3 remaining `print()` calls in `src/ssh/batch/interactive_batch_executor.py` with module-level `logging.info(...)` using `%`-style deferred formatting.

Migrated callsites:

1. `InteractiveBatchExecutor._setup_log_context` — per-host "Logging to: `<path>`" destination banner
2. `InteractiveBatchExecutor._handle_step_interrupt` — "[INTERRUPT] … Ctrl+C detected!" notice
3. `InteractiveBatchExecutor._write_step_header` — per-step "Executing step N: `<cmd>`" redacted console line

Each print's inline `# WHY: …` comment was moved one line above the migrated call so the source stays under the 120-char E501 gate. `import logging` was already present at module scope.

## Test plan

- [x] `ruff check --select T201,T203 src/ssh/batch/interactive_batch_executor.py` — clean
- [x] `ruff check src/ssh/batch/interactive_batch_executor.py` — clean
- [x] `black --check src/ssh/batch/interactive_batch_executor.py` — clean
- [x] Targeted pytest (`tests/unit/ssh/batch/` + `tests/unit/test_ssh_runner.py`): 173 passed, 0 failed
- [x] Full-suite pytest baseline held: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed
- [x] Scope guardrail: T20 stays scoped to migrated files; the global selector flip in `pyproject.toml` is deferred to the final wrap-up PR

Refs #886