### PR TITLE
chore(logging): migrate src/export/site_guest_authorization_exporter.py print() to logger (#886 slice 41/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 41/N: retire `print()` in `src/export/site_guest_authorization_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`
+  calls in `src/export/site_guest_authorization_exporter.py` with module-level
+  `logging.info(...)` using `%`-style deferred formatting. Migrated callsites
+  cover the empty-rows notice in `_persist_site_guest_authorizations`, the
+  per-site record-count notice, the `guest_authorizations` menu header, and
+  the user-facing error notice on the API-failure branch. Hoisted the inline
+  `# WHY:` comments above the migrated calls to keep line length under 120
+  chars. Full baseline holds: 8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed.
+
 ### #886 Phase 2 slice 40/N: retire `print()` in `src/export/site_client_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`

--- a/src/export/site_guest_authorization_exporter.py
+++ b/src/export/site_guest_authorization_exporter.py
@@ -53,7 +53,8 @@ class SiteGuestAuthorizationExporter:
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
         if not rawdata:  # No guest authorization rows for this site -- inform the operator and return.
-            print("! No guest authorization data found for this site")  # ASCII-only user notice.
+            # WHY: ASCII-only user notice.
+            logging.info("! No guest authorization data found for this site")
             return
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
         sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe multiline escape.
@@ -64,7 +65,8 @@ class SiteGuestAuthorizationExporter:
         logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
             "searchSiteGuestAuthorization persisted %d rows to %s", len(rawdata), filename
         )
-        print(f"! {len(rawdata)} guest authorization records exported to {filename}")  # User notice with count.
+        # WHY: user notice with count.
+        logging.info("! %d guest authorization records exported to %s", len(rawdata), filename)
 
     @staticmethod
     def guest_authorizations() -> None:
@@ -77,7 +79,8 @@ class SiteGuestAuthorizationExporter:
             to the user rather than crashing the menu loop.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
-        print("Site Guest Authorization Search:")  # Menu header echoed to operator.
+        # WHY: menu header echoed to operator.
+        logging.info("Site Guest Authorization Search:")
         logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
             "Starting searchSiteGuestAuthorization export..."
         )
@@ -102,4 +105,5 @@ class SiteGuestAuthorizationExporter:
             logging.error(  # ERROR trace with site context for post-mortem correlation.
                 "Error fetching guest authorization for site %s: %s", site_name, e
             )
-            print(f"! Error fetching guest authorization data: {e}")  # ASCII-only user notice.
+            # WHY: ASCII-only user notice.
+            logging.info("! Error fetching guest authorization data: %s", e)


### PR DESCRIPTION
## Summary

Slice 41/N of #886 (retire `print()` in favor of `logging`).

- Migrated 4 `print()` calls in `src/export/site_guest_authorization_exporter.py` to `logging.info(...)` with `%`-style deferred formatting.
- Callsites covered: empty-rows notice, per-site record-count notice, `guest_authorizations` menu header, and API-failure user notice.
- Hoisted inline `# WHY:` comments above each migrated call to stay under 120 chars.

## Test plan

- [x] `ruff check --select T201,T203 src/export/site_guest_authorization_exporter.py` -- No issues found
- [x] `ruff check src/export/site_guest_authorization_exporter.py` -- No issues found
- [x] `black --check src/export/site_guest_authorization_exporter.py` -- unchanged
- [x] Full pytest baseline holds: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed
- [x] No companion test file exists for this exporter -- no test migrations needed