### PR TITLE
chore(logging): migrate src/export/site_nac_client_events_exporter.py print() to logger (#886 slice 43/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 43/N: retire `print()` in `src/export/site_nac_client_events_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`
+  calls in `src/export/site_nac_client_events_exporter.py` with module-level
+  `logging.info(...)` using `%`-style deferred formatting. Migrated callsites
+  cover the empty-rows notice in `_persist_site_nac_client_events`, the
+  per-site record-count notice, the `nac_client_events` menu header, and the
+  user-facing error notice on the API-failure branch. Hoisted the inline
+  `# WHY:` comments above the migrated calls to keep line length under 120
+  chars. Full baseline holds: 8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed.
+
 ### #886 Phase 2 slice 42/N: retire `print()` in `src/export/site_mist_edge_events_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`

--- a/src/export/site_nac_client_events_exporter.py
+++ b/src/export/site_nac_client_events_exporter.py
@@ -53,7 +53,8 @@ class SiteNacClientEventsExporter:
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
         if not rawdata:  # No NAC client event rows for this site -- inform the operator and return.
-            print("! No NAC client event data found for this site")  # ASCII-only user notice.
+            # WHY: ASCII-only user notice.
+            logging.info("! No NAC client event data found for this site")
             return
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
         sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe multiline escape.
@@ -64,7 +65,8 @@ class SiteNacClientEventsExporter:
         logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
             "searchSiteNacClientEvents persisted %d rows to %s", len(rawdata), filename
         )
-        print(f"! {len(rawdata)} NAC client event records exported to {filename}")  # User notice with count.
+        # WHY: user notice with count.
+        logging.info("! %d NAC client event records exported to %s", len(rawdata), filename)
 
     @staticmethod
     def nac_client_events() -> None:
@@ -77,7 +79,8 @@ class SiteNacClientEventsExporter:
             to the user rather than crashing the menu loop.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
-        print("Site NAC Client Events Search:")  # Menu header echoed to operator.
+        # WHY: menu header echoed to operator.
+        logging.info("Site NAC Client Events Search:")
         logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
             "Starting searchSiteNacClientEvents export..."
         )
@@ -100,4 +103,5 @@ class SiteNacClientEventsExporter:
             logging.error(  # ERROR trace with site context for post-mortem correlation.
                 "Error fetching NAC client events for site %s: %s", site_name, e
             )
-            print(f"! Error fetching NAC client event data: {e}")  # ASCII-only user notice.
+            # WHY: ASCII-only user notice.
+            logging.info("! Error fetching NAC client event data: %s", e)


### PR DESCRIPTION
## Summary

Slice 43/N of #886 (retire `print()` in favor of `logging`).

- Migrated 4 `print()` calls in `src/export/site_nac_client_events_exporter.py` to `logging.info(...)` with `%`-style deferred formatting.
- Callsites covered: empty-rows notice, per-site record-count notice, `nac_client_events` menu header, and API-failure user notice.
- Hoisted inline `# WHY:` comments above each migrated call to stay under 120 chars.

## Test plan

- [x] `ruff check --select T201,T203 src/export/site_nac_client_events_exporter.py` -- No issues found
- [x] `ruff check src/export/site_nac_client_events_exporter.py` -- No issues found
- [x] `black --check src/export/site_nac_client_events_exporter.py` -- unchanged
- [x] Full pytest baseline holds: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed
- [x] No companion test file exists for this exporter -- no test migrations needed