### PR TITLE
chore(logging): migrate src/export/site_wan_usage_exporter.py print() to logger (#886 slice 44/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 44/N: retire `print()` in `src/export/site_wan_usage_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`
+  calls in `src/export/site_wan_usage_exporter.py` with module-level
+  `logging.info(...)` using `%`-style deferred formatting. Migrated callsites
+  cover the empty-rows notice in `_persist_site_wan_usages`, the per-site
+  record-count notice, the `wan_usages` menu header, and the user-facing
+  error notice on the API-failure branch. Hoisted the inline `# WHY:`
+  comments above the migrated calls to keep line length under 120 chars.
+  Full baseline holds: 8949 passed, 0 failed, 77 skipped, 5 xfailed,
+  1 xpassed.
+
 ### #886 Phase 2 slice 43/N: retire `print()` in `src/export/site_nac_client_events_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`

--- a/src/export/site_wan_usage_exporter.py
+++ b/src/export/site_wan_usage_exporter.py
@@ -53,7 +53,8 @@ class SiteWanUsageExporter:
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
         if not rawdata:  # No WAN usage rows for this site -- inform the operator and return.
-            print("! No WAN usage data found for this site")  # ASCII-only user notice.
+            # WHY: ASCII-only user notice.
+            logging.info("! No WAN usage data found for this site")
             return
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
         sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe multiline escape.
@@ -64,7 +65,8 @@ class SiteWanUsageExporter:
         logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
             "searchSiteWanUsage persisted %d rows to %s", len(rawdata), filename
         )
-        print(f"! {len(rawdata)} WAN usage records exported to {filename}")  # User notice with count.
+        # WHY: user notice with count.
+        logging.info("! %d WAN usage records exported to %s", len(rawdata), filename)
 
     @staticmethod
     def wan_usages() -> None:
@@ -77,7 +79,8 @@ class SiteWanUsageExporter:
             to the user rather than crashing the menu loop.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
-        print("Site WAN Usage Search:")  # Menu header echoed to operator.
+        # WHY: menu header echoed to operator.
+        logging.info("Site WAN Usage Search:")
         logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
             "Starting searchSiteWanUsage export..."
         )
@@ -100,4 +103,5 @@ class SiteWanUsageExporter:
             logging.error(  # ERROR trace with site context for post-mortem correlation.
                 "Error fetching WAN usage for site %s: %s", site_name, e
             )
-            print(f"! Error fetching WAN usage data: {e}")  # ASCII-only user notice.
+            # WHY: ASCII-only user notice.
+            logging.info("! Error fetching WAN usage data: %s", e)


### PR DESCRIPTION
## Summary
- Slice 44/N of issue #886. Migrated 4 `print()` calls in `src/export/site_wan_usage_exporter.py` to `logging.info(...)` with `%`-style deferred formatting.
- Callsites: empty-rows notice, per-site record-count notice, `wan_usages` menu header, error notice.
- Hoisted inline `# WHY:` comments above migrated calls to keep lines <120 chars.

## Test plan
- [x] `ruff check --select T201,T203 src/export/site_wan_usage_exporter.py` — clean
- [x] `ruff check src/export/site_wan_usage_exporter.py` — clean
- [x] `black --check src/export/site_wan_usage_exporter.py` — clean
- [x] Full pytest baseline holds: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed