### PR TITLE
chore(logging): migrate src/inventory/inventory_summary/pivot_renderer.py print() to logger (#886 slice 45/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 45/N: retire `print()` in `src/inventory/inventory_summary/pivot_renderer.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`
+  calls in `src/inventory/inventory_summary/pivot_renderer.py` with
+  `logging.info(...)` using `%`-style deferred formatting. Migrated callsites
+  all live in `_print_table`: the leading legacy banner rule, the
+  "Version Distribution per Model" header, the trailing rule, and the
+  PrettyTable body render itself. Companion test
+  `tests/unit/inventory/inventory_summary/test_pivot_renderer.py` was
+  updated: two stdout assertions (`_print_table` unit test and the
+  `render` end-to-end test) now read `caplog.text` instead of
+  `capsys.readouterr().out`, since the banner is emitted through the
+  logger. Full baseline holds: 8949 passed, 0 failed, 77 skipped,
+  5 xfailed, 1 xpassed.
+
 ### #886 Phase 2 slice 44/N: retire `print()` in `src/export/site_wan_usage_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`

--- a/src/inventory/inventory_summary/pivot_renderer.py
+++ b/src/inventory/inventory_summary/pivot_renderer.py
@@ -126,12 +126,14 @@ class PivotRenderer:  # Decomposed replacement for the original `_display_pivot_
     @staticmethod
     def _print_table(table: PrettyTable) -> None:  # Renders the legacy ASCII banner + table
         """Print the rendered table with the original banner verbatim."""
-        print(f"\n{'=' * 62}")  # Top banner preserved exactly from the legacy implementation
-        print(
-            "  Version Distribution per Model (All Device Types)"
-        )  # Header label preserved verbatim for NOC familiarity
-        print(f"{'=' * 62}")  # Bottom of top banner preserved exactly from the legacy implementation
-        print(table)  # PrettyTable renders to its built-in ASCII grid format
+        # WHY: Top banner preserved exactly from the legacy implementation.
+        logging.info("\n%s", "=" * 62)
+        # WHY: Header label preserved verbatim for NOC familiarity.
+        logging.info("  Version Distribution per Model (All Device Types)")
+        # WHY: Bottom of top banner preserved exactly from the legacy implementation.
+        logging.info("%s", "=" * 62)
+        # WHY: PrettyTable renders to its built-in ASCII grid format.
+        logging.info("%s", table)
 
     @staticmethod
     def _emit_export(  # Delegates persistence to DataExporter with stable column order

--- a/tests/unit/inventory/inventory_summary/test_pivot_renderer.py
+++ b/tests/unit/inventory/inventory_summary/test_pivot_renderer.py
@@ -7,10 +7,10 @@ Covers every static method of ``PivotRenderer``:
 - ``_update_row_and_columns``: returns dense row counts + row total and mutates col_totals in place.
 - ``_build_table``: composes PrettyTable + export rows + grand total; footer TOTAL row appended.
 - ``_build_export_row``: emits CSV-shaped dict with dense zero-filled columns.
-- ``_print_table``: prints the legacy banner + PrettyTable.
+- ``_print_table``: logs the legacy banner + PrettyTable via logging.info.
 - ``_emit_export``: delegates to ``_parent.DataExporter.write_with_format_selection`` with stable field order.
 
-Uses monkeypatch to swap ``_parent.DataExporter`` for a mock and capsys for stdout assertions.
+Uses monkeypatch to swap ``_parent.DataExporter`` for a mock and caplog for log assertions.
 No live network, no disk I/O. MagicMock(spec=...) mandatory on injected doubles.
 """
 
@@ -19,7 +19,7 @@ from __future__ import annotations  # WHY: PEP 604 unions in test type hints.
 import logging  # WHY: caplog verification of pre/post-action log lines.
 from unittest.mock import MagicMock, patch  # WHY: spec= mocks + patch decorators.
 
-import pytest  # WHY: monkeypatch + capsys + caplog fixtures.
+import pytest  # WHY: monkeypatch + caplog fixtures.
 from prettytable import PrettyTable  # WHY: verify _build_table returns a real PrettyTable.
 
 from src.inventory import org_device_inventory_summary as _parent  # WHY: DI slot patched here.
@@ -160,14 +160,15 @@ class TestBuildExportRow:
 
 
 class TestPrintTable:
-    """``_print_table`` prints the legacy banner + PrettyTable to stdout."""
+    """``_print_table`` logs the legacy banner + PrettyTable via logging.info."""
 
-    def test_prints_banner_and_table(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Banner text and the model row content must both appear in stdout."""
+    def test_prints_banner_and_table(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Banner text and the model row content must both appear in the log stream."""
         models, versions, model_type, pivot = PivotRenderer._compute_pivot(_sample_rows())
         table, _export_rows, _grand_total = PivotRenderer._build_table(models, versions, model_type, pivot)
-        PivotRenderer._print_table(table)
-        out = capsys.readouterr().out
+        with caplog.at_level(logging.INFO):
+            PivotRenderer._print_table(table)
+        out = caplog.text
         assert "Version Distribution per Model (All Device Types)" in out  # WHY: banner label.
         assert "AP32" in out  # WHY: model row rendered.
         assert "TOTAL" in out  # WHY: footer row rendered.
@@ -205,7 +206,6 @@ class TestRender:
     def test_full_orchestration(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture[str],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """End-to-end render call exercises compute→build→print→export path with all log lines."""
@@ -216,7 +216,7 @@ class TestRender:
         with caplog.at_level(logging.DEBUG):
             PivotRenderer.render(_sample_rows(), "OrgVersionPerModel.csv")
 
-        out = capsys.readouterr().out
+        out = caplog.text  # WHY: banner + table now emitted through logging.info, not stdout.
         assert "Version Distribution per Model" in out  # WHY: banner reached.
         assert "AP32" in out and "SW1" in out  # WHY: both models printed.
         assert fake_exporter.write_with_format_selection.called  # WHY: export was invoked exactly once.


### PR DESCRIPTION
## Summary
- Slice 45/N of issue #886. Migrated 4 `print()` calls in `src/inventory/inventory_summary/pivot_renderer.py` (all in `_print_table`) to `logging.info(...)` with `%`-style deferred formatting.
- Companion test `tests/unit/inventory/inventory_summary/test_pivot_renderer.py`: two stdout assertions (unit `_print_table` and `render` end-to-end) switched from `capsys.readouterr().out` to `caplog.text` since banner content is now emitted through the logger.

## Test plan
- [x] `ruff check --select T201,T203 src/inventory/inventory_summary/pivot_renderer.py` — clean
- [x] `ruff check src/... && black --check src/...` — clean
- [x] `ruff check tests/... && black --check tests/...` — clean
- [x] Full pytest baseline holds: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed