### PR TITLE
chore(logging): migrate src/ssh/config/command_parser.py print() to logger (#886 slice 46/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 46/N: retire `print()` in `src/ssh/config/command_parser.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`
+  calls in `src/ssh/config/command_parser.py` with `logger.warning(...)`
+  using `%`-style deferred formatting. Migrated callsites: the oversize-input
+  truncation notice in `_truncate_oversize`, the two invalid-command warnings
+  in `_warn_invalid_commands` (summary line plus "... and N more" tail), and
+  the too-many-commands cap notice in `_enforce_command_cap`. All user-facing
+  strings (including the `[WARNING]` prefixes and "... and N more" tail line)
+  are preserved verbatim.
+- **Docstring (Changed)**: updated `_warn_invalid_commands` summary line from
+  "Print the same user-facing warning..." to "Emit the same user-facing
+  warning..." to match the logger-based emission.
+- **Rationale**: incremental progress toward ruff `T20` (T201/T203) selector
+  enablement (issue #886). Behavior-preserving; the module already imported
+  `logging` and defined `logger = logging.getLogger(__name__)`, so no new
+  imports were introduced. `logger.warning` is used (rather than
+  `logging.info` as in the pivot_renderer slice) because the original
+  strings carried a `[WARNING]` prefix — the semantic level is warning.
+
 ### #886 Phase 2 slice 45/N: retire `print()` in `src/inventory/inventory_summary/pivot_renderer.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`

--- a/src/ssh/config/command_parser.py
+++ b/src/ssh/config/command_parser.py
@@ -39,9 +39,8 @@ class CommandListParser:
     def _truncate_oversize(commands_str: str) -> str:
         """Truncate the raw command string if it exceeds the safety cap."""
         if len(commands_str) > _MAX_INPUT_LEN:  # Length check to prevent DoS
-            print(
-                "[WARNING] Command list too long, truncating to first 50000 characters"
-            )  # Preserve user-facing string
+            # WHY: Preserve user-facing string; emit through logger for structured output.
+            logger.warning("[WARNING] Command list too long, truncating to first 50000 characters")
             return commands_str[:_MAX_INPUT_LEN]  # Return truncated copy
         return commands_str  # No truncation needed
 
@@ -63,20 +62,25 @@ class CommandListParser:
 
     @staticmethod
     def _warn_invalid_commands(invalid: list[str]) -> None:
-        """Print the same user-facing warning as the legacy implementation."""
+        """Emit the same user-facing warning as the legacy implementation."""
         if not invalid:  # Clean input — nothing to warn about
             return  # No-op
         sample = ", ".join(invalid[:3])  # Original showed first 3 entries in the warning
-        print(f"[WARNING] Skipping {len(invalid)} invalid commands: {sample}")  # Preserve user-facing string verbatim
+        # WHY: Preserve user-facing string verbatim; emit via logger.
+        logger.warning("[WARNING] Skipping %d invalid commands: %s", len(invalid), sample)
         if len(invalid) > 3:  # Indicate further truncation
-            print(f"    ... and {len(invalid) - 3} more")  # Preserve user-facing string verbatim
+            # WHY: Preserve user-facing string verbatim.
+            logger.warning("    ... and %d more", len(invalid) - 3)
 
     @staticmethod
     def _enforce_command_cap(commands: list[str]) -> list[str]:
         """Trim to the per-run command cap and warn if truncation happens."""
         if len(commands) > _MAX_COMMANDS:  # Resource exhaustion guard
-            print(  # Preserve user-facing string verbatim
-                f"[WARNING] Too many commands ({len(commands)}), limiting to first {_MAX_COMMANDS}"
+            # WHY: Preserve user-facing string verbatim; emit via logger.
+            logger.warning(
+                "[WARNING] Too many commands (%d), limiting to first %d",
+                len(commands),
+                _MAX_COMMANDS,
             )
             return commands[:_MAX_COMMANDS]  # Return truncated list
         return commands  # No truncation needed


### PR DESCRIPTION
## Summary

Slice 46/N of issue #886 (ruff T20 rollout). Migrates the 4 remaining `print()` calls in `src/ssh/config/command_parser.py` to `logger.warning(...)` with `%`-style deferred formatting.

**Callsites migrated (all in `CommandListParser`):**
- `_truncate_oversize`: oversize-input truncation notice
- `_warn_invalid_commands`: invalid-command summary + "... and N more" tail
- `_enforce_command_cap`: too-many-commands cap notice

**Notes:**
- Module already imported `logging` and defined `logger = logging.getLogger(__name__)` — no new imports.
- All user-facing strings preserved verbatim, including `[WARNING]` prefixes.
- `logger.warning` chosen (not `.info`) because the original strings carried a `[WARNING]` semantic level.
- Docstring for `_warn_invalid_commands` updated: "Print..." → "Emit...".

## Test plan

- [x] `ruff check --select T201,T203` clean on migrated file
- [x] `ruff check` clean on migrated file
- [x] `black --check` clean on migrated file
- [x] Companion test file (`tests/unit/test_ssh_runner.py`) — 168 passed
- [x] Full pytest baseline: **8949 passed**, 0 failed, 77 skipped, 5 xfailed, 1 xpassed
