### PR TITLE
chore(logging): migrate src/ssh/config/host_parser.py print() to logger (#886 slice 47/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 47/N: retire `print()` in `src/ssh/config/host_parser.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`
+  calls in `src/ssh/config/host_parser.py` with `logger.warning(...)` using
+  `%`-style deferred formatting. Migrated callsites: the oversize-input
+  truncation notice in `_truncate_oversize`, the two invalid-host warnings
+  in `_warn_invalid_hosts` (summary line plus "... and N more" tail), and
+  the too-many-hosts cap notice in `_enforce_host_cap`. All user-facing
+  strings (including the `[WARNING]` prefixes and "... and N more" tail
+  line) are preserved verbatim.
+- **Docstring (Changed)**: updated `_warn_invalid_hosts` summary line from
+  "Print the same user-facing warning..." to "Emit the same user-facing
+  warning..." to match the logger-based emission.
+- **Rationale**: incremental progress toward ruff `T20` (T201/T203) selector
+  enablement (issue #886). Behavior-preserving; the module already imported
+  `logging` and defined `logger = logging.getLogger(__name__)`, so no new
+  imports were introduced. `logger.warning` is used because the original
+  strings carried a `[WARNING]` prefix — the semantic level is warning.
+
 ### #886 Phase 2 slice 46/N: retire `print()` in `src/ssh/config/command_parser.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`

--- a/src/ssh/config/host_parser.py
+++ b/src/ssh/config/host_parser.py
@@ -31,7 +31,8 @@ class HostListParser:
     def _truncate_oversize(hosts_str: str) -> str:
         """Truncate the raw host string if it exceeds the safety cap."""
         if len(hosts_str) > _MAX_INPUT_LEN:  # Length check to prevent DoS
-            print("[WARNING] Host list too long, truncating to first 10000 characters")  # Preserve user-facing string
+            # WHY: Preserve user-facing string; emit through logger for structured output.
+            logger.warning("[WARNING] Host list too long, truncating to first 10000 characters")
             return hosts_str[:_MAX_INPUT_LEN]  # Return truncated copy
         return hosts_str  # No truncation needed
 
@@ -52,20 +53,25 @@ class HostListParser:
 
     @staticmethod
     def _warn_invalid_hosts(invalid: list[str]) -> None:
-        """Print the same user-facing warning as the legacy implementation."""
+        """Emit the same user-facing warning as the legacy implementation."""
         if not invalid:  # Nothing to warn about
             return  # No-op for clean inputs
         sample = ", ".join(invalid[:5])  # Show only the first 5 to keep output bounded
-        print(f"[WARNING] Skipping {len(invalid)} invalid hosts: {sample}")  # Preserve user-facing string verbatim
+        # WHY: Preserve user-facing string verbatim; emit via logger.
+        logger.warning("[WARNING] Skipping %d invalid hosts: %s", len(invalid), sample)
         if len(invalid) > 5:  # Indicate truncation only when extra entries exist
-            print(f"    ... and {len(invalid) - 5} more")  # Preserve user-facing string verbatim
+            # WHY: Preserve user-facing string verbatim.
+            logger.warning("    ... and %d more", len(invalid) - 5)
 
     @staticmethod
     def _enforce_host_cap(hosts: list[str]) -> list[str]:
         """Trim to the per-run host cap and warn if truncation happens."""
         if len(hosts) > _MAX_HOSTS:  # Enforce resource cap
-            print(
-                f"[WARNING] Too many hosts ({len(hosts)}), limiting to first {_MAX_HOSTS}"
-            )  # Preserve user-facing string
+            # WHY: Preserve user-facing string; emit via logger.
+            logger.warning(
+                "[WARNING] Too many hosts (%d), limiting to first %d",
+                len(hosts),
+                _MAX_HOSTS,
+            )
             return hosts[:_MAX_HOSTS]  # Return truncated list
         return hosts  # No truncation needed


### PR DESCRIPTION
## Summary

Slice 47/N of issue #886 (ruff T20 rollout). Migrates the 4 remaining `print()` calls in `src/ssh/config/host_parser.py` to `logger.warning(...)` with `%`-style deferred formatting.

**Callsites migrated (all in `HostListParser`):**
- `_truncate_oversize`: oversize-input truncation notice
- `_warn_invalid_hosts`: invalid-host summary + "... and N more" tail
- `_enforce_host_cap`: too-many-hosts cap notice

**Notes:**
- Module already imported `logging` and defined `logger = logging.getLogger(__name__)` — no new imports.
- All user-facing strings preserved verbatim, including `[WARNING]` prefixes.
- `logger.warning` chosen (not `.info`) because original strings carried a `[WARNING]` semantic level.
- Docstring for `_warn_invalid_hosts` updated: "Print..." → "Emit...".
- Parallel structure to slice 46/N (`command_parser.py`, PR #1557).

## Test plan

- [x] `ruff check --select T201,T203` clean
- [x] `ruff check` clean
- [x] `black --check` clean
- [x] Companion test file (`tests/unit/test_ssh_runner.py`) — 168 passed
- [x] Full pytest baseline: **8949 passed**, 0 failed, 77 skipped, 5 xfailed, 1 xpassed
