### PR TITLE
chore(logging): migrate src/analytics/insight_metrics_utils.py print() to logger (#886 slice 48/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 48/N: retire `print()` in `src/analytics/insight_metrics_utils.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 5 remaining `print()`
+  calls in `src/analytics/insight_metrics_utils.py` with `logging.info(...)` /
+  `logging.warning(...)`. All 5 calls live in
+  `InsightMetricsUtils.export_const_insight_metrics`: the "Export Available
+  Insight Metrics:" banner and two `! Note:` / `! For best results` guidance
+  lines, the "! ConstInsightMetrics.csv is available" success message, and
+  the "! Warning: ConstInsightMetrics.csv was not created..." missing-file
+  notice. The first four map to `logging.info` (banner/informational tone);
+  the last maps to `logging.warning` since the original string carried a
+  "Warning:" prefix. All user-facing strings preserved verbatim.
+- **Companion tests (Changed)**:
+  `tests/unit/analytics/test_insight_metrics_utils.py` updated so
+  `test_export_const_insight_metrics_delegates_and_reports_present` and
+  `test_export_const_insight_metrics_warns_when_csv_missing` capture
+  `caplog` records instead of `capsys` stdout. Root-logger `at_level("INFO")`
+  / `at_level("WARNING")` scoping added inside each test's context manager.
+- **Rationale**: incremental progress toward ruff `T20` (T201/T203) selector
+  enablement (issue #886). Behavior-preserving; the module already imported
+  `logging` and used `logging.info/warning/debug/error` directly (no module
+  `logger` object), so the migrated calls follow that existing convention.
+
 ### #886 Phase 2 slice 47/N: retire `print()` in `src/ssh/config/host_parser.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 4 remaining `print()`

--- a/src/analytics/insight_metrics_utils.py
+++ b/src/analytics/insight_metrics_utils.py
@@ -35,9 +35,12 @@ class InsightMetricsUtils:  # Insight-metrics helpers.
         Refreshes data/ConstInsightMetrics.csv so scope-filtering helpers can read it.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConstDefinitionsExporter + apisession.
-        print("Export Available Insight Metrics:")  # User-facing banner for the const insight metrics export
-        print("! Note: This function now uses the dynamic comprehensive const export system")  # Tell the user.
-        print("! For best results, consider using Menu 82: Export All Const Definitions")  # Tell the user.
+        # WHY: Preserve user-facing banner; emit via logging for structured output.
+        logging.info("Export Available Insight Metrics:")
+        # WHY: Preserve user-facing note verbatim.
+        logging.info("! Note: This function now uses the dynamic comprehensive const export system")
+        # WHY: Preserve user-facing note verbatim.
+        logging.info("! For best results, consider using Menu 82: Export All Const Definitions")
         logging.info("Legacy const insight metrics export called - using ConstDefinitionsExporter class")
 
         exporter = mh.ConstDefinitionsExporter(mh.apisession)  # type: ignore[no-untyped-call]
@@ -45,9 +48,11 @@ class InsightMetricsUtils:  # Insight-metrics helpers.
 
         insight_metrics_file = os.path.join("data", "ConstInsightMetrics.csv")  # Expected output file.
         if os.path.exists(insight_metrics_file):  # File present.
-            print("! ConstInsightMetrics.csv is available in the dynamic export results")  # Tell the user.
+            # WHY: Preserve user-facing success message verbatim.
+            logging.info("! ConstInsightMetrics.csv is available in the dynamic export results")
         else:
-            print("! Warning: ConstInsightMetrics.csv was not created during dynamic export")
+            # WHY: Preserve user-facing warning verbatim; semantic level is warning.
+            logging.warning("! Warning: ConstInsightMetrics.csv was not created during dynamic export")
 
     @staticmethod
     def _should_skip_row(metric_name: str, scopes: str) -> bool:

--- a/tests/unit/analytics/test_insight_metrics_utils.py
+++ b/tests/unit/analytics/test_insight_metrics_utils.py
@@ -48,36 +48,38 @@ def _make_mh(**extra):
 
 
 def test_export_const_insight_metrics_delegates_and_reports_present(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """CSV present -> exporter.export_all is called and 'available' message printed."""
+    """CSV present -> exporter.export_all is called and 'available' message logged."""
     fake_mh = _make_mh()
     exporter_instance = MagicMock()
     fake_mh.ConstDefinitionsExporter.return_value = exporter_instance
     with (
+        caplog.at_level("INFO", logger="root"),
         patch("src.analytics.insight_metrics_utils.os.path.exists", return_value=True),
         patch("src.analytics.insight_metrics_utils.importlib.import_module", return_value=fake_mh),
     ):
         InsightMetricsUtils.export_const_insight_metrics()
     fake_mh.ConstDefinitionsExporter.assert_called_once_with(fake_mh.apisession)
     exporter_instance.export_all.assert_called_once_with()
-    out = capsys.readouterr().out
-    assert "Export Available Insight Metrics" in out
-    assert "ConstInsightMetrics.csv is available" in out
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "Export Available Insight Metrics" in messages
+    assert "ConstInsightMetrics.csv is available" in messages
 
 
 def test_export_const_insight_metrics_warns_when_csv_missing(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """CSV absent -> warning is emitted."""
+    """CSV absent -> warning is logged."""
     fake_mh = _make_mh()
     with (
+        caplog.at_level("WARNING", logger="root"),
         patch("src.analytics.insight_metrics_utils.os.path.exists", return_value=False),
         patch("src.analytics.insight_metrics_utils.importlib.import_module", return_value=fake_mh),
     ):
         InsightMetricsUtils.export_const_insight_metrics()
-    out = capsys.readouterr().out
-    assert "was not created" in out
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "was not created" in messages
 
 
 # ---------- _should_skip_row ----------


### PR DESCRIPTION
## Summary
- Slice 48/N of issue #886 (retire `print()` in favor of `logging`).
- Migrates 5 `print()` calls in `InsightMetricsUtils.export_const_insight_metrics()` to `logging.info` (4) and `logging.warning` (1).
- Companion tests swapped from `capsys` to `caplog` for the two migrated behaviors.

## Rationale
- Module already uses `logging.info/warning/debug/error` directly (no module-level `logger` variable) — kept that convention.
- Preserves user-facing message text verbatim; `[Warning:]` string routed at WARNING level.
- `# WHY:` comments hoisted above each migrated call per docstring policy.

## Test plan
- [x] `pytest tests/unit/analytics/test_insight_metrics_utils.py` → 45 passed
- [x] Full baseline: 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed (unchanged)
- [x] `ruff check --select T20` on target: clean
- [x] `ruff check` on target + test: clean
- [x] `black --check` on target + test: clean