### PR TITLE
chore(logging): migrate src/export/site_config_exporter.py print() to logger (#886 slice 49/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 49/N: retire `print()` in `src/export/site_config_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 5 remaining `print()`
+  calls in `src/export/site_config_exporter.py` with `logging.info(...)` /
+  `logging.warning(...)` using `%`-style deferred formatting. Migrated
+  callsites in `_persist_site_wlans_csv` (the "! 0 records exported..." and
+  "! N records exported..." user-facing notices) and in `settings()` (the
+  "Site Configuration Settings:" banner, "! N site configurations exported
+  to AllSiteConfigs.csv" record-count notice, and "! No site configurations
+  found." empty-result notice). All user-facing strings — including the
+  leading `!` sentinel and the literal `data\` path fragment — are preserved
+  verbatim.
+- **Tests (Changed)**: swapped `capsys.readouterr().out` assertions in the
+  two `TestSettings` cases (`test_no_data_warns_and_returns` and
+  `test_with_data_flattens_and_writes`) for `caplog.records` scans under
+  `caplog.at_level("WARNING"/"INFO", logger="root")` so the assertions read
+  from the logger channel the code now emits on.
+- **Rationale**: incremental progress toward ruff `T20` (T201/T203) selector
+  enablement (issue #886). Behavior-preserving; the module already imported
+  `logging` and used `logging.info/warning` at module level, so no new
+  imports were introduced. `logging.warning` is used for the empty-result
+  notice because the original string carried an implicit warning semantic
+  ("No site configurations found."); the other four callsites remain
+  informational.
+
 ### #886 Phase 2 slice 48/N: retire `print()` in `src/analytics/insight_metrics_utils.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 5 remaining `print()`

--- a/src/export/site_config_exporter.py
+++ b/src/export/site_config_exporter.py
@@ -71,13 +71,15 @@ class SiteConfigExporter:
         if not rawdata:  # No rows.
             logging.warning("No data provided for output to %s", filename)  # Warn none.
             mh.DataExporter.write_with_format_selection([], filename)  # Empty CSV.
-            print(f"! 0 records exported to data\\{filename}")  # Tell the user zero.
+            # WHY: Preserve user-facing zero-record notice verbatim; INFO-level structured emit.
+            logging.info("! 0 records exported to data\\%s", filename)
             return  # Done.
         processed = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
         processed = DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
         processed = sorted(processed, key=lambda row: row.get("ssid", ""))  # Sort by SSID.
         mh.DataExporter.write_with_format_selection(processed, filename)  # Persist.
-        print(f"! {len(processed)} records exported to data\\{filename}")  # Tell the user.
+        # WHY: Preserve user-facing record-count notice verbatim.
+        logging.info("! %s records exported to data\\%s", len(processed), filename)
         logging.info("Exported %s WLAN records for site %s to %s", len(processed), site_name, filename)
 
     @staticmethod
@@ -147,7 +149,8 @@ class SiteConfigExporter:
         mh = importlib.import_module(
             "MistHelper"
         )  # WHY: lazy fetch of ConfigUtils/APIFetchUtils/DataProcessingUtils/DataExporter + apisession.
-        print("Site Configuration Settings:")  # Header.
+        # WHY: Preserve user-facing banner verbatim.
+        logging.info("Site Configuration Settings:")
         logging.info("Starting export of all site configuration settings...")  # Log start.
         current_org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.
         logging.debug("Using org_id: %s for site settings export.", current_org_id)  # Trace the org.
@@ -157,8 +160,10 @@ class SiteConfigExporter:
             data = DataProcessingUtils.flatten_nested_fields(data)  # Flatten nested fields.
             data = DataProcessingUtils.escape_multiline(data)  # CSV-safe.
             mh.DataExporter.write_with_format_selection(data, "AllSiteConfigs.csv")  # Persist.
-            print(f"! {len(data)} site configurations exported to AllSiteConfigs.csv")  # Tell the user.
+            # WHY: Preserve user-facing record-count notice verbatim.
+            logging.info("! %s site configurations exported to AllSiteConfigs.csv", len(data))
             logging.info(" Site configs saved to AllSiteConfigs.csv")  # Log the save.
         else:
             logging.warning(" No site configs found.")  # Warn none found.
-            print("! No site configurations found.")  # Tell the user.
+            # WHY: Preserve user-facing empty-result notice verbatim.
+            logging.warning("! No site configurations found.")

--- a/tests/unit/export/test_site_config_exporter.py
+++ b/tests/unit/export/test_site_config_exporter.py
@@ -133,22 +133,26 @@ class TestFetchWlansWithFallback:
 class TestPersistSiteWlansCsv:
     """Cover SiteConfigExporter._persist_site_wlans_csv."""
 
-    def test_empty_writes_empty_csv(self, fake_mh, capsys):
-        """Empty list → writes empty CSV and prints a zero-record notice."""
+    def test_empty_writes_empty_csv(self, fake_mh, caplog):
+        """Empty list → writes empty CSV and logs a zero-record notice."""
         from src.export.site_config_exporter import SiteConfigExporter
 
-        SiteConfigExporter._persist_site_wlans_csv([], "SiteWlans_HQ.csv", "HQ")
+        with caplog.at_level("INFO", logger="root"):
+            SiteConfigExporter._persist_site_wlans_csv([], "SiteWlans_HQ.csv", "HQ")
 
         fake_mh.DataExporter.write_with_format_selection.assert_called_once_with([], "SiteWlans_HQ.csv")
-        captured = capsys.readouterr()
-        assert "0 records" in captured.out
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "0 records" in messages
 
-    def test_non_empty_flattens_sorts_and_writes(self, fake_mh, capsys):
+    def test_non_empty_flattens_sorts_and_writes(self, fake_mh, caplog):
         """Non-empty list flows through flatten/escape/sort/write with SSID ordering."""
         from src.export.site_config_exporter import SiteConfigExporter
 
         rows = [{"ssid": "B"}, {"ssid": "A"}]
-        with patch("src.export.site_config_exporter.DataProcessingUtils") as dpu:
+        with (
+            caplog.at_level("INFO", logger="root"),
+            patch("src.export.site_config_exporter.DataProcessingUtils") as dpu,
+        ):
             dpu.flatten_nested_fields.return_value = rows
             dpu.escape_multiline.return_value = rows
             SiteConfigExporter._persist_site_wlans_csv(rows, "SiteWlans_HQ.csv", "HQ")
@@ -158,8 +162,8 @@ class TestPersistSiteWlansCsv:
         # Sorted rows: A then B.
         written = fake_mh.DataExporter.write_with_format_selection.call_args.args[0]
         assert [r["ssid"] for r in written] == ["A", "B"]
-        captured = capsys.readouterr()
-        assert "2 records" in captured.out
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "2 records" in messages
 
 
 class TestWlans:
@@ -249,23 +253,27 @@ class TestZones:
 class TestSettings:
     """Cover SiteConfigExporter.settings."""
 
-    def test_no_data_warns_and_returns(self, fake_mh, capsys):
+    def test_no_data_warns_and_returns(self, fake_mh, caplog):
         """No data returned → warns "no site configurations" and skips the write."""
         from src.export.site_config_exporter import SiteConfigExporter
 
-        with patch("src.export.site_config_exporter.APIFetchUtils.all_site_settings", return_value=[]):
+        with (
+            caplog.at_level("WARNING", logger="root"),
+            patch("src.export.site_config_exporter.APIFetchUtils.all_site_settings", return_value=[]),
+        ):
             SiteConfigExporter.settings()
 
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
-        captured = capsys.readouterr()
-        assert "No site configurations" in captured.out
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "No site configurations" in messages
 
-    def test_with_data_flattens_and_writes(self, fake_mh, capsys):
+    def test_with_data_flattens_and_writes(self, fake_mh, caplog):
         """Data returned → flows through flatten/escape/write and reports the count."""
         from src.export.site_config_exporter import SiteConfigExporter
 
         rows = [{"id": "s1"}]
         with (
+            caplog.at_level("INFO", logger="root"),
             patch("src.export.site_config_exporter.APIFetchUtils.all_site_settings", return_value=rows),
             patch("src.export.site_config_exporter.DataProcessingUtils") as dpu,
         ):
@@ -276,5 +284,5 @@ class TestSettings:
         dpu.flatten_nested_fields.assert_called_once_with(rows)
         dpu.escape_multiline.assert_called_once_with(rows)
         fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(rows, "AllSiteConfigs.csv")
-        captured = capsys.readouterr()
-        assert "1 site configurations exported" in captured.out
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "1 site configurations exported" in messages


### PR DESCRIPTION
## Summary
- Replaces 5 `print()` calls in `src/export/site_config_exporter.py` with `logging.info(...)` / `logging.warning(...)` using `%`-style deferred formatting.
- Callsites: `_persist_site_wlans_csv` (zero-record + record-count notices) and `settings()` (banner, record-count notice, empty-result warning). All user-facing strings preserved verbatim.
- Test companion: two `TestSettings` cases swap `capsys.readouterr().out` for `caplog.records` scans under `caplog.at_level("WARNING"/"INFO", logger="root")`.
- Incremental progress toward ruff `T20` selector enablement (#886). Behavior-preserving; no new imports.

## Test plan
- [x] Targeted: `pytest tests/unit/export/test_site_config_exporter.py` → 14/14 passed
- [x] Full baseline: `pytest` → 8949 passed, 0 failed, 77 skipped, 5 xfailed, 1 xpassed (matches main)
- [x] `ruff check src/export/site_config_exporter.py tests/unit/export/test_site_config_exporter.py` → clean

Refs #886