### PR TITLE
chore(logging): migrate src/export/site_export_utils.py print() to logger (#886 slice 50/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 50/N: retire `print()` in `src/export/site_export_utils.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 5 remaining `print()`
+  calls in `src/export/site_export_utils.py` with `logging.info(...)` /
+  `logging.warning(...)` / `logging.error(...)` using `%`-style deferred
+  formatting. Migrated callsites in `_emit_debug_table` (PrettyTable render),
+  `_write_insight_rows` (the "! N records" success and "! 0 records ... (no
+  metrics available)" empty branches), `_export_data` (record-count summary),
+  and `insights` (operator-facing error branch). Companion tests in
+  `tests/unit/export/test_site_export_utils_extended.py` migrated from
+  `capsys` to `caplog` (`caplog.at_level(..., logger="root")` + record-list
+  join). No behavioral change; operator messages preserved verbatim.
+
 ### #886 Phase 2 slice 49/N: retire `print()` in `src/export/site_config_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 5 remaining `print()`

--- a/src/export/site_export_utils.py
+++ b/src/export/site_export_utils.py
@@ -166,7 +166,8 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
         for item in self.tqdm(data, desc="Processing", unit="record"):  # WHY: progress bar per row.
             row = [item.get(field, "") for field in table.field_names]  # WHY: row in stable order.
             table.add_row(row)  # WHY: append to table.
-        print(table)  # WHY: legacy debug console output.
+        # WHY: legacy debug console output preserved via INFO-level structured emit.
+        logging.info("%s", table)
         logging.debug("Site data displayed in table format (debug mode).")  # WHY: audit debug render.
 
     def _write_site_report(  # WHY: single-endpoint export helper reused by many exports.
@@ -233,12 +234,14 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
         """Write insight rows to CSV, emitting operator messages for empty-payload cases."""
         if rows:  # WHY: happy-path when metric availability payload had data.
             self.DataExporter.write_with_format_selection(rows, filename)  # WHY: persist rows.
-            print(f"! {len(rows)} records exported to data\\{filename}")  # WHY: legacy operator message.
+            # WHY: preserve legacy operator record-count notice verbatim.
+            logging.info("! %s records exported to data\\%s", len(rows), filename)
             logging.info(
                 "Exported %s site SLE metric insight records to %s", len(rows), filename
             )  # WHY: success audit log.
             return  # WHY: skip empty-file emission when rows exist.
-        print(f"! 0 records exported to data\\{filename} (no metrics available)")  # WHY: legacy empty message.
+        # WHY: preserve legacy empty-payload operator notice verbatim.
+        logging.warning("! 0 records exported to data\\%s (no metrics available)", filename)
         logging.warning("No site SLE metric insight data available for site %s", site_name)  # WHY: warn empty.
         self.DataExporter.write_with_format_selection([], filename)  # WHY: still emit empty file for pipeline.
 
@@ -301,7 +304,8 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
             data = self._prepare_rows(rawdata, sort_key)  # WHY: sort, flatten, escape.
             logging.info("Saving exported site data to %s", filename)  # WHY: pre-save log.
             self.DataExporter.write_with_format_selection(data, filename)  # WHY: legacy writer entry.
-            print(f"! {len(data)} records exported to {_resolve_site_display_path(filename)}")
+            # WHY: preserve legacy operator record-count notice verbatim.
+            logging.info("! %s records exported to %s", len(data), _resolve_site_display_path(filename))
             logging.info("Site %s data written to %s (%s rows).", data_type, filename, len(data))
             self._display_or_log_results(data, data_type, filename)  # WHY: display or log.
         except Exception as e:
@@ -326,7 +330,8 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
             )
             self._write_insight_rows(rows, filename, site_name)  # WHY: persist and log.
         except Exception as exception:  # noqa: BLE001
-            print(f"! Error exporting site SLE metric insights: {exception}")  # WHY: legacy operator msg.
+            # WHY: preserve legacy operator error notice verbatim.
+            logging.error("! Error exporting site SLE metric insights: %s", exception)
             logging.error("Failed to export site SLE metric insights for site %s: %s", site_name, exception)
             self.DataExporter.write_with_format_selection([], filename)  # WHY: empty file preserves pipeline.
 

--- a/tests/unit/export/test_site_export_utils_extended.py
+++ b/tests/unit/export/test_site_export_utils_extended.py
@@ -375,25 +375,27 @@ def test_fetch_site_sle_metrics_payload_returns_dict_when_data_attribute_present
 
 
 def test_write_insight_rows_writes_and_logs_when_rows_present(
-    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """_write_insight_rows writes CSV and prints success line for non-empty rows."""
+    """_write_insight_rows writes CSV and logs success line for non-empty rows."""
     exporter, mocks = _build_exporter()
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INFO, logger="root"):
         exporter._write_insight_rows([{"metric_name": "m1"}], "f.csv", "site")
     mocks["exporter_mock"].assert_called_once_with([{"metric_name": "m1"}], "f.csv")
-    assert "1 records exported" in capsys.readouterr().out
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "1 records exported" in messages
 
 
 def test_write_insight_rows_writes_empty_file_when_rows_missing(
-    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """_write_insight_rows writes empty file + prints empty message when no rows."""
+    """_write_insight_rows writes empty file + logs empty message when no rows."""
     exporter, mocks = _build_exporter()
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING, logger="root"):
         exporter._write_insight_rows([], "f.csv", "site")
     mocks["exporter_mock"].assert_called_once_with([], "f.csv")
-    assert "no metrics available" in capsys.readouterr().out
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "no metrics available" in messages
     assert "No site SLE metric insight data available" in caplog.text
 
 
@@ -463,7 +465,7 @@ def test_export_data_raises_and_logs_on_api_failure(caplog: pytest.LogCaptureFix
             exporter._export_data(api_call=api, data_type="test data")
 
 
-def test_insights_happy_path_writes_rows(caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]) -> None:
+def test_insights_happy_path_writes_rows(caplog: pytest.LogCaptureFixture) -> None:
     """insights() resolves site, fetches SLE payload and writes rows."""
     exporter, mocks = _build_exporter()
     with caplog.at_level(logging.INFO):
@@ -483,16 +485,18 @@ def test_insights_returns_when_no_site_selected() -> None:
     mocks["exporter_mock"].assert_not_called()
 
 
-def test_insights_handles_api_error_by_writing_empty_file(capsys: pytest.CaptureFixture[str]) -> None:
-    """insights() error branch writes empty file and prints operator message."""
+def test_insights_handles_api_error_by_writing_empty_file(caplog: pytest.LogCaptureFixture) -> None:
+    """insights() error branch writes empty file and logs operator message."""
     exporter, mocks = _build_exporter()
     mocks["sle_ns"].listSiteSlesMetrics.side_effect = RuntimeError("boom")
-    exporter.insights()
+    with caplog.at_level(logging.ERROR, logger="root"):
+        exporter.insights()
     # writer should still be called once with empty rows.
     mocks["exporter_mock"].assert_called_once()
     args, _kwargs = mocks["exporter_mock"].call_args
     assert args[0] == []  # WHY: empty file for pipeline continuity.
-    assert "Error exporting site SLE metric insights" in capsys.readouterr().out
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "Error exporting site SLE metric insights" in messages
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 50/N of issue #886 (retire `print()` calls in favor of `logging`).

Migrates the 5 remaining `print()` calls in `src/export/site_export_utils.py`
to `logging.info/warning/error` with `%`-style deferred formatting.

## Migrated callsites

| Function | Level | Notes |
| --- | --- | --- |
| `_emit_debug_table` | INFO | PrettyTable render (operator-visible content) |
| `_write_insight_rows` (rows branch) | INFO | "! N records exported" success line |
| `_write_insight_rows` (empty branch) | WARNING | "! 0 records ... (no metrics available)" |
| `_export_data` | INFO | "! N records exported to <path>" summary |
| `insights` (except branch) | ERROR | "! Error exporting site SLE metric insights" |

Operator messages preserved verbatim.

## Companion tests

`tests/unit/export/test_site_export_utils_extended.py` — three tests migrated
from `capsys` to `caplog` using `caplog.at_level(..., logger="root")` plus
record-list join.

## Verification

- `ruff check src/export/site_export_utils.py --select T20` → All checks passed
- `black --check` → clean
- `pytest tests/unit/export/test_site_export_utils*.py` → 52 passed

## Test plan

- [x] Local ruff T20 clean on target file
- [x] Local black clean
- [x] 52 unit tests pass locally
- [ ] CI green