### PR TITLE
chore(logging): migrate src/site/address_audit/comparison_display.py print() to logger (#886 slice 52/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 52/N: retire `print()` in `src/site/address_audit/comparison_display.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 5 remaining `print()`
+  calls in `src/site/address_audit/comparison_display.py` with
+  `logging.info(...)` / `logging.warning(...)` using `%`-style deferred
+  formatting. Migrated callsites in `render` (PrettyTable render),
+  `prompt_post_table` (per-state summary line plus the `[1] Save` / `[q] Quit`
+  menu), and the invalid-choice re-prompt branch. User-facing message text
+  preserved verbatim; no behavior change beyond routing through the configured
+  logger.
+
 ### #886 Phase 2 slice 51/N: retire `print()` in `src/gateway/_wan2_variable_template.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 5 remaining `print()`

--- a/src/site/address_audit/comparison_display.py
+++ b/src/site/address_audit/comparison_display.py
@@ -40,7 +40,8 @@ class ComparisonTableRenderer:
         for result in results:  # Add one terminal row per audited CSV row.
             table.add_row(self._build_row(result))  # Append the (truncated) row cells.
         rendered = table.get_string()  # Materialize the table as a string.
-        print(rendered)  # Show the table to the operator.
+        # WHY: preserve operator-facing table render; route through logger for capture/redirection.
+        logging.info("%s", rendered)
         logging.debug("Comparison table rendered (%d rows)", len(results))  # Action-log completion.
         return rendered  # Return for tests/callers.
 
@@ -75,9 +76,10 @@ class ComparisonTableRenderer:
     def prompt_post_table(self, results: list[AuditResult]) -> str:
         """Print a one-line summary, then loop until the operator picks save/quit."""
         logging.info("Prompting operator for post-table action")  # Action-log start.
-        print(self._summary_line(results))  # Show the per-state summary line.
-        print("\n[1] Save comparison as CSV to data/ for review")  # Save option.
-        print("[q] Quit without saving")  # Quit option.
+        # WHY: preserve operator-facing summary + menu; route through logger for capture/redirection.
+        logging.info("%s", self._summary_line(results))
+        logging.info("\n[1] Save comparison as CSV to data/ for review")
+        logging.info("[q] Quit without saving")
         while True:  # Re-prompt until a valid choice is entered.
             choice = InputUtils.safe_input("Choice: ", context="address_audit_post_table").strip().lower()
             if choice == "1":  # Operator chose to save.
@@ -86,7 +88,8 @@ class ComparisonTableRenderer:
             if choice == "q":  # Operator chose to quit.
                 logging.debug("Operator selected quit")  # Trace the choice.
                 return "quit"  # Engine exits without saving.
-            print("Invalid choice. Enter 1 to save or q to quit.")  # One-line error, then re-prompt.
+            # WHY: preserve invalid-choice feedback verbatim; route through logger for capture/redirection.
+            logging.warning("Invalid choice. Enter 1 to save or q to quit.")
 
     def _summary_line(self, results: list[AuditResult]) -> str:
         """Build the 'N sites processed: ...' per-state summary string."""


### PR DESCRIPTION
## Summary

Slice 52/N of #886 print-to-logger migration.

Replaces the 5 remaining `print()` calls in `src/site/address_audit/comparison_display.py` with `logging.info` / `logging.warning` using `%`-style deferred formatting. Migrated callsites:

- `render` — PrettyTable render
- `prompt_post_table` — per-state summary line and the `[1] Save` / `[q] Quit` menu (3 prints)
- invalid-choice re-prompt branch (warning)

User-facing message text preserved verbatim. No behavior change beyond routing through the configured logger.

## Test plan

- [x] `python -m ruff check src/site/address_audit/comparison_display.py --select T20` → clean
- [x] `python -m ruff check src/site/address_audit/comparison_display.py` → clean
- [x] `python -m black --check src/site/address_audit/comparison_display.py` → unchanged
- [x] `python -m pytest tests/unit/site/address_audit/test_comparison_display.py` → 5 passed