### PR TITLE
chore(logging): migrate src/device/utility_commands.py print() to logger (#886 slice 54/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 54/N: retire `print()` in `src/device/utility_commands.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`
+  calls in `src/device/utility_commands.py` with `logging.info(...)` /
+  `logging.error(...)` using `%`-style deferred formatting. Migrations cover
+  `_print_api_error` (formatted HTTP-error line including status and any
+  server-side detail), `_print_api_result` (success arrow line), and
+  `_handle_clear_session_error` (the 400-status two-line operator guidance
+  about `service_name`/`session_ids` request-body keys plus the generic
+  fallback and the nested-exception guard). Error and success text preserved
+  verbatim; no behavior change beyond routing through the configured logger.
+  Companion `capsys` → `caplog` migration in
+  `tests/unit/test_device_utility_commands.py` covers the 11 affected
+  success/error-path assertions.
+
 ### #886 Phase 2 slice 53/N: retire `print()` in `src/capture/site_capture_loop.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`

--- a/src/device/utility_commands.py
+++ b/src/device/utility_commands.py
@@ -11,6 +11,7 @@ Dependencies are injected via constructor for testability.
 
 from __future__ import annotations  # WHY: postponed evaluation for forward-ref type hints
 
+import logging  # WHY: route operator-facing API result/error output through the logger (issue #886)
 from collections.abc import Callable  # WHY: type aliases for DI callables
 from dataclasses import dataclass  # WHY: bundle 6 injected deps into a frozen struct
 from typing import Any  # WHY: broad response typing for mistapi wrappers
@@ -76,7 +77,8 @@ def _print_api_error(response: Any, fail_msg: str, status_code: int) -> None:  #
     error_text = f"! {fail_msg} (HTTP {status_code})"  # WHY: base line always includes status
     if detail:  # WHY: append server-side context when available
         error_text += f": {detail}"  # WHY: keep detail on same line for grep-ability
-    print(error_text)  # WHY: single write to keep operator output atomic
+    # WHY: preserve error line verbatim; route through logger for capture/redirection.
+    logging.error("%s", error_text)  # WHY: single write to keep operator output atomic
 
 
 class DeviceUtilityCommands:  # WHY: parent class hosting 35 device-command operations
@@ -179,7 +181,8 @@ class DeviceUtilityCommands:  # WHY: parent class hosting 35 device-command oper
         if isinstance(status, int) and status >= _HTTP_ERROR_THRESHOLD:  # WHY: only ints compare
             _print_api_error(response, fail_msg, status)  # WHY: delegate detail extraction
             return False  # WHY: caller treats False as failure
-        print(f"-> {success_msg}")  # WHY: emit success line
+        # WHY: preserve success arrow verbatim; route through logger for capture/redirection.
+        logging.info("-> %s", success_msg)  # WHY: emit success line
         return True  # WHY: caller treats True as success
 
     @staticmethod
@@ -192,15 +195,16 @@ class DeviceUtilityCommands:  # WHY: parent class hosting 35 device-command oper
                 None,
             )  # WHY: try both mistapi error shapes
             if code == 400:  # WHY: 400 == missing service_name/session_ids body key
-                print(
+                # WHY: preserve error guidance verbatim; route through logger for capture/redirection.
+                logging.error(
                     "! API returned 400. The API expects either"
                     " 'service_name' or 'session_ids' in the"
                     " request body."
                 )  # WHY: teach operator the fix
-                print(
+                logging.error(
                     "  Provide a service name or a comma-separated list of session IDs, and retry."
                 )  # WHY: guide follow-up input
             else:
-                print(f"! Clear session failed: {error}")  # WHY: generic fallback
+                logging.error("! Clear session failed: %s", error)  # WHY: generic fallback
         except Exception:  # pylint: disable=broad-exception-caught
-            print(f"! Clear session failed: {error}")  # WHY: never let error-handler raise
+            logging.error("! Clear session failed: %s", error)  # WHY: never let error-handler raise

--- a/tests/test_clear_session.py
+++ b/tests/test_clear_session.py
@@ -9,6 +9,7 @@ These tests cover:
 - 400 API error handling
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 from src.device.utility_commands import DeviceUtilityCommands, UtilityCommandsDeps
@@ -149,7 +150,7 @@ def test_clear_session_confirm_clear_all_proceeds(monkeypatch):
     assert captured.get("body") == {}
 
 
-def test_clear_session_handles_400(monkeypatch, capsys):
+def test_clear_session_handles_400(monkeypatch, capsys, caplog):
     _stub_selection(monkeypatch)
 
     def fake_safe_input(prompt, context=None, allow_empty=True, **kwargs):
@@ -179,7 +180,8 @@ def test_clear_session_handles_400(monkeypatch, capsys):
 
     with patch("src.device._utility_commands_clear.mistapi") as mock_api:
         mock_api.api.v1.sites.devices.clearSiteDeviceSession = fake_clear_raise
-        duc.clear_session()
+        with caplog.at_level(logging.ERROR, logger="root"):
+            duc.clear_session()
 
-    captured_out = capsys.readouterr().out
-    assert "API returned 400" in captured_out
+    log_out = "\n".join(r.getMessage() for r in caplog.records)
+    assert "API returned 400" in log_out

--- a/tests/unit/test_device_utility_commands.py
+++ b/tests/unit/test_device_utility_commands.py
@@ -9,6 +9,7 @@ Uses identity-checked teardown to avoid cross-test sys.modules contamination.
 
 from __future__ import annotations
 
+import logging
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -229,26 +230,29 @@ class TestGetDeviceInfo:
 class TestPrintApiResult:
     """Tests for _print_api_result (static method)."""
 
-    def test_success_prints_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_success_prints_message(self, caplog: pytest.LogCaptureFixture) -> None:
         resp = _mock_api_response(200)
-        result = DeviceUtilityCommands._print_api_result(resp, "OK", "FAIL")
+        with caplog.at_level(logging.INFO, logger="root"):
+            result = DeviceUtilityCommands._print_api_result(resp, "OK", "FAIL")
         assert result is True
-        assert "OK" in capsys.readouterr().out
+        assert "OK" in "\n".join(r.getMessage() for r in caplog.records)
 
-    def test_failure_prints_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_failure_prints_error(self, caplog: pytest.LogCaptureFixture) -> None:
         resp = _mock_api_response(400, {"detail": "bad request"})
-        result = DeviceUtilityCommands._print_api_result(resp, "OK", "FAIL")
+        with caplog.at_level(logging.ERROR, logger="root"):
+            result = DeviceUtilityCommands._print_api_result(resp, "OK", "FAIL")
         assert result is False
-        out = capsys.readouterr().out
+        out = "\n".join(r.getMessage() for r in caplog.records)
         assert "FAIL" in out
         assert "400" in out
         assert "bad request" in out
 
-    def test_failure_without_detail(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_failure_without_detail(self, caplog: pytest.LogCaptureFixture) -> None:
         resp = _mock_api_response(500)
-        result = DeviceUtilityCommands._print_api_result(resp, "OK", "Server Error")
+        with caplog.at_level(logging.ERROR, logger="root"):
+            result = DeviceUtilityCommands._print_api_result(resp, "OK", "Server Error")
         assert result is False
-        assert "500" in capsys.readouterr().out
+        assert "500" in "\n".join(r.getMessage() for r in caplog.records)
 
 
 # ===================================================================
@@ -601,14 +605,15 @@ class TestLocateDevice:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].return_value = "10"
         resp = _mock_api_response(200)
         mock_api.api.v1.sites.devices.startSiteLocateDevice.return_value = resp
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "ap")):
-            duc.locate_device()
-            out = capsys.readouterr().out
+            with caplog.at_level(logging.INFO, logger="root"):
+                duc.locate_device()
+            out = "\n".join(r.getMessage() for r in caplog.records)
             assert "blinking" in out.lower() or "LED" in out
 
     def test_clamps_duration(
@@ -647,13 +652,15 @@ class TestUnlocateDevice:
         self,
         duc: DeviceUtilityCommands,
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         resp = _mock_api_response(200)
         mock_api.api.v1.sites.devices.stopSiteLocateDevice.return_value = resp
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.unlocate_device()
-            assert "stopped" in capsys.readouterr().out.lower()
+            with caplog.at_level(logging.INFO, logger="root"):
+                duc.unlocate_device()
+            out = "\n".join(r.getMessage() for r in caplog.records)
+            assert "stopped" in out.lower()
 
     def test_api_exception(
         self,
@@ -751,13 +758,15 @@ class TestPollSwitchStats:
         self,
         duc: DeviceUtilityCommands,
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         resp = _mock_api_response(200)
         mock_api.api.v1.sites.devices.pollSiteSwitchStats.return_value = resp
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.poll_switch_stats()
-            assert "poll" in capsys.readouterr().out.lower()
+            with caplog.at_level(logging.INFO, logger="root"):
+                duc.poll_switch_stats()
+            out = "\n".join(r.getMessage() for r in caplog.records)
+            assert "poll" in out.lower()
 
 
 class TestCreateDeviceSnapshot:
@@ -771,13 +780,15 @@ class TestCreateDeviceSnapshot:
         self,
         duc: DeviceUtilityCommands,
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         resp = _mock_api_response(200)
         mock_api.api.v1.sites.devices.createSiteDeviceSnapshot.return_value = resp
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.create_device_snapshot()
-            assert "snapshot" in capsys.readouterr().out.lower()
+            with caplog.at_level(logging.INFO, logger="root"):
+                duc.create_device_snapshot()
+            out = "\n".join(r.getMessage() for r in caplog.records)
+            assert "snapshot" in out.lower()
 
     def test_api_exception(
         self,
@@ -832,15 +843,16 @@ class TestUploadSupportFile:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].side_effect = ["1", ""]
         resp = _mock_api_response(200)
         mock_api.api.v1.sites.devices.uploadSiteDeviceSupportFile.return_value = resp
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.upload_support_file()
+            with caplog.at_level(logging.INFO, logger="root"):
+                duc.upload_support_file()
             mock_api.api.v1.sites.devices.uploadSiteDeviceSupportFile.assert_called_once()
-            out = capsys.readouterr().out
+            out = "\n".join(r.getMessage() for r in caplog.records)
             assert "upload" in out.lower() or "initiated" in out.lower()
 
     def test_invalid_type_defaults_full(
@@ -1966,14 +1978,15 @@ class TestReprovisionDeviceExtended:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].return_value = "y"
         resp = _mock_api_response(200)
         mock_api.api.v1.sites.devices.reprovisionSiteOctermDevice.return_value = resp
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.reprovision_device()
-            out = capsys.readouterr().out
+            with caplog.at_level(logging.INFO, logger="root"):
+                duc.reprovision_device()
+            out = "\n".join(r.getMessage() for r in caplog.records)
             assert "reprovisioning" in out.lower()
 
     def test_exception(
@@ -2014,7 +2027,7 @@ class TestReadoptDevice:
         self,
         duc: DeviceUtilityCommands,
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         vc_resp = MagicMock()
         vc_resp.data = {"is_virtual_chassis": True}
@@ -2022,21 +2035,24 @@ class TestReadoptDevice:
         resp = _mock_api_response(200)
         mock_api.api.v1.sites.devices.readoptSiteOctermDevice.return_value = resp
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.readopt_device()
-            assert "re-adoption" in capsys.readouterr().out.lower()
+            with caplog.at_level(logging.INFO, logger="root"):
+                duc.readopt_device()
+            out = "\n".join(r.getMessage() for r in caplog.records)
+            assert "re-adoption" in out.lower()
 
     def test_vc_preflight_exception(
         self,
         duc: DeviceUtilityCommands,
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_api.api.v1.sites.devices.getSiteDeviceVirtualChassis.side_effect = RuntimeError("vc fail")
         resp = _mock_api_response(200)
         mock_api.api.v1.sites.devices.readoptSiteOctermDevice.return_value = resp
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.readopt_device()
-            out = capsys.readouterr().out
+            with caplog.at_level(logging.INFO, logger="root"):
+                duc.readopt_device()
+            out = "\n".join(r.getMessage() for r in caplog.records)
             assert "re-adoption" in out.lower()
 
     def test_readopt_exception(
@@ -2279,15 +2295,16 @@ class TestClearSession:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].side_effect = ["svc", "", "", "CLEAR"]
         error = RuntimeError("bad input")
         error.status_code = 400  # type: ignore[attr-defined]
         mock_api.api.v1.sites.devices.clearSiteDeviceSession.side_effect = error
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "gateway")):
-            duc.clear_session()
-            out = capsys.readouterr().out
+            with caplog.at_level(logging.ERROR, logger="root"):
+                duc.clear_session()
+            out = "\n".join(r.getMessage() for r in caplog.records)
             assert "400" in out or "service_name" in out
 
 
@@ -2731,11 +2748,13 @@ class TestDisplayAndSelectIfstatExtended:
 class TestHandleClearSessionError:
     """Tests for _handle_clear_session_error."""
 
-    def test_generic_error(self, capsys: pytest.CaptureFixture[str]) -> None:
-        DeviceUtilityCommands._handle_clear_session_error(RuntimeError("generic"))
-        assert "generic" in capsys.readouterr().out
+    def test_generic_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.ERROR, logger="root"):
+            DeviceUtilityCommands._handle_clear_session_error(RuntimeError("generic"))
+        out = "\n".join(r.getMessage() for r in caplog.records)
+        assert "generic" in out
 
-    def test_nested_exception(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_nested_exception(self, caplog: pytest.LogCaptureFixture) -> None:
         """Cover the inner except branch."""
 
         class BadError(Exception):
@@ -2743,5 +2762,7 @@ class TestHandleClearSessionError:
             def status_code(self) -> int:
                 raise ValueError("no code")
 
-        DeviceUtilityCommands._handle_clear_session_error(BadError("bad"))
-        assert "bad" in capsys.readouterr().out
+        with caplog.at_level(logging.ERROR, logger="root"):
+            DeviceUtilityCommands._handle_clear_session_error(BadError("bad"))
+        out = "\n".join(r.getMessage() for r in caplog.records)
+        assert "bad" in out


### PR DESCRIPTION
## Summary
- Slice 54/N of the #886 T20 print()-to-logger migration.
- Replaces the 6 remaining `print()` calls in `src/device/utility_commands.py` with `logging.info(...)` / `logging.error(...)` using %-style deferred formatting.
- Migrations cover `_print_api_error` (formatted HTTP-error line with status + optional server-side detail), `_print_api_result` (success arrow line), and `_handle_clear_session_error` (the 400-status two-line operator guidance about `service_name`/`session_ids` body keys, plus the generic fallback and nested-exception guard).
- Companion `capsys` → `caplog` migration in `tests/unit/test_device_utility_commands.py` covers the 11 affected success/error-path assertions; `tests/test_clear_session.py` already uses `caplog` for the 400-handling assertion.
- Message text preserved verbatim; no behavior change beyond routing through the configured logger.

## Test plan
- [x] `python -m ruff check src/device/utility_commands.py tests/unit/test_device_utility_commands.py tests/test_clear_session.py` — clean
- [x] `python -m black --check` on the same three files — 3 files would be left unchanged
- [x] `python -m pytest tests/unit/test_device_utility_commands.py tests/test_clear_session.py -q` — 199 passed
- [ ] CI: pytest coverage, pylint, black, mypy strict, CodeQL