### PR TITLE
chore(logging): migrate src/export/org_device_stats_exporter.py print() to logger (#886 slice 55/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 55/N: retire `print()` in `src/export/org_device_stats_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`
+  calls in `src/export/org_device_stats_exporter.py` with `logging.info(...)`
+  and `logging.warning(...)` using `%`-style deferred formatting. Migrations
+  cover the fast-mode cache-hit operator notices in
+  `_device_stats_cache_hit`, `_port_stats_cache_hit`, and
+  `_vpn_peer_stats_cache_hit`; the empty-rows "no port statistics" warning
+  and post-export record-count confirmation in `_save_device_port_stats_output`;
+  and the fast-mode collected-records summary line in
+  `_log_fast_port_stats_summary`. Operator-facing text preserved verbatim; no
+  behavior change beyond routing through the configured logger. Companion
+  `capsys` → `caplog` migration in
+  `tests/unit/export/test_org_device_stats_exporter.py` covers the 6 affected
+  cache-hit/summary/export assertions.
+
 ### #886 Phase 2 slice 54/N: retire `print()` in `src/device/utility_commands.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`

--- a/src/export/org_device_stats_exporter.py
+++ b/src/export/org_device_stats_exporter.py
@@ -60,7 +60,8 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
                     age_minutes,
                     mh.CSV_FRESHNESS_MINUTES,
                 )
-                print(f"* Fast mode: Using cached {output_file} (age {age_minutes:.1f}m)")  # User notice
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logging.info("* Fast mode: Using cached %s (age %.1fm)", output_file, age_minutes)  # User notice
                 return True  # Caller skips re-fetch
         except Exception as e:  # Freshness-check error
             logging.debug("Fast mode freshness check failed for %s: %s", output_file, e)  # Log
@@ -110,7 +111,8 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
                     age_minutes,
                     mh.CSV_FRESHNESS_MINUTES,
                 )  # Record why no API calls were made
-                print(f"* Fast mode: Using cached {output_file} (age {age_minutes:.1f}m)")  # User notice
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logging.info("* Fast mode: Using cached %s (age %.1fm)", output_file, age_minutes)  # User notice
                 return True  # Caller can return early
         except Exception as exception:  # Cache metadata problems degrade gracefully
             logging.debug("Fast mode freshness check failed for %s: %s", output_file, exception)  # Log fallback
@@ -309,7 +311,8 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils/DataExporter.
         if not all_port_stats:  # Empty dataset should skip file creation and clearly tell the operator why.
             logging.warning(" No port statistics collected. CSV not created.")  # Log absence of exportable data.
-            print("! No port statistics collected. CSV not created.")  # Tell operator no file was written.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.warning("! No port statistics collected. CSV not created.")  # Tell operator no file was written.
             return  # Nothing to sort or write.
         try:  # Sorting is best-effort because some rows may lack MACs.
             all_port_stats = sorted(
@@ -322,8 +325,9 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
         )  # Normalize nested API payloads into flat CSV-friendly records.
         sanitized = DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]  # Escape embedded newlines so CSV stays row-stable.
         mh.DataExporter.write_with_format_selection(sanitized, output_file, api_function_name="searchSiteSwOrGwPorts")  # type: ignore[no-untyped-call]  # Persist to configured backend with endpoint metadata.
-        print(
-            f"! {len(all_port_stats)} port stat records exported to {output_file}"
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(
+            "! %s port stat records exported to %s", len(all_port_stats), output_file
         )  # Confirm output row count to the operator.
         logging.info(
             "! Port statistics saved to %s (%s records)", output_file, len(all_port_stats)
@@ -353,8 +357,13 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
             record_count,
             duration,
         )  # Structured run summary.
-        print(
-            f"* Fast mode: Collected {record_count} port stat records from {ok_count}/{len(sites)} sites in {duration:.1f}s"  # noqa: E501
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(
+            "* Fast mode: Collected %s port stat records from %s/%s sites in %.1fs",
+            record_count,
+            ok_count,
+            len(sites),
+            duration,
         )  # Operator timing summary.
 
     @staticmethod
@@ -426,7 +435,8 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
                     age_minutes,
                     mh.CSV_FRESHNESS_MINUTES,
                 )  # Structured log.
-                print(f"* Fast mode: Using cached {output_file} (age {age_minutes:.1f}m)")  # Operator-facing.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logging.info("* Fast mode: Using cached %s (age %.1fm)", output_file, age_minutes)  # Operator-facing.
                 return True
         except Exception as e:  # Freshness check failed -- fall through to fetch.
             logging.debug("Fast mode freshness check failed for %s: %s", output_file, e)  # Debug-only.

--- a/tests/unit/export/test_org_device_stats_exporter.py
+++ b/tests/unit/export/test_org_device_stats_exporter.py
@@ -12,6 +12,7 @@ Why:
 
 from __future__ import annotations
 
+import logging
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -77,7 +78,7 @@ class TestDeviceStatsCacheHit:
         with patch("os.path.exists", return_value=False):
             assert OrgDeviceStatsExporter._device_stats_cache_hit("x.csv", True) is False
 
-    def test_fresh_cache_returns_true(self, fake_mh, capsys):
+    def test_fresh_cache_returns_true(self, fake_mh, caplog):
         """Fresh cache should return True and emit user-visible cache-hit notice."""
         from src.export.org_device_stats_exporter import OrgDeviceStatsExporter
 
@@ -85,9 +86,10 @@ class TestDeviceStatsCacheHit:
             patch("os.path.exists", return_value=True),
             patch("os.path.getmtime", return_value=1000.0),
             patch("src.export.org_device_stats_exporter.time.time", return_value=1000.0),
+            caplog.at_level(logging.INFO, logger="root"),
         ):
             assert OrgDeviceStatsExporter._device_stats_cache_hit("x.csv", True) is True
-        assert "Fast mode" in capsys.readouterr().out
+        assert "Fast mode" in "\n".join(r.getMessage() for r in caplog.records)
 
     def test_stale_cache_returns_false(self, fake_mh):
         """Stale cache should return False without printing."""
@@ -127,7 +129,7 @@ class TestPortStatsCacheHit:
         with patch("os.path.exists", return_value=False):
             assert OrgDeviceStatsExporter._port_stats_cache_hit("x.csv", True) is False
 
-    def test_fresh(self, fake_mh, capsys):
+    def test_fresh(self, fake_mh, caplog):
         """Fresh cache returns True and prints operator-facing notice."""
         from src.export.org_device_stats_exporter import OrgDeviceStatsExporter
 
@@ -135,9 +137,10 @@ class TestPortStatsCacheHit:
             patch("os.path.exists", return_value=True),
             patch("os.path.getmtime", return_value=100.0),
             patch("src.export.org_device_stats_exporter.time.time", return_value=100.0),
+            caplog.at_level(logging.INFO, logger="root"),
         ):
             assert OrgDeviceStatsExporter._port_stats_cache_hit("x.csv", True) is True
-        assert "cached" in capsys.readouterr().out
+        assert "cached" in "\n".join(r.getMessage() for r in caplog.records)
 
     def test_stale(self, fake_mh):
         """Stale cache returns False."""
@@ -177,7 +180,7 @@ class TestVpnPeerStatsCacheHit:
         with patch("os.path.exists", return_value=False):
             assert OrgDeviceStatsExporter._vpn_peer_stats_cache_hit("x.csv", True) is False
 
-    def test_fresh(self, fake_mh, capsys):
+    def test_fresh(self, fake_mh, caplog):
         """Fresh cache returns True."""
         from src.export.org_device_stats_exporter import OrgDeviceStatsExporter
 
@@ -185,9 +188,10 @@ class TestVpnPeerStatsCacheHit:
             patch("os.path.exists", return_value=True),
             patch("os.path.getmtime", return_value=500.0),
             patch("src.export.org_device_stats_exporter.time.time", return_value=500.0),
+            caplog.at_level(logging.INFO, logger="root"),
         ):
             assert OrgDeviceStatsExporter._vpn_peer_stats_cache_hit("x.csv", True) is True
-        assert "cached" in capsys.readouterr().out
+        assert "cached" in "\n".join(r.getMessage() for r in caplog.records)
 
     def test_stale(self, fake_mh):
         """Stale cache returns False."""
@@ -656,15 +660,16 @@ class TestFlattenSitePortResults:
 class TestSaveDevicePortStatsOutput:
     """Empty rows, sort failure, and normal export."""
 
-    def test_empty_rows(self, fake_mh, capsys):
+    def test_empty_rows(self, fake_mh, caplog):
         """Empty rows should skip export and print a warning."""
         from src.export.org_device_stats_exporter import OrgDeviceStatsExporter
 
-        OrgDeviceStatsExporter._save_device_port_stats_output([], "out.csv")
-        assert "No port statistics" in capsys.readouterr().out
+        with caplog.at_level(logging.WARNING, logger="root"):
+            OrgDeviceStatsExporter._save_device_port_stats_output([], "out.csv")
+        assert "No port statistics" in "\n".join(r.getMessage() for r in caplog.records)
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
 
-    def test_normal_export(self, fake_mh, capsys):
+    def test_normal_export(self, fake_mh, caplog):
         """Rows should be sorted, flattened, escaped, and written."""
         from src.export.org_device_stats_exporter import OrgDeviceStatsExporter
 
@@ -678,10 +683,11 @@ class TestSaveDevicePortStatsOutput:
                 "src.export.org_device_stats_exporter.DataProcessingUtils.escape_multiline",
                 return_value=rows,
             ),
+            caplog.at_level(logging.INFO, logger="root"),
         ):
             OrgDeviceStatsExporter._save_device_port_stats_output(rows, "out.csv")
         fake_mh.DataExporter.write_with_format_selection.assert_called_once()
-        assert "port stat records exported" in capsys.readouterr().out
+        assert "port stat records exported" in "\n".join(r.getMessage() for r in caplog.records)
 
     def test_sort_failure_still_exports(self, fake_mh):
         """Sort failure should log and continue with unsorted rows."""
@@ -728,14 +734,15 @@ class TestValidateFastPortStatsStartTime:
 class TestLogFastPortStatsSummary:
     """Snapshot test for summary logger."""
 
-    def test_summary_runs(self, fake_mh, capsys):
+    def test_summary_runs(self, fake_mh, caplog):
         """Summary should print an operator-facing line."""
         from src.export.org_device_stats_exporter import OrgDeviceStatsExporter
 
-        OrgDeviceStatsExporter._log_fast_port_stats_summary(
-            [("s1", "n1"), ("s2", "n2")], [("s2", "n2")], [{"x": 1}], 1.23
-        )
-        assert "Fast mode" in capsys.readouterr().out
+        with caplog.at_level(logging.INFO, logger="root"):
+            OrgDeviceStatsExporter._log_fast_port_stats_summary(
+                [("s1", "n1"), ("s2", "n2")], [("s2", "n2")], [{"x": 1}], 1.23
+            )
+        assert "Fast mode" in "\n".join(r.getMessage() for r in caplog.records)
 
 
 class TestRunFastDevicePortStats:


### PR DESCRIPTION
## Summary

- Slice 55/N for issue #886. Migrates the 6 remaining `print()` calls in `src/export/org_device_stats_exporter.py` to `logging.info(...)` / `logging.warning(...)` using `%`-style deferred formatting.
- Migrations cover fast-mode cache-hit notices (`_device_stats_cache_hit`, `_port_stats_cache_hit`, `_vpn_peer_stats_cache_hit`), the "no port statistics" warning and post-export record-count line in `_save_device_port_stats_output`, and the fast-mode summary line in `_log_fast_port_stats_summary`.
- Companion `capsys` → `caplog` migration for the 6 affected assertions in `tests/unit/export/test_org_device_stats_exporter.py` (56/56 pass locally).

Operator-facing text preserved verbatim; no behavior change beyond routing through the configured logger.

Refs #886.

## Test plan

- [x] `python -m ruff check --select T20 src/export/org_device_stats_exporter.py` — no offenses
- [x] `python -m ruff check` + `python -m black --check` on both files
- [x] `pytest tests/unit/export/test_org_device_stats_exporter.py` — 56 passed
- [ ] CI green (pytest coverage, pylint, Black, mypy strict, CodeQL, Bandit, Radon, Vulture, pydocstyle, Interrogate, pip-audit, E2E smoke)