### PR TITLE
chore(logging): migrate src/export/org_template_exporter.py print() to logger (#886 slice 56/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 56/N: retire `print()` in `src/export/org_template_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`
+  calls in `src/export/org_template_exporter.py` with `logging.info(...)`
+  using `%`-style deferred formatting. Migrations cover the AP template
+  export header, empty-branch operator notice, and success count summary in
+  `_persist_ap_template_profiles()` / `ap_templates()`, plus the switch
+  template export header, empty-branch operator notice, and success count
+  summary in `_persist_switch_template_csv()` / `switch_templates()`.
+  Operator-visible text preserved verbatim; a `# WHY:` comment tags each
+  migrated line to make the redirection intent explicit for reviewers.
+- **Tests**: existing suite `tests/unit/export/test_org_template_exporter.py`
+  contained no `capsys` assertions on the migrated lines; 18/18 tests pass
+  unchanged.
+- **Lint**: `ruff --select T20 src/export/org_template_exporter.py` now clean.
+
 ### #886 Phase 2 slice 55/N: retire `print()` in `src/export/org_device_stats_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`

--- a/src/export/org_template_exporter.py
+++ b/src/export/org_template_exporter.py
@@ -97,7 +97,8 @@ class OrgTemplateExporter:
         """Flatten + write AP template profiles to CSV; emit operator + log summary."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter + DataProcessingUtils helpers.
         if not ap_profiles:  # No AP templates in this org.
-            print("! 0 AP templates exported to OrgApTemplates.csv (no templates found)")  # Inform user.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! 0 AP templates exported to OrgApTemplates.csv (no templates found)")  # Inform user.
             logging.info(
                 "No AP templates returned from canonical endpoint; writing empty OrgApTemplates.csv"
             )  # Log empty.
@@ -106,14 +107,16 @@ class OrgTemplateExporter:
         processed = DataProcessingUtils.flatten_nested_fields(ap_profiles)  # Flatten nested JSON.
         processed = DataProcessingUtils.escape_multiline(processed)  # Escape multiline.
         mh.DataExporter.write_with_format_selection(processed, filename)  # Persist.
-        print(f"! {len(processed)} AP templates exported to {filename}")  # Tell user.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! %s AP templates exported to %s", len(processed), filename)  # Tell user.
         logging.info("Exported %s AP templates to %s.", len(processed), filename)  # Log count.
 
     @staticmethod
     def ap_templates() -> None:
         """Export AP templates (canonical deviceprofiles type=ap) to OrgApTemplates.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils + DataExporter + apisession.
-        print("Export Organization AP Templates:")  # Header.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("Export Organization AP Templates:")  # Header.
         logging.info("Starting export of organization AP templates (canonical deviceprofiles type=ap)...")  # Log start.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org.
         filename = "OrgApTemplates.csv"  # Output filename.
@@ -136,7 +139,8 @@ class OrgTemplateExporter:
         """Flatten + escape + write switch-template payload, then log/emit a success line."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter + DataProcessingUtils helpers.
         if not switch_profiles:  # No templates returned from the API.
-            print("! 0 switch templates exported to OrgSwitchTemplates.csv (no templates found)")  # User notice.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! 0 switch templates exported to OrgSwitchTemplates.csv (no templates found)")  # User notice.
             logging.info(  # Trace empty-result branch.
                 "No switch templates returned from canonical endpoint; writing empty OrgSwitchTemplates.csv"
             )
@@ -145,14 +149,16 @@ class OrgTemplateExporter:
         processed = DataProcessingUtils.flatten_nested_fields(switch_profiles)  # Flatten nested template fields.
         processed = DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
         mh.DataExporter.write_with_format_selection(processed, filename)  # Persist.
-        print(f"! {len(processed)} switch templates exported to {filename}")  # User notice.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! %s switch templates exported to %s", len(processed), filename)  # User notice.
         logging.info("Exported %s switch templates to %s.", len(processed), filename)  # Trace count.
 
     @staticmethod
     def switch_templates() -> None:
         """Export switch templates to OrgSwitchTemplates.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils + DataExporter + apisession.
-        print("Export Organization Switch Templates:")  # Header.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("Export Organization Switch Templates:")  # Header.
         logging.info("Starting export of organization switch templates (canonical networktemplates)...")  # Log start.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.
         filename = "OrgSwitchTemplates.csv"  # Build the CSV name.


### PR DESCRIPTION
Part of #886 Phase 2. Retires the 6 remaining `print()` calls in `src/export/org_template_exporter.py` and replaces them with `logging.info(...)` using %-style deferred formatting.

Covers the AP template export header, empty-branch operator notice, and success count summary (in `_persist_ap_template_profiles()` / `ap_templates()`), plus the analogous switch template header, empty-branch operator notice, and success count summary (in `_persist_switch_template_csv()` / `switch_templates()`).

Operator-visible text preserved verbatim; `# WHY:` comment tags each migrated line.

## Gates
- `ruff --select T20 src/export/org_template_exporter.py` clean
- `ruff check` + `black --check` clean
- `pytest tests/unit/export/test_org_template_exporter.py` → 18/18 green
- No `capsys` assertions on migrated lines; no test migration required