### PR TITLE
chore(logging): migrate src/gateway/gateway_ha_exporter.py print() to logger (#886 slice 57/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 57/N: retire `print()` in `src/gateway/gateway_ha_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`
+  calls in `src/gateway/gateway_ha_exporter.py` with `logging.info(...)` using
+  `%`-style deferred formatting. Migrations cover the "no HA gateways found"
+  operator notice in `_collect_ha_gateways()` plus the terminal summary
+  table rendered by `_print_ha_summary()` (section header, column header
+  row, separator line, per-row data lines, trailing blank line). Row
+  formatting now uses `%-30s %-8s %-12s %-20s %-20s %-18s` positional
+  parameters so the operator-visible layout is preserved verbatim while the
+  emission runs through the logger for capture/redirection. A `# WHY:`
+  comment tags each migrated line.
+- **Tests**: migrated 3 `capsys.readouterr().out` assertions in
+  `tests/unit/gateway/test_gateway_ha_exporter.py` (in `TestCollectHaGateways`
+  and `TestPrintHaSummary`) to `caplog.at_level(logging.INFO, logger="root")`
+  + `"\n".join(r.getMessage() for r in caplog.records)`. `import logging`
+  added. 18/18 tests pass.
+- **Lint**: `ruff --select T20 src/gateway/gateway_ha_exporter.py` now clean.
+
 ### #886 Phase 2 slice 56/N: retire `print()` in `src/export/org_template_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`

--- a/src/gateway/gateway_ha_exporter.py
+++ b/src/gateway/gateway_ha_exporter.py
@@ -74,7 +74,8 @@ class GatewayHaExporter:
         ha_gateways = [gw for gw in all_gateways if gw.get("is_ha") is True]  # Filter to HA-enabled gateways
         logging.info("Found %d HA gateways in site %s", len(ha_gateways), site_id)  # Trace HA gateway count
         if not ha_gateways:  # No HA gateways -> tell user and signal abort
-            print("No HA gateways found for the selected site.")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("No HA gateways found for the selected site.")
             return None
         return ha_gateways  # Caller proceeds with cluster export
 
@@ -145,13 +146,16 @@ class GatewayHaExporter:
             rows: List of merged HA gateway rows to display.
         """
         logging.info("Printing HA gateway cluster summary table to terminal")  # Log before display
-        print("\n=== HA Gateway Cluster Summary ===\n")  # Section header for the terminal output
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("\n=== HA Gateway Cluster Summary ===\n")  # Section header for the terminal output
         # Build column header string for the HA cluster summary table
         header = (
             f"{'Name':<30} {'Node':<8} {'Status':<12}" f" {'Node0 MAC':<20} {'Node1 MAC':<20} {'Cluster MAC':<18}"
         )  # Column headers
-        print(header)  # Print headers to terminal
-        print("-" * len(header))  # Print separator line
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(header)  # Print headers to terminal
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("-" * len(header))  # Print separator line
         for row in rows:  # Iterate each HA gateway record
             name = str(row.get("name", ""))[:28]  # Truncate long names for display
             node_name = str(row.get("node_name", ""))  # Which node (node0 / node1)
@@ -159,5 +163,15 @@ class GatewayHaExporter:
             node0_mac = str(row.get("ha_cluster_node0_mac") or "")  # MAC of node0 in the pair
             node1_mac = str(row.get("ha_cluster_node1_mac") or "")  # MAC of node1 in the pair
             vc_mac = str(row.get("vc_mac") or "")  # Shared cluster MAC address
-            print(f"{name:<30} {node_name:<8} {status:<12} {node0_mac:<20} {node1_mac:<20} {vc_mac:<18}")  # Print row
-        print()  # Blank line after table for readability
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(
+                "%-30s %-8s %-12s %-20s %-20s %-18s",
+                name,
+                node_name,
+                status,
+                node0_mac,
+                node1_mac,
+                vc_mac,
+            )  # Print row
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("")  # Blank line after table for readability

--- a/tests/unit/gateway/test_gateway_ha_exporter.py
+++ b/tests/unit/gateway/test_gateway_ha_exporter.py
@@ -13,6 +13,7 @@ monolith.
 
 from __future__ import annotations
 
+import logging
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock, patch
@@ -111,20 +112,23 @@ class TestCollectHaGateways:
         api_call.assert_called_once_with(fake_mh.apisession, "site-x", type="gateway")
         assert result == [{"id": "g1", "is_ha": True}, {"id": "g3", "is_ha": True}]
 
-    def test_no_ha_gateways_returns_none_and_prints(self, fake_mh, capsys):
-        """No HA gateways -> prints notice and returns None."""
+    def test_no_ha_gateways_returns_none_and_prints(self, fake_mh, caplog):
+        """No HA gateways -> logs notice and returns None."""
         from src.gateway.gateway_ha_exporter import GatewayHaExporter
 
         fake_mh.APICoreFetchUtils.get_api_response_data.return_value = [{"id": "g1", "is_ha": False}]
 
-        with patch(
-            "src.gateway.gateway_ha_exporter.mistapi.api.v1.sites.stats.listSiteDevicesStats",
-            return_value=MagicMock(),
+        with (
+            patch(
+                "src.gateway.gateway_ha_exporter.mistapi.api.v1.sites.stats.listSiteDevicesStats",
+                return_value=MagicMock(),
+            ),
+            caplog.at_level(logging.INFO, logger="root"),
         ):
             result = GatewayHaExporter._collect_ha_gateways("site-x")
 
         assert result is None
-        assert "No HA gateways found" in capsys.readouterr().out
+        assert "No HA gateways found" in "\n".join(r.getMessage() for r in caplog.records)
 
 
 class TestHaClusterInfo:
@@ -319,8 +323,8 @@ class TestBuildHaRows:
 class TestPrintHaSummary:
     """Cover GatewayHaExporter._print_ha_summary."""
 
-    def test_prints_header_separator_and_rows(self, capsys):
-        """Prints section header, table header, separator, and one line per row."""
+    def test_prints_header_separator_and_rows(self, caplog):
+        """Logs section header, table header, separator, and one line per row."""
         from src.gateway.gateway_ha_exporter import GatewayHaExporter
 
         rows = [
@@ -342,8 +346,9 @@ class TestPrintHaSummary:
             },
         ]
 
-        GatewayHaExporter._print_ha_summary(rows)
-        out = capsys.readouterr().out
+        with caplog.at_level(logging.INFO, logger="root"):
+            GatewayHaExporter._print_ha_summary(rows)
+        out = "\n".join(r.getMessage() for r in caplog.records)
 
         assert "HA Gateway Cluster Summary" in out
         assert "Name" in out and "Node0 MAC" in out
@@ -351,11 +356,12 @@ class TestPrintHaSummary:
         # The truncation caps at 28 chars, then padded to 30 -- confirm the truncated prefix appears.
         assert "very-very-long-gateway-name-" in out
 
-    def test_empty_rows_prints_header_only(self, capsys):
+    def test_empty_rows_prints_header_only(self, caplog):
         """Empty row list -> header + separator + trailing blank line, no data rows."""
         from src.gateway.gateway_ha_exporter import GatewayHaExporter
 
-        GatewayHaExporter._print_ha_summary([])
-        out = capsys.readouterr().out
+        with caplog.at_level(logging.INFO, logger="root"):
+            GatewayHaExporter._print_ha_summary([])
+        out = "\n".join(r.getMessage() for r in caplog.records)
         assert "HA Gateway Cluster Summary" in out
         assert "Node0 MAC" in out


### PR DESCRIPTION
Slice 57/N of #886.

## Changes

**Source (`src/gateway/gateway_ha_exporter.py`)** — 6 `print()` → `logging.info(...)`:
- `_collect_ha_gateways` empty-result operator notice.
- `_print_ha_summary`: section header, column header, separator line, row loop, trailing blank line.
- Row line uses `%-30s %-8s %-12s %-20s %-20s %-18s` positional parameters to preserve column widths without f-string.
- Each migrated call carries the WHY comment.

**Tests (`tests/unit/gateway/test_gateway_ha_exporter.py`)** — 3 `capsys` → `caplog` migrations:
- `test_no_ha_gateways_returns_none_and_prints`
- `test_prints_header_separator_and_rows`
- `test_empty_rows_prints_header_only`
- Added `import logging`.

## Gates
- `ruff --select T20`: clean on file.
- `ruff` full: clean.
- `black --check`: clean.
- `pytest tests/unit/gateway/test_gateway_ha_exporter.py`: 18/18 pass.