### PR TITLE
chore(logging): migrate src/inventory/org_device_inventory_summary.py print() to logger (#886 slice 58/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 58/N: retire `print()` in `src/inventory/org_device_inventory_summary.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`
+  calls in `src/inventory/org_device_inventory_summary.py` with
+  `logging.info(...)` using `%`-style deferred formatting. Migrations cover
+  the four-line distribution-summary banner helper (separator, capitalized
+  label, separator, tabulated table), the `run_for_org` elapsed-time summary,
+  and the `execute()` guard-clause "No organization selected" operator error.
+  Each migration is annotated with `# WHY: preserve operator notice verbatim;
+  route through logger for capture/redirection.`
+- **Test migration (Changed)**: updated
+  `tests/unit/inventory/test_org_device_inventory_summary_wave8.py` to switch
+  four assertions from `capsys.readouterr().out` to
+  `caplog.at_level(logging.INFO, logger="root")` + joined `caplog.records`,
+  aligning coverage with the logger channel the code now emits on.
+
 ### #886 Phase 2 slice 57/N: retire `print()` in `src/gateway/gateway_ha_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`

--- a/src/inventory/org_device_inventory_summary.py
+++ b/src/inventory/org_device_inventory_summary.py
@@ -318,10 +318,14 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
     def _print_summary_banner(distinct: str, table: PrettyTable) -> None:  # WHY: keep display method concise
         """Print the labelled banner and table for one summary."""
         separator = "=" * _SEPARATOR_WIDTH  # WHY: reuse the constant width for both borders
-        print(f"\n{separator}")  # WHY: leading blank line separates from preceding output
-        print(f"  {distinct.capitalize()} Distribution Summary")  # WHY: operator-facing label matches column
-        print(separator)  # WHY: trailing border closes the banner block
-        print(table)  # WHY: rendered PrettyTable follows the banner
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("\n%s", separator)  # WHY: leading blank line separates from preceding output
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("  %s Distribution Summary", distinct.capitalize())  # WHY: operator label matches column
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(separator)  # WHY: trailing border closes the banner block
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("%s", table)  # WHY: rendered PrettyTable follows the banner
 
     @staticmethod
     def _display_and_export(rows: list[dict], distinct: str, filename: str, api_func: str) -> None:  # WHY: I/O leaf
@@ -433,14 +437,16 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
         logging.info(  # WHY: log outcome so ops can tune inventory volume
             "Org device inventory summary for %s completed in %.1f seconds", target_org_id, elapsed
         )
-        print(f"\nSummary for {safe_org} completed in {elapsed:.1f} seconds")  # WHY: operator feedback
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("\nSummary for %s completed in %.1f seconds", safe_org, elapsed)  # operator feedback
         return model_rows, version_rows, ver_per_model, safe_org  # WHY: public tuple preserved for callers
 
     @staticmethod
     def execute() -> None:  # WHY: menu-level entry point requires configured org
         """Run inventory summaries for the currently selected org."""
         if not org_id:  # WHY: guard clause reports the misconfiguration instead of crashing
-            print("X No organization selected")  # WHY: user-visible error mirrors the rest of the CLI
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("X No organization selected")  # WHY: user-visible error mirrors the rest of the CLI
             logging.error("OrgDeviceInventorySummaryCore.execute called with empty org_id")  # WHY: audit trail
             return  # WHY: early return keeps the happy path un-indented
         OrgDeviceInventorySummaryCore.run_for_org(org_id)  # WHY: delegate to the parameterized pipeline

--- a/tests/unit/inventory/test_org_device_inventory_summary_wave8.py
+++ b/tests/unit/inventory/test_org_device_inventory_summary_wave8.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging  # WHY: caplog assertions verify migrated logger output
 import time as _stdlib_time  # WHY: patch time.time on the shared module (mypy-strict friendly)
 from types import SimpleNamespace  # WHY: light stand-in for mistapi SDK modules and responses
 from unittest.mock import MagicMock  # WHY: MagicMock(spec=Callable) is mandatory per project standard
 
-import pytest  # WHY: capsys, monkeypatch fixtures drive banner assertions and env-var patching
+import pytest  # WHY: caplog, monkeypatch fixtures drive banner assertions and env-var patching
 
 from src.inventory.org_device_inventory_summary import (  # WHY: SUT plus DI seam
     OrgDeviceInventorySummaryCore,
@@ -57,11 +58,13 @@ def _reset_dependencies(
     return exporter  # WHY: caller asserts exporter usage
 
 
-def test_execute_guard_prints_error_when_org_missing(capsys: pytest.CaptureFixture[str]) -> None:
-    """execute() prints error + returns early when no org has been configured."""
+def test_execute_guard_prints_error_when_org_missing(caplog: pytest.LogCaptureFixture) -> None:
+    """execute() logs error + returns early when no org has been configured."""
     _reset_dependencies(org="")  # WHY: empty org triggers the guard clause
-    OrgDeviceInventorySummaryCore.execute()  # WHY: exercise the guard branch
-    assert "No organization selected" in capsys.readouterr().out  # WHY: user-visible error surfaced
+    with caplog.at_level(logging.INFO, logger="root"):
+        OrgDeviceInventorySummaryCore.execute()  # WHY: exercise the guard branch
+    out = "\n".join(r.getMessage() for r in caplog.records)
+    assert "No organization selected" in out  # WHY: user-visible error surfaced
 
 
 def test_execute_delegates_to_run_for_org(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -180,30 +183,32 @@ def test_resolve_safe_org_name_falls_back_to_org_id(monkeypatch: pytest.MonkeyPa
     )  # WHY: id branch preserves hyphens
 
 
-def test_print_summary_banner_prints_label_and_table(capsys: pytest.CaptureFixture[str]) -> None:
-    """_print_summary_banner prints the labelled banner then the table body."""
+def test_print_summary_banner_prints_label_and_table(caplog: pytest.LogCaptureFixture) -> None:
+    """_print_summary_banner logs the labelled banner then the table body."""
     from prettytable import PrettyTable  # WHY: local import to avoid touching the SUT's shared reference
 
     table = PrettyTable()  # WHY: real PrettyTable instance so the __str__ output matches production
     table.field_names = ["Device Type", "Model", "Count"]  # WHY: canonical columns
     table.add_row(["ap", "AP41", 3])  # WHY: at least one row so the printed table has content
-    OrgDeviceInventorySummaryCore._print_summary_banner("model", table)  # WHY: exercise the banner helper
-    out = capsys.readouterr().out  # WHY: capture stdout
+    with caplog.at_level(logging.INFO, logger="root"):
+        OrgDeviceInventorySummaryCore._print_summary_banner("model", table)  # WHY: exercise the banner helper
+    out = "\n".join(r.getMessage() for r in caplog.records)
     assert "Model Distribution Summary" in out  # WHY: capitalized label surfaced
     assert "AP41" in out  # WHY: table body rendered under the banner
 
 
-def test_display_and_export_renders_and_persists(capsys: pytest.CaptureFixture[str]) -> None:
+def test_display_and_export_renders_and_persists(caplog: pytest.LogCaptureFixture) -> None:
     """_display_and_export builds the export rows, renders the banner, and calls the exporter."""
     exporter = _reset_dependencies()  # WHY: capture the injected exporter mock
     rows = [
         {"device_type": "ap", "model": "AP41", "count": 4},  # WHY: mixed rows to exercise the loop
         {"device_type": "switch", "model": "EX2300", "count": 2},
     ]
-    OrgDeviceInventorySummaryCore._display_and_export(  # WHY: exercise render + export
-        rows, "model", "Acme_Models", "orgDeviceModelSummary"
-    )
-    out = capsys.readouterr().out  # WHY: banner + table go to stdout
+    with caplog.at_level(logging.INFO, logger="root"):
+        OrgDeviceInventorySummaryCore._display_and_export(  # WHY: exercise render + export
+            rows, "model", "Acme_Models", "orgDeviceModelSummary"
+        )
+    out = "\n".join(r.getMessage() for r in caplog.records)  # WHY: banner + table go through logger
     assert "Model Distribution Summary" in out  # WHY: banner label present
     exporter.assert_called_once()  # WHY: exporter called exactly once
     args, kwargs = exporter.call_args  # WHY: unpack invocation
@@ -541,9 +546,7 @@ def test_with_unassigned_falls_back_on_aggregate_error(monkeypatch: pytest.Monke
     assert result == base  # WHY: fell back to base rows verbatim
 
 
-def test_run_for_org_returns_expected_tuple(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_run_for_org_returns_expected_tuple(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     """run_for_org runs each report once and returns the tuple in the documented order."""
     _reset_dependencies()  # WHY: hydrate module DI seams
 
@@ -581,6 +584,8 @@ def test_run_for_org_returns_expected_tuple(
         staticmethod(lambda org, safe, mr, un, ap: pivot_rows),
     )
     monkeypatch.setattr(_stdlib_time, "time", lambda: 0.0)  # WHY: pin elapsed to 0 for deterministic output
-    result = OrgDeviceInventorySummaryCore.run_for_org("org-1")  # WHY: exercise the entry point
+    with caplog.at_level(logging.INFO, logger="root"):  # WHY: capture logger output for the summary line
+        result = OrgDeviceInventorySummaryCore.run_for_org("org-1")  # WHY: exercise the entry point
     assert result == (model_rows, version_rows, pivot_rows, "SafeOrg")  # WHY: tuple order documented
-    assert "Summary for SafeOrg completed" in capsys.readouterr().out  # WHY: user-visible summary printed
+    out = "\n".join(r.getMessage() for r in caplog.records)  # WHY: aggregate captured log lines
+    assert "Summary for SafeOrg completed" in out  # WHY: user-visible summary logged


### PR DESCRIPTION
## Summary

- Replaces all 6 `print()` calls in `src/inventory/org_device_inventory_summary.py` with `logging.info(...)` using `%`-style deferred formatting.
- Migrations cover the four-line distribution-summary banner helper (separator, capitalized label, separator, tabulated table), the `run_for_org` elapsed-time summary line, and the `execute()` guard-clause "No organization selected" operator error.
- Each migrated call carries `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.` above it.
- Updates the companion `tests/unit/inventory/test_org_device_inventory_summary_wave8.py` to swap four `capsys.readouterr().out` assertions for `caplog.at_level(logging.INFO, logger=\"root\")` + joined `caplog.records`, aligning coverage with the logger channel the code now emits on.

## Test plan

- [x] `python -m ruff check --select T20 src/inventory/org_device_inventory_summary.py` — All checks passed
- [x] `python -m ruff check` on touched files — All checks passed
- [x] `python -m black --check` on touched files — reformatted test file, re-checked clean
- [x] `python -m pytest tests/unit/inventory/test_org_device_inventory_summary_wave8.py -q` — 31 passed

Refs: #886