### PR TITLE
chore(logging): migrate src/export/site_insights/site_metric_operation.py print() to logger (#886 slice 60/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 60/N: retire `print()` in `src/export/site_insights/site_metric_operation.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 7 remaining `print()`
+  calls in `src/export/site_insights/site_metric_operation.py` with
+  `logging.info(...)` (module already uses root `logging.<level>(...)` for its
+  info/warning/error/debug traces) using `%`-style deferred formatting.
+  Migrations cover the operation banner, refresh-in-progress notice, empty-
+  metrics operator prompt, retrieval progress line, per-metric success summary,
+  zero-data summary, and the exception-path summary in `_export_error`. Each
+  migrated call carries the standard `# WHY: preserve operator notice
+  verbatim; route through logger for capture/redirection.` annotation.
+- **Test migration (Changed)**: converted the 5 `capsys` assertions in
+  `tests/unit/export/site_insights/test_site_metric_operation_wave9.py` to
+  `caplog` capture (`with caplog.at_level(logging.INFO, logger="root"):`,
+  followed by joining `r.getMessage() for r in caplog.records`) so the tests
+  read from the logger channel the code now emits on.
+
 ### #886 Phase 2 slice 59/N: retire `print()` in `src/ssh/config/csv_loader.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 6 remaining `print()`

--- a/src/export/site_insights/site_metric_operation.py
+++ b/src/export/site_insights/site_metric_operation.py
@@ -48,7 +48,8 @@ class SiteMetricOperation:
 
     def execute(self) -> None:  # WHY: Menu 74 dispatcher entry point invoked by MistHelper top-level menu
         """Top-level entry point invoked by the menu dispatcher for menu 74."""
-        print(_BANNER)  # WHY: User-facing banner preserved verbatim from legacy implementation
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(_BANNER)
         logging.info(_START_LOG)  # WHY: Trace operation start for ops visibility
         context = self._prompt_and_build_context()  # WHY: Resolve site id + name, or bail on cancel
         if context is None:
@@ -76,12 +77,14 @@ class SiteMetricOperation:
 
     def _refresh_const_metrics(self) -> None:  # WHY: Isolated call keeps execute() short and testable
         """Refresh ConstInsightMetrics.csv so metric lists reflect the latest API surface."""
-        print(_REFRESH_PROMPT)  # WHY: User-facing progress preserved verbatim from legacy implementation
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(_REFRESH_PROMPT)
         self.InsightMetricsUtils.export_const_insight_metrics()  # WHY: Refresh cache before scope-filtering metrics
 
     def _emit_empty_metric_list(self, filename: str) -> None:  # WHY: Defensive branch used when const file is empty
         """Emit the empty-file + error trio when scope filter yields zero metrics."""
-        print(_EMPTY_METRICS_PROMPT)  # WHY: User-facing error preserved verbatim from legacy implementation
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(_EMPTY_METRICS_PROMPT)
         logging.error(_EMPTY_METRICS_LOG)  # WHY: Persist failure cause in the log
         self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Emit empty file for downstream consistency
 
@@ -125,7 +128,8 @@ class SiteMetricOperation:
         """Iterate the metric list and collect any insight data the API returns."""
         all_insight_data: list[dict] = []  # WHY: Accumulator for every non-empty metric response
         retrieved = 0  # WHY: User-facing counter shown in the final summary line
-        print(f"! Retrieving {len(site_metrics)} different site insight metrics...")  # WHY: Progress preserved verbatim
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Retrieving %s different site insight metrics...", len(site_metrics))
         for metric in site_metrics:  # WHY: One API call per metric; individual failures must not abort the batch
             data = self._fetch_one_metric(context, metric)  # WHY: Enriched dict or None
             if data is not None:
@@ -190,7 +194,8 @@ class SiteMetricOperation:
         processed = self.DataProcessingUtils.flatten_nested_fields(all_insight_data)  # WHY: Flatten nested API objs
         processed = self.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]  # WHY: CSV-safe text
         self.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]  # WHY: Write to disk / DB
-        print(f"! {retrieved} site insight metrics exported to {filename}")  # WHY: User-facing summary preserved
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! %s site insight metrics exported to %s", retrieved, filename)
         logging.info(  # WHY: Persist success summary at info level for ops visibility
             "Exported %d site insight metrics for %s to %s",
             retrieved,
@@ -200,7 +205,8 @@ class SiteMetricOperation:
 
     def _export_empty(self, filename: str, context: SiteRunContext) -> None:  # WHY: Zero-data emit path
         """Emit user-visible zero-data summary and write an empty file for consistency."""
-        print(f"! 0 insight metrics exported to {filename} (no data available)")  # WHY: User-facing summary preserved
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! 0 insight metrics exported to %s (no data available)", filename)
         logging.warning("No insight data available for site %s", context.site_name)  # WHY: Distinguish empty from error
         self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Emit empty file for consistency
 
@@ -211,7 +217,8 @@ class SiteMetricOperation:
         context: SiteRunContext,
     ) -> None:
         """Log the failure with full context and emit an empty file so downstream consumers still see output."""
-        print(f"! Error exporting site insight metrics: {exception}")  # WHY: User-facing error preserved verbatim
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Error exporting site insight metrics: %s", exception)
         logging.error(  # WHY: Persist failure cause with site context for triage
             "Failed to export site insight metrics for %s: %s", context.site_name, exception
         )

--- a/tests/unit/export/site_insights/test_site_metric_operation_wave9.py
+++ b/tests/unit/export/site_insights/test_site_metric_operation_wave9.py
@@ -10,6 +10,8 @@ from __future__ import annotations  # WHY: PEP 604 unions module-wide
 import logging  # WHY: emit before/after action logs per project contract
 from unittest.mock import MagicMock  # WHY: build interchangeable injected collaborators
 
+import pytest  # WHY: caplog fixture typing for logger capture assertions
+
 from src.export.site_insights.site_metric_operation import (  # WHY: SUTs under test
     SiteMetricOperation,
     SiteRunContext,
@@ -58,21 +60,23 @@ def _make_context(**overrides) -> SiteRunContext:
 class TestExecuteCancelBranch:
     """Cover the cancel branch where the user does not select a site."""
 
-    def test_no_site_selected_returns_without_running_export(self, capsys) -> None:
+    def test_no_site_selected_returns_without_running_export(self, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: PromptUtils.select_site returning falsy must exit cleanly with no export attempt
         deps = _make_deps()  # WHY: fresh baseline
         deps["PromptUtils"].select_site.return_value = None  # WHY: simulate cancel
         op = SiteMetricOperation(**deps)  # WHY: build SUT
-        op.execute()  # WHY: exercise cancel path
+        with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses root logging.info
+            op.execute()  # WHY: exercise cancel path
         assert not deps["InsightMetricsUtils"].export_const_insight_metrics.called  # WHY: never refreshed
         assert not deps["DataExporter"].write_with_format_selection.called  # WHY: never wrote file
-        assert "Export Site Insight Metrics" in capsys.readouterr().out  # WHY: banner still printed
+        out = "\n".join(r.getMessage() for r in caplog.records)  # WHY: aggregate captured log records
+        assert "Export Site Insight Metrics" in out  # WHY: banner still logged
 
 
 class TestExecuteEmptyMetricsBranch:
     """Cover the empty-metric-list branch after site selection succeeds."""
 
-    def test_empty_metrics_writes_empty_file(self, capsys) -> None:
+    def test_empty_metrics_writes_empty_file(self, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: when InsightMetricsUtils.get_by_scope returns [], the empty-file branch fires
         deps = _make_deps()  # WHY: baseline
         deps["PromptUtils"].select_site.return_value = "site-xyz"  # WHY: valid site
@@ -80,19 +84,21 @@ class TestExecuteEmptyMetricsBranch:
         deps["mistapi"].api.v1.sites.listSites.return_value = MagicMock()  # WHY: minimal API stub
         deps["mistapi"].get_all.return_value = [{"id": "site-xyz", "name": "HQ Site"}]  # WHY: name lookup
         op = SiteMetricOperation(**deps)  # WHY: build SUT
-        op.execute()  # WHY: exercise empty-metrics branch
+        with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses root logging.info
+            op.execute()  # WHY: exercise empty-metrics branch
         # WHY: empty file must be written with [] payload
         deps["DataExporter"].write_with_format_selection.assert_called_once()
         args, _kwargs = deps["DataExporter"].write_with_format_selection.call_args  # WHY: inspect call
         assert args[0] == []  # WHY: first positional is the empty list
         assert "SiteInsightMetrics_HQ_Site.csv" in args[1]  # WHY: filename includes sanitized site name
-        assert "No metrics found for site scope" in capsys.readouterr().out  # WHY: user warning surfaced
+        out = "\n".join(r.getMessage() for r in caplog.records)  # WHY: aggregate captured log records
+        assert "No metrics found for site scope" in out  # WHY: user warning surfaced
 
 
 class TestExecuteHappyPath:
     """Cover the non-empty-payload success branch end-to-end."""
 
-    def test_success_writes_processed_rows(self, capsys) -> None:
+    def test_success_writes_processed_rows(self, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: get_by_scope returns metric list; API returns data; final export emits processed rows
         deps = _make_deps()  # WHY: baseline
         deps["PromptUtils"].select_site.return_value = "site-xyz"  # WHY: valid site
@@ -108,7 +114,8 @@ class TestExecuteHappyPath:
 
         deps["mistapi"].api.v1.sites.insights.getSiteInsightMetrics.side_effect = _fresh_response
         op = SiteMetricOperation(**deps)  # WHY: build SUT
-        op.execute()  # WHY: exercise full happy path
+        with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses root logging.info
+            op.execute()  # WHY: exercise full happy path
         # WHY: DataExporter must be called once with the annotated rows
         deps["DataExporter"].write_with_format_selection.assert_called_once()
         rows = deps["DataExporter"].write_with_format_selection.call_args.args[0]  # WHY: first positional
@@ -118,7 +125,8 @@ class TestExecuteHappyPath:
         assert metric_types == {"metric-a", "metric-b"}  # WHY: both metrics annotated
         assert all(row["site_id"] == "site-xyz" for row in rows)  # WHY: annotate stamps site id
         assert all(row["site_name"] == "HQ Site" for row in rows)  # WHY: annotate stamps site name
-        assert "2 site insight metrics exported" in capsys.readouterr().out  # WHY: user summary surfaced
+        out = "\n".join(r.getMessage() for r in caplog.records)  # WHY: aggregate captured log records
+        assert "2 site insight metrics exported" in out  # WHY: user summary surfaced
 
 
 class TestFetchOneMetricBranches:
@@ -211,28 +219,32 @@ class TestAnnotateRow:
 class TestFinalizeErrorBranch:
     """Cover the ``_finalize`` exception branch that emits an empty file on failure."""
 
-    def test_flatten_exception_emits_empty_file(self, capsys) -> None:
+    def test_flatten_exception_emits_empty_file(self, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: exception from flatten_nested_fields must be caught by _finalize and route to _export_error
         deps = _make_deps()  # WHY: baseline
         deps["DataProcessingUtils"].flatten_nested_fields.side_effect = RuntimeError("flatten failed")  # WHY: force
         op = SiteMetricOperation(**deps)  # WHY: build SUT
         ctx = _make_context()  # WHY: context bundle
-        op._finalize([{"row": 1}], 1, "out.csv", ctx)  # WHY: exercise error branch directly
+        with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses root logging.info
+            op._finalize([{"row": 1}], 1, "out.csv", ctx)  # WHY: exercise error branch directly
         # WHY: _export_error always writes an empty file so downstream consumers still get output
         deps["DataExporter"].write_with_format_selection.assert_called_once()
         args, _kwargs = deps["DataExporter"].write_with_format_selection.call_args  # WHY: inspect call
         assert args[0] == []  # WHY: empty payload on error path
-        assert "Error exporting site insight metrics" in capsys.readouterr().out  # WHY: user warning surfaced
+        out = "\n".join(r.getMessage() for r in caplog.records)  # WHY: aggregate captured log records
+        assert "Error exporting site insight metrics" in out  # WHY: user warning surfaced
 
-    def test_empty_data_emits_zero_data_summary(self, capsys) -> None:
+    def test_empty_data_emits_zero_data_summary(self, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: zero-data path emits the "no data available" summary and an empty file
         deps = _make_deps()  # WHY: baseline
         op = SiteMetricOperation(**deps)  # WHY: build SUT
         ctx = _make_context()  # WHY: context bundle
-        op._finalize([], 0, "out.csv", ctx)  # WHY: exercise zero-data branch
+        with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses root logging.info
+            op._finalize([], 0, "out.csv", ctx)  # WHY: exercise zero-data branch
         # WHY: empty-data path still writes empty file for consistency
         deps["DataExporter"].write_with_format_selection.assert_called_once_with([], "out.csv")
-        assert "0 insight metrics exported" in capsys.readouterr().out  # WHY: user summary surfaced
+        out = "\n".join(r.getMessage() for r in caplog.records)  # WHY: aggregate captured log records
+        assert "0 insight metrics exported" in out  # WHY: user summary surfaced
 
 
 class TestBuildFilename:


### PR DESCRIPTION
## Summary

Slice 60/N of #886. Retires the last 7 `print()` calls in
`src/export/site_insights/site_metric_operation.py` (menu-74 site-scope
insight metric exporter) by routing them through the module's existing
`logging.info(...)` channel with `%`-style deferred formatting.

- 7 `print()` → `logging.info(...)` in the source module
- 5 `capsys.readouterr().out` → `caplog` (`logger="root"`) assertions in
  the Wave 9 P2 test file
- `ruff --select T20`: clean on both files
- `black --check`: clean on both files
- `pytest tests/unit/export/site_insights/test_site_metric_operation_wave9.py`: 15/15 pass

Each migrated call carries the standard WHY annotation:
`# WHY: preserve operator notice verbatim; route through logger for capture/redirection.`

## Test plan

- [x] ruff clean on migrated files
- [x] black --check clean on migrated files
- [x] pytest 15/15 pass on the Wave 9 P2 file
- [ ] Quality Gates CI green