### PR TITLE
chore(logging): migrate src/refactors/serial_cc/security_events.py print() to logger (#886 slice 62/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 62/N: retire `print()` in `src/refactors/serial_cc/security_events.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 7 remaining `print()`
+  calls in `src/refactors/serial_cc/security_events.py` with `logging.info(...)`
+  (module already uses root `logging.<level>(...)` for its info/warning/error
+  traces) using `%`-style deferred formatting. Migrations cover the fast-mode
+  cache-hit notice in `execute`, the two banner lines in `_run_export_workflow`
+  (header + completion summary), the empty-dataset summary and populated-
+  dataset summary in `_export_flattened_dataset`, and the two rogue-export
+  summary lines in `_export_rogue_combined` (empty + populated). Each migrated
+  call carries the standard `# WHY: preserve operator notice verbatim; route
+  through logger for capture/redirection.` annotation.
+- **Test migration (Changed)**: converted 1 `capsys` assertion in
+  `tests/unit/serial_cc/test_security_events.py` and 4 `capsys` assertions in
+  `tests/unit/serial_cc/test_security_events_wave8.py` to `caplog` capture
+  (`with caplog.at_level(logging.INFO, logger="root"):`, aggregating
+  `record.getMessage()` values before substring assertions). Dropped the unused
+  `capsys` parameter from `test_export_rogue_data_iterate_exception_aborts`.
+  All 23 tests in the two suites pass locally.
+
 ### #886 Phase 2 slice 61/N: retire `print()` in `src/export/wan_client_events_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 7 remaining `print()`

--- a/src/refactors/serial_cc/security_events.py
+++ b/src/refactors/serial_cc/security_events.py
@@ -88,14 +88,16 @@ class SecurityEventsService:
             logging.info(
                 "Fast mode cache hit: All security data CSVs are fresh; skipping fetch."
             )  # Trace short-circuit.
-            print("* Fast mode: Using cached security data (all files fresh)")  # User-facing fast-mode message.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("* Fast mode: Using cached security data (all files fresh)")
             return  # No fetch needed; the cached CSVs are still valid.
         SecurityEventsService._run_export_workflow(deps)  # Delegate the actual export to keep this entrypoint short.
 
     @staticmethod
     def _run_export_workflow(deps: SimpleNamespace) -> None:
         """Execute the three security exports and emit progress bookends."""
-        print("Export Organization Security Data:")  # Section header for the console log.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("Export Organization Security Data:")
         logging.info("Starting export of organization security policies, intelligence profiles, and rogue data...")
         emitter = deps.PROGRESS_EMITTER  # Optional; None disables progress emission.
         if emitter:
@@ -107,7 +109,8 @@ class SecurityEventsService:
         for spec in SecurityEventsService._build_flattened_specs(deps, current_org_id):  # Loop over datasets.
             SecurityEventsService._export_flattened_dataset(deps, spec)  # Fetch + flatten + export one dataset.
         SecurityEventsService._export_rogue_data(deps)  # Third file: combined rogue export.
-        print("Security data export completed (3 files generated)")  # User-facing completion message.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("Security data export completed (3 files generated)")
         logging.info("Completed security policies, intelligence profiles, and rogue data export aggregate.")
         if emitter:
             emitter.emit_progress_complete(  # Bundle identity into a ProgressContext per issue #470.
@@ -163,14 +166,26 @@ class SecurityEventsService:
         """Fetch, flatten, and export a single org dataset described by ``spec``."""
         dataset = SecurityEventsService._fetch_dataset(deps, spec)  # Isolate the try/except paging in a helper.
         if not dataset:  # Guard clause: write an empty file and note the miss for observability.
-            print(f"! 0 {spec.data_label} exported to {spec.output_file} {spec.empty_suffix}")  # User summary.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(
+                "! 0 %s exported to %s %s",
+                spec.data_label,
+                spec.output_file,
+                spec.empty_suffix,
+            )
             logging.warning(spec.empty_message)  # Trace an empty result for postmortems.
             deps.DataExporter.write_with_format_selection([], spec.output_file)  # Write empty for consistency.
             return
         processed = deps.DataProcessingUtils.flatten_nested_fields(dataset)  # Flatten nested API structures.
         processed = deps.DataProcessingUtils.escape_multiline(processed)  # Escape multiline fields for CSV safety.
         deps.DataExporter.write_with_format_selection(processed, spec.output_file)  # Emit the CSV/XLSX file.
-        print(f"! {len(processed)} {spec.data_label} exported to {spec.output_file}")  # User-facing summary.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(
+            "! %d %s exported to %s",
+            len(processed),
+            spec.data_label,
+            spec.output_file,
+        )
         logging.info("Exported %d %s to %s", len(processed), spec.data_label, spec.output_file)  # Trace volume.
 
     @staticmethod
@@ -250,14 +265,16 @@ class SecurityEventsService:
     def _export_rogue_combined(deps: SimpleNamespace, all_rogue_data: list[dict[str, Any]]) -> None:
         """Flatten + export combined rogue data, or write an empty file when nothing was found."""
         if not all_rogue_data:  # Guard: no rogue devices anywhere; still emit an empty file for consistency.
-            print("! 0 rogue devices exported to OrgRogueData.csv (no rogue devices found)")  # User summary.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! 0 rogue devices exported to OrgRogueData.csv (no rogue devices found)")
             logging.info("No rogue devices found across all sites (OrgRogueData.csv written empty).")  # Trace empty.
             deps.DataExporter.write_with_format_selection([], _ROGUE_OUTPUT)  # Consistent empty export.
             return
         processed = deps.DataProcessingUtils.flatten_nested_fields(all_rogue_data)  # Flatten nested rogue fields.
         processed = deps.DataProcessingUtils.escape_multiline(processed)  # Escape multiline fields for CSV.
         deps.DataExporter.write_with_format_selection(processed, _ROGUE_OUTPUT)  # Write the combined rogue export.
-        print(f"! {len(processed)} rogue devices exported to OrgRogueData.csv")  # User summary.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! %d rogue devices exported to OrgRogueData.csv", len(processed))
         logging.info("Exported %d rogue devices to OrgRogueData.csv", len(processed))  # Trace export volume.
 
     @staticmethod

--- a/tests/unit/serial_cc/test_security_events.py
+++ b/tests/unit/serial_cc/test_security_events.py
@@ -1,6 +1,9 @@
 """Unit tests for offender #8 security export service."""
 
+import logging
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from src.refactors.serial_cc.security_events import SecurityEventsService
 
@@ -30,7 +33,9 @@ def _make_dependency_bundle():
 
 
 @patch("src.refactors.serial_cc.security_events._resolve_runtime_dependencies")
-def test_security_events_fast_mode_returns_on_fresh_cache(mock_resolve_runtime_dependencies, capsys):
+def test_security_events_fast_mode_returns_on_fresh_cache(
+    mock_resolve_runtime_dependencies, caplog: pytest.LogCaptureFixture
+):
     """Fast mode exits when all cache files are fresh."""
     deps = _make_dependency_bundle()
     mock_resolve_runtime_dependencies.return_value = deps
@@ -40,11 +45,12 @@ def test_security_events_fast_mode_returns_on_fresh_cache(mock_resolve_runtime_d
         patch("src.refactors.serial_cc.security_events.os.path.exists", return_value=True),
         patch("src.refactors.serial_cc.security_events.os.path.getmtime", return_value=0),
         patch("src.refactors.serial_cc.security_events.time.time", return_value=0),
+        caplog.at_level(logging.INFO, logger="root"),
     ):
         SecurityEventsService.execute(fast=True)
 
-    captured = capsys.readouterr()
-    assert "cached security data" in captured.out
+    out = "\n".join(record.getMessage() for record in caplog.records)
+    assert "cached security data" in out
 
 
 @patch("src.refactors.serial_cc.security_events._resolve_runtime_dependencies")

--- a/tests/unit/serial_cc/test_security_events_wave8.py
+++ b/tests/unit/serial_cc/test_security_events_wave8.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging  # WHY: caplog captures logging.info emissions after print() → logger migration (#886)
 from types import SimpleNamespace  # WHY: lightweight bundle for dependency injection into the resolver
 from typing import Any  # WHY: heterogeneous API payload typing
 from unittest.mock import MagicMock, patch  # WHY: MagicMock(spec=...) + resolver patch per project standard
 
-import pytest  # WHY: capsys fixture for stdout assertions
+import pytest  # WHY: caplog + monkeypatch fixtures used in this suite
 
 from src.refactors.serial_cc import security_events as sut  # WHY: SUT module (helpers + service class)
 from src.refactors.serial_cc.security_events import (  # WHY: named imports for direct helper coverage
@@ -123,8 +124,8 @@ def test_build_flattened_specs_returns_two_specs() -> None:
     assert specs[1].output_file == "OrgSecIntelProfiles.csv"  # WHY: secintel target file
 
 
-def test_export_flattened_dataset_empty_writes_empty_file(capsys: pytest.CaptureFixture[str]) -> None:
-    """An empty dataset writes an empty CSV and prints the empty summary."""
+def test_export_flattened_dataset_empty_writes_empty_file(caplog: pytest.LogCaptureFixture) -> None:
+    """An empty dataset writes an empty CSV and logs the empty summary."""
     deps = _make_deps()  # WHY: default bundle
     deps.mistapi.get_all.return_value = []  # WHY: force empty dataset
     spec = _FlattenedExportSpec(  # WHY: minimal spec for the empty branch
@@ -135,14 +136,16 @@ def test_export_flattened_dataset_empty_writes_empty_file(capsys: pytest.Capture
         empty_message="No data",
         empty_suffix="(no policies found)",
     )
-    SecurityEventsService._export_flattened_dataset(deps, spec)  # WHY: exercise the empty guard
+    with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses logging.info at root logger
+        SecurityEventsService._export_flattened_dataset(deps, spec)  # WHY: exercise the empty guard
     deps.DataExporter.write_with_format_selection.assert_called_once_with(
         [], "OrgSecurityPolicies.csv"
     )  # WHY: empty write
-    assert "no policies found" in capsys.readouterr().out  # WHY: empty summary printed
+    out = "\n".join(record.getMessage() for record in caplog.records)  # WHY: aggregate captured log lines
+    assert "no policies found" in out  # WHY: empty summary logged
 
 
-def test_export_flattened_dataset_populates(capsys: pytest.CaptureFixture[str]) -> None:
+def test_export_flattened_dataset_populates(caplog: pytest.LogCaptureFixture) -> None:
     """A populated dataset is flattened, escaped, and exported with a count summary."""
     deps = _make_deps()  # WHY: default bundle
     deps.mistapi.get_all.return_value = [{"id": "one"}, {"id": "two"}]  # WHY: two rows
@@ -156,9 +159,11 @@ def test_export_flattened_dataset_populates(capsys: pytest.CaptureFixture[str]) 
         empty_message="No data",
         empty_suffix="(no policies found)",
     )
-    SecurityEventsService._export_flattened_dataset(deps, spec)  # WHY: exercise the populated branch
+    with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses logging.info at root logger
+        SecurityEventsService._export_flattened_dataset(deps, spec)  # WHY: exercise the populated branch
     assert deps.DataExporter.write_with_format_selection.call_count == 1  # WHY: one write for populated
-    assert "2 security policies exported" in capsys.readouterr().out  # WHY: count summary printed
+    out = "\n".join(record.getMessage() for record in caplog.records)  # WHY: aggregate captured log lines
+    assert "2 security policies exported" in out  # WHY: count summary logged
 
 
 def test_fetch_dataset_returns_empty_on_exception() -> None:
@@ -306,27 +311,31 @@ def test_iterate_site_rogue_yields_valid_site(monkeypatch: pytest.MonkeyPatch) -
     assert clients[0]["rogue_type"] == "Client"  # WHY: Client tag applied
 
 
-def test_export_rogue_combined_empty_writes_empty(capsys: pytest.CaptureFixture[str]) -> None:
-    """Empty rogue list writes an empty file and prints the zero-count summary."""
+def test_export_rogue_combined_empty_writes_empty(caplog: pytest.LogCaptureFixture) -> None:
+    """Empty rogue list writes an empty file and logs the zero-count summary."""
     deps = _make_deps()  # WHY: default bundle
-    SecurityEventsService._export_rogue_combined(deps, [])  # WHY: exercise empty guard
+    with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses logging.info at root logger
+        SecurityEventsService._export_rogue_combined(deps, [])  # WHY: exercise empty guard
     deps.DataExporter.write_with_format_selection.assert_called_once_with([], "OrgRogueData.csv")  # WHY: empty write
-    assert "0 rogue devices" in capsys.readouterr().out  # WHY: zero summary printed
+    out = "\n".join(record.getMessage() for record in caplog.records)  # WHY: aggregate captured log lines
+    assert "0 rogue devices" in out  # WHY: zero summary logged
 
 
-def test_export_rogue_combined_populated_flattens_and_exports(capsys: pytest.CaptureFixture[str]) -> None:
+def test_export_rogue_combined_populated_flattens_and_exports(caplog: pytest.LogCaptureFixture) -> None:
     """Populated rogue list is flattened, escaped, and exported with a count summary."""
     deps = _make_deps()  # WHY: default bundle
     deps.DataProcessingUtils.flatten_nested_fields.side_effect = lambda rows: rows  # WHY: identity pipeline
     deps.DataProcessingUtils.escape_multiline.side_effect = lambda rows: rows  # WHY: identity pipeline
     rogue = [{"mac": "aa", "rogue_type": "AP"}, {"mac": "bb", "rogue_type": "Client"}]  # WHY: two records
-    SecurityEventsService._export_rogue_combined(deps, rogue)  # WHY: exercise populated branch
+    with caplog.at_level(logging.INFO, logger="root"):  # WHY: SUT uses logging.info at root logger
+        SecurityEventsService._export_rogue_combined(deps, rogue)  # WHY: exercise populated branch
     deps.DataExporter.write_with_format_selection.assert_called_once_with(rogue, "OrgRogueData.csv")  # WHY: write
-    assert "2 rogue devices exported" in capsys.readouterr().out  # WHY: count summary printed
+    out = "\n".join(record.getMessage() for record in caplog.records)  # WHY: aggregate captured log lines
+    assert "2 rogue devices exported" in out  # WHY: count summary logged
 
 
 def test_export_rogue_data_iterate_exception_aborts(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An exception during iteration aborts the rogue export leg silently."""
     deps = _make_deps()  # WHY: default bundle


### PR DESCRIPTION
## Summary
- Replaces the 7 remaining `print()` calls in `src/refactors/serial_cc/security_events.py` with `logging.info(...)` using `%`-style deferred formatting (fast-mode cache hit, workflow banner, completion, empty/populated flattened-dataset, empty/populated rogue-export summaries)
- Each migrated call carries the standard `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.` annotation
- Migrates 1 `capsys` assertion in `tests/unit/serial_cc/test_security_events.py` and 4 in `tests/unit/serial_cc/test_security_events_wave8.py` to `caplog` capture (`logger=root`); drops the unused `capsys` parameter from `test_export_rogue_data_iterate_exception_aborts`

## Test plan
- [x] `python -m ruff check src/refactors/serial_cc/security_events.py tests/unit/serial_cc/test_security_events.py tests/unit/serial_cc/test_security_events_wave8.py` → All checks passed
- [x] `python -m black --check` on the same files → 3 files would be left unchanged
- [x] `python -m pytest tests/unit/serial_cc/test_security_events.py tests/unit/serial_cc/test_security_events_wave8.py -q` → 23 passed
- [x] `grep -n "print(" src/refactors/serial_cc/security_events.py` → 0 matches

Refs #886.