### PR TITLE
chore(logging): migrate src/refactors/serial_cc/sle_metrics.py print() to logger (#886 slice 63/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 63/N: retire `print()` in `src/refactors/serial_cc/sle_metrics.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 7 remaining `print()`
+  calls in `src/refactors/serial_cc/sle_metrics.py` with `logging.info(...)`
+  (module already uses root `logging.<level>(...)` for its info/warning/error
+  traces) using `%`-style deferred formatting. Migrations cover the exported/
+  empty summary lines in `_export_results`, the retrieval-complete summary
+  and top-level error notice in `_run_retrieval`, the workflow banner in
+  `execute`, and the two "retrieving/attempting" info lines in `execute`
+  covering the service-category and specialized-metric counts. Each migrated
+  call carries the standard `# WHY: preserve operator notice verbatim; route
+  through logger for capture/redirection.` annotation.
+- **Test migration (Changed)**: converted the 1 `capsys` assertion in
+  `tests/unit/serial_cc/test_sle_metrics.py::test_sle_metrics_fast_mode_reduces_scope`
+  to `caplog` capture (`with caplog.at_level(logging.INFO, logger="root"):`,
+  aggregating `record.getMessage()` values before substring assertion on
+  "SLE data retrieval completed"). All 4 tests across the unit + integration
+  sle_metrics suites pass locally.
+
 ### #886 Phase 2 slice 62/N: retire `print()` in `src/refactors/serial_cc/security_events.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 7 remaining `print()`

--- a/src/refactors/serial_cc/sle_metrics.py
+++ b/src/refactors/serial_cc/sle_metrics.py
@@ -248,14 +248,20 @@ class SLEMetricsService:
             processed = deps.DataProcessingUtils.flatten_nested_fields(all_sle_data)  # Flatten nested SLE structures
             processed = deps.DataProcessingUtils.escape_multiline(processed)  # Escape multiline fields for CSV
             deps.DataExporter.write_with_format_selection(processed, "OrgSLEMetrics.csv")  # Write the export file
-            print(f"! {metrics_retrieved} organization SLE data sources exported to OrgSLEMetrics.csv")  # User summary
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(
+                "! %s organization SLE data sources exported to OrgSLEMetrics.csv", metrics_retrieved
+            )  # User summary
             logging.info(
                 "Exported %s org SLE data points from %s sources to OrgSLEMetrics.csv",
                 len(processed),
                 metrics_retrieved,
             )  # Trace export volume
         else:  # No data collected from any source
-            print("! 0 organization SLE metrics exported to OrgSLEMetrics.csv (no data available)")  # User summary
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(
+                "! 0 organization SLE metrics exported to OrgSLEMetrics.csv (no data available)"
+            )  # User summary
             logging.warning("No org SLE data available - all sources failed or returned empty")  # Warn on empty run
             deps.DataExporter.write_with_format_selection(
                 [], "OrgSLEMetrics.csv"
@@ -277,11 +283,15 @@ class SLEMetricsService:
             cat_ok, cat_fail = cls._run_category_loop(deps, org_id, config, all_sle_data, progress)  # Loop 2
             metrics_retrieved = spec_ok + cat_ok  # Total successful fetches
             metrics_failed = spec_fail + cat_fail  # Total failed fetches
-            print(f"! SLE data retrieval completed: {metrics_retrieved} successful, {metrics_failed} failed")  # Summary
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(
+                "! SLE data retrieval completed: %s successful, %s failed", metrics_retrieved, metrics_failed
+            )  # Summary
             logging.info("Org SLE data: %s retrieved successfully, %s failed", metrics_retrieved, metrics_failed)
             cls._export_results(deps, all_sle_data, metrics_retrieved)  # Flatten + export (or write empty)
         except Exception as exception:  # Any unexpected top-level failure still writes an empty export
-            print(f"! Error exporting organization SLE metrics: {exception}")  # User-facing error
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! Error exporting organization SLE metrics: %s", exception)  # User-facing error
             logging.error("Failed to export org SLE metrics: %s", exception)  # Trace the failure
             deps.DataExporter.write_with_format_selection([], "OrgSLEMetrics.csv")  # Write empty export on failure
 
@@ -289,7 +299,8 @@ class SLEMetricsService:
     def execute(cls, fast: bool = False) -> None:
         """Run the organization SLE metrics export workflow."""
         deps = _resolve_runtime_dependencies()  # Resolve MistHelper collaborators at call time
-        print("Export Organization SLE Metrics:")  # User-facing banner
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("Export Organization SLE Metrics:")  # User-facing banner
         logging.info("Starting export of organization SLE metrics...")  # Trace workflow start
         org_id = deps.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve target org (cached or prompted)
         config = cls._build_run_config(deps, fast)  # Resolve categories/metrics/duration (honors fast mode)
@@ -297,7 +308,12 @@ class SLEMetricsService:
         progress = _SleProgressTracker(deps.PROGRESS_EMITTER, total_items)  # Encapsulate progress + items-done counter
         progress.start()  # Emit the progress-start event
         all_sle_data: list[Any] = []  # Accumulates every SLE record across both loops
-        print(f"! Retrieving organization SLE data using {len(config.sle_categories)} service categories...")  # Info
-        print(f"! Also attempting {len(config.specialized_metrics)} specialized SLE aggregation metrics...")  # Info
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(
+            "! Retrieving organization SLE data using %s service categories...", len(config.sle_categories)
+        )  # Info
+        logging.info(
+            "! Also attempting %s specialized SLE aggregation metrics...", len(config.specialized_metrics)
+        )  # Info
         cls._run_retrieval(deps, org_id, config, all_sle_data, progress)  # Run both loops + export (or empty)
         progress.complete()  # Always emit the progress-complete event

--- a/tests/unit/serial_cc/test_sle_metrics.py
+++ b/tests/unit/serial_cc/test_sle_metrics.py
@@ -1,5 +1,6 @@
 """Unit tests for offender #9 SLE metrics service."""
 
+import logging
 from unittest.mock import MagicMock, patch
 
 from src.refactors.serial_cc.sle_metrics import SLEMetricsService
@@ -42,7 +43,7 @@ def test_sle_metrics_normal_mode_fetches_all_categories(mock_resolve_runtime_dep
 
 
 @patch("src.refactors.serial_cc.sle_metrics._resolve_runtime_dependencies")
-def test_sle_metrics_fast_mode_reduces_scope(mock_resolve_runtime_dependencies, capsys):
+def test_sle_metrics_fast_mode_reduces_scope(mock_resolve_runtime_dependencies, caplog):
     """Fast mode only fetches wifi category and summary metric."""
     deps = _make_dependency_bundle()
     mock_resolve_runtime_dependencies.return_value = deps
@@ -54,10 +55,11 @@ def test_sle_metrics_fast_mode_reduces_scope(mock_resolve_runtime_dependencies, 
     deps.DataProcessingUtils.flatten_nested_fields.side_effect = lambda rows: rows
     deps.DataProcessingUtils.escape_multiline.side_effect = lambda rows: rows
 
-    SLEMetricsService.execute(fast=True)
+    with caplog.at_level(logging.INFO, logger="root"):
+        SLEMetricsService.execute(fast=True)
 
-    captured = capsys.readouterr()
-    assert "SLE data retrieval completed" in captured.out
+    out = "\n".join(record.getMessage() for record in caplog.records)
+    assert "SLE data retrieval completed" in out
 
 
 @patch("src.refactors.serial_cc.sle_metrics._resolve_runtime_dependencies")


### PR DESCRIPTION
## Summary
- Replaces the 7 remaining `print()` calls in `src/refactors/serial_cc/sle_metrics.py` with `logging.info(...)` using `%`-style deferred formatting.
- Migrates the 1 `capsys` assertion in `tests/unit/serial_cc/test_sle_metrics.py::test_sle_metrics_fast_mode_reduces_scope` to `caplog` (`logger="root"`).
- All 4 tests across the unit + integration sle_metrics suites pass locally.

Part of the per-file rollout for issue #886. Slice 63/N.

## Test plan
- [x] `ruff check` clean on migrated files
- [x] `black --check` clean on migrated files
- [x] `pytest tests/unit/serial_cc/test_sle_metrics.py tests/integration/serial_cc/test_sle_metrics_integration.py` → 4 passed
- [x] `Grep print\(` count in migrated source → 0 matches