### PR TITLE
chore(logging): migrate src/export/site_webhook_deliveries_exporter.py print() to logger (#886 slice 64/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 64/N: retire `print()` in `src/export/site_webhook_deliveries_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 8 remaining `print()`
+  calls in `src/export/site_webhook_deliveries_exporter.py` with
+  `logging.info(...)` (module already uses root `logging.<level>(...)` for its
+  info/warning/error traces) using `%`-style deferred formatting. Migrations
+  cover: the no-webhooks-configured operator notice and the per-webhook
+  enumeration line in `_select_webhook_id`; the invalid-selection and
+  out-of-range validation notices in `_resolve_webhook_choice`; the no-data
+  and post-export count notices in `_persist_site_webhook_deliveries`; and
+  the workflow banner plus the SDK-error surface line in `deliveries`. Each
+  migrated call carries the standard `# WHY: preserve operator notice
+  verbatim; route through logger for capture/redirection.` annotation.
+- **Tests (Verified)**: no dedicated `test_site_webhook_deliveries_exporter.py`
+  suite exists, and no `capsys` assertion covered this module. The full
+  `tests/unit/test_arango_writer.py` suite (which references the
+  `searchSiteWebhooksDeliveries` operationId for entity-type mapping) passes
+  (249/249) locally, confirming no regression to shared persistence wiring.
+
 ### #886 Phase 2 slice 63/N: retire `print()` in `src/refactors/serial_cc/sle_metrics.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 7 remaining `print()`

--- a/src/export/site_webhook_deliveries_exporter.py
+++ b/src/export/site_webhook_deliveries_exporter.py
@@ -63,11 +63,13 @@ class SiteWebhookDeliveriesExporter:
         )
         webhooks = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page all rows.
         if not webhooks:  # Site has no configured webhooks -- nothing to search deliveries for.
-            print("! No webhooks configured for this site")  # ASCII-only user notice.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! No webhooks configured for this site")  # ASCII-only user notice.
             logging.warning("No webhooks configured for site_id=%s", site_id)  # Warn for logs.
             return None
         for idx, wh in enumerate(webhooks, start=1):  # Enumerate with 1-based index for humans.
-            print(f"  {idx}. {wh.get('name', '(unnamed)')}  [{wh.get('id', '?')}]")  # Show each webhook.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("  %s. %s  [%s]", idx, wh.get("name", "(unnamed)"), wh.get("id", "?"))  # Show each webhook.
         raw = InputUtils.safe_input(  # WHY: safe_input handles EOF/Ctrl-C gracefully in SSH/CI.
             "Select webhook number: ", context="site_webhook_deliveries_selection"
         )
@@ -91,11 +93,13 @@ class SiteWebhookDeliveriesExporter:
             1-based index, else ``None``.
         """
         if not raw.isdigit():  # Non-numeric input -- reject.
-            print("! Invalid selection (not a number)")  # ASCII-only user notice.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! Invalid selection (not a number)")  # ASCII-only user notice.
             return None
         idx = int(raw)  # Parse the operator's 1-based choice.
         if not 1 <= idx <= len(webhooks):  # Out-of-range index.
-            print(f"! Selection out of range (1..{len(webhooks)})")  # ASCII-only user notice.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! Selection out of range (1..%s)", len(webhooks))  # ASCII-only user notice.
             return None
         chosen = webhooks[idx - 1]  # Convert to 0-based access.
         return chosen.get("id", ""), chosen.get("name", chosen.get("id", "webhook"))  # Return id+name.
@@ -117,7 +121,8 @@ class SiteWebhookDeliveriesExporter:
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
         if not rawdata:  # No delivery rows in the query window -- inform the operator.
-            print("! No webhook delivery data found")  # ASCII-only user notice.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! No webhook delivery data found")  # ASCII-only user notice.
             return
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
         sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe multiline escape.
@@ -130,7 +135,8 @@ class SiteWebhookDeliveriesExporter:
         logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
             "searchSiteWebhooksDeliveries persisted %d rows to %s", len(rawdata), filename
         )
-        print(f"! {len(rawdata)} webhook delivery records exported to {filename}")  # User notice.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! %s webhook delivery records exported to %s", len(rawdata), filename)  # User notice.
 
     @staticmethod
     def deliveries() -> None:
@@ -144,7 +150,8 @@ class SiteWebhookDeliveriesExporter:
             surfaced to the user rather than crashing the menu loop.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
-        print("Site Webhook Deliveries Search:")  # Menu header echoed to operator.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("Site Webhook Deliveries Search:")  # Menu header echoed to operator.
         logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
             "Starting searchSiteWebhooksDeliveries export..."
         )
@@ -179,4 +186,5 @@ class SiteWebhookDeliveriesExporter:
                 webhook_name,
                 e,
             )
-            print(f"! Error fetching webhook delivery data: {e}")  # ASCII-only user notice.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! Error fetching webhook delivery data: %s", e)  # ASCII-only user notice.


### PR DESCRIPTION
Slice 64/N of #886. Retires the 8 remaining `print()` calls in `src/export/site_webhook_deliveries_exporter.py` in favor of `logging.info(...)` with %-style deferred formatting.

## Changes

- **src/export/site_webhook_deliveries_exporter.py**: 8 `print()` sites migrated to `logging.info(...)` covering the no-webhooks-configured notice + enumeration line in `_select_webhook_id`, invalid-selection + out-of-range validation in `_resolve_webhook_choice`, no-data + count notices in `_persist_site_webhook_deliveries`, and the workflow banner + SDK-error surface line in `deliveries`. Each carries the standard WHY annotation.
- **CHANGELOG.md**: slice 64/N Unreleased entry.

## Verification

- `grep -n "print(" src/export/site_webhook_deliveries_exporter.py` -> 0 matches
- `ruff check src/export/site_webhook_deliveries_exporter.py` -> All checks passed!
- `black --check src/export/site_webhook_deliveries_exporter.py` -> 1 file would be left unchanged
- `pytest tests/unit/test_arango_writer.py` -> 249 passed (no regression to shared entity-type mapping/writer wiring)
- No dedicated test file exists for this exporter; no `capsys` usages referenced it, so no test migration needed.

Part of the incremental #886 rollout — one file per PR, smallest-first ordering. Final `pyproject.toml` T20 flip will come after the last per-file slice.