### PR TITLE
chore(logging): migrate src/export/wifi_clients_exporter.py print() to logger (#886 slice 65/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 65/N: retire `print()` in `src/export/wifi_clients_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 8 remaining `print()`
+  calls in `src/export/wifi_clients_exporter.py` with `logging.info(...)` (module
+  already uses root `logging.<level>(...)` for its debug/info/warning/exception
+  traces) using `%`-style deferred formatting. Migrations cover the workflow
+  header in `_announce_start`, the pre-fetch operator line in `_announce_fetch`,
+  the failure surface line in `_log_export_failure`, the defensive empty-merge
+  banner in `_log_empty_merge`, the no-site cancel-path notice in
+  `_ensure_site_selected`, the no-data placeholder header in
+  `_write_no_data_placeholder`, and both operator lines in the success summary
+  emitter (`_print_success_summary`). Each migrated call carries the standard
+  `# WHY:` annotation preserving legacy operator-visible text via the logger.
+- **Tests (Migrated)**: `tests/unit/export/test_wifi_clients_exporter.py` had
+  two `capsys.readouterr().out` assertions covering the pipeline-failure and
+  empty-merge banners. Both were converted to `caplog.at_level(logging.INFO,
+  logger="root")` + record-based assertions (`out = "\n".join(rec.getMessage()
+  for rec in caplog.records)`); `import logging` was added to the test module.
+  Full local run: 30/30 pass across `tests/unit/export/test_wifi_clients_exporter.py`
+  and `tests/unit/test_wifi_clients_exporter.py`.
+
 ### #886 Phase 2 slice 64/N: retire `print()` in `src/export/site_webhook_deliveries_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 8 remaining `print()`

--- a/src/export/wifi_clients_exporter.py
+++ b/src/export/wifi_clients_exporter.py
@@ -58,20 +58,23 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
     @staticmethod
     def _announce_start() -> None:  # WHY: header + start-log emitter kept pure-static for testability.
         """Emit the legacy header line and start-of-workflow log entry."""
-        print("Export Site WiFi Clients:")  # WHY: preserve legacy header text so operator experience is identical.
+        # WHY: preserve legacy header text so operator experience is identical; route via logger for capture.
+        logging.info("Export Site WiFi Clients:")
         logging.info("Starting export of site WiFi clients...")  # WHY: log workflow start boundary for tracing.
 
     @staticmethod
     def _announce_fetch(site_id: str, site_name: str) -> None:  # WHY: pre-fetch messaging isolated for reuse.
         """Emit the pre-fetch log line and legacy operator-facing message."""
         logging.info("Fetching WiFi clients for site: %s (ID: %s)", site_name, site_id)  # WHY: log before API calls.
-        print(f"! Fetching WiFi clients for site: {site_name}")  # WHY: preserve legacy fetch-start operator text.
+        # WHY: preserve legacy fetch-start operator text; route via logger for capture/redirection.
+        logging.info("! Fetching WiFi clients for site: %s", site_name)
 
     @staticmethod
     def _log_export_failure(site_id: str, exception: BaseException) -> None:  # WHY: exception-path emitter.
         """Log the exception traceback and print the legacy operator-facing failure line."""
         logging.exception("! Failed to fetch WiFi data for site %s: %s", site_id, exception)  # WHY: traceback log.
-        print(f"! Failed to fetch WiFi data: {exception}")  # WHY: preserve legacy operator-facing error output.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Failed to fetch WiFi data: %s", exception)  # WHY: preserve legacy operator-facing error output.
 
     def _run_export_pipeline(self, stamp: _SiteStamp) -> None:  # WHY: try-guarded fetch/merge/finalize sequencer.
         """Execute the fetch, merge, and finalize stages that require exception-guard protection."""
@@ -89,7 +92,8 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
     def _log_empty_merge() -> None:  # WHY: empty-post-merge emitter isolated to keep pipeline branch-shallow.
         """Log + print the defensive empty-post-merge operator messages."""
         logging.warning(_NO_POST_MERGE_TEXT)  # WHY: preserve defensive empty-post-merge log severity + text.
-        print(_NO_POST_MERGE_TEXT)  # WHY: preserve legacy operator-facing empty-result message text.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(_NO_POST_MERGE_TEXT)  # WHY: preserve legacy operator-facing empty-result message text.
 
     def _ensure_site_selected(self, site_id: str | None) -> str | None:  # WHY: cache-seed + prompt orchestrator.
         """Ensure SiteList cache exists and resolve site_id (prompt operator when missing)."""
@@ -103,7 +107,8 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
         logging.debug("Site selection prompt completed with site_id=%s", chosen)  # WHY: result for traceability.
         if not chosen:
             logging.error(_NO_SITE_TEXT)  # WHY: cancel-path log preserved verbatim from the legacy exporter.
-            print(_NO_SITE_TEXT)  # WHY: preserve legacy operator-facing cancel-path message.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(_NO_SITE_TEXT)  # WHY: preserve legacy operator-facing cancel-path message.
             return None  # WHY: signal abort to orchestrator so no artifacts are written.
         return chosen  # WHY: resolved site identifier to operate on for the remainder of the workflow.
 
@@ -157,7 +162,8 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
     def _write_no_data_placeholder(self, stamp: _SiteStamp) -> None:
         """Write the legacy no-data sentinel CSV when neither clients nor sessions are found."""
         logging.warning(_NO_DATA_TEXT)  # WHY: preserve empty-result log severity + text from the legacy exporter.
-        print(_NO_DATA_TEXT)  # WHY: preserve legacy operator-facing empty-result message text.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(_NO_DATA_TEXT)  # WHY: preserve legacy operator-facing empty-result message text.
         logging.info("Writing no-data placeholder CSV for %s", _OUTPUT_CSV)  # WHY: log before placeholder write.
         wifi_clients_path = self.file_path_utils.get_csv_path(_OUTPUT_CSV)  # WHY: resolve canonical output path.
         with open(wifi_clients_path, "w", newline="", encoding="utf-8") as file_handle:
@@ -318,8 +324,13 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
             session_count,
             total_records,
         )  # WHY: structured log mirrors the operator print block for tracing parity.
-        print(f"! WiFi data exported to {_OUTPUT_CSV}")  # WHY: preserve legacy success confirmation line.
-        print(
-            f"   {client_count} current clients, {session_count} sessions, "
-            f"{total_records} total records from {site_name}"
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! WiFi data exported to %s", _OUTPUT_CSV)  # WHY: preserve legacy success confirmation line.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(
+            "   %d current clients, %d sessions, %d total records from %s",
+            client_count,
+            session_count,
+            total_records,
+            site_name,
         )  # WHY: preserve legacy detailed summary with counts and site context.

--- a/tests/unit/export/test_wifi_clients_exporter.py
+++ b/tests/unit/export/test_wifi_clients_exporter.py
@@ -10,6 +10,7 @@ _attach_latest_session zero-session path).
 from __future__ import annotations  # WHY: postponed annotations keep forward refs cheap under strict typing.
 
 import csv  # WHY: build CSV placeholders inline to verify _write_no_data_placeholder output shape.
+import logging  # WHY: caplog level filtering after print() → logger migration in wifi_clients_exporter.
 import os  # WHY: mkdir/write temporary fixture files under tests/fixtures for CSV-backed helpers.
 from pathlib import Path  # WHY: build platform-neutral tmp_path strings for CSV fixtures under pytest tmp_path.
 from typing import Any  # WHY: annotate mixed-value dict literals so mypy --strict accepts str/int co-occurrence.
@@ -79,7 +80,7 @@ def test_execute_exports_merged_records() -> None:
     data_exporter.write_with_format_selection.assert_called_once()
 
 
-def test_execute_logs_failure_when_pipeline_raises(capsys, caplog) -> None:
+def test_execute_logs_failure_when_pipeline_raises(caplog) -> None:
     """execute() should log + print the operator-facing failure line when the pipeline raises."""
     exporter, _prompt_utils, mistapi_module, data_exporter = _build_exporter()
     exporter.file_path_utils.get_csv_path.return_value = "tests/fixtures/site_list.csv"  # WHY: prevent lookup crash
@@ -88,11 +89,12 @@ def test_execute_logs_failure_when_pipeline_raises(capsys, caplog) -> None:
     with open("tests/fixtures/site_list.csv", "w", encoding="utf-8") as file_handle:  # WHY: minimal SiteList
         file_handle.write("id,name\nsite-1,Site One\n")
 
-    with caplog.at_level("ERROR"):
+    with caplog.at_level(logging.INFO, logger="root"):
         exporter.execute(site_id="site-1")
 
     data_exporter.write_with_format_selection.assert_not_called()  # WHY: pipeline aborted before final write
-    assert "Failed to fetch WiFi data" in capsys.readouterr().out  # WHY: legacy operator-facing failure text
+    out = "\n".join(record.getMessage() for record in caplog.records)  # WHY: caplog captures logged operator text
+    assert "Failed to fetch WiFi data" in out  # WHY: legacy operator-facing failure text routed via logger
     assert any("Failed to fetch WiFi data" in rec.message for rec in caplog.records)  # WHY: log captured
 
 
@@ -112,7 +114,7 @@ def test_execute_writes_placeholder_when_no_data(tmp_path: Path) -> None:
     assert "site-1" in contents  # WHY: site id stamped in placeholder body row
 
 
-def test_execute_logs_empty_merge_when_no_enriched_rows(tmp_path: Path, capsys) -> None:
+def test_execute_logs_empty_merge_when_no_enriched_rows(tmp_path: Path, caplog) -> None:
     """execute() should log + print the empty-merge banner when merge produces zero rows."""
     exporter, _prompt_utils, mistapi_module, data_exporter = _build_exporter()
     exporter.file_path_utils.get_csv_path.return_value = str(tmp_path / "site_list.csv")  # WHY: unused; safe path
@@ -124,10 +126,12 @@ def test_execute_logs_empty_merge_when_no_enriched_rows(tmp_path: Path, capsys) 
         [{"start_time": 1}],  # WHY: session without MAC — orphan pass skips it
     ]
 
-    exporter.execute(site_id="site-1")
+    with caplog.at_level(logging.INFO, logger="root"):
+        exporter.execute(site_id="site-1")
 
     data_exporter.write_with_format_selection.assert_not_called()  # WHY: empty-merge aborts before final write
-    assert "No data to export after processing" in capsys.readouterr().out  # WHY: legacy empty-merge banner
+    out = "\n".join(record.getMessage() for record in caplog.records)  # WHY: caplog captures the operator banner
+    assert "No data to export after processing" in out  # WHY: legacy empty-merge banner routed via logger
 
 
 def test_ensure_site_selected_returns_prompt_choice() -> None:


### PR DESCRIPTION
## Summary
- Slice 65/N of #886. Replaces the 8 remaining `print()` calls in
  `src/export/wifi_clients_exporter.py` with `logging.info(...)` using
  `%`-style deferred formatting. Sites: workflow banner, pre-fetch line,
  failure surface line, defensive empty-merge banner, no-site cancel,
  no-data placeholder header, and both success-summary lines.
- Each migrated call carries the standard `# WHY:` annotation preserving
  legacy operator text via the logger for capture/redirection.
- Migrated the two matching `capsys.readouterr().out` assertions in
  `tests/unit/export/test_wifi_clients_exporter.py` to
  `caplog.at_level(logging.INFO, logger="root")` + record aggregation.
  Added `import logging` to the test module.

## Test plan
- [x] `python -m ruff check src/export/wifi_clients_exporter.py tests/unit/export/test_wifi_clients_exporter.py` — clean
- [x] `python -m black --check src/export/wifi_clients_exporter.py tests/unit/export/test_wifi_clients_exporter.py` — clean
- [x] `python -m ruff check --select T20 src/export/wifi_clients_exporter.py` — 0 T20 hits
- [x] `python -m pytest tests/unit/export/test_wifi_clients_exporter.py tests/unit/test_wifi_clients_exporter.py` — 30/30 pass
- [ ] CI green on push

Refs #886.