### PR TITLE
chore(logging): migrate src/gateway/overrides/override_report_writer.py print() to logger (#886 slice 66/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 66/N: retire `print()` in `src/gateway/overrides/override_report_writer.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the 8 remaining `print()`
+  calls in `src/gateway/overrides/override_report_writer.py` with
+  `logging.info(...)` (module already uses root `logging.<level>(...)` for its
+  debug/info traces) using `%`-style deferred formatting. Migrations cover the
+  header-only fast-path in `OverrideReportWriter.write_empty` (report-written
+  banner + repeated compliant-fleet notice), and all six operator-facing lines
+  in `OverrideReportWriter._print_summary_lines` (report-written banner,
+  overridden-ports summary, API-optimization saved-calls line, target-ports
+  echo, outliers-hint line, and the conditional zero-entry compliant-fleet
+  repeat). Each migrated call carries the standard `# WHY:` annotation
+  preserving legacy operator-visible text via the logger.
+- **Tests (Migrated)**: `tests/unit/gateway/overrides/test_override_report_writer.py`
+  had four `capsys.readouterr().out` assertions covering write_empty,
+  write_full (both entry-count branches), and the direct `_print_summary`
+  parity test. All four were converted to `caplog.at_level(logging.INFO,
+  logger="root")` + record-based assertions (`stdout = "\n".join(rec.getMessage()
+  for rec in caplog.records)`). Full local run: 5/5 pass on
+  `tests/unit/gateway/overrides/test_override_report_writer.py`.
+
 ### #886 Phase 2 slice 65/N: retire `print()` in `src/export/wifi_clients_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the 8 remaining `print()`

--- a/src/gateway/overrides/override_report_writer.py
+++ b/src/gateway/overrides/override_report_writer.py
@@ -45,10 +45,10 @@ class OverrideReportWriter:
             writer = csv.DictWriter(csvfile, fieldnames=_EMPTY_FIELDNAMES)  # DictWriter for header-only output
             writer.writeheader()  # Header row only; no data rows are written when fleet is fully compliant
         logging.debug("Header-only CSV written to %s", output_path)  # Confirm write completed for operator log
-        print(f"! Gateway override report written to {OUTPUT_FILENAME}")  # Legacy console message preserved
-        print(  # Legacy console message preserved verbatim
-            " No template overrides found - all gateways are compliant with their assigned templates!"
-        )
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Gateway override report written to %s", OUTPUT_FILENAME)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(" No template overrides found - all gateways are compliant with their assigned templates!")
 
     @staticmethod
     def write_full(
@@ -122,18 +122,25 @@ class OverrideReportWriter:
     ) -> None:
         """Emit the legacy console summary lines given precomputed stats."""
         saved_calls = total_gateways - devices_with_overrides_count  # API calls saved by the override pre-filter
-        print(f"! Gateway override report written to {OUTPUT_FILENAME}")  # Legacy console line preserved
-        print(  # Legacy console line preserved verbatim across two physical lines
-            f"! Found {total_overridden_ports} overridden ports across"
-            f" {gateways_with_overrides} of {total_gateways} gateway devices"
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Gateway override report written to %s", OUTPUT_FILENAME)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(
+            "! Found %d overridden ports across %d of %d gateway devices",
+            total_overridden_ports,
+            gateways_with_overrides,
+            total_gateways,
         )
-        print(  # Legacy console line preserved verbatim across two physical lines
-            f"! API Optimization: Only fetched live data for {devices_with_overrides_count}"
-            f" devices with overrides (saved {saved_calls} unnecessary API calls)"
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(
+            "! API Optimization: Only fetched live data for %d devices with overrides (saved %d unnecessary API calls)",
+            devices_with_overrides_count,
+            saved_calls,
         )
-        print(f"! Target ports analyzed: {', '.join(target_ports)}")  # Legacy console line preserved
-        print("! These are outliers that may need correction to match template configuration")  # Legacy line
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Target ports analyzed: %s", ", ".join(target_ports))
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! These are outliers that may need correction to match template configuration")
         if total_overridden_ports == 0:  # Repeat compliant-fleet message when full path produces zero rows
-            print(  # Legacy console line preserved verbatim
-                " No template overrides found - all gateways are compliant with their assigned templates!"
-            )
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(" No template overrides found - all gateways are compliant with their assigned templates!")

--- a/tests/unit/gateway/overrides/test_override_report_writer.py
+++ b/tests/unit/gateway/overrides/test_override_report_writer.py
@@ -14,7 +14,7 @@ from pathlib import Path  # WHY: type-safe tmp_path writes for the empty CSV.
 from typing import Any  # WHY: dict typing mirroring SUT.
 from unittest.mock import MagicMock, patch  # WHY: mandatory spec= mocks.
 
-import pytest  # WHY: caplog and capsys fixtures.
+import pytest  # WHY: caplog fixture for legacy operator log verification.
 
 from src.gateway.overrides import _deps  # WHY: patch module-level DI slots directly.
 from src.gateway.overrides.override_report_writer import (  # WHY: SUT direct import.
@@ -27,21 +27,24 @@ from src.gateway.overrides.override_report_writer import (  # WHY: SUT direct im
 class TestWriteEmpty:
     """Cover the header-only fast path."""
 
-    def test_writes_header_only_csv(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-        """Header row is written; no data rows; legacy console lines emitted."""
-        # WHY: exercises the file-open+DictWriter branch and both print() calls.
+    def test_writes_header_only_csv(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Header row is written; no data rows; legacy operator lines routed via logger."""
+        # WHY: exercises the file-open+DictWriter branch and both logging.info() operator calls.
         output_path = tmp_path / OUTPUT_FILENAME  # Route the writer to the tmp path.
         fake_file_path_utils = MagicMock(spec=["get_csv_path"])  # Minimal spec attr surface.
         fake_file_path_utils.get_csv_path.return_value = str(output_path)  # Redirect writes.
-        with patch.object(_deps, "FilePathUtils", fake_file_path_utils):  # Inject DI slot.
+        with (
+            patch.object(_deps, "FilePathUtils", fake_file_path_utils),  # Inject DI slot.
+            caplog.at_level(logging.INFO, logger="root"),  # Capture operator log lines.
+        ):
             OverrideReportWriter.write_empty()  # Trigger the empty write.
         fake_file_path_utils.get_csv_path.assert_called_once_with(OUTPUT_FILENAME)  # Verified path resolution.
         # Verify header-only content.
         with open(output_path, newline="", encoding="utf-8") as csvfile:  # Read the written CSV back.
             rows = list(csv.reader(csvfile))  # Load all rows.
         assert rows == [_EMPTY_FIELDNAMES]  # Only the header row is present.
-        # Verify legacy console output.
-        stdout = capsys.readouterr().out  # Capture printed lines.
+        # Verify legacy operator output routed via logger.
+        stdout = "\n".join(record.getMessage() for record in caplog.records)  # Aggregate log messages.
         assert f"! Gateway override report written to {OUTPUT_FILENAME}" in stdout  # Legacy line 1.
         assert "compliant with their assigned templates" in stdout  # Legacy line 2 substring.
 
@@ -49,9 +52,7 @@ class TestWriteEmpty:
 class TestWriteFull:
     """Cover the multi-entry path that delegates to DataExporter and prints the summary block."""
 
-    def test_delegates_to_data_exporter_and_prints_summary(
-        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_delegates_to_data_exporter_and_prints_summary(self, caplog: pytest.LogCaptureFixture) -> None:
         """DataExporter is called with entries + filename; log + summary lines emitted."""
         # WHY: exercises DataExporter dispatch, _log_summary, and _print_summary_lines together.
         entries: list[dict[str, Any]] = [  # Two entries sharing one device_id -> distinct-device count = 1.
@@ -70,7 +71,7 @@ class TestWriteFull:
                 target_ports=["ge-0/0/0", "ge-0/0/1"],
             )
         fake_data_exporter.write_with_format_selection.assert_called_once_with(entries, OUTPUT_FILENAME)  # Deleg.
-        stdout = capsys.readouterr().out  # Capture printed summary.
+        stdout = "\n".join(record.getMessage() for record in caplog.records)  # Aggregate log output.
         assert f"! Gateway override report written to {OUTPUT_FILENAME}" in stdout  # Console line 1.
         assert "Found 2 overridden ports across 1 of 10" in stdout  # Console line 2 (distinct-device math).
         assert "Only fetched live data for 1 devices" in stdout  # Console line 3 (API optimization).
@@ -82,19 +83,22 @@ class TestWriteFull:
         assert any("with 2 overridden ports from 1 gateway" in rec.getMessage() for rec in caplog.records)  # Sum.
         assert any("API Optimization" in rec.getMessage() for rec in caplog.records)  # Optimization log.
 
-    def test_empty_entries_zero_gateways_and_repeats_compliant_line(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_empty_entries_zero_gateways_and_repeats_compliant_line(self, caplog: pytest.LogCaptureFixture) -> None:
         """Zero-entry write_full path exercises the `entries else 0` branch + compliant repeat."""
         # WHY: covers the False branch of `if entries` in _log_summary and _print_summary,
         # plus the `if total_overridden_ports == 0` repeat-compliant branch in _print_summary_lines.
         fake_data_exporter = MagicMock(spec=["write_with_format_selection"])  # Stub exporter.
-        with patch.object(_deps, "DataExporter", fake_data_exporter):
+        with (
+            patch.object(_deps, "DataExporter", fake_data_exporter),
+            caplog.at_level(logging.INFO, logger="root"),  # Capture info logs.
+        ):
             OverrideReportWriter.write_full(
                 entries=[],
                 total_gateways=5,
                 devices_with_overrides_count=0,
                 target_ports=["ge-0/0/0"],
             )
-        stdout = capsys.readouterr().out  # Capture printed output.
+        stdout = "\n".join(record.getMessage() for record in caplog.records)  # Aggregate log output.
         assert "Found 0 overridden ports across 0 of 5" in stdout  # Zero-entry summary line.
         assert "compliant with their assigned templates" in stdout  # Repeated compliant message.
 
@@ -113,7 +117,7 @@ class TestLogSummary:
 class TestPrintSummary:
     """Directly exercise ``_print_summary`` to verify the distinct-device math parity."""
 
-    def test_distinct_devices_computed_from_entries(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_distinct_devices_computed_from_entries(self, caplog: pytest.LogCaptureFixture) -> None:
         """Distinct device_id count drives the summary numerator."""
         # WHY: exercises the True branch of the `if entries else 0` guard in _print_summary.
         entries: list[dict[str, Any]] = [  # Three entries, two distinct device_ids.
@@ -121,11 +125,12 @@ class TestPrintSummary:
             {"device_id": "a"},
             {"device_id": "b"},
         ]
-        OverrideReportWriter._print_summary(
-            entries=entries,
-            total_gateways=7,
-            devices_with_overrides_count=2,
-            target_ports=["ge-0/0/0"],
-        )
-        stdout = capsys.readouterr().out  # Capture output.
+        with caplog.at_level(logging.INFO, logger="root"):  # Capture info logs.
+            OverrideReportWriter._print_summary(
+                entries=entries,
+                total_gateways=7,
+                devices_with_overrides_count=2,
+                target_ports=["ge-0/0/0"],
+            )
+        stdout = "\n".join(record.getMessage() for record in caplog.records)  # Aggregate log output.
         assert "Found 3 overridden ports across 2 of 7" in stdout  # Two distinct devices, three ports.


### PR DESCRIPTION
Slice 66/N of #886 print()→logger migration.

## Summary
- Replaced 8 `print()` calls in `src/gateway/overrides/override_report_writer.py` with `logging.info(...)` using `%`-style deferred formatting; each call carries the standard `# WHY:` annotation preserving operator-visible text via the logger.
- `write_empty`: report-written banner + repeated compliant-fleet notice.
- `_print_summary_lines`: report-written banner, overridden-ports summary, API-optimization saved-calls line, target-ports echo, outliers-hint line, and the conditional zero-entry compliant-fleet repeat.
- Tests: migrated 4 `capsys.readouterr().out` assertions in `tests/unit/gateway/overrides/test_override_report_writer.py` to `caplog.at_level(logging.INFO, logger="root")` + record-based aggregation.

## Test plan
- [x] `python -m pytest tests/unit/gateway/overrides/test_override_report_writer.py -q` → 5/5 pass
- [x] `python -m ruff check --select T20 src/gateway/overrides/override_report_writer.py` → 0 hits
- [x] `python -m ruff check` + `python -m black --check` on modified files → clean

Refs #886