### PR TITLE
chore(logging): migrate src/export/sites_by_ap_model_exporter.py print() to logger (#886 slice 70/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 70/N: retire `print()` in `src/export/sites_by_ap_model_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 9 `print()` calls in
+  `src/export/sites_by_ap_model_exporter.py` with `logging.info(...)` using
+  `%`-style deferred formatting to satisfy G004. Covers the "Available AP
+  models" header and numbered per-model listing in `_print_model_options`, the
+  invalid-selection notice in `_resolve_model_choice`, the export-success
+  summary line in `_finalize_ap_model_export`, and the menu banner plus the
+  inventory-fetch / no-APs / site-detail-fetch / no-matching-sites operator
+  notices in `export_sites_by_ap_model`. Each migrated call carries the
+  standard `# WHY:` annotation preserving legacy operator-visible text via the
+  logger.
+- **Tests (Migrated)**: `tests/unit/export/test_sites_by_ap_model_exporter.py`
+  swapped `capsys` for `caplog` across the six impacted tests
+  (`test_prints_numbered_list_with_counts`, `test_out_of_bounds_returns_none`,
+  `test_zero_selection_returns_none`, `test_non_numeric_returns_none`,
+  `test_slugifies_model_and_writes_csv`, `test_no_models_returns_early`,
+  `test_no_matching_rows_returns_early`) wrapping each call under
+  `with caplog.at_level(logging.INFO):` and asserting substrings against
+  `record.getMessage()`. All 21 tests pass locally.
+
 ### #886 Phase 2 slice 69/N: retire `print()` in `src/export/site_insights/device_metric_operation.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 9 `print()` calls in

--- a/src/export/sites_by_ap_model_exporter.py
+++ b/src/export/sites_by_ap_model_exporter.py
@@ -36,10 +36,12 @@ class SitesByAPModelExporter:
     @staticmethod
     def _print_model_options(models: list[str], aps: list[dict]) -> None:  # type: ignore[type-arg]
         """Print numbered list of AP models with per-model device count."""
-        print("\nAvailable AP models:")  # Header
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("\nAvailable AP models:")
         for idx, model in enumerate(models, 1):  # List each model
             count = sum(1 for d in aps if d.get("model") == model)  # APs of this model
-            print(f"  {idx:3d}. {model} ({count} APs)")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("  %3d. %s (%s APs)", idx, model, count)
 
     @staticmethod
     def _resolve_model_choice(choice: str, models: list[str]) -> str | None:
@@ -48,7 +50,8 @@ class SitesByAPModelExporter:
             selected = int(choice.strip()) - 1  # Convert to 0-based index
             return models[selected] if 0 <= selected < len(models) else None  # Bounds check
         except (ValueError, IndexError):
-            print("! Invalid selection.")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! Invalid selection.")
             return None
 
     @staticmethod
@@ -133,7 +136,8 @@ class SitesByAPModelExporter:
         safe_model = re.sub(r"[^a-zA-Z0-9_-]", "_", model)  # Slugify the model.
         filename = f"SitesByAPModel_{safe_model}.csv"  # Build the CSV name.
         mh.DataExporter.write_with_format_selection(rows, filename, api_function_name="getSitesByAPModel")  # Persist.
-        print(f"\n[OK] Exported {len(rows)} sites with {model} APs to {filename}")  # Tell the user.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("\n[OK] Exported %s sites with %s APs to %s", len(rows), model, filename)
         logging.info("Exported %s sites with AP model %s", len(rows), model)  # Log the export.
 
     @staticmethod
@@ -145,22 +149,27 @@ class SitesByAPModelExporter:
     def export_sites_by_ap_model() -> None:  # Export sites by AP model.
         """Export CSV of sites containing APs of a selected model with site address info."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils + APICoreFetchUtils facades.
-        print("Export Sites by AP Model:")  # Header
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("Export Sites by AP Model:")
         logging.info("Starting export of sites by AP model...")  # Trace start
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org
-        print("! Fetching AP inventory from organization...")  # Tell the user
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Fetching AP inventory from organization...")
         aps, models = SitesByAPModelExporter._get_ap_models(org_id)  # Fetch APs and models
         if not models:  # No models in inventory
-            print("! No APs found in organization inventory.")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! No APs found in organization inventory.")
             return
         model = SitesByAPModelExporter._prompt_model_selection(models, aps)  # Prompt operator for a model
         if not model:  # Operator skipped
             return
-        print(f"! Fetching site details for sites with {model} APs...")  # Tell the user
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Fetching site details for sites with %s APs...", model)
         all_sites = mh.APICoreFetchUtils.all_sites_with_limit(org_id)  # List all sites
         site_map = SitesByAPModelExporter._build_site_map(all_sites)  # Index sites by id for row lookup
         rows = SitesByAPModelExporter._build_export_rows(aps, model, site_map)  # Build export rows
         if not rows:  # No rows match the chosen model
-            print(f"! No sites found with {model} APs.")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! No sites found with %s APs.", model)
             return
         SitesByAPModelExporter._finalize_ap_model_export(rows, model)  # Slug + filename + write + log

--- a/tests/unit/export/test_sites_by_ap_model_exporter.py
+++ b/tests/unit/export/test_sites_by_ap_model_exporter.py
@@ -11,6 +11,7 @@ importing the monolith.
 
 from __future__ import annotations
 
+import logging
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock
@@ -61,7 +62,7 @@ class TestGetApModels:
 class TestPrintModelOptions:
     """Cover SitesByAPModelExporter._print_model_options."""
 
-    def test_prints_numbered_list_with_counts(self, capsys):
+    def test_prints_numbered_list_with_counts(self, caplog):
         """Prints a numbered list with per-model AP counts."""
         from src.export.sites_by_ap_model_exporter import SitesByAPModelExporter
 
@@ -71,12 +72,13 @@ class TestPrintModelOptions:
             {"model": "AP45"},
             {"model": "AP45"},
         ]
-        SitesByAPModelExporter._print_model_options(models, aps)
+        with caplog.at_level(logging.INFO):
+            SitesByAPModelExporter._print_model_options(models, aps)
 
-        out = capsys.readouterr().out
-        assert "Available AP models" in out
-        assert "1. AP41 (1 APs)" in out
-        assert "2. AP45 (2 APs)" in out
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("Available AP models" in m for m in messages)
+        assert any("1. AP41 (1 APs)" in m for m in messages)
+        assert any("2. AP45 (2 APs)" in m for m in messages)
 
 
 class TestResolveModelChoice:
@@ -89,28 +91,31 @@ class TestResolveModelChoice:
         models = ["AP41", "AP45"]
         assert SitesByAPModelExporter._resolve_model_choice("2", models) == "AP45"
 
-    def test_out_of_bounds_returns_none(self, capsys):
-        """Out-of-range selection returns None (bounds check branch, no print)."""
+    def test_out_of_bounds_returns_none(self, caplog):
+        """Out-of-range selection returns None (bounds check branch, no notice)."""
         from src.export.sites_by_ap_model_exporter import SitesByAPModelExporter
 
         models = ["AP41"]
-        assert SitesByAPModelExporter._resolve_model_choice("5", models) is None
-        assert "Invalid selection" not in capsys.readouterr().out
+        with caplog.at_level(logging.INFO):
+            assert SitesByAPModelExporter._resolve_model_choice("5", models) is None
+        assert not any("Invalid selection" in r.getMessage() for r in caplog.records)
 
-    def test_zero_selection_returns_none(self, capsys):
-        """Zero (1-based) becomes -1 index which is out of bounds -> None (no print)."""
+    def test_zero_selection_returns_none(self, caplog):
+        """Zero (1-based) becomes -1 index which is out of bounds -> None (no notice)."""
         from src.export.sites_by_ap_model_exporter import SitesByAPModelExporter
 
         models = ["AP41"]
-        assert SitesByAPModelExporter._resolve_model_choice("0", models) is None
-        assert "Invalid selection" not in capsys.readouterr().out
+        with caplog.at_level(logging.INFO):
+            assert SitesByAPModelExporter._resolve_model_choice("0", models) is None
+        assert not any("Invalid selection" in r.getMessage() for r in caplog.records)
 
-    def test_non_numeric_returns_none(self, capsys):
+    def test_non_numeric_returns_none(self, caplog):
         """Non-numeric input triggers ValueError branch -> None with error notice."""
         from src.export.sites_by_ap_model_exporter import SitesByAPModelExporter
 
-        assert SitesByAPModelExporter._resolve_model_choice("abc", ["AP41"]) is None
-        assert "Invalid selection" in capsys.readouterr().out
+        with caplog.at_level(logging.INFO):
+            assert SitesByAPModelExporter._resolve_model_choice("abc", ["AP41"]) is None
+        assert any("Invalid selection" in r.getMessage() for r in caplog.records)
 
 
 class TestPromptModelSelection:
@@ -254,12 +259,13 @@ class TestBuildSiteMap:
 class TestFinalizeApModelExport:
     """Cover SitesByAPModelExporter._finalize_ap_model_export."""
 
-    def test_slugifies_model_and_writes_csv(self, fake_mh, capsys):
-        """Model name is slugified for filename, DataExporter is called, summary is printed."""
+    def test_slugifies_model_and_writes_csv(self, fake_mh, caplog):
+        """Model name is slugified for filename, DataExporter is called, summary is logged."""
         from src.export.sites_by_ap_model_exporter import SitesByAPModelExporter
 
         rows = [{"site_id": "s1"}]
-        SitesByAPModelExporter._finalize_ap_model_export(rows, "AP-45 / Special!")
+        with caplog.at_level(logging.INFO):
+            SitesByAPModelExporter._finalize_ap_model_export(rows, "AP-45 / Special!")
 
         fake_mh.DataExporter.write_with_format_selection.assert_called_once()
         call = fake_mh.DataExporter.write_with_format_selection.call_args
@@ -268,14 +274,13 @@ class TestFinalizeApModelExport:
         assert call.args[1] == "SitesByAPModel_AP-45___Special_.csv"
         assert call.kwargs.get("api_function_name") == "getSitesByAPModel"
 
-        out = capsys.readouterr().out
-        assert "Exported 1 sites" in out
+        assert any("Exported 1 sites" in r.getMessage() for r in caplog.records)
 
 
 class TestExportSitesByApModel:
     """Cover SitesByAPModelExporter.export_sites_by_ap_model (public entry)."""
 
-    def test_no_models_returns_early(self, fake_mh, capsys, monkeypatch):
+    def test_no_models_returns_early(self, fake_mh, caplog, monkeypatch):
         """Empty AP inventory -> tells the user and returns before prompting."""
         from src.export.sites_by_ap_model_exporter import SitesByAPModelExporter
 
@@ -288,9 +293,10 @@ class TestExportSitesByApModel:
         prompt = MagicMock()
         monkeypatch.setattr(SitesByAPModelExporter, "_prompt_model_selection", staticmethod(prompt))
 
-        SitesByAPModelExporter.export_sites_by_ap_model()
+        with caplog.at_level(logging.INFO):
+            SitesByAPModelExporter.export_sites_by_ap_model()
 
-        assert "No APs found" in capsys.readouterr().out
+        assert any("No APs found" in r.getMessage() for r in caplog.records)
         prompt.assert_not_called()
 
     def test_operator_cancels_prompt(self, fake_mh, monkeypatch):
@@ -312,7 +318,7 @@ class TestExportSitesByApModel:
 
         fake_mh.APICoreFetchUtils.all_sites_with_limit.assert_not_called()
 
-    def test_no_matching_rows_returns_early(self, fake_mh, capsys, monkeypatch):
+    def test_no_matching_rows_returns_early(self, fake_mh, caplog, monkeypatch):
         """Prompt returns model but no sites match -> notice + no CSV write."""
         from src.export.sites_by_ap_model_exporter import SitesByAPModelExporter
 
@@ -337,9 +343,10 @@ class TestExportSitesByApModel:
         finalize = MagicMock()
         monkeypatch.setattr(SitesByAPModelExporter, "_finalize_ap_model_export", staticmethod(finalize))
 
-        SitesByAPModelExporter.export_sites_by_ap_model()
+        with caplog.at_level(logging.INFO):
+            SitesByAPModelExporter.export_sites_by_ap_model()
 
-        assert "No sites found with AP41" in capsys.readouterr().out
+        assert any("No sites found with AP41" in r.getMessage() for r in caplog.records)
         finalize.assert_not_called()
 
     def test_success_path_writes_csv(self, fake_mh, monkeypatch):


### PR DESCRIPTION
## Summary
- Replace all 9 `print()` calls in `src/export/sites_by_ap_model_exporter.py` with `logging.info()` using `%`-style deferred formatting to satisfy G004.
- Migrate 6 `capsys`-based tests in `tests/unit/export/test_sites_by_ap_model_exporter.py` to `caplog` with `caplog.at_level(logging.INFO)` wrappers and `record.getMessage()` substring assertions.
- Each migrated call carries the standard `# WHY:` annotation preserving legacy operator-visible text via the logger.

Refs #886 — Phase 2 slice 70/N.

## Test plan
- [x] `python -m pytest tests/unit/export/test_sites_by_ap_model_exporter.py -q` → 21 passed
- [x] `ruff check --select T20 src/export/sites_by_ap_model_exporter.py tests/unit/export/test_sites_by_ap_model_exporter.py` → 0 issues
- [x] `ruff check` full ruleset on the two files → 0 issues
- [x] `black --check` on the two files → clean