### PR TITLE
chore(logging): migrate src/gateway/gateway_stats_exporter.py print() to logger (#886 slice 71/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 71/N: retire `print()` in `src/gateway/gateway_stats_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 9 `print()` calls in
+  `src/gateway/gateway_stats_exporter.py` with `logging.info(...)` using
+  `%`-style deferred formatting to satisfy G004. Covers the load-error branch
+  in `_load_gateway_stats_for_conflicts`, the healthy-config short-circuit and
+  export-summary lines in `_export_conflict_results`, and the per-conflict
+  sample lines plus truncation trailer in `_display_conflict_samples`. Each
+  migrated call carries the standard `# WHY:` annotation preserving legacy
+  operator-visible text via the logger for capture/redirection.
+- **Test migration (Changed)**: migrated 5 tests in
+  `tests/unit/gateway/test_gateway_stats_exporter.py` from `capsys` to
+  `caplog` with `caplog.at_level(logging.INFO)` wrappers and
+  `record.getMessage()` substring assertions. 32/32 tests pass; ruff T20
+  clean; ruff full clean; black clean.
+
 ### #886 Phase 2 slice 70/N: retire `print()` in `src/export/sites_by_ap_model_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 9 `print()` calls in

--- a/src/gateway/gateway_stats_exporter.py
+++ b/src/gateway/gateway_stats_exporter.py
@@ -365,7 +365,8 @@ class GatewayStatsExporter:  # WHY: namespace class kept for legacy call-sites i
             return gateway_data
         except Exception as exception:  # pylint: disable=broad-exception-caught  # WHY: preserve legacy message.
             logging.error("! Failed to load %s: %s", stats_file, exception)
-            print(f"! Failed to load {stats_file}: {exception}")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("! Failed to load %s: %s", stats_file, exception)
             return None
 
     @staticmethod
@@ -448,25 +449,44 @@ class GatewayStatsExporter:  # WHY: namespace class kept for legacy call-sites i
         """Persist and display WAN conflict analysis results."""
         if not conflicts_found:  # WHY: guard clause — nothing to export or display.
             logging.info(" No internal WAN port IP conflicts found")
-            print(" No internal WAN port IP conflicts found - healthy WAN port configurations")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(" No internal WAN port IP conflicts found - healthy WAN port configurations")
             return
         conflicts_found.sort(key=lambda x: (x.get("device_name", ""), x.get("port_name", "")))  # WHY: stable.
         DataExporter.write_with_format_selection(conflicts_found, CONFLICTS_CSV_FILENAME)  # WHY: persist rows.
         unique_gateways = {row.get("device_name", UNKNOWN_LABEL) for row in conflicts_found}  # WHY: dedupe.
         logging.info("! Exported %s conflicts from %s gateways", len(conflicts_found), len(unique_gateways))
-        print(f"! WAN port IP conflicts exported to {CONFLICTS_CSV_FILENAME} ({len(conflicts_found)} records)")
-        print(f"! Summary: {len(unique_gateways)} gateways with IP conflicts")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info(
+            "! WAN port IP conflicts exported to %s (%s records)",
+            CONFLICTS_CSV_FILENAME,
+            len(conflicts_found),
+        )
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("! Summary: %s gateways with IP conflicts", len(unique_gateways))
         GatewayStatsExporter._display_conflict_samples(conflicts_found)  # WHY: emit operator-facing sample.
 
     @staticmethod
     def _display_conflict_samples(conflicts_found: list[dict]) -> None:
         """Print a short conflict sample section for quick operator review."""
-        print("\n  Sample WAN Port IP Conflicts Found:")  # WHY: legacy banner preserved verbatim.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logging.info("\n  Sample WAN Port IP Conflicts Found:")
         for idx, record in enumerate(conflicts_found[:SAMPLE_CONFLICT_LIMIT], 1):  # WHY: top-N sample only.
-            print(
-                f"{idx:2d}. {record.get('device_name', UNKNOWN_LABEL)} ({record.get('site_name', UNKNOWN_SITE_NAME)})"
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(
+                "%2d. %s (%s)",
+                idx,
+                record.get("device_name", UNKNOWN_LABEL),
+                record.get("site_name", UNKNOWN_SITE_NAME),
             )
-            print(f"    Port {record.get('port_name', UNKNOWN_LABEL)} has IP {record.get('port_ip', UNKNOWN_LABEL)}")
-            print(f"    Conflicts with: {record.get('conflict_with_ports', UNKNOWN_LABEL)}\n")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info(
+                "    Port %s has IP %s",
+                record.get("port_name", UNKNOWN_LABEL),
+                record.get("port_ip", UNKNOWN_LABEL),
+            )
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("    Conflicts with: %s\n", record.get("conflict_with_ports", UNKNOWN_LABEL))
         if len(conflicts_found) > SAMPLE_CONFLICT_LIMIT:  # WHY: only emit trailer when truncation happened.
-            print(f"... and {len(conflicts_found) - SAMPLE_CONFLICT_LIMIT} more conflicted ports")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logging.info("... and %s more conflicted ports", len(conflicts_found) - SAMPLE_CONFLICT_LIMIT)

--- a/tests/unit/gateway/test_gateway_stats_exporter.py
+++ b/tests/unit/gateway/test_gateway_stats_exporter.py
@@ -292,23 +292,24 @@ def test_export_stats_populated_writes_csv() -> None:
     module.DataExporter.write_with_format_selection.assert_called_once_with(stats, STATS_CSV_FILENAME)
 
 
-def test_export_conflict_results_empty_short_circuits(capsys: pytest.CaptureFixture[str]) -> None:
-    """Empty conflict list should print healthy banner and skip persistence."""
+def test_export_conflict_results_empty_short_circuits(caplog: pytest.LogCaptureFixture) -> None:
+    """Empty conflict list should log healthy banner and skip persistence."""
     _configure_dependencies()
 
     module.DataExporter.write_with_format_selection = MagicMock()
 
-    GatewayStatsExporter._export_conflict_results([])
+    with caplog.at_level(logging.INFO):
+        GatewayStatsExporter._export_conflict_results([])
 
     module.DataExporter.write_with_format_selection.assert_not_called()
-    captured = capsys.readouterr()
-    assert "healthy WAN port configurations" in captured.out
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("healthy WAN port configurations" in message for message in messages)
 
 
 def test_export_conflict_results_populated_writes_and_prints(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Populated conflicts should sort, write CSV, print summary + sample."""
+    """Populated conflicts should sort, write CSV, log summary + sample."""
     _configure_dependencies()
 
     module.DataExporter.write_with_format_selection = MagicMock()
@@ -330,21 +331,22 @@ def test_export_conflict_results_populated_writes_and_prints(
         },
     ]
 
-    GatewayStatsExporter._export_conflict_results(conflicts)
+    with caplog.at_level(logging.INFO):
+        GatewayStatsExporter._export_conflict_results(conflicts)
 
     module.DataExporter.write_with_format_selection.assert_called_once()
-    captured = capsys.readouterr()
-    assert "1 gateways with IP conflicts" in captured.out
-    assert "Sample WAN Port IP Conflicts" in captured.out
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("1 gateways with IP conflicts" in message for message in messages)
+    assert any("Sample WAN Port IP Conflicts" in message for message in messages)
 
 
 # -------------------------- _display_conflict_samples truncation --------------------------
 
 
 def test_display_conflict_samples_short_list_no_trailer(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Fewer than SAMPLE_CONFLICT_LIMIT items should not print trailing 'and N more'."""
+    """Fewer than SAMPLE_CONFLICT_LIMIT items should not log trailing 'and N more'."""
     _configure_dependencies()
 
     conflicts = [
@@ -352,14 +354,15 @@ def test_display_conflict_samples_short_list_no_trailer(
         for idx in range(3)
     ]
 
-    GatewayStatsExporter._display_conflict_samples(conflicts)
+    with caplog.at_level(logging.INFO):
+        GatewayStatsExporter._display_conflict_samples(conflicts)
 
-    captured = capsys.readouterr()
-    assert "more conflicted ports" not in captured.out
+    messages = [record.getMessage() for record in caplog.records]
+    assert not any("more conflicted ports" in message for message in messages)
 
 
 def test_display_conflict_samples_long_list_emits_trailer(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Lists exceeding SAMPLE_CONFLICT_LIMIT should emit trailer with remaining count."""
     _configure_dependencies()
@@ -370,10 +373,11 @@ def test_display_conflict_samples_long_list_emits_trailer(
         for idx in range(total)
     ]
 
-    GatewayStatsExporter._display_conflict_samples(conflicts)
+    with caplog.at_level(logging.INFO):
+        GatewayStatsExporter._display_conflict_samples(conflicts)
 
-    captured = capsys.readouterr()
-    assert f"and {total - SAMPLE_CONFLICT_LIMIT} more conflicted ports" in captured.out
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(f"and {total - SAMPLE_CONFLICT_LIMIT} more conflicted ports" in message for message in messages)
 
 
 # -------------------------- _analyze_device_ip_conflicts + _analyze_all_gateway_conflicts --------------------------
@@ -456,19 +460,20 @@ def test_load_gateway_stats_reads_csv_rows(tmp_path: Path) -> None:
 
 
 def test_load_gateway_stats_returns_none_on_failure(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Missing/unreadable file should return None and print an error banner."""
+    """Missing/unreadable file should return None and log an error banner."""
     _configure_dependencies()
 
     module.FilePathUtils = SimpleNamespace(get_csv_path=MagicMock(return_value="/no/such/path/nowhere.csv"))
     module.CacheUtils = SimpleNamespace(check_and_generate_csv=MagicMock(return_value=False))
 
-    result = GatewayStatsExporter._load_gateway_stats_for_conflicts()
+    with caplog.at_level(logging.INFO):
+        result = GatewayStatsExporter._load_gateway_stats_for_conflicts()
 
     assert result is None
-    captured = capsys.readouterr()
-    assert "Failed to load" in captured.out
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("Failed to load" in message for message in messages)
 
 
 # -------------------------- _fetch_one_device_stats retry loop --------------------------


### PR DESCRIPTION
Part of #886. Replaces the 9 remaining `print()` calls in `src/gateway/gateway_stats_exporter.py` with `logging.info(...)` using %-style deferred formatting (G004-safe). Migrates the 5 corresponding `capsys` tests in `tests/unit/gateway/test_gateway_stats_exporter.py` to `caplog`. 32/32 tests pass; ruff T20 clean; ruff full clean; black clean.