### PR TITLE
chore(logging): migrate src/ssh/config/env_loader.py print() to logger (#886 slice 72/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 72/N: retire `print()` in `src/ssh/config/env_loader.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 9 `print()` calls in
+  `src/ssh/config/env_loader.py` with `logger.warning(...)` using `%`-style
+  deferred formatting to satisfy G004. The module already exposes a
+  module-scoped `logger = logging.getLogger(__name__)`, so all operator
+  notices (invalid path, cannot access, too large, dotenv exception, encoding
+  error, generic read error, OS read error, too many lines, invalid username)
+  route through the existing logger. Each migrated call carries the standard
+  `# WHY: preserve operator notice verbatim; route through logger for
+  capture/redirection.` annotation and preserves the legacy `[WARNING]` prefix
+  verbatim in the message string.
+- **Test migration (Changed)**: migrated 8 tests in
+  `tests/unit/ssh/config/test_env_loader_wave9.py` from `capsys` to `caplog`
+  using `caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")`
+  and `any(SUBSTR in r.getMessage() for r in caplog.records)` assertions.
+  30/30 tests pass; ruff T20 clean; ruff full clean; black clean.
+
 ### #886 Phase 2 slice 71/N: retire `print()` in `src/gateway/gateway_stats_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 9 `print()` calls in

--- a/src/ssh/config/env_loader.py
+++ b/src/ssh/config/env_loader.py
@@ -87,7 +87,8 @@ class EnvSshConfigLoader:
     def _is_safe_env_path(env_file: str) -> bool:
         """Reject path-traversal or absolute paths up front."""
         if not env_file or ".." in env_file or env_file.startswith("/") or "\\" in env_file:
-            print(f"[WARNING] Invalid .env file path: {env_file}")  # Preserve user-facing string verbatim
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("[WARNING] Invalid .env file path: %s", env_file)
             return False  # Path is unsafe
         return True  # Path looks acceptable
 
@@ -97,10 +98,12 @@ class EnvSshConfigLoader:
         try:
             file_size = os.path.getsize(env_file)  # Single stat call
         except OSError as error:  # Permission denied / vanished etc.
-            print(f"[WARNING] Cannot access .env file: {error}")  # Preserve user-facing string verbatim
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("[WARNING] Cannot access .env file: %s", error)
             return False  # Treat as unloadable
         if file_size > _MAX_ENV_BYTES:  # 1MB defensive cap
-            print(f"[WARNING] .env file too large ({file_size} bytes), skipping")  # Preserve user-facing string
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("[WARNING] .env file too large (%s bytes), skipping", file_size)
             return False  # Refuse oversized files
         return True  # Within limits
 
@@ -117,7 +120,8 @@ class EnvSshConfigLoader:
             if ssh_commands:  # Only parse when present
                 config["commands"] = self._command_parser.parse(ssh_commands)  # Validated command list
         except Exception as error:  # noqa: BLE001 - mirror original broad catch
-            print(f"[WARNING] Error loading .env with python-dotenv: {error}")  # Preserve user-facing string
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("[WARNING] Error loading .env with python-dotenv: %s", error)
 
     def _populate_via_manual_parse(self, env_file: str, config: dict[str, Any]) -> None:
         """Populate ``config`` with a defensive manual line-by-line parser."""
@@ -125,18 +129,22 @@ class EnvSshConfigLoader:
             with open(env_file, encoding="utf-8", errors="ignore") as file_handle:  # Tolerate decode errors
                 self._read_and_apply_lines(file_handle, config)  # Delegated read+cap+dispatch loop
         except UnicodeDecodeError as error:  # Should be rare due to errors="ignore" but kept for parity
-            print(f"[WARNING] .env file encoding error: {error}")  # Preserve user-facing string
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("[WARNING] .env file encoding error: %s", error)
         except OSError as error:  # Filesystem-level errors
-            print(f"[WARNING] Error reading {env_file}: {error}")  # Preserve user-facing string
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("[WARNING] Error reading %s: %s", env_file, error)
         except Exception as error:  # noqa: BLE001 - mirror original broad catch
-            print(f"[WARNING] Unexpected error reading {env_file}: {error}")  # Preserve user-facing string
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("[WARNING] Unexpected error reading %s: %s", env_file, error)
 
     def _read_and_apply_lines(self, file_handle: Any, config: dict[str, Any]) -> None:
         """Iterate the file handle, cap runaway files, and apply each line to ``config``."""
         # WHY: extracting the loop drops _populate_via_manual_parse CC from 6 to 4.
         for line_count, raw_line in enumerate(file_handle, 1):  # 1-based for the cap comparison
             if line_count > _MAX_MANUAL_LINES:  # Stop runaway files defensively
-                print("[WARNING] .env file has too many lines, stopping at 1000")  # Preserve user-facing string
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("[WARNING] .env file has too many lines, stopping at 1000")
                 return  # Exit early once the cap is exceeded
             self._apply_env_line(raw_line, config)  # Delegated single-line handler
 
@@ -183,4 +191,5 @@ class EnvSshConfigLoader:
         if validate_username(username):  # Shared validation
             config["username"] = username  # Accept the username
             return  # Done
-        print(f"[WARNING] Invalid username format in .env file: {username}")  # Preserve user-facing string
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("[WARNING] Invalid username format in .env file: %s", username)

--- a/tests/unit/ssh/config/test_env_loader_wave9.py
+++ b/tests/unit/ssh/config/test_env_loader_wave9.py
@@ -57,8 +57,9 @@ class TestLoadPathGuards:
         config = EnvSshConfigLoader().load("nope.env")  # WHY: file does not exist
         assert config == _empty_config()  # WHY: early return before any parse
 
-    def test_size_getsize_raises_oserror(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_size_getsize_raises_oserror(self, tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: OSError from getsize is caught by _is_within_size_limit and returns False
+        caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")
         monkeypatch.chdir(tmp_path)  # WHY: isolate cwd
         env_path = tmp_path / "test.env"  # WHY: create file so exists() passes
         env_path.write_text("SSH_HOST=1.1.1.1\n", encoding="utf-8")  # WHY: real content is irrelevant here
@@ -72,16 +73,19 @@ class TestLoadPathGuards:
         monkeypatch.setattr(_os_mod.path, "getsize", _boom)  # WHY: force the OSError path
         config = EnvSshConfigLoader().load("test.env")  # WHY: exercise size guard exception branch
         assert config == _empty_config()  # WHY: unloadable file yields sentinel
-        assert "Cannot access .env file" in capsys.readouterr().out  # WHY: user-facing warning surfaced
+        assert any("Cannot access .env file" in r.getMessage() for r in caplog.records)  # WHY: warning surfaced
 
-    def test_oversized_file_rejected_prints_warning(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_oversized_file_rejected_prints_warning(
+        self, tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
         # WHY: files above _MAX_ENV_BYTES trip the size cap branch
+        caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")
         monkeypatch.chdir(tmp_path)  # WHY: isolate cwd
         env_path = tmp_path / "big.env"  # WHY: create an oversized file
         env_path.write_bytes(b"X" * (env_loader_module._MAX_ENV_BYTES + 1))  # WHY: > cap by 1 byte
         config = EnvSshConfigLoader().load("big.env")  # WHY: exercise size cap
         assert config == _empty_config()  # WHY: oversized files return sentinel
-        assert "too large" in capsys.readouterr().out  # WHY: user-facing warning surfaced
+        assert any("too large" in r.getMessage() for r in caplog.records)  # WHY: warning surfaced
 
 
 class TestManualParser:
@@ -155,17 +159,21 @@ class TestManualParser:
         config = EnvSshConfigLoader().load("test.env")  # WHY: exercise single-quote strip
         assert config["password"] == "secret"  # WHY: quotes removed
 
-    def test_invalid_username_rejected_with_warning(self, tmp_path, monkeypatch, capsys) -> None:
-        # WHY: invalid usernames hit the "print WARNING" branch of _set_username
+    def test_invalid_username_rejected_with_warning(
+        self, tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # WHY: invalid usernames hit the "warning log" branch of _set_username
+        caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")
         monkeypatch.chdir(tmp_path)  # WHY: isolate cwd
         env_path = tmp_path / "test.env"  # WHY: fixture file
         env_path.write_text("SSH_USER=; rm -rf /\n", encoding="utf-8")  # WHY: dangerous chars fail validation
         config = EnvSshConfigLoader().load("test.env")  # WHY: exercise invalid-username branch
         assert config["username"] is None  # WHY: invalid username left as sentinel
-        assert "Invalid username format" in capsys.readouterr().out  # WHY: warning surfaced to user
+        assert any("Invalid username format" in r.getMessage() for r in caplog.records)  # WHY: warning surfaced
 
-    def test_line_cap_stops_at_limit(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_line_cap_stops_at_limit(self, tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: > _MAX_MANUAL_LINES trips the runaway-file guard
+        caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")
         monkeypatch.chdir(tmp_path)  # WHY: isolate cwd
         monkeypatch.setattr(env_loader_module, "_MAX_MANUAL_LINES", 3)  # WHY: lower cap so test stays fast
         env_path = tmp_path / "test.env"  # WHY: fixture file
@@ -173,12 +181,13 @@ class TestManualParser:
             "# c1\n# c2\n# c3\nSSH_HOST=1.1.1.1\nSSH_USER=admin\n", encoding="utf-8"
         )
         config = EnvSshConfigLoader().load("test.env")  # WHY: exercise line-cap branch
-        assert "too many lines" in capsys.readouterr().out  # WHY: user-facing warning surfaced
+        assert any("too many lines" in r.getMessage() for r in caplog.records)  # WHY: warning surfaced
         # WHY: SSH_USER is on line 5 (beyond the cap) so it must not be applied
         assert config["username"] is None
 
-    def test_read_raises_unicode_decode_error(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_read_raises_unicode_decode_error(self, tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: UnicodeDecodeError path in _populate_via_manual_parse is exercised via monkeypatched open
+        caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")
         monkeypatch.chdir(tmp_path)  # WHY: isolate cwd
         env_path = tmp_path / "test.env"  # WHY: real file so size/exists checks pass
         env_path.write_text("SSH_USER=admin\n", encoding="utf-8")  # WHY: content irrelevant
@@ -190,10 +199,11 @@ class TestManualParser:
         monkeypatch.setattr(env_loader_module, "open", _bad_open, raising=False)  # WHY: shadow module open
         config = EnvSshConfigLoader().load("test.env")  # WHY: exercise decode-error branch
         assert config == _empty_config()  # WHY: parser gave up cleanly
-        assert "encoding error" in capsys.readouterr().out  # WHY: warning surfaced
+        assert any("encoding error" in r.getMessage() for r in caplog.records)  # WHY: warning surfaced
 
-    def test_read_raises_oserror(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_read_raises_oserror(self, tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: OSError path (permission denied, disk gone) in _populate_via_manual_parse
+        caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")
         monkeypatch.chdir(tmp_path)  # WHY: isolate cwd
         env_path = tmp_path / "test.env"  # WHY: real file so guards pass
         env_path.write_text("SSH_USER=admin\n", encoding="utf-8")  # WHY: content irrelevant
@@ -205,10 +215,11 @@ class TestManualParser:
         monkeypatch.setattr(env_loader_module, "open", _bad_open, raising=False)  # WHY: shadow module open
         config = EnvSshConfigLoader().load("test.env")  # WHY: exercise OSError branch
         assert config == _empty_config()  # WHY: sentinel returned
-        assert "Error reading" in capsys.readouterr().out  # WHY: warning surfaced
+        assert any("Error reading" in r.getMessage() for r in caplog.records)  # WHY: warning surfaced
 
-    def test_read_raises_generic_exception(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_read_raises_generic_exception(self, tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: broad except Exception guard in _populate_via_manual_parse
+        caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")
         monkeypatch.chdir(tmp_path)  # WHY: isolate cwd
         env_path = tmp_path / "test.env"  # WHY: real file so guards pass
         env_path.write_text("SSH_USER=admin\n", encoding="utf-8")  # WHY: content irrelevant
@@ -220,14 +231,15 @@ class TestManualParser:
         monkeypatch.setattr(env_loader_module, "open", _bad_open, raising=False)  # WHY: shadow module open
         config = EnvSshConfigLoader().load("test.env")  # WHY: exercise broad-except branch
         assert config == _empty_config()  # WHY: sentinel returned
-        assert "Unexpected error" in capsys.readouterr().out  # WHY: warning surfaced
+        assert any("Unexpected error" in r.getMessage() for r in caplog.records)  # WHY: warning surfaced
 
 
 class TestDotenvPath:
     """Cover the ``_populate_via_dotenv`` broad exception guard."""
 
-    def test_dotenv_exception_prints_warning(self, tmp_path, monkeypatch, capsys) -> None:
+    def test_dotenv_exception_prints_warning(self, tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture) -> None:
         # WHY: force dotenv path AND make it raise to hit the except-Exception guard
+        caplog.set_level(logging.WARNING, logger="src.ssh.config.env_loader")
         monkeypatch.chdir(tmp_path)  # WHY: isolate cwd
         env_path = tmp_path / "test.env"  # WHY: real file so exists / size checks pass
         env_path.write_text("SSH_USER=admin\n", encoding="utf-8")  # WHY: content irrelevant
@@ -240,7 +252,7 @@ class TestDotenvPath:
         monkeypatch.setattr(env_loader_module, "load_dotenv", _boom)  # WHY: patch parser to raise
         config = EnvSshConfigLoader().load("test.env")  # WHY: exercise dotenv exception branch
         assert config == _empty_config()  # WHY: parser gave up before setting anything
-        assert "python-dotenv" in capsys.readouterr().out  # WHY: warning surfaced
+        assert any("python-dotenv" in r.getMessage() for r in caplog.records)  # WHY: warning surfaced
 
 
 class TestUnquoteValueDirect:


### PR DESCRIPTION
## Summary
- Migrate 9 `print()` calls in `src/ssh/config/env_loader.py` to `logger.warning(...)` with %-style deferred formatting (G004 friendly)
- Module already had `logger = logging.getLogger(__name__)`; no new imports needed
- Preserve verbatim `[WARNING]` prefix on operator notices so capture/redirection remains identical
- Migrate 8 tests in `tests/unit/ssh/config/test_env_loader_wave9.py` from `capsys` to `caplog` scoped to `src.ssh.config.env_loader` logger

## Test plan
- [x] `ruff check --select T20 src/ssh/config/env_loader.py` — clean
- [x] `ruff check src/ssh/config/env_loader.py tests/unit/ssh/config/test_env_loader_wave9.py` — clean
- [x] `black --check` — clean
- [x] `pytest tests/unit/ssh/config/test_env_loader_wave9.py` — 30/30 pass

Refs #886