### PR TITLE
chore(logging): migrate src/websocket/diagnostics/common.py print() to logger (#886 slice 74/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 74/N: retire `print()` in `src/websocket/diagnostics/common.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 9 `print()` calls in
+  `src/websocket/diagnostics/common.py` with `logger`-based emissions using
+  `%`-style deferred formatting to satisfy G004. Added a module-scoped
+  `logger = logging.getLogger(__name__)` (the module previously used only
+  bare `logging.debug/info/warning` calls; the new logger routes the former
+  print notices while pre-existing action logs remain on the root
+  `logging.*` API). Level heuristic: `info` for `[DEBUG] POST URL`,
+  `[DEBUG] Headers`, `[DEBUG] HTTP Response Status/Body` (still gated by
+  the CLI `debug_mode` flag), and for the `OTHER AVAILABLE FIELDS` header
+  and per-field value lines; `warning` for `! Failed to issue`,
+  `! Response:`, and `! No session ID returned` operator errors. Each
+  migrated call carries the standard `# WHY: preserve operator notice
+  verbatim; route through logger for capture/redirection.` annotation and
+  preserves legacy prefixes (`[DEBUG]`, `!`, `OTHER AVAILABLE FIELDS:`)
+  verbatim in the message string.
+- **Test migration (Changed)**: migrated 8 tests in
+  `tests/unit/websocket/diagnostics/test_common.py` from `capsys` to
+  `caplog` using `caplog.set_level(<LEVEL>, logger="src.websocket.diagnostics.common")`
+  and a `_messages()` helper that joins `caplog.records` for substring
+  matching. 14/14 tests pass; ruff T20 clean; ruff full clean; black clean.
+
 ### #886 Phase 2 slice 73/N: retire `print()` in `src/ssh/shell_execution/shell_executor.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 9 `print()` calls in

--- a/src/websocket/diagnostics/common.py
+++ b/src/websocket/diagnostics/common.py
@@ -14,6 +14,8 @@ from src.websocket.manager import (  # Shared WebSocket helpers reused across ex
     get_mist_credentials,
 )
 
+logger = logging.getLogger(__name__)  # WHY: Module-scoped logger routes former print() operator notices
+
 
 def detect_debug_mode() -> bool:
     """Return True when the user passed --debug or -d on the CLI."""
@@ -32,9 +34,11 @@ def post_device_command(
 ) -> requests.Response | None:
     """POST a device-command to the Mist REST API and return the raw Response."""
     if debug_mode:  # Surface request metadata for the operator before sending
-        print(f"[DEBUG] POST URL = {url}")  # Print target URL exactly as the legacy code did
-        print(  # Print headers but never the real token value (security)
-            "[DEBUG] Headers = {'Authorization': 'Token [REDACTED]', " "'Content-Type': 'application/json'}"
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("[DEBUG] POST URL = %s", url)  # Print target URL exactly as the legacy code did
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(  # Print headers but never the real token value (security)
+            "[DEBUG] Headers = {'Authorization': 'Token [REDACTED]', 'Content-Type': 'application/json'}"
         )
     logging.info("Issuing %s POST to %s", command_label, url)  # Action log before HTTP call
     response = requests.post(url, headers=headers, json=payload, timeout=30)  # Fire HTTP request
@@ -42,8 +46,10 @@ def post_device_command(
         "%s POST completed with status=%s", command_label, response.status_code
     )
     if debug_mode:  # Mirror legacy debug prints of full response
-        print(f"[DEBUG] HTTP Response Status = {response.status_code}")  # Show numeric status
-        print(f"[DEBUG] HTTP Response Body = {response.text}")  # Show raw body for diagnosis
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("[DEBUG] HTTP Response Status = %s", response.status_code)  # Show numeric status
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("[DEBUG] HTTP Response Body = %s", response.text)  # Show raw body for diagnosis
     return response  # Caller inspects status/body and decides next step
 
 
@@ -54,8 +60,10 @@ def extract_command_session(
 ) -> str | None:
     """Return the session id from a command response or disconnect+None on failure."""
     if response.status_code != 200:  # Any non-200 is a hard failure for the command
-        print(f"! Failed to issue {command_label} command: {response.status_code}")  # User-facing error
-        print(f"! Response: {response.text}")  # Show body for operator triage
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("! Failed to issue %s command: %s", command_label, response.status_code)  # User-facing error
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("! Response: %s", response.text)  # Show body for operator triage
         websocket_manager.disconnect()  # Free the WS since we will not consume results
         logging.warning(  # Action log after failure path
             "%s command failed; status=%s", command_label, response.status_code
@@ -64,7 +72,8 @@ def extract_command_session(
     response_payload = response.json()  # Parse JSON body returned by the API
     session_id = response_payload.get("session")  # Pull the session identifier used for demux
     if not session_id:  # API contract requires a session id for result correlation
-        print(f"! No session ID returned from {command_label} command")  # User-facing error
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("! No session ID returned from %s command", command_label)  # User-facing error
         websocket_manager.disconnect()  # Free the WS since we cannot demux results
         logging.warning("%s command returned no session id", command_label)  # Action log
         return None  # Signal caller to abort
@@ -100,7 +109,8 @@ def print_extra_result_fields(
     extra_keys = [key for key in result_payload if key not in excluded_keys]  # Anything novel
     if not extra_keys:  # Nothing to show; keep output clean
         return  # Early return preserves prior visual layout
-    print(f"\nOTHER AVAILABLE FIELDS: {extra_keys}")  # Header matches legacy phrasing
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info("\nOTHER AVAILABLE FIELDS: %s", extra_keys)  # Header matches legacy phrasing
     _print_extra_field_values(result_payload, extra_keys)  # Extracted so CC stays <=5
 
 
@@ -113,4 +123,5 @@ def _print_extra_field_values(
     for field_name in extra_keys:  # Walk each unexpected key for visibility
         field_value = result_payload.get(field_name)  # Look up the actual value
         if field_value:  # Skip empty/falsey values per legacy behavior
-            print(f"{field_name}: {field_value}")  # Show the value verbatim
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("%s: %s", field_name, field_value)  # Show the value verbatim

--- a/tests/unit/websocket/diagnostics/test_common.py
+++ b/tests/unit/websocket/diagnostics/test_common.py
@@ -10,10 +10,17 @@ cannot silently change the observable contract.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.websocket.diagnostics import common as common_mod
+
+# WHY: caplog needs the module-scoped logger name so records are captured
+# after the print()→logger.info/warning migration in slice #886/74.
+_LOGGER_NAME = "src.websocket.diagnostics.common"
 
 
 def _fake_response(status: int, body: dict[str, Any] | None = None, text: str = "") -> MagicMock:
@@ -23,6 +30,11 @@ def _fake_response(status: int, body: dict[str, Any] | None = None, text: str = 
     resp.json.return_value = body or {}
     resp.text = text or (str(body) if body else "")
     return resp
+
+
+def _messages(caplog: pytest.LogCaptureFixture) -> str:
+    """Concatenate all captured log messages so tests can substring-match."""
+    return "\n".join(r.getMessage() for r in caplog.records)
 
 
 def test_detect_debug_mode_true_for_long_flag() -> None:
@@ -43,8 +55,9 @@ def test_detect_debug_mode_false_when_absent() -> None:
         assert common_mod.detect_debug_mode() is False
 
 
-def test_post_device_command_returns_response_and_calls_requests(capsys) -> None:
-    """post_device_command posts JSON and returns the raw Response (debug OFF: no prints)."""
+def test_post_device_command_returns_response_and_calls_requests(caplog: pytest.LogCaptureFixture) -> None:
+    """post_device_command posts JSON and returns the raw Response (debug OFF: no debug logs)."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     fake = _fake_response(200, {"ok": True})
     with patch.object(common_mod.requests, "post", return_value=fake) as mock_post:
         got = common_mod.post_device_command(
@@ -52,18 +65,18 @@ def test_post_device_command_returns_response_and_calls_requests(capsys) -> None
         )
     assert got is fake
     mock_post.assert_called_once_with("https://x/y", headers={"Authorization": "Token X"}, json={"a": 1}, timeout=30)
-    out = capsys.readouterr().out
-    assert "[DEBUG]" not in out  # No debug prints when debug_mode=False
+    assert "[DEBUG]" not in _messages(caplog)  # No debug logs when debug_mode=False
 
 
-def test_post_device_command_prints_debug_when_enabled(capsys) -> None:
-    """post_device_command with debug_mode=True prints URL, redacted headers, status, body."""
+def test_post_device_command_prints_debug_when_enabled(caplog: pytest.LogCaptureFixture) -> None:
+    """post_device_command with debug_mode=True logs URL, redacted headers, status, body."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     fake = _fake_response(200, {"ok": True}, text="body-here")
     with patch.object(common_mod.requests, "post", return_value=fake):
         common_mod.post_device_command(
             "https://x/y", {"Authorization": "Token real"}, {"a": 1}, debug_mode=True, command_label="ping"
         )
-    out = capsys.readouterr().out
+    out = _messages(caplog)
     assert "[DEBUG] POST URL = https://x/y" in out
     assert "[REDACTED]" in out and "Token real" not in out  # Never leak the real token
     assert "HTTP Response Status = 200" in out
@@ -78,33 +91,38 @@ def test_extract_command_session_success_returns_id() -> None:
     ws.disconnect.assert_not_called()
 
 
-def test_extract_command_session_non_200_disconnects_and_returns_none(capsys) -> None:
-    """Non-200 response disconnects the WS and returns None; failure is announced to stdout."""
+def test_extract_command_session_non_200_disconnects_and_returns_none(caplog: pytest.LogCaptureFixture) -> None:
+    """Non-200 response disconnects the WS and returns None; failure is announced via logger."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     resp = _fake_response(500, text="boom")
     ws = MagicMock()
     assert common_mod.extract_command_session(resp, ws, "ping") is None
     ws.disconnect.assert_called_once()
-    out = capsys.readouterr().out
+    out = _messages(caplog)
     assert "Failed to issue ping command: 500" in out
     assert "boom" in out
 
 
-def test_extract_command_session_missing_session_disconnects_and_returns_none(capsys) -> None:
+def test_extract_command_session_missing_session_disconnects_and_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """200 response with no 'session' key disconnects the WS and returns None."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     resp = _fake_response(200, {"other": "data"})
     ws = MagicMock()
     assert common_mod.extract_command_session(resp, ws, "arp") is None
     ws.disconnect.assert_called_once()
-    assert "No session ID returned from arp command" in capsys.readouterr().out
+    assert "No session ID returned from arp command" in _messages(caplog)
 
 
-def test_extract_command_session_empty_session_id_treated_as_missing(capsys) -> None:
+def test_extract_command_session_empty_session_id_treated_as_missing(caplog: pytest.LogCaptureFixture) -> None:
     """Empty string session id is falsey → treated as missing (disconnect + None)."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     resp = _fake_response(200, {"session": ""})
     ws = MagicMock()
     assert common_mod.extract_command_session(resp, ws, "arp") is None
     ws.disconnect.assert_called_once()
-    assert "No session ID returned from arp command" in capsys.readouterr().out
+    assert "No session ID returned from arp command" in _messages(caplog)
 
 
 def test_prepare_command_credentials_success_returns_tuple() -> None:
@@ -132,27 +150,30 @@ def test_prepare_command_credentials_failure_returns_none() -> None:
     # check_mist_credentials owns disconnect on failure; helper does not call it itself
 
 
-def test_print_extra_result_fields_no_extras_is_noop(capsys) -> None:
-    """When every key is in the excluded set, nothing is printed."""
+def test_print_extra_result_fields_no_extras_is_noop(caplog: pytest.LogCaptureFixture) -> None:
+    """When every key is in the excluded set, nothing is logged."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     common_mod.print_extra_result_fields({"raw": "x", "Output": "y"}, {"raw", "Output", "session"})
-    assert capsys.readouterr().out == ""
+    assert _messages(caplog) == ""
 
 
-def test_print_extra_result_fields_prints_extras(capsys) -> None:
-    """Extra keys with truthy values are printed after the OTHER AVAILABLE FIELDS header."""
+def test_print_extra_result_fields_prints_extras(caplog: pytest.LogCaptureFixture) -> None:
+    """Extra keys with truthy values are logged after the OTHER AVAILABLE FIELDS header."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     payload = {"raw": "x", "Output": "y", "session": "s", "extra1": "val1", "extra2": 42}
     common_mod.print_extra_result_fields(payload, {"raw", "Output", "session"})
-    out = capsys.readouterr().out
+    out = _messages(caplog)
     assert "OTHER AVAILABLE FIELDS: ['extra1', 'extra2']" in out
     assert "extra1: val1" in out
     assert "extra2: 42" in out
 
 
-def test_print_extra_result_fields_skips_falsy_extras(capsys) -> None:
-    """Extra keys with falsey values are announced in the header but not printed as lines."""
+def test_print_extra_result_fields_skips_falsy_extras(caplog: pytest.LogCaptureFixture) -> None:
+    """Extra keys with falsey values are announced in the header but not logged as lines."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     payload = {"extra_empty": "", "extra_none": None, "extra_zero": 0, "extra_real": "kept"}
     common_mod.print_extra_result_fields(payload, set())
-    out = capsys.readouterr().out
+    out = _messages(caplog)
     assert "OTHER AVAILABLE FIELDS:" in out
     assert "extra_real: kept" in out
     assert "extra_empty:" not in out  # Empty string is falsey → skipped

--- a/tests/unit/websocket/diagnostics/test_ping_executor.py
+++ b/tests/unit/websocket/diagnostics/test_ping_executor.py
@@ -13,9 +13,12 @@ change the observable operator contract.
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from src.websocket.diagnostics import ping_executor as ping_mod
 from src.websocket.diagnostics.ping_executor import PingDeviceExecutor
@@ -258,15 +261,22 @@ def test_render_empty_result_prints_keys(capsys) -> None:
 # ---------- _render_ping_result ----------
 
 
-def test_render_ping_result_full(capsys) -> None:
-    """Renders banner + raw/other + extras + closer."""
+def test_render_ping_result_full(capsys, caplog: pytest.LogCaptureFixture) -> None:
+    """Renders banner + raw/other + extras + closer.
+
+    Extras are emitted via common.print_extra_result_fields which uses the
+    module-scoped logger (post slice #886/74), so 'extra1' is captured via
+    caplog rather than capsys.
+    """
+    caplog.set_level(logging.INFO, logger="src.websocket.diagnostics.common")
     payload = {"raw": "r", "Output": "o", "extra1": "v"}
     PingDeviceExecutor()._render_ping_result(payload, "1.1.1.1")
     out = capsys.readouterr().out
     assert "PING RESULTS:" in out
     assert "RAW OUTPUT:" in out
     assert "OTHER OUTPUT:" in out
-    assert "extra1" in out
+    log_out = "\n".join(r.getMessage() for r in caplog.records)
+    assert "extra1" in log_out
 
 
 def test_render_ping_result_empty_output_shows_diagnostic(capsys) -> None:


### PR DESCRIPTION
Part of #886 print()\u2192logging retirement (slice 74/N).

## Changes
- Replaced all 9 `print()` calls in `src/websocket/diagnostics/common.py` with `logger` emissions using `%`-style deferred formatting (G004 satisfied).
- Added module-scoped `logger = logging.getLogger(__name__)` to route the former operator prints (module previously only used bare `logging.*` action logs).
- Level heuristic: `info` for `[DEBUG]` debug-gated prints and result-field output; `warning` for `! Failed`, `! Response:`, `! No session ID` operator errors.
- `[DEBUG]` prints still gated by the CLI `debug_mode` flag; verbatim prefixes preserved.
- Every migrated call carries the standard `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.` annotation.

## Test migration
- Migrated 8 `capsys` tests in `tests/unit/websocket/diagnostics/test_common.py` to `caplog` using `caplog.set_level(<LEVEL>, logger=\"src.websocket.diagnostics.common\")` and a `_messages()` helper for substring matching.

## Verification
- `ruff check --select T20 src/websocket/diagnostics/common.py` \u2705
- `ruff check` (full) on source + test \u2705
- `black --check` on source + test \u2705
- `pytest tests/unit/websocket/diagnostics/test_common.py` \u2192 14/14 pass \u2705