### PR TITLE
chore(logging): migrate src/ssh/batch/multi_host_runner.py print() to logger (#886 slice 76/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 76/N: retire `print()` in `src/ssh/batch/multi_host_runner.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 10 `print()` calls in
+  `src/ssh/batch/multi_host_runner.py` with `logger.info(...)` emissions
+  using `%`-style deferred formatting to satisfy G004. The class already
+  passed a `logger: logging.Logger` parameter into every staticmethod, so
+  no module-scoped logger addition was required — the migration routed all
+  former print notices through the caller-supplied logger. All migrated
+  lines are `info`-level (startup banner `\n>> Starting SSH execution on
+  N hosts (T threads)`, the multi-host execution summary block with
+  `[STATUS] EXECUTION SUMMARY`, `Total hosts:`, `Successful: N [OK]`,
+  `Failed: N [ERROR]`, the `Per-host logs:` hint, the optional
+  `[OK] Successful hosts:` / `[ERROR] Failed hosts:` blocks, and the
+  final `Multi-host execution completed: S/T successful` tally). Each
+  migrated call carries the standard `# WHY: preserve operator notice
+  verbatim; route through logger for capture/redirection.` annotation and
+  preserves legacy prefixes, brackets, and leading `\n` newlines verbatim
+  in the format string.
+- **Dead-code cleanup**: removed the now-unused `_STARTUP_TEMPLATE`
+  module-level constant (it used Python `{count}`/`{threads}` format
+  tokens incompatible with `%`-style logger substitution, and after
+  inlining the format string it had no remaining callers).
+- **No test migration needed**: no dedicated `test_multi_host_runner.py`
+  exists; cross-referencing tests in `tests/unit/ssh/` and
+  `tests/unit/test_ssh_runner.py` do not assert on any of the migrated
+  strings (existing `capsys` fixtures target `HostListParser` /
+  `CommandListParser`, not `MultiHostRunner`). Ruff T20 clean on the
+  target file; black clean; ruff full clean;
+  `pytest tests/unit/ssh/ tests/unit/test_ssh_runner.py` = 359 passed.
+
 ### #886 Phase 2 slice 75/N: retire `print()` in `src/site/address_audit/address_corrector.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 10 `print()` calls in

--- a/src/ssh/batch/multi_host_runner.py
+++ b/src/ssh/batch/multi_host_runner.py
@@ -29,7 +29,6 @@ _DEFAULT_MAX_THREADS = 5  # WHY: historical default fan-out width preserved for 
 _THREAD_NAME_PREFIX = "SSH"  # WHY: named worker threads aid diagnostic traces.
 _REQUIRED_CREDS_MSG = "username and password are required"  # WHY: shared validation message.
 _SUMMARY_DIVIDER = "=" * 60  # WHY: verbatim console divider from the pre-refactor output.
-_STARTUP_TEMPLATE = "\n>> Starting SSH execution on {count} hosts ({threads} threads)"  # WHY: verbatim banner.
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +133,12 @@ class MultiHostRunner:
     @staticmethod
     def _log_startup(request: MultiHostRunRequest, logger: logging.Logger) -> None:
         """Emit the verbatim startup banner + info/debug context lines."""
-        print(_STARTUP_TEMPLATE.format(count=len(request.hosts), threads=request.max_threads))  # WHY: verbatim.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(
+            "\n>> Starting SSH execution on %d hosts (%d threads)",
+            len(request.hosts),
+            request.max_threads,
+        )
         logger.info(  # WHY: high-level info line for operators watching the log stream.
             "Multi-host SSH execution: %d hosts, %d commands, %d threads",
             len(request.hosts),
@@ -314,17 +318,26 @@ class MultiHostRunner:
         logger: logging.Logger,
     ) -> None:
         """Print the multi-host execution summary block (verbatim)."""
-        print(f"\n{_SUMMARY_DIVIDER}")  # WHY: verbatim leading blank + divider.
-        print("[STATUS] EXECUTION SUMMARY")  # WHY: verbatim banner text.
-        print(_SUMMARY_DIVIDER)  # WHY: verbatim trailing divider.
-        print(f"Total hosts: {len(hosts)}")  # WHY: verbatim total-hosts line.
-        print(f"Successful: {len(state.successful_hosts)} [OK]")  # WHY: verbatim success line.
-        print(f"Failed: {len(state.failed_hosts)} [ERROR]")  # WHY: verbatim failure line.
-        print("Per-host logs: per-host-logs/ssh_output_<hostname>_<timestamp>.log")  # WHY: verbatim hint.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\n%s", _SUMMARY_DIVIDER)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("[STATUS] EXECUTION SUMMARY")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("%s", _SUMMARY_DIVIDER)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Total hosts: %d", len(hosts))
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Successful: %d [OK]", len(state.successful_hosts))
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Failed: %d [ERROR]", len(state.failed_hosts))
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Per-host logs: per-host-logs/ssh_output_<hostname>_<timestamp>.log")
         if state.successful_hosts:  # WHY: skip empty success block for cleaner output.
-            print(f"\n[OK] Successful hosts: {', '.join(state.successful_hosts)}")  # WHY: verbatim.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("\n[OK] Successful hosts: %s", ", ".join(state.successful_hosts))
         if state.failed_hosts:  # WHY: skip empty failure block for cleaner output.
-            print(f"\n[ERROR] Failed hosts: {', '.join(state.failed_hosts)}")  # WHY: verbatim.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("\n[ERROR] Failed hosts: %s", ", ".join(state.failed_hosts))
         logger.info(  # WHY: final info line summarizing the run outcome.
             "Multi-host execution completed: %d/%d successful", len(state.successful_hosts), len(hosts)
         )


### PR DESCRIPTION
## Summary
- Retire all 10 `print()` calls in `src/ssh/batch/multi_host_runner.py`; route through the caller-supplied `logger` staticmethod parameter with `%`-style deferred formatting (G004).
- All migrations are `info`-level: startup banner, EXECUTION SUMMARY block, optional Successful/Failed host lines, completion tally. Verbatim `[STATUS]` / `[OK]` / `[ERROR]` markers and leading `\n` newlines preserved in format strings.
- Removed unused `_STARTUP_TEMPLATE` module constant (Python-format tokens incompatible with `%`-style logger substitution; inline format string is cleaner).

## Test plan
- [x] `python -m pytest tests/unit/ssh/ -q` → 191 passed
- [x] `python -m pytest tests/unit/test_ssh_runner.py -q` → 168 passed
- [x] `python -m black --check src/ssh/batch/multi_host_runner.py` → clean
- [x] `python -m ruff check src/ssh/batch/multi_host_runner.py` → All checks passed
- [x] `grep -c "print(" src/ssh/batch/multi_host_runner.py` → 0

Refs #886.