### PR TITLE
chore(logging): migrate src/analytics/data_collection_manager.py print() to logger (#886 slice 40/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 77/N: retire `print()` in `src/analytics/data_collection_manager.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 11 `print()` calls in
+  `src/analytics/data_collection_manager.py` with `logger`-based emissions
+  using `%`-style deferred formatting to satisfy G004. Added a module-scoped
+  `logger = logging.getLogger(__name__)` (the module previously used only
+  bare `logging.info/error` calls; the new logger routes the former print
+  notices for capture/redirection while pre-existing action logs remain on
+  the root `logging.*` API). Level heuristic: `info` for the three-line
+  continuous-loop startup banner (` Starting continuous data collection
+  loop...`, `   This will collect core organizational data every 5
+  seconds`, `   Press CTRL+C to stop or create 'stop_loop.txt' file`), the
+  per-iteration header (`\n  Loop iteration N - TIMESTAMP`), each
+  exporter-step banner (`  Collecting site list...`, etc.), the
+  successful-loop tally (`  Loop N completed successfully`), and the
+  final `  Continuous data collection loop ended.` notice; `warning` for
+  the KeyboardInterrupt notice (`\n  Continuous data collection loop
+  stopped by user.`) and the per-iteration cycle-failure pair (`  Error
+  in loop N: ...`, `  Continuing to next iteration...`); `error` for the
+  fatal continuous-loop failure (`! Fatal error in continuous loop: ...`).
+  Each migrated call carries the standard `# WHY: preserve operator
+  notice verbatim; route through logger for capture/redirection.`
+  annotation and preserves the exact original string (leading `\n`,
+  double-space indentation, `! ` prefix) verbatim in the format string.
+- **Test migration (capsys → caplog)**: migrated six assertions in
+  `tests/unit/analytics/test_data_collection_manager.py` from
+  `capsys.readouterr().out` to `caplog.records` with
+  `caplog.set_level(logging.INFO|WARNING|ERROR,
+  logger="src.analytics.data_collection_manager")`, matching the level of
+  the migrated call under test. All 17 tests in the file pass.
+- **No dead-code cleanup this slice**: no unused helpers or constants were
+  produced by the migration; every migrated string is inlined at its call
+  site. Ruff T20 clean on the target file; black clean; ruff full clean.
+
 ### #886 Phase 2 slice 76/N: retire `print()` in `src/ssh/batch/multi_host_runner.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 10 `print()` calls in

--- a/src/analytics/data_collection_manager.py
+++ b/src/analytics/data_collection_manager.py
@@ -19,6 +19,8 @@ from src.export.org_inventory_exporter import (
     OrgInventoryExporter,  # WHY: 1015 T-06 canonical import (eliminates mh.OrgInventoryExporter).
 )
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger routes former print notices for capture/redirection.
+
 
 class DataCollectionManager:
     """Manages automated data collection and support package generation operations.
@@ -33,9 +35,12 @@ class DataCollectionManager:
     @staticmethod
     def _print_continuous_loop_banner() -> None:  # Print startup banner.
         """Print the startup banner for menu 76's continuous collection loop."""
-        print(" Starting continuous data collection loop...")  # Banner line 1.
-        print("   This will collect core organizational data every 5 seconds")  # Banner line 2.
-        print("   Press CTRL+C to stop or create 'stop_loop.txt' file")  # Banner line 3.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(" Starting continuous data collection loop...")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("   This will collect core organizational data every 5 seconds")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("   Press CTRL+C to stop or create 'stop_loop.txt' file")
 
     @staticmethod
     def continuous_loop() -> None:  # Run the collection loop.
@@ -46,16 +51,20 @@ class DataCollectionManager:
         try:
             while True:  # Loop until stopped.
                 loop_count += 1  # Count the iteration.
-                print(f"\n  Loop iteration {loop_count} - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.info("\n  Loop iteration %d - %s", loop_count, datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
                 if DataCollectionManager._check_stop_signal():  # Stop requested.
                     break  # Exit the loop.
                 DataCollectionManager._execute_collection_cycle(loop_count)  # Run one cycle.
         except KeyboardInterrupt:  # User pressed Ctrl+C.
-            print("\n  Continuous data collection loop stopped by user.")  # Tell the user.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("\n  Continuous data collection loop stopped by user.")
         except Exception as e:  # Unexpected failure.
             logging.error("Fatal error in continuous loop: %s", e)  # Log the error.
-            print(f"! Fatal error in continuous loop: {e}")  # Tell the user.
-        print(" Continuous data collection loop ended.")  # Tell the user ended.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Fatal error in continuous loop: %s", e)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(" Continuous data collection loop ended.")
 
     @staticmethod
     def _check_stop_signal() -> bool:  # Check the stop signal.
@@ -80,16 +89,20 @@ class DataCollectionManager:
         """Execute one cycle of data collection with rate limiting."""
         try:
             for banner, step_callable in DataCollectionManager._collection_cycle_steps():
-                print(banner)  # Tell the user which exporter is running.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.info(banner)
                 step_callable()  # Invoke the per-step exporter.
                 time.sleep(0.75)  # Pace the API between exporters.
-            print(f"  Loop {loop_count} completed successfully")  # Tell the user.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("  Loop %d completed successfully", loop_count)
         except KeyboardInterrupt:  # Propagate Ctrl+C.
             raise  # Re-raise to outer handler
         except Exception as e:  # Cycle failed.
             logging.error("Error in collection cycle %s: %s", loop_count, e)  # Log the error.
-            print(f"  Error in loop {loop_count}: {e}")  # Tell the user.
-            print("  Continuing to next iteration...")  # Tell the user.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("  Error in loop %d: %s", loop_count, e)
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("  Continuing to next iteration...")
             time.sleep(5)  # Back off then retry.
 
     @staticmethod

--- a/tests/unit/analytics/test_data_collection_manager.py
+++ b/tests/unit/analytics/test_data_collection_manager.py
@@ -14,12 +14,16 @@ Covers every static method on ``src.analytics.data_collection_manager``:
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from src.analytics.data_collection_manager import DataCollectionManager
+
+# WHY: caplog must target the module logger so INFO/WARNING/ERROR records surface (issue #886).
+_LOGGER_NAME = "src.analytics.data_collection_manager"
 
 
 def _make_mh(**extra):
@@ -40,10 +44,11 @@ def _make_mh(**extra):
 # ---------- _print_continuous_loop_banner ----------
 
 
-def test_print_continuous_loop_banner_emits_three_lines(capsys: pytest.CaptureFixture[str]) -> None:
-    """Banner prints the three-line startup message."""
+def test_print_continuous_loop_banner_emits_three_lines(caplog: pytest.LogCaptureFixture) -> None:
+    """Banner logs the three-line startup message at INFO."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     DataCollectionManager._print_continuous_loop_banner()
-    out = capsys.readouterr().out
+    out = "\n".join(r.getMessage() for r in caplog.records)
     assert "Starting continuous data collection loop" in out
     assert "every 5 seconds" in out
     assert "stop_loop.txt" in out
@@ -52,36 +57,39 @@ def test_print_continuous_loop_banner_emits_three_lines(capsys: pytest.CaptureFi
 # ---------- continuous_loop ----------
 
 
-def test_continuous_loop_exits_when_stop_signal_set(capsys: pytest.CaptureFixture[str]) -> None:
+def test_continuous_loop_exits_when_stop_signal_set(caplog: pytest.LogCaptureFixture) -> None:
     """First stop-signal check returning True breaks the loop before any cycle runs."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     with (
         patch.object(DataCollectionManager, "_check_stop_signal", return_value=True),
         patch.object(DataCollectionManager, "_execute_collection_cycle") as cycle,
     ):
         DataCollectionManager.continuous_loop()
     cycle.assert_not_called()
-    assert "Continuous data collection loop ended" in capsys.readouterr().out
+    assert any("Continuous data collection loop ended" in r.getMessage() for r in caplog.records)
 
 
-def test_continuous_loop_handles_keyboard_interrupt(capsys: pytest.CaptureFixture[str]) -> None:
+def test_continuous_loop_handles_keyboard_interrupt(caplog: pytest.LogCaptureFixture) -> None:
     """KeyboardInterrupt is caught and reported to the user."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     with (
         patch.object(DataCollectionManager, "_check_stop_signal", return_value=False),
         patch.object(DataCollectionManager, "_execute_collection_cycle", side_effect=KeyboardInterrupt),
     ):
         DataCollectionManager.continuous_loop()
-    out = capsys.readouterr().out
+    out = "\n".join(r.getMessage() for r in caplog.records)
     assert "stopped by user" in out
 
 
-def test_continuous_loop_handles_unexpected_exception(capsys: pytest.CaptureFixture[str]) -> None:
+def test_continuous_loop_handles_unexpected_exception(caplog: pytest.LogCaptureFixture) -> None:
     """A non-KeyboardInterrupt exception is logged + reported and loop ends."""
+    caplog.set_level(logging.ERROR, logger=_LOGGER_NAME)
     with (
         patch.object(DataCollectionManager, "_check_stop_signal", return_value=False),
         patch.object(DataCollectionManager, "_execute_collection_cycle", side_effect=RuntimeError("boom")),
     ):
         DataCollectionManager.continuous_loop()
-    out = capsys.readouterr().out
+    out = "\n".join(r.getMessage() for r in caplog.records)
     assert "Fatal error in continuous loop" in out
     assert "boom" in out
 
@@ -136,8 +144,9 @@ def test_collection_cycle_steps_returns_five_labelled_callables() -> None:
 # ---------- _execute_collection_cycle ----------
 
 
-def test_execute_collection_cycle_runs_all_steps_and_paces(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_collection_cycle_runs_all_steps_and_paces(caplog: pytest.LogCaptureFixture) -> None:
     """Happy path invokes every step and sleeps 0.75s between them."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     step_a, step_b = MagicMock(name="a"), MagicMock(name="b")
     steps = [("  step A", step_a), ("  step B", step_b)]
     with (
@@ -148,7 +157,7 @@ def test_execute_collection_cycle_runs_all_steps_and_paces(capsys: pytest.Captur
     step_a.assert_called_once_with()
     step_b.assert_called_once_with()
     assert sleep.call_args_list == [call(0.75), call(0.75)]
-    assert "Loop 3 completed successfully" in capsys.readouterr().out
+    assert any("Loop 3 completed successfully" in r.getMessage() for r in caplog.records)
 
 
 def test_execute_collection_cycle_propagates_keyboard_interrupt() -> None:
@@ -163,8 +172,9 @@ def test_execute_collection_cycle_propagates_keyboard_interrupt() -> None:
             DataCollectionManager._execute_collection_cycle(loop_count=1)
 
 
-def test_execute_collection_cycle_logs_and_backs_off_on_exception(capsys: pytest.CaptureFixture[str]) -> None:
+def test_execute_collection_cycle_logs_and_backs_off_on_exception(caplog: pytest.LogCaptureFixture) -> None:
     """A step exception is logged, user notified, and a 5s back-off runs."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     step = MagicMock(side_effect=RuntimeError("nope"))
     steps = [("  step", step)]
     with (
@@ -172,7 +182,7 @@ def test_execute_collection_cycle_logs_and_backs_off_on_exception(capsys: pytest
         patch("src.analytics.data_collection_manager.time.sleep") as sleep,
     ):
         DataCollectionManager._execute_collection_cycle(loop_count=7)
-    out = capsys.readouterr().out
+    out = "\n".join(r.getMessage() for r in caplog.records)
     assert "Error in loop 7" in out
     assert "Continuing to next iteration" in out
     # The 5-second back-off must have fired.


### PR DESCRIPTION
## Summary

Slice 40/N of issue #886 (retire every `print()` in favor of `logging`).

- Migrates all 11 `print()` calls in `src/analytics/data_collection_manager.py` to `logger.info/warning/error(...)` with %-style deferred formatting (G004-clean).
- Adds module-scoped `logger = logging.getLogger(__name__)`.
- Preserves every operator-notice string verbatim (leading `\n`, indentation, `! ` prefix).
- Level mapping:
  - `info`: three-line startup banner, per-iteration header, exporter-step banners, loop-completed tally, final ended notice.
  - `warning`: KeyboardInterrupt notice, per-cycle error + continuing pair.
  - `error`: fatal continuous-loop exception.
- Migrates six `capsys` assertions in `tests/unit/analytics/test_data_collection_manager.py` to `caplog` with `logger="src.analytics.data_collection_manager"` scoping.

## Test plan
- [x] `python -m black src/analytics/data_collection_manager.py tests/unit/analytics/test_data_collection_manager.py` -- clean
- [x] `python -m ruff check src/analytics/data_collection_manager.py tests/unit/analytics/test_data_collection_manager.py` -- clean
- [x] `python -m pytest tests/unit/analytics/test_data_collection_manager.py -q` -- 17 passed
- [x] `grep -c "print(" src/analytics/data_collection_manager.py` -- 0