### PR TITLE
chore(logging): migrate src/device/arp_command_manager.py print() to logger (#886 slice 41/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 78/N: retire `print()` in `src/device/arp_command_manager.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 11 `print()` calls in
+  `src/device/arp_command_manager.py` with `logger`-based emissions using
+  `%`-style deferred formatting to satisfy G004. Added a module-scoped
+  `logger = logging.getLogger(__name__)`. Level heuristic mirrors the
+  operational intent of each notice: `info` for the WebSocket-subscription
+  banner (` Subscribing to WebSocket stream...`), the trigger-success
+  notice (`! ARP command triggered. Session ID: <sid>`), the received-output
+  header (`\n  ARP Output Received:\n`), the debug-mode full-table dump,
+  the non-debug row-count summary (`! ARP output received with N rows.`),
+  and the CSV write-success line (`! Saved N rows to <path>`); `warning`
+  for the missing-credentials operator notice
+  (` Mist host or API token not found in session or environment.`) and the
+  empty-payload notice (` No ARP output received for this session.`);
+  `error` for the trigger-failure status/response body pair
+  (`! Failed to trigger ARP command: <status>` + response text) and the
+  CSV-export exception notice (`! Failed to export ARP output to CSV: <e>`).
+  Each migrated call carries the standard
+  `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.`
+  annotation and preserves legacy `!`/`  `/`\n` prefixes verbatim in the
+  format string.
+- **Test migration (Changed)**: `tests/unit/device/test_arp_command_manager.py`
+  migrated seven `capsys`-based assertions to `caplog` using a shared
+  `_LOGGER_NAME = "src.device.arp_command_manager"` constant with
+  `caplog.set_level(<LEVEL>, logger=_LOGGER_NAME)` gating and
+  `any("<needle>" in r.getMessage() for r in caplog.records)` matching.
+  Removed the vacuous `or True` assertion from
+  `test_debug_prints_full_table` (the migration surfaces the debug table
+  through the logger, so the fallback tautology is no longer needed and the
+  `table.get_string.assert_called_once()` check now stands on its own).
+  Suite result: 54 passed, ruff clean, black clean.
+
 ### #886 Phase 2 slice 77/N: retire `print()` in `src/analytics/data_collection_manager.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 11 `print()` calls in

--- a/src/device/arp_command_manager.py
+++ b/src/device/arp_command_manager.py
@@ -29,6 +29,8 @@ from prettytable import PrettyTable  # WHY: render parsed ARP rows as a table.
 import websocket  # WHY: websocket-client stream subscription.
 from src.dataclasses.websocket_stream_target import WebSocketStreamTarget  # Bundle for WS connection identity.
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger routes former print notices for capture/redirection.
+
 
 class ARPCommandManager:  # ARP WebSocket command manager.
     """Manages ARP command execution via WebSocket for network devices.
@@ -64,9 +66,13 @@ class ARPCommandManager:  # ARP WebSocket command manager.
             return
         mist_host, mist_apitoken = ARPCommandManager._resolve_mist_ws_credentials()  # Resolve creds
         if not mist_host or not mist_apitoken:  # Missing creds — abort
-            print(" Mist host or API token not found in session or environment.")  # User-facing notice
+            logger.warning(
+                " Mist host or API token not found in session or environment."
+            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
             return
-        print(" Subscribing to WebSocket stream...")  # User progress
+        logger.info(
+            " Subscribing to WebSocket stream..."
+        )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
         session_id = ARPCommandManager._trigger_command(mist_host, mist_apitoken, site_id, device_id)  # type: ignore[no-untyped-call]
         if not session_id:  # Trigger failed — nothing to listen for
             return
@@ -85,11 +91,17 @@ class ARPCommandManager:  # ARP WebSocket command manager.
 
         if response.status_code == 200:  # Success.
             session_id = response.json().get("session")  # Read the session id.
-            print(f"! ARP command triggered. Session ID: {session_id}")  # Tell the user.
+            logger.info(
+                "! ARP command triggered. Session ID: %s", session_id
+            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
             return session_id  # Return the session.
         else:
-            print(f"! Failed to trigger ARP command: {response.status_code}")  # Tell the user fail.
-            print(response.text)  # Show the body.
+            logger.error(
+                "! Failed to trigger ARP command: %s", response.status_code
+            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error(
+                "%s", response.text
+            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
             return None  # Return None.
 
     @staticmethod
@@ -217,13 +229,17 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         """Handle WebSocket close and process output."""
         logging.info(" WebSocket closed.")  # Log the close.
         if not output_lines:  # No output captured during this session.
-            print(" No ARP output received for this session.")  # Tell the user none.
+            logger.warning(
+                " No ARP output received for this session."
+            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
             logging.warning(" No ARP output received for this session.")  # Warn none.
             return  # Nothing further to process.
         compiled_output = "\n".join(output_lines)  # Join the captured lines into one block.
         ARPCommandManager._save_output(compiled_output)  # type: ignore[no-untyped-call]
         ARPCommandManager._export_to_csv("arp_output_raw.txt")  # type: ignore[no-untyped-call]
-        print("\n  ARP Output Received:\n")  # Tell the user output arrived.
+        logger.info(
+            "\n  ARP Output Received:\n"
+        )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
         ARPCommandManager._render_arp_table(compiled_output, debug)  # type: ignore[no-untyped-call]
 
     @staticmethod
@@ -261,10 +277,14 @@ class ARPCommandManager:  # ARP WebSocket command manager.
     def _emit_arp_table(table, row_count, debug):  # Print or log the rendered table.
         """Print the table in debug mode or report the row count otherwise."""
         if debug:  # Debug mode shows the full table.
-            print(table)  # Print the table for the user.
+            logger.info(
+                "%s", table
+            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
             logging.debug("\n%s", table.get_string())  # Log the table contents.
         else:  # Non-debug mode reports only the row count.
-            print(f"! ARP output received with {row_count} rows.")  # Tell the user the row count.
+            logger.info(
+                "! ARP output received with %d rows.", row_count
+            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
 
     @staticmethod
     def _save_output(compiled_output, filename="arp_output_raw.txt"):  # Save raw output.
@@ -305,7 +325,9 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         with open(path, "w", newline="", encoding="utf-8") as fout:  # Open the CSV.
             writer = csv.writer(fout)  # CSV writer.
             writer.writerows(rows)  # Write the rows.
-        print(f"! Saved {len(rows)} rows to {path}")  # Tell the user.
+        logger.info(
+            "! Saved %d rows to %s", len(rows), path
+        )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
 
     @staticmethod
     def _export_to_csv(txt_filename="arp_output_raw.txt", csv1="arp_dataset1.csv", csv2="arp_dataset2.csv"):
@@ -321,4 +343,6 @@ class ARPCommandManager:  # ARP WebSocket command manager.
             ARPCommandManager._write_dataset_csv(csv1_path, dataset1)  # Write first CSV.
             ARPCommandManager._write_dataset_csv(csv2_path, dataset2)  # Write second CSV.
         except Exception as e:  # Export failed.
-            print(f"! Failed to export ARP output to CSV: {e}")  # Tell the user.
+            logger.error(
+                "! Failed to export ARP output to CSV: %s", e
+            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.

--- a/tests/unit/device/test_arp_command_manager.py
+++ b/tests/unit/device/test_arp_command_manager.py
@@ -26,6 +26,9 @@ from src.dataclasses.websocket_stream_target import WebSocketStreamTarget
 from src.device import arp_command_manager as arp_mod
 from src.device.arp_command_manager import ARPCommandManager
 
+# WHY: caplog must target the module logger so INFO/WARNING/ERROR records surface (issue #886).
+_LOGGER_NAME = "src.device.arp_command_manager"
+
 
 @pytest.fixture
 def fake_mh(monkeypatch):
@@ -123,14 +126,15 @@ class TestExecute:
             ARPCommandManager.execute()
         trigger.assert_not_called()
 
-    def test_aborts_when_credentials_missing(self, fake_mh, monkeypatch, capsys):
+    def test_aborts_when_credentials_missing(self, fake_mh, monkeypatch, caplog):
         """Abort with user-facing notice when credentials cannot be resolved."""
         monkeypatch.delenv("MIST_HOST", raising=False)
         monkeypatch.delenv("MIST_APITOKEN", raising=False)
+        caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
         with patch.object(ARPCommandManager, "_trigger_command") as trigger:
             ARPCommandManager.execute("s1", "d1")
         trigger.assert_not_called()
-        assert "Mist host or API token not found" in capsys.readouterr().out
+        assert any("Mist host or API token not found" in r.getMessage() for r in caplog.records)
 
     def test_aborts_when_trigger_returns_none(self, fake_mh, monkeypatch):
         """Skip listener when REST trigger fails to return a session id."""
@@ -162,25 +166,27 @@ class TestExecute:
 class TestTriggerCommand:
     """Cover REST trigger success and failure branches."""
 
-    def test_returns_session_id_on_200(self, capsys):
+    def test_returns_session_id_on_200(self, caplog):
         """Extract the ``session`` field when the POST succeeds."""
         response = MagicMock(status_code=200)
         response.json.return_value = {"session": "abc"}
+        caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
         with patch.object(arp_mod.requests, "post", return_value=response) as post:
             result = ARPCommandManager._trigger_command("h", "t", "s", "d")
         assert result == "abc"
         post.assert_called_once()
-        assert "ARP command triggered" in capsys.readouterr().out
+        assert any("ARP command triggered" in r.getMessage() for r in caplog.records)
 
-    def test_returns_none_and_prints_body_on_failure(self, capsys):
+    def test_returns_none_and_prints_body_on_failure(self, caplog):
         """Non-200 responses log the body and return None."""
         response = MagicMock(status_code=500, text="boom")
+        caplog.set_level(logging.ERROR, logger=_LOGGER_NAME)
         with patch.object(arp_mod.requests, "post", return_value=response):
             result = ARPCommandManager._trigger_command("h", "t", "s", "d")
         assert result is None
-        out = capsys.readouterr().out
-        assert "Failed to trigger" in out
-        assert "boom" in out
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("Failed to trigger" in m for m in messages)
+        assert any("boom" in m for m in messages)
 
 
 class TestBuildWsSubscribe:
@@ -444,17 +450,17 @@ class TestHandleMessage:
 class TestHandleClose:
     """Cover empty and populated close paths."""
 
-    def test_reports_no_output_when_empty(self, capsys, caplog):
-        """Empty output_lines prints and warns, without CSV export."""
+    def test_reports_no_output_when_empty(self, caplog):
+        """Empty output_lines logs at WARNING, without CSV export."""
+        caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
         with (
             patch.object(ARPCommandManager, "_save_output") as save,
             patch.object(ARPCommandManager, "_export_to_csv") as export,
-            caplog.at_level(logging.WARNING),
         ):
             ARPCommandManager._handle_close([])
         save.assert_not_called()
         export.assert_not_called()
-        assert "No ARP output received" in capsys.readouterr().out
+        assert any("No ARP output received" in r.getMessage() for r in caplog.records)
 
     def test_processes_populated_output(self, capsys):
         """Non-empty output triggers save + export + render."""
@@ -529,21 +535,21 @@ class TestPadRows:
 class TestEmitArpTable:
     """Cover debug vs non-debug reporting."""
 
-    def test_debug_prints_full_table(self, capsys, caplog):
-        """debug=True prints the table string and logs it."""
+    def test_debug_prints_full_table(self, caplog):
+        """debug=True logs the table string and its formatted contents."""
         table = MagicMock()
         table.get_string.return_value = "TABLE"
-        with caplog.at_level(logging.DEBUG):
-            ARPCommandManager._emit_arp_table(table, 3, True)
-        assert str(table) in capsys.readouterr().out or "TABLE" in capsys.readouterr().out or True
-        # Just verify the branch was taken.
+        caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+        ARPCommandManager._emit_arp_table(table, 3, True)
+        # Just verify the debug branch was taken.
         table.get_string.assert_called_once()
 
-    def test_non_debug_reports_row_count(self, capsys):
+    def test_non_debug_reports_row_count(self, caplog):
         """debug=False emits a summary line only."""
         table = MagicMock()
+        caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
         ARPCommandManager._emit_arp_table(table, 5, False)
-        assert "5 rows" in capsys.readouterr().out
+        assert any("5 rows" in r.getMessage() for r in caplog.records)
         table.get_string.assert_not_called()
 
 
@@ -599,13 +605,14 @@ class TestSplitArpTextIntoDatasets:
 class TestWriteDatasetCsv:
     """Cover CSV write + user-facing count line."""
 
-    def test_writes_rows_and_reports_count(self, tmp_path, capsys):
-        """CSV file gets the expected rows and stdout announces the count."""
+    def test_writes_rows_and_reports_count(self, tmp_path, caplog):
+        """CSV file gets the expected rows and the logger announces the count."""
         path = tmp_path / "out.csv"
+        caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
         ARPCommandManager._write_dataset_csv(str(path), [["a", "b"], ["c", "d"]])
         contents = path.read_text(encoding="utf-8").replace("\r", "")
         assert contents == "a,b\nc,d\n"
-        assert "Saved 2 rows" in capsys.readouterr().out
+        assert any("Saved 2 rows" in r.getMessage() for r in caplog.records)
 
 
 class TestExportToCsv:
@@ -631,8 +638,9 @@ class TestExportToCsv:
         assert csv1.read_text(encoding="utf-8").replace("\r", "") == "a,b\n"
         assert csv2.read_text(encoding="utf-8").replace("\r", "") == "c,d\n"
 
-    def test_prints_failure_on_exception(self, fake_mh, capsys):
-        """Any exception during export becomes a user-facing failure line."""
+    def test_prints_failure_on_exception(self, fake_mh, caplog):
+        """Any exception during export becomes a user-facing failure log line."""
         fake_mh.FilePathUtils.get_csv_path.side_effect = RuntimeError("boom")
+        caplog.set_level(logging.ERROR, logger=_LOGGER_NAME)
         ARPCommandManager._export_to_csv()
-        assert "Failed to export ARP output to CSV" in capsys.readouterr().out
+        assert any("Failed to export ARP output to CSV" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary

Slice 41/N of issue #886 — retires the 11 remaining `print()` calls in `src/device/arp_command_manager.py` in favor of a module-scoped `logger = logging.getLogger(__name__)` using `%`-style deferred formatting (G004-clean). Level heuristic:

- **info** (6): WebSocket subscribe banner, trigger-success `Session ID`, received-output header, debug-mode full-table dump, non-debug row-count summary, CSV write-success line.
- **warning** (2): missing-credentials notice, empty-payload notice.
- **error** (3): trigger-failure status + response body, CSV-export exception.

Each migrated call preserves the operator-facing string verbatim (leading spaces, `!`/`\n` prefixes) and carries the standard `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.` annotation.

`tests/unit/device/test_arp_command_manager.py` migrates seven `capsys` assertions to `caplog` with `_LOGGER_NAME = "src.device.arp_command_manager"` gating and `r.getMessage()` iteration; removed the vacuous `or True` fallback from `test_debug_prints_full_table`.

## Test plan

- [x] `ruff check src/device/arp_command_manager.py tests/unit/device/test_arp_command_manager.py` — clean
- [x] `black` — reformatted the source; test file unchanged
- [x] `pytest tests/unit/device/test_arp_command_manager.py -v` — **54 passed**
- [ ] CI green on the branch