### PR TITLE
chore(logging): migrate src/gateway/_wan2_variable_io.py print() to logger (#886 slice 42/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 79/N: retire `print()` in `src/gateway/_wan2_variable_io.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 11 `print()` calls in
+  `src/gateway/_wan2_variable_io.py` with `logger`-based emissions using
+  `%`-style deferred formatting to satisfy G004. Added a module-scoped
+  `logger = logging.getLogger(__name__)` (module previously used bare
+  `logging.info/warning` for audit trail; that channel is preserved
+  unchanged while operator-facing notices route through the new module
+  logger). Level heuristic: `info` for the Menu #104 header banner, two
+  `"=" * 70` separators, the dry-run banner pair, and the CSV-loading
+  progress line; `warning` for the three live-mode cautions, the
+  empty-templates notice, and the SECURITY exclusion notice (refactored
+  from an f-string print with adjacent string-literal concatenation into
+  a single `%d`/`%s` deferred-format warning). Each migrated call carries
+  the standard `# WHY: preserve operator notice verbatim; route through
+  logger for capture/redirection.` annotation and preserves `!?`, `>>`,
+  and leading `\n` prefixes verbatim.
+- **No test migration needed**: only two `_print_header` smoke tests
+  accept `capsys` but never assert on captured output. Ruff clean;
+  black clean; `pytest tests/unit/test_wan2_variable.py` = 101 passed.
+
 ### #886 Phase 2 slice 78/N: retire `print()` in `src/device/arp_command_manager.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 11 `print()` calls in

--- a/src/gateway/_wan2_variable_io.py
+++ b/src/gateway/_wan2_variable_io.py
@@ -13,38 +13,49 @@ import logging  # WHY: audit-log destructive Menu #104 flow
 
 from ._wan2_variable_cluster import _ClusterBase  # WHY: parent-proxy pattern shared with peers
 
+logger = logging.getLogger(__name__)  # WHY: route former print() notices for capture/redirection (issue #886).
+
 
 class _Wan2VariableIO(_ClusterBase):
     """CSV loading + site filtering helpers."""
 
     def _print_header(self) -> None:
         """Display operation header with mode-specific warnings."""
-        print("\n  DESTRUCTIVE: Update Gateway Templates" " for WAN2 Variable Migration")  # WHY: banner line
-        print("=" * 70)  # WHY: visual separator matches other menus
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\n  DESTRUCTIVE: Update Gateway Templates for WAN2 Variable Migration")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("%s", "=" * 70)
         if self._dry_run:  # WHY: dry-run mode gets safer copy
             self._print_dry_run_header()  # WHY: extracted helper keeps block count low
         else:  # WHY: live mode gets destructive warnings
             self._print_live_header()  # WHY: extracted helper keeps block count low
-        print("=" * 70)  # WHY: closing separator
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("%s", "=" * 70)
 
     @staticmethod
     def _print_dry_run_header() -> None:
         """Print the dry-run banner lines."""
-        print("  >> DRY-RUN MODE: No changes will be made" " to templates or devices")  # WHY: mode indicator
-        print("  >> This will show what WOULD be changed" " without modifying anything")  # WHY: expectations
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  >> DRY-RUN MODE: No changes will be made to templates or devices")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  >> This will show what WOULD be changed without modifying anything")
 
     @staticmethod
     def _print_live_header() -> None:
         """Print the live-mode warning banner lines."""
-        print("  !? WARNING: This operation modifies gateway templates")  # WHY: caution line
-        print("  !? All sites using affected templates" " will inherit the change")  # WHY: scope warning
-        print("  !? Ensure sites have 'wan2_interface'" " variable set (Menu #103)")  # WHY: prerequisite
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("  !? WARNING: This operation modifies gateway templates")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("  !? All sites using affected templates will inherit the change")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("  !? Ensure sites have 'wan2_interface' variable set (Menu #103)")
 
     def _load_csv_data(
         self,
     ) -> tuple[list[dict[str, str]], list[dict[str, str]], dict[str, int]] | None:
         """Load template and site CSV data, filter excluded sites."""
-        print("\n  Loading gateway template data...")  # WHY: user progress feedback
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\n  Loading gateway template data...")
         self._check_csv("OrgGatewayTemplates.csv", self._gen_templates)  # WHY: ensure freshness
         self._check_csv("SiteList.csv", self._gen_sites)  # WHY: ensure freshness
         template_rows = self._read_csv_rows("OrgGatewayTemplates.csv")  # WHY: helper handles read
@@ -65,7 +76,8 @@ class _Wan2VariableIO(_ClusterBase):
     @staticmethod
     def _log_no_templates() -> None:
         """Emit the 'no templates' message and log line."""
-        print(" No gateway templates found.")  # WHY: user-facing empty result
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning(" No gateway templates found.")
         logging.warning("No gateway templates available for modification")  # WHY: audit line
 
     def _filter_excluded_sites(self, all_sites: list[dict[str, str]]) -> list[dict[str, str]]:
@@ -81,11 +93,12 @@ class _Wan2VariableIO(_ClusterBase):
 
     def _announce_exclusion(self, excluded: int) -> None:
         """Print SECURITY exclusion notice and matching audit log."""
-        print(
-            f"\n  !? SECURITY: Excluded {excluded}"
-            f" '{self._site_exclude_prefix}*' sites"
-            " from template impact analysis (early filter)"
-        )  # WHY: user visibility on early filter
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning(
+            "\n  !? SECURITY: Excluded %d '%s*' sites from template impact analysis (early filter)",
+            excluded,
+            self._site_exclude_prefix,
+        )
         logging.info(
             "Menu #104: Excluded %s sites matching prefix '%s' from WAN2 template operation",
             excluded,


### PR DESCRIPTION
## Summary

- Replace all 11 `print()` calls in `src/gateway/_wan2_variable_io.py` with module-scoped `logger` emissions using `%`-style deferred formatting (G004-clean).
- `info` level for Menu #104 header banner, `"=" * 70` separators, dry-run banner pair, CSV-loading progress line. `warning` level for three live-mode cautions, empty-templates notice, and SECURITY exclusion notice (refactored from f-string print with adjacent-string concatenation into single `%d`/`%s` deferred format).
- Existing bare `logging.info/warning` audit-trail calls preserved unchanged; operator-facing notices now route through the new module logger. Standard WHY comment on each migrated call; verbatim strings preserved (`!?`, `>>`, leading `\n`).
- No test migration needed: two `_print_header` smoke tests accept `capsys` but never assert on captured output.

## Test plan

- [x] `pytest tests/unit/test_wan2_variable.py` = 101 passed
- [x] `ruff check src/gateway/_wan2_variable_io.py` clean
- [x] `black --check src/gateway/_wan2_variable_io.py` clean

Refs: #886