### PR TITLE
chore(logging): migrate src/websocket/polling/result_combiner.py print() to logger (#886 slice 43/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,40 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
-### #886 Phase 2 slice 79/N: retire `print()` in `src/gateway/_wan2_variable_io.py` (issue #886)
+### #886 Phase 2 slice 80/N: retire `print()` in `src/websocket/polling/result_combiner.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 11 `print()` calls in
-  `src/gateway/_wan2_variable_io.py` with `logger`-based emissions using
-  `%`-style deferred formatting to satisfy G004. Added a module-scoped
-  `logger = logging.getLogger(__name__)` (module previously used bare
-  `logging.info/warning` for audit trail; that channel is preserved
-  unchanged while operator-facing notices route through the new module
-  logger). Level heuristic: `info` for the Menu #104 header banner, two
-  `"=" * 70` separators, the dry-run banner pair, and the CSV-loading
-  progress line; `warning` for the three live-mode cautions, the
-  empty-templates notice, and the SECURITY exclusion notice (refactored
-  from an f-string print with adjacent string-literal concatenation into
-  a single `%d`/`%s` deferred-format warning). Each migrated call carries
-  the standard `# WHY: preserve operator notice verbatim; route through
-  logger for capture/redirection.` annotation and preserves `!?`, `>>`,
-  and leading `\n` prefixes verbatim.
-- **No test migration needed**: only two `_print_header` smoke tests
-  accept `capsys` but never assert on captured output. Ruff clean;
-  black clean; `pytest tests/unit/test_wan2_variable.py` = 101 passed.
+  `src/websocket/polling/result_combiner.py` with `logger`-based emissions
+  using `%`-style deferred formatting to satisfy G004. Added a module-scoped
+  `logger = logging.getLogger(__name__)` that coexists with the pre-existing
+  per-request `request.logger` mirror calls (the caller-supplied structured
+  logger continues to receive the info/debug lines it always has; the new
+  module logger only carries the ten verbatim `[DEBUG] ...` diagnostic
+  lines and the single `[DEBUG] WARNING: Final result is empty` notice
+  that were previously written to stdout). Level heuristic: `debug` for
+  the header trio (segment count, wait time, checks performed), the
+  trailer preview block (length, fields, first/last 150 chars,
+  session-complete banner, `"=" * 60` separator), and the per-segment
+  trace line emitted only when `debug_mode and len(segments) > 5`;
+  `warning` for the empty-payload sentinel. Each migrated call carries the
+  standard `# WHY: preserve operator notice verbatim; route through
+  logger for capture/redirection.` annotation, preserves the `[DEBUG]`
+  prefix and `%r`/`%s`/`%d`/`%.2f` format specifiers, and continues to
+  respect the `_VERBOSE_SEGMENT_THRESHOLD = 5` guard.
+- **Test migration (Changed)**: `tests/unit/websocket/polling/test_result_combiner.py`
+  migrated 7 tests from `capsys` to `caplog` with
+  `_MODULE_LOGGER = "src.websocket.polling.result_combiner"` filter —
+  three in `TestMergeSegments` (verbose-off with debug off, verbose-off
+  at/below threshold, verbose-on above threshold) and four in
+  `TestAbsorbRawChunk` (missing raw key, empty raw string, verbose trace
+  index, verbose-off suppression). Each test asserts on
+  `caplog.records` filtered by `r.name == _MODULE_LOGGER` and keeps
+  `capsys.readouterr().out == ""` as a belt-and-suspenders guard that no
+  stray stdout writes crept back in. Pre-existing tests that assert on
+  the per-request logger via
+  `caplog.set_level(..., logger="test.result_combiner")` are unchanged.
+- Ruff clean; black clean;
+  `pytest tests/unit/websocket/polling/test_result_combiner.py` = 34 passed.
 
 ### #886 Phase 2 slice 78/N: retire `print()` in `src/device/arp_command_manager.py` (issue #886)
 

--- a/src/websocket/polling/result_combiner.py
+++ b/src/websocket/polling/result_combiner.py
@@ -6,6 +6,8 @@ import logging  # Standard logger type used by callers
 from dataclasses import dataclass  # Frozen bundle for the 6 caller inputs
 from typing import Any  # Segment dicts have heterogeneous values
 
+logger = logging.getLogger(__name__)  # WHY: route former print() diagnostics for capture/redirection (issue #886).
+
 _RESERVED_KEYS = {"raw", "session"}  # Keys handled specially and excluded from generic merge
 _VERBOSE_SEGMENT_THRESHOLD = 5  # Per-segment trace fires only when segment count exceeds this
 _TRAILER_BAR = "=" * 60  # Fixed-width visual separator preserved from original output
@@ -58,9 +60,12 @@ def _emit_debug_header(request: CombineRequest) -> None:  # Verbose header emitt
     request.logger.debug("Combining %s result segments", count)  # Logger mirror line
     request.logger.debug("Total wait time: %.2f seconds", request.elapsed)  # Wall time
     request.logger.debug("Total checks performed: %s", request.check_count)  # Poll iterations
-    print(f"[DEBUG] Combining {count} result segments")  # Verbatim stdout line 1
-    print(f"[DEBUG] Total wait time: {request.elapsed:.2f} seconds")  # Verbatim stdout line 2
-    print(f"[DEBUG] Total checks performed: {request.check_count}")  # Verbatim stdout line 3
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Combining %s result segments", count)
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Total wait time: %.2f seconds", request.elapsed)
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Total checks performed: %s", request.check_count)
 
 
 def _emit_debug_trailer(  # Verbose trailer emitter
@@ -69,14 +74,21 @@ def _emit_debug_trailer(  # Verbose trailer emitter
     """Emit the trailing debug block including head/tail previews and completion banner."""
     if not request.debug_mode:  # Guard: skip entirely when quiet mode is active
         return  # Nothing to emit when debug is off
-    print(f"[DEBUG] Final combined result length: {len(combined_raw)} characters")  # Length summary
-    print(f"[DEBUG] Final result fields: {list(final_result.keys())}")  # Field roster
-    print(f"[DEBUG] First 150 chars of final result: {repr(combined_raw[:_PREVIEW_CHARS])}")  # Head preview
-    print(f"[DEBUG] Last 150 chars of final result: {repr(combined_raw[-_PREVIEW_CHARS:])}")  # Tail preview
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Final combined result length: %s characters", len(combined_raw))
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Final result fields: %s", list(final_result.keys()))
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] First 150 chars of final result: %r", combined_raw[:_PREVIEW_CHARS])
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Last 150 chars of final result: %r", combined_raw[-_PREVIEW_CHARS:])
     if len(combined_raw) == 0:  # Empty payload sentinel
-        print("[DEBUG] WARNING: Final result is empty - this may indicate an issue")  # Verbatim warn
-    print(f"[DEBUG] Session {request.session_id} result collection complete")  # Completion line
-    print("[DEBUG] " + _TRAILER_BAR)  # Fixed-width separator
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("[DEBUG] WARNING: Final result is empty - this may indicate an issue")
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Session %s result collection complete", request.session_id)
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] %s", _TRAILER_BAR)
 
 
 def _merge_segments(final_results: list[dict[str, Any]], debug_mode: bool) -> MergedPayload:  # Merge driver
@@ -99,7 +111,8 @@ def _absorb_raw_chunk(  # Per-segment raw handler
         return  # Empty chunk contributes nothing to buffer or trace
     buffer.append(raw_content)  # Defer join to caller for single allocation
     if verbose:  # Emit per-segment trace when verbose mode is precomputed on
-        print(f"[DEBUG] Segment {index + 1}: {len(raw_content)} chars")  # Verbatim trace
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.debug("[DEBUG] Segment %s: %s chars", index + 1, len(raw_content))
 
 
 def _absorb_extras(result: dict[str, Any], accumulator: dict[str, Any]) -> None:  # Extras merger

--- a/tests/unit/websocket/polling/test_result_combiner.py
+++ b/tests/unit/websocket/polling/test_result_combiner.py
@@ -30,6 +30,8 @@ from src.websocket.polling.result_combiner import (
     combine_segments,
 )
 
+_MODULE_LOGGER = "src.websocket.polling.result_combiner"
+
 
 def _make_request(
     *,
@@ -150,10 +152,12 @@ class TestEmitDebugHeader:
     def test_silent_when_debug_off(self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
         req = _make_request(debug=False)
         caplog.set_level(logging.DEBUG, logger="test.result_combiner")
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
 
         _emit_debug_header(req)
 
         assert capsys.readouterr().out == ""
+        assert not any(r.name == _MODULE_LOGGER for r in caplog.records)
         assert caplog.records == []
 
     def test_emits_three_lines_when_debug_on(
@@ -161,46 +165,60 @@ class TestEmitDebugHeader:
     ) -> None:
         req = _make_request(segments=[{"raw": "x"}, {"raw": "y"}], debug=True, elapsed=2.5, check_count=42)
         caplog.set_level(logging.DEBUG, logger="test.result_combiner")
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
 
         _emit_debug_header(req)
 
-        out = capsys.readouterr().out
-        assert "[DEBUG] Combining 2 result segments" in out
-        assert "[DEBUG] Total wait time: 2.50 seconds" in out
-        assert "[DEBUG] Total checks performed: 42" in out
-        debug_msgs = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        module_msgs = [r.message for r in caplog.records if r.name == _MODULE_LOGGER]
+        assert any("[DEBUG] Combining 2 result segments" in m for m in module_msgs)
+        assert any("[DEBUG] Total wait time: 2.50 seconds" in m for m in module_msgs)
+        assert any("[DEBUG] Total checks performed: 42" in m for m in module_msgs)
+        debug_msgs = [
+            r.message for r in caplog.records if r.name == "test.result_combiner" and r.levelno == logging.DEBUG
+        ]
         assert any("Combining 2 result segments" in m for m in debug_msgs)
         assert any("Total wait time: 2.50 seconds" in m for m in debug_msgs)
         assert any("Total checks performed: 7" not in m for m in debug_msgs)  # sanity: uses request value
+        assert capsys.readouterr().out == ""
 
 
 class TestEmitDebugTrailer:
     """Trailer emitter branches (non-empty, empty warning)."""
 
-    def test_silent_when_debug_off(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_silent_when_debug_off(self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture) -> None:
         req = _make_request(debug=False)
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         _emit_debug_trailer(req, "abc", {"raw": "abc", "session": "sess-1"})
         assert capsys.readouterr().out == ""
+        assert not any(r.name == _MODULE_LOGGER for r in caplog.records)
 
-    def test_emits_all_lines_for_non_empty_payload(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_emits_all_lines_for_non_empty_payload(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
         req = _make_request(debug=True, session_id="SID")
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         payload = "x" * 300
         _emit_debug_trailer(req, payload, {"raw": payload, "session": "SID", "extra": "e"})
 
-        out = capsys.readouterr().out
-        assert f"[DEBUG] Final combined result length: {len(payload)} characters" in out
-        assert "[DEBUG] Final result fields: ['raw', 'session', 'extra']" in out
-        assert "[DEBUG] First 150 chars of final result:" in out
-        assert "[DEBUG] Last 150 chars of final result:" in out
-        assert "[DEBUG] Session SID result collection complete" in out
-        assert "[DEBUG] " + ("=" * 60) in out
-        assert "WARNING" not in out
+        msgs = [r.message for r in caplog.records if r.name == _MODULE_LOGGER]
+        assert any(f"[DEBUG] Final combined result length: {len(payload)} characters" in m for m in msgs)
+        assert any("[DEBUG] Final result fields: ['raw', 'session', 'extra']" in m for m in msgs)
+        assert any("[DEBUG] First 150 chars of final result:" in m for m in msgs)
+        assert any("[DEBUG] Last 150 chars of final result:" in m for m in msgs)
+        assert any("[DEBUG] Session SID result collection complete" in m for m in msgs)
+        assert any("[DEBUG] " + ("=" * 60) in m for m in msgs)
+        assert not any("WARNING" in m for m in msgs)
+        assert capsys.readouterr().out == ""
 
-    def test_emits_warning_when_payload_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_emits_warning_when_payload_empty(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
         req = _make_request(debug=True)
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         _emit_debug_trailer(req, "", {"raw": "", "session": "sess-1"})
-        out = capsys.readouterr().out
-        assert "[DEBUG] WARNING: Final result is empty" in out
+        warning_msgs = [r.message for r in caplog.records if r.name == _MODULE_LOGGER and r.levelno == logging.WARNING]
+        assert any("[DEBUG] WARNING: Final result is empty" in m for m in warning_msgs)
+        assert capsys.readouterr().out == ""
 
 
 class TestMergeSegments:
@@ -227,22 +245,34 @@ class TestMergeSegments:
         assert raw == "12"
         assert extras == {"note": "hello world", "count": "12"}
 
-    def test_verbose_off_when_debug_off(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_verbose_off_when_debug_off(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         segments = [{"raw": "x"}] * 10  # would trip threshold if debug were on
         _merge_segments(segments, debug_mode=False)
         assert capsys.readouterr().out == ""
+        assert not any(r.name == _MODULE_LOGGER for r in caplog.records)
 
-    def test_verbose_off_when_at_or_below_threshold(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_verbose_off_when_at_or_below_threshold(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         segments = [{"raw": "x"}] * 5  # threshold is `> 5`, so 5 is off
         _merge_segments(segments, debug_mode=True)
         assert capsys.readouterr().out == ""
+        assert not any(r.name == _MODULE_LOGGER for r in caplog.records)
 
-    def test_verbose_on_when_debug_on_and_above_threshold(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_verbose_on_when_debug_on_and_above_threshold(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         segments = [{"raw": "ab"}] * 6  # trips the > 5 threshold
         _merge_segments(segments, debug_mode=True)
-        out = capsys.readouterr().out
-        assert "[DEBUG] Segment 1: 2 chars" in out
-        assert "[DEBUG] Segment 6: 2 chars" in out
+        assert capsys.readouterr().out == ""
+        msgs = [r.message for r in caplog.records if r.name == _MODULE_LOGGER]
+        assert any("[DEBUG] Segment 1: 2 chars" in m for m in msgs)
+        assert any("[DEBUG] Segment 6: 2 chars" in m for m in msgs)
 
 
 class TestAbsorbRawChunk:
@@ -253,30 +283,46 @@ class TestAbsorbRawChunk:
         _absorb_raw_chunk({"raw": "abc"}, buf, verbose=False, index=0)
         assert buf == ["abc"]
 
-    def test_missing_raw_key_treated_as_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_missing_raw_key_treated_as_empty(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         buf: list[str] = []
         _absorb_raw_chunk({"other": 1}, buf, verbose=True, index=0)
         assert buf == []
         assert capsys.readouterr().out == ""
+        assert not any(r.name == _MODULE_LOGGER for r in caplog.records)
 
-    def test_empty_raw_string_skipped(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_empty_raw_string_skipped(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         buf: list[str] = []
         _absorb_raw_chunk({"raw": ""}, buf, verbose=True, index=3)
         assert buf == []
         assert capsys.readouterr().out == ""
+        assert not any(r.name == _MODULE_LOGGER for r in caplog.records)
 
-    def test_verbose_trace_uses_one_based_index(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_verbose_trace_uses_one_based_index(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         buf: list[str] = []
         _absorb_raw_chunk({"raw": "abcd"}, buf, verbose=True, index=4)
         assert buf == ["abcd"]
-        out = capsys.readouterr().out
-        assert "[DEBUG] Segment 5: 4 chars" in out
+        assert capsys.readouterr().out == ""
+        msgs = [r.message for r in caplog.records if r.name == _MODULE_LOGGER]
+        assert any("[DEBUG] Segment 5: 4 chars" in m for m in msgs)
 
-    def test_verbose_off_suppresses_trace(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_verbose_off_suppresses_trace(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=_MODULE_LOGGER)
         buf: list[str] = []
         _absorb_raw_chunk({"raw": "abcd"}, buf, verbose=False, index=0)
         assert buf == ["abcd"]
         assert capsys.readouterr().out == ""
+        assert not any(r.name == _MODULE_LOGGER for r in caplog.records)
 
 
 class TestAbsorbExtras:


### PR DESCRIPTION
## Summary

Retires the last 11 `print()` calls in `src/websocket/polling/result_combiner.py` per issue #886. Adds a module-scoped `logger = logging.getLogger(__name__)` that coexists with the pre-existing per-request `request.logger` mirror lines — the caller-supplied structured logger keeps its info/debug output unchanged; the new module logger only carries the ten verbatim `[DEBUG] ...` diagnostic lines and the single `[DEBUG] WARNING: Final result is empty` notice that were previously written to stdout.

Level heuristic: `debug` for the header trio (segment count, wait time, checks performed), the trailer preview block (length, fields, first/last 150 chars, session-complete banner, `"=" * 60` separator), and the per-segment trace line emitted only when `debug_mode and len(segments) > 5`; `warning` for the empty-payload sentinel. Each migrated call carries the standard `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.` annotation and preserves the `[DEBUG]` prefix + format specifiers verbatim.

`tests/unit/websocket/polling/test_result_combiner.py` migrated 7 tests from `capsys` to `caplog` filtered by `_MODULE_LOGGER = "src.websocket.polling.result_combiner"` (three in `TestMergeSegments`, four in `TestAbsorbRawChunk`). Each keeps `capsys.readouterr().out == ""` as a belt-and-suspenders guard.

## Test plan

- [x] `pytest tests/unit/websocket/polling/test_result_combiner.py` — 34 passed
- [x] `ruff check src/websocket/polling/result_combiner.py tests/unit/websocket/polling/test_result_combiner.py` — clean
- [x] `black --check src/websocket/polling/result_combiner.py tests/unit/websocket/polling/test_result_combiner.py` — clean
- [x] `grep -c 'print(' src/websocket/polling/result_combiner.py` — 0 real prints (only the WHY comment mention on line 9)