### PR TITLE
chore(logging): migrate src/maps/_maps_utils.py print() to logger (#886 slice 44/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 85/N: retire `print()` in `src/maps/_maps_utils.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced the sole `print()` call in
+  `src/maps/_maps_utils.py` (the CSV-save confirmation line
+  `   Data saved to: <filepath>` emitted by
+  `write_data_with_format_selection`) with a `logger.info` emission using
+  `%`-style deferred formatting to satisfy G004. The module already declared
+  `logger = logging.getLogger(__name__)` at line 17, so no logger import
+  changed. Converted the shared `_PRINT_SAVED_TMPL` module constant from a
+  `{filepath}` `str.format` template into the `%s` deferred-format
+  equivalent (`"   Data saved to: %s"`) so the logger call passes the
+  path as a positional arg (`logger.info(_PRINT_SAVED_TMPL, filepath)`),
+  keeping the exact user-visible text and leading indent verbatim. The
+  migrated call carries the standard `# WHY: preserve operator notice
+  verbatim; route through logger for capture/redirection.` annotation.
+- **No test migration needed**: `_maps_utils` has no `tests/` coverage that
+  imports the module or asserts on captured stdout from
+  `write_data_with_format_selection`. Ruff clean; black clean;
+  `pytest tests/unit/maps/ -q` passes existing suite unchanged.
+
 ### #886 Phase 2 slice 84/N: retire `print()` in `src/export/org_inventory_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 12 `print()` calls in

--- a/src/maps/_maps_utils.py
+++ b/src/maps/_maps_utils.py
@@ -34,7 +34,7 @@ _STRIP_CHARS: str = " ."  # WHY: Windows rejects trailing space/dot in file/dire
 _LOG_EMPTY_DATA: str = "write_data_with_format_selection: No data to write"  # WHY: no-op guard log message.
 _LOG_WRITE_ERROR: str = "Error writing CSV: %s"  # WHY: error template surfaces the underlying exception.
 _LOG_WRITE_OK: str = "Data written to %s (%s rows)"  # WHY: success template shows path + row count for audit.
-_PRINT_SAVED_TMPL: str = "   Data saved to: {filepath}"  # WHY: user-facing stdout confirmation with indent.
+_PRINT_SAVED_TMPL: str = "   Data saved to: %s"  # WHY: %s deferred-format template for logger.info (G004-clean).
 
 _CSV_MODE_WRITE: str = "w"  # WHY: overwrite existing file each run; callers version via distinct filenames.
 _CSV_NEWLINE: str = ""  # WHY: csv module handles newlines internally; empty avoids double-CR on Windows.
@@ -118,7 +118,8 @@ def write_data_with_format_selection(
         logger.error(_LOG_WRITE_ERROR, write_error)  # WHY: template log includes the underlying error text.
         return False  # WHY: False on write failure preserves batch-export resilience.
     logger.info(_LOG_WRITE_OK, filepath, len(data))  # WHY: audit log includes both path and row count.
-    print(_PRINT_SAVED_TMPL.format(filepath=filepath))  # WHY: user-facing confirmation echoed to stdout.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info(_PRINT_SAVED_TMPL, filepath)
     return True  # WHY: True indicates the CSV was successfully committed to disk.
 
 


### PR DESCRIPTION
## Summary
- Replace sole `print()` in `write_data_with_format_selection` with `logger.info` using `%`-style deferred formatting (G004-clean).
- Convert shared `_PRINT_SAVED_TMPL` constant from `{filepath}` `str.format` template to equivalent `%s` deferred template so `logger.info(_PRINT_SAVED_TMPL, filepath)` passes the path as a positional arg.
- User-visible text and leading indent preserved verbatim; standard WHY comment attached.

## Test plan
- [x] `black --check` clean on migrated file
- [x] `ruff check` clean on migrated file
- [x] Tokenize scan confirms zero `print` NAME tokens remain in `src/maps/_maps_utils.py`
- [x] No test coverage exists for `_maps_utils` — no capsys→caplog migration required

Refs #886