### PR TITLE
chore(logging): migrate src/maps/_maps_backup.py print() to logger (#886 slice 45/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 86/N: retire `print()` in `src/maps/_maps_backup.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 4 `print()` calls in
+  `src/maps/_maps_backup.py` with `logger`-based emissions using `%`-style
+  deferred formatting to satisfy G004. The module already had a module-scoped
+  `logger = logging.getLogger(__name__)`. The three summary lines in
+  `_print_summary` (backup saved header, image line, summary counts) now go
+  through `logger.info`; the exception-path CLI warning in
+  `backup_map_geometry` now goes through `logger.warning`. Each replaced call
+  carries the standard "preserve operator notice verbatim; route through
+  logger for capture/redirection" WHY comment. No test files import
+  `_maps_backup` directly and no capsys assertions target its output, so no
+  test migration was required.
+
 ### #886 Phase 2 slice 85/N: retire `print()` in `src/maps/_maps_utils.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced the sole `print()` call in

--- a/src/maps/_maps_backup.py
+++ b/src/maps/_maps_backup.py
@@ -271,10 +271,13 @@ def _print_summary(  # WHY: user-visible backup summary output
     """Log and print a human-readable summary of the backup contents."""
     summary = _build_summary(backup, image_filename)  # WHY: single source of formatted counts
     logger.info("Map backup saved: %s (%s)", backup_filename, summary)  # WHY: structured audit log
-    print(f"\n   [*] Map backup saved: {backup_filename}")  # WHY: CLI feedback line
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info("\n   [*] Map backup saved: %s", backup_filename)
     if image_filename:  # WHY: only show image line when there is one
-        print(f"       Image: {image_filename}")
-    print(f"       {summary}")  # WHY: always show the summary counts line
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("       Image: %s", image_filename)
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info("       %s", summary)
 
 
 def _fetch_map(request: BackupRequest) -> dict[str, Any] | None:  # WHY: fetch base map data
@@ -350,5 +353,6 @@ def backup_map_geometry(request: BackupRequest) -> str | None:  # WHY: public en
         return _perform_backup(request)
     except Exception as err:  # WHY: any failure surfaces as warning, not crash
         logger.exception("Map geometry backup failed: %s", err)  # WHY: full traceback in log
-        print(f"\n   [!] Warning: Could not backup map geometry: {err}")  # WHY: CLI feedback
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("\n   [!] Warning: Could not backup map geometry: %s", err)
         return None


### PR DESCRIPTION
## Summary
- Replaces the 4 `print()` calls in `src/maps/_maps_backup.py` with `logger` emissions using `%`-style deferred formatting (G004-clean).
- `_print_summary` header + optional image line + summary counts route through `logger.info`; the `backup_map_geometry` exception fallback routes through `logger.warning`.
- Module already had a module-scoped `logger`; no imports changed.
- No test files import `_maps_backup` directly and no capsys assertions target its output, so no test migration required.

## Test plan
- [x] `black --check src/maps/_maps_backup.py`
- [x] `ruff check src/maps/_maps_backup.py`
- [x] `pytest tests/maps/test_viewer_callbacks_wave_e1.py tests/maps/test_viewer_callbacks_wave_b_c.py` — 48 passed
- [x] Tokenize scan confirms 0 `print` calls remain in the file

Refs #886