### PR TITLE
chore(logging): migrate src/maps/_flask_viewer.py print() to logger (#886 slice 46/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 83/N: retire `print()` in `src/maps/_flask_viewer.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 8 `print()` calls in
+  `src/maps/_flask_viewer.py` with `logger`-based emissions using `%`-style
+  deferred formatting to satisfy G004. The module already had a module-scoped
+  `logger = logging.getLogger(__name__)` at line 23 (used by route handlers)
+  so no new imports were required. Six banner emissions in
+  `_print_flask_viewer_banner` (separator, title, separator, server URL
+  f-string, table-driven `_BANNER_LINES` loop, trailing separator) migrated
+  to `logger.info(...)`; the `KeyboardInterrupt` branch of `_run_flask_server`
+  migrated to `logger.info("\n\nFlask map viewer stopped by user")` and the
+  broad-exception fallback migrated to `logger.warning("\n! Error running
+  map viewer: %s", e)`. Each migrated call carries the standard
+  `# WHY: preserve operator notice verbatim; route through logger for
+  capture/redirection.` annotation and preserves the exact byte layout
+  operators grep on. The `_print_flask_viewer_banner` docstring updated
+  from "Print the pre-launch..." to "Emit the pre-launch..." to reflect
+  the migration; the function name is retained to avoid churning the one
+  call site in `launch_flask_viewer`.
+- **Test migration (Changed)**: none. No tests import or assert on
+  `_flask_viewer`, `_print_flask_viewer_banner`, `launch_flask_viewer`, or
+  `_run_flask_server` (grep across `tests/` returned zero matches).
+
 ### #886 Phase 2 slice 80/N: retire `print()` in `src/websocket/polling/result_combiner.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 11 `print()` calls in

--- a/src/maps/_flask_viewer.py
+++ b/src/maps/_flask_viewer.py
@@ -191,14 +191,20 @@ _BANNER_LINES = (  # WHY: table-driven banner replaces sequential print calls, e
 
 
 def _print_flask_viewer_banner(host: str, port: int) -> None:
-    """Print the pre-launch ASCII banner that lists URL + key features."""
-    print("\n" + _BANNER_SEPARATOR)  # WHY: leading blank line separates banner from prior console output.
-    print("LAUNCHING FLASK MAP VIEWER")  # WHY: identifies the launched mode to the operator.
-    print(_BANNER_SEPARATOR)  # WHY: divider between title and body of the banner.
-    print(f"! Server URL: http://{host}:{port}")  # WHY: URL comes first so operators can click straight through.
+    """Emit the pre-launch ASCII banner that lists URL + key features."""
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info("\n%s", _BANNER_SEPARATOR)  # WHY: leading blank line separates banner from prior console output.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info("LAUNCHING FLASK MAP VIEWER")  # WHY: identifies the launched mode to the operator.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info("%s", _BANNER_SEPARATOR)  # WHY: divider between title and body of the banner.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info("! Server URL: http://%s:%s", host, port)  # WHY: URL comes first so operators can click through.
     for line in _BANNER_LINES:
-        print(line)  # WHY: table-driven emission keeps additions trivial.
-    print(_BANNER_SEPARATOR)  # WHY: trailing divider signals end of banner block.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("%s", line)  # WHY: table-driven emission keeps additions trivial.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.info("%s", _BANNER_SEPARATOR)  # WHY: trailing divider signals end of banner block.
 
 
 def _maybe_open_browser(port: int) -> None:
@@ -225,11 +231,13 @@ def _run_flask_server(flask_app, host: str, port: int) -> None:
         logging.info("Starting Flask server on http://%s:%s", host, port)  # WHY: audit trail before blocking call.
         flask_app.run(host=host, port=port, debug=False, threaded=True, use_reloader=False)  # WHY: prod-safe args.
     except KeyboardInterrupt:
-        print("\n\nFlask map viewer stopped by user")  # WHY: friendly console signal on Ctrl+C.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\n\nFlask map viewer stopped by user")  # WHY: friendly console signal on Ctrl+C.
         logging.info("Flask map viewer stopped by user (Ctrl+C)")  # WHY: matching log entry for grep-based audits.
     except Exception as e:  # WHY: broad catch prevents a Flask crash from tearing down the CLI silently.
         logging.exception("Error running Flask server: %s", e)  # WHY: full stack for post-mortem log review.
-        print(f"\n! Error running map viewer: {e}")  # WHY: surface the failure to the operator on stdout as well.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("\n! Error running map viewer: %s", e)  # WHY: surface failure to operator on stdout as well.
 
 
 _HTML_TEMPLATE = """


### PR DESCRIPTION
Part of #886 — migrate remaining `print()` calls in `src/` to `logging`.

## Slice 46/N — `src/maps/_flask_viewer.py` (8 prints)

- Six banner `print()` calls in `_print_flask_viewer_banner` migrated to `logger.info(...)` with %-style deferred formatting.
- `_run_flask_server` `KeyboardInterrupt` branch → `logger.info(...)`; broad-exception branch → `logger.warning(...)`.
- No new imports (module-scoped logger already present at line 23).
- Each migrated call carries the standard `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.` annotation.
- Docstring for `_print_flask_viewer_banner` updated from "Print..." to "Emit..."; function name retained to avoid churn.

## Tests
- None to migrate: grep across `tests/` for `_flask_viewer`, `_print_flask_viewer_banner`, `launch_flask_viewer`, `_run_flask_server` returned zero matches.

## Gates
- `black --check` ✅
- `ruff check` ✅ (T201/T203 clean on the touched file)