### PR TITLE
chore(logging): migrate src/export/org_inventory_exporter.py print() to logger (#886 slice 47/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 84/N: retire `print()` in `src/export/org_inventory_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 12 `print()` calls in
+  `src/export/org_inventory_exporter.py` with `logger.info(...)` emissions
+  using `%`-style deferred formatting to satisfy G004. Added a module-scoped
+  `logger = logging.getLogger(__name__)` (module previously imported
+  `logging` for its `save_raw_json` helper but had no module logger).
+  Level heuristic: all twelve migrated sites are operator-visible status
+  lines (raw-JSON summary counts, VC-shell dashboard-parity note, menu 25
+  section headers, weekly/summary/master output paths and row counts,
+  device/gateway export confirmations, and the two "All Devices with Site
+  and Address Info" / "Gateways with Site and Address Info" banners), so
+  each maps to `logger.info`. Two helper docstrings updated from "Print" to
+  "Log" to match the new emission channel: `_emit_vc_shell_dashboard_diff`
+  and `_print_combined_inventory_summary` (function names left unchanged
+  to avoid churn in call sites). Each migrated call carries the standard
+  `# WHY: preserve operator notice verbatim; route through logger for
+  capture/redirection.` annotation.
+- **Test migration (Changed)**: `tests/unit/test_org_inventory_exporter_helpers.py`
+  migrated six `capsys.readouterr().out` assertions to `caplog.text` under
+  `caplog.at_level(logging.INFO, logger="src.export.org_inventory_exporter")`.
+  The affected tests cover `_emit_vc_shell_dashboard_diff` (three-line
+  dashboard-parity note), `_log_combined_inventory_vc_summary` (silent
+  path + emits-dashboard-note path), `_print_combined_inventory_summary`
+  (weekly / summary / master output naming), and the flatten/sort/export
+  device + gateway helpers. The "stays silent" assertion inverted from
+  `capsys.readouterr().out == ""` to `"provisioned VC shells" not in
+  caplog.text`, preserving the original behavioural contract now that the
+  module writes to the logger instead of stdout.
+- **Rationale**: brings `src/export/org_inventory_exporter.py` into
+  compliance with the module-by-module rollout of Ruff `T201` (`print()`
+  banned) and prepares the file for the eventual global flip in
+  `pyproject.toml`.
+
 ### #886 Phase 2 slice 83/N: retire `print()` in `src/maps/_flask_viewer.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 8 `print()` calls in

--- a/src/export/org_inventory_exporter.py
+++ b/src/export/org_inventory_exporter.py
@@ -41,6 +41,8 @@ from src.dataclasses.progress_event import ProgressContext  # Progress emitter p
 from src.export.org_site_exporter import OrgSiteExporter  # SiteList.csv generator for cache path.
 from src.utils.file_path_utils import FilePathUtils  # get_csv_path canonical location.
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger routes operator notices through capture/redirection.
+
 
 class OrgInventoryExporter:  # Org inventory exporters.
     """
@@ -175,10 +177,12 @@ class OrgInventoryExporter:  # Org inventory exporters.
                 )
                 for filename, kwargs in request_specs
             }
-            print(  # Show concise operator summary once all diagnostic files are written
-                f"  Raw JSON saved: vc=True ({counts_by_filename.get('raw_inventory_vc_true.json', 0)}), "
-                f"vc=False ({counts_by_filename.get('raw_inventory_vc_false.json', 0)}), "
-                f"no-vc ({counts_by_filename.get('raw_inventory_no_vc_param.json', 0)}) entries"
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info(  # Show concise operator summary once all diagnostic files are written
+                "  Raw JSON saved: vc=True (%s), vc=False (%s), no-vc (%s) entries",
+                counts_by_filename.get("raw_inventory_vc_true.json", 0),
+                counts_by_filename.get("raw_inventory_vc_false.json", 0),
+                counts_by_filename.get("raw_inventory_no_vc_param.json", 0),
             )
         except Exception as json_save_error:  # Diagnostic failure is non-fatal by design
             logging.warning("Failed to save raw inventory JSON: %s", json_save_error)  # Preserve root cause
@@ -232,16 +236,22 @@ class OrgInventoryExporter:  # Org inventory exporters.
     def _emit_vc_shell_dashboard_diff(
         site_configs: list[dict[str, str]], empty_vc_shells: list[dict[str, str]]
     ) -> None:
-        """Print the dashboard-vs-report parity note when empty VC shells exist."""
-        print(
-            f"  NOTE: {len(empty_vc_shells)} provisioned VC shells exist with no physical members."
+        """Log the dashboard-vs-report parity note when empty VC shells exist."""
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(
+            "  NOTE: %s provisioned VC shells exist with no physical members.",
+            len(empty_vc_shells),
         )  # Explain why dashboard counts may exceed report counts
-        print(  # Provide explicit comparison so operators trust the physical-only report totals
-            f"        Dashboard shows {len(site_configs) + len(empty_vc_shells)} 'Physical Devices' "
-            f"but {len(empty_vc_shells)} are empty VC placeholders (020003* MAC, no serial/SKU)."
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(  # Provide explicit comparison so operators trust the physical-only report totals
+            "        Dashboard shows %s 'Physical Devices' but %s are empty VC placeholders (020003* MAC, no serial/SKU).",  # noqa: E501
+            len(site_configs) + len(empty_vc_shells),
+            len(empty_vc_shells),
         )
-        print(
-            f"        Report correctly includes only {len(site_configs)} devices with real hardware."
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(
+            "        Report correctly includes only %s devices with real hardware.",
+            len(site_configs),
         )  # Confirm report logic remains intentional
 
     @staticmethod
@@ -442,7 +452,8 @@ class OrgInventoryExporter:  # Org inventory exporters.
     @staticmethod
     def combined_inventory_with_site_info():  # Export devices with site info.
         """Combine fresh AllDevicesWithSiteInfo data into weekly CSV files + summary + master CSV."""
-        print("Combined Inventory with Site Info by Calendar Week:")  # Announce menu 25 export scope
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Combined Inventory with Site Info by Calendar Week:")  # Announce menu 25 export scope
         ctx = OrgInventoryExporter._prepare_combined_inventory_context()  # Resolve org + customer + paths
         current_org_id, end_customer_name, end_customer_account_id, safe_org_name, output_folder = ctx
         OrgInventoryExporter.devices_with_site_info()  # Regenerate enriched inventory CSV first
@@ -471,15 +482,22 @@ class OrgInventoryExporter:  # Org inventory exporters.
         master_csv_filename: str,
         master_row_count: int,
     ) -> None:
-        """Print the three CombinedInventory output locations (weekly CSVs, summary, master) for the operator."""
-        print(
-            f"! {len(weekly_data)} weekly CSV files created in data/CombinedInventory_ByWeek/ folder ({len(site_configs)} total devices processed)"  # noqa: E501
+        """Log the three CombinedInventory output locations (weekly CSVs, summary, master) for the operator."""
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(
+            "! %s weekly CSV files created in data/CombinedInventory_ByWeek/ folder (%s total devices processed)",
+            len(weekly_data),
+            len(site_configs),
         )  # Summarize weekly export output counts for the operator.
-        print(
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(
             "! Summary report exported to data/CombinedInventory_ByWeek/CombinedInventory_Summary.csv"
         )  # Confirm summary report location.
-        print(
-            f"! Master inventory exported to data/CombinedInventory_ByWeek/{master_csv_filename} ({master_row_count} devices)"  # noqa: E501
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(
+            "! Master inventory exported to data/CombinedInventory_ByWeek/%s (%s devices)",
+            master_csv_filename,
+            master_row_count,
         )  # Confirm master report path and row count.
 
     @staticmethod
@@ -602,7 +620,8 @@ class OrgInventoryExporter:  # Org inventory exporters.
         devices = DataProcessingUtils.escape_multiline(devices)  # type: ignore[no-untyped-call]
         devices = sorted(devices, key=lambda x: x.get("site_name", ""))  # Sort by site name.
         mh.DataExporter.write_with_format_selection(devices, "AllDevicesWithSiteInfo.csv")  # type: ignore[no-untyped-call]
-        print(f"! {len(devices)} devices exported to AllDevicesWithSiteInfo.csv")  # Confirm export to operator.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("! %s devices exported to AllDevicesWithSiteInfo.csv", len(devices))  # Confirm export to operator.
         logging.info("All device data written to AllDevicesWithSiteInfo.csv (%s records).", len(devices))  # Log write.
         return devices  # Processed rows for the summary table.
 
@@ -635,7 +654,8 @@ class OrgInventoryExporter:  # Org inventory exporters.
         the data is fetched directly from the API. Physical VC members without a site_id inherit one from
         their VC parent. Also debug-logs a summary table.
         """
-        print("All Devices with Site and Address Info:")  # Inform operator of export.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("All Devices with Site and Address Info:")  # Inform operator of export.
         logging.info("Fetching All Devices with Site Info...")  # Log fetch start.
         if fast:  # Fast mode reuses cached CSVs.
             logging.info(" Fast mode enabled for devices with site info export")  # Log fast mode enabled.
@@ -654,7 +674,8 @@ class OrgInventoryExporter:  # Org inventory exporters.
         Fetches all gateway devices in the organization, enriches them with site and address info,
         and exports the result to GatewaysWithSiteInfo.csv. Also logs and displays a summary table.
         """
-        print("Gateways with Site and Address Info:")  # Inform operator of export.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Gateways with Site and Address Info:")  # Inform operator of export.
         logging.info("Fetching Gateways with Site Info...")  # Log fetch start.
         org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
 
@@ -678,7 +699,8 @@ class OrgInventoryExporter:  # Org inventory exporters.
         gateways = DataProcessingUtils.escape_multiline(gateways)  # type: ignore[no-untyped-call]
         gateways = sorted(gateways, key=lambda x: x.get("site_name", ""))  # Sort by site name.
         mh.DataExporter.write_with_format_selection(gateways, "GatewaysWithSiteInfo.csv")  # type: ignore[no-untyped-call]
-        print(f"! {len(gateways)} gateways exported to GatewaysWithSiteInfo.csv")  # Confirm export to operator.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("! %s gateways exported to GatewaysWithSiteInfo.csv", len(gateways))  # Confirm export to operator.
         logging.info("Gateway data written to GatewaysWithSiteInfo.csv")  # Log write success.
         return gateways  # Processed rows for the summary table
 

--- a/tests/unit/test_org_inventory_exporter_helpers.py
+++ b/tests/unit/test_org_inventory_exporter_helpers.py
@@ -168,21 +168,20 @@ def test_partition_combined_inventory_rows_composes_split_and_classify() -> None
 # ---------------------------------------------------------------------------
 
 
-def test_emit_vc_shell_dashboard_diff_prints_three_lines(capsys: pytest.CaptureFixture[str]) -> None:
+def test_emit_vc_shell_dashboard_diff_prints_three_lines(caplog: pytest.LogCaptureFixture) -> None:
     physical = [{"mac": "aabbccddee01"}]
     shells = [{"mac": "020003ffffff"}]
-    OrgInventoryExporter._emit_vc_shell_dashboard_diff(physical, shells)
-    captured = capsys.readouterr().out
-    assert "1 provisioned VC shells" in captured
-    assert "Dashboard shows 2" in captured
-    assert "Report correctly includes only 1" in captured
+    with caplog.at_level(logging.INFO, logger="src.export.org_inventory_exporter"):
+        OrgInventoryExporter._emit_vc_shell_dashboard_diff(physical, shells)
+    assert "1 provisioned VC shells" in caplog.text
+    assert "Dashboard shows 2" in caplog.text
+    assert "Report correctly includes only 1" in caplog.text
 
 
 def test_log_combined_inventory_vc_summary_without_shells_stays_silent(
     caplog: pytest.LogCaptureFixture,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """No empty shells -> no dashboard-parity print."""
+    """No empty shells -> no dashboard-parity log line."""
     with caplog.at_level(logging.INFO):
         OrgInventoryExporter._log_combined_inventory_vc_summary(
             all_devices=[{"mac": "aabb"}],
@@ -191,12 +190,11 @@ def test_log_combined_inventory_vc_summary_without_shells_stays_silent(
             duplicate_vc_entries=0,
         )
     assert "Loaded 1 total devices" in caplog.text
-    assert capsys.readouterr().out == ""
+    assert "provisioned VC shells" not in caplog.text
 
 
 def test_log_combined_inventory_vc_summary_with_shells_emits_dashboard_note(
     caplog: pytest.LogCaptureFixture,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     with caplog.at_level(logging.INFO):
         OrgInventoryExporter._log_combined_inventory_vc_summary(
@@ -206,7 +204,7 @@ def test_log_combined_inventory_vc_summary_with_shells_emits_dashboard_note(
             duplicate_vc_entries=0,
         )
     assert "Virtual VC breakdown" in caplog.text
-    assert "provisioned VC shells" in capsys.readouterr().out
+    assert "provisioned VC shells" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -342,13 +340,14 @@ def test_write_combined_inventory_master_csv_builds_filename_and_returns_row_cou
 # ---------------------------------------------------------------------------
 
 
-def test_print_combined_inventory_summary_names_three_outputs(capsys: pytest.CaptureFixture[str]) -> None:
+def test_print_combined_inventory_summary_names_three_outputs(caplog: pytest.LogCaptureFixture) -> None:
     weekly: defaultdict = defaultdict(list)
     weekly["2024_Week_01"] = [{}]
     weekly["2024_Week_02"] = [{}, {}]
     site_configs = [{}] * 3
-    OrgInventoryExporter._print_combined_inventory_summary(weekly, site_configs, "acme.csv", 3)
-    out = capsys.readouterr().out
+    with caplog.at_level(logging.INFO, logger="src.export.org_inventory_exporter"):
+        OrgInventoryExporter._print_combined_inventory_summary(weekly, site_configs, "acme.csv", 3)
+    out = caplog.text
     assert "2 weekly CSV files" in out
     assert "3 total devices processed" in out
     assert "CombinedInventory_Summary.csv" in out
@@ -458,7 +457,7 @@ class _RecordingDataExporter:
 
 
 def test_flatten_sort_export_devices_sorts_by_site_and_writes_csv(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     _RecordingDataExporter.calls = []
     monkeypatch.setattr(MistHelper, "DataExporter", _RecordingDataExporter)
@@ -466,14 +465,15 @@ def test_flatten_sort_export_devices_sorts_by_site_and_writes_csv(
         {"name": "d2", "site_name": "Zeta"},
         {"name": "d1", "site_name": "Alpha"},
     ]
-    result = OrgInventoryExporter._flatten_sort_export_devices(devices)
+    with caplog.at_level(logging.INFO, logger="src.export.org_inventory_exporter"):
+        result = OrgInventoryExporter._flatten_sort_export_devices(devices)
     assert [d["site_name"] for d in result] == ["Alpha", "Zeta"]
     assert _RecordingDataExporter.calls[-1][1] == "AllDevicesWithSiteInfo.csv"
-    assert "2 devices exported" in capsys.readouterr().out
+    assert "2 devices exported" in caplog.text
 
 
 def test_flatten_sort_export_gateways_sorts_by_site_and_writes_csv(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     _RecordingDataExporter.calls = []
     monkeypatch.setattr(MistHelper, "DataExporter", _RecordingDataExporter)
@@ -481,10 +481,11 @@ def test_flatten_sort_export_gateways_sorts_by_site_and_writes_csv(
         {"name": "g2", "site_name": "Zeta"},
         {"name": "g1", "site_name": "Alpha"},
     ]
-    result = OrgInventoryExporter._flatten_sort_export_gateways(gateways)
+    with caplog.at_level(logging.INFO, logger="src.export.org_inventory_exporter"):
+        result = OrgInventoryExporter._flatten_sort_export_gateways(gateways)
     assert [g["site_name"] for g in result] == ["Alpha", "Zeta"]
     assert _RecordingDataExporter.calls[-1][1] == "GatewaysWithSiteInfo.csv"
-    assert "2 gateways exported" in capsys.readouterr().out
+    assert "2 gateways exported" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 47/N of #886 (CHANGELOG slice 84/N). Retire every `print()` in
`src/export/org_inventory_exporter.py` (12 calls) in favor of a
module-scoped `logger = logging.getLogger(__name__)` with `%`-style
deferred formatting (G004-clean).

- All 12 sites map to `logger.info(...)` (operator-visible status lines:
  raw JSON summary counts, VC-shell dashboard-parity note, menu 25
  section headers, weekly/summary/master output paths, device/gateway
  export confirmations).
- Two helper docstrings updated from "Print" to "Log"
  (`_emit_vc_shell_dashboard_diff`, `_print_combined_inventory_summary`);
  function names left unchanged to avoid churn in call sites.
- Six `capsys` unit-test assertions migrated to `caplog.text` under
  `caplog.at_level(logging.INFO, logger="src.export.org_inventory_exporter")`.
  The "stays silent" assertion inverted from
  `capsys.readouterr().out == ""` to `"provisioned VC shells" not in
  caplog.text` to preserve the behavioural contract.

Each migrated call carries the standard
`# WHY: preserve operator notice verbatim; route through logger for
capture/redirection.` annotation.

## Test plan

- [x] `black --check src/export/org_inventory_exporter.py tests/unit/test_org_inventory_exporter_helpers.py`
- [x] `ruff check src/export/org_inventory_exporter.py tests/unit/test_org_inventory_exporter_helpers.py`
- [x] `pytest tests/unit/test_org_inventory_exporter_helpers.py` (57/57 pass)

Refs #886