### PR TITLE
chore(logging): migrate src/ssh/connection/connector.py print() to logger (#886 slice 51/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 51/N: retire `print()` in `src/ssh/connection/connector.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 14 `print()` calls in
+  `src/ssh/connection/connector.py` with `self.logger.*` emissions (or the
+  new module-scoped `logger.*` for the `@staticmethod _paramiko_available`
+  call sites that cannot access `self`), using `%`-style deferred
+  formatting to satisfy G004. Added a module-scoped `logger =
+  logging.getLogger(_LOGGER_NAME)` alongside the existing `_LOGGER_NAME =
+  "ssh_runner_v2"` constant so the two static-method emissions land on the
+  same unified SSH logger the rest of the class uses. Level heuristic:
+  `>>` preflight banner and `[OK]` / `[INFO]` status lines map to
+  `logger.info`; `[ERROR]` prefixed failure notices (`_fail_input`,
+  paramiko-missing hint pair in `_paramiko_available`, host key enrollment
+  failure, DNS resolution error, connection timeout, bad host key, auth
+  failure, untrusted host key, generic SSH error, unexpected error) map to
+  `logger.error`. Preserved: the pre-existing `import logging`,
+  `logging.getLogger(_LOGGER_NAME)` fallback getter in `__init__`, the
+  `logging.Logger` type annotations, and the `_LOGGER_NAME` constant.
+  Each migrated call carries the standard `# WHY: preserve operator
+  notice verbatim; route through logger for capture/redirection.`
+  annotation and preserves the exact user-visible text operators grep on.
+- **Test migration (Changed)**: none. `tests/unit/ssh/test_connector.py`
+  and `tests/unit/test_ssh_host_key_tofu.py` were grepped for
+  `capsys|capfd|readouterr` — no matches, so no stdout-based assertions
+  needed conversion to `caplog`.
+- **Rationale**: brings `src/ssh/connection/connector.py` into compliance
+  with the module-by-module rollout of Ruff `T201` (`print()` retirement)
+  tracked in issue #886. Routing through `self.logger` on the unified
+  `"ssh_runner_v2"` logger keeps SSH connection lifecycle output
+  capturable, redirectable, and consistent with the rest of the SSH
+  runner v2 stack.
+
 ### #886 Phase 2 slice 87/N: retire `print()` in `src/site/address_audit/audit_engine.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 5 `print()` calls

--- a/src/ssh/connection/connector.py
+++ b/src/ssh/connection/connector.py
@@ -50,6 +50,8 @@ _BAD_HOST_KEY_MSG = (  # WHY: verbatim operator message for a mismatched host ke
     "[ERROR] Host key verification failed - update the known_hosts entry before retrying"
 )
 
+logger = logging.getLogger(_LOGGER_NAME)  # WHY: module-scoped logger for @staticmethod call sites.
+
 
 # ---------------------------------------------------------------------------
 # Exception dispatch table (keeps _handle_connect_exception at CC <= 3)
@@ -114,7 +116,8 @@ class SshConnector:
         if not self._paramiko_available():  # WHY: hard requirement — paramiko import must have succeeded.
             return False  # WHY: paramiko-missing message already printed.
         self.logger.info("Attempting SSH connection to %s:%s as %s", hostname, port, username)  # WHY: audit.
-        print(f">> Connecting to {hostname}:{port} as {username}...")  # WHY: verbatim user-facing status line.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.info(">> Connecting to %s:%s as %s...", hostname, port, username)
         return True  # WHY: preflight passed, connect flow may proceed.
 
     # ------------------------------------------------------------------
@@ -139,7 +142,8 @@ class SshConnector:
     def _fail_input(self, error_msg: str) -> None:
         """Standard "log error + print bracketed ERROR" used for every input failure."""
         self.logger.error(error_msg)  # WHY: persistent record in script.log.
-        print(f"[ERROR] {error_msg}")  # WHY: user-facing console line (verbatim wording).
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.error("[ERROR] %s", error_msg)
 
     @staticmethod
     def _validate_port(port: int) -> bool:
@@ -152,8 +156,10 @@ class SshConnector:
         if SSHClient is not None and paramiko is not None:  # WHY: paramiko import succeeded at load.
             return True  # WHY: normal production path — nothing to warn about.
         logging.getLogger(_LOGGER_NAME).error(_PARAMIKO_MISSING_MSG)  # WHY: audit-log the missing import.
-        print(f"[ERROR] {_PARAMIKO_MISSING_MSG}")  # WHY: tell the operator what is missing.
-        print(_PARAMIKO_INSTALL_HINT)  # WHY: tell the operator how to install paramiko.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.error("[ERROR] %s", _PARAMIKO_MISSING_MSG)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.error(_PARAMIKO_INSTALL_HINT)
         return False  # WHY: paramiko unavailable, connect cannot continue.
 
     # ------------------------------------------------------------------
@@ -170,7 +176,8 @@ class SshConnector:
             self._trust_host_on_first_use(client, hostname, port)  # WHY: enroll first-seen key into managed store.
         except Exception as enroll_error:  # noqa: BLE001 - broad catch: log then translate to connection failure.
             self.logger.exception("TOFU enrollment failed for %s:%s: %s", hostname, port, enroll_error)  # WHY: audit.
-            print(f"[ERROR] Host key enrollment failed: {enroll_error}")  # WHY: verbatim operator message.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            self.logger.error("[ERROR] Host key enrollment failed: %s", enroll_error)
             return None  # WHY: caller treats None as a hard connection failure.
         return client  # WHY: client is ready to attempt authentication.
 
@@ -269,7 +276,8 @@ class SshConnector:
         self._save_host_keys(client)  # WHY: persist the new entry to the managed file.
         fingerprint = self._format_host_key_fingerprint(remote_host_key)  # WHY: compute display fingerprint.
         self.logger.warning("TOFU enrolled new SSH host key for %s (%s)", entry_name, fingerprint)  # WHY: audit.
-        print(f"[INFO] Trusted first-seen SSH host key for {entry_name} ({fingerprint})")  # WHY: verbatim notice.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.info("[INFO] Trusted first-seen SSH host key for %s (%s)", entry_name, fingerprint)
 
     # ------------------------------------------------------------------
     # Authenticated connect + exception handling
@@ -315,7 +323,8 @@ class SshConnector:
         """Log verbatim success traces and print the [OK] user-facing line."""
         self.logger.debug("SSH connection established in %.2f seconds", connection_time)  # WHY: verbatim.
         self.logger.info("Successfully connected to %s in %.2f seconds", hostname, connection_time)  # WHY: audit.
-        print(f"[OK] Successfully connected to {hostname}")  # WHY: verbatim user-facing success line.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.info("[OK] Successfully connected to %s", hostname)
 
     def _handle_connect_exception(
         self,
@@ -338,32 +347,38 @@ class SshConnector:
     def _log_dns_error(self, error: BaseException, hostname: str, _port: int, _username: str) -> None:
         """Handler row: DNS resolution failure (socket.gaierror)."""
         self.logger.error("DNS Resolution Error for %s: %s", hostname, error)  # WHY: audit DNS miss.
-        print(f"[ERROR] DNS Resolution Error: {error}")  # WHY: verbatim operator message.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.error("[ERROR] DNS Resolution Error: %s", error)
 
     def _log_timeout_error(self, _error: BaseException, hostname: str, port: int, _username: str) -> None:
         """Handler row: socket-level handshake timeout (TimeoutError)."""
         self.logger.error(  # WHY: audit timeout with host/port/timeout context.
             "Connection timeout to %s:%s after %s seconds", hostname, port, self.timeout
         )
-        print(f"[ERROR] Connection timeout after {self.timeout} seconds")  # WHY: verbatim operator message.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.error("[ERROR] Connection timeout after %s seconds", self.timeout)
 
     def _log_bad_host_key(self, error: BaseException, hostname: str, _port: int, _username: str) -> None:
         """Handler row: mismatched known host key (paramiko.BadHostKeyException)."""
         self.logger.error("Host key verification failed for %s: %s", hostname, error)  # WHY: audit.
-        print(_BAD_HOST_KEY_MSG)  # WHY: verbatim operator remediation prompt.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.error(_BAD_HOST_KEY_MSG)
 
     def _log_auth_failure(self, error: BaseException, hostname: str, _port: int, username: str) -> None:
         """Handler row: authentication failure (paramiko.AuthenticationException)."""
         self.logger.error("Authentication failed for %s@%s: %s", username, hostname, error)  # WHY: audit.
-        print(_AUTH_FAILURE_MSG)  # WHY: verbatim operator remediation prompt.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.error(_AUTH_FAILURE_MSG)
 
     def _log_ssh_error(self, error: BaseException, hostname: str, _port: int, _username: str) -> None:
         """Handler row: generic paramiko.SSHException with known-hosts specialisation."""
         self.logger.error("SSH Error connecting to %s: %s", hostname, error)  # WHY: audit generic SSH failure.
         if _KNOWN_HOSTS_MARKER in str(error):  # WHY: specialized message when the SSH error names known_hosts.
-            print(_UNTRUSTED_HOST_KEY_MSG)  # WHY: verbatim operator remediation prompt.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            self.logger.error(_UNTRUSTED_HOST_KEY_MSG)
             return  # WHY: specialised message already printed.
-        print(f"[ERROR] SSH Error: {error}")  # WHY: verbatim generic SSH error message.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.error("[ERROR] SSH Error: %s", error)
 
     def _log_unknown_error(self, error: BaseException, hostname: str) -> None:
         """Fallback handler for exceptions not covered by any table row."""
@@ -374,7 +389,8 @@ class SshConnector:
             error,
             exc_info=True,
         )
-        print(f"[ERROR] Unexpected error: {error}")  # WHY: verbatim catch-all operator message.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        self.logger.error("[ERROR] Unexpected error: %s", error)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Slice 51/N of #886: retires all 14 `print()` calls in `src/ssh/connection/connector.py` in favor of the unified `"ssh_runner_v2"` logger.

- All 14 prints converted to `self.logger.*` (instance methods) or `logger.*` (the two calls inside `@staticmethod _paramiko_available`) with `%`-style deferred formatting (G004-clean).
- Added a module-scoped `logger = logging.getLogger(_LOGGER_NAME)` so the static method can emit on the same unified SSH logger the rest of the class uses.
- Level heuristic: `>>` preflight + `[OK]` / `[INFO]` → `info`; `[ERROR]` failure notices → `error`.
- Preserved `import logging`, the `__init__` fallback `logging.getLogger(_LOGGER_NAME)`, the `logging.Logger` type annotations, and the `_LOGGER_NAME` constant.
- Every converted line carries the standard `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.` annotation.
- No `capsys`/`capfd`/`readouterr` in `tests/unit/ssh/test_connector.py` or `tests/unit/test_ssh_host_key_tofu.py` — no test migration needed. Local: `pytest` 28/28, `black`/`ruff` clean.

Refs #886.