### PR TITLE
chore(logging): migrate src/device/_utility_commands_clear.py print() to logger (#886 slice 79/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 79/N: retire `print()` in `src/device/_utility_commands_clear.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 15 `print()` calls
+  in `src/device/_utility_commands_clear.py` with module-scoped
+  `logger.*` emissions using `%`-style deferred formatting to satisfy
+  G004. Level heuristic: `>> …` progress lines and `[OK]` results map
+  to `logger.info`; `[!] … failed:` handlers map to `logger.error`;
+  "cancelled" / "… required" user-facing operator notices map to
+  `logger.warning`. Each converted call carries the standard
+  `# WHY: preserve operator notice verbatim; route through logger for
+  capture/redirection.` inline comment so future auditors can trace the
+  origin.
+- **Tests (Changed)**: migrated 12 tests in
+  `tests/unit/test_device_utility_commands.py` from `capsys` stdout
+  assertions to `caplog` log-record assertions
+  (`caplog.at_level(logging.LEVEL)` + `assert "…" in caplog.text`).
+  Full 194-test module passes locally under the new fixtures.
+
 ### #886 Phase 2 slice 51/N: retire `print()` in `src/ssh/connection/connector.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 14 `print()` calls in

--- a/src/device/_utility_commands_clear.py
+++ b/src/device/_utility_commands_clear.py
@@ -20,16 +20,16 @@ public command reads as ``select -> build -> confirm -> dispatch`` at
 cyclomatic complexity <= 5.
 """
 
-# pylint: disable=logging-fstring-interpolation
-
 from __future__ import annotations  # WHY: postponed evaluation for forward-ref type hints
 
-import logging  # WHY: exception-level logging when API calls fail
+import logging  # WHY: module-scoped logger + exception-level logging when API calls fail
 from typing import Any  # WHY: Any narrows the SDK response type
 
 import mistapi  # WHY: direct SDK access mirrors parent module usage
 
 from ._utility_commands_cluster import _ClusterBase  # WHY: shared proxy base
+
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger for %-style deferred formatting
 
 
 class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring earlier phase clusters
@@ -41,7 +41,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
 
     def clear_arp_cache(self) -> None:  # WHY: menu 147 destructive ARP-clear entry
         """Menu 147: Clear ARP cache (typed 'CLEAR' confirmation)."""
-        logging.info("Menu #147: Clear ARP Cache")  # WHY: audit menu entry
+        logger.info("Menu #147: Clear ARP Cache")  # WHY: audit menu entry
         selection = self._select_site_and_device("clear_arp")  # WHY: pick site + switch/gateway
         if not selection:  # WHY: cancelled -> abort
             return  # WHY: no work when operator cancels
@@ -83,8 +83,9 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Clear ARP cache failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Clear ARP cache failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Clear ARP cache failed: {error}")  # WHY: surface error to operator
+            logger.exception("Clear ARP cache failed: %s", error)  # WHY: audit failure with stack
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Clear ARP cache failed: %s", error)
 
     # ------------------------------------------------------------------
     # clear_bgp_routes
@@ -92,7 +93,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
 
     def clear_bgp_routes(self) -> None:  # WHY: menu 148 destructive BGP-clear entry
         """Menu 148: Clear BGP routes (typed 'CLEAR' confirmation)."""
-        logging.info("Menu #148: Clear BGP Routes")  # WHY: audit menu entry
+        logger.info("Menu #148: Clear BGP Routes")  # WHY: audit menu entry
         selection = self._select_site_and_device("clear_bgp", "gateway")  # WHY: gateway-only op
         if not selection:  # WHY: cancelled -> abort
             return  # WHY: no work when operator cancels
@@ -117,7 +118,8 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             allow_empty=False,
         )  # WHY: neighbor is mandatory
         if not neighbor:  # WHY: guard against empty submission
-            print("! Neighbor IP is required.")  # WHY: signal cancel reason
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Neighbor IP is required.")
             return None  # WHY: propagate missing-required signal to caller
         body: dict[str, Any] = {"neighbor": neighbor}  # WHY: seed with required field
         self._maybe_add_bgp_type(body)  # WHY: optional direction filter
@@ -168,8 +170,9 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Clear BGP routes failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Clear BGP routes failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Clear BGP routes failed: {error}")  # WHY: surface error to operator
+            logger.exception("Clear BGP routes failed: %s", error)  # WHY: audit failure with stack
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Clear BGP routes failed: %s", error)
 
     # ------------------------------------------------------------------
     # clear_session
@@ -177,7 +180,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
 
     def clear_session(self) -> None:  # WHY: menu 149 destructive session-clear entry
         """Menu 149: Clear session on SSR/SRX gateway."""
-        logging.info("Menu #149: Clear Session")  # WHY: audit menu entry
+        logger.info("Menu #149: Clear Session")  # WHY: audit menu entry
         selection = self._select_site_and_device("clear_session", "gateway")  # WHY: gateway-only op
         if not selection:  # WHY: cancelled -> abort
             return  # WHY: no work when operator cancels
@@ -214,7 +217,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Clear session failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Clear session failed: %s", error)  # WHY: audit failure with stack
+            logger.exception("Clear session failed: %s", error)  # WHY: audit failure with stack
             self._handle_clear_session_error(error)  # WHY: shared 400-aware error UX
 
     def _build_clear_session_body(self) -> dict[str, Any] | None:  # WHY: gather + validate session filters
@@ -264,7 +267,8 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             context="clear_session_confirm_all",
         )  # WHY: extra guard against unintended full clears
         if confirm_all != "CLEAR ALL":  # WHY: exact keyword required
-            print("Cancelled: No service name or session IDs provided.")  # WHY: signal cancel reason
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("Cancelled: No service name or session IDs provided.")
             return False  # WHY: operator declined CLEAR-ALL
         return True  # WHY: operator explicitly opted into CLEAR-ALL
 
@@ -274,7 +278,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
 
     def clear_mac_table(self) -> None:  # WHY: menu 150 destructive MAC-table clear entry
         """Menu 150: Clear MAC table (typed 'CLEAR' confirmation)."""
-        logging.info("Menu #150: Clear MAC Table")  # WHY: audit menu entry
+        logger.info("Menu #150: Clear MAC Table")  # WHY: audit menu entry
         selection = self._select_site_and_device("clear_mac_table")  # WHY: switch/gateway op
         if not selection:  # WHY: cancelled -> abort
             return  # WHY: no work when operator cancels selection
@@ -309,12 +313,13 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Clear MAC table failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Clear MAC table failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Clear MAC table failed: {error}")  # WHY: surface error to operator
+            logger.exception("Clear MAC table failed: %s", error)  # WHY: audit failure with stack
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Clear MAC table failed: %s", error)
 
     def clear_bpdu_error(self) -> None:  # WHY: menu 151 destructive BPDU-error clear entry
         """Menu 151: Clear BPDU errors on switch."""
-        logging.info("Menu #151: Clear BPDU Errors")  # WHY: audit menu entry
+        logger.info("Menu #151: Clear BPDU Errors")  # WHY: audit menu entry
         selection = self._select_site_and_device("clear_bpdu_error", "switch")  # WHY: switch-only
         if not selection:  # WHY: cancelled -> abort
             return  # WHY: no work when operator cancels selection
@@ -344,12 +349,13 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Clear BPDU errors failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Clear BPDU errors failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Clear BPDU errors failed: {error}")  # WHY: surface error to operator
+            logger.exception("Clear BPDU errors failed: %s", error)  # WHY: audit failure with stack
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Clear BPDU errors failed: %s", error)
 
     def clear_learned_macs(self) -> None:
         """Menu 152: Clear learned MACs from switch port."""
-        logging.info("Menu #152: Clear Learned MACs")  # WHY: audit menu entry
+        logger.info("Menu #152: Clear Learned MACs")  # WHY: audit menu entry
         selection = self._select_site_and_device("clear_macs", "switch")  # WHY: switch-only
         if not selection:  # WHY: cancelled -> abort
             return
@@ -369,7 +375,8 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         """Pick a required port and normalize ``xe-0/0/0`` -> ``xe-0/0/0.0``."""
         port_id = self._select_port_from_device(site_id, device_id)  # WHY: required port picker
         if not port_id:  # WHY: cancelled or empty selection
-            print("! Port selection is required for clearing learned MACs.")  # WHY: signal cancel
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Port selection is required for clearing learned MACs.")
             return None
         return port_id if "." in port_id else f"{port_id}.0"  # WHY: SDK requires .unit suffix
 
@@ -389,8 +396,9 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Clear learned MACs failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Clear learned MACs failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Clear learned MACs failed: {error}")  # WHY: surface error to operator
+            logger.exception("Clear learned MACs failed: %s", error)  # WHY: audit failure with stack
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Clear learned MACs failed: %s", error)
 
     # ------------------------------------------------------------------
     # clear_policy_hit_count
@@ -400,7 +408,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         """Menu 153: Clear policy hit count on SSR."""
         # TODO: Returns 400 on DC-West SSR120. Investigate API
         # requirements - may need node param or be unsupported.
-        logging.info("Menu #153: Clear Policy Hit Count")  # WHY: audit menu entry
+        logger.info("Menu #153: Clear Policy Hit Count")  # WHY: audit menu entry
         selection = self._select_site_and_device("clear_policy_hit_count", "gateway")  # WHY: gateway-only
         if not selection:  # WHY: cancelled -> abort
             return
@@ -430,8 +438,9 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Clear policy hit count failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Clear policy hit count failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Clear policy hit count failed: {error}")  # WHY: surface error to operator
+            logger.exception("Clear policy hit count failed: %s", error)  # WHY: audit failure with stack
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Clear policy hit count failed: %s", error)
 
     # ------------------------------------------------------------------
     # release_dhcp_lease / release_dhcp_ssr
@@ -439,7 +448,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
 
     def release_dhcp_lease(self) -> None:
         """Menu 154: Release DHCP lease on switch/gateway."""
-        logging.info("Menu #154: Release DHCP Lease")  # WHY: audit menu entry
+        logger.info("Menu #154: Release DHCP Lease")  # WHY: audit menu entry
         selection = self._select_site_and_device("release_dhcp")  # WHY: switch/gateway op
         if not selection:  # WHY: cancelled -> abort
             return
@@ -460,7 +469,8 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         """Build DHCP-release body from a required port pick + optional node."""
         port_id = self._select_port_from_device(site_id, device_id)  # WHY: required port picker
         if not port_id:  # WHY: cancelled or empty selection
-            print("! Port selection is required.")  # WHY: signal cancel reason
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Port selection is required.")
             return None
         body: dict[str, Any] = {"port_id": port_id}  # WHY: required field first
         self._maybe_add_input(body, "node", "Node (node0/node1, Enter to skip): ", node_context)
@@ -473,7 +483,8 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             context=context,
         )  # WHY: destructive-op confirmation
         if confirm.lower() != "y":  # WHY: anything other than 'y' aborts
-            print("! Operation cancelled.")  # WHY: acknowledge cancel
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Operation cancelled.")
             return False
         return True
 
@@ -492,12 +503,13 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Release DHCP lease failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Release DHCP lease failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Release DHCP lease failed: {error}")  # WHY: surface error to operator
+            logger.exception("Release DHCP lease failed: %s", error)  # WHY: audit failure with stack
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Release DHCP lease failed: %s", error)
 
     def release_dhcp_ssr(self) -> None:
         """Menu 155: Release DHCP lease on SSR/SRX."""
-        logging.info("Menu #155: Release DHCP Lease (SSR)")  # WHY: audit menu entry
+        logger.info("Menu #155: Release DHCP Lease (SSR)")  # WHY: audit menu entry
         selection = self._select_site_and_device("release_dhcp_ssr", "gateway")  # WHY: gateway-only
         if not selection:  # WHY: cancelled -> abort
             return
@@ -517,7 +529,8 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         """Build SSR DHCP-release body from a required interface pick + optional node."""
         port_id = self._select_interface_from_device(site_id, device_id)  # WHY: SSR uses named ifaces
         if not port_id:  # WHY: cancelled or empty selection
-            print("! Network interface is required.")  # WHY: signal cancel reason
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Network interface is required.")
             return None
         body: dict[str, Any] = {"port_id": port_id}  # WHY: required field first
         self._maybe_add_input(body, "node", "Node (node0/node1, Enter to skip): ", "release_dhcp_ssr_node")
@@ -530,7 +543,8 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             context="release_dhcp_ssr",
         )  # WHY: destructive-op confirmation
         if confirm.lower() != "y":  # WHY: anything other than 'y' aborts
-            print("! Operation cancelled.")  # WHY: acknowledge cancel
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Operation cancelled.")
             return False
         return True
 
@@ -549,8 +563,9 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
                 "Release SSR DHCP lease failed",
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
-            logging.exception("Release SSR DHCP lease failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Release SSR DHCP lease failed: {error}")  # WHY: surface error to operator
+            logger.exception("Release SSR DHCP lease failed: %s", error)  # WHY: audit failure with stack
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Release SSR DHCP lease failed: %s", error)
 
 
 def _assign_session_ids(body: dict[str, Any], raw: str) -> None:

--- a/tests/test_clear_session.py
+++ b/tests/test_clear_session.py
@@ -99,7 +99,7 @@ def test_clear_session_with_session_ids(monkeypatch):
     assert captured.get("body") == {"session_ids": ["s1", "s2", "s3"]}
 
 
-def test_clear_session_cancel_clear_all(monkeypatch, capsys):
+def test_clear_session_cancel_clear_all(monkeypatch, caplog):
     _stub_selection(monkeypatch)
 
     def fake_safe_input(prompt, context=None, allow_empty=True, **kwargs):
@@ -117,10 +117,11 @@ def test_clear_session_cancel_clear_all(monkeypatch, capsys):
 
     with patch("src.device._utility_commands_clear.mistapi") as mock_api:
         mock_api.api.v1.sites.devices.clearSiteDeviceSession = fake_clear
-        duc.clear_session()
+        with caplog.at_level("WARNING", logger="src.device._utility_commands_clear"):
+            duc.clear_session()
 
-    captured_out = capsys.readouterr().out
-    assert "Cancelled: No service name or session IDs provided." in captured_out
+    # WHY: slice 79 migrated print()->logger.warning; assertion now reads caplog, not stdout.
+    assert "Cancelled: No service name or session IDs provided." in caplog.text
     assert called["api"] is False
 
 

--- a/tests/unit/test_device_utility_commands.py
+++ b/tests/unit/test_device_utility_commands.py
@@ -2189,12 +2189,13 @@ class TestClearBgpRoutes:
         self,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].return_value = ""
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "gateway")):
-            duc.clear_bgp_routes()
-            assert "required" in capsys.readouterr().out.lower()
+            with caplog.at_level(logging.WARNING):
+                duc.clear_bgp_routes()
+            assert "required" in caplog.text.lower()
 
     def test_cancelled(
         self,
@@ -2223,13 +2224,14 @@ class TestClearBgpRoutes:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].side_effect = ["10.0.0.1", "", "", "", "CLEAR"]
         mock_api.api.v1.sites.devices.clearSiteSsrBgpRoutes.side_effect = RuntimeError("bgp fail")
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "gateway")):
-            duc.clear_bgp_routes()
-            assert "bgp fail" in capsys.readouterr().out
+            with caplog.at_level(logging.ERROR):
+                duc.clear_bgp_routes()
+            assert "bgp fail" in caplog.text
 
 
 class TestClearSession:
@@ -2270,12 +2272,13 @@ class TestClearSession:
         self,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].side_effect = ["", "", "nope"]
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "gateway")):
-            duc.clear_session()
-            assert "Cancelled" in capsys.readouterr().out
+            with caplog.at_level(logging.WARNING):
+                duc.clear_session()
+            assert "Cancelled" in caplog.text
 
     def test_no_ids_no_service_confirm_all(
         self,
@@ -2342,13 +2345,14 @@ class TestClearMacTable:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].side_effect = ["", "CLEAR"]
         mock_api.api.v1.sites.devices.clearSiteDeviceMacTable.side_effect = RuntimeError("mac fail")
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")):
-            duc.clear_mac_table()
-            assert "mac fail" in capsys.readouterr().out
+            with caplog.at_level(logging.ERROR):
+                duc.clear_mac_table()
+            assert "mac fail" in caplog.text
 
 
 class TestClearBpduError:
@@ -2389,7 +2393,7 @@ class TestClearBpduError:
         self,
         duc: DeviceUtilityCommands,
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_api.api.v1.sites.devices.clearBpduErrorsFromPortsOnSwitch.side_effect = RuntimeError("bpdu fail")
         with (
@@ -2397,8 +2401,9 @@ class TestClearBpduError:
             patch.object(duc, "_select_port_optional", return_value=""),
             patch.object(duc, "_confirm_destructive", return_value=True),
         ):
-            duc.clear_bpdu_error()
-            assert "bpdu fail" in capsys.readouterr().out
+            with caplog.at_level(logging.ERROR):
+                duc.clear_bpdu_error()
+            assert "bpdu fail" in caplog.text
 
 
 class TestClearLearnedMacs:
@@ -2411,14 +2416,15 @@ class TestClearLearnedMacs:
     def test_no_port(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         with (
             patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")),
             patch.object(duc, "_select_port_from_device", return_value=None),
         ):
-            duc.clear_learned_macs()
-            assert "required" in capsys.readouterr().out.lower()
+            with caplog.at_level(logging.WARNING):
+                duc.clear_learned_macs()
+            assert "required" in caplog.text.lower()
 
     def test_cancelled(
         self,
@@ -2467,7 +2473,7 @@ class TestClearLearnedMacs:
         self,
         duc: DeviceUtilityCommands,
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_api.api.v1.sites.devices.clearAllLearnedMacsFromPortOnSwitch.side_effect = RuntimeError("macs fail")
         with (
@@ -2475,8 +2481,9 @@ class TestClearLearnedMacs:
             patch.object(duc, "_select_port_from_device", return_value="ge-0/0/0"),
             patch.object(duc, "_confirm_destructive", return_value=True),
         ):
-            duc.clear_learned_macs()
-            assert "macs fail" in capsys.readouterr().out
+            with caplog.at_level(logging.ERROR):
+                duc.clear_learned_macs()
+            assert "macs fail" in caplog.text
 
 
 class TestClearPolicyHitCount:
@@ -2513,13 +2520,14 @@ class TestClearPolicyHitCount:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].side_effect = ["", "CLEAR"]
         mock_api.api.v1.sites.devices.clearSiteDevicePolicyHitCount.side_effect = RuntimeError("policy fail")
         with patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "gateway")):
-            duc.clear_policy_hit_count()
-            assert "policy fail" in capsys.readouterr().out
+            with caplog.at_level(logging.ERROR):
+                duc.clear_policy_hit_count()
+            assert "policy fail" in caplog.text
 
 
 class TestReleaseDhcpLease:
@@ -2532,14 +2540,15 @@ class TestReleaseDhcpLease:
     def test_no_port(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         with (
             patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")),
             patch.object(duc, "_select_port_from_device", return_value=None),
         ):
-            duc.release_dhcp_lease()
-            assert "required" in capsys.readouterr().out.lower()
+            with caplog.at_level(logging.WARNING):
+                duc.release_dhcp_lease()
+            assert "required" in caplog.text.lower()
 
     def test_cancelled(
         self,
@@ -2574,7 +2583,7 @@ class TestReleaseDhcpLease:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].side_effect = ["", "y"]
         mock_api.api.v1.sites.devices.releaseSiteDeviceDhcpLease.side_effect = RuntimeError("dhcp fail")
@@ -2582,8 +2591,9 @@ class TestReleaseDhcpLease:
             patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")),
             patch.object(duc, "_select_port_from_device", return_value="ge-0/0/0"),
         ):
-            duc.release_dhcp_lease()
-            assert "dhcp fail" in capsys.readouterr().out
+            with caplog.at_level(logging.ERROR):
+                duc.release_dhcp_lease()
+            assert "dhcp fail" in caplog.text
 
 
 class TestReleaseDhcpSsr:
@@ -2596,14 +2606,15 @@ class TestReleaseDhcpSsr:
     def test_no_interface(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         with (
             patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "gateway")),
             patch.object(duc, "_select_interface_from_device", return_value=None),
         ):
-            duc.release_dhcp_ssr()
-            assert "required" in capsys.readouterr().out.lower()
+            with caplog.at_level(logging.WARNING):
+                duc.release_dhcp_ssr()
+            assert "required" in caplog.text.lower()
 
     def test_cancelled(
         self,
@@ -2638,7 +2649,7 @@ class TestReleaseDhcpSsr:
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
         mock_api: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         mock_deps["safe_input_fn"].side_effect = ["", "y"]
         mock_api.api.v1.sites.devices.releaseSiteSsrDhcpLease.side_effect = RuntimeError("ssr fail")
@@ -2646,8 +2657,9 @@ class TestReleaseDhcpSsr:
             patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "gateway")),
             patch.object(duc, "_select_interface_from_device", return_value="wan0"),
         ):
-            duc.release_dhcp_ssr()
-            assert "ssr fail" in capsys.readouterr().out
+            with caplog.at_level(logging.ERROR):
+                duc.release_dhcp_ssr()
+            assert "ssr fail" in caplog.text
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Slice 79/N of #886: retire all 15 `print()` calls in
  `src/device/_utility_commands_clear.py` in favor of module-scoped
  `logger.*` emissions with `%`-style deferred formatting.
- Level heuristic: `>>` / `[OK]` progress → `logger.info`;
  `[!] … failed:` handlers → `logger.error`; "cancelled" /
  "… required" operator notices → `logger.warning`.
- Every converted call carries the standard verbatim-preservation
  `# WHY:` comment above it.
- Migrated 12 tests in `tests/unit/test_device_utility_commands.py`
  from `capsys` stdout assertions to `caplog` log-record assertions.

## Test plan
- [x] `pytest tests/unit/test_device_utility_commands.py -q` (194 pass)
- [x] `python -m black` (no reformat)
- [x] `python -m ruff check` (clean)

Refs #886.