### PR TITLE
chore(logging): migrate src/ssh/runtime/interactive_mode.py print() to logger (#886 slice 81/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,26 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   warning for `templates`) to `caplog.at_level(...)` reads against the
   module logger. Full module suite: 62/62 green.
 
+### #886 Phase 2 slice 81/N: retire `print()` in `src/ssh/runtime/interactive_mode.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 15 `print()` calls
+  in `src/ssh/runtime/interactive_mode.py` with module-scoped `logger.*`
+  emissions using `%`-style deferred formatting to satisfy G004. Level
+  heuristic: interactive banner, separator, and status line ("Starting SSH
+  session ...") route to `logger.info`; validation errors ("X  Hostname is
+  required", "X  Port must be between 1 and 65535", "X  Timeout must be a
+  valid number", etc.) and the empty-password abort message route to
+  `logger.warning`. Each converted call carries the standard
+  `# WHY: preserve operator notice verbatim; route through logger for
+  capture/redirection.` inline comment so future auditors can trace the
+  origin. Module-scoped `logger = logging.getLogger(__name__)` was added
+  alongside the pre-existing `logging.info/debug` audit calls.
+- **Tests (Unchanged)**: existing `TestInteractiveMode` suite (5 tests) in
+  `tests/unit/test_ssh_runner.py` continues to pass unmodified; the suite
+  asserts on boolean return values and `SingleCommandRunner.run` mock
+  invocations rather than captured stdout, so no capsys→caplog migration
+  was required.
+
 ### #886 Phase 2 slice 79/N: retire `print()` in `src/device/_utility_commands_clear.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 15 `print()` calls

--- a/src/ssh/runtime/interactive_mode.py
+++ b/src/ssh/runtime/interactive_mode.py
@@ -21,6 +21,8 @@ from src.ssh.config.validators import (  # Shared input validators
 from src.ssh.connection.connector import SshConnector  # Exposes _validate_port classmethod
 from src.utils.input_utils import InputUtils  # EOF-safe input wrapper (issue #452: replace raw input()).
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger for #886 print-to-logger migration.
+
 
 class InteractiveMode:  # Groups the interactive REPL prompt helpers under one namespace.
     """Run the SSH runner in interactive REPL mode with input validation."""
@@ -34,10 +36,12 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
                 "- Enter hostname or IP address: ", context="ssh_hostname"
             )  # EOF-safe read.
             if not hostname:  # Empty -> reprompt
-                print("X  Hostname is required")  # User-facing required-field message.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("X  Hostname is required")
                 continue  # Re-enter the validation loop.
             if not validate_hostname(hostname):  # Reject invalid syntax
-                print("X  Invalid hostname or IP address format")  # User-facing format error.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("X  Invalid hostname or IP address format")
                 continue  # Re-enter the validation loop.
             logging.debug("Hostname accepted: %s", hostname)  # After-action log
             return hostname  # Hand the validated hostname back to the caller.
@@ -49,10 +53,12 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
         while True:  # Validation loop
             username = InputUtils.safe_input("X  Enter username: ", context="ssh_username")  # EOF-safe read.
             if not username:  # Empty -> reprompt
-                print("X  Username is required")  # User-facing required-field message.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("X  Username is required")
                 continue  # Re-enter the validation loop.
             if not validate_username(username):  # Reject invalid chars
-                print("X  Invalid username format (alphanumeric, underscore, hyphen, dot only)")  # Format error.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("X  Invalid username format (alphanumeric, underscore, hyphen, dot only)")
                 continue  # Re-enter the validation loop.
             logging.debug("Username accepted: %s", username)  # After-action log
             return username  # Hand the validated username back to the caller.
@@ -79,12 +85,14 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
                     return 22  # Return the documented default port.
                 port = int(port_input)  # Parse user-provided integer
                 if not SshConnector._validate_port(port):  # Range check 1..65535
-                    print("X  Port must be between 1 and 65535")  # User-facing range-error message.
+                    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                    logger.warning("X  Port must be between 1 and 65535")
                     continue  # Re-enter the validation loop.
                 logging.debug("Port accepted: %d", port)  # After-action log
                 return port  # Hand the validated port back to the caller.
             except ValueError:  # Non-numeric input
-                print("X  Port must be a valid number")  # User-facing parse-error message.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("X  Port must be a valid number")
 
     @staticmethod
     def _prompt_timeout() -> int:
@@ -105,7 +113,8 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
                 "- Enter timeout in seconds (default 30): ", context="ssh_timeout"
             )  # EOF-safe read.
         except ValueError:  # Defensive; safe_input can raise on non-str contexts.
-            print("X  Timeout must be a valid number")  # User-facing parse-error message.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("X  Timeout must be a valid number")
             return None  # Signal caller to re-prompt.
         if not timeout_input:  # Empty entry selects the default timeout.
             logging.debug("Timeout defaulted to 30")  # Trace default-branch decision.
@@ -113,10 +122,12 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
         try:  # int() raises ValueError on non-numeric strings.
             timeout = int(timeout_input)  # Parse user-provided integer.
         except ValueError:  # Non-numeric input entered.
-            print("X  Timeout must be a valid number")  # User-facing parse-error message.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("X  Timeout must be a valid number")
             return None  # Signal caller to re-prompt.
         if not 1 <= timeout <= 3600:  # Bounded range check.
-            print("X  Timeout must be between 1 and 3600 seconds")  # User-facing range-error message.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("X  Timeout must be between 1 and 3600 seconds")
             return None  # Signal caller to re-prompt.
         return timeout  # Validated, in-range timeout value.
 
@@ -139,10 +150,12 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
         while True:  # Validation loop
             command = InputUtils.safe_input("!? Enter command to execute: ", context="ssh_command")  # EOF-safe read.
             if not command:  # Empty -> reprompt
-                print("X  Command is required")
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("X  Command is required")
                 continue
             if not validate_command(command):  # Reject too-long or NUL bytes
-                print("X  Invalid command (too long or contains null bytes)")
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("X  Invalid command (too long or contains null bytes)")
                 continue
             logging.debug("Command accepted (length=%d)", len(command))  # After-action log
             return command
@@ -151,20 +164,24 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
     def run() -> bool:
         """Orchestrate the interactive REPL and dispatch a single SSH command."""
         logging.info("Entering SSH runner interactive mode")  # Before-action log
-        print("- Enhanced SSH Command Runner v2 - Interactive Mode")  # Banner (verbatim preserved)
-        print("=" * 60)  # Banner separator (verbatim preserved)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("- Enhanced SSH Command Runner v2 - Interactive Mode")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("=" * 60)
         hostname = InteractiveMode._prompt_hostname()  # Phase 1: hostname
         username = InteractiveMode._prompt_username()  # Phase 2: username
         password = InteractiveMode._prompt_password()  # Phase 3: password
         if not password:  # Reject empty passwords explicitly
-            print("X  Password is required")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("X  Password is required")
             logging.debug("Interactive mode aborted: empty password")
             return False
         port = InteractiveMode._prompt_port()  # Phase 4: port
         timeout = InteractiveMode._prompt_timeout()  # Phase 5: timeout
         use_shell = InteractiveMode._prompt_shell_mode()  # Phase 6: shell mode
         command = InteractiveMode._prompt_command()  # Phase 7: command
-        print(f"\n>> Starting SSH session (shell_mode={use_shell})...")  # Status line (verbatim preserved)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\n>> Starting SSH session (shell_mode=%s)...", use_shell)
         logging.debug("Dispatching interactive SSH command to SingleCommandRunner.run")  # After-action log
         interactive_request = SingleCommandRequest(  # WHY: dataclass keeps SingleCommandRunner.run at 1 param.
             hostname=hostname,


### PR DESCRIPTION
## Summary
- Migrate 15 `print()` calls in `src/ssh/runtime/interactive_mode.py` to module-scoped `logger` (#886 slice 81/N).
- Level heuristic: banner/status → `info`, validation errors ("X  ... is required", "X  Invalid ...") → `warning`.
- `%`-style deferred formatting (G004-clean); operator notices preserved verbatim with the standard WHY comment.
- No behavioral change — only sink changes stdout → logger.

## Test plan
- [x] `pytest tests/unit/test_ssh_runner.py::TestInteractiveMode -q` (5 passed; no capsys usage — no test migration needed)
- [x] `black --check src/ssh/runtime/interactive_mode.py` clean
- [x] `ruff check src/ssh/runtime/interactive_mode.py` clean