### PR TITLE
chore(logging): migrate src/gateway/gateway_export_utils.py print() to logger (#886 slice 89/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 89/N: retire `print()` in `src/gateway/gateway_export_utils.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 16 `print()` calls in
+  `src/gateway/gateway_export_utils.py` with module-scoped `logger.*`
+  emissions using `%`-style deferred formatting. Added
+  `logger = logging.getLogger(__name__)` alongside the pre-existing
+  `import logging` and paired `logging.error/warning` calls that already
+  wrapped several of the migrated prints. Level heuristic: cache-status
+  hits/misses in `_prime_management_ip_caches`, the 5-line completion
+  banner in `_emit_management_ip_summary`, and the banner/step lines in
+  `management_ips` and `templates` map to `logger.info`; the
+  `"No gateway templates found for this organization."` operator notice
+  (paired with the existing `logging.warning`) maps to `logger.warning`;
+  the "Required CSV file not found" error notice (paired with the
+  existing `logging.error`) maps to `logger.error`. Each migrated call
+  carries the standard
+  `# WHY: preserve operator notice verbatim; route through logger for capture/redirection.`
+  annotation and preserves the exact user-visible text operators grep on.
+- **Test migration**: converted the two `capsys` assertions in
+  `tests/unit/gateway/test_gateway_export_utils_extended.py` (banner +
+  completion lines for `_emit_management_ip_summary`; empty-template
+  warning for `templates`) to `caplog.at_level(...)` reads against the
+  module logger. Full module suite: 62/62 green.
+
 ### #886 Phase 2 slice 79/N: retire `print()` in `src/device/_utility_commands_clear.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 15 `print()` calls

--- a/src/gateway/gateway_export_utils.py
+++ b/src/gateway/gateway_export_utils.py
@@ -15,6 +15,8 @@ from src.gateway.overrides import (  # WHY: import walker + override wiring entr
 )
 from src.refactors.connection_pool_executor import ConnectionPoolExecutor  # WHY: extracted pool executor (1012 SC-003).
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger for #886 print-to-logger migration.
+
 MANAGEMENT_IP_INPUT_CSVS: tuple[str, ...] = (  # WHY: fixed set of correlation inputs for management-IP export.
     "SiteList.csv",
     "OrgGatewayTemplates.csv",
@@ -302,7 +304,8 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
             loaded = tuple(_read_csv_rows(name) for name in MANAGEMENT_IP_INPUT_CSVS)  # WHY: table-driven reads.
         except FileNotFoundError as exception:
             logging.error("Required CSV file not found: %s", exception)  # WHY: preserve legacy error log.
-            print(f"! Error: Required CSV file not found: {exception}")  # WHY: preserve legacy operator message.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Error: Required CSV file not found: %s", exception)
             return None
         sites, templates, gateway_devices, gateway_configs = loaded  # WHY: unpack into named locals.
         logging.debug(
@@ -335,13 +338,17 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
     @staticmethod
     def _prime_management_ip_caches(fast: bool) -> None:  # WHY: isolate the 4 cache generation calls.
         """Ensure the 4 CSV caches consumed by management_ips are up to date."""
-        print("  1. Ensuring site list with template mappings is current...")  # WHY: preserve legacy operator log.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  1. Ensuring site list with template mappings is current...")
         CacheUtils.check_and_generate_csv("SiteList.csv", OrgSiteExporter.sites)  # WHY: refresh site cache.
-        print("  2. Ensuring gateway templates are current...")  # WHY: preserve legacy operator log.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  2. Ensuring gateway templates are current...")
         CacheUtils.check_and_generate_csv("OrgGatewayTemplates.csv", GatewayExportUtils.templates)
-        print("  3. Ensuring gateway device data with connection status is current...")  # WHY: legacy log.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  3. Ensuring gateway device data with connection status is current...")
         CacheUtils.check_and_generate_csv("GatewaysWithSiteInfo.csv", OrgInventoryExporter.gateways_with_site_info)
-        print("  4. Ensuring gateway configurations with management IPs are current...")  # WHY: legacy log.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  4. Ensuring gateway configurations with management IPs are current...")
         CacheUtils.check_and_generate_csv(
             "AllSiteGatewayConfigs.csv",
             lambda: GatewayExportUtils.device_configs(fast=fast),  # WHY: fast flag threaded into config generator.
@@ -382,11 +389,16 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
     @staticmethod
     def _emit_management_ip_summary(gateways_processed: int, gateways_with_mgmt_ip: int) -> None:
         """Emit the completion banner + audit log preserving legacy phrasing."""
-        print("! Gateway management IP export completed:")  # WHY: legacy completion banner headline.
-        print(f"  - Total gateways processed: {gateways_processed}")  # WHY: legacy phrasing preserved.
-        print(f"  - Gateways with management IPs: {gateways_with_mgmt_ip}")  # WHY: legacy phrasing preserved.
-        print(f"  - Gateways without management IPs: {gateways_processed - gateways_with_mgmt_ip}")
-        print("  - Output CSV: GatewayManagementIPs.csv")  # WHY: legacy phrasing preserved.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("! Gateway management IP export completed:")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  - Total gateways processed: %d", gateways_processed)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  - Gateways with management IPs: %d", gateways_with_mgmt_ip)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  - Gateways without management IPs: %d", gateways_processed - gateways_with_mgmt_ip)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  - Output CSV: GatewayManagementIPs.csv")
         logging.info(
             "Gateway management IP export completed. %d gateways processed, %d with management IPs.",
             gateways_processed,
@@ -397,11 +409,14 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
     def management_ips(fast: bool = False) -> None:
         """Export gateway management overlay IPs correlated with templates and site status."""
         logging.info("Menu #31: Starting gateway management IPs export")  # WHY: audit log for menu entry.
-        print("Gateway Management IP Export:")  # WHY: user-facing banner.
-        print("Collecting data from inventory, templates, and configurations...")  # WHY: legacy operator log.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Gateway Management IP Export:")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Collecting data from inventory, templates, and configurations...")
         ConfigUtils.get_cached_or_prompted_org_id()  # WHY: resolve org id via standard pathway.
         GatewayExportUtils._prime_management_ip_caches(fast)  # WHY: ensure all 4 CSV inputs are current.
-        print("  5. Processing and correlating data...")  # WHY: legacy operator log for step 5.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  5. Processing and correlating data...")
         loaded = GatewayExportUtils._load_management_ip_csv_inputs()  # WHY: read the four CSV inputs.
         if loaded is None:  # WHY: required CSV missing — error already printed/logged.
             return
@@ -462,19 +477,22 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
     @staticmethod
     def templates() -> None:
         """Export gateway templates for the selected organization."""
-        print("Gateway Templates:")  # WHY: user-facing banner.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Gateway Templates:")
         logging.info("Exporting gateway templates for the organization...")  # WHY: audit log for entry.
         current_org_id = ConfigUtils.get_cached_or_prompted_org_id()  # WHY: resolve org_id via standard path.
         response = mistapi.api.v1.orgs.gatewaytemplates.listOrgGatewayTemplates(apisession, current_org_id)
         templates = getattr(response, "data", [])  # WHY: defensive — response may lack .data attribute.
         if not templates:  # WHY: nothing to export — emit diagnostics and return.
             logging.warning("No gateway templates found for this organization.")
-            print("No gateway templates found for this organization.")
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("No gateway templates found for this organization.")
             return
         templates = DataProcessingUtils.flatten_nested_fields(templates)  # WHY: flatten nested JSON to cells.
         templates = DataProcessingUtils.escape_multiline(templates)  # WHY: escape multiline cells for CSV.
         DataExporter.write_with_format_selection(templates, "OrgGatewayTemplates.csv")  # WHY: persist output.
-        print(f"! {len(templates)} gateway templates exported to OrgGatewayTemplates.csv")  # WHY: banner.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("! %d gateway templates exported to OrgGatewayTemplates.csv", len(templates))
         logging.info(" Gateway templates exported to OrgGatewayTemplates.csv")  # WHY: audit log for exit.
 
     @staticmethod

--- a/tests/unit/gateway/test_gateway_export_utils_extended.py
+++ b/tests/unit/gateway/test_gateway_export_utils_extended.py
@@ -539,16 +539,17 @@ class TestGatewayExportUtilsStaticMethods:
         assert renamed[1]["Gateway Name"] == "gwB"  # WHY: TplB entry sorts second.
 
     def test_emit_management_ip_summary_writes_completion_lines(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Summary emits legacy console lines and audit log entry."""
+        """Summary emits legacy operator lines and audit log entry."""
         configure_gateway_export_utils_dependencies(**_build_dependency_bundle(tmp_path))  # WHY: DI wiring.
-        caplog.set_level(logging.INFO)  # WHY: audit line emitted at INFO.
-        GatewayExportUtils._emit_management_ip_summary(gateways_processed=5, gateways_with_mgmt_ip=3)
-        captured = capsys.readouterr().out  # WHY: assert on console output.
-        assert "Gateway management IP export completed" in captured  # WHY: banner headline.
-        assert "Total gateways processed: 5" in captured  # WHY: total line.
-        assert "Gateways without management IPs: 2" in captured  # WHY: derived arithmetic.
+        # WHY: slice 89 migrated print()->logger.info; assertions now read caplog, not stdout.
+        with caplog.at_level(logging.INFO):
+            GatewayExportUtils._emit_management_ip_summary(gateways_processed=5, gateways_with_mgmt_ip=3)
+        messages = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "Gateway management IP export completed" in messages  # WHY: banner headline.
+        assert "Total gateways processed: 5" in messages  # WHY: total line.
+        assert "Gateways without management IPs: 2" in messages  # WHY: derived arithmetic.
         assert any("Gateway management IP export completed" in rec.getMessage() for rec in caplog.records)
 
     def test_management_ips_returns_early_when_load_fails(
@@ -660,9 +661,7 @@ class TestGatewayExportUtilsStaticMethods:
         assert first_args[1] == "AllSiteGatewayConfigs.csv"  # WHY: full write filename.
         assert second_args[1] == "FilteredGatewayPortConfigs.csv"  # WHY: filtered write filename.
 
-    def test_templates_returns_early_when_no_templates(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_templates_returns_early_when_no_templates(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """Empty template list yields legacy warning log + operator message and no write."""
         writer = MagicMock()
         list_templates = MagicMock(return_value=SimpleNamespace(data=[]))
@@ -678,11 +677,12 @@ class TestGatewayExportUtilsStaticMethods:
             data_exporter=SimpleNamespace(write_with_format_selection=writer),
         )
         configure_gateway_export_utils_dependencies(**bundle)
-        caplog.set_level(logging.WARNING)  # WHY: warn logged on empty template set.
-        GatewayExportUtils.templates()
+        # WHY: slice 89 migrated print()->logger.warning; assertion now reads caplog, not stdout.
+        with caplog.at_level(logging.WARNING):
+            GatewayExportUtils.templates()
         writer.assert_not_called()  # WHY: no export when there are no templates.
-        captured = capsys.readouterr().out
-        assert "No gateway templates found" in captured  # WHY: legacy operator message.
+        messages = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "No gateway templates found" in messages  # WHY: legacy operator message.
 
     def test_templates_writes_export_when_templates_present(self, tmp_path: Path) -> None:
         """Happy path forwards flattened+escaped templates to DataExporter."""


### PR DESCRIPTION
## Summary
- Slice 89/N of #886. Replaces all 16 `print()` calls in `src/gateway/gateway_export_utils.py` with module-scoped `logger.*` using `%`-style deferred formatting.
- Adds `logger = logging.getLogger(__name__)`; pairs with pre-existing `import logging` and `logging.error/warning` calls that already wrapped several migrated prints.
- Level heuristic: cache-status hits/misses, 5-line completion banner, and step lines -> `info`; `"No gateway templates found for this organization."` -> `warning`; `"Required CSV file not found"` -> `error`.
- Migrates two `capsys` assertions in `tests/unit/gateway/test_gateway_export_utils_extended.py` (summary banner + empty-templates) to `caplog.at_level(...)`.

## Test plan
- [x] `pytest tests/unit/gateway/test_gateway_export_utils.py tests/unit/gateway/test_gateway_export_utils_extended.py` -> 62/62 green
- [x] `black --check src/gateway/gateway_export_utils.py tests/unit/gateway/test_gateway_export_utils_extended.py`
- [x] `ruff check src/gateway/gateway_export_utils.py tests/unit/gateway/test_gateway_export_utils_extended.py`
- [x] Verified zero `print(` remain in `src/gateway/gateway_export_utils.py`