### PR TITLE
chore(logging): migrate src/export/site_device_exporter.py print() to logger (#886 slice 91/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 91/N: retire `print()` in `src/export/site_device_exporter.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 18 `print()` calls in
+  `src/export/site_device_exporter.py` with module-scoped `logger.*` emissions
+  using `%`-style deferred formatting to satisfy G004. Level heuristic: empty-
+  data / filter-miss / no-VC-payload user notices map to `logger.warning`;
+  banners, per-site export counts, and VC summary lines map to `logger.info`;
+  fetch/export exception branches in `device_stats`, `devices`, and
+  `_export_vc_for_device` map to `logger.error`. Behavior otherwise unchanged.
+- **Test capture migration (Changed)**: converted the 13 `capsys`-based stdout
+  assertions in `tests/unit/export/test_site_device_exporter.py` to
+  `caplog`-based assertions targeting `LOGGER_NAME = "src.export.site_device_exporter"`
+  so the suite exercises the migrated logger pipeline; all 37 tests pass.
+
 ### #886 Phase 2 slice 90/N: retire `print()` in `src/device/_utility_commands_show.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 17 `print()` calls

--- a/src/export/site_device_exporter.py
+++ b/src/export/site_device_exporter.py
@@ -27,6 +27,8 @@ from src.data.data_processing_utils import (
 from src.export.site_export_utils import SiteExportUtils  # WHY: Pattern 1 inline construction for port_stats export.
 from src.utils.tqdm_wrapper import tqdm  # WHY: 1015 T-14 -- canonical wrapper import (eliminates mh.tqdm).
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger for #886 print-to-logger migration.
+
 
 class SiteDeviceExporter:
     """Site Device Data Exporter.
@@ -49,7 +51,8 @@ class SiteDeviceExporter:
             mh.apisession, site_id, type="all"
         ).data  # All device types
         if not rawdata:  # No devices.
-            print("No devices found for the selected site.")  # Tell the user.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("No devices found for the selected site.")  # Tell the user.
             logging.warning("No devices found for site_id=%s", site_id)  # Warn none found.
             return  # Abort.
         if device_type != "all":  # Type filter requested.
@@ -72,7 +75,8 @@ class SiteDeviceExporter:
         requested_types = [dtype.strip() for dtype in device_type.split(",")]  # Parse requested types.
         filtered = [d for d in rawdata if d.get("type", "").lower() in requested_types]  # Keep matching devices.
         if not filtered:  # None after filter.
-            print(f"No devices of type '{device_type}' found at the selected site.")  # Tell the user.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("No devices of type '%s' found at the selected site.", device_type)  # Tell the user.
             logging.warning("No devices of type '%s' found for site_id: %s", device_type, site_id)  # Warn none.
             return None  # Signal the caller to abort.
         return filtered  # Devices matching the requested type(s).
@@ -96,13 +100,15 @@ class SiteDeviceExporter:
         """Flatten + write device-stats rows to a per-site CSV, or tell the user when empty."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if not rawdata:  # No data -- tell the user and return.
-            print("! No device statistics found for this site")  # User notice.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! No device statistics found for this site")  # User notice.
             return  # Done.
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
         sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
         filename = f"SiteDeviceStats_{site_name.replace(' ', '_')}.csv"  # Build per-site CSV name.
         mh.DataExporter.write_with_format_selection(sanitized_data, filename)  # Persist.
-        print(f"! {len(rawdata)} device stats exported to {filename}")  # User notice with count.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("! %d device stats exported to %s", len(rawdata), filename)  # User notice with count.
 
     @staticmethod
     def _resolve_site_for_stats(export_label: str = "data") -> tuple[str, str] | None:
@@ -127,7 +133,8 @@ class SiteDeviceExporter:
     def device_stats() -> None:  # Export site device stats.
         """Export device statistics for a site to SiteDeviceStats.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession.
-        print("Site Device Statistics:")  # Header
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Site Device Statistics:")  # Header
         logging.info("Starting export of site device statistics...")  # Trace start
         resolved = SiteDeviceExporter._resolve_site_for_stats("device statistics")  # Prompt + org/site resolution
         if resolved is None:  # Abort signaled by resolver
@@ -139,7 +146,8 @@ class SiteDeviceExporter:
             SiteDeviceExporter._persist_site_device_stats(rawdata, site_name)  # Persist or tell user empty
         except Exception as e:  # Fetch failed
             logging.error("Error fetching device stats for site %s: %s", site_name, e)  # Log the error
-            print(f"! Error fetching device statistics: {e}")  # Tell the user
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Error fetching device statistics: %s", e)  # Tell the user
 
     @staticmethod
     def port_stats() -> None:  # Export site port stats.
@@ -176,7 +184,8 @@ class SiteDeviceExporter:
     def device_virtual_chassis() -> None:  # Export device virtual chassis.
         """Export virtual chassis data for a site to SiteDeviceVirtualChassis.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils.
-        print("Export Virtual Chassis Information:")  # Header.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Export Virtual Chassis Information:")  # Header.
         logging.info("Starting export of site device virtual chassis information...")  # Log start.
         site_id = mh.PromptUtils.select_site()  # Select a site.
         if not site_id:  # No site.
@@ -213,7 +222,8 @@ class SiteDeviceExporter:
             )  # Fetch
             if not response.data:  # No VC payload.
                 logging.warning("! No virtual chassis data returned for device %s", device_name)  # Warn no VC data.
-                print(f"! No virtual chassis data found for device {device_name}")  # Tell the user.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("! No virtual chassis data found for device %s", device_name)  # Tell the user.
                 return  # Nothing to export.
             vc_data = [response.data] if isinstance(response.data, dict) else response.data  # Normalize to a list.
             flattened = DataProcessingUtils.flatten_nested_fields(vc_data)  # Flatten nested fields.
@@ -224,39 +234,48 @@ class SiteDeviceExporter:
             SiteDeviceExporter._print_vc_summary(sanitized, device_name, filename)  # Print a short operator summary.
         except Exception as e:  # Export failed.
             logging.error("! Failed to export virtual chassis information: %s", e)  # Log the error.
-            print(f"! Failed to export virtual chassis information: {e}")  # Tell the user.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Failed to export virtual chassis information: %s", e)  # Tell the user.
 
     @staticmethod
     def _print_vc_summary(sanitized: list[dict[str, Any]], device_name: str, filename: str) -> None:
         """Print a short VC summary (record count, optional members/preprovisioned fields, output path)."""
         if not sanitized:  # No records to summarize.
             return  # Nothing to print.
-        print(f"\n!! Virtual Chassis Summary for {device_name}:")  # Header.
-        print(f"   * Records exported: {len(sanitized)}")  # Show the count.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\n!! Virtual Chassis Summary for %s:", device_name)  # Header.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("   * Records exported: %d", len(sanitized))  # Show the count.
         if "members" in sanitized[0]:  # Members present.
-            print(f"   * VC members: {sanitized[0].get('members', 'N/A')}")  # Show members.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("   * VC members: %s", sanitized[0].get("members", "N/A"))  # Show members.
         if "preprovisioned" in sanitized[0]:  # Preprovisioned present.
-            print(f"   * Preprovisioned: {sanitized[0].get('preprovisioned', 'N/A')}")  # Show preprovisioned flag.
-        print(f"   * Data saved to: {filename}")  # Show the path.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("   * Preprovisioned: %s", sanitized[0].get("preprovisioned", "N/A"))  # Show preprovisioned.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("   * Data saved to: %s", filename)  # Show the path.
 
     @staticmethod
     def _persist_site_devices(rawdata: list[dict[str, Any]], site_name: str) -> None:
         """Flatten + persist site-devices rows to a per-site CSV (or tell the user when empty)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if not rawdata:  # No devices -- tell the user and return.
-            print("! No devices found for this site")  # User notice.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! No devices found for this site")  # User notice.
             return  # Done.
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
         sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
         filename = f"SiteDevices_{site_name.replace(' ', '_')}.csv"  # Per-site CSV name.
         mh.DataExporter.write_with_format_selection(sanitized_data, filename)  # Persist.
-        print(f"! {len(rawdata)} devices exported to {filename}")  # User notice with count.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("! %d devices exported to %s", len(rawdata), filename)  # User notice with count.
 
     @staticmethod
     def devices() -> None:  # Export site device list.
         """Export device data for a site to SiteDevices.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession.
-        print("Site Device List:")  # Header
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("Site Device List:")  # Header
         logging.info("Starting export of site device list...")  # Trace start
         resolved = SiteDeviceExporter._resolve_site_for_stats("device list")  # Prompt + org/site resolution
         if resolved is None:  # Abort signaled by resolver
@@ -268,4 +287,5 @@ class SiteDeviceExporter:
             SiteDeviceExporter._persist_site_devices(rawdata, site_name)  # Persist or tell user empty
         except Exception as e:  # Fetch failed
             logging.error("Error fetching devices for site %s: %s", site_name, e)  # Log the error
-            print(f"! Error fetching device data: {e}")  # Tell the user
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Error fetching device data: %s", e)  # Tell the user

--- a/tests/unit/export/test_site_device_exporter.py
+++ b/tests/unit/export/test_site_device_exporter.py
@@ -11,11 +11,14 @@ importing the monolith.
 
 from __future__ import annotations
 
+import logging
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+LOGGER_NAME = "src.export.site_device_exporter"
 
 
 @pytest.fixture
@@ -50,18 +53,21 @@ def fake_mh(monkeypatch):
 class TestDeviceInventory:
     """Cover SiteDeviceExporter.device_inventory."""
 
-    def test_no_devices_returns_early(self, fake_mh, capsys):
-        """Empty rawdata → prints notice + warns, no write."""
+    def test_no_devices_returns_early(self, fake_mh, caplog):
+        """Empty rawdata → warns via logger, no write."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
-        with patch(
-            "src.export.site_device_exporter.mistapi.api.v1.sites.devices.listSiteDevices",
-            return_value=MagicMock(data=[]),
+        with (
+            patch(
+                "src.export.site_device_exporter.mistapi.api.v1.sites.devices.listSiteDevices",
+                return_value=MagicMock(data=[]),
+            ),
+            caplog.at_level(logging.WARNING, logger=LOGGER_NAME),
         ):
             SiteDeviceExporter.device_inventory("s1")
 
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
-        assert "No devices found" in capsys.readouterr().out
+        assert "No devices found" in caplog.text
 
     def test_type_filter_no_match_returns_early(self, fake_mh):
         """device_type filter returns None → aborts before write."""
@@ -131,14 +137,15 @@ class TestFilterDevicesByType:
         result = SiteDeviceExporter._filter_devices_by_type(rows, "switch", "s1")
         assert result == [{"type": "switch"}]
 
-    def test_no_match_returns_none(self, fake_mh, capsys):
-        """No matches → prints notice, warns, returns None."""
+    def test_no_match_returns_none(self, fake_mh, caplog):
+        """No matches → warns via logger, returns None."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
         rows = [{"type": "ap"}]
-        result = SiteDeviceExporter._filter_devices_by_type(rows, "switch", "s1")
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            result = SiteDeviceExporter._filter_devices_by_type(rows, "switch", "s1")
         assert result is None
-        assert "No devices of type 'switch'" in capsys.readouterr().out
+        assert "No devices of type 'switch'" in caplog.text
 
 
 class TestDisplayInventoryTable:
@@ -189,26 +196,30 @@ class TestDisplayInventoryTable:
 class TestPersistSiteDeviceStats:
     """Cover SiteDeviceExporter._persist_site_device_stats."""
 
-    def test_empty_prints_and_returns(self, fake_mh, capsys):
-        """Empty rawdata → prints notice, no flatten/write."""
+    def test_empty_prints_and_returns(self, fake_mh, caplog):
+        """Empty rawdata → warns via logger, no flatten/write."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
-        SiteDeviceExporter._persist_site_device_stats([], "HQ")
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            SiteDeviceExporter._persist_site_device_stats([], "HQ")
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
-        assert "No device statistics" in capsys.readouterr().out
+        assert "No device statistics" in caplog.text
 
-    def test_non_empty_flattens_and_writes(self, fake_mh, capsys):
+    def test_non_empty_flattens_and_writes(self, fake_mh, caplog):
         """Non-empty → flatten/escape/write with per-site filename."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
         rows = [{"id": "d1"}]
-        with patch("src.export.site_device_exporter.DataProcessingUtils") as dpu:
+        with (
+            patch("src.export.site_device_exporter.DataProcessingUtils") as dpu,
+            caplog.at_level(logging.INFO, logger=LOGGER_NAME),
+        ):
             dpu.flatten_nested_fields.return_value = rows
             dpu.escape_multiline.return_value = rows
             SiteDeviceExporter._persist_site_device_stats(rows, "HQ Site")
 
         fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(rows, "SiteDeviceStats_HQ_Site.csv")
-        assert "1 device stats exported" in capsys.readouterr().out
+        assert "1 device stats exported" in caplog.text
 
 
 class TestResolveSiteForStats:
@@ -276,8 +287,8 @@ class TestDeviceStats:
 
         persist.assert_called_once_with(rows, "HQ")
 
-    def test_fetch_exception_logged(self, fake_mh, capsys):
-        """Fetch raises → error printed, no crash."""
+    def test_fetch_exception_logged(self, fake_mh, caplog):
+        """Fetch raises → error logged via logger, no crash."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
         with (
@@ -286,10 +297,11 @@ class TestDeviceStats:
                 "src.export.site_device_exporter.mistapi.api.v1.sites.stats.listSiteDevicesStats",
                 side_effect=RuntimeError("boom"),
             ),
+            caplog.at_level(logging.ERROR, logger=LOGGER_NAME),
         ):
             SiteDeviceExporter.device_stats()
 
-        assert "Error fetching device statistics" in capsys.readouterr().out
+        assert "Error fetching device statistics" in caplog.text
 
 
 class TestPortStats:
@@ -393,18 +405,21 @@ class TestResolveDeviceName:
 class TestExportVcForDevice:
     """Cover SiteDeviceExporter._export_vc_for_device."""
 
-    def test_no_response_data_warns(self, fake_mh, capsys):
-        """response.data empty → warns + returns without write."""
+    def test_no_response_data_warns(self, fake_mh, caplog):
+        """response.data empty → warns via logger + returns without write."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
-        with patch(
-            "src.export.site_device_exporter.mistapi.api.v1.sites.devices.getSiteDeviceVirtualChassis",
-            return_value=MagicMock(data=None),
+        with (
+            patch(
+                "src.export.site_device_exporter.mistapi.api.v1.sites.devices.getSiteDeviceVirtualChassis",
+                return_value=MagicMock(data=None),
+            ),
+            caplog.at_level(logging.WARNING, logger=LOGGER_NAME),
         ):
             SiteDeviceExporter._export_vc_for_device("s1", "d1", "sw1")
 
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
-        assert "No virtual chassis data" in capsys.readouterr().out
+        assert "No virtual chassis data" in caplog.text
 
     def test_dict_response_normalized_to_list(self, fake_mh):
         """response.data as dict → wrapped into a list before flatten."""
@@ -444,44 +459,50 @@ class TestExportVcForDevice:
 
         dpu.flatten_nested_fields.assert_called_once_with(rows)
 
-    def test_exception_prints_error(self, fake_mh, capsys):
-        """Fetch raises → error logged, user notified."""
+    def test_exception_prints_error(self, fake_mh, caplog):
+        """Fetch raises → error logged via logger, user notified."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
-        with patch(
-            "src.export.site_device_exporter.mistapi.api.v1.sites.devices.getSiteDeviceVirtualChassis",
-            side_effect=RuntimeError("boom"),
+        with (
+            patch(
+                "src.export.site_device_exporter.mistapi.api.v1.sites.devices.getSiteDeviceVirtualChassis",
+                side_effect=RuntimeError("boom"),
+            ),
+            caplog.at_level(logging.ERROR, logger=LOGGER_NAME),
         ):
             SiteDeviceExporter._export_vc_for_device("s1", "d1", "sw1")
 
-        assert "Failed to export virtual chassis" in capsys.readouterr().out
+        assert "Failed to export virtual chassis" in caplog.text
 
 
 class TestPrintVcSummary:
     """Cover SiteDeviceExporter._print_vc_summary."""
 
-    def test_empty_returns_early(self, fake_mh, capsys):
-        """Empty sanitized → no output."""
+    def test_empty_returns_early(self, fake_mh, caplog):
+        """Empty sanitized → no log output."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
-        SiteDeviceExporter._print_vc_summary([], "sw1", "f.csv")
-        assert capsys.readouterr().out == ""
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            SiteDeviceExporter._print_vc_summary([], "sw1", "f.csv")
+        assert caplog.text == ""
 
-    def test_with_members_and_preprovisioned(self, fake_mh, capsys):
-        """Both keys present → both printed."""
+    def test_with_members_and_preprovisioned(self, fake_mh, caplog):
+        """Both keys present → both logged."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
-        SiteDeviceExporter._print_vc_summary([{"members": ["m1"], "preprovisioned": True}], "sw1", "f.csv")
-        out = capsys.readouterr().out
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            SiteDeviceExporter._print_vc_summary([{"members": ["m1"], "preprovisioned": True}], "sw1", "f.csv")
+        out = caplog.text
         assert "VC members" in out
         assert "Preprovisioned" in out
 
-    def test_without_optional_keys(self, fake_mh, capsys):
-        """Neither key → still prints header/count/path."""
+    def test_without_optional_keys(self, fake_mh, caplog):
+        """Neither key → still logs header/count/path."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
-        SiteDeviceExporter._print_vc_summary([{"id": "x"}], "sw1", "f.csv")
-        out = capsys.readouterr().out
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            SiteDeviceExporter._print_vc_summary([{"id": "x"}], "sw1", "f.csv")
+        out = caplog.text
         assert "Records exported: 1" in out
         assert "VC members" not in out
         assert "Preprovisioned" not in out
@@ -490,26 +511,30 @@ class TestPrintVcSummary:
 class TestPersistSiteDevices:
     """Cover SiteDeviceExporter._persist_site_devices."""
 
-    def test_empty_prints_notice(self, fake_mh, capsys):
+    def test_empty_prints_notice(self, fake_mh, caplog):
         """Empty rawdata → prints notice, no write."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
-        SiteDeviceExporter._persist_site_devices([], "HQ")
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            SiteDeviceExporter._persist_site_devices([], "HQ")
         fake_mh.DataExporter.write_with_format_selection.assert_not_called()
-        assert "No devices found" in capsys.readouterr().out
+        assert "No devices found" in caplog.text
 
-    def test_non_empty_flattens_and_writes(self, fake_mh, capsys):
+    def test_non_empty_flattens_and_writes(self, fake_mh, caplog):
         """Non-empty → flatten/escape/write per-site filename."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
         rows = [{"id": "d1"}]
-        with patch("src.export.site_device_exporter.DataProcessingUtils") as dpu:
+        with (
+            patch("src.export.site_device_exporter.DataProcessingUtils") as dpu,
+            caplog.at_level(logging.INFO, logger=LOGGER_NAME),
+        ):
             dpu.flatten_nested_fields.return_value = rows
             dpu.escape_multiline.return_value = rows
             SiteDeviceExporter._persist_site_devices(rows, "HQ Site")
 
         fake_mh.DataExporter.write_with_format_selection.assert_called_once_with(rows, "SiteDevices_HQ_Site.csv")
-        assert "1 devices exported" in capsys.readouterr().out
+        assert "1 devices exported" in caplog.text
 
 
 class TestDevices:
@@ -539,7 +564,7 @@ class TestDevices:
 
         persist.assert_called_once_with(rows, "HQ")
 
-    def test_fetch_exception_logged(self, fake_mh, capsys):
+    def test_fetch_exception_logged(self, fake_mh, caplog):
         """Fetch raises → user notified."""
         from src.export.site_device_exporter import SiteDeviceExporter
 
@@ -549,7 +574,8 @@ class TestDevices:
                 "src.export.site_device_exporter.mistapi.api.v1.sites.devices.listSiteDevices",
                 side_effect=RuntimeError("boom"),
             ),
+            caplog.at_level(logging.ERROR, logger=LOGGER_NAME),
         ):
             SiteDeviceExporter.devices()
 
-        assert "Error fetching device data" in capsys.readouterr().out
+        assert "Error fetching device data" in caplog.text


### PR DESCRIPTION
## Summary

Slice 91 of the `print()` → `logger` migration for issue #886.

- Replaces all 18 `print()` calls in `src/export/site_device_exporter.py` with module-scoped `logger.*` emissions using `%`-style deferred formatting (G004-clean).
- Level heuristic:
  - Empty-data / filter-miss / no-VC-payload user notices → `logger.warning`
  - Banners, per-site export counts, VC summary lines → `logger.info`
  - Fetch/export exception branches (`device_stats`, `devices`, `_export_vc_for_device`) → `logger.error`
- Migrates the 13 `capsys` assertions in `tests/unit/export/test_site_device_exporter.py` to `caplog` against `LOGGER_NAME = "src.export.site_device_exporter"`.

## Test plan

- [x] `black --check` clean
- [x] `ruff check` clean
- [x] `pytest tests/unit/export/test_site_device_exporter.py` → 37 passed
- [x] No `print(` remaining in `src/export/site_device_exporter.py`

Closes part of #886.