### PR TITLE
chore(logging): migrate src/websocket/manager.py print() to logger (#886 slice 95/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 95/N: retire `print()` in `src/websocket/manager.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 18 `print()` calls in
+  `src/websocket/manager.py` with module-scoped `logger.*` emissions using
+  `%`-style deferred formatting to satisfy G004. Level heuristic: credential
+  missing/timeout warnings map to `logger.warning`; connection/subscription
+  failures map to `logger.error`; `[DEBUG]` gated echoes map to `logger.debug`;
+  success/status banners map to `logger.info`. Every migrated line carries the
+  standard verbatim WHY comment. Also removed a redundant `self.logger.debug`
+  call in `_debug_log_sub` that duplicated the module-level `logger.debug`
+  (same logger object → double emission).
+- **Tests (Changed)**: migrated 24 tests in
+  `tests/unit/websocket/test_manager.py` from `capsys` to `caplog`, with a
+  module-level `_MANAGER_LOGGER = "src.websocket.manager"` constant driving
+  `caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)` calls. Preserved
+  targeted `patch.object(...)` sites that validate specific logger call
+  interactions (root `logging.error`, instance `self.logger.warning/error/info`).
+  71/71 unit tests pass.
+
 ### #886 Phase 2 slice 92/N: retire `print()` in `src/export/org_export_utils.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 18 `print()` calls in

--- a/src/websocket/manager.py
+++ b/src/websocket/manager.py
@@ -14,6 +14,8 @@ from typing import Any  # WHY: Callback frames from websocket-client have no ups
 from src.websocket.polling.message_router import MessageRouter  # WHY: _on_message collaborator.
 from src.websocket.polling.result_collector import ResultCollector  # WHY: wait_for_command_result collaborator.
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger for #886 print-to-logger migration.
+
 try:  # WHY: websocket-client is a hard runtime dep; fail loudly if missing.
     import websocket  # WHY: Actual client library import (may raise ImportError).
 except ImportError as _ws_err:  # WHY: Convert to project-branded ImportError with install hint.
@@ -45,10 +47,12 @@ def _is_debug_env_flag_set() -> bool:
 
 def log_ws_error(error_message: str, debug_mode: bool) -> None:
     """Print and log a WebSocket operation error with optional debug traceback."""
-    print(f"! {error_message}")  # WHY: User-visible error banner via stdout.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.error("! %s", error_message)  # WHY: User-visible error banner via logger.
     logging.error(error_message)  # WHY: Persist error to configured logging sinks.
     if debug_mode:  # WHY: Only emit stack trace when the operator asked for detail.
-        print("[DEBUG] Exception details:")  # WHY: Marker line preceding the traceback dump.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.debug("[DEBUG] Exception details:")  # WHY: Marker line preceding the traceback dump.
         traceback.print_exc()  # WHY: Full traceback for interactive debugging sessions.
 
 
@@ -57,9 +61,11 @@ def cleanup_ws_connection(ws_manager: Any, debug_mode: bool = False) -> None:
     try:  # WHY: Cleanup must never propagate — it runs from `finally` blocks.
         if ws_manager is not None:  # WHY: Callers may pass None if construction failed.
             ws_manager.disconnect()  # WHY: Release socket + clear internal state.
-            print("-> WebSocket connection closed")  # WHY: User confirmation on stdout.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("-> WebSocket connection closed")  # WHY: User confirmation via logger.
             if debug_mode:  # WHY: Extra diagnostic breadcrumb only for debug runs.
-                print("[DEBUG] WebSocket cleanup completed")  # WHY: Marks end of teardown.
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.debug("[DEBUG] WebSocket cleanup completed")  # WHY: Marks end of teardown.
     except Exception as cleanup_error:  # WHY: Broad catch — teardown must be resilient.
         logging.warning("WebSocket cleanup error: %s", cleanup_error)  # WHY: Warn but do not fail.
 
@@ -75,28 +81,36 @@ def dump_ws_debug_state(ws_mgr: Any, debug_mode: bool) -> None:
     """Print WebSocket manager debug state when debug mode is active."""
     if not debug_mode:  # WHY: Guard clause avoids nested block for non-debug runs.
         return  # WHY: No side effects when debug is off.
-    print("[DEBUG] Checking WebSocket manager state...")  # WHY: Section marker for debug dump.
-    print(f"[DEBUG] Connected = {ws_mgr.connected}")  # WHY: Surfaces socket-open flag.
-    print(f"[DEBUG] Subscribed channels = {ws_mgr.subscribed_channels}")  # WHY: Reveals routing state.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Checking WebSocket manager state...")  # WHY: Section marker for debug dump.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Connected = %s", ws_mgr.connected)  # WHY: Surfaces socket-open flag.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] Subscribed channels = %s", ws_mgr.subscribed_channels)  # WHY: Reveals routing state.
     with ws_mgr.results_lock:  # WHY: Snapshot pending results under the shared lock.
-        print(f"[DEBUG] Pending results = {list(ws_mgr.command_results.keys())}")  # WHY: In-flight sessions.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.debug("[DEBUG] Pending results = %s", list(ws_mgr.command_results.keys()))  # WHY: In-flight sessions.
 
 
 def select_ws_site(deps: Any, debug_mode: bool) -> str | None:
     """Prompt for site selection, returning None and printing a message if cancelled."""
     site_id: str | None = deps.select_site_fn() or None  # WHY: Normalise falsy return to None.
     if not site_id:  # WHY: Cancellation path — surface a clear message to the operator.
-        print("! No site selected. Operation cancelled.")  # WHY: Explains why nothing runs next.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("! No site selected. Operation cancelled.")  # WHY: Explains why nothing runs next.
         return None  # WHY: Callers detect None to abort the workflow.
     if debug_mode:  # WHY: Only echo the selected id when detail is requested.
-        print(f"[DEBUG] Selected site_id = {site_id}")  # WHY: Traceable id for later log correlation.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.debug("[DEBUG] Selected site_id = %s", site_id)  # WHY: Traceable id for later log correlation.
     return site_id  # WHY: Successful selection propagated to caller.
 
 
 def _log_credential_debug(mist_host: str, mist_apitoken: str) -> None:
     """Emit debug lines describing which credentials the manager will use."""
-    print(f"[DEBUG] mist_host = {mist_host}")  # WHY: Confirms target Mist cloud region.
-    print(f"[DEBUG] API token length = {len(mist_apitoken)}")  # WHY: Token itself never printed.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] mist_host = %s", mist_host)  # WHY: Confirms target Mist cloud region.
+    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    logger.debug("[DEBUG] API token length = %d", len(mist_apitoken))  # WHY: Token itself never printed.
 
 
 def check_mist_credentials(
@@ -107,7 +121,8 @@ def check_mist_credentials(
 ) -> bool:
     """Validate Mist host and token; disconnect ws_mgr and return False if invalid."""
     if not (mist_host and mist_apitoken):  # WHY: Combined guard shrinks branch count.
-        print("! Mist host or API token not found in session or environment")  # WHY: Actionable hint.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.error("! Mist host or API token not found in session or environment")  # WHY: Actionable hint.
         if ws_mgr is not None:  # WHY: Only tear down when a manager was actually constructed.
             ws_mgr.disconnect()  # WHY: Prevent leaked socket when we bail out early.
         return False  # WHY: Signals caller to abort the workflow.
@@ -199,13 +214,15 @@ class WebSocketManager:
     def _debug_print(self, message: str, debug_mode: bool) -> None:
         """Print a `[DEBUG] ...` line only when debug_mode is truthy."""
         if debug_mode:  # WHY: Guard keeps quiet mode noise-free.
-            print(f"[DEBUG] {message}")  # WHY: Uniform debug marker.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.debug("[DEBUG] %s", message)  # WHY: Uniform debug marker.
 
     def _subscribe_command_channel(self, site_id: str, device_id: str, debug_mode: bool) -> bool:
         """Subscribe to the site/device command channel and log the outcome."""
         command_channel = f"/sites/{site_id}/devices/{device_id}/cmd"  # WHY: Mist channel convention.
         if not self.subscribe_to_channel(command_channel):  # WHY: Delegates the wire message.
-            print("! Failed to subscribe to device command channel")  # WHY: User-visible error banner.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Failed to subscribe to device command channel")  # WHY: User-visible error banner.
             self.disconnect()  # WHY: Release the socket if subscribe failed.
             return False  # WHY: Caller must abort the workflow.
         self._debug_print(f"Subscribed to channel: {command_channel}", debug_mode)  # WHY: Trace success.
@@ -215,12 +232,14 @@ class WebSocketManager:
         """Connect to WebSocket and subscribe to the device command channel."""
         self._debug_print("WebSocketManager initialized", debug_mode)  # WHY: Trace lifecycle start.
         if not self.connect():  # WHY: Handshake is a hard precondition for subscribe.
-            print("! Failed to establish WebSocket connection")  # WHY: User-visible failure.
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Failed to establish WebSocket connection")  # WHY: User-visible failure.
             return False  # WHY: Cannot proceed without a live socket.
         self._debug_print("WebSocket connection established", debug_mode)  # WHY: Trace handshake success.
         if not self._subscribe_command_channel(site_id, device_id, debug_mode):  # WHY: Second precondition.
             return False  # WHY: Subscribe helper already emitted its own error banner.
-        print("-> WebSocket connected and subscribed")  # WHY: Positive user-facing confirmation.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("-> WebSocket connected and subscribed")  # WHY: Positive user-facing confirmation.
         time.sleep(_WS_STABILIZE_SLEEP_SECONDS)  # WHY: Brief settle before first command POST.
         return True  # WHY: Manager is ready for command traffic.
 
@@ -244,8 +263,8 @@ class WebSocketManager:
         """Log a subscription-lifecycle debug line to both logger and stdout."""
         if not debug_mode:  # WHY: Guard keeps quiet mode noise-free.
             return  # WHY: Nothing to log in non-debug runs.
-        self.logger.debug("%s: %s", action, channel_path)  # WHY: Structured logger trace.
-        print(f"[DEBUG] {action}: {channel_path}")  # WHY: Stdout echo for interactive debug.
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.debug("[DEBUG] %s: %s", action, channel_path)  # WHY: Debug echo for interactive debug.
 
     def _poll_subscription_confirmed(self, channel_path: str, timeout_seconds: float) -> bool:
         """Spin-wait for the router to record a subscription confirmation."""

--- a/tests/unit/websocket/test_manager.py
+++ b/tests/unit/websocket/test_manager.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import builtins
 import importlib
+import logging
 import sys
 import threading
 from typing import Any
@@ -31,6 +32,8 @@ import pytest
 
 from src.websocket import manager as manager_mod
 from src.websocket.manager import WebSocketManager
+
+_MANAGER_LOGGER = "src.websocket.manager"  # WHY: 886 capsys→caplog migration target logger name.
 
 # ---------- Module import guard: raise ImportError when websocket-client missing ----------
 
@@ -108,54 +111,56 @@ def test_is_debug_env_flag_set_false_when_absent_or_other() -> None:
 # ---------- Module-level helper: log_ws_error ----------
 
 
-def test_log_ws_error_prints_and_logs_without_traceback_when_not_debug(capsys) -> None:
-    """log_ws_error prints an error banner and calls logging.error; no traceback when debug=False."""
+def test_log_ws_error_prints_and_logs_without_traceback_when_not_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """log_ws_error emits an error banner and calls logging.error; no traceback when debug=False."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     with (
         patch.object(manager_mod.logging, "error") as mock_err,
         patch.object(manager_mod.traceback, "print_exc") as mock_tb,
     ):
         manager_mod.log_ws_error("boom", debug_mode=False)
-    out = capsys.readouterr().out
-    assert "! boom" in out
-    assert "[DEBUG] Exception details:" not in out
+    assert "! boom" in caplog.text
+    assert "[DEBUG] Exception details:" not in caplog.text
     mock_err.assert_called_once_with("boom")
     mock_tb.assert_not_called()
 
 
-def test_log_ws_error_prints_traceback_when_debug(capsys) -> None:
+def test_log_ws_error_prints_traceback_when_debug(caplog: pytest.LogCaptureFixture) -> None:
     """log_ws_error with debug_mode=True dumps traceback in addition to the banner."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     with patch.object(manager_mod.logging, "error"), patch.object(manager_mod.traceback, "print_exc") as mock_tb:
         manager_mod.log_ws_error("boom", debug_mode=True)
-    out = capsys.readouterr().out
-    assert "! boom" in out
-    assert "[DEBUG] Exception details:" in out
+    assert "! boom" in caplog.text
+    assert "[DEBUG] Exception details:" in caplog.text
     mock_tb.assert_called_once()
 
 
 # ---------- Module-level helper: cleanup_ws_connection ----------
 
 
-def test_cleanup_ws_connection_disconnects_manager(capsys) -> None:
-    """cleanup_ws_connection calls disconnect() and prints confirmation on stdout."""
+def test_cleanup_ws_connection_disconnects_manager(caplog: pytest.LogCaptureFixture) -> None:
+    """cleanup_ws_connection calls disconnect() and emits confirmation on the module logger."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     mgr = MagicMock()
     manager_mod.cleanup_ws_connection(mgr, debug_mode=False)
     mgr.disconnect.assert_called_once()
-    out = capsys.readouterr().out
-    assert "-> WebSocket connection closed" in out
-    assert "[DEBUG]" not in out
+    assert "-> WebSocket connection closed" in caplog.text
+    assert "[DEBUG]" not in caplog.text
 
 
-def test_cleanup_ws_connection_prints_debug_line_when_debug(capsys) -> None:
-    """cleanup_ws_connection prints an extra [DEBUG] confirmation when debug_mode=True."""
+def test_cleanup_ws_connection_prints_debug_line_when_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """cleanup_ws_connection emits an extra [DEBUG] confirmation when debug_mode=True."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     mgr = MagicMock()
     manager_mod.cleanup_ws_connection(mgr, debug_mode=True)
-    assert "[DEBUG] WebSocket cleanup completed" in capsys.readouterr().out
+    assert "[DEBUG] WebSocket cleanup completed" in caplog.text
 
 
-def test_cleanup_ws_connection_none_manager_is_noop(capsys) -> None:
+def test_cleanup_ws_connection_none_manager_is_noop(caplog: pytest.LogCaptureFixture) -> None:
     """Passing ws_manager=None is a no-op (safe when construction failed earlier)."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     manager_mod.cleanup_ws_connection(None, debug_mode=True)
-    assert capsys.readouterr().out == ""
+    assert caplog.records == []
 
 
 def test_cleanup_ws_connection_swallows_disconnect_exception() -> None:
@@ -199,16 +204,18 @@ def test_get_mist_credentials_returns_none_when_neither_source_has_value() -> No
 # ---------- Module-level helper: dump_ws_debug_state ----------
 
 
-def test_dump_ws_debug_state_noop_when_debug_off(capsys) -> None:
-    """dump_ws_debug_state with debug_mode=False prints nothing and does not touch state."""
+def test_dump_ws_debug_state_noop_when_debug_off(caplog: pytest.LogCaptureFixture) -> None:
+    """dump_ws_debug_state with debug_mode=False emits nothing and does not touch state."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     mgr = MagicMock()
     manager_mod.dump_ws_debug_state(mgr, debug_mode=False)
-    assert capsys.readouterr().out == ""
+    assert caplog.records == []
     mgr.results_lock.__enter__.assert_not_called()
 
 
-def test_dump_ws_debug_state_prints_state_when_debug_on(capsys) -> None:
-    """dump_ws_debug_state prints connected flag, subscribed_channels, and pending session ids."""
+def test_dump_ws_debug_state_prints_state_when_debug_on(caplog: pytest.LogCaptureFixture) -> None:
+    """dump_ws_debug_state emits connected flag, subscribed_channels, and pending session ids."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     mgr = MagicMock()
     mgr.connected = True
     mgr.subscribed_channels = {"/a/b/cmd"}
@@ -217,51 +224,53 @@ def test_dump_ws_debug_state_prints_state_when_debug_on(capsys) -> None:
     mgr.results_lock.__enter__ = MagicMock(return_value=mgr.results_lock)
     mgr.results_lock.__exit__ = MagicMock(return_value=False)
     manager_mod.dump_ws_debug_state(mgr, debug_mode=True)
-    out = capsys.readouterr().out
-    assert "Checking WebSocket manager state" in out
-    assert "Connected = True" in out
-    assert "/a/b/cmd" in out
-    assert "sess-1" in out and "sess-2" in out
+    assert "Checking WebSocket manager state" in caplog.text
+    assert "Connected = True" in caplog.text
+    assert "/a/b/cmd" in caplog.text
+    assert "sess-1" in caplog.text and "sess-2" in caplog.text
 
 
 # ---------- Module-level helper: select_ws_site ----------
 
 
-def test_select_ws_site_returns_selection(capsys) -> None:
+def test_select_ws_site_returns_selection(caplog: pytest.LogCaptureFixture) -> None:
     """A truthy select_site_fn return value is returned unchanged; no cancellation text."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     deps = MagicMock()
     deps.select_site_fn.return_value = "site-abc"
     got = manager_mod.select_ws_site(deps, debug_mode=False)
     assert got == "site-abc"
-    assert "cancelled" not in capsys.readouterr().out
+    assert "cancelled" not in caplog.text
 
 
-def test_select_ws_site_returns_none_on_empty_and_prints_cancel(capsys) -> None:
-    """Empty string return is normalised to None and a cancellation banner is printed."""
+def test_select_ws_site_returns_none_on_empty_and_prints_cancel(caplog: pytest.LogCaptureFixture) -> None:
+    """Empty string return is normalised to None and a cancellation banner is emitted."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     deps = MagicMock()
     deps.select_site_fn.return_value = ""
     assert manager_mod.select_ws_site(deps, debug_mode=False) is None
-    assert "No site selected. Operation cancelled." in capsys.readouterr().out
+    assert "No site selected. Operation cancelled." in caplog.text
 
 
-def test_select_ws_site_prints_debug_line_when_debug(capsys) -> None:
+def test_select_ws_site_prints_debug_line_when_debug(caplog: pytest.LogCaptureFixture) -> None:
     """Selected site id is echoed as a [DEBUG] line only in debug mode."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     deps = MagicMock()
     deps.select_site_fn.return_value = "site-xyz"
     manager_mod.select_ws_site(deps, debug_mode=True)
-    assert "[DEBUG] Selected site_id = site-xyz" in capsys.readouterr().out
+    assert "[DEBUG] Selected site_id = site-xyz" in caplog.text
 
 
 # ---------- Module-level helper: _log_credential_debug ----------
 
 
-def test_log_credential_debug_prints_host_and_token_length(capsys) -> None:
-    """Debug credential dump prints host verbatim but only the token length (never the token)."""
+def test_log_credential_debug_prints_host_and_token_length(caplog: pytest.LogCaptureFixture) -> None:
+    """Debug credential dump emits host verbatim but only the token length (never the token)."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     manager_mod._log_credential_debug("host-name", "abcdef")
-    out = capsys.readouterr().out
-    assert "mist_host = host-name" in out
-    assert "API token length = 6" in out
-    assert "abcdef" not in out
+    assert "mist_host = host-name" in caplog.text
+    assert "API token length = 6" in caplog.text
+    assert "abcdef" not in caplog.text
 
 
 # ---------- Module-level helper: check_mist_credentials ----------
@@ -274,12 +283,13 @@ def test_check_mist_credentials_true_when_both_present() -> None:
     mgr.disconnect.assert_not_called()
 
 
-def test_check_mist_credentials_false_when_host_missing_and_disconnects(capsys) -> None:
-    """Missing host → prints error, calls disconnect(), returns False."""
+def test_check_mist_credentials_false_when_host_missing_and_disconnects(caplog) -> None:
+    """Missing host → emits error, calls disconnect(), returns False."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     mgr = MagicMock()
     assert manager_mod.check_mist_credentials(mgr, None, "t", debug_mode=False) is False
     mgr.disconnect.assert_called_once()
-    assert "Mist host or API token not found" in capsys.readouterr().out
+    assert "Mist host or API token not found" in caplog.text
 
 
 def test_check_mist_credentials_false_when_token_missing() -> None:
@@ -289,17 +299,19 @@ def test_check_mist_credentials_false_when_token_missing() -> None:
     mgr.disconnect.assert_called_once()
 
 
-def test_check_mist_credentials_missing_with_none_manager_no_disconnect(capsys) -> None:
+def test_check_mist_credentials_missing_with_none_manager_no_disconnect(caplog) -> None:
     """When ws_mgr is None and creds are missing, no disconnect attempt; still returns False."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     assert manager_mod.check_mist_credentials(None, None, None, debug_mode=False) is False
-    assert "Mist host or API token not found" in capsys.readouterr().out
+    assert "Mist host or API token not found" in caplog.text
 
 
-def test_check_mist_credentials_prints_debug_when_valid_and_debug_mode(capsys) -> None:
-    """Valid creds + debug_mode=True → helper prints host + token length."""
+def test_check_mist_credentials_prints_debug_when_valid_and_debug_mode(caplog) -> None:
+    """Valid creds + debug_mode=True → helper emits host + token length."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     mgr = MagicMock()
     assert manager_mod.check_mist_credentials(mgr, "host", "tok", debug_mode=True) is True
-    assert "mist_host = host" in capsys.readouterr().out
+    assert "mist_host = host" in caplog.text
 
 
 # ---------- WebSocketManager.__init__ ----------
@@ -484,46 +496,49 @@ def test_connect_returns_false_on_exception() -> None:
 # ---------- WebSocketManager._debug_print ----------
 
 
-def test_debug_print_prints_only_when_debug(capsys) -> None:
+def test_debug_print_prints_only_when_debug(caplog) -> None:
     """_debug_print emits a [DEBUG] line only when debug_mode is True."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
     m._debug_print("hello", debug_mode=False)
-    assert capsys.readouterr().out == ""
+    assert caplog.records == []
     m._debug_print("hello", debug_mode=True)
-    assert "[DEBUG] hello" in capsys.readouterr().out
+    assert "[DEBUG] hello" in caplog.text
 
 
 # ---------- WebSocketManager._subscribe_command_channel ----------
 
 
-def test_subscribe_command_channel_success_prints_debug(capsys) -> None:
-    """Successful subscribe returns True and, in debug mode, prints the channel."""
+def test_subscribe_command_channel_success_prints_debug(caplog) -> None:
+    """Successful subscribe returns True and, in debug mode, emits the channel."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
     with patch.object(m, "subscribe_to_channel", return_value=True):
         assert m._subscribe_command_channel("s1", "d1", debug_mode=True) is True
-    out = capsys.readouterr().out
-    assert "/sites/s1/devices/d1/cmd" in out
-    assert "[DEBUG] Subscribed to channel" in out
+    assert "/sites/s1/devices/d1/cmd" in caplog.text
+    assert "[DEBUG] Subscribed to channel" in caplog.text
 
 
-def test_subscribe_command_channel_failure_disconnects(capsys) -> None:
-    """Failed subscribe returns False, disconnects the manager, prints error banner."""
+def test_subscribe_command_channel_failure_disconnects(caplog) -> None:
+    """Failed subscribe returns False, disconnects the manager, emits error banner."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
     with patch.object(m, "subscribe_to_channel", return_value=False), patch.object(m, "disconnect") as mock_disc:
         assert m._subscribe_command_channel("s", "d", debug_mode=False) is False
     mock_disc.assert_called_once()
-    assert "Failed to subscribe to device command channel" in capsys.readouterr().out
+    assert "Failed to subscribe to device command channel" in caplog.text
 
 
 # ---------- WebSocketManager.connect_and_subscribe ----------
 
 
-def test_connect_and_subscribe_returns_false_on_connect_failure(capsys) -> None:
-    """When connect() returns False, connect_and_subscribe returns False + prints error."""
+def test_connect_and_subscribe_returns_false_on_connect_failure(caplog) -> None:
+    """When connect() returns False, connect_and_subscribe returns False + emits error."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
     with patch.object(m, "connect", return_value=False):
         assert m.connect_and_subscribe("s", "d", debug_mode=False) is False
-    assert "Failed to establish WebSocket connection" in capsys.readouterr().out
+    assert "Failed to establish WebSocket connection" in caplog.text
 
 
 def test_connect_and_subscribe_returns_false_when_subscribe_fails() -> None:
@@ -537,8 +552,9 @@ def test_connect_and_subscribe_returns_false_when_subscribe_fails() -> None:
         assert m.connect_and_subscribe("s", "d", debug_mode=False) is False
 
 
-def test_connect_and_subscribe_success_sleeps_and_returns_true(capsys) -> None:
+def test_connect_and_subscribe_success_sleeps_and_returns_true(caplog) -> None:
     """Happy path: connect + subscribe both succeed → True; time.sleep stabiliser is called."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
     with (
         patch.object(m, "connect", return_value=True),
@@ -547,7 +563,7 @@ def test_connect_and_subscribe_success_sleeps_and_returns_true(capsys) -> None:
     ):
         assert m.connect_and_subscribe("s", "d", debug_mode=True) is True
     mock_sleep.assert_called_once_with(manager_mod._WS_STABILIZE_SLEEP_SECONDS)
-    assert "WebSocket connected and subscribed" in capsys.readouterr().out
+    assert "WebSocket connected and subscribed" in caplog.text
 
 
 # ---------- WebSocketManager.subscribe_to_channel ----------
@@ -592,20 +608,20 @@ def test_subscribe_to_channel_returns_false_on_send_exception() -> None:
 # ---------- WebSocketManager._debug_log_sub ----------
 
 
-def test_debug_log_sub_noop_when_debug_off(capsys) -> None:
+def test_debug_log_sub_noop_when_debug_off(caplog) -> None:
     """_debug_log_sub emits nothing when debug_mode is False."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
     m._debug_log_sub("Waiting", "/x", debug_mode=False)
-    assert capsys.readouterr().out == ""
+    assert caplog.records == []
 
 
-def test_debug_log_sub_prints_and_logs_when_debug_on(capsys) -> None:
-    """_debug_log_sub prints stdout line AND calls logger.debug when debug_mode is True."""
+def test_debug_log_sub_prints_and_logs_when_debug_on(caplog) -> None:
+    """_debug_log_sub emits a module-logger debug line when debug_mode is True."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
-    with patch.object(m.logger, "debug") as mock_dbg:
-        m._debug_log_sub("Waiting", "/x", debug_mode=True)
-    mock_dbg.assert_called_once()
-    assert "[DEBUG] Waiting: /x" in capsys.readouterr().out
+    m._debug_log_sub("Waiting", "/x", debug_mode=True)
+    assert "[DEBUG] Waiting: /x" in caplog.text
 
 
 # ---------- WebSocketManager._poll_subscription_confirmed ----------
@@ -665,19 +681,21 @@ def test_wait_for_subscription_confirmation_timeout_logs_warning() -> None:
     mock_warn.assert_called_once()
 
 
-def test_wait_for_subscription_confirmation_debug_env_flag_triggers_debug_output(capsys) -> None:
+def test_wait_for_subscription_confirmation_debug_env_flag_triggers_debug_output(caplog) -> None:
     """DEBUG env flag enables the [DEBUG] trace lines even without --debug arg."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
     with (
         patch.object(m, "_poll_subscription_confirmed", return_value=True),
         patch.object(manager_mod, "_is_debug_env_flag_set", return_value=True),
     ):
         m.wait_for_subscription_confirmation("/dbg")
-    assert "[DEBUG] Waiting for subscription confirmation for" in capsys.readouterr().out
+    assert "[DEBUG] Waiting for subscription confirmation for" in caplog.text
 
 
-def test_wait_for_subscription_confirmation_debug_mode_attr_triggers_debug(capsys) -> None:
-    """A manager with debug_mode attribute set True prints [DEBUG] lines too."""
+def test_wait_for_subscription_confirmation_debug_mode_attr_triggers_debug(caplog) -> None:
+    """A manager with debug_mode attribute set True emits [DEBUG] lines too."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     m = WebSocketManager(_make_session())
     m.debug_mode = True  # type: ignore[attr-defined]
     with (
@@ -685,9 +703,8 @@ def test_wait_for_subscription_confirmation_debug_mode_attr_triggers_debug(capsy
         patch.object(manager_mod, "_is_debug_env_flag_set", return_value=False),
     ):
         m.wait_for_subscription_confirmation("/dbg2")
-    out = capsys.readouterr().out
-    assert "Waiting for subscription confirmation" in out
-    assert "Timeout waiting for subscription confirmation" in out
+    assert "Waiting for subscription confirmation" in caplog.text
+    assert "Timeout waiting for subscription confirmation" in caplog.text
 
 
 # ---------- WebSocketManager._build_result_collector ----------
@@ -833,7 +850,8 @@ def test_await_handshake_flag_flip_after_last_sleep_returns_true() -> None:
 # ---------- Extra branch coverage: check_mist_credentials both missing, ws None ----------
 
 
-def test_check_mist_credentials_debug_mode_off_no_credential_dump(capsys) -> None:
-    """Valid creds but debug_mode=False → no credential dump printed."""
+def test_check_mist_credentials_debug_mode_off_no_credential_dump(caplog) -> None:
+    """Valid creds but debug_mode=False → no credential dump emitted."""
+    caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)
     assert manager_mod.check_mist_credentials(MagicMock(), "h", "t", debug_mode=False) is True
-    assert "mist_host" not in capsys.readouterr().out
+    assert "mist_host" not in caplog.text


### PR DESCRIPTION
## Summary
- Replace 18 `print()` calls in `src/websocket/manager.py` with module-scoped `logger.*` emissions using %-style deferred formatting (G004-clean). Verbatim operator notices preserved with the standard WHY comment.
- Level heuristic: credential/timeout warnings → `logger.warning`; connection/subscription failures → `logger.error`; `[DEBUG]` gated echoes → `logger.debug`; status/success banners → `logger.info`.
- Remove a redundant `self.logger.debug` call in `_debug_log_sub` that duplicated the module-level `logger.debug` (same logger object → double emission).
- Migrate 24 tests in `tests/unit/websocket/test_manager.py` from `capsys` to `caplog` using module-level `_MANAGER_LOGGER = "src.websocket.manager"` driving `caplog.set_level(logging.DEBUG, logger=_MANAGER_LOGGER)`. Targeted `patch.object(...)` sites that validate specific logger call interactions are preserved.

## Test plan
- [x] `python -m pytest tests/unit/websocket/test_manager.py` → 71/71 pass
- [x] `python -m black src/websocket/manager.py tests/unit/websocket/test_manager.py` → unchanged
- [x] `python -m ruff check src/websocket/manager.py tests/unit/websocket/test_manager.py` → clean

Refs #886