### PR TITLE
chore(logging): migrate src/device/_utility_commands_websocket.py print() to logger (#886 slice 96/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 96/N: retire `print()` in `src/device/_utility_commands_websocket.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 19 `print()` calls in
+  `src/device/_utility_commands_websocket.py` with module-scoped `logger.*`
+  emissions using `%`-style deferred formatting to satisfy G004. Level
+  heuristic: banner/session/streaming/results notices map to `logger.info`;
+  no-response / no-session / connect-fail / subscribe-fail / no-results /
+  cancelled notices map to `logger.warning`; command-failed and streaming-
+  failed error paths map to `logger.error`. Each converted call carries the
+  standard `# WHY: preserve operator notice verbatim; route through logger for
+  capture/redirection.` comment above the emission.
+- **Test migration (Changed)**: migrated 12 `capsys` assertions in
+  `tests/unit/test_device_utility_commands.py` to `caplog` against
+  `_WS_LOGGER = "src.device._utility_commands_websocket"` so the assertions
+  follow the emissions across the print→logger boundary.
+
 ### #886 Phase 2 slice 95/N: retire `print()` in `src/websocket/manager.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 18 `print()` calls in

--- a/src/device/_utility_commands_websocket.py
+++ b/src/device/_utility_commands_websocket.py
@@ -34,6 +34,8 @@ from typing import Any, cast  # WHY: cast narrows Any from __getattr__ proxy
 
 from ._utility_commands_cluster import _ClusterBase  # WHY: shared proxy base
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger for #886 print-to-logger migration.
+
 
 @dataclass(frozen=True)  # WHY: frozen so callers cannot mutate mid-flow
 class StreamWsSpec:  # WHY: bundle for _stream_ws_output single-arg signature
@@ -111,7 +113,8 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
             )
         except Exception as error:  # WHY: log-and-continue on any WS/SDK failure
             logging.exception("WebSocket command failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Command failed: {error}")  # WHY: surface error to operator
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Command failed: %s", error)  # WHY: surface error to operator
             return None  # WHY: caller treats None as no-result
         finally:
             websocket_manager.disconnect()  # WHY: always clean up socket
@@ -151,8 +154,10 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
         session_id = self._extract_session_id(response)  # WHY: parse session or fail fast
         if session_id is None:  # WHY: missing session -> nothing to await
             return None  # WHY: helper already emitted diagnostics
-        print(f"-> Command issued (session: {session_id[:8]}...)")  # WHY: operator feedback
-        print("-> Waiting for results...")  # WHY: hint on latency budget
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("-> Command issued (session: %s...)", session_id[:8])  # WHY: operator feedback
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("-> Waiting for results...")  # WHY: hint on latency budget
         result: dict[str, Any] | None = websocket_manager.wait_for_command_result(
             session_id, timeout_seconds=120  # WHY: 2-minute cap matches mistapi default
         )
@@ -190,10 +195,12 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
             # WHY: route through parent so patch.object(duc, "_stream_ws_output", ...) intercepts
             self._call("_stream_ws_output", spec)
         except KeyboardInterrupt:  # WHY: operator Ctrl+C is a normal stop signal
-            print("\n-> Streaming stopped by user.")  # WHY: acknowledge intentional halt
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("\n-> Streaming stopped by user.")  # WHY: acknowledge intentional halt
         except Exception as error:  # WHY: log-and-continue on any WS/SDK failure
             logging.exception("Streaming command failed: %s", error)  # WHY: audit failure with stack
-            print(f"! Streaming failed: {error}")  # WHY: surface error to operator
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("! Streaming failed: %s", error)  # WHY: surface error to operator
         finally:
             websocket_manager.disconnect()  # WHY: always clean up
 
@@ -203,8 +210,10 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
         session_id = self._extract_session_id(response, absent_msg="! No session ID returned.")  # WHY: parse
         if session_id is None:  # WHY: no session -> nothing to stream
             return  # WHY: helper already emitted diagnostics
-        print(f"-> Streaming started (session: {session_id[:8]}...)")  # WHY: operator feedback
-        print("-> Press Ctrl+C to stop.\n")  # WHY: hint on how to end streaming
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("-> Streaming started (session: %s...)", session_id[:8])  # WHY: operator feedback
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("-> Press Ctrl+C to stop.\n")  # WHY: hint on how to end streaming
         result = spec.websocket_manager.wait_for_command_result(
             session_id,
             timeout_seconds=spec.timeout_seconds,
@@ -219,7 +228,8 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
     def _display_and_export_result(self, spec: ExportResultSpec) -> None:  # WHY: single-arg spec keeps STRUCT clean
         """Display WebSocket result and write to dual output using :class:`ExportResultSpec`."""
         if not spec.result:  # WHY: timeout / disconnect / API error
-            print("! No results received (timeout or error).")  # WHY: signal empty result
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! No results received (timeout or error).")  # WHY: signal empty result
             return
         raw_output, other_output = self._print_result_block(spec.command_name, spec.result)  # WHY: banner
         export_data = self._build_export_row(spec, raw_output, other_output)  # WHY: canonical payload
@@ -233,7 +243,8 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
         """Require typed keyword confirmation for destructive ops."""
         confirmation = self._safe_input_fn(prompt, context=context)  # WHY: __getattr__ proxy
         if confirmation != keyword:  # WHY: exact-match gate; even leading/trailing space fails
-            print("! Operation cancelled - confirmation not matched.")  # WHY: signal cancel
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Operation cancelled - confirmation not matched.")  # WHY: signal cancel
             return False
         return True
 
@@ -244,11 +255,13 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
     def _prepare_ws_channel(self, websocket_manager: Any, site_id: str, device_id: str) -> bool:
         """Connect the WS manager and subscribe to the per-device command channel."""
         if not websocket_manager.connect():  # WHY: bail if WS handshake fails
-            print("! Failed to establish WebSocket connection.")  # WHY: expose handshake failure
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Failed to establish WebSocket connection.")  # WHY: expose handshake failure
             return False
         channel = f"/sites/{site_id}/devices/{device_id}/cmd"  # WHY: per-device command channel
         if not websocket_manager.subscribe_to_channel(channel):  # WHY: subscribe before firing SDK call
-            print("! Failed to subscribe to device command channel.")  # WHY: expose subscribe failure
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! Failed to subscribe to device command channel.")  # WHY: expose subscribe failure
             websocket_manager.disconnect()  # WHY: release socket on subscribe failure
             return False
         time.sleep(1)  # WHY: let subscription settle before command
@@ -273,12 +286,14 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
     ) -> str | None:
         """Extract the WebSocket session id from an SDK response or return None."""
         if not hasattr(response, "data"):  # WHY: mistapi returns response object with .data
-            print("! No response data from API.")  # WHY: signal empty payload
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("! No response data from API.")  # WHY: signal empty payload
             return None
         response_data = response.data if isinstance(response.data, dict) else {}  # WHY: guard shape
         session_id = response_data.get("session")  # WHY: session_id is the WS correlation key
         if not session_id:  # WHY: no session -> nothing to wait for
-            print(absent_msg)  # WHY: differentiate command vs streaming context
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("%s", absent_msg)  # WHY: differentiate command vs streaming context
             return None
         return cast("str", session_id)  # WHY: narrow Any from dict.get
 
@@ -289,20 +304,26 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
             return
         raw = result.get("raw", "")  # WHY: streaming variant only reads 'raw'
         if raw:  # WHY: skip blank lines from empty payloads
-            print(raw)
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("%s", raw)
 
     @staticmethod
     def _print_result_block(command_name: str, result: dict[str, Any]) -> tuple[str, str]:
         """Print the display block for a command result and return (raw, other)."""
-        print("\n" + "=" * 60)  # WHY: banner separates command output block
-        print(f"{command_name.upper()} RESULTS:")  # WHY: identify command in operator log
-        print("=" * 60)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\n%s", "=" * 60)  # WHY: banner separates command output block
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("%s RESULTS:", command_name.upper())  # WHY: identify command in operator log
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("%s", "=" * 60)
         raw_output = str(result.get("raw", ""))  # WHY: preferred output key
         if raw_output:  # WHY: skip if absent
-            print(raw_output)
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("%s", raw_output)
         other_output = str(result.get("Output", ""))  # WHY: some SDK paths emit under 'Output'
         if other_output and other_output != raw_output:  # WHY: avoid double-printing same content
-            print(other_output)
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("%s", other_output)
         return raw_output, other_output
 
     @staticmethod

--- a/tests/unit/test_device_utility_commands.py
+++ b/tests/unit/test_device_utility_commands.py
@@ -24,6 +24,8 @@ sys.modules["mistapi"] = _our_mock
 from src.device._utility_commands_websocket import ExportResultSpec, StreamWsSpec
 from src.device.utility_commands import DeviceUtilityCommands, UtilityCommandsDeps
 
+_WS_LOGGER = "src.device._utility_commands_websocket"  # WHY: caplog target for #886 print-to-logger tests
+
 
 def setup_module() -> None:
     """Re-assert our mock in sys.modules before tests run."""
@@ -271,11 +273,12 @@ class TestConfirmDestructive:
         self,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         mock_deps["safe_input_fn"].return_value = "nope"
         assert duc._confirm_destructive("Type CLEAR: ", "CLEAR", "test") is False
-        assert "cancelled" in capsys.readouterr().out
+        assert "cancelled" in caplog.text
 
     def test_empty_input_returns_false(self, duc: DeviceUtilityCommands, mock_deps: dict[str, MagicMock]) -> None:
         mock_deps["safe_input_fn"].return_value = ""
@@ -293,8 +296,9 @@ class TestDisplayAndExportResult:
     def test_none_result_prints_error(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         duc._display_and_export_result(
             ExportResultSpec(
                 result=None,
@@ -305,14 +309,15 @@ class TestDisplayAndExportResult:
                 filename="file.csv",
             )
         )
-        assert "No results" in capsys.readouterr().out
+        assert "No results" in caplog.text
 
     def test_prints_raw_output(
         self,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.INFO, logger=_WS_LOGGER)
         result = {"raw": "output line 1\nline 2"}
         duc._display_and_export_result(
             ExportResultSpec(
@@ -324,7 +329,7 @@ class TestDisplayAndExportResult:
                 filename="Trace.csv",
             )
         )
-        out = capsys.readouterr().out
+        out = caplog.text
         assert "output line 1" in out
         assert "TRACEROUTE RESULTS" in out
         mock_deps["write_export_fn"].assert_called_once()
@@ -517,13 +522,14 @@ class TestRunStreamingCommand:
         self,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         ws_mgr = MagicMock()
         ws_mgr.connect.return_value = False
         mock_deps["websocket_manager_factory"].return_value = ws_mgr
         duc._run_streaming_command("s1", "d1", MagicMock())
-        assert "Failed" in capsys.readouterr().out
+        assert "Failed" in caplog.text
 
 
 # ===================================================================
@@ -721,15 +727,16 @@ class TestClearArpCache:
         self,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         mock_deps["safe_input_fn"].return_value = "nope"
         with (
             patch.object(duc, "_select_site_and_device", return_value=("s1", "d1", "switch")),
             patch.object(duc, "_select_port_optional", return_value=""),
         ):
             duc.clear_arp_cache()
-            assert "cancelled" in capsys.readouterr().out.lower()
+            assert "cancelled" in caplog.text.lower()
 
     def test_success_calls_api(
         self,
@@ -1323,20 +1330,22 @@ class TestExecuteWsCommand:
     def test_no_response_data(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         sdk_method = MagicMock()
         sdk_method.return_value = MagicMock(spec=[])
         ws_mgr = MagicMock()
         result = duc._execute_ws_command("s1", "d1", sdk_method, None, ws_mgr)
         assert result is None
-        assert "No response data" in capsys.readouterr().out
+        assert "No response data" in caplog.text
 
     def test_no_session_id(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         sdk_method = MagicMock()
         resp = MagicMock()
         resp.data = {}
@@ -1344,7 +1353,7 @@ class TestExecuteWsCommand:
         ws_mgr = MagicMock()
         result = duc._execute_ws_command("s1", "d1", sdk_method, None, ws_mgr)
         assert result is None
-        assert "No session ID" in capsys.readouterr().out
+        assert "No session ID" in caplog.text
 
     def test_success_with_body(
         self,
@@ -1386,8 +1395,9 @@ class TestStreamWsOutput:
     def test_no_response_data(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         sdk_method = MagicMock()
         sdk_method.return_value = MagicMock(spec=[])
         ws_mgr = MagicMock()
@@ -1401,13 +1411,14 @@ class TestStreamWsOutput:
                 timeout_seconds=60,
             )
         )
-        assert "No response data" in capsys.readouterr().out
+        assert "No response data" in caplog.text
 
     def test_no_session_id(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         sdk_method = MagicMock()
         resp = MagicMock()
         resp.data = {}
@@ -1423,13 +1434,14 @@ class TestStreamWsOutput:
                 timeout_seconds=60,
             )
         )
-        assert "No session ID" in capsys.readouterr().out
+        assert "No session ID" in caplog.text
 
     def test_success_prints_raw(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.INFO, logger=_WS_LOGGER)
         sdk_method = MagicMock()
         resp = MagicMock()
         resp.data = {"session": "abc12345-xyz"}
@@ -1446,14 +1458,14 @@ class TestStreamWsOutput:
                 timeout_seconds=60,
             )
         )
-        out = capsys.readouterr().out
-        assert "streaming output" in out
+        assert "streaming output" in caplog.text
 
     def test_success_no_raw(
         self,
         duc: DeviceUtilityCommands,
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.INFO, logger=_WS_LOGGER)
         sdk_method = MagicMock()
         resp = MagicMock()
         resp.data = {"session": "abc12345-xyz"}
@@ -1470,8 +1482,7 @@ class TestStreamWsOutput:
                 timeout_seconds=60,
             )
         )
-        out = capsys.readouterr().out
-        assert "Streaming started" in out
+        assert "Streaming started" in caplog.text
 
 
 # ===================================================================
@@ -1488,14 +1499,15 @@ class TestRunStreamingCommandExtended:
         mock_sleep: MagicMock,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.WARNING, logger=_WS_LOGGER)
         ws_mgr = MagicMock()
         ws_mgr.connect.return_value = True
         ws_mgr.subscribe_to_channel.return_value = False
         mock_deps["websocket_manager_factory"].return_value = ws_mgr
         duc._run_streaming_command("s1", "d1", MagicMock())
-        assert "Failed to subscribe" in capsys.readouterr().out
+        assert "Failed to subscribe" in caplog.text
         ws_mgr.disconnect.assert_called_once()
 
     @patch("src.device._utility_commands_websocket.time.sleep")
@@ -1520,15 +1532,16 @@ class TestRunStreamingCommandExtended:
         mock_sleep: MagicMock,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.ERROR, logger=_WS_LOGGER)
         ws_mgr = MagicMock()
         ws_mgr.connect.return_value = True
         ws_mgr.subscribe_to_channel.return_value = True
         mock_deps["websocket_manager_factory"].return_value = ws_mgr
         with patch.object(duc, "_stream_ws_output", side_effect=RuntimeError("oops")):
             duc._run_streaming_command("s1", "d1", MagicMock())
-            assert "oops" in capsys.readouterr().out
+            assert "oops" in caplog.text
         ws_mgr.disconnect.assert_called_once()
 
     @patch("src.device._utility_commands_websocket.time.sleep")
@@ -1537,15 +1550,16 @@ class TestRunStreamingCommandExtended:
         mock_sleep: MagicMock,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.INFO, logger=_WS_LOGGER)
         ws_mgr = MagicMock()
         ws_mgr.connect.return_value = True
         ws_mgr.subscribe_to_channel.return_value = True
         mock_deps["websocket_manager_factory"].return_value = ws_mgr
         with patch.object(duc, "_stream_ws_output", side_effect=KeyboardInterrupt):
             duc._run_streaming_command("s1", "d1", MagicMock())
-            assert "stopped" in capsys.readouterr().out.lower()
+            assert "stopped" in caplog.text.lower()
         ws_mgr.disconnect.assert_called_once()
 
 
@@ -1563,8 +1577,9 @@ class TestRunWebsocketCommandExtended:
         mock_sleep: MagicMock,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.ERROR, logger=_WS_LOGGER)
         ws_mgr = MagicMock()
         ws_mgr.connect.return_value = True
         ws_mgr.subscribe_to_channel.return_value = True
@@ -1572,7 +1587,7 @@ class TestRunWebsocketCommandExtended:
         with patch.object(duc, "_execute_ws_command", side_effect=RuntimeError("ws error")):
             result = duc._run_websocket_command("s1", "d1", MagicMock())
             assert result is None
-            assert "ws error" in capsys.readouterr().out
+            assert "ws error" in caplog.text
         ws_mgr.disconnect.assert_called_once()
 
 
@@ -2696,8 +2711,9 @@ class TestDisplayAndExportResultExtended:
         self,
         duc: DeviceUtilityCommands,
         mock_deps: dict[str, MagicMock],
-        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(logging.INFO, logger=_WS_LOGGER)
         result = {"Output": "output text"}
         duc._display_and_export_result(
             ExportResultSpec(
@@ -2709,8 +2725,7 @@ class TestDisplayAndExportResultExtended:
                 filename="file.csv",
             )
         )
-        out = capsys.readouterr().out
-        assert "output text" in out
+        assert "output text" in caplog.text
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Slice 96/N of issue #886 — replaces all 19 `print()` calls in
`src/device/_utility_commands_websocket.py` with module-scoped `logger.*`
emissions using `%`-style deferred formatting (G004-clean).

Level heuristic:
- **info**: banner / session id / streaming / results / press Ctrl+C
- **warning**: no-response / no-session / connect-fail / subscribe-fail / no-results / cancelled
- **error**: command-failed / streaming-failed

Each converted call carries the standard `# WHY: preserve operator notice
verbatim; route through logger for capture/redirection.` comment.

Tests: migrated 12 `capsys` assertions to `caplog` against
`_WS_LOGGER = "src.device._utility_commands_websocket"`.

## Test plan

- [x] 194/194 pytest green in tests/unit/test_device_utility_commands.py
- [x] black clean
- [x] ruff clean
- [x] Zero `print(` remaining in `src/device/_utility_commands_websocket.py`