### PR TITLE
chore(logging): migrate src/gateway/device_template_cloner.py print() to logger (#886 slice 107/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #886 Phase 2 slice 107/N: retire `print()` in `src/gateway/device_template_cloner.py` (issue #886)
+
+- **Print-to-logger migration (Changed)**: replaced all 27 `print()` calls in
+  `src/gateway/device_template_cloner.py` with a module-scoped
+  `logger = logging.getLogger(__name__)` and level-appropriate `logger.*`
+  emissions using `%`-style deferred formatting to satisfy G004. Operator
+  banners, site/gateway selection prompts, template-selection listings, and
+  success notices route through `logger.info`; empty-list notices
+  (`No sites found`, `No gateway devices found`), retry prompts on empty or
+  duplicate template names, and invalid hardware-selection messages route
+  through `logger.warning`; clone failure notices (device-config fetch
+  failure, template-creation failure, unexpected-exception handler) route
+  through `logger.error`. Pre-existing `logging.info`/`logging.warning`/
+  `logging.error` audit-trail calls throughout the module were rebound to
+  the module-scoped `logger` for namespace consistency. Each converted call
+  carries the standard `# WHY: preserve operator notice verbatim; route
+  through logger for capture/redirection.` comment above the emission.
+- **Test migration (Changed)**:
+  `tests/unit/gateway/test_device_template_cloner_extended.py` swapped 10
+  `capsys`-based stdout assertions to `caplog` with
+  `caplog.set_level(<level>, logger="src.gateway.device_template_cloner")`
+  scoping so operator-facing notices are captured from the logger channel
+  the code now emits on. `tests/unit/gateway/test_device_template_cloner.py`
+  contained no `capsys` references and needed no changes. All 58 tests
+  across the two files remain green.
+
 ### #886 Phase 2 slice 106/N: retire `print()` in `src/refactors/serial_cc/start_site_scan_capture.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 26 `print()` calls in

--- a/src/gateway/device_template_cloner.py
+++ b/src/gateway/device_template_cloner.py
@@ -15,6 +15,8 @@ import mistapi.api.v1.orgs.gatewaytemplates  # Create/list org gateway templates
 import mistapi.api.v1.orgs.sites  # List org sites for site selection
 import mistapi.api.v1.sites.devices  # List and fetch device configs
 
+logger = logging.getLogger(__name__)  # WHY: module-scoped logger for #886 print-to-logger migration.
+
 # ---------------------------------------------------------------------------
 # Module-level constants
 # ---------------------------------------------------------------------------
@@ -131,24 +133,26 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _list_sites(self) -> list:
         """Fetch all sites in the org and return as a list of dicts."""
-        logging.info("Fetching org sites for org_id %s", self.org_id)  # Log before API call
+        logger.info("Fetching org sites for org_id %s", self.org_id)  # Log before API call
         response = mistapi.api.v1.orgs.sites.listOrgSites(  # Call Mist API for org sites
             self.apisession,
             self.org_id,
         )
         sites = response.data if hasattr(response, "data") else []  # Extract data list from response
-        logging.debug("Received %d sites from API", len(sites))  # Log result count after call
+        logger.debug("Received %d sites from API", len(sites))  # Log result count after call
         return sites  # Return site list for caller to display
 
     def _select_site(self) -> dict | None:
         """Display a numbered site menu and return the site the user picks."""
         sites = self._list_sites()  # Fetch site list from API
         if not sites:  # Guard - nothing to select if org has no sites
-            logging.warning("No sites found for org_id %s", self.org_id)  # Warn on empty list
-            print("No sites found for this org.")  # Inform the NOC engineer
+            logger.warning("No sites found for org_id %s", self.org_id)  # Warn on empty list
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("No sites found for this org.")
             return None  # Signal caller to abort the workflow
         for index, site in enumerate(sites, start=1):  # Build numbered list for display
-            print(f"  {index:3}. {site.get('name', 'Unknown')} ({site.get('id', '')})")  # Show name+ID
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("  %3d. %s (%s)", index, site.get("name", "Unknown"), site.get("id", ""))
         raw = self.input_fn("Select site number: ", context="site_selection")  # Prompt for choice
         return self._resolve_menu_choice(raw, sites)  # Delegate parse+validate to shared helper
 
@@ -158,7 +162,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _list_gateways(self, site_id: str) -> list:
         """Fetch all devices at a site and filter to gateway type only."""
-        logging.info("Fetching devices at site_id %s", site_id)  # Log before API call
+        logger.info("Fetching devices at site_id %s", site_id)  # Log before API call
         response = mistapi.api.v1.sites.devices.listSiteDevices(  # Call Mist API for all device types
             self.apisession,
             site_id,
@@ -166,18 +170,20 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         )
         devices = response.data if hasattr(response, "data") else []  # Extract data list from response
         gateways = [d for d in devices if d.get("type") == "gateway"]  # Keep only gateway-type devices
-        logging.debug("Found %d gateway device(s) at site %s", len(gateways), site_id)  # Log count
+        logger.debug("Found %d gateway device(s) at site %s", len(gateways), site_id)  # Log count
         return gateways  # Return filtered gateway list
 
     def _select_gateway(self, gateways: list) -> dict | None:
         """Display a numbered gateway menu and return the device the user picks."""
         if not gateways:  # Guard - nothing to select if site has no gateways
-            print("No gateway devices found at the selected site.")  # Inform engineer
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("No gateway devices found at the selected site.")
             return None  # Signal caller to abort
         for index, device in enumerate(gateways, start=1):  # Build numbered display list
             model = device.get("model", "Unknown")  # Extract model for display
             name = device.get("name", device.get("mac", "Unknown"))  # Fall back to MAC if no name
-            print(f"  {index:3}. {name} - {model} ({device.get('id', '')})")  # Display selection row
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("  %3d. %s - %s (%s)", index, name, model, device.get("id", ""))
         raw = self.input_fn("Select gateway number: ", context="gateway_selection")  # Prompt for choice
         return self._resolve_menu_choice(raw, gateways)  # Delegate parse+validate to shared helper
 
@@ -186,10 +192,12 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         try:
             choice = int(raw.strip())  # Parse response as integer index
         except ValueError:  # Non-numeric response - guide the engineer and abort
-            print("Invalid input - please enter a number.")  # Inform engineer of bad input
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("Invalid input - please enter a number.")
             return None  # Signal caller to abort
         if not 1 <= choice <= len(items):  # Validate 1-based range before indexing
-            print("Invalid selection.")  # Inform engineer of out-of-range input
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("Invalid selection.")
             return None  # Signal caller to abort
         return items[choice - 1]  # Convert to 0-based and return picked entry
 
@@ -199,7 +207,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _fetch_device_config(self, site_id: str, device_id: str) -> dict | None:
         """Fetch full device config from getSiteDevice and return as a dict."""
-        logging.info(  # Log before API call with identifying context
+        logger.info(  # Log before API call with identifying context
             "Fetching device config for device_id %s at site_id %s", device_id, site_id
         )
         response = mistapi.api.v1.sites.devices.getSiteDevice(  # Call Mist API for full device record
@@ -208,7 +216,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             device_id,
         )
         config = response.data if hasattr(response, "data") else {}  # Extract device dict from response
-        logging.debug(  # Log field count after fetch - safe summary without secret values
+        logger.debug(  # Log field count after fetch - safe summary without secret values
             "Received device config with %d top-level fields", len(config)
         )
         return config if config else None  # Return config dict or None on empty response
@@ -219,7 +227,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _fetch_existing_template_names(self) -> set:
         """Return a set of existing gateway template names for uniqueness validation."""
-        logging.info(  # Log before API call with org context
+        logger.info(  # Log before API call with org context
             "Fetching existing gateway templates for org_id %s to check name uniqueness", self.org_id
         )
         response = mistapi.api.v1.orgs.gatewaytemplates.listOrgGatewayTemplates(  # List all templates
@@ -228,7 +236,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         )
         templates = response.data if hasattr(response, "data") else []  # Extract template list
         names = {t.get("name", "") for t in templates if t.get("name")}  # Build name set for O(1) lookup
-        logging.debug("Found %d existing gateway template name(s)", len(names))  # Log count after fetch
+        logger.debug("Found %d existing gateway template name(s)", len(names))  # Log count after fetch
         return names  # Return name set for uniqueness validation
 
     # ------------------------------------------------------------------
@@ -244,9 +252,12 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _prompt_template_type(self) -> str:
         """Prompt for gateway template type and return 'standalone' or 'spoke'."""
-        print("\nTemplate type:")  # Section header for readability
-        print("  1. standalone")  # Most common type for branch gateways
-        print("  2. spoke")  # Used for SD-WAN spoke deployments
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\nTemplate type:")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  1. standalone")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  2. spoke")
         raw = self.input_fn("Select type [1]: ", context="template_type_selection")  # Prompt with default
         raw = raw.strip()  # Remove leading/trailing whitespace from input
         return "spoke" if raw == "2" else "standalone"  # Map selection to API type string
@@ -259,19 +270,24 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             )
             name = raw.strip() or default_name  # Use default if engineer pressed Enter
             if name in existing_names:  # Reject names already in use
-                print(f"Name '{name}' already exists - please choose a different name.")  # Guide engineer
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("Name '%s' already exists - please choose a different name.", name)
                 continue  # Retry the name prompt
             if not name:  # Reject empty names after default resolution
-                print("Name cannot be empty.")  # Guide engineer
+                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                logger.warning("Name cannot be empty.")
                 continue  # Retry the name prompt
             return name  # Accept valid unique name
 
     def _prompt_hardware_platform(self, source_model: str) -> str:
         """Prompt engineer to keep source model or select a different target model."""
-        print(f"\nHardware platform (source device: {source_model}):")  # Show source for context
-        print("  0. Same as source device")  # Quick option to keep current model
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\nHardware platform (source device: %s):", source_model)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  0. Same as source device")
         for index, model in enumerate(COMMON_GATEWAY_MODELS, start=1):  # List common models
-            print(f"  {index:2}. {model}")  # Display each model with its number
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("  %2d. %s", index, model)
         raw = self.input_fn("Select model [0 = same]: ", context="hardware_platform_selection")  # Prompt
         return self._resolve_hardware_choice(raw.strip(), source_model)  # Delegate parse to helper
 
@@ -282,11 +298,13 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         try:
             index = int(raw)  # Parse selection as integer index into COMMON_GATEWAY_MODELS
         except ValueError:  # Non-numeric response - fall through to safe default
-            print("Invalid selection - using source model.")  # Inform engineer of fallback
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.warning("Invalid selection - using source model.")
             return source_model  # Safe default preserves source model
         if 1 <= index <= len(COMMON_GATEWAY_MODELS):  # Validate range before indexing constant list
             return COMMON_GATEWAY_MODELS[index - 1]  # Return chosen model (1-based to 0-based)
-        print("Invalid selection - using source model.")  # Range failure - inform engineer
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.warning("Invalid selection - using source model.")
         return source_model  # Safe default preserves source model on out-of-range input
 
     # ------------------------------------------------------------------
@@ -299,7 +317,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         payload["name"] = name  # Inject template name provided by engineer
         payload["type"] = ttype  # Inject template type (standalone or spoke)
         payload["gateway_matching"] = self._build_gateway_matching(name, model)  # Inject match block
-        logging.debug(  # Log payload field count - safe summary without secret values
+        logger.debug(  # Log payload field count - safe summary without secret values
             "Built template payload with %d fields for template '%s' (type=%s, model=%s)",
             len(payload),
             name,
@@ -363,21 +381,27 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _confirm_creation(self, name: str, ttype: str, model: str) -> bool:
         """Display a pending-operation summary and require typed 'CREATE' confirmation."""
-        print("\n" + "=" * 60)  # Visual separator for the confirmation block
-        print("  PENDING OPERATION: Create Org Gateway Template")  # Header for clarity
-        print(f"  Template Name : {name}")  # Show template name for engineer review
-        print(f"  Template Type : {ttype}")  # Show template type for engineer review
-        print(f"  Target Model  : {model}")  # Show hardware model for engineer review
-        print("=" * 60)  # Bottom separator
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("\n%s", "=" * 60)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  PENDING OPERATION: Create Org Gateway Template")
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  Template Name : %s", name)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  Template Type : %s", ttype)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("  Target Model  : %s", model)
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info("%s", "=" * 60)
         raw = self.input_fn(  # Prompt for explicit typed confirmation
             "Type CREATE to confirm (or anything else to cancel): ",
             context="create_gateway_template_confirmation",
         )
         confirmed = raw.strip() == "CREATE"  # Exact case comparison - no shortcuts
         if confirmed:  # Log outcome for audit trail
-            logging.info("User confirmed template creation for '%s'", name)  # Log approval
+            logger.info("User confirmed template creation for '%s'", name)  # Log approval
         else:
-            logging.info("Operation cancelled - confirmation failed for template '%s'", name)  # Log cancel
+            logger.info("Operation cancelled - confirmation failed for template '%s'", name)  # Log cancel
         return confirmed  # Return bool for caller to branch on
 
     # ------------------------------------------------------------------
@@ -386,7 +410,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _create_template(self, payload: dict) -> dict | None:
         """Call createOrgGatewayTemplate and return the newly created template dict."""
-        logging.info(  # Log before API write call with non-secret identifying fields
+        logger.info(  # Log before API write call with non-secret identifying fields
             "Creating org gateway template '%s' (type=%s) for org_id %s",
             payload.get("name"),
             payload.get("type"),
@@ -398,7 +422,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             body=payload,  # Pass full payload dict as API request body
         )
         template = response.data if hasattr(response, "data") else {}  # Extract created template dict
-        logging.debug(  # Log new template ID after creation - safe identifying field
+        logger.debug(  # Log new template ID after creation - safe identifying field
             "Created gateway template with ID %s", template.get("id", "unknown")
         )
         return template if template else None  # Return template dict or None on empty response
@@ -419,14 +443,19 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             "source_device_model": device_info.get("model", ""),  # Source hardware model
             "source_site_id": device_info.get("site_id", ""),  # Site where source device lives
         }
-        logging.info("Exporting new gateway template result to CSV")  # Log before export action
+        logger.info("Exporting new gateway template result to CSV")  # Log before export action
         self.write_csv_fn(  # PK-aware writer that selects CSV or SQLite per global format
             [row],  # Wrap single row in list as expected by the writer
             "CloneGatewayTemplate.csv",  # Output filename (or table name in SQLite mode)
             api_function_name="createOrgGatewayTemplate",  # PK strategy key for upsert
         )
-        logging.debug("CSV export complete for template_id %s", row["template_id"])  # Log after export
-        print(f"\nSuccess: Created gateway template '{row['template_name']}' (ID: {row['template_id']})")
+        logger.debug("CSV export complete for template_id %s", row["template_id"])  # Log after export
+        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        logger.info(
+            "\nSuccess: Created gateway template '%s' (ID: %s)",
+            row["template_name"],
+            row["template_id"],
+        )
 
     # ------------------------------------------------------------------
     # Main workflow (split into phase helpers to satisfy STRUCT-* limits)
@@ -443,7 +472,8 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             return None  # Signal caller to abort the workflow
         device_config = self._fetch_device_config(site["id"], gateway["id"])  # Step 4: fetch config
         if device_config is None:  # Abort if config fetch returned empty
-            print("Failed to fetch device configuration.")  # Inform engineer
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("Failed to fetch device configuration.")
             return None  # Signal caller to abort the workflow
         return gateway, device_config  # Return combined tuple for downstream phases
 
@@ -453,7 +483,8 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         device_model = gateway.get("model", "SRX300")  # Use source model as default suggestion
         name, ttype, model = self._prompt_template_meta(device_model, existing_names)  # Step 6
         if not self._confirm_creation(name, ttype, model):  # Step 7: require explicit confirmation
-            print("Operation cancelled.")  # Inform engineer of cancellation
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.info("Operation cancelled.")
             return None  # Signal caller to abort - user declined the CREATE prompt
         return name, ttype, model  # Return metadata tuple for payload construction
 
@@ -463,7 +494,8 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         payload = self._build_template_payload(device_config, name, ttype, model)  # Step 8
         new_template = self._create_template(payload)  # Step 9: API write call
         if new_template is None:  # Abort if API returned no data
-            print("Template creation failed - no data returned from API.")  # Inform engineer
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("Template creation failed - no data returned from API.")
             return False  # Signal failure to caller
         self._export_result(gateway, new_template)  # Step 10: write CSV export row
         return True  # Signal successful completion to caller
@@ -480,6 +512,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
                 return False  # Signal cancellation to caller
             return self._create_and_export(gateway, device_config, meta)  # Phase 3: write + export
         except Exception as exc:  # Catch all unexpected errors for safe logging
-            logging.exception("DeviceConfigTemplateClonerManager.clone() failed: %s", exc)  # Log context
-            print(f"Error: {exc}")  # Print brief error message for interactive feedback
+            logger.exception("DeviceConfigTemplateClonerManager.clone() failed: %s", exc)  # Log context
+            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            logger.error("Error: %s", exc)
             return False  # Signal failure to caller

--- a/tests/unit/gateway/test_device_template_cloner_extended.py
+++ b/tests/unit/gateway/test_device_template_cloner_extended.py
@@ -7,6 +7,7 @@ clone() exception path.
 
 from __future__ import annotations  # PEP 563 postponed evaluation for typing forward refs
 
+import logging  # Set caplog levels for logger-based assertions after #886 print->logger migration
 from types import SimpleNamespace  # Build fake mistapi response objects with .data attr
 from typing import Any  # Untyped kwargs need explicit Any for mypy --strict compatibility
 from unittest.mock import MagicMock, patch  # MagicMock for injection, patch for mistapi calls
@@ -18,6 +19,8 @@ from src.gateway.device_template_cloner import (  # SUT imports for direct manip
     DeviceConfigTemplateClonerManager,  # Class under test
     DeviceTemplateClonerDeps,  # Frozen deps bundle required by the constructor
 )
+
+_SUT_LOGGER = "src.gateway.device_template_cloner"  # Module logger name for caplog level scoping
 
 
 def _build_deps(**overrides: Any) -> DeviceTemplateClonerDeps:
@@ -68,13 +71,14 @@ def test_list_sites_returns_empty_when_response_missing_data_attr() -> None:
     assert sites == []  # Must fall back to empty list when .data missing
 
 
-def test_select_site_returns_none_when_no_sites(capsys: pytest.CaptureFixture) -> None:
+def test_select_site_returns_none_when_no_sites(caplog: pytest.LogCaptureFixture) -> None:
     """_select_site must return None and inform the engineer when no sites exist."""
+    caplog.set_level(logging.WARNING, logger=_SUT_LOGGER)  # Warning level after #886 migration
     manager = _build_manager()  # Build cloner with default mocks
     with patch.object(manager, "_list_sites", return_value=[]):  # Force empty site list
         result = manager._select_site()  # Invoke helper under test
     assert result is None  # Must signal abort with None
-    assert "No sites found" in capsys.readouterr().out  # Must inform engineer via stdout
+    assert "No sites found" in caplog.text  # Must inform engineer via logger
 
 
 def test_select_site_returns_chosen_site_on_valid_input() -> None:
@@ -122,12 +126,13 @@ def test_list_gateways_returns_empty_when_response_missing_data_attr() -> None:
     assert gateways == []  # Must fall back to empty list when .data missing
 
 
-def test_select_gateway_returns_none_when_empty(capsys: pytest.CaptureFixture) -> None:
+def test_select_gateway_returns_none_when_empty(caplog: pytest.LogCaptureFixture) -> None:
     """_select_gateway must return None and inform engineer when no gateways found."""
+    caplog.set_level(logging.WARNING, logger=_SUT_LOGGER)  # Warning level after #886 migration
     manager = _build_manager()  # Build cloner with default mocks
     result = manager._select_gateway([])  # Empty gateway list triggers early return
     assert result is None  # Must signal abort with None
-    assert "No gateway devices found" in capsys.readouterr().out  # Must inform engineer via stdout
+    assert "No gateway devices found" in caplog.text  # Must inform engineer via logger
 
 
 def test_select_gateway_returns_chosen_gateway_on_valid_input() -> None:
@@ -143,13 +148,14 @@ def test_select_gateway_returns_chosen_gateway_on_valid_input() -> None:
     assert result["id"] == "gw-1"  # Must return the first gateway (1-based to 0-based conversion)
 
 
-def test_select_gateway_uses_mac_fallback_when_name_missing(capsys: pytest.CaptureFixture) -> None:
+def test_select_gateway_uses_mac_fallback_when_name_missing(caplog: pytest.LogCaptureFixture) -> None:
     """_select_gateway must display MAC address as fallback when device has no name."""
+    caplog.set_level(logging.INFO, logger=_SUT_LOGGER)  # Info level for display rows after #886 migration
     input_fn = MagicMock(return_value="1")  # Any valid input to reach display line
     manager = _build_manager(input_fn=input_fn)  # Inject controlled input mock
     gateways = [{"id": "gw-1", "mac": "aabbccddeeff", "model": "SSR120"}]  # No name field
     manager._select_gateway(gateways)  # Invoke helper - triggers display line
-    output = capsys.readouterr().out  # Capture stdout for assertion
+    output = caplog.text  # Capture logger output for assertion
     assert "aabbccddeeff" in output  # MAC must appear in display as name fallback
 
 
@@ -290,24 +296,26 @@ def test_prompt_template_name_returns_default_when_input_empty() -> None:
     assert result == "suggested-name"  # Must return the default when input empty
 
 
-def test_prompt_template_name_retries_when_name_already_exists(capsys: pytest.CaptureFixture) -> None:
+def test_prompt_template_name_retries_when_name_already_exists(caplog: pytest.LogCaptureFixture) -> None:
     """_prompt_template_name must loop when engineer provides a name already in use."""
+    caplog.set_level(logging.WARNING, logger=_SUT_LOGGER)  # Warning level after #886 migration
     input_fn = MagicMock(side_effect=["taken-name", "new-name"])  # First attempt taken, second unique
     manager = _build_manager(input_fn=input_fn)  # Inject controlled input mock
     result = manager._prompt_template_name("default", {"taken-name"})  # Existing set
     assert result == "new-name"  # Must return the second (unique) name
-    assert "already exists" in capsys.readouterr().out  # Guidance message must appear
+    assert "already exists" in caplog.text  # Guidance message must appear
 
 
 def test_prompt_template_name_retries_when_empty_after_default_empty(
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """_prompt_template_name must loop when both input and default resolve to empty."""
+    caplog.set_level(logging.WARNING, logger=_SUT_LOGGER)  # Warning level after #886 migration
     input_fn = MagicMock(side_effect=["", "final-name"])  # Empty then valid on retry
     manager = _build_manager(input_fn=input_fn)  # Inject controlled input mock
     result = manager._prompt_template_name("", set())  # Empty default - forces retry loop
     assert result == "final-name"  # Second attempt must be accepted
-    assert "cannot be empty" in capsys.readouterr().out  # Empty guard message must appear
+    assert "cannot be empty" in caplog.text  # Empty guard message must appear
 
 
 # ---------------------------------------------------------------------------
@@ -351,21 +359,23 @@ def test_resolve_hardware_choice_all_branches(raw: str, expected_kind: str) -> N
 
 
 def test_resolve_hardware_choice_prints_message_on_invalid_input(
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """_resolve_hardware_choice must inform engineer when falling back on invalid input."""
+    caplog.set_level(logging.WARNING, logger=_SUT_LOGGER)  # Warning level after #886 migration
     manager = _build_manager()  # Build cloner with default mocks
     manager._resolve_hardware_choice("invalid", "SRX340")  # Non-numeric fallback path
-    assert "Invalid selection" in capsys.readouterr().out  # Fallback message must appear
+    assert "Invalid selection" in caplog.text  # Fallback message must appear
 
 
 def test_resolve_hardware_choice_prints_message_on_out_of_range(
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """_resolve_hardware_choice must inform engineer when falling back on out-of-range."""
+    caplog.set_level(logging.WARNING, logger=_SUT_LOGGER)  # Warning level after #886 migration
     manager = _build_manager()  # Build cloner with default mocks
     manager._resolve_hardware_choice("999", "SRX340")  # Out-of-range fallback path
-    assert "Invalid selection" in capsys.readouterr().out  # Fallback message must appear
+    assert "Invalid selection" in caplog.text  # Fallback message must appear
 
 
 # ---------------------------------------------------------------------------
@@ -414,21 +424,23 @@ def test_create_template_returns_none_when_response_missing_data_attr() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_clone_returns_false_on_unexpected_exception(capsys: pytest.CaptureFixture) -> None:
+def test_clone_returns_false_on_unexpected_exception(caplog: pytest.LogCaptureFixture) -> None:
     """clone() must catch unexpected errors, log them, and return False."""
+    caplog.set_level(logging.ERROR, logger=_SUT_LOGGER)  # Error level after #886 migration
     manager = _build_manager()  # Build cloner with default mocks
     with patch.object(  # Force _gather_source_device to raise unexpected error
         manager, "_gather_source_device", side_effect=RuntimeError("boom")
     ):
         result = manager.clone()  # Invoke workflow under test
     assert result is False  # Must return False on any exception
-    assert "Error" in capsys.readouterr().out  # Must print user-friendly error message
+    assert "Error" in caplog.text  # Must log user-friendly error message
 
 
 def test_clone_returns_false_when_create_template_returns_none(
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """clone() must return False and inform engineer when _create_template returns None."""
+    caplog.set_level(logging.ERROR, logger=_SUT_LOGGER)  # Error level after #886 migration
     manager = _build_manager()  # Build cloner with default mocks
     gateway = {"id": "gw-1", "model": "SRX340"}  # Selected source gateway
     export_mock = MagicMock()  # Captured out here so mypy sees a MagicMock rather than a bound method
@@ -446,12 +458,13 @@ def test_clone_returns_false_when_create_template_returns_none(
     ):
         result = manager.clone()  # Invoke workflow under test
         assert result is False  # Must return False when template creation fails
-        assert "Template creation failed" in capsys.readouterr().out  # Failure message must appear
+        assert "Template creation failed" in caplog.text  # Failure message must appear
         export_mock.assert_not_called()  # Export must not fire (assertion inside `with`)
 
 
-def test_clone_returns_false_when_device_config_missing(capsys: pytest.CaptureFixture) -> None:
+def test_clone_returns_false_when_device_config_missing(caplog: pytest.LogCaptureFixture) -> None:
     """clone() must return False and inform engineer when device config fetch returns None."""
+    caplog.set_level(logging.ERROR, logger=_SUT_LOGGER)  # Error level after #886 migration
     manager = _build_manager()  # Build cloner with default mocks
     with patch.multiple(  # Stub phases through device config fetch
         manager,
@@ -462,7 +475,7 @@ def test_clone_returns_false_when_device_config_missing(capsys: pytest.CaptureFi
     ):
         result = manager.clone()  # Invoke workflow under test
     assert result is False  # Must return False when config missing
-    assert "Failed to fetch device configuration" in capsys.readouterr().out  # Message must appear
+    assert "Failed to fetch device configuration" in caplog.text  # Message must appear
 
 
 def test_clone_returns_false_when_gateway_selection_aborted() -> None:


### PR DESCRIPTION
## Summary

- Replace all 27 `print()` calls in `src/gateway/device_template_cloner.py` with a module-scoped `logger = logging.getLogger(__name__)` and level-appropriate `logger.*` emissions using `%`-style deferred formatting (G004-clean).
- Level heuristic: info for banners/prompts/selections/success, warning for empty-list notices and validation retry messages, error for clone failure paths.
- Rebind pre-existing `logging.*` audit calls to the module logger for namespace consistency.
- Migrate 10 `capsys`-based assertions in `tests/unit/gateway/test_device_template_cloner_extended.py` to `caplog` with logger-scoped `set_level` so operator notices are captured from the channel the code now emits on.

Refs #886.

## Test plan

- [x] `python -m black src/gateway/device_template_cloner.py tests/unit/gateway/test_device_template_cloner_extended.py` — 2 files left unchanged
- [x] `python -m ruff check src/gateway/device_template_cloner.py tests/unit/gateway/test_device_template_cloner_extended.py` — All checks passed
- [x] `python -m pytest tests/unit/gateway/test_device_template_cloner.py tests/unit/gateway/test_device_template_cloner_extended.py` — 58 passed