### PR TITLE
chore(quality): drop troubleshooting from pydocstyle match-dir exclusion (#887 slice 1/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #887 slice 1/N: drop `troubleshooting` from pydocstyle `match-dir` exclusion (issue #887)
+
+- **Pydocstyle scope narrowing (Changed)**: removed `troubleshooting` from
+  the `[tool.pydocstyle].match-dir` negation list in `pyproject.toml`.
+  Audit confirmed `src/troubleshooting/` (4 files: `__init__.py`,
+  `interactive_test_runner.py`, `marvis_troubleshoot_utils.py`,
+  `troubleshoot_utils.py`) already reports zero Google-style violations
+  under `pydocstyle --convention=google`, so the exclusion was dead weight.
+  `pydocstyle src/` remains clean after the regex change.
+
 ### #886 Phase 2 slice 108/N: retire `print()` in `src/export/site_anomaly_exporter.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 28 `print()` calls in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -426,7 +426,7 @@ good-names = ["db", "ok"]
 # --- pydocstyle ---
 [tool.pydocstyle]
 convention = "google"
-match-dir = "(?!tests|\\.|capture|inventory|troubleshooting).*"
+match-dir = "(?!tests|\\.|capture|inventory).*"
 
 # --- Interrogate (docstring coverage) ---
 [tool.interrogate]


### PR DESCRIPTION
## Summary
- Narrows `[tool.pydocstyle].match-dir` regex in `pyproject.toml` by removing `troubleshooting` from the negation list.
- Audit against `pydocstyle --convention=google src/troubleshooting/` reports zero violations across all 4 files (`__init__.py`, `interactive_test_runner.py`, `marvis_troubleshoot_utils.py`, `troubleshoot_utils.py`) — the exclusion was dead weight.
- Full-repo `pydocstyle src/` continues to pass after the narrow.

Refs #887 (slice 1/N). First of an N-slice campaign to eliminate exempted subtrees from pydocstyle scope, following the order suggested in the issue.

## Test plan
- [x] `python -m pydocstyle --convention=google src/troubleshooting/` — 0 violations before narrow
- [x] `python -m pydocstyle src/` — clean after narrow (regex now honors troubleshooting)
- [x] `python -m ruff check src/troubleshooting/` — clean
- [x] `python -m pytest tests/unit/troubleshooting/ -q` — 120 passed