### PR TITLE
chore(quality): drop analytics from pydocstyle match-dir exclusion (#887 slice 2/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #887 slice 2/N: drop `analytics` from pydocstyle `match-dir` exclusion (issue #887)
+
+- **Pydocstyle scope narrowing (Changed)**: removed `analytics` from the
+  `[tool.pydocstyle].match-dir` negation list in `pyproject.toml`. Added
+  Google-style docstrings to `TelemetryEmitter.__init__`,
+  `TelemetryEmitter.__enter__`, and `TelemetryEmitter.__exit__` in
+  `src/analytics/telemetry_emitter.py` (previously the only three D107/D105
+  violations in the subtree). Post-fix `pydocstyle --convention=google
+  src/analytics/` reports zero violations across all 7 files, so the subtree
+  is now enforced by CI going forward. Continues the #887 workstream of
+  shrinking the pydocstyle exclusion list one subtree at a time; next slice
+  targets `inventory` (8 files).
+
 ### #887 slice 7/N: drop `gateway` from pydocstyle match-dir exclusion (issue #887)
 
 - **Docstring quality (Changed)**: dropped `gateway` from the
@@ -51,7 +64,6 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   the code now emits on. `tests/unit/gateway/test_device_template_cloner.py`
   contained no `capsys` references and needed no changes. All 58 tests
   across the two files remain green.
-
 ### #886 Phase 2 slice 106/N: retire `print()` in `src/refactors/serial_cc/start_site_scan_capture.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 26 `print()` calls in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -416,7 +416,7 @@ good-names = ["db", "ok"]
 # --- pydocstyle ---
 [tool.pydocstyle]
 convention = "google"
-match-dir = "(?!tests|\\.|analytics|capture|export|inventory|site|troubleshooting|websocket).*"
+match-dir = "(?!tests|\\.|capture|export|inventory|site|troubleshooting|websocket).*"
 
 # --- Interrogate (docstring coverage) ---
 [tool.interrogate]

--- a/src/analytics/telemetry_emitter.py
+++ b/src/analytics/telemetry_emitter.py
@@ -36,6 +36,18 @@ class TelemetryEmitter:
     RETENTION_LIMIT = 10
 
     def __init__(self, file_path: str):
+        """Open *file_path* for append-only NDJSON writes.
+
+        Why:
+            Parent directories are created eagerly so callers can pass a fresh
+            path (e.g. ``data/telemetry/2026-07-21.jsonl``) without a separate
+            ``os.makedirs`` step. Open failures downgrade to a warning and leave
+            ``self._handle = None`` so subsequent ``emit()`` calls become no-ops
+            (FR-008: telemetry must never interrupt the primary operation).
+
+        Args:
+            file_path: Filesystem path to the NDJSON target file.
+        """
         self._path = file_path
         self._handle = None
         try:
@@ -70,9 +82,31 @@ class TelemetryEmitter:
     # -- context manager -----------------------------------------------------
 
     def __enter__(self) -> TelemetryEmitter:
+        """Return self so the emitter can be used as a context manager.
+
+        Why:
+            The file handle is already opened in ``__init__``; ``__enter__``
+            exists purely to enable ``with TelemetryEmitter(...) as e:`` syntax
+            and pair with ``__exit__`` for guaranteed close-on-scope-exit.
+
+        Returns:
+            The same TelemetryEmitter instance.
+        """
         return self
 
     def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object) -> None:
+        """Close the underlying file handle on scope exit.
+
+        Why:
+            Ensures the append handle is flushed and released even if the
+            ``with`` block raises. Exception details are intentionally
+            discarded — telemetry never suppresses exceptions from the caller.
+
+        Args:
+            exc_type: Exception type if the ``with`` block raised, else None.
+            exc_val: Exception instance if the ``with`` block raised, else None.
+            exc_tb: Traceback if the ``with`` block raised, else None.
+        """
         del exc_type, exc_val, exc_tb  # WHY: protocol params unused; silence vulture without renaming public signature.
         self.close()
 


### PR DESCRIPTION
## Summary

- Adds Google-style docstrings to `TelemetryEmitter.__init__`,
  `TelemetryEmitter.__enter__`, and `TelemetryEmitter.__exit__` in
  `src/analytics/telemetry_emitter.py` (the only three D107/D105
  violations in the subtree).
- Removes `analytics` from the `[tool.pydocstyle].match-dir` negation
  list in `pyproject.toml`.
- Post-fix `pydocstyle --convention=google src/analytics/` reports
  zero violations across all 7 files.

Continues the #887 workstream of shrinking the pydocstyle exclusion
list one subtree at a time. Next slice targets `inventory` (8 files).

Ref: #887

## Test plan

- [x] `pydocstyle --convention=google src/analytics/` → 0 violations
- [x] `ruff check src/analytics/telemetry_emitter.py` → clean
- [x] `black --check src/analytics/telemetry_emitter.py` → clean
- [x] `pytest tests/unit/analytics/` → 98 passed