### PR TITLE
chore(quality): drop inventory from pydocstyle match-dir exclusion (#887 slice 3/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #887 slice 3/N: drop `inventory` from pydocstyle `match-dir` exclusion (issue #887)
+
+- **Pydocstyle scope narrowing (Changed)**: removed `inventory` from the
+  `[tool.pydocstyle].match-dir` negation list in `pyproject.toml`. Audit
+  confirmed `src/inventory/` (8 files) already reports zero Google-style
+  violations, so the entry was dead weight; CI now enforces Google-style
+  docstrings on the subtree going forward. Continues the #887 workstream of
+  shrinking the pydocstyle exclusion list one subtree at a time; next slice
+  targets `capture` (13 files).
+
 ### #887 slice 1/N: drop `troubleshooting` from pydocstyle `match-dir` exclusion (issue #887)
 
 - **Pydocstyle scope narrowing (Changed)**: removed `troubleshooting` from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -426,7 +426,7 @@ good-names = ["db", "ok"]
 # --- pydocstyle ---
 [tool.pydocstyle]
 convention = "google"
-match-dir = "(?!tests|\\.|capture|inventory).*"
+match-dir = "(?!tests|\\.|capture).*"
 
 # --- Interrogate (docstring coverage) ---
 [tool.interrogate]


### PR DESCRIPTION
## Summary

- Removes `inventory` from the `[tool.pydocstyle].match-dir` negation list.
- Audit: `pydocstyle --convention=google src/inventory/` reports zero
  violations across all 8 files, so the entry was dead weight.

Continues the #887 workstream. Next slice targets `capture` (13 files).

Ref: #887

## Test plan

- [x] `pydocstyle --convention=google src/inventory/` → 0 violations
- [x] `ruff check pyproject.toml` → clean