### PR TITLE
chore(quality): drop websocket from pydocstyle match-dir exclusion (#887 slice 5/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #887 slice 5/N: drop `websocket` from pydocstyle `match-dir` exclusion (issue #887)
+
+- **Quality gate (Changed)**: removed `websocket` from the
+  `[tool.pydocstyle] match-dir` negation regex in `pyproject.toml`, so
+  `src/websocket/` is now scanned by `pydocstyle --convention=google`.
+  Audit surfaced two D107 (missing `__init__` docstring) violations,
+  both fixed:
+  - `src/websocket/polling/message_router.py:45` — `MessageRouter.__init__`
+    now documents why the five constructor args are packed into the frozen
+    `_RouterCtx` holder (immutable snapshot, cheaper attribute access,
+    stays within the project's argument-count limits).
+  - `src/websocket/polling/result_collector.py:121` — `ResultCollector.__init__`
+    documents the four-arg `WebSocketManager` wiring (results dict, its
+    lock, logger, debug flag) and why they collapse into the frozen
+    `_CollectorDeps`.
+  Next slice (6/N) targets `site` (17 files) per the #887 slicing plan.
+
 ### #887 slice 6/N: drop `site` from pydocstyle `match-dir` exclusion (issue #887)
 
 - **Quality gate (Changed)**: removed `site` from the `[tool.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -416,7 +416,7 @@ good-names = ["db", "ok"]
 # --- pydocstyle ---
 [tool.pydocstyle]
 convention = "google"
-match-dir = "(?!tests|\\.|capture|export|inventory|troubleshooting|websocket).*"
+match-dir = "(?!tests|\\.|capture|export|inventory|troubleshooting).*"
 
 # --- Interrogate (docstring coverage) ---
 [tool.interrogate]

--- a/src/websocket/polling/message_router.py
+++ b/src/websocket/polling/message_router.py
@@ -50,6 +50,26 @@ class MessageRouter:  # WHY: Public API preserved for WebSocketManager collabora
         logger: logging.Logger,
         debug_mode: bool,
     ) -> None:  # WHY: Preserve original five-argument constructor for the manager.
+        """Bundle manager-owned collaborators into an immutable ``_RouterCtx``.
+
+        Why:
+            The original ``WebSocketManager._on_message`` passed five loose
+            arguments each call; packing them into a frozen dataclass makes
+            attribute access cheaper (slots) and prevents accidental mutation
+            by dispatch handlers while preserving the constructor signature
+            expected by manager-side wiring.
+
+        Args:
+            command_results: Session → response-segments map owned by the
+                manager. Mutated by handlers under ``results_lock``.
+            results_lock: Threading lock that serializes writes to
+                ``command_results``.
+            confirmed_subscriptions: Set of channel names that have received
+                a confirmation frame; used to gate downstream dispatch.
+            logger: Logger used for parity trace lines (preserved verbatim
+                from the pre-extraction ``_on_message`` code path).
+            debug_mode: Verbose-trace toggle propagated from the manager.
+        """
         self._ctx = _RouterCtx(  # WHY: Pack manager state into one immutable holder.
             results=command_results,
             lock=results_lock,

--- a/src/websocket/polling/result_collector.py
+++ b/src/websocket/polling/result_collector.py
@@ -124,7 +124,26 @@ class ResultCollector:  # WHY: Public API preserved for WebSocketManager collabo
         results_lock: threading.Lock,
         logger: logging.Logger,
         debug_mode: bool,
-    ) -> None:  # WHY: Preserve original four-argument constructor for the manager.
+    ) -> None:
+        """Bind the collector to the manager-owned results map and its lock.
+
+        Why:
+            The four constructor arguments are the exact wiring
+            ``WebSocketManager`` supplies (results dict, its lock, a logger,
+            and a debug flag). They are packed into a single frozen
+            ``_CollectorDeps`` so downstream helpers receive one immutable
+            reference instead of four positional parameters, keeping method
+            signatures within the project's argument-count limits.
+
+        Args:
+            command_results: Shared results map owned by ``WebSocketManager``;
+                segments are appended under the session id.
+            results_lock: Threading lock that guards ``command_results`` from
+                concurrent mutation by the WebSocket callback thread.
+            logger: Logger used for start/timeout/completion traces.
+            debug_mode: When True, verbatim debug prints for the polling loop
+                are emitted alongside logger output.
+        """
         self._deps = _CollectorDeps(  # WHY: Pack manager state into one immutable holder.
             results=command_results,
             lock=results_lock,


### PR DESCRIPTION
## Summary

Slice 5/N of #887 pydocstyle `match-dir` cleanup: removes `websocket` from
the `[tool.pydocstyle] match-dir` negation regex so `src/websocket/` is now
scanned under `--convention=google`.

Audit found 2 D107 violations, both fixed with Google-style docstrings that
explain **why** the constructor args are packed into frozen dep holders
(immutable snapshot, cheaper attribute access, keeps method signatures
within the project's argument-count limits):

- `src/websocket/polling/message_router.py:45` — `MessageRouter.__init__`
- `src/websocket/polling/result_collector.py:121` — `ResultCollector.__init__`

## Test plan

- [x] `pydocstyle --convention=google src/websocket/` → 0 violations
- [x] `ruff check` → clean
- [x] `black --check` → clean
- [x] `pytest tests/unit/websocket/polling/` → 230 passed

Refs #887