### PR TITLE
chore(quality): drop site from pydocstyle match-dir exclusion (#887 slice 6/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #887 slice 6/N: drop `site` from pydocstyle `match-dir` exclusion (issue #887)
+
+- **Quality gate (Changed)**: removed `site` from the `[tool.pydocstyle]
+  match-dir` negation regex in `pyproject.toml`, so `src/site/` is now
+  scanned by `pydocstyle --convention=google`. Audit surfaced 4 violations
+  across 2 files, all fixed:
+  - `src/site/bulk_radius_wlan_config_manager.py:31` — D212 (multi-line
+    summary must start on the first line); reflowed the class docstring
+    so the summary sits directly after the opening quote.
+  - `src/site/address_audit/audit_engine.py:678` — D205/D209/D415 in
+    `_classify`; split the summary from the parenthetical exclusion note
+    into a separate paragraph and moved the closing quote to its own line.
+  Next slice (7/N) targets `gateway` (21 files) per the #887 slicing plan.
+
 ### #887 slice 2/N: drop `analytics` from pydocstyle `match-dir` exclusion (issue #887)
 
 - **Pydocstyle scope narrowing (Changed)**: removed `analytics` from the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -416,7 +416,7 @@ good-names = ["db", "ok"]
 # --- pydocstyle ---
 [tool.pydocstyle]
 convention = "google"
-match-dir = "(?!tests|\\.|capture|export|inventory|site|troubleshooting|websocket).*"
+match-dir = "(?!tests|\\.|capture|export|inventory|troubleshooting|websocket).*"
 
 # --- Interrogate (docstring coverage) ---
 [tool.interrogate]

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -675,8 +675,11 @@ class AddressAuditEngine:
         resolver_result: Any,
         authoritative_addr: dict[str, Any] | None = None,
     ) -> str:
-        """Return one of the resolved classification states for a row (excludes the
-        out-of-band UNMATCHED / CONFLICTING_HINTS / DUPLICATE_ADDRESS states)."""
+        """Return one of the resolved classification states for a row.
+
+        Excludes the out-of-band UNMATCHED / CONFLICTING_HINTS /
+        DUPLICATE_ADDRESS states, which are handled upstream.
+        """
         if not self._has_external_result(resolver_result):  # No external result -> use internal signals only.
             return self._classify_internal(mist_addr, csv_addr, snmp_loc, authoritative_addr or {})  # Internal path.
         return self._classify_external(mist_addr, resolver_result)  # External hit -> compare against Mist.

--- a/src/site/bulk_radius_wlan_config_manager.py
+++ b/src/site/bulk_radius_wlan_config_manager.py
@@ -28,8 +28,7 @@ import mistapi  # WHY: direct SDK access for listOrgWlans + updateOrgWlan endpoi
 
 
 class BulkRadiusWLANConfigManager:
-    """
-    Bulk configuration of RADIUS authentication timer settings for org WLANs.
+    """Bulk configuration of RADIUS authentication timer settings for org WLANs.
 
     Scans all WLANs in the organization, identifies those using RADIUS/RadSec
     authentication, and allows bulk update of auth_servers_timeout,


### PR DESCRIPTION
## Summary

Slice 6/N of #887 pydocstyle `match-dir` cleanup: removes `site` from the
`[tool.pydocstyle] match-dir` negation regex so `src/site/` is now scanned
under `--convention=google`.

Audit found 4 violations across 2 files, all fixed:

- `src/site/bulk_radius_wlan_config_manager.py:31` — D212 (multi-line
  summary must start on line 1); reflowed the class docstring.
- `src/site/address_audit/audit_engine.py:678` — D205/D209/D415 in
  `_classify`; split summary from parenthetical exclusion note and moved
  closing quote to its own line.

## Test plan

- [x] `pydocstyle --convention=google src/site/` → 0 violations
- [x] `ruff check` → clean
- [x] `black --check` → clean
- [x] `pytest tests/unit/site/ tests/unit/test_bulk_radius_wlan_config_manager.py` → 373 passed

Refs #887