### PR TITLE
chore(quality): drop gateway from pydocstyle match-dir exclusion (#887 slice 7/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### #887 slice 7/N: drop `gateway` from pydocstyle match-dir exclusion (issue #887)
+
+- **Docstring quality (Changed)**: dropped `gateway` from the
+  `[tool.pydocstyle] match-dir` negation regex so 21 `src/gateway/**.py`
+  files are now scanned under the Google convention. Fixed 4 pre-existing
+  violations across 2 files:
+  - `src/gateway/wan2_migration_manager.py:137` — D212 on
+    `WAN2MigrationManager` class docstring (reflowed summary onto the
+    opening `"""` line).
+  - `src/gateway/wan_probe_device_override_manager.py:76` — D212 on
+    `WANProbeDeviceOverrideManager` class docstring (same fix).
+  - `src/gateway/wan_probe_device_override_manager.py:110` — D212 + D415
+    on `configure` classmethod docstring (reflowed summary and added
+    terminal period after `"(DESTRUCTIVE)"`).
+  Post-audit `pydocstyle --convention=google src/gateway/` reports 0
+  violations. Next slice 8/N targets `export` (34 files); after that the
+  match-dir negation drops back to `tests|\\.` only, closing the
+  pydocstyle strand of #887.
+
 ### #886 Phase 2 slice 107/N: retire `print()` in `src/gateway/device_template_cloner.py` (issue #886)
 
 - **Print-to-logger migration (Changed)**: replaced all 27 `print()` calls in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -416,7 +416,7 @@ good-names = ["db", "ok"]
 # --- pydocstyle ---
 [tool.pydocstyle]
 convention = "google"
-match-dir = "(?!tests|\\.|analytics|capture|export|gateway|inventory|site|troubleshooting|websocket).*"
+match-dir = "(?!tests|\\.|analytics|capture|export|inventory|site|troubleshooting|websocket).*"
 
 # --- Interrogate (docstring coverage) ---
 [tool.interrogate]

--- a/src/gateway/wan2_migration_manager.py
+++ b/src/gateway/wan2_migration_manager.py
@@ -134,8 +134,7 @@ class OverrideAnalysisContext:  # WHY: immutable context bundle for override ana
 
 
 class WAN2MigrationManager:  # WHY: consolidated Menu 103/104 flow into a single manager.
-    """
-    Manages WAN2 interface variable migration for gateway templates and sites.
+    """Manages WAN2 interface variable migration for gateway templates and sites.
 
     Consolidates Menu Options 103 and 104:
     - set_site_variable(): Set wan2_interface site variable across sites (Menu 103)

--- a/src/gateway/wan_probe_device_override_manager.py
+++ b/src/gateway/wan_probe_device_override_manager.py
@@ -73,8 +73,7 @@ def configure_wan_probe_device_override_dependencies(  # WHY: wire module-level 
 
 
 class WANProbeDeviceOverrideManager:  # WHY: encapsulates Menu #167 destructive workflow.
-    """
-    Manages WAN probe configuration for device-level port overrides.
+    """Manages WAN probe configuration for device-level port overrides.
 
     Menu #167: Configure WAN probe override settings on gateway devices that
     have device-level port overrides. This complements Menu #166 (template-level)
@@ -107,8 +106,7 @@ class WANProbeDeviceOverrideManager:  # WHY: encapsulates Menu #167 destructive 
 
     @classmethod
     def configure(cls, dry_run: bool = False) -> None:  # WHY: single classmethod entry point for Menu #167.
-        """
-        Menu #167: Configure WAN Probe Override on Device Port Overrides (DESTRUCTIVE)
+        """Menu #167: Configure WAN Probe Override on Device Port Overrides (DESTRUCTIVE).
 
         Updates wan_probe_override settings for WAN ports that have device-level
         overrides from their gateway template.


### PR DESCRIPTION
## Summary

- Drops `gateway` from the `[tool.pydocstyle] match-dir` negation regex; 21 `src/gateway/**.py` files are now scanned under the Google convention.
- Fixes 4 pre-existing pydocstyle violations across 2 files (all D212/D415 docstring-shape issues; no behavior change).
- Post-audit: `pydocstyle --convention=google src/gateway/` reports 0 violations.

## Files changed

- `pyproject.toml` — remove `gateway` from `match-dir` regex.
- `src/gateway/wan2_migration_manager.py:137` — D212 class docstring reflow.
- `src/gateway/wan_probe_device_override_manager.py:76` — D212 class docstring reflow.
- `src/gateway/wan_probe_device_override_manager.py:110` — D212+D415 `configure` classmethod docstring.
- `CHANGELOG.md` — Unreleased entry for slice 7/N.

## Test plan

- [x] `pydocstyle --convention=google src/gateway/` → 0 violations
- [x] `ruff check src/gateway/ pyproject.toml` → clean
- [x] `black --check src/gateway/` → clean
- [ ] CI green

Refs #887. Next slice 8/N targets `export` (34 files), which closes the pydocstyle strand of #887.