### PR TITLE
chore(quality): drop W1203 from pylint disable list (#887 slice 9/N)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -404,11 +404,21 @@ fail-under = 9.5
 max-line-length = 120
 
 [tool.pylint."messages control"]
-# Docstring enforcement handled by pydocstyle/interrogate
-# W1203: logging-fstring-interpolation -- project uses f-strings throughout for readability
-# W0613: unused-argument -- WebSocket callback signatures are protocol-mandated
-# W0718: broad-exception-caught -- intentional in cleanup/error handlers
-disable = ["C0114", "C0115", "C0116", "W1203", "W0613", "W0718"]
+# Docstring enforcement handled by pydocstyle/interrogate.
+#
+# W1203 (logging-fstring-interpolation) was dropped from the disable list in
+# #887 (this commit) after `pylint --enable=W1203 --disable=all src/` reported
+# 0 violations -- the project's #429 logger sweep converted every `logger.info(f"...")`
+# site to `logger.info("... %s", val)` form, so the historical justification
+# ("project uses f-strings throughout for readability") is now obsolete.
+#
+# W0613 (unused-argument) and W0718 (broad-exception-caught) remain disabled
+# repo-wide; narrowing them is tracked as separate #887 follow-up slices --
+# W0613 has 20 sites (mostly WebSocket protocol-mandated callback signatures
+# in `src/websocket/manager.py` plus a scattering across capture/firmware/ssh
+# handlers), and W0718 has 493 sites where broad `except Exception:` blocks
+# are intentional in cleanup/error handlers. Each needs a per-site audit.
+disable = ["C0114", "C0115", "C0116", "W0613", "W0718"]
 
 [tool.pylint.basic]
 good-names = ["db", "ok"]


### PR DESCRIPTION
## Summary

Slice 9/N of #887: drop `W1203` (logging-fstring-interpolation) from the repo-wide pylint disable list in `[tool.pylint."messages control"]`. The historical justification ("project uses f-strings throughout for readability") is obsolete after #429's logger sweep converted every `logger.info(f"...")` call to the `logger.info("... %s", val)` form.

## Changes

- `pyproject.toml`: removed `"W1203"` from the `disable = [...]` list; expanded the surrounding comment block to document (a) why W1203 was dropped now, and (b) why `W0613` and `W0718` remain disabled and are tracked as separate follow-up slices.

## Verification

- `pylint --enable=W1203 --disable=all src/` → 10.00/10 (0 violations)
- `pylint --rcfile=pyproject.toml src/` → 9.33/10 (unchanged vs baseline main; neutral impact — the removal doesn't add any violations because there are none)
- `ruff check pyproject.toml` → clean

## Remaining #887 pylint work

Separate follow-up slices:
- **W0613** (unused-argument): 20 sites — mostly WebSocket protocol-mandated callback signatures in `src/websocket/manager.py`, plus a handful in capture/firmware/ssh handlers. Each needs per-site review to either rename to `_arg` or add scoped `# pylint: disable=unused-argument`.
- **W0718** (broad-exception-caught): 493 sites where `except Exception:` is intentional in cleanup/error handlers. Large audit; may be broken into subtree slices.

Refs #887
