### PR TITLE
fix(1636): distinguish logged operation errors from clean passes in --testinteractive

### DIFF
--- a/src/troubleshooting/interactive_test_runner.py
+++ b/src/troubleshooting/interactive_test_runner.py
@@ -13,6 +13,30 @@ from typing import Any  # WHY: emitter and registry protocols intentionally unco
 from src.dataclasses.progress_event import TestSummary  # WHY: reuse issue #470 aggregate telemetry container.
 
 
+class _LoggedErrorObserver(logging.Handler):
+    """Root-logger handler that counts ERROR (or higher) records emitted during an option run.
+
+    Why:
+        Issue #1636 — interactive handlers can call ``logging.error(...)`` and
+        then swallow the failure by returning None. Without observing those
+        records the runner treats the option as a clean pass, inflating the
+        pass rate and masking real defects. Attaching this handler scoped to
+        the ``_invoke_option`` call gives the runner a deterministic signal
+        that a logged-error occurred without an exception being raised, so it
+        can route to the failure emitter and keep the exit code accurate.
+    """
+
+    def __init__(self) -> None:
+        """Configure the handler at ERROR level with a zero-count captured tally."""
+        super().__init__(level=logging.ERROR)
+        self.error_count = 0  # WHY: cheap monotonic tally; callers only check >0.
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401 -- logging.Handler API
+        """Increment the captured error tally for each ERROR (or higher) record."""
+        if record.levelno >= logging.ERROR:
+            self.error_count += 1
+
+
 @dataclass(frozen=True, slots=True)
 class SuiteTallies:  # WHY: bundle counts+timing so summary/finalize signatures stay within 5-param limit.
     """Tallies produced by the interactive-safe option execution loop."""
@@ -333,7 +357,19 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         return False  # WHY: signal failure to caller.
 
     def _run_single_option(self, index: int, total: int, option: str, test_site_id: str | None, emitter: Any) -> bool:
-        """Run a single interactive option, emit telemetry, and return True on success."""
+        """Run a single interactive option, emit telemetry, and return True on success.
+
+        Why:
+            Issue #1636 — a handler that calls ``logging.error(...)`` and then
+            returns None must be classified as a failure, not a clean pass.
+            The ``_LoggedErrorObserver`` handler is attached to the root logger
+            only for the duration of ``_invoke_option`` and torn down before
+            emitting the pass/fail event so the runner's own success/failure
+            logging does not double-count. If any ERROR-level record is captured
+            while no exception was raised, the option is routed to the failure
+            emitter with a synthesized ``RuntimeError`` describing the logged
+            error condition.
+        """
         _function, description = self.menu_actions[option]  # WHY: resolve description for progress output.
         logging.warning(
             "   [%2d/%d] Testing option %3s: %s...", index, total, option, description[:60]
@@ -345,12 +381,23 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         logging.info(
             "INTERACTIVE_TEST: Starting test of menu option %s description='%s'", option, description
         )  # WHY: log before invocation.
+        observer = _LoggedErrorObserver()  # WHY: #1636 — capture ERROR records emitted by the handler.
+        root_logger = logging.getLogger()  # WHY: attach to root so any child logger's ERROR is observed.
+        root_logger.addHandler(observer)
         try:
-            self._invoke_option(option, test_site_id)  # WHY: invoke the menu callable.
+            try:
+                self._invoke_option(option, test_site_id)  # WHY: invoke the menu callable.
+            finally:
+                root_logger.removeHandler(observer)  # WHY: detach before pass/fail emission to avoid self-count.
+            if observer.error_count > 0:
+                # WHY: #1636 — logged error without an exception is still a failure.
+                synthesized = RuntimeError(f"operation logged {observer.error_count} error record(s) without raising")
+                return self._emit_option_fail(option, description, time.time() - op_start, synthesized, emitter)
             return self._emit_option_pass(
                 option, description, time.time() - op_start, emitter
             )  # WHY: delegate success emission.
         except Exception as error:
+            root_logger.removeHandler(observer)  # WHY: idempotent guard on the raise path.
             return self._emit_option_fail(
                 option, description, time.time() - op_start, error, emitter
             )  # WHY: delegate failure emission.

--- a/tests/unit/troubleshooting/test_interactive_test_runner.py
+++ b/tests/unit/troubleshooting/test_interactive_test_runner.py
@@ -399,3 +399,48 @@ def test_execute_returns_false_when_no_sites(monkeypatch: pytest.MonkeyPatch) ->
     mistapi_module.api.v1.orgs.sites.listOrgSites.return_value = site_response
     runner = _make_runner(mistapi_module=mistapi_module)
     assert runner.execute() is False  # WHY: no test site -> False verdict
+
+
+def test_run_option_loop_flags_logged_error_as_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """Handler that logs ERROR then returns None must be classified as failure, not pass.
+
+    Why:
+        Issue #1636 — the current runner treats any non-exception return as a
+        pass. A handler that emits ``logging.error(...)`` and swallows the
+        error silently reports success, inflating the pass rate. The runner
+        must observe ERROR records emitted during the option and treat them
+        as a logged-error outcome (failure), not a clean pass.
+    """
+
+    def _logs_error(site_id: str | None = None) -> None:
+        logging.error("simulated operation failure")
+        return None
+
+    menu_actions = {"1": (_logs_error, "Logs Error")}
+    runner = _make_runner(menu_actions=menu_actions)
+    emitter = _TelemetryStub("data/x.jsonl")
+    with caplog.at_level(logging.ERROR):
+        success, failure = runner._run_option_loop(["1"], "site-1", emitter)
+    assert success == 0  # WHY: option logged ERROR -> not a clean pass
+    assert failure == 1  # WHY: logged_error counts against the run
+    event_types = [event[0] for event in emitter.events]
+    assert "fail" in event_types  # WHY: emitter records the failure, not a pass
+    assert "pass" not in event_types  # WHY: logged-error path must not emit pass
+
+
+def test_print_summary_verdict_false_on_logged_error(caplog: pytest.LogCaptureFixture) -> None:
+    """_print_summary_verdict must return False when any operation logged an ERROR.
+
+    Why:
+        Issue #1636 exit-code path — a run containing logged-error outcomes
+        must produce a non-zero exit even if no exception was raised. The
+        verdict helper is the single seam that decides the process exit code
+        for ``--testinteractive``.
+    """
+    runner = _make_runner()
+    # WHY: error_count is the aggregate of logged_error + raised_exception; a
+    # run with one logged-error operation and no exceptions still fails.
+    tallies = SuiteTallies(success_count=0, error_count=1, skip_count=0, total_time=0.5)
+    with caplog.at_level(logging.WARNING):
+        result = runner._print_summary_verdict(tallies, interactive_total=1)
+    assert result is False  # WHY: any logged_error must fail the suite


### PR DESCRIPTION
Closes #1636

## Summary
`--testinteractive` currently reports handlers that log ERROR and return normally as passing, so runs with real operational failures exit all-clean. This PR narrows the outcome classification in `InteractiveTestRunner` so per-operation telemetry and the suite verdict distinguish clean returns from logged errors, raised exceptions, and prompt cancellations, per the contracts in `specs/1021-testinteractive-reliability-defects/contracts/interactive-test-telemetry.md`.

## Scope
- Extend `TelemetryEmitter.emit_test_pass` / `emit_test_summary` payloads with the contract fields (`completion`, `site_context`, `error_log_count`, `input_termination`, and summary counters).
- Add a scoped ERROR-log observer to `InteractiveTestRunner._run_single_option` and derive `OperationOutcome` per the precedence rule (`raised_exception` > `logged_error` > `prompt_cancelled` > `clean`).
- Update `_print_summary_verdict` / exit-code path so any `logged_error_count > 0` or `raised_exception_count > 0` yields a non-zero exit.
- Add regression tests reproducing the logs-error-and-returns handler (must be counted as `logged_error`, not clean).

## Out of scope
- Selector fallback (#1637), site-context propagation & cancellation (#1638), WAN client events fix (#1639), CLI flag UX (#1640), `--help` side-effect removal (#1641). These follow serially on fresh worktrees.

## Test plan
- [ ] `pytest tests/unit/troubleshooting/test_interactive_test_runner.py tests/unit/analytics/test_telemetry_emitter.py -q`
- [ ] `python -m py_compile MistHelper.py`
- [ ] Full quality gates (ruff, black --check, mypy, bandit, pydocstyle, interrogate, vulture, pip-audit)
- [ ] CI green before marking ready