### PR TITLE
fix(1638): meaningful site context + prompt-cancellation outcomes

### DIFF
--- a/src/troubleshooting/interactive_test_runner.py
+++ b/src/troubleshooting/interactive_test_runner.py
@@ -369,26 +369,50 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         )  # WHY: log invocation kwargs for diagnostics.
         function(**invoke_kwargs)  # WHY: execute target interactive-safe operation.
 
-    def _emit_option_pass(self, option: str, description: str, duration: float, emitter: Any) -> bool:
+    def _classify_site_context(self, option: str) -> str:
+        """Return the per-option test_mode label reflecting whether the handler accepts ``site_id``.
+
+        Why:
+            Issue #1638 — reports must distinguish handlers invoked with resolved
+            site context from those invoked without any, so telemetry consumers
+            can separate site-scoped exercise from stand-alone menu invocations
+            without inspecting the source signature themselves.
+
+        Args:
+            option: Menu option key resolved through ``self.menu_actions``.
+
+        Returns:
+            ``"interactive-site-scoped"`` when the handler declares a ``site_id``
+            parameter, else ``"interactive-no-context"``.
+        """
+        function, _description = self.menu_actions[option]  # WHY: resolve callable for signature inspection.
+        signature = inspect.signature(function)  # WHY: reuse inspect result to mirror _invoke_option gating.
+        if "site_id" in signature.parameters:
+            return "interactive-site-scoped"  # WHY: handler participates in site-scoped exercise.
+        return "interactive-no-context"  # WHY: handler runs without any site context injected.
+
+    def _emit_option_pass(self, option: str, description: str, duration: float, emitter: Any, test_mode: str) -> bool:
         """Emit telemetry pass event and preserve legacy success output for an option."""
         logging.warning("   [SUCCESS] Option %s completed successfully", option)  # WHY: #886 s18 success msg.
         logging.info("Emitting telemetry pass event for option %s", option)  # WHY: log before pass emission.
-        emitter.emit_test_pass(option, description, duration, "interactive")  # WHY: emit pass event.
+        emitter.emit_test_pass(option, description, duration, test_mode)  # WHY: #1638 — label site-context outcome.
         logging.debug("Telemetry pass event emitted for option %s", option)  # WHY: log pass completion.
         logging.info(
             "INTERACTIVE_TEST: Successfully completed menu option %s", option
         )  # WHY: log operator-facing success.
         return True  # WHY: signal success to caller.
 
-    def _emit_option_fail(self, option: str, description: str, duration: float, error: Exception, emitter: Any) -> bool:
+    def _emit_option_fail(
+        self, option: str, description: str, duration: float, error: Exception, emitter: Any, test_mode: str
+    ) -> bool:
         """Emit telemetry fail event and preserve legacy failure output for an option."""
         logging.warning(
             "   [FAILED]  Option %s failed: %s...", option, str(error)[:100]
         )  # WHY: #886 slice 18/N — failure message via logging.warning with legacy truncation.
         logging.info("Emitting telemetry fail event for option %s", option)  # WHY: log before fail emission.
         emitter.emit_test_fail(
-            option, description, duration, error, "interactive"
-        )  # WHY: emit fail event with exception context.
+            option, description, duration, error, test_mode
+        )  # WHY: #1638 — label site-context / prompt-cancellation outcome.
         logging.debug("Telemetry fail event emitted for option %s", option)  # WHY: log fail completion.
         logging.error("INTERACTIVE_TEST: Failed menu option %s: %s", option, error)  # WHY: log operator-facing failure.
         return False  # WHY: signal failure to caller.
@@ -406,6 +430,13 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
             while no exception was raised, the option is routed to the failure
             emitter with a synthesized ``RuntimeError`` describing the logged
             error condition.
+
+            Issue #1638 — the emitted test_mode label now differentiates three
+            distinct outcomes: ``interactive-site-scoped`` (handler accepts
+            ``site_id``), ``interactive-no-context`` (handler does not), and
+            ``interactive-cancelled`` (handler raised ``EOFError`` because the
+            user aborted a prompt), so reports no longer conflate a completed
+            no-context invocation with a prompt-cancelled site-scoped one.
         """
         _function, description = self.menu_actions[option]  # WHY: resolve description for progress output.
         logging.warning(
@@ -418,6 +449,7 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         logging.info(
             "INTERACTIVE_TEST: Starting test of menu option %s description='%s'", option, description
         )  # WHY: log before invocation.
+        test_mode = self._classify_site_context(option)  # WHY: #1638 — resolve per-option mode label upfront.
         observer = _LoggedErrorObserver()  # WHY: #1636 — capture ERROR records emitted by the handler.
         root_logger = logging.getLogger()  # WHY: attach to root so any child logger's ERROR is observed.
         root_logger.addHandler(observer)
@@ -429,15 +461,22 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
             if observer.error_count > 0:
                 # WHY: #1636 — logged error without an exception is still a failure.
                 synthesized = RuntimeError(f"operation logged {observer.error_count} error record(s) without raising")
-                return self._emit_option_fail(option, description, time.time() - op_start, synthesized, emitter)
+                return self._emit_option_fail(
+                    option, description, time.time() - op_start, synthesized, emitter, test_mode
+                )
             return self._emit_option_pass(
-                option, description, time.time() - op_start, emitter
+                option, description, time.time() - op_start, emitter, test_mode
             )  # WHY: delegate success emission.
+        except EOFError as error:
+            root_logger.removeHandler(observer)  # WHY: idempotent guard on the cancellation path.
+            return self._emit_option_fail(
+                option, description, time.time() - op_start, error, emitter, "interactive-cancelled"
+            )  # WHY: #1638 — distinguish prompt cancellation from a completed run or generic error.
         except Exception as error:
             root_logger.removeHandler(observer)  # WHY: idempotent guard on the raise path.
             return self._emit_option_fail(
-                option, description, time.time() - op_start, error, emitter
-            )  # WHY: delegate failure emission.
+                option, description, time.time() - op_start, error, emitter, test_mode
+            )  # WHY: delegate failure emission with the resolved per-option mode label.
 
     def _run_option_loop(
         self, interactive_options: list[str], test_site_id: str | None, emitter: Any

--- a/tests/unit/troubleshooting/test_interactive_test_runner.py
+++ b/tests/unit/troubleshooting/test_interactive_test_runner.py
@@ -582,3 +582,94 @@ def test_execute_returns_false_on_unresolved_selector(monkeypatch: pytest.Monkey
     assert "start" not in event_types  # WHY: no option ran against a wrong site.
     assert "pass" not in event_types
     assert "fail" not in event_types
+
+
+def test_run_single_option_marks_site_scoped_when_handler_accepts_site_id() -> None:
+    """Handler accepting ``site_id`` must be recorded as ``interactive-site-scoped``.
+
+    Why:
+        Issue #1638 — reports must distinguish handlers invoked *with* a resolved
+        site context from those invoked without one. Without this distinction the
+        operator cannot tell whether a green pass actually exercised the test site
+        or whether the callable ignored it entirely. The classifier is the
+        ``test_mode`` positional passed to ``emit_test_pass``.
+    """
+
+    def _accepts_site(site_id: str | None = None) -> None:
+        del site_id  # WHY: signature acceptance is the only behaviour under test.
+
+    menu_actions = {"1": (_accepts_site, "Site-Scoped Op")}
+    runner = _make_runner(menu_actions=menu_actions)
+    emitter = _TelemetryStub("data/x.jsonl")
+
+    success, failure = runner._run_option_loop(["1"], "site-1", emitter)
+
+    assert success == 1
+    assert failure == 0
+    pass_events = [event for event in emitter.events if event[0] == "pass"]
+    assert len(pass_events) == 1
+    # WHY: emit_test_pass args tuple: (option, description, duration, test_mode)
+    assert pass_events[0][1][3] == "interactive-site-scoped"
+
+
+def test_run_single_option_marks_no_context_when_handler_lacks_site_id() -> None:
+    """Handler without ``site_id`` parameter must be recorded as ``interactive-no-context``.
+
+    Why:
+        Issue #1638 — a handler that does not accept ``site_id`` cannot have been
+        exercised against the resolved test site. Conflating it with a
+        site-scoped pass hides a real coverage gap. The runner must classify the
+        outcome via a distinct ``test_mode`` so downstream reports can separate
+        the two populations.
+    """
+
+    def _no_site() -> None:
+        return None
+
+    menu_actions = {"1": (_no_site, "No Context Op")}
+    runner = _make_runner(menu_actions=menu_actions)
+    emitter = _TelemetryStub("data/x.jsonl")
+
+    success, failure = runner._run_option_loop(["1"], "site-1", emitter)
+
+    assert success == 1
+    assert failure == 0
+    pass_events = [event for event in emitter.events if event[0] == "pass"]
+    assert len(pass_events) == 1
+    assert pass_events[0][1][3] == "interactive-no-context"
+
+
+def test_run_single_option_marks_prompt_cancelled_on_eof(caplog: pytest.LogCaptureFixture) -> None:
+    """Handler raising ``EOFError`` must be recorded as ``interactive-cancelled``.
+
+    Why:
+        Issue #1638 — under ``--testinteractive`` an operator who cancels a
+        handler's prompt with Ctrl-D produces an ``EOFError``. The current
+        implementation catches this via the generic ``except Exception`` branch
+        and reports the option identically to a genuine crash. Reports must
+        distinguish an operator-cancelled prompt from a raised-exception failure
+        so a benign cancellation cannot masquerade as a real regression. The
+        outcome still counts against the suite verdict (the operation did not
+        complete) but the ``test_mode`` on ``emit_test_fail`` must reflect the
+        cancellation.
+    """
+
+    def _cancelled(site_id: str | None = None) -> None:
+        del site_id  # WHY: cancellation is the only behaviour under test.
+        raise EOFError("simulated Ctrl+D at prompt")
+
+    menu_actions = {"1": (_cancelled, "Prompt Cancelled")}
+    runner = _make_runner(menu_actions=menu_actions)
+    emitter = _TelemetryStub("data/x.jsonl")
+
+    with caplog.at_level(logging.WARNING):
+        success, failure = runner._run_option_loop(["1"], "site-1", emitter)
+
+    assert success == 0
+    assert failure == 1  # WHY: cancellation still counts as a non-completion.
+    fail_events = [event for event in emitter.events if event[0] == "fail"]
+    pass_events = [event for event in emitter.events if event[0] == "pass"]
+    assert len(fail_events) == 1
+    assert not pass_events
+    # WHY: emit_test_fail args tuple: (option, description, duration, error, test_mode)
+    assert fail_events[0][1][4] == "interactive-cancelled"


### PR DESCRIPTION
Fixes #1638

## Summary

User Story 3 of the \`--testinteractive\` reliability workstream: the harness currently reports every non-raising return as a plain "pass", so operators cannot tell whether an operation actually ran against the resolved test site or merely hit a cancelled prompt.

This PR:
- Adds a new outcome category for handlers invoked without site context (signature does not accept \`site_id\`) so operators can see genuine site-scoped coverage vs no-context invocations.
- Detects prompt cancellation / EOF from non-site-aware handlers and records those as a distinct outcome (not a clean pass).
- Extends the interactive test runner tests to cover site-aware, non-site-aware, and prompt-cancelled paths.
- Read-only against Mist; all tests are mock-first.

## Test plan

- [ ] Extended \`tests/unit/troubleshooting/test_interactive_test_runner.py\` covers all three paths.
- [ ] Full unit suite green.
- [ ] Ruff / Black / mypy / interrogate / pydocstyle clean on touched files.