### PR TITLE
fix(1640): reject --test-interactive with actionable suggestion

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -5219,6 +5219,52 @@ def _add_interface_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
+# Mapping of unsupported flag spellings -> the supported canonical spelling.
+# Why: users naturally type hyphenated variants (e.g. `--test-interactive`) but argparse
+# treats a hyphen as a token boundary, so it can't prefix-match to `--testinteractive`.
+# Left unchecked, the invocation is rejected by argparse with a generic "unrecognized
+# arguments" message and (worse) the interactive-test module-import sniff at the top of
+# this file — which literally checks `"--testinteractive" in sys.argv` — silently
+# proceeds as if no test flag were present, misrouting the user into normal interactive
+# mode. Issue #1640 requires an actionable rejection instead.
+_UNSUPPORTED_FLAG_VARIANTS: dict[str, str] = {
+    "--test-interactive": "--testinteractive",
+}
+
+
+def _reject_unsupported_flag_variants(argv: list[str]) -> None:
+    """Exit with actionable guidance when *argv* contains a known unsupported flag spelling.
+
+    Why:
+        argparse cannot prefix-match `--test-interactive` to `--testinteractive` (the hyphen
+        breaks matching), and the module-import-time argv sniff for `--testinteractive`
+        (see top of this file) would silently proceed as if the test flag were absent.
+        Issue #1640 requires that the unsupported spelling produce an actionable error
+        naming the correct canonical flag and NEVER silently reroute the user.
+
+    Args:
+        argv: The raw argument list (typically `sys.argv[1:]`) to scan. Tokens are also
+            split on `=` so `--flag=value` variants are caught.
+
+    Raises:
+        SystemExit: With exit code 2 (argparse convention) when a token matches a key
+            in `_UNSUPPORTED_FLAG_VARIANTS`. The stderr message names both the offending
+            spelling and the supported canonical spelling.
+    """
+    for token in argv:  # Scan every raw token in argv; order-independent match.
+        head = token.split("=", 1)[0]  # Strip any `=value` suffix so `--flag=1` is comparable.
+        if head in _UNSUPPORTED_FLAG_VARIANTS:  # Only gate the explicitly-listed bad spellings.
+            supported = _UNSUPPORTED_FLAG_VARIANTS[head]  # Look up the canonical replacement.
+            message = (
+                f"error: unsupported flag '{head}'. "
+                f"Did you mean '{supported}'? "
+                "This CLI uses collapsed flag names without internal hyphens."
+            )
+            logging.error("Rejecting unsupported flag variant %r; suggest %r", head, supported)
+            print(message, file=sys.stderr)  # Surface guidance directly to the user.
+            sys.exit(2)  # argparse convention for CLI usage errors.
+
+
 def _build_argument_parser() -> argparse.ArgumentParser:
     """Build and return the CLI argument parser for MistHelper with all supported flags."""
     logging.debug("_build_argument_parser: building argument parser")  # Log before parser creation

--- a/src/refactors/main_entrypoint.py
+++ b/src/refactors/main_entrypoint.py
@@ -22,6 +22,7 @@ from __future__ import annotations  # Enable postponed evaluation for forward-re
 
 import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
 import logging  # Reproduce the original entry-point trace log
+import sys  # Provides raw argv for the pre-argparse unsupported-flag-variant guard (#1640)
 from typing import Any  # Loose typing for late-bound MistHelper attributes
 
 
@@ -47,6 +48,8 @@ class MainEntrypoint:  # CLI main entry-point seam
         _MH._initialize_deferred_imports()  # Initialize deferred module imports if not already completed.
         _MH.InputUtils.ensure_tqdm_available()  # Ensure tqdm is accessible via InputUtils wrapper before use.
         parser = _MH._build_argument_parser()  # Build argparse parser with all supported CLI flags.
+        # Reject known bad flag spellings (e.g. --test-interactive) before argparse misroutes them (#1640).
+        _MH._reject_unsupported_flag_variants(sys.argv[1:])
         args = parser.parse_args()  # Parse command line arguments into typed Namespace object.
         _MH._setup_runtime_flags(args)  # Apply --standalone env, register globals()["args"], set FAST_MODE_ENABLED.
         _MH._initialize_dependencies(args)  # Initialize deferred dependencies (respects --skip-deps flag).

--- a/tests/unit/refactors/test_reject_unsupported_flag_variants.py
+++ b/tests/unit/refactors/test_reject_unsupported_flag_variants.py
@@ -1,0 +1,141 @@
+"""Regression tests for issue #1640: reject `--test-interactive` hyphenated variant.
+
+Verifies that the guard `MistHelper._reject_unsupported_flag_variants` rejects
+the natural hyphenated spelling `--test-interactive` (and its `=value` form)
+with an actionable error naming the supported spelling `--testinteractive`,
+exits with status code 2, and does NOT silently proceed as if the test flag
+had been omitted. Also verifies that supported spellings (empty argv, plain
+`--testinteractive`, unrelated flags) are passthrough no-ops.
+
+The guard is invoked from `src/refactors/main_entrypoint.py` before
+`parser.parse_args()`, so this test also patches the entrypoint pipeline to
+prove the guard runs before argparse would otherwise misroute the invocation.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions in type hints on Python 3.10+.
+
+import argparse  # WHY: MagicMock(spec=argparse.ArgumentParser) contract typing.
+import importlib  # WHY: resolve the live MistHelper module for the guard function.
+from typing import Any  # WHY: mocks dict holds mixed MagicMock and Namespace objects.
+from unittest.mock import MagicMock  # WHY: mock pipeline steps around the guard call.
+
+import pytest  # WHY: monkeypatch + capsys fixtures.
+
+from src.refactors.main_entrypoint import MainEntrypoint  # WHY: exercise full pipeline in one test.
+
+
+def _guard() -> Any:
+    """Return the live `_reject_unsupported_flag_variants` callable from MistHelper.
+
+    Why:
+        Resolved lazily so tests fail with a clear ImportError message if the guard
+        was accidentally removed or renamed, rather than a stale top-level ImportError
+        that would mask the actual regression.
+
+    Returns:
+        The bound callable `MistHelper._reject_unsupported_flag_variants`.
+    """
+    module = importlib.import_module("MistHelper")  # Live import; MistHelper is a top-level script module.
+    return module._reject_unsupported_flag_variants  # Access the guard as a module attribute.
+
+
+class TestRejectUnsupportedFlagVariants:
+    """`_reject_unsupported_flag_variants` gates raw argv before argparse."""
+
+    def test_hyphenated_variant_exits_with_actionable_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """`--test-interactive` triggers SystemExit(2) with both the bad and good spellings in stderr."""
+        with pytest.raises(SystemExit) as excinfo:  # WHY: guard MUST terminate the process, not silently return.
+            _guard()(["--test-interactive"])  # WHY: bare hyphenated variant is the primary defect case.
+        assert excinfo.value.code == 2  # WHY: argparse convention for usage errors is exit-code 2.
+        captured = capsys.readouterr()  # WHY: capture the stderr message for content assertions.
+        assert "--test-interactive" in captured.err  # WHY: user must see which spelling was rejected.
+        assert "--testinteractive" in captured.err  # WHY: user must see the supported spelling suggestion.
+
+    def test_hyphenated_variant_with_equals_value_is_rejected(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """`--test-interactive=1` (with an `=value` suffix) is also rejected."""
+        with pytest.raises(SystemExit) as excinfo:  # WHY: `--flag=value` form must not slip past by string mismatch.
+            _guard()(["--test-interactive=1"])  # WHY: argparse tokenises `=` so guard must split on it too.
+        assert excinfo.value.code == 2  # WHY: same exit convention as bare variant.
+        assert "--testinteractive" in capsys.readouterr().err  # WHY: suggestion still surfaced.
+
+    def test_supported_spelling_is_passthrough(self) -> None:
+        """The supported spelling `--testinteractive` is a no-op that returns None."""
+        assert _guard()(["--testinteractive"]) is None  # WHY: correct spelling must not raise.
+
+    def test_empty_argv_is_passthrough(self) -> None:
+        """An empty argument list is a no-op."""
+        assert _guard()([]) is None  # WHY: guard must not trigger on baseline no-arg invocation.
+
+    def test_unrelated_flags_are_passthrough(self) -> None:
+        """Flags that are not in the rejection table are not affected."""
+        assert _guard()(["--menu", "1", "--org", "abc"]) is None  # WHY: only the specific bad spelling is gated.
+
+    def test_hyphenated_variant_mixed_with_other_flags_is_rejected(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """The guard finds `--test-interactive` even when other flags precede/follow it."""
+        with pytest.raises(SystemExit) as excinfo:  # WHY: prove the guard scans all tokens, not just argv[0].
+            _guard()(["--debug", "--test-interactive", "--menu", "1"])  # WHY: realistic mixed-flag invocation.
+        assert excinfo.value.code == 2  # WHY: same exit convention.
+        assert "--testinteractive" in capsys.readouterr().err  # WHY: suggestion still surfaced.
+
+
+class TestMainEntrypointGuardIntegration:
+    """`MainEntrypoint.run` invokes the guard before `parser.parse_args()`."""
+
+    def test_run_rejects_hyphenated_variant_before_parse(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When `sys.argv` contains `--test-interactive`, `MainEntrypoint.run` exits before dispatch."""
+        parser_mock = MagicMock(spec=argparse.ArgumentParser)  # WHY: assert parse_args is NOT reached.
+        parser_mock.parse_args.return_value = argparse.Namespace(  # WHY: safety net if guard fails to fire.
+            standalone=False, debug=False, login=False, test=False, testinteractive=False
+        )
+        mocks: dict[str, Any] = {  # WHY: wire only the pre-guard steps the pipeline touches first.
+            "_initialize_deferred_imports": MagicMock(),
+            "InputUtils": MagicMock(),
+            "_build_argument_parser": MagicMock(return_value=parser_mock),
+            "_setup_runtime_flags": MagicMock(),
+            "_initialize_dependencies": MagicMock(),
+            "_establish_mist_session": MagicMock(),
+            "_configure_runtime_options": MagicMock(),
+            "_dispatch_main_mode": MagicMock(),
+        }
+        for attr_name, mock_obj in mocks.items():  # WHY: publish each mock as a MistHelper module attribute.
+            monkeypatch.setattr(f"MistHelper.{attr_name}", mock_obj, raising=False)
+        monkeypatch.setattr("sys.argv", ["MistHelper.py", "--test-interactive"])  # WHY: seed the guard input.
+
+        with pytest.raises(SystemExit) as excinfo:  # WHY: the entrypoint must exit early via the guard.
+            MainEntrypoint.run()
+
+        assert excinfo.value.code == 2  # WHY: guard propagates exit code 2.
+        captured = capsys.readouterr()  # WHY: verify stderr guidance surfaced through the pipeline.
+        assert "--testinteractive" in captured.err  # WHY: supported spelling must be surfaced.
+        # Critical: the pipeline must NOT have reached parse_args or any downstream step.
+        parser_mock.parse_args.assert_not_called()  # WHY: guard runs BEFORE parse_args.
+        mocks["_dispatch_main_mode"].assert_not_called()  # WHY: never silently proceed as if flag was omitted.
+        mocks["_setup_runtime_flags"].assert_not_called()  # WHY: no downstream side effects on rejection.
+
+    def test_run_allows_supported_spelling_through_pipeline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The supported `--testinteractive` spelling still reaches `_dispatch_main_mode`."""
+        parser_mock = MagicMock(spec=argparse.ArgumentParser)  # WHY: standard parser mock contract.
+        parsed_args = argparse.Namespace(  # WHY: post-parse namespace fed to downstream steps.
+            standalone=False, debug=False, login=False, test=False, testinteractive=True
+        )
+        parser_mock.parse_args.return_value = parsed_args  # WHY: entrypoint reads parse_args() result.
+        mocks: dict[str, Any] = {  # WHY: same wiring as reject-test to prove positive path is untouched.
+            "_initialize_deferred_imports": MagicMock(),
+            "InputUtils": MagicMock(),
+            "_build_argument_parser": MagicMock(return_value=parser_mock),
+            "_setup_runtime_flags": MagicMock(),
+            "_initialize_dependencies": MagicMock(),
+            "_establish_mist_session": MagicMock(),
+            "_configure_runtime_options": MagicMock(),
+            "_dispatch_main_mode": MagicMock(),
+        }
+        for attr_name, mock_obj in mocks.items():  # WHY: publish each mock as a MistHelper module attribute.
+            monkeypatch.setattr(f"MistHelper.{attr_name}", mock_obj, raising=False)
+        monkeypatch.setattr("sys.argv", ["MistHelper.py", "--testinteractive"])  # WHY: seed the supported spelling.
+
+        MainEntrypoint.run()  # WHY: must NOT raise; guard is a no-op for supported spellings.
+
+        parser_mock.parse_args.assert_called_once()  # WHY: pipeline proceeded past the guard.
+        mocks["_dispatch_main_mode"].assert_called_once_with(parsed_args)  # WHY: dispatch received parsed args.


### PR DESCRIPTION
Closes #1640.

## Summary
- Users typing the natural hyphenated variant `--test-interactive` were silently misrouted into a normal interactive session (the module-import-time argv sniff at MistHelper.py only matches `--testinteractive`, and argparse cannot prefix-match across an internal hyphen).
- Adds a pre-parse guard `_reject_unsupported_flag_variants` in MistHelper.py that scans raw argv (splitting on `=` so `--flag=value` variants are covered) and exits with code 2 plus an actionable stderr message naming both the rejected and the supported spelling.
- `MainEntrypoint.run` invokes the guard between `_build_argument_parser()` and `parse_args()`, via the existing `_MH` proxy.

## Acceptance criteria coverage
- Unsupported spelling produces an actionable error naming the supported flag ✅
- Never silently proceeds as if the test flag was omitted ✅
- CLI regression tests cover the spelling ✅ (8 new tests, 2 of them full-pipeline)

## Test plan
- [x] `pytest tests/unit/refactors/test_reject_unsupported_flag_variants.py tests/unit/refactors/test_main_entrypoint.py` — 13 passed
- [x] `ruff check` on all 3 changed files — clean
- [x] `black --check` on all 3 changed files — clean
- [x] `mypy --strict` on new/edited non-MistHelper files — no issues (MistHelper.py has pre-existing strict errors unrelated to this change)