### PR TITLE
feat(1022): menu 206 org-level Zscaler synthetic-probe manager

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -493,6 +493,9 @@ from src.network.routing_utils import (  # Cat A canonical (1014 P4)
     RoutingUtils,
 )
 from src.org.org_config_migration_manager import OrgConfigMigrationManager  # Cat B (1013 SC-001 position 5)
+from src.org.org_synthetic_probes_manager import (
+    manage_org_synthetic_probes,  # 1022: menu 206 Zscaler probe manager (side-effect-free, #1641)
+)
 from src.org.org_ticket_manager import (
     OrgTicketManager,  # Cat B (1013 SC-001 position 46) -- re-export for MistHelper.OrgTicketManager callers
 )
@@ -4752,6 +4755,11 @@ menu_actions: "dict[str, tuple[Callable[..., Any], str]]" = {
         " DESTRUCTIVE: Clone Device Config to Gateway Template"
         " - Select a gateway, extract its local config, and create a new org gateway template"
         " (Requires typing 'CREATE' to confirm)",
+    ),
+    "206": (
+        lambda mist_session, org_id: manage_org_synthetic_probes(mist_session, org_id),
+        " DESTRUCTIVE: Manage org Zscaler synthetic probes"
+        " - Build/merge/swap synthetic_test.custom_probes from curated Zscaler catalogue",
     ),
 }
 

--- a/specs/1022-org-synthetic-probes/plan.md
+++ b/specs/1022-org-synthetic-probes/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: Org-Level Synthetic Test Probes (Zscaler Destinations)
+
+**Feature Branch**: `1022-org-synthetic-probes`
+
+**Created**: 2026-07-23
+
+**Status**: Ready
+
+**Companion**: `spec.md`
+
+## 1. Architecture
+
+```text
+MistHelper.py  (menu wire-up + dispatch)
+    │
+    └─▶ src/org/org_synthetic_probes_manager.py  (this feature — new module)
+            │
+            ├─ Loads: data/zscaler_client_connector_probes.json
+            ├─ Loads: data/zscaler_cenr_hostnames.json
+            ├─ Uses:  mistapi.api.v1.orgs.setting.getOrgSettings / updateOrgSettings
+            └─ Emits: rich per-probe status via existing logging + stdout
+
+src/utils/operation_registry.py  (append: "206": {"category": "destructive", ...})
+tests/unit/org/test_org_synthetic_probes_manager.py  (new)
+```
+
+### 1.1 Module boundary
+
+The new module `src/org/org_synthetic_probes_manager.py` exposes a single public callable:
+
+```python
+def manage_org_synthetic_probes(mist_session, org_id: str) -> None: ...
+```
+
+This mirrors the signature convention of neighbouring org-level exporters/managers in `src/org/` and is what the menu dispatch entry will call.
+
+### 1.2 Internal helpers (all module-private, `_`-prefixed)
+
+- `_load_probe_sources(data_dir: Path) -> tuple[dict, dict]` — read the two curated JSON files, raise a clear error if either is missing/malformed.
+- `_prompt_vlan_list() -> list[int]` — prompt loop with per-entry `[0, 4094]` validation; empty list re-prompts.
+- `_build_probe_set(sources, vlan_ids) -> dict[str, dict]` — pure function that produces the `custom_probes` dict from the sources and a VLAN list. Skips wildcard entries. Applies `https://` prefix. Emits `name` per FR-010.
+- `_detect_existing(setting) -> dict[str, dict]` — extract `synthetic_test.custom_probes` safely, return `{}` if absent.
+- `_partition_tool_authored(existing) -> tuple[dict, dict]` — split existing probes into `(tool_authored, foreign)` by name-prefix.
+- `_merge_probes(existing_tool, new_probes, extra_vlans) -> dict` — union VLANs on shared names; return the merged tool-authored map.
+- `_swap_probes(new_probes) -> dict` — return new_probes unchanged (helper exists for symmetry with `_merge_probes` and to keep the dispatch table readable).
+- `_prompt_mode() -> str` — return `"merge"` or `"swap"` from the two-choice prompt.
+- `_prompt_confirm(summary: str) -> bool` — yes/no confirmation.
+- `_apply(mist_session, org_id, setting, probes) -> None` — construct the PUT body preserving all sibling fields, call `updateOrgSettings`, print per-probe status.
+
+### 1.3 Naming convention (FR-010)
+
+Probe name = `zcc-<role>-<fqdn-slug>` where slug is FQDN with `.` → `-` and lowercased. Examples: `zcc-pac-pac-zscaler-net`, `zcc-tunnel_zen-atl1-sme-zscaler-net`. The `zcc-` prefix is the sole marker used to identify tool-authored probes during merge/swap.
+
+## 2. Dependencies
+
+| Component | Version | Rationale |
+|---|---|---|
+| Python | ≥3.13 | Project constitution. |
+| mistapi | ≥0.63.1 (0.63.3 installed) | `orgs.setting.getOrgSettings` / `updateOrgSettings`. |
+| pytest, pytest-cov | (existing) | Unit tests. |
+| ruff, black, mypy, interrogate, pydoclint | (existing) | Quality gates. |
+
+**No new third-party dependency is added.** The curated JSON was pre-generated in a prior session and is checked into `data/`; no network fetch happens at menu-runtime.
+
+## 3. Phase Plan
+
+### Phase A — Spec & Data (already complete)
+
+- `data/zscaler_client_connector_probes.json` — authored 2026-07-23 (17 roles, 4 wildcards).
+- `data/zscaler_cenr_hostnames.json` — fetched & normalized 2026-07-23 (104 proxy + 104 VPN hostnames).
+- `specs/1022-org-synthetic-probes/spec.md` — authored 2026-07-23.
+- `specs/1022-org-synthetic-probes/plan.md` — this file.
+- `specs/1022-org-synthetic-probes/tasks.md` — see companion.
+
+### Phase B — Module skeleton + tests
+
+1. Create `src/org/__init__.py` if not present (verify first).
+2. Create `src/org/org_synthetic_probes_manager.py` with public entry + all `_`-prefixed helpers documented per DOCS.md (Google-style docstrings, ≥90% coverage).
+3. Create `tests/unit/org/__init__.py` if not present.
+4. Create `tests/unit/org/test_org_synthetic_probes_manager.py` covering: Story 1 build-from-empty, Story 2 merge, Story 3 swap preserving foreign, wildcard skipping, empty-VLAN rejection, no-changes-required, malformed-source-file failure.
+
+### Phase C — Registry + menu wire-up
+
+5. Append `"206": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Modifies org synthetic_test.custom_probes"}` to `src/utils/operation_registry.py`.
+6. Import the manager in `MistHelper.py` and add `"206": (lambda mist_session, org_id: manage_org_synthetic_probes(mist_session, org_id), "Manage org Zscaler synthetic probes")` to the `menu_actions` dispatch table (line ~5755).
+
+### Phase D — Quality gates
+
+7. Run `cd src; pytest -q; ruff check .; black --check .; interrogate -c pyproject.toml`.
+8. Fix any formatting / coverage issues.
+9. Verify `--testinteractive` still walks correctly (op 206 is `destructive`, so it MUST be skipped by the interactive harness — no code change required to achieve this, but verify empirically).
+10. Verify `python MistHelper.py --help` still exits without side-effects (issue #1641 guard).
+
+### Phase E — GH artefacts
+
+11. Commit all changes on branch `1022-org-synthetic-probes` (already checked out in worktree).
+12. Push branch.
+13. Open GitHub issue describing the feature (link to spec.md).
+14. Open draft PR referencing the issue.
+
+## 4. Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Concurrent agent edits `MistHelper.py` on main causing merge conflict | Medium | Worktree isolates the branch; conflict resolved at PR time by rebasing on latest main. Menu number 206 is chosen just above the current max (205) — collision only if the other agent also adds a new menu entry, in which case I'll bump to 207 at rebase time. |
+| Mist API shape drift under `synthetic_test` sibling fields | Low | FR-015 requires sibling preservation via full-block round-trip; tests assert siblings are retained. |
+| Wildcard entries accidentally emitted as probes | Low | `_build_probe_set` explicitly filters entries starting with `*.` and covers this in a unit test. |
+| Curated JSON becomes stale as Zscaler updates their list | Medium | Out of scope for this feature. Both source files carry `schema_version` and a `source` string with a fetch date; a follow-up feature can automate refresh. |
+| Operator confusion between merge and swap | Low | Two-choice prompt uses full words (`merge` / `swap`); confirmation prompt lists exact per-probe diff before PUT. |
+
+## 5. Traceability
+
+| Requirement | Design element |
+|---|---|
+| FR-001 (menu entry) | Phase C step 6 — `menu_actions["206"]` in MistHelper.py |
+| FR-002 (registry) | Phase C step 5 — `operation_registry.py` "206" |
+| FR-003 (VLAN prompt validation) | `_prompt_vlan_list` |
+| FR-004 (getOrgSettings) | `manage_org_synthetic_probes` top-level |
+| FR-005 (merge/swap prompt) | `_prompt_mode` |
+| FR-006 (data sources) | `_load_probe_sources` + `_build_probe_set` |
+| FR-007 (https:// prefix, no port) | `_build_probe_set` — hard-coded prefix, no port suffix concatenation |
+| FR-008 (wildcard skip) | `_build_probe_set` — filters `startswith("*.")` |
+| FR-009 (defaults) | `_build_probe_set` — `type="reachability"`, `aggressiveness="high"` |
+| FR-010 (naming convention) | `_build_probe_set` — `zcc-<role>-<slug>` |
+| FR-011 (merge behavior) | `_merge_probes` |
+| FR-012 (swap behavior) | `_swap_probes` + `_partition_tool_authored` (foreign preserved) |
+| FR-013 (confirmation) | `_prompt_confirm` |
+| FR-014 (single PUT) | `_apply` — exactly one `updateOrgSettings` call |
+| FR-015 (sibling preservation) | `_apply` — copies full setting block, only mutates `synthetic_test.custom_probes` |
+| FR-016 (--help side-effect-free) | No import-time side effects added; module import gated inside the menu callable |
+| FR-017 (tests) | Phase B step 4 |

--- a/specs/1022-org-synthetic-probes/spec.md
+++ b/specs/1022-org-synthetic-probes/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: Org-Level Synthetic Test Probes (Zscaler Destinations)
+
+**Feature Branch**: `1022-org-synthetic-probes`
+
+**Created**: 2026-07-23
+
+**Status**: Draft
+
+**Input**: User description: "Add a new MistHelper menu option that lets an operator create/manage org-level `synthetic_test` custom probes for Zscaler Client Connector destinations. Prompt for VLAN list; if probes already exist, offer merge (add VLANs to existing) vs. swap (replace probes entirely). Curated Zscaler destination data lives under `data/`. Targets are prefixed with `https://` and carry no port number. Register the new op in `OperationRegistry`. Include the menu wire-up in `MistHelper.py` on this branch."
+
+## Summary
+
+A network operator needs a repeatable, single-command way to apply a curated set of Zscaler Client Connector reachability probes as **org-level `synthetic_test.custom_probes`** in Mist, scoped to a chosen list of VLANs. The curated destination catalogue lives in `data/zscaler_client_connector_probes.json` (17 roles, ~30 concrete FQDNs) plus `data/zscaler_cenr_hostnames.json` (104 proxy + 104 VPN Cloud Enforcement Node hostnames). When the operator selects the new menu option, MistHelper prompts for the VLAN list, reads the current org setting, detects whether probes already exist, and offers a merge vs. swap choice before PUT-ing an updated `synthetic_test` block.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - First-Time Probe Deployment (Priority: P1)
+
+An operator with a fresh Mist org selects the new interactive menu option, enters a comma-separated VLAN list (e.g. `10,20,30`), and — because no `synthetic_test.custom_probes` exist yet — the tool builds the full probe set from the curated JSON data files, prefixes every target with `https://`, applies the VLAN list to each probe's `vlan_ids`, and PUTs the resulting org setting. The operator sees a per-probe success/failure summary and the org's Zscaler reachability probes are now in place.
+
+**Why this priority**: This is the primary use case; every downstream story assumes an initial deployment path exists and works.
+
+**Independent Test**: Given a mocked `getOrgSettings` returning no existing `synthetic_test.custom_probes`, invoking the manager with VLAN list `[10,20,30]` MUST produce a probe body containing one entry per FQDN in the curated JSON data files with `type="reachability"`, `target` prefixed with `https://`, no port suffix, and `vlan_ids=[10,20,30]`, and MUST call `updateOrgSettings` exactly once with that body.
+
+**Acceptance Scenarios**:
+
+1. **Given** the org has no existing `synthetic_test.custom_probes`, **When** the operator selects the menu option and enters a VLAN list, **Then** the tool MUST build the probe set from `data/zscaler_client_connector_probes.json` + `data/zscaler_cenr_hostnames.json`, applying the entered VLAN list to every probe's `vlan_ids`.
+2. **Given** the tool builds a probe body, **When** any concrete FQDN is emitted as a probe target, **Then** it MUST be prefixed with `https://` and MUST NOT include a port number (per operator constraint 2026-07-23).
+3. **Given** the operator confirms the change, **When** the tool applies it, **Then** it MUST call `mistapi.api.v1.orgs.setting.updateOrgSettings` exactly once with the constructed body and MUST report per-probe status.
+4. **Given** any curated `fqdn` entry contains a wildcard (`*.zscaler.net`), **When** the tool builds the probe body, **Then** it MUST skip that wildcard entry (documented in the source JSON `wildcards` array), because wildcards cannot be directly probed.
+
+### User Story 2 - Merge New VLANs Into Existing Probes (Priority: P2)
+
+An operator returning to add a new VLAN (e.g. `40`) to already-deployed probes selects the menu option, enters `[40]`, and is told existing probes already cover VLANs `[10,20,30]`. The operator chooses **merge**. The tool leaves the existing probe set intact and, for each existing probe, appends `40` to `vlan_ids` (deduplicated, preserving order where possible). No probes are added or removed.
+
+**Why this priority**: Merge is the safe, additive path — the most common operational reason to re-run the menu after a first deployment.
+
+**Independent Test**: Given a mocked existing `synthetic_test.custom_probes` block with `vlan_ids=[10,20,30]` on every probe, invoking the manager with new VLAN list `[40]` in merge mode MUST result in a body where each probe's `vlan_ids` is exactly `[10,20,30,40]` (deduplicated), with no probe added, removed, or renamed.
+
+**Acceptance Scenarios**:
+
+1. **Given** existing probes are detected, **When** the tool prompts the operator, **Then** it MUST clearly display: (a) number of existing probes, (b) union of existing VLAN ids across those probes, and (c) an unambiguous two-choice prompt (merge | swap).
+2. **Given** the operator chooses **merge**, **When** the tool builds the updated body, **Then** every existing probe MUST be preserved by name and target, and each probe's `vlan_ids` MUST be the deduplicated union of the existing ids and the newly-entered ids.
+3. **Given** the operator's newly-entered VLAN list is a subset of what each probe already carries, **When** the tool computes the merge diff, **Then** it MUST report "no changes required" and MUST NOT issue a PUT.
+
+### User Story 3 - Swap Replaces Probes Entirely (Priority: P3)
+
+An operator wants to replace a legacy probe set with a freshly curated set (e.g. because the curated JSON was updated). They enter a VLAN list, choose **swap**, and confirm. The tool discards every existing entry under `synthetic_test.custom_probes` whose name matches the curated set's naming scheme (plus any probe not present in the new curated set), rebuilds the probe set from the curated JSON with the new VLAN list, and PUTs the result. Non-conflicting user-owned probes (i.e. probes not authored by this tool) MUST be preserved.
+
+**Why this priority**: Swap is the destructive path, needed for legitimate re-curation but must not blow away hand-authored probes.
+
+**Independent Test**: Given a mocked existing block with 3 tool-authored probes plus 1 hand-authored probe (name prefix outside the tool's namespace), invoking swap MUST leave the hand-authored probe untouched and rewrite only the tool-authored ones.
+
+**Acceptance Scenarios**:
+
+1. **Given** the operator chooses **swap**, **When** the tool builds the updated body, **Then** it MUST rewrite exactly the probes whose names match this tool's naming convention (documented in `data-model.md`), leaving any other probes untouched.
+2. **Given** swap mode, **When** the tool builds the new probe set, **Then** it MUST derive `vlan_ids` for every new probe **only** from the operator's newly-entered VLAN list — no VLAN from a prior deployment is carried forward.
+3. **Given** the operator declines to confirm at the final prompt, **When** the confirmation prompt is answered "no", **Then** the tool MUST NOT call `updateOrgSettings` and MUST report that no changes were made.
+
+### Edge Cases
+
+- Empty VLAN list at the prompt → the tool MUST re-prompt (or exit cleanly) rather than PUT probes with empty `vlan_ids`.
+- Non-integer or negative VLAN entries → the tool MUST reject them at the prompt with a helpful message.
+- `getOrgSettings` returns a `synthetic_test` block with `custom_probes` absent (only `vlans` or other siblings present) → the tool MUST treat this identically to "no existing probes" and MUST NOT drop the sibling fields when it PUTs the updated block.
+- `getOrgSettings` returns an unexpected shape (missing `synthetic_test` key entirely) → the tool MUST create a new `synthetic_test` block containing only `custom_probes`, without setting other sibling fields.
+- The two source JSON files are missing or malformed → the tool MUST fail closed with a clear error identifying which file was unreadable.
+- The operator running the menu option lacks org-scope write permission → the mistapi call will surface an HTTP error; the tool MUST report it verbatim and MUST NOT silently succeed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: MistHelper MUST expose a new interactive menu entry that launches the org-level synthetic-probe manager.
+- **FR-002**: The menu entry MUST be registered in `src/utils/operation_registry.py` with category `destructive` (it PUTs to org settings via `updateOrgSettings`).
+- **FR-003**: The manager MUST prompt for a comma-separated VLAN list and MUST validate each entry as a non-negative integer in the range `[0, 4094]`.
+- **FR-004**: The manager MUST call `mistapi.api.v1.orgs.setting.getOrgSettings(session, org_id)` to read the current org setting.
+- **FR-005**: The manager MUST inspect the response's `synthetic_test.custom_probes` field. If present and non-empty, it MUST prompt the operator for **merge** vs. **swap** using an unambiguous two-choice prompt.
+- **FR-006**: The manager MUST build probe entries from `data/zscaler_client_connector_probes.json` (all roles) plus, for the `tunnel_zen` role only, the union of `proxy_hostnames` and `vpn_hostnames` from `data/zscaler_cenr_hostnames.json`.
+- **FR-007**: Every probe target MUST be prefixed with `https://` and MUST NOT include a port number.
+- **FR-008**: Wildcard FQDN entries in the source JSON MUST be skipped (they cannot be directly probed).
+- **FR-009**: Every probe MUST use `type="reachability"` and `aggressiveness="high"` unless the curated JSON explicitly overrides these fields per-role.
+- **FR-010**: Probe `name` MUST follow the pattern `zcc-<role>-<fqdn-slug>` (e.g. `zcc-pac-pac-zscaler-net`) so this tool can unambiguously identify probes it authored during a later swap.
+- **FR-011**: In **merge** mode, existing probes matching the tool's `zcc-` name prefix MUST have their `vlan_ids` set to the deduplicated union of existing ids and newly-entered ids; probe names, targets, and other fields MUST be preserved.
+- **FR-012**: In **swap** mode, every existing probe whose name matches the tool's `zcc-` prefix MUST be removed and replaced with the freshly-built set. Probes NOT matching the tool's prefix MUST be preserved unmodified.
+- **FR-013**: The manager MUST show a final confirmation prompt summarizing (a) count of probes to be added/removed/updated, (b) resulting VLAN id list per probe, and (c) the resulting total probe count. A "no" answer MUST abort without calling `updateOrgSettings`.
+- **FR-014**: The manager MUST call `mistapi.api.v1.orgs.setting.updateOrgSettings(session, org_id, body)` exactly once per confirmed run, and MUST report success/failure at both the HTTP-response level and the per-probe level.
+- **FR-015**: The manager MUST NOT drop or overwrite any sibling fields (e.g. `synthetic_test.vlans`, `synthetic_test.wan_speedtest`) inside the org setting when constructing the PUT body.
+- **FR-016**: `MistHelper.py --help` MUST NOT be regressed by this feature — help output MUST remain side-effect-free (per issue #1641, guarded on `main`).
+- **FR-017**: The feature MUST include pytest unit tests covering: build-from-empty (Story 1), merge with existing (Story 2), swap preserving foreign probes (Story 3), wildcard skipping, empty-VLAN rejection, and the "no changes required" merge path.
+
+### Key Entities *(include if feature involves data)*
+
+- **Probe source (Zscaler Client Connector)** — `data/zscaler_client_connector_probes.json`. Schema v1. Contains `roles[]` (17 entries), each with `role`, `description`, `ports[]`, and either `fqdns[]` (concrete) or `fqdns_ref` (external file reference). Also contains a top-level `wildcards[]` array of informational wildcards.
+- **Probe source (Zscaler CENR)** — `data/zscaler_cenr_hostnames.json`. Schema v1. Contains `proxy_hostnames[]` (104 entries, `*.sme.zscaler.net` naming) and `vpn_hostnames[]` (104 entries, `*-vpn.zscaler.net` naming). Fetched from `https://config.zscaler.com/api/zscaler.net/cenr/json` on 2026-07-23. IPs intentionally omitted per operator requirement.
+- **Custom probe (Mist)** — an entry inside `org_setting["synthetic_test"]["custom_probes"]`, keyed by probe `name`. Fields consumed by this tool: `name`, `type`, `target`, `vlan_ids`, `aggressiveness`. Other fields (if the API adds them later) MUST be preserved unmodified when merging.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After a fresh first-time deployment (Story 1), `getOrgSettings` returns a `synthetic_test.custom_probes` block containing one probe per non-wildcard FQDN in the curated JSON data files. All target strings begin with `https://` and contain no `:` port separator after the host.
+- **SC-002**: After a merge run (Story 2) adding one VLAN to an existing 3-VLAN deployment, every tool-authored probe reports `vlan_ids` of length 4 with the new VLAN appended; probe count is unchanged; no non-tool-authored probe is modified.
+- **SC-003**: After a swap run (Story 3) against a set containing one hand-authored probe (name outside the `zcc-` prefix), the hand-authored probe is present verbatim in `getOrgSettings` post-run; every remaining probe carries `vlan_ids` exactly equal to the newly-entered VLAN list.
+- **SC-004**: The new menu op appears in `OperationRegistry.destructive_options` with a `skip_reason` explicitly identifying it as an org-settings write. `python -m pytest tests/unit/test_operation_registry_guardrail.py` continues to pass.
+- **SC-005**: `python -m pytest tests/unit/org/test_org_synthetic_probes_manager.py` (new) achieves ≥90% coverage of the new module.
+- **SC-006**: `ruff check .`, `black --check .`, `interrogate` (≥90%), and `pydoclint --style=google` continue to pass on all new/modified files.

--- a/specs/1022-org-synthetic-probes/tasks.md
+++ b/specs/1022-org-synthetic-probes/tasks.md
@@ -1,0 +1,118 @@
+# Tasks: Org-Level Synthetic Test Probes (Zscaler Destinations)
+
+**Feature Branch**: `1022-org-synthetic-probes`
+
+**Created**: 2026-07-23
+
+**Companion**: `spec.md`, `plan.md`
+
+Tasks are dependency-ordered. `[P]` = parallelisable with the immediately preceding `[P]` task.
+
+## T001 — Verify worktree state and pre-existing artefacts
+
+Verify:
+- Working directory is `.claude/worktrees/1022-org-synthetic-probes/`.
+- Current branch is `1022-org-synthetic-probes`.
+- `data/zscaler_client_connector_probes.json` exists (~4.5 KB, schema_version 1).
+- `data/zscaler_cenr_hostnames.json` exists (~22 KB, schema_version 1, 104 proxy + 104 vpn hostnames).
+- `specs/1022-org-synthetic-probes/spec.md`, `plan.md`, `tasks.md` exist.
+
+## T002 — Confirm `src/org/` package structure
+
+Check whether `src/org/__init__.py` exists. If not, create an empty one (with a one-line module docstring) so Python can import the new module.
+
+## T003 — Confirm `tests/unit/org/` package structure
+
+Check whether `tests/unit/org/__init__.py` exists. If not, create an empty one.
+
+## T004 — Author `src/org/org_synthetic_probes_manager.py`
+
+Write the module implementing all helpers named in `plan.md §1.2`, using Google-style docstrings per `~/.claude/DOCS.md` (every public/private function documented with a **Why:** section where the summary is not self-evident).
+
+Public API: `manage_org_synthetic_probes(mist_session, org_id: str) -> None`.
+
+Behavior: implements FR-003 through FR-015 verbatim. Module-import must be side-effect free (no top-level I/O, no top-level network, only `import` statements).
+
+## T005 [P] — Author `tests/unit/org/test_org_synthetic_probes_manager.py`
+
+Cover, at minimum, one test per acceptance scenario in `spec.md`:
+
+- `test_build_from_empty_produces_https_prefixed_no_port_targets` (Story 1 / SC-001)
+- `test_build_from_empty_skips_wildcards` (FR-008)
+- `test_build_from_empty_includes_tunnel_zen_cenr_hostnames` (FR-006)
+- `test_merge_dedupes_vlan_union` (Story 2 / SC-002)
+- `test_merge_reports_no_changes_when_subset` (Story 2 acceptance #3)
+- `test_swap_preserves_foreign_probes` (Story 3 / SC-003)
+- `test_swap_replaces_vlan_ids_completely` (Story 3 acceptance #2)
+- `test_prompt_rejects_empty_vlan_list`
+- `test_prompt_rejects_out_of_range_vlan`
+- `test_apply_preserves_synthetic_test_sibling_fields` (FR-015)
+- `test_confirm_no_aborts_without_put` (Story 3 acceptance #3)
+- `test_missing_source_file_raises_with_clear_message`
+
+Use `unittest.mock.patch` to stub `mistapi.api.v1.orgs.setting.getOrgSettings` / `updateOrgSettings` and `input()`.
+
+## T006 [P] — Register op "206" in `src/utils/operation_registry.py`
+
+Append entry:
+
+```python
+"206": {
+    "category": "destructive",
+    "skip_reason": "DESTRUCTIVE: Modifies org synthetic_test.custom_probes",
+},
+```
+
+Ensure the alphabetical/numeric ordering matches surrounding entries (numeric keys are grouped near the bottom in existing patterns).
+
+## T007 — Wire the menu entry in `MistHelper.py`
+
+At the top of `MistHelper.py`, guard the import inside a lazy accessor or place it alongside other org-manager imports so that `--help` remains side-effect-free (issue #1641). Then, in the `menu_actions` dict (line ~5755), add:
+
+```python
+"206": (
+    lambda mist_session, org_id: manage_org_synthetic_probes(mist_session, org_id),
+    "Manage org Zscaler synthetic probes",
+),
+```
+
+The `float(x.replace("a", "."))` sort key already handles "206" correctly.
+
+## T008 — Local quality gate
+
+Run from repo root (inside worktree):
+
+```bash
+cd src
+pytest tests/unit/org/test_org_synthetic_probes_manager.py -q
+pytest tests/unit/test_operation_registry_guardrail.py -q
+ruff check .
+black --check .
+interrogate -c ../pyproject.toml src/org/org_synthetic_probes_manager.py
+pydoclint --style=google src/org/org_synthetic_probes_manager.py
+```
+
+Fix anything red. Do not proceed to T009 until every gate is green.
+
+## T009 — Regression sanity checks
+
+```bash
+python MistHelper.py --help >/dev/null           # exit 0, no side effects (#1641)
+```
+
+## T010 — Commit + push
+
+```bash
+git add -A
+git status
+git commit -m "feat(1022): org synthetic_test probes for Zscaler destinations"
+git push -u origin 1022-org-synthetic-probes
+```
+
+## T011 — Open GitHub issue
+
+Body: link to `specs/1022-org-synthetic-probes/spec.md`; summarize FR-001..FR-017; note the feature is destructive (writes to org settings via PUT).
+
+## T012 — Open draft PR
+
+Base = `main`; head = `1022-org-synthetic-probes`. Reference the issue from T011. Attach the acceptance-scenario checklist so a reviewer can walk each one against the diff.

--- a/src/org/org_synthetic_probes_manager.py
+++ b/src/org/org_synthetic_probes_manager.py
@@ -1,0 +1,504 @@
+"""Org-level Zscaler synthetic-probe manager (menu 206).
+
+Builds, merges, or swaps ``synthetic_test.custom_probes`` entries on the
+Mist org setting using a curated catalogue of Zscaler Client Connector
+destinations shipped with the repo under ``data/``.
+
+Why:
+    Operators need a single-command way to keep the Zscaler reachability
+    probe fleet in sync with their VLAN topology. Hand-maintaining the
+    probe block against Zscaler's evolving Cloud Enforcement Node list is
+    error-prone; this module treats the JSON in ``data/`` as the source of
+    truth, and marks every probe it writes with the ``zcc-`` name prefix
+    so a follow-up run can safely merge or swap without disturbing
+    probes authored elsewhere (see FR-010 through FR-015 in the spec).
+
+Module-import must remain side-effect free (issue #1641 --help guard):
+    Only ``import`` statements at module scope; all I/O, prompts, and API
+    calls live inside functions invoked from the menu dispatch table.
+"""
+
+from __future__ import annotations  # PEP 604 unions for future annotations.
+
+import json  # Read curated Zscaler JSON catalogues.
+import logging  # Structured trace + info/warn/error logging.
+from pathlib import Path  # Cross-platform path handling for data/ files.
+from typing import Any  # Precise annotations for setting dicts.
+
+# WHY: Import the mistapi setting module at module load. This is
+# side-effect free (just a re-export of two API callables) and lets us
+# monkey-patch it cleanly in unit tests via ``patch.object``.
+from mistapi.api.v1.orgs import setting as _mist_setting
+
+_DEFAULT_DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
+_PROBE_SOURCE_FILE = "zscaler_client_connector_probes.json"
+_CENR_SOURCE_FILE = "zscaler_cenr_hostnames.json"
+_TOOL_NAME_PREFIX = "zcc-"  # FR-010: marks probes authored by this tool.
+_TUNNEL_ZEN_ROLE = "tunnel_zen"  # Only role that expands via CENR hostnames.
+_VLAN_MIN = 0  # FR-003 lower bound.
+_VLAN_MAX = 4094  # FR-003 upper bound.
+
+
+def manage_org_synthetic_probes(mist_session: Any, org_id: str) -> None:
+    """Interactive entry point for menu 206.
+
+    Why:
+        Single public API surface for the feature. The menu dispatch table
+        calls this exact callable; keeping it thin and delegating to the
+        ``_``-prefixed helpers below preserves testability -- each helper
+        can be exercised directly without stubbing the whole flow.
+
+    Args:
+        mist_session: Authenticated ``mistapi`` session object used for
+            both the ``getOrgSettings`` read and the ``updateOrgSettings``
+            write.
+        org_id: Mist organisation UUID whose ``synthetic_test.custom_probes``
+            block is being managed.
+
+    Returns:
+        None. Side effects (API PUT + stdout prints) are the observable
+        outcome.
+
+    Raises:
+        FileNotFoundError: If either curated JSON file is missing (bubbled
+            from ``_load_probe_sources``).
+        ValueError: If either curated JSON file is malformed.
+    """
+    logging.info("Menu 206: starting org Zscaler synthetic-probe manager")
+    logging.debug("ENTRY: manage_org_synthetic_probes(org_id=%s)", org_id)
+
+    sources = _load_probe_sources(_DEFAULT_DATA_DIR)  # Fail-fast on missing data.
+    vlan_ids = _prompt_vlan_list()  # FR-003.
+    setting = _fetch_setting(mist_session, org_id)  # FR-004.
+    existing_probes = _detect_existing(setting)  # FR-005 precondition.
+    tool_authored, foreign = _partition_tool_authored(existing_probes)
+
+    new_probes = _build_probe_set(sources, vlan_ids)  # FR-006..FR-010.
+
+    if tool_authored:
+        mode = _prompt_mode(tool_authored)  # FR-005.
+        if mode == "merge":
+            merged_tool = _merge_probes(tool_authored, new_probes, vlan_ids)
+            if merged_tool == tool_authored:
+                print("  No changes required -- newly-entered VLANs already covered.")
+                logging.info("Merge no-op: entered VLANs already covered by all probes")
+                return
+            resulting_tool = merged_tool
+        else:
+            resulting_tool = _swap_probes(new_probes)
+    else:
+        resulting_tool = new_probes  # Fresh deployment path (Story 1).
+
+    summary = _summarise(resulting_tool, tool_authored, foreign)
+    if not _prompt_confirm(summary):  # FR-013.
+        print("  Operation cancelled -- no changes were made.")
+        logging.info("Operator declined final confirmation; no PUT issued")
+        return
+
+    combined = {**foreign, **resulting_tool}  # FR-012: foreign preserved.
+    _apply(mist_session, org_id, setting, combined)  # FR-014.
+    logging.debug("EXIT: manage_org_synthetic_probes - success")
+
+
+def _load_probe_sources(data_dir: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Load the two curated Zscaler JSON files from ``data_dir``.
+
+    Why:
+        Centralising the file reads gives a single fail-closed choke point
+        (edge case: files missing or malformed) and lets tests point the
+        module at a fixture directory.
+
+    Args:
+        data_dir: Directory containing both curated files.
+
+    Returns:
+        A tuple ``(probes, cenr)`` -- the parsed contents of the client
+        connector probe file and the CENR hostnames file, respectively.
+
+    Raises:
+        FileNotFoundError: If either source file is missing.
+        ValueError: If either source file contains invalid JSON.
+    """
+    probes_path = data_dir / _PROBE_SOURCE_FILE
+    cenr_path = data_dir / _CENR_SOURCE_FILE
+    for path in (probes_path, cenr_path):
+        if not path.is_file():
+            raise FileNotFoundError(f"Required Zscaler source file is missing: {path}")
+    try:
+        probes = json.loads(probes_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as err:
+        raise ValueError(f"Malformed JSON in {probes_path}: {err}") from err
+    try:
+        cenr = json.loads(cenr_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as err:
+        raise ValueError(f"Malformed JSON in {cenr_path}: {err}") from err
+    return probes, cenr
+
+
+def _prompt_vlan_list() -> list[int]:
+    """Prompt the operator for a comma-separated VLAN id list.
+
+    Why:
+        The VLAN list is the only per-invocation parameter; validating
+        the range at prompt time (FR-003) avoids surfacing an opaque
+        API-side rejection later.
+
+    Returns:
+        Sorted, deduplicated list of VLAN ids in ``[0, 4094]``. Never
+        returns an empty list -- the prompt loops until at least one
+        valid id is entered.
+    """
+    while True:
+        raw = input("  Enter VLAN ids (comma-separated, each in [0, 4094]): ").strip()
+        if not raw:
+            print("  VLAN list cannot be empty. Please try again.")
+            continue
+        parts = [item.strip() for item in raw.split(",") if item.strip()]
+        try:
+            ids = [int(part) for part in parts]
+        except ValueError:
+            print("  Non-integer VLAN id detected. Please try again.")
+            continue
+        if any(vid < _VLAN_MIN or vid > _VLAN_MAX for vid in ids):
+            print(f"  VLAN ids must be in [{_VLAN_MIN}, {_VLAN_MAX}]. Please try again.")
+            continue
+        if not ids:
+            print("  VLAN list cannot be empty. Please try again.")
+            continue
+        return sorted(set(ids))
+
+
+def _fetch_setting(mist_session: Any, org_id: str) -> dict[str, Any]:
+    """Return the current org setting block via mistapi.
+
+    Why:
+        Isolating the read call makes it trivial to mock in tests and
+        clarifies the FR-004 boundary (get) from the FR-014 boundary
+        (put).
+
+    Args:
+        mist_session: Authenticated ``mistapi`` session.
+        org_id: Mist organisation UUID.
+
+    Returns:
+        The parsed JSON payload of ``getOrgSettings`` (defensively an
+        empty dict if the API returned no body).
+    """
+    logging.debug("Calling getOrgSettings(org_id=%s)", org_id)
+    response = _mist_setting.getOrgSettings(mist_session, org_id)
+    data = getattr(response, "data", None)
+    if not isinstance(data, dict):
+        logging.warning("getOrgSettings returned non-dict payload; treating as empty")
+        return {}
+    return data
+
+
+def _detect_existing(setting: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Extract ``synthetic_test.custom_probes`` from ``setting``.
+
+    Why:
+        Guarded accessor so callers don't have to worry about the
+        edge case where either ``synthetic_test`` or ``custom_probes``
+        is absent.
+
+    Args:
+        setting: Org setting block as returned by ``getOrgSettings``.
+
+    Returns:
+        The ``custom_probes`` map (``{name: probe_dict}``) if present,
+        otherwise an empty dict.
+    """
+    synthetic = setting.get("synthetic_test") if isinstance(setting, dict) else None
+    if not isinstance(synthetic, dict):
+        return {}
+    probes = synthetic.get("custom_probes")
+    if not isinstance(probes, dict):
+        return {}
+    return probes
+
+
+def _partition_tool_authored(
+    existing: dict[str, dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Split existing probes into tool-authored and foreign sets.
+
+    Why:
+        FR-012 mandates that foreign probes (any probe whose name lacks
+        the ``zcc-`` prefix) are preserved verbatim through merge and
+        swap. Partitioning up-front keeps the downstream helpers pure.
+
+    Args:
+        existing: Full ``custom_probes`` map from the org setting.
+
+    Returns:
+        ``(tool_authored, foreign)`` -- two disjoint dicts whose union is
+        ``existing``.
+    """
+    tool_authored: dict[str, dict[str, Any]] = {}
+    foreign: dict[str, dict[str, Any]] = {}
+    for name, probe in existing.items():
+        if isinstance(name, str) and name.startswith(_TOOL_NAME_PREFIX):
+            tool_authored[name] = probe
+        else:
+            foreign[name] = probe
+    return tool_authored, foreign
+
+
+def _fqdn_slug(fqdn: str) -> str:
+    """Convert an FQDN to the slug segment used in probe names.
+
+    Why:
+        The naming rule (FR-010) requires a stable, filesystem-safe
+        derivation from the FQDN so tool-authored probes are recognisable
+        across re-runs. Lowercase + ``.`` -> ``-`` is sufficient because
+        Zscaler FQDNs are ASCII-only.
+
+    Args:
+        fqdn: The concrete hostname (never a wildcard by the time this
+            is called).
+
+    Returns:
+        Lowercased slug with dots replaced by hyphens.
+    """
+    return fqdn.lower().replace(".", "-")
+
+
+def _iter_role_fqdns(role: dict[str, Any], cenr: dict[str, Any]) -> list[str]:
+    """Yield the concrete FQDN list for a single role, expanding CENR.
+
+    Why:
+        Only the ``tunnel_zen`` role expands via the CENR file; every
+        other role carries its FQDNs inline. Centralising the branch
+        keeps ``_build_probe_set`` readable.
+
+    Args:
+        role: One entry from ``roles[]`` in the probe source file.
+        cenr: Parsed CENR hostnames file (for the tunnel_zen expansion).
+
+    Returns:
+        A list of concrete FQDN strings (may include wildcards which the
+        caller will filter).
+    """
+    if role.get("role") == _TUNNEL_ZEN_ROLE:
+        proxy = cenr.get("proxy_hostnames", []) or []
+        vpn = cenr.get("vpn_hostnames", []) or []
+        return [*proxy, *vpn]
+    fqdns = role.get("fqdns") or []
+    return list(fqdns)
+
+
+def _build_probe_set(
+    sources: tuple[dict[str, Any], dict[str, Any]],
+    vlan_ids: list[int],
+) -> dict[str, dict[str, Any]]:
+    """Build the full tool-authored probe set from the curated sources.
+
+    Why:
+        Pure function -- no I/O -- so the acceptance tests can pin the
+        exact probe body produced for a given VLAN list.
+
+    Args:
+        sources: The ``(probes, cenr)`` tuple from ``_load_probe_sources``.
+        vlan_ids: VLAN id list to apply to every emitted probe.
+
+    Returns:
+        A ``{probe_name: probe_body}`` map ready to be merged into the
+        setting block. Wildcard FQDNs are skipped per FR-008.
+    """
+    probes_source, cenr_source = sources
+    result: dict[str, dict[str, Any]] = {}
+    for role in probes_source.get("roles", []) or []:
+        role_name = role.get("role") or "unknown"
+        for fqdn in _iter_role_fqdns(role, cenr_source):
+            if not isinstance(fqdn, str) or fqdn.startswith("*."):
+                continue  # FR-008: wildcards cannot be probed directly.
+            probe_name = f"{_TOOL_NAME_PREFIX}{role_name}-{_fqdn_slug(fqdn)}"
+            result[probe_name] = {
+                "name": probe_name,
+                "type": role.get("type", "reachability"),  # FR-009 default.
+                "target": f"https://{fqdn}",  # FR-007: prefix, no port.
+                "vlan_ids": list(vlan_ids),
+                "aggressiveness": role.get("aggressiveness", "high"),  # FR-009.
+            }
+    return result
+
+
+def _merge_probes(
+    existing_tool: dict[str, dict[str, Any]],
+    new_probes: dict[str, dict[str, Any]],
+    extra_vlans: list[int],
+) -> dict[str, dict[str, Any]]:
+    """Union ``extra_vlans`` into each existing tool-authored probe.
+
+    Why:
+        Merge is the safe additive path (Story 2). Names, targets, and
+        siblings are preserved -- only ``vlan_ids`` is rewritten as the
+        deduplicated, sorted union.
+
+    Args:
+        existing_tool: Probes currently on the org matching ``zcc-``.
+        new_probes: Freshly-built probe set (unused for merge -- kept in
+            the signature for symmetry with ``_swap_probes`` and to give
+            the caller a landing spot for FR-011 future extension).
+        extra_vlans: VLAN ids to add.
+
+    Returns:
+        Merged probe map. Identical to ``existing_tool`` if no probe
+        gained a new VLAN.
+    """
+    _ = new_probes  # Reserved for future FR-011 extension; keeps API symmetric.
+    merged: dict[str, dict[str, Any]] = {}
+    for name, probe in existing_tool.items():
+        current_vlans = probe.get("vlan_ids") or []
+        union = sorted(set(current_vlans) | set(extra_vlans))
+        merged_probe = dict(probe)
+        merged_probe["vlan_ids"] = union
+        merged[name] = merged_probe
+    return merged
+
+
+def _swap_probes(
+    new_probes: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Return the freshly-built probe set unchanged.
+
+    Why:
+        Swap is the destructive path (Story 3). The helper exists purely
+        so the dispatch table in ``manage_org_synthetic_probes`` reads
+        as a symmetric pair with ``_merge_probes``.
+
+    Args:
+        new_probes: Freshly-built probe set from ``_build_probe_set``.
+
+    Returns:
+        ``new_probes`` unchanged.
+    """
+    return new_probes
+
+
+def _prompt_mode(existing_tool: dict[str, dict[str, Any]]) -> str:
+    """Prompt the operator for merge vs. swap.
+
+    Why:
+        Explicit two-choice prompt (FR-005). Displaying the existing
+        probe count and VLAN union up-front gives the operator the
+        context needed to make the call without needing to walk the
+        setting themselves.
+
+    Args:
+        existing_tool: Tool-authored probes currently on the org.
+
+    Returns:
+        Either ``"merge"`` or ``"swap"``.
+    """
+    all_vlans: set[int] = set()
+    for probe in existing_tool.values():
+        for vid in probe.get("vlan_ids") or []:
+            if isinstance(vid, int):
+                all_vlans.add(vid)
+    print(f"  Existing tool-authored probes: {len(existing_tool)}")
+    print(f"  VLAN union across existing probes: {sorted(all_vlans)}")
+    while True:
+        choice = input("  Choose action [merge/swap]: ").strip().lower()
+        if choice in ("merge", "swap"):
+            return choice
+        print("  Please answer 'merge' or 'swap'.")
+
+
+def _summarise(
+    resulting_tool: dict[str, dict[str, Any]],
+    existing_tool: dict[str, dict[str, Any]],
+    foreign: dict[str, dict[str, Any]],
+) -> str:
+    """Build the human-readable confirmation summary string.
+
+    Why:
+        FR-013 requires the operator to see counts of add/remove/update
+        and the resulting total before authorising the PUT. Splitting
+        the summary out keeps ``_prompt_confirm`` reusable.
+
+    Args:
+        resulting_tool: The tool-authored probe set that will be written.
+        existing_tool: The tool-authored probe set currently on the org.
+        foreign: Probes not owned by this tool (preserved unchanged).
+
+    Returns:
+        A multi-line string suitable for printing.
+    """
+    added = set(resulting_tool) - set(existing_tool)
+    removed = set(existing_tool) - set(resulting_tool)
+    updated = {name for name in set(resulting_tool) & set(existing_tool) if resulting_tool[name] != existing_tool[name]}
+    total_after = len(resulting_tool) + len(foreign)
+    lines = [
+        f"  Probes to add:     {len(added)}",
+        f"  Probes to remove:  {len(removed)}",
+        f"  Probes to update:  {len(updated)}",
+        f"  Foreign preserved: {len(foreign)}",
+        f"  Resulting total:   {total_after}",
+    ]
+    return "\n".join(lines)
+
+
+def _prompt_confirm(summary: str) -> bool:
+    """Show ``summary`` and ask the operator to confirm.
+
+    Why:
+        Isolated so tests can patch ``input`` without touching the rest
+        of the flow. Only exact ``y`` / ``yes`` (case-insensitive)
+        answers proceed; anything else aborts (FR-013 safe-default).
+
+    Args:
+        summary: Multi-line pre-PUT summary from ``_summarise``.
+
+    Returns:
+        ``True`` if the operator confirmed, ``False`` otherwise.
+    """
+    print("  Change summary:")
+    print(summary)
+    answer = input("  Proceed with PUT to org settings? [y/N]: ").strip().lower()
+    return answer in ("y", "yes")
+
+
+def _apply(
+    mist_session: Any,
+    org_id: str,
+    setting: dict[str, Any],
+    combined_probes: dict[str, dict[str, Any]],
+) -> None:
+    """PUT the updated setting block via ``updateOrgSettings``.
+
+    Why:
+        Wrapper enforces FR-014 (exactly one PUT) and FR-015 (sibling
+        preservation): we deep-copy the fetched ``setting`` block and
+        only overwrite ``synthetic_test.custom_probes``.
+
+    Args:
+        mist_session: Authenticated ``mistapi`` session.
+        org_id: Mist organisation UUID.
+        setting: The setting block previously returned by
+            ``_fetch_setting`` (used as the base for the PUT body so any
+            sibling fields under ``synthetic_test`` survive round-trip).
+        combined_probes: Union of foreign and (merged/swapped)
+            tool-authored probes.
+    """
+    body: dict[str, Any] = json.loads(json.dumps(setting)) if setting else {}
+    synthetic = body.get("synthetic_test")
+    if not isinstance(synthetic, dict):
+        synthetic = {}
+        body["synthetic_test"] = synthetic
+    synthetic["custom_probes"] = combined_probes
+    logging.debug(
+        "Calling updateOrgSettings(org_id=%s, probe_count=%d)",
+        org_id,
+        len(combined_probes),
+    )
+    response = _mist_setting.updateOrgSettings(mist_session, org_id, body)
+    status = getattr(response, "status_code", None)
+    if status is not None and (status < 200 or status >= 300):
+        logging.error("updateOrgSettings HTTP %s", status)
+        print(f"  updateOrgSettings failed with HTTP {status}")
+        return
+    print(f"  updateOrgSettings succeeded ({len(combined_probes)} probes written)")
+    for probe_name in sorted(combined_probes):
+        print(f"    - {probe_name}")
+    logging.info("Wrote %d probes via updateOrgSettings", len(combined_probes))

--- a/src/org/org_synthetic_probes_manager.py
+++ b/src/org/org_synthetic_probes_manager.py
@@ -135,6 +135,25 @@ def _load_probe_sources(data_dir: Path) -> tuple[dict[str, Any], dict[str, Any]]
     return probes, cenr
 
 
+def _validate_vlan_input(raw: str) -> tuple[bool, str, list[int]]:
+    """Parse and validate VLAN input string.
+
+    Returns:
+        (is_valid, error_message, vlan_ids). If is_valid is True, vlan_ids
+        is non-empty and deduplicated; error_message is empty.
+    """
+    if not raw.strip():
+        return False, "VLAN list cannot be empty. Please try again.", []
+    parts = [item.strip() for item in raw.split(",") if item.strip()]
+    try:
+        ids = [int(part) for part in parts]
+    except ValueError:
+        return False, "Non-integer VLAN id detected. Please try again.", []
+    if any(vid < _VLAN_MIN or vid > _VLAN_MAX for vid in ids):
+        return False, f"VLAN ids must be in [{_VLAN_MIN}, {_VLAN_MAX}]. Please try again.", []
+    return True, "", sorted(set(ids))
+
+
 def _prompt_vlan_list() -> list[int]:
     """Prompt the operator for a comma-separated VLAN id list.
 
@@ -149,23 +168,11 @@ def _prompt_vlan_list() -> list[int]:
         valid id is entered.
     """
     while True:
-        raw = input("  Enter VLAN ids (comma-separated, each in [0, 4094]): ").strip()
-        if not raw:
-            print("  VLAN list cannot be empty. Please try again.")
-            continue
-        parts = [item.strip() for item in raw.split(",") if item.strip()]
-        try:
-            ids = [int(part) for part in parts]
-        except ValueError:
-            print("  Non-integer VLAN id detected. Please try again.")
-            continue
-        if any(vid < _VLAN_MIN or vid > _VLAN_MAX for vid in ids):
-            print(f"  VLAN ids must be in [{_VLAN_MIN}, {_VLAN_MAX}]. Please try again.")
-            continue
-        if not ids:
-            print("  VLAN list cannot be empty. Please try again.")
-            continue
-        return sorted(set(ids))
+        raw = input("  Enter VLAN ids (comma-separated, each in [0, 4094]): ")
+        is_valid, error, ids = _validate_vlan_input(raw)
+        if is_valid:
+            return ids
+        print(f"  {error}")
 
 
 def _fetch_setting(mist_session: Any, org_id: str) -> dict[str, Any]:

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -364,6 +364,10 @@ class OperationRegistry:
         "190": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Adds a comment to a live support ticket"},
         "191": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Updates fields on an existing support ticket"},
         "194": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Clone Device Config to Gateway Template"},
+        "206": {
+            "category": "destructive",
+            "skip_reason": "DESTRUCTIVE: Modifies org synthetic_test.custom_probes",
+        },
         # --- ticket viewer (interactive selection) --------------------------
         "192": {"category": "interactive", "skip_reason": "View support ticket - requires interactive selection"},
     }

--- a/tests/unit/org/__init__.py
+++ b/tests/unit/org/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for src/org/* extracted org-scoped modules."""

--- a/tests/unit/org/test_org_synthetic_probes_manager.py
+++ b/tests/unit/org/test_org_synthetic_probes_manager.py
@@ -1,0 +1,380 @@
+"""Unit tests for ``src/org/org_synthetic_probes_manager.py`` (menu 206).
+
+Why:
+    The synthetic-probe manager mutates a shared org setting on every run,
+    so every acceptance scenario in ``spec.md`` gets its own pinned test.
+    Tests exercise the pure helpers directly and the public entry via
+    ``patch.object`` on the module-level ``_mist_setting`` re-export.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.org import org_synthetic_probes_manager as ospm
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def probes_source() -> dict:
+    """Return a curated probe-source dict with roles + wildcards.
+
+    Why:
+        Mirrors the shape of the real
+        ``data/zscaler_client_connector_probes.json`` so the tests exercise
+        the same code paths as production (including tunnel_zen expansion).
+
+    Returns:
+        Parsed probe-source dict fixture.
+    """
+    return {
+        "schema_version": 1,
+        "source": "fixture",
+        "wildcards": ["*.prod.zpath.net", "*.private.zscaler.com"],
+        "roles": [
+            {
+                "role": "pac",
+                "ports": [80, 443],
+                "fqdns": ["pac.zscaler.net"],
+            },
+            {
+                "role": "service_discovery",
+                "ports": [443],
+                "fqdns": ["mobile.zscaler.net", "login.zscaler.net"],
+            },
+            {
+                "role": "tunnel_zen",
+                "ports": [80, 443, 8080],
+                "fqdns_ref": "data/zscaler_cenr_hostnames.json",
+            },
+            {
+                "role": "wildcards_only",
+                "ports": [443],
+                "fqdns": ["*.zscaler.net"],  # Should be skipped.
+            },
+        ],
+    }
+
+
+@pytest.fixture()
+def cenr_source() -> dict:
+    """Return a curated CENR hostnames dict.
+
+    Why:
+        The tunnel_zen role expands via the CENR file; a small fixture keeps
+        assertions readable while still exercising both proxy+vpn arms.
+
+    Returns:
+        Parsed CENR dict fixture.
+    """
+    return {
+        "schema_version": 1,
+        "proxy_hostnames": [
+            "atl1.sme.zscaler.net",
+            "mad3.sme.zscaler.net",
+        ],
+        "vpn_hostnames": [
+            "atl1-vpn.zscaler.net",
+        ],
+    }
+
+
+@pytest.fixture()
+def data_dir(tmp_path: Path, probes_source: dict, cenr_source: dict) -> Path:
+    """Write the two curated JSON fixtures into a temp dir.
+
+    Why:
+        ``_load_probe_sources`` reads from disk; a tmp fixture lets us stress
+        both success and failure paths without polluting the real repo.
+
+    Args:
+        tmp_path: pytest-supplied temp directory.
+        probes_source: probe fixture dict.
+        cenr_source: CENR fixture dict.
+
+    Returns:
+        The temp directory path containing both files.
+    """
+    (tmp_path / ospm._PROBE_SOURCE_FILE).write_text(json.dumps(probes_source), encoding="utf-8")
+    (tmp_path / ospm._CENR_SOURCE_FILE).write_text(json.dumps(cenr_source), encoding="utf-8")
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- #
+# Story 1 — build from empty
+# --------------------------------------------------------------------------- #
+
+
+def test_build_from_empty_produces_https_prefixed_no_port_targets(probes_source: dict, cenr_source: dict) -> None:
+    """Every probe target uses https:// prefix and no port suffix.
+
+    Why:
+        FR-007 requires ``https://<fqdn>`` targets with no port number,
+        even when the source file lists ports. This is SC-001.
+    """
+    result = ospm._build_probe_set((probes_source, cenr_source), [10])
+    assert result, "Expected at least one probe"
+    for name, probe in result.items():
+        assert probe["target"].startswith("https://"), name
+        assert ":" not in probe["target"].removeprefix("https://"), name
+        assert name.startswith(ospm._TOOL_NAME_PREFIX), name
+
+
+def test_build_from_empty_skips_wildcards(probes_source: dict, cenr_source: dict) -> None:
+    """Entries starting with ``*.`` are filtered out (FR-008)."""
+    result = ospm._build_probe_set((probes_source, cenr_source), [10])
+    for probe in result.values():
+        assert "*." not in probe["target"], probe
+
+
+def test_build_from_empty_includes_tunnel_zen_cenr_hostnames(probes_source: dict, cenr_source: dict) -> None:
+    """The tunnel_zen role expands via CENR (FR-006).
+
+    Why:
+        FR-006 mandates that the tunnel_zen role pulls its FQDN list from
+        the CENR file. Both proxy and vpn hostnames must be present.
+    """
+    result = ospm._build_probe_set((probes_source, cenr_source), [10])
+    tunnel_names = {n for n in result if "tunnel_zen" in n}
+    assert any("atl1-sme" in n for n in tunnel_names)
+    assert any("mad3-sme" in n for n in tunnel_names)
+    assert any("atl1-vpn" in n for n in tunnel_names)
+
+
+def test_build_applies_defaults(probes_source: dict, cenr_source: dict) -> None:
+    """Type defaults to reachability and aggressiveness to high (FR-009)."""
+    result = ospm._build_probe_set((probes_source, cenr_source), [10])
+    for probe in result.values():
+        assert probe["type"] == "reachability"
+        assert probe["aggressiveness"] == "high"
+        assert probe["vlan_ids"] == [10]
+
+
+# --------------------------------------------------------------------------- #
+# Story 2 — merge
+# --------------------------------------------------------------------------- #
+
+
+def test_merge_dedupes_vlan_union() -> None:
+    """Merge produces sorted, deduplicated VLAN union per probe (SC-002)."""
+    existing_tool = {
+        "zcc-pac-pac-zscaler-net": {
+            "name": "zcc-pac-pac-zscaler-net",
+            "target": "https://pac.zscaler.net",
+            "vlan_ids": [10, 20],
+            "type": "reachability",
+            "aggressiveness": "high",
+        }
+    }
+    merged = ospm._merge_probes(existing_tool, {}, [20, 30])
+    assert merged["zcc-pac-pac-zscaler-net"]["vlan_ids"] == [10, 20, 30]
+
+
+def test_merge_reports_no_changes_when_subset() -> None:
+    """Merge is a no-op when new VLANs are already present on every probe.
+
+    Why:
+        Story 2 acceptance #3 says the tool should short-circuit and skip
+        the PUT when nothing would actually change.
+    """
+    existing_tool = {
+        "zcc-pac-pac-zscaler-net": {
+            "name": "zcc-pac-pac-zscaler-net",
+            "target": "https://pac.zscaler.net",
+            "vlan_ids": [10, 20, 30],
+            "type": "reachability",
+            "aggressiveness": "high",
+        }
+    }
+    merged = ospm._merge_probes(existing_tool, {}, [10, 20])
+    assert merged == existing_tool
+
+
+# --------------------------------------------------------------------------- #
+# Story 3 — swap
+# --------------------------------------------------------------------------- #
+
+
+def test_swap_preserves_foreign_probes() -> None:
+    """Foreign probes survive swap unchanged (SC-003 / FR-012)."""
+    existing = {
+        "zcc-pac-pac-zscaler-net": {"vlan_ids": [10]},
+        "custom-user-probe": {"vlan_ids": [99], "target": "https://acme.example"},
+    }
+    tool_authored, foreign = ospm._partition_tool_authored(existing)
+    assert "custom-user-probe" in foreign
+    assert "zcc-pac-pac-zscaler-net" in tool_authored
+
+
+def test_swap_replaces_vlan_ids_completely() -> None:
+    """Swap replaces existing tool-authored VLAN lists with new list.
+
+    Why:
+        Story 3 acceptance #2: swap must not preserve legacy VLAN ids on
+        tool-authored probes.
+    """
+    new_probes = {
+        "zcc-pac-pac-zscaler-net": {
+            "name": "zcc-pac-pac-zscaler-net",
+            "target": "https://pac.zscaler.net",
+            "vlan_ids": [42],
+            "type": "reachability",
+            "aggressiveness": "high",
+        }
+    }
+    result = ospm._swap_probes(new_probes)
+    assert result["zcc-pac-pac-zscaler-net"]["vlan_ids"] == [42]
+
+
+# --------------------------------------------------------------------------- #
+# Prompt validation
+# --------------------------------------------------------------------------- #
+
+
+def test_prompt_rejects_empty_vlan_list() -> None:
+    """Empty input re-prompts until a valid list is entered."""
+    with patch("builtins.input", side_effect=["", "  ", "10, 20"]):
+        assert ospm._prompt_vlan_list() == [10, 20]
+
+
+def test_prompt_rejects_out_of_range_vlan() -> None:
+    """VLAN ids outside [0, 4094] re-prompt."""
+    with patch("builtins.input", side_effect=["4095", "-1", "abc", "0, 4094"]):
+        assert ospm._prompt_vlan_list() == [0, 4094]
+
+
+def test_prompt_dedupes_and_sorts() -> None:
+    """Duplicate VLAN ids collapse and result is sorted."""
+    with patch("builtins.input", side_effect=["30, 10, 30, 20"]):
+        assert ospm._prompt_vlan_list() == [10, 20, 30]
+
+
+# --------------------------------------------------------------------------- #
+# Apply / PUT
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_preserves_synthetic_test_sibling_fields() -> None:
+    """FR-015: sibling fields under synthetic_test survive round-trip."""
+    setting = {
+        "synthetic_test": {
+            "custom_probes": {"old": {"name": "old"}},
+            "other_sibling_field": {"keep": "me"},
+        },
+        "top_level_sibling": "keep me too",
+    }
+    new_probes = {"zcc-new": {"name": "zcc-new"}}
+    session = MagicMock()
+    fake_response = MagicMock(status_code=200)
+    with patch.object(ospm._mist_setting, "updateOrgSettings", return_value=fake_response) as put_mock:
+        ospm._apply(session, "org-uuid", setting, new_probes)
+    put_mock.assert_called_once()
+    body = put_mock.call_args.args[2]
+    assert body["synthetic_test"]["custom_probes"] == new_probes
+    assert body["synthetic_test"]["other_sibling_field"] == {"keep": "me"}
+    assert body["top_level_sibling"] == "keep me too"
+
+
+def test_apply_reports_http_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """Non-2xx status codes surface via stdout for the operator."""
+    session = MagicMock()
+    fake_response = MagicMock(status_code=500)
+    with patch.object(ospm._mist_setting, "updateOrgSettings", return_value=fake_response):
+        ospm._apply(session, "org-uuid", {}, {"zcc-x": {"name": "zcc-x"}})
+    out = capsys.readouterr().out
+    assert "HTTP 500" in out
+
+
+# --------------------------------------------------------------------------- #
+# Confirmation & abort
+# --------------------------------------------------------------------------- #
+
+
+def test_confirm_no_aborts_without_put(
+    data_dir: Path,
+) -> None:
+    """When the operator answers 'n', no PUT is issued (Story 3 accept #3)."""
+    session = MagicMock()
+    get_response = MagicMock(data={"synthetic_test": {"custom_probes": {}}})
+    inputs = iter(["10", "n"])  # VLAN prompt, then confirmation.
+    with (
+        patch.object(ospm, "_DEFAULT_DATA_DIR", data_dir),
+        patch.object(ospm._mist_setting, "getOrgSettings", return_value=get_response),
+        patch.object(ospm._mist_setting, "updateOrgSettings") as put_mock,
+        patch("builtins.input", lambda _prompt: next(inputs)),
+    ):
+        ospm.manage_org_synthetic_probes(session, "org-uuid")
+    put_mock.assert_not_called()
+
+
+def test_confirm_yes_triggers_put(data_dir: Path) -> None:
+    """'y' at the confirmation prompt fires exactly one PUT."""
+    session = MagicMock()
+    get_response = MagicMock(data={"synthetic_test": {"custom_probes": {}}})
+    inputs = iter(["10", "y"])
+    put_response = MagicMock(status_code=200)
+    with (
+        patch.object(ospm, "_DEFAULT_DATA_DIR", data_dir),
+        patch.object(ospm._mist_setting, "getOrgSettings", return_value=get_response),
+        patch.object(ospm._mist_setting, "updateOrgSettings", return_value=put_response) as put_mock,
+        patch("builtins.input", lambda _prompt: next(inputs)),
+    ):
+        ospm.manage_org_synthetic_probes(session, "org-uuid")
+    put_mock.assert_called_once()
+
+
+# --------------------------------------------------------------------------- #
+# Failure paths
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_source_file_raises_with_clear_message(tmp_path: Path) -> None:
+    """Missing curated file surfaces a FileNotFoundError with the path."""
+    with pytest.raises(FileNotFoundError) as exc:
+        ospm._load_probe_sources(tmp_path)
+    assert ospm._PROBE_SOURCE_FILE in str(exc.value)
+
+
+def test_malformed_source_file_raises_value_error(tmp_path: Path) -> None:
+    """Malformed JSON in either file raises a ValueError referencing it."""
+    (tmp_path / ospm._PROBE_SOURCE_FILE).write_text("{not-json", encoding="utf-8")
+    (tmp_path / ospm._CENR_SOURCE_FILE).write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError) as exc:
+        ospm._load_probe_sources(tmp_path)
+    assert ospm._PROBE_SOURCE_FILE in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# Detection / partition helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_existing_returns_empty_when_missing() -> None:
+    """Missing synthetic_test or custom_probes returns an empty dict."""
+    assert ospm._detect_existing({}) == {}
+    assert ospm._detect_existing({"synthetic_test": None}) == {}
+    assert ospm._detect_existing({"synthetic_test": {}}) == {}
+
+
+def test_partition_splits_by_prefix() -> None:
+    """Only names starting with the zcc- prefix are tool-authored."""
+    tool, foreign = ospm._partition_tool_authored(
+        {
+            "zcc-foo": {"vlan_ids": [1]},
+            "user-bar": {"vlan_ids": [2]},
+        }
+    )
+    assert tool == {"zcc-foo": {"vlan_ids": [1]}}
+    assert foreign == {"user-bar": {"vlan_ids": [2]}}
+
+
+def test_fqdn_slug_lowercases_and_replaces_dots() -> None:
+    """Slugs are lowercased with dots replaced by hyphens."""
+    assert ospm._fqdn_slug("PAC.Zscaler.Net") == "pac-zscaler-net"


### PR DESCRIPTION
## Summary
- Adds MistHelper menu option 206: org-level Zscaler Client Connector synthetic-probe manager (`src/org/org_synthetic_probes_manager.py`)
- Builds/merges/swaps `synthetic_test.custom_probes` on the Mist org setting from curated destination catalogues (`data/zscaler_client_connector_probes.json`, `data/zscaler_cenr_hostnames.json`)
- Registers op 206 in `OperationRegistry` under category `destructive` (writes org settings via `updateOrgSettings`)
- VLAN prompt validates `[0, 4094]` non-negative integers; two-choice merge/swap prompt when existing probes are detected
- Probe targets prefixed `https://`, no port; wildcard FQDNs skipped; naming convention `zcc-<role>-<fqdn-slug>` for tool-authored-probe identification
- Preserves `synthetic_test` sibling fields (e.g. `vlans`, `wan_speedtest`) and any non-tool-authored probes during merge/swap
- `MistHelper.py --help` remains side-effect-free (guarded per issue #1641)

Closes #1650

## Test plan
- [x] `python -m pytest tests/unit/org/test_org_synthetic_probes_manager.py -q` — 20 passed
- [x] `interrogate -c pyproject.toml -v` on new module — 100% (min 90%)
- [x] `pydocstyle` (Google convention) on new module — zero violations
- [x] `ruff check .` / `black --check .` on all changed files — clean
- [x] `python MistHelper.py --help` — exit 0, no error/traceback strings
- [x] `python -m pytest tests/unit/test_operation_registry_guardrail.py` — passes with new "206" entry