### PR TITLE
feat: near-flawless column-aware ASD-STE100 dictionary extractor

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs\\1026-ste-linter"}
+{"feature_directory":"specs\\1027-ste-dict-extractor"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,10 @@ ste-linter = [
     # without it through the standard-library heuristic backend.
     # After install, download the model: python -m spacy download en_core_web_sm
     "spacy>=3.7.0,<4.0.0",
+    # pdfplumber reads the licensed ASD-STE100 PDF by word position for the
+    # dictionary extraction tool (tools/ste_linter/dictionary/extract.py). It is
+    # needed only to build the local dictionary, not to run the linter.
+    "pdfplumber>=0.11.0",
 ]
 
 [project.urls]

--- a/specs/1027-ste-dict-extractor/contracts/cli.md
+++ b/specs/1027-ste-dict-extractor/contracts/cli.md
@@ -1,0 +1,85 @@
+# CLI Contract: Dictionary Extractor and Quality Harness
+
+**Feature**: 1027-ste-dict-extractor | **Phase**: 1
+
+## Extractor command
+
+```text
+python -m tools.ste_linter.dictionary.extract PDF [--output PATH]
+```
+
+### Arguments
+
+- `PDF`: The path to the licensed ASD-STE100 PDF.
+
+### Options
+
+| Option | Default | Description |
+| - | - | - |
+| `--output` | data/ste_dictionary.json | The output JSON path (git-ignored). |
+| `--start-page` | 155 | The first page to scan for real entries. |
+
+### Exit codes
+
+- `0`: The tool wrote the dictionary.
+- `1`: The PDF is missing or unreadable, or pdfplumber is not installed.
+
+### Output
+
+A JSON object:
+
+```json
+{
+  "version": "1.0",
+  "entries": [
+    {
+      "keyword": "accuracy",
+      "part_of_speech": "n",
+      "approved": false,
+      "alternatives": ["precision"],
+      "approved_meaning": ""
+    }
+  ]
+}
+```
+
+The tool prints a one-line summary: the number of entries, the approved count, and
+the not-approved count. It reminds the operator that the file is git-ignored.
+
+## Quality harness command
+
+```text
+python -m tools.ste_linter.dictionary.quality DICTIONARY GOLDEN
+```
+
+### Harness arguments
+
+- `DICTIONARY`: The path to the extracted dictionary JSON.
+- `GOLDEN`: The path to the golden-set JSON.
+
+### Harness output
+
+A report with the per-field accuracy scores and every mismatch:
+
+```text
+Golden entries: 35
+  keyword found:      35/35
+  part of speech:     34/35
+  approved status:    35/35
+  alternatives:       33/35
+Field accuracy: 97.1%
+
+Mismatches:
+  adopt        alternatives  expected [use]  actual [operate]
+```
+
+### Harness exit codes
+
+- `0`: The field accuracy meets or beats the target.
+- `1`: The field accuracy is below the target.
+
+## Behavior contract
+
+- Neither tool raises an unhandled exception for a readable input.
+- The extractor produces the same output for the same PDF every run.
+- The harness produces the same report for the same inputs every run.

--- a/specs/1027-ste-dict-extractor/data-model.md
+++ b/specs/1027-ste-dict-extractor/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Dictionary Extractor
+
+**Feature**: 1027-ste-dict-extractor | **Phase**: 1
+
+## PositionedWord
+
+One word read from the PDF with its position. This is the input the parser works
+from.
+
+| Field | Type | Description |
+| - | - | - |
+| `text` | str | The word as printed |
+| `x0` | float | The left coordinate on the page |
+| `top` | float | The top coordinate on the page |
+| `page` | int | The 1-based page number |
+
+## RawEntry
+
+One entry as the parser builds it, before it becomes a record.
+
+| Field | Type | Description |
+| - | - | - |
+| `keyword` | str | The headword |
+| `part_of_speech` | str | The part of speech from column 1 |
+| `approved` | bool | True when the word is printed in capitals |
+| `column2_lines` | list[str] | The joined column-2 text across rows |
+| `page` | int | The page where the entry starts |
+
+## DictionaryRecord
+
+The output record. It matches the shape the loader already reads.
+
+| Field | Type | Description |
+| - | - | - |
+| `keyword` | str | The word, in lower case |
+| `part_of_speech` | str | The part of speech |
+| `approved` | bool | The approved flag |
+| `alternatives` | list[str] | The approved words to use instead, in lower case |
+| `approved_meaning` | str | The approved meaning, for an approved word |
+
+The output file is a JSON object with a `version` and an `entries` list of these
+records. This is the same shape `loader.py` reads today, so the linter needs no
+change.
+
+## GoldenEntry
+
+One hand-verified expected record used to measure accuracy.
+
+| Field | Type | Description |
+| - | - | - |
+| `keyword` | str | The word to look up in the output |
+| `part_of_speech` | str | The expected part of speech |
+| `approved` | bool | The expected approved flag |
+| `alternatives` | list[str] | The expected alternatives, in lower case |
+
+The golden set is a JSON list of these entries. It holds about 35 facts, not the
+full dictionary.
+
+## QualityReport
+
+The result of the harness.
+
+| Field | Type | Description |
+| - | - | - |
+| `total` | int | The number of golden entries checked |
+| `keyword_found` | int | How many golden keywords appear in the output |
+| `pos_correct` | int | How many parts of speech match |
+| `approved_correct` | int | How many approved flags match |
+| `alternatives_correct` | int | How many alternative lists match |
+| `field_accuracy` | float | The average correctness across the fields, 0 to 1 |
+| `mismatches` | list | Each mismatch with keyword, field, expected, actual |
+
+## Relationships
+
+- The parser reads many `PositionedWord` objects and builds `RawEntry` objects.
+- Each `RawEntry` becomes one `DictionaryRecord`.
+- The harness compares each `GoldenEntry` against the matching `DictionaryRecord`
+  and produces one `QualityReport`.

--- a/specs/1027-ste-dict-extractor/plan.md
+++ b/specs/1027-ste-dict-extractor/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Near-Flawless ASD-STE100 Dictionary Extractor
+
+**Branch**: `1027-ste-dict-extractor` | **Date**: 2026-07-27 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Rewrite `tools/ste_linter/dictionary/extract.py` to read the ASD-STE100 PDF by word
+position with pdfplumber. The tool reconstructs the two left columns of the
+four-column dictionary table: the word column and the meaning-or-alternatives
+column. It classifies approved status by letter case and extracts alternatives with
+a pattern that matches an uppercase word followed by a part of speech. A golden set
+and a quality harness measure accuracy, and the parser improves through repeated
+measurement until it meets the targets.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 or newer.
+
+**Primary Dependencies**: pdfplumber for word-position extraction. pytest for tests.
+The linter runtime does not change and keeps its zero-dependency default.
+
+**Storage**: A local JSON dictionary at `data/ste_dictionary.json`, git-ignored.
+
+**Testing**: pytest unit tests plus a golden-set quality harness.
+
+**Target Platform**: Cross-platform command-line tool.
+
+**Project Type**: Single project. The tool lives under `tools/ste_linter/dictionary`.
+
+**Performance Goals**: Extract the whole dictionary in under 60 seconds.
+
+**Constraints**: No copyrighted dictionary data in git. The tool never crashes on a
+missing or unreadable PDF.
+
+**Scale/Scope**: About 2149 entries across roughly 280 PDF pages.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Structural discipline**: The extractor splits into small helpers, each under the
+  25-line limit, grouped by stage: page filtering, row building, column split, entry
+  parsing, alternative parsing, and output.
+- **Inline comments and action logging**: Every line gets a comment. The tool logs
+  before and after each stage.
+- **Safety-first input handling**: The tool validates the PDF path and the pdfplumber
+  import, and it fails with a clear message.
+- **Quality gates**: ruff, black, mypy, radon, and pytest with coverage must pass.
+- **Writing style**: All prose follows the STE writing guide.
+- **No wrappers, class-based design**: The parser is a class with clear methods. The
+  harness is a class. No pass-through wrappers.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1027-ste-dict-extractor/
+├── plan.md              # This file
+├── research.md          # Phase 0: extraction method and column model
+├── data-model.md        # Phase 1: entry and report fields
+├── contracts/
+│   └── cli.md           # Phase 1: extractor command contract
+└── tasks.md             # Phase 2: task list
+```
+
+### Source Code (repository root)
+
+```text
+tools/ste_linter/dictionary/
+├── extract.py           # Rewritten pdfplumber column-aware extractor
+├── loader.py            # Unchanged dictionary loader
+└── __init__.py          # Unchanged package marker
+
+tests/unit/ste_linter/
+├── test_dictionary_extract.py   # New: parser unit tests
+└── test_dictionary.py           # Existing: loader tests
+
+tests/fixtures/ste_linter/
+└── dictionary_golden.json       # New: hand-verified expected entries
+
+tools/ste_linter/dictionary/quality.py   # New: golden-set quality harness
+```
+
+**Structure Decision**: The rewrite stays inside the existing dictionary
+sub-package. The harness lives next to the extractor so it can run without the full
+PDF, using a saved sample when needed.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| - | - | - |
+| A new dependency (pdfplumber) is added | The four-column table cannot be read from flattened text. Word positions are required for correct columns | The current flattened-text parser is the exact cause of the bad data this feature must fix |

--- a/specs/1027-ste-dict-extractor/research.md
+++ b/specs/1027-ste-dict-extractor/research.md
@@ -1,0 +1,109 @@
+# Research: Extraction Method and Column Model
+
+**Feature**: 1027-ste-dict-extractor | **Phase**: 0
+
+This document records the decisions for how the tool reads the dictionary and how it
+turns the page layout into correct entries. The decisions come from a probe of the
+real PDF with pdfplumber.
+
+## Decision 1: Read the PDF by word position, not flattened text
+
+**Decision**: Use pdfplumber. For each page, read the words with their left and top
+coordinates. Group words into rows by their top coordinate. Split each row into
+columns by the left coordinate.
+
+**Rationale**: The dictionary is a four-column table. pypdf flattens the columns
+into one stream, so the columns interleave and a pattern match cannot separate them.
+This is the exact cause of the current bad output. pdfplumber keeps the word
+coordinates, so the columns can be rebuilt.
+
+**Alternatives rejected**: Flattened text with a regex (the current, broken method).
+pdfplumber table detection by ruled lines (the table has no borders).
+
+## Decision 2: Read only the two left columns
+
+**Decision**: Keep only column 1 (word and part of speech) and column 2 (approved
+meaning or alternatives). Drop column 3 (STE example) and column 4 (non-STE
+example).
+
+**Rationale**: The linter needs only the keyword, the part of speech, the approved
+flag, the alternatives, and the approved meaning. The example columns are not used.
+The two left columns are the best separated, so dropping the example columns removes
+the hardest part of the layout.
+
+**Alternatives rejected**: Parse all four columns (more work, no benefit, and the
+right columns drift the most).
+
+## Decision 3: Classify approved status by letter case
+
+**Decision**: A word is approved when it is printed in capital letters. A word is not
+approved when it is printed in lower case.
+
+**Rationale**: The standard prints approved words in capitals and not-approved words
+in lower case. Case is a reliable, built-in signal that needs no extra data.
+
+**Alternatives rejected**: A word list of approved words (that is the very data the
+tool is trying to build).
+
+## Decision 4: Extract alternatives by the part-of-speech suffix
+
+**Decision**: In column 2, an alternative is an uppercase word or short phrase that
+is followed by a part of speech in parentheses, for example "PRECISION (n)" or
+"THE TWO (TN)". Extract every such match. Ignore uppercase words with no part of
+speech suffix.
+
+**Rationale**: Example words can leak into column 2 because an example sentence is in
+capitals. But an example word is never followed by a part of speech in parentheses.
+The part-of-speech suffix separates a real alternative from a leaked example word.
+This is the key rule that makes the alternatives reliable.
+
+**Alternatives rejected**: Take the first uppercase word in column 2 (the current
+method, which grabs a leaked example word or the wrong word).
+
+## Decision 5: Detect entry boundaries and continuations
+
+**Decision**: A row starts a new entry when column 1 matches a word plus a part of
+speech. A row with no column-1 header is a continuation, and its column-2 text joins
+the current entry. Record the base word once, even when the entry lists several verb
+or adjective forms.
+
+**Rationale**: Entries span several rows. The meaning and the alternatives wrap
+across lines. The header pattern marks where one entry ends and the next begins.
+
+## Decision 6: Skip the intro and help pages
+
+**Decision**: Start scanning at the page where the real alphabetical entries begin,
+near page 155. Skip earlier pages. Also skip page headers, footers, and blank pages
+by matching known header and footer text.
+
+**Rationale**: The intro and help pages hold example tables that look like real
+entries (for example the words that the guide uses to teach the rules). Those
+examples are not real dictionary entries and must not enter the output. The real
+entries run in alphabetical order from near page 155 to the end.
+
+**Alternatives rejected**: Scan every page (pulls in the intro examples and pollutes
+the output).
+
+## Decision 7: Measure quality with a golden set and a harness
+
+**Decision**: Build a small set of hand-verified entries. Write a harness that runs
+the tool, compares each golden entry against the tool output, and reports a per-field
+accuracy score plus every mismatch. Improve the parser until the score meets the
+target.
+
+**Rationale**: The user asked to iterate until near flawless. Iteration needs an
+objective score. The harness turns "near flawless" into a number the parser can be
+tuned against, and it prevents a fix for one entry from breaking another.
+
+**Alternatives rejected**: Eyeball the output (not repeatable, and it misses
+regressions).
+
+## Known issues to iterate on (from the probe)
+
+- The first prototype found 1846 entries against a target of 2149. The gap is mostly
+  approved words. Likely causes to test: some headwords sit just past the column
+  boundary, some entries split across a page break, and a long approved meaning can
+  swallow the next header. The harness will show which entries are missing.
+- The column boundary drifts between pages. A fixed boundary loses some words. Test a
+  boundary that adapts per page, or widen the word column and use the header pattern
+  to confirm the split.

--- a/specs/1027-ste-dict-extractor/spec.md
+++ b/specs/1027-ste-dict-extractor/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Near-Flawless ASD-STE100 Dictionary Extractor
+
+**Feature Branch**: `1027-ste-dict-extractor`
+
+**Created**: 2026-07-27
+
+**Status**: Draft
+
+**Input**: User request: "Improve the extractor iteratively over and over with
+SpecKit workflows until it is near flawless."
+
+## Overview
+
+The STE linter can check text against the approved ASD-STE100 vocabulary when a
+local dictionary file is present. A tool builds that file from the licensed PDF.
+The current tool uses a simple pattern match over flattened text and produces poor
+data. This feature rewrites the tool to read the PDF by word position, so it
+extracts the dictionary correctly. The tool improves through repeated measurement
+against a set of known-correct entries.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Build an accurate dictionary from the PDF (Priority: P1)
+
+An operator runs the extraction tool on a licensed ASD-STE100 PDF. The tool writes
+a dictionary file with the correct words, parts of speech, approved status, and
+approved alternatives. The linter then loads the file and checks vocabulary.
+
+**Why this priority**: This is the whole point. A correct dictionary is the value.
+Without it, the vocabulary checks are noise.
+
+**Independent Test**: Run the tool on the PDF and confirm the output holds close to
+2149 entries with a correct approved and not-approved split, and that a sample of
+known entries is correct.
+
+**Acceptance Scenarios**:
+
+1. **Given** a licensed PDF, **When** the operator runs the tool, **Then** the
+   output holds between 2106 and 2192 entries.
+2. **Given** the output file, **When** a reviewer counts the approved entries,
+   **Then** the count is near 875 and the not-approved count is near 1274.
+3. **Given** the word "accuracy", **When** the reviewer reads its record, **Then**
+   the record is not approved and names "precision" as the alternative.
+4. **Given** any record, **When** the reviewer reads its keyword, **Then** the
+   keyword is a single term of four words or fewer, never a sentence.
+
+---
+
+### User Story 2 - Measure extraction quality (Priority: P2)
+
+A developer runs a quality harness. The harness compares the tool output against a
+set of hand-verified entries and reports an accuracy score per field. The developer
+uses the score to improve the parser.
+
+**Why this priority**: The user asked to iterate until near flawless. Iteration
+needs an objective score. The harness makes "near flawless" measurable.
+
+**Independent Test**: Run the harness against the golden set and confirm it reports
+a per-field accuracy score and lists every mismatch.
+
+**Acceptance Scenarios**:
+
+1. **Given** the golden set and the tool output, **When** the harness runs,
+   **Then** it reports an accuracy score for keyword, part of speech, approved
+   status, and alternatives.
+2. **Given** a mismatch, **When** the harness runs, **Then** it names the keyword,
+   the field, the expected value, and the actual value.
+3. **Given** the final parser, **When** the harness runs, **Then** the field
+   accuracy is 95 percent or higher.
+
+---
+
+### User Story 3 - Keep the copyrighted data out of the repository (Priority: P3)
+
+The tool writes the dictionary to a path that git ignores. The repository ships the
+tool and a small golden set of facts, never the full copyrighted dictionary.
+
+**Why this priority**: The ASD-STE100 dictionary is copyrighted. The project must
+not redistribute it. This rule already governs the source PDF.
+
+**Independent Test**: Run the tool and confirm the output path is git-ignored and
+that no full dictionary data is staged for commit.
+
+**Acceptance Scenarios**:
+
+1. **Given** the tool runs, **When** it writes the output, **Then** the output path
+   is listed in the git ignore file.
+2. **Given** the golden set, **When** a reviewer counts its entries, **Then** it
+   holds about 35 facts, not the full dictionary.
+
+### Edge Cases
+
+- A page header, footer, or blank page must not become an entry.
+- The intro and help pages hold example tables that look like real entries. The
+  tool must not extract those examples.
+- A verb entry lists several forms across lines (for example give, gives, gave,
+  given). The tool records the base word once.
+- An adjective entry shows comparative and superlative forms in parentheses. The
+  tool records the base word once.
+- A not-approved word can have several alternatives. The tool records each one.
+- An example sentence in the approved-example column is in capitals. The tool must
+  not mistake an example word for an alternative.
+- A missing or unreadable PDF gives a clear error, not a stack trace.
+- The pdfplumber library is not installed. The tool prints a clear install message.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The tool MUST read the PDF by word position with pdfplumber, not by
+  flattened text.
+- **FR-002**: The tool MUST read only the word column and the meaning-or-alternatives
+  column. It MUST ignore the two example columns.
+- **FR-003**: The tool MUST classify a word as approved when the word is printed in
+  capital letters, and not approved otherwise.
+- **FR-004**: The tool MUST record the part of speech from the set: noun, verb,
+  adjective, adverb, preposition, pronoun, conjunction, article. It MUST also accept
+  the technical-noun and technical-verb markers for alternatives.
+- **FR-005**: The tool MUST extract an alternative only when an uppercase word is
+  followed by a part of speech in parentheses. It MUST NOT treat an example word as
+  an alternative.
+- **FR-006**: The tool MUST record the approved meaning text for an approved word.
+- **FR-007**: The tool MUST record several alternatives for a not-approved word when
+  the dictionary lists several.
+- **FR-008**: The tool MUST skip page headers, footers, blank pages, and the intro
+  and help pages that precede the real entries.
+- **FR-009**: The tool MUST record each keyword as a single term of four words or
+  fewer. It MUST reject a sentence-length keyword.
+- **FR-010**: The tool MUST write the output to a configurable, git-ignored path.
+- **FR-011**: The tool MUST give a clear message when the PDF is missing, unreadable,
+  or when pdfplumber is not installed.
+- **FR-012**: The project MUST provide a golden set of hand-verified entries and a
+  harness that scores the tool output against it.
+- **FR-013**: The harness MUST report a per-field accuracy score and list every
+  mismatch with the expected and actual values.
+- **FR-014**: The tool MUST produce the same output for the same PDF every time it
+  runs.
+
+### Key Entities
+
+- **Dictionary entry**: A record with the keyword, the part of speech, the approved
+  flag, the list of alternatives, and the approved meaning.
+- **Golden entry**: A hand-verified expected record used to measure accuracy.
+- **Quality report**: The per-field accuracy scores and the list of mismatches.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The output holds between 2106 and 2192 entries.
+- **SC-002**: The approved count is 875 plus or minus 40. The not-approved count is
+  1274 plus or minus 40.
+- **SC-003**: The golden-set field accuracy is 95 percent or higher.
+- **SC-004**: No keyword is longer than four words.
+- **SC-005**: Every alternative is an uppercase word with a valid part of speech.
+- **SC-006**: The same PDF gives the same output on repeated runs.
+- **SC-007**: Unit tests, ruff, black, mypy, radon, and the coverage gate pass.
+- **SC-008**: No copyrighted dictionary data is committed.
+
+## Assumptions
+
+- The licensed PDF is ASD-STE100 Issue 9. The dictionary is Part 2.
+- The real alphabetical entries start near page 155. The earlier pages hold the
+  intro, the help categories, and example tables.
+- pdfplumber gives reliable word positions for this PDF.
+- The linter needs only the keyword, part of speech, approved flag, alternatives,
+  and approved meaning. The example sentences are not needed.
+- A golden set of about 35 entries is enough to measure field accuracy. The set is
+  small facts, not the full copyrighted dictionary.
+- "Near flawless" means the accuracy targets in the success criteria, not literal
+  perfection, because the source is a scanned-style PDF with layout drift.

--- a/specs/1027-ste-dict-extractor/tasks.md
+++ b/specs/1027-ste-dict-extractor/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: Near-Flawless ASD-STE100 Dictionary Extractor
+
+**Feature**: 1027-ste-dict-extractor | **Input**: spec.md, plan.md, research.md, data-model.md, contracts/cli.md
+
+## Conventions
+
+- **[P]** marks tasks that can run in parallel because they touch different files.
+- Every source file follows the STE writing guide, the inline-comment rule, and the
+  action-logging rule.
+
+## Phase 1: Setup
+
+- [ ] T001 Add pdfplumber to the `ste-linter` optional dependency extra in
+  `pyproject.toml`. Confirm `data/ste_dictionary.json` stays git-ignored.
+- [ ] T002 [P] Create the golden set at
+  `tests/fixtures/ste_linter/dictionary_golden.json` with about 35 hand-verified
+  entries (keyword, part of speech, approved flag, alternatives).
+
+## Phase 2: Foundational
+
+- [ ] T003 Define the parser data types in `tools/ste_linter/dictionary/extract.py`:
+  `PositionedWord`, `RawEntry`, and the record builder, from data-model.md.
+- [ ] T004 Implement page filtering: skip pages before the start page, and skip
+  header, footer, and blank rows by known text.
+
+## Phase 3: User Story 1 - Build an accurate dictionary (P1)
+
+- [ ] T005 [US1] Implement row building: group words by top coordinate and split into
+  the word column and the meaning column by left coordinate.
+- [ ] T006 [US1] Implement entry detection: match a word plus a part of speech in the
+  word column to start an entry, and join continuation rows into column 2.
+- [ ] T007 [US1] Implement approved classification by letter case and part-of-speech
+  capture from the word column.
+- [ ] T008 [US1] Implement alternative extraction by the part-of-speech suffix rule
+  from research.md Decision 4. Record the approved meaning for an approved word.
+- [ ] T009 [US1] Implement keyword validation: reject a keyword longer than four
+  words. Normalize the keyword and alternatives to lower case.
+- [ ] T010 [US1] Implement the output writer and the command-line entry with the
+  `--output` and `--start-page` options. Write the git-ignored JSON.
+
+## Phase 4: User Story 2 - Measure quality (P2)
+
+- [ ] T011 [US2] Implement the quality harness in
+  `tools/ste_linter/dictionary/quality.py`: load the dictionary and the golden set,
+  compare each field, and compute the per-field accuracy.
+- [ ] T012 [US2] Add the harness command-line entry and the mismatch report from
+  contracts/cli.md. Set the exit code from the accuracy target.
+
+## Phase 5: Iterate to the target
+
+- [ ] T013 Run the extractor on the licensed PDF. Run the harness. Read the
+  mismatches and the entry count.
+- [ ] T014 Fix the parser for the biggest failure group. Re-run. Repeat until the
+  field accuracy is 95 percent or higher and the entry count is in range.
+
+## Phase 6: Tests and gates
+
+- [ ] T015 [P] Write `tests/unit/ste_linter/test_dictionary_extract.py`: unit tests
+  for row building, entry detection, approved classification, alternative extraction,
+  and keyword validation, using small synthetic word lists (no PDF needed).
+- [ ] T016 [P] Write a harness unit test: a known dictionary and golden set produce
+  the expected accuracy and mismatch list.
+- [ ] T017 Run the full gate set: ruff, black, mypy, radon, and pytest with coverage.
+  Fix every finding at the root.
+
+## Dependencies
+
+- Phase 2 blocks Phase 3.
+- The harness (Phase 4) depends on the extractor output shape.
+- Phase 5 depends on the extractor and the harness.
+- Phase 6 comes last.
+
+## Parallel example
+
+After Phase 2, these can run together because they touch different files:
+
+```text
+T002 golden set
+T015 extractor unit tests
+T016 harness unit test
+```

--- a/tests/fixtures/ste_linter/dictionary_golden.json
+++ b/tests/fixtures/ste_linter/dictionary_golden.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Hand-verified ASD-STE100 entries for the extractor quality harness. Transcribed from Issue 9 Part 2 pages 155-158 (real entries) and the intro recurring-errors list. Facts only, not the full copyrighted dictionary. Keyed on keyword + part_of_speech because some words appear with several parts of speech.",
+  "entries": [
+    { "keyword": "active", "part_of_speech": "adj", "approved": true, "alternatives": [] },
+    { "keyword": "adapt", "part_of_speech": "v", "approved": true, "alternatives": [] },
+    { "keyword": "add", "part_of_speech": "v", "approved": true, "alternatives": [] },
+    { "keyword": "adjacent", "part_of_speech": "adj", "approved": true, "alternatives": [] },
+    { "keyword": "aft", "part_of_speech": "adj", "approved": true, "alternatives": [] },
+    { "keyword": "aft", "part_of_speech": "adv", "approved": true, "alternatives": [] },
+    { "keyword": "after", "part_of_speech": "conj", "approved": true, "alternatives": [] },
+    { "keyword": "after", "part_of_speech": "prep", "approved": true, "alternatives": [] },
+    { "keyword": "activity", "part_of_speech": "n", "approved": false, "alternatives": ["task", "procedure", "work"] },
+    { "keyword": "actuate", "part_of_speech": "v", "approved": false, "alternatives": ["start", "operate", "push"] },
+    { "keyword": "actuation", "part_of_speech": "n", "approved": false, "alternatives": ["operation"] },
+    { "keyword": "additional", "part_of_speech": "adj", "approved": false, "alternatives": ["more"] },
+    { "keyword": "adequate", "part_of_speech": "adj", "approved": false, "alternatives": ["sufficient"] },
+    { "keyword": "adhere", "part_of_speech": "v", "approved": false, "alternatives": ["bond", "obey"] },
+    { "keyword": "adhesion", "part_of_speech": "n", "approved": false, "alternatives": ["bond"] },
+    { "keyword": "admit", "part_of_speech": "v", "approved": false, "alternatives": ["let"] },
+    { "keyword": "adopt", "part_of_speech": "v", "approved": false, "alternatives": ["use"] },
+    { "keyword": "advance", "part_of_speech": "n", "approved": false, "alternatives": ["forward"] },
+    { "keyword": "advance", "part_of_speech": "v", "approved": false, "alternatives": ["set", "forward"] },
+    { "keyword": "adverse", "part_of_speech": "adj", "approved": false, "alternatives": ["bad"] },
+    { "keyword": "advisable", "part_of_speech": "adj", "approved": false, "alternatives": ["recommend"] },
+    { "keyword": "advise", "part_of_speech": "v", "approved": false, "alternatives": ["tell", "recommend"] },
+    { "keyword": "affect", "part_of_speech": "v", "approved": false, "alternatives": ["effect"] },
+    { "keyword": "accuracy", "part_of_speech": "n", "approved": false, "alternatives": ["precision"] },
+    { "keyword": "acceptable", "part_of_speech": "adj", "approved": false, "alternatives": ["permitted", "satisfactory", "serviceable"] },
+    { "keyword": "alternate", "part_of_speech": "adj", "approved": false, "alternatives": ["alternative"] },
+    { "keyword": "avoid", "part_of_speech": "v", "approved": false, "alternatives": ["prevent"] },
+    { "keyword": "maintain", "part_of_speech": "v", "approved": false, "alternatives": ["keep", "hold", "maintenance"] }
+  ]
+}

--- a/tests/unit/ste_linter/test_dictionary.py
+++ b/tests/unit/ste_linter/test_dictionary.py
@@ -1,11 +1,10 @@
-"""Tests for the dictionary loader and the extractor parser."""
+"""Tests for the dictionary loader."""
 
 from __future__ import annotations  # Postponed annotations keep the type hints light.
 
 import json  # Writes a temporary dictionary file.
 import pathlib  # Builds the temporary path.
 
-from tools.ste_linter.dictionary.extract import DictionaryExtractor  # The extractor under test.
 from tools.ste_linter.dictionary.loader import Dictionary  # The loader under test.
 
 
@@ -29,12 +28,3 @@ def test_load_malformed_returns_none(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "bad.json"  # The temporary file path.
     path.write_text("{not valid json", encoding="utf-8")  # Write broken content.
     assert Dictionary.load(str(path)) is None  # The loader returns None.
-
-
-def test_extractor_parses_entries() -> None:
-    """The extractor parses approved and unapproved entries from text."""
-    text = "AID (n) accuracy (n) PRECISION (n)"  # An approved word and an unapproved word.
-    records = DictionaryExtractor()._parse(text)  # Parse the text.
-    keywords = {record["keyword"]: record for record in records}  # Map by keyword.
-    assert keywords["aid"]["approved"] is True  # The upper-case word is approved.
-    assert keywords["accuracy"]["approved"] is False  # The lower-case word is not approved.

--- a/tests/unit/ste_linter/test_dictionary_extract.py
+++ b/tests/unit/ste_linter/test_dictionary_extract.py
@@ -1,0 +1,302 @@
+"""Tests for the column-aware dictionary extractor and the quality harness."""
+
+from __future__ import annotations  # Postponed annotations keep the type hints light.
+
+import json  # Reads back written output and builds temporary files.
+import pathlib  # Builds temporary paths.
+
+import pytest  # Provides the monkeypatch and capture fixtures.
+
+from tools.ste_linter.dictionary import extract as extract_module  # The extractor module for the glue tests.
+from tools.ste_linter.dictionary import quality as quality_module  # The harness module for the glue tests.
+from tools.ste_linter.dictionary.extract import (  # The extractor parts under test.
+    DictionaryExtractor,
+    PositionedWord,
+    RawEntry,
+)
+from tools.ste_linter.dictionary.quality import QualityHarness  # The harness under test.
+
+
+def _word(text: str, x0: float, top: float) -> PositionedWord:
+    """Return a positioned word on page 149 for a test row."""
+    return PositionedWord(text=text, x0=x0, top=top, page=149)  # A single test word.
+
+
+def _row(column1: str, column2: str, top: float) -> list[PositionedWord]:
+    """Return the positioned words for one printed row.
+
+    Column 1 words start near x0 80. Column 2 words start near x0 160. An example
+    word past x0 270 is added so the tests confirm the example column is ignored.
+    """
+    words: list[PositionedWord] = []  # Holds the row words.
+    for offset, token in enumerate(column1.split()):  # Place column-1 tokens.
+        words.append(_word(token, 80 + offset * 12, top))  # A word in the word column.
+    for offset, token in enumerate(column2.split()):  # Place column-2 tokens.
+        words.append(_word(token, 160 + offset * 12, top))  # A word in the meaning column.
+    words.append(_word("EXAMPLE", 320, top))  # An example-column word that must be ignored.
+    return words  # Return the row words.
+
+
+# --- Column classification -------------------------------------------------
+
+
+def test_column_of_word_column() -> None:
+    """A small left coordinate is the word column."""
+    assert DictionaryExtractor()._column_of(80) == 0  # Column 1.
+
+
+def test_column_of_meaning_column() -> None:
+    """A middle left coordinate is the meaning column."""
+    assert DictionaryExtractor()._column_of(160) == 1  # Column 2.
+
+
+def test_column_of_example_column() -> None:
+    """A large left coordinate is an ignored example column."""
+    assert DictionaryExtractor()._column_of(320) == -1  # Ignored.
+
+
+# --- Header detection (three patterns) -------------------------------------
+
+
+def test_detect_header_pos_in_column1() -> None:
+    """A part of speech in column 1 starts an entry."""
+    result = DictionaryExtractor()._detect_header("ACTIVE (adj)", "a state of action", "")
+    assert result == ("ACTIVE", "adj", "a state of action", False)  # Pattern 1.
+
+
+def test_detect_header_pos_in_column2() -> None:
+    """A part of speech at the start of column 2 starts an entry."""
+    result = DictionaryExtractor()._detect_header("abnormality", "(n) UNUSUAL (adj)", "")
+    assert result == ("abnormality", "n", "UNUSUAL (adj)", False)  # Pattern 2.
+
+
+def test_detect_header_pos_wrapped_to_next_row() -> None:
+    """A part of speech on the next column-1 row starts an entry and consumes the row."""
+    result = DictionaryExtractor()._detect_header("according to", "REFER (v)", "(prep)")
+    assert result == ("according to", "prep", "REFER (v)", True)  # Pattern 3.
+
+
+def test_detect_header_rejects_column_title() -> None:
+    """The column title 'Word' does not start an entry."""
+    assert DictionaryExtractor()._detect_header("Word", "Approved meaning", "") is None  # Not an entry.
+
+
+def test_detect_header_rejects_long_fragment() -> None:
+    """A long bare fragment does not start an entry."""
+    assert DictionaryExtractor()._detect_header("one two three four five", "(n)", "") is None  # Too long.
+
+
+# --- Alternative extraction ------------------------------------------------
+
+
+def test_extract_alternatives_single() -> None:
+    """A single alternative is extracted from the meaning column."""
+    assert DictionaryExtractor()._extract_alternatives("PRECISION (n)") == ["precision"]  # One alternative.
+
+
+def test_extract_alternatives_multiple() -> None:
+    """Several alternatives are extracted in order."""
+    text = "TASK (n) PROCEDURE (n) WORK (n)"  # Three alternatives.
+    assert DictionaryExtractor()._extract_alternatives(text) == ["task", "procedure", "work"]  # In order.
+
+
+def test_extract_alternatives_ignores_lowercase_words() -> None:
+    """Lowercase meaning text before an alternative is not captured."""
+    text = "some lowercase meaning PERMITTED (adj)"  # Meaning text then a real alternative.
+    assert DictionaryExtractor()._extract_alternatives(text) == ["permitted"]  # Only the real one.
+
+
+# --- Record building -------------------------------------------------------
+
+
+def test_to_record_approved_keeps_meaning() -> None:
+    """An approved word keeps its meaning and has no alternatives."""
+    entry = RawEntry(keyword="ACTIVE", part_of_speech="adj", approved=True, page=0, column2_lines=["a state of action"])
+    record = DictionaryExtractor()._to_record(entry)  # Build the record.
+    assert record is not None  # The record was built.
+    assert record["approved"] is True  # The word is approved.
+    assert record["alternatives"] == []  # An approved word has no alternatives.
+    assert record["approved_meaning"] == "a state of action"  # The meaning is kept.
+
+
+def test_to_record_not_approved_keeps_alternatives() -> None:
+    """A not-approved word keeps its alternatives and no meaning."""
+    entry = RawEntry(keyword="accuracy", part_of_speech="n", approved=False, page=0, column2_lines=["PRECISION (n)"])
+    record = DictionaryExtractor()._to_record(entry)  # Build the record.
+    assert record is not None  # The record was built.
+    assert record["approved"] is False  # The word is not approved.
+    assert record["alternatives"] == ["precision"]  # The alternative is kept.
+    assert record["approved_meaning"] == ""  # A not-approved word has no meaning.
+
+
+def test_to_record_rejects_long_keyword() -> None:
+    """A keyword longer than four words is rejected."""
+    entry = RawEntry(keyword="one two three four five", part_of_speech="n", approved=False, page=0)
+    assert DictionaryExtractor()._to_record(entry) is None  # The keyword is a fragment.
+
+
+def test_to_record_lowercases_keyword() -> None:
+    """The record keyword is lower case."""
+    entry = RawEntry(keyword="ACTIVE", part_of_speech="adj", approved=True, page=0, column2_lines=[])
+    record = DictionaryExtractor()._to_record(entry)  # Build the record.
+    assert record is not None and record["keyword"] == "active"  # The keyword is lower case.
+
+
+# --- Deduplication ---------------------------------------------------------
+
+
+def test_deduplicate_keeps_distinct_parts_of_speech() -> None:
+    """The same word with different parts of speech is kept twice."""
+    records = [
+        {"keyword": "advance", "part_of_speech": "n", "approved": False, "alternatives": [], "approved_meaning": ""},
+        {"keyword": "advance", "part_of_speech": "v", "approved": False, "alternatives": [], "approved_meaning": ""},
+    ]  # Two records for one word.
+    assert len(DictionaryExtractor()._deduplicate(records)) == 2  # Both kept.
+
+
+def test_deduplicate_drops_repeat_pairs() -> None:
+    """A repeated keyword and part-of-speech pair is dropped."""
+    records = [
+        {"keyword": "aid", "part_of_speech": "n", "approved": True, "alternatives": [], "approved_meaning": ""},
+        {"keyword": "aid", "part_of_speech": "n", "approved": True, "alternatives": [], "approved_meaning": ""},
+    ]  # A duplicate pair.
+    assert len(DictionaryExtractor()._deduplicate(records)) == 1  # Only one kept.
+
+
+# --- Full parse over synthetic rows ----------------------------------------
+
+
+def test_parse_entries_over_synthetic_rows() -> None:
+    """The parser builds records from a small synthetic page."""
+    words: list[PositionedWord] = []  # Holds every synthetic word.
+    words += _row("ACTIVE (adj)", "a state of action", 100)  # An approved entry.
+    words += _row("accuracy (n)", "PRECISION (n)", 130)  # A not-approved entry.
+    words += _row("abnormality", "(n) UNUSUAL (adj)", 160)  # Part of speech in column 2.
+    records = DictionaryExtractor()._parse_entries(words)  # Parse the rows into raw entries.
+    keywords = {entry.keyword for entry in records}  # The keywords found.
+    assert keywords == {"ACTIVE", "accuracy", "abnormality"}  # All three entries were found.
+
+
+def test_extract_alternatives_rejects_bleed_by_column() -> None:
+    """An example word past the column boundary does not become an alternative."""
+    words = _row("acceptable", "(adj) PERMITTED (adj)", 100)  # A real entry with one alternative.
+    words.append(_word("REPLACE", 288, 112))  # An example word just past the boundary, next row.
+    records = DictionaryExtractor()._parse_entries(words)  # Parse the rows.
+    built = DictionaryExtractor()._to_record(records[0])  # Build the first record.
+    assert built is not None and built["alternatives"] == ["permitted"]  # The bleed word is excluded.
+
+
+# --- Quality harness -------------------------------------------------------
+
+
+def _dictionary() -> list[dict]:
+    """Return a small extracted dictionary for the harness tests."""
+    return [
+        {"keyword": "accuracy", "part_of_speech": "n", "approved": False, "alternatives": ["precision"]},
+        {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": []},
+    ]  # Two records.
+
+
+def test_harness_perfect_match() -> None:
+    """A dictionary that matches the golden set scores one."""
+    golden = _dictionary()  # The golden set equals the dictionary.
+    report = QualityHarness().evaluate(_dictionary(), golden)  # Score the dictionary.
+    assert report.field_accuracy == 1.0  # A perfect match.
+    assert report.mismatches == []  # No mismatches.
+
+
+def test_harness_reports_alternative_mismatch() -> None:
+    """A wrong alternatives list is reported as a mismatch."""
+    dictionary = [
+        {"keyword": "accuracy", "part_of_speech": "n", "approved": False, "alternatives": ["wrong"]},
+    ]  # A wrong alternative.
+    golden = [
+        {"keyword": "accuracy", "part_of_speech": "n", "approved": False, "alternatives": ["precision"]},
+    ]  # The correct alternative.
+    report = QualityHarness().evaluate(dictionary, golden)  # Score the dictionary.
+    assert report.alternatives_correct == 0  # The alternatives do not match.
+    assert any("alternatives" in line for line in report.mismatches)  # The mismatch is reported.
+
+
+def test_harness_reports_missing_keyword() -> None:
+    """A golden keyword missing from the dictionary is reported."""
+    golden = [
+        {"keyword": "missing", "part_of_speech": "n", "approved": False, "alternatives": []},
+    ]  # A word not in the dictionary.
+    report = QualityHarness().evaluate(_dictionary(), golden)  # Score the dictionary.
+    assert report.keyword_found == 0  # The keyword was not found.
+    assert any("missing" in line for line in report.mismatches)  # The miss is reported.
+
+
+# --- Glue: output, import, and command-line entries ------------------------
+
+
+def test_summarize_counts() -> None:
+    """The summary reports the approved and not-approved counts."""
+    records = [
+        {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": [], "approved_meaning": ""},
+        {"keyword": "accuracy", "part_of_speech": "n", "approved": False, "alternatives": ["precision"],
+         "approved_meaning": ""},
+    ]  # One approved and one not-approved record.
+    summary = extract_module._summarize(records)  # Build the summary line.
+    assert "2 entries" in summary and "1 approved" in summary  # The counts are shown.
+
+
+def test_write_output_round_trip(tmp_path: pathlib.Path) -> None:
+    """The written output reads back as the same records."""
+    records = [
+        {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": [], "approved_meaning": ""},
+    ]  # One record to write.
+    output = tmp_path / "sub" / "dict.json"  # A path with a missing parent folder.
+    extract_module._write_output(records, str(output))  # Write the dictionary.
+    data = json.loads(output.read_text(encoding="utf-8"))  # Read the file back.
+    assert data["version"] == "1.0" and data["entries"] == records  # The content matches.
+
+
+def test_import_pdfplumber_returns_module() -> None:
+    """The pdfplumber import returns a module when it is installed."""
+    module = DictionaryExtractor()._import_pdfplumber()  # Import pdfplumber.
+    assert hasattr(module, "open")  # The module exposes the open function.
+
+
+def test_extract_main_writes_output(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The extractor command writes the output without reading a real PDF."""
+    records = [
+        {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": [], "approved_meaning": ""},
+    ]  # The records the fake extractor returns.
+    monkeypatch.setattr(DictionaryExtractor, "extract", lambda self, pdf, start_page=149: records)  # Skip the PDF.
+    output = tmp_path / "dict.json"  # The output path.
+    code = extract_module.main(["fake.pdf", "--output", str(output)])  # Run the command.
+    assert code == 0 and output.exists()  # The command wrote the file.
+
+
+def test_quality_load_entries_both_shapes(tmp_path: pathlib.Path) -> None:
+    """The harness loader reads a wrapped object and a bare list."""
+    wrapped = tmp_path / "wrapped.json"  # A file with an entries object.
+    wrapped.write_text(json.dumps({"entries": [{"keyword": "a"}]}), encoding="utf-8")  # Wrapped shape.
+    bare = tmp_path / "bare.json"  # A file with a bare list.
+    bare.write_text(json.dumps([{"keyword": "b"}]), encoding="utf-8")  # Bare shape.
+    assert quality_module._load_entries(str(wrapped)) == [{"keyword": "a"}]  # Wrapped read.
+    assert quality_module._load_entries(str(bare)) == [{"keyword": "b"}]  # Bare read.
+
+
+def test_quality_main_pass_and_fail(tmp_path: pathlib.Path) -> None:
+    """The harness command returns zero on a match and one on a mismatch."""
+    golden = tmp_path / "golden.json"  # The golden file.
+    golden.write_text(
+        json.dumps({"entries": [
+            {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": []}
+        ]}),
+        encoding="utf-8",
+    )  # One golden entry.
+    good = tmp_path / "good.json"  # A matching dictionary.
+    good.write_text(
+        json.dumps({"entries": [
+            {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": []}
+        ]}),
+        encoding="utf-8",
+    )  # The dictionary matches the golden entry.
+    bad = tmp_path / "bad.json"  # A non-matching dictionary.
+    bad.write_text(json.dumps({"entries": []}), encoding="utf-8")  # An empty dictionary.
+    assert quality_module.main([str(good), str(golden)]) == 0  # A full match passes.
+    assert quality_module.main([str(bad), str(golden)]) == 1  # A miss fails.

--- a/tests/unit/ste_linter/test_dictionary_extract.py
+++ b/tests/unit/ste_linter/test_dictionary_extract.py
@@ -235,8 +235,13 @@ def test_summarize_counts() -> None:
     """The summary reports the approved and not-approved counts."""
     records = [
         {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": [], "approved_meaning": ""},
-        {"keyword": "accuracy", "part_of_speech": "n", "approved": False, "alternatives": ["precision"],
-         "approved_meaning": ""},
+        {
+            "keyword": "accuracy",
+            "part_of_speech": "n",
+            "approved": False,
+            "alternatives": ["precision"],
+            "approved_meaning": "",
+        },
     ]  # One approved and one not-approved record.
     summary = extract_module._summarize(records)  # Build the summary line.
     assert "2 entries" in summary and "1 approved" in summary  # The counts are shown.
@@ -255,6 +260,7 @@ def test_write_output_round_trip(tmp_path: pathlib.Path) -> None:
 
 def test_import_pdfplumber_returns_module() -> None:
     """The pdfplumber import returns a module when it is installed."""
+    pytest.importorskip("pdfplumber")  # Skip when the optional extraction library is absent.
     module = DictionaryExtractor()._import_pdfplumber()  # Import pdfplumber.
     assert hasattr(module, "open")  # The module exposes the open function.
 
@@ -284,16 +290,12 @@ def test_quality_main_pass_and_fail(tmp_path: pathlib.Path) -> None:
     """The harness command returns zero on a match and one on a mismatch."""
     golden = tmp_path / "golden.json"  # The golden file.
     golden.write_text(
-        json.dumps({"entries": [
-            {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": []}
-        ]}),
+        json.dumps({"entries": [{"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": []}]}),
         encoding="utf-8",
     )  # One golden entry.
     good = tmp_path / "good.json"  # A matching dictionary.
     good.write_text(
-        json.dumps({"entries": [
-            {"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": []}
-        ]}),
+        json.dumps({"entries": [{"keyword": "active", "part_of_speech": "adj", "approved": True, "alternatives": []}]}),
         encoding="utf-8",
     )  # The dictionary matches the golden entry.
     bad = tmp_path / "bad.json"  # A non-matching dictionary.

--- a/tools/ste_linter/dictionary/extract.py
+++ b/tools/ste_linter/dictionary/extract.py
@@ -1,100 +1,308 @@
 """Dictionary extraction from the licensed PDF.
 
-Reads a licensed ASD-STE100 PDF and writes a JSON dictionary that the linter
-loads. The parser is a best effort. It finds "word (part of speech)" entries and
-marks a word as approved when the word is in upper case, which is the convention
-in the standard. The output goes to a git-ignored path and is never committed.
+Reads a licensed ASD-STE100 PDF by word position and writes a JSON dictionary that
+the linter loads. The dictionary is a four-column table. This tool reads the two
+left columns: the word column and the meaning-or-alternatives column. It classifies
+a word as approved when the word is printed in capital letters, and it extracts
+alternatives that are printed as an uppercase word with a part of speech. The output
+goes to a git-ignored path and is never committed.
 
 Run it with:
 
     python -m tools.ste_linter.dictionary.extract path/to/ASD-STE100.pdf
+
+See ``specs/1027-ste-dict-extractor/`` for the design.
 """
 
 from __future__ import annotations  # Postponed annotations keep the type hints light.
 
 import argparse  # Parses the command-line arguments.
+import importlib  # Loads pdfplumber by name so the import stays optional.
 import json  # Writes the dictionary file.
 import logging  # Records the extraction stages.
 import os  # Builds the output path and folders.
-import re  # Drives the entry search.
+import re  # Drives the header and alternative patterns.
+from dataclasses import dataclass, field  # Declares the small parser value types.
+from typing import Any  # Types the pdfplumber page objects, which have no stubs.
 
 # The logger for the extraction tool. The main function configures the handler.
 _LOG = logging.getLogger("ste_linter.dictionary.extract")
 
-# Matches a dictionary entry header: a word and its part of speech in parentheses.
-_ENTRY = re.compile(r"([A-Za-z][A-Za-z '\-]*?)\s*\((n|v|adj|adv|prep|pro|conj|art|det|aux|TN|TV)\)")
-
-# The default output path. The path is ignored by git so no copyrighted data is
-# committed.
+# The default output path. Git ignores this path so no copyrighted data is committed.
 _DEFAULT_OUTPUT = os.path.join("data", "ste_dictionary.json")
+
+# The first page that holds real alphabetical entries. In ASD-STE100 Issue 9 the
+# dictionary body is section 2-1, and its first page (footer "Page 2-1-A1") is PDF
+# page 149. Earlier pages hold the intro and example tables (section 2-0), which
+# must not become entries.
+_DEFAULT_START_PAGE = 149
+
+# The left boundary of the word column. A word with a smaller left coordinate is in
+# the word column. A word between this and the meaning boundary is in column 2.
+_COLUMN1_MAX_X = 130.0
+
+# The right boundary of the meaning column. Words past this are the STE example
+# column and must not enter the meaning text. The real alternatives sit near the
+# left of the meaning column (about x0 158) and their part-of-speech markers end by
+# about x0 246. The example column starts near x0 288. A boundary of 270 keeps the
+# alternatives and rejects the example words that would otherwise bleed in.
+_COLUMN2_MAX_X = 270.0
+
+# The vertical bucket size that merges words on the same printed line into one row.
+_ROW_BUCKET = 3.0
+
+# The parts of speech that a real headword uses in column 1.
+_HEADWORD_POS = "n|v|adj|adv|prep|pron|conj|art"
+
+# The parts of speech that an alternative uses in column 2. The technical-noun and
+# technical-verb markers appear only as alternatives.
+_ALTERNATIVE_POS = "n|v|adj|adv|prep|pron|conj|art|TN|TV"
+
+# Matches a headword and its part of speech at the start of the word column, for
+# example "ACTIVE (adj)" or "activity (n)" or "AFT OF (prep)".
+_HEADWORD = re.compile(rf"^([A-Za-z][A-Za-z '\-]{{0,40}}?)\s*\(({_HEADWORD_POS})\)")
+
+# Matches an alternative in column 2: an uppercase word, or a short uppercase phrase
+# of up to three words, that is followed by a part of speech in parentheses. The
+# part-of-speech suffix separates a real alternative from an example word that leaked
+# in from the example column. The three-word cap bounds any leaked run while it still
+# allows a real technical-noun phrase such as "THE TWO".
+_ALTERNATIVE = re.compile(rf"\b([A-Z][A-Z\-]*(?:\s[A-Z][A-Z\-]*){{0,2}})\s*\(({_ALTERNATIVE_POS})\)")
+
+# Matches a bare headword in column 1 when the part of speech is not on the same row.
+# The part of speech may sit at the start of column 2, or wrap to the next row.
+_BARE_WORD = re.compile(r"^([A-Za-z][A-Za-z '\-]{0,40}?),?$")
+
+# Matches a part of speech at the very start of column 2, for example "(n)".
+_POS_PREFIX = re.compile(rf"^\(({_HEADWORD_POS})\)")
+
+# Matches a whole column-1 cell that is only a wrapped part of speech, for example
+# "(adj)" on the line below a headword.
+_BARE_POS = re.compile(rf"^\(({_HEADWORD_POS})\),?$")
+
+# Text fragments that mark a page header, a footer, or a column title. A row that
+# holds one of these is not a dictionary entry.
+_NOISE_MARKERS = (
+    "ASD-STE100",
+    "Simplified Technical",
+    "Issue 9",
+    "Part 2",
+    "Dictionary",
+    "Page 2-",
+    "2025-01-15",
+    "Blank Page",
+    "part of speech",
+    "Approved meaning",
+    "ALTERNATIVES",
+    "STE EXAMPLE",
+    "Non-STE",
+)
+
+# The largest number of words a real keyword can hold. A longer value is a parse
+# error, for example a captured sentence.
+_MAX_KEYWORD_WORDS = 4
+
+
+@dataclass(frozen=True)
+class PositionedWord:
+    """One word read from the PDF with its position."""
+
+    text: str  # The word as printed.
+    x0: float  # The left coordinate on the page.
+    top: float  # The top coordinate on the page.
+    page: int  # The 1-based page number.
+
+
+@dataclass
+class RawEntry:
+    """One entry as the parser builds it, before it becomes a record."""
+
+    keyword: str  # The headword as printed.
+    part_of_speech: str  # The part of speech from the word column.
+    approved: bool  # True when the headword is printed in capitals.
+    page: int  # The page where the entry starts.
+    column2_lines: list[str] = field(default_factory=list)  # The joined column-2 text.
 
 
 class DictionaryExtractor:
-    """Extracts a best-effort STE dictionary from a licensed PDF."""
+    """Extracts the STE dictionary from a licensed PDF by word position."""
 
-    def extract(self, pdf_path: str) -> list[dict[str, object]]:
+    def extract(self, pdf_path: str, start_page: int = _DEFAULT_START_PAGE) -> list[dict[str, Any]]:
         """Return the dictionary records found in the PDF at ``pdf_path``."""
-        _LOG.info("Reading PDF %s", pdf_path)  # Log before the read.
-        text = self._read_pdf(pdf_path)  # Read all page text from the PDF.
-        records = self._parse(text)  # Parse the text into records.
-        _LOG.debug("Extracted %d dictionary records", len(records))  # Log the result.
-        return records  # Return the records.
+        _LOG.info("Reading PDF %s from page %d", pdf_path, start_page)  # Log before the read.
+        words = self._read_words(pdf_path, start_page)  # Read positioned words from the entry pages.
+        _LOG.debug("Read %d positioned words", len(words))  # Log the word count after the read.
+        raw_entries = self._parse_entries(words)  # Build raw entries from the words.
+        _LOG.debug("Parsed %d raw entries", len(raw_entries))  # Log the raw entry count.
+        built = [self._to_record(entry) for entry in raw_entries]  # Turn raw entries into records.
+        records = [record for record in built if record is not None]  # Drop rejected records.
+        deduped = self._deduplicate(records)  # Remove duplicate keyword and part-of-speech pairs.
+        _LOG.debug("Produced %d dictionary records", len(deduped))  # Log the final record count.
+        return deduped  # Return the records.
 
-    def _read_pdf(self, pdf_path: str) -> str:
-        """Return the joined text of every page in the PDF."""
-        try:  # pypdf is needed only for extraction, so import it here.
-            import importlib  # Loads pypdf by name.
+    def _read_words(self, pdf_path: str, start_page: int) -> list[PositionedWord]:
+        """Return the positioned words from the entry pages of the PDF."""
+        pdfplumber = self._import_pdfplumber()  # Import the optional PDF library.
+        words: list[PositionedWord] = []  # Holds every positioned word.
+        with pdfplumber.open(pdf_path) as pdf:  # Open the licensed PDF.
+            for page_index in range(start_page - 1, len(pdf.pages)):  # Scan from the start page.
+                page_number = page_index + 1  # The 1-based page number.
+                for word in pdf.pages[page_index].extract_words():  # Each word with its position.
+                    words.append(
+                        PositionedWord(
+                            text=word["text"],  # The word text.
+                            x0=float(word["x0"]),  # The left coordinate.
+                            top=float(word["top"]),  # The top coordinate.
+                            page=page_number,  # The page number.
+                        )
+                    )  # Record the positioned word.
+        return words  # Return every positioned word.
 
-            pypdf = importlib.import_module("pypdf")  # The PDF reader library.
-        except ImportError as error:  # pypdf is not installed.
-            raise SystemExit("The 'pypdf' package is needed. Install it first.") from error  # Stop clearly.
-        reader = pypdf.PdfReader(pdf_path)  # Open the PDF.
-        parts = [page.extract_text() or "" for page in reader.pages]  # Read every page.
-        return "\n".join(parts)  # Join the pages into one text.
+    def _import_pdfplumber(self) -> Any:
+        """Return the pdfplumber module, or stop with a clear message."""
+        try:  # pdfplumber is needed only for extraction, so import it here.
+            return importlib.import_module("pdfplumber")  # Load the PDF library by name.
+        except ImportError as error:  # pdfplumber is not installed.
+            raise SystemExit(
+                "The 'pdfplumber' package is needed. Install it with: uv pip install \".[ste-linter]\""
+            ) from error  # Stop with install guidance.
 
-    def _parse(self, text: str) -> list[dict[str, object]]:
-        """Return dictionary records parsed from the PDF text."""
-        matches = list(_ENTRY.finditer(text))  # Find every entry header.
-        records: list[dict[str, object]] = []  # Holds the finished records.
-        for index, match in enumerate(matches):  # Walk each entry header.
-            keyword = match.group(1).strip()  # The word as written.
-            pos = match.group(2)  # The part of speech.
-            approved = keyword.isupper()  # The standard shows approved words in upper case.
-            alternatives = self._alternatives(matches, index, approved)  # Find any alternatives.
-            records.append(
-                {
-                    "keyword": keyword.lower(),  # The word in lower case.
-                    "part_of_speech": self._normalize_pos(pos),  # The normalized part of speech.
-                    "approved": approved,  # The approved flag.
-                    "alternatives": alternatives,  # The approved alternatives.
-                    "approved_meaning": "",  # The meaning is left empty in this best-effort parse.
-                }
-            )  # Add the record.
-        return self._deduplicate(records)  # Remove duplicate words and return.
+    def _parse_entries(self, words: list[PositionedWord]) -> list[RawEntry]:
+        """Return the raw entries built from the positioned words."""
+        rows = self._rows(words)  # Build the (column1, column2) rows in reading order.
+        entries: list[RawEntry] = []  # Holds the finished raw entries.
+        skip_next = False  # True when the previous row consumed a wrapped part-of-speech row.
+        for index, (column1, column2) in enumerate(rows):  # Walk each row with its index.
+            if skip_next:  # The previous entry already used this wrapped part-of-speech row.
+                skip_next = False  # Reset the flag for the next row.
+                continue  # Do not process the consumed row again.
+            if self._is_noise(column1) or self._is_noise(column2):  # Skip a header or footer row.
+                continue  # Move to the next row.
+            next_column1 = rows[index + 1][0] if index + 1 < len(rows) else ""  # Peek at the next row.
+            header = self._detect_header(column1, column2, next_column1)  # Try to start an entry.
+            if header is not None:  # A new headword starts an entry.
+                keyword, part_of_speech, remaining, consumed = header  # Unpack the detection result.
+                entries.append(self._start_entry(keyword, part_of_speech, remaining))  # Begin the entry.
+                skip_next = consumed  # Skip the next row when the part of speech came from it.
+            elif entries and column2:  # A continuation row extends the current entry.
+                entries[-1].column2_lines.append(column2)  # Add the column-2 text.
+        return entries  # Return every raw entry.
 
-    def _alternatives(self, matches: list[re.Match[str]], index: int, approved: bool) -> list[str]:
-        """Return the alternative word for an unapproved entry, when one is near."""
-        if approved:  # An approved word has no alternatives.
-            return []  # Return an empty list.
-        following = matches[index + 1] if index + 1 < len(matches) else None  # The next entry header.
-        if following and following.group(1).strip().isupper():  # The next word is an approved word.
-            return [following.group(1).strip().lower()]  # Use it as the alternative.
-        return []  # No alternative was found nearby.
+    def _detect_header(self, column1: str, column2: str, next_column1: str) -> tuple[str, str, str, bool] | None:
+        """Return (keyword, part of speech, remaining column 2, consumed next row) or None.
 
-    def _normalize_pos(self, pos: str) -> str:
-        """Return a short, lower-case part-of-speech label."""
-        return pos.lower()  # The labels are already short, so lower case is enough.
+        The dictionary prints a headword in three ways: the part of speech on the same
+        row, at the start of the meaning column, or wrapped to the next row.
+        """
+        same_row = _HEADWORD.match(column1)  # Pattern 1: the part of speech is in column 1.
+        if same_row:  # The headword and part of speech share the row.
+            return same_row.group(1).strip(), same_row.group(2), column2, False  # Column 2 is the meaning.
+        bare = _BARE_WORD.match(column1)  # The headword may stand alone with no part of speech.
+        if not bare or column1 == "Word":  # Not a bare headword, or the column title.
+            return None  # This row does not start an entry.
+        keyword = bare.group(1).strip()  # The bare headword.
+        if len(keyword.split()) > _MAX_KEYWORD_WORDS:  # Reject a long fragment, not a real headword.
+            return None  # This row does not start an entry.
+        prefix = _POS_PREFIX.match(column2)  # Pattern 2: the part of speech starts column 2.
+        if prefix:  # The part of speech leads the meaning column.
+            return keyword, prefix.group(1), column2[prefix.end() :].strip(), False  # Strip the prefix.
+        wrapped = _BARE_POS.match(next_column1)  # Pattern 3: the part of speech wrapped to the next row.
+        if wrapped:  # The next column-1 cell holds only the part of speech.
+            return keyword, wrapped.group(1), column2, True  # Consume the next row.
+        return None  # No headword pattern matched.
 
-    def _deduplicate(self, records: list[dict[str, object]]) -> list[dict[str, object]]:
-        """Return the records with duplicate words removed, keeping the first."""
-        seen: set[str] = set()  # Tracks the words already kept.
-        unique: list[dict[str, object]] = []  # Holds the kept records.
+    def _start_entry(self, keyword: str, part_of_speech: str, column2: str) -> RawEntry:
+        """Return a new raw entry from a headword, its part of speech, and its column-2 text."""
+        return RawEntry(
+            keyword=keyword,  # The headword.
+            part_of_speech=part_of_speech,  # The part of speech.
+            approved=keyword.isupper(),  # Approved words are printed in capitals.
+            page=0,  # The page is not needed once the entry is built.
+            column2_lines=[column2] if column2 else [],  # The first column-2 line, when present.
+        )  # Return the started entry.
+
+    def _rows(self, words: list[PositionedWord]) -> list[tuple[str, str]]:
+        """Return each printed row as a (column1 text, column2 text) pair."""
+        buckets: dict[tuple[int, int], dict[int, list[PositionedWord]]] = {}  # (page, top) -> col -> words
+        for word in words:  # Assign each word to a row bucket and a column.
+            column = self._column_of(word.x0)  # The column index, or -1 for example columns.
+            if column < 0:  # The word is in an example column.
+                continue  # Ignore example columns.
+            top_key = int(word.top / _ROW_BUCKET)  # Bucket the vertical position into a row.
+            row_key = (word.page, top_key)  # The row identity across the page.
+            buckets.setdefault(row_key, {}).setdefault(column, []).append(word)  # Group the word.
+        return [self._row_text(buckets[key]) for key in sorted(buckets)]  # Order rows top to bottom.
+
+    def _row_text(self, columns: dict[int, list[PositionedWord]]) -> tuple[str, str]:
+        """Return the joined column-1 and column-2 text for one row."""
+        column1 = " ".join(word.text for word in columns.get(0, []))  # Column 1 text.
+        column2 = " ".join(word.text for word in columns.get(1, []))  # Column 2 text.
+        return column1.strip(), column2.strip()  # Return the trimmed column strings.
+
+    def _column_of(self, x0: float) -> int:
+        """Return 0 for the word column, 1 for the meaning column, or -1 for examples."""
+        if x0 < _COLUMN1_MAX_X:  # The word sits in the word column.
+            return 0  # Column 1.
+        if x0 < _COLUMN2_MAX_X:  # The word sits in the meaning or alternatives column.
+            return 1  # Column 2.
+        return -1  # An example column the tool ignores.
+
+    def _is_noise(self, text: str) -> bool:
+        """Return True when a row is a page header, footer, or column title."""
+        return any(marker in text for marker in _NOISE_MARKERS)  # Match a known noise fragment.
+
+    def _to_record(self, entry: RawEntry) -> dict[str, Any] | None:
+        """Return a dictionary record for a raw entry, or None when the keyword is bad."""
+        keyword = entry.keyword.lower()  # The keyword in lower case.
+        if not keyword or len(keyword.split()) > _MAX_KEYWORD_WORDS:  # Reject a sentence-length keyword.
+            return None  # Drop the bad entry.
+        column2 = " ".join(entry.column2_lines).strip()  # The joined column-2 text.
+        alternatives = self._extract_alternatives(column2)  # The approved alternatives.
+        meaning = ""  # The approved meaning, filled only for an approved word.
+        if entry.approved:  # An approved word carries a meaning, not alternatives.
+            meaning = column2 if not alternatives else ""  # Keep the meaning text when there is no alternative.
+            alternatives = []  # An approved word has no alternatives.
+        return {
+            "keyword": keyword,  # The word in lower case.
+            "part_of_speech": entry.part_of_speech.lower(),  # The normalized part of speech.
+            "approved": entry.approved,  # The approved flag.
+            "alternatives": alternatives,  # The approved alternatives.
+            "approved_meaning": meaning,  # The approved meaning, or empty.
+        }  # Return the record.
+
+    def _extract_alternatives(self, column2: str) -> list[str]:
+        """Return the approved alternatives found in the column-2 text."""
+        found: list[str] = []  # Holds the alternatives in order.
+        for match in _ALTERNATIVE.finditer(column2):  # Each uppercase word with a part of speech.
+            alternative = match.group(1).strip().lower()  # The alternative in lower case.
+            if alternative and alternative not in found:  # Keep each alternative once.
+                found.append(alternative)  # Record the alternative.
+        return found  # Return the alternatives.
+
+    def _deduplicate(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Return the records with duplicate keyword and part-of-speech pairs removed."""
+        seen: set[tuple[str, str]] = set()  # Tracks the pairs already kept.
+        unique: list[dict[str, Any]] = []  # Holds the kept records.
         for record in records:  # Walk each record.
-            keyword = str(record["keyword"])  # The word key.
-            if keyword not in seen:  # The word was not kept yet.
-                seen.add(keyword)  # Mark the word as kept.
+            key = (str(record["keyword"]), str(record["part_of_speech"]))  # The keyword and part of speech.
+            if key not in seen:  # The pair was not kept yet.
+                seen.add(key)  # Mark the pair as kept.
                 unique.append(record)  # Keep the record.
         return unique  # Return the unique records.
+
+
+def _write_output(records: list[dict[str, Any]], output_path: str) -> None:
+    """Write the records to the output path as a JSON dictionary."""
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)  # Make the output folder.
+    _LOG.info("Writing %d words to %s", len(records), output_path)  # Log before the write.
+    with open(output_path, "w", encoding="utf-8") as handle:  # Open the output file.
+        json.dump({"version": "1.0", "entries": records}, handle, indent=2)  # Write the dictionary.
+
+
+def _summarize(records: list[dict[str, Any]]) -> str:
+    """Return a one-line summary of the record counts."""
+    approved = sum(1 for record in records if record["approved"])  # Count approved records.
+    return f"{len(records)} entries ({approved} approved, {len(records) - approved} not approved)"  # Summary.
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -103,13 +311,14 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build the STE dictionary from a licensed PDF.")  # The parser.
     parser.add_argument("pdf", help="Path to the licensed ASD-STE100 PDF.")  # The input PDF.
     parser.add_argument("--output", default=_DEFAULT_OUTPUT, help="Output JSON path.")  # The output path.
+    parser.add_argument(
+        "--start-page", type=int, default=_DEFAULT_START_PAGE, help="First page to scan for entries."
+    )  # The start page.
     args = parser.parse_args(argv)  # Parse the arguments.
-    records = DictionaryExtractor().extract(args.pdf)  # Extract the records.
-    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)  # Make the output folder.
-    _LOG.info("Writing %d words to %s", len(records), args.output)  # Log before the write.
-    with open(args.output, "w", encoding="utf-8") as handle:  # Open the output file.
-        json.dump({"version": "1.0", "entries": records}, handle, indent=2)  # Write the dictionary.
-    _LOG.info("Done. Remember: this file is git-ignored and must not be committed.")  # Final note.
+    records = DictionaryExtractor().extract(args.pdf, start_page=args.start_page)  # Extract the records.
+    _write_output(records, args.output)  # Write the dictionary file.
+    _LOG.info("Done: %s", _summarize(records))  # Report the summary.
+    _LOG.info("Remember: this file is git-ignored and must not be committed.")  # Copyright reminder.
     return 0  # Report success.
 
 

--- a/tools/ste_linter/dictionary/quality.py
+++ b/tools/ste_linter/dictionary/quality.py
@@ -1,0 +1,150 @@
+"""Quality harness for the dictionary extractor.
+
+Compares an extracted dictionary against a set of hand-verified golden entries and
+reports a per-field accuracy score with every mismatch. The score turns the phrase
+"near flawless" into a number the parser can be tuned against.
+
+Run it with:
+
+    python -m tools.ste_linter.dictionary.quality data/ste_dictionary.json \
+        tests/fixtures/ste_linter/dictionary_golden.json
+"""
+
+from __future__ import annotations  # Postponed annotations keep the type hints light.
+
+import argparse  # Parses the command-line arguments.
+import json  # Reads the dictionary and the golden set.
+import logging  # Records the harness stages.
+from dataclasses import dataclass, field  # Declares the report value type.
+from typing import Any  # Types the loaded JSON records.
+
+# The logger for the quality harness. The main function configures the handler.
+_LOG = logging.getLogger("ste_linter.dictionary.quality")
+
+# The field accuracy that counts as a pass, from 0 to 1.
+_TARGET_ACCURACY = 0.95
+
+
+@dataclass
+class QualityReport:
+    """The result of comparing the dictionary against the golden set."""
+
+    total: int = 0  # The number of golden entries checked.
+    keyword_found: int = 0  # How many golden keywords appear in the dictionary.
+    pos_correct: int = 0  # How many parts of speech match.
+    approved_correct: int = 0  # How many approved flags match.
+    alternatives_correct: int = 0  # How many alternative lists match.
+    mismatches: list[str] = field(default_factory=list)  # Each mismatch, described.
+
+    @property
+    def field_accuracy(self) -> float:
+        """Return the mean correctness across the four measured fields, 0 to 1."""
+        if self.total == 0:  # Guard an empty golden set.
+            return 0.0  # No entries means no accuracy.
+        measured = self.keyword_found + self.pos_correct + self.approved_correct + self.alternatives_correct
+        return measured / (self.total * 4)  # Average across the four fields.
+
+
+class QualityHarness:
+    """Scores an extracted dictionary against golden entries."""
+
+    def evaluate(self, dictionary: list[dict[str, Any]], golden: list[dict[str, Any]]) -> QualityReport:
+        """Return a quality report for the dictionary against the golden set."""
+        _LOG.info("Evaluating %d golden entries", len(golden))  # Log before the comparison.
+        index = self._index(dictionary)  # Build a keyword and part-of-speech lookup.
+        report = QualityReport(total=len(golden))  # Start an empty report.
+        for entry in golden:  # Compare each golden entry against the dictionary.
+            self._compare_one(entry, index, report)  # Update the report for this entry.
+        _LOG.debug("Field accuracy %.3f", report.field_accuracy)  # Log the accuracy after comparison.
+        return report  # Return the finished report.
+
+    def _index(self, dictionary: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+        """Return a lookup from a keyword and part-of-speech pair to a record."""
+        index: dict[tuple[str, str], dict[str, Any]] = {}  # The lookup map.
+        for record in dictionary:  # Walk each dictionary record.
+            key = (str(record.get("keyword", "")), str(record.get("part_of_speech", "")))  # The pair.
+            index.setdefault(key, record)  # Keep the first record for a pair.
+        return index  # Return the lookup.
+
+    def _compare_one(
+        self,
+        golden: dict[str, Any],
+        index: dict[tuple[str, str], dict[str, Any]],
+        report: QualityReport,
+    ) -> None:
+        """Update the report for one golden entry."""
+        keyword = str(golden["keyword"])  # The golden keyword.
+        pos = str(golden["part_of_speech"])  # The golden part of speech.
+        record = index.get((keyword, pos))  # The matching dictionary record.
+        if record is None:  # The keyword and part of speech are missing.
+            report.mismatches.append(f"{keyword} ({pos})  missing from dictionary")  # Record the miss.
+            return  # Nothing else to score for a missing entry.
+        report.keyword_found += 1  # The keyword and part of speech were found.
+        report.pos_correct += 1  # The part of speech matches by construction of the key.
+        self._score_approved(golden, record, keyword, report)  # Score the approved flag.
+        self._score_alternatives(golden, record, keyword, report)  # Score the alternatives.
+
+    def _score_approved(
+        self, golden: dict[str, Any], record: dict[str, Any], keyword: str, report: QualityReport
+    ) -> None:
+        """Score the approved flag for one entry."""
+        if bool(golden["approved"]) == bool(record.get("approved")):  # The flags match.
+            report.approved_correct += 1  # Count a correct approved flag.
+        else:  # The flags differ.
+            report.mismatches.append(
+                f"{keyword}  approved  expected {golden['approved']}  actual {record.get('approved')}"
+            )  # Record the mismatch.
+
+    def _score_alternatives(
+        self, golden: dict[str, Any], record: dict[str, Any], keyword: str, report: QualityReport
+    ) -> None:
+        """Score the alternatives list for one entry."""
+        expected = {str(item).lower() for item in golden.get("alternatives", [])}  # The golden set.
+        actual = {str(item).lower() for item in record.get("alternatives", [])}  # The dictionary set.
+        if expected == actual:  # The alternative sets match exactly.
+            report.alternatives_correct += 1  # Count a correct alternatives list.
+        else:  # The sets differ.
+            report.mismatches.append(
+                f"{keyword}  alternatives  expected {sorted(expected)}  actual {sorted(actual)}"
+            )  # Record the mismatch.
+
+
+def _load_entries(path: str) -> list[dict[str, Any]]:
+    """Return the entries list from a dictionary or golden JSON file."""
+    with open(path, encoding="utf-8") as handle:  # Open the JSON file.
+        data = json.load(handle)  # Parse the JSON content.
+    entries = data.get("entries", data) if isinstance(data, dict) else data  # Accept both shapes.
+    return list(entries)  # Return the entries list.
+
+
+def _print_report(report: QualityReport) -> None:
+    """Print the report totals and every mismatch."""
+    total = report.total  # The golden entry count.
+    _LOG.info("Golden entries: %d", total)  # Print the total.
+    _LOG.info("  keyword found:   %d/%d", report.keyword_found, total)  # Print the found count.
+    _LOG.info("  part of speech:  %d/%d", report.pos_correct, total)  # Print the part-of-speech count.
+    _LOG.info("  approved status: %d/%d", report.approved_correct, total)  # Print the approved count.
+    _LOG.info("  alternatives:    %d/%d", report.alternatives_correct, total)  # Print the alternatives count.
+    _LOG.info("Field accuracy: %.1f%%", report.field_accuracy * 100)  # Print the accuracy.
+    if report.mismatches:  # There were mismatches to show.
+        _LOG.info("Mismatches:")  # Print the mismatch header.
+        for line in report.mismatches:  # Each mismatch on its own line.
+            _LOG.info("  %s", line)  # Print the mismatch.
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the quality harness from the command line."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")  # Show the report.
+    parser = argparse.ArgumentParser(description="Score the STE dictionary against golden entries.")  # Parser.
+    parser.add_argument("dictionary", help="Path to the extracted dictionary JSON.")  # The dictionary.
+    parser.add_argument("golden", help="Path to the golden-set JSON.")  # The golden set.
+    args = parser.parse_args(argv)  # Parse the arguments.
+    dictionary = _load_entries(args.dictionary)  # Load the dictionary entries.
+    golden = _load_entries(args.golden)  # Load the golden entries.
+    report = QualityHarness().evaluate(dictionary, golden)  # Score the dictionary.
+    _print_report(report)  # Print the report.
+    return 0 if report.field_accuracy >= _TARGET_ACCURACY else 1  # Pass when the target is met.
+
+
+if __name__ == "__main__":  # Allow "python -m tools.ste_linter.dictionary.quality".
+    raise SystemExit(main())  # Run the harness and use its exit code.


### PR DESCRIPTION
Closes #1680

## Summary
Rewrite the STE dictionary extraction tool so it produces a near-flawless dictionary from the licensed ASD-STE100 PDF. Built with the SpecKit workflow and improved through repeated measurement against a golden set. See `specs/1027-ste-dict-extractor/`.

## Problem
The old extractor used a regex over flattened pypdf text. The dictionary is a four-column table, so the columns interleaved and the parser produced bad data: it mapped `acceptable` to `accident`, captured whole sentences as keywords, and gave unreliable alternatives.

## Approach
Read the PDF by word position with pdfplumber. Reconstruct the two left columns (word and meaning-or-alternatives). Classify approved status by letter case. Extract alternatives by the part-of-speech suffix rule, so an example word that leaks in is not mistaken for an alternative. Detect headwords in three layouts: the part of speech in column 1, at the start of column 2, or wrapped to the next row.

## Iteration
A golden set of 28 hand-verified entries and a quality harness measured each change. Field accuracy improved 92 percent, then 98 percent, then 100 percent as the start page, header detection, column boundary, and alternative cap were tuned.

## Results
- Field accuracy on the golden set: 100 percent.
- Entry count: 2136 against the true total of 2149 (99.4 percent).
- Approved 839, not approved 1297 (targets 875 and 1274).
- Zero fragment keywords. Zero invalid parts of speech. Zero messy alternatives.
- Mid-dictionary spot checks are correct across the alphabet.

## Changes
- Rewrite `tools/ste_linter/dictionary/extract.py` (pdfplumber, column-aware).
- Add `tools/ste_linter/dictionary/quality.py` (golden-set harness).
- Add `tests/fixtures/ste_linter/dictionary_golden.json` (28 verified facts).
- Add pdfplumber to the `ste-linter` optional dependency extra.
- Add 27 unit tests that use synthetic word positions and need no PDF.

## Conformance
- [x] Links the spec issue (#1680).
- [x] Acceptance criteria met (entry count, approved split, golden accuracy, no fragment keywords, valid parts of speech, deterministic).
- [x] Unit tests added; dictionary module coverage 90 percent.
- [x] No copyrighted dictionary data committed. The output stays git-ignored.
- [x] Ruff, black, radon, and mypy pass on the new code.