### PR TITLE
refactor: bring MistHelper.py comments into Simplified Technical English compliance

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs\\1027-ste-dict-extractor"}
+{"feature_directory":"specs\\1028-ste-compliance-cleanup"}

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -78,7 +78,7 @@ if TYPE_CHECKING:  # These imports only used by static type checkers (Pylance, m
 # ============================================================================
 # Conditional import for ArangoDB + Redis TimeSeries backends.
 # Falls back gracefully in standalone mode (no python-arango/redis installed).
-try:  # Attempt to import polyglot database layer for ArangoDB/Redis export backends
+try:  # Try to import polyglot database layer for ArangoDB/Redis export backends
     from src.db import DatabaseConfig as _DatabaseConfigImpl
     from src.db import configure_db_logging as _configure_db_logging_impl
     from src.db.router import DatabaseRouter as _DatabaseRouterImpl
@@ -711,7 +711,7 @@ logging.basicConfig(  # Configure root logger with handlers and format
 )
 
 # Attach LogSanitizer to redact sensitive fields (API tokens, passwords, MACs) from logs
-try:  # Attempt to import LogSanitizer from mistapi library
+try:  # Try to import LogSanitizer from mistapi library
     from mistapi.__logger import LogSanitizer  # Import mistapi log sanitizer (redacts secrets from output)
 
     logging.getLogger().addFilter(LogSanitizer())  # Register sanitizer filter on root logger to redact all log records
@@ -764,7 +764,7 @@ if sys.version_info < MINIMUM_PYTHON_VERSION:  # Check if Python is below minimu
 
 # Load .env BEFORE dependency check so DISABLE_AUTO_INSTALL and
 # AUTO_UPGRADE_TO_LATEST are honoured when set in .env.
-try:  # Attempt to load environment variables from a .env file before any dependency checks
+try:  # Try to load environment variables from a .env file before any dependency checks
     from dotenv import (
         load_dotenv as _early_load_dotenv,
     )  # Import python-dotenv's loader (aliased to mark it as early-stage)
@@ -772,7 +772,7 @@ try:  # Attempt to load environment variables from a .env file before any depend
     _early_load_dotenv()  # Read .env and populate os.environ so config flags are available during startup
 except Exception:  # If python-dotenv is not installed yet, fall back to a manual parser
     # Inline fallback: read .env manually so env vars are available
-    try:  # Attempt a best-effort manual parse of the .env file
+    try:  # Try a best-effort manual parse of the .env file
         with open(".env") as _ef:  # Open .env in the current working directory
             for _line in _ef:  # Process the file one line at a time
                 _line = _line.strip()  # Remove surrounding whitespace and the trailing newline
@@ -793,7 +793,7 @@ except Exception:  # If python-dotenv is not installed yet, fall back to a manua
 
 def _get_installed_version(package_name: str) -> str:  # Look up the installed version string for a package
     """Get installed version of a package using importlib.metadata."""
-    try:  # Attempt to read version metadata from the installed distribution
+    try:  # Try to read version metadata from the installed distribution
         from importlib.metadata import version as get_version  # Import the stdlib version lookup (Python 3.8+)
 
         return get_version(package_name)  # Return the installed version string (for example '0.59.3')
@@ -1388,7 +1388,7 @@ class GlobalImportManager:
             logging.warning("UV package manager check failed: %s", e)  # Log why the probe failed
             return False  # UV is not usable
 
-    def _install_uv(self) -> bool:  # Attempt to install UV via pip when it is missing
+    def _install_uv(self) -> bool:  # Try to install UV by pip when it is missing
         """Install UV package manager if not present."""
         if not self.auto_upgrade_uv:  # UV auto-management disabled by config
             logging.info("Auto-upgrade of UV is disabled in configuration")  # Note that we will not install UV

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -94,7 +94,7 @@ except ImportError:  # If database dependencies (python-arango, redis) not insta
     DB_LAYER_AVAILABLE = False  # Set flag to disable database output formats (CSV/SQLite only)
 
 # Explicit public API surface (issue #895).
-# Every name below is re-exported from a src.* submodule for external
+# A src.* submodule re-exports every name below for external
 # consumers. Adding a name here MUST accompany a corresponding update to
 # specs/1016-misthelper-suppression-cleanup/contracts/public_api_snapshot.txt.
 __all__ = [
@@ -653,7 +653,7 @@ from src.websocket.manager import WebSocketManager  # Import WebSocket connectio
 # ============================================================================
 # Configure logging IMMEDIATELY after imports to prevent Python from creating
 # a default handler that writes script.log to the root directory.
-# This configuration will be enhanced later by GlobalImportManager._setup_logging()
+# GlobalImportManager._setup_logging() enhances this configuration later
 # with additional handlers and formatting, but this ensures all early logging
 # calls go to the correct location.
 _early_log_dir = "data"  # Define data directory for logs (same as runtime output directory)
@@ -724,7 +724,7 @@ if sys.version_info < MINIMUM_PYTHON_VERSION:  # Check if Python is below minimu
         f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"  # Format current Python version
     )
     required_str = f"{MINIMUM_PYTHON_VERSION[0]}.{MINIMUM_PYTHON_VERSION[1]}"  # Format minimum required version
-    logging.warning(  # Log warning (will be written to script.log after handler setup)
+    logging.warning(  # Log warning (this text goes to script.log after handler setup)
         "Python %s detected. MistHelper requires Python %s+. Some features may not work correctly.",
         version_str,
         required_str,
@@ -813,7 +813,7 @@ def _leading_digits(segment: str) -> str:  # Extract the numeric prefix of one v
 
 def _parse_version(version_str: str) -> tuple[int, ...]:  # Convert a version string into a comparable integer tuple
     """Parse version string into comparable tuple (for example '0.59.3' -> (0, 59, 3))."""
-    try:  # Malformed input is handled by the except below
+    try:  # The except below handles malformed input
         parts = [
             int(_leading_digits(part) or "0") for part in version_str.split(".")
         ]  # Numeric prefix of each dotted segment, defaulting empty/non-numeric segments to 0
@@ -864,7 +864,7 @@ def _version_satisfies(installed: str, spec: str) -> bool:  # Decide whether ins
         return False  # Treat 'not installed' as 'requirement not satisfied'
 
     operator_symbol, required_version = _extract_version_constraint(spec)  # Parse operator + required version
-    if not required_version:  # No version constraint was found in the spec
+    if not required_version:  # The spec had no version constraint
         return True  # No version requirement, any version satisfies
 
     installed_tuple, required_tuple = _pad_version_tuples(  # Align both versions to equal length for comparison
@@ -1016,7 +1016,7 @@ from datetime import UTC, timezone  # UTC marker plus timezone helper for tz-awa
 # Required dependencies: raise clear error if missing (auto-installed by early dependency check)
 # Optional dependencies: use _has_X availability flags for runtime guards
 # Pylance uses the TYPE_CHECKING imports above for type analysis.
-try:  # PrettyTable is required for formatted console tables
+try:  # The tool needs PrettyTable for formatted console tables
     from prettytable import PrettyTable  # ASCII table renderer used across menus and reports
 except ImportError as _pt_err:  # Required dependency is not installed
     raise ImportError(
@@ -1030,7 +1030,7 @@ try:  # numpy is optional (only some analytics need it)
 except ImportError:  # numpy not installed
     np = None  # None lets runtime guards detect absence
 
-try:  # websocket-client is required for live device diagnostics
+try:  # The tool needs websocket-client for live device diagnostics
     import websocket  # WebSocket client fail-fast install guard (used by src.device.arp_command_manager)
 except ImportError as _ws_err:  # Required dependency is not installed
     raise ImportError(
@@ -1045,7 +1045,7 @@ except ImportError:  # Extremely unlikely for a stdlib module, but guard anyway
     SequenceMatcher = None  # None lets callers detect absence
 
 # Import mistapi later through GlobalImportManager for better dependency management
-# Using Any type since mistapi is dynamically loaded but guaranteed to be available before use
+# Using Any type since GlobalImportManager loads mistapi dynamically but it is available before use
 mistapi: Any = None  # Placeholder. The real mistapi module is loaded later by GlobalImportManager
 
 
@@ -1054,7 +1054,7 @@ mistapi: Any = None  # Placeholder. The real mistapi module is loaded later by G
 # Re-exported here so ``MistHelper.tqdm`` / ``mh.tqdm`` callers keep working unchanged.
 from src.utils.tqdm_wrapper import tqdm  # noqa: E402, I001  # Cat E canonical (1015 T-14) -- re-export.
 
-try:  # requests is required for all HTTP calls
+try:  # The tool needs requests for all HTTP calls
     import requests  # HTTP library fail-fast install guard (also used via function-local imports)
 except ImportError as _req_err:  # Required dependency is not installed
     raise ImportError(
@@ -1103,7 +1103,7 @@ try:  # rapidfuzz is optional (fast fuzzy string matching)
 except ImportError:  # rapidfuzz not installed
     fuzz = None  # None lets callers skip fuzzy matching
 
-# Keyboard listener functionality was extracted to src/refactors/keyboard_listener.py
+# Keyboard listener functionality moved to src/refactors/keyboard_listener.py
 # (PR-13). The extracted class KeyboardListener preserves the no-op stub for the
 # single remaining call site (interactive SSR/SRX websocket shell). No wrapper or
 # alias is retained here per FR-005 (no shims left in MistHelper).
@@ -1592,7 +1592,7 @@ class GlobalImportManager:
 
     def _install_dependency_batch(self, packages_to_process: list[tuple[str, str]]) -> int:  # Install a batch
         """Install each (name, spec) package via the best backend. Return the count that installed successfully."""
-        uv_available = self._check_uv_installation()  # Detect whether UV can be used as the fast installer
+        uv_available = self._check_uv_installation()  # Detect whether the tool can use UV as the fast installer
         logging.info(  # Record which installer backend will be used
             "Using UV package manager for installations"
             if uv_available
@@ -2260,9 +2260,9 @@ tuning_data_file = _get_tuning_data_file_path()  # Resolve the tuning-data path 
 
 # API usage tracking cache
 _api_usage_cache = {  # Module-level cache for Mist API rate-limit accounting
-    "timestamp": 0,  # Epoch seconds when the cache was last populated from the API
+    "timestamp": 0,  # Epoch seconds when the code last populated the cache from the API
     "used": 0,  # Number of API requests the server reports as consumed
-    "limit": 5000,  # Default per-window request quota until the real limit is learned
+    "limit": 5000,  # Default per-window request quota until the code learns the real limit
     "last_updated": 0,  # Epoch seconds of the most recent local update
     "perceived_requests": 0,  # Locally counted requests since the last server sync
     "initialized": False,  # Whether the cache was seeded from a real API response yet
@@ -2319,7 +2319,7 @@ if _initialize_imports_now:  # Eager path: prepare all imports now
             "Applied %s global variable assignments", len(global_assignments)
         )  # Report how many bindings were applied
 
-        # Verify tqdm was properly imported
+        # Verify the import loaded tqdm properly
         if "tqdm" in global_assignments:  # tqdm binding is present
             logging.info(
                 "tqdm is available in global namespace: %s", type(globals().get("tqdm"))
@@ -2334,7 +2334,7 @@ if _initialize_imports_now:  # Eager path: prepare all imports now
             "Some required imports failed - functionality may be limited"
         )  # Warn the user features may be degraded
 else:  # Deferred path: imports happen later in main()
-    # Deferred initialization - will be done in main()
+    # Deferred initialization - main() does this
     success, global_assignments = False, {}  # Placeholder values until main() runs initialization
 
 # ============================================================================
@@ -2361,7 +2361,7 @@ LAST_SELECTED_SITE_ID: str | None = None
 # transparently -- the re-exported symbol is the same class, not a delegator.
 # The rebind dance ``ensure_tqdm_available`` used to perform is no longer
 # needed since T-14 makes ``tqdm`` resolve through ``src.utils.tqdm_wrapper``
-# at import time. The probe was retained for its logging side effect at the
+# at import time. This code keeps the probe for its logging side effect at the
 # single caller (``src/refactors/main_entrypoint.py``).
 from src.utils.input_utils import InputUtils  # noqa: E402, I001  # Cat E canonical (1015 T-09) -- re-export.
 
@@ -2433,7 +2433,7 @@ PROGRESS_EMITTER = None  # Set in main() to a telemetry sink. None disables prog
 # ============================================================================
 
 # Initialize Mist API session (prepared after authentication)
-# Type annotation uses Any since mistapi is dynamically imported
+# Type annotation uses Any since the code imports mistapi dynamically
 apisession: Any | None = None
 
 # MSP privilege tracking (populated after authentication)
@@ -2589,7 +2589,7 @@ def _prompt_switch_login_confirmation() -> bool:
 
 def _select_msp_and_org() -> None:
     """Select MSP and organization via extracted interactive session manager."""
-    global apisession, mistapi, msp_privileges, selected_msp, org_id  # These globals are updated by the selection flow
+    global apisession, mistapi, msp_privileges, selected_msp, org_id  # The selection flow updates these globals
 
     state = {  # Snapshot current session globals into a mutable bag for the manager to update
         "apisession": apisession,  # Current API session object
@@ -2626,7 +2626,7 @@ def _invoke_mistapi_org_picker_and_apply() -> None:
             ConfigUtils.set_cached_org_id(org_id)  # Mirror the picker's choice into ConfigUtils cache (1015 T-12)
             logging.warning("  + Organization ID set: %s", org_id)  # Legacy console echo routed via logger.
             logging.info("User selected org from session: %s", org_id)  # Log the chosen org
-        else:  # Nothing was selected
+        else:  # The user selected nothing
             logging.warning("  X No organization selected")  # Legacy console echo routed via logger.
             logging.warning("No organization selected from session privileges")  # Log the empty selection
     except Exception as e:  # The SDK picker raised an error
@@ -2715,7 +2715,7 @@ def _preflight_verify_credentials(require_token: bool = True) -> None:
     Feature 1020 (US3): invoked at the top of ``_establish_mist_session()`` for every dispatch mode. It
     performs only local string validation. It never imports ``requests`` or ``mistapi`` and never issues
     an HTTP request. So a misconfigured run exits with a redacted, actionable message instead of a
-    malformed URL from mistapi. Token presence is required for token-based modes
+    malformed URL from mistapi. Token-based modes need a token
     (``--test``/``--testinteractive``/TUI/CLI). The ``require_token`` is False for interactive ``--login``,
     which authenticates via email/password rather than a token. Any token value present is shown only via
     ``_redact_tokens()`` previews, never raw (FR-015/SC-005).
@@ -2744,7 +2744,7 @@ def _preflight_verify_credentials(require_token: bool = True) -> None:
     logging.error(
         "[ERROR] For --test/--testinteractive, also set org_id (or ORG_ID) - not MIST_ORG_ID - for this path."
     )  # Legacy console echo routed via logger.
-    sys.exit(1)  # Exit non-zero before any session/network object is constructed.
+    sys.exit(1)  # Exit non-zero before the code constructs any session or network object.
 
 
 def _check_token_rate_limit(token: str, test_host: str) -> bool:
@@ -2833,7 +2833,7 @@ def _build_fallback_session_attempts(
     """Build env_file/host fallback attempts, only when no env tokens are present."""
     logging.debug("Building fallback (env_file/host) APISession attempts")  # Trace fallback construction
     attempts: list[dict[str, str]] = []  # Accumulate fallback attempts
-    if tokens:  # Env tokens present -- fallbacks are skipped to avoid duplicate token reads
+    if tokens:  # Env tokens present -- the code skips fallbacks to avoid duplicate token reads
         return attempts  # No fallback needed -- token attempts already cover auth
     if "env_file" in sig_params:  # env_file only when no env tokens (avoids double-read)
         attempts.append({"env_file": ".env"})  # Read credentials from .env file
@@ -2886,7 +2886,7 @@ def _try_single_session_kwargs(
     total: int,
 ) -> tuple[Any, bool]:
     """Try one APISession kwargs dict. Return (session_or_None, rate_limit_seen)."""
-    if apisession_cls is None:  # Guard: class must be present if attempts list was built
+    if apisession_cls is None:  # Guard: the class must be present if the code built the attempts list
         raise AssertionError("apisession_cls should be set if attempts list is populated")
     try:  # APISession constructor may raise on auth/validation/rate-limit
         session = apisession_cls(**kwargs)  # Attempt APISession constructor with these kwargs
@@ -2911,7 +2911,7 @@ def _execute_session_attempts(
     """Try each kwargs dict until one constructs a valid APISession. Track rate-limit signal."""
     tried_variants: list[str] = []  # Track all attempted kwargs for error reporting on total failure
     successful_method: Any = None  # Will hold the kwargs dict that succeeded
-    rate_limit_detected = False  # Set True if NoneType rate-limit error signature is seen
+    rate_limit_detected = False  # Set True when a NoneType rate-limit error signature appears
     session: Any = None  # Will hold the created APISession object on success
     for i, kwargs in enumerate(attempts, start=1):  # Try each kwargs dict in priority order
         tried_variants.append(str(list(kwargs.keys())))  # Record attempt as string of keys before trying
@@ -3095,7 +3095,7 @@ def _log_detected_auth(used_env_file: bool, used_direct_token: bool, has_readabl
     """Emit a single debug line describing the detected auth path (env_file > token param > attr)."""
     if used_env_file:  # Highest-priority detected path -- credentials came from .env
         logging.debug("Session initialized using env_file - authentication configured via .env file")  # env_file path
-    elif used_direct_token:  # Next priority -- a token was passed directly to the constructor
+    elif used_direct_token:  # Next priority -- the caller passed a token directly to the constructor
         logging.debug(
             "Session initialized using direct token parameter - authentication configured"
         )  # token-param path
@@ -3238,7 +3238,7 @@ def _configure_session_timeout(session_obj: Any) -> None:
 
 
 # Issue #431: module-level alias `PacketCaptureManager = ExtractedPacketCaptureManager`
-# was removed. The canonical name is now imported directly at module top.
+# was removed. The code now imports the canonical name directly at module top.
 
 
 # SFPTransceiverDataProcessor moved to src/reports/sfp_transceiver_data_processor.py
@@ -3621,7 +3621,7 @@ def _build_ssh_runner_deps() -> SSHRunnerManagerDeps:  # Build the deps bundle f
     )
 
 
-# CLIShellManager was extracted to src/ssh/cli_shell_manager.py in initiative 1013 (Cat B, position 30).
+# CLIShellManager moved to src/ssh/cli_shell_manager.py in initiative 1013 (Cat B, position 30).
 # Re-exported via the alphabetized `from src.ssh.cli_shell_manager import CLIShellManager` alias above.
 
 
@@ -3790,7 +3790,7 @@ def _build_org_ap_upgrader(**overrides: Any) -> _OrgLevelAPFirmwareUpgrader:
 # BulkRadiusWLANConfigManager moved to src/site/bulk_radius_wlan_config_manager.py (1013 SC-001 position 15)
 
 
-# SiteAnalyticsConfigurator and SiteInventoryHealthAnalyzer were extracted to
+# SiteAnalyticsConfigurator and SiteInventoryHealthAnalyzer moved to
 # src/analytics/site_analytics_configurator.py and
 # src/analytics/site_inventory_health_analyzer.py for phase-1 decomposition.
 
@@ -4948,7 +4948,7 @@ def _fast_mode_from_cli_args() -> bool:
     """Return True iff parsed ``args`` exist in globals and carry ``--fast`` (errors -> False)."""
     try:  # CLI args presence + attribute lookup can both fail. Degrade safely.
         cli_args = globals().get("args") if "args" in globals() else None  # Locate parsed args, if any.
-        return bool(cli_args and getattr(cli_args, "fast", False))  # Truthy only when --fast was set.
+        return bool(cli_args and getattr(cli_args, "fast", False))  # Truthy only when the caller set --fast.
     except Exception:  # Defensive -- never propagate.
         return False  # Safe default for any introspection failure.
 
@@ -5322,7 +5322,7 @@ def _add_interface_arguments(parser: argparse.ArgumentParser) -> None:
 # Mapping of unsupported flag spellings -> the supported canonical spelling.
 # Why: users naturally type hyphenated variants (for example `--test-interactive`) but argparse
 # treats a hyphen as a token boundary, so it cannot prefix-match to `--testinteractive`.
-# Left unchecked, the invocation is rejected by argparse with a generic "unrecognized
+# Left unchecked, argparse rejects the invocation with a generic "unrecognized
 # arguments" message and (worse) the interactive-test module-import sniff at the top of
 # this file — which literally checks `"--testinteractive" in sys.argv` — silently
 # proceeds as if no test flag were present, misrouting the user into normal interactive
@@ -5632,7 +5632,7 @@ def _run_tui_event_loop(args: argparse.Namespace) -> None:
 
         tui = MistHelperTUI(debug_mode=args.debug)  # Create TUI with debug flag
         tui.apisession = apisession  # Pass global API session so TUI can execute live API calls
-        if args.debug:  # Debug: record that TUI was launched with debug enabled
+        if args.debug:  # Debug: record that the code launched the TUI with debug enabled
             logging.debug("TUI_MODE: Debug mode is ACTIVE - enhanced logging enabled")  # Log debug state
         tui.run()  # Launch TUI event loop (blocks until user exits)
     except KeyboardInterrupt:  # User pressed Ctrl+C inside the TUI
@@ -5983,7 +5983,7 @@ _MEANINGFUL_CLI_ATTRS: tuple[str, ...] = (
 
 
 def _has_meaningful_cli_args(args: argparse.Namespace) -> bool:
-    """Return True if any non-interactive CLI flag was provided (triggers CLI dispatch mode)."""
+    """Return True if the caller provided any non-interactive CLI flag (triggers CLI dispatch mode)."""
     return any(getattr(args, name, None) for name in _MEANINGFUL_CLI_ATTRS)  # Any flag => CLI mode
 
 

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -28,8 +28,8 @@ if sys.version_info < MINIMUM_PYTHON_VERSION:  # Exit early if Python is too old
     print(f"\n{'=' * 70}", file=sys.stderr)  # noqa: T201
     print(warning_msg, file=sys.stderr)  # noqa: T201
     print(f"{'=' * 70}\n", file=sys.stderr)  # noqa: T201
-    # Log will be configured later, but we can't use logging yet
-    # The warning is printed to stderr so it's visible regardless
+    # Log will be configured later, but we cannot use logging yet
+    # The warning is printed to stderr so it is visible regardless
 
 # ============================================================================
 # GLOBAL DEPENDENCY MANAGEMENT AND IMPORT SYSTEM
@@ -43,7 +43,7 @@ warnings.filterwarnings(
 import argparse  # Import argparse for command-line argument parsing (--menu, --test, --fast flags)
 import logging  # Import logging for structured logging to script.log and console
 import os  # Import os for file path operations, environment variables, and data/ directory setup
-import re  # Import re for regex pattern matching in data parsing (SSIDs, descriptions, etc.)
+import re  # Import re for regex pattern matching in data parsing (SSIDs, descriptions, and so on)
 import subprocess  # nosec B404  # Injected into src/bootstrap/PackageInstaller DI seam only; all runtime calls in this module use SubprocessRunner (initiative 1016).
 import time  # Import time for rate limiting, delays, and performance monitoring
 import traceback  # Import traceback for detailed exception context in error logs
@@ -57,13 +57,13 @@ from typing import TYPE_CHECKING, Any, NoReturn, TextIO, cast
 
 from src.utils.subprocess_runner import (  # Centralized subprocess dispatch + exception re-exports (initiative 1016).
     SubprocessError,  # Base class for subprocess errors (parent of TimeoutExpired/CalledProcessError).
-    SubprocessRunner,  # Audited dispatcher; sole entry point for external command execution.
+    SubprocessRunner,  # Audited dispatcher. Sole entry point for external command execution.
     TimeoutExpired,  # Raised when subprocess.run exceeds its timeout.
 )
 
 # Type stubs for dynamically imported modules
 # These allow type checking while the actual imports happen at runtime via GlobalImportManager
-# Pylance uses these unconditionally; runtime try/except blocks below handle actual loading.
+# Pylance uses these unconditionally. Runtime try/except blocks below handle actual loading.
 if TYPE_CHECKING:  # These imports only used by static type checkers (Pylance, mypy), not at runtime
     from types import ModuleType  # ModuleType annotation for optional-module fallback typing
 
@@ -330,13 +330,13 @@ from src.audit.audit_analysis_ops import (
 from src.auth.interactive import (
     LoginOrchestrator,  # Re-exported so extracted refactors can resolve it via MistHelper (SC-023)
     MspOrgSelector,
-)  # Duplicate import (re-stated with comment below); kept to preserve module load behavior
+)  # Duplicate import (re-stated with comment below). Kept to preserve module load behavior
 from src.bootstrap.dependency_check import (
     DependencyCheckOrchestrator,
-)  # Duplicate import; harmless re-import of dependency check orchestrator
+)  # Duplicate import. Harmless re-import of dependency check orchestrator
 from src.bootstrap.package_installer import (
     PackageInstaller,
-)  # Duplicate import; harmless re-import of package installer
+)  # Duplicate import. Harmless re-import of package installer
 from src.cache.cache_utils import (
     CacheUtils,
 )  # Cat E canonical (1014 P14) -- re-export for MistHelper.CacheUtils callers
@@ -517,10 +517,10 @@ from src.refactors.device_config_template_cloner_manager import (
     DeviceConfigTemplateClonerManager,  # Extracted device config template cloner (SC-020)
 )
 from src.refactors.device_data_fetcher import (
-    DeviceDataFetcher,  # Extracted device fetcher (SC-017); lazy re-export for interactive_display_utils
+    DeviceDataFetcher,  # Extracted device fetcher (SC-017). Lazy re-export for interactive_display_utils
 )
 from src.refactors.fast_mode_backoff_multiplier import (
-    FastModeBackoffMultiplier,  # Extracted backoff multiplier (SC-028); lazy re-export for org_device_stats_exporter
+    FastModeBackoffMultiplier,  # Extracted backoff multiplier (SC-028). Lazy re-export for org_device_stats_exporter
 )
 
 # FastModeDevicesPerThread import removed: only referenced from within ConnectionPoolExecutor (1012 SC-003)
@@ -657,7 +657,7 @@ from src.websocket.manager import WebSocketManager  # Import WebSocket connectio
 # with additional handlers and formatting, but this ensures all early logging
 # calls go to the correct location.
 _early_log_dir = "data"  # Define data directory for logs (same as runtime output directory)
-os.makedirs(_early_log_dir, exist_ok=True)  # Create data/ directory if it doesn't exist (no error if already present)
+os.makedirs(_early_log_dir, exist_ok=True)  # Create data/ directory if it does not exist (no error if already present)
 _early_log_path = os.path.join(
     _early_log_dir, "script.log"
 )  # Define full path to script.log using os.path.join for cross-platform compatibility
@@ -682,11 +682,11 @@ _early_file_level = int(
     os.environ.get("LOGGING_LOG_LEVEL", logging.INFO)
 )  # Read file log level from env (default: INFO=20)
 
-# Make stdout/stderr resilient to non-cp1252 characters in real data (e.g. the Hawaiian
+# Make stdout/stderr resilient to non-cp1252 characters in real data (for example the Hawaiian
 # 'okina in addresses like "Maka'ala Street"). Without this, printing the comparison table
 # or logging such strings raises UnicodeEncodeError under the default Windows console codec.
 for _std_stream in (sys.stdout, sys.stderr):  # Harden both standard streams (best-effort).
-    _reconfigure = getattr(_std_stream, "reconfigure", None)  # TextIOWrapper has this; plain TextIO does not.
+    _reconfigure = getattr(_std_stream, "reconfigure", None)  # TextIOWrapper has this. Plain TextIO does not.
     if callable(_reconfigure):  # Only proceed when the stream supports reconfiguration.
         try:
             _reconfigure(encoding="utf-8", errors="backslashreplace")  # UTF-8 + never-crash fallback
@@ -700,11 +700,11 @@ _early_console_handler.setLevel(
 )  # Set console handler to respect CONSOLE_LOG_LEVEL environment variable
 _early_file_handler = logging.FileHandler(
     _early_log_path, encoding="utf-8"
-)  # script.log file output; UTF-8 so non-cp1252 chars (e.g. Hawaiian 'okina) never crash logging
+)  # script.log file output. UTF-8 keeps non-cp1252 chars (for example Hawaiian 'okina) from a crash in logging
 _early_file_handler.setLevel(_early_file_level)  # Set file handler to respect LOGGING_LOG_LEVEL environment variable
 
 logging.basicConfig(  # Configure root logger with handlers and format
-    level=logging.DEBUG,  # Root logger captures all levels; handlers filter based on their individual levels
+    level=logging.DEBUG,  # Root logger captures all levels. Handlers filter based on their individual levels
     format="%(asctime)s - %(levelname)s - %(message)s",  # Define log message format with timestamp, level, and message
     handlers=[_early_file_handler, _early_console_handler],  # Register both file and console handlers
     force=True,  # Force reconfiguration even if logging was already configured (needed for module init)
@@ -715,8 +715,8 @@ try:  # Attempt to import LogSanitizer from mistapi library
     from mistapi.__logger import LogSanitizer  # Import mistapi log sanitizer (redacts secrets from output)
 
     logging.getLogger().addFilter(LogSanitizer())  # Register sanitizer filter on root logger to redact all log records
-except ImportError:  # If LogSanitizer not available, skip (mistapi pre-0.59.3 doesn't have it)
-    pass  # mistapi pre-0.59.3 does not have LogSanitizer; safe to skip
+except ImportError:  # If LogSanitizer not available, skip (mistapi pre-0.59.3 does not have it)
+    pass  # mistapi pre-0.59.3 does not have LogSanitizer. Safe to skip
 
 # Log Python version warning if below minimum requirement
 if sys.version_info < MINIMUM_PYTHON_VERSION:  # Check if Python is below minimum version
@@ -742,11 +742,11 @@ if sys.version_info < MINIMUM_PYTHON_VERSION:  # Check if Python is below minimu
 # per function. Each dataclass encapsulates configuration for a specific domain.
 
 
-# NOTE: SSHConnectionConfig removed (1014 P3) - was a dead duplicate of src/ssh/ssh_runner.py:155;
-#       nothing in MistHelper.py imported the local copy, and all src/ssh/*.py callers
+# NOTE: SSHConnectionConfig removed (1014 P3) - was a dead duplicate of src/ssh/ssh_runner.py:155.
+#       Nothing in MistHelper.py imported the local copy, and all src/ssh/*.py callers
 #       already imported from src.ssh.ssh_runner. Import from src.ssh.ssh_runner instead.
-# NOTE: SSHExecutionConfig removed (1014 P1) - was a dead duplicate of src/ssh/ssh_runner.py:167;
-#       nothing in MistHelper.py imported the local copy, and all src/ssh/batch/*.py callers
+# NOTE: SSHExecutionConfig removed (1014 P1) - was a dead duplicate of src/ssh/ssh_runner.py:167.
+#       Nothing in MistHelper.py imported the local copy, and all src/ssh/batch/*.py callers
 #       already imported from src.ssh.ssh_runner. Import from src.ssh.ssh_runner instead.
 # NOTE: WebSocketListenerConfig removed - use ARPCommandManager._listen_for_output parameters directly
 # NOTE: MapViewerConfig removed (SC-002) - unused dataclass, MapsManager builds runtime state directly
@@ -782,13 +782,13 @@ except Exception:  # If python-dotenv is not installed yet, fall back to a manua
                     _k, _v = _line.split("=", 1)  # Split on the first '=' into key and value (values may contain '=')
                     os.environ.setdefault(
                         _k.strip(), _v.strip()
-                    )  # Set the var only if not already defined (don't override real env)
+                    )  # Set the var only if not already defined (do not override real env)
     except (FileNotFoundError, PermissionError, OSError) as _dotenv_exc:  # .env absent, unreadable, or IO error.
-        logging.debug("Skipping .env fallback parse: %s", _dotenv_exc)  # Diagnostic-only; .env is optional.
+        logging.debug("Skipping .env fallback parse: %s", _dotenv_exc)  # Diagnostic-only. The .env file is optional.
 
 # NOTE: PACKAGE_IMPORT_MAP extracted to
 # src/refactors/package_import_map.py::PackageImportMapManager.MAPPING
-# per initiative 1011 SC-025 (FR-003: no wrapper shim; FR-005: fn->method).
+# per initiative 1011 SC-025 (FR-003: no wrapper shim, FR-005: fn->method).
 
 
 def _get_installed_version(package_name: str) -> str:  # Look up the installed version string for a package
@@ -796,23 +796,23 @@ def _get_installed_version(package_name: str) -> str:  # Look up the installed v
     try:  # Attempt to read version metadata from the installed distribution
         from importlib.metadata import version as get_version  # Import the stdlib version lookup (Python 3.8+)
 
-        return get_version(package_name)  # Return the installed version string (e.g., '0.59.3')
+        return get_version(package_name)  # Return the installed version string (for example '0.59.3')
     except Exception:  # Package not installed or its metadata is missing
         return ""  # Return empty string to signal 'not installed' to callers
 
 
 def _leading_digits(segment: str) -> str:  # Extract the numeric prefix of one version segment
-    """Return the leading digit run of a version segment (e.g., '0a1' -> '0')."""
+    """Return the leading digit run of a version segment (for example '0a1' -> '0')."""
     numeric = ""  # Accumulate the leading digit characters of this segment
     for char in segment:  # Walk characters left to right until a non-digit ends the prefix
-        if not char.isdigit():  # First non-digit (e.g., the 'a' in '0a1') ends the numeric prefix
+        if not char.isdigit():  # First non-digit (for example the 'a' in '0a1') ends the numeric prefix
             break  # Ignore any pre-release suffix for comparison purposes
         numeric += char  # Append this digit to the numeric prefix
     return numeric  # Caller defaults empty results to 0
 
 
 def _parse_version(version_str: str) -> tuple[int, ...]:  # Convert a version string into a comparable integer tuple
-    """Parse version string into comparable tuple (e.g., '0.59.3' -> (0, 59, 3))."""
+    """Parse version string into comparable tuple (for example '0.59.3' -> (0, 59, 3))."""
     try:  # Malformed input is handled by the except below
         parts = [
             int(_leading_digits(part) or "0") for part in version_str.split(".")
@@ -842,12 +842,12 @@ def _pad_version_tuples(
 ) -> tuple[tuple[int, ...], tuple[int, ...]]:  # Zero-pad two version tuples to equal length
     """Right-pad both version tuples with zeros so they compare element-by-element."""
     max_len = max(len(installed_tuple), len(required_tuple))  # Longest of the two drives the padding width
-    installed_padded = installed_tuple + (0,) * (max_len - len(installed_tuple))  # Pad installed (e.g., 1.2 -> 1.2.0)
+    installed_padded = installed_tuple + (0,) * (max_len - len(installed_tuple))  # Pad installed to equal length
     required_padded = required_tuple + (0,) * (max_len - len(required_tuple))  # Pad required to align lengths
     return installed_padded, required_padded  # Equal-length tuples ready for comparison
 
 
-# Operator symbol -> comparison predicate; dict dispatch keeps _version_satisfies flat (no if/elif chain).
+# Operator symbol -> comparison predicate. Dict dispatch keeps _version_satisfies flat (no if/elif chain).
 _VERSION_COMPARATORS: dict[str, Callable[[tuple[int, ...], tuple[int, ...]], bool]] = {
     ">=": lambda installed, required: installed >= required,  # 'at least' constraint
     ">": lambda installed, required: installed > required,  # 'strictly newer' constraint
@@ -860,7 +860,7 @@ _VERSION_COMPARATORS: dict[str, Callable[[tuple[int, ...], tuple[int, ...]], boo
 
 def _version_satisfies(installed: str, spec: str) -> bool:  # Decide whether installed meets the spec constraint
     """Check if installed version satisfies the version specification."""
-    if not installed:  # An empty installed version means the package isn't present
+    if not installed:  # An empty installed version means the package is not present
         return False  # Treat 'not installed' as 'requirement not satisfied'
 
     operator_symbol, required_version = _extract_version_constraint(spec)  # Parse operator + required version
@@ -882,10 +882,10 @@ def _get_latest_pypi_version(package_name: str) -> str:  # Ask PyPI for a packag
     """Query PyPI for the latest version of a package.
 
     Uses a bounded read to prevent hangs behind corporate
-    proxies (e.g. Zscaler SSL inspection).
+    proxies (for example Zscaler SSL inspection).
     """
-    try:  # Network calls can fail many ways; treat any failure as 'latest unknown'
-        import json as json_mod  # Local import keeps startup fast when this code path isn't used
+    try:  # Network calls can fail many ways. Treat any failure as 'latest unknown'
+        import json as json_mod  # Local import keeps startup fast when this code path is not used
         import ssl  # Needed to build a TLS context for the HTTPS request
         import urllib.request  # Standard-library HTTP client (avoids needing 'requests' this early)
 
@@ -902,7 +902,7 @@ def _get_latest_pypi_version(package_name: str) -> str:  # Ask PyPI for a packag
             data = json_mod.loads(raw.decode())  # Parse the JSON metadata into a dict
             version = data.get("info", {}).get("version", "")  # Return latest version string, or '' if absent
             return str(version) if version else ""  # Cast to str for strict typing
-    except Exception:  # Any error (offline, proxy block, parse failure) means we can't determine the latest version
+    except Exception:  # Any error (offline, proxy block, parse failure) means we cannot determine the latest version
         return ""  # Empty string signals 'latest unknown' so callers skip the upgrade check
 
 
@@ -926,10 +926,10 @@ def _parse_requirement_line(line: str) -> tuple[str, str] | None:  # Parse one r
 def _parse_requirements_file(filepath: str = "requirements.txt") -> list[tuple[str, str]]:
     """Parse requirements.txt into a list of (package_name, package_spec) tuples.
 
-    SECURITY: only reads requirements.txt (no arbitrary file access); skips comments/blanks/dev deps.
+    SECURITY: only reads requirements.txt (no arbitrary file access). Skips comments/blanks/dev deps.
     """
     packages = []  # Accumulate (name, spec) tuples to return to the dependency checker
-    try:  # The file may be missing or unreadable; handle that gracefully below
+    try:  # The file may be missing or unreadable. Handle that gracefully below
         with open(filepath, encoding="utf-8") as requirements_file:  # Open requirements.txt as UTF-8 text
             for line in requirements_file:  # Process one dependency line at a time
                 parsed = _parse_requirement_line(line)  # Parse this line into (name, spec) or None to skip
@@ -953,7 +953,7 @@ def _parse_requirements_file(filepath: str = "requirements.txt") -> list[tuple[s
 
 
 # Simplified facade delegating dependency bootstrap logic to extracted src/bootstrap modules.
-def _early_dependency_check() -> None:  # Public entry point; delegates to the extracted bootstrap modules
+def _early_dependency_check() -> None:  # Public entry point. Delegates to the extracted bootstrap modules
     """Run early dependency checks through the extracted bootstrap orchestrator."""
     installer = PackageInstaller(  # Build the installer with stdlib modules injected (enables testing/mocking)
         os_module=os,  # Inject os for path/env operations
@@ -962,7 +962,7 @@ def _early_dependency_check() -> None:  # Public entry point; delegates to the e
         logging_module=logging,  # Inject logging for progress messages
     )
     orchestrator = DependencyCheckOrchestrator(  # Build the orchestrator that drives the detect-and-install flow
-        os_module=os,  # Inject os for env checks (DISABLE_AUTO_INSTALL, etc.)
+        os_module=os,  # Inject os for env checks (DISABLE_AUTO_INSTALL, and so on)
         logging_module=logging,  # Inject logging for progress messages
         sys_module=sys,  # Inject sys for the interpreter path
         package_import_map=PackageImportMapManager.MAPPING,  # Provide the pip-name -> import-name mapping
@@ -980,20 +980,20 @@ def _is_help_invocation(argv: list[str]) -> bool:
     """Return True when *argv* requests help output (``--help`` or ``-h``).
 
     Why:
-        ``--help`` must be side-effect-free (issue #1641): argparse renders
-        usage and exits immediately, so kicking off dependency installation
-        or eager import initialization before that point is wasted work
-        (and, on a fresh box, actively harmful). This helper is the single
+        ``--help`` must be side-effect-free (issue #1641). The argparse module
+        renders usage and exits at once. Work that starts dependency
+        installation or eager import initialization before that point is
+        wasted, and on a fresh box it is harmful. This helper is the single
         source of truth used by both the dependency-check guard and the
         deferred-imports conditional below.
 
     Args:
         argv: The full argument vector (typically ``sys.argv``). The program
-            name at position 0 is ignored; only the flag tail is inspected.
+            name at position 0 is ignored. Only the flag tail is inspected.
 
     Returns:
-        True if ``--help`` or ``-h`` appears as a full token in the tail;
-        False otherwise. Substring matches (e.g. ``--helpme``) do not count.
+        True if ``--help`` or ``-h`` appears as a full token in the tail.
+        False otherwise. Substring matches (for example ``--helpme``) do not count.
     """
     return any(token in ("--help", "-h") for token in argv[1:])
 
@@ -1046,7 +1046,7 @@ except ImportError:  # Extremely unlikely for a stdlib module, but guard anyway
 
 # Import mistapi later through GlobalImportManager for better dependency management
 # Using Any type since mistapi is dynamically loaded but guaranteed to be available before use
-mistapi: Any = None  # Placeholder; the real mistapi module is loaded later by GlobalImportManager
+mistapi: Any = None  # Placeholder. The real mistapi module is loaded later by GlobalImportManager
 
 
 # tqdm wrapper: canonical home is src/utils/tqdm_wrapper.py (1015 T-14, Cat E).
@@ -1119,7 +1119,7 @@ except ImportError:  # rapidfuzz not installed
 # CENTRALIZED PAGINATION DEFAULTS
 # ============================================================================
 # Several legacy code paths relied on the mistapi client's implicit default page
-# size (commonly 100). That caused excessive paging (e.g., 10x HTTP calls for
+# size (commonly 100). That caused excessive paging (for example 10x HTTP calls for
 # 1000-item datasets). We unify a single configurable default via environment
 # variable MIST_PAGE_LIMIT (clamped to 1..1000). All new/updated listOrgSites /
 # getOrgInventory calls should pass limit=DEFAULT_API_PAGE_LIMIT or use the
@@ -1151,14 +1151,14 @@ def _apply_dotenv_line(line: str) -> None:  # Set one KEY=VALUE pair from a .env
 
 
 # Early dotenv import for configuration loading
-def _fallback_load_dotenv() -> None:  # Minimal .env parser used when python-dotenv isn't installed
+def _fallback_load_dotenv() -> None:  # Minimal .env parser used when python-dotenv is not installed
     """Fallback .env loader when python-dotenv package is not installed."""
-    try:  # The .env file is optional; handle its absence/errors gracefully
+    try:  # The .env file is optional. Handle its absence/errors gracefully
         with open(".env") as dotenv_file:  # Open .env in the current working directory
             for line in dotenv_file:  # Process the file one line at a time
                 _apply_dotenv_line(line)  # Set this KEY=VALUE pair (skips blanks/comments internally)
     except FileNotFoundError:  # No .env file present
-        logging.debug("No .env file found")  # Not an error; just note it at debug level
+        logging.debug("No .env file found")  # Not an error. Just note it at debug level
     except Exception as parse_error:  # Any other read/parse problem
         logging.debug("Error loading .env file: %s", parse_error)  # Log the reason without crashing startup
 
@@ -1170,7 +1170,7 @@ try:  # Prefer the full-featured python-dotenv loader when available
     DOTENV_AVAILABLE = True  # Flag that the real loader is in use
     load_dotenv()  # Load .env now so config is available to the import manager
 except ImportError:  # python-dotenv not installed
-    DOTENV_AVAILABLE = False  # Flag that we're using the minimal fallback
+    DOTENV_AVAILABLE = False  # Flag that we are using the minimal fallback
     # Use fallback loader and create an alias for later calls
     load_dotenv = _fallback_load_dotenv  # Alias so later load_dotenv() calls still work
     _fallback_load_dotenv()  # Load .env now using the fallback parser
@@ -1241,7 +1241,7 @@ class GlobalImportManager:
         self._initialize_dependency_tracking()  # Prepare package-tracking lists and import/UV caches
         self._initialize_import_mappings()  # Build package->import name maps and special import handlers
         self._setup_logging()  # Configure handlers/levels before other init runs
-        self._detect_virtual_environment()  # Log whether we're in a venv (affects installs)
+        self._detect_virtual_environment()  # Log whether we are in a venv (affects installs)
         self._define_package_requirements()  # Populate the required/optional package dicts
 
     def _load_upgrade_configuration(self) -> None:  # Read upgrade/UV/CSV settings from the environment
@@ -1297,7 +1297,7 @@ class GlobalImportManager:
         }
 
     def _detect_virtual_environment(self) -> None:  # Determine and log whether a venv is active
-        """Detect if we're running in a virtual environment and log info."""
+        """Detect if we are running in a virtual environment and log info."""
         self.in_venv = hasattr(sys, "real_prefix") or (
             hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
         )  # venv when prefixes differ
@@ -1317,7 +1317,7 @@ class GlobalImportManager:
         console_handler = self._build_console_log_handler(console_log_level)  # Build the console handler at env level
         file_handler = self._build_file_log_handler(file_log_level)  # Build the file handler (creates data/ if missing)
         logging.basicConfig(  # Wire up the root logger with both handlers
-            level=logging.DEBUG,  # Root captures everything; handlers filter by their own levels
+            level=logging.DEBUG,  # Root captures everything. Handlers filter by their own levels
             format="%(asctime)s - %(levelname)s - %(message)s",  # Default format (handlers override with their own)
             handlers=[file_handler, console_handler],  # Register both the file and console handlers
             force=True,  # Replace the earlier module-import basicConfig
@@ -1342,7 +1342,7 @@ class GlobalImportManager:
         os.makedirs("data", exist_ok=True)  # Create data/ if missing (no error if present)
         file_handler = logging.FileHandler(
             log_file_path, encoding="utf-8"
-        )  # script.log writer; UTF-8 so non-cp1252 chars (e.g. Hawaiian 'okina) never crash logging
+        )  # script.log writer. UTF-8 keeps non-cp1252 chars (for example Hawaiian 'okina) from a crash in logging
         file_handler.setLevel(level)  # Apply the file verbosity threshold
         file_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")  # Same timestamped format
         file_handler.setFormatter(file_formatter)  # Attach the format to the file handler
@@ -1369,13 +1369,13 @@ class GlobalImportManager:
         if self._uv_checked:  # We already probed UV earlier this run
             return self._uv_available  # Reuse the cached answer (avoids repeated subprocess calls)
         self._uv_available = self._probe_uv_binary()  # Probe via subprocess and cache the answer
-        self._uv_checked = True  # Mark that we've probed UV so we don't repeat it
+        self._uv_checked = True  # Mark that we have probed UV so we do not repeat it
         return self._uv_available  # Return the (now cached) availability
 
     def _probe_uv_binary(self) -> bool:  # Run 'uv --version' to detect UV availability
         """Probe the UV binary by running 'uv --version' and log the outcome."""
         logging.debug("_probe_uv_binary: probing UV binary via subprocess")  # Log before probe
-        try:  # Probing UV may fail if it's not installed
+        try:  # Probing UV may fail if it is not installed
             result = SubprocessRunner.run(  # Audited dispatch (initiative 1016) -- shell=False + argv allow-list.
                 ["uv", "--version"], timeout=10, check=False
             )  # Run 'uv --version' via SubprocessRunner (validates argv, no shell).
@@ -1388,10 +1388,10 @@ class GlobalImportManager:
             logging.warning("UV package manager check failed: %s", e)  # Log why the probe failed
             return False  # UV is not usable
 
-    def _install_uv(self) -> bool:  # Attempt to install UV via pip when it's missing
+    def _install_uv(self) -> bool:  # Attempt to install UV via pip when it is missing
         """Install UV package manager if not present."""
         if not self.auto_upgrade_uv:  # UV auto-management disabled by config
-            logging.info("Auto-upgrade of UV is disabled in configuration")  # Note that we won't install UV
+            logging.info("Auto-upgrade of UV is disabled in configuration")  # Note that we will not install UV
             return False  # Signal UV is unavailable
 
         logging.info("Attempting to install UV package manager...")  # Announce the install attempt
@@ -1399,7 +1399,7 @@ class GlobalImportManager:
             # Try installing UV using pip as fallback
             result = SubprocessRunner.run(  # Audited dispatch (initiative 1016) -- interpreter self-invoke allowed.
                 [sys.executable, "-m", "pip", "install", "uv"],  # pip install command for the current interpreter
-                timeout=self.upgrade_check_timeout,  # Bound the install so startup can't hang
+                timeout=self.upgrade_check_timeout,  # Bound the install so startup cannot hang
                 check=False,  # Caller inspects returncode to branch on success/failure.
             )
             if result.returncode == 0:  # pip reported success
@@ -1415,7 +1415,7 @@ class GlobalImportManager:
     def _upgrade_uv(self) -> bool:  # Keep UV up to date, throttled to once per configured interval
         """Upgrade UV package manager to latest version (only if needed)."""
         if not self.auto_upgrade_uv:  # UV auto-management disabled by config
-            return True  # Nothing to do; treat as success
+            return True  # Nothing to do. Treat as success
         now = time.time()  # Current timestamp used for throttling
         if self._uv_update_within_throttle(now):  # Still inside the throttle window
             return True  # No update needed yet
@@ -1436,8 +1436,8 @@ class GlobalImportManager:
         return False  # Throttle window elapsed -- allow the check
 
     def _run_uv_self_update(self, now: float) -> bool:  # Run 'uv self update', recording the attempt time
-        """Attempt 'uv self update'; on failure, dispatch to the pip-fallback handler. Always non-fatal."""
-        try:  # The update may fail; treat most failures as non-critical
+        """Attempt 'uv self update'. On failure, dispatch to the pip-fallback handler. Always non-fatal."""
+        try:  # The update may fail. Treat most failures as non-critical
             logging.info("Checking for UV package manager updates...")  # Announce the update check
             result = SubprocessRunner.run(  # Audited dispatch (initiative 1016) -- 'uv' basename allow-listed.
                 ["uv", "self", "update"],
@@ -1450,13 +1450,13 @@ class GlobalImportManager:
                 return True  # Done
             return self._handle_uv_selfupdate_failure(result)  # Inspect stderr and try the pip fallback
         except (TimeoutExpired, SubprocessError) as e:  # Update process hung or failed to launch
-            self._last_uv_update_check = now  # Record the attempt so we don't retry immediately
+            self._last_uv_update_check = now  # Record the attempt so we do not retry immediately
             logging.warning("UV self-update failed: %s", e)  # Log the exception
             return True  # Non-critical failure -- the current UV still works
 
     def _handle_uv_selfupdate_failure(self, result: Any) -> bool:  # Handle a non-zero 'uv self update' result
-        """When self-update fails because UV was pip-installed, upgrade via pip; otherwise just log. Non-fatal."""
-        pip_installed_marker = (  # Marker stderr emits when self-update isn't supported for this install method
+        """When self-update fails because UV was pip-installed, upgrade via pip. Otherwise just log. Non-fatal."""
+        pip_installed_marker = (  # Marker stderr emits when self-update is not supported for this install method
             "Self-update is only available for uv binaries installed via the standalone installation scripts"
         )
         if pip_installed_marker not in result.stderr:  # Self-update failed for some other reason
@@ -1466,7 +1466,7 @@ class GlobalImportManager:
         pip_result = SubprocessRunner.run(  # Audited dispatch (initiative 1016) -- interpreter self-invoke allowed.
             [sys.executable, "-m", "pip", "install", "--upgrade", "uv"],  # pip upgrade command
             timeout=self.upgrade_check_timeout,  # Bound the upgrade
-            check=False,  # Caller inspects returncode; non-zero is warned, not raised.
+            check=False,  # Caller inspects returncode. Non-zero is warned, not raised.
         )
         if pip_result.returncode == 0:  # pip upgrade succeeded
             logging.info("UV package manager updated successfully via pip")  # Confirm the upgrade
@@ -1490,10 +1490,10 @@ class GlobalImportManager:
             return False  # Signal failure so the caller can fall back to pip
 
     def _attempt_uv_install(self, cmd: list[str], package_spec: str, *, fallback: bool) -> bool:  # One UV install try
-        """Run one UV install attempt; on success log+return True. On failure return False (logs stderr if fallback)."""
+        """Run one UV install attempt. On success log+return True. On failure return False (logs stderr if fallback)."""
         result = SubprocessRunner.run(  # Audited dispatch (initiative 1016) -- cmd argv built from allow-listed pieces.
             cmd,  # The assembled UV command
-            timeout=self.upgrade_check_timeout,  # Bound the install so it can't hang forever
+            timeout=self.upgrade_check_timeout,  # Bound the install so it cannot hang forever
             check=False,  # Non-zero rc is handled by the caller (fallback logging).
         )
         if result.returncode == 0:  # UV reported a successful install
@@ -1515,7 +1515,7 @@ class GlobalImportManager:
         return "uv"  # venv has no local UV -- fall back to PATH 'uv'
 
     def _build_uv_install_cmd(self, uv_cmd: str, package_spec: str, no_build_isolation: bool) -> list[str]:  # UV argv
-        """Assemble the 'uv pip install' argv: pin to this interpreter in a venv; add --no-build-isolation if set."""
+        """Assemble the 'uv pip install' argv: pin to this interpreter in a venv. Add --no-build-isolation if set."""
         cmd = [uv_cmd, "pip", "install"]  # Base UV install command
         if hasattr(self, "in_venv") and self.in_venv:  # Inside a venv -- pin the install to this interpreter
             cmd += ["--python", sys.executable]  # Target the current Python explicitly
@@ -1531,7 +1531,7 @@ class GlobalImportManager:
             # Always use the current Python executable to ensure installation in the right environment
             result = SubprocessRunner.run(  # Audited dispatch (initiative 1016) -- interpreter self-invoke allowed.
                 [sys.executable, "-m", "pip", "install", package_spec],  # Invoke pip as a module of this Python
-                timeout=self.upgrade_check_timeout,  # Bound the install so it can't hang forever
+                timeout=self.upgrade_check_timeout,  # Bound the install so it cannot hang forever
                 check=False,  # Non-zero rc is inspected below rather than raised.
             )
             if result.returncode == 0:  # pip reported a successful install
@@ -1566,7 +1566,7 @@ class GlobalImportManager:
                 ["uv", "--version"], timeout=5, check=False
             )  # Query installed UV version via SubprocessRunner (validates argv, no shell).
             if result.returncode != 0:  # UV is missing or failed to report its version
-                return False  # Can't determine an update is needed
+                return False  # Cannot determine an update is needed
 
             # For now, we'll assume UV is up to date since checking remote version is complex
             # In a production environment, you might want to implement version comparison
@@ -1580,7 +1580,7 @@ class GlobalImportManager:
         """Install missing dependencies and upgrade existing ones."""
         if not self.auto_upgrade_dependencies:  # Auto-upgrade disabled by configuration
             logging.info("Auto-upgrade of dependencies is disabled in configuration")  # Note the skip
-            return True  # Nothing to do; treat as success
+            return True  # Nothing to do. Treat as success
         packages_to_process = self._collect_packages_to_process()  # (name, spec) pairs, built-ins excluded
         if not packages_to_process:  # Caller supplied an empty work list
             logging.info("No packages to process")  # Note there is nothing to do
@@ -1591,7 +1591,7 @@ class GlobalImportManager:
         return success_count > 0  # Report success if at least one package installed
 
     def _install_dependency_batch(self, packages_to_process: list[tuple[str, str]]) -> int:  # Install a batch
-        """Install each (name, spec) package via the best backend; return the count that installed successfully."""
+        """Install each (name, spec) package via the best backend. Return the count that installed successfully."""
         uv_available = self._check_uv_installation()  # Detect whether UV can be used as the fast installer
         logging.info(  # Record which installer backend will be used
             "Using UV package manager for installations"
@@ -1679,7 +1679,7 @@ class GlobalImportManager:
                 if isinstance(iterable, Sized):  # The iterable has a known length
                     total = len(cast(Sized, iterable))  # Compute total item count for the message
                     logging.info("%s: %s %ss to process", desc, total, unit)  # Log a one-shot progress summary
-                else:  # Length is unknown (e.g. a generator)
+                else:  # Length is unknown (for example a generator)
                     logging.info("%s: processing %ss...", desc, unit)  # Log an indefinite progress message
                 return iterable  # Pass the iterable through unchanged (no live bar)
 
@@ -1687,8 +1687,8 @@ class GlobalImportManager:
 
     def _check_and_upgrade_package(self, module_name: str, package_spec: str) -> bool:
         """Check if a package needs upgrading and upgrade it if necessary. Always non-fatal (returns True)."""
-        if not package_spec:  # No version spec provided (e.g. a stdlib module)
-            return True  # Built-in modules don't need upgrading
+        if not package_spec:  # No version spec provided (for example a stdlib module)
+            return True  # Built-in modules do not need upgrading
         try:  # Upgrade problems must never block startup
             package_name = self._bare_package_name(package_spec)  # Strip version operators to the bare name
             result = self._run_pip_show(package_name)  # Ask pip what version is currently installed
@@ -1707,7 +1707,7 @@ class GlobalImportManager:
 
     @staticmethod
     def _bare_package_name(package_spec: str) -> str:  # Strip version operators from a package spec
-        """Return the bare package name from a spec (e.g. 'requests>=2.28.0' -> 'requests')."""
+        """Return the bare package name from a spec (for example 'requests>=2.28.0' -> 'requests')."""
         return package_spec.split(">=")[0].split("==")[0].split("<")[0].split(">")[0].strip()  # Drop any constraint
 
     def _run_pip_show(self, package_name: str) -> Any:  # Query pip for a package's metadata
@@ -1740,7 +1740,7 @@ class GlobalImportManager:
         """Run the upgrade command and log whether the version advanced. Always non-fatal (returns True)."""
         upgrade_result = SubprocessRunner.run(  # Audited dispatch (initiative 1016).
             self._build_upgrade_cmd(package_spec),  # UV or pip upgrade argv
-            timeout=self.upgrade_check_timeout,  # Bound the upgrade so it can't hang
+            timeout=self.upgrade_check_timeout,  # Bound the upgrade so it cannot hang
             check=False,  # Non-zero rc is downgraded to a debug log, not raised.
         )
         if upgrade_result.returncode != 0:  # The upgrade command failed
@@ -1776,7 +1776,7 @@ class GlobalImportManager:
         )  # All four install gates must pass before attempting an install.
 
     def _attempt_install(self, package_spec: str) -> bool:
-        """Install a package, preferring UV then falling back to pip; return True if either succeeded."""
+        """Install a package, preferring UV then falling back to pip. Return True if either succeeded."""
         installed = False  # Track whether any installer succeeded.
         if self._check_uv_installation():  # UV is the preferred fast installer.
             logging.debug("Trying UV installation for %s", package_spec)  # Note the UV attempt.
@@ -1798,7 +1798,7 @@ class GlobalImportManager:
                 logging.debug("Cleared cached module: %s", mod_name)  # Record the cache purge.
 
     def _retry_import_after_install(self, module_name: str, package_spec: str, required: bool) -> Any | None:
-        """Re-import a module after a successful install; return it, or None if the import still fails."""
+        """Re-import a module after a successful install. Return it, or None if the import still fails."""
         try:  # The install may still not satisfy the import in this Python session.
             module = self._resolve_and_import(module_name)  # Re-import now that the package is installed.
             self.imports[module_name] = module  # Cache the now-successful import.
@@ -1820,7 +1820,7 @@ class GlobalImportManager:
     def _install_and_retry(
         self, module_name: str, package_spec: str | None, required: bool, skip_deps: bool
     ) -> Any | None:
-        """Install a missing dependency (when permitted) and retry the import; return the module or None."""
+        """Install a missing dependency (when permitted) and retry the import. Return the module or None."""
         if not self._auto_install_allowed(package_spec, skip_deps):  # Auto-install must be permitted.
             return None  # Installation not allowed -- nothing to retry.
         if package_spec is None:  # Defensive guard: an overridden gate must never trigger an unbounded install.
@@ -1981,12 +1981,12 @@ class GlobalImportManager:
         Import packages concurrently for faster dependency resolution.
 
         Args:
-            packages_dict: Dictionary of package_name: package_spec
-            required: Whether these are required (True) or optional (False) packages
-            skip_deps: Whether to skip dependency installation
-            max_workers: Maximum number of concurrent workers
+            packages_dict: A package to spec map.
+            required: True for required packages.
+            skip_deps: Skip installation when True.
+            max_workers: The thread pool size.
         """
-        log_lock = threading.Lock()  # Guards logging so concurrent threads don't interleave messages
+        log_lock = threading.Lock()  # Guards logging so concurrent threads do not interleave messages
         builtin_packages, external_packages = self._partition_dependencies(packages_dict)  # Split by spec presence
         for item in builtin_packages.items():  # Built-ins import instantly with no network needed
             self._import_single_dependency(item, required, skip_deps, log_lock)  # Import each sequentially
@@ -2243,15 +2243,15 @@ class GlobalImportManager:
 def _get_tuning_data_file_path() -> str:
     """Return full path to tuning data JSON stored in data/ directory.
 
-    Ensures the directory exists. Separated for future extension (e.g.,
+    Ensures the directory exists. Separated for future extension (for example,
     namespacing by org or mode) without scattering path logic.
     """
     data_dir = os.path.join(os.getcwd(), "data")  # Build the path to the data/ subdirectory under the CWD
     try:
         os.makedirs(data_dir, exist_ok=True)  # Create data/ if it does not already exist (idempotent)
     except Exception:
-        # If directory creation fails, fall back to current working directory;
-        # logging deferred until logger configured.
+        # If directory creation fails, fall back to current working directory.
+        # Logging deferred until logger configured.
         return os.path.join(os.getcwd(), "tuning_data.json")  # Degrade gracefully to a CWD-level file
     return os.path.join(data_dir, "tuning_data.json")  # Normal case: store tuning data inside data/
 
@@ -2300,7 +2300,7 @@ if (
     else:  # Some other deferring flag combination
         logging.info("Deferring import initialization due to CLI flags")  # Generic deferral notice
 
-if _initialize_imports_now:  # Eager path: set up all imports now
+if _initialize_imports_now:  # Eager path: prepare all imports now
     # Initialize all imports upfront for faster runtime performance
     success, global_assignments = (
         import_manager.initialize_all_imports()
@@ -2361,7 +2361,7 @@ LAST_SELECTED_SITE_ID: str | None = None
 # transparently -- the re-exported symbol is the same class, not a delegator.
 # The rebind dance ``ensure_tqdm_available`` used to perform is no longer
 # needed since T-14 makes ``tqdm`` resolve through ``src.utils.tqdm_wrapper``
-# at import time; the probe was retained for its logging side effect at the
+# at import time. The probe was retained for its logging side effect at the
 # single caller (``src/refactors/main_entrypoint.py``).
 from src.utils.input_utils import InputUtils  # noqa: E402, I001  # Cat E canonical (1015 T-09) -- re-export.
 
@@ -2377,7 +2377,7 @@ AUTO_UPGRADE_DEPENDENCIES: bool = config["auto_upgrade_dependencies"]  # Whether
 UPGRADE_CHECK_TIMEOUT: int = config["upgrade_check_timeout"]  # Seconds before an install/upgrade subprocess times out
 
 # API Request Timeout (seconds) - prevents indefinite hangs on slow/dropped connections
-# Default 120s is generous; most Mist API calls return within 30s
+# Default 120s is generous. Most Mist API calls return within 30s
 API_REQUEST_TIMEOUT = int(os.getenv("API_REQUEST_TIMEOUT", "120"))  # Hard cap on a single API request
 API_REQUEST_MAX_RETRIES = int(os.getenv("API_REQUEST_MAX_RETRIES", "3"))  # How many times to retry a failed API request
 API_REQUEST_RETRY_DELAY = float(os.getenv("API_REQUEST_RETRY_DELAY", "5.0"))  # Seconds to wait between API retries
@@ -2391,13 +2391,13 @@ org_id = None  # Active organization ID, populated after the user selects an org
 # Additional Fast Mode Configuration from .env (continuing from earlier definitions)
 # NOTE: FAST_MODE_BACKOFF_MULTIPLIER extracted to
 # src/refactors/fast_mode_backoff_multiplier.py::FastModeBackoffMultiplier.VALUE
-# per initiative 1011 SC-028 (FR-003: no wrapper shim; FR-005: const->classattr).
+# per initiative 1011 SC-028 (FR-003: no wrapper shim, FR-005: const->classattr).
 # NOTE: FAST_MODE_DEVICES_PER_THREAD extracted to
 # src/refactors/fast_mode_devices_per_thread.py::FastModeDevicesPerThread.VALUE
-# per initiative 1011 SC-029 (FR-003: no wrapper shim; FR-005: const->classattr).
+# per initiative 1011 SC-029 (FR-003: no wrapper shim, FR-005: const->classattr).
 # NOTE: FAST_MODE_SEQUENTIAL_MAX_RETRIES extracted to
 # src/refactors/fast_mode_sequential_max_retries.py::FastModeSequentialMaxRetries.VALUE
-# per initiative 1011 SC-030 (FR-003: no wrapper shim; FR-005: const->classattr).
+# per initiative 1011 SC-030 (FR-003: no wrapper shim, FR-005: const->classattr).
 FAST_MODE_RETRY_THREADS = int(os.getenv("FAST_MODE_RETRY_THREADS", "4"))  # Thread count for the retry pass
 FAST_MODE_RETRY_MAX_RETRIES = int(os.getenv("FAST_MODE_RETRY_MAX_RETRIES", "2"))  # Retry ceiling within the retry pass
 FAST_MODE_FALLBACK_THREADS = int(os.getenv("FAST_MODE_FALLBACK_THREADS", "8"))  # Thread count for the fallback pass
@@ -2410,7 +2410,7 @@ FAST_MODE_FALLBACK_THREADS = int(os.getenv("FAST_MODE_FALLBACK_THREADS", "8"))  
 FAST_MODE_ENABLED: bool = False  # Set to True via --fast CLI flag at startup
 
 # NOTE: MIST_WAN_TARGET_PORTS extracted to src/refactors/mist_wan_target_ports.py
-# per initiative 1011 SC-032 (FR-003: no wrapper shim; FR-005: assignment->classattr).
+# per initiative 1011 SC-032 (FR-003: no wrapper shim, FR-005: assignment->classattr).
 
 # NOTE: MIST_SITE_EXCLUDE_PREFIX extracted to src/refactors/mist_site_exclude_prefix.py (T-15, Cat E).
 # Site Exclusion Configuration from .env (REQUIRED - no defaults).
@@ -2426,13 +2426,13 @@ OUTPUT_FORMAT = "csv"  # Valid values: "csv", "sqlite"
 DATABASE_PATH = os.path.join("data", "mist_data.db")  # Path to hybrid SQLite database with natural primary keys
 
 # Global progress telemetry emitter (initialized in main(), best-effort per FR-008)
-PROGRESS_EMITTER = None  # Set in main() to a telemetry sink; None disables progress reporting
+PROGRESS_EMITTER = None  # Set in main() to a telemetry sink. None disables progress reporting
 
 # ============================================================================
 # GLOBAL SESSION INITIALIZATION
 # ============================================================================
 
-# Initialize Mist API session (will be set up after authentication)
+# Initialize Mist API session (prepared after authentication)
 # Type annotation uses Any since mistapi is dynamically imported
 apisession: Any | None = None
 
@@ -2480,7 +2480,7 @@ def _restore_session_globals_from_state(state: dict[str, Any]) -> None:
 
 # NOTE: initialize_mist_session_interactive() extracted to
 # src/refactors/initialize_mist_session_interactive.py::MistSessionInteractiveInitializer.initialize
-# per initiative 1011 SC-023 (FR-003: no wrapper shim; FR-005: fn->method).
+# per initiative 1011 SC-023 (FR-003: no wrapper shim, FR-005: fn->method).
 
 
 def _print_switch_login_header() -> None:
@@ -2520,7 +2520,7 @@ def _attempt_interactive_login_with_rollback(old_session: Any, old_org_id: str |
     global apisession, msp_privileges, org_id  # We may overwrite or restore these globals
 
     logging.debug("Entering _attempt_interactive_login_with_rollback()")  # Trace entry for debugging
-    logging.debug("Clearing existing session state for re-authentication")  # Note we're resetting before re-login
+    logging.debug("Clearing existing session state for re-authentication")  # Note we are resetting before re-login
 
     apisession = None  # Drop the current session so the interactive flow starts clean
     msp_privileges = []  # Clear cached MSP grants from the old session
@@ -2642,7 +2642,7 @@ def _select_org_from_session() -> None:
         "  Selecting organization from your session privileges..."
     )  # Legacy console echo routed via logger.
     logging.warning("")  # Legacy console echo routed via logger.
-    _invoke_mistapi_org_picker_and_apply()  # Run picker; updates the org_id global
+    _invoke_mistapi_org_picker_and_apply()  # Run picker. Updates the org_id global
 
 
 def _load_mistapi_module(current_mistapi: Any) -> Any:
@@ -2713,10 +2713,10 @@ def _preflight_verify_credentials(require_token: bool = True) -> None:
     """Fail closed before any mistapi/requests call when host/token config is missing or a placeholder.
 
     Feature 1020 (US3): invoked at the top of ``_establish_mist_session()`` for every dispatch mode. It
-    performs only local string validation - it never imports ``requests``/``mistapi`` and never issues an
-    HTTP request - so a misconfigured run exits with a redacted, actionable message instead of letting
-    mistapi build a malformed URL. Token presence is required for token-based modes
-    (``--test``/``--testinteractive``/TUI/CLI); ``require_token`` is False for interactive ``--login``,
+    performs only local string validation. It never imports ``requests`` or ``mistapi`` and never issues
+    an HTTP request. So a misconfigured run exits with a redacted, actionable message instead of a
+    malformed URL from mistapi. Token presence is required for token-based modes
+    (``--test``/``--testinteractive``/TUI/CLI). The ``require_token`` is False for interactive ``--login``,
     which authenticates via email/password rather than a token. Any token value present is shown only via
     ``_redact_tokens()`` previews, never raw (FR-015/SC-005).
     """
@@ -2748,7 +2748,7 @@ def _preflight_verify_credentials(require_token: bool = True) -> None:
 
 
 def _check_token_rate_limit(token: str, test_host: str) -> bool:
-    """Probe a token via GET /self; True if rate-limited/unreachable, False if usable."""
+    """Probe a token via GET /self. True if rate-limited/unreachable, False if usable."""
     try:
         import requests  # Import here -- only needed for this edge-case rate-limit probe path
 
@@ -2885,7 +2885,7 @@ def _try_single_session_kwargs(
     attempt_num: int,
     total: int,
 ) -> tuple[Any, bool]:
-    """Try one APISession kwargs dict; return (session_or_None, rate_limit_seen)."""
+    """Try one APISession kwargs dict. Return (session_or_None, rate_limit_seen)."""
     if apisession_cls is None:  # Guard: class must be present if attempts list was built
         raise AssertionError("apisession_cls should be set if attempts list is populated")
     try:  # APISession constructor may raise on auth/validation/rate-limit
@@ -2908,7 +2908,7 @@ def _execute_session_attempts(
     apisession_cls: Any,
     attempts: list[dict[str, str]],
 ) -> tuple[Any, Any, bool, list[str]]:
-    """Try each kwargs dict until one constructs a valid APISession; track rate-limit signal."""
+    """Try each kwargs dict until one constructs a valid APISession. Track rate-limit signal."""
     tried_variants: list[str] = []  # Track all attempted kwargs for error reporting on total failure
     successful_method: Any = None  # Will hold the kwargs dict that succeeded
     rate_limit_detected = False  # Set True if NoneType rate-limit error signature is seen
@@ -2917,7 +2917,7 @@ def _execute_session_attempts(
         tried_variants.append(str(list(kwargs.keys())))  # Record attempt as string of keys before trying
         session, attempt_rate_limit = _try_single_session_kwargs(
             apisession_cls, kwargs, i, len(attempts)
-        )  # Try one kwargs dict; capture rate-limit signal
+        )  # Try one kwargs dict. Capture rate-limit signal
         if attempt_rate_limit:  # Even a failed attempt may surface the rate-limit signature
             rate_limit_detected = True  # Preserve the signal across iterations
         if session is not None:  # Successful construction -- record winning kwargs and stop
@@ -3122,7 +3122,7 @@ def _validate_initialized_session(session: Any, successful_method: Any) -> bool:
 
     Calls _ensure_mist_get_method to verify/add mist_get compatibility, then
     calls _log_session_auth_status to warn if authentication cannot be confirmed.
-    Returns False only for hard failures (missing mist_get); auth warnings are non-fatal.
+    Returns False only for hard failures (missing mist_get). Auth warnings are non-fatal.
 
     Args:
         session: The initialized APISession or Session object.
@@ -3163,14 +3163,14 @@ def _log_failed_session_variants(tried_variants: list[str]) -> None:
 
 # NOTE: initialize_mist_session() extracted to
 # src/refactors/initialize_mist_session.py::MistSessionInitializer.initialize
-# per initiative 1011 SC-024 (FR-003: no wrapper shim; FR-005: fn->method).
+# per initiative 1011 SC-024 (FR-003: no wrapper shim, FR-005: fn->method).
 
 
 def _install_default_request_timeout(inner_session: Any) -> None:
     """Install API_REQUEST_TIMEOUT as the default timeout on the requests.Session."""
-    from requests.adapters import HTTPAdapter  # Lazy import; requests is large and only needed here
+    from requests.adapters import HTTPAdapter  # Lazy import. The requests package is large and only needed here
 
-    class TimeoutAdapter(HTTPAdapter):  # Nested so we don't expose a public adapter class
+    class TimeoutAdapter(HTTPAdapter):  # Nested so we do not expose a public adapter class
         """HTTPAdapter that injects a default timeout."""
 
         def __init__(self, default_timeout: int, **kwargs: Any) -> None:  # Capture the project-wide timeout default
@@ -3188,7 +3188,7 @@ def _install_default_request_timeout(inner_session: Any) -> None:
         ) -> Any:
             if timeout is None:  # Caller did not supply a per-call timeout -- substitute our default
                 timeout = self.default_timeout
-            # Issue #431: forward args verbatim; signature must match parent for adapter contract.
+            # Issue #431: forward args verbatim. The signature must match parent for adapter contract.
             return super().send(request, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
 
     adapter = TimeoutAdapter(default_timeout=API_REQUEST_TIMEOUT)  # Single instance shared by both schemes
@@ -3301,7 +3301,7 @@ from src.data.data_processing_utils import DataProcessingUtils  # noqa: E402, I0
 # Dependency injection is used so the module has no circular import with MistHelper.
 # NOTE: marvis_data_utils singleton extracted to
 # src/refactors/marvis_data_utils.py::MarvisDataUtilsFactory.instance()
-# per initiative 1011 SC-027 (FR-003: no wrapper shim; FR-005: fn->method).
+# per initiative 1011 SC-027 (FR-003: no wrapper shim, FR-005: fn->method).
 # DatabaseSchemaUtils moved to src/db/database_schema_utils.py (1013 SC-001 position 38)
 # DataExporter body extracted to src/export/data_exporter.py per issue #1015 T-08 (Cat E).
 # Class is imported at module top via: from src.export.data_exporter import DataExporter
@@ -3339,19 +3339,19 @@ from src.ui.prompt_utils import PromptUtils  # noqa: E402,F401  # T-07 re-export
 
 
 # --- OrgInventoryExporter body removed (1015 T-06 Cat E) ---
-# Canonical implementation lives in src/export/org_inventory_exporter.py; re-exported above.
+# Canonical implementation lives in src/export/org_inventory_exporter.py. Re-exported above.
 
 
 # --- OrgDeviceStatsExporter facade removed (1013 SC-001 Cat B pos 45) ---
-# Canonical implementation lives in src/export/org_device_stats_exporter.py; re-exported above.
+# Canonical implementation lives in src/export/org_device_stats_exporter.py. Re-exported above.
 
 
 # --- OfflineDeviceReporter facade removed (1013 SC-001 Cat B pos 44) ---
-# Canonical implementation lives in src/reports/offline_device_reporter.py; re-exported above.
+# Canonical implementation lives in src/reports/offline_device_reporter.py. Re-exported above.
 
 
 # --- OrgDeviceInventorySummary facade removed (1013 SC-001 Cat B pos 29) ---
-# Canonical implementation lives in src/inventory/org_device_inventory_summary_facade.py; re-exported above.
+# Canonical implementation lives in src/inventory/org_device_inventory_summary_facade.py. Re-exported above.
 
 
 # OrgTemplateExporter moved to src/export/org_template_exporter.py (1013 SC-001 position 22)
@@ -3383,7 +3383,7 @@ from src.ui.prompt_utils import PromptUtils  # noqa: E402,F401  # T-07 re-export
 # OrgConfigExporter moved to src/export/org_config_exporter.py (issue #1013 SC-001 position 31)
 
 
-# --- OrgExportUtils facade removed (1013 SC-001 Cat B pos 47); see src/export/org_export_utils.py ---
+# --- OrgExportUtils facade removed (1013 SC-001 Cat B pos 47). See src/export/org_export_utils.py ---
 
 
 # ============================================================================
@@ -3401,11 +3401,11 @@ from src.ui.prompt_utils import PromptUtils  # noqa: E402,F401  # T-07 re-export
 
 
 # --- SiteAnomalyExporter facade removed (1013 SC-001 Cat B pos 43) ---
-# Canonical implementation lives in src/export/site_anomaly_exporter.py; re-exported above.
+# Canonical implementation lives in src/export/site_anomaly_exporter.py. Re-exported above.
 
 
 # --- SitesByAPModelExporter facade removed (1013 SC-001 Cat B pos 28) ---
-# Canonical implementation lives in src/export/sites_by_ap_model_exporter.py; re-exported above.
+# Canonical implementation lives in src/export/sites_by_ap_model_exporter.py. Re-exported above.
 
 # ============================================================================
 # WEBSOCKET COMMAND FUNCTIONS
@@ -3453,7 +3453,7 @@ def _get_duc_instance() -> DeviceUtilityCommands:  # Build DeviceUtilityCommands
 
 
 # NOTE: DeviceUtilityCommands facade removed 2026-07-07 (Issue #1013, SC-001 position 4).
-# The 188-LOC facade of 35 @staticmethod delegates lived here; menu_actions callsites now
+# The 188-LOC facade of 35 @staticmethod delegates lived here. The menu_actions callsites now
 # invoke `lambda: _get_duc_instance().method_name()` directly against the canonical
 # instance-based class in `src/device/utility_commands.py`. See PR history for details.
 
@@ -3576,7 +3576,7 @@ def _dispatch_gateway_device_configs(debug: bool = False, fast: bool = False) ->
 
 # NOTE: GatewayExportUtils facade removed per 1013 SC-001 (Cat A, position 13).
 # Canonical class lives at src/gateway/gateway_export_utils.py and is imported at
-# top-of-file. DI wiring lives in _configure_gateway_module() above; menu callbacks
+# top-of-file. DI wiring lives in _configure_gateway_module() above. Menu callbacks
 # route through _dispatch_gateway_* shims to ensure DI cascade runs first.
 
 
@@ -3604,7 +3604,7 @@ def _dispatch_gateway_device_configs(debug: bool = False, fast: bool = False) ->
 # ============================================================================
 # SSH RUNNER MANAGER FACADE REMOVED (1014 P15, Cat A)
 # ============================================================================
-# Canonical class lives at src/ssh/ssh_runner_manager.py; imported at top of file.
+# Canonical class lives at src/ssh/ssh_runner_manager.py. Imported at top of file.
 # The helper below builds the DI container from MistHelper module globals.
 def _build_ssh_runner_deps() -> SSHRunnerManagerDeps:  # Build the deps bundle for SSHRunnerManager entrypoints.
     """Build dependency container for SSH runner logic (reads MistHelper globals)."""
@@ -3752,7 +3752,7 @@ def _build_firmware_manager(session: Any, target_org_id: str) -> FirmwareManager
 
 # NOTE: OrgLevelAPFirmwareUpgrader facade removed per initiative 1014 SC-001 position 7
 # (FR-004 fold-in / FR-003 no wrapper shim). The canonical body lives at
-# src/firmware/org_ap_upgrader.py; menu 157 + menu 168 callbacks now build the
+# src/firmware/org_ap_upgrader.py. Menu 157 + menu 168 callbacks now build the
 # implementation directly via _build_org_ap_upgrader() and inline DI.
 
 
@@ -3763,8 +3763,8 @@ def _build_org_ap_upgrader(**overrides: Any) -> _OrgLevelAPFirmwareUpgrader:
     ``selected_msp`` via keyword. All remaining hooks bind to canonical
     MistHelper.py collaborators.
     """
-    # WHY: read-only references to module globals msp_privileges/apisession/selected_msp;
-    # no assignment means `global` is unnecessary (drops PLW0602 site, initiative 1016).
+    # WHY: read-only references to module globals msp_privileges/apisession/selected_msp.
+    # No assignment means `global` is unnecessary (drops PLW0602 site, initiative 1016).
     kwargs: dict[str, Any] = dict(  # WHY: build DI kwargs dict for src class
         org_id=ConfigUtils.get_cached_or_prompted_org_id() or "",
         apisession=apisession,
@@ -3783,7 +3783,7 @@ def _build_org_ap_upgrader(**overrides: Any) -> _OrgLevelAPFirmwareUpgrader:
 
 
 # NOTE: BulkSwitchFirmwareUpgrader folded into FirmwareManager per initiative 1011 SC-033
-# (FR-015: fold-in to caller; FR-003: no wrapper shim). Sole caller now dispatches directly
+# (FR-015: fold-in to caller, FR-003: no wrapper shim). Sole caller now dispatches directly
 # to src.firmware.bulk_switch_upgrader.BulkSwitchFirmwareUpgrader.
 
 
@@ -4846,7 +4846,7 @@ def _systematic_test_build_safe_list(
     for opt in optimized_test_order:  # Place optimized-order options first to minimize total test run time.
         if opt in remaining:  # Only include options present in the actual safe set.
             safe_options.append(opt)  # Add to the ordered result.
-            remaining.discard(opt)  # Remove so it won't appear in the remainder block.
+            remaining.discard(opt)  # Remove so it will not appear in the remainder block.
     safe_options.extend(
         sorted(remaining, key=lambda x: float(x.replace("a", ".1")))
     )  # Append all remaining safe options in natural numeric order.
@@ -4876,7 +4876,7 @@ def _systematic_test_emit_skips(emitter: Any, unsafe_list: list[str]) -> int:
 def _resolve_systematic_test_invoke_kwargs(func: Any, fast_enabled: bool) -> dict[str, Any]:
     """Inspect a menu function's signature and build invoke kwargs (fast=True only if supported)."""
     supports_fast = False  # Default to no fast-mode support until introspection confirms it.
-    try:  # inspect.signature can raise on built-in callables; degrade gracefully.
+    try:  # inspect.signature can raise on built-in callables. Degrade gracefully.
         sig = inspect.signature(func)  # Detect optional 'fast' parameter
         supports_fast = "fast" in sig.parameters  # True when function accepts fast-mode
     except Exception:  # Signature inspection failure is non-fatal
@@ -4890,7 +4890,7 @@ def _resolve_systematic_test_invoke_kwargs(func: Any, fast_enabled: bool) -> dic
 def _invoke_one_systematic_test(
     emitter: Any, case: SystematicTestOption, invoke_kwargs: dict[str, Any], op_start: float
 ) -> tuple[bool, float]:
-    """Call one menu func with the resolved kwargs; record pass/fail in telemetry and return (success, duration)."""
+    """Call one menu func with the resolved kwargs. Record pass/fail in telemetry and return (success, duration)."""
     option, func, description = case.option, case.func, case.description  # Unpack identity (issue #470)
     try:  # Each option runs independently so one failure does not abort remaining tests
         func(**invoke_kwargs)  # Call menu action
@@ -4946,7 +4946,7 @@ def _fast_mode_from_global() -> bool:
 
 def _fast_mode_from_cli_args() -> bool:
     """Return True iff parsed ``args`` exist in globals and carry ``--fast`` (errors -> False)."""
-    try:  # CLI args presence + attribute lookup can both fail; degrade safely.
+    try:  # CLI args presence + attribute lookup can both fail. Degrade safely.
         cli_args = globals().get("args") if "args" in globals() else None  # Locate parsed args, if any.
         return bool(cli_args and getattr(cli_args, "fast", False))  # Truthy only when --fast was set.
     except Exception:  # Defensive -- never propagate.
@@ -5021,7 +5021,7 @@ def _initialize_systematic_telemetry(unsafe_list: list[str]) -> tuple[TelemetryE
     emitter = TelemetryEmitter(telemetry_path)  # Open emitter so all events land in one timestamped file.
     skip_count = _systematic_test_emit_skips(
         emitter, unsafe_list
-    )  # Print skip list and emit skip events; returns actual skip count.
+    )  # Print skip list and emit skip events. Returns actual skip count.
     return emitter, telemetry_path, skip_count
 
 
@@ -5050,7 +5050,7 @@ def _execute_systematic_test_loop(
         else:  # Non-success means the option raised or returned an error.
             error_count += 1  # Increment on failed option execution.
         if not fast_enabled:  # API-respectful delay between test runs in normal mode.
-            time.sleep(1)  # One-second pause so the API isn't hammered by rapid-fire requests.
+            time.sleep(1)  # One-second pause so the API is not hammered by rapid-fire requests.
     return success_count, error_count
 
 
@@ -5087,7 +5087,7 @@ def _report_systematic_outcome(success_count: int, error_count: int, safe_count:
             success_count,
             total_time,
         )  # Record all-pass event for monitoring.
-        return True  # Signal all-pass to callers (e.g., for exit-code logic).
+        return True  # Signal all-pass to callers (for example, for exit-code logic).
     logging.warning(
         "    %d operations failed - check logs for details", error_count
     )  # Legacy console echo routed via logger.
@@ -5320,8 +5320,8 @@ def _add_interface_arguments(parser: argparse.ArgumentParser) -> None:
 
 
 # Mapping of unsupported flag spellings -> the supported canonical spelling.
-# Why: users naturally type hyphenated variants (e.g. `--test-interactive`) but argparse
-# treats a hyphen as a token boundary, so it can't prefix-match to `--testinteractive`.
+# Why: users naturally type hyphenated variants (for example `--test-interactive`) but argparse
+# treats a hyphen as a token boundary, so it cannot prefix-match to `--testinteractive`.
 # Left unchecked, the invocation is rejected by argparse with a generic "unrecognized
 # arguments" message and (worse) the interactive-test module-import sniff at the top of
 # this file — which literally checks `"--testinteractive" in sys.argv` — silently
@@ -5336,11 +5336,11 @@ def _reject_unsupported_flag_variants(argv: list[str]) -> None:
     """Exit with actionable guidance when *argv* contains a known unsupported flag spelling.
 
     Why:
-        argparse cannot prefix-match `--test-interactive` to `--testinteractive` (the hyphen
-        breaks matching), and the module-import-time argv sniff for `--testinteractive`
-        (see top of this file) would silently proceed as if the test flag were absent.
-        Issue #1640 requires that the unsupported spelling produce an actionable error
-        naming the correct canonical flag and NEVER silently reroute the user.
+        argparse cannot prefix-match `--test-interactive` to `--testinteractive`, because the
+        hyphen breaks matching. The module-import-time argv sniff for `--testinteractive`
+        (see top of this file) would then proceed as if the test flag were absent.
+        Issue #1640 requires that the unsupported spelling produce an actionable error.
+        The error must name the correct canonical flag and NEVER silently reroute the user.
 
     Args:
         argv: The raw argument list (typically `sys.argv[1:]`) to scan. Tokens are also
@@ -5351,7 +5351,7 @@ def _reject_unsupported_flag_variants(argv: list[str]) -> None:
             in `_UNSUPPORTED_FLAG_VARIANTS`. The stderr message names both the offending
             spelling and the supported canonical spelling.
     """
-    for token in argv:  # Scan every raw token in argv; order-independent match.
+    for token in argv:  # Scan every raw token in argv. Order-independent match.
         head = token.split("=", 1)[0]  # Strip any `=value` suffix so `--flag=1` is comparable.
         if head in _UNSUPPORTED_FLAG_VARIANTS:  # Only gate the explicitly-listed bad spellings.
             supported = _UNSUPPORTED_FLAG_VARIANTS[head]  # Look up the canonical replacement.
@@ -5488,7 +5488,7 @@ def _establish_mist_session(args: argparse.Namespace) -> None:
     # Feature 1020 (US3, R4 insertion-point 1): host/token preflight for every dispatch mode. Runs before
     # the --login/token branches so a missing/placeholder host or token exits with a redacted, actionable
     # message BEFORE mistapi/requests can build a malformed URL. require_token is False for interactive
-    # --login (email/password auth needs no token); host is still validated in both modes. The second,
+    # --login (email/password auth needs no token). Host is still validated in both modes. The second,
     # distinct failure mode - a non-interactive org-id miss - is guarded separately in ConfigUtils (R4
     # insertion-point 2), since org selection is interactive-vs-non-interactive dependent.
     _preflight_verify_credentials(require_token=not args.login)  # Fail closed pre-network on bad host/token
@@ -5554,7 +5554,7 @@ def _configure_runtime_options(args: argparse.Namespace) -> None:
             "Progress telemetry emitter init failed (non-blocking): %s", emitter_exc
         )  # Log non-fatal failure
         PROGRESS_EMITTER = None  # Set to None so callers skip telemetry gracefully
-    if args.debug:  # Apply debug logging level to file handlers; keep console at INFO to avoid noise
+    if args.debug:  # Apply debug logging level to file handlers. Keep console at INFO to avoid noise
         _apply_debug_log_level()  # Promote root + file handlers to DEBUG
     logging.debug("_configure_runtime_options: complete")  # Log exit
 
@@ -5587,7 +5587,7 @@ def _ensure_tui_api_session() -> None:
 
 
 def _silence_console_handlers_for_tui() -> None:
-    """Remove non-file console handlers from the root logger so they don't disrupt the Rich UI."""
+    """Remove non-file console handlers from the root logger so they do not disrupt the Rich UI."""
     root_logger = logging.getLogger()  # Access root logger to modify handlers.
     console_handlers = [  # Identify console handlers to suppress during TUI.
         h
@@ -5595,7 +5595,7 @@ def _silence_console_handlers_for_tui() -> None:
         if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
     ]
     for handler in console_handlers:  # Iterate handlers to remove each.
-        root_logger.removeHandler(handler)  # Remove console handler so logs don't disrupt Rich display.
+        root_logger.removeHandler(handler)  # Remove console handler so logs do not disrupt Rich display.
         logging.debug("TUI_MODE: Removed console handler to prevent interference with Rich TUI")  # Log removal.
 
 
@@ -5679,7 +5679,7 @@ def _resolve_cli_org_id(args: argparse.Namespace) -> str:
     """Return --org if given, otherwise resolve from cache / interactive prompt."""
     if args.org:  # CLI explicitly provided the org ID.
         logging.info("Using org_id from CLI argument: %s", args.org)  # Log CLI org ID.
-        return str(args.org)  # Return the CLI org ID (argparse gives Any; narrow to str).
+        return str(args.org)  # Return the CLI org ID (argparse gives Any, so narrow to str).
     return ConfigUtils.get_cached_or_prompted_org_id()  # Fall back to cache or prompt.
 
 
@@ -5687,12 +5687,12 @@ def _build_site_name_to_id_map(sites: list[dict[str, Any]]) -> dict[str, str]:
     """Build a {name: id} lookup map from a list of site dicts, skipping entries missing either field."""
     return {
         str(site["name"]): str(site["id"]) for site in sites if site.get("name") and site.get("id")
-    }  # Build name->id map; drop sites missing name or id
+    }  # Build name->id map. Drop sites missing name or id
 
 
 def _resolve_cli_site_id(args: argparse.Namespace, org_id: str) -> str | None:
     """Resolve --site name to a site_id via API lookup. Exit 1 if name not found. Return None if no --site."""
-    if not args.site:  # No --site supplied; nothing to resolve.
+    if not args.site:  # No --site supplied. Nothing to resolve.
         return None  # Caller treats None as "no site filter".
     logging.info(
         "Resolving site name '%s' to site_id using unified pagination limit %d...",
@@ -5712,7 +5712,7 @@ def _resolve_cli_site_id(args: argparse.Namespace, org_id: str) -> str | None:
 
 def _resolve_cli_device_id(args: argparse.Namespace, site_id: str | None) -> str | None:
     """Resolve --device name to a device_id via site-scoped API lookup. Requires site context."""
-    if not (args.device and site_id):  # Either no --device or no site context; nothing to resolve.
+    if not (args.device and site_id):  # Either no --device or no site context. Nothing to resolve.
         return None  # Caller treats None as "no device filter".
     logging.info("Resolving device name '%s' at site_id '%s'...", args.device, site_id)  # Log before device resolution.
     response = mistapi.api.v1.sites.devices.listSiteDevices(
@@ -5728,7 +5728,7 @@ def _resolve_cli_device_id(args: argparse.Namespace, site_id: str | None) -> str
         )  # Legacy console echo routed via logger.
         sys.exit(1)  # Exit -- cannot proceed with unknown device.
     logging.info("Resolved device name '%s' to device_id '%s'.", args.device, device_id)  # Log resolution success.
-    return str(device_id)  # Return the resolved device_id (dev["id"] is Any; narrow to str).
+    return str(device_id)  # Return the resolved device_id (dev["id"] is Any, so narrow to str).
 
 
 def _dispatch_cli_menu_action(args: argparse.Namespace, site_id: str | None, device_id: str | None) -> None:
@@ -5785,7 +5785,7 @@ def _run_interactive_mode(args: argparse.Namespace) -> None:
         selected = menu_actions.get(iwant)  # Look up user selection in dispatch table.
         if not selected:  # Invalid (non-empty) selection entered -- redisplay or exit.
             _handle_interactive_invalid_selection(iwant, container_mode)  # Print + maybe exit on invalid input.
-            continue  # In container mode, loop again; direct mode already exited inside the handler.
+            continue  # In container mode, loop again. Direct mode already exited inside the handler.
         func, _ = selected  # Extract callable from menu_actions entry.
         logging.info(
             "User selected menu option '%s'. Executing associated function.", iwant
@@ -5794,7 +5794,7 @@ def _run_interactive_mode(args: argparse.Namespace) -> None:
 
 
 def _setup_interactive_container_mode() -> bool:
-    """Detect whether MistHelper is running inside a container; print banner if yes."""
+    """Detect whether MistHelper is running inside a container. Print banner if yes."""
     container_mode = EnvironmentUtils.is_running_in_container()  # Check Podman/Docker container marker files.
     if container_mode:  # Container mode: show banner and loop after each operation.
         logging.info("Container mode detected - enabling continuous menu loop")  # Log container detection.
@@ -5802,7 +5802,7 @@ def _setup_interactive_container_mode() -> bool:
             "[CONTAINER MODE] MistHelper will return to menu after each operation"
         )  # Legacy console echo routed via logger.
         logging.warning("                 Use option 0 to exit the container")  # Legacy console echo routed via logger.
-    return container_mode  # Return flag so the loop can branch on container vs. direct mode.
+    return container_mode  # Return flag so the loop can branch on container or direct mode.
 
 
 def _print_interactive_menu() -> None:
@@ -5867,9 +5867,9 @@ def _execute_interactive_menu_action(iwant: str, func: Callable[[], None], conta
         logging.info("Menu option '%s' execution complete.", iwant)  # Log completion after function returns.
         _dispatch_post_menu_success(iwant, container_mode)  # Branch on container vs direct + session-management ops.
     except KeyboardInterrupt:  # User pressed Ctrl+C during operation.
-        _handle_post_menu_interrupt(iwant, container_mode)  # Container loops; direct exits with SIGINT code.
+        _handle_post_menu_interrupt(iwant, container_mode)  # Container loops. Direct exits with SIGINT code.
     except Exception as error:  # Unexpected error during menu function execution.
-        _handle_post_menu_exception(iwant, error, container_mode)  # Container loops; direct exits with error code.
+        _handle_post_menu_exception(iwant, error, container_mode)  # Container loops. Direct exits with error code.
 
 
 def _dispatch_post_menu_success(iwant: str, container_mode: bool) -> None:
@@ -5924,7 +5924,7 @@ def _handle_post_menu_exception(iwant: str, error: Exception, container_mode: bo
 
 # NOTE: main entrypoint extracted to
 # src/refactors/main_entrypoint.py::MainEntrypoint.run
-# per initiative 1011 SC-026 (FR-003: no wrapper shim; FR-005: fn->method).
+# per initiative 1011 SC-026 (FR-003: no wrapper shim, FR-005: fn->method).
 
 
 def _run_systematic_test_mode(_args: argparse.Namespace) -> None:
@@ -5968,7 +5968,7 @@ def _dispatch_main_mode(args: argparse.Namespace) -> None:
     for predicate, handler in mode_table:  # Stop on first predicate that matches
         if predicate(args):
             handler(args)
-            return  # Most handlers sys.exit; return is defensive for _run_cli_mode
+            return  # Most handlers call sys.exit. The return is defensive for _run_cli_mode
     _run_interactive_mode(args)  # Fallback: interactive menu loop
 
 
@@ -6002,7 +6002,7 @@ if __name__ == "__main__":
             if IS_TEST_MODE:
                 logging.info("TEST MODE ACTIVE: Reducing default 24h lookback windows to 1h for eligible exports.")
         except NameError:
-            # IS_TEST_MODE may not yet be defined if refactor order changes; ignore safely
+            # IS_TEST_MODE may not yet be defined if refactor order changes. Ignore safely
             pass
 
         # Install a global exception hook early so we capture full tracebacks for unexpected issues

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -797,7 +797,7 @@ def _get_installed_version(package_name: str) -> str:  # Look up the installed v
         from importlib.metadata import version as get_version  # Import the stdlib version lookup (Python 3.8+)
 
         return get_version(package_name)  # Return the installed version string (for example '0.59.3')
-    except Exception:  # Package not installed or its metadata is missing
+    except Exception:  # Package not installed or its metadata is absent
         return ""  # Return empty string to signal 'not installed' to callers
 
 
@@ -929,7 +929,7 @@ def _parse_requirements_file(filepath: str = "requirements.txt") -> list[tuple[s
     SECURITY: only reads requirements.txt (no arbitrary file access). Skips comments/blanks/dev deps.
     """
     packages = []  # Accumulate (name, spec) tuples to return to the dependency checker
-    try:  # The file may be missing or unreadable. Handle that gracefully below
+    try:  # The file may be absent or unreadable. Handle that gracefully below
         with open(filepath, encoding="utf-8") as requirements_file:  # Open requirements.txt as UTF-8 text
             for line in requirements_file:  # Process one dependency line at a time
                 parsed = _parse_requirement_line(line)  # Parse this line into (name, spec) or None to skip
@@ -999,7 +999,7 @@ def _is_help_invocation(argv: list[str]) -> bool:
 
 
 # Run early dependency check (will be skipped if DISABLE_AUTO_INSTALL=true
-# or if the user is asking for --help/-h, which must be side-effect-free per #1641).
+# or if the user asks for --help/-h, which must be side-effect-free per #1641).
 if not _is_help_invocation(sys.argv):
     _early_dependency_check()  # Run the bootstrap immediately at import time
 
@@ -1018,7 +1018,7 @@ from datetime import UTC, timezone  # UTC marker plus timezone helper for tz-awa
 # Pylance uses the TYPE_CHECKING imports above for type analysis.
 try:  # PrettyTable is required for formatted console tables
     from prettytable import PrettyTable  # ASCII table renderer used across menus and reports
-except ImportError as _pt_err:  # Required dependency is missing
+except ImportError as _pt_err:  # Required dependency is not installed
     raise ImportError(
         "PrettyTable is required but not installed. Run: pip install prettytable"
     ) from _pt_err  # Fail fast with install guidance
@@ -1032,7 +1032,7 @@ except ImportError:  # numpy not installed
 
 try:  # websocket-client is required for live device diagnostics
     import websocket  # WebSocket client fail-fast install guard (used by src.device.arp_command_manager)
-except ImportError as _ws_err:  # Required dependency is missing
+except ImportError as _ws_err:  # Required dependency is not installed
     raise ImportError(
         "websocket-client is required but not installed. Run: pip install websocket-client"
     ) from _ws_err  # Fail fast with install guidance
@@ -1056,7 +1056,7 @@ from src.utils.tqdm_wrapper import tqdm  # noqa: E402, I001  # Cat E canonical (
 
 try:  # requests is required for all HTTP calls
     import requests  # HTTP library fail-fast install guard (also used via function-local imports)
-except ImportError as _req_err:  # Required dependency is missing
+except ImportError as _req_err:  # Required dependency is not installed
     raise ImportError(
         "requests is required but not installed. Run: pip install requests"
     ) from _req_err  # Fail fast with install guidance
@@ -1131,7 +1131,7 @@ except Exception:  # Missing or non-numeric value
     _parsed_limit = 1000  # Fall back to a sensible default page size
 
 DEFAULT_API_PAGE_LIMIT = max(1, min(_parsed_limit, 1000))  # Clamp to the 1..1000 range the Mist API accepts
-if _parsed_limit != DEFAULT_API_PAGE_LIMIT:  # The configured value was out of range and had to be clamped
+if _parsed_limit != DEFAULT_API_PAGE_LIMIT:  # The code clamped a value that was out of range
     logging.warning(
         "MIST_PAGE_LIMIT value %s adjusted to %s (valid range 1..1000)", _parsed_limit, DEFAULT_API_PAGE_LIMIT
     )  # Warn about the adjustment
@@ -1170,7 +1170,7 @@ try:  # Prefer the full-featured python-dotenv loader when available
     DOTENV_AVAILABLE = True  # Flag that the real loader is in use
     load_dotenv()  # Load .env now so config is available to the import manager
 except ImportError:  # python-dotenv not installed
-    DOTENV_AVAILABLE = False  # Flag that we are using the minimal fallback
+    DOTENV_AVAILABLE = False  # Flag that we use the minimal fallback
     # Use fallback loader and create an alias for later calls
     load_dotenv = _fallback_load_dotenv  # Alias so later load_dotenv() calls still work
     _fallback_load_dotenv()  # Load .env now using the fallback parser
@@ -1270,9 +1270,9 @@ class GlobalImportManager:
         self.installed_packages: list[str] = []  # Names of packages installed during this run
         self.imports: dict[str, Any] = {}  # Cache of imported modules keyed by name for global reuse
         self._uv_available: bool = False  # Cached answer to 'is UV usable?'
-        self._uv_checked: bool = False  # Whether the UV availability check has run yet
+        self._uv_checked: bool = False  # Whether the UV availability check ran
         self._last_uv_update_check: float | None = None  # Track when we last checked for UV updates
-        self._deferred_init_done: bool = False  # Whether the deferred (lazy) init has run
+        self._deferred_init_done: bool = False  # Whether the deferred (lazy) init ran
         self._initialization_complete: bool = False  # Whether full initialization finished
         self._initialization_success: bool = False  # Whether initialization succeeded
         self._cached_global_assignments: dict[str, Any] = {}  # Module globals to publish once imports complete
@@ -1297,7 +1297,7 @@ class GlobalImportManager:
         }
 
     def _detect_virtual_environment(self) -> None:  # Determine and log whether a venv is active
-        """Detect if we are running in a virtual environment and log info."""
+        """Detect if this runs in a virtual environment and log info."""
         self.in_venv = hasattr(sys, "real_prefix") or (
             hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
         )  # venv when prefixes differ
@@ -1369,7 +1369,7 @@ class GlobalImportManager:
         if self._uv_checked:  # We already probed UV earlier this run
             return self._uv_available  # Reuse the cached answer (avoids repeated subprocess calls)
         self._uv_available = self._probe_uv_binary()  # Probe via subprocess and cache the answer
-        self._uv_checked = True  # Mark that we have probed UV so we do not repeat it
+        self._uv_checked = True  # Mark that we probed UV so we do not repeat it
         return self._uv_available  # Return the (now cached) availability
 
     def _probe_uv_binary(self) -> bool:  # Run 'uv --version' to detect UV availability
@@ -1388,7 +1388,7 @@ class GlobalImportManager:
             logging.warning("UV package manager check failed: %s", e)  # Log why the probe failed
             return False  # UV is not usable
 
-    def _install_uv(self) -> bool:  # Try to install UV by pip when it is missing
+    def _install_uv(self) -> bool:  # Try to install UV by pip when it is absent
         """Install UV package manager if not present."""
         if not self.auto_upgrade_uv:  # UV auto-management disabled by config
             logging.info("Auto-upgrade of UV is disabled in configuration")  # Note that we will not install UV
@@ -1477,7 +1477,7 @@ class GlobalImportManager:
     def _install_package_with_uv(self, package_spec: str) -> bool:
         """Install a package using UV package manager with fast resolution and virtual environment awareness."""
         try:
-            logging.debug("Installing package with UV: %s", package_spec)  # Log which package is being installed
+            logging.debug("Installing package with UV: %s", package_spec)  # Log which package the tool installs
             uv_cmd = self._resolve_uv_binary()  # Pick venv-local UV when available, else PATH 'uv'
             first_cmd = self._build_uv_install_cmd(uv_cmd, package_spec, no_build_isolation=True)  # First attempt
             if self._attempt_uv_install(first_cmd, package_spec, fallback=False):  # First UV attempt succeeded
@@ -1551,7 +1551,7 @@ class GlobalImportManager:
         if not self.auto_upgrade_uv:  # UV auto-upgrade is disabled by configuration
             return False  # Never check when the feature is off
 
-        if self._last_uv_update_check is None:  # No prior check has ever run this session
+        if self._last_uv_update_check is None:  # No prior check ran this session
             return True  # Force an initial check
 
         time_since_check = time.time() - self._last_uv_update_check  # Seconds elapsed since the last check
@@ -1565,7 +1565,7 @@ class GlobalImportManager:
             result = SubprocessRunner.run(  # Audited dispatch (initiative 1016) -- 'uv' basename allow-listed.
                 ["uv", "--version"], timeout=5, check=False
             )  # Query installed UV version via SubprocessRunner (validates argv, no shell).
-            if result.returncode != 0:  # UV is missing or failed to report its version
+            if result.returncode != 0:  # UV is absent or gave no version
                 return False  # Cannot determine an update is needed
 
             # For now, we'll assume UV is up to date since checking remote version is complex
@@ -1676,7 +1676,7 @@ class GlobalImportManager:
 
                 desc = kwargs.get("desc", "Processing")  # Description label for the log line
                 unit = kwargs.get("unit", "item")  # Unit noun for the progress message
-                if isinstance(iterable, Sized):  # The iterable has a known length
+                if isinstance(iterable, Sized):  # The iterable length is known
                     total = len(cast(Sized, iterable))  # Compute total item count for the message
                     logging.info("%s: %s %ss to process", desc, total, unit)  # Log a one-shot progress summary
                 else:  # Length is unknown (for example a generator)
@@ -1699,7 +1699,7 @@ class GlobalImportManager:
             if not current_version:  # Could not determine the installed version
                 return True  # Treat as non-fatal -- nothing reliable to upgrade against
             logging.debug("Current version of %s: %s", package_name, current_version)  # Record the current version
-            logging.info("  Checking for updates to %s...", package_name)  # Inform the user an upgrade check is running
+            logging.info("  Checking for updates to %s...", package_name)  # Inform the user an upgrade check runs
             return self._upgrade_and_verify(package_name, package_spec, current_version)  # Upgrade + report
         except Exception as e:  # Any unexpected error during the check/upgrade
             logging.debug("Error checking/upgrading %s: %s", module_name, e)  # Log for diagnostics
@@ -2042,7 +2042,7 @@ class GlobalImportManager:
     def _hoist_module_globals(self, module_name: str, module_obj: Any) -> None:
         """Hoist commonly-used attributes of a known module into globals (data-driven, with optional-pkg cases)."""
         simple_hoists = self._SIMPLE_GLOBAL_HOISTS.get(module_name)  # Lookup the simple hoist list for this module
-        if simple_hoists:  # This module has a fixed set of attributes to hoist
+        if simple_hoists:  # This module lists a fixed set of attributes to hoist
             self._apply_simple_hoists(module_obj, simple_hoists)  # Bind each (global_name, attr) pair
         elif module_name == "usaddress-scourgify":  # Optional address-normalization package needs custom handling
             self._hoist_scourgify_global(module_obj)  # Bind its normalize function (with direct-import fallback)
@@ -2086,13 +2086,13 @@ class GlobalImportManager:
 
     def _add_fallbacks_to_globals(self, global_vars: dict[str, Any]) -> None:
         """Add fallbacks for optional modules that failed to import."""
-        self._install_scourgify_fallback(global_vars)  # Address-normalization shim when scourgify is missing
-        self._install_fuzz_fallback(global_vars)  # Fuzzy-match shim (difflib-backed) when rapidfuzz is missing
+        self._install_scourgify_fallback(global_vars)  # Address-normalization shim when scourgify is absent
+        self._install_fuzz_fallback(global_vars)  # Fuzzy-match shim (difflib-backed) when rapidfuzz is absent
         self._install_ssh_fallbacks(global_vars)  # paramiko/redexpect shims that fail loudly with install guidance
 
     @staticmethod
     def _install_scourgify_fallback(global_vars: dict[str, Any]) -> None:
-        """When normalize_address_record is missing, install a shim returning the raw string with empty fields."""
+        """When normalize_address_record is absent, install a shim returning the raw string with empty fields."""
         if global_vars.get("normalize_address_record") is not None:  # A real normalizer is already present
             return  # No fallback needed
 
@@ -2111,7 +2111,7 @@ class GlobalImportManager:
 
     @staticmethod
     def _install_fuzz_fallback(global_vars: dict[str, Any]) -> None:  # Install the rapidfuzz fallback when absent
-        """When fuzz is missing, install a difflib-backed shim exposing token_sort_ratio (0-100 score)."""
+        """When fuzz is absent, install a difflib-backed shim exposing token_sort_ratio (0-100 score)."""
         if global_vars.get("fuzz") is not None:  # A real fuzzy matcher is already present
             return  # No fallback needed
 
@@ -2137,7 +2137,7 @@ class GlobalImportManager:
 
     @staticmethod
     def _install_paramiko_fallback(global_vars: dict[str, Any]) -> None:  # Install a paramiko shim that errors on use
-        """When paramiko is missing, install a shim whose SSHClient() raises ImportError with install guidance."""
+        """When paramiko is absent, install a shim whose SSHClient() raises ImportError with install guidance."""
         if global_vars.get("paramiko") is not None:  # paramiko (or an existing shim) is already present
             return  # No fallback needed
 
@@ -2154,7 +2154,7 @@ class GlobalImportManager:
 
     @staticmethod
     def _install_redexpect_fallback(global_vars: dict[str, Any]) -> None:  # Install a redexpect shim that errors on use
-        """When redexpect is missing, install a shim whose spawn() raises ImportError with install guidance."""
+        """When redexpect is absent, install a shim whose spawn() raises ImportError with install guidance."""
         if global_vars.get("redexpect") is not None:  # redexpect (or an existing shim) is already present
             return  # No fallback needed
 
@@ -2198,7 +2198,7 @@ class GlobalImportManager:
         """Verify mistapi.api.v1 module structure is present and log the result."""
         if hasattr(mistapi, "api") and hasattr(mistapi.api, "v1"):  # Confirm expected nested API surface
             logging.debug("mistapi.api.v1 module structure confirmed")  # Structure looks correct
-        else:  # The expected nested structure is missing
+        else:  # The expected nested structure is absent
             logging.warning(
                 "mistapi.api.v1 structure not found - this may cause API call failures"
             )  # Warn about likely failures
@@ -2207,7 +2207,7 @@ class GlobalImportManager:
         """Log whether websocket-client successfully loaded."""
         if "websocket-client" in self.imports:  # The websocket client library loaded
             logging.debug("websocket-client available for WebSocket operations")  # WebSocket features enabled
-        else:  # The websocket client library is missing
+        else:  # The websocket client library is absent
             logging.debug(
                 "websocket-client not available - WebSocket operations will be disabled"
             )  # WebSocket features disabled
@@ -2265,7 +2265,7 @@ _api_usage_cache = {  # Module-level cache for Mist API rate-limit accounting
     "limit": 5000,  # Default per-window request quota until the real limit is learned
     "last_updated": 0,  # Epoch seconds of the most recent local update
     "perceived_requests": 0,  # Locally counted requests since the last server sync
-    "initialized": False,  # Whether the cache has been seeded from a real API response yet
+    "initialized": False,  # Whether the cache was seeded from a real API response yet
 }
 
 # ============================================================================
@@ -2324,7 +2324,7 @@ if _initialize_imports_now:  # Eager path: prepare all imports now
             logging.info(
                 "tqdm is available in global namespace: %s", type(globals().get("tqdm"))
             )  # Confirm availability and type
-        else:  # tqdm binding is missing
+        else:  # tqdm binding is absent
             logging.warning(
                 "tqdm was not found in global assignments - progress bars will not be functional"
             )  # Warn progress bars are off
@@ -2520,7 +2520,7 @@ def _attempt_interactive_login_with_rollback(old_session: Any, old_org_id: str |
     global apisession, msp_privileges, org_id  # We may overwrite or restore these globals
 
     logging.debug("Entering _attempt_interactive_login_with_rollback()")  # Trace entry for debugging
-    logging.debug("Clearing existing session state for re-authentication")  # Note we are resetting before re-login
+    logging.debug("Clearing existing session state for re-authentication")  # Note we reset before re-login
 
     apisession = None  # Drop the current session so the interactive flow starts clean
     msp_privileges = []  # Clear cached MSP grants from the old session
@@ -2710,7 +2710,7 @@ def _looks_like_placeholder(value: str) -> bool:
 
 
 def _preflight_verify_credentials(require_token: bool = True) -> None:
-    """Fail closed before any mistapi/requests call when host/token config is missing or a placeholder.
+    """Fail closed before any mistapi/requests call when host/token config is absent or a placeholder.
 
     Feature 1020 (US3): invoked at the top of ``_establish_mist_session()`` for every dispatch mode. It
     performs only local string validation. It never imports ``requests`` or ``mistapi`` and never issues
@@ -3022,7 +3022,7 @@ def _try_session_fallback(mistapi_module: Any) -> tuple[Any, Any]:
     """Attempt legacy session creation via mistapi.Session() as last resort.
 
     mistapi.Session reads credentials from environment directly without explicit
-    parameter passing. Used when all APISession constructor variants have failed.
+    parameter passing. Used when all APISession constructor variants failed.
 
     Args:
         mistapi_module: The imported mistapi module.
@@ -3118,7 +3118,7 @@ def _log_session_auth_status(session: Any, successful_method: Any) -> None:
 
 
 def _validate_initialized_session(session: Any, successful_method: Any) -> bool:
-    """Validate that an initialized session has required methods and detectable authentication.
+    """Validate that an initialized session provides the required methods and detectable authentication.
 
     Calls _ensure_mist_get_method to verify/add mist_get compatibility, then
     calls _log_session_auth_status to warn if authentication cannot be confirmed.
@@ -3212,7 +3212,7 @@ def _configure_session_timeout(session_obj: Any) -> None:
 # ============================================================================
 # ENDPOINT PRIMARY KEY STRATEGY CONFIGURATION
 # ============================================================================
-# NOTE: ENDPOINT_PRIMARY_KEY_STRATEGIES has been extracted to
+# NOTE: ENDPOINT_PRIMARY_KEY_STRATEGIES moved to
 # src/refactors/endpoint_primary_key_strategies.py (initiative 1015 T-04, Cat E).
 # External consumers (src/db/database_schema_utils.py, tests/test_ticket_manager.py)
 # import the symbol directly from that module. MistHelper.py imports it at the
@@ -3224,7 +3224,7 @@ def _configure_session_timeout(session_obj: Any) -> None:
 # ============================================================================
 # CACHE UTILITIES CLASS
 # ============================================================================
-# NOTE: CacheUtils has been extracted to
+# NOTE: CacheUtils moved to
 # src/cache/cache_utils.py (initiative 1014 P14, Cat E position 14)
 # The top-level from src.cache.cache_utils import CacheUtils re-export
 # alias keeps historical MistHelper.CacheUtils callers working unchanged.
@@ -3233,7 +3233,7 @@ def _configure_session_timeout(session_obj: Any) -> None:
 # ============================================================================
 # DISPLAY UTILITIES CLASS
 # ============================================================================
-# NOTE: DisplayUtils has been extracted to
+# NOTE: DisplayUtils moved to
 # src/ui/display_utils.py (issue #1013 SC-001 position 11)
 
 
@@ -3319,10 +3319,10 @@ from src.export.data_exporter import DataExporter  # noqa: E402,F401  # T-08 re-
 # Class is imported at module top via: from src.ui.prompt_utils import PromptUtils
 from src.ui.prompt_utils import PromptUtils  # noqa: E402,F401  # T-07 re-export
 
-# NOTE: show_site_device_inventory() has been refactored into SiteDeviceExporter.device_inventory()
+# NOTE: show_site_device_inventory() moved into SiteDeviceExporter.device_inventory()
 
 
-# NOTE: DeviceUtils has been extracted to src/device/device_utils.py (issue #1013 SC-001 position 6)
+# NOTE: DeviceUtils moved to src/device/device_utils.py (issue #1013 SC-001 position 6)
 
 
 # OrgTicketManager moved to src/org/org_ticket_manager.py (1013 SC-001 Cat B position 46)
@@ -3334,7 +3334,7 @@ from src.ui.prompt_utils import PromptUtils  # noqa: E402,F401  # T-07 re-export
 # ============================================================================
 # ORGANIZATION DATA EXPORT UTILITIES CLASS
 # ============================================================================
-# NOTE: OrgSiteExporter has been extracted to
+# NOTE: OrgSiteExporter moved to
 # src/export/org_site_exporter.py (issue #1014 P9)
 
 
@@ -3377,7 +3377,7 @@ from src.ui.prompt_utils import PromptUtils  # noqa: E402,F401  # T-07 re-export
 # LicenseExportUtils moved to src/export/license_export_utils.py (1013 SC-001 position 24)
 
 
-# NOTE: SelfExportUtils has been extracted to src/export/self_export_utils.py (issue #1013 SC-001 position 7)
+# NOTE: SelfExportUtils moved to src/export/self_export_utils.py (issue #1013 SC-001 position 7)
 
 
 # OrgConfigExporter moved to src/export/org_config_exporter.py (issue #1013 SC-001 position 31)
@@ -3486,7 +3486,7 @@ def _get_duc_instance() -> DeviceUtilityCommands:  # Build DeviceUtilityCommands
 # ============================================================================
 # INTERACTIVE DISPLAY UTILITIES CLASS
 # ============================================================================
-# NOTE: InteractiveDisplayUtils has been extracted to
+# NOTE: InteractiveDisplayUtils moved to
 # src/ui/interactive_display_utils.py (issue #1013 SC-001 position 10)
 
 
@@ -3694,8 +3694,8 @@ def _configure_site_config_manager() -> type[SiteConfigManager]:
 # DeviceRebootManager moved to src/device/device_reboot_manager.py (1013 SC-001 position 41)
 
 
-# The standalone function reboot_devices_by_gateway_template_list() has been
-# refactored into DeviceRebootManager class methods.
+# The standalone function reboot_devices_by_gateway_template_list() moved
+# into DeviceRebootManager class methods.
 
 
 # NOTE: FirmwareManager facade removed per 1013 SC-002 (Cat A, position 2).
@@ -3731,7 +3731,7 @@ def _build_firmware_manager(session: Any, target_org_id: str) -> FirmwareManager
 # NOTE: get_auto_upgrade_time_settings removed - dead code (never called)
 
 # NOTE: The standalone functions bulk_upgrade_ap_firmware_by_site() and
-# bulk_upgrade_switch_firmware_by_site() have been refactored. Menu entries
+# bulk_upgrade_switch_firmware_by_site() moved to class methods. Menu entries
 # now call FirmwareManager class methods directly.
 
 
@@ -3743,7 +3743,7 @@ def _build_firmware_manager(session: Any, target_org_id: str) -> FirmwareManager
 # NOTE: bulk_upgrade_ap_firmware_by_site_impl removed - use BulkAPFirmwareUpgrader class directly
 
 
-# NOTE: MSPInventoryExporter has been extracted to src/export/msp_inventory_exporter.py (issue #1013 SC-001 position 8)
+# NOTE: MSPInventoryExporter moved to src/export/msp_inventory_exporter.py (issue #1013 SC-001 position 8)
 
 
 # NOTE: SiteAutoUpgradeConfigurator facade removed (1014 P2, Cat A) - canonical body at
@@ -3812,7 +3812,7 @@ def _ws_cmd_deps() -> WebSocketCmdDeps:
 # ============================================================================
 # AUDIT ANALYSIS OPS CLASS
 # ============================================================================
-# NOTE: AuditAnalysisOps has been extracted to
+# NOTE: AuditAnalysisOps moved to
 # src/audit/audit_analysis_ops.py (issue #1013 SC-001 position 12)
 
 
@@ -4825,7 +4825,7 @@ menu_actions: dict[str, tuple[Callable[..., Any], str]] = {
 }
 
 
-# NOTE: TelemetryEmitter has been extracted to src/analytics/telemetry_emitter.py (issue #1013 SC-001 position 9)
+# NOTE: TelemetryEmitter moved to src/analytics/telemetry_emitter.py (issue #1013 SC-001 position 9)
 
 
 # OperationRegistry moved to src/utils/operation_registry.py (1013 SC-001 position 13)
@@ -5794,7 +5794,7 @@ def _run_interactive_mode(args: argparse.Namespace) -> None:
 
 
 def _setup_interactive_container_mode() -> bool:
-    """Detect whether MistHelper is running inside a container. Print banner if yes."""
+    """Detect whether MistHelper runs inside a container. Print banner if yes."""
     container_mode = EnvironmentUtils.is_running_in_container()  # Check Podman/Docker container marker files.
     if container_mode:  # Container mode: show banner and loop after each operation.
         logging.info("Container mode detected - enabling continuous menu loop")  # Log container detection.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,22 @@ ste-linter = "tools.ste_linter.__main__:main"
 min_score = 80
 dictionary = "data/ste_dictionary.json"
 prefer_spacy = true
+# Approved technical terms the dictionary rules must not flag. These are correct
+# programming and networking words that are not in the general ASD-STE100
+# vocabulary. The allowlist raises the signal so the linter flags real prose words,
+# not normal software terms. Keep the list sorted and lower case.
+allowlist = [
+    "api", "async", "attribute", "backend", "boolean", "buffer", "build", "cache",
+    "call", "callable", "checksum", "cli", "commit", "config", "csv", "daemon",
+    "debug", "decorator", "dispatch", "dns", "endpoint", "enum", "env", "exception",
+    "file", "firmware", "frontend", "getter", "gui", "hash", "http", "https", "id",
+    "int", "iterable", "json", "kwarg", "lan", "lint", "list", "log", "mac",
+    "metadata", "middleware", "mock", "module", "namespace", "org", "param",
+    "parser", "payload", "pip", "proxy", "query", "regex", "repo", "retry", "return",
+    "run", "schema", "session", "setter", "socket", "sql", "ssh", "stub", "tcp",
+    "thread", "timeout", "timestamp", "token", "trace", "traceback", "tui", "tuple",
+    "udp", "url", "uuid", "venv", "vpn", "wan", "wrapper",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/specs/1028-ste-compliance-cleanup/plan.md
+++ b/specs/1028-ste-compliance-cleanup/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: MistHelper.py STE Compliance Cleanup
+
+**Branch**: `1028-ste-compliance-cleanup` | **Date**: 2026-07-27 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Clean up the comments and docstrings in `MistHelper.py` so the prose follows
+Simplified Technical English. Fix the mechanical structural findings, split the four
+over-length sentences, apply a curated dictionary swap map to comment prose, and add
+a technical-noun allowlist to the linter. Change no code, no identifier, and no
+logging string. Verify with the linter, the test suite, and the quality gates.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 or newer.
+
+**Primary Dependencies**: None new for the file itself. The STE linter and its
+optional spaCy backend measure progress.
+
+**Storage**: No change. The dictionary stays git-ignored.
+
+**Testing**: The existing test suite proves the code behavior did not change. The
+linter measures the prose improvement.
+
+**Target Platform**: Cross-platform.
+
+**Project Type**: Single project. The change is to one file plus a linter config.
+
+**Performance Goals**: No runtime change.
+
+**Constraints**: Comments and docstrings only. No code behavior change. The
+120-character line limit and the inline-comment rule apply.
+
+**Scale/Scope**: One file of about 5100 lines. About 148 mechanical fixes, 4 sentence
+splits, and a curated set of dictionary swaps.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Structural discipline**: The change edits prose, not structure. It adds no
+  function and no class.
+- **Inline comments**: Every touched line keeps its inline comment. The edits improve
+  the comment text, they do not remove it.
+- **Safety-first**: The change touches no input handling and no destructive path. The
+  test suite guards behavior.
+- **Quality gates**: Ruff, black, mypy, radon, and pytest must pass. `py_compile`
+  must pass.
+- **Writing style**: The whole point is to make the prose follow the STE guide.
+- **No wrappers, class-based design**: Not applicable. No code changes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1028-ste-compliance-cleanup/
+├── plan.md              # This file
+├── research.md          # Phase 0: fix categories and safe-edit method
+├── tasks.md             # Phase 2: the task list
+└── swap-map.md          # Phase 1: the curated word-swap map
+```
+
+### Source Code (repository root)
+
+```text
+MistHelper.py            # The file to clean up (comments and docstrings only)
+pyproject.toml           # Add the technical-noun allowlist under [tool.ste_linter]
+tools/ste_linter/        # Add allowlist support to the dictionary rules
+```
+
+**Structure Decision**: The change is almost entirely in `MistHelper.py`. The
+allowlist is a small, additive linter feature so the dictionary rules can skip
+approved technical terms.
+
+## Phased Approach
+
+- **Phase A (P1)**: Mechanical structural fixes. Latin, contractions, phrasal verbs,
+  semicolons, and the four sentence splits. Verifiable in continuous integration.
+- **Phase B (P2)**: Curated dictionary swaps in comment prose only, from a fixed map.
+- **Phase C (P3)**: The technical-noun allowlist in the linter and the configuration.
+- **Deferred**: Passive voice, noun clusters, and complex tense. Tracked for later.
+
+## Risk and Mitigation
+
+| Risk | Mitigation |
+| - | - |
+| A text edit changes code behavior | Edit comments and docstrings only. Run the full test suite. Run py_compile. |
+| A swap changes a word inside an identifier or a logging string | Apply swaps by reading the comment text only, never the code. Review each swap. |
+| A sentence split pushes a line past 120 characters | Wrap the comment across lines. Run ruff, which flags E501. |
+| The hot file has a competing pull request | Confirm no other open pull request modifies MistHelper.py before starting. |
+
+## Complexity Tracking
+
+*No constitution deviations. The change adds no structure and no new dependency for
+the file. The allowlist is a small, additive linter option.*

--- a/specs/1028-ste-compliance-cleanup/research.md
+++ b/specs/1028-ste-compliance-cleanup/research.md
@@ -1,0 +1,86 @@
+# Research: Fix Categories and Safe-Edit Method
+
+**Feature**: 1028-ste-compliance-cleanup | **Phase**: 0
+
+This document records how the findings were grouped and how each group is fixed
+without any risk to code behavior.
+
+## Decision 1: Fix only comment and docstring prose
+
+**Decision**: Every edit is to a comment or a docstring. No edit touches code, an
+identifier, a variable name, or a string inside a logging or print call.
+
+**Rationale**: The STE linter grades comments and docstrings only. The prose is the
+target. Code text is not graded and must not change, because a change to code could
+change behavior. The test suite proves behavior is unchanged after the edits.
+
+## Decision 2: Group the findings by risk
+
+**Decision**: Sort the findings into three groups by how much judgment each needs.
+
+- **Mechanical (no judgment)**: Latin abbreviations, contractions, phrasal verbs,
+  and comment semicolons. Each has one correct fix.
+- **Small judgment (fixed map)**: The top unapproved words that have a clear
+  approved replacement, applied from a fixed map.
+- **Large judgment (deferred)**: Passive voice, noun clusters, and complex tense.
+  Each needs a rewrite that changes sentence shape.
+
+**Rationale**: The mechanical group is safe and the continuous integration gate can
+verify it. The fixed-map group is safe when the map is small and each entry is
+unambiguous. The large-judgment group is deferred because it carries more risk for
+little score gain on source-code prose.
+
+## Decision 3: Method for each mechanical fix
+
+- **Latin abbreviations (20)**: Replace "e.g." with "for example", "i.e." with "that
+  is", and "etc." with "and so on". Read the comment, confirm the abbreviation is
+  prose and not part of a URL or an identifier, then replace it.
+- **Contractions (34)**: Replace each contraction with its full form. The linter
+  gives the exact replacement.
+- **Phrasal verbs (2)**: Replace each with a single precise verb from the linter
+  suggestion.
+- **Comment semicolons (92)**: Rewrite the comment as two sentences. Keep the same
+  meaning. Confirm the semicolon is not inside a code example.
+
+## Decision 4: The four over-length sentences
+
+**Decision**: Split each of the four flagged comment sentences into two shorter
+sentences, each within the word limit. Wrap across lines so no line passes 120
+characters.
+
+**Rationale**: These are the only errors. Each is a single long comment that packs
+several ideas. Splitting improves clarity and clears the error.
+
+## Decision 5: The curated swap map
+
+**Decision**: Build a fixed map of the top unambiguous unapproved words to approved
+words, and apply it to comment prose only. See swap-map.md for the map.
+
+**Rationale**: Of the 368 unique unapproved words, only a small number have a single
+clear approved replacement that fits every use in a comment. The map holds only
+those. Words with several senses (for example "present", which can be a verb or an
+adjective) are left out to avoid a wrong change.
+
+**Method**: For each comment, read the text. For each word in the map, replace the
+whole-word prose use. Never change a word that is part of an identifier, a quoted
+string, a URL, or a logging string. Review each file section after the pass.
+
+## Decision 6: The technical-noun allowlist
+
+**Decision**: Add an allowlist option to the dictionary rules. The linter skips a
+word that is in the allowlist. Seed the allowlist with the common programming terms
+that the report flags (for example "log", "file", "list", "call", "return").
+
+**Rationale**: These words are correct in a software project. They are not prose
+errors. The allowlist stops the linter from flagging them, which raises the signal
+for every future run. This is a small, additive linter change with its own tests.
+
+## Known limits
+
+- Grading source-code prose stays noisy even after this work, because most
+  programming words are not in the approved vocabulary. The goal is a clear
+  improvement in the structural rules and the top dictionary words, not a perfect
+  score.
+- The continuous integration gate runs the structural rules only, because the
+  dictionary is git-ignored. The dictionary swaps improve the local score and the
+  readability, but the gate cannot measure them.

--- a/specs/1028-ste-compliance-cleanup/spec.md
+++ b/specs/1028-ste-compliance-cleanup/spec.md
@@ -1,0 +1,180 @@
+# Feature Specification: MistHelper.py Simplified Technical English Compliance Cleanup
+
+**Feature Branch**: `1028-ste-compliance-cleanup`
+
+**Created**: 2026-07-27
+
+**Status**: Draft
+
+**Input**: User request: "Start a new issue and SpecKit workflow to use our new
+report results to clean up our MistHelper file to bring it into compliance.
+Please include the dictionary checks."
+
+## Overview
+
+The STE linter graded the comments and docstrings in `MistHelper.py` at 97 out of
+100. This feature uses the linter report to clean up the prose so it follows
+Simplified Technical English. The work changes comments and docstrings only. It
+does not change any code, identifier, or logging string. The goal is a targeted,
+measurable improvement, not a perfect score.
+
+## Why a perfect score is not the goal
+
+The linter reports 3369 findings. Most (2873) come from the dictionary rules,
+because normal programming words such as "file", "list", and "dispatch" are not in
+the ASD-STE100 approved vocabulary of about 875 words. A score of 100 would force
+stilted prose and an allowlist of hundreds of technical terms, and it would make
+the comments harder to read, not easier. So this feature fixes the high-value,
+low-risk findings and a curated set of dictionary swaps, and it defers the rest.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Fix the mechanical structural findings (Priority: P1)
+
+A maintainer fixes every Latin abbreviation, contraction, phrasal verb, and comment
+semicolon, and splits the four over-length sentences. These are unambiguous text
+edits with no judgment and no code risk.
+
+**Why this priority**: These are the clearest wins. Each has one correct fix, the
+continuous integration STE gate can verify them, and they carry no risk to code
+behavior.
+
+**Independent Test**: Run the linter on the file before and after. Confirm the
+counts for STE-S9-LATIN, STE-S4-CONTRACTION, STE-S9-PHRASAL, STE-S8-SEMICOLON, and
+STE-S4-LEN all reach zero.
+
+**Acceptance Scenarios**:
+
+1. **Given** a comment with "e.g.", **When** the maintainer fixes it, **Then** the
+   comment reads "for example".
+2. **Given** a comment with "can't", **When** the maintainer fixes it, **Then** the
+   comment reads "cannot".
+3. **Given** a comment with a semicolon, **When** the maintainer fixes it, **Then**
+   the comment is two sentences with no semicolon.
+4. **Given** an over-length comment sentence, **When** the maintainer fixes it,
+   **Then** the comment is two shorter sentences, each within the word limit.
+
+---
+
+### User Story 2 - Apply curated dictionary swaps in comments (Priority: P2)
+
+A maintainer applies a small, curated map of unapproved words to approved words in
+comment prose only. For example "via" becomes "by" and "attempt" becomes "try". The
+maintainer does not touch identifiers, variable names, or logging strings.
+
+**Why this priority**: This adds real clarity, but each swap needs judgment to keep
+the meaning. It builds on the mechanical pass and uses a fixed map to stay safe.
+
+**Independent Test**: Run the linter before and after. Confirm the unapproved-word
+count for the mapped words drops, and confirm no code line changed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the word "via" in a comment, **When** the maintainer applies the swap,
+   **Then** the comment reads "by" or "through" and the meaning is the same.
+2. **Given** the word "via" inside an identifier or a logging string, **When** the
+   maintainer runs the pass, **Then** that word is not changed.
+3. **Given** the curated map, **When** a word is not in the map, **Then** the
+   maintainer does not change it.
+
+---
+
+### User Story 3 - Add a technical-noun allowlist (Priority: P3)
+
+A maintainer adds an allowlist of legitimate technical terms (for example "API",
+"URL", "MAC", "log", "file") to the linter configuration, so the linter stops
+flagging them. This raises the signal from the dictionary rules for every future
+run, not only this file.
+
+**Why this priority**: The allowlist is a durable improvement, but it is a
+configuration change that needs a linter feature, so it comes after the direct
+text fixes.
+
+**Independent Test**: Add a term to the allowlist, run the linter, and confirm that
+term is no longer flagged while other unapproved words still are.
+
+**Acceptance Scenarios**:
+
+1. **Given** "API" in the allowlist, **When** the linter runs, **Then** "API" is
+   not flagged as unapproved.
+2. **Given** a word not in the allowlist, **When** the linter runs, **Then** that
+   word is still flagged.
+
+### Edge Cases
+
+- A word appears both as an identifier and as a prose word in the same comment. The
+  maintainer changes only the prose use.
+- A semicolon appears inside a code example in a docstring. The maintainer does not
+  change code examples.
+- A contraction appears inside a quoted string in a docstring. The maintainer does
+  not change quoted text.
+- Splitting a long sentence must not push the line past the 120-character limit. The
+  maintainer wraps the comment across lines when needed.
+- A Latin abbreviation appears inside a URL or an identifier. The maintainer does
+  not change it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The change MUST modify comments and docstrings only. It MUST NOT
+  change code, identifiers, variable names, or the string text inside logging and
+  print calls.
+- **FR-002**: The change MUST replace every Latin abbreviation in comments with plain
+  English ("e.g." to "for example", "i.e." to "that is", "etc." to "and so on").
+- **FR-003**: The change MUST replace every contraction in comments with its full
+  form ("can't" to "cannot", "it's" to "it is", "do not" for "don't").
+- **FR-004**: The change MUST replace every phrasal verb in comments with a single
+  precise verb.
+- **FR-005**: The change MUST rewrite every comment semicolon as two sentences.
+- **FR-006**: The change MUST split the four over-length comment sentences into
+  shorter sentences within the word limit.
+- **FR-007**: The change MUST apply a curated word-swap map to comment prose only,
+  for the top unambiguous unapproved words.
+- **FR-008**: The change MUST NOT apply a swap to a word that is part of an
+  identifier, a quoted string, a URL, or a logging string.
+- **FR-009**: The change MUST add a technical-noun allowlist to the linter
+  configuration so legitimate terms are not flagged.
+- **FR-010**: Every touched line MUST keep its inline comment per the project
+  standard.
+- **FR-011**: The change MUST keep the file valid. `python -m py_compile
+  MistHelper.py` MUST pass.
+- **FR-012**: The test suite MUST still pass, which proves the code behavior did not
+  change.
+
+### Key Entities
+
+- **Swap map**: A fixed map from an unapproved word to its approved replacement,
+  used for comment prose only.
+- **Technical-noun allowlist**: A list of approved technical terms the linter must
+  not flag.
+- **Linter report**: The before and after findings used to measure progress.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The counts for Latin abbreviations, contractions, phrasal verbs, and
+  comment semicolons reach zero.
+- **SC-002**: The four over-length sentence errors reach zero.
+- **SC-003**: The total structural findings (all rules except the two dictionary
+  rules) drop by at least 60 percent from the baseline of 496.
+- **SC-004**: The overall linter score rises from 97 toward the high nineties with
+  the dictionary active, and the structural-only score rises measurably.
+- **SC-005**: The test suite passes, which proves no code behavior changed.
+- **SC-006**: Ruff, black, mypy, radon, and the coverage gate pass. `py_compile`
+  passes.
+- **SC-007**: No identifier, variable name, or logging string is changed.
+
+## Assumptions
+
+- The linter report is the source of truth for the findings and their lines.
+- The dictionary file is present locally, so the dictionary rules run during the
+  work. The continuous integration gate runs the structural rules only, because the
+  dictionary is git-ignored.
+- The passive-voice, noun-cluster, and complex-tense rewrites are out of scope for
+  this feature and are tracked for a later pass.
+- The file is the designated hot file, so this work holds the only open pull request
+  that modifies it while it is in progress.
+- The 120-character line limit and the inline-comment rule from the project standard
+  apply to every edit.

--- a/specs/1028-ste-compliance-cleanup/swap-map.md
+++ b/specs/1028-ste-compliance-cleanup/swap-map.md
@@ -1,0 +1,51 @@
+# Curated Word-Swap Map
+
+**Feature**: 1028-ste-compliance-cleanup | **Phase**: 1
+
+This map holds the unapproved words that have a single clear approved replacement in
+comment prose. The maintainer applies these to comment and docstring text only,
+never to code, identifiers, quoted strings, URLs, or logging strings.
+
+A word is in this map only when the replacement fits every prose use with the same
+meaning. Words with several senses are left out on purpose.
+
+## Map
+
+| Unapproved word | Approved replacement | Note |
+| - | - | - |
+| via | by | Or "through" when it means a path. |
+| per | for each | "as per" becomes "as stated in". |
+| attempt (verb) | try | The verb sense only. |
+| attempt (noun) | try | Keep the noun as "try" or reword. |
+| failure | fault | When it means a fault condition. |
+| failed | did not work | Or "stopped" when it means a stop. |
+| whether | if | When it introduces a condition. |
+| both | the two | Matches the STE recurring-errors list. |
+| prior to | before | Common non-STE phrase. |
+| in order to | to | Removes filler. |
+| additional | more | Matches the dictionary alternative. |
+| adequate | sufficient | Matches the dictionary alternative. |
+| approximately | about | Shorter and approved. |
+| initiate | start | Matches the "start" convention. |
+| terminate | stop | When it means to stop. |
+| utilize | use | Plain word. |
+| obtain | get | Plain word. |
+| require | need | When it means need. |
+
+## Words deliberately excluded
+
+These frequent words are left unchanged because they are correct programming terms,
+comment markers, or words with several senses. They belong in the allowlist, not the
+swap map.
+
+- `Log`, `log`, `file`, `list`, `call`, `return`, `run`, `build`, `dispatch`,
+  `exception`, `option`, `progress`, `trace`, `pass`, `detect` — programming terms.
+- `NOTE`, `Note` — comment markers, not prose.
+- `present`, `real`, `direct`, `now`, `already`, `never`, `any`, `may` — several
+  senses, or already clear enough. A wrong swap would change the meaning.
+
+## Application rule
+
+For each comment, replace only a whole-word prose use. Keep the sentence meaning.
+After the pass, run the linter to confirm the mapped words dropped, and run the test
+suite to confirm no code changed.

--- a/specs/1028-ste-compliance-cleanup/tasks.md
+++ b/specs/1028-ste-compliance-cleanup/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: MistHelper.py STE Compliance Cleanup
+
+**Feature**: 1028-ste-compliance-cleanup | **Input**: spec.md, plan.md, research.md, swap-map.md
+
+## Conventions
+
+- **[P]** marks tasks that can run in parallel because they touch different files.
+- Every edit is to a comment or a docstring only. No edit changes code, an
+  identifier, or a logging string.
+- Every touched line keeps its inline comment per the project standard.
+
+## Phase 0: Baseline
+
+- [ ] T001 Confirm no other open pull request modifies `MistHelper.py`. Record the
+  baseline linter counts (structural and dictionary) for the before and after
+  compare.
+- [ ] T002 Regenerate the local dictionary if needed so the dictionary rules run
+  during the work.
+
+## Phase A: Mechanical structural fixes (P1)
+
+- [ ] T003 [US1] Fix the 20 Latin abbreviations in comments ("e.g." to "for
+  example", "i.e." to "that is", "etc." to "and so on"). Confirm each is prose.
+- [ ] T004 [US1] Fix the 34 contractions in comments to their full forms.
+- [ ] T005 [US1] Fix the 2 phrasal verbs in comments to a single precise verb.
+- [ ] T006 [US1] Rewrite the 92 comment semicolons as two sentences each. Skip any
+  semicolon inside a code example.
+- [ ] T007 [US1] Split the 4 over-length comment sentences. Wrap lines so none pass
+  120 characters.
+- [ ] T008 [US1] Run the linter. Confirm STE-S9-LATIN, STE-S4-CONTRACTION,
+  STE-S9-PHRASAL, STE-S8-SEMICOLON, and STE-S4-LEN all reach zero.
+
+**Checkpoint**: The mechanical structural findings are gone. The continuous
+integration STE gate can verify this phase.
+
+## Phase B: Curated dictionary swaps (P2)
+
+- [ ] T009 [US2] Apply the swap map from swap-map.md to comment prose only. Work
+  through the file in sections.
+- [ ] T010 [US2] Review each swap. Confirm no identifier, quoted string, URL, or
+  logging string changed.
+- [ ] T011 [US2] Run the linter. Confirm the mapped words dropped in the
+  unapproved-word count.
+
+**Checkpoint**: The curated swaps are applied. The prose is clearer.
+
+## Phase C: Technical-noun allowlist (P3)
+
+- [ ] T012 [P] [US3] Add an allowlist option to the dictionary rules in
+  `tools/ste_linter/rules/dictionary.py`. The linter skips a word in the allowlist.
+- [ ] T013 [P] [US3] Add the `[tool.ste_linter]` allowlist to `pyproject.toml`,
+  seeded with the common programming terms from the report.
+- [ ] T014 [US3] Add a unit test that a listed term is not flagged and an unlisted
+  word still is.
+- [ ] T015 [US3] Run the linter with the allowlist. Confirm the listed terms are no
+  longer flagged.
+
+**Checkpoint**: The allowlist raises the signal for every future run.
+
+## Phase D: Verify and gate
+
+- [ ] T016 Run `python -m py_compile MistHelper.py`. Confirm it passes.
+- [ ] T017 Run the test suite. Confirm it passes, which proves no code behavior
+  changed.
+- [ ] T018 Run ruff, black, mypy, radon, and the coverage gate. Fix any finding.
+- [ ] T019 Record the after counts. Confirm the structural findings dropped by at
+  least 60 percent and the four errors reached zero.
+
+## Dependencies
+
+- Phase A is the core and comes first.
+- Phase B depends on the swap map.
+- Phase C is independent of A and B and can run in parallel.
+- Phase D comes last.
+
+## Parallel example
+
+Phase C can run alongside Phase A or B because it touches the linter and the
+configuration, not the comment prose:
+
+```text
+T012 allowlist option in the linter
+T013 allowlist in pyproject.toml
+T003 Latin abbreviations in MistHelper.py
+```

--- a/tests/unit/ste_linter/test_config.py
+++ b/tests/unit/ste_linter/test_config.py
@@ -40,6 +40,23 @@ def test_zero_weight_disables_rule() -> None:
     assert not config.is_enabled("STE-S3-PASSIVE")  # The rule is disabled.
 
 
+def test_is_allowlisted_ignores_case() -> None:
+    """The allowlist match ignores letter case."""
+    config = LinterConfig(allowlist={"api", "log"})  # Two approved technical terms.
+    assert config.is_allowlisted("API")  # The upper-case form matches.
+    assert config.is_allowlisted("log")  # The lower-case form matches.
+    assert not config.is_allowlisted("via")  # A word not in the list does not match.
+
+
+def test_load_allowlist_from_toml(tmp_path: pathlib.Path) -> None:
+    """The loader reads the allowlist from a TOML file."""
+    content = '[tool.ste_linter]\nallowlist = ["API", "Log"]\n'  # An allowlist with mixed case.
+    path = tmp_path / "pyproject.toml"  # The temporary file path.
+    path.write_text(content, encoding="utf-8")  # Write the config file.
+    config = LinterConfig.load(str(path))  # Load the config.
+    assert config.is_allowlisted("api") and config.is_allowlisted("log")  # Both load in lower case.
+
+
 def test_load_from_toml(tmp_path: pathlib.Path) -> None:
     """The loader reads settings from a TOML file."""
     content = "[tool.ste_linter]\nmin_score = 85\nprocedural_limit = 15\n"  # A small config.

--- a/tools/ste_linter/config.py
+++ b/tools/ste_linter/config.py
@@ -35,12 +35,17 @@ class LinterConfig:
     section_weights: dict[str, float] = field(default_factory=dict)  # Per-section weight overrides.
     selected: set[str] = field(default_factory=set)  # Only run these rules when not empty.
     ignored: set[str] = field(default_factory=set)  # Never run these rules.
+    allowlist: set[str] = field(default_factory=set)  # Technical words the dictionary rules must not flag.
 
     def limit_for(self, mode: str) -> int:
         """Return the word limit for a sentence mode."""
         if mode == "procedural":  # A procedural sentence is a step.
             return self.procedural_limit  # Use the tighter step limit.
         return self.descriptive_limit  # Otherwise use the description limit.
+
+    def is_allowlisted(self, word: str) -> bool:
+        """Return True when a word is an approved technical term the linter must skip."""
+        return word.lower() in self.allowlist  # Compare in lower case so the match ignores letter case.
 
     def weight_for(self, rule_id: str, default: float) -> float:
         """Return the weight for a rule, or the default from its severity."""
@@ -99,3 +104,4 @@ class LinterConfig:
         config.section_weights = {
             str(key): float(value) for key, value in table.get("section_weights", {}).items()
         }  # Section weights.
+        config.allowlist = {str(word).lower() for word in table.get("allowlist", [])}  # Approved technical terms.

--- a/tools/ste_linter/rules/dictionary.py
+++ b/tools/ste_linter/rules/dictionary.py
@@ -50,6 +50,8 @@ class UnapprovedWordRule(Rule):
             for token in context.tokens(sentence.text):  # Each analyzed token.
                 if token.pos in _SKIP_TAGS or not token.text.isalpha():  # Skip non-words.
                     continue  # Move to the next token.
+                if context.config.is_allowlisted(token.text):  # Skip an approved technical term.
+                    continue  # The allowlist marks this word as correct for the project.
                 entries = context.dictionary.lookup(token.text.lower())  # Look up the word.
                 if entries and all(not entry.approved for entry in entries):  # The word is unapproved.
                     yield self._violation(
@@ -83,6 +85,8 @@ class WrongPartOfSpeechRule(Rule):
             for token in context.tokens(sentence.text):  # Each analyzed token.
                 if token.pos not in (NOUN, VERB, ADJ, ADV):  # Only check content words.
                     continue  # Move to the next token.
+                if context.config.is_allowlisted(token.text):  # Skip an approved technical term.
+                    continue  # The allowlist marks this word as correct for the project.
                 if self._is_wrong(context, token):  # The word is used as the wrong part of speech.
                     yield self._violation(
                         document.path,  # The file path.


### PR DESCRIPTION
Closes #1685

## Summary
Use the STE linter report to clean up the comments and docstrings in `MistHelper.py`. This is a comment and docstring change only. It changes no code, no identifier, and no logging string. The test suite proves the code behavior did not change.

## What changed (by phase)
- **Allowlist (linter feature)**: Add a technical-noun allowlist to the dictionary rules, seeded with 82 programming and networking terms (`api`, `log`, `file`, `dispatch`). The linter now skips these so it flags real prose words, not normal software terms. On MistHelper.py this drops the unapproved-word count from 2542 to 1944.
- **Mechanical fixes**: Every Latin abbreviation (20), contraction (34), phrasal verb (2), and comment semicolon (92). Split the 4 over-length comment sentences.
- **Curated word swaps**: Apply clean swaps in comment prose only (`Attempt to` to `Try to`, `via` to `by`).
- **Complex tense**: Convert perfect and progressive tenses to simple tenses (`has been extracted` to `moved`, `is missing` to `is absent`, progressive to simple present).
- **Passive voice**: Rewrite genuine passive comments to active voice by naming the actor.

## Results

| Rule | Baseline | After |
| - | - | - |
| Latin abbreviations | 20 | 0 |
| Contractions | 34 | 0 |
| Phrasal verbs | 2 | 0 |
| Comment semicolons | 92 | 0 |
| Over-length sentences (errors) | 4 | 0 |
| Complex tense | 47 | 0 |
| Passive voice | 114 | 69 |
| Noun clusters | 178 | 179 |

Total structural findings dropped from 496 to 249 (50 percent).

## An honest note on noun clusters and remaining passives
The noun-cluster rule has a high false-positive rate on this technical file. The flagged phrases are almost all legitimate technical terms (for example `Live Mist API session`, `Current API session object`, `mistapi SDK module reference`) or tokenizer errors that split hyphenated compounds (`non-critical` read as `non - critical`, `re-export` read as `re - export`). Rewording these would make the comments wordier and less clear for a developer, which is the opposite of the goal. Per the spec principle "readable over compliant", I left them.

The remaining 69 passive findings are idiomatic state adjectives (`is installed`, `is imported at top-of-file`) where active voice reads worse. I fixed the 45 genuine passives that have a clear actor.

Every meaningful structural rule (Latin, contraction, phrasal, semicolon, length, tense) is now at zero.

## Conformance
- [x] Comments and docstrings only. No code behavior changed.
- [x] Test suite passes (91 ste_linter + 316 refactor tests confirmed locally).
- [x] `python -m py_compile MistHelper.py` passes. Ruff and black pass on the whole repo.
- [x] Every touched line keeps its inline comment.
- [x] Links the spec issue (#1685).