### PR TITLE
docs(1030): Phase 1 mechanical STE fixes in src/ comments and docstrings

### DIFF
--- a/specs/1030-ste-src-cleanup/plan.md
+++ b/specs/1030-ste-src-cleanup/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: STE Compliance for src/ Comments and Docstrings
+
+**Branch**: `1030-ste-src-cleanup` | **Date**: 2026-07-27 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1030-ste-src-cleanup/spec.md`
+
+## Summary
+
+Apply the STE linter to the `src/` tree. Remove genuine STE violations in
+comments and docstrings. Do not change code behavior. Split the work into
+phases. Phase 1 fixes mechanical rules. Later phases fix judgment rules, grouped
+by module cluster, one pull request per phase.
+
+## Technical Context
+
+**Language/Version**: Python 3.13+ (per constitution binding minimum)
+
+**Primary Dependencies**: None new. Uses the existing STE linter in
+`tools/ste_linter/` and the dictionary at `data/ste_dictionary.json`.
+
+**Storage**: N/A. This feature edits source comments and docstrings only.
+
+**Testing**: Existing pytest suite under `tests/`. The STE linter itself
+provides the pass or fail signal for each rule.
+
+**Target Platform**: Developer workstation and CI (Windows and Linux).
+
+**Project Type**: Single project. Source lives in `src/`.
+
+**Performance Goals**: N/A. This is a documentation cleanup.
+
+**Constraints**:
+
+- Edit comments and docstrings only. No code behavior change.
+- `src/` has CI gates that MistHelper.py comments did not: coverage at 80
+  percent, mypy on `src/`, and radon at CC 10 or less.
+- Keep code examples inside docstrings unchanged, including semicolons.
+- Every touched code line keeps its inline comment.
+
+**Scale/Scope**: 359 files, 108,543 lines. In scope: about 4,313 fixes (309
+mechanical plus about 4,004 judgment). Out of scope: about 62,877 false
+positives on code words and noun clusters.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research.*
+
+| Principle | Status | Notes |
+| - | - | - |
+| I. Five-Item Rule | PASS | No new functions. Comment and docstring edits only. |
+| II. Class-Based Architecture | PASS | No code structure change. |
+| III. Safety-First | PASS | No input handling change. No destructive path. |
+| IV. Full Deployment Pipeline | PASS | Standard PR flow. No container change needed. |
+| V. Observability & Logging | PASS | No log strings edited. Linter skips log strings. |
+| VI. Inline Comments | PASS | Every touched code line keeps its inline comment. |
+| VII. Action Logging | PASS | No action code touched. |
+
+Result: PASS. No violations. No complexity deviations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1030-ste-src-cleanup/
+├── spec.md          # Feature specification
+├── plan.md          # This file
+├── research.md      # Scan findings and rule decisions
+└── tasks.md         # Phased task list
+```
+
+No `data-model.md` and no `contracts/`. This feature adds no data model and no
+new CLI. The linter CLI already exists on `main`.
+
+### Source Code (repository root)
+
+```text
+src/
+├── firmware/        # Worst cluster by structural count
+├── org/             # org_synthetic_probes_manager.py is the top file
+├── maps/
+├── site/address_audit/
+├── analytics/
+├── export/
+├── refactors/
+└── ... (359 files total)
+```
+
+**Structure Decision**: The feature touches files across many `src/`
+subpackages. It adds no new files to `src/`. It groups edits by subpackage for
+the judgment phases.
+
+## Complexity Tracking
+
+No constitution violations. This table is empty by design.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| - | - | - |
+| None | N/A | N/A |
+
+## Phasing
+
+- **Phase 1 — Mechanical (P1)**: Fix the six mechanical rules across all of
+  `src/`. Target zero violations. One pull request. Safe and CI-verifiable.
+- **Phase 2 — Semicolons (P2)**: Fix prose semicolons. Verify each file to keep
+  code examples in docstrings. Group by module cluster. One pull request per
+  cluster or a small set of clusters.
+- **Phase 3 — Passive, length, tense (P3)**: Fix judgment rules by module
+  cluster. One pull request per cluster.
+
+Each phase links to issue #1687 and closes only when its rules meet the target.

--- a/specs/1030-ste-src-cleanup/research.md
+++ b/specs/1030-ste-src-cleanup/research.md
@@ -1,0 +1,119 @@
+# Research: STE Compliance for src/ Comments and Docstrings
+
+**Feature**: 1030-ste-src-cleanup | **Date**: 2026-07-27
+
+This document records the scan findings and the rule-by-rule decisions. It
+grounds the plan and tasks in real data, not guesses.
+
+## Scan Method
+
+- Tool: the STE linter in `tools/ste_linter/` on `main`.
+- Backend: spaCy (`en_core_web_sm`), auto-selected when present.
+- Dictionary: `data/ste_dictionary.json`, 2,136 entries, generated from the
+  ASD-STE100 Issue 9 source.
+- Input: all `src/**/*.py` files (359 files, 108,543 lines).
+- Method: one in-process pass. The scan builds the spaCy backend once, then
+  loops all files. It aggregates violations by rule and by file.
+
+## Finding 1: All Files Already Pass the Gate
+
+Every file scores 80 or higher. The score buckets are:
+
+| Score band | Files |
+| - | - |
+| 80 to 89 | 10 |
+| 90 to 99 | 321 |
+| 100 | 28 |
+
+**Decision**: This feature reduces the count of real violations. It does not
+fix a failure. The value is readability, not a passing grade.
+
+## Finding 2: Most Violations Are False Positives
+
+The scan found 67,161 raw violations. The split is:
+
+| Group | Count | Share |
+| - | - | - |
+| Dictionary (STE-S1-WORD, STE-S1-POS) | 58,994 | 88 percent |
+| Noun clusters (STE-S2-NOUNCLUSTER) | 3,883 | 6 percent |
+| In scope (mechanical plus judgment) | 4,313 | 6 percent |
+
+**Decision**: The dictionary rules flag normal code words such as `api`,
+`async`, and `dict`. These words are not in the ASD-STE100 vocabulary of about
+875 words. The team does not edit these. It does not grow the allowlist to hide
+them. Feature 1028 reached the same decision for `MistHelper.py`.
+
+The noun-cluster rule flags legitimate technical terms such as "Live Mist API
+session" and tokenizer hyphen splits such as "non - critical". About 95 percent
+are false positives. The team leaves these unchanged.
+
+## Finding 3: Mechanical Rules Are Finite and Safe
+
+The six mechanical rules total 309 violations across 128 files.
+
+| Rule | Count | Fix pattern |
+| - | - | - |
+| STE-S9-LATIN | 167 | "e.g." to "for example". "etc." to "and so on". "i.e." to "that is". "vs." to "versus". |
+| STE-S4-CONTRACTION | 117 | "doesn't" to "does not". "can't" to "cannot". "it's" to "it is". |
+| STE-S7-WARNING | 10 | State the consequence after the signal word. |
+| STE-S9-PHRASAL | 9 | "kick off" to "start". |
+| STE-S6-PARA | 4 | Split a long paragraph. |
+| STE-S9-GENDER | 2 | Use a neutral term. |
+
+**Decision**: Fix all six rules in Phase 1. Each fix is a direct swap. The
+linter confirms the result. This is the safest and largest clear win.
+
+## Finding 4: Semicolons Need Per-File Review
+
+The scan found 2,147 STE-S8-SEMICOLON violations. Many are code examples inside
+docstrings, such as PowerShell one-liners like `podman stop; podman rm`. These
+are shell syntax, not prose. The linter cannot tell them apart.
+
+**Decision**: Review each file before a fix. Split prose semicolons into two
+sentences. Keep code examples unchanged. This is Phase 2.
+
+## Finding 5: Passive, Length, and Tense Need Judgment
+
+| Rule | Count |
+| - | - |
+| STE-S3-PASSIVE | 1,200 |
+| STE-S4-LEN | 446 |
+| STE-S3-TENSE | 182 |
+
+**Decision**: Fix these by module cluster in Phase 3. Each fix needs a human
+decision to keep the meaning. Rewrite passive voice only when the actor is
+known. Split long sentences into single ideas. Change past tense to present for
+instructions.
+
+## Finding 6: Worst Files by Structural Count
+
+The structural count excludes the dictionary and noun-cluster false positives.
+
+| File | Structural |
+| - | - |
+| src/org/org_synthetic_probes_manager.py | 319 |
+| src/firmware/org_ap_upgrader.py | 228 |
+| src/firmware/firmware_manager.py | 210 |
+| src/firmware/bulk_ap_upgrader.py | 173 |
+| src/maps/maps_manager.py | 165 |
+
+**Decision**: The `firmware` and `org` clusters carry the most work. Order the
+judgment phases to take the worst clusters first.
+
+## Finding 7: src/ Has Stricter CI Gates
+
+Unlike `MistHelper.py` comments, `src/` files are covered by coverage (80
+percent), mypy (`src/`), and radon (CC 10 or less). Comment and docstring edits
+do not change code, so these gates stay green. The team verifies each phase with
+the full gate set before it adds the auto-merge label.
+
+## Alternatives Considered
+
+- **Fix everything, including dictionary words**: Rejected. About 88 percent are
+  false positives. Editing them harms readability and inflates the allowlist.
+- **One large pull request**: Rejected. About 4,313 fixes in one diff is
+  unreviewable. It also risks merge conflicts on hot files such as
+  `firmware_manager.py`.
+- **Grow the allowlist to zero the dictionary rules**: Rejected. The allowlist
+  is for a small set of core code terms, not a mask for the whole code
+  vocabulary.

--- a/specs/1030-ste-src-cleanup/spec.md
+++ b/specs/1030-ste-src-cleanup/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: STE Compliance for src/ Comments and Docstrings
+
+**Feature Branch**: `1030-ste-src-cleanup`
+
+**Created**: 2026-07-27
+
+**Status**: Draft
+
+**Input**: User description: "use the linter on the python submodules for this
+repo and build a new speckit workflow to address all of those results."
+
+## Overview
+
+The Simplified Technical English (STE) linter grades comments and docstrings.
+Feature 1028 brought `MistHelper.py` into compliance. This feature applies the
+same linter to the `src/` submodule tree and removes genuine STE violations.
+
+The linter grades comments and docstrings only. It does not grade code or
+logging strings. Every edit in this feature stays in comments and docstrings.
+The code behavior does not change.
+
+### Scan Baseline
+
+The scan covered 359 files and 108,543 lines. Every file already passes the 80
+percent score gate. This work reduces the count of real violations. It does not
+fix a failure.
+
+The scan found 67,161 raw violations. Most are false positives on code words.
+
+| Rule | Count | Verdict |
+| - | - | - |
+| STE-S1-WORD | 51,966 | False positive. Code words. Out of scope. |
+| STE-S1-POS | 7,028 | False positive. Out of scope. |
+| STE-S2-NOUNCLUSTER | 3,883 | About 95 percent false positive. Out of scope. |
+| STE-S8-SEMICOLON | 2,147 | In scope. Verify each file. |
+| STE-S3-PASSIVE | 1,200 | In scope. Judgment. |
+| STE-S4-LEN | 446 | In scope. Judgment. |
+| STE-S3-TENSE | 182 | In scope. Judgment. |
+| STE-S9-LATIN | 167 | In scope. Mechanical. |
+| STE-S4-CONTRACTION | 117 | In scope. Mechanical. |
+| STE-S7-WARNING | 10 | In scope. Mechanical. |
+| STE-S9-PHRASAL | 9 | In scope. Mechanical. |
+| STE-S6-PARA | 4 | In scope. Mechanical. |
+| STE-S9-GENDER | 2 | In scope. Mechanical. |
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Remove mechanical STE violations (Priority: P1)
+
+A junior NOC engineer reads a docstring in `src/`. The text uses plain English.
+It has no Latin abbreviations, no contractions, and no phrasal verbs. The
+meaning is clear on the first read.
+
+**Why this priority**: Mechanical rules are finite, unambiguous, and safe. Each
+fix is a direct word swap. The result is CI-verifiable. This story removes 309
+real violations and delivers the largest clear win.
+
+**Independent Test**: Run the linter across `src/` with only the mechanical
+rules active. Confirm zero violations for STE-S9-LATIN, STE-S4-CONTRACTION,
+STE-S9-PHRASAL, STE-S9-GENDER, STE-S7-WARNING, and STE-S6-PARA.
+
+**Acceptance Scenarios**:
+
+1. **Given** a docstring with "e.g.", **When** the fix is applied, **Then** the
+   text reads "for example" and the linter reports no STE-S9-LATIN violation.
+2. **Given** a comment with "doesn't", **When** the fix is applied, **Then** the
+   text reads "does not" and the linter reports no STE-S4-CONTRACTION violation.
+3. **Given** the full `src/` tree, **When** the linter runs, **Then** the six
+   mechanical rules report zero violations.
+
+---
+
+### User Story 2 - Reduce prose semicolons (Priority: P2)
+
+A reader finds two short sentences where a semicolon joined two ideas before.
+Code examples inside docstrings keep their semicolons, because those are shell
+or Python syntax, not prose.
+
+**Why this priority**: Semicolons are the largest judgment group at 2,147. Many
+are code examples in docstrings, such as PowerShell one-liners. Each file needs
+a check to separate prose semicolons from code semicolons. This story needs care
+but gives a clear readability gain.
+
+**Independent Test**: Run the linter with the semicolon rule active on the
+changed files. Confirm prose semicolons are gone. Confirm code examples in
+docstrings still work and still read correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a docstring sentence joined by a prose semicolon, **When** the fix
+   splits it into two sentences, **Then** the linter reports no STE-S8-SEMICOLON
+   violation for that line.
+2. **Given** a docstring with a PowerShell example that uses a semicolon,
+   **When** the file is reviewed, **Then** the example is left unchanged.
+
+---
+
+### User Story 3 - Reduce passive, long, and past-tense sentences (Priority: P3)
+
+A reader finds active-voice sentences that name the actor. Sentences are short.
+Instructions use the present tense.
+
+**Why this priority**: Passive voice (1,200), sentence length (446), and tense
+(182) are judgment rules. Each fix needs a human decision to keep the meaning.
+The gain is real but the effort per fix is higher. This story runs last and is
+grouped by module.
+
+**Independent Test**: Run the linter with the passive, length, and tense rules
+active on the changed module. Confirm the counts drop and no meaning is lost.
+
+**Acceptance Scenarios**:
+
+1. **Given** a passive docstring sentence, **When** it is rewritten in active
+   voice, **Then** the actor is named and the meaning is the same.
+2. **Given** a sentence longer than the STE limit, **When** it is split, **Then**
+   each new sentence states one idea.
+
+---
+
+### Edge Cases
+
+- A semicolon appears inside a code example in a docstring. Keep it. It is
+  shell or Python syntax, not prose.
+- A word looks like a contraction but is a quoted identifier or string literal.
+  Keep it. The linter does not grade code, so this is rare, but verify.
+- A passive sentence has no clear actor. Rewrite only if the actor is known.
+  If the actor is unknown, keep the sentence and note the reason.
+- A fix would remove an inline comment from a code line. Do not remove the
+  comment. Every touched code line keeps its inline comment.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The six mechanical rules (STE-S9-LATIN, STE-S4-CONTRACTION,
+  STE-S9-PHRASAL, STE-S9-GENDER, STE-S7-WARNING, STE-S6-PARA) MUST report zero
+  violations across `src/` after Phase 1.
+- **FR-002**: The system MUST edit comments and docstrings only. The code
+  behavior MUST NOT change.
+- **FR-003**: The system MUST keep code examples inside docstrings unchanged,
+  including their semicolons.
+- **FR-004**: The counts for STE-S1-WORD, STE-S1-POS, and STE-S2-NOUNCLUSTER
+  MUST NOT be a target. These are false positives on code words. The team does
+  not edit them.
+- **FR-005**: Every code line that is touched MUST keep its inline comment.
+- **FR-006**: All CI gates MUST pass: ruff, black, mypy, radon, pytest coverage,
+  and CodeQL.
+- **FR-007**: The work MUST be split into phases. Phase 1 is mechanical fixes.
+  Later phases are judgment fixes grouped by module cluster.
+- **FR-008**: Each phase MUST be a separate pull request to keep reviews small
+  and to reduce merge conflicts on hot files.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The six mechanical rules report zero violations across `src/`.
+- **SC-002**: Prose semicolons in changed files drop to zero. Code examples in
+  docstrings stay unchanged.
+- **SC-003**: Passive, length, and tense counts drop in each changed module,
+  with no loss of meaning.
+- **SC-004**: STE-S1-WORD, STE-S1-POS, and STE-S2-NOUNCLUSTER counts do not
+  change (no edits to false positives).
+- **SC-005**: All CI gates stay green on every phase pull request.
+- **SC-006**: No code behavior change. A reviewer can confirm each diff touches
+  only comments and docstrings.
+
+## Assumptions
+
+- The STE linter and dictionary on `main` are the source of truth for grades.
+- The allowlist in `pyproject.toml` `[tool.ste_linter].allowlist` stays as is.
+  The team does not grow it to hide false positives.
+- The reader audience is junior NOC engineers. Clear language is the goal, not a
+  perfect score.
+- `src/` has CI gates that `MistHelper.py` comments did not: coverage at 80
+  percent, mypy on `src/`, and radon at CC 10 or less. Comment-only edits keep
+  these gates green.
+- The scope is Option C: mechanical rules plus all judgment rules. Dictionary
+  and noun-cluster false positives are out of scope.

--- a/specs/1030-ste-src-cleanup/tasks.md
+++ b/specs/1030-ste-src-cleanup/tasks.md
@@ -1,0 +1,150 @@
+# Tasks: STE Compliance for src/ Comments and Docstrings
+
+**Feature**: 1030-ste-src-cleanup | **Input**: [spec.md](spec.md), [plan.md](plan.md), [research.md](research.md)
+
+**Issue**: #1687
+
+## Conventions
+
+- `[P]` marks tasks that can run in parallel (different files, no dependency).
+- Each phase is a separate pull request. Each pull request links to issue #1687.
+- Run all edits from the worktree with `.venv\Scripts\python.exe`.
+- Verify each phase with the full CI gate set before the auto-merge label.
+- Every touched code line keeps its inline comment.
+
+## Gate Command Reference
+
+Run these from the worktree root before each pull request:
+
+```powershell
+& ".venv\Scripts\python.exe" -m ruff check .
+& ".venv\Scripts\python.exe" -m black --check .
+& ".venv\Scripts\python.exe" -m mypy src/ --config-file pyproject.toml
+& ".venv\Scripts\python.exe" -m radon cc src/ -n C
+& ".venv\Scripts\python.exe" -m pytest --cov=src --cov-fail-under=80
+```
+
+Per-rule linter check across `src/` (adjust `--ignore` to isolate a rule group):
+
+```powershell
+& ".venv\Scripts\python.exe" -m tools.ste_linter --format json src/**/*.py
+```
+
+---
+
+## Phase 1: Mechanical Fixes (User Story 1, P1)
+
+**Goal**: Zero violations for the six mechanical rules across `src/`.
+
+**Pull request**: `1030-ste-src-cleanup` Phase 1.
+
+- [ ] T001 Regenerate the dictionary if missing:
+  `& ".venv\Scripts\python.exe" -m tools.ste_linter.dictionary.extract documentation/ASD-STE100_ISSUE9.pdf`.
+- [ ] T002 Produce the Phase 1 target list. Run the linter across `src/` and
+  filter to STE-S9-LATIN, STE-S4-CONTRACTION, STE-S9-PHRASAL, STE-S9-GENDER,
+  STE-S7-WARNING, and STE-S6-PARA. Save the file and line list.
+- [ ] T003 [P] Fix STE-S9-LATIN (167). Replace "e.g." with "for example".
+  Replace "i.e." with "that is". Replace "etc." with "and so on". Replace
+  "vs." with "versus".
+- [ ] T004 [P] Fix STE-S4-CONTRACTION (117). Expand each contraction. For
+  example, "does not" for "doesn't".
+- [ ] T005 [P] Fix STE-S9-PHRASAL (9). Replace each phrasal verb with a single
+  verb. For example, "start" for "kick off".
+- [ ] T006 [P] Fix STE-S7-WARNING (10). Add the consequence after the signal
+  word. For example, "Warning: this step can delete data."
+- [ ] T007 [P] Fix STE-S6-PARA (4). Split the long paragraph into shorter ones.
+- [ ] T008 [P] Fix STE-S9-GENDER (2). Replace the gendered term with a neutral
+  term.
+- [ ] T009 Re-run the linter on `src/`. Confirm the six mechanical rules report
+  zero violations.
+- [ ] T010 Run the full CI gate set. Confirm all gates pass.
+- [ ] T011 Open the Phase 1 pull request. Link issue #1687. Wait for CodeQL.
+  Add the auto-merge label after all checks pass.
+
+**Checkpoint**: Phase 1 merged. Mechanical rules at zero.
+
+---
+
+## Phase 2: Prose Semicolons (User Story 2, P2)
+
+**Goal**: Remove prose semicolons. Keep code examples in docstrings.
+
+**Pull request**: one per module cluster, or a small set of clusters.
+
+- [ ] T012 Produce the Phase 2 target list. Run the linter across `src/` and
+  filter to STE-S8-SEMICOLON. Group by module cluster.
+- [ ] T013 [P] Cluster `firmware`. Review each semicolon. Split prose into two
+  sentences. Keep shell and Python examples unchanged.
+- [ ] T014 [P] Cluster `org`. Same review and fix pattern.
+- [ ] T015 [P] Cluster `maps`. Same review and fix pattern.
+- [ ] T016 [P] Cluster `site` (includes `address_audit`). Same pattern.
+- [ ] T017 [P] Cluster `analytics`. Same pattern.
+- [ ] T018 [P] Cluster `export`. Same pattern.
+- [ ] T019 [P] Cluster `refactors`. Same pattern.
+- [ ] T020 [P] Remaining clusters (`utils`, `device`, `capture`, `network`,
+  `websocket`, `troubleshooting`, `gateway`, `inventory`, and others). Same
+  pattern.
+- [ ] T021 Re-run the linter with the semicolon rule on the changed files.
+  Confirm prose semicolons are gone. Confirm code examples still work.
+- [ ] T022 Run the full CI gate set for each cluster pull request. Confirm pass.
+- [ ] T023 Open each cluster pull request. Link issue #1687. Wait for CodeQL.
+  Add the auto-merge label after all checks pass.
+
+**Checkpoint**: Phase 2 merged. Prose semicolons removed. Code examples kept.
+
+---
+
+## Phase 3: Passive, Length, and Tense (User Story 3, P3)
+
+**Goal**: Reduce passive voice, long sentences, and past tense by module.
+Keep the meaning.
+
+**Pull request**: one per module cluster. Take the worst clusters first.
+
+- [ ] T024 Produce the Phase 3 target list. Run the linter across `src/` and
+  filter to STE-S3-PASSIVE, STE-S4-LEN, and STE-S3-TENSE. Group by cluster.
+- [ ] T025 [P] Cluster `org` (worst: org_synthetic_probes_manager.py). Rewrite
+  passive to active when the actor is known. Split long sentences. Use present
+  tense for instructions.
+- [ ] T026 [P] Cluster `firmware` (org_ap_upgrader.py, firmware_manager.py,
+  bulk_ap_upgrader.py). Same fix pattern.
+- [ ] T027 [P] Cluster `maps` (maps_manager.py). Same fix pattern.
+- [ ] T028 [P] Cluster `site` and `address_audit`. Same fix pattern.
+- [ ] T029 [P] Cluster `utils` (zscaler_catalogue.py, zscaler_probe.py,
+  address_utils.py). Same fix pattern.
+- [ ] T030 [P] Cluster `export`, `analytics`, `refactors`. Same fix pattern.
+- [ ] T031 [P] Remaining clusters. Same fix pattern.
+- [ ] T032 Re-run the linter with the three judgment rules on each changed
+  module. Confirm the counts drop and no meaning is lost.
+- [ ] T033 Run the full CI gate set for each cluster pull request. Confirm pass.
+- [ ] T034 Open each cluster pull request. Link issue #1687. Wait for CodeQL.
+  Add the auto-merge label after all checks pass.
+
+**Checkpoint**: Phase 3 merged. Judgment rules reduced. Meaning kept.
+
+---
+
+## Final Verification
+
+- [ ] T035 Run the full linter on `src/`. Confirm the six mechanical rules stay
+  at zero. Confirm the judgment counts dropped.
+- [ ] T036 Confirm STE-S1-WORD, STE-S1-POS, and STE-S2-NOUNCLUSTER counts did
+  not change (no edits to false positives).
+- [ ] T037 Confirm every phase pull request touched comments and docstrings
+  only. No code behavior change.
+- [ ] T038 Close issue #1687 when all phases are merged.
+
+## Dependencies
+
+- Phase 1 has no dependency. It can start first.
+- Phase 2 depends on Phase 1 merged, to avoid overlap on the same files.
+- Phase 3 depends on Phase 2 merged, for the same reason.
+- Within a phase, tasks marked `[P]` touch different clusters and can run in
+  parallel. One agent should hold one cluster at a time to avoid a hot-file
+  conflict.
+
+## Notes on Scope
+
+- Total in scope: about 4,313 fixes (309 mechanical plus about 4,004 judgment).
+- Out of scope: STE-S1-WORD, STE-S1-POS, STE-S2-NOUNCLUSTER (false positives).
+- Every touched code line keeps its inline comment (project mandate).

--- a/src/analytics/data_collection_manager.py
+++ b/src/analytics/data_collection_manager.py
@@ -128,7 +128,7 @@ class DataCollectionManager:
         logging.info("Support packages generated for applicable sites.")  # Log completion.
 
     @staticmethod
-    def _refresh_support_data() -> None:  # Refresh required CSVs.
+    def _refresh_support_data() -> None:  # Refresh required CSV files.
         """Refresh all required CSV files for support package generation."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of exporter facades + CacheUtils.
         required_files = [  # Required files and fetchers.

--- a/src/analytics/telemetry_emitter.py
+++ b/src/analytics/telemetry_emitter.py
@@ -40,7 +40,7 @@ class TelemetryEmitter:
 
         Why:
             Parent directories are created eagerly so callers can pass a fresh
-            path (e.g. ``data/telemetry/2026-07-21.jsonl``) without a separate
+            path (for example ``data/telemetry/2026-07-21.jsonl``) without a separate
             ``os.makedirs`` step. Open failures downgrade to a warning and leave
             ``self._handle = None`` so subsequent ``emit()`` calls become no-ops
             (FR-008: telemetry must never interrupt the primary operation).

--- a/src/api/api_fetch_utils.py
+++ b/src/api/api_fetch_utils.py
@@ -153,7 +153,7 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
         """Fetch one gateway device's config (site-tagged); return the config dict, or None on empty/failure."""
         work_site_id, work_device_id, work_site_name = work_item  # Unpack the work item.
         with connection_semaphore:  # Limit concurrent connections via the pool semaphore.
-            try:  # Isolate per-device failures so one bad device doesn't abort the batch.
+            try:  # Isolate per-device failures so one bad device does not abort the batch.
                 logging.debug("Fetching config for %s (%s)", work_device_id, work_site_name)  # Trace the fetch.
                 config_response = mistapi.api.v1.sites.devices.getSiteDevice(  # Call the device API.
                     apisession, work_site_id, work_device_id

--- a/src/audit/_renderer_delta.py
+++ b/src/audit/_renderer_delta.py
@@ -150,7 +150,7 @@ def compute_delta_list(  # WHY: exported list-diff entry point with identity fal
         return None, None  # WHY: None sentinel signals 'no delta' to caller
     all_dicts = _all_dicts(before) and _all_dicts(after)  # WHY: identity match only makes sense for dicts
     if not all_dicts:  # WHY: fall back to raw before/after for mixed types
-        return before, after  # WHY: mixed types can't share identity keys, so emit raw lists
+        return before, after  # WHY: mixed types cannot share identity keys, so emit raw lists
     return delta_by_identity(before, after)  # WHY: dict-of-dicts path handles reorder/added/removed
 
 
@@ -164,7 +164,7 @@ def element_identity(element: dict[str, Any]) -> str | None:  # WHY: exported fo
     for key in _IDENTITY_KEYS:  # WHY: priority order controls collision resolution
         val = element.get(key)  # WHY: first non-None wins
         if val is not None:  # WHY: skip missing/explicit-null identity slots
-            return f"{key}={val}"  # WHY: prefix key so 'name=foo' and 'id=foo' don't collide
+            return f"{key}={val}"  # WHY: prefix key so 'name=foo' and 'id=foo' do not collide
     return None  # WHY: caller treats missing identity as anonymous element
 
 

--- a/src/audit/audit_analysis_ops.py
+++ b/src/audit/audit_analysis_ops.py
@@ -16,7 +16,7 @@ import mistapi  # WHY: audit-logs API + get_all pagination helper.
 from src.audit.analyzer import AuditAnalysisResult, AuditLogAnalyzer  # Audit analysis result + engine.
 from src.audit.filter import AuditLogFilter  # Audit log filtering to remove noise and system events.
 from src.audit.renderer import AuditReportRenderer  # Mermaid timeline + HTML report rendering.
-from src.audit.time_parser import ParsedTimeRange, TimeRangeParser  # Audit log time range parsing (7d, 4w, etc.).
+from src.audit.time_parser import ParsedTimeRange, TimeRangeParser  # Audit log time range parsing (7d, 4w, and so on).
 
 
 class AuditAnalysisOps:
@@ -28,7 +28,7 @@ class AuditAnalysisOps:
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of IS_TEST_MODE + InputUtils.
         if mh.IS_TEST_MODE:  # Use a fixed time range so --test runs without interactive input.
             return "7d"  # Default to 7 days in test mode; skips the safe_input prompt.
-        logging.warning(  # WARNING so hint surfaces on default root-logger config (#886 Phase 2 print->logger).
+        logging.warning(  # Uses warning level so the hint shows by default (#886).
             "Time range examples: 7d, 4w, 3m, 1y, 6w-2w (6 weeks ago to 2 weeks ago)"
         )
         raw = mh.InputUtils.safe_input("Enter time range [7d]: ", context="audit_analysis")
@@ -59,10 +59,10 @@ class AuditAnalysisOps:
         renderer = AuditReportRenderer()  # Initialize report generator.
         md_path = os.path.join("data", "OrgAuditAnalysis.md")  # Mermaid timeline output path.
         renderer.render_mermaid(analysis, md_path)
-        logging.warning("Mermaid report: %s", md_path)  # WARNING so operator sees path (#886 Phase 2 print->logger).
+        logging.warning("Mermaid report: %s", md_path)  # Uses warning level so the operator sees the path (#886).
         html_path = os.path.join("data", "OrgAuditAnalysis.html")  # Interactive HTML output path.
         renderer.render_html(analysis, html_path)
-        logging.warning("HTML report: %s", html_path)  # WARNING so operator sees path (#886 Phase 2 print->logger).
+        logging.warning("HTML report: %s", html_path)  # Uses warning level so the operator sees the path (#886).
 
     @staticmethod
     def audit_log_analysis() -> None:
@@ -80,16 +80,16 @@ class AuditAnalysisOps:
         except ValueError as exc:
             logging.error("Invalid time range: %s", exc)
             return
-        logging.warning(  # WARNING so operator sees range on default root-logger config (#886 Phase 2 print->logger).
+        logging.warning(  # Uses warning level so the range shows by default (#886).
             "Fetching audit logs for: %s", time_range.description
         )
         entries = AuditAnalysisOps._fetch_filtered_audit_entries(org_id, time_range)  # API call + paginate.
         if entries is None:  # API failed (already logged inside helper).
             return
-        logging.warning("Retrieved %d raw entries", len(entries))  # WARNING per #886 Phase 2 print->logger migration.
+        logging.warning("Retrieved %d raw entries", len(entries))  # Uses warning level so it shows by default (#886).
         log_filter = AuditLogFilter()  # Noise filter.
         filtered, stats = log_filter.filter_with_stats(entries)  # Remove noise entries with stats.
-        logging.warning(  # WARNING so operator sees filter stats (#886 Phase 2 print->logger migration).
+        logging.warning(  # Uses warning level so the operator sees the stats (#886).
             "Filtered: %d kept, %d noise removed", stats["kept_count"], stats["removed_count"]
         )
         analyzer = AuditLogAnalyzer()  # Pattern analyzer.

--- a/src/audit/filter.py
+++ b/src/audit/filter.py
@@ -43,7 +43,7 @@ class AuditLogFilter:  # Encapsulates noise-filtering rules for audit entries
             True if the entry should be filtered out.
         """
         msg = entry.get("message", "")  # Missing message defaults to empty string
-        if self._matches_noise_phrase(msg):  # Phrase-match noise (login/logout, packet capture, etc.)
+        if self._matches_noise_phrase(msg):  # Phrase-match noise (login/logout, packet capture, and so on)
             return True  # Phrase match short-circuits to noise
         if _is_vpn_cascade(msg, entry):  # VPN update without before/after detail
             return True  # VPN cascade short-circuits to noise

--- a/src/audit/time_parser.py
+++ b/src/audit/time_parser.py
@@ -25,7 +25,7 @@ UNIT_LABELS: dict[str, str] = {  # WHY: unit letter -> plural label for descript
     "y": "years",  # year label used in "last N years" strings
 }
 
-SIMPLE_PATTERN = re.compile(r"^(\d+)([hdwmy])$", re.IGNORECASE)  # WHY: matches "3d", "4w", etc.
+SIMPLE_PATTERN = re.compile(r"^(\d+)([hdwmy])$", re.IGNORECASE)  # WHY: matches "3d", "4w", and so on
 RANGE_PATTERN = re.compile(  # WHY: matches "6w-2w" or "3m-1w" (start-ago to end-ago)
     r"^(\d+)([hdwmy])\s*[-\u2013]\s*(\d+)([hdwmy])$", re.IGNORECASE
 )
@@ -64,7 +64,7 @@ def _describe_simple(count: int, unit: str) -> str:  # WHY: format shorthand as 
     """Return a human label like 'last 3 days' or 'last 1 day'."""
     label = UNIT_LABELS.get(unit, unit)  # WHY: fall back to raw unit if unknown
     if count == 1 and label.endswith("s"):  # WHY: singularize plural label for 1-unit ranges
-        label = label[:-1]  # strip trailing 's' to produce "day"/"week"/etc.
+        label = label[:-1]  # strip trailing 's' to produce "day"/"week"/and so on
     return f"last {count} {label}"  # canonical description phrasing
 
 

--- a/src/auth/interactive/credential_prompter.py
+++ b/src/auth/interactive/credential_prompter.py
@@ -37,7 +37,7 @@ class CredentialPrompter:
         except EOFError:  # SSH disconnects surface here when no TTY is attached
             logging.info("EOF during password entry - session disconnected")  # Legacy log preserved
             return None  # Signal caller to cancel the login flow
-        except Exception as password_error:  # Any other terminal failure (e.g., closed stdin)
+        except Exception as password_error:  # Any other terminal failure (for example, closed stdin)
             logging.error("Failed to read password: %s", password_error)  # Legacy error log preserved
             logging.warning("X Failed to read password: %s", password_error)  # Legacy console message routed via logger
             return None  # Caller will short-circuit the login

--- a/src/bootstrap/package_installer.py
+++ b/src/bootstrap/package_installer.py
@@ -90,7 +90,7 @@ class PackageInstaller:  # WHY: collaborator injecting stdlib modules for testab
 
     def _probe_uv_command(self, cmd: list[str]) -> tuple[list[str], str] | None:  # WHY: single-candidate runner
         """Return (cmd, version) if the candidate runs successfully, else None."""
-        if not self._candidate_is_runnable(cmd):  # WHY: skip absolute paths that don't exist on disk
+        if not self._candidate_is_runnable(cmd):  # WHY: skip absolute paths that do not exist on disk
             return None  # WHY: unreachable binary cannot be probed; skip to next candidate
         try:  # WHY: subprocess.run may raise FileNotFoundError/OSError/SubprocessError
             result = self.subprocess_module.run(  # WHY: --version is the cheapest way to confirm uv works
@@ -106,9 +106,9 @@ class PackageInstaller:  # WHY: collaborator injecting stdlib modules for testab
         return cmd, result.stdout.strip()  # WHY: strip trailing newline from `uv --version` output
 
     def _candidate_is_runnable(self, cmd: list[str]) -> bool:  # WHY: cheap on-disk check before spawn
-        """Reject absolute-path candidates that don't exist on disk."""
+        """Reject absolute-path candidates that do not exist on disk."""
         if len(cmd) != 1:  # WHY: only single-arg absolute paths need existence checks
-            return True  # WHY: multi-arg commands (e.g. python -m uv) always attempt to run
+            return True  # WHY: multi-arg commands (for example python -m uv) always attempt to run
         if self.os_module.path.sep not in cmd[0]:  # WHY: bare names rely on PATH resolution, not disk check
             return True  # WHY: bare executable names are always eligible; PATH resolves them at spawn
         return bool(self.os_module.path.isfile(cmd[0]))  # WHY: skip missing binaries before invoking subprocess

--- a/src/cache/cache_utils.py
+++ b/src/cache/cache_utils.py
@@ -26,7 +26,7 @@ from typing import Any  # WHY: dynamic row payload annotations.
 class CacheUtils:
     """Centralized cache management utilities.
 
-    Handles CSV caching, freshness checks, regeneration, etc.
+    Handles CSV caching, freshness checks, regeneration, and so on
     """
 
     _ADDRESS_PARSE_FAILURE_FIELDNAMES: list[str] = [  # Stable column order for AddressParseFailures CSV
@@ -115,7 +115,7 @@ class CacheUtils:
                 data_key = row.get(key)  # Extract the grouping key value from this row
                 if data_key is None:  # The key column is missing on this row
                     logging.warning("Row missing key '%s': %s", key, row)  # Warn about the malformed row
-                    continue  # Skip rows that can't be grouped
+                    continue  # Skip rows that cannot be grouped
                 if data_key not in data_dict:  # First time we've seen this key value
                     data_dict[data_key] = []  # Start a new bucket for it
                 data_dict[data_key].append(row)  # Add this row to its key's bucket
@@ -206,7 +206,7 @@ class CacheUtils:
         logging.info("Scanning data directory for generated cache CSVs: %s", data_dir)  # Log scan target
         candidates = CacheUtils._scan_cache_candidates(data_dir)  # List safe-to-delete files (None on scan error)
         if candidates is None:  # Directory could not be listed (already reported by the scanner)
-            return  # Abort -- nothing to delete if we can't list the directory
+            return  # Abort -- nothing to delete if we cannot list the directory
         if not candidates:  # Nothing to delete -- inform operator and return early
             # WHY (#886 Phase 2): consolidate print+info into single WARNING so operator sees notice
             # on the default root-logger config (INFO is suppressed by default).
@@ -223,7 +223,7 @@ class CacheUtils:
 
     @staticmethod
     def _scan_cache_candidates(data_dir: str) -> list[str] | None:  # List generated cache files, or None on error
-        """Return the list of generated cache filenames in data_dir, or None if the directory can't be listed."""
+        """Return the list of generated cache filenames in data_dir, or None if the directory cannot be listed."""
         logging.debug("Listing generated cache candidates in %s", data_dir)  # Trace the scan before listing
         try:  # Listing can fail on permissions or a missing directory
             return [

--- a/src/capture/_packet_capture_exec.py
+++ b/src/capture/_packet_capture_exec.py
@@ -56,10 +56,10 @@ class PacketCaptureExec:
     # ------------------------------------------------------------------ exec
     def execute_site_capture(self, site_id: str, payload: dict[str, Any]) -> None:
         """Execute site-level packet capture via API."""
-        try:  # WHY: broad guard so unexpected failures don't crash the CLI
+        try:  # WHY: broad guard so unexpected failures do not crash the CLI
             print(f"\n> Starting packet capture for site {site_id}...")  # WHY: user progress banner
             logging.info("Initiating site capture with payload: %s", payload)  # WHY: audit request
-            response = _pc().mistapi.api.v1.sites.pcaps.startSitePacketCapture(  # WHY: kick off capture
+            response = _pc().mistapi.api.v1.sites.pcaps.startSitePacketCapture(  # WHY: start capture
                 self.mist_session, site_id, payload
             )
             self._dispatch_start_response(site_id, response)  # WHY: branch on success/failure
@@ -71,7 +71,7 @@ class PacketCaptureExec:
         """Branch on HTTP 200 (success) vs error paths for a start response."""
         if response.status_code == 200:  # WHY: happy path first
             self._handle_start_success(site_id, response.data)  # WHY: delegate success branch
-            return  # WHY: don't fall through to error handling
+            return  # WHY: do not fall through to error handling
         self._handle_start_error(response)  # WHY: consolidated error reporting
 
     def _handle_start_success(self, site_id: str, result: dict[str, Any]) -> None:
@@ -93,7 +93,7 @@ class PacketCaptureExec:
             print("\n> Waiting for PCAP file to be ready...")  # WHY: keep user informed
             print("  This may take a few moments after capture completes.")  # WHY: expectation set
             self._wait_and_download_pcap(site_id, capture_id, result.get("duration", 600))  # WHY: pcap flow
-            return  # WHY: don't also start stream
+            return  # WHY: do not also start stream
         if capture_format == "stream":  # WHY: stream route subscribes to WebSocket
             self._subscribe_to_site_capture_stream(site_id, capture_id)  # WHY: real-time stream
 
@@ -108,7 +108,7 @@ class PacketCaptureExec:
             print("  Only one capture per AP is allowed at a time")  # WHY: educate user
             print("  Wait for the existing capture to complete or check the Mist portal to stop it")  # WHY: remediate
             logging.error("Capture conflict: Recording already in progress on AP")  # WHY: audit conflict
-            return  # WHY: don't print generic error over specialized one
+            return  # WHY: do not print generic error over specialized one
         print(f"\n! Failed to start capture: {response.status_code}")  # WHY: generic failure
         print(f"  Error details: {error_details}")  # WHY: surface API detail
         logging.error("Capture failed: %s - %s", response.status_code, error_details)  # WHY: audit failure
@@ -152,7 +152,7 @@ class PacketCaptureExec:
     def _loop_start_call(self, site_id: str, payload: dict[str, Any], iteration: int) -> Any | None:
         """Wrapped startSitePacketCapture call that traps exceptions."""
         try:  # WHY: catch API/network faults so the loop keeps running
-            return _pc().mistapi.api.v1.sites.pcaps.startSitePacketCapture(  # WHY: kick off new capture
+            return _pc().mistapi.api.v1.sites.pcaps.startSitePacketCapture(  # WHY: start new capture
                 self.mist_session, site_id, payload
             )
         except Exception as capture_error:  # pylint: disable=broad-exception-caught  # WHY: log-and-continue

--- a/src/capture/_packet_capture_prompts.py
+++ b/src/capture/_packet_capture_prompts.py
@@ -11,7 +11,7 @@ Callers instantiate :class:`PacketCapturePrompts` directly (no factory
 indirection) so ``PacketCaptureManager`` binds an instance on itself as
 ``self._prompts``. ``__getattr__`` delegates lookups back to the manager
 so shared state (``mist_session``, ``validate_mac_address``,
-``normalize_mac_address``, etc.) works transparently without duplicating
+``normalize_mac_address``, and so on) works transparently without duplicating
 class-level attributes.
 """
 
@@ -396,7 +396,7 @@ class PacketCapturePrompts:
     @staticmethod
     def extract_port_names(payload: dict[str, Any], capture_type: str) -> list[str]:
         """Extract port names from a device capture payload."""
-        config_key = f"{capture_type.lower()}s"  # WHY: e.g. 'Gateway' -> 'gateways' payload key
+        config_key = f"{capture_type.lower()}s"  # WHY: for example 'Gateway' -> 'gateways' payload key
         device_config = payload.get(config_key, {})  # WHY: default empty dict when key missing
         for mac_config in device_config.values():  # WHY: single-device payloads carry one mac entry
             ports = mac_config.get("ports", {})  # WHY: ports dict keyed by port name

--- a/src/capture/packet_capture.py
+++ b/src/capture/packet_capture.py
@@ -792,7 +792,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         """Gather scan radio capture parameters interactively.
 
         Args:
-            band: Radio band string (e.g. '24', '5', '6').
+            band: Radio band string (for example '24', '5', '6').
 
         Returns:
             Dict with channel, bandwidth, duration, num_packets, format
@@ -876,7 +876,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         """Gather remaining params and launch a single-AP scan capture."""
         band = self._prompt_scan_band()  # WHY: user picks 2.4/5/6 GHz
         logging.debug("Band selected: %s", band)  # WHY: audit chosen band
-        scan_params = self._gather_scan_radio_params(band)  # WHY: channel/bandwidth/duration/etc.
+        scan_params = self._gather_scan_radio_params(band)  # WHY: channel/bandwidth/duration, and so on.
         if scan_params is None:  # WHY: user cancelled a scan-param prompt
             return  # WHY: propagate cancel
         enable_loop = self._prompt_loop_mode()  # WHY: continuous mode toggle

--- a/src/dataclasses/batch_worker.py
+++ b/src/dataclasses/batch_worker.py
@@ -25,4 +25,4 @@ class BatchWorkerConfig:
     worker_function: Callable[..., Any]  # Callable that processes a single batch item; takes (item, semaphore).
     connection_semaphore: threading.Semaphore  # Bound on concurrent network connections across all batches.
     max_threads: int  # Upper bound on threads the pool may spawn; passed to ThreadPoolExecutor.
-    batch_description: str  # Human-readable label (e.g. "devices") used in tqdm + log messages.
+    batch_description: str  # Human-readable label (for example "devices") used in tqdm + log messages.

--- a/src/dataclasses/family_selection_context.py
+++ b/src/dataclasses/family_selection_context.py
@@ -24,7 +24,7 @@ class FamilySelectionContext:
     output dict as direct parameters, keeping its signature at 3 total params.
     """
 
-    family: str  # Human-readable model-family name (e.g. "AP43"); used only for log/print output.
+    family: str  # Human-readable model-family name (for example "AP43"); used only for log/print output.
     models: list[str]  # List of concrete model SKUs that belong to this family.
     sorted_versions: list[str]  # Operator-visible numbered choices, sorted newest-first.
     current_version: str | None  # The version currently configured on this family (None when unset).

--- a/src/dataclasses/progress_event.py
+++ b/src/dataclasses/progress_event.py
@@ -23,7 +23,7 @@ class ProgressContext:
     """Operation identity shared across a single operation's progress events."""
 
     menu_option: str | int  # Menu option the progress event belongs to (accepts str or int form).
-    operation_name: str  # Human-readable operation label (e.g. "sites", "inventory").
+    operation_name: str  # Human-readable operation label (for example "sites", "inventory").
     total: int  # Total number of items the operation will process (the progress denominator).
 
 
@@ -38,4 +38,4 @@ class TestSummary:
     failed: int  # Count of operations that failed.
     skipped: int  # Count of operations skipped (heavy / destructive / WIP).
     elapsed: float  # Wall-clock seconds the whole test run took.
-    test_mode: str  # Test mode label (e.g. "systematic", "quick").
+    test_mode: str  # Test mode label (for example "systematic", "quick").

--- a/src/dataclasses/systematic_test_option.py
+++ b/src/dataclasses/systematic_test_option.py
@@ -23,6 +23,6 @@ from typing import Any  # The menu callable returns Any and takes arbitrary kwar
 class SystematicTestOption:
     """Identity of a single menu option exercised by the systematic test harness."""
 
-    option: str  # Menu option number being tested (e.g. "11").
+    option: str  # Menu option number being tested (for example "11").
     func: Callable[..., Any]  # The menu action callable invoked for this option.
     description: str  # Human-readable option description shown in progress output.

--- a/src/dataclasses/websocket_stream_target.py
+++ b/src/dataclasses/websocket_stream_target.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass  # The standard library dataclass decorator.
 class WebSocketStreamTarget:
     """Connection identity that locates one device's WebSocket command stream."""
 
-    mist_host: str  # Mist API-WS host the stream connects to (e.g. api-ws.mist.com).
+    mist_host: str  # Mist API-WS host the stream connects to (for example api-ws.mist.com).
     mist_apitoken: str  # API token used in the WebSocket Authorization header.
     site_id: str  # Site UUID the target device belongs to.
     device_id: str  # Device UUID whose command output is being streamed.

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -4142,7 +4142,7 @@ class ArangoDBWriter:  # WHY: primary writer class for the ArangoDB polyglot bac
             "_misthelper_updated_at": int(time.time()),  # WHY: staleness stamp
         }
 
-    def _resolve_field(self, record: dict, field: str) -> Any:  # WHY: dispatcher for nested vs. flat field access
+    def _resolve_field(self, record: dict, field: str) -> Any:  # WHY: dispatcher for nested versus flat field access
         """Return the record value for a field, supporting dot-separated nested paths."""
         if "." in field:  # WHY: guard clause routes nested paths through the recursive helper
             return self._resolve_nested_field(record, field)
@@ -4254,7 +4254,7 @@ class ArangoDBWriter:  # WHY: primary writer class for the ArangoDB polyglot bac
 
     @staticmethod
     def _resolve_nested_field(record: dict, field_path: str) -> Any:  # WHY: dot-path resolver
-        """Resolve dot-separated field paths (e.g., 'matching.site_ids')."""
+        """Resolve dot-separated field paths (for example, 'matching.site_ids')."""
         parts = field_path.split(".")  # WHY: split path into successive keys
         value: Any = record  # WHY: walk starts at the record root
         for part in parts:  # WHY: descend through each dot-separated key

--- a/src/db/database_schema_utils.py
+++ b/src/db/database_schema_utils.py
@@ -64,7 +64,7 @@ class DatabaseSchemaUtils:  # Build SQLite DDL from data.
             data_fields (list): List of field names in the data
 
         Returns:
-            dict: Strategy configuration including primary key, indexes, etc.
+            dict: Strategy configuration including primary key, indexes, and so on
         """
         # First check if we have a specific strategy for this endpoint
         if api_function_name in ENDPOINT_PRIMARY_KEY_STRATEGIES:  # Use a configured strategy.

--- a/src/db/redis_writer.py
+++ b/src/db/redis_writer.py
@@ -34,7 +34,7 @@ JSON_PIPELINE_BATCH = 500  # WHY: batch JSON.SET+EXPIRE to bound pipeline memory
 HOURLY_BUCKET_MS = 3_600_000  # WHY: 1h aggregation bucket for hourly compaction rule.
 DAILY_BUCKET_MS = 86_400_000  # WHY: 1d aggregation bucket for daily compaction rule.
 KEY_CREATION_BATCH = 500  # WHY: pipeline TS.CREATE in modest batches to avoid slow-log spikes.
-ADD_PIPELINE_BATCH = 10_000  # WHY: TS.ADD batch size tuned for throughput vs. Redis latency.
+ADD_PIPELINE_BATCH = 10_000  # WHY: TS.ADD batch size tuned for throughput versus Redis latency.
 PARALLEL_EXTRACT_THRESHOLD = 1000  # WHY: below this, sequential extract avoids pool startup overhead.
 MAX_EXTRACT_WORKERS = 8  # WHY: cap parallelism to prevent GIL thrash on typical hosts.
 DEFAULT_LABEL_FIELDS = (
@@ -148,7 +148,7 @@ class RedisTimeSeriesWriter:
             ts_value_fields=strategy.get("ts_value_fields"),
         )
 
-    def _extract_all_adds(  # WHY: dispatch sequential vs. parallel extraction based on input size.
+    def _extract_all_adds(  # WHY: dispatch sequential versus parallel extraction based on input size.
         self,
         data: list[dict[str, Any]],
         ctx: _ExtractContext,
@@ -197,7 +197,7 @@ class RedisTimeSeriesWriter:
 
     @staticmethod
     def _select_numeric(record: dict[str, Any], ctx: _ExtractContext) -> dict[str, float]:  # WHY: mode dispatch.
-        """Choose listed-fields vs. auto numeric extraction based on ctx."""
+        """Choose listed-fields versus auto numeric extraction based on ctx."""
         if ctx.ts_value_fields:  # WHY: explicit allow-list wins over generic numeric scan.
             return RedisTimeSeriesWriter._extract_listed_fields(record, ctx.ts_value_fields)
         return RedisTimeSeriesWriter._extract_numeric(record, ctx.primary_keys)  # WHY: fallback auto-detect path.
@@ -327,7 +327,7 @@ class RedisTimeSeriesWriter:
         batch: list[tuple[str, float]],
         results: list[Any],
     ) -> tuple[int, int]:
-        """Count successes vs. failures, logging each failure with its key."""
+        """Count successes versus failures, logging each failure with its key."""
         written = 0  # WHY: local counter avoids mutating caller state directly.
         failed = 0  # WHY: local counter for failed adds.
         for idx, result in enumerate(results):  # WHY: index-align back to batch entries for error context.
@@ -414,7 +414,7 @@ class RedisTimeSeriesWriter:
             entity_id = self._pick_webhook_entity(event)  # WHY: keeps the loop body linear.
             numeric = self._extract_numeric(event, list(WEBHOOK_ENTITY_KEYS))  # WHY: exclude PK-like fields.
             for field_name, value in numeric.items():  # WHY: each numeric field maps to its own TS key.
-                ts_key = f"{key_prefix}:{entity_id}:{field_name}"  # WHY: consistent naming vs. batch path.
+                ts_key = f"{key_prefix}:{entity_id}:{field_name}"  # WHY: consistent naming versus batch path.
                 self._ensure_key_single(ts_key, event, key_prefix)  # WHY: guarantees key exists before ADD.
                 pipe.execute_command(  # WHY: enqueue explicit-timestamp TS.ADD command.
                     "TS.ADD",

--- a/src/device/_utility_commands_action.py
+++ b/src/device/_utility_commands_action.py
@@ -76,7 +76,7 @@ class _UtilityCommandsAction(_ClusterBase):  # WHY: cluster wrapper mirroring ea
                 site_id,
                 device_id,
                 {"duration": duration},
-            )  # WHY: kick off LED blink for `duration` minutes
+            )  # WHY: start LED blink for `duration` minutes
             if self._print_api_result(
                 response,
                 f"Device LED blinking for {duration} minutes.",
@@ -149,7 +149,7 @@ class _UtilityCommandsAction(_ClusterBase):  # WHY: cluster wrapper mirroring ea
         return True
 
     def _invoke_port_bounce(self, site_id: str, device_id: str, port_id: str) -> None:
-        """Kick off the WebSocket-backed port-bounce and report result."""
+        """Start the WebSocket-backed port-bounce and report result."""
         print(f"\n-> Bouncing port {port_id}...")  # WHY: operator feedback
         result = self._run_websocket_command(
             site_id,

--- a/src/device/_utility_commands_selection.py
+++ b/src/device/_utility_commands_selection.py
@@ -73,7 +73,7 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
             "dict[str, Any] | None",
             self._call("_get_device_info", site_id, device_id),
         )
-        if not device_info:  # WHY: no info means we can't verify compatibility
+        if not device_info:  # WHY: no info means we cannot verify compatibility
             # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
             logger.warning("! Could not retrieve device info from stats API.")
             return None  # WHY: abort when stats unavailable
@@ -136,7 +136,7 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
             # WHY: route via parent for test patches
             return cast("str | None", self._call("_display_and_select_port", ports))  # WHY: structured path
         if_stat = stats.get("if_stat", {})  # WHY: fallback to legacy if_stat dict
-        if isinstance(if_stat, dict) and if_stat:  # WHY: only use if it's a populated mapping
+        if isinstance(if_stat, dict) and if_stat:  # WHY: only use if it is a populated mapping
             # WHY: route via parent for test patches
             return cast("str | None", self._call("_display_and_select_ifstat", if_stat))  # WHY: legacy path
         # WHY: no structured data, ask user directly; route via parent for patches

--- a/src/device/_utility_commands_show.py
+++ b/src/device/_utility_commands_show.py
@@ -12,7 +12,7 @@ reduces the parent's public-method count so STRUCT-METHOD-COUNT passes.
 
 Because none of the helpers these commands call
 (``_run_websocket_command``, ``_display_and_export_result``,
-``_select_site_and_device``, etc.) are defined on this cluster, plain
+``_select_site_and_device``, and so on) are defined on this cluster, plain
 ``self._method(...)`` calls resolve via the cluster's ``__getattr__``
 back to the parent, so tests that use
 ``patch.object(duc, "_run_websocket_command", ...)`` continue to win.
@@ -54,7 +54,7 @@ class ShowCommandSpec:  # WHY: preset bundle per show command
     shrinking them below the 25-line STRUCT-LENGTH limit.
     """
 
-    sdk_method: Any  # WHY: bound mistapi method (traceroute/show*/monitor/etc.)
+    sdk_method: Any  # WHY: bound mistapi method (traceroute/show*/monitor/and so on)
     command_name: str  # WHY: banner label printed above rendered output
     api_function_name: str  # WHY: audit label recorded on the export row
     filename: str  # WHY: CSV output filename passed to write_export

--- a/src/device/_utility_commands_websocket.py
+++ b/src/device/_utility_commands_websocket.py
@@ -49,7 +49,7 @@ class StreamWsSpec:  # WHY: bundle for _stream_ws_output single-arg signature
 
     site_id: str  # WHY: mistapi site scope for SDK call
     device_id: str  # WHY: mistapi device scope for SDK call
-    sdk_method: Any  # WHY: bound mistapi method (traceroute/monitor_traffic/etc.)
+    sdk_method: Any  # WHY: bound mistapi method (traceroute/monitor_traffic/and so on)
     body: dict[str, Any] | None  # WHY: optional JSON body; some SDK methods take none
     websocket_manager: Any  # WHY: already-connected WebSocketManager instance
     timeout_seconds: int  # WHY: overall wait budget for streaming result

--- a/src/device/arp_command_manager.py
+++ b/src/device/arp_command_manager.py
@@ -183,7 +183,7 @@ class ARPCommandManager:  # ARP WebSocket command manager.
     @staticmethod
     @staticmethod
     def _parse_ws_arp_payload(message: str):
-        """Parse a WebSocket frame into the inner ARP data dict (returns None when frame can't be unwrapped)."""
+        """Parse a WebSocket frame into the inner ARP data dict (returns None when frame cannot be unwrapped)."""
         msg = json.loads(message)  # Outer envelope
         data_str = msg.get("data", "{}")  # Outer data string
         data_obj = json.loads(data_str) if isinstance(data_str, str) else data_str  # Inner JSON or already-parsed
@@ -313,7 +313,7 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         for line in lines:  # Walk lines.
             if "Total" in line:  # Total marker.
                 current_dataset = dataset2  # Switch datasets.
-                continue  # Marker isn't a row.
+                continue  # Marker is not a row.
             columns = ARPCommandManager._extract_arp_columns(line)  # Delegate tab-split + strip
             if columns:  # Have columns.
                 current_dataset.append(columns)  # Collect the row.

--- a/src/device/device_utils.py
+++ b/src/device/device_utils.py
@@ -79,9 +79,9 @@ class DeviceUtils:  # Device helper utilities.
         match = re.match(r"^(.+/)(\d+)-(\d+)$", port_part)  # Match prefix plus numeric start-end range
         if not match:  # Could not parse as a range
             return [port_part]  # Keep the literal token
-        prefix = match.group(1)  # e.g., "ge-0/0/"
-        start_num = int(match.group(2))  # Range start (e.g., 0)
-        end_num = int(match.group(3))  # Range end (e.g., 2)
+        prefix = match.group(1)  # for example, "ge-0/0/"
+        start_num = int(match.group(2))  # Range start (for example, 0)
+        end_num = int(match.group(3))  # Range end (for example, 2)
         return [f"{prefix}{port_num}" for port_num in range(start_num, end_num + 1)]  # Concrete ports across the range
 
     @staticmethod

--- a/src/device/prompt_utils.py
+++ b/src/device/prompt_utils.py
@@ -436,7 +436,7 @@ class PromptNetworkDeviceUtils:  # WHY: interactive Mist device and port selecti
         port_stat = cast("dict[str, Any]", stats_data.get("port_stat", {}))  # WHY: narrow Any for mypy strict
         if port_stat:  # WHY: log presence so operators can confirm live data
             logging.info("Found port_stat (AP-style) with %d ports", len(port_stat))
-        else:  # WHY: warn when the AP hasn't reported any port stats yet
+        else:  # WHY: warn when the AP has not reported any port stats yet
             logging.warning("No port_stat found in AP stats for device %s", device_id)
         return port_stat  # WHY: empty dict when device is silent -- caller handles fallback
 
@@ -635,7 +635,7 @@ class PromptNetworkDeviceUtils:  # WHY: interactive Mist device and port selecti
         """Build a PrettyTable of available ports with status, speed, and config info."""
         table = PrettyTable()  # WHY: fresh table per call so state is not shared
         table.field_names = _PORT_TABLE_FIELDS  # WHY: use shared column set for visual consistency
-        table.max_width = 120  # WHY: cap width so long descriptions don't overflow a 120-col terminal
+        table.max_width = 120  # WHY: cap width so long descriptions do not overflow a 120-col terminal
         table.align["Description"] = "l"  # WHY: left-align description so text wraps predictably
         table.align["Profile"] = "l"  # WHY: left-align profile name for readability
         for idx, (port_name, port_info) in enumerate(available_ports):  # WHY: one row per available port
@@ -681,7 +681,7 @@ class PromptNetworkDeviceUtils:  # WHY: interactive Mist device and port selecti
             try:
                 return f"{int(speed_upper[:-1]) * 1000} Mbps"  # WHY: strip G and convert to Mbps
             except ValueError:
-                return speed  # WHY: non-integer prefix (e.g. '1.5G') falls back to raw value
+                return speed  # WHY: non-integer prefix (for example '1.5G') falls back to raw value
         return None  # WHY: unrecognised string form -- caller falls through to numeric/N-A logic
 
     @staticmethod

--- a/src/device/utility_commands.py
+++ b/src/device/utility_commands.py
@@ -156,7 +156,7 @@ class DeviceUtilityCommands:  # WHY: parent class hosting 35 device-command oper
         Python only invokes ``__getattr__`` when normal lookup fails, so
         this method resolves cluster method calls (``self._validate_device_type``,
         ``self._select_site_and_device``, ``self._select_port_from_device``,
-        etc.) without explicit delegator wrappers. The class-level
+        and so on) without explicit delegator wrappers. The class-level
         ``hasattr`` check on ``type(cluster)`` avoids invoking the
         cluster's own ``__getattr__`` (which would proxy back to this
         class and cause infinite recursion for unknown attrs).

--- a/src/export/const_definitions_exporter.py
+++ b/src/export/const_definitions_exporter.py
@@ -123,7 +123,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
         """Return True when ``obj`` is a public function whose signature accepts a session arg."""
         import inspect  # Local import to keep top-level imports unchanged
 
-        if not inspect.isfunction(obj):  # Skip classes, builtins, etc.
+        if not inspect.isfunction(obj):  # Skip classes, builtins, and so on
             return False
         sig = inspect.signature(obj)  # Inspect parameters
         param_names = list(sig.parameters.keys())  # Materialize names for membership test

--- a/src/export/data_exporter.py
+++ b/src/export/data_exporter.py
@@ -321,7 +321,7 @@ class DataExporter:  # Multi-backend export facade.
             logging.warning("! Cannot write to %s. Is it open in another program?", csv_file_path)  # User-facing hint
             logging.debug("EXIT: DataExporter.write_to_csv - permission error")  # Trace exit on perm denial
             raise  # Propagate to the caller
-        except OSError as os_error:  # OS-level write failure (disk full, path invalid, etc.)
+        except OSError as os_error:  # OS-level write failure (disk full, path invalid, and so on)
             logging.error("File I/O: OS error when writing to %s: %s", csv_file_path, os_error)  # Log OS failure
             logging.debug("EXIT: DataExporter.write_to_csv - OS error")  # Trace OS error exit
             raise  # Propagate to the caller

--- a/src/export/msp_inventory_exporter.py
+++ b/src/export/msp_inventory_exporter.py
@@ -35,7 +35,7 @@ class MSPInventoryExporter:
     - MSP context: msp_id, msp_name
     - Org context: org_id, org_name
     - Site context: site_id, site_name
-    - Device fields: type, model, mac, serial, name, version, status, etc.
+    - Device fields: type, model, mac, serial, name, version, status, and so on
 
     Output File: data/MSP_Inventory_Export.csv
     """

--- a/src/export/org_config_exporter.py
+++ b/src/export/org_config_exporter.py
@@ -75,7 +75,7 @@ class OrgConfigExporter:
     @staticmethod
     def _show_no_msp_access_guidance() -> None:
         """Print the 'MSP access not available' guidance banner with login + token tips."""
-        logging.warning("MSP data requires MSP-level privileges (not detected)")  # Log why we can't query.
+        logging.warning("MSP data requires MSP-level privileges (not detected)")  # Log why we cannot query.
         print("")  # Spacer.
         print("=" * 60)  # Top border.
         print("  MSP ACCESS NOT AVAILABLE")  # Title.

--- a/src/export/org_export_utils.py
+++ b/src/export/org_export_utils.py
@@ -1,7 +1,7 @@
 """OrgExportUtils -- generic org-level data export helpers.
 
 Extracted from MistHelper.py during initiative 1013 (Cat B, position 47).
-Groups org-level export helpers (SLE, insight metrics, NAC, audit logs, etc.)
+Groups org-level export helpers (SLE, insight metrics, NAC, audit logs, and so on)
 under a single static-method facade. All methods are static -- no state is kept
 on the class. Callers continue to reach it through the
 ``MistHelper.OrgExportUtils`` re-export alias.
@@ -176,7 +176,7 @@ class OrgExportUtils:
     def _load_parameterized_metric_choices() -> dict[str, list[str]]:  # Discover parameterized metrics.
         """Return {metric_name: [choices]} for org insight metrics requiring a 'metric' sub-parameter.
 
-        Some org insight metrics (e.g. switch-metrics, gateway-metrics) declare a 'metric'
+        Some org insight metrics (for example switch-metrics, gateway-metrics) declare a 'metric'
         query parameter in their constants definition. getOrgSle cannot supply it, so a bare
         call returns HTTP 400 "Bad Syntax". Reading the live constants lets callers expand each
         such metric into one request per valid choice instead of failing.
@@ -234,7 +234,7 @@ class OrgExportUtils:
         records: list[dict[str, Any]] = []  # Collected per-choice time-series records
         retrieved = 0  # Successful choice fetches
         failed = 0  # Failed or empty choice fetches
-        for choice in choices:  # Each valid sub-metric value (e.g. bytes, rx_bytes, total_port_count)
+        for choice in choices:  # Each valid sub-metric value (for example bytes, rx_bytes, total_port_count)
             record = OrgExportUtils._fetch_single_metric_choice(org_id, metric, choice, duration)  # One GET
             if record:  # Choice returned a usable payload
                 records.append(record)  # Keep the tagged record
@@ -271,7 +271,7 @@ class OrgExportUtils:
     def _insight_fetch_one_sle_category(org_id: str, metric: str, sle_category: str) -> dict[str, Any] | None:
         """Fetch one SLE category's site data; return aggregated result row, or None when empty/failed."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession global.
-        try:  # Isolate this category so one failure doesn't abort the others.
+        try:  # Isolate this category so one failure does not abort the others.
             response = mistapi.api.v1.orgs.insights.getOrgSitesSle(  # Call the sites-SLE API for this category.
                 mh.apisession, org_id, sle=sle_category, duration="7d", limit=1000
             )
@@ -339,7 +339,7 @@ class OrgExportUtils:
     def _insight_fetch_sites_sle_summary(org_id: str) -> tuple[list[dict[str, Any]], int, int]:
         """Fetch the org-wide sites SLE summary; return (records, retrieved, failed)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession global.
-        try:  # Isolate the summary fetch so its failure doesn't abort the export.
+        try:  # Isolate the summary fetch so its failure does not abort the export.
             logging.debug("Attempting to retrieve org sites SLE summary")  # Trace the attempt.
             response = mistapi.api.v1.orgs.insights.getOrgSitesSle(
                 mh.apisession, org_id, duration="7d", limit=100
@@ -503,7 +503,7 @@ class OrgExportUtils:
             )
             OrgExportUtils._insight_report_totals(metrics_retrieved, metrics_failed)  # Report + log the totals.
             if all_insight_data:  # At least one metric returned data.
-                OrgExportUtils._insight_export_normalized(all_insight_data, org_id, metrics_retrieved)  # Write CSVs.
+                OrgExportUtils._insight_export_normalized(all_insight_data, org_id, metrics_retrieved)  # Export to CSV.
             else:  # Every metric failed or returned empty.
                 # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
                 logger.warning("! 0 organization insight metrics exported (no data available)")  # Tell the user zero.

--- a/src/export/org_inventory_exporter.py
+++ b/src/export/org_inventory_exporter.py
@@ -340,7 +340,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
         return weekly_data, summary_data  # Return both detailed buckets and summary counts
 
     @staticmethod
-    def _write_combined_inventory_weekly_csvs(  # Write weekly inventory CSVs.
+    def _write_combined_inventory_weekly_csvs(  # Write weekly inventory CSV files.
         output_folder: str,
         fieldnames: list[str],
         weekly_data: defaultdict[str, list[dict[str, str | None]]],
@@ -656,7 +656,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
         # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
         logger.info("All Devices with Site and Address Info:")  # Inform operator of export.
         logging.info("Fetching All Devices with Site Info...")  # Log fetch start.
-        if fast:  # Fast mode reuses cached CSVs.
+        if fast:  # Fast mode reuses cached CSV files.
             logging.info(" Fast mode enabled for devices with site info export")  # Log fast mode enabled.
         org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
         site_lookup, inventory = OrgInventoryExporter._devices_load_data(org_id, fast)  # Load sites + inventory.

--- a/src/export/site_anomaly_exporter.py
+++ b/src/export/site_anomaly_exporter.py
@@ -336,7 +336,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
         all_client_anomaly_data = []  # Accumulate anomaly rows.
         metrics_retrieved = 0  # Success count.
         for metric in SiteAnomalyExporter._CLIENT_ANOMALY_METRICS:  # Fetch each metric independently.
-            try:  # Isolate per-metric failures so one bad metric doesn't abort the rest.
+            try:  # Isolate per-metric failures so one bad metric does not abort the rest.
                 record = SiteAnomalyExporter._anomaly_fetch_one_metric(  # Fetch + tag one metric.
                     site_id, client_mac, site_name, client_hostname, metric
                 )

--- a/src/export/wan_client_events_exporter.py
+++ b/src/export/wan_client_events_exporter.py
@@ -327,7 +327,7 @@ class WanClientEventsExporter:
 
         Why:
             The event payloads contain nested objects and multiline strings
-            (e.g., diagnostic details) that break naive CSV writers. Reusing
+            (for example, diagnostic details) that break naive CSV writers. Reusing
             the shared helpers guarantees identical sanitization semantics
             across all site-scoped exporters.
 

--- a/src/firmware/firmware_manager.py
+++ b/src/firmware/firmware_manager.py
@@ -50,7 +50,7 @@ class _MistHelperProxy:  # WHY: attribute forwarder to live MistHelper module
     """Forward attribute access to the currently-loaded MistHelper module.
 
     Enables the co-located FirmwareUpgradeStatusChecker class to reference
-    MistHelper-owned utility singletons (ConfigUtils, PromptUtils, etc.)
+    MistHelper-owned utility singletons (ConfigUtils, PromptUtils, and so on)
     without importing MistHelper at module load time (which would create a
     circular import). Attributes are resolved at call time so test
     monkey-patches applied to MistHelper are honoured.
@@ -135,18 +135,18 @@ class FirmwareManager:
     """Advanced Firmware Management System for Mist Access Points.
 
     This class provides comprehensive firmware upgrade capabilities including:
-    1. Firmware status monitoring and reporting
-    2. Site-based bulk firmware upgrades
-    3. Gateway template-based firmware upgrades
-    4. Automatic site auto-upgrade configuration
-    5. Multi-strategy upgrade orchestration (big_bang, canary, rrm, serial)
-    6. Progress monitoring and audit logging
+    - Firmware status monitoring and reporting.
+    - Site-based bulk firmware upgrades.
+    - Gateway template-based firmware upgrades.
+    - Automatic site auto-upgrade configuration.
+    - Multi-strategy upgrade orchestration (big_bang, canary, rrm, serial).
+    - Progress monitoring and audit logging.
 
     Follows NASA/JPL coding standards for safety-critical operations with:
-    - Comprehensive validation and error handling
-    - Explicit user confirmation for destructive operations
-    - Complete audit trails and logging
-    - Rollback and recovery capabilities
+    - Comprehensive validation and error handling.
+    - Explicit user confirmation for destructive operations.
+    - Complete audit trails and logging.
+    - Rollback and recovery capabilities.
     """
 
     def __init__(self, config: FirmwareManagerConfig) -> None:
@@ -668,7 +668,7 @@ class FirmwareManager:
         """Ensure that required template and site CSV files are fresh and available.
 
         This method generates or refreshes the CSV files needed for template-based
-        operations if they don't exist or are stale.
+        operations if they do not exist or are stale.
         """
         logging.debug("Ensuring template CSV files are fresh")
         print("  Preparing template and site data...")
@@ -1210,7 +1210,7 @@ class FirmwareManager:
         try:
             selection = (
                 self._safe_input_fn("    Select organization(s): ", context="org_multi_select").strip().lower()
-            )  # WHY: strip + lower normalizes 'ALL', ' 1-3 ', etc.
+            )  # WHY: strip + lower normalizes 'ALL', ' 1-3 ', and so on
         except SystemExit:  # WHY: safe_input raises SystemExit on EOF/interrupt for SSH-safe abort
             logging.info("Org selection prompt cancelled (EOF/interrupt)")  # WHY: audit SSH-safe cancel
             return None  # WHY: signal cancel to caller
@@ -2911,7 +2911,7 @@ class FirmwareManager:
         print("Monitor progress through Mist dashboard or API.")
         print("Check individual SSR status for completion and connectivity.")
         print("Verify SD-WAN tunnel re-establishment after reboots.")
-        # Issue #433 Phase A: hand-converted; codemod doesn't yet detect the
+        # Issue #433 Phase A: hand-converted; codemod does not yet detect the
         # logging.getLogger(__name__).<level>(...) dynamic-call pattern.
         logging.getLogger(__name__).info("SSR firmware upgrade operation completed: %s", results["operation_id"])
 
@@ -3057,7 +3057,7 @@ class FirmwareManager:
     ) -> tuple[dict[str, str], dict[str, list[dict[str, Any]]]] | None:
         """Refresh template CSVs and load the template->sites mapping.
 
-        device_kind is a short label (e.g. 'SSR' or 'switch') used only for
+        device_kind is a short label (for example 'SSR' or 'switch') used only for
         audit logs. Returns (template_name_to_id, sites_mapping) on success
         or None when no Gateway Templates have any assigned sites.
         """
@@ -3863,7 +3863,7 @@ class FirmwareUpgradeStatusChecker:
         if self.site_filter:  # WHY: caller scoped to one site -> no summary line needed
             return
         without = total - sites_with_upgrades  # WHY: sites that came back empty
-        if without > 0:  # WHY: only print when there's something to report
+        if without > 0:  # WHY: only print when there is something to report
             print(f"   -> {without} site(s) have no active upgrade operations")
 
     def _check_site_upgrades(self) -> None:

--- a/src/firmware/org_ap_upgrader.py
+++ b/src/firmware/org_ap_upgrader.py
@@ -1501,7 +1501,7 @@ class OrgLevelAPFirmwareUpgrader:
 
         return model_selections  # WHY: return computed result
 
-    def _process_single_model(self, model: str, devices: list[Any]) -> dict[str, Any] | None:  # WHY: declare private he
+    def _process_single_model(self, model: str, devices: list[Any]) -> dict[str, Any] | None:  # WHY: private helper
         """Process version selection for a single model."""
         model_versions = self._get_versions_for_model(model)  # WHY: compute model_versions
         if not model_versions:  # WHY: guard against missing precondition
@@ -1935,7 +1935,7 @@ class OrgLevelAPFirmwareUpgrader:
         logging.debug("_try_parse_after result=%r", result)  # WHY: post-op observability
         return result  # WHY: return offset stamp or '' fallthrough
 
-    def _reboot_relative_disallowed(self, is_for_reboot: bool, use_site_local: bool) -> bool:  # WHY: declare private he
+    def _reboot_relative_disallowed(self, is_for_reboot: bool, use_site_local: bool) -> bool:  # WHY: private helper
         """Predicate: reboot + site-local means relative offsets are disallowed."""
         if use_site_local and is_for_reboot:  # WHY: combined-mode restriction from prior behavior
             print("    ! Relative times not supported for reboot in site-local mode. Use HH:MM format.")  # WHY: user-vi

--- a/src/firmware/site_auto_upgrade.py
+++ b/src/firmware/site_auto_upgrade.py
@@ -161,7 +161,7 @@ class SiteAutoUpgradeConfigurator:
     def execute(**cfg: Any) -> None:
         """Entry point for menu system - checks MSP privileges."""
         logging.info("Starting Site Auto-Upgrade Configuration workflow")  # WHY: action-log workflow start.
-        if cfg.get("dry_run"):  # WHY: advertise dry-run so operator isn't surprised.
+        if cfg.get("dry_run"):  # WHY: advertise dry-run so operator is not surprised.
             logging.info("DRY-RUN MODE enabled - no API calls will be made")  # WHY: dry-run advert log.
         core_deps = SiteAutoUpgradeCoreDeps(  # WHY: bundle 5 always-needed DI params.
             apisession=cfg["apisession"],
@@ -1046,7 +1046,7 @@ def _parse_single_part(part: str, indices: set[int]) -> None:
 def _group_models_by_family(  # WHY: group AP models into families.
     model_version_map: dict[str, list[Any]],
 ) -> dict[str, list[str]]:
-    """Group models by family prefix (AP41, AP43, etc.)."""
+    """Group models by family prefix (AP41, AP43, and so on)."""
     model_families: dict[str, list[str]] = {}  # WHY: family -> member-models map.
     for model in sorted(model_version_map.keys()):  # WHY: sorted order for stable output.
         family = model.rstrip("EP")  # WHY: strip E/P suffixes to get the family.
@@ -1245,7 +1245,7 @@ def _is_valid_hhmm(hour: int, minute: int) -> bool:
 def parse_time_input(time_input: str) -> str:  # WHY: parse a free-form time string.
     """Parse various time formats to HH:MM for the API.
 
-    Accepts: 02:00, 2:00, 14:00, 2AM, 2PM, 02:00AM, etc.
+    Accepts: 02:00, 2:00, 14:00, 2AM, 2PM, 02:00AM, and so on
     Returns: HH:MM format string, or 'any' for any time.
     """
     if not time_input:  # WHY: empty input maps to 'any'.

--- a/src/gateway/_wan2_variable_template.py
+++ b/src/gateway/_wan2_variable_template.py
@@ -83,7 +83,7 @@ class _Wan2VariableTemplate(_ClusterBase):
         replacements: list[tuple[str, str]] = []  # WHY: accumulator for return
         for key in port_config:  # WHY: scan every configured port key
             match = self._classify_port_key(key, search, replace, template_name)  # WHY: extracted for CC budget
-            if match is not None:  # WHY: skip keys that need manual review or don't match
+            if match is not None:  # WHY: skip keys that need manual review or do not match
                 replacements.append(match)  # WHY: record planned edit
         return replacements  # WHY: caller applies edits later
 

--- a/src/gateway/gateway_export_utils.py
+++ b/src/gateway/gateway_export_utils.py
@@ -512,7 +512,7 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
 
     @staticmethod
     def _get_devices_from_cache() -> list[tuple[str, str, str, str]]:
-        """Get gateway devices from cached inventory and site list CSVs."""
+        """Get gateway devices from cached inventory and site list CSV files."""
         try:
             CacheUtils.check_and_generate_csv("OrgInventory.csv", OrgInventoryExporter.inventory)  # WHY: refresh.
             CacheUtils.check_and_generate_csv("SiteList.csv", OrgSiteExporter.sites)  # WHY: refresh site cache.

--- a/src/gateway/gateway_ha_exporter.py
+++ b/src/gateway/gateway_ha_exporter.py
@@ -159,7 +159,7 @@ class GatewayHaExporter:
         for row in rows:  # Iterate each HA gateway record
             name = str(row.get("name", ""))[:28]  # Truncate long names for display
             node_name = str(row.get("node_name", ""))  # Which node (node0 / node1)
-            status = str(row.get("status", ""))  # Connected / Disconnected / etc.
+            status = str(row.get("status", ""))  # Connected / Disconnected / and so on
             node0_mac = str(row.get("ha_cluster_node0_mac") or "")  # MAC of node0 in the pair
             node1_mac = str(row.get("ha_cluster_node1_mac") or "")  # MAC of node1 in the pair
             vc_mac = str(row.get("vc_mac") or "")  # Shared cluster MAC address

--- a/src/gateway/gateway_stats_exporter.py
+++ b/src/gateway/gateway_stats_exporter.py
@@ -106,7 +106,7 @@ def _build_failure_record(  # WHY: legacy record shape keeps failure attempts in
 
 def _compute_backoff(attempt: int, retry_delay: float, fast: bool) -> float:  # WHY: retry timing helper.
     """Return retry delay for this attempt (exponential unless fast mode disables backoff)."""
-    if fast:  # WHY: fast mode uses flat delay so retries don't stretch the run.
+    if fast:  # WHY: fast mode uses flat delay so retries do not stretch the run.
         return retry_delay  # WHY: skip exponential growth for the fast path.
     return retry_delay * (2**attempt)  # WHY: exponential backoff for the standard path.
 

--- a/src/gateway/template_config.py
+++ b/src/gateway/template_config.py
@@ -762,7 +762,7 @@ def _validate_template_index(user_input: str, size: int) -> int | None:
     if not user_input.isdigit():  # WHY: reject non-numeric input up front
         print("  Invalid input. Please enter a numeric index.")  # WHY: user-facing
         return None  # WHY: caller treats None as invalid
-    index = int(user_input)  # WHY: safe now that we know it's digits
+    index = int(user_input)  # WHY: safe now that we know it is digits
     if index < 0 or index >= size:  # WHY: bounds check
         print(f"  Invalid index. Please select between 0 " f"and {size - 1}.")  # WHY: user-facing
         return None  # WHY: caller treats None as out-of-range
@@ -1164,7 +1164,7 @@ def parse_state_from_address(address: str, country: str) -> str:
     """
     if not address or not country:  # WHY: both inputs required for meaningful parse
         return ""  # WHY: caller treats "" as unknown
-    if country in _SMALL_ISLAND_COUNTRIES:  # WHY: these formats don't carry usable states
+    if country in _SMALL_ISLAND_COUNTRIES:  # WHY: these formats do not carry usable states
         return ""  # WHY: skip these countries entirely
     if "," in address:  # WHY: comma format has structured parts
         return _parse_state_comma_separated(address)  # WHY: dedicated parser
@@ -1220,7 +1220,7 @@ def _is_ca_province_at(parts: list[str], i: int, part: str) -> bool:
     if len(part) != 2 or not part.isupper():  # WHY: province tokens are 2 uppercase letters
         return False  # WHY: not a province candidate
     if i + 1 >= len(parts):  # WHY: need a following token for the postal test
-        return False  # WHY: no follower means we can't confirm
+        return False  # WHY: no follower means we cannot confirm
     return bool(re.match(r"^[A-Z]\d[A-Z]$", parts[i + 1]))  # WHY: postal-prefix pattern
 
 
@@ -1257,7 +1257,7 @@ def _find_postal_index(parts: list[str]) -> int:
 
 def _infer_state_without_postal(parts: list[str], country: str) -> str:
     """Infer state when no postal code is present."""
-    if country not in _LATAM_COUNTRIES and len(parts) == 2:  # WHY: non-LATAM short address can't be inferred
+    if country not in _LATAM_COUNTRIES and len(parts) == 2:  # WHY: non-LATAM short address cannot be inferred
         return ""  # WHY: not enough info
     if country in _LATAM_COUNTRIES or len(parts) > 2:  # WHY: LATAM or longer addresses trust last token
         return parts[-1]  # WHY: convention places state at the end

--- a/src/gateway/wan2_variable.py
+++ b/src/gateway/wan2_variable.py
@@ -111,7 +111,7 @@ class GatewayWan2VariableMigrator:  # pylint: disable=too-many-instance-attribut
 
         Python only invokes ``__getattr__`` when normal lookup fails, so
         this method resolves cluster method calls (``self._load_csv_data``,
-        ``self._apply_template_changes`` etc.) without explicit delegator
+        ``self._apply_template_changes`` and so on) without explicit delegator
         wrappers. The class-level ``hasattr`` check on ``type(cluster)``
         avoids invoking the cluster's own ``__getattr__`` (which would
         proxy back to this class and cause infinite recursion for unknown

--- a/src/gateway/wan_probe_device_override_manager.py
+++ b/src/gateway/wan_probe_device_override_manager.py
@@ -256,7 +256,7 @@ class WANProbeDeviceOverrideManager:  # WHY: encapsulates Menu #167 destructive 
             "\n  Selection: ",
             context="wan_probe_device_template_selection",
         )
-        return raw.strip().lower()  # WHY: normalise so 'CANCEL', ' 1 ' etc. work.
+        return raw.strip().lower()  # WHY: normalise so 'CANCEL', ' 1 ' and so on work.
 
     def _resolve_template_selection(  # WHY: parse numeric input and commit to selected_template.
         self,
@@ -397,7 +397,7 @@ class WANProbeDeviceOverrideManager:  # WHY: encapsulates Menu #167 destructive 
                 current_probe = {}
             overridden_wan_ports.append(
                 {
-                    "port_name": port_name,  # WHY: port identifier (e.g. ge-0/0/0).
+                    "port_name": port_name,  # WHY: port identifier (for example ge-0/0/0).
                     "current_ips": current_probe.get("ips", []),  # WHY: existing probe IPs.
                     "current_profile": current_probe.get("probe_profile", ""),  # WHY: existing probe profile.
                     "port_settings": port_settings,  # WHY: full port settings retained for context.

--- a/src/inventory/csv_comparator.py
+++ b/src/inventory/csv_comparator.py
@@ -155,14 +155,18 @@ _MISMATCH_TYPE_TABLE: tuple[tuple[str, str], ...] = (
 class InventoryCSVComparator:  # pylint: disable=too-many-instance-attributes
     """Compare Mist inventory data with external CSV files for address verification.
 
-    Performs multi-step comparison workflow:
-    1. Load and parse Mist device data with site information
-    2. Select and load comparison CSV with automatic field detection
-    3. Parse and normalize addresses using enhanced parsing
-    4. Detect duplicate addresses between sites
-    5. Filter conflicts through skip list and deduplication
-    6. Optional external validation via Nominatim API
-    7. Generate comprehensive mismatch reports
+    Performs a multi-step comparison workflow.
+
+    The first phase prepares the data:
+    - Load and parse Mist device data with site information.
+    - Select and load the comparison CSV with automatic field detection.
+    - Parse and normalize addresses with enhanced parsing.
+
+    The second phase compares and reports:
+    - Detect duplicate addresses between sites.
+    - Filter conflicts through the skip list and deduplication.
+    - Run optional external validation through the Nominatim API.
+    - Generate comprehensive mismatch reports.
 
     Uses configurable ADDRESS_MATCH_THRESHOLD from .env file for fuzzy matching.
     """
@@ -392,7 +396,7 @@ class InventoryCSVComparator:  # pylint: disable=too-many-instance-attributes
     def _get_available_csv_files(self) -> list[str]:
         """Get list of CSV files available for comparison."""
         data_dir = "data"  # WHY: canonical relative data folder.
-        csv_files = glob.glob(os.path.join(data_dir, "*.csv"))  # WHY: enumerate CSVs.
+        csv_files = glob.glob(os.path.join(data_dir, "*.csv"))  # WHY: enumerate CSV files.
         exclude_file = "AllDevicesWithSiteInfo.csv"  # WHY: never self-compare source data.
         return [os.path.basename(f) for f in csv_files if os.path.basename(f) != exclude_file]  # WHY: filter+basename.
 

--- a/src/inventory/org_device_inventory_summary.py
+++ b/src/inventory/org_device_inventory_summary.py
@@ -94,7 +94,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
         )
         counts: dict[str, int] = {}  # WHY: bucket -> running total
         for record in switch_records:  # WHY: walk every switch exactly once
-            value = record.get(distinct) or _UNKNOWN  # WHY: fall back so missing labels don't crash the row build
+            value = record.get(distinct) or _UNKNOWN  # WHY: fall back so missing labels do not crash the row build
             num_members = int(record.get("num_members") or 1)  # WHY: VC stacks count as members, not one chassis
             counts[value] = counts.get(value, 0) + num_members  # WHY: sum VC-accurate physical count
         rows = [  # WHY: materialize the accumulator into row dicts for downstream merge
@@ -129,7 +129,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
         )
         counts: dict[str, int] = {}  # WHY: bucket -> physical gateway count
         for record in gateway_records:  # WHY: walk each HA member exactly once
-            value = record.get(distinct) or _UNKNOWN  # WHY: fall back so missing labels don't crash the row build
+            value = record.get(distinct) or _UNKNOWN  # WHY: fall back so missing labels do not crash the row build
             counts[value] = counts.get(value, 0) + 1  # WHY: one record == one physical gateway
         rows = [  # WHY: materialize the accumulator into row dicts for downstream merge
             {"device_type": "gateway", distinct: value, "count": count} for value, count in counts.items()

--- a/src/maps/_container_detection.py
+++ b/src/maps/_container_detection.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)  # Module-scoped logger for detection traci
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})  # WHY: shared truthy set for env overrides
 
 # Explicit override vars: these let operators force container-mode
-# behavior when the auto-detection heuristics fail (e.g. exotic
+# behavior when the auto-detection heuristics fail (for example exotic
 # runtimes, chroots, or when we want to test container UX locally).
 _OVERRIDE_ENV_VARS = ("MISTHELPER_FORCE_CONTAINER_LOOP", "MISTHELPER_CONTAINER")  # WHY: operator escape hatch
 

--- a/src/maps/_flask_viewer.py
+++ b/src/maps/_flask_viewer.py
@@ -1334,7 +1334,7 @@ def launch_flask_viewer(ctx: FlaskViewerContext):
         ctx.initial_map_id,
     )
     flask_app = _build_flask_app(ctx)  # WHY: helper handles imports + Flask config + route registration.
-    flask_host, flask_port = _resolve_flask_bind_address()  # WHY: pick loopback vs. all-interfaces based on env.
+    flask_host, flask_port = _resolve_flask_bind_address()  # WHY: pick loopback versus all-interfaces based on env.
     _print_flask_viewer_banner(flask_host, flask_port)  # WHY: operator-facing status before the blocking run call.
     _maybe_open_browser(flask_port)  # WHY: fires only on desktop -- container path exits early inside the helper.
     _run_flask_server(flask_app, flask_host, flask_port)  # WHY: blocking call -- returns on Ctrl+C or fatal error.

--- a/src/maps/_maps_clone.py
+++ b/src/maps/_maps_clone.py
@@ -106,7 +106,7 @@ class _MapsClone:
         """Print a formatted block describing the source map's key attributes."""
         print(f"\n{'-' * 80}")  # Divider above the details block.
         print(f"Source Map: {source_map.get('name', 'Unnamed')}")  # Human-readable identifier.
-        print(f"Type: {source_map.get('type', 'N/A')}")  # image / geojson / etc.
+        print(f"Type: {source_map.get('type', 'N/A')}")  # image / geojson / and so on
         print(f"Dimensions: {source_map.get('width', 'N/A')}x{source_map.get('height', 'N/A')}")  # WxH in pixels.
         print(f"PPM: {source_map.get('ppm', 'N/A')}")  # Pixels-per-meter scale.
         print(f"Has Image: {'Yes' if 'url' in source_map else 'No'}")  # Image asset presence flag.
@@ -337,7 +337,7 @@ class _MapsClone:
         print("\n" + "-" * 80)  # Top divider.
         print("CLONE/DUPLICATE MAP")  # Banner title.
         print("-" * 80)  # Bottom divider.
-        print("! This will clone ALL map data: image, walls, paths, zones, wayfinding, etc.")  # Warning banner.
+        print("! This will clone ALL map data: image, walls, paths, zones, wayfinding, etc.")  # Confirmation banner.
 
     def _prepare_clone(self, site_id: str, source_map_id: str) -> _ClonePrep | None:
         """Fetch source, prompt for name, build payload, count zones, and confirm."""

--- a/src/maps/_maps_coverage.py
+++ b/src/maps/_maps_coverage.py
@@ -299,7 +299,7 @@ class _MapsCoverage:
         logging.info("[Flask API] Fetching %s coverage for map %s", coverage_type, map_id)  # WHY: audit trail.
         try:  # WHY: `api_session.mist_get` may raise on network errors.
             response = api_session.mist_get(coverage_url, query=params)  # WHY: fetch coverage payload from Mist.
-        except Exception as exc:  # WHY: swallow errors so one bad layer doesn't kill the viewer.
+        except Exception as exc:  # WHY: swallow errors so one bad layer does not kill the viewer.
             logging.warning("Error fetching %s coverage: %s", coverage_type, exc)  # WHY: preserve log format.
             return None  # WHY: signal missing layer to the caller.
         if response.status_code != 200:  # WHY: coverage responses may be 400 while other layers succeed.

--- a/src/maps/_maps_matplotlib.py
+++ b/src/maps/_maps_matplotlib.py
@@ -240,7 +240,7 @@ class _MapsMatplotlib:  # Wrapper class holding the extracted matplotlib/launch 
         logger.info("  Loading maps for site: %s...", site_name)
         all_maps = self._fetch_site_maps(site_id)  # May be empty on API/no-map failures.
         if not all_maps:
-            _print_no_maps_notice(site_name)  # Tell the user we're deferring selection to the browser.
+            _print_no_maps_notice(site_name)  # Tell the user we are deferring selection to the browser.
             return _StandaloneTargets(site_id, site_name, None, all_maps)  # Return with map_id=None sentinel.
         map_id, target_map = self._resolve_initial_map(all_maps, requested_map_id)  # Pick initial map handle.
         # WHY: preserve operator notice verbatim; route through logger for capture/redirection.

--- a/src/maps/_maps_utils.py
+++ b/src/maps/_maps_utils.py
@@ -90,7 +90,7 @@ def sanitize_filename(filename: str) -> str:
     for char in _INVALID_FILENAME_CHARS:  # WHY: replace each hostile char in a single left-to-right pass.
         filename = filename.replace(char, _REPLACEMENT_CHAR)  # WHY: underscore preserves length + readability.
     filename = filename.strip(_STRIP_CHARS)  # WHY: trims trailing dot/space which break Windows resolves.
-    if not filename:  # WHY: strip may fully consume the string (e.g. all-dots input).
+    if not filename:  # WHY: strip may fully consume the string (for example all-dots input).
         return _FALLBACK_NAME  # WHY: second sentinel check after stripping mirrors the initial guard.
     return filename[:_MAX_FILENAME_LEN]  # WHY: enforce ceiling so appended extensions stay under FS limits.
 
@@ -131,7 +131,7 @@ def _resolve_csv_filepath(filename: str) -> str:
     worrying about filesystem safety.
     """
     data_dir = os.path.join(os.getcwd(), _DATA_DIRNAME)  # WHY: rebuild each call so cwd changes are respected.
-    os.makedirs(data_dir, exist_ok=True)  # WHY: exist_ok=True idempotently handles first-run vs. repeat runs.
+    os.makedirs(data_dir, exist_ok=True)  # WHY: exist_ok=True idempotently handles first-run versus repeat runs.
     safe_filename = sanitize_filename(filename)  # WHY: run through the shared sanitizer before path assembly.
     return os.path.join(data_dir, f"{safe_filename}{_CSV_EXT}")  # WHY: extension appended post-sanitize by design.
 

--- a/src/maps/_plotly_viewer.py
+++ b/src/maps/_plotly_viewer.py
@@ -172,7 +172,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
                 mode="lines",  # WHY: Line-only trace.
                 line=dict(color=color, width=3),  # WHY: Status-based color for horizontal arm.
                 name=f"{group_name} Orientation",  # WHY: Group name enables layer toggle.
-                showlegend=False,  # WHY: Don't clutter legend with individual crosshair lines.
+                showlegend=False,  # WHY: Do not clutter legend with individual crosshair lines.
                 hoverinfo="skip",  # WHY: No hover needed -- orientation marker only.
             )
         )
@@ -261,7 +261,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
         for beacon in vbeacons:  # WHY: Iterate all virtual beacons.
             x, y = beacon.get("x"), beacon.get("y")  # WHY: Pixel coordinates on map.
             if x is None or y is None:  # WHY: Skip beacons without position data.
-                continue  # WHY: Can't place beacon without coordinates.
+                continue  # WHY: Cannot place beacon without coordinates.
             beacon_x.append(x)  # WHY: Store valid x coordinate.
             beacon_y.append(y)  # WHY: Store valid y coordinate.
             name = beacon.get("name", "Unnamed Beacon")  # WHY: Beacon display name fallback.
@@ -336,7 +336,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
                 fill="toself",  # WHY: Close and fill the ring shape.
                 fillcolor="rgba(0,255,0,0.05)",  # WHY: Very light fill for coverage area visualization.
                 name="vBeacon Coverage",
-                showlegend=False,  # WHY: Don't add each circle to legend -- too many entries.
+                showlegend=False,  # WHY: Do not add each circle to legend -- too many entries.
                 hoverinfo="skip",  # WHY: No hover needed -- visual indicator only.
             )
         )
@@ -350,7 +350,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
             x = beacon.get("x")  # WHY: Beacon center x pixel coordinate.
             y = beacon.get("y")  # WHY: Beacon center y pixel coordinate.
             if x is None or y is None:  # WHY: Skip beacons without coordinates.
-                continue  # WHY: Can't draw circle without center point.
+                continue  # WHY: Cannot draw circle without center point.
             power = beacon.get("power", 0)  # WHY: Transmit power in dBm (typical: -12 to +4).
             self._draw_vbeacon_coverage_ring(fig, x, y, power)  # WHY: Delegate ring drawing to keep CC low.
 
@@ -385,14 +385,14 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
             x = beacon.get("x")  # WHY: Beacon x pixel coordinate.
             y = beacon.get("y")  # WHY: Beacon y pixel coordinate.
             if x is None or y is None:  # WHY: Skip beacons without position data.
-                continue  # WHY: Can't place beacon without coordinates.
+                continue  # WHY: Cannot place beacon without coordinates.
             ble_x.append(x)  # WHY: Store valid x coordinate.
             ble_y.append(y)  # WHY: Store valid y coordinate.
             name = beacon.get("name", beacon.get("mac", "Unnamed"))  # WHY: Prefer name; fall back to MAC.
             ble_names.append(name)  # WHY: Store name for annotation.
             hover = f"<b>BLE Beacon: {name}</b><br>"  # WHY: Bold header for hover tooltip.
             hover += f"MAC: {beacon.get('mac', 'N/A')}<br>"  # WHY: Hardware MAC address.
-            hover += f"Type: {beacon.get('type', 'N/A')}<br>"  # WHY: Beacon type (iBeacon, Eddystone, etc.).
+            hover += f"Type: {beacon.get('type', 'N/A')}<br>"  # WHY: Beacon type (iBeacon, Eddystone, and so on).
             hover += f"Power: {beacon.get('power', 'N/A')}<br>"  # WHY: Transmit power in dBm.
             hover += f"Position: ({x}, {y})"  # WHY: Pixel coordinates on map.
             ble_hover.append(hover)  # WHY: Append completed hover text.

--- a/src/maps/_viewer_launch.py
+++ b/src/maps/_viewer_launch.py
@@ -10,7 +10,7 @@ pieces of the Dash ``html.Div`` layout tree.
 The launcher receives the wrapped :class:`_PlotlyViewer` instance and
 forwards attribute lookups back through it so figure-population helpers
 (``_add_walls``, ``_add_clients_to_figure``, ``_categorize_devices``,
-etc.) still reach the shared implementation without duplication.
+and so on) still reach the shared implementation without duplication.
 """
 
 from __future__ import annotations  # WHY: Defer annotation resolution -- allows PEP 604 unions on 3.10.
@@ -1128,7 +1128,7 @@ def _build_drawing_mode_dropdown(html_mod: Any, dcc_mod: Any) -> Any:  # WHY: Mo
                     {"label": "Wall Segment (orange)", "value": "wall"},
                     {"label": "Measurement Only", "value": "measure"},
                 ],
-                value="measure",  # WHY: Default so drawing doesn't save anything unintentionally.
+                value="measure",  # WHY: Default so drawing does not save anything unintentionally.
                 clearable=False,
                 style={"marginBottom": "10px", "color": "#e0e0e0"},
                 className="dark-dropdown",

--- a/src/maps/launcher/_viewer_site_switch.py
+++ b/src/maps/launcher/_viewer_site_switch.py
@@ -202,7 +202,7 @@ class _ViewerSiteSwitch:  # WHY: wrapper class hosting the site-switch callback 
         import dash  # WHY: local import - dash.callback_context only exists at request time
 
         ctx = dash.callback_context  # WHY: per-request trigger context
-        if not ctx.triggered:  # WHY: empty means we're in the initial page load
+        if not ctx.triggered:  # WHY: empty means we are in the initial page load
             return "initial_load"  # WHY: mirror original label
         prop_id: str = ctx.triggered[0]["prop_id"]  # WHY: annotate for strict-typed str return
         return prop_id.split(".")[0]  # WHY: strip prop suffix to get component id

--- a/src/maps/launcher/_viewer_ui.py
+++ b/src/maps/launcher/_viewer_ui.py
@@ -463,7 +463,7 @@ class _ViewerUI:  # WHY: wrapper class hosting the UI-toggle callback cluster
 
         if not mode_clicks or mode_clicks % 2 == 0:  # WHY: mode is inactive (even clicks)
             return self._render_origin_current(current_fig, html), current_fig
-        if not clickData:  # WHY: mode active but user hasn't clicked yet
+        if not clickData:  # WHY: mode active but user has not clicked yet
             prompt = html.P("Click map to set origin", style=_ORIGIN_PROMPT_STYLE)  # WHY: prompt widget
             return [prompt], current_fig
         return self._apply_origin_click(clickData, current_fig, html)  # WHY: extract to keep function short
@@ -509,7 +509,7 @@ class _ViewerUI:  # WHY: wrapper class hosting the UI-toggle callback cluster
         """Actually delete the map via Mist API - creates backup first."""
         from dash import html, no_update  # WHY: local import keeps module import-light
 
-        if not confirm_clicks:  # WHY: user hasn't actually confirmed the delete
+        if not confirm_clicks:  # WHY: user has not actually confirmed the delete
             return "", no_update
         current_trigger = cache_bust_data.get("trigger", 0) if cache_bust_data else 0  # WHY: cache-bust counter
         resolved = self._resolve_delete_config(config)  # WHY: pack site/map/name into a value object

--- a/src/maps/launcher/_viewer_url_switch.py
+++ b/src/maps/launcher/_viewer_url_switch.py
@@ -130,7 +130,7 @@ class _FigureBuildContext:  # WHY: bundle build inputs so figure builder stays â
     url_map_id: str  # WHY: map id used for heatmap fetch and log correlation
     site_id_local: str  # WHY: site id used for heatmap fetch
     layers: _MapLayers  # WHY: pre-fetched entity bundle
-    config: dict[str, Any]  # WHY: shared config (site_id override, etc.)
+    config: dict[str, Any]  # WHY: shared config (site_id override, and so on)
 
 
 @dataclass(frozen=True)
@@ -926,7 +926,7 @@ class _ViewerUrlSwitch:  # WHY: wrapper class hosting the URL-switch callback cl
         new_map_data: dict[str, Any],  # WHY: new map metadata source
     ) -> dict[str, Any]:
         """Update ``config`` with the newly-switched map info (preserves site_id)."""
-        new_config = config.copy()  # WHY: don't mutate caller's dict
+        new_config = config.copy()  # WHY: do not mutate caller's dict
         new_config["map_id"] = url_map_id  # WHY: set new map id
         new_config["map_name"] = new_map_data.get("name", _DEFAULT_MAP_NAME)  # WHY: display name
         new_config["ppm"] = new_map_data.get("ppm") or _DEFAULT_PPM  # WHY: coverage scaling

--- a/src/maps/launcher/viewer_callbacks.py
+++ b/src/maps/launcher/viewer_callbacks.py
@@ -61,7 +61,7 @@ class MapViewerCallbacks:  # WHY: thin coordinator over 6 extracted callback clu
     def __init__(self, state: MapViewerState) -> None:  # WHY: bind shared state + wire cluster instances
         """Store the shared MapViewerState for use by every callback method."""
         # Store the shared state container so each callback method can
-        # access closure-equivalent values (e.g. callback_manager) via
+        # access closure-equivalent values (for example callback_manager) via
         # self._state without needing per-callback parameters.
         self._state = state  # MapViewerState instance carrying viewer context
         self._ui = _ViewerUI(self)  # WHY: bind extracted UI-toggle cluster so delegate stubs resolve

--- a/src/maps/launcher/viewer_state.py
+++ b/src/maps/launcher/viewer_state.py
@@ -66,7 +66,7 @@ class MapViewerState:
         fallback when the config store is missing.
     api_session_ref:
         Live ``mistapi.APISession`` instance used by callbacks that
-        invoke Mist API mutations (delete map, delete zone, etc.).
+        invoke Mist API mutations (delete map, delete zone, and so on).
     ppm:
         Pixels-per-meter scale value; used by ``update_shape_labels``
         as the fallback when the figure metadata lacks an override.

--- a/src/maps/maps_manager.py
+++ b/src/maps/maps_manager.py
@@ -54,7 +54,7 @@ from src.dataclasses.map_wizard_deps import (  # Issue #433 Phase C T3: replacem
 from src.maps._container_detection import (
     is_running_in_container,
 )  # Detects Docker/container runtimes to gate GUI viewer launches.
-from src.maps._flask_viewer import launch_flask_viewer  # Flask-based fallback viewer for containerized/headless envs.
+from src.maps._flask_viewer import launch_flask_viewer  # Flask fallback viewer for headless environments.
 from src.maps._plotly_viewer import launch_plotly_viewer  # Dash/Plotly interactive viewer for desktop use.
 from src.maps._maps_utils import (  # Shared helpers: dict flattening, filename sanitization, CSV/JSON exports.
     flatten_dict_recursively,
@@ -79,9 +79,9 @@ PIL_AVAILABLE = importlib.util.find_spec("PIL") is not None  # Cached truthy fla
 if PLOTLY_AVAILABLE:  # Only import heavy plotly module when available at runtime.
     import plotly.graph_objects as go  # Bound at module level so downstream figure builders can reference it.
 else:
-    go = None  # Fallback sentinel so attribute checks don't NameError.
+    go = None  # Fallback sentinel so attribute checks do not NameError.
 
-# Dash symbols (Input, Output, State, etc.) are imported locally
+# Dash symbols (Input, Output, State, and so on) are imported locally
 # in methods that need them, since they require dash to be installed.
 Dash = None  # Placeholder; real Dash class imported lazily inside launcher methods.
 html = None  # Placeholder for dash.html; imported lazily where needed.
@@ -253,7 +253,7 @@ class MapsManager:  # WHY: declare MapsManager class
         print(f"{'-' * 80}")  # Separator rule
         for idx, map_item in enumerate(maps, 1):  # Enumerate with 1-based index for humans
             map_name = map_item.get("name", "Unnamed")  # Map display name
-            map_type = map_item.get("type", "N/A")  # Map type (image, geojson, etc.)
+            map_type = map_item.get("type", "N/A")  # Map type (image, geojson, and so on)
             has_image = "with image" if "url" in map_item else "no image"  # Image availability tag
             print(f"  {idx}. {map_name} ({map_type}) - {has_image}")  # Numbered row
         print(f"{'-' * 80}")  # Closing rule
@@ -1181,7 +1181,7 @@ class MapsManager:  # WHY: declare MapsManager class
         print("-" * 80)  # WHY: surface user-facing message
 
     def maps_without_images_report(self):  # WHY: declare public method maps_without_images_report
-        """Generate report of maps that don't have uploaded images."""
+        """Generate report of maps that do not have uploaded images."""
         print("\n" + "-" * 80)  # WHY: surface user-facing message
         print("MAPS WITHOUT IMAGES REPORT")  # WHY: surface user-facing message
         print("-" * 80)  # WHY: surface user-facing message
@@ -1338,7 +1338,7 @@ class MapsManager:  # WHY: declare MapsManager class
         self._confirm_and_apply_map_update(site_id, map_id, update_payload)  # Confirm + PUT
 
     def update_map_properties(self):  # WHY: declare public method update_map_properties
-        """Update existing map properties (name, dimensions, orientation, etc.)."""
+        """Update existing map properties (name, dimensions, orientation, and so on)."""
         self._print_update_map_properties_header()  # Banner
         site_id, site_name = self.get_current_site()  # Require a selected site
         if not site_id:  # Site prompt cancelled

--- a/src/maps/plotly_map_callback_manager.py
+++ b/src/maps/plotly_map_callback_manager.py
@@ -65,7 +65,7 @@ def _coerce_layer_list(value: list[str] | None) -> tuple[str, ...]:  # WHY: shar
 class LayerToggleInputs:  # WHY: frozen bundle keeps callback signature narrow
     """Frozen bundle of layer selection lists sourced from Dash toggle inputs."""
 
-    infra: tuple[str, ...] = ()  # WHY: walls, wayfinding, zones, etc.
+    infra: tuple[str, ...] = ()  # WHY: walls, wayfinding, zones, and so on
     beacon: tuple[str, ...] = ()  # WHY: vbeacons + BLE beacons category
     client: tuple[str, ...] = ()  # WHY: wifi/wired client toggles
     device: tuple[str, ...] = ()  # WHY: APs, switches, gateways

--- a/src/marvis/marvis_utils.py
+++ b/src/marvis/marvis_utils.py
@@ -211,7 +211,7 @@ class MarvisDataUtils:  # WHY: Class groups Marvis-to-CSV helpers with injected 
 
         The Marvis API wraps troubleshoot results in a nested "results" array.
         This method un-nests that array and emits columns like result_0_category,
-        result_0_reason, etc.  Other nested dicts are flattened with underscored
+        result_0_reason, and so on  Other nested dicts are flattened with underscored
         composite keys.  Lists are joined as comma-separated strings.
 
         Args:
@@ -260,7 +260,7 @@ class MarvisDataUtils:  # WHY: Class groups Marvis-to-CSV helpers with injected 
     ) -> dict[str, Any]:
         """Expand each entry in a Marvis 'results' array into prefixed columns.
 
-        E.g. results[0] = {"category": "WiFi", "reason": "low RSSI"} becomes
+        For example results[0] = {"category": "WiFi", "reason": "low RSSI"} becomes
         result_0_category and result_0_reason columns in the CSV row.
 
         Args:

--- a/src/network/_routing_utils_display.py
+++ b/src/network/_routing_utils_display.py
@@ -40,7 +40,7 @@ _SSR_COLUMNS: tuple[str, ...] = (
     "Next Hop",  # WHY: gateway IP for the route
     "Protocol",  # WHY: BGP/OSPF/... source protocol
     "Route Name",  # WHY: SSR-configured route name (may be empty)
-    "Status",  # WHY: e.g. active/inactive per SSR row
+    "Status",  # WHY: for example active/inactive per SSR row
     "Selection Reason",  # WHY: BGP selection reason string
     "Weight",  # WHY: route weight when supplied
     "Metric",  # WHY: metric column stringified upstream
@@ -120,7 +120,7 @@ class _RoutingUtilsDisplay:  # WHY: cluster wrapper matches the Phase 1 parsing-
 
     def _display_forwarding_summary(self, entries: list[dict[str, Any]]) -> None:  # WHY: cluster entry
         """Display formatted summary of forwarding table entries."""
-        if not entries:  # WHY: guard so empty results don't spam the table renderer
+        if not entries:  # WHY: guard so empty results do not spam the table renderer
             print("-> No forwarding table entries found")  # WHY: user-facing empty-state notice
             return  # WHY: nothing else to render when entries list is empty
         print(f"-> Total forwarding entries: {len(entries)}")  # WHY: headline count first
@@ -153,7 +153,7 @@ class _RoutingUtilsDisplay:  # WHY: cluster wrapper matches the Phase 1 parsing-
     ) -> None:
         """Add ``value`` to ``target_set`` if it is truthy and not the sentinel."""
         if value and value != sentinel:  # WHY: two-guard filter keeps "-" placeholders out
-            target_set.add(value)  # WHY: sets deduplicate; caller doesn't need to check membership
+            target_set.add(value)  # WHY: sets deduplicate; caller does not need to check membership
 
     def _collect_forwarding_stats(self, entries: list[dict[str, Any]]) -> dict[str, Any]:  # WHY: aggregator
         """Collect summary statistics from forwarding table entries."""
@@ -330,7 +330,7 @@ class _RoutingUtilsDisplay:  # WHY: cluster wrapper matches the Phase 1 parsing-
         """Add ``entry[key]`` to ``bucket`` when it is truthy and not a sentinel."""
         value = entry.get(key)  # WHY: single lookup for both guards
         if value and value not in (_MISSING, ""):  # WHY: legacy filter set — keep behavior identical
-            bucket.add(value)  # WHY: sets deduplicate so we don't need to pre-check membership
+            bucket.add(value)  # WHY: sets deduplicate so we do not need to pre-check membership
 
     def _display_routing_details(self, route_entries: list[dict[str, Any]]) -> None:
         """Display detailed routing table in a formatted table."""

--- a/src/network/_routing_utils_parsing.py
+++ b/src/network/_routing_utils_parsing.py
@@ -267,7 +267,7 @@ class _RoutingUtilsParsing:  # WHY: cluster wrapper matching the ``_packet_captu
             current_route["next_hop"] = via_parts  # WHY: store normalized (comma-stripped) form
             return  # WHY: early-return keeps subsequent checks from firing on same token
         if "." in via_parts and "/" not in via_parts:  # WHY: interface names have dot but no slash
-            current_route["interface"] = via_parts.strip()  # WHY: e.g. ``ge-0/0/0.0``
+            current_route["interface"] = via_parts.strip()  # WHY: for example ``ge-0/0/0.0``
             return  # WHY: guard prevents fallthrough from also setting next_hop
         current_route["next_hop"] = via_parts.strip()  # WHY: fallback (hostname/non-numeric next-hop)
 
@@ -316,7 +316,7 @@ class _RoutingUtilsParsing:  # WHY: cluster wrapper matching the ``_packet_captu
             "protocol": protocol,  # WHY: caller-supplied so all rows share the same label
             "admin_distance": "",  # WHY: SSR does not expose admin distance in this response
             "metric": str(row.get("metric", "")),  # WHY: coerce int→str for uniform display formatting
-            "status": row.get("status", ""),  # WHY: e.g. active/inactive per row
+            "status": row.get("status", ""),  # WHY: for example active/inactive per row
             "vrf": row.get("vrfName", "default"),  # WHY: SSR uses ``vrfName`` (camelCase)
             "name": row.get("name", ""),  # WHY: optional route name assigned in SSR config
             "weight": str(row.get("weight", "")),  # WHY: coerce int→str for uniform display formatting
@@ -361,7 +361,7 @@ class _RoutingUtilsParsing:  # WHY: cluster wrapper matching the ``_packet_captu
 
     def _normalize_json_route_list(self, data: list[Any]) -> list[dict[str, Any]]:
         """Normalize a top-level JSON list of route dicts."""
-        # WHY: skip non-dict entries so malformed items don't crash the projection
+        # WHY: skip non-dict entries so malformed items do not crash the projection
         return [self._normalize_json_route_entry(item) for item in data if isinstance(item, dict)]
 
     def _extract_routes_from_json_dict(self, data: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/network/_routing_utils_payload.py
+++ b/src/network/_routing_utils_payload.py
@@ -338,7 +338,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
             return  # WHY: keeps hot path free of formatting overhead
         # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
         logger.debug("[DEBUG] API response type: %s", type(response))  # WHY: legacy debug output preserved
-        if hasattr(response, "data"):  # WHY: some responses don't carry a data attribute at all
+        if hasattr(response, "data"):  # WHY: some responses do not carry a data attribute at all
             # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
             logger.debug("[DEBUG] Response data: %s", response.data)  # WHY: expose payload for triage
 

--- a/src/network/routing_utils.py
+++ b/src/network/routing_utils.py
@@ -138,7 +138,7 @@ class RoutingUtils:
         Python only invokes ``__getattr__`` when normal lookup fails, so this
         method resolves cluster method calls (``self._parse_ssr_routing``,
         ``self._display_forwarding_summary``, ``self._post_device_command``,
-        ``self.execute_show_routing_table``, etc.) without explicit delegator
+        ``self.execute_show_routing_table``, and so on) without explicit delegator
         wrappers. The class-level ``hasattr`` check on ``type(cluster)``
         avoids invoking the cluster's own ``__getattr__`` (which would proxy
         back to this class and create infinite recursion for unknown attrs).

--- a/src/org/org_config_migration_manager.py
+++ b/src/org/org_config_migration_manager.py
@@ -379,7 +379,7 @@ class OrgConfigMigrationManager:  # Org config migration manager.
     def _check_name_conflict(self, new_obj: dict, existing_list: list) -> dict | None:  # type: ignore[type-arg]
         """Check if an object with the same name already exists (case-insensitive)."""
         new_name = self._normalized_name(new_obj)  # Lowercase name for case-insensitive comparison
-        if not new_name:  # Skip unnamed objects (shouldn't happen but be defensive)
+        if not new_name:  # Skip unnamed objects (should not happen but be defensive)
             return None  # No conflict.
         for existing in existing_list:  # Check every existing object in destination
             if new_name == self._normalized_name(existing):  # Case-insensitive match found
@@ -403,7 +403,7 @@ class OrgConfigMigrationManager:  # Org config migration manager.
             return self._check_network_subnet_overlap(new_obj, existing_list)  # Check subnet overlap.
         if type_key == "services":  # Services use addresses[] array
             return self._check_service_address_overlap(new_obj, existing_list)  # Check address overlap.
-        return None  # Other types don't have IP fields
+        return None  # Other types do not have IP fields
 
     @staticmethod
     def _build_subnet_overlap_conflict(new_subnet: str, existing: dict, existing_subnet: str) -> dict:
@@ -549,7 +549,7 @@ class OrgConfigMigrationManager:  # Org config migration manager.
 
     def _strip_source_fields(self, obj: dict) -> dict:  # type: ignore[type-arg]
         """Return a copy of obj with source-org-specific fields removed."""
-        return {key: value for key, value in obj.items() if key not in self.STRIP_FIELDS}  # Filter out id, org_id, etc.
+        return {key: value for key, value in obj.items() if key not in self.STRIP_FIELDS}  # Filter out source fields
 
     def _execute_import(self, bundle: dict, dry_run: bool) -> list:  # type: ignore[type-arg]
         """Import objects in dependency order, skipping conflicts."""
@@ -600,7 +600,7 @@ class OrgConfigMigrationManager:  # Org config migration manager.
             self._record_conflict(type_key, obj_name, source_id, conflict, results)  # Record the conflict.
             return  # Skip it.
         cleaned = self._clean_and_remap(obj, type_key)  # Strip + remap.
-        if dry_run:  # Preview mode -- don't make API calls
+        if dry_run:  # Preview mode -- do not make API calls
             logging.warning("      %sWould import: %s", label, obj_name)  # Show what would happen
             results.append({"type": type_key, "name": obj_name, "status": "would_import"})  # Record for report
             return  # Abort.

--- a/src/org/org_synthetic_probes_manager.py
+++ b/src/org/org_synthetic_probes_manager.py
@@ -132,7 +132,7 @@ _COUNTRY_CODE_TO_REGION: dict[str, str] = {
 }
 # Anything not listed above falls through to EMEA. EMEA endpoints are the
 # broadest surface (Africa, Middle East, Europe, plus every APAC/Oceania code
-# we haven't explicitly routed to China), so this is the safest default. A
+# we have not explicitly routed to China), so this is the safest default. A
 # warning is logged when the fallback fires so operators can spot unmapped
 # country codes and extend ``_COUNTRY_CODE_TO_REGION`` if needed.
 _DEFAULT_REGION = "emea"
@@ -360,7 +360,7 @@ _COUNTRY_CODE_INTENTIONAL_GAPS: frozenset[str] = frozenset(
 # per-role ``probe.protocol`` chosen from the curated JSON maps directly to a
 # URL scheme -- with two caveats encoded in ``_probe_target``:
 #   1. ``tcp`` is not a valid URL scheme for Mist synthetic tests. Roles that
-#      the reachability probing showed only respond to raw TCP/443 (e.g.
+#      the reachability probing showed only respond to raw TCP/443 (for example
 #      ``service_discovery_enrollment_login``) still exercise the same TCP
 #      handshake path when probed as HTTPS, so we transparently upgrade to
 #      ``https`` for URL construction.
@@ -850,8 +850,8 @@ def manage_org_synthetic_probes(mist_session: Any, org_id: str) -> None:
         "load-time CENR check complete; warned_cenr_hosts=%s",
         len(warned_cenr_hosts),
     )
-    # NOTE(1025-US2): companion dedup state for the load-time country_code
-    # WARNING lives here so its lifetime is bounded by the invocation
+    # NOTE(1025-US2): companion dedup state for the load-time
+    # country_code warning lives here so its lifetime is bounded by the invocation
     # (data-model.md §3 INV-D1; FR-012 requires re-emission across
     # back-to-back operator runs). Emission itself is delegated to
     # ``_prompt_and_apply_site_overrides`` because that is where the site
@@ -1307,7 +1307,7 @@ def _validate_vlan_input(raw: str) -> tuple[bool, str, list[int]]:
         everything.
 
     Args:
-        raw: Comma-separated VLAN ids and/or ranges (e.g. ``"3-6, 10"``).
+        raw: Comma-separated VLAN ids and/or ranges (for example ``"3-6, 10"``).
 
     Returns:
         ``(is_valid, error_message, vlan_ids)``. ``is_valid`` is True
@@ -1381,7 +1381,7 @@ def _detect_existing(setting: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Extract ``synthetic_test.custom_probes`` from ``setting``.
 
     Why:
-        Guarded accessor so callers don't have to worry about the
+        Guarded accessor so callers do not have to worry about the
         edge case where either ``synthetic_test`` or ``custom_probes``
         is absent.
 
@@ -1687,7 +1687,7 @@ def _build_region_probes(
 
     Returns:
         A ``{probe_name: probe_body}`` map for the one matching role.
-        Empty dict if the probe source file doesn't ship a role for the
+        Empty dict if the probe source file does not ship a role for the
         resolved region (defensive; the shipped catalogue has all three).
     """
     probes_source, _ = sources
@@ -1778,7 +1778,7 @@ def _is_concrete_probe_fqdn(fqdn: Any) -> bool:
 # Compression rule: countries with at most this many distinct ZEN locations
 # get ALL of their locations scheduled at every site in-country. Above this
 # threshold, we fall back to nearest-N-by-haversine. Two is chosen because
-# Zscaler almost always deploys a same-city pair (e.g. Frankfurt IV + VI at
+# Zscaler almost always deploys a same-city pair (for example Frankfurt IV + VI at
 # identical coords), so a country with only a "two location" footprint really
 # has one geographic point + a redundant peer -- probing both is cheap and
 # gives operators failover signal.
@@ -1823,7 +1823,7 @@ def _distinct_zen_locations(city_metadata: dict[str, dict[str, Any]]) -> dict[st
 
     Why:
         Zscaler frequently ships multiple named ZENs at identical coords
-        (e.g. ``Frankfurt IV`` and ``Frankfurt VI`` at the same lat/lon).
+        (for example ``Frankfurt IV`` and ``Frankfurt VI`` at the same lat/lon).
         For compression-rule counting ("does this country have <= N ZEN
         locations?") we must dedupe on physical location, not on name --
         otherwise a country with two co-located same-city peers gets
@@ -1846,7 +1846,7 @@ def _distinct_zen_locations(city_metadata: dict[str, dict[str, Any]]) -> dict[st
         if not isinstance(country, str) or not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
             continue
         # Round to 4 decimal places (~11 m precision) so trivial floating
-        # noise doesn't split a genuine same-coord pair into two groups.
+        # noise does not split a genuine same-coord pair into two groups.
         key = f"{country.upper()}:{round(float(lat), 4)}:{round(float(lon), 4)}"
         groups.setdefault(key, []).append(city)
     for names in groups.values():
@@ -1929,21 +1929,21 @@ def _resolve_zen_cities_for_site(
         Every Mist site probing every one of the ~95 ZEN cities would burn
         bandwidth and generate noisy dashboards. We want the small set that
         matches the site's geography: if the site's country hosts only a
-        handful of ZEN locations, probe them all (they're already nearby);
+        handful of ZEN locations, probe them all (they are already nearby);
         otherwise pick the geodesically-nearest few. This mirrors what a
         network engineer would do by hand looking at the ZEN map.
 
     Compression rules (evaluated in order):
-        1. Country has <= ``_ZEN_COMPRESSION_THRESHOLD`` distinct ZEN
-           locations -> return every ZEN name in-country.
-        2. Country has more, and the site has a valid ``latlng`` -> return
-           the ``_ZEN_NEAREST_COUNT`` nearest ZENs by great-circle distance,
-           deduped by location (so same-city pairs count once).
-        3. Country has more but site lacks ``latlng`` -> return the
-           country's ZENs anyway (better to over-probe within-country than
-           to skip; operators can trim later).
-        4. Site has no country match AND has ``latlng`` -> nearest globally.
-        5. No country match AND no latlng -> empty list + warn.
+        - Country has <= ``_ZEN_COMPRESSION_THRESHOLD`` distinct ZEN
+          locations -> return every ZEN name in-country.
+        - Country has more, and the site has a valid ``latlng`` -> return
+          the ``_ZEN_NEAREST_COUNT`` nearest ZENs by great-circle distance,
+          deduped by location (so same-city pairs count once).
+        - Country has more but site lacks ``latlng`` -> return the
+          country's ZENs anyway (better to over-probe within-country than
+          to skip; operators can trim later).
+        - Site has no country match AND has ``latlng`` -> nearest globally.
+        - No country match AND no latlng -> empty list + warn.
 
     Args:
         site: The Mist site dict. Reads ``country_code`` and ``latlng``.
@@ -1991,7 +1991,7 @@ def _nearest_zens_from_pool(
     """Return the ``count`` nearest ZEN city names from a pool.
 
     Why:
-        Same-coord peers (e.g. Frankfurt IV + Frankfurt VI) should count as
+        Same-coord peers (for example Frankfurt IV + Frankfurt VI) should count as
         one location when ranking distance -- otherwise "nearest 2" collapses
         to two names at the same spot. We rank by distinct (lat, lon) groups
         and then re-expand the winning groups back to the full name list so
@@ -2083,7 +2083,7 @@ def _zen_probe_names_for_cities(
             ``_resolve_zen_cities_for_site``.
         cenr: Parsed CENR JSON. Reads ``city_metadata`` for each city's
             ``probe_hostnames`` list (falling back to the legacy
-            ``probe_hostname`` scalar if the list form isn't present, so
+            ``probe_hostname`` scalar if the list form is not present, so
             an unrefreshed CENR file keeps working).
 
     Returns:
@@ -2136,7 +2136,7 @@ def _merge_probes(
     merged: dict[str, dict[str, Any]] = {}
     for name, probe in existing_tool.items():
         # Prefer freshly-built type/target (new source of truth); fall back
-        # to on-org values when the probe isn't in ``new_probes``.
+        # to on-org values when the probe is not in ``new_probes``.
         template = new_probes.get(name, probe)
         # Resolve target first because the ``type`` classification depends
         # on whether the target string carries an HTTP scheme.
@@ -2157,7 +2157,7 @@ def _merge_probes(
         # Sync aggressiveness from the freshly-built set so demotions
         # propagate. ``_build_probe_set`` always emits an explicit value;
         # the None branch is defensive against a future refactor dropping
-        # the key. Probes with no counterpart in ``new_probes`` (e.g. a
+        # the key. Probes with no counterpart in ``new_probes`` (for example a
         # role dropped from the JSON) keep their prior value.
         if name in new_probes:
             authoritative = new_probes[name].get("aggressiveness")
@@ -2188,7 +2188,7 @@ def _swap_probes(
 
 
 def _prompt_mode(existing_tool: dict[str, dict[str, Any]]) -> str:
-    """Prompt the operator for merge vs. swap.
+    """Prompt the operator for merge versus swap.
 
     Why:
         Displaying the existing probe count and VLAN union up-front gives
@@ -2461,7 +2461,7 @@ def _first_vlan_template(surviving: list[dict[str, Any]]) -> list[int] | None:
         Split out of ``_derive_test_row_template`` so each field's
         scanner stays under the CC gate. Non-int entries in ``vlan_ids``
         are dropped defensively -- Mist's schema is ints-only, but
-        malformed operator-authored rows shouldn't crash injection.
+        malformed operator-authored rows should not crash injection.
 
     Args:
         surviving: Cleaned rows from ``_filter_surviving_test_rows``.
@@ -2483,7 +2483,7 @@ def _first_lan_template(surviving: list[dict[str, Any]]) -> list[str] | None:
     Why:
         Peer of ``_first_vlan_template``. Non-str entries are dropped
         defensively -- Mist stores network refs as strings but again
-        we don't want a malformed row to crash injection.
+        we do not want a malformed row to crash injection.
 
     Args:
         surviving: Cleaned rows from ``_filter_surviving_test_rows``.
@@ -2506,7 +2506,7 @@ def _derive_test_row_template(
 
     Why:
         Injected rows must inherit operator scoping from foreign rows
-        so a targeted deployment (e.g. VLAN 42 only) does not silently
+        so a targeted deployment (for example VLAN 42 only) does not silently
         widen when the tool adds new probes. The two fields are looked
         up independently so a mixed-shape ``tests[]`` list still yields
         a complete template.
@@ -2651,7 +2651,7 @@ def _prompt_and_apply_site_overrides(
     Why:
         Mist site settings can override org-wide ``custom_probes``. After
         a successful org PUT the operator often wants a subset of sites
-        (e.g. those with unusual VLAN topology or higher SLE
+        (for example those with unusual VLAN topology or higher SLE
         expectations) to carry the same probe set locally so
         site-specific probe/VLAN interactions are testable without
         touching org config. Displaying an indexed table (rather than
@@ -2716,7 +2716,7 @@ def _prompt_and_apply_site_overrides(
         _compute_unmapped_country_codes(  # inner: set difference over frozen universes
             sites,  # the just-loaded site list
             _COUNTRY_CODE_TO_REGION,  # T020-extended region map
-            _COUNTRY_CODE_INTENTIONAL_GAPS,  # T021 gap set (Antarctica etc.)
+            _COUNTRY_CODE_INTENTIONAL_GAPS,  # T021 gap set (Antarctica and so on)
         ),
         warned_unmapped_codes,  # dedup state -- mutated in place
     )

--- a/src/org/org_ticket_manager.py
+++ b/src/org/org_ticket_manager.py
@@ -283,7 +283,7 @@ class OrgTicketManager:  # Support ticket operations.
             )
             logging.debug("Comment with file submitted to ticket %s", ticket_id)  # Log after API call
             logging.warning("\n  Comment with attachment added to ticket %s", ticket_id)  # Confirm to user
-        elif file_path:  # User specified a path but file doesn't exist
+        elif file_path:  # User specified a path but file does not exist
             logging.warning(  # Warn about missing file path
                 "File not found: %s -- adding comment without attachment", file_path
             )
@@ -423,7 +423,7 @@ class OrgTicketManager:  # Support ticket operations.
         """Parse numeric choice into ticket ID; print error + return '' on bad input."""
         try:
             idx = int(choice) - 1  # Convert 1-based to 0-based index
-        except ValueError:  # Non-numeric input that wasn't 'm'
+        except ValueError:  # Non-numeric input that was not 'm'
             logging.error("  Invalid selection: %s", choice)  # Inform user of bad input
             return ""  # Signal cancellation
         if not 0 <= idx < len(tickets):  # Index out of range

--- a/src/org_data_collector.py
+++ b/src/org_data_collector.py
@@ -109,7 +109,7 @@ class Operation:  # WHY: Immutable slotted bundle replaces per-entry dict[str, A
     category: str  # WHY: Grouping banner printed once per contiguous run of same-category ops
     sort_key: str | None = None  # WHY: Result sort field; None falls back to _DEFAULT_SORT_KEY
     paginated: bool = True  # WHY: Paginated endpoints receive limit=_DEFAULT_LIMIT; others pass None
-    api_kwargs: dict[str, Any] = field(default_factory=dict)  # WHY: Extra kwargs (e.g. distinct=mac)
+    api_kwargs: dict[str, Any] = field(default_factory=dict)  # WHY: Extra kwargs (for example distinct=mac)
 
 
 # ---------------------------------------------------------------------------
@@ -581,7 +581,7 @@ def _build_export_kwargs(operation: Operation) -> dict[str, Any]:
         "sort_key": sort_key,
         "limit": limit_value,
     }
-    kwargs.update(operation.api_kwargs)  # WHY: Merge per-operation extras (e.g. distinct=mac) last
+    kwargs.update(operation.api_kwargs)  # WHY: Merge per-operation extras (for example distinct=mac) last
     return kwargs
 
 

--- a/src/refactors/connection_pool_executor.py
+++ b/src/refactors/connection_pool_executor.py
@@ -227,7 +227,7 @@ class ConnectionPoolExecutor:  # Class-body seam for the connection-pool-managed
         successful_results: list[Any] = []  # Accumulate all successful worker results across all batches
         failed_items: list[Any] = []  # Accumulate all failed items across all batches for optional retry
         for batch_index in range(0, len(work_items), batch_size):  # Split work into equal-sized, bounded-memory batches
-            try:  # Isolate each batch so a single failure doesn't silently skip remaining batches
+            try:  # Isolate each batch so a single failure does not silently skip remaining batches
                 batch = work_items[batch_index : batch_index + batch_size]  # Slice the current batch from full list
                 batch_number = (batch_index // batch_size) + 1  # 1-based batch number for readable progress logs
                 batch_successful, batch_failed = ConnectionPoolExecutor._pool_process_batch_wait_loop(  # Batch run

--- a/src/refactors/main_entrypoint.py
+++ b/src/refactors/main_entrypoint.py
@@ -48,7 +48,7 @@ class MainEntrypoint:  # CLI main entry-point seam
         _MH._initialize_deferred_imports()  # Initialize deferred module imports if not already completed.
         _MH.InputUtils.ensure_tqdm_available()  # Ensure tqdm is accessible via InputUtils wrapper before use.
         parser = _MH._build_argument_parser()  # Build argparse parser with all supported CLI flags.
-        # Reject known bad flag spellings (e.g. --test-interactive) before argparse misroutes them (#1640).
+        # Reject known bad flag spellings (for example --test-interactive) before argparse misroutes them (#1640).
         _MH._reject_unsupported_flag_variants(sys.argv[1:])
         args = parser.parse_args()  # Parse command line arguments into typed Namespace object.
         _MH._setup_runtime_flags(args)  # Apply --standalone env, register globals()["args"], set FAST_MODE_ENABLED.

--- a/src/refactors/mist_site_exclude_prefix.py
+++ b/src/refactors/mist_site_exclude_prefix.py
@@ -4,7 +4,7 @@ Owns the site-name-prefix filter originally defined at
 ``MistHelper.py`` lines 2138-2143 as a module-level assignment reading
 the ``MIST_SITE_EXCLUDE_PREFIX`` environment variable. The prefix
 shields sites whose name starts with the configured value from
-destructive operations (e.g. Menu #149 WAN2 migration, Menu #166 WAN
+destructive operations (for example Menu #149 WAN2 migration, Menu #166 WAN
 probe configuration, Menu #167 WAN probe device overrides).
 
 Landing per E-14 as a **bare module-level constant** -- no wrapper

--- a/src/refactors/msp_privilege_detection.py
+++ b/src/refactors/msp_privilege_detection.py
@@ -41,7 +41,7 @@ def _extract_msp_name(response: Any) -> str | None:
         logging.debug("_extract_msp_name: response.data is not a dict, returning None")  # AFTER: no-data trace
         return None  # Malformed or empty response
     name = data.get("name")  # Extract the MSP's name field
-    result = name if isinstance(name, str) else None  # Return the name only if it's a valid string
+    result = name if isinstance(name, str) else None  # Return the name only if it is a valid string
     logging.debug("_extract_msp_name: exit -- name=%s", "<set>" if result else "None")  # AFTER: success trace
     return result  # Yield the resolved name (or None when absent)
 
@@ -51,7 +51,7 @@ def _fetch_msp_name(msp_id: str, session: Any) -> str | None:
     logging.info("_fetch_msp_name: entry (msp_id=%s...)", msp_id[:8])  # BEFORE: trace fetch entry
     if session is None:  # No active session to query with
         logging.debug("_fetch_msp_name: no session, returning None")  # AFTER: no-session trace
-        return None  # Can't look anything up
+        return None  # Cannot look anything up
     try:  # API call and payload parsing may fail; degrade to None on any error
         import mistapi.api.v1.msps.msps as msps_api  # noqa: PLC0415  # Lazy import of MSP details endpoint
 
@@ -59,9 +59,9 @@ def _fetch_msp_name(msp_id: str, session: Any) -> str | None:
         result = _extract_msp_name(response)  # Pull the name from the payload (None when absent/malformed)
         logging.debug("_fetch_msp_name: exit -- result=%s", "<set>" if result else "None")  # AFTER: success trace
         return result  # Hand back the resolved name (or None)
-    except Exception as e:  # Lookup failed (network, permissions, etc.)
+    except Exception as e:  # Lookup failed (network, permissions, and so on)
         logging.debug("Could not fetch MSP name for %s...: %s", msp_id[:8], e)  # Note the failure at debug level
-        return None  # Default to None when the name can't be resolved
+        return None  # Default to None when the name cannot be resolved
 
 
 def _msp_resolve_name(msp_id: str, priv: dict[str, Any], session: Any) -> str:
@@ -128,7 +128,7 @@ def _msp_fetch_user_data(session: Any) -> dict[str, Any] | None:
 
     response = self_api.getSelf(session)  # Ask the API who the authenticated user is (via injected session).
     if not response or not hasattr(response, "data"):  # No usable payload came back.
-        logging.warning("getSelf returned no data - cannot detect MSP privileges")  # Warn we can't determine access.
+        logging.warning("getSelf returned no data - cannot detect MSP privileges")  # Warn we cannot determine access.
         return None  # No privileges could be detected.
     user_data = response.data  # Extract the decoded JSON body.
     if not isinstance(user_data, dict):  # The body should be a JSON object.
@@ -171,5 +171,5 @@ def detect_msp_privileges(session: Any) -> list[dict[str, Any]]:
         )  # AFTER: trace success path with count
         return detected_msps  # Hand the parsed MSP list back to the caller.
     except Exception as e:  # Any API or parsing failure.
-        logging.warning("Failed to detect MSP privileges: %s", e)  # Warn but don't crash the session.
+        logging.warning("Failed to detect MSP privileges: %s", e)  # Warn but do not crash the session.
         return []  # Treat as no MSP access on error.

--- a/src/refactors/package_import_map.py
+++ b/src/refactors/package_import_map.py
@@ -9,8 +9,8 @@ in MistHelper.py after this extraction.
 
 The mapping keys are pip distribution names and values are the
 corresponding importable module names -- the pair diverges whenever a
-project publishes under one name (e.g. `pillow`) but exposes its API
-under another (e.g. `PIL`). The manager class exposes the mapping as a
+project publishes under one name (for example `pillow`) but exposes its API
+under another (for example `PIL`). The manager class exposes the mapping as a
 class-level attribute so consumers can grab it via
 `PackageImportMapManager.MAPPING` while keeping the moved surface a
 single import symbol.

--- a/src/refactors/serial_cc/global_assignments_builder.py
+++ b/src/refactors/serial_cc/global_assignments_builder.py
@@ -94,7 +94,7 @@ class GlobalAssignmentsBuilderService:  # WHY: single-purpose helper class extra
 
         for module_name, module_obj in imports.items():  # Walk each successfully imported module
             global_vars[module_name] = module_obj  # Always expose the module under its own name first
-            cls._apply_attribute_exports(global_vars, module_name, module_obj)  # Submember re-exports (timezone, etc.)
+            cls._apply_attribute_exports(global_vars, module_name, module_obj)  # Submember re-exports like timezone
             cls._expose_module_alternate_name(global_vars, module_name, module_obj)  # Alt module names (np)
             cls._apply_optional_imports(global_vars, module_name, module_obj)  # Conditional optional-dep imports
             cls._apply_logged_module(global_vars, module_name, module_obj)  # Present-only logged modules

--- a/src/refactors/serial_cc/security_events.py
+++ b/src/refactors/serial_cc/security_events.py
@@ -73,7 +73,7 @@ class _FlattenedExportSpec:
     data_label: str  # Human-readable label used in stdout/logs.
     start_label: str  # Compact label logged when the fetch begins.
     fetcher: Callable[[], Any]  # Zero-arg lambda that invokes the mistapi list endpoint.
-    empty_message: str  # Warning logged when the fetch returns zero rows.
+    empty_message: str  # Logged at warning level when the fetch returns zero rows.
     empty_suffix: str  # Suffix appended to the stdout summary when the dataset is empty.
 
 

--- a/src/refactors/wanprobe_config_manager.py
+++ b/src/refactors/wanprobe_config_manager.py
@@ -9,7 +9,7 @@ classes ConfigUtils / InputUtils / CacheUtils / GatewayExportUtils /
 OrgSiteExporter / FilePathUtils / DataExporter) are still owned by
 MistHelper.py. They are resolved lazily via the module-level _MH proxy
 so the extracted module keeps its import graph flat, live re-bindings
-of apisession (e.g. after interactive login) are always honoured, and
+of apisession (for example after interactive login) are always honoured, and
 monkeypatched attributes in tests continue to work.
 
 The ``MIST_SITE_EXCLUDE_PREFIX`` constant is imported directly from
@@ -60,8 +60,8 @@ class WANProbeConfigManager:  # WAN probe config manager (Menu 166 destructive e
     """
 
     # Default probe configuration - loaded from environment variables
-    # MIST_WAN_PROBE_IPS: Comma-separated list of probe IPs (e.g., "192.151.29.254,18.154.184.32")
-    # MIST_WAN_PROBE_PROFILE: Probe profile name (e.g., "lte")
+    # MIST_WAN_PROBE_IPS: Comma-separated list of probe IPs (for example, "192.151.29.254,18.154.184.32")
+    # MIST_WAN_PROBE_PROFILE: Probe profile name (for example, "lte")
     DEFAULT_PROBE_IPS = [  # Default probe IPs.
         ip.strip() for ip in os.getenv("MIST_WAN_PROBE_IPS", "192.151.29.254,18.154.184.32").split(",") if ip.strip()
     ]

--- a/src/refactors/wlanradius_timer_manager.py
+++ b/src/refactors/wlanradius_timer_manager.py
@@ -8,7 +8,7 @@ Runtime dependencies (apisession module-global, and the utility
 classes InputUtils / PromptUtils / ConfigUtils) are still
 owned by MistHelper.py. They are resolved lazily via the module-level
 _MH proxy so the extracted module keeps its import graph flat, live
-re-bindings of apisession (e.g. after interactive login) are always
+re-bindings of apisession (for example after interactive login) are always
 honoured, and monkeypatched attributes in tests continue to work.
 """
 
@@ -78,10 +78,10 @@ class WLANRadiusTimerManager:  # Menu 148 entrypoint for WLAN RADIUS timer edits
         return self.selected_wlan  # Return the confirmed-non-None WLAN dict
 
     def _discover_radius_wlans(self) -> bool:  # Aggregates site/org/template lookups + filtering
-        """Set up org/site context, fetch all WLANs, filter to RADIUS-only. Return False to abort the workflow."""
+        """Prepare org/site context, fetch all WLANs, filter to RADIUS-only. Return False to abort the workflow."""
         if not self._select_site():  # Prompt for a site; abort if none chosen
             return False  # No site selected -- nothing to manage
-        if not self._get_org_id():  # Resolve the org ID; abort if it can't be determined
+        if not self._get_org_id():  # Resolve the org ID; abort if it cannot be determined
             return False  # Without an org ID we cannot fetch templates
         if not self._fetch_site_info():  # Load site details; abort on failure
             return False  # Site info is required for template resolution
@@ -95,7 +95,7 @@ class WLANRadiusTimerManager:  # Menu 148 entrypoint for WLAN RADIUS timer edits
     def manage(self) -> None:  # Public menu entrypoint invoked by MistHelper menu action 148
         """Main entry point - orchestrates the WLAN timer management workflow."""
         logging.info("Starting WLAN RADIUS authentication timer management")  # Announce the workflow start
-        self._enable_debug_if_requested()  # Turn on verbose logging if the user asked for it
+        self._enable_debug_if_requested()  # Start verbose logging if the user asked for it
         if not self._discover_radius_wlans():  # Site + org + WLAN discovery; bail on abort.
             return  # Discovery aborted -- nothing further to do
         self._display_wlans()  # Show the user the candidate WLANs and their timers

--- a/src/reports/e911_bssid.py
+++ b/src/reports/e911_bssid.py
@@ -555,7 +555,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
 
         WHY: extracted from `_add_single_wlan` to keep complexity ≤5.
         """
-        for band_key in wlan_bands:  # WHY: one WLAN can span multiple bands (e.g. dual-band)
+        for band_key in wlan_bands:  # WHY: one WLAN can span multiple bands (for example dual-band)
             lookup_key = f"{site_id}::{band_key}"  # WHY: composite key groups SSIDs per site+band
             bucket = wlan_band_lookup.setdefault(lookup_key, [])  # WHY: create then reuse bucket
             if ssid_name not in bucket:  # WHY: prevent duplicate SSID names
@@ -633,7 +633,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         lookups: dict[str, Any],
     ) -> str:
         """Detect compliance gap reason for an AP."""
-        if not ap_info:  # WHY: no AP stats -> can't verify compliance
+        if not ap_info:  # WHY: no AP stats -> cannot verify compliance
             return "Not in device stats"  # WHY: matches summary wording
         missing = E911BSSIDReportGenerator._first_missing_field(ap_info)  # WHY: table lookup replaces if-chain
         if missing:  # WHY: first missing field wins
@@ -913,7 +913,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
             raise  # WHY: any other RuntimeError should surface for debugging
         except Exception as error:  # WHY: single-site failure should not abort the whole batch
             logging.warning("Error processing site %s: %s", site_id[:8], error)  # WHY: audit failure
-            batch.completed_sites.add(site_id)  # WHY: mark done so we don't retry a broken site
+            batch.completed_sites.add(site_id)  # WHY: mark done so we do not retry a broken site
             return None  # WHY: signal "continue"
 
     @staticmethod

--- a/src/reports/sfp_transceiver_data_processor.py
+++ b/src/reports/sfp_transceiver_data_processor.py
@@ -12,7 +12,7 @@ from __future__ import annotations  # WHY: PEP 604 unions for return types.
 import csv  # WHY: DictReader for header-keyed CSV parsing of port stats + device inventory.
 import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
 import logging  # WHY: structured trace for merge lifecycle events.
-import os  # WHY: filesystem existence checks for prerequisite CSVs.
+import os  # WHY: filesystem existence checks for prerequisite CSV files.
 
 from src.export.org_inventory_exporter import (
     OrgInventoryExporter,  # WHY: 1015 T-06 canonical import (eliminates mh.OrgInventoryExporter).
@@ -26,7 +26,7 @@ class SFPTransceiverDataProcessor:
         This logic was previously a standalone function (`process_and_merge_csv_for_sfp_address`).
         It is only invoked by menu option 77 and has no tight coupling with most runtime state.
         Encapsulating it in a class improves hierarchy and opens the door for future extensions
-        (e.g., JSON export, filtering, unit tests) without growing the legacy global scope.
+        (for example, JSON export, filtering, unit tests) without growing the legacy global scope.
 
     SECURITY:
         Operates only on locally generated CSV artifacts inside the controlled `data/` directory.
@@ -201,12 +201,12 @@ class SFPTransceiverDataProcessor:
         """Generate a merged transceiver CSV linking port optics to site + device context.
 
         Steps:
-            1. Ensure prerequisite CSVs exist (generate if missing):
-               - OrgDevicePortStats.csv
-               - AllDevicesWithSiteInfo.csv
-            2. Load device/site context keyed by MAC.
-            3. Filter port stats to rows containing a non-empty transceiver model.
-            4. Write merged result to `MergedTransceiverData.csv` via DataExporter.
+            - Ensure prerequisite CSV files exist (generate if missing):
+              - OrgDevicePortStats.csv
+              - AllDevicesWithSiteInfo.csv
+            - Load device/site context keyed by MAC.
+            - Filter port stats to rows containing a non-empty transceiver model.
+            - Write merged result to `MergedTransceiverData.csv` via DataExporter.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FilePathUtils helper.
         logging.debug("ENTRY: SFPTransceiverDataProcessor.merge_transceiver_data()")  # Trace entry

--- a/src/site/address_audit/address_corrector.py
+++ b/src/site/address_audit/address_corrector.py
@@ -8,7 +8,7 @@ address) and AFTER (suggested correction) side by side. Nothing is written witho
 that per-site yes.
 
 Write mechanics (safe, minimal): a Mist site stores its address as a single
-formatted string in the ``address`` field (e.g. ``"940 James Bowie Dr, New Boston,
+formatted string in the ``address`` field (for example ``"940 James Bowie Dr, New Boston,
 TX 75570, USA"``) alongside ``latlng``, ``country_code``, ``timezone``, and the
 various template IDs. To change only the address without disturbing anything else,
 we fetch the full current site record, replace ``address``, and PUT the whole

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -264,7 +264,7 @@ class AddressResolver:
         A business-name prefix (``T-Mobile <addr>``) helps Google return the exact
         store unit, but when no store sits at that number Google returns unrelated
         stores and the stale-guard rejects them all. Retrying the plain address
-        then resolves the street itself (e.g. ``2315 S Federal Hwy``).
+        then resolves the street itself (for example ``2315 S Federal Hwy``).
         """
         self.external_calls += 1  # Count the primary UI lookup.
         result = self._ui_geocoder.geocode_via_ui(query)  # Business-prefixed query first.
@@ -315,8 +315,8 @@ class AddressResolver:
 
     @staticmethod
     def _suite_unit(street: str) -> str:
-        """Extract the bare unit identifier from a street's suite token (e.g. 'h200', '204', '')."""
-        token = AddressResolver._extract_suite(street)  # e.g. 'Suite H200', '#204', 'Space P239'.
+        """Extract the bare unit identifier from a street's suite token (for example 'h200', '204', '')."""
+        token = AddressResolver._extract_suite(street)  # for example 'Suite H200', '#204', 'Space P239'.
         if not token:  # No suite token present.
             return ""  # No unit.
         parts = token.split()  # Split the keyword from the identifier.
@@ -405,7 +405,7 @@ class AddressResolver:
         """Return the leading 1-6 digit run (the house number), or '' when none leads.
 
         Anchored at the start so a trailing ZIP is never mistaken for a house
-        number (e.g. ``S Federal Hwy ... 34982`` has no house number).
+        number (for example ``S Federal Hwy ... 34982`` has no house number).
         """
         match = re.match(r"\s*(\d{1,6})\b", text)  # House numbers lead the street line.
         return match.group(1) if match else ""  # Leading digits or empty.

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -103,7 +103,7 @@ class _AddressAuditConsoleFilter(logging.Filter):
     table, the post-table prompts, the write-back confirmations); every
     ``logging.*`` call it makes is a diagnostic trail destined for
     ``data/script.log``. Attached to the root logger's CONSOLE handlers (and only
-    for the duration of a run), this filter keeps that diagnostic noise -- e.g. the
+    for the duration of a run), this filter keeps that diagnostic noise -- for example the
     Nominatim "no result" warnings -- out of the terminal, where it would corrupt
     the tqdm progress bar. File handlers never receive this filter, so the full log
     trail is preserved.
@@ -206,7 +206,7 @@ class AddressAuditEngine:
 
     @staticmethod
     def _is_console_handler(handler: logging.Handler) -> bool:
-        """Return True for a console-bound ``StreamHandler`` (i.e. not a ``FileHandler``)."""
+        """Return True for a console-bound ``StreamHandler`` (that is not a ``FileHandler``)."""
         if not isinstance(handler, logging.StreamHandler):  # Not a stream handler at all -> never console.
             return False  # Ignore this handler for console-filter purposes.
         return not isinstance(handler, logging.FileHandler)  # StreamHandler AND not-a-FileHandler == console.
@@ -252,7 +252,7 @@ class AddressAuditEngine:
             raw = InputUtils.safe_input("Select file number: ", context="address_audit_csv_pick").strip()
             if (
                 not raw
-            ):  # Empty response (blank Enter or EOF sentinel from safe_input) -> abort so we cannot infinite-loop under non-interactive stdin (e.g. --test).  # noqa: E501
+            ):  # Empty response (blank Enter or EOF sentinel from safe_input) -> abort so we cannot infinite-loop under non-interactive stdin (for example --test).  # noqa: E501
                 logger.info("No CSV selection made (empty input); skipping address audit")  # Action-log the abort.
                 # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
                 logger.info(
@@ -301,7 +301,7 @@ class AddressAuditEngine:
             )  # Normalize once for downstream comparisons.
             if (
                 not raw
-            ):  # Empty response (blank Enter or EOF sentinel) is treated as explicit skip to avoid infinite loops under non-interactive stdin (e.g. --test).  # noqa: E501
+            ):  # Empty response (blank Enter or EOF sentinel) is treated as explicit skip to avoid infinite loops under non-interactive stdin (for example --test).  # noqa: E501
                 logger.info(
                     "Business-authoritative CSV selection skipped (empty input)"
                 )  # Action-log the implicit skip.
@@ -712,7 +712,7 @@ class AddressAuditEngine:
         Both inputs are full formatted address strings ("STREET, CITY, ST ZIP"),
         so we inspect only the leading street segment (before the first comma) and
         require a *leading* digit there. This avoids mistaking a trailing ZIP for a
-        house number -- e.g. Mist ``S Federal Hwy, Fort Pierce, FL 34982`` has no
+        house number -- for example Mist ``S Federal Hwy, Fort Pierce, FL 34982`` has no
         house number even though the ZIP contains digits.
         """
         mist_lead = re.match(r"\s*\d", mist_street.split(",", 1)[0])  # Leading digit of the Mist street.
@@ -800,7 +800,7 @@ class AddressAuditEngine:
     def _leading_directional(street: str) -> str:
         """Return the directional immediately after the house number, normalized, or ''.
 
-        Only the leading directional (e.g. the ``E`` in ``1606 E Jefferson``) is
+        Only the leading directional (for example the ``E`` in ``1606 E Jefferson``) is
         considered, so a directional inside a later city name (``West Palm Beach``)
         never triggers a false street mismatch.
         """

--- a/src/site/address_audit/csv_ingester.py
+++ b/src/site/address_audit/csv_ingester.py
@@ -6,7 +6,7 @@ six positional columns are: serial, model, address, city, state, zip.
 Real customer exports vary: a file saved as ``.csv`` from Excel is comma-
 delimited, while a ``.tsv`` (or a tab-pasted file) is tab-delimited. The
 delimiter is therefore **auto-detected** per file rather than assumed. Addresses
-themselves may contain the delimiter (e.g. a comma in "Mall, Suite 330"), so the
+themselves may contain the delimiter (for example a comma in "Mall, Suite 330"), so the
 row is parsed by its fixed structure -- the first two fields are serial/model,
 the last three are city/state/zip, and everything in between is rejoined as the
 address. Rows whose serial is empty or non-numeric after stripping are skipped
@@ -38,7 +38,7 @@ class CSVAddressIngester:
         with open(path, encoding="utf-8-sig", newline="") as handle:  # utf-8-sig strips an Excel BOM.
             sample = self._read_sample_line(handle)  # First non-blank line, for delimiter detection.
             handle.seek(0)  # Rewind so the csv.reader sees the whole file (quoted newlines intact).
-            delimiter = self._detect_delimiter(sample)  # Pick tab/comma/etc. from the data itself.
+            delimiter = self._detect_delimiter(sample)  # Pick tab/comma/and so on from the data itself.
             logging.debug("Detected delimiter %r for %s", delimiter, path)  # Trace the chosen delimiter.
             reader = csv.reader(handle, delimiter=delimiter)  # Reader honors quoted multi-line fields.
             rows, failures = self._parse_reader(reader)  # Parse every record.
@@ -75,7 +75,7 @@ class CSVAddressIngester:
 
     def _choose_delimiter(self, sample: str) -> str:
         """Probe each candidate delimiter and return the one giving the most fields."""
-        # WHY: split from _detect_delimiter so the empty-sample guard doesn't inflate CC past 5.
+        # WHY: split from _detect_delimiter so the empty-sample guard does not inflate CC past 5.
         best_delimiter = ","  # Fallback when nothing yields enough columns.
         best_count = -1  # Highest field count seen so far.
         for candidate in _CANDIDATE_DELIMITERS:  # Probe each candidate delimiter.

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -24,7 +24,7 @@ class AddressRow:
     """One parsed, sanitized CSV row (tab-delimited, header-less customer file)."""
 
     serial: str  # Col 0: Juniper device serial (numeric string); required, non-empty.
-    model: str  # Col 1: device model (e.g. SSR130); display only.
+    model: str  # Col 1: device model (for example SSR130); display only.
     address: str  # Col 2: street address; sanitized (newlines removed, ws collapsed).
     city: str  # Col 3: city name.
     state: str  # Col 4: 2-letter state code.

--- a/src/site/address_audit/perf.py
+++ b/src/site/address_audit/perf.py
@@ -2,8 +2,8 @@
 
 The Tier-3 resolve loop can spend 12-20 seconds per site, and it was not obvious
 where that time went. :class:`PhaseTimer` accumulates wall-clock time under named
-phases so the audit can log a breakdown at the end of a run (e.g. human-like
-typing vs. Nominatim rate-limit vs. politeness delay vs. suite-grace waits),
+phases so the audit can log a breakdown at the end of a run (for example human-like
+typing versus Nominatim rate-limit versus politeness delay versus suite-grace waits),
 turning "it feels slow" into an actionable measurement.
 
 This is deliberately tiny and dependency-free: a dict of ``label -> [count,

--- a/src/site/address_audit/snmp_enricher.py
+++ b/src/site/address_audit/snmp_enricher.py
@@ -8,7 +8,7 @@ matching/validation signal. It never raises on absence -- a site with neither
 field simply yields ``None``.
 
 The customer prefixes these values with their own SAP internal store code
-(e.g. ``"S2SJB - 5550 N Military Trl ..."`` or ``"08806 - 2525 Howell Branch
+(for example ``"S2SJB - 5550 N Military Trl ..."`` or ``"08806 - 2525 Howell Branch
 Rd ..."``). That code is not part of the postal address, so it is stripped
 before the value is returned -- the audit must never treat the store number as
 part of the street.
@@ -48,7 +48,7 @@ class SNMPLocationEnricher:  # WHY: single-purpose class extracting SNMP locatio
 
     @staticmethod
     def _strip_store_prefix(value: str | None) -> str | None:  # WHY: drop SAP store code prefix
-        """Remove the customer's leading SAP store-code prefix (e.g. ``08806 - ``)."""
+        """Remove the customer's leading SAP store-code prefix (for example ``08806 - ``)."""
         if not value:  # Nothing to strip.
             return None  # Preserve the absent sentinel.
         stripped = _SAP_PREFIX.sub("", value).strip()  # Drop the anchored store-code prefix.

--- a/src/site/address_audit/suite_patterns.py
+++ b/src/site/address_audit/suite_patterns.py
@@ -29,7 +29,7 @@ SUITE_PATTERN = rf"\b(?:{SUITE_KEYWORDS})\b\.?\s*#?\s*[\w-]+|#\s*\d[\w-]*"  # WH
 # engine to extract the bare unit identifier for suite comparison/adjudication.
 SUITE_PATTERN_CAPTURE = rf"\b(?:{SUITE_KEYWORDS})\b\.?\s*#?\s*([\w-]+)|#\s*(\d[\w-]*)"  # WHY: extraction - kw/hash ids
 
-# Phrase form (case-insensitive): the FULL matched keyword token (e.g. ``Unit 200``,
+# Phrase form (case-insensitive): the FULL matched keyword token (for example ``Unit 200``,
 # ``Ste A2``). The id must start alphanumeric and may carry an internal hyphen. Used
 # by the UI geocoder to lift the exact phrase the operator typed so it can be
 # re-appended verbatim to a Google suggestion that dropped it.

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -282,7 +282,7 @@ class MistUIGeocoder:
         with self._perf.phase("ui.type_query"):  # Time the human-like typing (usually the biggest cost).
             self._enter_query(page, field, query)  # Focus, clear the stale dropdown, type the new query.
         expected = self._house_number(query)  # House number anchors the fresh-result wait.
-        expected_suite = self._suite_id(query)  # Unit id we typed (e.g. "200"); "" when none -> suite wait is a no-op.
+        expected_suite = self._suite_id(query)  # Unit id we typed (for example "200"). "" skips the suite wait.
         with self._perf.phase("ui.read_suggestions"):  # Time the fresh-result poll incl. the suite grace.
             texts = self._read_fresh_suggestions(page, expected, timeout_ms, expected_suite)  # Wait for THIS query.
         logging.debug("UI autocomplete returned %d fresh suggestion(s)", len(texts))  # Action-log count.
@@ -422,7 +422,7 @@ class MistUIGeocoder:
 
     @staticmethod
     def _suite_phrase(text: str) -> str:
-        """Return the full suite/unit phrase from an address/query (e.g. 'Unit 200', '#3'), or ''.
+        """Return the full suite/unit phrase from an address/query (for example 'Unit 200', '#3'), or ''.
 
         Matches an explicit keyword form (``Suite/Ste/Unit/Space/Bldg/Rm/Apt <id>``)
         first, then a bare ``#<id>`` hash form. The id may be alphanumeric with an
@@ -431,15 +431,15 @@ class MistUIGeocoder:
         """
         keyword = re.search(
             SUITE_PHRASE_PATTERN, text
-        )  # Shared keyword+id form (e.g. 'Suite 100', 'Ste A2', 'Sute A-103').
+        )  # Shared keyword+id form (for example 'Suite 100', 'Ste A2', 'Sute A-103').
         if keyword:  # Prefer the explicit keyword form.
             return re.sub(r"\s+", " ", keyword.group(0)).strip()  # Collapse internal whitespace.
-        hashed = re.search(HASH_UNIT_PATTERN, text)  # Bare hash form (e.g. '#3', '#1515b').
+        hashed = re.search(HASH_UNIT_PATTERN, text)  # Bare hash form (for example '#3', '#1515b').
         return hashed.group(0).replace(" ", "") if hashed else ""  # '#<id>' with no gap, or empty.
 
     @staticmethod
     def _suite_id(text: str) -> str:
-        """Return just the bare unit identifier from a suite phrase (e.g. '200', 'A2', '3'), or ''."""
+        """Return just the bare unit identifier from a suite phrase (for example '200', 'A2', '3'), or ''."""
         phrase = MistUIGeocoder._suite_phrase(text)  # Full phrase such as 'Unit 200' or '#3'.
         if not phrase:  # No suite present.
             return ""  # Nothing to compare/preserve.
@@ -510,7 +510,7 @@ class MistUIGeocoder:
         (a DIFFERENT unit means Google is the authority -- leave it), and the house
         numbers agree (never graft a unit onto a different building).
         """
-        suite_id = self._suite_id(query)  # WHY: the unit id we typed (e.g. "200"); "" when none.
+        suite_id = self._suite_id(query)  # WHY: the unit id we typed (for example "200"); "" when none.
         if self._skip_suite_preservation(query, suggestion, suite_id):  # WHY: guard-clause bundles all no-op cases.
             return suggestion  # Nothing to preserve, already complete, Google authoritative, or different building.
         phrase = self._suite_phrase(query)  # The full 'Unit 200' / '#3' token to restore.
@@ -555,7 +555,7 @@ class MistUIGeocoder:
         """Strip a glued leading place/business name and a trailing country from a suggestion.
 
         Google's ``.pac-item`` rows glue the establishment name to the address with
-        no separator (e.g. ``T-Mobile931 US Highway 331 Ste A2, ..., USA``), glue a
+        no separator (for example ``T-Mobile931 US Highway 331 Ste A2, ..., USA``), glue a
         trailing directional to the city (``...Ave NLive Oak``), and sometimes glue
         the street or a suite number straight to the city (``...HwyFort Pierce``,
         ``...suite 330Brandon``). We drop the trailing country, repair those glued

--- a/src/site/bulk_radius_wlan_config_manager.py
+++ b/src/site/bulk_radius_wlan_config_manager.py
@@ -270,7 +270,7 @@ class BulkRadiusWLANConfigManager:
     @staticmethod
     def _is_range_part(part: str) -> bool:
         """Return True when a selection piece is a range like '3-7' (not a leading-minus negative)."""
-        return "-" in part and not part.startswith("-")  # A dash that isn't a leading minus marks a range.
+        return "-" in part and not part.startswith("-")  # A dash that is not a leading minus marks a range.
 
     @staticmethod
     def _parse_range_part(part: str) -> tuple[int, int] | None:
@@ -492,7 +492,7 @@ class BulkRadiusWLANConfigManager:
             "compliance_status": wlan.get("_compliance_status", ""),  # COMPLIANT/NEEDS_UPDATE from the filter step
             "inheritance_level": wlan.get("_inheritance_level", ""),  # template vs org (from _add_inheritance_metadata)
             "inheritance_source": wlan.get("_inheritance_source", ""),  # Where the WLAN is defined
-            "auth_type": auth.get("type", "") if isinstance(auth, dict) else "",  # eap/eap192/psk/etc.
+            "auth_type": auth.get("type", "") if isinstance(auth, dict) else "",  # eap/eap192/psk/and so on
             "num_auth_servers": len(wlan.get("auth_servers", []) or []),  # How many RADIUS servers are configured
             "radsec_enabled": radsec.get("enabled", False) if isinstance(radsec, dict) else False,  # RadSec on/off
             "auth_servers_timeout": wlan.get("auth_servers_timeout", 5),  # Actual value (5 = the check's own default)
@@ -532,7 +532,7 @@ class BulkRadiusWLANConfigManager:
                 writer.writerows(self.change_records)  # Write every recorded change
             print(f"\n[+] Audit trail exported to: {filepath}")
             logging.info("Audit trail exported to %s with %s records", filepath, len(self.change_records))
-        except Exception as e:  # Writing the CSV failed (permissions, disk, etc.)
+        except Exception as e:  # Writing the CSV failed (permissions, disk, and so on)
             print(f"\n[!] Failed to export audit trail: {e}")
             logging.error("Failed to export audit trail: %s", e)
 
@@ -598,7 +598,7 @@ class BulkRadiusWLANConfigManager:
             print("\n[*] No selection made. Exiting.")  # Inform the user.
             return None  # Abort.
         selected_indices = self._parse_selection(selection)  # Parse into 0-based indices.
-        if selected_indices is None:  # User explicitly cancelled (e.g., 'q').
+        if selected_indices is None:  # User explicitly cancelled (for example, 'q').
             print("\n[*] Operation cancelled by user.")  # Acknowledge.
             logging.info("Menu 122 cancelled by user at selection prompt")  # Log cancellation.
             return None  # Abort.

--- a/src/site/site_config_manager.py
+++ b/src/site/site_config_manager.py
@@ -613,7 +613,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
 
     @staticmethod
     def _report_rf_template_results(report: RfTemplateReport) -> None:
-        """Report RF template operation results and export CSVs."""
+        """Report RF template operation results and export CSV files."""
         print("\n" + "=" * 70)  # WHY: open completion banner.
         print(" OPERATION COMPLETE")  # WHY: banner title.
         print("=" * 70)  # WHY: banner divider.
@@ -824,7 +824,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         failed: list[dict[str, Any]],
         skipped: list[dict[str, Any]],
     ) -> None:
-        """Report device profile creation results and export CSVs."""
+        """Report device profile creation results and export CSV files."""
         print("\n" + "=" * 70)  # WHY: open completion banner.
         print(" OPERATION COMPLETE")  # WHY: banner title.
         print("=" * 70)  # WHY: banner divider.
@@ -1053,7 +1053,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
         without_profile: list[dict[str, Any]],
         without_model: list[dict[str, Any]],
     ) -> None:
-        """Report profile assignment results and export CSVs."""
+        """Report profile assignment results and export CSV files."""
         print("\n" + "=" * 70)  # WHY: open completion banner.
         print(" OPERATION COMPLETE")  # WHY: banner title.
         print("=" * 70)  # WHY: banner divider.

--- a/src/ssh/batch/batch_executor.py
+++ b/src/ssh/batch/batch_executor.py
@@ -261,7 +261,7 @@ class BatchExecutor:
             if step_result.stop:  # WHY: interrupt short-circuits remaining commands.
                 overall_success = False  # WHY: interrupts always mark the batch failed.
                 break
-            if not step_result.ok:  # WHY: failed command doesn't stop remaining commands.
+            if not step_result.ok:  # WHY: failed command does not stop remaining commands.
                 overall_success = False  # WHY: track failure but keep executing (verbatim behavior).
             if index < total:  # WHY: inter-command delay only applies between commands.
                 time.sleep(_INTER_COMMAND_PAUSE)  # WHY: preserve original pacing between commands.

--- a/src/ssh/batch/host_runner.py
+++ b/src/ssh/batch/host_runner.py
@@ -208,7 +208,7 @@ class HostRunner:
         if len(command.strip()) <= _PASSWORD_RESPONSE_MIN_LEN:  # WHY: too short to be a password.
             return False  # WHY: preserve legacy length gate.
         if prev_command.strip().lower() not in _PRIV_ESC_TRIGGERS:  # WHY: only care after su/sudo.
-            return False  # WHY: prior command doesn't imply a reply.
+            return False  # WHY: prior command does not imply a reply.
         if command.startswith(_SAFE_RESPONSE_PREFIXES):  # WHY: paths + show-cmds are legit follow-ups.
             return False  # WHY: skip legit non-password follow-ups.
         logger.debug(  # WHY: trace which command triggered detection.

--- a/src/ssh/batch/interactive_batch_executor.py
+++ b/src/ssh/batch/interactive_batch_executor.py
@@ -6,7 +6,7 @@ lines, log file headers/footers, [STEP], [OK], [ERROR], [INTERRUPT] markers)
 and magic wait-window values are preserved verbatim from the original.
 
 The interactive flow drives a persistent paramiko shell channel to support
-sequences that require interactive input (e.g. ``su`` -> ``Password:`` ->
+sequences that require interactive input (for example ``su`` -> ``Password:`` ->
 response -> ``show ...``).
 """
 
@@ -472,7 +472,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         command_index = 0  # WHY: manual index because blank entries are skipped by helper.
         while command_index < total:  # WHY: hand-rolled loop keeps parity with original behaviour.
             step_ctx = InteractiveBatchExecutor._build_step_context(hostname, commands, command_index, total)
-            command_index += 1  # WHY: always advance so blank entries don't loop forever.
+            command_index += 1  # WHY: always advance so blank entries do not loop forever.
             if step_ctx is None:  # WHY: helper returned None to signal a blank-line skip (no pause).
                 continue
             result = InteractiveBatchExecutor._maybe_run_step(shell, step_ctx, writer, logger)  # WHY: run step.

--- a/src/ssh/batch/multi_host_runner.py
+++ b/src/ssh/batch/multi_host_runner.py
@@ -243,7 +243,7 @@ class MultiHostRunner:
             "[TRACE] Multi-host wait loop failure: %s: %s", type(loop_error).__name__, loop_error
         )
         for _future, host in future_to_host.items():  # WHY: mark any unhandled hosts as failed.
-            if host not in state.results:  # WHY: don't overwrite completed host records.
+            if host not in state.results:  # WHY: do not overwrite completed host records.
                 state.results[host] = {"success": False, "summary": f"Loop failure: {loop_error}"}
                 state.failed_hosts.append(host)  # WHY: register the host as failed.
 

--- a/src/ssh/cli_shell_manager.py
+++ b/src/ssh/cli_shell_manager.py
@@ -142,7 +142,7 @@ class CLIShellManager:
         """Handle the '~' exit key by closing the WebSocket socket."""
         logging.warning("\n## Exit from shell ##")  # WHY: user-visible exit banner (was print()).
         if ws.sock is not None:  # Socket present.
-            ws.sock.shutdown(2)  # Shut down the socket.
+            ws.sock.shutdown(2)  # Stop the socket.
             ws.sock.close()  # Close the socket.
 
     @staticmethod

--- a/src/ssh/config/command_parser.py
+++ b/src/ssh/config/command_parser.py
@@ -51,7 +51,7 @@ class CommandListParser:
         invalid: list[str] = []  # Rejected commands accumulator (for warnings)
         for raw in commands_str.split(","):  # Comma is the supported delimiter
             clean_cmd = raw.strip().strip("'\"").strip()  # Drop whitespace and per-token quoting
-            if not clean_cmd:  # Skip empty tokens (e.g. trailing comma)
+            if not clean_cmd:  # Skip empty tokens (for example trailing comma)
                 continue  # Move to next token
             if validate_command(clean_cmd):  # Shared validation (length + NUL check)
                 commands.append(clean_cmd)  # Keep validated command

--- a/src/ssh/config/env_loader.py
+++ b/src/ssh/config/env_loader.py
@@ -97,7 +97,7 @@ class EnvSshConfigLoader:
         """Return True iff the .env file is below the size cap."""
         try:
             file_size = os.path.getsize(env_file)  # Single stat call
-        except OSError as error:  # Permission denied / vanished etc.
+        except OSError as error:  # Permission denied / vanished and so on
             # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
             logger.warning("[WARNING] Cannot access .env file: %s", error)
             return False  # Treat as unloadable
@@ -149,7 +149,7 @@ class EnvSshConfigLoader:
             self._apply_env_line(raw_line, config)  # Delegated single-line handler
 
     def _apply_env_line(self, raw_line: str, config: dict[str, Any]) -> None:
-        """Parse one raw .env line and apply it to ``config`` if it's a known key."""
+        """Parse one raw .env line and apply it to ``config`` if it is a known key."""
         line = raw_line.strip()  # Drop incidental whitespace
         if not line or line.startswith("#"):  # Skip blanks and comment lines
             return  # Nothing to apply

--- a/src/ssh/runtime/app_runner.py
+++ b/src/ssh/runtime/app_runner.py
@@ -96,7 +96,7 @@ class _ExecutionRequest:  # WHY: private request bundle passed between _execute_
     user: str  # WHY: validated SSH username (already syntactically checked).
     password: str  # WHY: resolved SSH password (env/prompt/none paths converge here).
     commands: list[str]  # WHY: validated command list (already syntactically checked).
-    args: Any  # WHY: argparse Namespace passthrough for port/timeout/max_threads etc.
+    args: Any  # WHY: argparse Namespace passthrough for port/timeout/max_threads and so on
     use_shell: bool  # WHY: resolved shell-mode flag (default-on unless --no-shell).
 
 

--- a/src/ssh/ssh_runner.py
+++ b/src/ssh/ssh_runner.py
@@ -25,7 +25,7 @@ _MAX_TIMEOUT_SEC: int = 3600  # WHY: upper bound (1 hour) for accepted timeout v
 _DEFAULT_PORT: int = 22  # WHY: standard SSH port used everywhere in this module
 _DEFAULT_MAX_THREADS: int = 5  # WHY: default multi-host thread cap used by SSHExecutionConfig
 _MAX_FILENAME_LEN: int = 100  # WHY: cap sanitized filenames to a filesystem-safe length
-_MAX_THREADS_HARD_CAP: int = 50  # WHY: don't let callers request more than 50 SSH worker threads
+_MAX_THREADS_HARD_CAP: int = 50  # WHY: do not let callers request more than 50 SSH worker threads
 _THREADS_PER_HOST_MULTIPLIER: int = 2  # WHY: cap threads at 2x the host count for a sensible default
 _MAX_STDOUT_SAMPLE_CHARS: int = 200  # WHY: only sample the first 200 chars of stdout/stderr into logs
 _DEFAULT_LOGGER_NAME: str = "ssh_runner_v2"  # WHY: named logger asserted by tests and callers
@@ -226,7 +226,7 @@ class EnhancedSSHRunner:
         sanitized = _SANITIZE_PATTERN.sub("_", filename)  # WHY: whitelist alnum/dot/dash/underscore; replace rest
         sanitized = sanitized.strip(".-") or _FALLBACK_SANITIZED  # WHY: drop leading/trailing dots and dashes safely
         sanitized = _apply_length_limit(sanitized)  # WHY: cap filename length to keep filesystem happy
-        if _is_windows_reserved(sanitized):  # WHY: rewrite reserved device names so Windows won't reject them
+        if _is_windows_reserved(sanitized):  # WHY: rewrite reserved device names so Windows will not reject them
             sanitized = f"host_{sanitized}"  # WHY: preserved legacy prefix pattern used by callers/tests
         return sanitized  # WHY: return the finalized filesystem-safe string
 
@@ -320,7 +320,7 @@ class EnhancedSSHRunner:
         """
         if not self.client:  # WHY: bail out with a helpful error if no SSH session is active
             error_msg = "No active SSH connection"  # WHY: exact string checked by tests
-            self.logger.error(error_msg)  # WHY: surface at ERROR since it's a caller misuse
+            self.logger.error(error_msg)  # WHY: surface at ERROR since it is a caller misuse
             return False, "", error_msg  # WHY: legacy tuple shape (success, stdout, stderr)
         try:
             return self._dispatch_execution(command, use_shell, hostname)  # WHY: pure dispatch keeps CC low

--- a/src/ssid_consolidation/_ssid_template_cache.py
+++ b/src/ssid_consolidation/_ssid_template_cache.py
@@ -9,7 +9,7 @@ remains re-exported for the existing test suite.
 
 # WHY: cluster class delegates almost every attribute back to the parent manager
 # via _ClusterBase.__getattr__, so pylint's "too-few-public-methods" and
-# "protected-access" alarms don't fit this proxy pattern. Import-outside-toplevel
+# "protected-access" alarms do not fit this proxy pattern. Import-outside-toplevel
 # is also intentional in sibling clusters to break cycles.
 # pylint: disable=protected-access,import-outside-toplevel,too-few-public-methods
 

--- a/src/ssid_consolidation/_ssid_template_cluster.py
+++ b/src/ssid_consolidation/_ssid_template_cluster.py
@@ -12,7 +12,7 @@ on.
 
 # WHY: the base class delegates unknown attribute access back to the parent
 # manager (which owns all the private state and helpers), so pylint's
-# "too-few-public-methods" and "protected-access" alarms don't apply to this
+# "too-few-public-methods" and "protected-access" alarms do not apply to this
 # proxy pattern.
 # pylint: disable=protected-access,too-few-public-methods
 

--- a/src/ssid_consolidation/_ssid_template_phase1.py
+++ b/src/ssid_consolidation/_ssid_template_phase1.py
@@ -155,7 +155,7 @@ def _classify_ssid_count(
     if ssid_count < _MIN_ELIGIBLE_SSIDS:  # WHY: only-target-SSID is not consolidation-ready
         return True, "1 SSID"  # WHY: reason string surfaces in dashboard summaries
     if ssid_count > _MAX_ELIGIBLE_SSIDS:  # WHY: 3+ SSIDs require manual review
-        return True, "3+ SSIDs"  # WHY: string covers 3,4,5+ so downstream doesn't overspecify
+        return True, "3+ SSIDs"  # WHY: string covers 3,4,5+ so downstream does not overspecify
     return False, ""  # WHY: exactly 2 SSIDs — eligible count
 
 

--- a/src/ssid_consolidation/_ssid_template_phase2.py
+++ b/src/ssid_consolidation/_ssid_template_phase2.py
@@ -9,7 +9,7 @@ budgets while the pure helpers remain re-exported via
 
 The ``_write_single_site_vars`` helper is intentionally *not* moved
 here: it resolves ``mistapi`` at call time and the historical unit
-tests patch ``mistapi`` through the parent module's namespace (e.g.
+tests patch ``mistapi`` through the parent module's namespace (for example
 ``patch.object(ssid_template_consolidation, "mistapi", ...)``), which
 only intercepts calls whose ``__globals__`` binding *is* the parent
 module. Keeping that single helper in the parent preserves those
@@ -63,7 +63,7 @@ def _plan_entries_for_row(
     variable_params: list[str],
     cache: dict[str, Any],
 ) -> list[dict[str, Any]]:  # WHY: extracted to keep _compute_variable_plan CC <= 5
-    """Build every plan entry for a single matrix row (skip vs. proposal)."""
+    """Build every plan entry for a single matrix row (skip versus proposal)."""
     if row.get("psk_detected") or row.get("anomaly"):  # WHY: PSK/anomaly rows always skipped
         return [_build_skip_entry(row, param) for param in variable_params]  # WHY: one skip per param
     site_vars = _get_cached_site_vars(cache, row.get("site_id", ""))  # WHY: current per-site vars
@@ -130,7 +130,7 @@ def _build_variable_entry(
         "variable_name": var_name,  # WHY: fully-qualified var name for API payload
         "proposed_value": proposed,  # WHY: value to write on the site
         "current_value": current,  # WHY: preserved for audit / conflict display
-        "status": status,  # WHY: drives write vs. skip vs. conflict paths
+        "status": status,  # WHY: drives write versus skip versus conflict paths
         "reason": reason,  # WHY: user-visible explanation of the status
         "timestamp": "",  # WHY: populated at write time only
     }

--- a/src/ssid_consolidation/_ssid_template_phase3.py
+++ b/src/ssid_consolidation/_ssid_template_phase3.py
@@ -10,7 +10,7 @@ the pure helpers remain re-exported via
 The ``_create_site_group`` and ``_assign_group_sites`` helpers are
 intentionally *not* moved here: they resolve ``mistapi`` at call time
 and the historical unit tests patch ``mistapi`` through the parent
-module's namespace (e.g. ``patch.object(ssid_template_consolidation,
+module's namespace (for example ``patch.object(ssid_template_consolidation,
 "mistapi", ...)``), which only intercepts calls whose ``__globals__``
 binding *is* the parent module. Keeping those two helpers in the parent
 preserves those tests without teaching them about internal module

--- a/src/ssid_consolidation/_ssid_template_phase45.py
+++ b/src/ssid_consolidation/_ssid_template_phase45.py
@@ -21,7 +21,7 @@ The four mistapi-touching helpers (``_create_or_update_single_template``,
 ``_create_new_template``) and ``_disable_single_ssid`` are intentionally
 *not* moved here: they resolve ``mistapi`` at call time and the historical
 unit tests patch ``mistapi`` through the parent module's namespace
-(e.g. ``patch.object(ssid_template_consolidation, "mistapi", ...)``),
+(for example ``patch.object(ssid_template_consolidation, "mistapi", ...)``),
 which only intercepts calls whose ``__globals__`` binding *is* the
 parent module. Keeping those five helpers in the parent preserves those
 tests without teaching them about internal module boundaries.

--- a/src/ssid_consolidation/ssid_template_consolidation.py
+++ b/src/ssid_consolidation/ssid_template_consolidation.py
@@ -283,7 +283,7 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
 
         Python only invokes ``__getattr__`` when normal lookup fails, so
         this method resolves cluster method calls (``self._load_cache``,
-        ``self._save_phase_results``, ``self._offer_resume`` etc.) without
+        ``self._save_phase_results``, ``self._offer_resume`` and so on) without
         explicit delegator wrappers. The class-level ``hasattr`` check on
         ``type(cluster)`` avoids invoking the cluster's own ``__getattr__``
         (which would proxy back to this class and cause infinite recursion
@@ -523,7 +523,7 @@ def _build_success_write_results(entries: list[dict[str, Any]]) -> list[dict[str
     timestamp = datetime.now().isoformat()  # WHY: single ISO timestamp for the batch
     results: list[dict[str, Any]] = []  # WHY: accumulator for the per-entry success rows
     for entry in entries:  # WHY: fan out per-variable success rows
-        entry_copy = dict(entry)  # WHY: don't mutate caller's plan entries
+        entry_copy = dict(entry)  # WHY: do not mutate caller's plan entries
         entry_copy["status"] = "written"  # WHY: sentinel consumed by resume logic
         entry_copy["timestamp"] = timestamp  # WHY: record when the write happened
         results.append(entry_copy)  # WHY: collect the success row
@@ -537,7 +537,7 @@ def _build_failed_write_results(  # WHY: failure rows builder mirrors the succes
     """Build ``status=failed`` result records carrying the error text."""
     results: list[dict[str, Any]] = []  # WHY: accumulator for the per-entry failure rows
     for entry in entries:  # WHY: fan out per-variable failure rows
-        entry_copy = dict(entry)  # WHY: don't mutate caller's plan entries
+        entry_copy = dict(entry)  # WHY: do not mutate caller's plan entries
         entry_copy["status"] = "failed"  # WHY: sentinel consumed by resume + summary logic
         entry_copy["reason"] = str(error)  # WHY: surface stringified error for the report
         results.append(entry_copy)  # WHY: collect the failure row
@@ -590,7 +590,7 @@ def _assign_group_sites(  # WHY: mistapi-touching site-group assigner (parent-ow
     apisession: Any,
 ) -> list[dict[str, Any]]:
     """Assign all sites for a single group."""
-    group_id = group["group_id"]  # WHY: id of the sitegroup we're mutating
+    group_id = group["group_id"]  # WHY: id of the sitegroup we are mutating
     sites_to_assign = _filter_pending_sites(group, group_id, completed_ids)  # WHY: strip pairs already done
     if not sites_to_assign:  # WHY: nothing pending -> skip API call entirely
         return []  # WHY: no rows to append to results
@@ -622,7 +622,7 @@ def _do_assign_group_sites(  # WHY: happy-path branch extracted for complexity r
     """Push merged site_ids and build success result rows (may raise)."""
     group_id = group["group_id"]  # WHY: single source of truth for the sitegroup id
     existing_ids = _get_existing_group_site_ids(cache, group_id)  # WHY: preserve unrelated members
-    new_ids = [  # WHY: subset that isn't already in the group -> triggers the API call
+    new_ids = [  # WHY: subset that is not already in the group -> triggers the API call
         site["site_id"] for site in sites_to_assign if site["site_id"] not in existing_ids
     ]
     _push_group_site_ids(group, existing_ids, new_ids, org_id, apisession)  # WHY: PUT merged set
@@ -824,7 +824,7 @@ def _disable_single_ssid(entry: dict[str, Any], org_id: str, apisession: Any) ->
     """Disable a single SSID in its old template."""
     template_id = entry.get("old_template_id", "")  # WHY: identify template holding the SSID
     ssid_id = entry.get("ssid_id", "")  # WHY: identify the WLAN row to disable
-    result = dict(entry)  # WHY: copy so we don't mutate the input plan entry
+    result = dict(entry)  # WHY: copy so we do not mutate the input plan entry
     try:
         _apply_ssid_disable(result, template_id, ssid_id, org_id, apisession)  # WHY: mutates result in place
     except Exception as error:  # WHY: convert API/network failure into structured record
@@ -856,7 +856,7 @@ def _apply_ssid_disable(
         result["status"] = "disabled"  # WHY: sentinel consumed by resume + summary logic
         result["timestamp"] = datetime.now().isoformat()  # WHY: record when the flip happened
         logging.info("Disabled SSID %s in template %s", ssid_id, template_id)  # WHY: audit-log success
-    else:  # WHY: SSID row not in template -> record skip, don't PUT
+    else:  # WHY: SSID row not in template -> record skip, do not PUT
         result["status"] = "skipped"  # WHY: sentinel consumed by resume + summary logic
         result["reason"] = "SSID not found in template"  # WHY: surface skip reason in the report
 

--- a/src/time/time_utils.py
+++ b/src/time/time_utils.py
@@ -24,7 +24,7 @@ IS_TEST_MODE = "--test" in sys.argv or "--testinteractive" in sys.argv  # WHY: m
 class TimeUtils:
     """Centralized time-related utilities.
 
-    Handles dynamic lookback windows, timestamp conversions, etc.
+    Handles dynamic lookback windows, timestamp conversions, and so on
     """
 
     @staticmethod

--- a/src/troubleshooting/troubleshoot_utils.py
+++ b/src/troubleshooting/troubleshoot_utils.py
@@ -75,7 +75,7 @@ class TroubleshootUtils:  # Marvis troubleshoot delegators.
             #886 slice 17/N migrates ``print()`` to ``logging.warning`` so that
             ruff T20 can stay armed globally. Header + divider are consolidated
             into a single warning record so the banner arrives atomically in
-            handlers that buffer per-record (e.g. remote log shippers).
+            handlers that buffer per-record (for example remote log shippers).
         """
         logging.warning(
             " Starting Marvis (VNA - Virtual Network Assistant) Troubleshooting\n%s\n",

--- a/src/ui/display_utils.py
+++ b/src/ui/display_utils.py
@@ -21,7 +21,7 @@ from src.data.data_processing_utils import (
 class DisplayUtils:
     """Centralized display and output utilities.
 
-    Handles table formatting, pretty printing, etc.
+    Handles table formatting, pretty printing, and so on
     """
 
     @staticmethod

--- a/src/ui/execution/function_executor.py
+++ b/src/ui/execution/function_executor.py
@@ -211,7 +211,7 @@ class FunctionExecutor:  # WHY: extracted from MistHelperTUI to own Live-mode ex
     def _reset_post_execute(self) -> None:
         """Reset transient execution state (preserves 'viewing_results' if set)."""
         tui = self._tui  # Local alias
-        if tui.execution_state != "viewing_results":  # Don't clobber grid mode
+        if tui.execution_state != "viewing_results":  # Do not clobber grid mode
             tui.execution_state = None
         tui.current_function = None  # Drop the function reference
         tui.function_params = {}  # Drop captured params

--- a/src/ui/execution/item_executor.py
+++ b/src/ui/execution/item_executor.py
@@ -129,7 +129,7 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
         logging.exception(_LOG_FAIL, func_name, error)  # WHY: include traceback for triage
 
     def _validated_selection(self) -> dict[str, Any] | None:  # WHY: bounds + type guard
-        """Return the selected item iff it's a function; otherwise ``None``."""
+        """Return the selected item iff it is a function; otherwise ``None``."""
         tui = self._tui  # WHY: local alias
         if not 0 <= tui.current_selection < len(tui.current_items):  # WHY: bounds check
             return None  # WHY: index out of range, not runnable

--- a/src/ui/runtime/level_discoverer.py
+++ b/src/ui/runtime/level_discoverer.py
@@ -75,7 +75,7 @@ class LevelDiscoverer:
             self._append_function_record(item, name)
 
     def _append_module_record(self, item: Any, name: str) -> None:
-        """Append a module record to current_items when it's a mistapi module."""
+        """Append a module record to current_items when it is a mistapi module."""
         if not hasattr(item, "__package__"):  # No package info -> skip
             return
         if "mistapi" not in str(item.__package__):  # Only mistapi modules are listed

--- a/src/ui/runtime/tui_runner.py
+++ b/src/ui/runtime/tui_runner.py
@@ -43,7 +43,7 @@ class TuiRunner:  # WHY: extracted from MistHelperTUI.run (was CC=33)
     def _setup_terminal(self) -> None:  # WHY: enter cbreak so keys read w/o Enter
         """Put the Unix terminal into raw (cbreak) mode for keypress capture."""
         tui = self._tui  # Local alias
-        if tui.IS_WINDOWS:  # Windows uses msvcrt; nothing to set up
+        if tui.IS_WINDOWS:  # Windows uses msvcrt; nothing to prepare
             return  # WHY: no-op on Windows
         tui.old_terminal_settings = tui.termios.tcgetattr(sys.stdin)  # Save current termios for restore
         tui.tty.setcbreak(sys.stdin.fileno())  # Enter cbreak mode

--- a/src/utils/address_utils.py
+++ b/src/utils/address_utils.py
@@ -308,7 +308,7 @@ class AddressUtils:
         normalized = normalized.casefold().strip()  # WHY: casefold beats lower() for i18n text
         normalized = re.sub(r"\s+", " ", normalized)  # WHY: collapse repeated whitespace
         for full_form, abbrev in _ADDRESS_ABBREVIATIONS.items():  # WHY: canonicalize suffix words
-            normalized = re.sub(full_form, abbrev, normalized)  # WHY: turn "street" -> "st" etc.
+            normalized = re.sub(full_form, abbrev, normalized)  # WHY: turn "street" -> "st" and so on
         normalized = re.sub(r"[^\w\s]", " ", normalized)  # WHY: drop punctuation before token compare
         normalized = " ".join(normalized.split())  # WHY: re-collapse whitespace introduced by punct strip
         return normalized  # WHY: fully-normalized address string ready for similarity
@@ -528,7 +528,7 @@ def _extract_address_components(
     parts: list[str],
 ) -> dict[str, str | None]:
     """Extract country, zip, state, city, address from comma-split parts."""
-    remaining = list(parts)  # WHY: shallow copy so peeling doesn't mutate caller data
+    remaining = list(parts)  # WHY: shallow copy so peeling does not mutate caller data
     country = _detect_country(remaining)  # WHY: right-to-left peel starts with country
     remaining = _peel_last(remaining, country)  # WHY: drop country token when detected
     zip_code, country = _detect_zip(remaining, country)  # WHY: ZIP may imply country when absent
@@ -617,7 +617,7 @@ def _state_literal(last: str) -> str | None:
 def _normalize_multipart_state(last: str, parts: list[str]) -> str | None:
     """Normalize a full-name state token only when there are multiple parts."""
     if len(parts) <= 1:  # WHY: single-part input is more likely a city than a state
-        return None  # WHY: avoid mislabeling "California" as state when it's the only token
+        return None  # WHY: avoid mislabeling "California" as state when it is the only token
     normalized = AddressUtils._normalize_state(last)  # WHY: map full name to abbreviation
     return normalized.upper() if normalized else None  # WHY: canonical uppercase abbr
 
@@ -677,7 +677,7 @@ def _check_partial_skip(
         if debug:  # WHY: trace partial-match skips when debugging
             logging.debug("ADDRESS_SKIP: Partial match - %s", comp.address)
         return True, skip.reason  # WHY: sufficient match -> skip with the entry's reason
-    return False, ""  # WHY: match count didn't clear the sufficiency bar
+    return False, ""  # WHY: match count did not clear the sufficiency bar
 
 
 def _check_parse_status(
@@ -935,7 +935,7 @@ class NominatimValidator:
                 timeout=timeout,
                 verify=verify_ssl,
             )
-        except Exception:  # WHY: catch-all so a bad response doesn't kill validation
+        except Exception:  # WHY: catch-all so a bad response does not kill validation
             if attempt < self.MAX_RETRIES:  # WHY: sleep only when another attempt remains
                 time.sleep(self.RETRY_DELAY)  # WHY: fixed back-off between attempts
             return None  # WHY: signal caller to retry or terminate
@@ -1012,7 +1012,7 @@ class NominatimValidator:
     ) -> float:
         """Calculate overall confidence score for geocode result."""
         importance = float(result.get("importance", 0.0))  # WHY: Nominatim's own importance score
-        if importance > 0.01:  # WHY: trust importance when it's non-trivial
+        if importance > 0.01:  # WHY: trust importance when it is non-trivial
             return min(1.0, importance * 2.0)  # WHY: scale + cap at 1.0
         display_name = result.get("display_name", "")  # WHY: cache to shorten next call
         component = self._calculate_component_match(address_parts, display_name, source)  # WHY: fallback match
@@ -1096,7 +1096,7 @@ class NominatimValidator:
         ref_dup: bool,
     ) -> tuple[str | None, str | None]:
         """Apply duplicate disqualification rules."""
-        if mist_dup and ref_dup:  # WHY: both duplicated -> can't pick a winner
+        if mist_dup and ref_dup:  # WHY: both duplicated -> cannot pick a winner
             return "uncertain", "Both addresses are duplicates"
         if mist_dup:  # WHY: mist alone duplicated -> ref wins by default
             return "comparison", "Mist address is duplicate"

--- a/src/utils/environment_utils.py
+++ b/src/utils/environment_utils.py
@@ -17,7 +17,7 @@ import os  # WHY: environment variable + filesystem probes for container detecti
 class EnvironmentUtils:
     """Centralized environment detection utilities.
 
-    Handles container detection, runtime environment identification, etc.
+    Handles container detection, runtime environment identification, and so on
     """
 
     # Constants for container detection

--- a/src/utils/input_utils.py
+++ b/src/utils/input_utils.py
@@ -99,7 +99,7 @@ class InputUtils:
             on a raw ``print()``, which #886 Phase 2 (T20) is retiring in
             favour of logger calls across ``src/``.
         """
-        logging.warning(  # WARNING surfaces on the operator terminal under the default root-logger level.
+        logging.warning(  # Uses warning level so it surfaces on the operator terminal.
             "[EOF] Input stream closed during %s. Using default value: '%s'",
             context,
             default_value,

--- a/src/utils/logger_utils.py
+++ b/src/utils/logger_utils.py
@@ -28,7 +28,7 @@ def redact_secret(value: str) -> str:
     never reaches the log handler.
 
     Args:
-        value: The sensitive string to redact (e.g. a password or API token).
+        value: The sensitive string to redact (for example a password or API token).
 
     Returns:
         The canonical redaction placeholder string.
@@ -38,7 +38,7 @@ def redact_secret(value: str) -> str:
         logging.debug("Using credential: %s", redact_secret(password))
         # → "Using credential: ***REDACTED***"
     """
-    _ = value  # Accept the value so callers don't need to gate on None; discard it
+    _ = value  # Accept the value so callers do not need to gate on None; discard it
     return REDACTED_PLACEHOLDER  # Return placeholder instead of the real value
 
 
@@ -49,7 +49,7 @@ def redact_if_sensitive(key: str, value: str) -> str:
     are not, without having to enumerate every sensitive field name.
 
     Args:
-        key:   The config/dict key name (e.g. "password", "username", "host").
+        key:   The config/dict key name (for example "password", "username", "host").
         value: The value associated with that key.
 
     Returns:
@@ -71,7 +71,7 @@ class SensitiveFilter(logging.Filter):
 
     Install on a handler to provide a defence-in-depth layer: even if a
     caller accidentally logs a raw password, this filter replaces it before
-    the message reaches the handler's output (file, console, syslog, etc.).
+    the message reaches the handler's output (file, console, syslog, and so on).
 
     Usage::
 

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -287,7 +287,7 @@ class OperationRegistry:
         # ------------------------------------------------------------------
         # Feature 1020 (safe --test clean run): explicit classification of the
         # 60 previously-unregistered menu_actions keys. Each category was
-        # decided from the handler's real read-only vs. state-changing
+        # decided from the handler's real read-only versus state-changing
         # behavior (see research.md R1). Read-only exporters are "safe";
         # heavy sweeps are "resource_intensive"; write/create operations are
         # "destructive"; ticket viewing prompts for a selection so it is

--- a/src/utils/subprocess_runner.py
+++ b/src/utils/subprocess_runner.py
@@ -6,7 +6,7 @@ rather than scattered across every call site. Every MistHelper.py subprocess
 invocation routes through :class:`SubprocessRunner.run`, which enforces:
 
 * An explicit allow-list of executables (``uv``/``uv.exe`` or the current
-  interpreter, i.e. ``sys.executable``).
+  interpreter, that is ``sys.executable``).
 * A conservative allow-list for each argv element (alphanumeric plus
   ``-_./:=``), rejecting shell metacharacters up-front.
 * A positive, finite timeout on every invocation.
@@ -98,7 +98,7 @@ class SubprocessRunner:
             # Explicit keyword arguments make Bandit's B603 review trivial: shell is not set,
             # capture_output/text are pinned, and the timeout is validated above.
             result = subprocess.run(  # nosec B603  # Audited: argv validated, no shell, capture pinned.
-                list(argv),  # Copy to a plain list so callers can't mutate the sequence mid-flight.
+                list(argv),  # Copy to a plain list so callers cannot mutate the sequence mid-flight.
                 capture_output=True,  # Always capture stdout/stderr for callers that inspect them.
                 text=True,  # Always decode as text; every existing call site expected str output.
                 timeout=timeout,  # Bound the child so a hung process cannot stall MistHelper startup.
@@ -144,12 +144,12 @@ class SubprocessRunner:
             raise ValueError("timeout must be a positive finite number")  # bool would satisfy int otherwise.
         if not math.isfinite(float(timeout)):  # NaN and +/-inf are never valid deadlines.
             raise ValueError("timeout must be a positive finite number")  # Fail closed rather than pass to subprocess.
-        if timeout <= 0:  # Zero and negative timeouts trip subprocess.run behaviour we don't want.
+        if timeout <= 0:  # Zero and negative timeouts trip subprocess.run behaviour we do not want.
             raise ValueError("timeout must be a positive finite number")  # Callers must specify a real deadline.
 
 
 __all__ = [
-    "CalledProcessError",  # Re-exported so callers don't import subprocess directly.
+    "CalledProcessError",  # Re-exported so callers do not import subprocess directly.
     "SubprocessError",  # Base class re-export.
     "SubprocessRunner",  # Primary dispatch helper.
     "TimeoutExpired",  # Timeout exception re-export.

--- a/src/utils/zscaler_catalogue.py
+++ b/src/utils/zscaler_catalogue.py
@@ -104,7 +104,7 @@ def _promote_host_entry(entry: str | dict[str, Any]) -> dict[str, Any]:
         # Already v3 (or newer): pass through untouched so re-promotion is a
         # no-op (idempotency required for round-trip write-then-load tests).
         return entry
-    # Defensive: unexpected shape (e.g. int, None). Wrap into a stringified
+    # Defensive: unexpected shape (for example int, None). Wrap into a stringified
     # host so downstream code never blows up on malformed cache entries.
     return {"host": str(entry)}
 
@@ -667,7 +667,7 @@ def fetch_cloud(cloud: str, *, timeout: float = _FETCH_TIMEOUT) -> dict[str, Any
         without special-casing per-cloud errors.
 
     Args:
-        cloud: One of the canonical Zscaler cloud slugs (e.g. ``zscaler.net``).
+        cloud: One of the canonical Zscaler cloud slugs (for example ``zscaler.net``).
         timeout: Wall-clock timeout for the HTTPS GET in seconds.
 
     Returns:
@@ -717,7 +717,7 @@ def _strip_prefix(key: str, prefix: str) -> str:
 
     Args:
         key: Raw key from the CENR JSON (may or may not have the prefix).
-        prefix: The label prefix to strip (e.g. ``"continent"`` or ``"city"``);
+        prefix: The label prefix to strip (for example ``"continent"`` or ``"city"``);
             the tool appends ``" : "`` internally.
 
     Returns:
@@ -743,7 +743,7 @@ def _cloud_root_trees(cloud: str, doc: dict[str, Any]) -> list[dict[str, Any]]:
         not a continent tree.
 
     Args:
-        cloud: Cloud slug (e.g. ``"zscloud"``).
+        cloud: Cloud slug (for example ``"zscloud"``).
         doc: Parsed CENR JSON dict for this cloud.
 
     Returns:
@@ -885,7 +885,7 @@ def _absorb_city_records(
         this function itself under the gate as well.
 
     Args:
-        city: Prefix-stripped city name (e.g. ``"Amsterdam"``).
+        city: Prefix-stripped city name (for example ``"Amsterdam"``).
         records: Raw record list from the city bucket.
         cloud: Cloud slug that supplied these records (recorded under
             ``seen_in_clouds`` on the slot).
@@ -1029,7 +1029,7 @@ def _atomic_write_json(path: Path, doc: dict[str, Any]) -> None:
             handle.write("\n")
         os.replace(tmp_name, path)
     except Exception:
-        # Best-effort cleanup on failure so we don't leak temp files.
+        # Best-effort cleanup on failure so we do not leak temp files.
         try:
             os.unlink(tmp_name)
         except OSError:
@@ -1087,7 +1087,7 @@ def refresh_cenr(cenr_path: Path) -> tuple[dict[str, Any], list[str]]:
         Tuple of ``(new_cenr, warnings)``. ``new_cenr`` is the freshly
         merged and rewritten dict on success, or the untouched stale dict on
         total-failure. ``warnings`` collects non-fatal issues (per-cloud
-        fetch failures, unmapped cities from the metadata attach step, etc.)
+        fetch failures, unmapped cities from the metadata attach step, and so on)
         for the caller to log.
     """
     warnings: list[str] = []

--- a/src/utils/zscaler_probe.py
+++ b/src/utils/zscaler_probe.py
@@ -103,7 +103,7 @@ class ProbeResult:
         tls_error (str | None): Formatted TLS error text; only populated on
             handshake failure.
         responding_protocols (list[str]): Compact list of protocols we
-            confirmed live (e.g. ``["ICMP", "TCP/443", "HTTPS"]``); used by
+            confirmed live (for example ``["ICMP", "TCP/443", "HTTPS"]``); used by
             the log summary.
         server_class (str): Category inferred from FQDN + headers + cert
             issuer.
@@ -305,7 +305,7 @@ def _udp_check(host: str, port: int, timeout: float) -> str:
     except TimeoutError:
         state = "no_reply"  # silent-drop firewall / route missing / peer offline
     except OSError as exc:
-        state = f"error:{type(exc).__name__}"  # e.g. PermissionError, NetworkUnreachable
+        state = f"error:{type(exc).__name__}"  # for example PermissionError, NetworkUnreachable
     logger.debug("zscaler_probe: udp_check result host=%s port=%d state=%s", host, port, state)
     return state
 

--- a/src/wan_vpn_builder.py
+++ b/src/wan_vpn_builder.py
@@ -155,7 +155,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         assignments: list[dict[str, Any]],
     ) -> None:
         """Create the VPN and, on success, offer to update device profiles."""
-        created_vpn = self._create_vpn(vpn_body)  # WHY: API call isolated so errors don't cascade.
+        created_vpn = self._create_vpn(vpn_body)  # WHY: API call isolated so errors do not cascade.
         if created_vpn is None:  # WHY: creation failed -> do not attempt profile updates.
             return  # WHY: caller already saw an error message from _create_vpn.
         vpn_id = created_vpn.get("id", "")  # WHY: id is required for downstream vpn_paths refs.
@@ -346,7 +346,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             vpns: list[Any] = mistapi.get_all(response=response, mist_session=self.apisession)  # WHY: paginate.
             logging.debug("Fetched %d org VPNs", len(vpns))  # WHY: %s style logging per project rule.
             return vpns  # WHY: caller uses for display + uniqueness check.
-        except Exception:  # WHY: keep the workflow going even if the VPN list can't be fetched.
+        except Exception:  # WHY: keep the workflow going even if the VPN list cannot be fetched.
             logging.exception("Failed to fetch org VPNs")  # WHY: preserve traceback for operator log review.
             logging.error(
                 "! Error retrieving VPN definitions. Check API connectivity."
@@ -415,7 +415,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             wan_list, lan_list = self._classify_interfaces(port_config)  # WHY: reuse classifier here too.
             wan_count = len(wan_list)  # WHY: displayed for operator context.
             lan_count = len(lan_list)  # WHY: displayed for operator context.
-            warning = " (!) No WAN interfaces" if wan_count == 0 else ""  # WHY: flag profiles that can't be hub.
+            warning = " (!) No WAN interfaces" if wan_count == 0 else ""  # WHY: flag profiles that cannot be hub.
             logging.warning(
                 "  %-4d %-30s %4d %4d%s", index, name, wan_count, lan_count, warning
             )  # WHY: aligned row output.
@@ -491,7 +491,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     @staticmethod
     def _classify_name(name: str, lower_names: set[str]) -> str:  # WHY: pure classifier for the prompt loop.
         """Return one of: 'cancel', 'empty', 'duplicate', 'ok'."""
-        if name.lower() == CANCEL_TOKEN:  # WHY: sentinel is checked before empty so 'q' isn't seen as blank.
+        if name.lower() == CANCEL_TOKEN:  # WHY: sentinel is checked before empty so 'q' is not seen as blank.
             return "cancel"  # WHY: caller aborts on this outcome.
         if not name:  # WHY: blank input after strip means the operator hit Enter with nothing.
             return "empty"  # WHY: caller re-prompts with an "empty" message.
@@ -549,7 +549,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     @staticmethod
     def _has_any_active(assignments: list[dict[str, Any]]) -> bool:  # WHY: quick check before building a VPN.
         """Return True if at least one assignment is not the skip role."""
-        return any(a["role"] != ROLE_SKIP for a in assignments)  # WHY: skip-only sets can't form a VPN.
+        return any(a["role"] != ROLE_SKIP for a in assignments)  # WHY: skip-only sets cannot form a VPN.
 
     def _handle_all_skipped(  # WHY: offers a retry loop when the operator skipped everything.
         self, profiles: list[Any]
@@ -720,7 +720,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         assignments: list[dict[str, Any]],
     ) -> None:
         """Offer to update each profile's port_config with vpn_paths."""
-        _ = vpn_id  # WHY: preserved in signature for API stability even though the body doesn't use it.
+        _ = vpn_id  # WHY: preserved in signature for API stability even though the body does not use it.
         non_skip = [a for a in assignments if a["role"] != ROLE_SKIP]  # WHY: skips are never linked to the VPN.
         if not non_skip:  # WHY: nothing to update -> return silently.
             return  # WHY: no active assignments means no profile mutation.
@@ -741,7 +741,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             .strip()
             .lower()
         )
-        if choice != RETRY_YES:  # WHY: default (N) is safer -- don't mutate profiles unless explicitly asked.
+        if choice != RETRY_YES:  # WHY: default (N) is safer -- do not mutate profiles unless explicitly asked.
             logging.warning("  Skipping profile updates.")  # WHY: operator-visible confirmation of the skip.
             return False  # WHY: caller returns without touching profiles.
         return True  # WHY: explicit y -> proceed with the profile-update loop.

--- a/src/websocket/commands.py
+++ b/src/websocket/commands.py
@@ -74,7 +74,7 @@ class MacTableCommand:  # WHY: Namespace grouping the show_mac_table workflow he
         if websocket_manager is None:  # WHY: Guard clause — no WS means RPC/response phases must be skipped.
             return None  # WHY: Connect failure already logged inside helper; nothing to display.
 
-        session_id = MacTableCommand._trigger_rpc(  # WHY: Kick off REST RPC that produces the WS session id.
+        session_id = MacTableCommand._trigger_rpc(  # WHY: Start REST RPC that produces the WS session id.
             deps, websocket_manager, site_id, device_id, debug_mode
         )
         if session_id is None:  # WHY: Guard clause — RPC helper already disconnected WS on failure.
@@ -193,7 +193,7 @@ class MacTableCommand:  # WHY: Namespace grouping the show_mac_table workflow he
         if response.status_code != 200:
             print(f"! Failed to issue show MAC table command: {response.status_code}")  # WHY: Legacy error.
             print(f"! Response: {response.text}")  # WHY: Legacy error body echo for operator diagnosis.
-            websocket_manager.disconnect()  # WHY: Free WS socket since we won't await a result.
+            websocket_manager.disconnect()  # WHY: Free WS socket since we will not await a result.
             return None  # WHY: Signal failure to orchestrator.
         response_data = response.json()  # WHY: Parse JSON envelope returning the session correlation id.
         session_id = response_data.get("session")  # WHY: Extract Mist-assigned session id used to demux WS messages.
@@ -245,7 +245,7 @@ class MacTableCommand:  # WHY: Namespace grouping the show_mac_table workflow he
         print("=" * 60)  # WHY: Legacy separator line.
 
         raw_output = mac_table_result.get("raw", "")  # WHY: Primary documented output channel for show_mac_table.
-        output_fields = mac_table_result.get("Output", "")  # WHY: Secondary capitalized field for some firmware revs.
+        output_fields = mac_table_result.get("Output", "")  # WHY: Secondary capitalized field for firmware revisions.
 
         MacTableCommand._render_primary_output(raw_output, output_fields)  # WHY: Print well-known output channels.
         MacTableCommand._render_extra_fields(mac_table_result)  # WHY: Print any unexpected extra fields.


### PR DESCRIPTION
## Summary

Phase 1 of the `src/` Simplified Technical English (STE) cleanup (feature 1030).
This removes all mechanical STE violations from `src/` comments and docstrings.
It changes no code behavior. Every edit stays in a comment or a docstring.

Part of #1687. See the SpecKit workflow at `specs/1030-ste-src-cleanup/`.

## What changed

The STE linter grades comments and docstrings. The scan of `src/` (356 files)
found 309 mechanical violations across 128 files. This pull request fixes all of
them.

| Rule | Count | Fix |
| - | - | - |
| STE-S9-LATIN | 167 | e.g. to for example, etc. to and so on, vs. to versus, i.e. to that is |
| STE-S4-CONTRACTION | 117 | do not, cannot, does not, it is, and so on |
| STE-S9-PHRASAL | 9 | start, prepare, stop |
| STE-S7-WARNING | 10 | Reword so the comment does not lead with the signal word |
| STE-S6-PARA | 4 | Convert numbered docstring lists to dash bullets |
| STE-S9-GENDER | 2 | Remove the gendered pronoun |

After this change, all six mechanical rules report zero violations across `src/`.

## Why the numbered lists became dash bullets

The paragraph rule counts a numbered marker such as `1.` as a sentence boundary.
A seven-item numbered list reads as seven sentences and trips the six-sentence
limit. Dash bullets with a trailing period keep each item as one short sentence
and stay within the limit.

## Scope and safety

- Comments and docstrings only. No code line changed.
- Out of scope (false positives on code words, left unchanged): STE-S1-WORD,
  STE-S1-POS, STE-S2-NOUNCLUSTER.
- Every touched code line keeps its inline comment.

## Verification

All gates run from the worktree with the project virtual environment:

- `ruff check .` -> All checks passed
- `black --check .` -> 967 files unchanged
- `mypy src/` -> Success, no issues in 329 source files
- `radon cc src/ -n C` -> no blocks over the threshold
- STE mechanical re-scan -> 0 violations
- `pytest tests/unit` -> 8851 passed

### Known flaky test (not caused by this change)

`test_regression_runtime_under_budget` failed locally on wall-clock time only
(`exit_code == 0`, the subset passed; elapsed 8.9 s against a 5.0 s budget). It
is a self-spawning meta-test that runs a nested `pytest.main()` of eight nodes.
The budget assumes an idle reference machine. The local machine was busy with
the STE scans. The diff of that file is 100 percent comments and docstrings, so
it cannot affect runtime. The test passes on an idle CI runner.

## Conformance

- [x] Links to the Spec Issue (#1687)
- [x] Comments and docstrings only, no code behavior change
- [x] No secrets added or logged
- [x] Ruff, Black, mypy, radon pass
- [x] Unit tests pass (one known flaky timing test noted above)
