### PR TITLE
docs(1030): Phase 2 split prose semicolons in src/ comments and docstrings

### DIFF
--- a/src/analytics/data_collection_manager.py
+++ b/src/analytics/data_collection_manager.py
@@ -35,11 +35,11 @@ class DataCollectionManager:
     @staticmethod
     def _print_continuous_loop_banner() -> None:  # Print startup banner.
         """Print the startup banner for menu 76's continuous collection loop."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(" Starting continuous data collection loop...")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("   This will collect core organizational data every 5 seconds")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("   Press CTRL+C to stop or create 'stop_loop.txt' file")
 
     @staticmethod
@@ -51,19 +51,19 @@ class DataCollectionManager:
         try:
             while True:  # Loop until stopped.
                 loop_count += 1  # Count the iteration.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.info("\n  Loop iteration %d - %s", loop_count, datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
                 if DataCollectionManager._check_stop_signal():  # Stop requested.
                     break  # Exit the loop.
                 DataCollectionManager._execute_collection_cycle(loop_count)  # Run one cycle.
         except KeyboardInterrupt:  # User pressed Ctrl+C.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("\n  Continuous data collection loop stopped by user.")
         except Exception as e:  # Unexpected failure.
             logging.error("Fatal error in continuous loop: %s", e)  # Log the error.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Fatal error in continuous loop: %s", e)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(" Continuous data collection loop ended.")
 
     @staticmethod
@@ -89,19 +89,19 @@ class DataCollectionManager:
         """Execute one cycle of data collection with rate limiting."""
         try:
             for banner, step_callable in DataCollectionManager._collection_cycle_steps():
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.info(banner)
                 step_callable()  # Invoke the per-step exporter.
                 time.sleep(0.75)  # Pace the API between exporters.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  Loop %d completed successfully", loop_count)
         except KeyboardInterrupt:  # Propagate Ctrl+C.
             raise  # Re-raise to outer handler
         except Exception as e:  # Cycle failed.
             logging.error("Error in collection cycle %s: %s", loop_count, e)  # Log the error.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("  Error in loop %d: %s", loop_count, e)
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("  Continuing to next iteration...")
             time.sleep(5)  # Back off then retry.
 
@@ -171,7 +171,7 @@ class DataCollectionManager:
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of CacheUtils.
         site_data = data_sources["site_data"]  # Read the site data.
 
-        for site_id in site_data:  # Walk sites; values are looked up per-site as needed.
+        for site_id in site_data:  # Walk sites. Values are looked up per-site as needed.
             # Skip sites without alarms or events
             has_alarms = bool(data_sources["alarms_data"].get(site_id))  # Has alarms?
             has_events = bool(data_sources["events_data"].get(site_id))  # Has events?

--- a/src/analytics/insight_metrics_utils.py
+++ b/src/analytics/insight_metrics_utils.py
@@ -35,7 +35,7 @@ class InsightMetricsUtils:  # Insight-metrics helpers.
         Refreshes data/ConstInsightMetrics.csv so scope-filtering helpers can read it.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConstDefinitionsExporter + apisession.
-        # WHY: Preserve user-facing banner; emit via logging for structured output.
+        # WHY: Preserve user-facing banner. Emit via logging for structured output.
         logging.info("Export Available Insight Metrics:")
         # WHY: Preserve user-facing note verbatim.
         logging.info("! Note: This function now uses the dynamic comprehensive const export system")
@@ -51,7 +51,7 @@ class InsightMetricsUtils:  # Insight-metrics helpers.
             # WHY: Preserve user-facing success message verbatim.
             logging.info("! ConstInsightMetrics.csv is available in the dynamic export results")
         else:
-            # WHY: Preserve user-facing warning verbatim; semantic level is warning.
+            # WHY: Preserve user-facing warning verbatim. Semantic level is warning.
             logging.warning("! Warning: ConstInsightMetrics.csv was not created during dynamic export")
 
     @staticmethod
@@ -248,7 +248,7 @@ class InsightMetricsUtils:  # Insight-metrics helpers.
 
     @staticmethod
     def _parse_results_key(key: str) -> tuple[str, str] | None:
-        """Split a 'results_<index>_<field>' key into (index, field); return None if pattern fails."""
+        """Split a 'results_<index>_<field>' key into (index, field). Return None if pattern fails."""
         if not (key.startswith("results_") and "_" in key):  # Only results_* keys are valid here.
             return None  # Reject non-matching keys.
         parts = key.split("_", 2)  # Split into at most 3 parts: ['results', index, field].

--- a/src/analytics/site_analytics_configurator.py
+++ b/src/analytics/site_analytics_configurator.py
@@ -512,7 +512,7 @@ class SiteAnalyticsConfigurator:  # WHY: static namespace collecting configurato
         """Apply standard configuration to a single site."""  # WHY: orchestrate GET + mutate + PUT for one site.
         site_id = site["site_id"]  # WHY: primary key needed for both API calls.
         site_name = site["site_name"]  # WHY: display label for log lines.
-        result: dict[str, Any] = {  # WHY: seed result with PENDING status; helpers mutate as needed.
+        result: dict[str, Any] = {  # WHY: seed result with PENDING status. Helpers mutate as needed.
             "site_id": site_id,
             "site_name": site_name,
             "status": "PENDING",

--- a/src/analytics/site_inventory_health_analyzer.py
+++ b/src/analytics/site_inventory_health_analyzer.py
@@ -53,12 +53,12 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
         SiteInventoryHealthAnalyzer._print_header()  # WHY: banner + start log
         org_id = deps.get_org_id_fn()  # WHY: resolve current org id from harness state
         if not org_id:  # WHY: bail early when no org is selected
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No organization selected. Exiting.")
             return  # WHY: nothing to analyze without an org
         site_inventory, site_lookup = SiteInventoryHealthAnalyzer._collect_inventory(org_id, deps)  # WHY: fetch+group
         if site_inventory is None:  # WHY: fetch failed → abort with user-facing hint
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Failed to fetch required data. Please verify API access.")
             return  # WHY: cannot proceed without inventory
         missing_report = SiteInventoryHealthAnalyzer._find_sites_missing_infrastructure(  # WHY: gap analysis
@@ -74,9 +74,9 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
     @staticmethod
     def _print_header() -> None:  # WHY: extracted header block keeps analyze under length cap
         """Emit banner and start log."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Site Inventory Health Analyzer:")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", "=" * 60)
         logging.info("Starting site inventory health analysis...")  # WHY: audit trail entry
 
@@ -98,12 +98,12 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
     @staticmethod
     def _fetch_sites(org_id: str, deps: SiteInventoryHealthAnalyzerDeps) -> list[dict[str, Any]]:  # WHY: sites list
         """Fetch all sites in the organization."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Fetching sites...")
         logging.info("Fetching all organization sites...")  # WHY: pre-action log
         try:
             sites = deps.all_sites_fn(org_id)  # WHY: injected fetcher for testability
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  Found %d sites", len(sites))
             return sites  # WHY: hand off list to caller for grouping
         except Exception as error:  # noqa: BLE001 - Mist SDK raises bare Exception subclasses
@@ -113,7 +113,7 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
     @staticmethod
     def _fetch_devices(org_id: str, deps: SiteInventoryHealthAnalyzerDeps) -> list[dict[str, Any]]:  # WHY: devices
         """Fetch all devices (inventory) in the organization."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Fetching device inventory...")
         logging.info("Fetching all organization devices from inventory...")  # WHY: pre-action log
         try:
@@ -138,7 +138,7 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
                 counts[device_type] += 1  # WHY: increment matched-type slot
             if device.get("connected") is True:  # WHY: connected counter independent of type
                 counts["connected"] += 1
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "  Found %d devices: %d APs, %d switches, %d gateways (%d connected)",
             len(devices),
@@ -312,23 +312,23 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
         missing_report: list[dict[str, Any]], offline_report: list[dict[str, Any]]
     ) -> None:
         """Display analysis results to console."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", "=" * 60)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("ANALYSIS RESULTS")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", "=" * 60)
         SiteInventoryHealthAnalyzer._display_missing_section(missing_report)  # WHY: missing block
         SiteInventoryHealthAnalyzer._display_offline_section(offline_report)  # WHY: offline block
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", "=" * 60)
 
     @staticmethod
     def _display_missing_section(missing_report: list[dict[str, Any]]) -> None:  # WHY: missing console block
         """Console block for sites missing switch/gateway infrastructure."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n[SITES MISSING INFRASTRUCTURE]")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Sites with APs but missing switch/gateway: %d", len(missing_report))
         if not missing_report:  # WHY: nothing more to render when report is empty
             return
@@ -340,18 +340,18 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
         """Print aggregate counts of missing switches and gateways."""
         missing_switches = sum(1 for r in missing_report if "switch" in r["missing_types"])  # WHY: switch tally
         missing_gateways = sum(1 for r in missing_report if "gateway" in r["missing_types"])  # WHY: gateway tally
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("    - Missing switches: %d", missing_switches)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("    - Missing gateways: %d", missing_gateways)
 
     @staticmethod
     def _print_missing_samples(missing_report: list[dict[str, Any]]) -> None:  # WHY: bounded preview helper
         """Print sample preview lines from the missing-infrastructure report."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  Sample sites (first 5):")
         for site in missing_report[:_PREVIEW_LIMIT]:  # WHY: bounded preview
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info(
                 "    - %s: %d APs, missing %s",
                 site["site_name"],
@@ -362,9 +362,9 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
     @staticmethod
     def _display_offline_section(offline_report: list[dict[str, Any]]) -> None:  # WHY: offline console block
         """Console block for sites with offline switch/gateway infrastructure."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n[SITES WITH OFFLINE INFRASTRUCTURE]")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Sites with APs and offline switch/gateway: %d", len(offline_report))
         if not offline_report:  # WHY: nothing more to render when report is empty
             return
@@ -376,20 +376,20 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
         """Print aggregate counts of offline switches and gateways."""
         total_switches = sum(r["offline_switches"] for r in offline_report)  # WHY: switch tally
         total_gateways = sum(r["offline_gateways"] for r in offline_report)  # WHY: gateway tally
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("    - Total offline switches: %d", total_switches)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("    - Total offline gateways: %d", total_gateways)
 
     @staticmethod
     def _print_offline_samples(offline_report: list[dict[str, Any]]) -> None:  # WHY: bounded preview helper
         """Print sample preview lines from the offline-infrastructure report."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  Sample sites (first 5):")
         for site in offline_report[:_PREVIEW_LIMIT]:  # WHY: bounded preview
             label = site["offline_devices"]  # WHY: raw joined label
             suffix = "..." if len(label) > _DETAIL_TRUNC else ""  # WHY: truncate long strings
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info(
                 "    - %s: %d APs, offline: %s%s",
                 site["site_name"],
@@ -431,10 +431,10 @@ class SiteInventoryHealthAnalyzer:  # WHY: namespace for the analyzer entry poin
     ) -> None:
         """Export a single report to CSV or print the empty-message fallback."""
         if not rows:  # WHY: nothing to write → user hint instead
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("%s", spec.empty_message)
             return
         deps.save_data_fn(rows, spec.filename, api_function_name=spec.api_function_name)  # WHY: delegated write
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! %s report exported to %s", spec.label, spec.filename)
         logging.info("Exported %d sites to %s", len(rows), spec.filename)  # WHY: audit trail

--- a/src/analytics/telemetry_emitter.py
+++ b/src/analytics/telemetry_emitter.py
@@ -107,7 +107,7 @@ class TelemetryEmitter:
             exc_val: Exception instance if the ``with`` block raised, else None.
             exc_tb: Traceback if the ``with`` block raised, else None.
         """
-        del exc_type, exc_val, exc_tb  # WHY: protocol params unused; silence vulture without renaming public signature.
+        del exc_type, exc_val, exc_tb  # WHY: protocol params unused. Silence vulture without renaming public signature.
         self.close()
 
     # -- test event helpers ---------------------------------------------------

--- a/src/analytics/zone_analyzer.py
+++ b/src/analytics/zone_analyzer.py
@@ -71,7 +71,7 @@ class ZoneConfigurationAnalyzer:
         logging.info("Starting zone and engagement configuration analysis across all sites...")  # WHY: audit trail
         current_org_id = get_org_id_fn()  # WHY: resolve active org id via injected callback
         if not _validate_org_id(current_org_id):  # WHY: cannot analyze without an org selection
-            return  # WHY: precondition failed; abort
+            return  # WHY: precondition failed. Abort
         collected = _collect_all_data(  # WHY: gather zones + settings from every site
             apisession=apisession,
             org_id=current_org_id or "",
@@ -394,7 +394,7 @@ def _print_analytics_status(occupancy_analysis: dict[str, Any]) -> None:
 
 
 def _validate_org_id(current_org_id: str | None) -> bool:
-    """Return True when ``current_org_id`` is usable; emit abort message otherwise."""
+    """Return True when ``current_org_id`` is usable. Emit abort message otherwise."""
     if current_org_id:  # WHY: any truthy id lets the analyzer proceed
         return True  # WHY: precondition satisfied
     print("! No organization selected. Exiting.")  # WHY: user-friendly abort message
@@ -674,7 +674,7 @@ def _empty_zone_stats(total_sites: int, sites_with_zones: int) -> dict[str, Any]
 
 def _std_dev(zone_counts: list[int], mean: float) -> float:
     """Return population standard deviation (matches legacy variance formula)."""
-    if len(zone_counts) <= 1:  # WHY: variance is undefined for n<=1; legacy returns 0
+    if len(zone_counts) <= 1:  # WHY: variance is undefined for n<=1. Legacy returns 0
         return 0.0  # WHY: preserve prior behavior
     variance = sum((c - mean) ** 2 for c in zone_counts) / len(zone_counts)  # WHY: population variance
     return variance**0.5  # WHY: sqrt of variance is std dev
@@ -1137,7 +1137,7 @@ def _normalize_analyses(
     """Accept either the bundled ``analyses`` dict or the legacy positional triple.
 
     Legacy callers passed (zone_analysis, engagement_analysis, occupancy_analysis)
-    as separate arguments; the analyses parameter takes precedence when supplied
+    as separate arguments. The analyses parameter takes precedence when supplied
     as a dict shaped like ``{"zones": {...}, "engagement": {...}, "occupancy": {...}}``.
     """
     if _looks_like_bundle(analyses):  # WHY: bundle path is the modern convention

--- a/src/api/api_core_fetch_utils.py
+++ b/src/api/api_core_fetch_utils.py
@@ -38,7 +38,7 @@ class APICoreFetchUtils:  # Low-level Mist API fetch helpers.
         Returns:
             List of site dictionaries
 
-        SECURITY: Read-only; no sensitive data logged.
+        SECURITY: Read-only. No sensitive data logged.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + DEFAULT_API_PAGE_LIMIT.
         response = mistapi.api.v1.orgs.sites.listOrgSites(mh.apisession, org_id, limit=mh.DEFAULT_API_PAGE_LIMIT)
@@ -54,7 +54,7 @@ class APICoreFetchUtils:  # Low-level Mist API fetch helpers.
         Returns:
             List of inventory dictionaries (includes all VC physical members)
 
-        SECURITY: Read-only; no secrets in inventory object fields.
+        SECURITY: Read-only. No secrets in inventory object fields.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + DEFAULT_API_PAGE_LIMIT.
         response = mistapi.api.v1.orgs.inventory.getOrgInventory(
@@ -66,4 +66,4 @@ class APICoreFetchUtils:  # Low-level Mist API fetch helpers.
     def get_api_response_data(response: Any) -> Any:
         """Return a mistapi response's .data payload, or the response itself when .data is absent."""
         logging.debug("Unwrapping API response payload (type=%s)", type(response).__name__)  # Trace unwrap calls
-        return getattr(response, "data", response)  # mistapi carries parsed JSON on .data; fall back to the raw object
+        return getattr(response, "data", response)  # mistapi carries parsed JSON on .data. Fall back to the raw object

--- a/src/api/api_data_fetcher.py
+++ b/src/api/api_data_fetcher.py
@@ -249,7 +249,7 @@ class APIDataFetcher:
 
     def _handle_api_exception(self, error: Exception) -> None:  # Handle a fetch exception.
         """Handle exceptions during API data retrieval."""
-        # WHY (#886 Phase 2): retired duplicate print(); the logging.error calls below already
+        # WHY (#886 Phase 2): retired duplicate print(). The logging.error calls below already
         # surface the failure via the ERROR-level default handler.
         logging.error("Exception occurred during API data retrieval: %s", error)  # log exception.
         logging.error("Exception type: %s", type(error).__name__)  # log type.

--- a/src/api/api_fetch_utils.py
+++ b/src/api/api_fetch_utils.py
@@ -37,7 +37,7 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def organization_services() -> list[dict[str, Any]]:  # Fetch and flatten org services.
-        """Fetch all org-level services via the Mist API; return list of service dicts (empty on error).
+        """Fetch all org-level services via the Mist API. Return list of service dicts (empty on error).
 
         SECURITY: Read-only operation fetching configuration data only.
         """
@@ -80,7 +80,7 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def _fetch_single_site_setting(apisession, site):
-        """Fetch one site's settings; tag with id/name; return dict or None on failure."""
+        """Fetch one site's settings. Tag with id/name. Return dict or None on failure."""
         site_id = site.get("id")  # Target site id
         site_name = site.get("name", "Unnamed Site")  # Friendly site label
         try:
@@ -95,8 +95,8 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def all_site_settings(apisession, org_id, limit=1000):  # Fetch settings for every site.
-        """Fetch per-site settings for every site in the org; limit param is unused (kept for back-compat)."""
-        del limit  # Kept in signature for back-compat; explicitly discard so linters do not flag it.
+        """Fetch per-site settings for every site in the org. Limit param is unused (kept for back-compat)."""
+        del limit  # Kept in signature for back-compat. Explicitly discard so linters do not flag it.
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of APICoreFetchUtils + ConfigUtils.
         logging.info("Fetching all site settings...")  # Log before fetching sites
         sites = mh.APICoreFetchUtils.all_sites_with_limit(org_id)  # List all sites first
@@ -112,9 +112,9 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def _gw_load_inventory(apisession, org_id):
-        """Fetch the org inventory; return the device list, or None when the fetch fails."""
+        """Fetch the org inventory. Return the device list, or None when the fetch fails."""
         logging.info("Fetching org inventory to find gateway devices...")  # Log before the inventory fetch.
-        try:  # The inventory fetch is the one hard dependency; isolate its failure.
+        try:  # The inventory fetch is the one hard dependency. Isolate its failure.
             response = mistapi.api.v1.orgs.inventory.getOrgInventory(apisession, org_id, limit=1000)  # Fetch inventory.
             return mistapi.get_all(response=response, mist_session=apisession)  # Page through all devices.
         except Exception as error:  # Inventory fetch failed.
@@ -123,8 +123,8 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def _gw_load_site_names():
-        """Load the site id -> name map from SiteList.csv; return an empty map when the file is unavailable."""
-        try:  # The site-name CSV is optional enrichment; missing file is non-fatal.
+        """Load the site id -> name map from SiteList.csv. Return an empty map when the file is unavailable."""
+        try:  # The site-name CSV is optional enrichment. Missing file is non-fatal.
             mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FilePathUtils.
             site_list_path = mh.FilePathUtils.get_csv_path("SiteList.csv")  # Locate the site list CSV.
             with open(site_list_path, encoding="utf-8") as file_handle:  # Read site names from CSV.
@@ -139,7 +139,7 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
         """Build (site_id, device_id, site_name) work items for each gateway device in the inventory."""
         work_items = []  # Accumulate one tuple per gateway needing a config fetch.
         for device in inventory:  # Scan every inventory device.
-            if device.get("type") != "gateway":  # Only gateways need configs; skip everything else.
+            if device.get("type") != "gateway":  # Only gateways need configs. Skip everything else.
                 continue  # Move to the next device.
             site_id = device.get("site_id")  # Owning site id.
             device_id = device.get("id")  # Device id.
@@ -150,7 +150,7 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def _gw_fetch_one_config(apisession, work_item, connection_semaphore):
-        """Fetch one gateway device's config (site-tagged); return the config dict, or None on empty/failure."""
+        """Fetch one gateway device's config (site-tagged). Return the config dict, or None on empty/failure."""
         work_site_id, work_device_id, work_site_name = work_item  # Unpack the work item.
         with connection_semaphore:  # Limit concurrent connections via the pool semaphore.
             try:  # Isolate per-device failures so one bad device does not abort the batch.
@@ -172,7 +172,7 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def _gw_retry_one_item(apisession, failed_work_item, connection_semaphore, max_retries):
-        """Retry one failed gateway config fetch up to max_retries with backoff; return the config or None."""
+        """Retry one failed gateway config fetch up to max_retries with backoff. Return the config or None."""
         _, failed_device_id, _ = failed_work_item  # Only the device id is needed here (for logging).
         for attempt in range(max_retries + 1):  # Bounded retry loop (initial try plus retries).
             result = APIFetchUtils._gw_fetch_one_config(apisession, failed_work_item, connection_semaphore)  # Try.
@@ -195,7 +195,7 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def _gw_retry_configs(apisession, failed_items, connection_semaphore):
-        """Retry failed gateway config fetches with bounded exponential backoff; return the recovered configs."""
+        """Retry failed gateway config fetches with bounded exponential backoff. Return the recovered configs."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FastModeSequentialMaxRetries.
         max_retries = mh.FastModeSequentialMaxRetries.VALUE  # Configurable retry count from extracted class attribute.
         retry_results = []  # Collect configs recovered on retry.
@@ -209,19 +209,19 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
 
     @staticmethod
     def _gw_collect_fast(apisession, work_items):
-        """Fetch gateway configs concurrently through the connection pool with retry; return the successes."""
+        """Fetch gateway configs concurrently through the connection pool with retry. Return the successes."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConnectionPoolExecutor.
-        successful_results, _ = mh.ConnectionPoolExecutor.execute(  # Pooled concurrent fetch; discard failures.
+        successful_results, _ = mh.ConnectionPoolExecutor.execute(  # Pooled concurrent fetch. Discard failures.
             work_items=work_items,
             worker_function=functools.partial(APIFetchUtils._gw_fetch_one_config, apisession),  # Bind apisession.
             batch_description="gateway device configs",
             retry_function=functools.partial(APIFetchUtils._gw_retry_configs, apisession),  # Bind apisession.
         )
-        return successful_results  # The pool already retried failures; return the successes.
+        return successful_results  # The pool already retried failures. Return the successes.
 
     @staticmethod
     def _gw_collect_sequential(apisession, work_items):
-        """Fetch each gateway config sequentially using a serializing semaphore; return the collected configs."""
+        """Fetch each gateway config sequentially using a serializing semaphore. Return the collected configs."""
         all_device_configs = []  # Accumulate sequential results.
         dummy_semaphore = threading.Semaphore(1)  # Serialize sequential fetches with a single permit.
         for work_item in tqdm(work_items, desc="Fetching Configs", unit="device"):  # type: ignore[no-untyped-call]
@@ -235,11 +235,11 @@ class APIFetchUtils:  # Higher-level org/site fetchers.
         """Fetch configuration details for all gateway devices in the org inventory.
 
         When ``fast`` is True the per-device fetches run concurrently through the
-        connection pool (with retry); otherwise they run sequentially. Returns a list
+        connection pool (with retry). Otherwise they run sequentially. Returns a list
         of site-tagged device configuration dicts (empty when the inventory fetch fails).
         ``max_workers`` is accepted for call-site compatibility.
         """
-        del max_workers  # Kept in signature for call-site compatibility; explicitly discard so linters do not flag it.
+        del max_workers  # Kept in signature for call-site compatibility. Explicitly discard so linters do not flag it.
         inventory = APIFetchUtils._gw_load_inventory(apisession, org_id)  # Fetch the org inventory (None on failure).
         if inventory is None:  # The inventory fetch failed outright.
             return []  # Degrade to an empty list.

--- a/src/api/tenant_fetch.py
+++ b/src/api/tenant_fetch.py
@@ -30,7 +30,7 @@ def _add_valid_name(target: set[str], value: Any) -> None:  # Reusable single-va
 
 def _add_valid_names(target: set[str], values: Iterable[Any]) -> None:  # Bulk variant over any iterable
     """Add every non-empty string from ``values`` into ``target`` (dict keys, lists, sets)."""
-    for value in values:  # Iterate any iterable; caller passes dict keys, lists, or generators
+    for value in values:  # Iterate any iterable. Caller passes dict keys, lists, or generators
         _add_valid_name(target, value)  # Delegate per-item validity to keep logic single-sourced
 
 
@@ -151,7 +151,7 @@ class APITenantFetchUtils:  # Public class re-exported to MistHelper.py via the 
 
     # ------------------------------------------------------------------
     # Private helpers -- kept @staticmethod because none touch instance
-    # state; several are called from other @staticmethods via the class.
+    # state. Several are called from other @staticmethods via the class.
     # ------------------------------------------------------------------
 
     @staticmethod

--- a/src/audit/_renderer_delta.py
+++ b/src/audit/_renderer_delta.py
@@ -94,10 +94,10 @@ def diff_key(
     """Diff one key's values, dispatching on type."""
     if isinstance(ctx.val_b, dict) and isinstance(ctx.val_a, dict):  # WHY: recurse into nested dicts
         diff_key_dict(ctx.key, ctx.val_b, ctx.val_a, delta_b, delta_a)  # WHY: dict branch delegates to nested walker
-        return  # WHY: consumed by nested walker; skip remaining dispatch
+        return  # WHY: consumed by nested walker. Skip remaining dispatch
     if isinstance(ctx.val_b, list) and isinstance(ctx.val_a, list):  # WHY: recurse into nested lists
         diff_key_list(ctx.key, ctx.val_b, ctx.val_a, delta_b, delta_a)  # WHY: identity-aware list walker
-        return  # WHY: consumed by list walker; skip remaining dispatch
+        return  # WHY: consumed by list walker. Skip remaining dispatch
     _emit_scalar_delta(ctx, delta_b, delta_a)  # WHY: mixed/scalar path emits raw values
 
 
@@ -105,7 +105,7 @@ def _emit_scalar_delta(
     ctx: DiffKeyContext,
     delta_b: dict[str, Any],
     delta_a: dict[str, Any],
-) -> None:  # WHY: side effects only; writes into caller-owned dicts
+) -> None:  # WHY: side effects only. Writes into caller-owned dicts
     """Emit scalar or mixed-type value into the delta dicts."""
     if ctx.in_before:  # WHY: preserve explicit None distinct from absent
         delta_b[ctx.key] = ctx.val_b  # WHY: record before-side value even if None
@@ -168,7 +168,7 @@ def element_identity(element: dict[str, Any]) -> str | None:  # WHY: exported fo
     return None  # WHY: caller treats missing identity as anonymous element
 
 
-def build_identity_map(  # WHY: exported for tests; splits list into id-keyed + positional groups
+def build_identity_map(  # WHY: exported for tests. Splits list into id-keyed + positional groups
     elements: list[dict[str, Any]],
 ) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
     """Split ``elements`` into identified and anonymous groups."""
@@ -176,14 +176,14 @@ def build_identity_map(  # WHY: exported for tests; splits list into id-keyed + 
     anon: list[dict[str, Any]] = []  # WHY: collect unidentifiable elements for positional diff
     for elem in elements:  # WHY: single-pass classification keeps CC low
         eid = element_identity(elem)  # WHY: try each identity candidate in priority order
-        if eid and eid not in id_map:  # WHY: first occurrence wins; duplicates fall through to anon
+        if eid and eid not in id_map:  # WHY: first occurrence wins. Duplicates fall through to anon
             id_map[eid] = elem  # WHY: record identity-keyed element for O(1) later lookup
         else:
             anon.append(elem)  # WHY: unidentifiable/duplicate falls to positional diff bucket
     return id_map, anon  # WHY: caller uses tuple to drive identified + anon diff passes
 
 
-def diff_identified(  # WHY: exported for tests; runs identity-matched pair diff loop
+def diff_identified(  # WHY: exported for tests. Runs identity-matched pair diff loop
     before_map: dict[str, dict[str, Any]],
     after_map: dict[str, dict[str, Any]],
     delta_b: list[dict[str, Any]],
@@ -208,7 +208,7 @@ def _apply_identity_pair(  # WHY: single-pair delta dispatcher keeps diff_identi
         return  # WHY: skip unchanged pairs to keep delta minimal
     if item_b is not None and item_a is not None:  # WHY: both present -> recurse to find sub-delta
         _append_pair_delta(item_b, item_a, delta_b, delta_a)  # WHY: matched pair delegated to nested walker
-        return  # WHY: pair path consumed; skip single-side branch
+        return  # WHY: pair path consumed. Skip single-side branch
     _apply_single_side(item_b, item_a, delta_b, delta_a)  # WHY: exactly one side present branch
 
 

--- a/src/audit/_renderer_format.py
+++ b/src/audit/_renderer_format.py
@@ -19,8 +19,8 @@ class _DictItemCtx:
 
     key: object  # WHY: dict key to be JSON-quoted then HTML-escaped
     val: object  # WHY: dict value that recurses back through format_delta_html
-    idx: int  # WHY: 0-based entry index; drives trailing comma placement
-    total: int  # WHY: total entry count; comparator for last-item check
+    idx: int  # WHY: 0-based entry index. Drives trailing comma placement
+    total: int  # WHY: total entry count. Comparator for last-item check
     inner_pad: str  # WHY: precomputed indentation prefix for this entry
     indent: int  # WHY: recursion depth passed to the child call
 

--- a/src/audit/_renderer_html.py
+++ b/src/audit/_renderer_html.py
@@ -21,7 +21,7 @@ from ._renderer_time import epoch_to_readable  # WHY: shared timestamp formatter
 if TYPE_CHECKING:  # WHY: only imported by type-checkers
     from src.audit.analyzer import AuditAnalysisResult  # WHY: analysis payload type
 
-# WHY: Plotly marker palette; index cycles through admins for stable per-admin coloring
+# WHY: Plotly marker palette. Index cycles through admins for stable per-admin coloring
 _TIMELINE_COLORS: tuple[str, ...] = (  # WHY: module constant so palette is shared across trace builds
     "#00d4ff",
     "#ff6b6b",

--- a/src/audit/_renderer_mermaid.py
+++ b/src/audit/_renderer_mermaid.py
@@ -48,7 +48,7 @@ class _MermaidCluster:  # WHY: private cluster owned by AuditReportRenderer
         analysis: AuditAnalysisResult,
         lines: list[str],
     ) -> int:  # WHY: returns updated node count so parent can respect global cap
-        """Emit per-admin subgraph blocks; return total node count emitted."""
+        """Emit per-admin subgraph blocks. Return total node count emitted."""
         node_count = 0  # WHY: shared counter respects MERMAID_NODE_CAP across admins
         for timeline in analysis.admin_timelines:  # WHY: one subgraph per admin
             node_count = self._render_one_admin_subgraph(timeline, node_count, lines)  # WHY: accumulate emitted nodes
@@ -97,7 +97,7 @@ class _MermaidCluster:  # WHY: private cluster owned by AuditReportRenderer
         self,
         analysis: AuditAnalysisResult,
         lines: list[str],
-    ) -> None:  # WHY: side effect only; extends the shared lines list
+    ) -> None:  # WHY: side effect only. Extends the shared lines list
         """Append the trailing bulleted summary of per-admin activity."""
         for timeline in analysis.admin_timelines:  # WHY: one bullet per admin
             start = epoch_to_readable(timeline.first_action)  # WHY: shared formatter, module-level import

--- a/src/audit/audit_analysis_ops.py
+++ b/src/audit/audit_analysis_ops.py
@@ -27,7 +27,7 @@ class AuditAnalysisOps:
         """Capture the audit-log time-range input string (test-mode fixed default or interactive prompt)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of IS_TEST_MODE + InputUtils.
         if mh.IS_TEST_MODE:  # Use a fixed time range so --test runs without interactive input.
-            return "7d"  # Default to 7 days in test mode; skips the safe_input prompt.
+            return "7d"  # Default to 7 days in test mode. Skips the safe_input prompt.
         logging.warning(  # Uses warning level so the hint shows by default (#886).
             "Time range examples: 7d, 4w, 3m, 1y, 6w-2w (6 weeks ago to 2 weeks ago)"
         )

--- a/src/audit/time_parser.py
+++ b/src/audit/time_parser.py
@@ -37,7 +37,7 @@ MAX_LOOKBACK_SECONDS = 31536000 * 2  # WHY: 2-year cap keeps audit queries bound
 MIN_DURATION_SECONDS = 60  # WHY: reject sub-minute windows as accidental input
 FUTURE_SKEW_ALLOWANCE = 60  # WHY: tolerate ~1 min of clock skew on end epochs
 
-LEGEND_TEXT = (  # WHY: cached user-facing help block; identical across every call
+LEGEND_TEXT = (  # WHY: cached user-facing help block. Identical across every call
     "\n  Time Range Shortcuts:\n"
     "    2h = 2 hours    3d = 3 days     4w = 4 weeks\n"
     "    6m = 6 months   1y = 1 year\n"

--- a/src/auth/interactive/credential_prompter.py
+++ b/src/auth/interactive/credential_prompter.py
@@ -15,7 +15,7 @@ class CredentialPrompter:
         self.safe_input = safe_input  # Injected EOF-safe input wrapper
 
     def prompt_email(self) -> str | None:
-        """Prompt for an email address; return None on EOF or blank input."""
+        """Prompt for an email address. Return None on EOF or blank input."""
         logging.info("Prompting user for login email")  # Trace prompt start
         try:
             email = self.safe_input("  Email: ", context="interactive_login").strip()  # EOF-safe read
@@ -30,7 +30,7 @@ class CredentialPrompter:
         return email  # Hand back the trimmed email address
 
     def prompt_password(self) -> str | None:
-        """Prompt for a password with masking; return None on EOF, error or blank."""
+        """Prompt for a password with masking. Return None on EOF, error or blank."""
         logging.info("Prompting user for login password (masked)")  # Trace prompt start
         try:
             password = getpass.getpass("  Password: ")  # Masked stdin read via getpass
@@ -49,7 +49,7 @@ class CredentialPrompter:
         return password  # Hand back the raw password for the API session
 
     def prompt_two_factor(self) -> str | None:
-        """Prompt for a 2FA code; return None on EOF or blank input."""
+        """Prompt for a 2FA code. Return None on EOF or blank input."""
         logging.info("Prompting user for 2FA verification code")  # Trace prompt start
         try:
             code = self.safe_input("  Enter 2FA code: ", context="interactive_login").strip()  # EOF-safe read

--- a/src/auth/interactive/login_orchestrator.py
+++ b/src/auth/interactive/login_orchestrator.py
@@ -25,7 +25,7 @@ class LoginOrchestrator:
         self.detect_msp_privileges = detect_msp_privileges  # Post-login MSP detection callback
 
     def execute(self) -> bool:
-        """Run the interactive login workflow; return True on successful login."""
+        """Run the interactive login workflow. Return True on successful login."""
         logging.info("LoginOrchestrator.execute() starting")  # Trace entry for operator timeline
         mistapi_module = self._resolve_mistapi()  # Resolve SDK from state or via fallback import
         if mistapi_module is None:  # Hard failure: SDK is not available
@@ -60,7 +60,7 @@ class LoginOrchestrator:
         return mistapi_fallback  # Hand the SDK reference back to the orchestrator
 
     def _collect_credentials(self) -> tuple[str, str] | None:
-        """Collect (email, password); return None when either prompt fails."""
+        """Collect (email, password). Return None when either prompt fails."""
         prompter = CredentialPrompter(self.safe_input)  # Build the per-call prompt helper
         email = prompter.prompt_email()  # Read and validate the operator email
         if email is None:  # Abort or validation failure
@@ -152,7 +152,7 @@ class LoginOrchestrator:
     def _clear_pre_existing_token(apisession: Any) -> None:
         """Clear any cached SDK API token so email/password login is used."""
         # WHY: extracted so _create_api_session drops from 29 lines to 22 (STRUCT-LENGTH).
-        if not apisession._apitoken:  # No cached token; nothing to clear
+        if not apisession._apitoken:  # No cached token. Nothing to clear
             return  # Fast exit preserves legacy behaviour
         logging.debug(  # Legacy debug log preserved verbatim
             "Clearing API token to force email/password login (had %s token(s))",

--- a/src/bootstrap/dependency_check.py
+++ b/src/bootstrap/dependency_check.py
@@ -11,9 +11,9 @@ from src.bootstrap.package_installer import PackageInstaller  # WHY: UV/pip inst
 _ENV_DISABLE_AUTO_INSTALL = "DISABLE_AUTO_INSTALL"  # WHY: Env var toggling auto-install off
 _ENV_AUTO_UPGRADE_LATEST = "AUTO_UPGRADE_TO_LATEST"  # WHY: Preferred env for latest-version upgrades
 _ENV_AUTO_UPGRADE_DEPS = "AUTO_UPGRADE_DEPENDENCIES"  # WHY: Legacy env fallback for upgrade toggle
-# Feature 1020: explicit opt-in to install into a non-isolated (system) Python; default is fail-closed.
+# Feature 1020: explicit opt-in to install into a non-isolated (system) Python. Default is fail-closed.
 _ENV_ALLOW_SYSTEM_PYTHON_INSTALL = "MISTHELPER_ALLOW_SYSTEM_PYTHON_INSTALL"  # WHY: override for system-Python installs
-_ENV_VIRTUAL_ENV = "VIRTUAL_ENV"  # WHY: set by venv activation; used only to pick the diagnostic message text
+_ENV_VIRTUAL_ENV = "VIRTUAL_ENV"  # WHY: set by venv activation. Used only to pick the diagnostic message text
 
 _FLAG_TRUE = "true"  # WHY: Case-normalized truthy sentinel for env flags
 _FLAG_FALSE = "false"  # WHY: Case-normalized falsy sentinel for env-flag defaults
@@ -81,7 +81,7 @@ class DependencyCheckOrchestrator:  # WHY: Public entry-point object called from
             self.logging_module.debug(_MSG_DISABLED)  # WHY: Debug log so operators can audit skips
             return  # WHY: Nothing more to do when disabled
         if not self._install_permitted_for_interpreter():  # WHY: Feature 1020 - block install into system Python
-            return  # WHY: Diagnostic already logged; never mutate the base interpreter by default
+            return  # WHY: Diagnostic already logged. Never mutate the base interpreter by default
         all_packages = self.parse_requirements_file_fn()  # WHY: Load the required-package list
         if not all_packages:  # WHY: Empty requirements is not an error - just nothing to do
             self.logging_module.warning(_MSG_NO_REQS)  # WHY: Warn so misconfig is visible in logs

--- a/src/bootstrap/package_installer.py
+++ b/src/bootstrap/package_installer.py
@@ -39,7 +39,7 @@ class PackageInstaller:  # WHY: collaborator injecting stdlib modules for testab
             probed = self._probe_uv_command(candidate)  # WHY: try each candidate in priority order
             if probed is not None:  # WHY: return the first working command with its version string
                 return probed  # WHY: short-circuit on the first successful uv candidate
-        return None, None  # WHY: no candidate responded successfully; signal absence to caller
+        return None, None  # WHY: no candidate responded successfully. Signal absence to caller
 
     def install_uv_with_pip(self) -> bool:  # WHY: bootstrap uv when no candidate command was found
         """Install UV using pip in the active Python environment."""
@@ -78,7 +78,7 @@ class PackageInstaller:  # WHY: collaborator injecting stdlib modules for testab
         suffix = _WINDOWS_EXECUTABLE_SUFFIX if self.os_module.name == _WINDOWS_OS_NAME else ""
         candidates: list[list[str]] = [[_UV_EXECUTABLE_NAME]]  # WHY: PATH lookup is fastest and most common
         scripts_dir = sysconfig.get_path("scripts")  # WHY: interpreter's Scripts/bin dir may hold bundled uv
-        if scripts_dir:  # WHY: sysconfig can return None for unusual installs; guard before joining
+        if scripts_dir:  # WHY: sysconfig can return None for unusual installs. Guard before joining
             # WHY: absolute-path probe against interpreter's Scripts directory.
             candidates.append([self.os_module.path.join(scripts_dir, _UV_EXECUTABLE_NAME + suffix)])
         # WHY: virtualenvs place uv beside the python executable, so probe that directory too.
@@ -91,7 +91,7 @@ class PackageInstaller:  # WHY: collaborator injecting stdlib modules for testab
     def _probe_uv_command(self, cmd: list[str]) -> tuple[list[str], str] | None:  # WHY: single-candidate runner
         """Return (cmd, version) if the candidate runs successfully, else None."""
         if not self._candidate_is_runnable(cmd):  # WHY: skip absolute paths that do not exist on disk
-            return None  # WHY: unreachable binary cannot be probed; skip to next candidate
+            return None  # WHY: unreachable binary cannot be probed. Skip to next candidate
         try:  # WHY: subprocess.run may raise FileNotFoundError/OSError/SubprocessError
             result = self.subprocess_module.run(  # WHY: --version is the cheapest way to confirm uv works
                 cmd + [_UV_VERSION_ARG],
@@ -110,7 +110,7 @@ class PackageInstaller:  # WHY: collaborator injecting stdlib modules for testab
         if len(cmd) != 1:  # WHY: only single-arg absolute paths need existence checks
             return True  # WHY: multi-arg commands (for example python -m uv) always attempt to run
         if self.os_module.path.sep not in cmd[0]:  # WHY: bare names rely on PATH resolution, not disk check
-            return True  # WHY: bare executable names are always eligible; PATH resolves them at spawn
+            return True  # WHY: bare executable names are always eligible. PATH resolves them at spawn
         return bool(self.os_module.path.isfile(cmd[0]))  # WHY: skip missing binaries before invoking subprocess
 
     def _build_uv_install_command(  # WHY: uv argv builder shared by install/upgrade paths

--- a/src/bootstrap/uv_runtime.py
+++ b/src/bootstrap/uv_runtime.py
@@ -76,7 +76,7 @@ class UVRuntimeHelper:  # Groups version parsing/comparison helpers under one na
     @staticmethod
     def package_name_from_spec(package_spec: str) -> str:
         """Extract the package name from a versioned package specification."""
-        package_name = package_spec  # Start with the full spec; strip operator tail if any is found.
+        package_name = package_spec  # Start with the full spec. Strip operator tail if any is found.
         for operator in [">=", "<=", "==", "!=", ">", "<"]:  # 2-char operators first to avoid '>' false-match.
             if operator in package_name:  # Spec contains this operator token.
                 package_name = package_name.split(operator, 1)[0]  # Keep only the name portion.

--- a/src/cache/cache_utils.py
+++ b/src/cache/cache_utils.py
@@ -47,7 +47,7 @@ class CacheUtils:
         generate_function: Callable,  # type: ignore[type-arg]
         freshness_minutes: int | None = None,
     ) -> bool:
-        """Return True if file_name's CSV exists and is fresh; otherwise run generate_function.
+        """Return True if file_name's CSV exists and is fresh. Otherwise run generate_function.
 
         freshness_minutes defaults to CSV_FRESHNESS_MINUTES (.env). Returns True when the file is
         fresh or was regenerated successfully, False if regeneration failed.
@@ -89,9 +89,9 @@ class CacheUtils:
 
     @staticmethod
     def _run_csv_generator(generate_function: Callable, file_name: str) -> bool:  # type: ignore[type-arg]  # Run generator
-        """Invoke the generate_function to produce the CSV; return True on success, False on failure."""
+        """Invoke the generate_function to produce the CSV. Return True on success, False on failure."""
         logging.info("* Running %s to generate %s...", generate_function.__name__, file_name)  # Log before generating
-        try:  # The generator may raise; never let that crash the caller
+        try:  # The generator may raise. Never let that crash the caller
             generate_function()  # Produce or refresh the CSV file
             logging.info("! %s generated or refreshed.", file_name)  # Confirm success to operator
             return True  # Generation succeeded
@@ -101,7 +101,7 @@ class CacheUtils:
 
     @staticmethod
     def load_csv_grouped_by_key(filename: str, key: str) -> dict[str, list[dict[str, Any]]]:
-        """Load a CSV into a dict keyed by the named column; value is the list of rows sharing it."""
+        """Load a CSV into a dict keyed by the named column. Value is the list of rows sharing it."""
         logging.info(
             "Loading CSV file '%s' into dictionary keyed by '%s'...", filename, key
         )  # Log before reading the file
@@ -137,9 +137,9 @@ class CacheUtils:
 
     @staticmethod
     def _write_data_rows_to_csv(writer: csv.DictWriter, data: dict[str, list[dict[str, Any]]]) -> int:  # type: ignore[type-arg]
-        """Write every row from every section through writer; return total row count."""
+        """Write every row from every section through writer. Return total row count."""
         row_count = 0  # Tally rows actually written so the caller can log the total
-        for section in data.values():  # Iterate sections in insertion order; keys are unused here
+        for section in data.values():  # Iterate sections in insertion order. Keys are unused here
             for row in section:  # Write each row through the DictWriter
                 writer.writerow(row)  # csv handles encoding/escaping for us
                 row_count += 1  # Increment after a successful write
@@ -237,7 +237,7 @@ class CacheUtils:
 
     @staticmethod
     def _delete_cache_files(data_dir: str, candidates: list[str]) -> tuple[int, int]:  # Delete files, count outcomes
-        """Delete each candidate cache file; return (deleted_count, error_count)."""
+        """Delete each candidate cache file. Return (deleted_count, error_count)."""
         deleted = 0  # Track successful deletions for summary
         errors = 0  # Track failures for summary
         for name in candidates:  # Delete each identified cache file
@@ -258,7 +258,7 @@ class CacheUtils:
     def create_address_parse_failures_csv(
         parse_failures: list[dict[str, Any]], filename: str = "AddressParseFailures.csv"
     ) -> None:
-        """Write address-parse failures to a CSV in data/; safe no-op when list is empty."""
+        """Write address-parse failures to a CSV in data/. Safe no-op when list is empty."""
         if not parse_failures:
             logging.info("No address parsing failures to document.")
             return

--- a/src/capture/_packet_capture_exec.py
+++ b/src/capture/_packet_capture_exec.py
@@ -49,7 +49,7 @@ class PacketCaptureExec:
     def __getattr__(self, name: str) -> Any:
         """Delegate unknown attributes to the wrapped manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(mm, name)  # WHY: transparent proxy to the parent manager
 
@@ -223,7 +223,7 @@ class PacketCaptureExec:
         """Calculate sleep time before next loop iteration."""
         if wait_time > 0:  # WHY: honor an explicit wait first
             return wait_time  # WHY: user asked to wait
-        if loop_duration < 30:  # WHY: fast iteration; nudge to 30s cadence
+        if loop_duration < 30:  # WHY: fast iteration. Nudge to 30s cadence
             return 30 - loop_duration  # WHY: brings total iteration >= 30s
         return 10  # WHY: default backoff for slow iterations
 
@@ -357,7 +357,7 @@ class PacketCaptureExec:
             logging.exception("Exception in _monitor_capture_stream: %s", error)  # WHY: full traceback
 
     def _subscribe_channel(self, channel: str) -> bool:
-        """Ensure WebSocket manager exists, connect, and subscribe; return confirmation."""
+        """Ensure WebSocket manager exists, connect, and subscribe. Return confirmation."""
         if not self.websocket_manager:  # WHY: lazy WebSocket creation
             self._mm.websocket_manager = _pc()._get_websocket_manager()(self.mist_session)  # WHY: instantiate on parent
         if not self.websocket_manager.connected:  # WHY: reuse existing connection when possible
@@ -385,7 +385,7 @@ class PacketCaptureExec:
             return  # WHY: nothing to read
         state = {"count": 0, "start": _pc().time.time()}  # WHY: mutable state shared with helper
         try:  # WHY: catch Ctrl-C to print summary
-            while True:  # WHY: infinite drain; helper returns when capture ends
+            while True:  # WHY: infinite drain. Helper returns when capture ends
                 if self._drain_stream_batch(channel, capture_id, state):  # WHY: batch drain returns True on end
                     return  # WHY: capture ended cleanly
                 _pc().time.sleep(0.1)  # WHY: gentle CPU yield between batches
@@ -394,7 +394,7 @@ class PacketCaptureExec:
             print(f"  Total packets received: {state['count']}")  # WHY: expose summary
 
     def _drain_stream_batch(self, channel: str, capture_id: str, state: dict[str, Any]) -> bool:
-        """Drain one batch of WebSocket messages; return True when the capture end signal is seen."""
+        """Drain one batch of WebSocket messages. Return True when the capture end signal is seen."""
         with self.websocket_manager.results_lock:  # WHY: consistent read of shared results dict
             messages = list(self.websocket_manager.command_results.values())  # WHY: snapshot values
         for msg in messages:  # WHY: iterate snapshot
@@ -405,7 +405,7 @@ class PacketCaptureExec:
             if msg.get("data", {}).get("pcap_dict") is None:  # WHY: Mist end-of-capture sentinel
                 print(f"\n* Capture completed: {state['count']} packets received")  # WHY: user summary
                 return True  # WHY: signal caller to exit outer loop
-        return False  # WHY: batch drained; keep looping
+        return False  # WHY: batch drained. Keep looping
 
     @staticmethod
     def _msg_matches(msg: dict[str, Any], channel: str, capture_id: str) -> bool:

--- a/src/capture/_packet_capture_org.py
+++ b/src/capture/_packet_capture_org.py
@@ -53,7 +53,7 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy so callers see combined API
         """Delegate unknown attributes to the wrapped manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(mm, name)  # WHY: transparent proxy to the parent manager
 
@@ -97,14 +97,14 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
         """Return an ``{id: stats}`` map, best-effort (empty on error)."""
         print("  Fetching MxEdge status information...")  # WHY: cue user before secondary call
         stats_map: dict[str, Any] = {}  # WHY: default-empty so failure still yields a usable value
-        try:  # WHY: stats are advisory; failures must not block capture
+        try:  # WHY: stats are advisory. Failures must not block capture
             stats_response = _pc().mistapi.api.v1.orgs.stats.listOrgMxEdgesStats(  # WHY: org-scope stats endpoint
                 self.mist_session, self.org_id, limit=1000
             )
             stats_data = _pc().mistapi.get_all(response=stats_response, mist_session=self.mist_session)  # WHY: paginate
             for stat in stats_data or []:  # WHY: guard against None response payload
                 mxedge_id = stat.get("id")  # WHY: id keys the map, skip records lacking it
-                if mxedge_id:  # WHY: id is required for the map key; skip records lacking it
+                if mxedge_id:  # WHY: id is required for the map key. Skip records lacking it
                     stats_map[mxedge_id] = stat  # WHY: populate map keyed by mxedge id
         except Exception as error:  # pylint: disable=broad-exception-caught
             logging.warning("Menu #10: Failed to fetch MxEdge stats: %s", error)  # WHY: legacy log line
@@ -146,7 +146,7 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
         return index_to_mxedge  # WHY: hand map to the outer prompt loop
 
     def _prompt_mxedge_index(self, count: int) -> int | None:  # WHY: safe numeric-index prompt with bounds check
-        """Prompt for a numeric MxEdge index; return None on cancel/invalid input."""
+        """Prompt for a numeric MxEdge index. Return None on cancel/invalid input."""
         try:  # WHY: safe_input can raise on EOF/Ctrl-C
             selection_input = (  # WHY: prompt and strip whitespace inline for parse below
                 _lazy_input_utils()
@@ -158,7 +158,7 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
             logging.info("Menu #10: User cancelled MxEdge selection")  # WHY: legacy audit log
             return None  # WHY: signal cancel to caller
         try:  # WHY: int() may raise on non-numeric input
-            idx = int(selection_input)  # WHY: parse index; ValueError caught below
+            idx = int(selection_input)  # WHY: parse index. ValueError caught below
         except ValueError:  # WHY: non-numeric input path warns and returns None
             print("\n! Invalid input format. Please enter a single numeric index.")  # WHY: legacy user error
             logging.warning("Menu #10: Invalid selection input: %s", selection_input)  # WHY: legacy log line
@@ -250,7 +250,7 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
 
     @staticmethod
     def _prompt_port_input(port_list: list[str], mxedge_name: str, mxedge_id: str) -> str | None:  # WHY: safe prompt
-        """Safely prompt for a port index string; None on cancel."""
+        """Safely prompt for a port index string. None on cancel."""
         try:  # WHY: safe_input can raise on EOF/Ctrl-C
             return cast(  # WHY: safe_input->str traverses untyped lazy proxy
                 str,
@@ -270,7 +270,7 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
     def _resolve_port_index(port_list: list[str], port_input: str) -> list[str] | None:  # WHY: legacy index parser
         """Parse a numeric index and return the selected single-port list."""
         try:  # WHY: int() may raise on non-numeric input
-            idx = int(port_input)  # WHY: parse port index; ValueError caught below
+            idx = int(port_input)  # WHY: parse port index. ValueError caught below
         except ValueError:  # WHY: non-numeric input path warns and returns None
             print("\n! Invalid input format. Please enter a single numeric index.")  # WHY: legacy user error
             logging.warning("Menu #10: Invalid port input: %s", port_input)  # WHY: legacy audit log
@@ -301,7 +301,7 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
         return self.select_port_by_index(port_list, mxedge_name, mxedge_id)  # WHY: interactive picker
 
     def _fetch_single_mxedge_stats(self, mxedge_id: str, mxedge_name: str) -> dict[str, Any] | None:
-        """Fetch stats for a single MxEdge; return dict or None on failure."""
+        """Fetch stats for a single MxEdge. Return dict or None on failure."""
         try:  # WHY: SDK may raise on transport errors
             stats_response = _pc().mistapi.api.v1.orgs.stats.getOrgMxEdgeStats(  # WHY: per-mxedge stats endpoint
                 self.mist_session, self.org_id, mxedge_id
@@ -333,7 +333,7 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
 
     @staticmethod
     def _prompt_tzsp_target() -> tuple[str, str | None, int | None] | None:
-        """Prompt for TZSP host + port; return the tzsp tuple or None on invalid."""
+        """Prompt for TZSP host + port. Return the tzsp tuple or None on invalid."""
         tzsp_host = _lazy_input_utils().safe_input("Enter TZSP host (IP address or hostname): ", context="tzsp_host")
         if not tzsp_host:  # WHY: TZSP requires a target host
             print("\n! TZSP host required")
@@ -398,7 +398,7 @@ class PacketCaptureOrg:  # WHY: wraps org/MxEdge capture helpers extracted from 
     ) -> dict[str, Any]:
         """Build the API payload for org-level MxEdge capture."""
         mxedge_id: str = mxedge.get("id", "")  # WHY: default empty preserves legacy behavior
-        capture_format = capture_config["format"]  # WHY: required key; missing = programmer error
+        capture_format = capture_config["format"]  # WHY: required key. Missing = programmer error
         payload: dict[str, Any] = self._base_org_payload(
             mxedge_id, capture_format, capture_config
         )  # WHY: split for length

--- a/src/capture/_packet_capture_prompts.py
+++ b/src/capture/_packet_capture_prompts.py
@@ -76,7 +76,7 @@ class PacketCapturePrompts:
     def __getattr__(self, name: str) -> Any:
         """Delegate unknown attributes to the wrapped manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(mm, name)  # WHY: transparent proxy back to the parent manager
 
@@ -137,7 +137,7 @@ class PacketCapturePrompts:
         )
 
     def _handle_ap_manual_entry(self) -> str | None:
-        """Prompt for manual AP MAC entry and validate; return normalized MAC or None."""
+        """Prompt for manual AP MAC entry and validate. Return normalized MAC or None."""
         ap_mac = _lazy_input_utils().safe_input("Enter AP MAC address: ", context="ap_mac")  # WHY: prompt
         if not self._mm.validate_mac_address(ap_mac):  # WHY: reject malformed MAC before API use
             print(f"\n! Invalid AP MAC address format: {ap_mac}")  # WHY: user-facing error message
@@ -254,7 +254,7 @@ class PacketCapturePrompts:
         return True  # WHY: signal user chose to proceed despite the conflict
 
     def check_existing_ap_capture(self, site_id: str, ap_mac: str) -> bool:
-        """Return True if safe to proceed; False if a conflict caused user cancel."""
+        """Return True if safe to proceed. False if a conflict caused user cancel."""
         print(f"\n> Checking for existing captures on AP {ap_mac}...")  # WHY: user status message
         captures = self._fetch_site_pcaps(site_id)  # WHY: fetch current pcap list
         if captures is None:  # WHY: fetch failed - fail-open to allow capture attempt
@@ -297,7 +297,7 @@ class PacketCapturePrompts:
 
     @staticmethod
     def _handle_multi_ap_conflict(response: Any, error_details: Any) -> bool:
-        """Print conflict message when API rejects due to existing capture; return True if handled."""
+        """Print conflict message when API rejects due to existing capture. Return True if handled."""
         if response.status_code != 400 or not isinstance(error_details, dict):  # WHY: only 400+dict here
             return False  # WHY: caller should print generic failure instead
         detail = error_details.get("detail", "")  # WHY: extract API-provided reason string
@@ -314,7 +314,7 @@ class PacketCapturePrompts:
             capture_id = self._multi_ap_success_summary(response.data, capture_format, duration)  # WHY: log
             self._mm._export_capture_info_to_csv(response.data, "site", site_id)  # WHY: audit CSV export
             self._dispatch_multi_ap_output(site_id, capture_id, capture_format)  # WHY: route by format
-            return  # WHY: success handled; caller does not need further branching
+            return  # WHY: success handled. Caller does not need further branching
         error_details = response.data if hasattr(response, "data") else "Unknown"  # WHY: safe access
         if self._handle_multi_ap_conflict(response, error_details):  # WHY: dedicated conflict path
             return  # WHY: conflict path already logged and messaged

--- a/src/capture/_packet_capture_tcpdump.py
+++ b/src/capture/_packet_capture_tcpdump.py
@@ -161,7 +161,7 @@ class PacketCaptureTcpdump:  # WHY: wraps tcpdump menu helpers extracted from Pa
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy so callers see combined API
         """Delegate unknown attributes to the wrapped manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(mm, name)  # WHY: transparent proxy to the parent manager
 
@@ -169,19 +169,19 @@ class PacketCaptureTcpdump:  # WHY: wraps tcpdump menu helpers extracted from Pa
     def print_tcpdump_menu() -> None:  # WHY: renders the picker header + all filter sections
         """Print the tcpdump filter selection menu using data-driven sections."""
         separator = "=" * 80  # WHY: consistent visual boundary matching original format
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", separator)  # WHY: leading newline improves terminal readability
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(" PACKET FILTER SELECTION (tcpdump expression)")  # WHY: menu title matches prior UX
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", separator)  # WHY: bottom border of the title band
         for header, items in _MENU_SECTIONS:  # WHY: iterate the module-level section table
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n--- %s ---", header)  # WHY: preserves original section header format
             for item in items:  # WHY: render each numbered filter line
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.info("  %s", item)  # WHY: leading spaces match legacy indentation
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", separator)  # WHY: closes the menu block visually
 
     @staticmethod
@@ -207,7 +207,7 @@ class PacketCaptureTcpdump:  # WHY: wraps tcpdump menu helpers extracted from Pa
             return self._announce_expression(_EXPRESSIONS[choice])  # WHY: uniform user feedback
         if choice == "40":  # WHY: sentinel for custom-expression branch
             return self._prompt_custom_expression()  # WHY: isolate custom-entry logic
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("\n! Invalid choice, using no filter")  # WHY: explicit fallback message to user
         return ""  # WHY: safe default when user enters an unknown menu number
 
@@ -215,19 +215,19 @@ class PacketCaptureTcpdump:  # WHY: wraps tcpdump menu helpers extracted from Pa
     def _announce_expression(expr: str) -> str:  # WHY: shared user-feedback branch for happy-path selection
         """Print user feedback for a chosen expression and return it."""
         if expr:  # WHY: distinguish "no filter" from a real expression for UX clarity
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n! Filter applied: %s", expr)  # WHY: confirm to the user which filter is active
         else:  # WHY: explicit branch for "no filter" case
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n! Filter: None (capturing all traffic)")  # WHY: reassure user that no filter is active
         return expr  # WHY: hand the value back to the caller unchanged
 
     @staticmethod
     def _prompt_custom_expression() -> str:  # WHY: isolates free-form input branch from menu-driven path
         """Prompt for and validate a custom tcpdump expression."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nEnter custom tcpdump expression:")  # WHY: guide user into free-form input mode
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Examples: 'host 192.168.1.1', 'net 10.0.0.0/8', 'port 8080'")  # WHY: help user with syntax
         custom_expr = _lazy_input_utils().safe_input(  # WHY: safe wrapper handles Ctrl-C / EOF
             "Expression: ",  # WHY: minimal prompt matches legacy behavior
@@ -235,10 +235,10 @@ class PacketCaptureTcpdump:  # WHY: wraps tcpdump menu helpers extracted from Pa
             allow_empty=True,  # WHY: allow user to cancel by submitting an empty line
         )
         if custom_expr:  # WHY: only echo confirmation when a real expression was supplied
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n! Filter applied: %s", custom_expr)  # WHY: confirm active filter to the user
             return str(custom_expr)  # WHY: coerce to str so return type stays uniform
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n! No filter applied")  # WHY: explicit "no filter" feedback when input was empty
         return ""  # WHY: preserve legacy return type for downstream API calls
 
@@ -253,11 +253,11 @@ class PacketCaptureTcpdump:  # WHY: wraps tcpdump menu helpers extracted from Pa
         Returns:
             The selected format, either ``"pcap"`` or ``"stream"``.
         """
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nCapture format:")  # WHY: header for the two-option selector
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  1. PCAP file - downloadable (default, recommended)")  # WHY: default choice for most users
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  2. Stream to Mist Cloud (WebSocket real-time)")  # WHY: alternate for real-time monitoring
         format_choice = _lazy_input_utils().safe_input(  # WHY: reuse safe wrapper for consistency
             "Enter choice (default 1): ",  # WHY: prompt matches legacy UX

--- a/src/capture/client_pcap_downloader.py
+++ b/src/capture/client_pcap_downloader.py
@@ -115,7 +115,7 @@ class ClientPacketCaptureDownloader:
     def _step1_select_site(self) -> str | None:
         """Prompt for a site via the shared PromptUtils helper."""
         logging.debug("Step 1: prompting for site selection")  # WHY: action-log entry.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n[Step 1/4] Select a site")  # WHY: operator-visible step banner.
         site_id = _get_prompt_utils().select_site_with_logging()  # WHY: shared CSV-driven chooser.
         logging.info("Step 1 selected site_id=%s", site_id)  # WHY: audit selection outcome.
@@ -124,11 +124,11 @@ class ClientPacketCaptureDownloader:
     def _step2_select_client(self, site_id: str) -> str | None:
         """Fetch site wireless clients and let operator pick by index or MAC."""
         logging.debug("Step 2: fetching wireless clients for site %s", site_id)  # WHY: action-log entry.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n[Step 2/4] Select a wireless client")  # WHY: operator-visible step banner.
         clients = self._fetch_wireless_clients(site_id)  # WHY: isolate SDK call for testability.
         if not clients:  # WHY: no clients seen in the query window -> abort.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  No wireless clients found in the last 7 days.")  # WHY: operator feedback.
             logging.warning("Step 2 aborted: no wireless clients for site %s", site_id)  # WHY: audit no-op.
             return None  # WHY: caller treats None as cancel/abort.
@@ -149,7 +149,7 @@ class ClientPacketCaptureDownloader:
             return clients  # WHY: caller renders and prompts.
         except Exception as exc:  # pylint: disable=broad-exception-caught  # WHY: keep menu resilient.
             logging.exception("Failed to fetch wireless clients: %s", exc)  # WHY: capture stack for triage.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("  Error fetching wireless clients: %s", exc)  # WHY: operator-visible feedback.
             return []  # WHY: empty list drives abort path.
 
@@ -157,15 +157,15 @@ class ClientPacketCaptureDownloader:
     def _render_client_table(clients: list[dict[str, Any]]) -> None:
         """Display an index/hostname/MAC/last-seen table to the operator."""
         logging.debug("Rendering %s client rows", len(clients))  # WHY: action-log entry.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  %4s  %-32s  %-17s  Last IP", "#", "Hostname", "MAC")  # WHY: column header.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  %s  %s  %s  %s", "-" * 4, "-" * 32, "-" * 17, "-" * 15)  # WHY: divider row.
         for idx, client in enumerate(clients, start=1):  # WHY: 1-based index matches operator prompt.
             hostname = str(client.get("hostname") or client.get("username") or "-")[:32]  # WHY: truncate wide names.
             mac = str(client.get("mac") or "-")  # WHY: guard missing MAC.
             last_ip = str(client.get("ip") or client.get("last_ip") or "-")  # WHY: helps disambiguate hosts.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %4d  %-32s  %-17s  %s", idx, hostname, mac, last_ip)  # WHY: uniform aligned rendering.
 
     def _prompt_client_choice(self, clients: list[dict[str, Any]]) -> str | None:
@@ -187,14 +187,14 @@ class ClientPacketCaptureDownloader:
                 mac = str(clients[idx - 1].get("mac") or "")  # WHY: pull MAC from selected row.
                 if mac:  # WHY: guard rows without a MAC field.
                     return normalise_mac(mac)  # WHY: normalise before returning to caller.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("  Invalid row number: %s", raw)  # WHY: operator feedback on bad index.
             logging.warning("Step 2 rejected bad index: %s", raw)  # WHY: audit bad input.
             return None  # WHY: cancel path.
-        try:  # WHY: non-numeric input treated as MAC; catch bad format loudly.
+        try:  # WHY: non-numeric input treated as MAC. Catch bad format loudly.
             return normalise_mac(raw)  # WHY: accept any punctuation blend.
         except ValueError as exc:  # WHY: normalise_mac raises on non-12-hex input.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("  %s", exc)  # WHY: operator feedback on bad MAC.
             logging.warning("Step 2 rejected bad MAC: %s", raw)  # WHY: audit bad input.
             return None  # WHY: cancel path.
@@ -202,11 +202,11 @@ class ClientPacketCaptureDownloader:
     def _step3_select_vlan(self, site_id: str, mac: str) -> list[_CaptureRow]:
         """List PCAPs for ``mac`` at ``site_id`` grouped by VLAN and let operator choose."""
         logging.debug("Step 3: listing PCAPs for site %s client %s", site_id, mac)  # WHY: action-log entry.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n[Step 3/4] Select a VLAN for client %s", mac)  # WHY: operator-visible step banner.
         captures = self._fetch_captures(site_id, mac)  # WHY: isolate SDK call for testability.
         if not captures:  # WHY: no PCAPs matched -> abort with feedback.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  No packet captures found for this client in the last 7 days.")  # WHY: feedback.
             logging.warning("Step 3 aborted: no PCAPs for %s at %s", mac, site_id)  # WHY: audit no-op.
             return []  # WHY: empty list signals abort to caller.
@@ -231,7 +231,7 @@ class ClientPacketCaptureDownloader:
             return captures  # WHY: caller normalises/groups.
         except Exception as exc:  # pylint: disable=broad-exception-caught  # WHY: keep menu resilient.
             logging.exception("Failed to fetch PCAPs: %s", exc)  # WHY: capture stack for triage.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("  Error fetching PCAPs: %s", exc)  # WHY: operator-visible feedback.
             return []  # WHY: empty list drives abort path.
 
@@ -252,17 +252,17 @@ class ClientPacketCaptureDownloader:
     def _prompt_vlan_choice(self, grouped: dict[str, list[_CaptureRow]]) -> list[_CaptureRow]:
         """Show one VLAN row per bucket with a count column and return the chosen rows."""
         if not grouped:  # WHY: all captures were URL-less -> nothing to download.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  No completed PCAPs available (all still in progress).")  # WHY: operator feedback.
             logging.warning("Step 3: no VLAN groups had downloadable URLs")  # WHY: audit no-op.
             return []  # WHY: caller aborts flow.
         vlan_ids = sorted(grouped.keys())  # WHY: deterministic ordering for stable operator UX.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  %4s  %-10s  Captures", "#", "VLAN")  # WHY: column header for readability.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  %s  %s  %s", "-" * 4, "-" * 10, "-" * 8)  # WHY: divider separates header/rows.
         for idx, vlan_id in enumerate(vlan_ids, start=1):  # WHY: 1-based index matches prompt.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %4d  %-10s  %d", idx, vlan_id, len(grouped[vlan_id]))  # WHY: show count per bucket.
         raw = _get_input_utils().safe_input(
             "\nEnter row number to download all captures for that VLAN (blank to cancel): ",
@@ -277,13 +277,13 @@ class ClientPacketCaptureDownloader:
             logging.info("Step 3 cancelled by operator (blank input)")  # WHY: audit cancel.
             return []  # WHY: caller treats [] as cancel.
         if not raw.isdigit():  # WHY: only accept numeric row selection here.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("  Invalid row number: %s", raw)  # WHY: operator feedback on non-numeric.
             logging.warning("Step 3 rejected non-numeric: %s", raw)  # WHY: audit bad input.
             return []  # WHY: cancel path.
         idx = int(raw)  # WHY: parse 1-based row number.
         if not 1 <= idx <= len(vlan_ids):  # WHY: bounds-check before dereference.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("  Row number out of range: %s", raw)  # WHY: operator feedback on bad index.
             logging.warning("Step 3 rejected out-of-range: %s", raw)  # WHY: audit bad input.
             return []  # WHY: cancel path.
@@ -296,16 +296,16 @@ class ClientPacketCaptureDownloader:
         vlan_id = rows[0].vlan_id  # WHY: all rows in this call share the same VLAN by construction.
         target = capture_dir(Path("data"), mac, vlan_id)  # WHY: single spec-defined path builder.
         logging.debug("Step 4: creating output dir %s", target)  # WHY: action-log entry.
-        target.mkdir(parents=True, exist_ok=True)  # WHY: idempotent; safe on repeat runs.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        target.mkdir(parents=True, exist_ok=True)  # WHY: idempotent. Safe on repeat runs.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n[Step 4/4] Downloading %d PCAP(s) to %s", len(rows), target)  # WHY: banner.
         succeeded = self._download_all(rows, target)  # WHY: isolate loop for testability.
         logging.info("Step 4 done: %s/%s PCAPs downloaded", succeeded, len(rows))  # WHY: audit result.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  Complete: %d/%d files written to %s", succeeded, len(rows), target)  # WHY: summary.
 
     def _download_all(self, rows: list[_CaptureRow], target: Path) -> int:
-        """Iterate over rows and download each; return the count of successful writes."""
+        """Iterate over rows and download each. Return the count of successful writes."""
         succeeded = 0  # WHY: accumulator for summary line.
         for row in rows:  # WHY: sequential to preserve per-file operator feedback ordering.
             if self._download_one(row, target):  # WHY: bool return keeps accumulator arithmetic simple.
@@ -320,7 +320,7 @@ class ClientPacketCaptureDownloader:
         try:  # WHY: transfer + write must not crash the batch.
             response = requests.get(row.pcap_url, stream=True, timeout=_DEFAULT_TIMEOUT_SEC)  # WHY: stream.
             if response.status_code != _HTTP_OK:  # WHY: guard non-200 responses before write.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.error("    Failed %s: HTTP %s", row.filename, response.status_code)  # WHY: feedback.
                 logging.error("Download failed %s: %s", row.capture_id, response.status_code)  # WHY: audit.
                 return False  # WHY: skip write on failure.
@@ -328,12 +328,12 @@ class ClientPacketCaptureDownloader:
                 for chunk in response.iter_content(chunk_size=_STREAM_CHUNK_BYTES):  # WHY: chunked stream.
                     pcap_file.write(chunk)  # WHY: persist each chunk incrementally.
             size_mb = local_path.stat().st_size / _BYTES_PER_MB  # WHY: compute size for user feedback.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("    Downloaded %s (%.2f MB)", row.filename, size_mb)  # WHY: operator success line.
             logging.info("Downloaded %s: %.2f MB -> %s", row.capture_id, size_mb, local_path)  # WHY: audit.
             return True  # WHY: successful write.
         except Exception as exc:  # pylint: disable=broad-exception-caught  # WHY: keep batch resilient.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("    Error downloading %s: %s", row.filename, exc)  # WHY: operator failure line.
             logging.exception("Download exception for %s: %s", row.capture_id, exc)  # WHY: audit stack.
             return False  # WHY: signal failure to accumulator.

--- a/src/capture/multi_ap_scan_workflow.py
+++ b/src/capture/multi_ap_scan_workflow.py
@@ -162,7 +162,7 @@ class MultiApScanCaptureWorkflow:
         return self._parse_bounded_int(packets_str, spec)  # WHY: Delegate parsing + range validation.
 
     def _parse_bounded_int(self, raw: str, spec: BoundedIntSpec) -> int | None:  # WHY: Shared parse + range check.
-        """Convert raw string to bounded int; emit legacy messages on failure."""
+        """Convert raw string to bounded int. Emit legacy messages on failure."""
         try:
             value = int(raw)  # WHY: Convert textual input to integer for numeric validation.
         except ValueError:
@@ -244,7 +244,7 @@ class MultiApScanCaptureWorkflow:
                 logging.debug("%d capture(s) already in progress or recently completed", len(existing))  # WHY: Log.
 
     def _gather_capture_config(self) -> CaptureConfig | None:  # WHY: Sequence operator prompts and validate output.
-        """Prompt operator for capture parameters; return CaptureConfig or None on abort."""
+        """Prompt operator for capture parameters. Return CaptureConfig or None on abort."""
         band = self._prompt_band()  # WHY: Prompt for band first per legacy flow.
         channel = self._prompt_channel(band)  # WHY: Prompt for channel constrained by band.
         if channel is None:  # WHY: Abort early when channel input is invalid.

--- a/src/capture/org_capture_workflow.py
+++ b/src/capture/org_capture_workflow.py
@@ -30,7 +30,7 @@ class OrgCaptureWorkflow:  # WHY: frozen slotted bundle groups manager binding f
         self._finalize_org_capture(selection, capture_config)  # WHY: build payload + confirm + dispatch
 
     def _collect_org_selection(self) -> tuple[Any, Any, str] | None:  # WHY: unify selection-prompt sequence
-        """Prompt for mxedge, port and tcpdump expression; return None if the user aborts."""
+        """Prompt for mxedge, port and tcpdump expression. Return None if the user aborts."""
         fetched = self.manager._fetch_org_mxedges()  # WHY: retrieve org-scope mxedge inventory + stats
         if fetched is None:  # WHY: fetch failed or org has zero edges available
             return None  # WHY: no edges available or inventory fetch failed -> cancel workflow

--- a/src/capture/org_pcap_wait_download_workflow.py
+++ b/src/capture/org_pcap_wait_download_workflow.py
@@ -37,7 +37,7 @@ class OrgPcapWaitDownloadWorkflow:
 
         def save_callback(
             pcap_url: str, capture_identifier: str, capture_prefix: str
-        ) -> None:  # Callback returns None; return value of save_pcap_file is intentionally discarded.
+        ) -> None:  # Callback returns None. Return value of save_pcap_file is intentionally discarded.
             return download_manager.save_pcap_file(  # Delegate save operation to shared manager.
                 pcap_url,  # Pass resolved download URL from polling results.
                 capture_identifier,  # Pass capture identifier for deterministic output filename.

--- a/src/capture/packet_capture.py
+++ b/src/capture/packet_capture.py
@@ -417,7 +417,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         max_pkt_len = self._prompt_max_packet_length(default=1300)  # WHY: wireless default MTU-friendly length
         if max_pkt_len is None:  # WHY: user cancelled max-length prompt
             return None  # WHY: bail out cleanly
-        return {  # WHY: bundle required params only; extras added by caller
+        return {  # WHY: bundle required params only. Extras added by caller
             "client_mac": client_mac,
             "ap_mac": ap_mac,
             "duration": duration,
@@ -448,7 +448,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         logging.info("Starting site wireless client capture")  # WHY: entry-point audit log
         site_id = _get_prompt_utils().select_site_with_logging()  # WHY: interactive site chooser
         if not site_id:  # WHY: user cancelled site selection
-            return  # WHY: helper logged reason; bail silently
+            return  # WHY: helper logged reason. Bail silently
         self._print_wireless_client_banner()  # WHY: helper owns banner + educate-user prints
         params = self._wireless_client_gather_params(site_id)  # WHY: consolidate all prompts
         if params is None:  # WHY: user cancelled somewhere in the prompts
@@ -555,7 +555,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         validated = self._validate_port_selection(port_selection_result)  # WHY: reuse shared validation
         if validated is None:  # WHY: validation logs its own reason
             return None  # WHY: propagate cancel
-        port_list, _available_ports = validated  # WHY: unpack ports; ignore available list here
+        port_list, _available_ports = validated  # WHY: unpack ports. Ignore available list here
         return gateway_mac, port_list  # WHY: hand consolidated selection back to orchestrator
 
     def _gateway_build_payload(self, gateway_mac: str, port_list: list[str], params: dict[str, Any]) -> dict[str, Any]:
@@ -621,7 +621,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         validated = self._validate_port_selection(port_selection_result)  # WHY: reuse shared validation helper
         if validated is None:  # WHY: validation logs its own reason
             return None  # WHY: propagate cancel to caller
-        port_list, _available_ports = validated  # WHY: unpack ports; ignore available list here
+        port_list, _available_ports = validated  # WHY: unpack ports. Ignore available list here
         return switch_mac, port_list  # WHY: hand consolidated selection back to orchestrator
 
     def _switch_pick_and_normalize(self, site_id: str) -> str | None:
@@ -682,7 +682,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         logging.info("Starting site switch capture")  # WHY: entry-point audit log
         site_id = _get_prompt_utils().select_site_with_logging()  # WHY: interactive site chooser
         if not site_id:  # WHY: user cancelled site selection
-            return  # WHY: bail out silently; helper logs its own reason
+            return  # WHY: bail out silently. Helper logs its own reason
         self._print_switch_banner()  # WHY: banner rendering owned by helper
         selection = self._switch_select_device_and_ports(site_id)  # WHY: gather switch + ports interactively
         if selection is None:  # WHY: helper logged the cancel reason
@@ -741,7 +741,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
 
     def _new_assoc_gather_params(self) -> dict[str, Any] | None:
         """Prompt user for new-association capture parameters."""
-        ssid = _get_input_utils().safe_input(  # WHY: SSID is optional; user may press Enter
+        ssid = _get_input_utils().safe_input(  # WHY: SSID is optional. User may press Enter
             "\nEnter SSID to monitor (optional, press Enter for all): ",
             context="ssid",
             allow_empty=True,
@@ -808,7 +808,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         return {**radio, **counts, "format": capture_format}  # WHY: merge sub-dicts + format into full result
 
     def _gather_scan_radio_core(self, band: str) -> dict[str, Any] | None:
-        """Prompt for channel and bandwidth; return None if cancelled."""
+        """Prompt for channel and bandwidth. Return None if cancelled."""
         channel = self._prompt_scan_channel(band)  # WHY: channel choices depend on band
         if channel is None:  # WHY: user cancelled channel prompt
             return None  # WHY: propagate cancel
@@ -818,7 +818,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         return {"channel": channel, "bandwidth": bandwidth}  # WHY: sub-dict merged upstream
 
     def _gather_scan_counts(self) -> dict[str, Any] | None:
-        """Prompt for duration and packet count; return None if cancelled."""
+        """Prompt for duration and packet count. Return None if cancelled."""
         duration = self._prompt_capture_duration()  # WHY: enforce API minimums via helper
         if duration is None:  # WHY: user cancelled duration prompt
             return None  # WHY: propagate cancel

--- a/src/capture/packet_capture_download.py
+++ b/src/capture/packet_capture_download.py
@@ -287,7 +287,7 @@ class PacketCaptureDownloadManager:
         prefix: str,
         save_pcap_file_fn: Callable[[str, str, str], None] | None,
     ) -> None:
-        """Invoke the save callback once a URL is ready; short-circuit otherwise."""
+        """Invoke the save callback once a URL is ready. Short-circuit otherwise."""
         if not pcap_url:  # WHY: Preserve the early exit when the URL never appears.
             logging.debug(
                 "Polling finished for %s without a downloadable URL", capture_id
@@ -346,7 +346,7 @@ class PacketCaptureDownloadManager:
         return self._report_poll_timeout(capture_id, ctx.start_time)  # WHY: Emit timeout banner and preserve contract.
 
     def _poll_once(self, ctx: _PollContext, poll_attempt: int) -> str | None:
-        """Execute one poll iteration; return the URL or None to keep waiting."""
+        """Execute one poll iteration. Return the URL or None to keep waiting."""
         try:  # WHY: Catch transient poll failures and continue retrying within same wait budget.
             elapsed = int(time.time() - ctx.start_time)  # WHY: Calculate elapsed time for progress and ready messages.
             response = ctx.list_captures_fn()  # WHY: Invoke caller-provided list callback for current attempt.

--- a/src/capture/site_capture_loop.py
+++ b/src/capture/site_capture_loop.py
@@ -25,7 +25,7 @@ class _LoopState:  # WHY: bundle four otherwise-local variables threaded through
     min_interval: int  # WHY: minimum seconds between consecutive capture attempts, sourced from payload
     download_folder: str  # WHY: absolute path where completed pcaps are downloaded each iteration
     iteration: int = 0  # WHY: increment-first counter of loop iterations for user-visible logging
-    last_capture_time: float | None = None  # WHY: epoch of last successful attempt; None on first pass
+    last_capture_time: float | None = None  # WHY: epoch of last successful attempt. None on first pass
 
 
 @dataclass(frozen=True, slots=True)  # WHY: frozen slotted bundle keeps the manager binding immutable
@@ -53,7 +53,7 @@ class SiteCaptureLoopRunner:  # WHY: orchestrator delegating capture steps to a 
         """Execute a single loop iteration: fetch, download, maybe capture, then sleep."""
         state.iteration += 1  # WHY: bump counter first so iteration number is 1-based in logs
         loop_start = time.time()  # WHY: mark iteration start to compute the accurate sleep budget later
-        # WHY: preserve iteration header banner verbatim; route through logger for capture/redirection.
+        # WHY: preserve iteration header banner verbatim. Route through logger for capture/redirection.
         logging.info("\n%s\nLoop Iteration #%s\n%s", _ITER_BANNER, state.iteration, _ITER_BANNER)
         completed = self.manager._fetch_completed_pcaps(site_id, state.iteration)  # WHY: gather ready pcaps
         self.manager._download_manager.download_pending_pcaps(  # WHY: download all currently-ready pcaps
@@ -65,7 +65,7 @@ class SiteCaptureLoopRunner:  # WHY: orchestrator delegating capture steps to a 
         if wait_time == _READY_TO_CAPTURE:  # WHY: zero cooldown means we may attempt a capture this pass
             self._attempt_capture(site_id, payload, state)  # WHY: delegate attempt + timestamp update
         sleep_time = self.manager._calc_loop_sleep(wait_time, time.time() - loop_start)  # WHY: adaptive nap
-        # WHY: preserve iteration close banner + nap notice verbatim; route through logger.
+        # WHY: preserve iteration close banner + nap notice verbatim. Route through logger.
         logging.info("\n%s\nLoop iteration #%s complete", _ITER_BANNER, state.iteration)
         logging.info("Waiting %.0f seconds before next check...\n%s\n", sleep_time, _ITER_BANNER)
         time.sleep(sleep_time)  # WHY: honor cooldown plus remaining sleep budget before next iteration
@@ -80,7 +80,7 @@ class SiteCaptureLoopRunner:  # WHY: orchestrator delegating capture steps to a 
 
     def _handle_user_interrupt(self, iteration: int) -> None:  # WHY: isolate exit-path IO to one helper
         """Print the interrupt banner and notify the manager of graceful loop termination."""
-        # WHY: preserve interrupt banner + iteration count + reassurance line verbatim; route through logger.
+        # WHY: preserve interrupt banner + iteration count + reassurance line verbatim. Route through logger.
         logging.info("\n\n%s\n%s\n%s", _INTERRUPT_BANNER, _LOOP_INTERRUPT_TITLE, _INTERRUPT_BANNER)
         logging.info("  Completed %s loop iteration(s)", iteration)
         logging.info("  All available PCAPs have been downloaded\n  Exiting gracefully...")

--- a/src/capture/site_pcap_wait_download_workflow.py
+++ b/src/capture/site_pcap_wait_download_workflow.py
@@ -37,7 +37,7 @@ class SitePcapWaitDownloadWorkflow:
 
         def save_callback(
             pcap_url: str, capture_identifier: str, capture_prefix: str
-        ) -> None:  # Callback returns None; return value of save_pcap_file is intentionally discarded.
+        ) -> None:  # Callback returns None. Return value of save_pcap_file is intentionally discarded.
             return download_manager.save_pcap_file(  # Delegate save operation to shared manager.
                 pcap_url,  # Pass URL discovered by polling flow for actual file retrieval.
                 capture_identifier,  # Pass capture identifier for deterministic filename generation.

--- a/src/config/config_utils.py
+++ b/src/config/config_utils.py
@@ -35,7 +35,7 @@ from __future__ import annotations  # Enable PEP 604 unions in annotations on 3.
 import logging  # Structured action logging per Constitution VII.
 import os  # Filesystem + environment primitives for .env parsing and stop-signal check.
 import sys  # sys.exit when org selection fails.
-from typing import Any, ClassVar  # ClassVar for cached state; Any for the mistapi session.
+from typing import Any, ClassVar  # ClassVar for cached state. Any for the mistapi session.
 
 import mistapi  # Third-party API SDK used only for interactive org selection.
 
@@ -79,7 +79,7 @@ class ConfigUtils:
 
     @staticmethod
     def _resolve_org_id_from_dotenv() -> str | None:
-        """Parse org_id from a sibling .env file; return the value or None."""
+        """Parse org_id from a sibling .env file. Return the value or None."""
         try:
             with open(".env") as env_file:  # Fall back to the .env file.
                 for line in env_file:  # Scan each line for org_id.

--- a/src/data/data_processing_utils.py
+++ b/src/data/data_processing_utils.py
@@ -25,14 +25,14 @@ from typing import Any  # Broad typing for arbitrary field values.
 class DataProcessingUtils:
     """Centralized data-transformation utilities (canonical home in ``src/data/``).
 
-    All methods are static; the class is a namespace for JSON flattening,
+    All methods are static. The class is a namespace for JSON flattening,
     key normalization, and CSV-safety helpers. ``MistHelper.py`` re-exports
     this class so historical callers keep working without a delegator.
     """
 
     @staticmethod
     def _flatten_list_value(new_key: str, sep: str, v: list[Any]) -> list[tuple[str, Any]]:
-        """Flatten a list value: list-of-dicts gets index keys; scalar lists join as CSV."""
+        """Flatten a list value: list-of-dicts gets index keys. Scalar lists join as CSV."""
         out: list[tuple[str, Any]] = []  # Accumulator for produced pairs.
         if all(isinstance(i, dict) for i in v):  # List of dicts: index each entry.
             for idx, item in enumerate(v):  # Walk list items.
@@ -43,7 +43,7 @@ class DataProcessingUtils:
 
     @staticmethod
     def flatten_dict(d: dict[str, Any], parent_key: str = "", sep: str = "_") -> dict[str, Any]:
-        """Recursively flatten nested dict for CSV/JSON; lists-of-dicts get index keys."""
+        """Recursively flatten nested dict for CSV/JSON. Lists-of-dicts get index keys."""
         items: list[tuple[str, Any]] = []  # Accumulate flattened (key, value) pairs.
         for k, v in d.items():  # Walk every key/value in the input dict.
             k_str = str(k)  # Stringify the key for safe concatenation.
@@ -61,8 +61,8 @@ class DataProcessingUtils:
     def flatten_nested_fields(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Flatten nested fields in a list of dictionaries.
 
-        Attempts to parse stringified dicts/lists; recursively flattens
-        nested dicts and lists of dicts; joins non-dict lists as CSV.
+        Attempts to parse stringified dicts/lists. Recursively flattens
+        nested dicts and lists of dicts. Joins non-dict lists as CSV.
         """
         flattened = []  # Collect flattened rows.
         for entry in data:  # Process each record.
@@ -86,14 +86,14 @@ class DataProcessingUtils:
         """Try to parse a string starting with ``{`` or ``[`` as Python literal or JSON."""
         if not isinstance(value, str):  # Non-string values pass through unchanged.
             return value  # Nothing to parse.
-        if not value.startswith(("{", "[")):  # Not embedded JSON-ish; skip parsing.
+        if not value.startswith(("{", "[")):  # Not embedded JSON-ish. Skip parsing.
             return value  # Return as-is.
         try:
             return ast.literal_eval(value)  # Try Python-literal parse first.
-        except Exception:  # ast.literal_eval failed; try JSON.
+        except Exception:  # ast.literal_eval failed. Try JSON.
             try:
                 return json.loads(value)  # Fall back to JSON parse.
-            except Exception:  # nosec B110 - both parses failed; leave value as string.
+            except Exception:  # nosec B110 - both parses failed. Leave value as string.
                 return value  # Final fallback: original string.
 
     @staticmethod
@@ -138,7 +138,7 @@ class DataProcessingUtils:
     def escape_multiline(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Escape multiline strings for CSV compatibility.
 
-        Joins list values as CSV-separated strings; replaces newline
+        Joins list values as CSV-separated strings. Replaces newline
         characters with escaped versions on string fields.
         """
         for entry in data:  # Process each record.

--- a/src/dataclasses/batch_worker.py
+++ b/src/dataclasses/batch_worker.py
@@ -3,7 +3,7 @@
 The original ``_pool_process_batch_wait_loop`` function in ``MistHelper.py`` took 7
 positional parameters which exceeded the 5-Item Rule's max-5 limit. The 4 fields
 here are the configuration values that stay constant across batch iterations
-(worker function, connection semaphore, thread count, batch description); the
+(worker function, connection semaphore, thread count, batch description). The
 remaining per-batch values (batch payload, batch number, total batches) stay as
 direct parameters because they change every loop iteration.
 
@@ -22,7 +22,7 @@ from typing import Any  # Type alias for the worker callable's payload items.
 class BatchWorkerConfig:
     """Configuration values that stay constant across batches in a thread-pool batch loop."""
 
-    worker_function: Callable[..., Any]  # Callable that processes a single batch item; takes (item, semaphore).
+    worker_function: Callable[..., Any]  # Callable that processes a single batch item. Takes (item, semaphore).
     connection_semaphore: threading.Semaphore  # Bound on concurrent network connections across all batches.
-    max_threads: int  # Upper bound on threads the pool may spawn; passed to ThreadPoolExecutor.
+    max_threads: int  # Upper bound on threads the pool may spawn. Passed to ThreadPoolExecutor.
     batch_description: str  # Human-readable label (for example "devices") used in tqdm + log messages.

--- a/src/dataclasses/family_selection_context.py
+++ b/src/dataclasses/family_selection_context.py
@@ -24,8 +24,8 @@ class FamilySelectionContext:
     output dict as direct parameters, keeping its signature at 3 total params.
     """
 
-    family: str  # Human-readable model-family name (for example "AP43"); used only for log/print output.
+    family: str  # Human-readable model-family name (for example "AP43"). Used only for log/print output.
     models: list[str]  # List of concrete model SKUs that belong to this family.
     sorted_versions: list[str]  # Operator-visible numbered choices, sorted newest-first.
     current_version: str | None  # The version currently configured on this family (None when unset).
-    model_version_map: dict[str, list[Any]]  # Per-model raw API entries; used to validate the selection.
+    model_version_map: dict[str, list[Any]]  # Per-model raw API entries. Used to validate the selection.

--- a/src/dataclasses/map_wizard_deps.py
+++ b/src/dataclasses/map_wizard_deps.py
@@ -45,4 +45,4 @@ class MapWizardSummaryContext:  # Bundle inputs for the summary printer.
 
     map_name: str  # Human-readable map name printed in the summary header.
     backup_file: str  # Path to the JSON backup written before any changes were applied.
-    errors: list[str]  # Accumulated apply-step failures; empty means a clean run.
+    errors: list[str]  # Accumulated apply-step failures. Empty means a clean run.

--- a/src/db/arango_writer.py
+++ b/src/db/arango_writer.py
@@ -3940,7 +3940,7 @@ class ArangoDBWriter:  # WHY: primary writer class for the ArangoDB polyglot bac
         else:
             self._db.create_graph(GRAPH_NAME, edge_definitions=GRAPH_EDGE_DEFINITIONS)  # WHY: create fresh graph
             logger.info("graph_created", name=GRAPH_NAME)  # WHY: audit trail for graph creation
-        self._backfill_snapshot_edges()  # WHY: legacy snapshots may lack edges; fill them in on boot
+        self._backfill_snapshot_edges()  # WHY: legacy snapshots may lack edges. Fill them in on boot
 
     def _refresh_graph_if_stale(self) -> None:  # WHY: extracted helper trims _ensure_graph blocks
         """Recreate the named graph when live edge definitions drift from the expected set."""
@@ -4125,7 +4125,7 @@ class ArangoDBWriter:  # WHY: primary writer class for the ArangoDB polyglot bac
 
     @staticmethod
     def _as_nonempty_list(raw: Any) -> list[Any]:  # WHY: shared normalizer used by edges and stubs
-        """Return raw as a list with falsy entries dropped; empty list when raw is falsy."""
+        """Return raw as a list with falsy entries dropped. Empty list when raw is falsy."""
         if not raw:  # WHY: guard clause propagates a missing/empty value as an empty list
             return []
         values = raw if isinstance(raw, list) else [raw]  # WHY: normalize scalar to list

--- a/src/db/database_schema_utils.py
+++ b/src/db/database_schema_utils.py
@@ -37,7 +37,7 @@ class DatabaseSchemaUtils:  # Build SQLite DDL from data.
 
     @staticmethod
     def determine_api_function_name_from_context() -> str:  # Infer API name from the call stack.
-        """Walk the call stack and return the first frame whose name looks like a Mist API call; else 'unknown'."""
+        """Walk the call stack and return the first frame whose name looks like a Mist API call. Else 'unknown'."""
         frame = inspect.currentframe()  # Start at the current frame.
         try:
             while frame:  # Walk up the stack.
@@ -94,7 +94,7 @@ class DatabaseSchemaUtils:  # Build SQLite DDL from data.
 
     @staticmethod
     def _sanitize_table_name(name: str) -> str:
-        """Sanitize a SQL table name; force a non-digit leading character to keep DDL valid."""
+        """Sanitize a SQL table name. Force a non-digit leading character to keep DDL valid."""
         safe = re.sub(r"[^a-zA-Z0-9_]", "_", name)  # Replace any non-alphanum/underscore with '_'
         if not safe or safe[0].isdigit():  # Empty or digit-led identifier is not valid SQL
             safe = f"table_{safe}"  # Prefix to ensure a valid identifier
@@ -107,7 +107,7 @@ class DatabaseSchemaUtils:  # Build SQLite DDL from data.
 
     @staticmethod
     def _pk_aware_column_defs(fields: list[str], pk_fields: list[str]) -> list[str]:
-        """Return TEXT column-def strings; columns named in pk_fields are flagged NOT NULL."""
+        """Return TEXT column-def strings. Columns named in pk_fields are flagged NOT NULL."""
         defs: list[str] = []  # Collect column definitions in field order
         for field_name in fields:  # Walk each input field name
             safe = DatabaseSchemaUtils._sanitize_column(field_name)  # Sanitize column for SQL safety

--- a/src/db/redis_writer.py
+++ b/src/db/redis_writer.py
@@ -60,11 +60,11 @@ class _ExtractContext:  # WHY: collapse the 5-arg extract signature into one imm
     api_function_name: str  # WHY: prefix component for every emitted TS key.
     primary_keys: list[str]  # WHY: fields excluded from generic numeric scan.
     entity_key_field: str  # WHY: field whose value becomes the entity id in the TS key.
-    ts_value_fields: list[str] | None  # WHY: explicit numeric field allow-list; None means auto-detect.
+    ts_value_fields: list[str] | None  # WHY: explicit numeric field allow-list. None means auto-detect.
 
 
 def _swallow_already_exists(action: Callable[[], Any]) -> None:  # WHY: reused around TS.CREATE / TS.CREATERULE calls.
-    """Run `action`; re-raise any ResponseError that is not a duplicate-key error."""
+    """Run `action`. Re-raise any ResponseError that is not a duplicate-key error."""
     try:
         action()  # WHY: single call site so both create and createrule share the same suppression policy.
     except redis.ResponseError as error:  # WHY: only ResponseError carries the "already exists" text.
@@ -78,7 +78,7 @@ def _module_names(client: Any) -> list[str]:  # WHY: shared between TS and JSON 
     return [_decode_name(m.get("name", b"")) for m in modules]  # WHY: normalize bytes/str variants in one place.
 
 
-def _decode_name(raw: Any) -> str:  # WHY: decode_responses varies with server config; handle both.
+def _decode_name(raw: Any) -> str:  # WHY: decode_responses varies with server config. Handle both.
     """Return a lowercase str name whether the source is bytes or str."""
     if isinstance(raw, str):  # WHY: fast path when decode_responses already yielded a str.
         return raw.lower()
@@ -98,7 +98,7 @@ class RedisTimeSeriesWriter:
         """Initialize Redis TimeSeries connection and verify module."""
         self._log = structlog.get_logger("redis_writer")  # WHY: structured logger scoped to this writer.
         self._preflight_dns(config.redis_host)  # WHY: fail fast with a clear message before opening the socket.
-        self._client = redis.Redis(  # WHY: sync client is fine; writers run in worker threads.
+        self._client = redis.Redis(  # WHY: sync client is fine. Writers run in worker threads.
             host=config.redis_host,
             port=config.redis_port,
             password=config.redis_password or None,  # WHY: pass None (not "") so redis-py skips AUTH.
@@ -174,11 +174,11 @@ class RedisTimeSeriesWriter:
             for future in futures:  # WHY: preserve chunk order for deterministic first-seen mapping.
                 chunk_adds, chunk_keys = future.result()  # WHY: block for chunk completion.
                 all_adds.extend(chunk_adds)  # WHY: append rather than assign to preserve running total.
-                key_records.update(chunk_keys)  # WHY: dict.update is last-write-wins; chunks are disjoint.
+                key_records.update(chunk_keys)  # WHY: dict.update is last-write-wins. Chunks are disjoint.
         self._log.info("extraction_complete", data_points=len(all_adds), unique_keys=len(key_records), workers=workers)
         return all_adds, key_records
 
-    def _extract_chunk(  # WHY: pure worker; safe to call from any thread.
+    def _extract_chunk(  # WHY: pure worker. Safe to call from any thread.
         self,
         records: list[dict[str, Any]],
         ctx: _ExtractContext,
@@ -192,7 +192,7 @@ class RedisTimeSeriesWriter:
             for field_name, value in numeric.items():  # WHY: each numeric field becomes its own TS key.
                 ts_key = f"{ctx.api_function_name}:{entity_id}:{field_name}"  # WHY: three-part key aids querying.
                 adds.append((ts_key, value))  # WHY: preserve emission order to keep timestamps monotonic.
-                key_records.setdefault(ts_key, record)  # WHY: first-seen only; label state is stable per key.
+                key_records.setdefault(ts_key, record)  # WHY: first-seen only. Label state is stable per key.
         return adds, key_records
 
     @staticmethod
@@ -229,7 +229,7 @@ class RedisTimeSeriesWriter:
         for ts_key, record in batch:  # WHY: enqueue one TS.CREATE per key in the batch.
             labels = self._build_labels(record, api_function_name, ts_key, ts_label_fields)  # WHY: metadata per key.
             self._queue_ts_create(pipe, ts_key, labels)  # WHY: encapsulate the LABELS flag-args expansion.
-        results = pipe.execute(raise_on_error=False)  # WHY: capture per-command errors; do not abort the batch.
+        results = pipe.execute(raise_on_error=False)  # WHY: capture per-command errors. Do not abort the batch.
         self._pipeline_create_compaction(batch, results)  # WHY: proceed with compaction using result-driven filter.
 
     @staticmethod
@@ -266,7 +266,7 @@ class RedisTimeSeriesWriter:
             self._register_compaction_keys(ts_key)
 
     @staticmethod
-    def _collect_pending(  # WHY: pure filter over create results; easy to test in isolation.
+    def _collect_pending(  # WHY: pure filter over create results. Easy to test in isolation.
         batch: list[tuple[str, dict[str, Any]]],
         create_results: list,
     ) -> list[str]:
@@ -348,7 +348,7 @@ class RedisTimeSeriesWriter:
         if ts_key in self._created_keys:  # WHY: cache hit skips network round-trip.
             return
         labels = self._build_labels(record, api_function_name, ts_key)  # WHY: label extraction identical to batch.
-        _swallow_already_exists(  # WHY: idempotent create; parallel workers may have raced ahead.
+        _swallow_already_exists(  # WHY: idempotent create. Parallel workers may have raced ahead.
             lambda: self._ts.create(  # WHY: use TimeSeries wrapper for the single-shot path.
                 ts_key,
                 retention_msecs=RAW_RETENTION_MS,
@@ -454,11 +454,11 @@ class RedisTimeSeriesWriter:
         exclude_keys: list[str],
     ) -> dict[str, float]:
         """Return only numeric (int/float) fields, excluding PKs."""
-        result: dict[str, float] = {}  # WHY: build fresh dict; caller may merge with others.
+        result: dict[str, float] = {}  # WHY: build fresh dict. Caller may merge with others.
         for key, value in record.items():  # WHY: single pass over the record.
             if key in exclude_keys:  # WHY: skip PK fields to avoid emitting identifiers as metrics.
                 continue
-            if isinstance(value, (int, float)) and not isinstance(value, bool):  # WHY: bool is int subclass; exclude.
+            if isinstance(value, (int, float)) and not isinstance(value, bool):  # WHY: bool is int subclass. Exclude.
                 result[key] = float(value)  # WHY: normalize to float so TS.ADD gets a consistent type.
         return result
 
@@ -468,7 +468,7 @@ class RedisTimeSeriesWriter:
         value_fields: list[str],
     ) -> dict[str, float]:
         """Extract only named fields that have numeric values."""
-        result: dict[str, float] = {}  # WHY: local dict; caller merges into per-chunk totals.
+        result: dict[str, float] = {}  # WHY: local dict. Caller merges into per-chunk totals.
         for field in value_fields:  # WHY: iterate over the caller's explicit list.
             value = record.get(field)  # WHY: absent fields silently drop.
             if isinstance(value, (int, float)) and not isinstance(value, bool):  # WHY: bool exclusion mirrors above.
@@ -486,7 +486,7 @@ class RedisTimeSeriesWriter:
         parts = ts_key.rsplit(":", 1)  # WHY: metric name is the trailing token after the final colon.
         metric_name = parts[-1] if len(parts) > 1 else ts_key  # WHY: fall back to full key when no colon.
         labels: dict[str, str] = {"api_function": api_function_name, "metric_name": metric_name}  # WHY: base labels.
-        fields = ts_label_fields or DEFAULT_LABEL_FIELDS  # WHY: single loop; removes if/else branching.
+        fields = ts_label_fields or DEFAULT_LABEL_FIELDS  # WHY: single loop. Removes if/else branching.
         for field in fields:  # WHY: only fields actually present on the record are emitted.
             if field in record:
                 labels[field] = str(record[field])  # WHY: TS labels must be strings.

--- a/src/db/retention.py
+++ b/src/db/retention.py
@@ -99,7 +99,7 @@ class RetentionManager:  # WHY: single owner of ArangoDB+Redis retention
         """Query ArangoDB storage usage in GB."""
         database = getattr(self._arango, "_database", None)  # WHY: MagicMock safe
         if database is None:  # WHY: writer without _database -> zero usage
-            return 0.0  # WHY: zero means "no data yet"; sweep continues
+            return 0.0  # WHY: zero means "no data yet". Sweep continues
         try:
             stats = database.statistics()  # WHY: server-level stats dict
             data_size = stats.get("dataSize", 0)  # WHY: bytes, may be missing

--- a/src/db/router.py
+++ b/src/db/router.py
@@ -121,7 +121,7 @@ class DatabaseRouter:
         self._connect_redis_json()  # WHY: attempt redis-json connect (non-fatal on failure)
 
     def _connect_arango(self) -> None:  # WHY: isolate connect errors from constructor
-        """Attempt ArangoDB connection; set availability flag."""
+        """Attempt ArangoDB connection. Set availability flag."""
         try:
             self._arango_writer = ArangoDBWriter(self.config)  # WHY: sync connect + probe
             self._arango_available = True  # WHY: mark healthy for later dispatch
@@ -130,7 +130,7 @@ class DatabaseRouter:
             logger.warning(EVT_ARANGO_UNAVAIL, error=str(error))  # WHY: single warning per attempt
 
     def _connect_redis(self) -> None:  # WHY: isolate connect errors from constructor
-        """Attempt Redis connection; set availability flag."""
+        """Attempt Redis connection. Set availability flag."""
         try:
             self._redis_writer = RedisTimeSeriesWriter(self.config)  # WHY: sync connect + probe
             self._redis_available = True  # WHY: mark healthy for later dispatch
@@ -139,7 +139,7 @@ class DatabaseRouter:
             logger.warning(EVT_REDIS_UNAVAIL, error=str(error))  # WHY: single warning per attempt
 
     def _connect_redis_json(self) -> None:  # WHY: isolate connect errors from constructor
-        """Attempt Redis JSON connection; set availability flag."""
+        """Attempt Redis JSON connection. Set availability flag."""
         try:
             self._redis_json_writer = RedisJSONWriter(self.config)  # WHY: sync connect + probe
             self._redis_json_available = True  # WHY: mark healthy for later dispatch
@@ -170,7 +170,7 @@ class DatabaseRouter:
         api_function_name: str,
         strategy: dict[str, Any],
     ) -> WriteResult:  # WHY: arango-only write path with snapshot side-effect
-        """Dispatch to ArangoDB; degrade to csv_only if unavailable."""
+        """Dispatch to ArangoDB. Degrade to csv_only if unavailable."""
         if not self._arango_available or self._arango_writer is None:  # WHY: guard clause for unavailable
             return self._csv_fallback(api_function_name, BACKEND_ARANGO)
         try:
@@ -239,7 +239,7 @@ class DatabaseRouter:
         api_function_name: str,
         strategy: dict[str, Any],
     ) -> WriteResult:  # WHY: redis timeseries write path with csv fallback
-        """Dispatch to Redis TS; degrade to csv_only if unavailable."""
+        """Dispatch to Redis TS. Degrade to csv_only if unavailable."""
         if not self._redis_available or self._redis_writer is None:  # WHY: guard clause for unavailable
             return self._csv_fallback(api_function_name, BACKEND_REDIS)
         try:
@@ -254,7 +254,7 @@ class DatabaseRouter:
         api_function_name: str,
         strategy: dict[str, Any],
     ) -> WriteResult:  # WHY: redis JSON write path with csv fallback
-        """Dispatch to Redis JSON; degrade to csv_only if unavailable."""
+        """Dispatch to Redis JSON. Degrade to csv_only if unavailable."""
         if not self._redis_json_available or self._redis_json_writer is None:  # WHY: guard for unavailable
             return self._csv_fallback(api_function_name, BACKEND_REDIS_JSON)
         try:
@@ -279,7 +279,7 @@ class DatabaseRouter:
         return dual.combined  # WHY: caller receives a single WriteResult regardless of leg outcomes
 
     def _resolve_strategy(self, api_function_name: str) -> dict[str, Any]:  # WHY: strategy lookup helper
-        """Look up PK strategy; fall back to default."""
+        """Look up PK strategy. Fall back to default."""
         if api_function_name in self._strategies:  # WHY: prefer per-endpoint override
             return self._strategies[api_function_name]
         return self._strategies.get("default", DEFAULT_STRATEGY)  # WHY: user default > module default
@@ -340,7 +340,7 @@ class DatabaseRouter:
         return stored  # WHY: return count so caller can log ingestion progress
 
     def _snapshot_config_history_record(self, config_record: dict[str, Any]) -> bool:  # WHY: per-record helper
-        """Snapshot a single config-history record; return True on store."""
+        """Snapshot a single config-history record. Return True on store."""
         entity_id = str(config_record.get("device_id", config_record.get("mac", "")))  # WHY: device_id or mac
         if not entity_id:  # WHY: skip rows missing both identifiers
             return False

--- a/src/device/_utility_commands_action.py
+++ b/src/device/_utility_commands_action.py
@@ -135,7 +135,7 @@ class _UtilityCommandsAction(_ClusterBase):  # WHY: cluster wrapper mirroring ea
         if port_id.startswith(("vme", "ae", "irb")):  # WHY: block prefixes unsafe to bounce
             print(f"! Port '{port_id}' cannot be bounced (management/aggregate/IRB port).")  # WHY: signal reject
             return None
-        return str(port_id)  # WHY: proxied picker returns Any; coerce to satisfy mypy strict
+        return str(port_id)  # WHY: proxied picker returns Any. Coerce to satisfy mypy strict
 
     def _confirm_bounce(self, port_id: str) -> bool:
         """Confirm the port-bounce with a y/N prompt."""
@@ -226,7 +226,7 @@ class _UtilityCommandsAction(_ClusterBase):  # WHY: cluster wrapper mirroring ea
             if not vc_data.get("is_virtual_chassis", False):  # WHY: readopt requires VC
                 print("! Device is not a Virtual Chassis member. 'readopt' applies only to VC devices. Skipping.")
                 return False
-        except Exception as error:  # WHY: warn-and-continue; readopt may still work
+        except Exception as error:  # WHY: warn-and-continue. Readopt may still work
             logging.warning("VC preflight check failed: %s", error, exc_info=True)  # WHY: audit warning
         return True  # WHY: preflight passed or was inconclusive
 

--- a/src/device/_utility_commands_clear.py
+++ b/src/device/_utility_commands_clear.py
@@ -58,7 +58,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
 
     def _build_arp_body(self, site_id: str, device_id: str) -> dict[str, Any]:  # WHY: collect optional ARP filters
         """Gather ARP-clear filter inputs (node, port, ip) from the operator."""
-        body: dict[str, Any] = {}  # WHY: seed empty; add only supplied filters
+        body: dict[str, Any] = {}  # WHY: seed empty. Add only supplied filters
         self._add_node_port_filters(body, site_id, device_id, "clear_arp_node")  # WHY: shared helper (dedupes vs show)
         ip_addr = self._safe_input_fn(
             "IP address to clear (Enter for all): ",
@@ -84,7 +84,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             logger.exception("Clear ARP cache failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Clear ARP cache failed: %s", error)
 
     # ------------------------------------------------------------------
@@ -118,7 +118,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             allow_empty=False,
         )  # WHY: neighbor is mandatory
         if not neighbor:  # WHY: guard against empty submission
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Neighbor IP is required.")
             return None  # WHY: propagate missing-required signal to caller
         body: dict[str, Any] = {"neighbor": neighbor}  # WHY: seed with required field
@@ -171,7 +171,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             logger.exception("Clear BGP routes failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Clear BGP routes failed: %s", error)
 
     # ------------------------------------------------------------------
@@ -222,7 +222,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
 
     def _build_clear_session_body(self) -> dict[str, Any] | None:  # WHY: gather + validate session filters
         """Gather clear-session parameters from user input, or return None on cancel."""
-        body: dict[str, Any] = {}  # WHY: seed empty; add only supplied filters
+        body: dict[str, Any] = {}  # WHY: seed empty. Add only supplied filters
         service_name = self._safe_input_fn(
             "Service name to clear (Enter to skip): ",
             context="clear_session_service_name",
@@ -267,7 +267,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             context="clear_session_confirm_all",
         )  # WHY: extra guard against unintended full clears
         if confirm_all != "CLEAR ALL":  # WHY: exact keyword required
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("Cancelled: No service name or session IDs provided.")
             return False  # WHY: operator declined CLEAR-ALL
         return True  # WHY: operator explicitly opted into CLEAR-ALL
@@ -283,7 +283,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         if not selection:  # WHY: cancelled -> abort
             return  # WHY: no work when operator cancels selection
         site_id, device_id, _ = selection  # WHY: unpack (site, device, name)
-        body: dict[str, Any] = {}  # WHY: seed empty; only add optional node
+        body: dict[str, Any] = {}  # WHY: seed empty. Only add optional node
         self._maybe_add_input(  # WHY: attach optional VC-node target to MAC-clear body
             body,
             "node",
@@ -314,7 +314,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             logger.exception("Clear MAC table failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Clear MAC table failed: %s", error)
 
     def clear_bpdu_error(self) -> None:  # WHY: menu 151 destructive BPDU-error clear entry
@@ -350,7 +350,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             logger.exception("Clear BPDU errors failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Clear BPDU errors failed: %s", error)
 
     def clear_learned_macs(self) -> None:
@@ -375,7 +375,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         """Pick a required port and normalize ``xe-0/0/0`` -> ``xe-0/0/0.0``."""
         port_id = self._select_port_from_device(site_id, device_id)  # WHY: required port picker
         if not port_id:  # WHY: cancelled or empty selection
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Port selection is required for clearing learned MACs.")
             return None
         return port_id if "." in port_id else f"{port_id}.0"  # WHY: SDK requires .unit suffix
@@ -397,7 +397,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             logger.exception("Clear learned MACs failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Clear learned MACs failed: %s", error)
 
     # ------------------------------------------------------------------
@@ -413,7 +413,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         if not selection:  # WHY: cancelled -> abort
             return
         site_id, device_id, _ = selection  # WHY: unpack (site, device, name)
-        body: dict[str, Any] = {}  # WHY: seed empty; only add optional node
+        body: dict[str, Any] = {}  # WHY: seed empty. Only add optional node
         self._maybe_add_input(body, "node", "Node (node0/node1, Enter to skip): ", "clear_policy_node")
         if not self._confirm_destructive(
             "Type 'CLEAR' to clear policy hit count: ",
@@ -439,7 +439,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             logger.exception("Clear policy hit count failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Clear policy hit count failed: %s", error)
 
     # ------------------------------------------------------------------
@@ -469,7 +469,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         """Build DHCP-release body from a required port pick + optional node."""
         port_id = self._select_port_from_device(site_id, device_id)  # WHY: required port picker
         if not port_id:  # WHY: cancelled or empty selection
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Port selection is required.")
             return None
         body: dict[str, Any] = {"port_id": port_id}  # WHY: required field first
@@ -483,7 +483,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             context=context,
         )  # WHY: destructive-op confirmation
         if confirm.lower() != "y":  # WHY: anything other than 'y' aborts
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Operation cancelled.")
             return False
         return True
@@ -504,7 +504,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             logger.exception("Release DHCP lease failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Release DHCP lease failed: %s", error)
 
     def release_dhcp_ssr(self) -> None:
@@ -529,7 +529,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
         """Build SSR DHCP-release body from a required interface pick + optional node."""
         port_id = self._select_interface_from_device(site_id, device_id)  # WHY: SSR uses named ifaces
         if not port_id:  # WHY: cancelled or empty selection
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Network interface is required.")
             return None
         body: dict[str, Any] = {"port_id": port_id}  # WHY: required field first
@@ -543,7 +543,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             context="release_dhcp_ssr",
         )  # WHY: destructive-op confirmation
         if confirm.lower() != "y":  # WHY: anything other than 'y' aborts
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Operation cancelled.")
             return False
         return True
@@ -564,7 +564,7 @@ class _UtilityCommandsClear(_ClusterBase):  # WHY: cluster wrapper mirroring ear
             )  # WHY: emit success/error line
         except Exception as error:  # WHY: log-and-continue on SDK/transport failure
             logger.exception("Release SSR DHCP lease failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Release SSR DHCP lease failed: %s", error)
 
 

--- a/src/device/_utility_commands_cluster.py
+++ b/src/device/_utility_commands_cluster.py
@@ -14,7 +14,7 @@ from __future__ import annotations  # WHY: postponed evaluation for forward-ref 
 
 from typing import TYPE_CHECKING, Any  # WHY: Any lets __getattr__ proxy any parent method
 
-if TYPE_CHECKING:  # WHY: only pulled in by type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only pulled in by type checkers. Skipped at runtime
     from src.device.utility_commands import DeviceUtilityCommands  # WHY: parent type for annotation
 
 
@@ -34,7 +34,7 @@ class _ClusterBase:  # WHY: shared wrapper base for every utility_commands clust
     def __getattr__(self, name: str) -> Any:  # WHY: proxy unknown attrs back to parent
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_uc")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy so self._apisession / helpers work
 

--- a/src/device/_utility_commands_selection.py
+++ b/src/device/_utility_commands_selection.py
@@ -20,7 +20,7 @@ mirrors the wrapper + ``__getattr__`` pattern used by
 from __future__ import annotations  # WHY: postponed evaluation for forward-ref type hints
 
 import logging  # WHY: debug-level logging when stat lookups fail silently
-from typing import Any, cast  # WHY: Any parameterizes SDK payload dicts; cast narrows API responses
+from typing import Any, cast  # WHY: Any parameterizes SDK payload dicts. Cast narrows API responses
 
 import mistapi  # WHY: stats + device APIs live under mistapi.api.v1.sites.*
 
@@ -53,37 +53,37 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
         allowed = self._uc.DEVICE_TYPE_COMPATIBILITY_MAP.get(command_name, [])  # WHY: closed enum per cmd
         if device_type not in allowed:  # WHY: reject incompatible device types up front
             allowed_str = ", ".join(allowed)  # WHY: comma-list for user-facing hint
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! This command is only available on: %s", allowed_str)
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! The selected device is a %s.", device_type)
             return False  # WHY: caller aborts command flow
         return True  # WHY: caller proceeds with matching device
 
     def _select_site_and_device(
         self, command_name: str, device_type_filter: str = "all"
-    ) -> tuple[str, str, str] | None:  # WHY: three-tuple result; None on cancel
+    ) -> tuple[str, str, str] | None:  # WHY: three-tuple result. None on cancel
         """Select site and device, validate type, warn if offline."""
         ids = self._resolve_site_device_ids(device_type_filter)  # WHY: gather user picks first
         if ids is None:  # WHY: user cancelled selection at some stage
             return None  # WHY: propagate cancellation to caller
         site_id, device_id = ids  # WHY: unpack for downstream stats lookup
         # WHY: route through parent so patch.object(duc, "_get_device_info", ...) intercepts
-        device_info = cast(  # WHY: parent proxy returns Any; narrow to concrete type
+        device_info = cast(  # WHY: parent proxy returns Any. Narrow to concrete type
             "dict[str, Any] | None",
             self._call("_get_device_info", site_id, device_id),
         )
         if not device_info:  # WHY: no info means we cannot verify compatibility
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Could not retrieve device info from stats API.")
             return None  # WHY: abort when stats unavailable
         device_type = device_info.get("type")  # WHY: needed for compatibility check
         if not device_type:  # WHY: guard against malformed stats payload
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Could not determine device type.")
             return None  # WHY: abort without a device type
         if not self._validate_device_type(device_type, command_name):  # WHY: enforce per-command allowlist
-            return None  # WHY: incompatible device; caller must not proceed
+            return None  # WHY: incompatible device. Caller must not proceed
         self._warn_if_offline(device_info)  # WHY: soft warning, does not abort
         return (site_id, device_id, device_type)  # WHY: caller uses this tuple to route commands
 
@@ -91,22 +91,22 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
         """Prompt the user for a site and device, returning both IDs."""
         site_id = self._select_site_fn()  # WHY: interactive site picker (via __getattr__ proxy)
         if not site_id:  # WHY: user cancelled or no site available
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No site selected. Operation cancelled.")
             return None  # WHY: abort without a site
         device_id = self._select_device_fn(site_id, device_type_filter)  # WHY: device picker (proxy)
         if not device_id:  # WHY: user cancelled or no device available
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No device selected. Operation cancelled.")
             return None  # WHY: abort without a device
-        return (site_id, device_id)  # WHY: both IDs known; caller continues to stats lookup
+        return (site_id, device_id)  # WHY: both IDs known. Caller continues to stats lookup
 
     @staticmethod
     def _warn_if_offline(device_info: dict[str, Any]) -> None:  # WHY: soft-warn helper
         """Emit a soft warning when the target device is not connected."""
         status = device_info.get("status", "unknown")  # WHY: default keeps message informative
         if status != "connected":  # WHY: only warn on non-connected states
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] Device status is '%s' - command may not succeed.", status)
 
     def _get_device_info(self, site_id: str, device_id: str) -> dict[str, Any] | None:  # WHY: type+status
@@ -139,7 +139,7 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
         if isinstance(if_stat, dict) and if_stat:  # WHY: only use if it is a populated mapping
             # WHY: route via parent for test patches
             return cast("str | None", self._call("_display_and_select_ifstat", if_stat))  # WHY: legacy path
-        # WHY: no structured data, ask user directly; route via parent for patches
+        # WHY: no structured data, ask user directly. Route via parent for patches
         return cast("str | None", self._call("_manual_port_entry"))  # WHY: last-resort manual entry
 
     def _fetch_stats_data(self, site_id: str, device_id: str) -> dict[str, Any] | None:  # WHY: raw stats
@@ -163,7 +163,7 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
             context="port_selection",
         )
         if not selection:  # WHY: empty input cancels selection
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No port selected.")
             return None  # WHY: caller treats None as user cancel
         return self._resolve_port_choice(selection, ports)  # WHY: numeric or literal path
@@ -171,14 +171,14 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
     @staticmethod
     def _render_port_rows(ports: list[dict[str, Any]]) -> None:  # WHY: numbered-list printer
         """Print the numbered port list for interactive selection."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nAvailable ports:")
         for index, port in enumerate(ports, 1):  # WHY: 1-based numbering matches operator input
             port_name = port.get("port_id", port.get("name", f"port_{index}"))  # WHY: fallback name
             port_status = port.get("up", "unknown")  # WHY: default informs "unknown" rendering
             status_str = "UP" if port_status else "DOWN"  # WHY: boolean → human label
             speed = port.get("speed", "")  # WHY: optional speed hint for operator
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %d. %s [%s] %s", index, port_name, status_str, speed)
 
     @staticmethod
@@ -189,7 +189,7 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
             if 0 <= idx < len(ports):  # WHY: bounds check
                 result: str = str(ports[idx].get("port_id", ports[idx].get("name", "")))  # WHY: fallback
                 return result  # WHY: matched port name from index lookup
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Invalid port number.")
             return None  # WHY: out-of-range index yields no selection
         return selection  # WHY: literal port name typed by user
@@ -203,7 +203,7 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
             context="ifstat_selection",
         )
         if not selection:  # WHY: empty input cancels selection
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No port selected.")
             return None  # WHY: caller treats None as user cancel
         return self._resolve_ifstat_choice(selection, physical)  # WHY: numeric or literal path
@@ -220,12 +220,12 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
     @staticmethod
     def _render_ifstat_rows(if_stat: dict[str, Any], physical: list[str]) -> None:  # WHY: printer
         """Print numbered rows of if_stat entries with UP/DOWN status."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nAvailable ports/interfaces:")
         for idx, name in enumerate(physical, 1):  # WHY: 1-based numbering
             info = if_stat.get(name, {})  # WHY: per-interface dict may be missing
             up = "UP" if info.get("up") else "DOWN"  # WHY: boolean → human label
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %d. %s [%s]", idx, name, up)
 
     @staticmethod
@@ -236,7 +236,7 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
             if 0 <= sel_idx < len(physical):  # WHY: bounds check
                 base = physical[sel_idx]  # WHY: pick the matched interface
                 return base.split(".")[0] if "." in base else base  # WHY: drop unit suffix
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Invalid port number.")
             return None  # WHY: out-of-range index yields no selection
         return selection  # WHY: literal port name typed by user
@@ -274,12 +274,12 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
     def _display_ports_from_list(ports: list[dict[str, Any]]) -> list[str]:
         """Display ports from the ports array in stats response."""
         port_names: list[str] = []  # WHY: accumulate names returned to caller
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nAvailable ports:")
         for idx, port in enumerate(ports, 1):  # WHY: 1-based numbering
             name = port.get("port_id", port.get("name", f"port_{idx}"))  # WHY: fallback name
             up = "UP" if port.get("up") else "DOWN"  # WHY: boolean → human label
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %d. %s [%s]", idx, name, up)
             port_names.append(name)  # WHY: caller resolves numeric input via this list
         return port_names
@@ -303,12 +303,12 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
     def _emit_if_stat_rows(if_stat: dict[str, Any], physical: list[str]) -> list[str]:
         """Print numbered if_stat rows and return the port-name list."""
         port_names: list[str] = []  # WHY: caller resolves numeric input via this list
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nAvailable ports:")
         for idx, name in enumerate(physical, 1):  # WHY: 1-based numbering
             info = if_stat.get(name, {})  # WHY: per-interface dict may be missing
             up = "UP" if info.get("up") else "DOWN"  # WHY: boolean → human label
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %d. %s [%s]", idx, name, up)
             port_names.append(name)  # WHY: build parallel array for resolve step
         return port_names
@@ -380,11 +380,11 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
         ip_stat: dict[str, Any] | Any,
     ) -> None:
         """Print a numbered list of available interfaces."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nAvailable interfaces:")
         for idx, iface in enumerate(interfaces, 1):  # WHY: 1-based numbering
             extra = self._format_iface_extra(iface, if_stat, ip_stat)  # WHY: append IP metadata
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %d. %s%s", idx, iface, extra)
 
     @staticmethod
@@ -425,14 +425,14 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
             ),
         )
         if not selection:  # WHY: empty input cancels selection
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No interface selected.")
             return None
         if selection.isdigit():  # WHY: numeric selection references list index
             sel_idx = int(selection) - 1  # WHY: 0-based indexing
             if 0 <= sel_idx < len(interfaces):  # WHY: bounds check
                 return interfaces[sel_idx]
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Invalid interface number.")
             return None
         return selection  # WHY: literal interface name typed by user
@@ -456,7 +456,7 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
         if network_names:  # WHY: only render menu when discovery yielded entries
             self._display_network_list(network_names, network_labels)  # WHY: render numbered menu
             if len(network_names) == 1:  # WHY: single option: auto-pick for operator convenience
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.info("\n-> Auto-selecting: %s", network_names[0])
                 return network_names[0]
         selection = self._safe_input_fn(  # WHY: EOF-safe prompt (via __getattr__ proxy)
@@ -531,11 +531,11 @@ class _UtilityCommandsSelection(_ClusterBase):  # WHY: cluster wrapper matching 
     @staticmethod
     def _display_network_list(network_names: list[str], network_labels: list[str]) -> None:
         """Print a numbered list of available networks."""
-        del network_names  # WHY: names unused for rendering; kept for API symmetry with resolver
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        del network_names  # WHY: names unused for rendering. Kept for API symmetry with resolver
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nAvailable networks:")
         for idx, label in enumerate(network_labels, 1):  # WHY: 1-based numbering
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %d. %s", idx, label)
 
     @staticmethod

--- a/src/device/_utility_commands_show.py
+++ b/src/device/_utility_commands_show.py
@@ -199,11 +199,11 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             allow_empty=False,  # WHY: reject blank input at the prompt layer
         )
         if not host:  # WHY: defensive re-check even though allow_empty=False
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Destination host is required.")  # WHY: surface reason to operator
             return  # WHY: abort without firing SDK call
         body = self._build_traceroute_body(host)  # WHY: extract keeps public method under 25 lines
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Running traceroute to %s...", host)  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _TRACEROUTE_SPEC)  # WHY: dispatch + export
 
@@ -231,13 +231,13 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_ospf_neighbors_body()  # WHY: extract keeps public method under 25 lines
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching OSPF neighbors...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _OSPF_NEIGHBORS_SPEC)  # WHY: dispatch + export
 
     def _build_ospf_neighbors_body(self) -> dict[str, Any]:
         """Prompt for optional vrf / node / neighbor filters."""
-        body: dict[str, Any] = {}  # WHY: start empty; only add prompted filters
+        body: dict[str, Any] = {}  # WHY: start empty. Only add prompted filters
         vrf = self._safe_input_fn("VRF (Enter to skip): ", context="ospf_vrf")  # WHY: optional VRF
         if vrf:  # WHY: skip filter if blank
             body["vrf"] = vrf  # WHY: propagate to SDK
@@ -257,13 +257,13 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_ospf_interfaces_body(site_id, device_id)  # WHY: extract keeps <=25 lines
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching OSPF interfaces...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _OSPF_INTERFACES_SPEC)  # WHY: dispatch + export
 
     def _build_ospf_interfaces_body(self, site_id: str, device_id: str) -> dict[str, Any]:
         """Prompt for optional vrf / node / port filters."""
-        body: dict[str, Any] = {}  # WHY: start empty; only add prompted filters
+        body: dict[str, Any] = {}  # WHY: start empty. Only add prompted filters
         vrf = self._safe_input_fn("VRF (Enter to skip): ", context="ospf_vrf")  # WHY: optional VRF
         if vrf:  # WHY: skip filter if blank
             body["vrf"] = vrf  # WHY: propagate to SDK
@@ -278,13 +278,13 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_ospf_database_body()  # WHY: extract keeps this method at C<=5
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching OSPF database...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _OSPF_DATABASE_SPEC)  # WHY: dispatch + export
 
     def _build_ospf_database_body(self) -> dict[str, Any]:
         """Collect optional OSPF database filter inputs into a body dict."""
-        body: dict[str, Any] = {}  # WHY: start empty; only add prompted filters
+        body: dict[str, Any] = {}  # WHY: start empty. Only add prompted filters
         vrf = self._safe_input_fn("VRF (Enter to skip): ", context="ospf_vrf")  # WHY: optional VRF
         if vrf:  # WHY: skip filter if blank
             body["vrf"] = vrf  # WHY: propagate to SDK
@@ -307,13 +307,13 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_vrf_node_body("ospf_vrf", "ospf_node")  # WHY: shared vrf+node prompt helper
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching OSPF summary...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _OSPF_SUMMARY_SPEC)  # WHY: dispatch + export
 
     def _build_vrf_node_body(self, vrf_ctx: str, node_ctx: str) -> dict[str, Any]:
         """Prompt for optional VRF + node and return a filter body dict."""
-        body: dict[str, Any] = {}  # WHY: start empty; only add prompted filters
+        body: dict[str, Any] = {}  # WHY: start empty. Only add prompted filters
         vrf = self._safe_input_fn("VRF (Enter to skip): ", context=vrf_ctx)  # WHY: optional VRF
         if vrf:  # WHY: skip filter if blank
             body["vrf"] = vrf  # WHY: propagate to SDK
@@ -324,7 +324,7 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
 
     def _build_node_only_body(self, node_ctx: str) -> dict[str, Any]:
         """Prompt for optional node filter only (BGP/ARP/DOT1X/EVPN pattern)."""
-        body: dict[str, Any] = {}  # WHY: start empty; only add prompted node
+        body: dict[str, Any] = {}  # WHY: start empty. Only add prompted node
         node = self._safe_input_fn("Node (node0/node1, Enter to skip): ", context=node_ctx)  # WHY: node
         if node:  # WHY: skip filter if blank
             body["node"] = node  # WHY: propagate to SDK
@@ -341,7 +341,7 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
         if not selection:  # WHY: user cancelled / no picks
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Testing DNS resolution on device...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, None, _DNS_RESOLUTION_SPEC)  # WHY: no body for this SDK
 
@@ -356,7 +356,7 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
         if not port_id:  # WHY: no port -> no traffic to sniff
             return  # WHY: abort without firing SDK call
         body, duration = self._build_monitor_traffic_body(port_id)  # WHY: extract keeps <=25 lines
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Monitoring traffic on port %s...", port_id)  # WHY: operator progress feedback
         self._run_streaming_command(  # WHY: __getattr__ -> websocket cluster
             site_id,
@@ -387,7 +387,7 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
         if not selection:  # WHY: user cancelled / no picks
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Running top command...")  # WHY: operator progress feedback
         self._run_streaming_command(  # WHY: __getattr__ -> websocket cluster
             site_id,
@@ -408,13 +408,13 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_session_body()  # WHY: extract keeps public method under 25 lines
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching device sessions...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _SESSION_SPEC)  # WHY: dispatch + export
 
     def _build_session_body(self) -> dict[str, Any]:
         """Prompt for optional service_name / session_id / node filters."""
-        body: dict[str, Any] = {}  # WHY: start empty; only add prompted filters
+        body: dict[str, Any] = {}  # WHY: start empty. Only add prompted filters
         service = self._safe_input_fn(  # WHY: optional service filter
             "Service name filter (Enter to skip): ",
             context="session_service",  # WHY: context key wires into safe_input policy
@@ -443,13 +443,13 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_service_path_body()  # WHY: extract keeps public method under 25 lines
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching service path...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _SERVICE_PATH_SPEC)  # WHY: dispatch + export
 
     def _build_service_path_body(self) -> dict[str, Any]:
         """Prompt for optional service_name and node filters."""
-        body: dict[str, Any] = {}  # WHY: start empty; only add prompted filters
+        body: dict[str, Any] = {}  # WHY: start empty. Only add prompted filters
         service = self._safe_input_fn(  # WHY: optional service filter
             "Service name (Enter to skip): ",
             context="service_path_name",  # WHY: context key wires into safe_input policy
@@ -472,7 +472,7 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_node_only_body("bgp_node")  # WHY: shared node-only prompt helper
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching BGP summary...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _BGP_SUMMARY_SPEC)  # WHY: dispatch + export
 
@@ -484,7 +484,7 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_node_only_body("arp_node")  # WHY: shared node-only prompt helper
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching ARP table...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _ARP_TABLE_SPEC)  # WHY: dispatch + export
 
@@ -496,13 +496,13 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_dhcp_leases_body(site_id, device_id)  # WHY: extract keeps <=25 lines
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching DHCP leases...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _DHCP_LEASES_SPEC)  # WHY: dispatch + export
 
     def _build_dhcp_leases_body(self, site_id: str, device_id: str) -> dict[str, Any]:
         """Prompt for optional network + node filters."""
-        body: dict[str, Any] = {}  # WHY: start empty; only add prompted filters
+        body: dict[str, Any] = {}  # WHY: start empty. Only add prompted filters
         network = self._select_network_from_device(site_id, device_id)  # WHY: __getattr__ -> selection
         if network:  # WHY: only add if operator picked one
             body["network"] = network  # WHY: propagate to SDK
@@ -519,7 +519,7 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_node_only_body("dot1x_node")  # WHY: shared node-only prompt helper
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching 802.1X table...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _DOT1X_SPEC)  # WHY: dispatch + export
 
@@ -531,7 +531,7 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
             return  # WHY: nothing to do without a device target
         site_id, device_id, _ = selection  # WHY: destructure IDs, ignore display name
         body = self._build_node_only_body("evpn_node")  # WHY: shared node-only prompt helper
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Fetching EVPN database...")  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _EVPN_DATABASE_SPEC)  # WHY: dispatch + export
 
@@ -550,6 +550,6 @@ class _UtilityCommandsShow(_ClusterBase):  # WHY: cluster wrapper mirroring _Uti
         if not port_id:  # WHY: cable test needs a physical port target
             return  # WHY: abort without firing SDK call
         body: dict[str, Any] = {"port": port_id}  # WHY: SDK expects 'port' key (not port_id)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Running cable test on port %s...", port_id)  # WHY: operator progress feedback
         self._run_and_export(site_id, device_id, body, _CABLE_TEST_SPEC)  # WHY: dispatch + export

--- a/src/device/_utility_commands_websocket.py
+++ b/src/device/_utility_commands_websocket.py
@@ -50,7 +50,7 @@ class StreamWsSpec:  # WHY: bundle for _stream_ws_output single-arg signature
     site_id: str  # WHY: mistapi site scope for SDK call
     device_id: str  # WHY: mistapi device scope for SDK call
     sdk_method: Any  # WHY: bound mistapi method (traceroute/monitor_traffic/and so on)
-    body: dict[str, Any] | None  # WHY: optional JSON body; some SDK methods take none
+    body: dict[str, Any] | None  # WHY: optional JSON body. Some SDK methods take none
     websocket_manager: Any  # WHY: already-connected WebSocketManager instance
     timeout_seconds: int  # WHY: overall wait budget for streaming result
 
@@ -64,7 +64,7 @@ class ExportResultSpec:  # WHY: bundle for _display_and_export_result single-arg
     method has a single-argument signature satisfying STRUCT-PARAMS.
     """
 
-    result: dict[str, Any] | None  # WHY: WebSocket command payload; None on timeout
+    result: dict[str, Any] | None  # WHY: WebSocket command payload. None on timeout
     command_name: str  # WHY: label rendered in banner header
     site_id: str  # WHY: audit metadata on exported row
     device_id: str  # WHY: audit metadata on exported row
@@ -113,7 +113,7 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
             )
         except Exception as error:  # WHY: log-and-continue on any WS/SDK failure
             logging.exception("WebSocket command failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Command failed: %s", error)  # WHY: surface error to operator
             return None  # WHY: caller treats None as no-result
         finally:
@@ -129,7 +129,7 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
     ) -> dict[str, Any] | None:
         """Route ``_execute_ws_command`` through the parent proxy and narrow the result."""
         # WHY: route through parent so patch.object(duc, "_execute_ws_command", ...) intercepts
-        return cast(  # WHY: parent proxy returns Any; narrow to concrete type
+        return cast(  # WHY: parent proxy returns Any. Narrow to concrete type
             "dict[str, Any] | None",
             self._call(
                 "_execute_ws_command",
@@ -154,9 +154,9 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
         session_id = self._extract_session_id(response)  # WHY: parse session or fail fast
         if session_id is None:  # WHY: missing session -> nothing to await
             return None  # WHY: helper already emitted diagnostics
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> Command issued (session: %s...)", session_id[:8])  # WHY: operator feedback
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> Waiting for results...")  # WHY: hint on latency budget
         result: dict[str, Any] | None = websocket_manager.wait_for_command_result(
             session_id, timeout_seconds=120  # WHY: 2-minute cap matches mistapi default
@@ -174,7 +174,7 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
         sdk_method: Any,
         body: dict[str, Any] | None = None,
         timeout_seconds: int = 120,
-    ) -> None:  # WHY: streaming variant prints inline; no return payload
+    ) -> None:  # WHY: streaming variant prints inline. No return payload
         """Execute streaming WebSocket command with output display."""
         websocket_manager = self._ws_factory(self._apisession)  # WHY: __getattr__ proxy to parent state
         if not self._prepare_ws_channel(websocket_manager, site_id, device_id):  # WHY: connect+subscribe
@@ -195,11 +195,11 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
             # WHY: route through parent so patch.object(duc, "_stream_ws_output", ...) intercepts
             self._call("_stream_ws_output", spec)
         except KeyboardInterrupt:  # WHY: operator Ctrl+C is a normal stop signal
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n-> Streaming stopped by user.")  # WHY: acknowledge intentional halt
         except Exception as error:  # WHY: log-and-continue on any WS/SDK failure
             logging.exception("Streaming command failed: %s", error)  # WHY: audit failure with stack
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Streaming failed: %s", error)  # WHY: surface error to operator
         finally:
             websocket_manager.disconnect()  # WHY: always clean up
@@ -210,9 +210,9 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
         session_id = self._extract_session_id(response, absent_msg="! No session ID returned.")  # WHY: parse
         if session_id is None:  # WHY: no session -> nothing to stream
             return  # WHY: helper already emitted diagnostics
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> Streaming started (session: %s...)", session_id[:8])  # WHY: operator feedback
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> Press Ctrl+C to stop.\n")  # WHY: hint on how to end streaming
         result = spec.websocket_manager.wait_for_command_result(
             session_id,
@@ -228,7 +228,7 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
     def _display_and_export_result(self, spec: ExportResultSpec) -> None:  # WHY: single-arg spec keeps STRUCT clean
         """Display WebSocket result and write to dual output using :class:`ExportResultSpec`."""
         if not spec.result:  # WHY: timeout / disconnect / API error
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No results received (timeout or error).")  # WHY: signal empty result
             return
         raw_output, other_output = self._print_result_block(spec.command_name, spec.result)  # WHY: banner
@@ -242,8 +242,8 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
     def _confirm_destructive(self, prompt: str, keyword: str, context: str) -> bool:
         """Require typed keyword confirmation for destructive ops."""
         confirmation = self._safe_input_fn(prompt, context=context)  # WHY: __getattr__ proxy
-        if confirmation != keyword:  # WHY: exact-match gate; even leading/trailing space fails
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        if confirmation != keyword:  # WHY: exact-match gate. Even leading/trailing space fails
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Operation cancelled - confirmation not matched.")  # WHY: signal cancel
             return False
         return True
@@ -255,12 +255,12 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
     def _prepare_ws_channel(self, websocket_manager: Any, site_id: str, device_id: str) -> bool:
         """Connect the WS manager and subscribe to the per-device command channel."""
         if not websocket_manager.connect():  # WHY: bail if WS handshake fails
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Failed to establish WebSocket connection.")  # WHY: expose handshake failure
             return False
         channel = f"/sites/{site_id}/devices/{device_id}/cmd"  # WHY: per-device command channel
         if not websocket_manager.subscribe_to_channel(channel):  # WHY: subscribe before firing SDK call
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Failed to subscribe to device command channel.")  # WHY: expose subscribe failure
             websocket_manager.disconnect()  # WHY: release socket on subscribe failure
             return False
@@ -286,13 +286,13 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
     ) -> str | None:
         """Extract the WebSocket session id from an SDK response or return None."""
         if not hasattr(response, "data"):  # WHY: mistapi returns response object with .data
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No response data from API.")  # WHY: signal empty payload
             return None
         response_data = response.data if isinstance(response.data, dict) else {}  # WHY: guard shape
         session_id = response_data.get("session")  # WHY: session_id is the WS correlation key
         if not session_id:  # WHY: no session -> nothing to wait for
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("%s", absent_msg)  # WHY: differentiate command vs streaming context
             return None
         return cast("str", session_id)  # WHY: narrow Any from dict.get
@@ -304,25 +304,25 @@ class _UtilityCommandsWebsocket(_ClusterBase):  # WHY: cluster wrapper mirroring
             return
         raw = result.get("raw", "")  # WHY: streaming variant only reads 'raw'
         if raw:  # WHY: skip blank lines from empty payloads
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("%s", raw)
 
     @staticmethod
     def _print_result_block(command_name: str, result: dict[str, Any]) -> tuple[str, str]:
         """Print the display block for a command result and return (raw, other)."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", "=" * 60)  # WHY: banner separates command output block
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s RESULTS:", command_name.upper())  # WHY: identify command in operator log
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", "=" * 60)
         raw_output = str(result.get("raw", ""))  # WHY: preferred output key
         if raw_output:  # WHY: skip if absent
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("%s", raw_output)
         other_output = str(result.get("Output", ""))  # WHY: some SDK paths emit under 'Output'
         if other_output and other_output != raw_output:  # WHY: avoid double-printing same content
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("%s", other_output)
         return raw_output, other_output
 

--- a/src/device/arp_command_manager.py
+++ b/src/device/arp_command_manager.py
@@ -68,11 +68,11 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         if not mist_host or not mist_apitoken:  # Missing creds — abort
             logger.warning(
                 " Mist host or API token not found in session or environment."
-            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             return
         logger.info(
             " Subscribing to WebSocket stream..."
-        )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         session_id = ARPCommandManager._trigger_command(mist_host, mist_apitoken, site_id, device_id)  # type: ignore[no-untyped-call]
         if not session_id:  # Trigger failed — nothing to listen for
             return
@@ -93,15 +93,15 @@ class ARPCommandManager:  # ARP WebSocket command manager.
             session_id = response.json().get("session")  # Read the session id.
             logger.info(
                 "! ARP command triggered. Session ID: %s", session_id
-            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             return session_id  # Return the session.
         else:
             logger.error(
                 "! Failed to trigger ARP command: %s", response.status_code
-            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error(
                 "%s", response.text
-            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             return None  # Return None.
 
     @staticmethod
@@ -125,17 +125,17 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         """Return on_message/on_close/on_error/on_open callbacks closed over a mutable state dict."""
 
         def on_message(ws, message):  # WebSocket message handler.
-            del ws  # The websocket client passes itself; unused here but required by the callback signature.
+            del ws  # The websocket client passes itself. Unused here but required by the callback signature.
             state["last_message_time"], state["buffer"] = ARPCommandManager._handle_message(  # type: ignore[no-untyped-call]
                 message, target.session_id, state["buffer"], output_lines, debug
             )
 
         def on_close(ws, *args):  # WebSocket close handler.
-            del ws, args  # Signature required by websocket-client; parameters unused here.
+            del ws, args  # Signature required by websocket-client. Parameters unused here.
             ARPCommandManager._handle_close(output_lines, debug)  # type: ignore[no-untyped-call]
 
         def on_error(ws, error):  # WebSocket error handler.
-            del ws  # Signature required by websocket-client; ws unused here.
+            del ws  # Signature required by websocket-client. Ws unused here.
             logging.error("! WebSocket error: %s", error)  # Log the error.
 
         def on_open(ws):  # WebSocket open handler.
@@ -194,7 +194,7 @@ class ARPCommandManager:  # ARP WebSocket command manager.
 
     @staticmethod
     def _safe_parse_ws_arp_payload(message):  # type: ignore[no-untyped-def]
-        """Parse the nested ARP payload and log+swallow JSON/key errors; return inner dict or ``None`` on failure."""
+        """Parse the nested ARP payload and log+swallow JSON/key errors. Return inner dict or ``None`` on failure."""
         try:
             return ARPCommandManager._parse_ws_arp_payload(message)  # Nested JSON unwrap
         except json.JSONDecodeError as exception:  # Malformed JSON anywhere in the chain
@@ -231,7 +231,7 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         if not output_lines:  # No output captured during this session.
             logger.warning(
                 " No ARP output received for this session."
-            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.warning(" No ARP output received for this session.")  # Warn none.
             return  # Nothing further to process.
         compiled_output = "\n".join(output_lines)  # Join the captured lines into one block.
@@ -239,7 +239,7 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         ARPCommandManager._export_to_csv("arp_output_raw.txt")  # type: ignore[no-untyped-call]
         logger.info(
             "\n  ARP Output Received:\n"
-        )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         ARPCommandManager._render_arp_table(compiled_output, debug)  # type: ignore[no-untyped-call]
 
     @staticmethod
@@ -279,12 +279,12 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         if debug:  # Debug mode shows the full table.
             logger.info(
                 "%s", table
-            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.debug("\n%s", table.get_string())  # Log the table contents.
         else:  # Non-debug mode reports only the row count.
             logger.info(
                 "! ARP output received with %d rows.", row_count
-            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
 
     @staticmethod
     def _save_output(compiled_output, filename="arp_output_raw.txt"):  # Save raw output.
@@ -327,7 +327,7 @@ class ARPCommandManager:  # ARP WebSocket command manager.
             writer.writerows(rows)  # Write the rows.
         logger.info(
             "! Saved %d rows to %s", len(rows), path
-        )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
 
     @staticmethod
     def _export_to_csv(txt_filename="arp_output_raw.txt", csv1="arp_dataset1.csv", csv2="arp_dataset2.csv"):
@@ -345,4 +345,4 @@ class ARPCommandManager:  # ARP WebSocket command manager.
         except Exception as e:  # Export failed.
             logger.error(
                 "! Failed to export ARP output to CSV: %s", e
-            )  # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            )  # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.

--- a/src/device/device_reboot_manager.py
+++ b/src/device/device_reboot_manager.py
@@ -3,7 +3,7 @@
 Extracted from MistHelper.py during initiative 1013 (Cat B, position 41).
 Manages device reboot operations with comprehensive safety checks and audit
 logging. Supports reboot by gateway template list (bulk operations) via
-``GatewayTemplateRebootList.CSV``; logs results to
+``GatewayTemplateRebootList.CSV``. Logs results to
 ``GatewayTemplateRebootResults.CSV``. All operations require explicit user
 confirmation and log results for auditing.
 

--- a/src/device/device_utils.py
+++ b/src/device/device_utils.py
@@ -73,7 +73,7 @@ class DeviceUtils:  # Device helper utilities.
 
     @staticmethod
     def _expand_one_port_part(port_part: str) -> list[str]:  # Expand a single port token into concrete port names
-        """Expand one port token: a 'prefix/N-M' range -> [prefix/N..prefix/M]; anything else -> [port_part]."""
+        """Expand one port token: a 'prefix/N-M' range -> [prefix/N..prefix/M]. Anything else -> [port_part]."""
         if "-" not in port_part:  # Not a range expression
             return [port_part]  # Single literal port name
         match = re.match(r"^(.+/)(\d+)-(\d+)$", port_part)  # Match prefix plus numeric start-end range
@@ -87,7 +87,7 @@ class DeviceUtils:  # Device helper utilities.
     @staticmethod
     def _warn_degraded_identifier(value: str, prior_fields: str, key: str) -> None:
         """Log a warning when ``key`` is used as identifier because ``prior_fields`` were blank."""
-        if not prior_fields:  # First-choice field was non-empty; nothing degraded
+        if not prior_fields:  # First-choice field was non-empty. Nothing degraded
             return
         logging.warning(  # Warn that earlier identifier fields are missing
             "Device %s missing %s field, using %s as identifier",  # Format string

--- a/src/device/utility_commands.py
+++ b/src/device/utility_commands.py
@@ -77,7 +77,7 @@ def _print_api_error(response: Any, fail_msg: str, status_code: int) -> None:  #
     error_text = f"! {fail_msg} (HTTP {status_code})"  # WHY: base line always includes status
     if detail:  # WHY: append server-side context when available
         error_text += f": {detail}"  # WHY: keep detail on same line for grep-ability
-    # WHY: preserve error line verbatim; route through logger for capture/redirection.
+    # WHY: preserve error line verbatim. Route through logger for capture/redirection.
     logging.error("%s", error_text)  # WHY: single write to keep operator output atomic
 
 
@@ -181,7 +181,7 @@ class DeviceUtilityCommands:  # WHY: parent class hosting 35 device-command oper
         if isinstance(status, int) and status >= _HTTP_ERROR_THRESHOLD:  # WHY: only ints compare
             _print_api_error(response, fail_msg, status)  # WHY: delegate detail extraction
             return False  # WHY: caller treats False as failure
-        # WHY: preserve success arrow verbatim; route through logger for capture/redirection.
+        # WHY: preserve success arrow verbatim. Route through logger for capture/redirection.
         logging.info("-> %s", success_msg)  # WHY: emit success line
         return True  # WHY: caller treats True as success
 
@@ -195,7 +195,7 @@ class DeviceUtilityCommands:  # WHY: parent class hosting 35 device-command oper
                 None,
             )  # WHY: try both mistapi error shapes
             if code == 400:  # WHY: 400 == missing service_name/session_ids body key
-                # WHY: preserve error guidance verbatim; route through logger for capture/redirection.
+                # WHY: preserve error guidance verbatim. Route through logger for capture/redirection.
                 logging.error(
                     "! API returned 400. The API expects either"
                     " 'service_name' or 'session_ids' in the"

--- a/src/device/virtual_chassis.py
+++ b/src/device/virtual_chassis.py
@@ -180,7 +180,7 @@ class VirtualChassisManager:
         """Interactively convert a single VC switch to virtual MAC (Menu 92)."""
         VirtualChassisManager._print_intro(dry_run)  # WHY: banner + optional dry-run notice.
         site = VirtualChassisManager._resolve_site(apisession, select_site_fn)  # WHY: gate on selection.
-        if site is None:  # WHY: user cancelled or no site returned; nothing to convert.
+        if site is None:  # WHY: user cancelled or no site returned. Nothing to convert.
             return  # WHY: exit silently without touching API state.
         site_id, site_name = site  # WHY: unpack for readable downstream calls.
         selected = VirtualChassisManager._pick_switch(site_id, site_name, io_deps, safe_input_fn)  # WHY.
@@ -188,7 +188,7 @@ class VirtualChassisManager:
             return  # WHY: nothing to convert, exit cleanly.
         device_id = VirtualChassisManager._validate_switch(selected, safe_input_fn)  # WHY: preflight.
         if device_id is None:  # WHY: preflight or id check failed.
-            return  # WHY: already logged; nothing to do.
+            return  # WHY: already logged. Nothing to do.
         target = _ConvertTarget(  # WHY: bundle to keep _convert_or_dry_run under param limit.
             selected=selected, site_id=site_id, site_name=site_name, device_id=device_id
         )
@@ -207,7 +207,7 @@ class VirtualChassisManager:
             io_deps, safe_input_fn
         )
         if not target_ids:  # WHY: nothing to convert if there are no resolvable sites.
-            return  # WHY: early exit; user-facing messaging already emitted.
+            return  # WHY: early exit. User-facing messaging already emitted.
         switches = VirtualChassisManager._load_switches_for_sites(  # WHY: load VC switches for the sites.
             target_ids, site_name_to_id, io_deps.get_csv_path_fn
         )
@@ -217,7 +217,7 @@ class VirtualChassisManager:
             return  # WHY: exit cleanly.
         VirtualChassisManager._display_switches_for_conversion(switches)  # WHY: show what will convert.
         if not VirtualChassisManager._confirm_bulk(safe_input_fn):  # WHY: destructive-op double-check.
-            return  # WHY: cancelled; already printed.
+            return  # WHY: cancelled. Already printed.
         VirtualChassisManager._execute_bulk_conversion(apisession, switches)  # WHY: perform conversion.
 
     @staticmethod
@@ -327,7 +327,7 @@ class VirtualChassisManager:
             return None  # WHY: caller aborts on None.
         if not VirtualChassisManager._preflight_check(selected, safe_input_fn):  # WHY: eligibility.
             return None  # WHY: preflight failed or operator declined.
-        return str(device_id)  # WHY: valid target device id; coerce dict[Any] value to str.
+        return str(device_id)  # WHY: valid target device id. Coerce dict[Any] value to str.
 
     # ------------------------------------------------------------------
     # convert_by_site_list helpers
@@ -447,7 +447,7 @@ class VirtualChassisManager:
         site_name: str,
     ) -> None:
         """Execute API call to convert one switch to virtual MAC."""
-        import mistapi  # WHY: lazy import; module is import-free without a session.
+        import mistapi  # WHY: lazy import. Module is import-free without a session.
 
         print(  # WHY: pre-call progress message.
             f"! Converting switch '{switch_name}' (device_id: {device_id}) at site '{site_name}' to virtual MAC..."
@@ -480,7 +480,7 @@ class VirtualChassisManager:
 
     @staticmethod
     def _log_http_error(response: Any, switch_name: str, site_name: str) -> bool:
-        """Print + log an HTTP >= 400 error; return True when handled."""
+        """Print + log an HTTP >= 400 error. Return True when handled."""
         if hasattr(response, "status_code") and response.status_code >= 400:  # WHY: HTTP error path.
             data = getattr(response, "data", "")  # WHY: include payload for context.
             print(f"! Conversion failed (HTTP {response.status_code}): {data}")  # WHY: operator.
@@ -491,11 +491,11 @@ class VirtualChassisManager:
                 response.status_code,
             )
             return True  # WHY: caller should stop processing.
-        return False  # WHY: no HTTP error; caller continues checking body.
+        return False  # WHY: no HTTP error. Caller continues checking body.
 
     @staticmethod
     def _log_detail_error(response: Any, switch_name: str, site_name: str) -> bool:
-        """Print + log a body-level detail error; return True when handled."""
+        """Print + log a body-level detail error. Return True when handled."""
         resp_data = getattr(response, "data", None)  # WHY: normalize access to payload.
         if isinstance(resp_data, dict) and "detail" in resp_data:  # WHY: mistapi body error shape.
             print(f"! Conversion failed: {resp_data['detail']}")  # WHY: operator feedback.
@@ -544,7 +544,7 @@ class VirtualChassisManager:
         idx: int,
         total: int,
     ) -> bool:
-        """Convert one switch inside the bulk loop; return True on success."""
+        """Convert one switch inside the bulk loop. Return True on success."""
         switch_name = switch.get("name", "")  # WHY: user-visible identifier for progress banner.
         site_name = switch.get("site_name", "")  # WHY: user-visible identifier for progress banner.
         print(f"\n[{idx + 1}/{total}] Converting '{switch_name}' at site '{site_name}'...")  # WHY: progress.
@@ -552,7 +552,7 @@ class VirtualChassisManager:
 
     @staticmethod
     def _call_convert_api(apisession: Any, switch: dict[str, Any]) -> bool:
-        """Call mistapi convert endpoint; return True on success, False on error."""
+        """Call mistapi convert endpoint. Return True on success, False on error."""
         import mistapi  # WHY: lazy import keeps module light for unit tests.
 
         site_id = switch.get("site_id", "")  # WHY: mistapi endpoint requires site_id.
@@ -642,7 +642,7 @@ class VirtualChassisManager:
 
     @staticmethod
     def _prompt_yes_no(safe_input_fn: SafeInputFn) -> str:
-        """Prompt the operator to create an empty VCConvert template; return normalized answer."""
+        """Prompt the operator to create an empty VCConvert template. Return normalized answer."""
         return (  # WHY: normalize input to lower-case stripped string for comparison.
             safe_input_fn(
                 "   Would you like to create an empty file to get started? (y/n): ",

--- a/src/export/const_definitions_exporter.py
+++ b/src/export/const_definitions_exporter.py
@@ -4,7 +4,7 @@ Extracted from MistHelper.py during initiative 1013 (Cat B, position 17).
 Walks ``mistapi.api.v1.const`` via ``pkgutil.iter_modules``, inspects each
 module's public functions, and dispatches API calls per special-handling flag
 (``all_models`` / ``all_countries`` / ``all_countries_channels`` / ``None``).
-Cached CSVs under 24 hours old are reused; stale or missing files trigger a
+Cached CSVs under 24 hours old are reused. Stale or missing files trigger a
 fresh fetch.  Callers continue to reach the class via the
 ``MistHelper.ConstDefinitionsExporter`` re-export alias.
 """
@@ -252,7 +252,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
 
     def _process_all_endpoints(self) -> None:  # Process all endpoints.
         """Process each discovered endpoint."""
-        for config in self.discovered_endpoints.values():  # Walk endpoints; keys are unused here.
+        for config in self.discovered_endpoints.values():  # Walk endpoints. Keys are unused here.
             self._process_single_endpoint(config)  # Process each.
 
     def _process_single_endpoint(self, config: EndpointConfig) -> None:  # Process one endpoint.
@@ -275,7 +275,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
             self.endpoints_processed += 1  # Count processed.
 
     def _evaluate_cache_window(self, config: EndpointConfig, file_age_hours: float, file_timestamp: str) -> bool:
-        """Decide whether the file is within the cache window; emit fresh/stale user messages either way."""
+        """Decide whether the file is within the cache window. Emit fresh/stale user messages either way."""
         if file_age_hours < self.CACHE_MAX_AGE_HOURS:  # Within the window.
             print(f"  ! Found fresh {config.filename} (created {file_timestamp}, {file_age_hours:.1f}h old)")
             print(f"  ! Skipping API call - using cached data (cache valid for {self.CACHE_MAX_AGE_HOURS}h)")
@@ -336,14 +336,14 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
         """Fetch data from a standard endpoint with no special parameters."""
         api_function = getattr(config.module, config.function_name)  # Resolve the function.
         response = api_function(self.api_session)  # Call the API.
-        return getattr(response, "data", response) or {}  # Unwrap data; default empty.
+        return getattr(response, "data", response) or {}  # Unwrap data. Default empty.
 
     def _fetch_one_gateway_model(self, config: EndpointConfig, model: str) -> list:
         """Call the per-model API and return normalized records (or [] on empty / error)."""
         try:
             api_function = getattr(config.module, config.function_name)  # Resolve the function.
             response = api_function(self.api_session, model=model)  # Call with the model.
-            model_data = getattr(response, "data", response) or {}  # Unwrap data; default empty.
+            model_data = getattr(response, "data", response) or {}  # Unwrap data. Default empty.
             if model_data:  # Have data.
                 return self._normalize_model_data(model, model_data)  # Normalize and return.
             return []  # No data for this model.
@@ -375,7 +375,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
             device_models_module = importlib.import_module("mistapi.api.v1.const.device_models")
             device_models_function = device_models_module.listDeviceModels  # Resolve the function.
             response = device_models_function(self.api_session)  # Call the API.
-            device_models_data = getattr(response, "data", response) or {}  # Unwrap data; default empty.
+            device_models_data = getattr(response, "data", response) or {}  # Unwrap data. Default empty.
 
             gateway_models = self._extract_gateway_models(device_models_data)  # Extract gateway models.
 
@@ -455,7 +455,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
             try:
                 api_function = getattr(config.module, config.function_name)  # Resolve the function.
                 response = api_function(self.api_session, country_code=country_code)  # Call with the country.
-                country_data = getattr(response, "data", response) or {}  # Unwrap data; default empty.
+                country_data = getattr(response, "data", response) or {}  # Unwrap data. Default empty.
 
                 if country_data:  # Have data.
                     records = self._normalize_states_data(country_code, country_data)  # Normalize state rows.
@@ -474,7 +474,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
             countries_module = importlib.import_module("mistapi.api.v1.const.countries")  # Endpoint module
             countries_function = countries_module.listCountryCodes  # Resolve API entrypoint
             response = countries_function(self.api_session)  # Call the Mist API
-            return getattr(response, "data", response) or {}  # Unwrap; default to empty
+            return getattr(response, "data", response) or {}  # Unwrap. Default to empty
         except Exception as error:  # Network/import/auth failure
             logging.warning("Failed to get countries list: %s", error)  # Warn for diagnostics
             return {}  # Empty signals caller to use fallback
@@ -588,7 +588,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
             try:
                 api_function = getattr(config.module, config.function_name)  # Resolve the function.
                 response = api_function(self.api_session, country_code=country_code)  # Call with the country.
-                country_data = getattr(response, "data", response) or {}  # Unwrap data; default empty.
+                country_data = getattr(response, "data", response) or {}  # Unwrap data. Default empty.
 
                 if country_data:  # Have data.
                     records = self._normalize_channels_data(country_code, country_data)  # Normalize channel rows.
@@ -603,7 +603,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
 
     @staticmethod
     def _filter_to_iso2_country_codes(country_codes: list[str]) -> list[str]:
-        """Keep only 2-letter alphabetic ISO country codes; log when entries were dropped."""
+        """Keep only 2-letter alphabetic ISO country codes. Log when entries were dropped."""
         original_count = len(country_codes)  # Remember the original count for logging.
         filtered = [c for c in country_codes if ConstDefinitionsExporter._is_valid_alpha2(c)]  # Delegate predicate
         if len(filtered) < original_count:  # Some were filtered.
@@ -618,7 +618,7 @@ class ConstDefinitionsExporter:  # Const definitions exporter.
             countries_module = importlib.import_module("mistapi.api.v1.const.countries")  # Import countries.
             countries_function = countries_module.listCountryCodes  # Resolve the function.
             response = countries_function(self.api_session)  # Call the API.
-            countries_data = getattr(response, "data", response) or {}  # Unwrap data; default empty.
+            countries_data = getattr(response, "data", response) or {}  # Unwrap data. Default empty.
             country_codes = self._extract_channel_country_codes(countries_data)  # Extract country codes.
             if country_codes:  # Have codes.
                 country_codes = self._filter_to_iso2_country_codes(country_codes)  # ISO-2 filter + logging.

--- a/src/export/data_exporter.py
+++ b/src/export/data_exporter.py
@@ -92,7 +92,7 @@ class DataExporter:  # Multi-backend export facade.
         fieldnames: list[str] | None,
         api_function_name: str | None,
     ) -> bool:
-        """Pick CSV vs SQLite write path; return success flag; catches and logs write exceptions."""
+        """Pick CSV vs SQLite write path. Return success flag. Catches and logs write exceptions."""
         try:
             if output_format == "csv":  # CSV branch
                 return DataExporter._write_csv_format(data, filename_or_table, fieldnames=fieldnames)
@@ -109,7 +109,7 @@ class DataExporter:  # Multi-backend export facade.
         fieldnames: list[str] | None = None,
         backend_options: ExportBackendOptions | None = None,
     ) -> bool:
-        """Write data to CSV or SQLite per OUTPUT_FORMAT (or backend_options.format_override); mirror to polyglot DB."""
+        """Write data to CSV or SQLite per OUTPUT_FORMAT (or backend_options.format_override). Mirror to polyglot DB."""
         opts = backend_options if backend_options is not None else ExportBackendOptions()  # Resolve defaults
         mh = importlib.import_module("MistHelper")  # OUTPUT_FORMAT is a mutable module-level global in MistHelper.
         output_format = opts.format_override if opts.format_override else mh.OUTPUT_FORMAT  # Override or global
@@ -157,7 +157,7 @@ class DataExporter:  # Multi-backend export facade.
 
     @staticmethod
     def _perform_polyglot_write(payload: list[dict[str, Any]], api_function_name: str) -> None:
-        """Issue the actual router write call, logging result; never raises (logs warning on failure)."""
+        """Issue the actual router write call, logging result. Never raises (logs warning on failure)."""
         try:
             assert DataExporter._router is not None  # Caller checks _should_skip_polyglot first
             result = DataExporter._router.write(payload, api_function_name)  # Write to polyglot DB
@@ -247,7 +247,7 @@ class DataExporter:  # Multi-backend export facade.
         Args:
             data: Rows to write.
             csv_file: Destination filename (placed in data/ if no directory is given).
-            fieldnames: Optional explicit column order; defaults to sorted unique keys.
+            fieldnames: Optional explicit column order. Defaults to sorted unique keys.
         """
         logging.debug("ENTRY: DataExporter.write_to_csv(data_rows=%s, csv_file=%s)", len(data) if data else 0, csv_file)
         if not data:  # No rows to write -- short-circuit and trace the early exit
@@ -277,7 +277,7 @@ class DataExporter:  # Multi-backend export facade.
 
     @staticmethod
     def _resolve_csv_fields(escaped_data: list[dict[str, Any]], fieldnames: list[str] | None) -> list[str]:
-        """Return the CSV column order; honor caller-supplied fieldnames or fall back to sorted unique keys."""
+        """Return the CSV column order. Honor caller-supplied fieldnames or fall back to sorted unique keys."""
         if fieldnames is not None:  # Caller supplied an explicit column order -- preserve it verbatim
             logging.debug("Using caller-supplied fieldnames for CSV column order")  # Trace explicit ordering
             return fieldnames  # Use as-is
@@ -287,7 +287,7 @@ class DataExporter:  # Multi-backend export facade.
 
     @staticmethod
     def _emit_rows(writer: csv.DictWriter, escaped_data: list[dict[str, Any]], fields: list[str]) -> None:
-        """Write every row in escaped_data through writer; debug-log the first three for diagnostics."""
+        """Write every row in escaped_data through writer. Debug-log the first three for diagnostics."""
         for idx, row in enumerate(escaped_data):  # Walk each row in input order
             writer.writerow({field_name: row.get(field_name, "") for field_name in fields})  # Emit in col order
             if idx < 3:  # Trace the first three rows to aid post-mortem debugging
@@ -299,7 +299,7 @@ class DataExporter:  # Multi-backend export facade.
         escaped_data: list[dict[str, Any]],
         fields: list[str],
     ) -> None:
-        """Open the destination CSV and write header + rows; lets I/O errors propagate to the caller."""
+        """Open the destination CSV and write header + rows. Lets I/O errors propagate to the caller."""
         logging.debug("File I/O: Attempting to open %s for writing", csv_file_path)  # Trace pre-open
         with open(csv_file_path, "w", newline="", encoding="utf-8") as file_handle:  # Open CSV for writing
             writer = csv.DictWriter(file_handle, fieldnames=fields)  # Dict-based CSV writer

--- a/src/export/gateway_test_exporter.py
+++ b/src/export/gateway_test_exporter.py
@@ -322,4 +322,4 @@ class GatewayTestExporter:
         GatewayTestExporter._resolve_misthelper_runtime()  # WHY: the service uses wired gateway helpers.
         from src.refactors.serial_cc.test_results_by_site import GatewayTestResultsService  # noqa: PLC0415
 
-        GatewayTestResultsService.execute(fast=fast)  # Delegate to extracted service; keeps CC at A(1)
+        GatewayTestResultsService.execute(fast=fast)  # Delegate to extracted service. Keeps CC at A(1)

--- a/src/export/license_export_utils.py
+++ b/src/export/license_export_utils.py
@@ -77,7 +77,7 @@ class LicenseExportUtils:
 
     @staticmethod
     def _prompt_async_claim_include_detail() -> bool:
-        """Prompt user for per-device detail preference; returns parsed boolean."""
+        """Prompt user for per-device detail preference. Returns parsed boolean."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of InputUtils helper.
         logging.info("Prompting for include_detail in async-claim export")  # Log before detail prompt.
         detail_answer = mh.InputUtils.safe_input(  # Collect detail preference from user.

--- a/src/export/msp_inventory_exporter.py
+++ b/src/export/msp_inventory_exporter.py
@@ -184,7 +184,7 @@ class MSPInventoryExporter:
     def _normalize_msp_orgs_response(orgs_data) -> list:  # type: ignore[no-untyped-def, type-arg]
         """Coerce listMspOrgs payload into a list (handles single-dict and None)."""
         if not isinstance(orgs_data, list):  # Not a list -- wrap or default
-            return [orgs_data] if orgs_data else []  # Single dict -> 1-element list; None -> empty
+            return [orgs_data] if orgs_data else []  # Single dict -> 1-element list. None -> empty
         return orgs_data  # Already a list
 
     def _fetch_msp_orgs(self, msp_id: str, msp_name: str) -> list:  # type: ignore[type-arg]
@@ -291,7 +291,7 @@ class MSPInventoryExporter:
         print(f"      {org_name}: {len(devices_data)} devices ({type_summary})")
 
     def _validate_org(self, org: dict) -> tuple[str, str] | None:  # type: ignore[type-arg]
-        """Pull (org_id, org_name) from an org dict; return None when org_id is missing/invalid."""
+        """Pull (org_id, org_name) from an org dict. Return None when org_id is missing/invalid."""
         org_id = org.get("id")  # Required identifier
         org_name = org.get("name", "Unknown Org")  # Default name for diagnostics
         if not org_id or not isinstance(org_id, str):  # Bad org row.

--- a/src/export/org_device_stats_exporter.py
+++ b/src/export/org_device_stats_exporter.py
@@ -4,7 +4,7 @@ Extracted from MistHelper.py during initiative 1013 (Cat B, position 45)
 under the SC-001 facade pattern. Handles device stats, port stats, VPN
 peer stats, and VC stats exports. Fast mode caches recent CSV
 (CSV_FRESHNESS_MINUTES) and parallelizes site fetches with bounded
-concurrency; non-fast mode issues one org-level paginated call.
+concurrency. Non-fast mode issues one org-level paginated call.
 
 Direct imports cover stdlib (concurrent.futures, csv, importlib, logging,
 os, time) and third-party (tqdm). Every live-global read
@@ -60,7 +60,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
                     age_minutes,
                     mh.CSV_FRESHNESS_MINUTES,
                 )
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logging.info("* Fast mode: Using cached %s (age %.1fm)", output_file, age_minutes)  # User notice
                 return True  # Caller skips re-fetch
         except Exception as e:  # Freshness-check error
@@ -111,7 +111,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
                     age_minutes,
                     mh.CSV_FRESHNESS_MINUTES,
                 )  # Record why no API calls were made
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logging.info("* Fast mode: Using cached %s (age %.1fm)", output_file, age_minutes)  # User notice
                 return True  # Caller can return early
         except Exception as exception:  # Cache metadata problems degrade gracefully
@@ -175,7 +175,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
 
     @staticmethod
     def _attempt_site_port_stats_fetch(site_id, site_name, connection_semaphore):
-        """Single fetch attempt for one site's port stats; returns list or raises."""
+        """Single fetch attempt for one site's port stats. Returns list or raises."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of mistapi + apisession.
         with connection_semaphore:  # Bound concurrent API calls
             response = mh.mistapi.api.v1.sites.stats.searchSiteSwOrGwPorts(mh.apisession, site_id, limit=1000)
@@ -195,7 +195,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
 
     @staticmethod
     def _handle_site_port_stats_retry(attempt, site_name, exception):
-        """Backoff + log retry; return True if more attempts remain."""
+        """Backoff + log retry. Return True if more attempts remain."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of FAST_MODE_* + FastModeBackoffMultiplier.
         if attempt < mh.FAST_MODE_MAX_RETRIES:  # More retries remain
             backoff_delay = mh.FAST_MODE_RETRY_DELAY * (mh.FastModeBackoffMultiplier.VALUE**attempt)  # Backoff curve
@@ -238,7 +238,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
 
     @staticmethod
     def _process_retry_future(future, retry_futures, retry_results, still_failed):
-        """Resolve one retried-site future; mutate retry_results + still_failed."""
+        """Resolve one retried-site future. Mutate retry_results + still_failed."""
         site_info = retry_futures[future]  # Recover original site tuple
         try:
             result = future.result()  # Resolve retried site rows
@@ -311,7 +311,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils/DataExporter.
         if not all_port_stats:  # Empty dataset should skip file creation and clearly tell the operator why.
             logging.warning(" No port statistics collected. CSV not created.")  # Log absence of exportable data.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.warning("! No port statistics collected. CSV not created.")  # Tell operator no file was written.
             return  # Nothing to sort or write.
         try:  # Sorting is best-effort because some rows may lack MACs.
@@ -325,7 +325,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
         )  # Normalize nested API payloads into flat CSV-friendly records.
         sanitized = DataProcessingUtils.escape_multiline(flattened)  # type: ignore[no-untyped-call]  # Escape embedded newlines so CSV stays row-stable.
         mh.DataExporter.write_with_format_selection(sanitized, output_file, api_function_name="searchSiteSwOrGwPorts")  # type: ignore[no-untyped-call]  # Persist to configured backend with endpoint metadata.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "! %s port stat records exported to %s", len(all_port_stats), output_file
         )  # Confirm output row count to the operator.
@@ -357,7 +357,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
             record_count,
             duration,
         )  # Structured run summary.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "* Fast mode: Collected %s port stat records from %s/%s sites in %.1fs",
             record_count,
@@ -421,7 +421,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
 
     @staticmethod
     def _vpn_peer_stats_cache_hit(output_file: str, fast: bool) -> bool:
-        """Return True if fast-mode cache for VPN peer stats is fresh; emit cache-hit log + print."""
+        """Return True if fast-mode cache for VPN peer stats is fresh. Emit cache-hit log + print."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of CSV_FRESHNESS_MINUTES.
         if not (fast and os.path.exists(output_file)):  # Either non-fast or no file yet.
             return False
@@ -435,7 +435,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
                     age_minutes,
                     mh.CSV_FRESHNESS_MINUTES,
                 )  # Structured log.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logging.info("* Fast mode: Using cached %s (age %.1fm)", output_file, age_minutes)  # Operator-facing.
                 return True
         except Exception as e:  # Freshness check failed -- fall through to fetch.
@@ -446,7 +446,7 @@ class OrgDeviceStatsExporter:  # Org device-stats exporters.
     def vpn_peer_stats(fast: bool = False):  # Export VPN peer stats.
         """Export VPN peer path statistics to OrgVPNPeerStats.csv.
 
-        Fast mode reuses recent CSV; normal mode does an org-level paginated fetch. SECURITY: read-only.
+        Fast mode reuses recent CSV. Normal mode does an org-level paginated fetch. SECURITY: read-only.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live globals.
         output_file = "OrgVPNPeerStats.csv"  # Output filename.

--- a/src/export/org_export_utils.py
+++ b/src/export/org_export_utils.py
@@ -86,11 +86,11 @@ class OrgExportUtils:
             processed = DataProcessingUtils.flatten_nested_fields(all_sites_sle_data)  # Flatten nested fields.
             processed = DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]  # CSV-safe.
             mh.DataExporter.write_with_format_selection(processed, "OrgSitesSLESummary.csv")  # type: ignore[no-untyped-call]
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("! %d sites SLE summary exported to OrgSitesSLESummary.csv", len(processed))  # Tell the user.
             logging.info("Exported %s sites SLE summary to OrgSitesSLESummary.csv", len(processed))  # Log count.
             return  # Done.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning(
             "! 0 sites SLE summary exported to OrgSitesSLESummary.csv (no data available)"
         )  # Tell user zero.
@@ -99,7 +99,7 @@ class OrgExportUtils:
 
     @staticmethod
     def _gather_all_sites_sle(org_id: str, sle_types: list, emitter: Any) -> tuple[list, int]:
-        """Walk SLE types, accumulate rows, tick progress per type; return (rows, items_done)."""
+        """Walk SLE types, accumulate rows, tick progress per type. Return (rows, items_done)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ProgressContext class.
         all_sites_sle_data: list = []  # Accumulator for SLE rows across types.
         items_done = 0  # Items processed counter.
@@ -119,7 +119,7 @@ class OrgExportUtils:
     def sites_sle_summary():  # Export sites SLE summary.
         """Export SLE summary metrics for all sites in the organization to OrgSitesSLESummary.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils, PROGRESS_EMITTER, ProgressContext.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Export Organization Sites SLE Summary:")  # Header.
         logging.info("Starting export of sites SLE summary...")  # Log start.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.
@@ -199,7 +199,7 @@ class OrgExportUtils:
     def _fetch_single_metric_choice(
         org_id: str, metric: str, choice: str, duration: str
     ) -> dict[str, Any] | None:  # One (metric, choice) GET.
-        """Issue the org-insight GET for one (metric, choice) pair; return a tagged record or None."""
+        """Issue the org-insight GET for one (metric, choice) pair. Return a tagged record or None."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession global.
         uri = f"/api/v1/orgs/{org_id}/insights/{metric}"  # Org insight endpoint for this parameterized metric
         query = {"metric": choice, "duration": duration}  # Required 'metric' choice plus the lookback window
@@ -269,7 +269,7 @@ class OrgExportUtils:
 
     @staticmethod
     def _insight_fetch_one_sle_category(org_id: str, metric: str, sle_category: str) -> dict[str, Any] | None:
-        """Fetch one SLE category's site data; return aggregated result row, or None when empty/failed."""
+        """Fetch one SLE category's site data. Return aggregated result row, or None when empty/failed."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession global.
         try:  # Isolate this category so one failure does not abort the others.
             response = mistapi.api.v1.orgs.insights.getOrgSitesSle(  # Call the sites-SLE API for this category.
@@ -283,13 +283,13 @@ class OrgExportUtils:
                 "Got %s sites for insight metric: %s SLE: %s", len(sites_data), metric, sle_category
             )
             return OrgExportUtils._insight_build_sites_result(org_id, metric, sle_category, sites_data)
-        except Exception as sites_error:  # Category fetch failed; log and report None without counting a failure.
+        except Exception as sites_error:  # Category fetch failed. Log and report None without counting a failure.
             logging.debug("Failed to get sites data for metric '%s' SLE '%s': %s", metric, sle_category, sites_error)
             return None  # Treat the failed category as no data.
 
     @staticmethod
     def _insight_fetch_worst_sites_sle(org_id: str, metric: str) -> tuple[list[dict[str, Any]], int, int]:
-        """Fetch one site-SLE metric across wifi/wan/wired categories; return (records, retrieved, failed)."""
+        """Fetch one site-SLE metric across wifi/wan/wired categories. Return (records, retrieved, failed)."""
         records: list[dict[str, Any]] = []  # Aggregated per-category insight results for this metric.
         retrieved = 0  # Count of categories that returned usable site data.
         for sle_category in ("wifi", "wan", "wired"):  # The three SLE service categories to analyze.
@@ -301,12 +301,12 @@ class OrgExportUtils:
 
     @staticmethod
     def _insight_fetch_default_metric(org_id: str, metric: str) -> tuple[list[dict[str, Any]], int, int]:
-        """Fetch one ordinary metric via getOrgSle; return (records, retrieved, failed)."""
+        """Fetch one ordinary metric via getOrgSle. Return (records, retrieved, failed)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession global.
         response = mistapi.api.v1.orgs.insights.getOrgSle(
             mh.apisession, org_id, metric, duration="7d"
         )  # Direct SLE GET.
-        insight_data = getattr(response, "data", response) or {}  # Unwrap the response payload; default to empty.
+        insight_data = getattr(response, "data", response) or {}  # Unwrap the response payload. Default to empty.
         if insight_data:  # The metric returned a usable payload.
             insight_data["metric_type"] = metric  # Tag the metric name onto the payload.
             insight_data["org_id"] = org_id  # Tag the owning org onto the payload.
@@ -319,7 +319,7 @@ class OrgExportUtils:
     def _insight_fetch_one_metric(
         org_id: str, metric: str, parameterized_metrics: dict[str, list[str]]
     ) -> tuple[list[dict[str, Any]], int, int]:
-        """Dispatch one metric to the right fetch strategy; return (records, retrieved, failed)."""
+        """Dispatch one metric to the right fetch strategy. Return (records, retrieved, failed)."""
         try:  # Any metric-level failure is caught here so the overall loop continues.
             logging.debug("Attempting to retrieve org insight metric: %s", metric)  # Trace the attempt.
             if metric in parameterized_metrics:  # Parameterized metric -> expand across its required 'metric' choices.
@@ -331,13 +331,13 @@ class OrgExportUtils:
             if OrgExportUtils._insight_is_worst_sites_metric(metric):  # Site-SLE metric -> per-category analysis.
                 return OrgExportUtils._insight_fetch_worst_sites_sle(org_id, metric)  # Fetch across wifi/wan/wired.
             return OrgExportUtils._insight_fetch_default_metric(org_id, metric)  # Ordinary metric -> single getOrgSle.
-        except Exception as metric_error:  # The metric failed entirely; count it and keep going.
+        except Exception as metric_error:  # The metric failed entirely. Count it and keep going.
             logging.debug("Failed to get org insight data for metric '%s': %s", metric, metric_error)  # Trace failure.
             return [], 0, 1  # No records, one failed metric.
 
     @staticmethod
     def _insight_fetch_sites_sle_summary(org_id: str) -> tuple[list[dict[str, Any]], int, int]:
-        """Fetch the org-wide sites SLE summary; return (records, retrieved, failed)."""
+        """Fetch the org-wide sites SLE summary. Return (records, retrieved, failed)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession global.
         try:  # Isolate the summary fetch so its failure does not abort the export.
             logging.debug("Attempting to retrieve org sites SLE summary")  # Trace the attempt.
@@ -350,8 +350,8 @@ class OrgExportUtils:
                     item["metric_type"] = "org_sites_sle_summary"  # Mark these as the sites SLE summary.
                     item["org_id"] = org_id  # Tag the owning org.
                 logging.debug("Successfully retrieved org sites SLE data for %s sites", len(sites_data))  # Trace count.
-                return list(sites_data), 1, 0  # All rows as records; counts as one successful retrieval.
-            return [], 0, 0  # No summary data; neither retrieved nor failed (matches original).
+                return list(sites_data), 1, 0  # All rows as records. Counts as one successful retrieval.
+            return [], 0, 0  # No summary data. Neither retrieved nor failed (matches original).
         except Exception as sites_error:  # Summary fetch failed.
             logging.debug("Failed to get org sites SLE summary: %s", sites_error)  # Trace the failure.
             return [], 0, 1  # Count the summary as a single failure.
@@ -360,7 +360,7 @@ class OrgExportUtils:
     def _insight_collect_all_metrics(
         org_id: str, org_metrics: list[str], parameterized_metrics: dict[str, list[str]]
     ) -> tuple[list[dict[str, Any]], int, int]:
-        """Retrieve every org-scope metric plus the sites SLE summary; return (all_records, retrieved, failed)."""
+        """Retrieve every org-scope metric plus the sites SLE summary. Return (all_records, retrieved, failed)."""
         all_insight_data: list[dict[str, Any]] = []  # Accumulate every metric's records.
         metrics_retrieved = 0  # Running count of successful retrievals.
         metrics_failed = 0  # Running count of failed or empty retrievals.
@@ -399,10 +399,10 @@ class OrgExportUtils:
     def _insight_export_normalized(all_insight_data: list[dict[str, Any]], org_id: str, metrics_retrieved: int) -> None:
         """Normalize the insight rows and export them to the four normalized CSVs plus the legacy combined file."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter helpers.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Parsing metrics into normalized data structures...")  # Tell the user normalization is starting.
         buckets = OrgExportUtils._insight_normalize_records(all_insight_data, org_id)  # Build the 4 output buckets.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Exporting to normalized CSV files...")  # Tell the user the writes are starting.
         outputs = [  # Drive the four normalized writes from one table to avoid repeated blocks.
             (buckets["summary"], "OrgMetricsSummary.csv", "summary"),  # Summary file + its label.
@@ -413,9 +413,9 @@ class OrgExportUtils:
         for rows, filename, label in outputs:  # Write each normalized bucket to its CSV.
             processed = DataProcessingUtils.escape_multiline(rows)  # type: ignore[no-untyped-call]  # Escape newlines.
             mh.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]  # Write it.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  !? %d %s records -> %s", len(processed), label, filename)  # Report row count.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "\n! Successfully exported %d organization insight metrics to 4 normalized CSV files",
             metrics_retrieved,
@@ -434,7 +434,7 @@ class OrgExportUtils:
         processed_combined = DataProcessingUtils.flatten_nested_fields(all_insight_data)  # Flatten for combined.
         processed_combined = DataProcessingUtils.escape_multiline(processed_combined)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(processed_combined, "OrgInsightMetrics_Legacy.csv")  # type: ignore[no-untyped-call]
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  !? Legacy format maintained -> OrgInsightMetrics_Legacy.csv")  # Confirm the file write.
 
     @staticmethod
@@ -454,17 +454,17 @@ class OrgExportUtils:
 
     @staticmethod
     def _insight_setup_or_empty() -> list[str] | None:
-        """Refresh and load org-scope metrics; write empty outputs and return None when none exist."""
+        """Refresh and load org-scope metrics. Write empty outputs and return None when none exist."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of InsightMetricsUtils helper.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Export Organization Insight Metrics (Normalized):")  # Header for the operation.
         logging.info("Starting export of organization insight metrics with normalized structure...")  # Log start.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Refreshing available insight metrics from Mist API...")  # Tell the user about the refresh.
         mh.InsightMetricsUtils.export_const_insight_metrics()  # Refresh ConstInsightMetrics.csv before scope filtering.
         org_metrics = mh.InsightMetricsUtils.get_by_scope("org")  # Load the metrics that support org scope.
         if not org_metrics:  # No org-scope metrics are available.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No metrics found for org scope. Check ConstInsightMetrics.csv file.")  # Tell the user.
             logging.error("No org-scope metrics found in const insight metrics")  # Log the error condition.
             OrgExportUtils._insight_write_empty_outputs(include_legacy=False)  # Write the 4 empty normalized files.
@@ -474,7 +474,7 @@ class OrgExportUtils:
     @staticmethod
     def _insight_report_totals(metrics_retrieved: int, metrics_failed: int) -> None:
         """Print and log the retrieval totals for the insight-metrics run."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "! Metric retrieval completed: %d successful, %d failed", metrics_retrieved, metrics_failed
         )  # Tell user.
@@ -490,11 +490,11 @@ class OrgExportUtils:
         if org_metrics is None:  # Setup wrote empty outputs and signaled there is nothing to export.
             return  # Abort the export.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org to query.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "! Retrieving %d different organization insight metrics...", len(org_metrics)
         )  # Tell the user the count.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Processing each metric individually with proper error handling...")  # Explain per-metric.
         parameterized_metrics = OrgExportUtils._load_parameterized_metric_choices()  # Metrics needing a 'metric' param.
         try:  # Guard the whole fetch-and-export so a failure still leaves consistent empty outputs.
@@ -505,12 +505,12 @@ class OrgExportUtils:
             if all_insight_data:  # At least one metric returned data.
                 OrgExportUtils._insight_export_normalized(all_insight_data, org_id, metrics_retrieved)  # Export to CSV.
             else:  # Every metric failed or returned empty.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("! 0 organization insight metrics exported (no data available)")  # Tell the user zero.
                 logging.warning("No org insight data available - all metrics failed or returned empty")  # Warn no data.
                 OrgExportUtils._insight_write_empty_outputs(include_legacy=True)  # Write the 5 empty files.
         except Exception as exception:  # The export failed unexpectedly.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Error exporting organization insight metrics: %s", exception)  # Tell the user.
             logging.error("Failed to export org insight metrics: %s", exception)  # Log the failure with context.
             OrgExportUtils._insight_write_empty_outputs(include_legacy=True)  # Write the 5 empty files on error.
@@ -719,7 +719,7 @@ class OrgExportUtils:
             data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
             data = DataProcessingUtils.escape_multiline(data)  # type: ignore[no-untyped-call]
             mh.DataExporter.write_with_format_selection(data, "OrgAuditLogs.csv")  # type: ignore[no-untyped-call]
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("! %d audit logs exported to OrgAuditLogs.csv", len(data))  # Tell the user.
             logging.info("Completed audit logs export and wrote results to OrgAuditLogs.csv.")  # Log completion.
             logging.info("Menu #22: Audit logs export completed - %s records", len(data))  # Log the count.
@@ -758,7 +758,7 @@ class OrgExportUtils:
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils + apisession + helpers.
         current_org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.
         if not current_org_id:  # No org.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No organization selected. Exiting.")  # Tell the user.
             return  # Abort.
         mh.E911BSSIDReportGenerator.execute(  # Run the report.

--- a/src/export/org_inventory_exporter.py
+++ b/src/export/org_inventory_exporter.py
@@ -146,7 +146,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
     def _fetch_and_persist_raw_inventory_variant(
         filename: str, request_kwargs: dict, current_org_id: str, output_folder: str
     ) -> int:
-        """Fetch one inventory variant and persist as raw JSON; return row count."""
+        """Fetch one inventory variant and persist as raw JSON. Return row count."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession.
         logging.info("Fetching raw inventory variant for %s...", filename)  # Log before API call
         response = mistapi.api.v1.orgs.inventory.getOrgInventory(mh.apisession, current_org_id, **request_kwargs)
@@ -176,7 +176,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
                 )
                 for filename, kwargs in request_specs
             }
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info(  # Show concise operator summary once all diagnostic files are written
                 "  Raw JSON saved: vc=True (%s), vc=False (%s), no-vc (%s) entries",
                 counts_by_filename.get("raw_inventory_vc_true.json", 0),
@@ -236,18 +236,18 @@ class OrgInventoryExporter:  # Org inventory exporters.
         site_configs: list[dict[str, str]], empty_vc_shells: list[dict[str, str]]
     ) -> None:
         """Log the dashboard-vs-report parity note when empty VC shells exist."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "  NOTE: %s provisioned VC shells exist with no physical members.",
             len(empty_vc_shells),
         )  # Explain why dashboard counts may exceed report counts
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(  # Provide explicit comparison so operators trust the physical-only report totals
             "        Dashboard shows %s 'Physical Devices' but %s are empty VC placeholders (020003* MAC, no serial/SKU).",  # noqa: E501
             len(site_configs) + len(empty_vc_shells),
             len(empty_vc_shells),
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "        Report correctly includes only %s devices with real hardware.",
             len(site_configs),
@@ -440,7 +440,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
         weekly_data: defaultdict,
         summary_data: defaultdict,
     ) -> tuple[str, int]:
-        """Emit weekly CSVs + summary + master CSV; return master filename + row count."""
+        """Emit weekly CSVs + summary + master CSV. Return master filename + row count."""
         fieldnames = OrgInventoryExporter._COMBINED_INVENTORY_FIELDNAMES  # Stable weekly-export column order
         OrgInventoryExporter._write_combined_inventory_weekly_csvs(output_folder, fieldnames, weekly_data)
         OrgInventoryExporter._write_combined_inventory_summary(output_folder, summary_data)  # Year/week summary
@@ -451,7 +451,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
     @staticmethod
     def combined_inventory_with_site_info():  # Export devices with site info.
         """Combine fresh AllDevicesWithSiteInfo data into weekly CSV files + summary + master CSV."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Combined Inventory with Site Info by Calendar Week:")  # Announce menu 25 export scope
         ctx = OrgInventoryExporter._prepare_combined_inventory_context()  # Resolve org + customer + paths
         current_org_id, end_customer_name, end_customer_account_id, safe_org_name, output_folder = ctx
@@ -482,17 +482,17 @@ class OrgInventoryExporter:  # Org inventory exporters.
         master_row_count: int,
     ) -> None:
         """Log the three CombinedInventory output locations (weekly CSVs, summary, master) for the operator."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "! %s weekly CSV files created in data/CombinedInventory_ByWeek/ folder (%s total devices processed)",
             len(weekly_data),
             len(site_configs),
         )  # Summarize weekly export output counts for the operator.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "! Summary report exported to data/CombinedInventory_ByWeek/CombinedInventory_Summary.csv"
         )  # Confirm summary report location.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "! Master inventory exported to data/CombinedInventory_ByWeek/%s (%s devices)",
             master_csv_filename,
@@ -512,7 +512,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
     @staticmethod
     def _load_site_lookup_from_cache(org_id: str) -> dict:  # type: ignore[type-arg]
         """Load the site lookup from cached SiteList.csv, falling back to the API on any read failure."""
-        try:  # Cached CSV is preferred; fall back to the API if it is missing or unreadable.
+        try:  # Cached CSV is preferred. Fall back to the API if it is missing or unreadable.
             site_list_path = FilePathUtils.get_csv_path("SiteList.csv")  # Resolve site CSV path.
             with open(site_list_path, encoding="utf-8") as file:  # Open cached site CSV.
                 reader = csv.DictReader(file)  # Read site CSV rows.
@@ -528,7 +528,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
     @staticmethod
     def _load_inventory_from_cache(org_id: str) -> list:  # type: ignore[type-arg]
         """Load the org inventory from cached OrgInventory.csv, falling back to the API on any read failure."""
-        try:  # Cached CSV is preferred; fall back to the API if it is missing or unreadable.
+        try:  # Cached CSV is preferred. Fall back to the API if it is missing or unreadable.
             inventory_path = FilePathUtils.get_csv_path("OrgInventory.csv")  # Resolve inventory CSV path.
             with open(inventory_path, encoding="utf-8") as file:  # Open cached inventory CSV.
                 reader = csv.DictReader(file)  # Read inventory CSV rows.
@@ -559,7 +559,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
     def _build_mac_to_site_id(inventory: list) -> dict:  # type: ignore[type-arg]
         """Index every device's mac -> site_id so VC members without a site_id can inherit one from their parent.
 
-        Physical VC members carry vc_mac but no site_id; that vc_mac may point at the virtual VC entry (020003* MAC)
+        Physical VC members carry vc_mac but no site_id. That vc_mac may point at the virtual VC entry (020003* MAC)
         or the primary physical chassis MAC. Indexing ALL devices with a site_id covers both cases.
         """
         mac_to_site_id: dict[str, str] = {}  # Universal mac -> site_id lookup for inheritance.
@@ -574,7 +574,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
 
     @staticmethod
     def _enrich_one_device(device: dict, site_lookup: dict, mac_to_site_id: dict) -> bool:  # type: ignore[type-arg]
-        """Attach site name/address + split-address fields to one device; return True if its site was VC-inherited."""
+        """Attach site name/address + split-address fields to one device. Return True if its site was VC-inherited."""
         site_id = device.get("site_id")  # Check if device has its own site_id.
         inherited = False  # Track whether this device inherited its site from a VC parent.
         if not site_id and device.get("vc_mac"):  # Device missing a site assignment but part of a VC.
@@ -613,13 +613,13 @@ class OrgInventoryExporter:  # Org inventory exporters.
 
     @staticmethod
     def _flatten_sort_export_devices(devices: list) -> list:  # type: ignore[type-arg]
-        """Flatten, escape, sort by site name, and write the all-devices CSV; return the processed rows for display."""
+        """Flatten, escape, sort by site name, and write the all-devices CSV. Return the processed rows for display."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter (T-08 pending).
         devices = DataProcessingUtils.flatten_nested_fields(devices)  # Flatten enriched fields.
         devices = DataProcessingUtils.escape_multiline(devices)  # type: ignore[no-untyped-call]
         devices = sorted(devices, key=lambda x: x.get("site_name", ""))  # Sort by site name.
         mh.DataExporter.write_with_format_selection(devices, "AllDevicesWithSiteInfo.csv")  # type: ignore[no-untyped-call]
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! %s devices exported to AllDevicesWithSiteInfo.csv", len(devices))  # Confirm export to operator.
         logging.info("All device data written to AllDevicesWithSiteInfo.csv (%s records).", len(devices))  # Log write.
         return devices  # Processed rows for the summary table.
@@ -649,11 +649,11 @@ class OrgInventoryExporter:  # Org inventory exporters.
     def devices_with_site_info(fast: bool = False):
         """Fetch all org devices, enrich them with site/address info, and export AllDevicesWithSiteInfo.csv.
 
-        When ``fast`` is True, cached SiteList.csv / OrgInventory.csv are used (with API fallback); otherwise
+        When ``fast`` is True, cached SiteList.csv / OrgInventory.csv are used (with API fallback). Otherwise
         the data is fetched directly from the API. Physical VC members without a site_id inherit one from
         their VC parent. Also debug-logs a summary table.
         """
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("All Devices with Site and Address Info:")  # Inform operator of export.
         logging.info("Fetching All Devices with Site Info...")  # Log fetch start.
         if fast:  # Fast mode reuses cached CSV files.
@@ -674,7 +674,7 @@ class OrgInventoryExporter:  # Org inventory exporters.
         Fetches all gateway devices in the organization, enriches them with site and
         address info, writes GatewaysWithSiteInfo.csv, and logs a summary table.
         """
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Gateways with Site and Address Info:")  # Inform operator of export.
         logging.info("Fetching Gateways with Site Info...")  # Log fetch start.
         org_id = ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
@@ -688,25 +688,25 @@ class OrgInventoryExporter:  # Org inventory exporters.
 
         gateways = OrgInventoryExporter._enrich_gateways_with_site_info(inventory, site_lookup)  # Filter + enrich
         logging.info("Enriched %s gateway devices with site info.", len(gateways))  # Log enriched gateway count.
-        gateways = OrgInventoryExporter._flatten_sort_export_gateways(gateways)  # Flatten/sort/write CSV; returns rows
+        gateways = OrgInventoryExporter._flatten_sort_export_gateways(gateways)  # Flatten/sort/write CSV. Returns rows
         OrgInventoryExporter._display_gateways_summary_table(gateways)  # Debug-log a PrettyTable of the gateways.
 
     @staticmethod
     def _flatten_sort_export_gateways(gateways: list) -> list:  # type: ignore[type-arg]  # Flatten/sort/write the CSV
-        """Flatten, escape, sort by site name, and write the gateways CSV; return the processed rows for display."""
+        """Flatten, escape, sort by site name, and write the gateways CSV. Return the processed rows for display."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter (T-08 pending).
         gateways = DataProcessingUtils.flatten_nested_fields(gateways)  # Flatten gateway fields.
         gateways = DataProcessingUtils.escape_multiline(gateways)  # type: ignore[no-untyped-call]
         gateways = sorted(gateways, key=lambda x: x.get("site_name", ""))  # Sort by site name.
         mh.DataExporter.write_with_format_selection(gateways, "GatewaysWithSiteInfo.csv")  # type: ignore[no-untyped-call]
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! %s gateways exported to GatewaysWithSiteInfo.csv", len(gateways))  # Confirm export to operator.
         logging.info("Gateway data written to GatewaysWithSiteInfo.csv")  # Log write success.
         return gateways  # Processed rows for the summary table
 
     @staticmethod
     def _split_full_address(address: str) -> tuple[str, str, str, str, str]:  # Parse address into parts.
-        """Split a full address into (street, city, state, zip, country); raw street + blanks on parse failure."""
+        """Split a full address into (street, city, state, zip, country). Raw street + blanks on parse failure."""
         try:
             parts = address.split(", ")  # Split on comma separators.
             state_zip = parts[2].split()  # Split state and zip.

--- a/src/export/org_site_exporter.py
+++ b/src/export/org_site_exporter.py
@@ -70,17 +70,17 @@ class OrgSiteExporter:  # Org site exporters.
         output_file = "SiteList_ListAPI.csv"  # Define output filename.
         if os.path.exists(output_file):  # Branch: cached file exists.
             logging.info("! Using cached %s (already exists)", output_file)  # Log cache reuse.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! Using cached %s (already exists)", output_file)
             return  # Skip re-fetch.
         logging.info("Fetching all sites using the 'list' sites API endpoint...")  # Log fetch start.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Fetching all sites using the 'list' sites API endpoint...")
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
         sites = mh.APICoreFetchUtils.all_sites_with_limit(org_id)  # Fetch all sites.
         if not sites:  # Branch: no sites returned.
             logging.warning(" No sites returned from API.")  # Log empty result.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(" No sites returned from API.")
             return  # Skip write.
         sites = DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
@@ -90,7 +90,7 @@ class OrgSiteExporter:  # Org site exporters.
         # Write to the configured output backend (CSV or SQLite) via the DataExporter abstraction
         mh.DataExporter.write_with_format_selection(sites, output_file)  # type: ignore[no-untyped-call]
         logging.info("! Sites exported to %s", output_file)  # Log the successful export
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Sites exported to %s", output_file)
 
     @staticmethod
@@ -99,7 +99,7 @@ class OrgSiteExporter:  # Org site exporters.
         mh = importlib.import_module(
             "MistHelper"
         )  # WHY: lazy fetch of ConfigUtils/APICoreFetchUtils/DataProcessingUtils/DataExporter.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Sites with Location and Timezone Info:")
         logging.info("Listing Sites with Full Info:")  # Log listing start.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
@@ -109,7 +109,7 @@ class OrgSiteExporter:  # Org site exporters.
         flattened_sites = DataProcessingUtils.flatten_nested_fields(sites)  # Flatten nested site fields.
         sanitized_sites = DataProcessingUtils.escape_multiline(flattened_sites)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(sanitized_sites, "SitesWithLocations.csv")  # type: ignore[no-untyped-call]
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %s sites exported to SitesWithLocations.csv", len(sanitized_sites))
         logging.info(" Full site data written to SitesWithLocations.csv")  # Log write success.
 
@@ -119,7 +119,7 @@ class OrgSiteExporter:  # Org site exporters.
         mh = importlib.import_module(
             "MistHelper"
         )  # WHY: lazy fetch of ConfigUtils/DataProcessingUtils/DataExporter + apisession.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Current and Historical Guest Users:")
         logging.info("Exporting all current guest users in the org...")  # Log guest export start.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org id.
@@ -130,7 +130,7 @@ class OrgSiteExporter:  # Org site exporters.
         guests = DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
         guests = DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(guests, "OrgCurrentGuests.csv")  # type: ignore[no-untyped-call]
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %s current guest users exported to OrgCurrentGuests.csv", len(guests))
         logging.info(" Current guests exported to OrgCurrentGuests.csv")  # Log write success.
 
@@ -153,6 +153,6 @@ class OrgSiteExporter:  # Org site exporters.
         guests = DataProcessingUtils.flatten_nested_fields(guests)  # Flatten nested guest fields.
         guests = DataProcessingUtils.escape_multiline(guests)  # type: ignore[no-untyped-call]
         mh.DataExporter.write_with_format_selection(guests, "OrgHistoricalGuests.csv")  # type: ignore[no-untyped-call]
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %s historical guest users exported to OrgHistoricalGuests.csv", len(guests))
         logging.info(" Historical guests exported to OrgHistoricalGuests.csv")  # Log write success.

--- a/src/export/org_template_exporter.py
+++ b/src/export/org_template_exporter.py
@@ -61,7 +61,7 @@ class OrgTemplateExporter:
 
     @staticmethod
     def _export_one_template(title: str, api_call: Any, filename: str, error_label: str) -> None:
-        """Fetch one template type to its CSV; log (do not raise) on failure so other types still export."""
+        """Fetch one template type to its CSV. Log (do not raise) on failure so other types still export."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of APIDataFetcher helper.
         try:
             mh.APIDataFetcher(  # Fetch this template type and write it to CSV.
@@ -94,10 +94,10 @@ class OrgTemplateExporter:
 
     @staticmethod
     def _persist_ap_template_profiles(ap_profiles: list[Any], filename: str) -> None:
-        """Flatten + write AP template profiles to CSV; emit operator + log summary."""
+        """Flatten + write AP template profiles to CSV. Emit operator + log summary."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter + DataProcessingUtils helpers.
         if not ap_profiles:  # No AP templates in this org.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! 0 AP templates exported to OrgApTemplates.csv (no templates found)")  # Inform user.
             logging.info(
                 "No AP templates returned from canonical endpoint; writing empty OrgApTemplates.csv"
@@ -107,7 +107,7 @@ class OrgTemplateExporter:
         processed = DataProcessingUtils.flatten_nested_fields(ap_profiles)  # Flatten nested JSON.
         processed = DataProcessingUtils.escape_multiline(processed)  # Escape multiline.
         mh.DataExporter.write_with_format_selection(processed, filename)  # Persist.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %s AP templates exported to %s", len(processed), filename)  # Tell user.
         logging.info("Exported %s AP templates to %s.", len(processed), filename)  # Log count.
 
@@ -115,7 +115,7 @@ class OrgTemplateExporter:
     def ap_templates() -> None:
         """Export AP templates (canonical deviceprofiles type=ap) to OrgApTemplates.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils + DataExporter + apisession.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Export Organization AP Templates:")  # Header.
         logging.info("Starting export of organization AP templates (canonical deviceprofiles type=ap)...")  # Log start.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve org.
@@ -139,17 +139,17 @@ class OrgTemplateExporter:
         """Flatten + escape + write switch-template payload, then log/emit a success line."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter + DataProcessingUtils helpers.
         if not switch_profiles:  # No templates returned from the API.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! 0 switch templates exported to OrgSwitchTemplates.csv (no templates found)")  # User notice.
             logging.info(  # Trace empty-result branch.
                 "No switch templates returned from canonical endpoint; writing empty OrgSwitchTemplates.csv"
             )
             mh.DataExporter.write_with_format_selection([], filename)
-            return  # Done; empty CSV written.
+            return  # Done. Empty CSV written.
         processed = DataProcessingUtils.flatten_nested_fields(switch_profiles)  # Flatten nested template fields.
         processed = DataProcessingUtils.escape_multiline(processed)  # CSV-safe.
         mh.DataExporter.write_with_format_selection(processed, filename)  # Persist.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %s switch templates exported to %s", len(processed), filename)  # User notice.
         logging.info("Exported %s switch templates to %s.", len(processed), filename)  # Trace count.
 
@@ -157,7 +157,7 @@ class OrgTemplateExporter:
     def switch_templates() -> None:
         """Export switch templates to OrgSwitchTemplates.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils + DataExporter + apisession.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Export Organization Switch Templates:")  # Header.
         logging.info("Starting export of organization switch templates (canonical networktemplates)...")  # Log start.
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org.

--- a/src/export/self_export_utils.py
+++ b/src/export/self_export_utils.py
@@ -20,7 +20,7 @@ from src.time.time_utils import TimeUtils  # WHY: 1014 P6 direct import (FR-005)
 
 
 class SelfExportUtils:  # Self/account exporters.
-    # pylint: disable=too-few-public-methods  # WHY: static-method utility class; grouping by domain is the point.
+    # pylint: disable=too-few-public-methods  # WHY: static-method utility class. Grouping by domain is the point.
     """Authenticated self/account export utilities.
 
     Exports data scoped to the currently authenticated admin account rather

--- a/src/export/site_anomaly_exporter.py
+++ b/src/export/site_anomaly_exporter.py
@@ -41,12 +41,12 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def anomaly_events():
         """Export comprehensive anomaly events for a selected site to SiteAnomalyEvents_[SiteName].csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils + EnhancedSSHRunner.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Export Site Anomaly Events:")  # User-visible header.
         logger.info("Starting export of site anomaly events...")  # Trace start of export.
         site_id = mh.PromptUtils.select_site()  # Prompt the user for a site.
         if not site_id:  # No site chosen.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No site selected. Exiting.")  # Tell the user.
             return  # Abort the export.
         site_name = SiteAnomalyExporter._anomaly_resolve_site_name(site_id)  # Resolve display name for filename.
@@ -58,7 +58,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
             data, count = SiteAnomalyExporter._aggregate_site_anomaly_data(site_id, site_name, metrics)  # Fetch.
             SiteAnomalyExporter._export_anomaly_data(data, filename, "site anomaly event", count, site_name)  # CSV
         except Exception as exception:  # Broader export failure (flatten/write).
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Error exporting site anomaly events: %s", exception)  # Tell the user.
             logger.error("Failed to export site anomaly events for %s: %s", site_name, exception)  # Log it.
 
@@ -66,18 +66,18 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def device_anomaly_events():
         """Export device anomaly events to SiteDeviceAnomalyEvents_[Site]_[Device].csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Export Site Device Anomaly Events:")  # User-visible header.
         logger.info("Starting export of site device anomaly events...")  # Trace start of export.
         site_id = mh.PromptUtils.select_site()  # Prompt the user for a site.
         if not site_id:  # No site chosen.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No site selected. Exiting.")  # Tell the user.
             return  # Abort the export.
         site_name = SiteAnomalyExporter._anomaly_resolve_site_name(site_id)  # Resolve display name.
         selection = mh.PromptUtils.select_device_id_from_inventory(site_id)  # Prompt for a device.
         if not selection:  # No device chosen.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No device selected. Exiting.")  # Tell the user.
             return  # Abort the export.
         device_mac, device_name = selection[0], selection[1]  # Unpack the MAC and display name.
@@ -89,7 +89,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
             )  # Loop + fetch each metric.
             SiteAnomalyExporter._export_anomaly_data(data, filename, "device anomaly event", count, device_name)  # CSV
         except Exception as exception:  # Broader export failure (flatten/write).
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Error exporting device anomaly events: %s", exception)  # Tell the user.
             logger.error("Failed to export device anomaly events for %s: %s", device_name, exception)  # Log it.
 
@@ -105,17 +105,17 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def _discover_site_anomaly_metrics() -> list[str]:
         """Discover potential site anomaly metric names, announce them, return [] when none found."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of AnomalyMetricsDiscovery.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Discovering potential anomaly metrics from Mist API definitions...")  # Tell the user.
         potential = mh.AnomalyMetricsDiscovery.discover()  # Pull discovery list from CSV.
         names = [info["metric_name"] for info in potential]  # Extract just the metric names.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Found %s potential anomaly metrics:", len(names))  # Tell the user the count.
         for info in potential:  # Show each metric to the user.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  - %s: %s...", info["metric_name"], info["description"][:60])  # Trim long descriptions.
         if not names:  # No metrics discovered at all.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No potential anomaly metrics found. Please check ConstInsightMetrics.csv availability.")
         return names  # Return the names (possibly empty).
 
@@ -127,22 +127,22 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
         display_label, data_type = scope  # Unpack the scope tuple for printing + tagging.
         try:
             response = fetch_callable()  # Issue the API call (callable is already bound via functools.partial).
-            data = getattr(response, "data", response) or {}  # Unwrap data; default empty.
+            data = getattr(response, "data", response) or {}  # Unwrap data. Default empty.
             if data:  # API returned actual data for this metric.
                 data["metric_type"] = metric  # Tag the metric name.
                 data["data_type"] = data_type  # Tag the data type for downstream consumers.
                 for key, value in tags.items():  # Apply caller-supplied tags (site_id, site_name, ...).
                     data[key] = value  # Set each tag on the result row.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.info("!? Retrieved %s %s", metric, display_label)  # Tell the user.
                 logger.debug("Successfully retrieved %s %s for %s", metric, display_label, tags)  # Trace success.
                 return data  # Return the tagged row.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("! No %s %s available", metric, display_label)  # Tell the user the metric had no data.
             logger.info("No %s %s available for %s", metric, display_label, tags)  # Log the absence.
             return None  # Signal caller to skip.
         except Exception as metric_error:  # This metric's fetch failed.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Error retrieving %s %s: %s", metric, display_label, metric_error)  # Tell the user.
             logger.warning("Error retrieving %s %s for %s: %s", metric, display_label, tags, metric_error)  # Warn.
             return None  # Signal caller to skip.
@@ -154,7 +154,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
         tags: dict[str, Any],
         scope: tuple[str, str],
     ) -> tuple[list[dict[str, Any]], int]:
-        """Loop metrics with mistapi loggers silenced; build fetch with fetch_builder(metric); collect tagged rows."""
+        """Loop metrics with mistapi loggers silenced. Build fetch with fetch_builder(metric). Collect tagged rows."""
         original_levels = SiteAnomalyExporter._anomaly_suppress_mistapi_loggers()  # Quiet mistapi internal loggers.
         rows: list[dict[str, Any]] = []  # Accumulator for successful rows.
         count = 0  # Number of metrics that returned data.
@@ -173,11 +173,11 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def _aggregate_site_anomaly_data(
         site_id: str, site_name: str, metrics: list[str]
     ) -> tuple[list[dict[str, Any]], int]:
-        """Loop site anomaly metrics with mistapi loggers silenced; return (rows, success_count)."""
+        """Loop site anomaly metrics with mistapi loggers silenced. Return (rows, success_count)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of mistapi + apisession.
         tags = {"site_id": site_id, "site_name": site_name}  # Tags attached to every row.
         scope = ("anomaly events", "site_anomaly_events")  # Display label + data_type tag.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Retrieving %s different site anomaly events...", len(metrics))  # Tell the user.
         builder = lambda metric: functools.partial(  # noqa: E731 — bind site-anomaly fetch per metric.
             mh.mistapi.api.v1.sites.anomaly.listSiteAnomalyEvents, mh.apisession, site_id, metric
@@ -188,7 +188,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def _aggregate_device_anomaly_data(
         site_id: str, site_name: str, device_mac: str, device_name: str, metrics: list[str]
     ) -> tuple[list[dict[str, Any]], int]:
-        """Loop device anomaly metrics with mistapi loggers silenced; return (rows, success_count)."""
+        """Loop device anomaly metrics with mistapi loggers silenced. Return (rows, success_count)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of mistapi + apisession.
         tags = {  # Tags attached to every row.
             "site_id": site_id,
@@ -197,7 +197,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
             "device_name": device_name,
         }
         scope = ("device anomaly data", "device_anomaly_events")  # Display label + data_type tag.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "! Retrieving %s different device anomaly events for %s...", len(metrics), device_name
         )  # Tell the user.
@@ -220,11 +220,11 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
             processed = DataProcessingUtils.flatten_nested_fields(data_list)  # Flatten nested fields.
             processed = DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
             mh.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("! %s %s types exported to %s", success_count, label, filename)  # Tell the user the count.
             logger.info("Exported %s %s types for %s to %s", success_count, label, scope_name, filename)  # Log.
         else:  # No data from any metric.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! 0 %ss exported to %s (no data available)", label, filename)  # Tell the user zero.
             logger.warning("No %s available for %s", label, scope_name)  # Warn about the empty result.
             mh.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]
@@ -239,7 +239,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def _anomaly_resolve_site_name(site_id: str) -> str:
         """Resolve the human-readable site name for a site_id, falling back to the id on lookup failure."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of mistapi + apisession.
-        try:  # The site-name lookup is best-effort; the id is an acceptable fallback for the filename.
+        try:  # The site-name lookup is best-effort. The id is an acceptable fallback for the filename.
             response = mh.mistapi.api.v1.sites.listSites(mh.apisession, site_id)  # List the site.
             sites = mh.mistapi.get_all(response=response, mist_session=mh.apisession)  # Page all rows.
             return next((site["name"] for site in sites if site["id"] == site_id), site_id)  # Resolve site name.
@@ -250,11 +250,11 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def _anomaly_lookup_client_hostname(site_id: str, client_mac: str) -> str:
         """Look up a client's hostname from its wireless stats, falling back to the MAC on failure."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of mistapi + apisession.
-        try:  # Hostname enrichment is best-effort; the MAC is an acceptable fallback.
+        try:  # Hostname enrichment is best-effort. The MAC is an acceptable fallback.
             response = mh.mistapi.api.v1.sites.stats.listSiteWirelessClientsStats(  # List client stats.
                 mh.apisession, site_id, limit=100, duration="1d"
             )
-            clients = getattr(response, "data", response) or []  # Unwrap data; default empty.
+            clients = getattr(response, "data", response) or []  # Unwrap data. Default empty.
             for client in clients:  # Find the matching client.
                 if client.get("mac") == client_mac:  # MAC matches.
                     return client.get("hostname", client.get("name", "Unknown"))  # Read the hostname.
@@ -265,7 +265,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
 
     @staticmethod
     def _anomaly_suppress_mistapi_loggers() -> dict:  # type: ignore[type-arg]
-        """Raise mistapi logger levels to CRITICAL to keep the console clean; return their original levels."""
+        """Raise mistapi logger levels to CRITICAL to keep the console clean. Return their original levels."""
         mistapi_loggers = [
             "apirequest",
             "apiresponse",
@@ -290,13 +290,13 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def _anomaly_fetch_one_metric(
         site_id: str, client_mac: str, site_name: str, client_hostname: str, metric: str
     ) -> dict | None:  # type: ignore[type-arg]
-        """Fetch one client anomaly metric and tag it with site/client metadata; return the record, or None if empty."""
+        """Fetch one client anomaly metric and tag it with site/client metadata. Return the record, or None if empty."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of mistapi + apisession.
         # Get client anomalies for this metric.
         response = mh.mistapi.api.v1.sites.anomaly.getSiteAnomalyEventsForClient(
             mh.apisession, site_id, client_mac, metric
         )
-        client_anomaly_data = getattr(response, "data", response) or {}  # Unwrap data; default empty.
+        client_anomaly_data = getattr(response, "data", response) or {}  # Unwrap data. Default empty.
         if not client_anomaly_data:  # The metric returned no data.
             return None  # Signal an empty metric.
         client_anomaly_data["metric_type"] = metric  # Tag the metric.
@@ -309,14 +309,14 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
 
     @staticmethod
     def _anomaly_handle_metric_result(record: dict | None, metric: str, client_mac: str, all_data: list) -> int:  # type: ignore[type-arg]
-        """Record one fetched metric: append + announce on data, announce 'none' otherwise; return 1 if kept else 0."""
+        """Record one fetched metric: append + announce on data, announce 'none' otherwise. Return 1 if kept else 0."""
         if record is not None:  # The metric returned data.
             all_data.append(record)  # Collect the row.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("!? Retrieved %s client anomaly data", metric)  # Tell the user.
             logger.debug("Successfully retrieved %s client anomaly data for %s", metric, client_mac)  # Trace.
             return 1  # One successful metric.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! No %s client anomaly data available", metric)  # Tell the user none.
         logger.info("No %s client anomaly data available for %s", metric, client_mac)  # Log none.
         return 0  # No data for this metric.
@@ -325,8 +325,8 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
     def _anomaly_collect_metrics(
         site_id: str, client_mac: str, site_name: str, client_hostname: str
     ) -> tuple[list, int]:  # type: ignore[type-arg]
-        """Fetch all client anomaly metrics for one client; return (records, retrieved_count)."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        """Fetch all client anomaly metrics for one client. Return (records, retrieved_count)."""
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "! Retrieving %s different client anomaly events for %s (%s)...",
             len(SiteAnomalyExporter._CLIENT_ANOMALY_METRICS),
@@ -344,7 +344,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
                     record, metric, client_mac, all_client_anomaly_data
                 )
             except Exception as metric_error:  # Metric fetch failed.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("! Error retrieving %s client anomaly data: %s", metric, metric_error)  # Tell the user.
                 logger.warning(
                     "Error retrieving %s client anomaly data for %s: %s", metric, client_mac, metric_error
@@ -359,13 +359,13 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
             processed = DataProcessingUtils.flatten_nested_fields(all_data)  # Flatten nested fields.
             processed = DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
             mh.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("! %s client anomaly event types exported to %s", metrics_retrieved, filename)  # Tell the user.
             logger.info(
                 "Exported %s client anomaly event types for %s to %s", metrics_retrieved, client_mac, filename
             )  # Log the export.
         else:  # No metric returned data.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(
                 "! 0 client anomaly events exported to %s (no data available)", filename
             )  # Tell the user zero.
@@ -382,13 +382,13 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils + PromptClientUtils + SSH.
         site_id = mh.PromptUtils.select_site()  # Select a site.
         if not site_id:  # No site selected.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No site selected. Exiting.")  # Tell the user.
             return None  # Abort.
         site_name = SiteAnomalyExporter._anomaly_resolve_site_name(site_id)  # Resolve site name for the filename.
         client_mac, _, _ = mh.PromptClientUtils.select_client(site_id)  # Select a client (only MAC is used).
         if not client_mac:  # No client selected.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No client selected. Exiting.")  # Tell the user.
             return None  # Abort.
         client_hostname = SiteAnomalyExporter._anomaly_lookup_client_hostname(site_id, client_mac)  # Hostname lookup.
@@ -403,7 +403,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
         Prompts for a site and client, fetches the successful_connect / roaming / throughput
         anomaly metrics, and writes SiteClientAnomalyEvents_[SiteName]_[ClientMAC].csv.
         """
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Export Site Client Anomaly Events:")  # Header.
         logger.info("Starting export of site client anomaly events...")  # Log start.
         prepared = SiteAnomalyExporter._anomaly_prepare()  # Prompt + resolve site/client/filename.
@@ -417,7 +417,7 @@ class SiteAnomalyExporter:  # Site anomaly exporters.
             )
             SiteAnomalyExporter._anomaly_export(all_data, metrics_retrieved, client_mac, filename)  # Write the CSV.
         except Exception as exception:  # Export failed.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Error exporting client anomaly events: %s", exception)  # Tell the user.
             logger.error("Failed to export client anomaly events for %s: %s", client_mac, exception)  # Log the error.
         finally:  # Always restore the mistapi logger levels.

--- a/src/export/site_config_exporter.py
+++ b/src/export/site_config_exporter.py
@@ -46,7 +46,7 @@ class SiteConfigExporter:
 
     @staticmethod
     def _fetch_wlans_with_fallback(site_id: str) -> list[Any]:
-        """Prefer derived WLANs (includes inherited/template); fall back to site-local on failure."""
+        """Prefer derived WLANs (includes inherited/template). Fall back to site-local on failure."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession module global.
         try:
             derived_response = mistapi.api.v1.sites.wlans.listSiteWlansDerived(  # List derived WLANs.
@@ -71,7 +71,7 @@ class SiteConfigExporter:
         if not rawdata:  # No rows.
             logging.warning("No data provided for output to %s", filename)  # Warn none.
             mh.DataExporter.write_with_format_selection([], filename)  # Empty CSV.
-            # WHY: Preserve user-facing zero-record notice verbatim; INFO-level structured emit.
+            # WHY: Preserve user-facing zero-record notice verbatim. INFO-level structured emit.
             logging.info("! 0 records exported to data\\%s", filename)
             return  # Done.
         processed = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.

--- a/src/export/site_device_exporter.py
+++ b/src/export/site_device_exporter.py
@@ -51,7 +51,7 @@ class SiteDeviceExporter:
             mh.apisession, site_id, type="all"
         ).data  # All device types
         if not rawdata:  # No devices.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("No devices found for the selected site.")  # Tell the user.
             logging.warning("No devices found for site_id=%s", site_id)  # Warn none found.
             return  # Abort.
@@ -71,11 +71,11 @@ class SiteDeviceExporter:
     def _filter_devices_by_type(
         rawdata: list[dict[str, Any]], device_type: str, site_id: str
     ) -> list[dict[str, Any]] | None:
-        """Keep only devices whose type is in the comma-separated device_type; return None when none remain."""
+        """Keep only devices whose type is in the comma-separated device_type. Return None when none remain."""
         requested_types = [dtype.strip() for dtype in device_type.split(",")]  # Parse requested types.
         filtered = [d for d in rawdata if d.get("type", "").lower() in requested_types]  # Keep matching devices.
         if not filtered:  # None after filter.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("No devices of type '%s' found at the selected site.", device_type)  # Tell the user.
             logging.warning("No devices of type '%s' found for site_id: %s", device_type, site_id)  # Warn none.
             return None  # Signal the caller to abort.
@@ -100,14 +100,14 @@ class SiteDeviceExporter:
         """Flatten + write device-stats rows to a per-site CSV, or tell the user when empty."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if not rawdata:  # No data -- tell the user and return.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No device statistics found for this site")  # User notice.
             return  # Done.
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
         sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
         filename = f"SiteDeviceStats_{site_name.replace(' ', '_')}.csv"  # Build per-site CSV name.
         mh.DataExporter.write_with_format_selection(sanitized_data, filename)  # Persist.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! %d device stats exported to %s", len(rawdata), filename)  # User notice with count.
 
     @staticmethod
@@ -133,7 +133,7 @@ class SiteDeviceExporter:
     def device_stats() -> None:  # Export site device stats.
         """Export device statistics for a site to SiteDeviceStats.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Site Device Statistics:")  # Header
         logging.info("Starting export of site device statistics...")  # Trace start
         resolved = SiteDeviceExporter._resolve_site_for_stats("device statistics")  # Prompt + org/site resolution
@@ -146,7 +146,7 @@ class SiteDeviceExporter:
             SiteDeviceExporter._persist_site_device_stats(rawdata, site_name)  # Persist or tell user empty
         except Exception as e:  # Fetch failed
             logging.error("Error fetching device stats for site %s: %s", site_name, e)  # Log the error
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Error fetching device statistics: %s", e)  # Tell the user
 
     @staticmethod
@@ -184,7 +184,7 @@ class SiteDeviceExporter:
     def device_virtual_chassis() -> None:  # Export device virtual chassis.
         """Export virtual chassis data for a site to SiteDeviceVirtualChassis.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Export Virtual Chassis Information:")  # Header.
         logging.info("Starting export of site device virtual chassis information...")  # Log start.
         site_id = mh.PromptUtils.select_site()  # Select a site.
@@ -222,7 +222,7 @@ class SiteDeviceExporter:
             )  # Fetch
             if not response.data:  # No VC payload.
                 logging.warning("! No virtual chassis data returned for device %s", device_name)  # Warn no VC data.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("! No virtual chassis data found for device %s", device_name)  # Tell the user.
                 return  # Nothing to export.
             vc_data = [response.data] if isinstance(response.data, dict) else response.data  # Normalize to a list.
@@ -234,7 +234,7 @@ class SiteDeviceExporter:
             SiteDeviceExporter._print_vc_summary(sanitized, device_name, filename)  # Print a short operator summary.
         except Exception as e:  # Export failed.
             logging.error("! Failed to export virtual chassis information: %s", e)  # Log the error.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Failed to export virtual chassis information: %s", e)  # Tell the user.
 
     @staticmethod
@@ -242,17 +242,17 @@ class SiteDeviceExporter:
         """Print a short VC summary (record count, optional members/preprovisioned fields, output path)."""
         if not sanitized:  # No records to summarize.
             return  # Nothing to print.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n!! Virtual Chassis Summary for %s:", device_name)  # Header.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("   * Records exported: %d", len(sanitized))  # Show the count.
         if "members" in sanitized[0]:  # Members present.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("   * VC members: %s", sanitized[0].get("members", "N/A"))  # Show members.
         if "preprovisioned" in sanitized[0]:  # Preprovisioned present.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("   * Preprovisioned: %s", sanitized[0].get("preprovisioned", "N/A"))  # Show preprovisioned.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("   * Data saved to: %s", filename)  # Show the path.
 
     @staticmethod
@@ -260,21 +260,21 @@ class SiteDeviceExporter:
         """Flatten + persist site-devices rows to a per-site CSV (or tell the user when empty)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataProcessingUtils + DataExporter.
         if not rawdata:  # No devices -- tell the user and return.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No devices found for this site")  # User notice.
             return  # Done.
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested fields.
         sanitized_data = DataProcessingUtils.escape_multiline(flattened_data)  # CSV-safe.
         filename = f"SiteDevices_{site_name.replace(' ', '_')}.csv"  # Per-site CSV name.
         mh.DataExporter.write_with_format_selection(sanitized_data, filename)  # Persist.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! %d devices exported to %s", len(rawdata), filename)  # User notice with count.
 
     @staticmethod
     def devices() -> None:  # Export site device list.
         """Export device data for a site to SiteDevices.csv."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of live apisession.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Site Device List:")  # Header
         logging.info("Starting export of site device list...")  # Trace start
         resolved = SiteDeviceExporter._resolve_site_for_stats("device list")  # Prompt + org/site resolution
@@ -283,9 +283,9 @@ class SiteDeviceExporter:
         site_id, site_name = resolved  # Unpack resolved identifiers
         try:
             response = mistapi.api.v1.sites.devices.listSiteDevices(mh.apisession, site_id, type="all")
-            rawdata = getattr(response, "data", [])  # Unwrap data; default empty
+            rawdata = getattr(response, "data", [])  # Unwrap data. Default empty
             SiteDeviceExporter._persist_site_devices(rawdata, site_name)  # Persist or tell user empty
         except Exception as e:  # Fetch failed
             logging.error("Error fetching devices for site %s: %s", site_name, e)  # Log the error
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Error fetching device data: %s", e)  # Tell the user

--- a/src/export/site_export_utils.py
+++ b/src/export/site_export_utils.py
@@ -75,7 +75,7 @@ def _channel_planning_rows_from_raw(
     """Return flattened channel-planning rows from a raw API payload shape."""
     if isinstance(raw, dict):  # WHY: dispatch to dict flattener.
         return _flatten_channel_planning_dict(raw, site_id)  # WHY: dict shape needs bespoke flatten.
-    return raw if isinstance(raw, list) else [raw]  # WHY: list stays as-is; scalar wraps.
+    return raw if isinstance(raw, list) else [raw]  # WHY: list stays as-is. Scalar wraps.
 
 
 def _build_insight_rows(  # WHY: per-metric availability row builder.
@@ -254,7 +254,7 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
             return site_id  # WHY: fall back to raw id.
 
     def _resolve_site_name(self, site_id: str) -> str:  # WHY: class-side name resolver with legacy log format.
-        """Resolve human-readable site name from org sites list; fall back to site_id."""
+        """Resolve human-readable site name from org sites list. Fall back to site_id."""
         try:
             logging.info("Fetching org sites to resolve site name for %s", site_id)  # WHY: pre-API log.
             site_name = self._fetch_org_site_name(site_id)  # WHY: shared org-name lookup.
@@ -267,7 +267,7 @@ class SiteExportUtils(SiteInsightsExporter):  # WHY: inherit insights exporters 
     def _call_site_api(
         self, api_call: Any, site_id: str, api_kwargs: dict[str, Any]
     ) -> Any:  # WHY: bridge to fetch helper with logs.
-        """Invoke site API call, respecting limit-parameter support; return paginated rawdata."""
+        """Invoke site API call, respecting limit-parameter support. Return paginated rawdata."""
         logging.debug(
             "Making site-specific API call: %s with site_id: %s", api_call.__name__, site_id
         )  # WHY: pre-call log.

--- a/src/export/site_guest_authorization_exporter.py
+++ b/src/export/site_guest_authorization_exporter.py
@@ -23,7 +23,7 @@ import mistapi  # WHY: direct SDK access for searchSiteGuestAuthorization + get_
 
 from src.data.data_processing_utils import (
     DataProcessingUtils,
-)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+)  # WHY: canonical flatten/escape helpers. Keeps CSV output consistent with peers.
 
 
 class SiteGuestAuthorizationExporter:
@@ -42,7 +42,7 @@ class SiteGuestAuthorizationExporter:
 
         Why:
             Empty responses are legitimate (a site with no authorized guests
-            in the query window); we surface a friendly message rather than
+            in the query window). We surface a friendly message rather than
             failing so scheduled runs stay quiet in that case.
 
         Args:

--- a/src/export/site_insights/device_metric_operation.py
+++ b/src/export/site_insights/device_metric_operation.py
@@ -56,13 +56,13 @@ class DeviceMetricOperation:
 
     def execute(self) -> None:  # WHY: Menu 76 dispatcher entry point invoked by MistHelper top-level menu
         """Top-level entry point invoked by the menu dispatcher for menu 76."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Export Site Device Insights:")
         logging.info("Starting export of site device insights...")  # WHY: Trace operation start for ops visibility
         self._refresh_const_metrics()  # WHY: Refresh ConstInsightMetrics.csv before reading it
         prompts = self._prompt_site_and_device()  # WHY: Run both selection prompts up front
         if prompts is None:
-            return  # WHY: Helper already logged the cancel reason; exit cleanly
+            return  # WHY: Helper already logged the cancel reason. Exit cleanly
         context = self._build_context(*prompts)  # WHY: Resolve names, MAC, and validate MAC once
         if context is None:
             return  # WHY: Helper already surfaced the specific validation failure
@@ -70,12 +70,12 @@ class DeviceMetricOperation:
 
     def _refresh_const_metrics(self) -> None:  # WHY: Isolated call keeps execute() short and testable
         """Refresh ConstInsightMetrics.csv so metric lists reflect the latest API surface."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Refreshing available insight metrics from Mist API...")
         self.InsightMetricsUtils.export_const_insight_metrics()  # WHY: Refresh cache before scope-filtering metrics
 
     def _prompt_site_and_device(self) -> tuple[str, str] | None:  # WHY: Two prompts share cancel semantics
-        """Prompt for site then device; return None on either cancel."""
+        """Prompt for site then device. Return None on either cancel."""
         site_id = self.PromptUtils.select_site()  # WHY: Existing prompt utility handles cancel / invalid input
         if not site_id:
             logging.error("No site selected. Exiting.")  # WHY: Match legacy error log message verbatim
@@ -84,7 +84,7 @@ class DeviceMetricOperation:
         if not device_id:
             logging.error("No device selected. Exiting.")  # WHY: Match legacy error log message verbatim
             return None
-        return site_id, device_id  # WHY: Both selections succeeded; pass to downstream context builder
+        return site_id, device_id  # WHY: Both selections succeeded. Pass to downstream context builder
 
     def _build_context(
         self, site_id: str, device_id: str
@@ -118,13 +118,13 @@ class DeviceMetricOperation:
 
     def _emit_empty_metric_list(self, filename: str) -> None:  # WHY: Defensive branch used when const file is empty
         """Emit the empty-file + error trio when scope filter yields zero metrics."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(_EMPTY_METRICS_PROMPT)
         logging.error(_EMPTY_METRICS_LOG)  # WHY: Persist failure cause in the log
         self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]
 
     def _resolve_site_name(self, site_id: str) -> str:  # WHY: Named lookup keeps execute path narrative
-        """Best-effort site-name lookup; fall back to site_id when API call fails."""
+        """Best-effort site-name lookup. Fall back to site_id when API call fails."""
         try:
             response = self.mistapi.api.v1.sites.listSites(  # WHY: API call may raise on auth / network
                 self.apisession, site_id
@@ -132,7 +132,7 @@ class DeviceMetricOperation:
             sites = self.mistapi.get_all(  # WHY: Materialize paged result list
                 response=response, mist_session=self.apisession
             )
-            return next(  # WHY: Match by id; fall back to id on miss
+            return next(  # WHY: Match by id. Fall back to id on miss
                 (site["name"] for site in sites if site["id"] == site_id), site_id
             )
         except Exception:
@@ -141,7 +141,7 @@ class DeviceMetricOperation:
     def _resolve_device_info(
         self, site_id: str, device_id: str
     ) -> dict:  # WHY: Return dict decouples caller from API shape
-        """Best-effort device-name / MAC / model lookup; return shaped dict with defaults on failure."""
+        """Best-effort device-name / MAC / model lookup. Return shaped dict with defaults on failure."""
         try:
             response = self.mistapi.api.v1.sites.devices.listSiteDevices(  # WHY: type=all covers switches/gateways
                 self.apisession,
@@ -167,15 +167,15 @@ class DeviceMetricOperation:
     def _validate_mac(
         self, device_id: str, device_name: str, device_mac: str | None
     ) -> str | None:  # WHY: Guard MAC use
-        """Confirm MAC is present and well-formed; print + log error and return None on failure."""
+        """Confirm MAC is present and well-formed. Print + log error and return None on failure."""
         if not device_mac:
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(_MISSING_MAC_PROMPT.format(name=device_name))
             logging.error("Could not find MAC address for device %s", device_id)  # WHY: Persist failure cause
             return None
         normalized = self._insights_exporter._normalize_device_mac_or_none(device_mac)  # WHY: Reuse normalizer
         if not normalized:
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(_INVALID_MAC_PROMPT.format(name=device_name, mac=device_mac))
             logging.error(  # WHY: Persist failure cause with device id + raw MAC for triage
                 "Invalid device MAC address format for device %s: %s", device_id, device_mac
@@ -209,13 +209,13 @@ class DeviceMetricOperation:
         """Iterate the device-scope metric list and collect any insight data the API returns."""
         all_device_data: list[dict] = []  # WHY: Accumulator for every non-empty metric response
         retrieved = 0  # WHY: User-facing counter shown in final summary line
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "! Retrieving %s different device insight metrics for %s...",
             len(device_metrics),
             context.device_name,
         )
-        for metric in device_metrics:  # WHY: One API call per metric; individual failures must not abort the batch
+        for metric in device_metrics:  # WHY: One API call per metric. Individual failures must not abort the batch
             data = self._fetch_one_metric(context, metric)  # WHY: Enriched dict or None
             if data is not None:
                 all_device_data.append(data)  # WHY: Append enriched record for export
@@ -263,7 +263,7 @@ class DeviceMetricOperation:
         filename: str,
         context: DeviceRunContext,
     ) -> None:
-        """Flatten, escape, and save collected data; emit summary user output."""
+        """Flatten, escape, and save collected data. Emit summary user output."""
         try:
             if all_device_data:
                 self._export_with_data(  # WHY: Non-empty path writes flattened rows and summary
@@ -281,11 +281,11 @@ class DeviceMetricOperation:
         filename: str,
         context: DeviceRunContext,
     ) -> None:
-        """Flatten, escape, and write the non-empty result set; log the success summary."""
+        """Flatten, escape, and write the non-empty result set. Log the success summary."""
         processed = self.DataProcessingUtils.flatten_nested_fields(all_device_data)  # WHY: Flatten nested API objs
         processed = self.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]
         self.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %s device insight metrics exported to %s", retrieved, filename)
         logging.info(  # WHY: Persist success summary at info level for ops visibility
             "Exported %s device insight metrics for %s at %s to %s",
@@ -297,7 +297,7 @@ class DeviceMetricOperation:
 
     def _export_empty(self, filename: str, context: DeviceRunContext) -> None:  # WHY: Zero-data emit path
         """Emit user-visible zero-data summary and write an empty file for consistency."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! 0 device insights exported to %s (no data available)", filename)
         logging.warning(  # WHY: Distinguish empty result from error for ops triage
             "No device insight data available for %s at %s",
@@ -313,7 +313,7 @@ class DeviceMetricOperation:
         context: DeviceRunContext,
     ) -> None:
         """Log the failure with full context and emit an empty file so downstream consumers still see output."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Error exporting device insights: %s", exception)
         logging.error(  # WHY: Persist failure cause with both site and device context for triage
             "Failed to export device insights for %s at %s: %s",

--- a/src/export/site_insights/site_metric_operation.py
+++ b/src/export/site_insights/site_metric_operation.py
@@ -48,16 +48,16 @@ class SiteMetricOperation:
 
     def execute(self) -> None:  # WHY: Menu 74 dispatcher entry point invoked by MistHelper top-level menu
         """Top-level entry point invoked by the menu dispatcher for menu 74."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(_BANNER)
         logging.info(_START_LOG)  # WHY: Trace operation start for ops visibility
         context = self._prompt_and_build_context()  # WHY: Resolve site id + name, or bail on cancel
         if context is None:
-            return  # WHY: Helper already logged the cancel reason; exit cleanly
+            return  # WHY: Helper already logged the cancel reason. Exit cleanly
         self._run_export(context)  # WHY: Orchestrate refresh + collect + finalize using bundled context
 
     def _prompt_and_build_context(self) -> SiteRunContext | None:  # WHY: Consolidate prompt + name lookup for execute()
-        """Prompt for site selection and resolve name; return None on cancel."""
+        """Prompt for site selection and resolve name. Return None on cancel."""
         site_id = self._prompt_site_id()  # WHY: Bail out early if user cancels selection
         if not site_id:
             return None  # WHY: Prompt helper already logged the cancel reason for ops visibility
@@ -77,29 +77,29 @@ class SiteMetricOperation:
 
     def _refresh_const_metrics(self) -> None:  # WHY: Isolated call keeps execute() short and testable
         """Refresh ConstInsightMetrics.csv so metric lists reflect the latest API surface."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(_REFRESH_PROMPT)
         self.InsightMetricsUtils.export_const_insight_metrics()  # WHY: Refresh cache before scope-filtering metrics
 
     def _emit_empty_metric_list(self, filename: str) -> None:  # WHY: Defensive branch used when const file is empty
         """Emit the empty-file + error trio when scope filter yields zero metrics."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(_EMPTY_METRICS_PROMPT)
         logging.error(_EMPTY_METRICS_LOG)  # WHY: Persist failure cause in the log
         self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Emit empty file for downstream consistency
 
     def _prompt_site_id(self) -> str | None:  # WHY: Wrap prompt in cancel-aware helper for execute()
-        """Prompt the user for a site selection; return None when the user cancels."""
+        """Prompt the user for a site selection. Return None when the user cancels."""
         site_id = self.PromptUtils.select_site()  # WHY: Existing prompt utility handles cancel / invalid input
         if not site_id:
             logging.error(_NO_SITE_LOG)  # WHY: Match legacy error log message verbatim
             return None
-        return site_id  # WHY: Selection succeeded; downstream will resolve name and run export
+        return site_id  # WHY: Selection succeeded. Downstream will resolve name and run export
 
     def _resolve_site_name(
         self, site_id: str
     ) -> str:  # WHY: Best-effort name lookup keeps execute path narrative clean
-        """Best-effort site-name lookup; fall back to site_id when API call fails."""
+        """Best-effort site-name lookup. Fall back to site_id when API call fails."""
         try:
             response = self.mistapi.api.v1.sites.listSites(  # WHY: API call may raise on auth / network
                 self.apisession, site_id
@@ -107,7 +107,7 @@ class SiteMetricOperation:
             sites = self.mistapi.get_all(  # WHY: Materialize paged result list
                 response=response, mist_session=self.apisession
             )
-            return next(  # WHY: Match by id; fall back to id on miss
+            return next(  # WHY: Match by id. Fall back to id on miss
                 (site["name"] for site in sites if site["id"] == site_id), site_id
             )
         except Exception:
@@ -128,9 +128,9 @@ class SiteMetricOperation:
         """Iterate the metric list and collect any insight data the API returns."""
         all_insight_data: list[dict] = []  # WHY: Accumulator for every non-empty metric response
         retrieved = 0  # WHY: User-facing counter shown in the final summary line
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Retrieving %s different site insight metrics...", len(site_metrics))
-        for metric in site_metrics:  # WHY: One API call per metric; individual failures must not abort the batch
+        for metric in site_metrics:  # WHY: One API call per metric. Individual failures must not abort the batch
             data = self._fetch_one_metric(context, metric)  # WHY: Enriched dict or None
             if data is not None:
                 all_insight_data.append(data)  # WHY: Append the enriched per-metric record for export
@@ -172,7 +172,7 @@ class SiteMetricOperation:
         filename: str,
         context: SiteRunContext,
     ) -> None:
-        """Flatten, escape, and save collected data; emit summary user output."""
+        """Flatten, escape, and save collected data. Emit summary user output."""
         try:
             if all_insight_data:
                 self._export_with_data(  # WHY: Non-empty path writes flattened rows and summary
@@ -190,11 +190,11 @@ class SiteMetricOperation:
         filename: str,
         context: SiteRunContext,
     ) -> None:
-        """Flatten, escape, and write the non-empty result set; log the success summary."""
+        """Flatten, escape, and write the non-empty result set. Log the success summary."""
         processed = self.DataProcessingUtils.flatten_nested_fields(all_insight_data)  # WHY: Flatten nested API objs
         processed = self.DataProcessingUtils.escape_multiline(processed)  # type: ignore[no-untyped-call]  # WHY: CSV-safe text
         self.DataExporter.write_with_format_selection(processed, filename)  # type: ignore[no-untyped-call]  # WHY: Write to disk / DB
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %s site insight metrics exported to %s", retrieved, filename)
         logging.info(  # WHY: Persist success summary at info level for ops visibility
             "Exported %d site insight metrics for %s to %s",
@@ -205,7 +205,7 @@ class SiteMetricOperation:
 
     def _export_empty(self, filename: str, context: SiteRunContext) -> None:  # WHY: Zero-data emit path
         """Emit user-visible zero-data summary and write an empty file for consistency."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! 0 insight metrics exported to %s (no data available)", filename)
         logging.warning("No insight data available for site %s", context.site_name)  # WHY: Distinguish empty from error
         self.DataExporter.write_with_format_selection([], filename)  # type: ignore[no-untyped-call]  # WHY: Emit empty file for consistency
@@ -217,7 +217,7 @@ class SiteMetricOperation:
         context: SiteRunContext,
     ) -> None:
         """Log the failure with full context and emit an empty file so downstream consumers still see output."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Error exporting site insight metrics: %s", exception)
         logging.error(  # WHY: Persist failure cause with site context for triage
             "Failed to export site insight metrics for %s: %s", context.site_name, exception

--- a/src/export/site_mist_edge_events_exporter.py
+++ b/src/export/site_mist_edge_events_exporter.py
@@ -23,7 +23,7 @@ import mistapi  # WHY: direct SDK access for searchSiteMistEdgeEvents + get_all 
 
 from src.data.data_processing_utils import (
     DataProcessingUtils,
-)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+)  # WHY: canonical flatten/escape helpers. Keeps CSV output consistent with peers.
 
 
 class SiteMistEdgeEventsExporter:
@@ -42,7 +42,7 @@ class SiteMistEdgeEventsExporter:
 
         Why:
             Empty responses are legitimate (a site with no Mist Edge events
-            in the query window); we surface a friendly message rather than
+            in the query window). We surface a friendly message rather than
             failing so scheduled runs stay quiet in that case.
 
         Args:

--- a/src/export/site_nac_client_events_exporter.py
+++ b/src/export/site_nac_client_events_exporter.py
@@ -23,7 +23,7 @@ import mistapi  # WHY: direct SDK access for searchSiteNacClientEvents + get_all
 
 from src.data.data_processing_utils import (
     DataProcessingUtils,
-)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+)  # WHY: canonical flatten/escape helpers. Keeps CSV output consistent with peers.
 
 
 class SiteNacClientEventsExporter:
@@ -42,7 +42,7 @@ class SiteNacClientEventsExporter:
 
         Why:
             Empty responses are legitimate (a site with no NAC client events
-            in the query window); we surface a friendly message rather than
+            in the query window). We surface a friendly message rather than
             failing so scheduled runs stay quiet in that case.
 
         Args:

--- a/src/export/site_wan_usage_exporter.py
+++ b/src/export/site_wan_usage_exporter.py
@@ -23,7 +23,7 @@ import mistapi  # WHY: direct SDK access for searchSiteWanUsage + get_all pagina
 
 from src.data.data_processing_utils import (
     DataProcessingUtils,
-)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+)  # WHY: canonical flatten/escape helpers. Keeps CSV output consistent with peers.
 
 
 class SiteWanUsageExporter:
@@ -42,7 +42,7 @@ class SiteWanUsageExporter:
 
         Why:
             Empty responses are legitimate (a site with no WAN telemetry in
-            the query window); we surface a friendly message rather than
+            the query window). We surface a friendly message rather than
             failing so scheduled runs stay quiet in that case.
 
         Args:

--- a/src/export/site_webhook_deliveries_exporter.py
+++ b/src/export/site_webhook_deliveries_exporter.py
@@ -25,7 +25,7 @@ import mistapi  # WHY: direct SDK access for listSiteWebhooks + searchSiteWebhoo
 
 from src.data.data_processing_utils import (
     DataProcessingUtils,
-)  # WHY: canonical flatten/escape helpers; keeps CSV output consistent with peers.
+)  # WHY: canonical flatten/escape helpers. Keeps CSV output consistent with peers.
 from src.utils.input_utils import InputUtils  # WHY: safe_input honors EOF/Ctrl-C per Constitution.
 
 
@@ -63,12 +63,12 @@ class SiteWebhookDeliveriesExporter:
         )
         webhooks = mistapi.get_all(response=response, mist_session=mh.apisession)  # Page all rows.
         if not webhooks:  # Site has no configured webhooks -- nothing to search deliveries for.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! No webhooks configured for this site")  # ASCII-only user notice.
             logging.warning("No webhooks configured for site_id=%s", site_id)  # Warn for logs.
             return None
         for idx, wh in enumerate(webhooks, start=1):  # Enumerate with 1-based index for humans.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("  %s. %s  [%s]", idx, wh.get("name", "(unnamed)"), wh.get("id", "?"))  # Show each webhook.
         raw = InputUtils.safe_input(  # WHY: safe_input handles EOF/Ctrl-C gracefully in SSH/CI.
             "Select webhook number: ", context="site_webhook_deliveries_selection"
@@ -81,7 +81,7 @@ class SiteWebhookDeliveriesExporter:
 
         Why:
             Extracted from ``_select_webhook_id`` to keep the caller under
-            the 25-line 5-Item Rule ceiling; also makes the validation logic
+            the 25-line 5-Item Rule ceiling. Also makes the validation logic
             unit-testable in isolation.
 
         Args:
@@ -93,12 +93,12 @@ class SiteWebhookDeliveriesExporter:
             1-based index, else ``None``.
         """
         if not raw.isdigit():  # Non-numeric input -- reject.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! Invalid selection (not a number)")  # ASCII-only user notice.
             return None
         idx = int(raw)  # Parse the operator's 1-based choice.
         if not 1 <= idx <= len(webhooks):  # Out-of-range index.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! Selection out of range (1..%s)", len(webhooks))  # ASCII-only user notice.
             return None
         chosen = webhooks[idx - 1]  # Convert to 0-based access.
@@ -110,7 +110,7 @@ class SiteWebhookDeliveriesExporter:
 
         Why:
             Empty responses are legitimate (a webhook that has never fired in
-            the search window); we surface a friendly message rather than
+            the search window). We surface a friendly message rather than
             failing so scheduled runs stay quiet in that case.
 
         Args:
@@ -121,7 +121,7 @@ class SiteWebhookDeliveriesExporter:
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter helper.
         if not rawdata:  # No delivery rows in the query window -- inform the operator.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! No webhook delivery data found")  # ASCII-only user notice.
             return
         flattened_data = DataProcessingUtils.flatten_nested_fields(rawdata)  # Flatten nested dicts for CSV.
@@ -135,7 +135,7 @@ class SiteWebhookDeliveriesExporter:
         logging.debug(  # DEBUG-level count trace per Action Logging principle (post-call).
             "searchSiteWebhooksDeliveries persisted %d rows to %s", len(rawdata), filename
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %s webhook delivery records exported to %s", len(rawdata), filename)  # User notice.
 
     @staticmethod
@@ -150,7 +150,7 @@ class SiteWebhookDeliveriesExporter:
             surfaced to the user rather than crashing the menu loop.
         """
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of apisession + shared helpers.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Site Webhook Deliveries Search:")  # Menu header echoed to operator.
         logging.info(  # INFO trace before the API call per Action Logging principle (pre-call).
             "Starting searchSiteWebhooksDeliveries export..."
@@ -186,5 +186,5 @@ class SiteWebhookDeliveriesExporter:
                 webhook_name,
                 e,
             )
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! Error fetching webhook delivery data: %s", e)  # ASCII-only user notice.

--- a/src/export/sites_by_ap_model_exporter.py
+++ b/src/export/sites_by_ap_model_exporter.py
@@ -36,11 +36,11 @@ class SitesByAPModelExporter:
     @staticmethod
     def _print_model_options(models: list[str], aps: list[dict]) -> None:  # type: ignore[type-arg]
         """Print numbered list of AP models with per-model device count."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\nAvailable AP models:")
         for idx, model in enumerate(models, 1):  # List each model
             count = sum(1 for d in aps if d.get("model") == model)  # APs of this model
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("  %3d. %s (%s APs)", idx, model, count)
 
     @staticmethod
@@ -50,7 +50,7 @@ class SitesByAPModelExporter:
             selected = int(choice.strip()) - 1  # Convert to 0-based index
             return models[selected] if 0 <= selected < len(models) else None  # Bounds check
         except (ValueError, IndexError):
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! Invalid selection.")
             return None
 
@@ -136,7 +136,7 @@ class SitesByAPModelExporter:
         safe_model = re.sub(r"[^a-zA-Z0-9_-]", "_", model)  # Slugify the model.
         filename = f"SitesByAPModel_{safe_model}.csv"  # Build the CSV name.
         mh.DataExporter.write_with_format_selection(rows, filename, api_function_name="getSitesByAPModel")  # Persist.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\n[OK] Exported %s sites with %s APs to %s", len(rows), model, filename)
         logging.info("Exported %s sites with AP model %s", len(rows), model)  # Log the export.
 
@@ -149,27 +149,27 @@ class SitesByAPModelExporter:
     def export_sites_by_ap_model() -> None:  # Export sites by AP model.
         """Export CSV of sites containing APs of a selected model with site address info."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of ConfigUtils + APICoreFetchUtils facades.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Export Sites by AP Model:")
         logging.info("Starting export of sites by AP model...")  # Trace start
         org_id = mh.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve the org
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Fetching AP inventory from organization...")
         aps, models = SitesByAPModelExporter._get_ap_models(org_id)  # Fetch APs and models
         if not models:  # No models in inventory
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! No APs found in organization inventory.")
             return
         model = SitesByAPModelExporter._prompt_model_selection(models, aps)  # Prompt operator for a model
         if not model:  # Operator skipped
             return
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Fetching site details for sites with %s APs...", model)
         all_sites = mh.APICoreFetchUtils.all_sites_with_limit(org_id)  # List all sites
         site_map = SitesByAPModelExporter._build_site_map(all_sites)  # Index sites by id for row lookup
         rows = SitesByAPModelExporter._build_export_rows(aps, model, site_map)  # Build export rows
         if not rows:  # No rows match the chosen model
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! No sites found with %s APs.", model)
             return
         SitesByAPModelExporter._finalize_ap_model_export(rows, model)  # Slug + filename + write + log

--- a/src/export/wan_client_events_exporter.py
+++ b/src/export/wan_client_events_exporter.py
@@ -101,7 +101,7 @@ class WanClientEventsExporter:
             header line before the SiteList prompt and a structured info log
             marking the workflow boundary for tracing.
         """
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Export Site WAN Client Events:")
         logging.info("Starting export of site WAN client events...")  # WHY: log workflow start boundary.
 
@@ -121,7 +121,7 @@ class WanClientEventsExporter:
         logging.info(
             "Fetching WAN client events for site: %s (ID: %s)", site_name, site_id
         )  # WHY: log before API calls for tracing.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Fetching WAN client events for site: %s", site_name)
 
     @staticmethod
@@ -140,7 +140,7 @@ class WanClientEventsExporter:
         logging.exception(
             "! Failed to fetch WAN client events for site %s: %s", site_id, exception
         )  # WHY: full traceback log.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.error("! Failed to fetch WAN client events: %s", exception)
 
     def _run_export_pipeline(self, stamp: _SiteStamp) -> None:
@@ -170,7 +170,7 @@ class WanClientEventsExporter:
             prompting avoids a redundant round-trip when the operator selects.
 
         Args:
-            site_id: Caller-supplied site UUID; None triggers interactive prompt.
+            site_id: Caller-supplied site UUID. None triggers interactive prompt.
 
         Returns:
             Resolved site UUID string, or None when the operator cancelled.
@@ -185,7 +185,7 @@ class WanClientEventsExporter:
         logging.debug("Site selection prompt completed with site_id=%s", chosen)  # WHY: result for traceability.
         if not chosen:
             logging.error(_NO_SITE_TEXT)  # WHY: cancel-path log preserved for operator debugging.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(_NO_SITE_TEXT)
             return None  # WHY: signal abort to orchestrator so no artifacts are written.
         return chosen  # WHY: resolved site identifier to operate on for the remainder of the workflow.
@@ -248,7 +248,7 @@ class WanClientEventsExporter:
             site_id: Site UUID scoping the search endpoint.
 
         Returns:
-            List of event-row dicts (possibly empty); never ``None``.
+            List of event-row dicts (possibly empty). Never ``None``.
         """
         logging.info("Fetching WAN client events data...")  # WHY: log before first-page API call for tracing.
         # WHY: #1639 — mistapi 0.63.3 exposes the callable flat under wan_clients, not under .events.search.
@@ -271,7 +271,7 @@ class WanClientEventsExporter:
             stamp: Site identifiers used to populate the sentinel row.
         """
         logging.warning(_NO_DATA_TEXT)  # WHY: preserve empty-result log severity + text from sibling exporters.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(_NO_DATA_TEXT)
         logging.info("Writing no-data placeholder CSV for %s", _OUTPUT_CSV)  # WHY: log before placeholder write.
         output_path = self.file_path_utils.get_csv_path(_OUTPUT_CSV)  # WHY: resolve canonical output path.
@@ -289,7 +289,7 @@ class WanClientEventsExporter:
         """Stamp site identifiers on every event row in place.
 
         Why:
-            The SDK returns raw event rows without site context; downstream
+            The SDK returns raw event rows without site context. Downstream
             joins and per-site aggregations rely on both the UUID (stable) and
             the display name (human readability).
 
@@ -379,6 +379,6 @@ class WanClientEventsExporter:
         logging.info(
             "! WAN client events exported to %s (%d records)", _OUTPUT_CSV, total_records
         )  # WHY: structured log mirrors the operator print block for tracing parity.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! WAN client events exported to %s", _OUTPUT_CSV)
         logging.info("   %d WAN client event records", total_records)

--- a/src/export/wifi_clients_exporter.py
+++ b/src/export/wifi_clients_exporter.py
@@ -58,7 +58,7 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
     @staticmethod
     def _announce_start() -> None:  # WHY: header + start-log emitter kept pure-static for testability.
         """Emit the legacy header line and start-of-workflow log entry."""
-        # WHY: preserve legacy header text so operator experience is identical; route via logger for capture.
+        # WHY: preserve legacy header text so operator experience is identical. Route via logger for capture.
         logging.info("Export Site WiFi Clients:")
         logging.info("Starting export of site WiFi clients...")  # WHY: log workflow start boundary for tracing.
 
@@ -66,14 +66,14 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
     def _announce_fetch(site_id: str, site_name: str) -> None:  # WHY: pre-fetch messaging isolated for reuse.
         """Emit the pre-fetch log line and legacy operator-facing message."""
         logging.info("Fetching WiFi clients for site: %s (ID: %s)", site_name, site_id)  # WHY: log before API calls.
-        # WHY: preserve legacy fetch-start operator text; route via logger for capture/redirection.
+        # WHY: preserve legacy fetch-start operator text. Route via logger for capture/redirection.
         logging.info("! Fetching WiFi clients for site: %s", site_name)
 
     @staticmethod
     def _log_export_failure(site_id: str, exception: BaseException) -> None:  # WHY: exception-path emitter.
         """Log the exception traceback and print the legacy operator-facing failure line."""
         logging.exception("! Failed to fetch WiFi data for site %s: %s", site_id, exception)  # WHY: traceback log.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Failed to fetch WiFi data: %s", exception)  # WHY: preserve legacy operator-facing error output.
 
     def _run_export_pipeline(self, stamp: _SiteStamp) -> None:  # WHY: try-guarded fetch/merge/finalize sequencer.
@@ -92,7 +92,7 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
     def _log_empty_merge() -> None:  # WHY: empty-post-merge emitter isolated to keep pipeline branch-shallow.
         """Log + print the defensive empty-post-merge operator messages."""
         logging.warning(_NO_POST_MERGE_TEXT)  # WHY: preserve defensive empty-post-merge log severity + text.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(_NO_POST_MERGE_TEXT)  # WHY: preserve legacy operator-facing empty-result message text.
 
     def _ensure_site_selected(self, site_id: str | None) -> str | None:  # WHY: cache-seed + prompt orchestrator.
@@ -107,7 +107,7 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
         logging.debug("Site selection prompt completed with site_id=%s", chosen)  # WHY: result for traceability.
         if not chosen:
             logging.error(_NO_SITE_TEXT)  # WHY: cancel-path log preserved verbatim from the legacy exporter.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(_NO_SITE_TEXT)  # WHY: preserve legacy operator-facing cancel-path message.
             return None  # WHY: signal abort to orchestrator so no artifacts are written.
         return chosen  # WHY: resolved site identifier to operate on for the remainder of the workflow.
@@ -137,7 +137,7 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
     def _fetch_clients_and_sessions(
         self, stamp: _SiteStamp
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]] | None:
-        """Fetch clients + sessions; on empty result write placeholder CSV and return None."""
+        """Fetch clients + sessions. On empty result write placeholder CSV and return None."""
         clients = self._fetch_paginated(
             self.mistapi_module.api.v1.sites.clients.searchSiteWirelessClients, stamp.site_id, "wireless clients"
         )  # WHY: pull the full paginated wireless clients dataset for the site.
@@ -148,7 +148,7 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
         )  # WHY: pull the full paginated wireless session dataset for the site.
         if not clients and not sessions:
             self._write_no_data_placeholder(stamp)  # WHY: persist sentinel artifact so downstream tools see the run.
-            return None  # WHY: signal early-exit to orchestrator; the placeholder already satisfied the contract.
+            return None  # WHY: signal early-exit to orchestrator. The placeholder already satisfied the contract.
         return clients or [], sessions or []  # WHY: normalize None so merge helpers can iterate safely.
 
     def _fetch_paginated(self, endpoint: Any, site_id: str, label: str) -> list[dict[str, Any]]:
@@ -162,7 +162,7 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
     def _write_no_data_placeholder(self, stamp: _SiteStamp) -> None:
         """Write the legacy no-data sentinel CSV when neither clients nor sessions are found."""
         logging.warning(_NO_DATA_TEXT)  # WHY: preserve empty-result log severity + text from the legacy exporter.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(_NO_DATA_TEXT)  # WHY: preserve legacy operator-facing empty-result message text.
         logging.info("Writing no-data placeholder CSV for %s", _OUTPUT_CSV)  # WHY: log before placeholder write.
         wifi_clients_path = self.file_path_utils.get_csv_path(_OUTPUT_CSV)  # WHY: resolve canonical output path.
@@ -274,7 +274,7 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
         session["data_source"] = _SOURCE_SESSION_ONLY  # WHY: mark provenance for downstream consumers.
         session["session_count"] = 1  # WHY: legacy semantics — one represented session per orphan row.
         return {
-            key if key in _META_KEYS else f"session_{key}": value  # WHY: preserve meta keys; prefix payload keys.
+            key if key in _META_KEYS else f"session_{key}": value  # WHY: preserve meta keys. Prefix payload keys.
             for key, value in session.items()
         }
 
@@ -324,9 +324,9 @@ class WifiClientsExporter:  # WHY: orchestrator dataclass — attributes act as 
             session_count,
             total_records,
         )  # WHY: structured log mirrors the operator print block for tracing parity.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! WiFi data exported to %s", _OUTPUT_CSV)  # WHY: preserve legacy success confirmation line.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "   %d current clients, %d sessions, %d total records from %s",
             client_count,

--- a/src/firmware/bulk_ap_upgrader.py
+++ b/src/firmware/bulk_ap_upgrader.py
@@ -17,7 +17,7 @@ import json  # WHY: parse Mist API JSON responses and serialize tracking state
 import logging  # WHY: FR-007 info-before / debug-after logging pattern used throughout module
 import os  # WHY: OS-safe path operations (Constitution VI portable file paths)
 import time  # WHY: unix timestamps for schedule offsets and filename discriminators
-from collections.abc import Callable  # WHY: PEP 585 preferred; ruff UP035 forbids typing.Callable
+from collections.abc import Callable  # WHY: PEP 585 preferred. Ruff UP035 forbids typing.Callable
 from dataclasses import dataclass  # WHY: frozen dataclass replaces 10-param __init__ (FR-004 / Constitution I)
 from datetime import UTC, datetime  # WHY: UTC-anchored timestamps in tracking/results filenames
 from typing import Any  # WHY: type-erase mistapi session for both prod object and MagicMock test doubles
@@ -37,8 +37,8 @@ class BulkAPUpgraderConfig:  # WHY: class definition (see docstring)
     # ------------------------------------------------------------------
     # Required session inputs (no defaults so omission raises TypeError)
     # ------------------------------------------------------------------
-    org_id: str  # WHY: Mist organization UUID this run targets; required by every downstream API call
-    apisession: Any  # WHY: authenticated mistapi session used by every remote call; type-erased for test doubles
+    org_id: str  # WHY: Mist organization UUID this run targets. Required by every downstream API call
+    apisession: Any  # WHY: authenticated mistapi session used by every remote call. Type-erased for test doubles
 
     # ------------------------------------------------------------------
     # Optional behavior flags
@@ -152,12 +152,12 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         """
         logging.info("Starting advanced bulk AP firmware upgrade for org_id=%s", self.org_id)  # WHY: info-before FR-007
         try:
-            self._announce_start()  # WHY: user-facing banner + dry-run notice; extracted so execute stays flat
-            if not self._run_discovery_phase():  # WHY: steps 1-4 populate sites/APs/firmware; may early-exit
+            self._announce_start()  # WHY: user-facing banner + dry-run notice. Extracted so execute stays flat
+            if not self._run_discovery_phase():  # WHY: steps 1-4 populate sites/APs/firmware. May early-exit
                 return  # WHY: early exit from branch
-            if not self._run_planning_phase():  # WHY: steps 5-7 build plan + confirm; may early-exit
+            if not self._run_planning_phase():  # WHY: steps 5-7 build plan + confirm. May early-exit
                 return  # WHY: early exit from branch
-            self._run_execution_phase()  # WHY: steps 8-11 mutate Mist + persist results; terminal
+            self._run_execution_phase()  # WHY: steps 8-11 mutate Mist + persist results. Terminal
         except KeyboardInterrupt:  # WHY: recover from failure
             print("\n Operation cancelled by user.")  # WHY: preserved verbatim per FR-017 observable-equivalence
             logging.info("Bulk AP firmware upgrade cancelled by user interrupt")  # WHY: audit trail for interrupt
@@ -386,7 +386,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         print("\n  Enter site numbers (comma-separated, e.g., 1,3,5):")  # WHY: prompt guidance
 
     def _read_site_indices(self, max_count: int) -> list[int]:
-        """Prompt for site selection; return parsed 0-based indices or empty on abort."""
+        """Prompt for site selection. Return parsed 0-based indices or empty on abort."""
         try:  # WHY: EOF/Ctrl-C during prompt should yield empty selection
             selection = self._input_fn("Selection: ").strip()  # WHY: capture raw user text
         except (EOFError, KeyboardInterrupt):  # WHY: recover from terminal interrupt
@@ -401,7 +401,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         return indices  # WHY: surface computed result
 
     def _absorb_index_token(self, part: str, max_count: int, indices: list[int]) -> None:
-        """Append token's indices to accumulator; silently drop malformed tokens."""
+        """Append token's indices to accumulator. Silently drop malformed tokens."""
         if "-" in part:  # WHY: range token like "3-7" requires range parsing
             self._absorb_range_token(part, max_count, indices)  # WHY: delegate range branch
             return  # WHY: single-branch dispatch keeps nesting shallow
@@ -468,7 +468,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
             site_id,
             type="ap",
         )
-        # WHY: get_all handles pagination transparently; returns list or None on empty
+        # WHY: get_all handles pagination transparently. Returns list or None on empty
         site_aps = mistapi.get_all(response=response, mist_session=self.apisession)  # WHY: capture intermediate value
         return site_aps or []  # WHY: normalise None to [] so callers can iterate safely
 
@@ -672,7 +672,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         if models:  # WHY: multi-model form takes precedence
             return list(models)  # WHY: copy to isolate caller state
         model = version_info.get("model")  # WHY: fallback single-model field
-        return [model] if model else []  # WHY: wrap single into list; empty for missing
+        return [model] if model else []  # WHY: wrap single into list. Empty for missing
 
     # =========================================================================
     # STEP 5: FIRMWARE VERSION SELECTION
@@ -771,13 +771,13 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
     def _dedupe_versions_by_number(self, raw_versions: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Return one entry per unique version-number string (first sighting wins)."""
         version_dict: dict[str, dict[str, Any]] = {}  # WHY: dedup by version-number string
-        for entry in raw_versions:  # WHY: single pass; first entry per number wins
+        for entry in raw_versions:  # WHY: single pass. First entry per number wins
             num = entry.get("version", "Unknown")  # WHY: version string is the dedup key
             version_dict.setdefault(num, entry)  # WHY: preserve API-order priority
         return list(version_dict.values())  # WHY: surface computed result
 
     def _sort_versions_desc(self, versions: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Sort versions descending by numeric dotted tuple; fall back to string sort."""
+        """Sort versions descending by numeric dotted tuple. Fall back to string sort."""
         try:  # WHY: attempt numeric sort first for correct dotted-version ordering
             versions.sort(key=lambda x: tuple(map(int, x.get("version", "0").split("."))), reverse=True)
         except ValueError:  # WHY: non-numeric segment triggers string fallback
@@ -813,11 +813,11 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         devices: list[dict[str, Any]],
         versions: list[dict[str, Any]],
     ) -> bool:
-        """Prompt for version index; loop until user selects or skips."""
+        """Prompt for version index. Loop until user selects or skips."""
         prompt = f"Select version for {model} (0-{len(versions) - 1}, 's' to skip): "  # WHY: reuse prompt text
-        while True:  # WHY: retry on invalid input; explicit exits inside branches
+        while True:  # WHY: retry on invalid input. Explicit exits inside branches
             outcome = self._read_version_choice(model, devices, versions, prompt)  # WHY: single-turn resolver
-            if outcome is not None:  # WHY: helper signals completion via bool; None means "retry"
+            if outcome is not None:  # WHY: helper signals completion via bool. None means "retry"
                 return outcome  # WHY: propagate accept/skip decision
 
     def _read_version_choice(
@@ -827,7 +827,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         versions: list[dict[str, Any]],
         prompt: str,
     ) -> bool | None:
-        """Resolve one prompt turn; None => retry loop, bool => terminate loop."""
+        """Resolve one prompt turn. None => retry loop, bool => terminate loop."""
         try:  # WHY: consolidate parse + interrupt handling in one turn
             user_input = self._input_fn(prompt).strip().lower()  # WHY: normalize whitespace + case
         except KeyboardInterrupt:  # WHY: Ctrl-C during prompt exits selection as "no"
@@ -835,7 +835,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         if user_input == "s":  # WHY: explicit skip token
             print(f"!  Skipping firmware upgrade for {model}")  # WHY: user-facing feedback
             return False  # WHY: skip decision terminates loop
-        try:  # WHY: parse index; ValueError triggers retry
+        try:  # WHY: parse index. ValueError triggers retry
             idx = int(user_input)  # WHY: convert to 0-based index
         except ValueError:  # WHY: non-integer -> retry with feedback
             print(" Invalid input.")  # WHY: user-facing feedback
@@ -910,7 +910,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         logging.debug("record_selection_in_plan committed model=%s", model)  # WHY: FR-007 debug-after
 
     def _validate_upgrade_plan(self) -> bool:
-        """Validate and display upgrade plan summary; prompt only when multi-version."""
+        """Validate and display upgrade plan summary. Prompt only when multi-version."""
         self._print_plan_summary()  # WHY: PCPP present the plan
         if len({p["version"] for p in self.upgrade_plan.values()}) <= 1:  # WHY: single-version needs no prompt
             return True  # WHY: uniform upgrade proceeds without extra confirmation
@@ -929,7 +929,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
             print(f"   Skipped: {self.skipped_already_at_target} devices already at target version")  # WHY: FR-017
 
     def _prompt_multi_version_confirmation(self) -> bool:
-        """Ask user to confirm multi-version upgrade; return True on yes, False otherwise."""
+        """Ask user to confirm multi-version upgrade. Return True on yes, False otherwise."""
         confirm = self._input_fn("\n  Proceed with multi-version upgrade? (y/n): ").strip().lower() or "y"
         return confirm in ("y", "yes")  # WHY: single expression evaluates confirmation
 
@@ -1016,14 +1016,14 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         self.upgrade_config = {  # WHY: single write establishes the mutable config dict for later phases
             "download_strategy": download_strategy,  # WHY: consumed by _build_upgrade_body when POSTing
             "reboot_strategy": reboot_strategy,  # WHY: consumed by _build_upgrade_body when POSTing
-            "force": False,  # WHY: default off; user can flip via _configure_force_option
-            "enable_p2p": True,  # WHY: default on; user can adjust via _configure_p2p
+            "force": False,  # WHY: default off. User can flip via _configure_force_option
+            "enable_p2p": True,  # WHY: default on. User can adjust via _configure_p2p
             "max_failure_percentage": 7,  # WHY: pre-refactor default retained for FR-017 parity
             "start_time": None,  # WHY: None means "start immediately" per Mist API semantics
             "canary_phases": [1, 2, 4, 8, 16, 32, 64, 100],  # WHY: geometric phase ramp used for canary strategy
             "p2p_cluster_size": 5,  # WHY: default cluster size for peer-to-peer downloads
             "p2p_parallelism": 100,  # WHY: default parallelism percentage for P2P transfer
-            "reboot": True,  # WHY: default on; user can override via reboot toggle
+            "reboot": True,  # WHY: default on. User can override via reboot toggle
         }
         # WHY: FR-017 verbatim final-strategy banner preserved from pre-refactor UI
         print(f"\n! Final strategy: Download={download_strategy.upper()}," f" Reboot={reboot_strategy.upper()}")
@@ -1306,7 +1306,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
             print(f"   {model}: {len(plan['devices'])} devices" f" firmware {plan['version']}")  # WHY: user-facing f...
 
     def _get_upgrade_confirmation(self, total: int) -> bool:
-        """Prompt user for UPGRADE confirmation token; return True on match."""
+        """Prompt user for UPGRADE confirmation token. Return True on match."""
         sites_count = len({d.get("_site_id") for p in self.upgrade_plan.values() for d in p["devices"]})  # WHY: unique
         self._print_confirmation_prompt(total, sites_count)  # WHY: single- vs multi-site header
         try:  # WHY: consolidate Ctrl-C / EOF handling around one prompt
@@ -1349,7 +1349,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
             self._execute_site_upgrade(idx, len(sites_with_upgrades), site_id, site_data, mistapi)  # WHY: per-site call
 
     def _prepare_sites_with_upgrades(self) -> dict[str, dict[str, Any]]:
-        """Return only sites that still have devices to upgrade; log any skipped."""
+        """Return only sites that still have devices to upgrade. Log any skipped."""
         devices_by_site = self._organize_devices_by_site()  # WHY: group current plan by site
         sites_with_upgrades = {sid: data for sid, data in devices_by_site.items() if data["devices"]}  # WHY: non-empty
         skipped = len(devices_by_site) - len(sites_with_upgrades)  # WHY: count sites filtered out
@@ -1531,7 +1531,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         resp = mistapi.api.v1.sites.devices.upgradeSiteDevices(self.apisession, site_id, body=body)  # WHY: capture i...
         # WHY: capture upgrade_id when API returns dict payload so status-check step can poll it
         if hasattr(resp, "data") and resp.data and isinstance(resp.data, dict):  # WHY: guard on condition
-            if "upgrade_id" in resp.data:  # WHY: some responses omit id (partial success); guard first
+            if "upgrade_id" in resp.data:  # WHY: some responses omit id (partial success). Guard first
                 self.upgrade_ids.append(resp.data["upgrade_id"])  # WHY: track for post-upgrade status
         self.successful_upgrades += len(devices)  # WHY: increment aggregate counter for summary
         # WHY: user-visible progress line mirrors pre-refactor format for FR-017 equivalence
@@ -1575,7 +1575,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
 
     def _augment_body_p2p(self, body: dict[str, Any]) -> None:  # WHY: helper definition (see docstring)
         """Add p2p_cluster_size when P2P is enabled."""
-        # WHY: p2p_cluster_size only makes sense when enable_p2p is True; guard against noise
+        # WHY: p2p_cluster_size only makes sense when enable_p2p is True. Guard against noise
         if self.upgrade_config["enable_p2p"]:  # WHY: guard on condition
             body["p2p_cluster_size"] = self.upgrade_config["p2p_cluster_size"]  # WHY: capture intermediate value
 
@@ -1589,17 +1589,17 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
 
     def _augment_body_rrm(self, body: dict[str, Any]) -> None:  # WHY: helper definition (see docstring)
         """Add rrm_* tunables when reboot strategy is rrm."""
-        # WHY: RRM fields only accepted by API when reboot_strategy == "rrm"; skip otherwise
+        # WHY: RRM fields only accepted by API when reboot_strategy == "rrm". Skip otherwise
         if self.upgrade_config["reboot_strategy"] != "rrm":  # WHY: guard on condition
             return  # WHY: early exit from branch
-        # WHY: hard-coded key list mirrors pre-refactor logic; each field is optional per key
+        # WHY: hard-coded key list mirrors pre-refactor logic. Each field is optional per key
         for key in ("rrm_node_order", "rrm_first_batch_percentage", "rrm_max_batch_percentage"):  # WHY: iterate coll...
             if key in self.upgrade_config:  # WHY: only copy keys the user actually configured
                 body[key] = self.upgrade_config[key]  # WHY: capture intermediate value
 
     def _augment_body_start_time(self, body: dict[str, Any]) -> None:  # WHY: helper definition (see docstring)
         """Add start_time when user configured a scheduled upgrade window."""
-        # WHY: start_time absent for immediate upgrades; only inject when explicitly set
+        # WHY: start_time absent for immediate upgrades. Only inject when explicitly set
         if self.upgrade_config.get("start_time"):  # WHY: guard on condition
             body["start_time"] = self.upgrade_config["start_time"]  # WHY: capture intermediate value
 
@@ -1655,13 +1655,13 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
 
     def _resolve_upgrade_id_column(self) -> str:  # WHY: helper definition (see docstring)
         """Pick the value for the Upgrade ID CSV column (real id, dry-run sentinel, or N/A)."""
-        # WHY: pull last upgrade id when available; matches pre-refactor selection semantics
+        # WHY: pull last upgrade id when available. Matches pre-refactor selection semantics
         if self.upgrade_ids:  # WHY: guard on condition
             return str(self.upgrade_ids[-1])  # WHY: surface computed result
-        # WHY: dry-run runs never mutate; label sentinel distinguishes them from real N/A
+        # WHY: dry-run runs never mutate. Label sentinel distinguishes them from real N/A
         if self.dry_run:  # WHY: guard on condition
             return "N/A (DRY-RUN)"  # WHY: surface computed result
-        return "N/A"  # WHY: no upgrade_id returned and not a dry-run; report unknown
+        return "N/A"  # WHY: no upgrade_id returned and not a dry-run. Report unknown
 
     def _get_device_target_version(self, device: dict[str, Any]) -> str:  # WHY: helper definition (see docstring)
         """Get target version for a device."""
@@ -1680,7 +1680,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         logging.info("Fetching AP model families from Mist const/device_models")  # WHY: FR-007 info-before
         print("   Fetching AP model definitions from Mist API...")  # WHY: user-visible progress marker
         raw_models = self._request_device_models()  # WHY: Prepare — isolate the API call for error handling
-        if raw_models is None:  # WHY: None sentinel signals request failure; empty list means real empty payload
+        if raw_models is None:  # WHY: None sentinel signals request failure. Empty list means real empty payload
             return {}  # WHY: surface computed result
         families = self._group_models_by_ap_type(raw_models)  # WHY: Compute — pure grouping over raw records
         logging.debug(
@@ -1713,7 +1713,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         return {ap_type: sorted(models) for ap_type, models in sorted(ap_type_to_models.items())}  # WHY: deterministic
 
     def _add_ap_model_to_group(self, model_info: Any, groups: dict[str, list[str]]) -> None:
-        """Append AP model_info's model name to its ap_type bucket; skip non-AP or malformed."""
+        """Append AP model_info's model name to its ap_type bucket. Skip non-AP or malformed."""
         if not isinstance(model_info, dict):  # WHY: skip unexpected payload shapes
             return  # WHY: defensive guard
         if model_info.get("type") != "ap":  # WHY: only APs matter to this workflow
@@ -1782,7 +1782,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         """Prepare phase: ask whether to add versions for other models."""
         try:
             add_more = self._input_fn("\n  Add firmware versions for other AP models? (y/N): ").strip().lower()
-            return add_more in ("y", "yes")  # WHY: default answer is no; only explicit y/yes proceeds
+            return add_more in ("y", "yes")  # WHY: default answer is no. Only explicit y/yes proceeds
         except (EOFError, KeyboardInterrupt):  # WHY: treat Ctrl+C/EOF as decline, matching pre-refactor behavior
             return False  # WHY: surface computed result
 
@@ -1823,7 +1823,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         family_list: list[tuple[str, list[str]]],
         selected: dict[str, list[str]],
     ) -> None:
-        """Append family for one integer token; silently drop malformed/out-of-range tokens."""
+        """Append family for one integer token. Silently drop malformed/out-of-range tokens."""
         if not part.isdigit():  # WHY: only accept pure integer indices
             return  # WHY: match legacy silent-drop behavior
         idx = int(part) - 1  # WHY: convert 1-based UI index to 0-based
@@ -2002,7 +2002,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         print("   Configure when auto-upgrades should occur")  # WHY: one-line intent statement
 
     def _prompt_schedule_day(self) -> str:
-        """Prepare phase: prompt operator to pick a day-of-week; default 'any'."""
+        """Prepare phase: prompt operator to pick a day-of-week. Default 'any'."""
         days = ["any", "mon", "tue", "wed", "thu", "fri", "sat", "sun"]  # WHY: 8 slots, index 0 = any
         self._print_schedule_day_menu(days)  # WHY: extract menu rendering
         try:  # WHY: consolidate parse + interrupt handling
@@ -2019,20 +2019,20 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
             print(f"   [{idx}] {day}")  # WHY: render each real day option
 
     def _resolve_schedule_day(self, day_choice: str, days: list[str]) -> str:
-        """Map digit input to canonical day string; anything else -> 'any'."""
+        """Map digit input to canonical day string. Anything else -> 'any'."""
         if day_choice.isdigit() and 0 <= int(day_choice) < len(days):  # WHY: bounds check before index
             return days[int(day_choice)]  # WHY: numeric pick maps to canonical day string
         return "any"  # WHY: invalid input silently falls back to default
 
     def _prompt_schedule_time(self) -> str:  # WHY: helper definition (see docstring)
-        """Prepare phase: prompt operator to pick HH:MM or 'any'; default 'any'."""
+        """Prepare phase: prompt operator to pick HH:MM or 'any'. Default 'any'."""
         print("\n  Time of day (24-hour format HH:MM, or 'any'):")  # WHY: input format guidance
         print("   Examples: 02:00 (2 AM), 14:00 (2 PM), any")  # WHY: concrete examples reduce operator error
         try:
             time_input = self._input_fn("   Enter time (default=any): ").strip() or "any"  # WHY: default any
             if time_input.lower() == "any":  # WHY: explicit 'any' means no schedule constraint
                 return "any"  # WHY: surface computed result
-            if ":" in time_input:  # WHY: minimal HH:MM shape check; API validates the exact format
+            if ":" in time_input:  # WHY: minimal HH:MM shape check. API validates the exact format
                 return time_input  # WHY: surface computed result
             return "any"  # WHY: fallback for malformed strings without a colon
         except (EOFError, KeyboardInterrupt):  # WHY: Ctrl+C/EOF matches the pre-refactor 'any' default
@@ -2235,7 +2235,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         )
 
     def _write_results_csv(self, filename: str) -> bool:  # WHY: helper definition (see docstring)
-        """Persist self.results to CSV; return True on success."""
+        """Persist self.results to CSV. Return True on success."""
         try:
             # WHY: newline="" required by csv module to avoid double line endings on Windows
             with open(filename, "w", newline="", encoding="utf-8") as fp:  # WHY: scoped resource

--- a/src/firmware/bulk_switch_upgrader.py
+++ b/src/firmware/bulk_switch_upgrader.py
@@ -48,7 +48,7 @@ class BulkSwitchFirmwareUpgrader:  # pylint: disable=too-few-public-methods,too-
     - Verify backup connectivity paths before execution
     """
 
-    # WHY: relative path so tests can override; kept as class attr for compatibility.
+    # WHY: relative path so tests can override. Kept as class attr for compatibility.
     CACHE_FILE = os.path.join(CACHE_DIR, CACHE_FILENAME)
     CACHE_FRESHNESS_HOURS = 24  # WHY: reuse cached firmware list if newer than one day.
 
@@ -321,7 +321,7 @@ class BulkSwitchFirmwareUpgrader:  # pylint: disable=too-few-public-methods,too-
             # WHY: EOF-safe strategy prompt through injected input helper.
             strategy_choice = self.safe_input_fn("\nSelect upgrade strategy (1-3): ", context="bulk_switch_strategy")
             resolved = self._resolve_strategy_choice(strategy_choice)  # WHY: single-branch mapping.
-            if resolved is not None:  # WHY: None means invalid; loop again.
+            if resolved is not None:  # WHY: None means invalid. Loop again.
                 self.upgrade_strategy = resolved  # WHY: commit valid strategy.
                 break  # WHY: exit prompt loop.
             print("X  Please enter 1, 2, or 3")  # WHY: invalid input feedback.
@@ -461,7 +461,7 @@ class BulkSwitchFirmwareUpgrader:  # pylint: disable=too-few-public-methods,too-
         """Load firmware data from cache or API."""
         print("\n-> Checking for cached firmware versions...")  # WHY: progress cue.
         cached_data = self._load_from_cache()  # WHY: prefer fresh cache to avoid API load.
-        if cached_data:  # WHY: fresh cache returns list; stale/missing returns None.
+        if cached_data:  # WHY: fresh cache returns list. Stale/missing returns None.
             return cached_data  # WHY: short-circuit with cached firmware list.
         return self._fetch_firmware_from_api()  # WHY: fall back to live API.
 
@@ -732,7 +732,7 @@ class BulkSwitchFirmwareUpgrader:  # pylint: disable=too-few-public-methods,too-
                 return result if result else None  # WHY: empty dict -> None on success.
 
     def _version_prompt_iteration(self) -> dict[str, Any] | None:
-        """Run one iteration of the version prompt loop; return dict or None to reloop."""
+        """Run one iteration of the version prompt loop. Return dict or None to reloop."""
         count = len(self.available_versions)  # WHY: recomputed each loop for clarity.
         try:  # WHY: numeric parse must not crash the loop.
             print(f"\nSelect firmware version by index (1-{count}):")  # WHY: instruction.

--- a/src/firmware/firmware_manager.py
+++ b/src/firmware/firmware_manager.py
@@ -18,7 +18,7 @@ import time  # WHY: polling delays for continuous monitoring mode
 from collections.abc import Callable  # WHY: type hints for injected dependency callables
 from dataclasses import dataclass  # WHY: FirmwareManagerConfig frozen value object
 from datetime import UTC, datetime  # WHY: UTC-aware ISO timestamps and CSV filenames
-from typing import Any, cast  # WHY: Any for opaque API objects; cast narrows mypy return types
+from typing import Any, cast  # WHY: Any for opaque API objects. Cast narrows mypy return types
 
 # Type aliases for injected dependencies keep readable signatures across helpers.
 SafeInputFn = Callable[..., str]  # WHY: safe_input(prompt, context=...) returning stripped text
@@ -73,7 +73,7 @@ class FirmwareManagerConfig:
     argument, satisfying STRUCT-PARAMS (threshold 5) and matching the 1004
     ``BulkAPUpgraderConfig`` prior-art template exactly.
 
-    All six ``*_fn`` hooks are Optional; the class supplies sensible fallbacks
+    All six ``*_fn`` hooks are Optional. The class supplies sensible fallbacks
     where required, preserving pre-refactor behavior (FR-017).
     """
 
@@ -81,7 +81,7 @@ class FirmwareManagerConfig:
     apisession: Any  # WHY: Mist API session for all HTTP calls
     org_id: str  # WHY: organization scope for every operation
 
-    # Dependency-injection hooks (all optional; class supplies defaults)
+    # Dependency-injection hooks (all optional. Class supplies defaults)
     safe_input_fn: SafeInputFn | None = None  # WHY: prompt helper with context-tag audit trail
     select_site_fn: SelectSiteFn | None = None  # WHY: site-picker used by menu 196 sub-flows
     check_cache_fn: CheckCacheFn | None = None  # WHY: CSV cache warm-up / regenerate logic
@@ -172,7 +172,7 @@ class FirmwareManager:
         logging.debug("FirmwareManager init complete for org %s", config.org_id)  # WHY: confirm bootstrap finished
 
     def _compare_version_parts(self, current_parts: list[str], target_parts: list[str]) -> bool:
-        """Compare version part lists numerically; return True if target is older than current."""
+        """Compare version part lists numerically. Return True if target is older than current."""
         for current_part, target_part in zip(current_parts, target_parts, strict=False):  # WHY: iterate part-wise
             outcome = self._compare_single_version_pair(current_part, target_part)  # WHY: delegate per-part
             if outcome is not None:  # WHY: only stop when a definitive verdict is reached
@@ -180,7 +180,7 @@ class FirmwareManager:
         return False  # WHY: all parts equal — not a downgrade
 
     def _compare_single_version_pair(self, current_part: str, target_part: str) -> bool | None:
-        """Compare one version segment; return True if downgrade, False if upgrade, None if equal."""
+        """Compare one version segment. Return True if downgrade, False if upgrade, None if equal."""
         try:
             current_num, target_num = int(current_part), int(target_part)  # WHY: prefer numeric compare
         except ValueError:
@@ -287,7 +287,7 @@ class FirmwareManager:
         scope_choice: str,
         site_filter: str | None,
     ) -> str | None:
-        """Return site filter for the status check; prompt when scope=2 and none supplied."""
+        """Return site filter for the status check. Prompt when scope=2 and none supplied."""
         if scope_choice != "2" or site_filter is not None:  # WHY: only mode 2 with no filter needs prompt
             return site_filter  # WHY: pass through untouched
         logging.debug("User selected specific site mode")  # WHY: audit interactive path
@@ -369,7 +369,7 @@ class FirmwareManager:
         print("=" * 70)  # WHY: closing divider
 
     def _handle_monitoring_result(self, result: int | None, iteration: int) -> bool:
-        """Interpret the check result; return True if loop should exit."""
+        """Interpret the check result. Return True if loop should exit."""
         if result is None:  # WHY: transient error path
             print("\n   Error fetching upgrade status. Retrying...")  # WHY: user-visible retry hint
             logging.warning("Monitoring iteration %s failed", iteration)  # WHY: audit failure
@@ -523,7 +523,7 @@ class FirmwareManager:
             try:
                 is_active = (time.time() - fw_timestamp) / 3600 <= 1  # WHY: only recent (<=1hr) counts as active
             except (ValueError, OSError, TypeError):
-                pass  # WHY: guard bad epoch; leave is_active as-is
+                pass  # WHY: guard bad epoch. Leave is_active as-is
         return is_active  # WHY: propagate active flag
 
     def _get_active_upgrades_from_stats(self, all_device_stats: list[Any]) -> list[dict[str, Any]]:
@@ -558,7 +558,7 @@ class FirmwareManager:
         print("  " + "-" * 86)  # WHY: header/body separator
         for upgrade in active_upgrades:  # WHY: emit one row per active upgrade
             if _main_d is None:
-                progress_bar = ""  # WHY: MistHelper unavailable; render blank bar
+                progress_bar = ""  # WHY: MistHelper unavailable. Render blank bar
             else:
                 progress_bar = _main_d.DisplayUtils.create_progress_bar(  # WHY: ASCII bar
                     upgrade["progress"], bar_length=15
@@ -641,7 +641,7 @@ class FirmwareManager:
         template_id: str,
         template_name: str,
     ) -> list[dict[str, Any]]:
-        """Look up sites for the selected template; warn + return [] if empty."""
+        """Look up sites for the selected template. Warn + return [] if empty."""
         _template_name_to_id, template_sites_mapping = self._load_template_sites_mapping()  # WHY: reload mapping
         sites_to_upgrade = template_sites_mapping.get(template_id, [])  # WHY: fetch mapped sites
         if not sites_to_upgrade:  # WHY: empty template
@@ -867,7 +867,7 @@ class FirmwareManager:
     def execute_firmware_upgrade_with_mode_selection(self) -> list[dict[str, Any]] | None:
         """Main entry point for AP firmware upgrades with mode selection.
 
-        Presents site/template/MSP choice; delegates to picked flow. MSP option
+        Presents site/template/MSP choice. Delegates to picked flow. MSP option
         appears only when an MSP session is active.
         """
         logging.info("Starting AP firmware upgrade with mode selection")  # WHY: audit entry
@@ -909,7 +909,7 @@ class FirmwareManager:
         return ["1", "2"], "\n  Select mode (1-2): "  # WHY: two-way choice contract
 
     def _prompt_ap_upgrade_mode(self, prompt: str, valid_choices: list[str]) -> str | None:
-        """Loop until operator enters a valid choice; return None on KeyboardInterrupt."""
+        """Loop until operator enters a valid choice. Return None on KeyboardInterrupt."""
         while True:  # WHY: retry until valid/cancel
             try:  # WHY: catch Ctrl-C
                 mode_choice = self._safe_input_fn(prompt, context="firmware_manager").strip()  # WHY: audited
@@ -982,7 +982,7 @@ class FirmwareManager:
         """Print destructive-operation warning and ask user to type UPGRADE.
 
         Returns:
-            True if user confirmed; False otherwise.
+            True if user confirmed. False otherwise.
         """
         total_sites = sum(len(p["sites"]) for p in upgrade_plan)  # WHY: aggregate site count across orgs
         total_orgs = len(upgrade_plan)  # WHY: total org count for banner
@@ -1018,7 +1018,7 @@ class FirmwareManager:
         return results  # WHY: return aggregate results to caller
 
     def _finalize_msp_upgrade(self, upgrade_plan: list[Any], dry_run: bool) -> list[dict[str, Any]] | None:
-        """Render plan summary, confirm, execute, and print closing summary; return results or None."""
+        """Render plan summary, confirm, execute, and print closing summary. Return results or None."""
         self._display_upgrade_plan_summary(upgrade_plan, dry_run)  # WHY: preview via typed helper
         if not self._await_msp_upgrade_confirmation(upgrade_plan, dry_run):  # WHY: gate execution
             return None  # WHY: operator declined confirmation
@@ -1035,14 +1035,14 @@ class FirmwareManager:
         print("  Please review selections carefully before confirming.\n")  # WHY: operator caution
 
     def _collect_msp_upgrade_plan(self) -> list[Any] | None:
-        """Drive MSP + org + site selection; return upgrade plan list, or None on cancel."""
+        """Drive MSP + org + site selection. Return upgrade plan list, or None on cancel."""
         selected_msps = self._select_msps_for_upgrade()  # WHY: pick MSPs via typed selector
         if not selected_msps:  # WHY: cancel signal from selector
             print("  Cancelled - no MSP selected")  # WHY: operator feedback
             return None  # WHY: propagate cancel upward
         print(f"\n  + Selected {len(selected_msps)} MSP(s)")  # WHY: confirm count
         upgrade_plan = self._build_msp_upgrade_plan(selected_msps)  # WHY: expand MSPs -> orgs -> sites
-        return upgrade_plan  # WHY: empty list means no targets; caller handles
+        return upgrade_plan  # WHY: empty list means no targets. Caller handles
 
     def _await_msp_upgrade_confirmation(self, upgrade_plan: list[Any], dry_run: bool) -> bool:
         """Return True when execution should proceed (dry-run auto-approves)."""
@@ -1099,7 +1099,7 @@ class FirmwareManager:
         print("")  # WHY: separator before prompt
 
     def _prompt_msp_selection_input(self) -> str | None:
-        """Prompt operator for MSP selection token; return normalized string or None."""
+        """Prompt operator for MSP selection token. Return normalized string or None."""
         try:  # WHY: safe_input may raise SystemExit
             token = self._safe_input_fn("  Select MSP(s): ", context="msp_multi_select")  # WHY: audited prompt
         except SystemExit:  # WHY: honour Ctrl-C / EOF
@@ -1205,7 +1205,7 @@ class FirmwareManager:
         print("\n    Selection: single '1', multiple '1,3,5', range '1-3', 'all', or 'q'\n")  # WHY: syntax help
 
     def _prompt_org_selection_input(self) -> str | None:
-        """Prompt operator for org selection string; returns lowercase text or None."""
+        """Prompt operator for org selection string. Returns lowercase text or None."""
         logging.debug("Prompting operator for org selection")  # WHY: trace prompt entry
         try:
             selection = (
@@ -1371,7 +1371,7 @@ class FirmwareManager:
         target_org_id: str,
         org_name: str,
     ) -> list[dict[str, Any]] | None:
-        """Fetch sites from org and let user select which to upgrade; return picks or None."""
+        """Fetch sites from org and let user select which to upgrade. Return picks or None."""
         global apisession
         logging.info("Selecting sites for org upgrade org=%s", target_org_id)  # WHY: audit entry
         print(f"      Fetching sites from {org_name}...")  # WHY: operator progress signal
@@ -1387,7 +1387,7 @@ class FirmwareManager:
         return result  # WHY: propagate selection to caller
 
     def _safe_fetch_sites_for_org(self, target_org_id: str) -> list[dict[str, Any]] | None:
-        """Fetch org sites with error handling; return list, empty, or None sentinel."""
+        """Fetch org sites with error handling. Return list, empty, or None sentinel."""
         try:
             sites_data = self._fetch_and_validate_org_sites(target_org_id)  # WHY: HTTP + validation
         except Exception as e:  # WHY: broad guard for network/lib errors
@@ -1415,7 +1415,7 @@ class FirmwareManager:
         return start, end  # WHY: bounds ready for expansion
 
     def _append_index_if_valid(self, idx: int, max_count: int, selected_indices: list[int]) -> None:
-        """Append a 0-based index if within bounds and not already selected; log overflow diagnostic."""
+        """Append a 0-based index if within bounds and not already selected. Log overflow diagnostic."""
         if 0 <= idx < max_count and idx not in selected_indices:  # WHY: bounds + dedupe gate
             selected_indices.append(idx)  # WHY: register valid index
         elif idx >= max_count:  # WHY: overflow diagnostic path
@@ -1440,7 +1440,7 @@ class FirmwareManager:
         self._append_index_if_valid(idx, max_count, selected_indices)  # WHY: delegate bounds/dedupe check
 
     def _parse_selection_input(self, user_input: str, max_count: int) -> list[int]:
-        """Parse selection input into 0-based indices; supports single, csv, dash and 'through' ranges."""
+        """Parse selection input into 0-based indices. Supports single, csv, dash and 'through' ranges."""
         selected_indices: list[int] = []  # WHY: accumulator for parsed indices
         normalized_input = (  # WHY: unify range syntax before tokenizing
             user_input.lower().replace(" through ", "-").replace("through", "-")
@@ -1520,7 +1520,7 @@ class FirmwareManager:
         dry_run: bool,
         results: list[dict[str, Any]],
     ) -> bool:
-        """Iterate the upgrade plan; return True if the user requested stop."""
+        """Iterate the upgrade plan. Return True if the user requested stop."""
         total_items = len(upgrade_plan)  # WHY: used for progress header rendering
         for idx, plan in enumerate(upgrade_plan, 1):  # WHY: 1-based counter matches user-facing display
             self._present_msp_plan_header(idx, total_items, plan)  # WHY: print banner before work begins
@@ -1548,7 +1548,7 @@ class FirmwareManager:
         plan: dict[str, Any],
         dry_run: bool,
     ) -> dict[str, Any]:
-        """Execute a single org upgrade; return record + stop flag."""
+        """Execute a single org upgrade. Return record + stop flag."""
         global org_id  # WHY: helper mutates module scope for underlying upgrader
         target_org_id = plan["org_id"]  # WHY: pin target once for consistent record fields
         target_org_name = plan["org_name"]  # WHY: rendered in prompts and logs
@@ -1810,7 +1810,7 @@ class FirmwareManager:
     def execute_switch_firmware_upgrade_with_mode_selection(self) -> None:
         """Main entry point for switch firmware upgrades with mode selection.
 
-        Presents site-based vs template-based choice; delegates to the picked flow.
+        Presents site-based vs template-based choice. Delegates to the picked flow.
         """
         logging.info("Starting switch firmware upgrade with mode selection")  # WHY: audit entry
         self._print_switch_upgrade_banner()  # WHY: destructive-op warnings
@@ -1843,7 +1843,7 @@ class FirmwareManager:
         print("   [2] By Gateway Template - Upgrade all sites assigned to a selected Gateway Template")  # tmpl
 
     def _prompt_switch_upgrade_mode(self) -> str | None:
-        """Loop until operator enters a valid mode ('1' or '2'); return None on EOF."""
+        """Loop until operator enters a valid mode ('1' or '2'). Return None on EOF."""
         while True:  # WHY: retry until valid or cancel
             try:  # WHY: catch EOF/interrupt
                 mode_choice = self._safe_input_fn("\n  Select mode (1-2): ", context="firmware_manager").strip()
@@ -1977,7 +1977,7 @@ class FirmwareManager:
         print("   [2] By Gateway Template - Upgrade all sites assigned to a selected Gateway Template")  # WHY: mode 2
 
     def _prompt_ssr_mode_selection(self) -> str | None:
-        """Prompt for SSR upgrade mode until valid or cancelled; returns "1", "2", or None."""
+        """Prompt for SSR upgrade mode until valid or cancelled. Returns "1", "2", or None."""
         logging.info("Prompting SSR upgrade mode selection")  # WHY: trace prompt entry
         while True:  # WHY: retry until valid input or EOF/interrupt
             try:  # WHY: catch shell/SSH interrupt for safe exit
@@ -2226,7 +2226,7 @@ class FirmwareManager:
         return available_versions  # WHY: caller uses this list
 
     def _fetch_ssr_version_rows(self, firmware_channel: str) -> list[Any] | None:
-        """Fetch raw SSR version rows from the API; None on failure."""
+        """Fetch raw SSR version rows from the API. None on failure."""
         logging.info("Fetching SSR version rows channel=%s", firmware_channel)  # WHY: entry audit
         response = mistapi.api.v1.orgs.ssr.listOrgAvailableSsrVersions(  # WHY: channel-scoped SSR versions
             self.apisession, self.org_id, channel=firmware_channel
@@ -2911,7 +2911,7 @@ class FirmwareManager:
         print("Monitor progress through Mist dashboard or API.")
         print("Check individual SSR status for completion and connectivity.")
         print("Verify SD-WAN tunnel re-establishment after reboots.")
-        # Issue #433 Phase A: hand-converted; codemod does not yet detect the
+        # Issue #433 Phase A: hand-converted. Codemod does not yet detect the
         # logging.getLogger(__name__).<level>(...) dynamic-call pattern.
         logging.getLogger(__name__).info("SSR firmware upgrade operation completed: %s", results["operation_id"])
 
@@ -3001,7 +3001,7 @@ class FirmwareManager:
     def _resolve_ssr_org_and_sites(
         self, sites_to_upgrade_override: list[dict[str, Any]] | None
     ) -> tuple[tuple[str, list[dict[str, Any]]] | None, dict[str, Any] | None]:
-        """Validate org access and resolve sites; return ((org_name, sites), None) or (None, error)."""
+        """Validate org access and resolve sites. Return ((org_name, sites), None) or (None, error)."""
         org_name, error = self._validate_org_for_ssr_upgrade()  # WHY: verify org access before user prompts
         if error:  # WHY: propagate org validation error
             return None, error  # WHY: two-slot tuple keeps caller uniform
@@ -3014,7 +3014,7 @@ class FirmwareManager:
     def _resolve_ssr_config_and_version(
         self,
     ) -> tuple[tuple[dict[str, Any], str] | None, dict[str, Any] | None]:
-        """Prompt for SSR upgrade params and firmware version; return ((cfg, version), None) or (None, error)."""
+        """Prompt for SSR upgrade params and firmware version. Return ((cfg, version), None) or (None, error)."""
         upgrade_config = self._setup_ssr_upgrade_params()  # WHY: pick channel/strategy/timeouts
         if upgrade_config is None:  # WHY: user cancelled param prompts
             return None, {"cancelled": True}  # WHY: preserve pre-refactor cancel sentinel
@@ -3258,7 +3258,7 @@ class FirmwareUpgradeStatusChecker:
     def _fetch_site_lookup(self) -> None:
         """Fetch site information for device enrichment."""
         print("   Fetching site information for device enrichment...")  # WHY: operator-facing progress banner
-        try:  # WHY: tolerate API failure; lookup is optional enrichment
+        try:  # WHY: tolerate API failure. Lookup is optional enrichment
             all_sites = _MH.APICoreFetchUtils.all_sites_with_limit(self.org_id)  # WHY: cached fetch via MistHelper
             for site in all_sites:  # WHY: build site_id -> site_name map
                 site_id = site.get("id")  # WHY: primary lookup key
@@ -3411,7 +3411,7 @@ class FirmwareUpgradeStatusChecker:
 
     def _update_summary_counters(self, device_info: dict[str, Any], fw_info: dict[str, Any]) -> None:
         """Update summary counters for version, model, and type."""
-        del fw_info  # WHY: kept in signature for symmetry with sibling; only device_info is used
+        del fw_info  # WHY: kept in signature for symmetry with sibling. Only device_info is used
         version = device_info["device_version"]  # WHY: histogram key
         model = device_info["device_model"]  # WHY: histogram key
         device_type = device_info["device_type"]  # WHY: histogram key
@@ -3618,7 +3618,7 @@ class FirmwareUpgradeStatusChecker:
         self._check_site_upgrades()  # WHY: per-site upgrade endpoint probe
 
     def _fetch_ssr_upgrades_payload(self) -> list | None:  # type: ignore[type-arg]
-        """Fetch SSR upgrades list; returns list-or-None (empty list signals 'no upgrades')."""
+        """Fetch SSR upgrades list. Returns list-or-None (empty list signals 'no upgrades')."""
         ssr_resp = mistapi.api.v1.orgs.ssr.listOrgSsrUpgrades(apisession, self.org_id)  # WHY: SSR API call
         if ssr_resp.status_code != 200 or not hasattr(ssr_resp, "data"):  # WHY: HTTP or shape error
             print(f"   -> Failed to retrieve SSR upgrade operations: {ssr_resp.status_code}")  # WHY: user-facing
@@ -3899,7 +3899,7 @@ class FirmwareUpgradeStatusChecker:
             return False
 
     def _record_site_upgrade(self, info: dict[str, Any]) -> None:
-        """Append one site-upgrade record into active_upgrades; info bundles identity + stage fields."""
+        """Append one site-upgrade record into active_upgrades. Info bundles identity + stage fields."""
         counts = info["counts"]  # WHY: stage-count sub-dict
         self.active_upgrades.append(
             {

--- a/src/firmware/org_ap_upgrader.py
+++ b/src/firmware/org_ap_upgrader.py
@@ -26,7 +26,7 @@ class OrgAPUpgraderConfig:  # WHY: declare OrgAPUpgraderConfig class
     already pass. Satisfies STRUCT-PARAMS (threshold 5) with a formal count
     of 1 (the __init__ signature becomes ``def __init__(self, **cfg)``).
 
-    All six *_fn hooks are Optional; the class supplies sensible defaults
+    All six *_fn hooks are Optional. The class supplies sensible defaults
     (matching pre-refactor `_default_*` fallbacks) when None is provided.
     ``msp_privileges`` and ``selected_msp`` accept None for the org-mode
     entry points (callsites at lines 20247/20269) and are set to real
@@ -35,7 +35,7 @@ class OrgAPUpgraderConfig:  # WHY: declare OrgAPUpgraderConfig class
 
     org_id: str  # WHY: organization scope (empty string permitted at MSP-select callsites)
     apisession: Any  # WHY: Mist API session used for every HTTP call (never None)
-    dry_run: bool = False  # WHY: preview-only toggle; no upgrades committed when True
+    dry_run: bool = False  # WHY: preview-only toggle. No upgrades committed when True
     safe_input_fn: Any | None = None  # WHY: injected safe_input helper (None -> default)
     check_stop_fn: Any | None = None  # WHY: cooperative-cancel probe (None -> no-op)
     get_org_id_fn: Any | None = None  # WHY: resolves org id from prompt / cache (None -> default)
@@ -58,7 +58,7 @@ class OrgAPUpgraderConfig:  # WHY: declare OrgAPUpgraderConfig class
         """Enforce identity-field types per data-model.md validation-rules table."""
         if not isinstance(self.org_id, str):  # WHY: enforce string identity (empty allowed for MSP paths)
             raise TypeError("org_id must be a string")  # WHY: fail-fast on wrong identity type
-        # WHY: apisession=None is permitted here; every network-call site guards it explicitly
+        # WHY: apisession=None is permitted here. Every network-call site guards it explicitly
         # WHY: (see _fetch_org_aps, _step3_fetch_firmware_stats, _step4_fetch_available_firmware,
         # WHY: _select_orgs_from_msp) and returns False/[] for graceful degradation.
 
@@ -207,7 +207,7 @@ class OrgLevelAPFirmwareUpgrader:
         """Entry point that detects MSP privileges and branches accordingly."""
         logging.info("OrgLevelAPFirmwareUpgrader workflow started, dry_run=%s", self.dry_run)  # WHY: audit workflow ent
         if self._try_msp_mode():  # WHY: consume MSP branch when privileges detected and user selects it
-            return  # WHY: MSP mode fully handled; no single-org fallthrough
+            return  # WHY: MSP mode fully handled. No single-org fallthrough
         self._run_single_org_mode()  # WHY: default single-org path
         logging.debug("OrgLevelAPFirmwareUpgrader.run completed")  # WHY: bracket exit
 
@@ -222,7 +222,7 @@ class OrgLevelAPFirmwareUpgrader:
         if mode == "2":  # WHY: option 2 == MSP multi-org
             logging.info("User selected MSP Multi-Org mode")  # WHY: audit selection
             self._execute_msp_mode()  # WHY: run MSP workflow
-            return True  # WHY: MSP path finished; skip single-org
+            return True  # WHY: MSP path finished. Skip single-org
         return False  # WHY: user chose single-org (option 1)
 
     def _has_msp_privileges(self) -> bool:  # WHY: declare private helper _has_msp_privileges
@@ -275,7 +275,7 @@ class OrgLevelAPFirmwareUpgrader:
         """Execute MSP multi-organization upgrade mode via three phase helpers."""
         logging.info("Starting MSP Multi-Org AP firmware upgrade workflow")  # WHY: workflow entry audit
         self._print_msp_mode_header()  # WHY: banner + dry-run notice for user
-        selected_orgs = self._msp_phase_select()  # WHY: pick MSPs, gather orgs; None on cancel
+        selected_orgs = self._msp_phase_select()  # WHY: pick MSPs, gather orgs. None on cancel
         if selected_orgs is None:  # WHY: guard cancelled selection - cancel msg already printed
             return  # WHY: exit early on user cancel
         if not self._confirm_msp_orgs(selected_orgs):  # WHY: user must confirm before execution
@@ -668,7 +668,7 @@ class OrgLevelAPFirmwareUpgrader:
         """Coerce a listMspOrgs data payload into a list of org dicts."""
         if isinstance(raw, list):  # WHY: happy-path is a list of org dicts
             return raw  # WHY: pass through unchanged
-        if raw:  # WHY: single org payload arrives as a dict; wrap to preserve caller contract
+        if raw:  # WHY: single org payload arrives as a dict. Wrap to preserve caller contract
             return [raw]  # WHY: caller iterates a list, wrap scalar to keep loop uniform
         return []  # WHY: None / empty -> caller-visible empty inventory
 
@@ -1095,7 +1095,7 @@ class OrgLevelAPFirmwareUpgrader:
         return self._fetch_org_aps_safely()  # WHY: wrap fetch in guarded helper
 
     def _fetch_org_aps_safely(self) -> bool:  # WHY: declare private helper _fetch_org_aps_safely
-        """Guarded fetch of org devices; return True on success, False on any error."""
+        """Guarded fetch of org devices. Return True on success, False on any error."""
         try:  # WHY: broad guard preserves pre-refactor behavior
             devices_data = self._get_org_inventory()  # WHY: hit inventory API for full page
             return self._process_inventory_result(devices_data)  # WHY: normalize + assign result
@@ -1151,7 +1151,7 @@ class OrgLevelAPFirmwareUpgrader:
     def _collect_paginated_inventory(self, response: Any) -> list[Any]:  # WHY: declare private helper _collect_paginate
         """Normalize mistapi paginated response into a list."""
         logging.info("Collecting paginated inventory for org %s", self.org_id)  # WHY: trace pagination step
-        import mistapi  # WHY: lazy import; only needed for pagination helper
+        import mistapi  # WHY: lazy import. Only needed for pagination helper
 
         devices_data = mistapi.get_all(response=response, mist_session=self.apisession)  # WHY: exhaust pagination curso
         if not isinstance(devices_data, list):  # WHY: mistapi may return a single dict on empty pages
@@ -1910,7 +1910,7 @@ class OrgLevelAPFirmwareUpgrader:
     def _resolve_time_strategy(  # WHY: declare private helper _resolve_time_strategy
         self, strategy: Any, ctx: tuple[str, datetime | None, bool, bool]
     ) -> tuple[bool, str | None]:
-        """Invoke a parser strategy; return (matched, resolved_value) for the dispatcher."""
+        """Invoke a parser strategy. Return (matched, resolved_value) for the dispatcher."""
         outcome = strategy(*ctx)  # WHY: unpack ctx into strategy's argument list
         if outcome is None:  # WHY: None means 'strategy did not match'
             return (False, None)  # WHY: dispatcher keeps iterating on unmatched strategy
@@ -2233,7 +2233,7 @@ class OrgLevelAPFirmwareUpgrader:
     def _tokenize_canary_phases(phases_input: str) -> list[int] | None:  # WHY: declare private helper _tokenize_canary_
         """Split canary-phase CSV and coerce each non-empty token to int()."""
         try:  # WHY: comprehension may raise ValueError on any non-integer token
-            return [  # WHY: build integer list from CSV; skip empty segments so stray commas are tolerated
+            return [  # WHY: build integer list from CSV. Skip empty segments so stray commas are tolerated
                 int(part.strip()) for part in phases_input.split(",") if part.strip()
             ]
         except ValueError:  # WHY: any bad token invalidates the entire wave definition
@@ -2272,7 +2272,7 @@ class OrgLevelAPFirmwareUpgrader:
         print("    Example: '1,2,4,8,16,32,64,100' means 1%, then 2%, then 4%, etc.")  # WHY: illustrate wave format
 
     def _canary_phase_prompt(self) -> str | None:  # WHY: declare private helper _canary_phase_prompt
-        """Prompt for canary phase values; return stripped input or None on SystemExit."""
+        """Prompt for canary phase values. Return stripped input or None on SystemExit."""
         try:  # WHY: safe_input may raise SystemExit if session drops
             phases_input = self._input_fn(  # WHY: safe_input wrapper for SSH/container resiliency
                 "  Canary phases (comma-separated) [1,2,4,8,16,32,64,100]: ",
@@ -2773,7 +2773,7 @@ class OrgLevelAPFirmwareUpgrader:
                     "version": version,  # WHY: retain target firmware version
                     "device_id": device_id,  # WHY: identify the individual AP
                     "upgrade_id": upgrade_id,  # WHY: link result to Mist upgrade job
-                    "status": "Initiated",  # WHY: initial state; polling not part of this workflow
+                    "status": "Initiated",  # WHY: initial state. Polling not part of this workflow
                 }
             )
 

--- a/src/firmware/site_auto_upgrade.py
+++ b/src/firmware/site_auto_upgrade.py
@@ -43,11 +43,11 @@ class SiteAutoUpgradeConfig:
     """
 
     org_id: str  # WHY: Mist organization UUID used for every API call.
-    apisession: Any  # WHY: authenticated mistapi session (may be None; helpers degrade).
+    apisession: Any  # WHY: authenticated mistapi session (may be None. Helpers degrade).
     safe_input_fn: SafeInputFn  # WHY: EOF-safe interactive input helper.
     fetch_sites_fn: FetchSitesFn  # WHY: returns the org's sites.
     check_stop_fn: CheckStopFn  # WHY: cooperative stop-signal predicate.
-    dry_run: bool = False  # WHY: when True, suppress API mutations; print-only mode.
+    dry_run: bool = False  # WHY: when True, suppress API mutations. Print-only mode.
 
     def __post_init__(self) -> None:
         """Permissive validation - only reject clearly-wrong types."""
@@ -137,7 +137,7 @@ class SiteAutoUpgradeConfigurator:
         self.safe_input_fn = cfg.safe_input_fn  # WHY: prompt helper with EOF safety.
         self.fetch_sites_fn = cfg.fetch_sites_fn  # WHY: callable returning all sites for an org.
         self.check_stop_fn = cfg.check_stop_fn  # WHY: predicate that signals operator stop.
-        self.dry_run = cfg.dry_run  # WHY: True suppresses API mutations; print-only.
+        self.dry_run = cfg.dry_run  # WHY: True suppresses API mutations. Print-only.
 
     def _reset_workflow_state(self) -> None:
         """Seed the 11 workflow-scoped attributes to empty defaults."""
@@ -265,7 +265,7 @@ class SiteAutoUpgradeConfigurator:
 
     def _build_auto_upgrade_settings(self) -> dict[str, Any]:
         """Assemble the auto_upgrade payload for the site settings API."""
-        return {  # WHY: return a fresh dict; Mist API expects these keys verbatim.
+        return {  # WHY: return a fresh dict. Mist API expects these keys verbatim.
             "enabled": True,  # WHY: enable auto-upgrade at the site.
             "version": "custom",  # WHY: 'custom' selects per-model version overrides.
             "day_of_week": self.schedule.get("day_of_week", "any"),  # WHY: default 'any' means daily.
@@ -379,14 +379,14 @@ class SiteAutoUpgradeConfigurator:
             return None  # WHY: abort selection.
 
     def _prompt_single_site_index(self) -> int | None:
-        """Prompt operator for a single-site index; return 0-based idx or None."""
+        """Prompt operator for a single-site index. Return 0-based idx or None."""
         selection = self._read_single_site_input()  # WHY: fetch raw input via EOF-safe helper.
         if selection is None or selection == "q":  # WHY: EOF or explicit quit.
             return None  # WHY: abort selection silently.
         if not selection.isdigit():  # WHY: non-digits are invalid.
             print("  Invalid input")  # WHY: tell operator.
             return None  # WHY: abort selection.
-        idx = int(selection) - 1  # WHY: display is 1-based; convert to 0-based index.
+        idx = int(selection) - 1  # WHY: display is 1-based. Convert to 0-based index.
         if not 0 <= idx < len(self.all_sites):  # WHY: guard against out-of-range indices.
             print("  Invalid selection")  # WHY: tell operator.
             return None  # WHY: abort selection.
@@ -428,7 +428,7 @@ class SiteAutoUpgradeConfigurator:
             return self._extract_auto_upgrade_from_response(response)  # WHY: extract block via helper.
         except Exception as exc:  # WHY: settings read may raise mistapi errors - non-fatal.
             logging.debug("Could not fetch current site settings: %s", exc)  # WHY: trace and continue.
-            return {}  # WHY: pre-fill best-effort; empty on failure.
+            return {}  # WHY: pre-fill best-effort. Empty on failure.
 
     def _ingest_auto_upgrade_block(self, auto_upgrade: dict[str, Any]) -> None:
         """Hydrate current_site_versions and schedule from an auto_upgrade block."""
@@ -569,7 +569,7 @@ class SiteAutoUpgradeConfigurator:
         return True  # WHY: loop completed without operator abort.
 
     def _read_family_choice(self, num_versions: int) -> str | None:
-        """Prompt for a numeric family choice; None on EOF."""
+        """Prompt for a numeric family choice. None on EOF."""
         try:
             raw = self.safe_input_fn(  # WHY: read the operator's numeric choice.
                 f"  Select version (1-{num_versions}): ", "auto_upgrade_config"
@@ -582,7 +582,7 @@ class SiteAutoUpgradeConfigurator:
         """Prompt the operator for one family and apply the selection."""
         sorted_versions = _get_family_versions(self.model_version_map, models)  # WHY: family versions.
         if not sorted_versions:  # WHY: skip families with no versions.
-            return True  # WHY: nothing to prompt; treat as success.
+            return True  # WHY: nothing to prompt. Treat as success.
         current_version = _get_current_family_version(  # WHY: resolve family's current version.
             self.is_single_site, self.current_site_versions, models
         )
@@ -655,7 +655,7 @@ class SiteAutoUpgradeConfigurator:
             )
         except SystemExit:  # WHY: safe_input raises SystemExit on EOF.
             return False  # WHY: abort apply.
-        if confirm not in ("y", "yes"):  # WHY: default N; only explicit yes proceeds.
+        if confirm not in ("y", "yes"):  # WHY: default N. Only explicit yes proceeds.
             print("  Cancelled.")  # WHY: tell operator we bailed.
             return False  # WHY: abort apply.
         return True  # WHY: operator confirmed.
@@ -759,7 +759,7 @@ def _msp_select_entities(  # WHY: select MSPs then their orgs.
 
 
 def _select_msps_or_bail(select_msps_fn: SelectMspsFn) -> list[Any] | None:
-    """Run the MSP selection prompt; return None on empty selection."""
+    """Run the MSP selection prompt. Return None on empty selection."""
     print("\n" + "-" * 70)  # WHY: visual section divider.
     print("  STEP 1: MSP Selection")  # WHY: step header.
     print("-" * 70 + "\n")  # WHY: visual section divider.
@@ -772,7 +772,7 @@ def _select_msps_or_bail(select_msps_fn: SelectMspsFn) -> list[Any] | None:
 
 
 def _select_orgs_or_bail(select_orgs_fn: SelectOrgsFromMspFn, selected_msps: list[Any]) -> list[dict[str, Any]] | None:
-    """Run the org selection prompt within the chosen MSPs; None on empty."""
+    """Run the org selection prompt within the chosen MSPs. None on empty."""
     print("\n" + "-" * 70)  # WHY: visual section divider.
     print("  STEP 2: Organization Selection")  # WHY: step header.
     print("-" * 70 + "\n")  # WHY: visual section divider.
@@ -836,7 +836,7 @@ def _msp_confirm_and_apply(  # WHY: confirm then apply across MSP orgs.
 
 
 def _prompt_msp_final_confirm(safe_input_fn: SafeInputFn) -> bool:
-    """Read Y/n confirmation for MSP apply; default Y on bare Enter."""
+    """Read Y/n confirmation for MSP apply. Default Y on bare Enter."""
     try:
         final_confirm = (
             safe_input_fn(  # WHY: read the Y/n via EOF-safe prompt.

--- a/src/gateway/_wan2_variable_cluster.py
+++ b/src/gateway/_wan2_variable_cluster.py
@@ -13,7 +13,7 @@ from __future__ import annotations  # WHY: postponed evaluation for forward-ref 
 
 from typing import TYPE_CHECKING, Any  # WHY: Any lets __getattr__ proxy any parent method
 
-if TYPE_CHECKING:  # WHY: only pulled in by type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only pulled in by type checkers. Skipped at runtime
     from src.gateway.wan2_variable import GatewayWan2VariableMigrator  # WHY: parent type for annotation
 
 
@@ -34,7 +34,7 @@ class _ClusterBase:  # WHY: shared wrapper base for every wan2_variable cluster
     def __getattr__(self, name: str) -> Any:  # WHY: proxy unknown attrs back to parent
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_uc")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy so self._apisession / helpers work
 

--- a/src/gateway/_wan2_variable_device.py
+++ b/src/gateway/_wan2_variable_device.py
@@ -33,7 +33,7 @@ class _Wan2VariableDevice(_ClusterBase):
         """Find devices with port overrides matching the search pattern."""
         import mistapi  # pylint: disable=import-outside-toplevel  # WHY: lazy import breaks cycle
 
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "\n  Step 7: Migrating device-level port overrides (%s mode)...",
             self._operation_mode.upper(),
@@ -45,7 +45,7 @@ class _Wan2VariableDevice(_ClusterBase):
             len(affected),
             len(sites),
         )  # WHY: audit scope
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "  >> Optimization: Checking only %s affected sites (not all %s sites)",
             len(affected),
@@ -53,7 +53,7 @@ class _Wan2VariableDevice(_ClusterBase):
         )
         if not affected:  # WHY: nothing to scan when zero affected sites
             return []  # WHY: skip API calls entirely
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "  >> Fetching gateway device configurations for %s affected sites...",
             len(affected),
@@ -65,14 +65,14 @@ class _Wan2VariableDevice(_ClusterBase):
         search = self._search_pattern  # WHY: alias for readability
         replace = self._replacement_value  # WHY: alias for readability
         if self._operation_mode == "apply":  # WHY: apply-mode copy
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  !? CRITICAL: Preserving static IP configurations on devices")
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  !? Renaming device overrides from '%s' to '%s'", search, replace)
             return  # WHY: skip revert branch
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  !? REVERT: Updating device overrides to match template reversion")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  !? Renaming device overrides from '%s' to '%s'", search, replace)
 
     def _build_affected_site_set(
@@ -266,8 +266,8 @@ class _Wan2VariableDevice(_ClusterBase):
         result: dict[str, Any],
         mistapi_mod: Any,
     ) -> None:
-        """Send API update or mark dry-run; populates result status/error."""
-        config = result.pop("_config", {})  # WHY: retrieved earlier; drop from public payload
+        """Send API update or mark dry-run. Populates result status/error."""
+        config = result.pop("_config", {})  # WHY: retrieved earlier. Drop from public payload
         config["port_config"] = port_config  # WHY: ensure mutation persists in outer config
         name = device_info["device_name"]  # WHY: reused in both branches
         if self._dry_run:  # WHY: dry-run bypasses API mutation
@@ -302,7 +302,7 @@ class _Wan2VariableDevice(_ClusterBase):
     ) -> list[str]:
         """Rename port_config keys matching the search pattern in-place."""
         renamed: list[str] = []  # WHY: accumulator for return
-        for key in list(port_config.keys()):  # WHY: snapshot keys; mutating dict during iteration
+        for key in list(port_config.keys()):  # WHY: snapshot keys. Mutating dict during iteration
             new_key = _match_port_rename(key, search, replacement)  # WHY: module helper for CC budget
             if new_key is None:  # WHY: key does not match
                 continue  # WHY: leave untouched
@@ -318,7 +318,7 @@ class _Wan2VariableDevice(_ClusterBase):
     ) -> list[dict[str, Any]]:
         """Orchestrate device override migrations."""
         if not devices_needing_migration:  # WHY: empty list -> emit no-op message and return
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n  No devices with ge-0/0/1 overrides found - no device migrations needed")
             logging.info("No device-level override migrations required")  # WHY: audit no-op
             return []  # WHY: nothing to report
@@ -331,11 +331,11 @@ class _Wan2VariableDevice(_ClusterBase):
     @staticmethod
     def _print_device_migration_intro(count: int) -> None:
         """Print the migration-intro block for the found device count."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  Found %s devices with port overrides to migrate", count)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  These devices will have port_config keys renamed from 'ge-0/0/1' to '{{wan2_interface}}'")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  This preserves static IP configurations after template migration")
 
     def _dispatch_device_migration(
@@ -354,15 +354,15 @@ class _Wan2VariableDevice(_ClusterBase):
         """Print the post-migration counters block."""
         success = sum(1 for r in results if r["status"] == "SUCCESS")  # WHY: aggregate for banner
         failed = len(results) - success  # WHY: derive failure count
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  Device Override Migration Complete!")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Devices Processed: %s", len(results))
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Successfully Migrated: %s", success)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Failed: %s", failed)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Device migration report: GatewayDevice_WAN2_Override_Migration.csv")
         logging.info("Device override migration: %s successful, %s failed", success, failed)  # WHY: audit
 
@@ -371,7 +371,7 @@ class _Wan2VariableDevice(_ClusterBase):
         assert self._pool_fn is not None  # noqa: S101  # WHY: preserved from original module
 
         count = len(devices)  # WHY: banner count
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  !? Fast mode enabled: Processing %s devices with connection pooling", count)
         logging.info("Fast mode: Using connection pool for %s device migrations", count)  # WHY: audit
         results, failed = self._pool_fn(
@@ -405,10 +405,10 @@ class _Wan2VariableDevice(_ClusterBase):
     def _print_sequential_banner(count: int, fast: bool) -> None:
         """Print the sequential-mode intro banner."""
         if fast and count <= 5:  # WHY: fast requested but too few devices
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n  Sequential mode: Processing %s devices (fast mode requires >5 devices)", count)
             return  # WHY: alternate copy branch handled
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  Sequential mode: Processing %s devices", count)
 
 

--- a/src/gateway/_wan2_variable_io.py
+++ b/src/gateway/_wan2_variable_io.py
@@ -21,40 +21,40 @@ class _Wan2VariableIO(_ClusterBase):
 
     def _print_header(self) -> None:
         """Display operation header with mode-specific warnings."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  DESTRUCTIVE: Update Gateway Templates for WAN2 Variable Migration")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", "=" * 70)
         if self._dry_run:  # WHY: dry-run mode gets safer copy
             self._print_dry_run_header()  # WHY: extracted helper keeps block count low
         else:  # WHY: live mode gets destructive warnings
             self._print_live_header()  # WHY: extracted helper keeps block count low
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", "=" * 70)
 
     @staticmethod
     def _print_dry_run_header() -> None:
         """Print the dry-run banner lines."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  >> DRY-RUN MODE: No changes will be made to templates or devices")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  >> This will show what WOULD be changed without modifying anything")
 
     @staticmethod
     def _print_live_header() -> None:
         """Print the live-mode warning banner lines."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("  !? WARNING: This operation modifies gateway templates")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("  !? All sites using affected templates will inherit the change")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("  !? Ensure sites have 'wan2_interface' variable set (Menu #103)")
 
     def _load_csv_data(
         self,
     ) -> tuple[list[dict[str, str]], list[dict[str, str]], dict[str, int]] | None:
         """Load template and site CSV data, filter excluded sites."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  Loading gateway template data...")
         self._check_csv("OrgGatewayTemplates.csv", self._gen_templates)  # WHY: ensure freshness
         self._check_csv("SiteList.csv", self._gen_sites)  # WHY: ensure freshness
@@ -76,7 +76,7 @@ class _Wan2VariableIO(_ClusterBase):
     @staticmethod
     def _log_no_templates() -> None:
         """Emit the 'no templates' message and log line."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning(" No gateway templates found.")
         logging.warning("No gateway templates available for modification")  # WHY: audit line
 
@@ -93,7 +93,7 @@ class _Wan2VariableIO(_ClusterBase):
 
     def _announce_exclusion(self, excluded: int) -> None:
         """Print SECURITY exclusion notice and matching audit log."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning(
             "\n  !? SECURITY: Excluded %d '%s*' sites from template impact analysis (early filter)",
             excluded,

--- a/src/gateway/_wan2_variable_selection.py
+++ b/src/gateway/_wan2_variable_selection.py
@@ -184,7 +184,7 @@ class _Wan2VariableSelection(_ClusterBase):
         print("  !? Type 'MIGRATE' (all caps) to proceed" " or anything else to cancel")  # WHY: gate
 
     def _collect_confirmation(self) -> bool:
-        """Prompt for the typed-MIGRATE gate; True in dry-run or on match."""
+        """Prompt for the typed-MIGRATE gate. True in dry-run or on match."""
         if self._dry_run:  # WHY: dry-run bypasses the typed-word gate
             return True  # WHY: safe path proceeds without extra confirmation
         confirmation = self._input_fn("\n  Confirmation: ").strip()  # WHY: normalize input

--- a/src/gateway/_wan2_variable_template.py
+++ b/src/gateway/_wan2_variable_template.py
@@ -104,7 +104,7 @@ class _Wan2VariableTemplate(_ClusterBase):
             return (key, new_key)  # WHY: rename with suffix retained
         if search in key:  # WHY: complex pattern needs manual review
             logging.warning("Found complex port pattern in template %s: %s", template_name, key)  # WHY: audit
-            # WHY: preserve legacy operator warnings verbatim; operators rely on the "!?" prefix.
+            # WHY: preserve legacy operator warnings verbatim. Operators rely on the "!?" prefix.
             logging.warning("\n  !? Template '%s' uses complex port pattern: '%s'", template_name, key)
             logging.warning("     This requires manual review - cannot automatically replace")
         return None  # WHY: unmatched or complex - no automatic edit
@@ -190,7 +190,7 @@ class _Wan2VariableTemplate(_ClusterBase):
         result: dict[str, Any],
         mistapi_mod: Any,
     ) -> None:
-        """Apply changes and set result status; may raise on API failure."""
+        """Apply changes and set result status. May raise on API failure."""
         port_config = tmpl["config"].get("port_config", {})  # WHY: mutate this dict in place
         changes_list = self._rename_template_ports(port_config, tmpl["ports_to_replace"], tmpl["name"])
         if not changes_list:  # WHY: no keys matched at apply time
@@ -222,7 +222,7 @@ class _Wan2VariableTemplate(_ClusterBase):
         result: dict[str, Any],
         mistapi_mod: Any,
     ) -> None:
-        """Send API update or mark dry-run; populates result status/error."""
+        """Send API update or mark dry-run. Populates result status/error."""
         if self._dry_run:  # WHY: dry-run bypasses API mutation
             result["status"] = "DRY-RUN"  # WHY: report path
             logging.info(

--- a/src/gateway/device_template_cloner.py
+++ b/src/gateway/device_template_cloner.py
@@ -147,11 +147,11 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         sites = self._list_sites()  # Fetch site list from API
         if not sites:  # Guard - nothing to select if org has no sites
             logger.warning("No sites found for org_id %s", self.org_id)  # Warn on empty list
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("No sites found for this org.")
             return None  # Signal caller to abort the workflow
         for index, site in enumerate(sites, start=1):  # Build numbered list for display
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %3d. %s (%s)", index, site.get("name", "Unknown"), site.get("id", ""))
         raw = self.input_fn("Select site number: ", context="site_selection")  # Prompt for choice
         return self._resolve_menu_choice(raw, sites)  # Delegate parse+validate to shared helper
@@ -176,13 +176,13 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
     def _select_gateway(self, gateways: list) -> dict | None:
         """Display a numbered gateway menu and return the device the user picks."""
         if not gateways:  # Guard - nothing to select if site has no gateways
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("No gateway devices found at the selected site.")
             return None  # Signal caller to abort
         for index, device in enumerate(gateways, start=1):  # Build numbered display list
             model = device.get("model", "Unknown")  # Extract model for display
             name = device.get("name", device.get("mac", "Unknown"))  # Fall back to MAC if no name
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %3d. %s - %s (%s)", index, name, model, device.get("id", ""))
         raw = self.input_fn("Select gateway number: ", context="gateway_selection")  # Prompt for choice
         return self._resolve_menu_choice(raw, gateways)  # Delegate parse+validate to shared helper
@@ -192,11 +192,11 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         try:
             choice = int(raw.strip())  # Parse response as integer index
         except ValueError:  # Non-numeric response - guide the engineer and abort
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("Invalid input - please enter a number.")
             return None  # Signal caller to abort
         if not 1 <= choice <= len(items):  # Validate 1-based range before indexing
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("Invalid selection.")
             return None  # Signal caller to abort
         return items[choice - 1]  # Convert to 0-based and return picked entry
@@ -244,7 +244,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
     # ------------------------------------------------------------------
 
     def _prompt_template_meta(self, device_model: str, existing_names: set) -> tuple[str, str, str]:
-        """Prompt engineer for template type, name, and hardware model; return (name, type, model)."""
+        """Prompt engineer for template type, name, and hardware model. Return (name, type, model)."""
         ttype = self._prompt_template_type()  # Get template type first
         name = self._prompt_template_name(device_model, existing_names)  # Get unique name
         model = self._prompt_hardware_platform(device_model)  # Get target hardware model
@@ -252,11 +252,11 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _prompt_template_type(self) -> str:
         """Prompt for gateway template type and return 'standalone' or 'spoke'."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nTemplate type:")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  1. standalone")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  2. spoke")
         raw = self.input_fn("Select type [1]: ", context="template_type_selection")  # Prompt with default
         raw = raw.strip()  # Remove leading/trailing whitespace from input
@@ -270,23 +270,23 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             )
             name = raw.strip() or default_name  # Use default if engineer pressed Enter
             if name in existing_names:  # Reject names already in use
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("Name '%s' already exists - please choose a different name.", name)
                 continue  # Retry the name prompt
             if not name:  # Reject empty names after default resolution
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("Name cannot be empty.")
                 continue  # Retry the name prompt
             return name  # Accept valid unique name
 
     def _prompt_hardware_platform(self, source_model: str) -> str:
         """Prompt engineer to keep source model or select a different target model."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nHardware platform (source device: %s):", source_model)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  0. Same as source device")
         for index, model in enumerate(COMMON_GATEWAY_MODELS, start=1):  # List common models
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %2d. %s", index, model)
         raw = self.input_fn("Select model [0 = same]: ", context="hardware_platform_selection")  # Prompt
         return self._resolve_hardware_choice(raw.strip(), source_model)  # Delegate parse to helper
@@ -298,12 +298,12 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         try:
             index = int(raw)  # Parse selection as integer index into COMMON_GATEWAY_MODELS
         except ValueError:  # Non-numeric response - fall through to safe default
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("Invalid selection - using source model.")
             return source_model  # Safe default preserves source model
         if 1 <= index <= len(COMMON_GATEWAY_MODELS):  # Validate range before indexing constant list
             return COMMON_GATEWAY_MODELS[index - 1]  # Return chosen model (1-based to 0-based)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("Invalid selection - using source model.")
         return source_model  # Safe default preserves source model on out-of-range input
 
@@ -381,17 +381,17 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
 
     def _confirm_creation(self, name: str, ttype: str, model: str) -> bool:
         """Display a pending-operation summary and require typed 'CREATE' confirmation."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", "=" * 60)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  PENDING OPERATION: Create Org Gateway Template")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Template Name : %s", name)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Template Type : %s", ttype)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Target Model  : %s", model)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", "=" * 60)
         raw = self.input_fn(  # Prompt for explicit typed confirmation
             "Type CREATE to confirm (or anything else to cancel): ",
@@ -450,7 +450,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             api_function_name="createOrgGatewayTemplate",  # PK strategy key for upsert
         )
         logger.debug("CSV export complete for template_id %s", row["template_id"])  # Log after export
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "\nSuccess: Created gateway template '%s' (ID: %s)",
             row["template_name"],
@@ -472,7 +472,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             return None  # Signal caller to abort the workflow
         device_config = self._fetch_device_config(site["id"], gateway["id"])  # Step 4: fetch config
         if device_config is None:  # Abort if config fetch returned empty
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("Failed to fetch device configuration.")
             return None  # Signal caller to abort the workflow
         return gateway, device_config  # Return combined tuple for downstream phases
@@ -483,7 +483,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         device_model = gateway.get("model", "SRX300")  # Use source model as default suggestion
         name, ttype, model = self._prompt_template_meta(device_model, existing_names)  # Step 6
         if not self._confirm_creation(name, ttype, model):  # Step 7: require explicit confirmation
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("Operation cancelled.")
             return None  # Signal caller to abort - user declined the CREATE prompt
         return name, ttype, model  # Return metadata tuple for payload construction
@@ -494,7 +494,7 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
         payload = self._build_template_payload(device_config, name, ttype, model)  # Step 8
         new_template = self._create_template(payload)  # Step 9: API write call
         if new_template is None:  # Abort if API returned no data
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("Template creation failed - no data returned from API.")
             return False  # Signal failure to caller
         self._export_result(gateway, new_template)  # Step 10: write CSV export row
@@ -513,6 +513,6 @@ class DeviceConfigTemplateClonerManager:  # Menu 194 clone-to-template manager
             return self._create_and_export(gateway, device_config, meta)  # Phase 3: write + export
         except Exception as exc:  # Catch all unexpected errors for safe logging
             logger.exception("DeviceConfigTemplateClonerManager.clone() failed: %s", exc)  # Log context
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("Error: %s", exc)
             return False  # Signal failure to caller

--- a/src/gateway/gateway_export_utils.py
+++ b/src/gateway/gateway_export_utils.py
@@ -304,7 +304,7 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
             loaded = tuple(_read_csv_rows(name) for name in MANAGEMENT_IP_INPUT_CSVS)  # WHY: table-driven reads.
         except FileNotFoundError as exception:
             logging.error("Required CSV file not found: %s", exception)  # WHY: preserve legacy error log.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Error: Required CSV file not found: %s", exception)
             return None
         sites, templates, gateway_devices, gateway_configs = loaded  # WHY: unpack into named locals.
@@ -324,7 +324,7 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
         template_lookup: dict,
         mgmt_ip_lookup: dict,
     ) -> tuple[list[dict], int, int]:
-        """Build per-device management-IP rows; return (rows, processed_count, with_mgmt_ip_count)."""
+        """Build per-device management-IP rows. Return (rows, processed_count, with_mgmt_ip_count)."""
         lookups = {"site": site_lookup, "template": template_lookup, "mgmt_ip": mgmt_ip_lookup}  # WHY: bundle.
         results: list[dict] = []  # WHY: per-device records for export.
         with_mgmt_ip = 0  # WHY: track devices with a usable management IP.
@@ -338,16 +338,16 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
     @staticmethod
     def _prime_management_ip_caches(fast: bool) -> None:  # WHY: isolate the 4 cache generation calls.
         """Ensure the 4 CSV caches consumed by management_ips are up to date."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  1. Ensuring site list with template mappings is current...")
         CacheUtils.check_and_generate_csv("SiteList.csv", OrgSiteExporter.sites)  # WHY: refresh site cache.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  2. Ensuring gateway templates are current...")
         CacheUtils.check_and_generate_csv("OrgGatewayTemplates.csv", GatewayExportUtils.templates)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  3. Ensuring gateway device data with connection status is current...")
         CacheUtils.check_and_generate_csv("GatewaysWithSiteInfo.csv", OrgInventoryExporter.gateways_with_site_info)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  4. Ensuring gateway configurations with management IPs are current...")
         CacheUtils.check_and_generate_csv(
             "AllSiteGatewayConfigs.csv",
@@ -389,15 +389,15 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
     @staticmethod
     def _emit_management_ip_summary(gateways_processed: int, gateways_with_mgmt_ip: int) -> None:
         """Emit the completion banner + audit log preserving legacy phrasing."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Gateway management IP export completed:")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  - Total gateways processed: %d", gateways_processed)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  - Gateways with management IPs: %d", gateways_with_mgmt_ip)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  - Gateways without management IPs: %d", gateways_processed - gateways_with_mgmt_ip)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  - Output CSV: GatewayManagementIPs.csv")
         logging.info(
             "Gateway management IP export completed. %d gateways processed, %d with management IPs.",
@@ -409,13 +409,13 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
     def management_ips(fast: bool = False) -> None:
         """Export gateway management overlay IPs correlated with templates and site status."""
         logging.info("Menu #31: Starting gateway management IPs export")  # WHY: audit log for menu entry.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Gateway Management IP Export:")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Collecting data from inventory, templates, and configurations...")
         ConfigUtils.get_cached_or_prompted_org_id()  # WHY: resolve org id via standard pathway.
         GatewayExportUtils._prime_management_ip_caches(fast)  # WHY: ensure all 4 CSV inputs are current.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  5. Processing and correlating data...")
         loaded = GatewayExportUtils._load_management_ip_csv_inputs()  # WHY: read the four CSV inputs.
         if loaded is None:  # WHY: required CSV missing — error already printed/logged.
@@ -477,7 +477,7 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
     @staticmethod
     def templates() -> None:
         """Export gateway templates for the selected organization."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Gateway Templates:")
         logging.info("Exporting gateway templates for the organization...")  # WHY: audit log for entry.
         current_org_id = ConfigUtils.get_cached_or_prompted_org_id()  # WHY: resolve org_id via standard path.
@@ -485,13 +485,13 @@ class GatewayExportUtils:  # WHY: centralised gateway export utility class extra
         templates = getattr(response, "data", [])  # WHY: defensive — response may lack .data attribute.
         if not templates:  # WHY: nothing to export — emit diagnostics and return.
             logging.warning("No gateway templates found for this organization.")
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("No gateway templates found for this organization.")
             return
         templates = DataProcessingUtils.flatten_nested_fields(templates)  # WHY: flatten nested JSON to cells.
         templates = DataProcessingUtils.escape_multiline(templates)  # WHY: escape multiline cells for CSV.
         DataExporter.write_with_format_selection(templates, "OrgGatewayTemplates.csv")  # WHY: persist output.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! %d gateway templates exported to OrgGatewayTemplates.csv", len(templates))
         logging.info(" Gateway templates exported to OrgGatewayTemplates.csv")  # WHY: audit log for exit.
 

--- a/src/gateway/gateway_ha_exporter.py
+++ b/src/gateway/gateway_ha_exporter.py
@@ -74,7 +74,7 @@ class GatewayHaExporter:
         ha_gateways = [gw for gw in all_gateways if gw.get("is_ha") is True]  # Filter to HA-enabled gateways
         logging.info("Found %d HA gateways in site %s", len(ha_gateways), site_id)  # Trace HA gateway count
         if not ha_gateways:  # No HA gateways -> tell user and signal abort
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("No HA gateways found for the selected site.")
             return None
         return ha_gateways  # Caller proceeds with cluster export
@@ -146,15 +146,15 @@ class GatewayHaExporter:
             rows: List of merged HA gateway rows to display.
         """
         logging.info("Printing HA gateway cluster summary table to terminal")  # Log before display
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\n=== HA Gateway Cluster Summary ===\n")  # Section header for the terminal output
         # Build column header string for the HA cluster summary table
         header = (
             f"{'Name':<30} {'Node':<8} {'Status':<12}" f" {'Node0 MAC':<20} {'Node1 MAC':<20} {'Cluster MAC':<18}"
         )  # Column headers
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(header)  # Print headers to terminal
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("-" * len(header))  # Print separator line
         for row in rows:  # Iterate each HA gateway record
             name = str(row.get("name", ""))[:28]  # Truncate long names for display
@@ -163,7 +163,7 @@ class GatewayHaExporter:
             node0_mac = str(row.get("ha_cluster_node0_mac") or "")  # MAC of node0 in the pair
             node1_mac = str(row.get("ha_cluster_node1_mac") or "")  # MAC of node1 in the pair
             vc_mac = str(row.get("vc_mac") or "")  # Shared cluster MAC address
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(
                 "%-30s %-8s %-12s %-20s %-20s %-18s",
                 name,
@@ -173,5 +173,5 @@ class GatewayHaExporter:
                 node1_mac,
                 vc_mac,
             )  # Print row
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("")  # Blank line after table for readability

--- a/src/gateway/gateway_stats_exporter.py
+++ b/src/gateway/gateway_stats_exporter.py
@@ -9,9 +9,9 @@ import threading  # WHY: Semaphore bounds concurrent Mist API connections.
 import time  # WHY: sleep between bounded retries when fetching device stats.
 from typing import Any  # WHY: opaque types for injected utility modules.
 
-# WHY: ConnectionPoolExecutor is DI-injected via the execute_fn slot (1012 SC-003); no direct import needed.
+# WHY: ConnectionPoolExecutor is DI-injected via the execute_fn slot (1012 SC-003). No direct import needed.
 
-STATS_CSV_FILENAME: str = "AllGatewayDeviceStats.csv"  # WHY: canonical output CSV; consumed by conflict analysis.
+STATS_CSV_FILENAME: str = "AllGatewayDeviceStats.csv"  # WHY: canonical output CSV. Consumed by conflict analysis.
 CONFLICTS_CSV_FILENAME: str = "GatewayWANPortConflicts.csv"  # WHY: canonical WAN conflict output filename.
 WAN_PORT_IDS: tuple[str, ...] = ("0/0/0", "0/0/1", "0/0/2")  # WHY: gateway WAN ports monitored for IP conflicts.
 EMPTY_IP_TOKENS: frozenset[str] = frozenset({"", "nan", "None", "null"})  # WHY: cells treated as missing IPs.
@@ -33,7 +33,7 @@ CacheUtils: Any = None  # WHY: CSV cache generator facade.
 FilePathUtils: Any = None  # WHY: resolves CSV cache file locations.
 # NOTE: execute_with_connection_pool_management extracted to ConnectionPoolExecutor.execute.
 # See specs/1012-misthelper-refactor-hot-functions/spec.md.
-# WHY: renamed from execute_with_connection_pool_management per 1012 SC-003; DI-injected pool runner.
+# WHY: renamed from execute_with_connection_pool_management per 1012 SC-003. DI-injected pool runner.
 execute_fn: Any = None
 FAST_MODE_MAX_RETRIES: int = 2  # WHY: retry cap for fast-mode API calls.
 FAST_MODE_RETRY_DELAY: float = 0.5  # WHY: base delay (seconds) between retries.
@@ -173,7 +173,7 @@ class GatewayStatsExporter:  # WHY: namespace class kept for legacy call-sites i
         fast: bool,
         connection_semaphore: threading.Semaphore | None = None,
     ) -> dict:
-        """Fetch single-device stats with bounded retry; return enriched dict or failure record."""
+        """Fetch single-device stats with bounded retry. Return enriched dict or failure record."""
         max_retries = FAST_MODE_MAX_RETRIES  # WHY: use configured retry ceiling.
         retry_delay = FAST_MODE_RETRY_DELAY  # WHY: use configured base retry delay.
         for attempt in range(max_retries + 1):  # WHY: N retries means N+1 total attempts.
@@ -239,7 +239,7 @@ class GatewayStatsExporter:  # WHY: namespace class kept for legacy call-sites i
     def _process_devices_concurrent(  # WHY: fan-out concurrent path used by fast mode.
         gateway_devices: list[tuple[str, str, str, str]],
     ) -> list[dict]:
-        """Fetch device stats concurrently with a bounded thread pool; return aggregated results."""
+        """Fetch device stats concurrently with a bounded thread pool. Return aggregated results."""
         logging.info("! Fast mode: Processing %s gateway devices concurrently...", len(gateway_devices))  # WHY: banner.
         max_workers = min(CONCURRENT_WORKER_CAP, len(gateway_devices))  # WHY: cap workers to avoid conn overuse.
         connection_semaphore = threading.Semaphore(max_workers)  # WHY: bound concurrent API connections.
@@ -253,7 +253,7 @@ class GatewayStatsExporter:  # WHY: namespace class kept for legacy call-sites i
     def _process_devices_sequential(  # WHY: sequential fallback path for non-fast mode.
         gateway_devices: list[tuple[str, str, str, str]], fast: bool
     ) -> list[dict]:
-        """Fetch device stats sequentially; return aggregated results."""
+        """Fetch device stats sequentially. Return aggregated results."""
         logging.info("! Processing %s gateway devices sequentially...", len(gateway_devices))  # WHY: legacy banner.
         all_stats: list[dict] = []  # WHY: accumulate per-device stats records.
         for index, device_info in enumerate(  # WHY: enumerate to keep legacy "index/total" progress log.
@@ -335,7 +335,7 @@ class GatewayStatsExporter:  # WHY: namespace class kept for legacy call-sites i
         output_file = STATS_CSV_FILENAME  # WHY: canonical output CSV name.
         if CacheUtils.check_and_generate_csv(
             output_file, lambda: GatewayStatsExporter.device_stats(fast=fast)
-        ):  # WHY: cache hit returns True; miss regenerates via the lambda.
+        ):  # WHY: cache hit returns True. Miss regenerates via the lambda.
             logging.info("! %s already exists and is fresh - using cached data", output_file)
             return
         logging.info("! %s was generated or refreshed", output_file)
@@ -365,7 +365,7 @@ class GatewayStatsExporter:  # WHY: namespace class kept for legacy call-sites i
             return gateway_data
         except Exception as exception:  # pylint: disable=broad-exception-caught  # WHY: preserve legacy message.
             logging.error("! Failed to load %s: %s", stats_file, exception)
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! Failed to load %s: %s", stats_file, exception)
             return None
 
@@ -449,44 +449,44 @@ class GatewayStatsExporter:  # WHY: namespace class kept for legacy call-sites i
         """Persist and display WAN conflict analysis results."""
         if not conflicts_found:  # WHY: guard clause — nothing to export or display.
             logging.info(" No internal WAN port IP conflicts found")
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(" No internal WAN port IP conflicts found - healthy WAN port configurations")
             return
         conflicts_found.sort(key=lambda x: (x.get("device_name", ""), x.get("port_name", "")))  # WHY: stable.
         DataExporter.write_with_format_selection(conflicts_found, CONFLICTS_CSV_FILENAME)  # WHY: persist rows.
         unique_gateways = {row.get("device_name", UNKNOWN_LABEL) for row in conflicts_found}  # WHY: dedupe.
         logging.info("! Exported %s conflicts from %s gateways", len(conflicts_found), len(unique_gateways))
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "! WAN port IP conflicts exported to %s (%s records)",
             CONFLICTS_CSV_FILENAME,
             len(conflicts_found),
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Summary: %s gateways with IP conflicts", len(unique_gateways))
         GatewayStatsExporter._display_conflict_samples(conflicts_found)  # WHY: emit operator-facing sample.
 
     @staticmethod
     def _display_conflict_samples(conflicts_found: list[dict]) -> None:
         """Print a short conflict sample section for quick operator review."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\n  Sample WAN Port IP Conflicts Found:")
         for idx, record in enumerate(conflicts_found[:SAMPLE_CONFLICT_LIMIT], 1):  # WHY: top-N sample only.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(
                 "%2d. %s (%s)",
                 idx,
                 record.get("device_name", UNKNOWN_LABEL),
                 record.get("site_name", UNKNOWN_SITE_NAME),
             )
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(
                 "    Port %s has IP %s",
                 record.get("port_name", UNKNOWN_LABEL),
                 record.get("port_ip", UNKNOWN_LABEL),
             )
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("    Conflicts with: %s\n", record.get("conflict_with_ports", UNKNOWN_LABEL))
         if len(conflicts_found) > SAMPLE_CONFLICT_LIMIT:  # WHY: only emit trailer when truncation happened.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("... and %s more conflicted ports", len(conflicts_found) - SAMPLE_CONFLICT_LIMIT)

--- a/src/gateway/overrides/_deps.py
+++ b/src/gateway/overrides/_deps.py
@@ -8,17 +8,17 @@ from typing import Any, Final  # Typing helpers for module-level dependency hold
 
 _LOG_CONFIGURED: Final[str] = "Gateway override dependencies configured"  # WHY: single-source log template.
 
-apisession: Any = None  # Mist API session; set by configure_gateway_override_dependencies
-mistapi: Any = None  # mistapi SDK module; set by configure_gateway_override_dependencies
-CacheUtils: Any = None  # CSV cache helper; set by configure_gateway_override_dependencies
-FilePathUtils: Any = None  # Output path helper; set by configure_gateway_override_dependencies
-DataExporter: Any = None  # Multi-backend writer; set by configure_gateway_override_dependencies
-OrgSiteExporter: Any = None  # Site list exporter; set by configure_gateway_override_dependencies
+apisession: Any = None  # Mist API session. Set by configure_gateway_override_dependencies
+mistapi: Any = None  # mistapi SDK module. Set by configure_gateway_override_dependencies
+CacheUtils: Any = None  # CSV cache helper. Set by configure_gateway_override_dependencies
+FilePathUtils: Any = None  # Output path helper. Set by configure_gateway_override_dependencies
+DataExporter: Any = None  # Multi-backend writer. Set by configure_gateway_override_dependencies
+OrgSiteExporter: Any = None  # Site list exporter. Set by configure_gateway_override_dependencies
 MIST_WAN_TARGET_PORTS: list[str] = []  # Operator-configured WAN ports list from .env
 # NOTE: execute_with_connection_pool_management extracted to ConnectionPoolExecutor.execute.
 # See specs/1012-misthelper-refactor-hot-functions/spec.md.
 execute_fn: Any = (
-    None  # Pool-managed parallel runner (1012 SC-003; renamed from execute_with_connection_pool_management)
+    None  # Pool-managed parallel runner (1012 SC-003. Renamed from execute_with_connection_pool_management)
 )
 GatewayExportUtilsRef: Any = None  # Gateway export helpers ref (device_configs/templates funcs)
 
@@ -34,7 +34,7 @@ class GatewayOverrideDependencies:
     data_exporter: Any  # DataExporter class exposing write_with_format_selection
     org_site_exporter: Any  # OrgSiteExporter class exposing sites_list_api
     mist_wan_target_ports: list[str]  # Operator-configured WAN target ports list from .env
-    execute_fn: Any  # ConnectionPoolExecutor.execute callable (1012 SC-003; renamed from connection_pool_fn)
+    execute_fn: Any  # ConnectionPoolExecutor.execute callable (1012 SC-003. Renamed from connection_pool_fn)
     gateway_export_utils_ref: Any  # GatewayExportUtils reference (device_configs / templates)
 
 

--- a/src/gateway/overrides/override_report_writer.py
+++ b/src/gateway/overrides/override_report_writer.py
@@ -43,11 +43,11 @@ class OverrideReportWriter:
         output_path = _deps.FilePathUtils.get_csv_path(OUTPUT_FILENAME)  # Resolves data/ output dir
         with open(output_path, mode="w", newline="", encoding="utf-8") as csvfile:  # Truncate-and-write CSV
             writer = csv.DictWriter(csvfile, fieldnames=_EMPTY_FIELDNAMES)  # DictWriter for header-only output
-            writer.writeheader()  # Header row only; no data rows are written when fleet is fully compliant
+            writer.writeheader()  # Header row only. No data rows are written when fleet is fully compliant
         logging.debug("Header-only CSV written to %s", output_path)  # Confirm write completed for operator log
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Gateway override report written to %s", OUTPUT_FILENAME)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(" No template overrides found - all gateways are compliant with their assigned templates!")
 
     @staticmethod
@@ -122,25 +122,25 @@ class OverrideReportWriter:
     ) -> None:
         """Emit the legacy console summary lines given precomputed stats."""
         saved_calls = total_gateways - devices_with_overrides_count  # API calls saved by the override pre-filter
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Gateway override report written to %s", OUTPUT_FILENAME)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "! Found %d overridden ports across %d of %d gateway devices",
             total_overridden_ports,
             gateways_with_overrides,
             total_gateways,
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "! API Optimization: Only fetched live data for %d devices with overrides (saved %d unnecessary API calls)",
             devices_with_overrides_count,
             saved_calls,
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! Target ports analyzed: %s", ", ".join(target_ports))
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! These are outliers that may need correction to match template configuration")
         if total_overridden_ports == 0:  # Repeat compliant-fleet message when full path produces zero rows
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(" No template overrides found - all gateways are compliant with their assigned templates!")

--- a/src/gateway/overrides/wan_override_walker.py
+++ b/src/gateway/overrides/wan_override_walker.py
@@ -29,7 +29,7 @@ class WanOverrideWalker:
                 " MIST_WAN_TARGET_PORTS not configured in .env - skipping port override analysis"
             )
             logging.warning("MIST_WAN_TARGET_PORTS environment variable not set")  # operator hint in logs
-            return  # No work possible without target ports; abort the walker
+            return  # No work possible without target ports. Abort the walker
         WanOverrideWalker._run_pipeline(fast=fast, target_ports=target_ports)  # Delegate the full pipeline
 
     @staticmethod
@@ -46,7 +46,7 @@ class WanOverrideWalker:
         )
         if not devices_with_overrides:  # Fleet fully compliant: emit empty CSV and exit
             OverrideReportWriter.write_empty()  # Header-only CSV plus the legacy compliance console message
-            return  # Done; no live API calls needed
+            return  # Done. No live API calls needed
         WanOverrideWalker._run_live_passes(  # Delegate 2nd/3rd passes + final write to keep this fn short
             fast=fast,
             target_ports=target_ports,
@@ -191,7 +191,7 @@ class WanOverrideWalker:
         overridden_ports = OverrideClassifier.classify(row, target_ports)  # Decide which ports are overridden
         if not overridden_ports:  # Skip devices with zero overrides to save API calls in the second pass
             return None  # Caller treats None as "no entry to add"
-        _, site_id, _ = identifiers  # Only site_id is needed here; the rest flow through the builder
+        _, site_id, _ = identifiers  # Only site_id is needed here. The rest flow through the builder
         template_id, template_name = WanOverrideWalker._resolve_template_name(  # Resolve template metadata
             site_id, site_to_template, template_lookup
         )

--- a/src/gateway/template_config.py
+++ b/src/gateway/template_config.py
@@ -70,7 +70,7 @@ class GatewayTemplateConfigManager:  # pylint: disable=too-many-instance-attribu
         if not templates:  # WHY: nothing to extract when no templates or fetch failed
             return  # WHY: _fetch_templates already surfaced the reason
         selected = self._select_template(templates, "extract")  # WHY: user picks source template
-        if not selected:  # WHY: selection cancelled/invalid; nothing further to do
+        if not selected:  # WHY: selection cancelled/invalid. Nothing further to do
             return  # WHY: _select_template printed the cancel reason
         template_config = self._fetch_template_config(selected)  # WHY: need full body to mine configs
         if not template_config:  # WHY: fetch error or unexpected shape
@@ -994,7 +994,7 @@ def _assignment_skip_reason(target_id: str, assignment: dict[str, str]) -> str |
     """Return a skip reason string or None if the assignment should proceed."""
     if not target_id:  # WHY: template not created / not found
         return "Target template not found"  # WHY: audit-friendly reason
-    if assignment["current_template_id"] == target_id:  # WHY: idempotency; already correct
+    if assignment["current_template_id"] == target_id:  # WHY: idempotency. Already correct
         return "Already assigned"  # WHY: audit-friendly reason
     return None  # WHY: caller performs the API PUT
 
@@ -1060,7 +1060,7 @@ def _scan_service_policies(service_policies: Any, template_name: str) -> dict[st
     """Return the first Picocell entry from service_policies, or None."""
     if not isinstance(service_policies, list):  # WHY: guard against malformed configs
         return None  # WHY: nothing to scan
-    for policy in service_policies:  # WHY: linear scan; count is small
+    for policy in service_policies:  # WHY: linear scan. Count is small
         if isinstance(policy, dict) and policy.get("name") == "Picocell":  # WHY: name match anchors identity
             print("  -> Found 'Picocell' in Application Policies")  # WHY: positive result
             logging.info("GatewayTemplateConfigManager: Found Picocell in %s", template_name)  # WHY: audit
@@ -1128,7 +1128,7 @@ def _find_existing_picocell_index(
     policies: list[dict[str, Any]],
 ) -> int | None:
     """Find the index of existing Picocell policy in service_policies."""
-    for idx, policy in enumerate(policies):  # WHY: linear scan; count is small
+    for idx, policy in enumerate(policies):  # WHY: linear scan. Count is small
         if isinstance(policy, dict) and policy.get("name") == "Picocell":  # WHY: name match anchors identity
             return idx  # WHY: caller uses index to overwrite
     return None  # WHY: caller inserts instead
@@ -1145,7 +1145,7 @@ def _insert_picocell_policy(
         policies.insert(_PICOCELL_INSERT_ANCHOR, picocell)  # WHY: land at position 14 (0-indexed 13)
         result["changes_made"].append("Inserted Picocell at position 14")  # WHY: audit change
         return  # WHY: skip the append path
-    policies.append(picocell)  # WHY: too few policies; append at end
+    policies.append(picocell)  # WHY: too few policies. Append at end
     result["changes_made"].append(f"Added Picocell at position {policy_count + 1}")  # WHY: audit change
 
 
@@ -1232,9 +1232,9 @@ def _parse_general_state(address: str, parts: list[str], country: str) -> str:
     postal_index = _find_postal_index(parts)  # WHY: postal token anchors state position
     if postal_index > 1:  # WHY: state usually sits directly before postal
         return parts[postal_index - 1]  # WHY: token immediately before postal
-    if postal_index == -1:  # WHY: no postal found; fall back to country-based heuristic
+    if postal_index == -1:  # WHY: no postal found. Fall back to country-based heuristic
         return _infer_state_without_postal(parts, country)  # WHY: dedicated inference
-    return ""  # WHY: postal is at index 0 or 1; nothing reliable to return
+    return ""  # WHY: postal is at index 0 or 1. Nothing reliable to return
 
 
 def _match_special_regions(address: str) -> str:
@@ -1249,7 +1249,7 @@ def _match_special_regions(address: str) -> str:
 
 def _find_postal_index(parts: list[str]) -> int:
     """Find the index of the first part starting with a digit."""
-    for i, part in enumerate(parts):  # WHY: linear scan; count is small
+    for i, part in enumerate(parts):  # WHY: linear scan. Count is small
         if re.match(r"^\d", part):  # WHY: leading digit denotes postal-like token
             return i  # WHY: caller consumes index
     return -1  # WHY: sentinel means no postal found

--- a/src/gateway/wan2_variable.py
+++ b/src/gateway/wan2_variable.py
@@ -13,7 +13,7 @@ STRUCT-LENGTH budget while each cluster keeps CC/length budgets:
 * :mod:`._wan2_variable_device` - per-device override migration.
 * :mod:`._wan2_variable_reporting` - audit CSV + final summary block.
 
-The parent orchestrates the flow via :meth:`execute`; every private
+The parent orchestrates the flow via :meth:`execute`. Every private
 helper referenced there is provided by one of the clusters and reached
 through the class-level ``__getattr__`` proxy defined below.
 """
@@ -65,7 +65,7 @@ class GatewayWan2VariableMigrator:  # pylint: disable=too-many-instance-attribut
 
     Both modes preserve device-level static IP overrides by migrating
     port_config keys on individual devices. Implementation lives in the
-    ``_wan2_variable_*`` cluster modules; this class holds the orchestration
+    ``_wan2_variable_*`` cluster modules. This class holds the orchestration
     entry point and shared state.
     """
 
@@ -104,7 +104,7 @@ class GatewayWan2VariableMigrator:  # pylint: disable=too-many-instance-attribut
         self._input_fn = deps.input_fn or input  # WHY: default to builtin input()
         self._pool_fn = (
             deps.execute_fn
-        )  # WHY: fast-mode parallel executor (may be None); renamed from connection_pool_fn per 1012 SC-003
+        )  # WHY: fast-mode parallel executor (may be None). Renamed from connection_pool_fn per 1012 SC-003
 
     def __getattr__(self, name: str) -> Any:
         """Proxy cluster-attribute access to helper clusters.

--- a/src/gateway/wan_probe_device_override_manager.py
+++ b/src/gateway/wan_probe_device_override_manager.py
@@ -120,7 +120,7 @@ class WANProbeDeviceOverrideManager:  # WHY: encapsulates Menu #167 destructive 
     def _execute(self, dry_run: bool) -> None:  # WHY: high-level pipeline orchestrator.
         """Main execution flow for device-level WAN probe configuration."""
         self._display_header(dry_run)  # WHY: banner + operator warning first.
-        if not self._prepare_run():  # WHY: init + load + template + sites phase; bail on failure.
+        if not self._prepare_run():  # WHY: init + load + template + sites phase. Bail on failure.
             return
         devices = self._find_devices_with_overrides()  # WHY: identify targets for probe config.
         if not devices:  # WHY: nothing to do if no overrides exist.
@@ -265,7 +265,7 @@ class WANProbeDeviceOverrideManager:  # WHY: encapsulates Menu #167 destructive 
     ) -> bool:
         """Parse a numeric selection string and record the chosen template."""
         try:
-            idx = int(selection) - 1  # WHY: operator indexes from 1; internal index is 0-based.
+            idx = int(selection) - 1  # WHY: operator indexes from 1. Internal index is 0-based.
         except ValueError:
             print(f" Invalid selection: {selection}")  # WHY: user-facing diagnostic.
             logging.error("Menu #167: Invalid template selection: %s", selection)  # WHY: audit log.
@@ -545,7 +545,7 @@ class WANProbeDeviceOverrideManager:  # WHY: encapsulates Menu #167 destructive 
         overridden_wan_ports: list[dict[str, Any]],
         device_name: str,
     ) -> list[str]:
-        """Patch wan_probe_override on each matching port; return modified port names."""
+        """Patch wan_probe_override on each matching port. Return modified port names."""
         ports_modified: list[str] = []  # WHY: names of ports that were actually patched.
         for wan_port in overridden_wan_ports:  # WHY: iterate planned overrides.
             port_name = wan_port["port_name"]  # WHY: cached port identifier.

--- a/src/input/prompt_client_utils.py
+++ b/src/input/prompt_client_utils.py
@@ -53,7 +53,7 @@ class PromptClientUtils:
 
     @staticmethod
     def _log_combined_client_counts(wireless: list | None, wired: list | None) -> None:
-        """Log counts when at least one of the two client lists has data; silent on fully empty input."""
+        """Log counts when at least one of the two client lists has data. Silent on fully empty input."""
         wireless_list = wireless or []  # Coerce None -> empty for safe len()
         wired_list = wired or []  # Coerce None -> empty for safe len()
         if not (wireless_list or wired_list):  # Nothing to log when both empty
@@ -89,7 +89,7 @@ class PromptClientUtils:
 
     @staticmethod
     def _tag_connection_type(clients: list | None, label: str) -> None:
-        """Tag each ``client`` dict with ``connection_type=label``; tolerate empty/None."""
+        """Tag each ``client`` dict with ``connection_type=label``. Tolerate empty/None."""
         if not clients:  # Nothing to tag.
             return  # No-op when empty.
         for client in clients:  # Iterate clients.
@@ -193,7 +193,7 @@ class PromptClientUtils:
 
     @staticmethod
     def select_client(site_id: str | None = None) -> tuple[str | None, str | None, str | None]:
-        """Prompt user to select a wireless/wired client; returns (mac, type, site_id) or (None,None,None)."""
+        """Prompt user to select a wireless/wired client. Returns (mac, type, site_id) or (None,None,None)."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of PromptUtils + ConfigUtils.
         # WHY (#886 Phase 2): retire print() decorations in favor of logging.warning
         # (visible on default root-logger config while satisfying the ruff T20 ban).

--- a/src/inventory/inventory_summary/pivot_renderer.py
+++ b/src/inventory/inventory_summary/pivot_renderer.py
@@ -1,6 +1,6 @@
 """Renders the version-per-model pivot table and exports it via DataExporter."""  # File docstring
 
-from __future__ import annotations  # Defer annotation evaluation; cheap forward refs
+from __future__ import annotations  # Defer annotation evaluation. Cheap forward refs
 
 import logging  # Structured action logging
 
@@ -46,7 +46,7 @@ class PivotRenderer:  # Decomposed replacement for the original `_display_pivot_
         for row in rows:  # Fold every input row into the (model, version) cell
             pivot[row["model"]][row["version"]] = row.get(
                 "count", 0
-            )  # Last write wins; input data has no duplicate cells
+            )  # Last write wins. Input data has no duplicate cells
 
     @staticmethod
     def _compute_pivot(  # Computes axes + nested counts

--- a/src/inventory/inventory_summary/version_per_model_fetcher.py
+++ b/src/inventory/inventory_summary/version_per_model_fetcher.py
@@ -28,7 +28,7 @@ class VersionPerModelFetcher:  # WHY: namespace for the decomposed version-per-m
                 switch_records,
                 gateway_records,
             )  # Delegate per-row expansion to a small helper
-            all_rows.extend(rows)  # Append helper output verbatim; helper returns [] on skip
+            all_rows.extend(rows)  # Append helper output verbatim. Helper returns [] on skip
         return all_rows  # WHY: caller merges these into the final row set
 
     @staticmethod
@@ -199,7 +199,7 @@ class VersionPerModelFetcher:  # WHY: namespace for the decomposed version-per-m
             return VersionPerModelFetcher._switch_rows(model_name, switch_records)
         if device_type == "gateway":  # Aggregate HA-aware gateway counts from prefetched inventory
             return VersionPerModelFetcher._gateway_rows(model_name, gateway_records)
-        return []  # APs are handled in bulk by _ap_rows; any other type has no per-model expansion here
+        return []  # APs are handled in bulk by _ap_rows. Any other type has no per-model expansion here
 
     @staticmethod
     def _accumulate_switch_versions(  # Folds switch inventory records into version->count map (VC-aware)
@@ -213,7 +213,7 @@ class VersionPerModelFetcher:  # WHY: namespace for the decomposed version-per-m
             version = record.get("version") or "unknown"  # Treat missing firmware version as "unknown"
             num_members = int(
                 record.get("num_members") or 1
-            )  # Count each VC member individually; default to 1 for standalone
+            )  # Count each VC member individually. Default to 1 for standalone
             version_counts[version] = (
                 version_counts.get(version, 0) + num_members
             )  # Add this record's VC members to the bucket
@@ -232,7 +232,7 @@ class VersionPerModelFetcher:  # WHY: namespace for the decomposed version-per-m
 
     @staticmethod
     def _gateway_rows(model_name: str, gateway_records: list[dict]) -> list[dict]:
-        """Aggregate gateway version counts; one row per inventory record (HA pairs already split)."""
+        """Aggregate gateway version counts. One row per inventory record (HA pairs already split)."""
         version_counts: dict[str, int] = {}  # Per-version running total for this specific model
         for record in gateway_records:  # Iterate the prefetched inventory once per call
             if record.get("model") != model_name:  # Skip records belonging to a different gateway model

--- a/src/inventory/org_device_inventory_msp.py
+++ b/src/inventory/org_device_inventory_msp.py
@@ -23,7 +23,7 @@ _MODEL_EXPORT_SUFFIX: str = "_CombinedDeviceModelCounts"  # WHY: filename suffix
 _VERSION_EXPORT_SUFFIX: str = "_CombinedDeviceFirmwareSummary"  # WHY: filename suffix for combined version export.
 _PIVOT_EXPORT_SUFFIX: str = "_CombinedDeviceVersionPerModel"  # WHY: filename suffix for combined pivot export.
 
-apisession: Any = None  # WHY: mistapi session injected by MistHelper; None until configured.
+apisession: Any = None  # WHY: mistapi session injected by MistHelper. None until configured.
 InputUtils: Any = None  # WHY: injected EOF-safe input wrapper (issue #452).
 DataExporter: Any = None  # WHY: injected exporter class exposing write_with_format_selection.
 msp_privileges: list[dict[str, Any]] = []  # WHY: injected MSP privilege records from mistapi self endpoint.
@@ -215,7 +215,7 @@ def _print_dispatch_menu() -> None:
 
 
 def _prompt_dispatch_mode() -> str | None:
-    """Prompt operator for menu mode; return the raw string or None if input aborted."""
+    """Prompt operator for menu mode. Return the raw string or None if input aborted."""
     try:
         return InputUtils.safe_input("  Select mode (1/2/3): ", context="inventory_dispatch").strip()  # WHY: read.
     except SystemExit:  # WHY: EOF/interrupt should exit the dispatcher cleanly.
@@ -448,7 +448,7 @@ class OrgDeviceInventoryMSPOrchestrator:
         run_for_org_fn: Callable[[str], tuple[list[dict], list[dict], list[dict], str]],
         collected: list[dict[str, Any]],
     ) -> None:
-        """Invoke per-org runner and append its outputs; log/surface errors on failure."""
+        """Invoke per-org runner and append its outputs. Log/surface errors on failure."""
         try:
             model_rows, version_rows, ver_per_model, safe_org = run_for_org_fn(child_org_id)  # WHY: invoke runner.
             collected.append(
@@ -458,7 +458,7 @@ class OrgDeviceInventoryMSPOrchestrator:
                     "version_rows": version_rows,  # WHY: per-org firmware rows fed into combined version report.
                     "ver_per_model": ver_per_model,  # WHY: per-org rows fed into combined pivot.
                 }
-            )  # WHY: append raw dict; adapter converts later.
+            )  # WHY: append raw dict. Adapter converts later.
         except Exception as error:  # WHY: one failing org should not abort the whole batch.
             print(f"    X Error processing {child_org_name}: {error}")  # WHY: surface error to operator.
             logging.exception("run_for_org failed for org %s: %s", child_org_id, error)  # WHY: full trace in log.

--- a/src/inventory/org_device_inventory_summary.py
+++ b/src/inventory/org_device_inventory_summary.py
@@ -11,9 +11,9 @@ from typing import Any  # WHY: apisession / mistapi / DataExporter typed as Any 
 from prettytable import PrettyTable  # WHY: console rendering for the operator-facing summary tables
 
 apisession: Any = None  # WHY: mistapi session injected by configure_* to keep the module import-safe
-mistapi: Any = None  # WHY: mistapi module injected lazily; direct import would create cycles at load
+mistapi: Any = None  # WHY: mistapi module injected lazily. Direct import would create cycles at load
 DataExporter: Any = None  # WHY: exporter injected so tests can substitute a mock without touching disk
-org_id: str = ""  # WHY: selected org for execute(); empty string means "no org chosen yet"
+org_id: str = ""  # WHY: selected org for execute(). Empty string means "no org chosen yet"
 
 _SEPARATOR_WIDTH: int = 62  # WHY: fixed banner width keeps CLI output aligned across reports
 _INVENTORY_PAGE_SIZE: int = 1000  # WHY: large page size minimizes round-trips for big inventories
@@ -48,7 +48,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
     @staticmethod
     def _search_switch_page(target_org_id: str, next_url: str | None) -> dict | None:  # WHY: single-page fetch helper
         """Return one page of switch inventory results or ``None`` when the API errors."""
-        try:  # WHY: mistapi raises on transport errors; caller treats None as stop-signal
+        try:  # WHY: mistapi raises on transport errors. Caller treats None as stop-signal
             response = (  # WHY: continuation URL preserves cursor across pages when present
                 apisession.mist_get(next_url)  # WHY: mist_get follows the next-page URL verbatim
                 if next_url  # WHY: first page has no continuation, so fall through to primary search
@@ -67,7 +67,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
         """Fetch switch inventory records with full pagination."""
         logging.info("Fetching switch physical inventory via searchOrgDevices, org=%s", target_org_id)  # WHY: op trace
         all_records: list[dict] = []  # WHY: accumulator across pages
-        next_url: str | None = None  # WHY: cursor for the next page; None means "first request"
+        next_url: str | None = None  # WHY: cursor for the next page. None means "first request"
         page_num: int = 0  # WHY: counter for log context
         while True:  # WHY: exit conditions live inside via guard clauses to keep complexity flat
             page_num += 1  # WHY: increment before fetch so logs show the page being requested
@@ -80,7 +80,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
             all_records.extend(results)  # WHY: fold this page into the accumulator
             next_url = page_data.get("next")  # WHY: continuation URL for the next iteration
             if not next_url:  # WHY: API omits "next" once the final page is served
-                break  # WHY: final page reached; stop looping
+                break  # WHY: final page reached. Stop looping
         logging.info(  # WHY: summarize outcome once at the end so logs stay quiet during success
             "Switch physical inventory complete: %d logical devices org=%s", len(all_records), target_org_id
         )
@@ -204,7 +204,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
 
     @staticmethod
     def _aggregate_unassigned_counts(unassigned_records: list[dict], distinct: str) -> list[dict]:  # WHY: stock rollup
-        """Aggregate unassigned device counts; firmware rows bucket under an 'unassigned' label."""
+        """Aggregate unassigned device counts. Firmware rows bucket under an 'unassigned' label."""
         logging.info("Aggregating %d unassigned records by %s", len(unassigned_records), distinct)  # WHY: op trace
         counts: dict[tuple[str, str], int] = {}  # WHY: key on (device_type, bucket) to keep types separate
         for record in unassigned_records:  # WHY: walk each unassigned inventory record once
@@ -265,7 +265,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
     def _fetch_ap_type_rows(target_org_id: str, distinct: str, ap_records: list[dict] | None) -> list[dict]:
         """Return AP rows using full inventory so claimed-but-never-connected APs are counted."""  # WHY: AP handler
         try:  # WHY: AP counting must never abort the combined report
-            resolved = (  # WHY: direct/test callers may omit the shared fetch; pull it ourselves
+            resolved = (  # WHY: direct/test callers may omit the shared fetch. Pull it ourselves
                 ap_records
                 if ap_records is not None
                 else OrgDeviceInventorySummaryCore._fetch_ap_inventory(target_org_id)
@@ -302,7 +302,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
         all_rows: list[dict], target_org_id: str, distinct: str, unassigned_records: list[dict] | None
     ) -> list[dict]:
         """Merge unassigned AP/switch stock into assigned counts so totals are not understated."""
-        resolved = (  # WHY: direct/test callers may omit the shared fetch; pull it ourselves
+        resolved = (  # WHY: direct/test callers may omit the shared fetch. Pull it ourselves
             unassigned_records
             if unassigned_records is not None
             else OrgDeviceInventorySummaryCore._fetch_unassigned_inventory(target_org_id)
@@ -318,13 +318,13 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
     def _print_summary_banner(distinct: str, table: PrettyTable) -> None:  # WHY: keep display method concise
         """Print the labelled banner and table for one summary."""
         separator = "=" * _SEPARATOR_WIDTH  # WHY: reuse the constant width for both borders
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\n%s", separator)  # WHY: leading blank line separates from preceding output
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("  %s Distribution Summary", distinct.capitalize())  # WHY: operator label matches column
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(separator)  # WHY: trailing border closes the banner block
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("%s", table)  # WHY: rendered PrettyTable follows the banner
 
     @staticmethod
@@ -349,7 +349,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
         try:  # WHY: API failures fall back to env / org id at higher level
             org_response = mistapi.api.v1.orgs.orgs.getOrg(apisession, target_org_id)  # WHY: authoritative name source
         except Exception as error:  # WHY: never break the summary run on a naming lookup
-            logging.warning("Could not resolve org name from API: %s", error)  # WHY: warn-only; recovery follows
+            logging.warning("Could not resolve org name from API: %s", error)  # WHY: warn-only. Recovery follows
             return None  # WHY: signal caller to try env / id fallbacks
         return getattr(org_response, "data", {}).get("name")  # WHY: response may be dict-like or missing name key
 
@@ -374,7 +374,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
     def _run_model_report(
         target_org_id: str, safe_org: str, unassigned_records: list[dict], ap_records: list[dict]
     ) -> list[dict]:  # WHY: keep run_for_org within length budget
-        """Compute, render and export the per-model report; return the rows for reuse."""
+        """Compute, render and export the per-model report. Return the rows for reuse."""
         model_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(  # WHY: shared fetches reuse across reports
             target_org_id, "model", unassigned_records, ap_records
         )
@@ -387,7 +387,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
     def _run_version_report(
         target_org_id: str, safe_org: str, unassigned_records: list[dict], ap_records: list[dict]
     ) -> list[dict]:  # WHY: mirror of _run_model_report
-        """Compute, render and export the per-version report; return the rows."""
+        """Compute, render and export the per-version report. Return the rows."""
         version_rows = OrgDeviceInventorySummaryCore._fetch_all_counts(  # WHY: shared fetches reuse across reports
             target_org_id, "version", unassigned_records, ap_records
         )
@@ -404,7 +404,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
         unassigned_records: list[dict],
         ap_records: list[dict],
     ) -> list[dict]:  # WHY: collaborator
-        """Compute the per-model version pivot; delegate render to PivotRenderer."""
+        """Compute the per-model version pivot. Delegate render to PivotRenderer."""
         from src.inventory.inventory_summary.pivot_renderer import PivotRenderer  # WHY: lazy import breaks cycle
         from src.inventory.inventory_summary.version_per_model_fetcher import (
             VersionPerModelFetcher,  # WHY: collaborator owns per-type version expansion
@@ -437,7 +437,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
         logging.info(  # WHY: log outcome so ops can tune inventory volume
             "Org device inventory summary for %s completed in %.1f seconds", target_org_id, elapsed
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\nSummary for %s completed in %.1f seconds", safe_org, elapsed)  # operator feedback
         return model_rows, version_rows, ver_per_model, safe_org  # WHY: public tuple preserved for callers
 
@@ -445,7 +445,7 @@ class OrgDeviceInventorySummaryCore:  # WHY: single-org inventory summarization 
     def execute() -> None:  # WHY: menu-level entry point requires configured org
         """Run inventory summaries for the currently selected org."""
         if not org_id:  # WHY: guard clause reports the misconfiguration instead of crashing
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("X No organization selected")  # WHY: user-visible error mirrors the rest of the CLI
             logging.error("OrgDeviceInventorySummaryCore.execute called with empty org_id")  # WHY: audit trail
             return  # WHY: early return keeps the happy path un-indented

--- a/src/inventory/org_device_inventory_summary_facade.py
+++ b/src/inventory/org_device_inventory_summary_facade.py
@@ -14,7 +14,7 @@ re-export alias.
 from __future__ import annotations  # WHY: PEP 604 unions for return types.
 
 import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
-from typing import Any, cast  # WHY: raw impl classes are duck-typed; cast org_id str for the checker.
+from typing import Any, cast  # WHY: raw impl classes are duck-typed. Cast org_id str for the checker.
 
 
 class OrgDeviceInventorySummary:
@@ -35,7 +35,7 @@ class OrgDeviceInventorySummary:
             apisession_dependency=mh.apisession,
             mistapi_dependency=mh.mistapi,
             data_exporter=mh.DataExporter,
-            org_id_value=cast(str, mh.org_id),  # Global org_id is set before this runs; assert str for the checker.
+            org_id_value=cast(str, mh.org_id),  # Global org_id is set before this runs. Assert str for the checker.
         )
         return OrgDeviceInventorySummaryCore  # Return the core class.
 

--- a/src/maps/_container_detection.py
+++ b/src/maps/_container_detection.py
@@ -74,7 +74,7 @@ def _check_container_env_vars() -> bool:  # WHY: runtime/orchestrator env-var sc
 
 def _check_cgroup_markers() -> bool:  # WHY: Linux init cgroup fingerprint scan
     """Return True when /proc/1/cgroup mentions a container runtime."""
-    try:  # /proc/1/cgroup absent on non-Linux; permission may be restricted
+    try:  # /proc/1/cgroup absent on non-Linux. Permission may be restricted
         with open("/proc/1/cgroup", encoding="utf-8", errors="ignore") as cgroup_file:  # Read init's cgroup path
             cgroup_content = cgroup_file.read().lower()  # Normalize case for substring match
     except (FileNotFoundError, PermissionError):  # Non-Linux or restricted env
@@ -88,8 +88,8 @@ def _check_cgroup_markers() -> bool:  # WHY: Linux init cgroup fingerprint scan
 
 def _check_runtime_user() -> bool:  # WHY: image-conventional user identity probe
     """Return True when running as the canonical 'misthelper' user (Unix only)."""
-    try:  # pwd is Unix-only; getuid absent on Windows
-        import pwd  # Unix only; import lazily to keep Windows imports clean.
+    try:  # pwd is Unix-only. Getuid absent on Windows
+        import pwd  # Unix only. Import lazily to keep Windows imports clean.
 
         current_user_name = pwd.getpwuid(os.getuid()).pw_name  # type: ignore[attr-defined]
     except Exception:  # Non-Unix or lookup failure

--- a/src/maps/_flask_viewer.py
+++ b/src/maps/_flask_viewer.py
@@ -6,7 +6,7 @@ takes explicit callables for the map-payload/response builders so the
 module stays independent of MapsManager and easy to test.
 
 SECURITY: :func:`_resolve_flask_bind_address` binds 0.0.0.0 only when
-the container heuristics fire; direct execution stays on localhost.
+the container heuristics fire. Direct execution stays on localhost.
 """
 
 from __future__ import annotations  # WHY: enable postponed annotations for slotted dataclasses referencing Callable.
@@ -87,7 +87,7 @@ class FlaskViewerContext:  # WHY: single-param bundle for launch_flask_viewer's 
 
 
 def _summarise_named_records(records: list[dict]) -> list[dict]:  # WHY: dropdown payload shared across handlers.
-    """Return only ``id``/``name`` pairs from each record; used for both site + map dropdowns."""
+    """Return only ``id``/``name`` pairs from each record. Used for both site + map dropdowns."""
     return [{"id": r.get("id"), "name": r.get("name", _UNNAMED)} for r in records]  # WHY: minimal dropdown payload.
 
 
@@ -110,7 +110,7 @@ def _handle_map_data_request(request: MapDataRequest):  # WHY: single orchestrat
 
 
 def _render_viewer_page(html_template: str, ctx: ViewerPageContext):  # WHY: pure Jinja render of the root page.
-    """Render the Flask root page; injects sorted-sites + maps JSON into the HTML template."""
+    """Render the Flask root page. Injects sorted-sites + maps JSON into the HTML template."""
     sites_sorted = sorted(ctx.all_sites, key=lambda x: x.get("name", "").lower())  # WHY: alphabetise dropdown.
     sites_json = ctx.json_module.dumps(_summarise_named_records(sites_sorted))  # WHY: encode dropdown payload.
     maps_json = ctx.json_module.dumps(_summarise_named_records(ctx.all_maps))  # WHY: encode map dropdown payload.
@@ -192,18 +192,18 @@ _BANNER_LINES = (  # WHY: table-driven banner replaces sequential print calls, e
 
 def _print_flask_viewer_banner(host: str, port: int) -> None:
     """Emit the pre-launch ASCII banner that lists URL + key features."""
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("\n%s", _BANNER_SEPARATOR)  # WHY: leading blank line separates banner from prior console output.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("LAUNCHING FLASK MAP VIEWER")  # WHY: identifies the launched mode to the operator.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("%s", _BANNER_SEPARATOR)  # WHY: divider between title and body of the banner.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("! Server URL: http://%s:%s", host, port)  # WHY: URL comes first so operators can click through.
     for line in _BANNER_LINES:
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", line)  # WHY: table-driven emission keeps additions trivial.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("%s", _BANNER_SEPARATOR)  # WHY: trailing divider signals end of banner block.
 
 
@@ -213,7 +213,7 @@ def _maybe_open_browser(port: int) -> None:
     import webbrowser  # WHY: local import mirrors threading -- optional path when running headless.
 
     if is_running_in_container():
-        return  # WHY: containers expose ports externally; caller handles browser launch on the host side.
+        return  # WHY: containers expose ports externally. Caller handles browser launch on the host side.
 
     def open_browser() -> None:
         """Wait briefly then point the default browser at the local Flask server."""
@@ -226,17 +226,17 @@ def _maybe_open_browser(port: int) -> None:
 
 
 def _run_flask_server(flask_app, host: str, port: int) -> None:
-    """Run the Flask server until interrupted; mirror the original KeyboardInterrupt path."""
+    """Run the Flask server until interrupted. Mirror the original KeyboardInterrupt path."""
     try:
         logging.info("Starting Flask server on http://%s:%s", host, port)  # WHY: audit trail before blocking call.
         flask_app.run(host=host, port=port, debug=False, threaded=True, use_reloader=False)  # WHY: prod-safe args.
     except KeyboardInterrupt:
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n\nFlask map viewer stopped by user")  # WHY: friendly console signal on Ctrl+C.
         logging.info("Flask map viewer stopped by user (Ctrl+C)")  # WHY: matching log entry for grep-based audits.
     except Exception as e:  # WHY: broad catch prevents a Flask crash from tearing down the CLI silently.
         logging.exception("Error running Flask server: %s", e)  # WHY: full stack for post-mortem log review.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("\n! Error running map viewer: %s", e)  # WHY: surface failure to operator on stdout as well.
 
 
@@ -1306,7 +1306,7 @@ def _register_flask_routes(
 
 
 def _build_flask_app(ctx: FlaskViewerContext):
-    """Construct and wire the Flask app; returns the ready-to-run instance."""
+    """Construct and wire the Flask app. Returns the ready-to-run instance."""
     import json as json_module  # WHY: local import keeps JSON module out of import graph unless viewer runs.
 
     from flask import Flask, jsonify, render_template_string  # WHY: local so import cost is deferred to launch time.

--- a/src/maps/_maps_backup.py
+++ b/src/maps/_maps_backup.py
@@ -2,7 +2,7 @@
 
 Split out of ``src/maps/maps_manager.py`` so the geometry-backup flow
 lives in its own module. Callers construct a :class:`BackupRequest`
-and hand it to :func:`backup_map_geometry`; the module also fixes the
+and hand it to :func:`backup_map_geometry`. The module also fixes the
 missing ``os`` import the original class-based version silently relied
 on. MapsManager keeps a thin ``_backup_map_geometry`` delegating method
 because ``src/maps/launcher/viewer_callbacks.py`` invokes it through
@@ -111,7 +111,7 @@ def _image_ext(url: str) -> str:  # WHY: derive image extension without exceptio
 
 def _http_get_bytes(url: str) -> tuple[bytes | None, int]:  # WHY: isolate HTTP call from callers
     """GET ``url`` and return ``(content-or-None, status_code)``."""
-    try:  # WHY: network I/O may raise; caller wants graceful fallback
+    try:  # WHY: network I/O may raise. Caller wants graceful fallback
         response = requests.get(url, timeout=_IMG_TIMEOUT_SECS)  # WHY: bounded network wait
     except Exception as err:  # WHY: any failure downgrades to warn + skip
         logger.warning("Image backup failed: %s", err)  # WHY: surface reason to operator
@@ -131,7 +131,7 @@ def _write_image(filename: str, content: bytes) -> None:  # WHY: persist downloa
 def _download_image(
     map_data: dict[str, Any], map_name: str, reason: str
 ) -> tuple[str | None, tuple[str, str] | None]:  # WHY: orchestrate image download
-    """Download the map image; return ``(filename, (safe_name, timestamp))`` or ``(None, None)``."""
+    """Download the map image. Return ``(filename, (safe_name, timestamp))`` or ``(None, None)``."""
     url = map_data.get("url")  # WHY: image URL is optional in the map record
     if not url:  # WHY: no URL means nothing to download
         return None, None
@@ -151,7 +151,7 @@ def _call_api(  # WHY: encapsulate try/except around a Mist listSite* call
     api_call: Callable[..., Any], api_session: Any, site_id: str, label: str
 ) -> Any | None:
     """Invoke ``api_call`` and return the response or ``None`` on exception."""
-    try:  # WHY: fetch is best-effort; caller degrades gracefully
+    try:  # WHY: fetch is best-effort. Caller degrades gracefully
         return api_call(api_session, site_id=site_id)  # WHY: shared site-scoped signature
     except Exception as err:  # WHY: swallow to keep the backup usable
         logger.debug("%s backup skipped: %s", label, err)  # WHY: diagnostic trace only
@@ -182,8 +182,8 @@ def _fetch_items(  # WHY: generic fetch + filter for zones / beacons / vbeacons
 
 
 def _fetch_devices(request: BackupRequest) -> Any | None:  # WHY: wrap listSiteDevices exception path
-    """Fetch site-device response object; returns ``None`` on error."""
-    try:  # WHY: network I/O may raise; caller wants graceful fallback
+    """Fetch site-device response object. Returns ``None`` on error."""
+    try:  # WHY: network I/O may raise. Caller wants graceful fallback
         return mistapi.api.v1.sites.devices.listSiteDevices(  # WHY: Mist API listing
             request.api_session, site_id=request.site_id, type="all"
         )
@@ -216,7 +216,7 @@ def _fetch_device_placements(request: BackupRequest) -> list[dict[str, Any]]:  #
 def _write_backup(  # WHY: persist final backup document to disk
     backup: dict[str, Any], map_name: str, reason: str, name_ts: tuple[str, str] | None
 ) -> tuple[str, str]:
-    """Write ``backup`` as JSON; return ``(absolute_path, filename)``."""
+    """Write ``backup`` as JSON. Return ``(absolute_path, filename)``."""
     safe_name, stamp = name_ts if name_ts else (_safe_name(map_name), _timestamp())  # WHY: reuse image stamp
     filename = f"map_backup_{safe_name}_{reason}_{stamp}.json"  # WHY: matches image filename layout
     path = os.path.join(_data_dir(), filename)  # WHY: absolute destination path
@@ -271,17 +271,17 @@ def _print_summary(  # WHY: user-visible backup summary output
     """Log and print a human-readable summary of the backup contents."""
     summary = _build_summary(backup, image_filename)  # WHY: single source of formatted counts
     logger.info("Map backup saved: %s (%s)", backup_filename, summary)  # WHY: structured audit log
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("\n   [*] Map backup saved: %s", backup_filename)
     if image_filename:  # WHY: only show image line when there is one
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("       Image: %s", image_filename)
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("       %s", summary)
 
 
 def _fetch_map(request: BackupRequest) -> dict[str, Any] | None:  # WHY: fetch base map data
-    """Fetch the base map record; return dict payload or ``None`` on failure."""
+    """Fetch the base map record. Return dict payload or ``None`` on failure."""
     response = mistapi.api.v1.sites.maps.getSiteMap(  # WHY: Mist API read for map record
         request.api_session, site_id=request.site_id, map_id=request.map_id
     )
@@ -327,7 +327,7 @@ def _populate_related(backup: dict[str, Any], request: BackupRequest) -> None:  
 
 
 def _perform_backup(request: BackupRequest) -> str | None:  # WHY: end-to-end backup pipeline
-    """Run the full backup pipeline; return the JSON backup path or ``None``."""
+    """Run the full backup pipeline. Return the JSON backup path or ``None``."""
     logger.info(  # WHY: audit start of the pipeline
         "Map geometry backup initiated - map: %s (%s), reason: %s",
         request.map_name,
@@ -348,11 +348,11 @@ def _perform_backup(request: BackupRequest) -> str | None:  # WHY: end-to-end ba
 
 
 def backup_map_geometry(request: BackupRequest) -> str | None:  # WHY: public entry point
-    """Backup map geometry data to a JSON file; return path on success or ``None``."""
-    try:  # WHY: pipeline may raise; wrapper degrades to warning
+    """Backup map geometry data to a JSON file. Return path on success or ``None``."""
+    try:  # WHY: pipeline may raise. Wrapper degrades to warning
         return _perform_backup(request)
     except Exception as err:  # WHY: any failure surfaces as warning, not crash
         logger.exception("Map geometry backup failed: %s", err)  # WHY: full traceback in log
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("\n   [!] Warning: Could not backup map geometry: %s", err)
         return None

--- a/src/maps/_maps_clone.py
+++ b/src/maps/_maps_clone.py
@@ -87,7 +87,7 @@ class _MapsClone:
         return getattr(mm, name)  # Delegate all missing lookups to the wrapped manager.
 
     def _fetch_source_map_with_display(self, site_id: str, source_map_id: str) -> dict | None:
-        """Fetch source map from API and display its key attributes; return None on failure."""
+        """Fetch source map from API and display its key attributes. Return None on failure."""
         logging.debug(
             "Calling getSiteMap API - site_id: %s, map_id: %s", site_id, source_map_id
         )  # Trace API call args.
@@ -115,7 +115,7 @@ class _MapsClone:
         print(f"{'-' * 80}")  # Divider below the details block.
 
     def _prompt_clone_name(self, source_map: dict) -> str | None:
-        """Prompt for a clone name using the source map name as default; return None on EOF."""
+        """Prompt for a clone name using the source map name as default. Return None on EOF."""
         default_name = (
             f"{source_map.get('name', 'Map')} (Copy)"  # Compose a safe default so blank input still names it.
         )
@@ -133,11 +133,11 @@ class _MapsClone:
         payload: dict[str, Any] = {"name": new_name, "type": source_map.get("type", "image")}  # Required attrs first.
         for field in _CLONEABLE_MAP_FIELDS:  # Iterate the module-level whitelist for stable ordering.
             if field in source_map:  # Skip missing fields so we do not overwrite server defaults with None.
-                payload[field] = source_map[field]  # Copy the raw value; API tolerates whatever type came in.
+                payload[field] = source_map[field]  # Copy the raw value. API tolerates whatever type came in.
         return payload  # Fully assembled body for createSiteMap.
 
     def _fetch_source_zone_count(self, site_id: str, source_map_id: str) -> int:
-        """Count zones belonging to the source map; return 0 if fetch fails."""
+        """Count zones belonging to the source map. Return 0 if fetch fails."""
         try:
             zones_check = mistapi.api.v1.sites.zones.listSiteZones(self.apisession, site_id=site_id)  # Fetch all zones.
             if zones_check.status_code == 200:  # Only trust the count on a clean response.
@@ -147,7 +147,7 @@ class _MapsClone:
         return 0  # Default to zero so the plan text still reads sensibly.
 
     def _confirm_clone(self, source_map: dict, new_name: str, source_zones_count: int, clone_payload: dict) -> bool:
-        """Display the clone plan and prompt user to confirm; return True to proceed."""
+        """Display the clone plan and prompt user to confirm. Return True to proceed."""
         print(f"\n{'-' * 80}")  # Divider above the plan block.
         print("Clone Plan:")  # Section title for the pre-flight summary.
         print(f"  New name: {new_name}")  # Show the resolved clone name.
@@ -169,7 +169,7 @@ class _MapsClone:
         return True  # Green-light the write phase.
 
     def _download_clone_image(self, source_map: dict) -> str | None:
-        """Download the source map image to a temp file; return the temp path or None."""
+        """Download the source map image to a temp file. Return the temp path or None."""
         if "url" not in source_map:  # No image URL means nothing to download.
             return None  # Signal the caller to skip the image upload phase.
         image_temp_path: str | None = None  # Track the temp path so we can clean up on failure.
@@ -177,14 +177,14 @@ class _MapsClone:
             image_temp_path = self._download_image_to_tempfile(source_map["url"])  # Delegate HTTP + write.
             if image_temp_path is not None:  # Only report success when the file actually landed on disk.
                 return image_temp_path  # Path is now owned by the caller until upload/cleanup.
-        except Exception as download_error:  # Network/O errors are non-fatal; clone can proceed without image.
+        except Exception as download_error:  # Network/O errors are non-fatal. Clone can proceed without image.
             logging.error("Error downloading map image: %s", download_error)  # Full stack trace to the log.
             print(f"! Warning: Could not download image: {download_error}")  # User-facing warning.
         self._cleanup_temp_file(image_temp_path)  # Idempotent cleanup handles both partial-download failure modes.
         return None  # Signal image-less clone path.
 
     def _download_image_to_tempfile(self, image_url: str) -> str | None:
-        """Perform the HTTP GET and write the body to a fresh temp file; return path or None."""
+        """Perform the HTTP GET and write the body to a fresh temp file. Return path or None."""
         print("\nDownloading map image...")  # Progress marker for the user.
         file_ext = self._determine_image_extension(image_url)  # Reuse MapsManager's URL->ext heuristic.
         temp_fd, image_temp_path = tempfile.mkstemp(suffix=file_ext)  # Get an exclusive temp file with correct suffix.
@@ -195,20 +195,20 @@ class _MapsClone:
             self._cleanup_temp_file(image_temp_path)  # Remove the empty temp file we just created.
             return None  # Report failure to the caller so it can log a warning.
         with open(image_temp_path, "wb") as f:  # Overwrite the temp file with the image bytes.
-            f.write(response.content)  # Persist the payload in one shot; images fit comfortably in memory.
+            f.write(response.content)  # Persist the payload in one shot. Images fit comfortably in memory.
         print(f"Downloaded image ({len(response.content) / 1024:.1f} KB)")  # Report size for user feedback.
         return image_temp_path  # Hand the path to the caller for upload.
 
     @staticmethod
     def _cleanup_temp_file(path: str | None) -> None:
-        """Remove ``path`` if it exists; tolerate missing paths and OS errors quietly."""
+        """Remove ``path`` if it exists. Tolerate missing paths and OS errors quietly."""
         if not path:  # Guard: nothing to clean up.
             return
         if os.path.exists(path):  # Only unlink real files to avoid noisy exceptions.
-            os.remove(path)  # Best-effort cleanup; errors here are not actionable.
+            os.remove(path)  # Best-effort cleanup. Errors here are not actionable.
 
     def _create_cloned_map_entry(self, site_id: str, clone_payload: dict, image_temp_path: str | None) -> str | None:
-        """Call createSiteMap API and return the new map ID; cleans up temp on failure."""
+        """Call createSiteMap API and return the new map ID. Cleans up temp on failure."""
         print("\nCreating cloned map...")  # Progress marker.
         clone_response = mistapi.api.v1.sites.maps.createSiteMap(self.apisession, site_id=site_id, body=clone_payload)
         if clone_response.status_code not in _OK_CREATE_STATUS:  # Non-success codes abort the flow.
@@ -254,7 +254,7 @@ class _MapsClone:
             self._cleanup_temp_file(image_temp_path)  # Always release the temp file regardless of outcome.
 
     def _clone_single_zone(self, site_id: str, cloned_map_id: str, zone: dict) -> bool:
-        """Clone a single zone to the new map; return True on success."""
+        """Clone a single zone to the new map. Return True on success."""
         try:
             zone_payload: dict[str, Any] = {
                 "name": zone.get("name", "Unnamed Zone"),
@@ -287,7 +287,7 @@ class _MapsClone:
         return [z for z in zones_response.data if z.get("map_id") == source_map_id]  # Filter by owning map.
 
     def _clone_zones(self, site_id: str, source_map_id: str, cloned_map_id: str) -> tuple[int, int]:
-        """Clone all zones from source map to cloned map; return (cloned, failed)."""
+        """Clone all zones from source map to cloned map. Return (cloned, failed)."""
         print("\nCloning zones...")  # Progress marker.
         try:
             source_zones = self._fetch_source_zones(site_id, source_map_id)  # Delegate list+filter.
@@ -301,7 +301,7 @@ class _MapsClone:
             failed = len(results) - cloned  # Failures = total minus successes.
             print(f"Zones cloned: {cloned} (failed: {failed})")  # Summary line.
             return cloned, failed  # Hand the tallies to the caller.
-        except Exception as zones_error:  # Blanket safety net; keeps outer clone flow intact.
+        except Exception as zones_error:  # Blanket safety net. Keeps outer clone flow intact.
             logging.exception("Error during zone cloning: %s", zones_error)  # Full trace to the log.
             print(f"! Warning: Zone cloning failed: {zones_error}")  # User-facing warning.
             return 0, 0  # Fall back to zero counts.

--- a/src/maps/_maps_coverage.py
+++ b/src/maps/_maps_coverage.py
@@ -43,7 +43,7 @@ _EMPTY_RESPONSE: Any = None  # WHY: named sentinel improves grep-ability over ba
 
 def _safe_call(label: str, api_call: Callable[[], Any]) -> Any:  # WHY: shared safe API-call wrapper.
     """Invoke ``api_call`` and return the response or ``None`` on failure/empty."""
-    try:  # WHY: Mist SDK raises broadly (HTTP, JSON, connection); we log and continue.
+    try:  # WHY: Mist SDK raises broadly (HTTP, JSON, connection). We log and continue.
         response = api_call()  # WHY: run the caller-provided Mist API call.
     except Exception as exc:  # WHY: never crash a map-render because one layer failed.
         logging.warning("Error fetching %s: %s", label, exc)  # WHY: preserve prior log format for grep.
@@ -263,7 +263,7 @@ class _MapsCoverage:
     @staticmethod
     def _resolve_coverage_indices(result_def: list[str]) -> tuple[int, int, int]:
         """Return (x_idx, y_idx, rssi_idx) into a coverage row, with a -1 RSSI sentinel."""
-        try:  # WHY: result_def may omit expected columns; fall back on legacy layout.
+        try:  # WHY: result_def may omit expected columns. Fall back on legacy layout.
             x_idx = result_def.index("x")  # WHY: locate the x column.
             y_idx = result_def.index("y")  # WHY: locate the y column.
             rssi_idx = _pick_rssi_index(result_def)  # WHY: max_rssi preferred over avg_rssi, -1 when absent.

--- a/src/maps/_maps_matplotlib.py
+++ b/src/maps/_maps_matplotlib.py
@@ -123,7 +123,7 @@ class _MapsMatplotlib:  # Wrapper class holding the extracted matplotlib/launch 
     ) -> None:  # Fallback viewer entry.
         """Fallback matplotlib viewer (view-only)."""
         logging.info("_launch_matplotlib_viewer called - basic fallback mode")  # Trace entry.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("\n! Using matplotlib viewer (view-only, no interactivity)")
         logging.debug("Creating matplotlib figure for basic visualization")  # Debug breadcrumb.
         bounds = _extract_bounds(map_data)  # Read canvas dims/title with safe defaults.
@@ -132,7 +132,7 @@ class _MapsMatplotlib:  # Wrapper class holding the extracted matplotlib/launch 
         _plot_devices(ax, devices)  # Draw every valid device marker.
         ax.legend()  # Show legend keyed by device-type entries added during plotting.
         ax.grid(True, alpha=_GRID_ALPHA)  # Light grid for spatial orientation.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n! Displaying map... Close window to return to menu")
         logging.info("Displaying matplotlib figure (blocking until window closed)")  # Trace.
         plt.show()  # Blocking call until user closes the window.
@@ -169,7 +169,7 @@ class _MapsMatplotlib:  # Wrapper class holding the extracted matplotlib/launch 
         return _filter_response_by_map(resp, map_id)  # Handle status/data checks + filter downstream.
 
     def _fetch_site_maps(self, site_id: str) -> list[dict[str, Any]]:
-        """Fetch maps for a site; return empty list on failure."""
+        """Fetch maps for a site. Return empty list on failure."""
         try:
             resp = mistapi.api.v1.sites.maps.listSiteMaps(self.apisession, site_id=site_id)  # Mist API call.
         except Exception as error:
@@ -183,7 +183,7 @@ class _MapsMatplotlib:  # Wrapper class holding the extracted matplotlib/launch 
     def launch_viewer_standalone(
         self, requested_site_id: str | None = None, requested_map_id: str | None = None
     ) -> None:
-        """Launch the standalone Flask viewer; site/map picked in-browser."""
+        """Launch the standalone Flask viewer. Site/map picked in-browser."""
         _print_banner()  # Announce mode to the operator.
         sites_sorted = self._bootstrap_sites()  # Fetch and sort or return None on empty.
         if sites_sorted is None:
@@ -214,17 +214,17 @@ class _MapsMatplotlib:  # Wrapper class holding the extracted matplotlib/launch 
         )  # Delegate to the Flask-based interactive viewer.
 
     def _bootstrap_sites(self) -> list[dict[str, Any]] | None:
-        """Fetch and sort all org sites; return None when the org has none."""
+        """Fetch and sort all org sites. Return None when the org has none."""
         logging.info("launch_viewer_standalone: Starting web-first viewer mode")  # Trace entry.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n  Loading sites...")
         all_sites = self._fetch_sites()  # Delegated to MapsManager via __getattr__.
         if not all_sites:
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("\n  [!] No sites found in organization")
             return None  # Signal the caller to abort the launch.
         sites_sorted = sorted(all_sites, key=_site_sort_key)  # Alphabetic case-insensitive sort by name.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Found %s sites", len(sites_sorted))
         return sites_sorted  # Ready-to-use, ordered site list.
 
@@ -236,14 +236,14 @@ class _MapsMatplotlib:  # Wrapper class holding the extracted matplotlib/launch 
     ) -> _StandaloneTargets:
         """Resolve site + map targets that the Flask viewer will bootstrap with."""
         site_id, site_name = self._resolve_initial_site(sites_sorted, requested_site_id)  # Reuse core helper.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Loading maps for site: %s...", site_name)
         all_maps = self._fetch_site_maps(site_id)  # May be empty on API/no-map failures.
         if not all_maps:
             _print_no_maps_notice(site_name)  # Tell the user we are deferring selection to the browser.
             return _StandaloneTargets(site_id, site_name, None, all_maps)  # Return with map_id=None sentinel.
         map_id, target_map = self._resolve_initial_map(all_maps, requested_map_id)  # Pick initial map handle.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  Loading map: %s...", target_map.get("name", _DEFAULT_MAP_NAME))
         return _StandaloneTargets(site_id, site_name, map_id, all_maps)  # Return fully-resolved bundle.
 
@@ -286,7 +286,7 @@ def _configure_axes(ax: Any, bounds: _MapBounds) -> None:
 
 
 def _plot_devices(ax: Any, devices: list[dict[str, Any]]) -> None:
-    """Draw every valid device on the axes; skip records without coordinates."""
+    """Draw every valid device on the axes. Skip records without coordinates."""
     for device in devices:  # Iterate through hydrated device list once.
         marker = _device_to_marker(device)  # Build marker bundle or None sentinel.
         if marker is None:
@@ -311,7 +311,7 @@ def _device_to_marker(device: dict[str, Any]) -> _DeviceMarker | None:
 
 
 def _draw_marker(ax: Any, marker: _DeviceMarker) -> None:
-    """Plot the marker point and label; register legend entry once per type."""
+    """Plot the marker point and label. Register legend entry once per type."""
     legend_label = _legend_label_for(ax, marker.device_type)  # Dedup legend entries by type.
     ax.plot(
         marker.x,
@@ -357,7 +357,7 @@ def _draw_orientation_arrow(ax: Any, marker: _DeviceMarker) -> None:
 
 def _find_by_id(records: list[dict[str, Any]], target_id: str) -> dict[str, Any] | None:
     """Return the first record whose id matches target_id, or None."""
-    return next((r for r in records if r.get("id") == target_id), None)  # Linear scan; lists are small.
+    return next((r for r in records if r.get("id") == target_id), None)  # Linear scan. Lists are small.
 
 
 def _find_named_default(sites_sorted: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -367,8 +367,8 @@ def _find_named_default(sites_sorted: list[dict[str, Any]]) -> dict[str, Any] | 
 
 def _site_tuple(site: dict[str, Any]) -> tuple[str, str]:
     """Extract (id, name) tuple with a safe name default for logging."""
-    site_id = str(site.get("id", ""))  # Cast Any->str; missing id becomes empty string.
-    site_name = str(site.get("name", _UNKNOWN_NAME))  # Cast Any->str; fallback preserves prior behavior.
+    site_id = str(site.get("id", ""))  # Cast Any->str. Missing id becomes empty string.
+    site_name = str(site.get("name", _UNKNOWN_NAME))  # Cast Any->str. Fallback preserves prior behavior.
     return site_id, site_name  # Consistent (str, str) tuple for mypy strict.
 
 
@@ -378,15 +378,15 @@ def _site_sort_key(site: dict[str, Any]) -> str:
 
 
 def _safe_api_call(api_fn: Callable[..., Any], apisession: Any, site_id: str, kwargs: dict[str, Any]) -> Any:
-    """Invoke api_fn; return None on any raised exception (caller treats as empty)."""
+    """Invoke api_fn. Return None on any raised exception (caller treats as empty)."""
     try:
         return api_fn(apisession, site_id=site_id, **kwargs)  # Delegate the actual API call.
     except Exception:
-        return None  # Silent failure; caller returns empty list downstream.
+        return None  # Silent failure. Caller returns empty list downstream.
 
 
 def _filter_response_by_map(resp: Any, map_id: str) -> list[dict[str, Any]]:
-    """Return entries whose `map_id` matches; empty list on any failure."""
+    """Return entries whose `map_id` matches. Empty list on any failure."""
     if not _is_ok_response(resp):
         return []  # Non-OK responses collapse into the empty-list result.
     return _entries_for_map(resp.data, map_id)  # Delegate matching to comprehension helper.
@@ -406,21 +406,21 @@ def _entries_for_map(data: Any, map_id: str) -> list[dict[str, Any]]:
 
 def _print_banner() -> None:
     """Print the standalone-viewer banner block."""
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("\n%s", "=" * _BANNER_WIDTH)  # Top rule.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("  MAPS MANAGER - Standalone Web Viewer")  # Title line.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("  Select a site and map from the browser interface")  # Subtitle line.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("%s", "=" * _BANNER_WIDTH)  # Bottom rule.
 
 
 def _print_no_maps_notice(site_name: str) -> None:
     """Notify the user that the target site has no maps yet."""
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.warning("\n  [!] No maps found for site %s", site_name)  # Explicit empty-site notice.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("  Launching viewer anyway - select a different site in browser")  # Guidance to switch.
 
 
@@ -428,7 +428,7 @@ def _print_entity_counts(entities: _MapEntities, targets: _StandaloneTargets) ->
     """Print the hydrated entity counts unless the initial map is undecided."""
     if targets.map_id is None:
         return  # Nothing meaningful to report without a chosen map.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info(
         "  Found %s devices, %s zones, %s clients",
         len(entities.devices),

--- a/src/maps/_maps_utils.py
+++ b/src/maps/_maps_utils.py
@@ -27,7 +27,7 @@ _INVALID_FILENAME_CHARS: str = '<>:"/\\|?*'  # WHY: superset of Windows-reserved
 
 _FALLBACK_NAME: str = "unnamed"  # WHY: sentinel returned for empty/whitespace filenames to avoid empty writes.
 _DATA_DIRNAME: str = "data"  # WHY: repo convention places CSV exports under ./data at cwd.
-_CSV_EXT: str = ".csv"  # WHY: single-format export; suffix appended after sanitization.
+_CSV_EXT: str = ".csv"  # WHY: single-format export. Suffix appended after sanitization.
 _REPLACEMENT_CHAR: str = "_"  # WHY: underscore is safe on every target filesystem and shell.
 _STRIP_CHARS: str = " ."  # WHY: Windows rejects trailing space/dot in file/directory names.
 
@@ -36,8 +36,8 @@ _LOG_WRITE_ERROR: str = "Error writing CSV: %s"  # WHY: error template surfaces 
 _LOG_WRITE_OK: str = "Data written to %s (%s rows)"  # WHY: success template shows path + row count for audit.
 _PRINT_SAVED_TMPL: str = "   Data saved to: %s"  # WHY: %s deferred-format template for logger.info (G004-clean).
 
-_CSV_MODE_WRITE: str = "w"  # WHY: overwrite existing file each run; callers version via distinct filenames.
-_CSV_NEWLINE: str = ""  # WHY: csv module handles newlines internally; empty avoids double-CR on Windows.
+_CSV_MODE_WRITE: str = "w"  # WHY: overwrite existing file each run. Callers version via distinct filenames.
+_CSV_NEWLINE: str = ""  # WHY: csv module handles newlines internally. Empty avoids double-CR on Windows.
 _CSV_ENCODING: str = "utf-8"  # WHY: broadest-compatibility encoding for exported Mist data.
 _CSV_EXTRAS: Literal["ignore"] = "ignore"  # WHY: silently drop keys missing from the computed superset header.
 
@@ -45,12 +45,12 @@ _CSV_EXTRAS: Literal["ignore"] = "ignore"  # WHY: silently drop keys missing fro
 def flatten_dict_recursively(d: dict[str, Any], parent_key: str = "", sep: str = "_") -> dict[str, Any]:
     """Flatten nested dicts/lists into a single flat mapping.
 
-    Nested dicts contribute joined keys; lists of dicts contribute
-    index-suffixed keys; scalar lists are stringified so the return
+    Nested dicts contribute joined keys. Lists of dicts contribute
+    index-suffixed keys. Scalar lists are stringified so the return
     value is always a flat ``dict[str, Any]`` suitable for CSV rows.
     """
     items: list[tuple[str, Any]] = []  # WHY: accumulate as pairs so ordering follows insertion for stability.
-    for k, v in d.items():  # WHY: walk top-level keys; dispatch by value type below.
+    for k, v in d.items():  # WHY: walk top-level keys. Dispatch by value type below.
         new_key = f"{parent_key}{sep}{k}" if parent_key else k  # WHY: prefix only when nested to avoid leading sep.
         if isinstance(v, dict):  # WHY: dict branch recurses to flatten nested structures.
             items.extend(flatten_dict_recursively(v, new_key, sep=sep).items())  # WHY: merge child pairs verbatim.
@@ -118,7 +118,7 @@ def write_data_with_format_selection(
         logger.error(_LOG_WRITE_ERROR, write_error)  # WHY: template log includes the underlying error text.
         return False  # WHY: False on write failure preserves batch-export resilience.
     logger.info(_LOG_WRITE_OK, filepath, len(data))  # WHY: audit log includes both path and row count.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info(_PRINT_SAVED_TMPL, filepath)
     return True  # WHY: True indicates the CSV was successfully committed to disk.
 
@@ -147,7 +147,7 @@ def _write_csv_rows(data: list[dict[str, Any]], filepath: str) -> None:
     for row in data:  # WHY: single pass over rows populates the union of keys.
         all_keys.update(row.keys())  # WHY: update() is O(k) per row and avoids intermediate lists.
     fieldnames = sorted(all_keys)  # WHY: sorted header keeps CSV output deterministic run-to-run.
-    # WHY: text-mode CSV write; csv module inserts its own line terminators.
+    # WHY: text-mode CSV write. Csv module inserts its own line terminators.
     with open(filepath, _CSV_MODE_WRITE, newline=_CSV_NEWLINE, encoding=_CSV_ENCODING) as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames, extrasaction=_CSV_EXTRAS)  # WHY: ignore stray keys.
         writer.writeheader()  # WHY: emit the deterministic header row before data rows.

--- a/src/maps/_maps_wizard.py
+++ b/src/maps/_maps_wizard.py
@@ -85,7 +85,7 @@ class _CommitBundle:  # WHY: 5-Item Rule bundle for the apply-tail helper signat
 
 
 class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
-    """Wrapper class holding the extracted wizard methods; delegates to MapsManager."""
+    """Wrapper class holding the extracted wizard methods. Delegates to MapsManager."""
 
     def __init__(self, maps_manager: Any) -> None:  # WHY: keep a reference to MapsManager for delegation.
         """Store the wrapped MapsManager for attribute delegation."""
@@ -290,7 +290,7 @@ class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
         print("  4. No Scaling - Replace image only, keep all coordinates unchanged")
 
     def _prompt_scale_choice(self) -> str | None:
-        """Prompt for the scaling menu selection; return the trimmed string or None on EOF."""
+        """Prompt for the scaling menu selection. Return the trimmed string or None on EOF."""
         try:
             raw = InputUtils.safe_input(  # WHY: uniform EOF/CTRL-C handling.
                 "\nSelect scaling mode [1]: ", context="_wizard_determine_scaling"
@@ -328,7 +328,7 @@ class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
         return "preserve_physical", DEFAULT_SCALE_FACTOR, DEFAULT_SCALE_FACTOR, new_ppm  # WHY: identity xy.
 
     def _resolve_manual_ppm(self, ctx: ScaleChoiceContext) -> tuple[str, float, float, float]:
-        """Prompt for a manual PPM value; fall back to original PPM on invalid/EOF input."""
+        """Prompt for a manual PPM value. Fall back to original PPM on invalid/EOF input."""
         try:
             raw = InputUtils.safe_input(  # WHY: EOF-safe prompt.
                 f"Enter new PPM (current: {ctx.original_ppm:.2f}): ", context="_apply_scale_choice"
@@ -404,12 +404,12 @@ class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
         )
 
     def _update_single_device(self, record: dict[str, Any], params: _AssetScaleParams) -> bool:
-        """Update one device's x/y via the API; return True on success."""
+        """Update one device's x/y via the API. Return True on success."""
         resp = mistapi.api.v1.sites.devices.updateSiteDevice(  # WHY: PATCH-style position update.
             self.apisession,
             site_id=params.site_id,
             device_id=record.get("id"),
-            body={  # WHY: only x/y change; other device fields left untouched.
+            body={  # WHY: only x/y change. Other device fields left untouched.
                 "x": record.get("x", 0) * params.scale_x,
                 "y": record.get("y", 0) * params.scale_y,
             },
@@ -429,10 +429,10 @@ class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
         )
 
     def _update_single_zone(self, record: dict[str, Any], params: _AssetScaleParams) -> bool:
-        """Update one zone's vertices via the API; return True on success."""
+        """Update one zone's vertices via the API. Return True on success."""
         vertices = record.get("vertices", [])  # WHY: zone shape is a vertex list.
         if not vertices:  # WHY: empty polygon has nothing to scale.
-            return True  # WHY: count as success; nothing changed but nothing failed either.
+            return True  # WHY: count as success. Nothing changed but nothing failed either.
         scaled_vertices = [  # WHY: element-wise multiply on x/y.
             {"x": v.get("x", 0) * params.scale_x, "y": v.get("y", 0) * params.scale_y} for v in vertices
         ]
@@ -454,7 +454,7 @@ class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
         )
 
     def _update_single_beacon(self, record: dict[str, Any], params: _AssetScaleParams) -> bool:
-        """Update one physical beacon's x/y via the API; return True on success."""
+        """Update one physical beacon's x/y via the API. Return True on success."""
         resp = mistapi.api.v1.sites.beacons.updateSiteBeacon(  # WHY: PATCH beacon position.
             self.apisession,
             site_id=params.site_id,
@@ -473,7 +473,7 @@ class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
         )
 
     def _update_single_vbeacon(self, record: dict[str, Any], params: _AssetScaleParams) -> bool:
-        """Update one virtual beacon's x/y via the API; return True on success."""
+        """Update one virtual beacon's x/y via the API. Return True on success."""
         resp = mistapi.api.v1.sites.vbeacons.updateSiteVBeacon(  # WHY: PATCH vbeacon position.
             self.apisession,
             site_id=params.site_id,
@@ -682,7 +682,7 @@ class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
         return self._prompt_continue_without_backup()  # WHY: handles yes/no + EOF in one place.
 
     def _prompt_continue_without_backup(self) -> str | None:
-        """Ask the user to continue without a verified backup; return empty on yes else None."""
+        """Ask the user to continue without a verified backup. Return empty on yes else None."""
         try:
             proceed = (
                 InputUtils.safe_input(  # WHY: EOF/CTRL-C safe prompt.
@@ -810,7 +810,7 @@ class _MapsWizard:  # WHY: wrapper class hosting extracted wizard flow methods.
         print(f"    ! Failed to update map: HTTP {resp.status_code}")  # WHY: user-visible failure.
 
     def _apply_image_upload(self, target: _ImageUploadTarget, errors: list[Any]) -> None:
-        """Upload the new floor-plan image; record any failure in ``errors``."""
+        """Upload the new floor-plan image. Record any failure in ``errors``."""
         print("  Uploading new image...")  # WHY: sub-step label.
         try:
             resp = mistapi.api.v1.sites.maps.addSiteMapImageFile(  # WHY: multipart image upload.

--- a/src/maps/_plotly_viewer.py
+++ b/src/maps/_plotly_viewer.py
@@ -2,7 +2,7 @@
 
 Split out of ``src/maps/maps_manager.py`` so the ~2000 LOC plotly/dash
 viewer cluster lives in a dedicated module. The extracted code stays
-as methods on a small wrapper class :class:`_PlotlyViewer`; a magic
+as methods on a small wrapper class :class:`_PlotlyViewer`. A magic
 ``__getattr__`` fallback delegates any attribute the plotly cluster
 does not define directly (``apisession``, ``org_id``, non-plotly helper
 methods) to the wrapped MapsManager, so the extraction diff stays tiny.
@@ -60,7 +60,7 @@ else:
 
 # Dash symbols placeholders -- real modules imported lazily in the
 # ``_try_import_dash_modules`` helper (matches original MapsManager
-# behavior; keeps import cost off the hot path).
+# behavior. Keeps import cost off the hot path).
 Dash = None  # WHY: Lazy Dash sentinel replaced after successful runtime import.
 html = None  # WHY: Lazy dash.html sentinel replaced during runtime import.
 dcc = None  # WHY: Lazy dash.dcc sentinel replaced during runtime import.
@@ -76,7 +76,7 @@ except ImportError:  # WHY: Provide silent progress fallback when tqdm is not in
 
     def tqdm(iterable, **_kwargs):  # WHY: Iterable pass-through keeps caller code identical.
         """No-op fallback for tqdm progress bar."""
-        return iterable  # WHY: Yield the input unchanged; caller relies on iterator semantics.
+        return iterable  # WHY: Yield the input unchanged. Caller relies on iterator semantics.
 
 
 class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer methods.
@@ -388,7 +388,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
                 continue  # WHY: Cannot place beacon without coordinates.
             ble_x.append(x)  # WHY: Store valid x coordinate.
             ble_y.append(y)  # WHY: Store valid y coordinate.
-            name = beacon.get("name", beacon.get("mac", "Unnamed"))  # WHY: Prefer name; fall back to MAC.
+            name = beacon.get("name", beacon.get("mac", "Unnamed"))  # WHY: Prefer name. Fall back to MAC.
             ble_names.append(name)  # WHY: Store name for annotation.
             hover = f"<b>BLE Beacon: {name}</b><br>"  # WHY: Bold header for hover tooltip.
             hover += f"MAC: {beacon.get('mac', 'N/A')}<br>"  # WHY: Hardware MAC address.
@@ -458,7 +458,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
         self._add_ble_label_annotations(fig, ble_x, ble_y, ble_names)  # WHY: Per-beacon text labels.
         logger.info("Added %d BLE beacons to map", len(ble_x))  # WHY: Log final count.
 
-    def _launch_plotly_viewer(  # WHY: Public entry point; delegates to extracted ViewerLauncher.
+    def _launch_plotly_viewer(  # WHY: Public entry point. Delegates to extracted ViewerLauncher.
         self,
         scope: MapViewerScope,  # WHY: Site/map identity bundle for the viewer session.
         data: MapViewerData,  # WHY: Map/devices/zones/clients payload for the figure.
@@ -484,7 +484,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
     @staticmethod
     def _resolve_coverage_count(coverage_data: dict | None) -> int:  # WHY: Safe grid-result count.
         """Return the number of grid results in ``coverage_data`` (0 if missing)."""
-        if not coverage_data:  # Original used a ternary; explicit guard preserves behavior
+        if not coverage_data:  # Original used a ternary. Explicit guard preserves behavior
             return 0  # WHY: No coverage payload means zero grid results.
         return len(coverage_data.get("results", []))  # WHY: Count of grid samples.
 
@@ -499,20 +499,20 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
         )  # WHY: None-safe defaults.
 
     def _try_import_dash_modules(self, map_data: dict, devices: list) -> tuple | None:  # WHY: Import Dash or fall back.
-        """Import dash + companions; on ImportError run the static fallback and return ``None``."""
+        """Import dash + companions. On ImportError run the static fallback and return ``None``."""
         logger.info("_try_import_dash_modules: attempting to import dash")  # Trace start
         try:
             logger.debug("Importing Dash modules for interactive viewer")  # WHY: Mirror original log.
-            import dash  # WHY: Heavy module; local import keeps top-of-file imports minimal.
+            import dash  # WHY: Heavy module. Local import keeps top-of-file imports minimal.
             from dash import Dash, Input, Output, State, dcc, html, no_update  # WHY: Names used in layout/callbacks.
 
             logger.info("Dash version: %s", dash.__version__)  # WHY: Record actual Dash version at launch.
             return dash, Dash, Input, Output, State, dcc, html, no_update  # WHY: Return full Dash symbol tuple.
         except ImportError as e:  # WHY: Fallback path (mirrors original except block).
             logger.exception("Failed to import Dash, falling back to static view: %s", e)  # WHY: Surface import fail.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Dash not available - using static Plotly view only")
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Install with: pip install dash")
             self._create_static_plotly_map(map_data, devices)  # WHY: Render static figure instead.
             return None  # WHY: Signal to caller that Dash is unavailable.
@@ -520,33 +520,33 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
     @staticmethod
     def _print_viewer_intro_banner() -> None:  # WHY: Print operator-facing launch banner.
         """Print the user-facing 'LAUNCHING INTERACTIVE MAP VIEWER' banner (no decisions)."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-" * 80)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("LAUNCHING INTERACTIVE MAP VIEWER")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-" * 80)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Opening web browser with interactive map...")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Features:")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("!   - Toggle layers (walls, zones, wayfinding, devices, clients)")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("!   - Live data refresh (clients update every 30s, RF every 5min)")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("!   - Ruler tool - Draw lines to measure distances")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("!   - Connected client visualization (green dots)")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("!   - Click devices/clients to see details")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("!   - Drag devices to new positions (future: save to cloud)")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("!   - Pan and zoom")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Press Ctrl+C in terminal to stop server")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-" * 80)
 
     @staticmethod
@@ -572,7 +572,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
     def _categorize_devices_by_type(devices: list[dict]) -> dict[str, list[dict]]:
         """Bucket devices by type filtered to those with both x and y coordinates."""
         buckets: dict[str, list[dict]] = {"ap": [], "switch": [], "gateway": []}  # Mirror original keys
-        for device in devices:  # One pass; ignores devices without coords or unknown type
+        for device in devices:  # One pass. Ignores devices without coords or unknown type
             device_type = device.get("type", "unknown")
             if device_type not in buckets:  # Skip unknown device types
                 continue
@@ -728,7 +728,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
 
     @staticmethod
     def _add_origin_marker_trace(fig: object, map_data: dict, go: object) -> None:
-        """Add the map-origin marker trace (hidden by default; mirrors original)."""
+        """Add the map-origin marker trace (hidden by default. Mirrors original)."""
         origin = map_data.get("origin") or {}  # Drop ``or {}`` BoolOp from parent
         origin_x = origin.get("x", 0)
         origin_y = origin.get("y", 0)
@@ -862,23 +862,23 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
     @staticmethod
     def _print_dash_startup_banner(dash_host: str, dash_port: int) -> None:
         """Print the user-facing 'Starting Dash server...' banner."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nStarting Dash server...")
         if is_running_in_container():  # Container-specific lines
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("! Map viewer available at http://<container-ip>:%s", dash_port)
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("! Access from host: http://localhost:%s (if port is mapped)", dash_port)
         else:
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("! Map viewer will open in your default browser")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Press Ctrl+C to stop the server\n")
         logger.info("Starting Dash server on http://%s:%s", dash_host, dash_port)  # Mirror original log
 
     def _schedule_browser_open(self, dash_port: int) -> None:
         """Start a daemon thread that opens the browser shortly after server boots (skip in container)."""
-        if is_running_in_container():  # No display in container; skip browser
+        if is_running_in_container():  # No display in container. Skip browser
             return
 
         threading.Thread(  # Background thread -> _open_browser_after_delay
@@ -899,12 +899,12 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
                 threaded=True,
             )
         except KeyboardInterrupt:  # Mirror original user-cancel path
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n\nMap viewer stopped by user")
             logger.info("Interactive map viewer stopped by user (Ctrl+C)")
         except Exception as e:  # Mirror original catch-all
             logger.exception("Error running Dash server: %s", e)
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("\n! Error running map viewer: %s", e)
 
     @staticmethod
@@ -980,9 +980,9 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
         temp_html = os.path.join(tempfile.gettempdir(), f"mist_map_{map_id}.html")  # WHY: OS-appropriate temp path.
         logger.debug("Saving static map to: %s", temp_html)  # WHY: Debug the resolved path.
         fig.write_html(temp_html)  # WHY: Serialise the figure to a self-contained HTML file.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n! Map saved to: %s", temp_html)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("! Opening in browser...")
         logger.info("Static HTML map created: %s", temp_html)  # WHY: Record for audit.
         webbrowser.open(f"file://{temp_html}")  # WHY: Trigger the OS browser handler.
@@ -992,7 +992,7 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
         """Create static Plotly HTML map when Dash is not available."""
         import plotly.graph_objects as go  # WHY: Only import when this path is taken.
 
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n! Creating static HTML map...")
         fig = go.Figure()  # WHY: Fresh figure receives all traces + layout.
         map_width = map_data.get("width", 1000)  # WHY: Fallback width in pixels.

--- a/src/maps/_viewer_launch.py
+++ b/src/maps/_viewer_launch.py
@@ -522,7 +522,7 @@ def _figure_layout_kwargs(  # WHY: Kwargs bundle extracted from _apply_figure_la
         plot_bgcolor="#1a1a1a",  # WHY: Dark plot surface.
         paper_bgcolor="#1a1a1a",  # WHY: Dark paper surface.
         margin=dict(l=50, r=50, t=80, b=50),  # WHY: Even padding around plot.
-        dragmode="zoom",  # WHY: Default to pan/zoom; drawing tools toggle this.
+        dragmode="zoom",  # WHY: Default to pan/zoom. Drawing tools toggle this.
         newshape=_figure_layout_newshape(),  # WHY: Extracted drawing outline defaults.
         meta=_figure_layout_meta(data, ppm),  # WHY: Extracted meta dict.
     )
@@ -587,7 +587,7 @@ def _build_site_dropdown(html_mod: Any, dcc_mod: Any, site_id: str, options: lis
                 options=options,  # WHY: Populated list of {label, value} entries.
                 value=site_id,  # WHY: Pre-select current site.
                 clearable=False,
-                searchable=True,  # WHY: Force a value; allow keyboard filter.
+                searchable=True,  # WHY: Force a value. Allow keyboard filter.
                 style={"width": "250px", "display": "inline-block", "verticalAlign": "middle"},  # WHY: Row layout.
                 className="dark-dropdown",  # WHY: Custom CSS for dark theme.
             ),
@@ -606,7 +606,7 @@ def _build_map_dropdown(html_mod: Any, dcc_mod: Any, map_id: str, options: list[
                 options=options,  # WHY: Populated list of {label, value} entries.
                 value=map_id,  # WHY: Pre-select current map.
                 clearable=False,
-                searchable=False,  # WHY: Force a value; small list so no search needed.
+                searchable=False,  # WHY: Force a value. Small list so no search needed.
                 style={"width": "200px", "display": "inline-block", "verticalAlign": "middle"},  # WHY: Row layout.
                 className="dark-dropdown",  # WHY: Custom CSS for dark theme.
             ),
@@ -756,7 +756,7 @@ def _build_clone_panel(html_mod: Any, dcc_mod: Any, map_data: dict[str, Any]) ->
         ],
         style={
             "display": "none",
-            "padding": "12px 20px",  # WHY: Hidden by default; padded when shown.
+            "padding": "12px 20px",  # WHY: Hidden by default. Padded when shown.
             "backgroundColor": "#1a1a1a",
             "borderBottom": "1px solid #00ff88",
         },

--- a/src/maps/launcher/_viewer_clone.py
+++ b/src/maps/launcher/_viewer_clone.py
@@ -63,7 +63,7 @@ def _error_response(message: str) -> tuple[Any, Any]:  # WHY: (span, no_update) 
 
 
 def _safe_unlink(path: str | None) -> None:  # WHY: dedup temp-file cleanup across three call sites
-    """Remove ``path`` if it exists; silently ignore missing files."""
+    """Remove ``path`` if it exists. Silently ignore missing files."""
     if path and os.path.exists(path):  # WHY: guard against None and stale paths
         os.remove(path)  # WHY: drop temp file to avoid disk-space leakage
 
@@ -82,7 +82,7 @@ def _create_temp_image_path(image_url: str) -> str:  # WHY: encapsulate temp-fil
     """Create an empty temp file with an extension inferred from ``image_url``."""
     file_ext = _infer_image_extension(image_url)  # WHY: pick correct suffix
     temp_fd, image_temp_path = tempfile.mkstemp(suffix=file_ext)  # WHY: allocate a unique temp path
-    os.close(temp_fd)  # WHY: close fd; caller will reopen the path for writing
+    os.close(temp_fd)  # WHY: close fd. Caller will reopen the path for writing
     return image_temp_path  # WHY: hand back only the path to the caller
 
 
@@ -106,7 +106,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy for shared state access
         """Delegate unknown attributes to the wrapped parent manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly
         return getattr(mm, name)  # WHY: forward all other attributes to parent
 
@@ -138,7 +138,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
         config: dict[str, Any],  # WHY: config store for backup metadata
         current_trigger: int,  # WHY: current cache-bust counter
     ) -> tuple[Any, Any]:
-        """Run the clone workflow under a broad-except guard; return callback tuple."""
+        """Run the clone workflow under a broad-except guard. Return callback tuple."""
         try:
             self._backup_before_clone(site_id, source_map_id, config)  # WHY: safety net
             source_map = self._fetch_source_map(site_id, source_map_id)  # WHY: step 1 fetch
@@ -196,7 +196,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
             logging.info("Pre-clone backup saved: %s", backup_path)  # WHY: path for operator recovery
 
     def _fetch_source_map(self, site_id: str, source_map_id: str) -> dict[str, Any] | None:
-        """Fetch the source map record from Mist; return None on failure."""
+        """Fetch the source map record from Mist. Return None on failure."""
         logging.info("Fetching source map %s for clone", source_map_id)  # WHY: audit start
         source_response = self._state.mistapi_ref.api.v1.sites.maps.getSiteMap(  # WHY: Mist API read
             self._state.api_session_ref, site_id=site_id, map_id=source_map_id
@@ -245,7 +245,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
 
     @staticmethod
     def _download_source_image(source_map: dict[str, Any]) -> str | None:
-        """Download the source map image to a temp file; return path or None on any failure."""
+        """Download the source map image to a temp file. Return path or None on any failure."""
         if "url" not in source_map:  # WHY: no image to download
             return None  # WHY: signal absence to callers
         image_url = source_map["url"]  # WHY: URL of the source map image
@@ -271,7 +271,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
         clone_payload: dict[str, Any],  # WHY: payload prepared by _build_clone_payload
         image_temp_path: str | None,  # WHY: temp file cleaned up on failure
     ) -> str | None:
-        """Call createSiteMap; clean up temp image on failure; return new map_id or None."""
+        """Call createSiteMap. Clean up temp image on failure. Return new map_id or None."""
         logging.info("Creating cloned map '%s' at site %s", clone_payload.get("name"), site_id)  # WHY: audit
         clone_response = self._state.mistapi_ref.api.v1.sites.maps.createSiteMap(  # WHY: Mist API write
             self._state.api_session_ref, site_id=site_id, body=clone_payload
@@ -287,7 +287,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
         return cloned_map_id  # WHY: hand ID to caller
 
     def _upload_clone_image(self, site_id: str, cloned_map_id: str, image_temp_path: str | None) -> bool:
-        """Upload the temp image to the cloned map; always remove temp file on exit."""
+        """Upload the temp image to the cloned map. Always remove temp file on exit."""
         if not image_temp_path or not os.path.exists(image_temp_path):  # WHY: nothing to upload
             return False  # WHY: signal skipped upload
         try:
@@ -296,7 +296,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
             _safe_unlink(image_temp_path)  # WHY: always clean up temp file
 
     def _do_image_upload(self, site_id: str, cloned_map_id: str, image_temp_path: str) -> bool:
-        """Invoke Mist ``addSiteMapImageFile`` and log outcome; return True on success."""
+        """Invoke Mist ``addSiteMapImageFile`` and log outcome. Return True on success."""
         try:
             logging.info("Uploading image to cloned map %s", cloned_map_id)  # WHY: audit start
             upload_response = self._state.mistapi_ref.api.v1.sites.maps.addSiteMapImageFile(  # WHY: Mist write
@@ -318,7 +318,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
             return False  # WHY: never raise past callback boundary
 
     def _clone_zones_for_map(self, site_id: str, source_map_id: str, cloned_map_id: str) -> int:
-        """Replicate each zone associated with source_map_id under cloned_map_id; return count cloned."""
+        """Replicate each zone associated with source_map_id under cloned_map_id. Return count cloned."""
         try:
             source_zones = self._fetch_source_zones(site_id, source_map_id)  # WHY: filtered zone list
         except Exception as zone_err:  # noqa: BLE001 - preserve original broad-except behavior
@@ -342,7 +342,7 @@ class _ViewerClone:  # WHY: wrapper class hosting the clone-map callback cluster
         return source_zones  # WHY: hand filtered list to caller
 
     def _clone_single_zone(self, site_id: str, cloned_map_id: str, zone: dict[str, Any]) -> bool:
-        """Create one zone under cloned_map_id; return True on success."""
+        """Create one zone under cloned_map_id. Return True on success."""
         try:
             zone_payload = self._build_zone_payload(cloned_map_id, zone)  # WHY: shape the create payload
             zone_response = self._state.mistapi_ref.api.v1.sites.zones.createSiteZone(  # WHY: Mist write

--- a/src/maps/launcher/_viewer_drawing.py
+++ b/src/maps/launcher/_viewer_drawing.py
@@ -75,7 +75,7 @@ class _ViewerDrawing:  # WHY: wrapper class hosting the drawing-tools callback c
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy for shared state access
         """Delegate unknown attributes to the wrapped parent manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly
         return getattr(mm, name)  # WHY: forward all other attributes to parent
 
@@ -552,7 +552,7 @@ class _ViewerDrawing:  # WHY: wrapper class hosting the drawing-tools callback c
         )
 
     def _delete_zones_one_by_one(self, site_id: str | None, map_zones: list[dict[str, Any]]) -> tuple[int, int]:
-        """Delete each zone individually; return (deleted, failed) counts."""
+        """Delete each zone individually. Return (deleted, failed) counts."""
         deleted_count = 0  # WHY: successful deletes
         failed_count = 0  # WHY: failed deletes (logged but tolerated)
         for zone in map_zones:  # WHY: one DELETE per zone (Mist has no bulk endpoint)

--- a/src/maps/launcher/_viewer_refresh.py
+++ b/src/maps/launcher/_viewer_refresh.py
@@ -124,7 +124,7 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy for shared state access
         """Delegate unknown attributes to the wrapped parent manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly
         return getattr(mm, name)  # WHY: forward all other attributes to parent
 
@@ -177,7 +177,7 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
         return self._run_client_refresh(map_ctx, current_fig, updated_refresh_times)  # WHY: try/except body
 
     def _is_refresh_triggered(self) -> bool:  # WHY: guard body returns bool for caller short-circuit
-        """Return True when Dash reports a callback trigger; audit manual clicks in passing."""
+        """Return True when Dash reports a callback trigger. Audit manual clicks in passing."""
         import dash  # WHY: dash.callback_context only exists at request time
 
         ctx = dash.callback_context  # WHY: Dash exposes trigger info on every callback
@@ -453,7 +453,7 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
     # ------------------------------------------------------------------
 
     def _refresh_zones_silent(self, site_id: str, map_id: str) -> None:
-        """Fetch zones for logging visibility only; swallow errors per original behavior."""
+        """Fetch zones for logging visibility only. Swallow errors per original behavior."""
         try:
             zones_response = self._state.mistapi_ref.api.v1.sites.zones.listSiteZones(  # WHY: API call
                 self._state.api_session_ref, site_id=site_id
@@ -472,7 +472,7 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
         logging.info("Live data refresh: Found %s zones on map", len(zones_on_map))  # WHY: audit
 
     def _refresh_walls_silent(self, site_id: str, map_id: str, current_fig: dict[str, Any]) -> None:
-        """Fetch map walls for logging visibility only; swallow errors per original behavior."""
+        """Fetch map walls for logging visibility only. Swallow errors per original behavior."""
         try:
             map_response = self._state.mistapi_ref.api.v1.sites.maps.getSiteMap(  # WHY: API call
                 self._state.api_session_ref, site_id=site_id, map_id=map_id
@@ -561,7 +561,7 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
         layer_values: list[str] | None,
         updated_refresh_times: dict[str, float],
     ) -> tuple[Any, Any]:
-        """Execute coverage fetch + grid projection + trace mutation; broad-except audits."""
+        """Execute coverage fetch + grid projection + trace mutation. Broad-except audits."""
         from dash import no_update  # WHY: local import for the no_update sentinel
 
         try:
@@ -592,7 +592,7 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
     # ------------------------------------------------------------------
 
     def _fetch_coverage_results(self, site_id: str, map_id: str) -> tuple[list[Any], list[str]] | None:
-        """Call the coverage endpoint and validate the payload; return (results, result_def) or None."""
+        """Call the coverage endpoint and validate the payload. Return (results, result_def) or None."""
         logging.info(  # WHY: preserve original audit log
             "Live data refresh: Fetching RF coverage data for map %s (site: %s)", map_id, site_id
         )
@@ -657,7 +657,7 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
             return result_def.index("max_rssi")
         if "avg_rssi" in result_def:  # WHY: fall back to avg_rssi
             return result_def.index("avg_rssi")
-        return -1  # WHY: no usable RSSI column; caller handles the sentinel
+        return -1  # WHY: no usable RSSI column. Caller handles the sentinel
 
     @staticmethod
     def _aggregate_grid_cells(
@@ -710,7 +710,7 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
 
     @staticmethod
     def _compute_rssi_bounds(grid_data: dict[tuple[float, float], float]) -> tuple[float, float]:
-        """Compute (min, max) RSSI for the heatmap color scale; defaults preserve original behavior."""
+        """Compute (min, max) RSSI for the heatmap color scale. Defaults preserve original behavior."""
         all_rssi = [v for v in grid_data.values() if v is not None]  # WHY: non-null samples only
         if not all_rssi:  # WHY: empty grid => use the original defaults
             return _DEFAULT_RSSI_MIN, _DEFAULT_RSSI_MAX
@@ -718,9 +718,9 @@ class _ViewerRefresh:  # WHY: wrapper class hosting the live-refresh callback cl
 
     @classmethod
     def _build_coverage_grid(cls, results: list[Any], result_def: list[str], ppm_local: float) -> _CoverageGrid | None:
-        """Translate the coverage results into a heatmap-ready grid; return None when unusable."""
+        """Translate the coverage results into a heatmap-ready grid. Return None when unusable."""
         indices = cls._extract_coverage_indices(result_def)  # WHY: resolve column indices
-        if indices is None:  # WHY: missing required columns; already logged
+        if indices is None:  # WHY: missing required columns. Already logged
             return None
         x_idx, y_idx, rssi_idx = indices  # WHY: unpack index triple
         grid_data = cls._aggregate_grid_cells(results, x_idx, y_idx, rssi_idx)  # WHY: rows -> cells

--- a/src/maps/launcher/_viewer_site_switch.py
+++ b/src/maps/launcher/_viewer_site_switch.py
@@ -56,7 +56,7 @@ class _ViewerSiteSwitch:  # WHY: wrapper class hosting the site-switch callback 
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy for shared state access
         """Delegate unknown attributes to the wrapped parent manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly
         return getattr(mm, name)  # WHY: forward all other attributes to parent
 
@@ -373,7 +373,7 @@ class _ViewerSiteSwitch:  # WHY: wrapper class hosting the site-switch callback 
     def _preflight_site_switch(  # WHY: extracted guard chain so callback has CC ≤5
         self, selected_site_id: str | None, config: dict[str, Any] | None
     ) -> bool:
-        """Return True if a site switch should proceed; log + return False otherwise."""
+        """Return True if a site switch should proceed. Log + return False otherwise."""
         if not selected_site_id:  # WHY: guard missing input
             logging.warning("[SITE-SWITCH] No selected_site_id provided")  # WHY: mirror original log
             return False  # WHY: caller should skip
@@ -408,7 +408,7 @@ class _ViewerSiteSwitch:  # WHY: wrapper class hosting the site-switch callback 
         return self._build_first_map_payload(selected_site_id, site_name, new_maps, config)  # WHY: pick first map
 
     def _fetch_site_maps(self, site_id: str) -> list[dict[str, Any]] | None:  # WHY: HTTP guard + normalize empty
-        """Fetch site map list; return ``None`` on API failure, ``[]`` on empty."""
+        """Fetch site map list. Return ``None`` on API failure, ``[]`` on empty."""
         maps_response = self._state.mistapi_ref.api.v1.sites.maps.listSiteMaps(  # WHY: Mist API call
             self._state.api_session_ref, site_id=site_id
         )
@@ -531,7 +531,7 @@ class _ViewerSiteSwitch:  # WHY: wrapper class hosting the site-switch callback 
             xref="x",
             yref="y",
             x=0,
-            y=map_height if anchor_top else 0,  # WHY: site-switch used map_height; URL-switch used 0
+            y=map_height if anchor_top else 0,  # WHY: site-switch used map_height. URL-switch used 0
             sizex=map_width,
             sizey=map_height,
             sizing="stretch",

--- a/src/maps/launcher/_viewer_ui.py
+++ b/src/maps/launcher/_viewer_ui.py
@@ -273,7 +273,7 @@ class _ViewerUI:  # WHY: wrapper class hosting the UI-toggle callback cluster
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy for shared state access
         """Delegate unknown attributes to the wrapped parent manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly
         return getattr(mm, name)  # WHY: forward all other attributes to parent
 
@@ -541,7 +541,7 @@ class _ViewerUI:  # WHY: wrapper class hosting the UI-toggle callback cluster
         return self._render_delete_result(delete_response, resolved.map_name, resolved.map_id, current_trigger)
 
     def _backup_before_delete(self, site_id: str | None, map_id: str | None, map_name: str) -> Any:
-        """Run pre-delete backup and log the outcome; return backup path or None."""
+        """Run pre-delete backup and log the outcome. Return backup path or None."""
         logging.info("Creating safety backup before deleting map '%s'", map_name)  # WHY: audit trail
         backup_path = self._state.maps_manager_ref._backup_map_geometry(  # WHY: MapsManager helper
             api_session=self._state.api_session_ref,

--- a/src/maps/launcher/_viewer_url_switch.py
+++ b/src/maps/launcher/_viewer_url_switch.py
@@ -270,7 +270,7 @@ class _ViewerUrlSwitch:  # WHY: wrapper class hosting the URL-switch callback cl
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy for shared state access
         """Delegate unknown attributes to the wrapped parent manager."""
         mm = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if mm is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if mm is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly
         return getattr(mm, name)  # WHY: forward all other attributes to parent
 
@@ -282,9 +282,9 @@ class _ViewerUrlSwitch:  # WHY: wrapper class hosting the URL-switch callback cl
         self,
         url_search: str | None,  # WHY: URL query string carrying map_id
         config: dict[str, Any] | None,  # WHY: current map-config store contents
-        _current_fig: dict[str, Any],  # WHY: prev figure (unused; kept for callback signature)
+        _current_fig: dict[str, Any],  # WHY: prev figure (unused. Kept for callback signature)
         available_maps: list[dict[str, Any]] | None,  # WHY: cached map allow-list
-        _dropdown_value: str | None,  # WHY: current dropdown (unused; kept for signature)
+        _dropdown_value: str | None,  # WHY: current dropdown (unused. Kept for signature)
     ) -> tuple[Any, Any]:
         """Handle map switching when URL contains map_id parameter."""
         from dash import no_update  # WHY: sentinel used to skip output updates
@@ -305,7 +305,7 @@ class _ViewerUrlSwitch:  # WHY: wrapper class hosting the URL-switch callback cl
         config: dict[str, Any] | None,  # WHY: nullable config store
         available_maps: list[dict[str, Any]] | None,  # WHY: nullable map allow-list
     ) -> tuple[str, str, dict[str, Any]] | None:
-        """Run all URL-switch preflight guards; return ``(url_map_id, site_id, config)`` or ``None``."""
+        """Run all URL-switch preflight guards. Return ``(url_map_id, site_id, config)`` or ``None``."""
         url_map_id = self._extract_url_map_id(url_search)  # WHY: parse map_id from URL
         if url_map_id is None:  # WHY: missing param -> abort
             return None  # WHY: guard failure signals no-update
@@ -369,7 +369,7 @@ class _ViewerUrlSwitch:  # WHY: wrapper class hosting the URL-switch callback cl
         return [m.get("id") for m in available_maps]  # WHY: store fallback on any failure
 
     def _try_fetch_fresh_map_ids(self, site_id_local: str) -> list[str | None] | None:  # WHY: isolate try/except
-        """Attempt a fresh listSiteMaps call; return ``None`` on any failure to signal fallback."""
+        """Attempt a fresh listSiteMaps call. Return ``None`` on any failure to signal fallback."""
         try:
             fresh_response = self._state.mistapi_ref.api.v1.sites.maps.listSiteMaps(  # WHY: call fresh listing
                 self._state.api_session_ref, site_id=site_id_local
@@ -776,7 +776,7 @@ class _ViewerUrlSwitch:  # WHY: wrapper class hosting the URL-switch callback cl
         ppm_local: float,  # WHY: pixels-per-meter for heatmap scaling
         config: dict[str, Any],  # WHY: config store may override site_id
     ) -> None:
-        """Fetch RF coverage and add a heatmap trace; silently logs on failure."""
+        """Fetch RF coverage and add a heatmap trace. Silently logs on failure."""
         site_id_for_coverage = config.get("site_id") or site_id_local  # WHY: mirror original site_id source
         if not site_id_for_coverage:  # WHY: mirror original guard
             logging.warning("URL map switch: Cannot fetch RF coverage - site_id is None")
@@ -790,7 +790,7 @@ class _ViewerUrlSwitch:  # WHY: wrapper class hosting the URL-switch callback cl
             logging.warning("URL map switch: Could not load RF coverage - %s", rf_error, exc_info=True)
 
     def _fetch_url_switch_coverage(self, url_map_id: str, site_id_for_coverage: str) -> dict[str, Any] | None:
-        """Hit the RF coverage endpoint; return parsed data or None on failure/error envelope."""
+        """Hit the RF coverage endpoint. Return parsed data or None on failure/error envelope."""
         coverage_url = f"/api/v1/sites/{site_id_for_coverage}/location/coverage"  # WHY: mirror original path
         coverage_params = dict(_COVERAGE_QUERY_PARAMS, map_id=url_map_id)  # WHY: add map_id to shared params
         logging.info("URL map switch: Fetching RF coverage for map %s", url_map_id)

--- a/src/maps/launcher/viewer_callbacks.py
+++ b/src/maps/launcher/viewer_callbacks.py
@@ -19,7 +19,7 @@ naturally or by delegating to private ``_handle_*`` helpers.
 
 To add a callback in a later wave:
 
-1. Implement the method on this class (keep CC <= 10; extract
+1. Implement the method on this class (keep CC <= 10. Extract
    ``_handle_*`` helpers when complexity demands it).
 2. Add any new closure dependencies as fields on
    :class:`src.maps.launcher.viewer_state.MapViewerState`.

--- a/src/maps/launcher/viewer_state.py
+++ b/src/maps/launcher/viewer_state.py
@@ -28,13 +28,13 @@ Conventions for adding state fields:
    can trace ``self._state.foo`` back to the original ``foo`` local.
 2. Prefer immutable types (str, int, tuple) for read-only context and
    mutable list/dict only when a callback needs to update shared data.
-3. Type-annotate every field; use ``TYPE_CHECKING`` imports for heavy
+3. Type-annotate every field. Use ``TYPE_CHECKING`` imports for heavy
    modules (``mistapi``, ``Dash``) to keep import cost low.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field  # Container types; field used for mutable defaults
+from dataclasses import dataclass, field  # Container types. Field used for mutable defaults
 from typing import TYPE_CHECKING, Any  # Type guards + Any for mistapi/manager references
 
 if TYPE_CHECKING:  # pragma: no cover - imports for static analysis only
@@ -57,18 +57,18 @@ class MapViewerState:
         Site zone records (from ``listSiteZones``) used by zone toggle
         and zone-action callbacks to resolve zone names to IDs.
     map_id:
-        Current map UUID; used for logging context in panel-toggle and
+        Current map UUID. Used for logging context in panel-toggle and
         utility callbacks and as a fallback when the config store is
         missing.
     site_id:
-        Current site UUID; used by delete and zone-action callbacks as
+        Current site UUID. Used by delete and zone-action callbacks as
         the ``site_id`` parameter to Mist API delete calls and as a
         fallback when the config store is missing.
     api_session_ref:
         Live ``mistapi.APISession`` instance used by callbacks that
         invoke Mist API mutations (delete map, delete zone, and so on).
     ppm:
-        Pixels-per-meter scale value; used by ``update_shape_labels``
+        Pixels-per-meter scale value. Used by ``update_shape_labels``
         as the fallback when the figure metadata lacks an override.
     mistapi_ref:
         Reference to the ``mistapi`` module itself so callbacks can

--- a/src/maps/maps_manager.py
+++ b/src/maps/maps_manager.py
@@ -83,9 +83,9 @@ else:
 
 # Dash symbols (Input, Output, State, and so on) are imported locally
 # in methods that need them, since they require dash to be installed.
-Dash = None  # Placeholder; real Dash class imported lazily inside launcher methods.
-html = None  # Placeholder for dash.html; imported lazily where needed.
-dcc = None  # Placeholder for dash.dcc; imported lazily where needed.
+Dash = None  # Placeholder. Real Dash class imported lazily inside launcher methods.
+html = None  # Placeholder for dash.html. Imported lazily where needed.
+dcc = None  # Placeholder for dash.dcc. Imported lazily where needed.
 
 try:
     import requests  # Used to download map images from Mist-signed URLs.
@@ -103,7 +103,7 @@ except ImportError:  # WHY: handle expected error
 
 # Mist API import
 try:
-    import mistapi  # type: ignore[import-untyped]  # Optional dependency; required for real API calls.
+    import mistapi  # type: ignore[import-untyped]  # Optional dependency. Required for real API calls.
 except ImportError:  # WHY: handle expected error
     mistapi = None  # type: ignore[assignment]  # Sentinel so tests can run without the SDK.
 
@@ -117,7 +117,7 @@ logger = logging.getLogger(__name__)  # Module-scoped logger for MapsManager ope
 # Page limit configuration
 try:
     _raw_page_limit_env = os.environ.get("MIST_PAGE_LIMIT", "1000").strip()  # Read override from env, default "1000".
-    _parsed_limit = int(_raw_page_limit_env)  # Parse to int; may raise ValueError caught below.
+    _parsed_limit = int(_raw_page_limit_env)  # Parse to int. May raise ValueError caught below.
 except Exception:  # WHY: handle expected error
     _parsed_limit = 1000  # Fall back to safe default on any parse failure.
 
@@ -181,7 +181,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _match_site_by_name(
         sites_sorted: list, selection: str
     ) -> "dict | None":  # WHY: declare private helper _match_site_by_name
-        """Substring-match against site names; None if no unique hit."""
+        """Substring-match against site names. None if no unique hit."""
         matches = [s for s in sites_sorted if selection.lower() in s.get("name", "").lower()]  # WHY: compute matches
         if len(matches) == 1:  # WHY: branch on condition
             return matches[0]  # WHY: return computed result
@@ -456,7 +456,7 @@ class MapsManager:  # WHY: declare MapsManager class
         self._print_menu_bulk_and_analytics_section()  # WHY: advance computation
 
     def _read_menu_choice(self) -> "str | None":  # WHY: declare private helper _read_menu_choice
-        """Prompt for a menu selection; return None on EOF."""
+        """Prompt for a menu selection. Return None on EOF."""
         try:
             return (  # WHY: return computed result
                 InputUtils.safe_input("\nEnter your selection number now: ", context="run_interactive_menu")
@@ -478,7 +478,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _dispatch_menu_choice(
         self, choice: "str | None", dispatch: dict
     ) -> bool:  # WHY: declare private helper _dispatch_menu_choice
-        """Handle one menu choice; return True to keep looping, False to exit."""
+        """Handle one menu choice. Return True to keep looping, False to exit."""
         if choice is None or choice == "0":  # Sentinel or explicit quit
             if choice == "0":  # Only log the deliberate exit
                 logging.info("Exiting Maps Manager")  # Note the exit reason
@@ -504,7 +504,7 @@ class MapsManager:  # WHY: declare MapsManager class
                 return  # Exit sentinel returned
 
     def _fetch_maps_for_site(self, site_id: str):  # WHY: declare private helper _fetch_maps_for_site
-        """Fetch maps for a site; return list or None on non-200 / error."""
+        """Fetch maps for a site. Return list or None on non-200 / error."""
         try:
             resp = mistapi.api.v1.sites.maps.listSiteMaps(self.apisession, site_id=site_id)  # WHY: compute resp
         except Exception as e:  # WHY: handle expected error
@@ -574,7 +574,7 @@ class MapsManager:  # WHY: declare MapsManager class
         }
 
     def _collect_all_org_map_rows(self, sites: list) -> list:  # WHY: declare private helper _collect_all_org_map_rows
-        """Iterate sites; return the flattened summary rows for every map."""
+        """Iterate sites. Return the flattened summary rows for every map."""
         all_maps: list = []  # WHY: assign computed value
         for site in tqdm(sites, desc="Scanning sites", unit="site"):  # WHY: iterate collection
             try:
@@ -584,7 +584,7 @@ class MapsManager:  # WHY: declare MapsManager class
                 for map_item in resp.data:  # WHY: iterate collection
                     all_maps.append(self._build_org_map_row(site, map_item))  # WHY: advance computation
             except Exception as e:  # WHY: handle expected error
-                # Skip sites whose listSiteMaps failed; keep scanning the rest.
+                # Skip sites whose listSiteMaps failed. Keep scanning the rest.
                 logging.debug("Error fetching maps for site %s: %s", site["id"], e)  # WHY: action-log after operation
                 continue  # WHY: skip to next iteration
         return all_maps  # WHY: return computed result
@@ -682,7 +682,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _fetch_site_maps_safe(
         self, site_id: str, err_context: str
     ) -> list:  # WHY: declare private helper _fetch_site_maps_safe
-        """Fetch maps for a site; swallow + log per-site failures so the outer loop continues."""
+        """Fetch maps for a site. Swallow + log per-site failures so the outer loop continues."""
         try:
             resp = mistapi.api.v1.sites.maps.listSiteMaps(self.apisession, site_id=site_id)  # WHY: compute resp
             if resp.status_code == 200:  # WHY: branch on condition
@@ -694,7 +694,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _collect_flat_map_rows(
         self, sites: list, desc: str
     ) -> list:  # WHY: declare private helper _collect_flat_map_rows
-        """Fetch + flatten every map across sites; progress-bar labelled `desc`."""
+        """Fetch + flatten every map across sites. Progress-bar labelled `desc`."""
         rows: list = []  # WHY: assign computed value
         for site in tqdm(sites, desc=desc, unit="site"):  # WHY: iterate collection
             for map_item in self._fetch_site_maps_safe(site["id"], "exporting maps for"):  # WHY: iterate collection
@@ -939,7 +939,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _fetch_map_detail(
         self, site_id: str, map_id: str
     ) -> dict | None:  # WHY: declare private helper _fetch_map_detail
-        """Fetch a single map detail record; return None and print on failure."""
+        """Fetch a single map detail record. Return None and print on failure."""
         detail_response = mistapi.api.v1.sites.maps.getSiteMap(
             self.apisession, site_id=site_id, map_id=map_id
         )  # API call for map details.
@@ -989,7 +989,7 @@ class MapsManager:  # WHY: declare MapsManager class
             print(f"\n! Error viewing map details: {e}")  # Surface error to the operator.
 
     def _prompt_map_name(self) -> str | None:  # WHY: declare private helper _prompt_map_name
-        """Prompt user for a map name; return None if empty or EOF."""
+        """Prompt user for a map name. Return None if empty or EOF."""
         try:
             map_name = InputUtils.safe_input(
                 "Enter map name: ", context="_prompt_map_name"
@@ -1017,7 +1017,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _prompt_image_dimensions(
         self,
     ) -> tuple[int, int, float]:  # WHY: declare private helper _prompt_image_dimensions
-        """Prompt for image map dimensions; return (width, height, ppm) with defaults."""
+        """Prompt for image map dimensions. Return (width, height, ppm) with defaults."""
         width_input = InputUtils.safe_input(  # WHY: compute width_input
             "Enter width in pixels (default=1024): ", context="_prompt_image_dimensions"
         ).strip()
@@ -1146,7 +1146,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _collect_maps_missing_images(
         self, sites: list
     ) -> tuple[list, int]:  # WHY: declare private helper _collect_maps_missing_images
-        """Scan every site's maps; return (rows without url, total scanned)."""
+        """Scan every site's maps. Return (rows without url, total scanned)."""
         rows: list = []  # Accumulated rows across all sites
         total = 0  # Running total of maps scanned
         for site in tqdm(sites, desc="Scanning sites", unit="site"):  # Progress-visible iteration
@@ -1301,7 +1301,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _load_map_for_update(
         self, site_id: str, site_name: str
     ) -> "tuple[str, dict] | None":  # WHY: declare private helper _load_map_for_update
-        """Pick a map and fetch its current state; None if user cancels or fetch fails."""
+        """Pick a map and fetch its current state. None if user cancels or fetch fails."""
         map_id = self._select_map_from_site(site_id, site_name)  # WHY: compute map_id
         if not map_id:  # WHY: guard against missing precondition
             return None  # WHY: return computed result
@@ -1378,7 +1378,7 @@ class MapsManager:  # WHY: declare MapsManager class
 
     @staticmethod
     def _confirm_map_delete(map_id: str) -> bool:  # WHY: declare private helper _confirm_map_delete
-        """Require user to type DELETE in uppercase; True iff they confirmed."""
+        """Require user to type DELETE in uppercase. True iff they confirmed."""
         print("\nType 'DELETE' in uppercase to confirm deletion:")  # WHY: surface user-facing message
         confirmation = InputUtils.safe_input(
             "Confirmation: ", context="delete_site_map"
@@ -1458,7 +1458,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _validate_image_file_path(
         file_path: str,
     ) -> str | None:  # WHY: declare private helper _validate_image_file_path
-        """Validate a filesystem path points at a supported image; return path or None."""
+        """Validate a filesystem path points at a supported image. Return path or None."""
         if not file_path:  # Empty input -> nothing to validate.
             print("\n! No file path provided")  # Report empty input.
             return None  # WHY: return computed result
@@ -1479,7 +1479,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _prompt_and_validate_image_path(
         self,
     ) -> str | None:  # WHY: declare private helper _prompt_and_validate_image_path
-        """Prompt user for image file path and validate it; return path or None if invalid."""
+        """Prompt user for image file path and validate it. Return path or None if invalid."""
         return self._validate_image_file_path(self._read_image_path_input())  # Compose read + validate.
 
     @staticmethod
@@ -1493,7 +1493,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _check_upload_size(
         self, file_path: str
     ) -> tuple[float, bool]:  # WHY: declare private helper _check_upload_size
-        """Compute file size MB and confirm large uploads; return (size_mb, proceed)."""
+        """Compute file size MB and confirm large uploads. Return (size_mb, proceed)."""
         file_size_mb = os.path.getsize(file_path) / (1024 * 1024)  # Bytes to megabytes.
         if file_size_mb <= 10:  # Small file -> no extra confirm needed.
             return file_size_mb, True  # WHY: return computed result
@@ -1508,7 +1508,7 @@ class MapsManager:  # WHY: declare MapsManager class
     ) -> None:  # WHY: declare private helper _perform_image_upload
         """Call the addSiteMapImageFile endpoint and print the outcome."""
         print("\nUploading image...")  # Progress note before HTTP call.
-        with open(file_path, "rb"):  # Ensure file is readable; API takes path itself.
+        with open(file_path, "rb"):  # Ensure file is readable. API takes path itself.
             upload_response = mistapi.api.v1.sites.maps.addSiteMapImageFile(
                 self.apisession, site_id=site_id, map_id=map_id, file=file_path
             )  # Multipart upload of the image asset.
@@ -1577,7 +1577,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _get_devices_on_map(
         self, site_id: str, map_id: str
     ) -> list | None:  # WHY: declare private helper _get_devices_on_map
-        """Fetch all site devices and return those placed on the specified map; None on failure."""
+        """Fetch all site devices and return those placed on the specified map. None on failure."""
         print("\nFetching devices for site...")  # WHY: surface user-facing message
         devices_response = mistapi.api.v1.sites.devices.listSiteDevices(
             self.apisession, site_id=site_id, type="all"
@@ -1702,7 +1702,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _download_all_site_map_images(
         self, site: dict, base_dir: str
     ) -> tuple[int, int]:  # WHY: declare private helper _download_all_site_map_images
-        """Download all map images for a single site; return (downloaded, total_with_images)."""
+        """Download all map images for a single site. Return (downloaded, total_with_images)."""
         site_id = site["id"]  # Site identifier
         site_name = site.get("name", "Unknown")  # Human-friendly folder name
         try:
@@ -1833,7 +1833,7 @@ class MapsManager:  # WHY: declare MapsManager class
 
     @staticmethod
     def _prompt_matplotlib_fallback() -> bool:  # WHY: declare private helper _prompt_matplotlib_fallback
-        """Prompt user to fall back to matplotlib mode; return True if user consented."""
+        """Prompt user to fall back to matplotlib mode. Return True if user consented."""
         confirm = (
             InputUtils.safe_input(
                 "\nWould you like to continue without interactive features? (yes/no): ",
@@ -1934,7 +1934,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _fetch_map_details(
         self, site_id: str, map_id: str
     ) -> "dict | None":  # WHY: declare private helper _fetch_map_details
-        """Fetch map metadata from the API; warn if PPM is unset.
+        """Fetch map metadata from the API. Warn if PPM is unset.
 
         Returns the map data dict on success, or None on API failure.
         """
@@ -2142,7 +2142,7 @@ class MapsManager:  # WHY: declare MapsManager class
     def _load_map_viewer_bundle(
         self, site_id: str, map_id: str
     ) -> tuple[dict, list, list, list, object, list] | None:  # WHY: declare private helper _load_map_viewer_bundle
-        """Fetch all viewer inputs; return (map_data, devices, zones, clients, coverage, all_sites) or None on missing map."""
+        """Fetch all viewer inputs. Return (map_data, devices, zones, clients, coverage, all_sites) or None on missing map."""
         map_data = self._fetch_map_details(site_id, map_id)  # WHY: compute map_data
         if map_data is None:  # WHY: branch on condition
             return None  # WHY: return computed result
@@ -2624,7 +2624,7 @@ class MapsManager:  # WHY: declare MapsManager class
 
 
 def _check_dependencies() -> None:  # WHY: declare private helper _check_dependencies
-    """Verify required dependencies are available; exit with error if not."""
+    """Verify required dependencies are available. Exit with error if not."""
     if not DASH_AVAILABLE or not PLOTLY_AVAILABLE:  # WHY: guard against missing precondition
         print("ERROR: This module requires dash and plotly packages.")  # WHY: surface user-facing message
         print("Install with: pip install dash plotly")  # WHY: surface user-facing message
@@ -2649,7 +2649,7 @@ def _configure_logging(debug: bool) -> None:  # WHY: declare private helper _con
 
 
 def _setup_api_session(env_file: str):  # WHY: declare private helper _setup_api_session
-    """Initialize and return a Mist API session; exit on failure."""
+    """Initialize and return a Mist API session. Exit on failure."""
     try:
         if os.path.exists(env_file):  # WHY: branch on condition
             apisession = mistapi.APISession(env_file=env_file)  # WHY: compute apisession
@@ -2669,7 +2669,7 @@ def _setup_api_session(env_file: str):  # WHY: declare private helper _setup_api
 
 
 def _prompt_org_selection(orgs: list) -> str:  # WHY: declare private helper _prompt_org_selection
-    """Display org choices and return the selected org_id; exit on invalid input."""
+    """Display org choices and return the selected org_id. Exit on invalid input."""
     print("\nAvailable Organizations:")  # WHY: surface user-facing message
     for idx, oid in enumerate(orgs, 1):  # WHY: iterate collection
         print(f"  {idx}. {oid}")  # WHY: surface user-facing message
@@ -2705,7 +2705,7 @@ def _pick_org_from_privileges(
 def _detect_org_from_session(
     apisession, test_mode: bool
 ) -> str | None:  # WHY: declare private helper _detect_org_from_session
-    """Detect org_id from the API session privileges; return None if not found."""
+    """Detect org_id from the API session privileges. Return None if not found."""
     try:
         self_info = mistapi.api.v1.self.self.getSelf(apisession)  # Fetch the authenticated user info.
         if not (hasattr(self_info, "data") and self_info.data):  # Guard against empty API responses.

--- a/src/maps/plotly_map_callback_manager.py
+++ b/src/maps/plotly_map_callback_manager.py
@@ -105,7 +105,7 @@ def _resolve_by_rules(  # WHY: table-driven visibility lookup shared by traces +
     rules: tuple[tuple[str, str], ...],
     all_layers: frozenset[str],
 ) -> bool | None:
-    """Consult a visibility rule table; return None when no rule matches."""
+    """Consult a visibility rule table. Return None when no rule matches."""
     for layer_name, token in rules:  # WHY: linear scan preserves original ordering semantics
         if token in entity_name:  # WHY: substring match against lowercased entity name
             return layer_name in all_layers  # WHY: first-match wins

--- a/src/maps/plotly_map_figure_builder.py
+++ b/src/maps/plotly_map_figure_builder.py
@@ -190,7 +190,7 @@ class PlotlyMapFigureBuilder:  # WHY: attaches walls/wayfinding/zones traces ont
         for node in nodes:  # WHY: single top-level loop keeps CC at 3.
             self._add_node_edges(fig, node, node_lookup, style)  # WHY: per-node fan-out extracted below.
 
-    def _add_node_edges(  # WHY: draw all outbound edges for one node; keeps _add_edge_segments flat.
+    def _add_node_edges(  # WHY: draw all outbound edges for one node. Keeps _add_edge_segments flat.
         self,
         fig: go.Figure,
         node: dict[str, Any],
@@ -217,7 +217,7 @@ class PlotlyMapFigureBuilder:  # WHY: attaches walls/wayfinding/zones traces ont
         index: int,
         zone: dict[str, Any],
     ) -> None:
-        """Render one polygon+label for a zone dict; skip if too few vertices."""
+        """Render one polygon+label for a zone dict. Skip if too few vertices."""
         zone_name = zone.get("name", f"Zone {index + 1}")  # WHY: fallback name preserves legacy labels.
         vertices = zone.get("vertices", [])  # WHY: polygon geometry source.
         self.logger.debug("Zone '%s': %s vertices - %s", zone_name, len(vertices), vertices)  # WHY: trace.

--- a/src/marvis/marvis_utils.py
+++ b/src/marvis/marvis_utils.py
@@ -69,7 +69,7 @@ class MarvisDataUtils:  # WHY: Class groups Marvis-to-CSV helpers with injected 
     ) -> list[dict[str, Any]]:
         """Convert a raw Marvis API response into a flat list of dicts for CSV export.
 
-        Handles the sites SLE expansion and generic per-item flattening; any
+        Handles the sites SLE expansion and generic per-item flattening. Any
         internal error routes to the legacy flatten+escape fallback so callers
         always receive a list rather than an exception.
         """

--- a/src/network/_routing_utils_display.py
+++ b/src/network/_routing_utils_display.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any  # WHY: TYPE_CHECKING avoids runtime cycle
 
 from prettytable import PrettyTable  # WHY: every table renderer builds a PrettyTable instance
 
-if TYPE_CHECKING:  # WHY: only needed for static type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only needed for static type checkers. Skipped at runtime
     from src.network.routing_utils import RoutingUtils  # WHY: parent type for cross-reference only
 
 
@@ -75,7 +75,7 @@ class RoutingStatsAcc:  # WHY: bundles the 5 routing stat buckets into one param
     """Mutable buckets used while accumulating routing-table statistics.
 
     ``frozen=True`` prevents the *reference* to each container from
-    being swapped mid-loop; the containers themselves stay mutable so
+    being swapped mid-loop. The containers themselves stay mutable so
     per-entry helpers add without re-wiring the accumulator. Bundling
     the five stat buckets into one dataclass drops
     ``_accumulate_route_stats`` from six parameters to two, resolving
@@ -110,7 +110,7 @@ class _RoutingUtilsDisplay:  # WHY: cluster wrapper matches the Phase 1 parsing-
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy so callers see combined API
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_ru")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy to the parent RoutingUtils
 
@@ -153,7 +153,7 @@ class _RoutingUtilsDisplay:  # WHY: cluster wrapper matches the Phase 1 parsing-
     ) -> None:
         """Add ``value`` to ``target_set`` if it is truthy and not the sentinel."""
         if value and value != sentinel:  # WHY: two-guard filter keeps "-" placeholders out
-            target_set.add(value)  # WHY: sets deduplicate; caller does not need to check membership
+            target_set.add(value)  # WHY: sets deduplicate. Caller does not need to check membership
 
     def _collect_forwarding_stats(self, entries: list[dict[str, Any]]) -> dict[str, Any]:  # WHY: aggregator
         """Collect summary statistics from forwarding table entries."""
@@ -297,7 +297,7 @@ class _RoutingUtilsDisplay:  # WHY: cluster wrapper matches the Phase 1 parsing-
         acc = RoutingStatsAcc.empty()  # WHY: single dataclass replaces 5 local buckets
         active_routes = 0  # WHY: separate int counter — dataclass fields are containers only
         for entry in route_entries:  # WHY: single pass keeps overall cost O(n)
-            self._accumulate_route_stats(entry, acc)  # WHY: mutates acc in place; two params only
+            self._accumulate_route_stats(entry, acc)  # WHY: mutates acc in place. Two params only
             if entry.get("active"):  # WHY: count active routes outside the acc for clarity
                 active_routes += 1  # WHY: increment only on truthy 'active' field
         return {  # WHY: dict projection preserves the legacy return shape

--- a/src/network/_routing_utils_forwarding.py
+++ b/src/network/_routing_utils_forwarding.py
@@ -23,7 +23,7 @@ import json  # WHY: forwarding output arrives as either raw text or a JSON body
 import logging  # WHY: orchestrator emits structured log lines around device commands
 from typing import TYPE_CHECKING, Any  # WHY: TYPE_CHECKING avoids runtime cycle with parent
 
-if TYPE_CHECKING:  # WHY: only needed for static type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only needed for static type checkers. Skipped at runtime
     from src.network.routing_utils import RoutingUtils  # WHY: parent type for cross-reference only
 
 
@@ -50,7 +50,7 @@ class _RoutingUtilsForwarding:  # WHY: cluster wrapper matching the parsing/disp
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy so callers see combined API
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_ru")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy to the parent RoutingUtils
 
@@ -101,7 +101,7 @@ class _RoutingUtilsForwarding:  # WHY: cluster wrapper matching the parsing/disp
         payload: dict[str, Any],
         debug_mode: bool,
     ) -> tuple[Any, str] | None:
-        """Open WebSocket + issue forwarding-table command; return (ws, sid) or None on failure."""
+        """Open WebSocket + issue forwarding-table command. Return (ws, sid) or None on failure."""
         websocket_manager = self._ru._connect_websocket(site_id, device_id, debug_mode)  # WHY: WS
         if not websocket_manager:  # WHY: guard: connection failed
             return None  # WHY: nothing to disconnect

--- a/src/network/_routing_utils_parsing.py
+++ b/src/network/_routing_utils_parsing.py
@@ -19,7 +19,7 @@ import logging  # WHY: emit warning when SSR JSON is malformed (production visib
 import re  # WHY: multiple parsers use regex to pluck fields out of legacy text formats
 from typing import TYPE_CHECKING, Any  # WHY: TYPE_CHECKING avoids runtime import cycle with parent
 
-if TYPE_CHECKING:  # WHY: only needed for static type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only needed for static type checkers. Skipped at runtime
     from src.network.routing_utils import RoutingUtils  # WHY: parent type for cross-reference only
 
 
@@ -50,9 +50,9 @@ _VIA_RE: re.Pattern[str] = re.compile(r"via\s+(\S+)")
 def _empty_route_entry() -> dict[str, Any]:  # WHY: canonical shape reused by tabular/juniper builders
     """Return a fresh route-entry dict with every field zero-initialized."""
     return {  # WHY: dict literal is cheaper and clearer than dict(...) constructor
-        "destination": "",  # WHY: prefix/CIDR string; empty until a parser fills it
-        "next_hop": "",  # WHY: gateway address; empty for connected/local routes
-        "interface": "",  # WHY: egress interface name; empty when not known
+        "destination": "",  # WHY: prefix/CIDR string. Empty until a parser fills it
+        "next_hop": "",  # WHY: gateway address. Empty for connected/local routes
+        "interface": "",  # WHY: egress interface name. Empty when not known
         "protocol": "",  # WHY: BGP/OSPF/STATIC/... routing protocol tag
         "admin_distance": "",  # WHY: administrative distance kept as string for uniform display
         "metric": "",  # WHY: route metric kept as string for uniform display
@@ -71,7 +71,7 @@ class _RoutingUtilsParsing:  # WHY: cluster wrapper matching the ``_packet_captu
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy so callers see combined API
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_ru")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy to the parent RoutingUtils
 
@@ -85,7 +85,7 @@ class _RoutingUtilsParsing:  # WHY: cluster wrapper matching the ``_packet_captu
         Uses a dispatch chain of early-return handlers so cyclomatic
         complexity and nesting stay well under the compliance limits.
         """
-        # WHY: each handler returns True when it consumes ``part``; short-circuit stops the chain
+        # WHY: each handler returns True when it consumes ``part``. Short-circuit stops the chain
         if self._set_protocol_token(entry, part):  # WHY: BGP/OSPF/STATIC/... keyword match
             return  # WHY: keep nesting flat by exiting as soon as one handler succeeds
         if self._set_cidr_destination(entry, part):  # WHY: CIDR (``a.b.c.d/N``) → destination
@@ -98,7 +98,7 @@ class _RoutingUtilsParsing:  # WHY: cluster wrapper matching the ``_packet_captu
     def _set_protocol_token(entry: dict[str, Any], part: str) -> bool:
         """Set ``entry['protocol']`` if ``part`` is a known protocol keyword."""
         upper = part.upper()  # WHY: normalize to match uppercase _PROTOCOL_TOKENS
-        if upper not in _PROTOCOL_TOKENS:  # WHY: guard clause; leaves entry untouched on miss
+        if upper not in _PROTOCOL_TOKENS:  # WHY: guard clause. Leaves entry untouched on miss
             return False  # WHY: signal caller to try the next handler
         entry["protocol"] = upper  # WHY: store normalized uppercase form for uniform display
         return True  # WHY: caller stops the classification chain
@@ -221,7 +221,7 @@ class _RoutingUtilsParsing:  # WHY: cluster wrapper matching the ``_packet_captu
         if current_route:  # WHY: flush previous entry before starting a fresh one
             routes.append(current_route)  # WHY: keep append order matching input line order
         new_route = self._build_juniper_route(dest_match, line_stripped, current_table)  # WHY: build
-        return new_route, current_table  # WHY: table stays; only the current route advances
+        return new_route, current_table  # WHY: table stays. Only the current route advances
 
     @staticmethod
     def _build_juniper_route(
@@ -288,7 +288,7 @@ class _RoutingUtilsParsing:  # WHY: cluster wrapper matching the ``_packet_captu
 
     @staticmethod
     def _decode_ssr_payload(json_data: str) -> dict[str, Any] | None:
-        """Decode SSR JSON and validate status; return ``None`` on any failure."""
+        """Decode SSR JSON and validate status. Return ``None`` on any failure."""
         try:  # WHY: SSR JSON can be truncated or malformed in real traffic
             data = json.loads(json_data)  # WHY: only place json.loads runs for SSR parsing
         except (json.JSONDecodeError, KeyError, TypeError) as error:  # WHY: match legacy exception set

--- a/src/network/_routing_utils_payload.py
+++ b/src/network/_routing_utils_payload.py
@@ -28,7 +28,7 @@ import requests  # WHY: generic device command endpoint is invoked via requests.
 
 logger = logging.getLogger(__name__)  # WHY: module-scoped logger for print-to-logger migration
 
-if TYPE_CHECKING:  # WHY: only needed for static type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only needed for static type checkers. Skipped at runtime
     from src.network.routing_utils import RoutingUtils, SsrRouteQuery  # WHY: types for annotation only
 
 
@@ -73,12 +73,12 @@ class RoutingPayloadQuery:
     :class:`SsrRouteQuery` on the parent module.
     """
 
-    prefix_input: str  # WHY: CIDR string filter; empty means match every prefix
-    protocol_input: str  # WHY: protocol keyword (bgp/ospf/static/direct/evpn/any); coerced to 'any'
-    vrf_input: str  # WHY: VRF/routing-instance name; empty means default VRF
-    neighbor_input: str  # WHY: BGP neighbor IP filter; empty disables neighbor scoping
-    route_direction: str  # WHY: received/advertised when neighbor is set; empty means both
-    node_input: str  # WHY: HA node identifier (node0/node1); empty means unspecified
+    prefix_input: str  # WHY: CIDR string filter. Empty means match every prefix
+    protocol_input: str  # WHY: protocol keyword (bgp/ospf/static/direct/evpn/any). Coerced to 'any'
+    vrf_input: str  # WHY: VRF/routing-instance name. Empty means default VRF
+    neighbor_input: str  # WHY: BGP neighbor IP filter. Empty disables neighbor scoping
+    route_direction: str  # WHY: received/advertised when neighbor is set. Empty means both
+    node_input: str  # WHY: HA node identifier (node0/node1). Empty means unspecified
 
 
 class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display split
@@ -91,7 +91,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy so callers see combined API
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_ru")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy to the parent RoutingUtils
 
@@ -112,7 +112,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
     @staticmethod
     def _apply_prefix(payload: dict[str, Any], prefix_input: str) -> None:
         """Attach a route prefix to ``payload`` when the user supplied one."""
-        if prefix_input:  # WHY: empty string means "match all prefixes"; omit key entirely
+        if prefix_input:  # WHY: empty string means "match all prefixes". Omit key entirely
             payload["prefix"] = prefix_input  # WHY: preserve original casing/format for the API
 
     @staticmethod
@@ -127,7 +127,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
     @staticmethod
     def _apply_vrf(payload: dict[str, Any], vrf_input: str) -> None:
         """Attach a VRF name to ``payload`` when the user supplied one."""
-        if vrf_input:  # WHY: empty means default VRF; API omission = default
+        if vrf_input:  # WHY: empty means default VRF. API omission = default
             payload["vrf"] = vrf_input  # WHY: preserve original casing for name-matching
 
     def _apply_neighbor(
@@ -137,7 +137,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
         route_direction: str,
     ) -> None:
         """Attach neighbor IP (and optional route direction) to ``payload``."""
-        if not neighbor_input:  # WHY: neighbor filter is optional; short-circuit when unset
+        if not neighbor_input:  # WHY: neighbor filter is optional. Short-circuit when unset
             return  # WHY: skip both neighbor and direction fields when neighbor is empty
         payload["neighbor"] = neighbor_input  # WHY: preserve exact IP the user entered
         direction = route_direction.lower() if route_direction else ""  # WHY: normalize once
@@ -181,7 +181,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
     @staticmethod
     def _apply_ssr_neighbor(request_body: dict[str, Any], query: SsrRouteQuery) -> None:
         """Attach BGP neighbor (and optional direction) to ``request_body``."""
-        if not query.neighbor_input:  # WHY: neighbor filter is optional; short-circuit when unset
+        if not query.neighbor_input:  # WHY: neighbor filter is optional. Short-circuit when unset
             return  # WHY: skip both neighbor + direction fields when neighbor is empty
         request_body["neighbor"] = query.neighbor_input  # WHY: preserve exact IP the user entered
         if query.route_direction in _VALID_ROUTE_DIRECTIONS:  # WHY: only received/advertised valid
@@ -190,7 +190,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
     @staticmethod
     def _apply_ssr_node(request_body: dict[str, Any], node_input: str) -> None:
         """Attach HA node object to ``request_body`` when identifier validates."""
-        if node_input in _VALID_NODES:  # WHY: only node0/node1 accepted; SSR wraps in nested object
+        if node_input in _VALID_NODES:  # WHY: only node0/node1 accepted. SSR wraps in nested object
             request_body["node"] = {"node": node_input}  # WHY: SSR API expects nested {"node": ...}
 
     def _apply_ssr_refresh_params(
@@ -204,7 +204,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
         if interval_val is None:  # WHY: invalid/blank interval disables the entire refresh block
             return  # WHY: skip both interval and duration when interval is missing
         request_body["interval"] = interval_val  # WHY: always attach interval when it validates
-        if interval_val == 0:  # WHY: interval=0 means one-shot; duration is meaningless then
+        if interval_val == 0:  # WHY: interval=0 means one-shot. Duration is meaningless then
             return  # WHY: early-return omits duration for one-shot queries
         request_body["duration"] = self._parse_refresh_duration(duration_input)  # WHY: parsed once
 
@@ -245,7 +245,7 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
             return None, "Mist host or API token not found in session or environment"  # WHY: signal
         url = f"https://{host}/api/v1/sites/{site_id}/devices/{device_id}/{endpoint}"  # WHY: standard path
         if debug_mode:  # WHY: expose URL for troubleshooting when debug is on
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] POST URL = %s", url)  # WHY: match legacy debug output verbatim
         response = requests.post(  # WHY: synchronous POST with hard timeout
             url,
@@ -275,9 +275,9 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
         """Emit response status + body when debug mode is on."""
         if not debug_mode:  # WHY: guard clause avoids formatting the body when debug is off
             return  # WHY: keeps the hot path free of debug string formatting
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("[DEBUG] HTTP Response Status = %s", response.status_code)  # WHY: legacy debug format
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("[DEBUG] HTTP Response Body = %s", response.text)  # WHY: legacy debug format
 
     @staticmethod
@@ -317,10 +317,10 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
         debug_mode: bool,
     ) -> str | None:
         """Perform the SSR/SRX API call and hand the response to session-id extraction."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> Calling dedicated SSR/SRX routing table API...")  # WHY: legacy UX text preserved
         if debug_mode:  # WHY: mirror legacy verbose logging for debug traces
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] Calling mistapi.api.v1.sites.devices.showSiteSsrAndSrxRoutes")  # WHY: URL
         response = mistapi.api.v1.sites.devices.showSiteSsrAndSrxRoutes(  # WHY: dedicated endpoint
             self._ru.apisession,  # WHY: reuse the parent-injected authenticated session
@@ -336,42 +336,42 @@ class _RoutingUtilsPayload:  # WHY: cluster wrapper matching the parsing/display
         """Emit SSR API response metadata when debug mode is on."""
         if not debug_mode:  # WHY: guard clause avoids attribute lookups when debug is off
             return  # WHY: keeps hot path free of formatting overhead
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("[DEBUG] API response type: %s", type(response))  # WHY: legacy debug output preserved
         if hasattr(response, "data"):  # WHY: some responses do not carry a data attribute at all
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] Response data: %s", response.data)  # WHY: expose payload for triage
 
     @staticmethod
     def _handle_ssr_api_error(api_error: Exception, debug_mode: bool) -> None:
         """Emit uniform failure output for an SSR API exception and return ``None``."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("! Error calling SSR/SRX routing table API: %s", api_error)  # WHY: user-facing message
         logger.error("SSR/SRX routing table API error: %s", api_error)  # WHY: capture for logs
         if debug_mode:  # WHY: only dump the traceback when debug mode is explicitly on
             import traceback  # WHY: local import matches legacy lazy behavior (rare failure path)
 
             traceback.print_exc()  # WHY: full stack aids on-site triage
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Try the generic routing table command (Menu 7) as fallback")  # WHY: guidance
         return None  # WHY: signal failure to caller so it can skip the results wait
 
     def _extract_ssr_session_id(self, response: Any, debug_mode: bool) -> str | None:
         """Extract session ID from SSR API response."""
         if not (hasattr(response, "data") and response.data):  # WHY: guard against empty responses
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Unexpected API response format")  # WHY: legacy message preserved for UX parity
             return None  # WHY: caller treats None as "no session started"
         session_id: str | None = response.data.get("session")  # WHY: 'session' key holds the id
         if not session_id:  # WHY: guard against present-but-empty session field
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No session ID returned from SSR/SRX routing API")  # WHY: legacy message
             return None  # WHY: caller cancels the wait when no id is present
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> Command initiated (session: %s...)", session_id[:8])  # WHY: legacy UX preserved
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> Waiting for SSR/SRX routing table results...")  # WHY: user context between calls
         if debug_mode:  # WHY: full-id debug output when debug is on
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] Full session ID: %s", session_id)  # WHY: match legacy debug format
         return session_id  # WHY: caller uses this id to correlate WebSocket results

--- a/src/network/_routing_utils_routing.py
+++ b/src/network/_routing_utils_routing.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, cast  # WHY: cast narrows Any from parent
 
 from src.network._routing_utils_payload import RoutingPayloadQuery  # WHY: params builder returns one
 
-if TYPE_CHECKING:  # WHY: only needed for static type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only needed for static type checkers. Skipped at runtime
     from src.network.routing_utils import RoutingTableContext, RoutingUtils  # WHY: types only
 
 
@@ -54,7 +54,7 @@ class _RoutingUtilsRouting:  # WHY: cluster wrapper matching the parsing/display
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy so callers see combined API
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_ru")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy to the parent RoutingUtils
 
@@ -99,7 +99,7 @@ class _RoutingUtilsRouting:  # WHY: cluster wrapper matching the parsing/display
 
     def _verify_ssr_compatibility(self, device_info: dict[str, Any] | None) -> bool:
         """Verify device is SSR/SRX compatible. False to cancel."""
-        if not device_info:  # WHY: no info → assume compatible; caller keeps going
+        if not device_info:  # WHY: no info → assume compatible. Caller keeps going
             return True  # WHY: matches legacy behavior — proceed on missing metadata
         device_type = device_info.get("type", "unknown")  # WHY: type steers the branch
         device_model = device_info.get("model", "unknown")  # WHY: model shown in guidance text
@@ -407,7 +407,7 @@ class _RoutingUtilsRouting:  # WHY: cluster wrapper matching the parsing/display
         payload: dict[str, Any],
         debug_mode: bool,
     ) -> tuple[Any, str] | None:
-        """Open WebSocket + issue routing-table command; return (ws, sid) or None on failure."""
+        """Open WebSocket + issue routing-table command. Return (ws, sid) or None on failure."""
         websocket_manager = self._ru._connect_websocket(site_id, device_id, debug_mode)  # WHY: WS
         if not websocket_manager:  # WHY: guard: connection failed
             return None  # WHY: nothing to disconnect

--- a/src/network/_routing_utils_ssr.py
+++ b/src/network/_routing_utils_ssr.py
@@ -18,7 +18,7 @@ from __future__ import annotations  # WHY: postponed evaluation for forward-ref 
 import logging  # WHY: orchestrator emits structured log lines around device commands
 from typing import TYPE_CHECKING, Any  # WHY: TYPE_CHECKING avoids runtime cycle with parent
 
-if TYPE_CHECKING:  # WHY: only needed for static type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only needed for static type checkers. Skipped at runtime
     from src.network.routing_utils import RoutingUtils, SsrRouteContext  # WHY: types only
 
 
@@ -40,7 +40,7 @@ class _RoutingUtilsSSR:  # WHY: cluster wrapper matching parsing/display/payload
     def __getattr__(self, name: str) -> Any:  # WHY: transparent proxy for combined API surface
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_ru")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy to parent RoutingUtils
 
@@ -99,7 +99,7 @@ class _RoutingUtilsSSR:  # WHY: cluster wrapper matching parsing/display/payload
         request_body: dict[str, Any],
         debug_mode: bool,
     ) -> tuple[Any, str] | None:
-        """Open WebSocket + issue SSR command; return (ws, session_id) or None on failure."""
+        """Open WebSocket + issue SSR command. Return (ws, session_id) or None on failure."""
         websocket_manager = self._ru._connect_websocket(site_id, device_id, debug_mode)  # WHY: WS
         if not websocket_manager:  # WHY: guard: connection failed
             return None  # WHY: nothing to disconnect
@@ -163,7 +163,7 @@ class _RoutingUtilsSSR:  # WHY: cluster wrapper matching parsing/display/payload
         interval_input, duration_input = self._collect_ssr_refresh()  # WHY: split for length
         from src.network.routing_utils import SsrRouteQuery  # WHY: lazy import avoids cycle
 
-        query = SsrRouteQuery(  # WHY: dataclass fields auto-populate __init__; not counted as func params
+        query = SsrRouteQuery(  # WHY: dataclass fields auto-populate __init__. Not counted as func params
             protocol_input=protocol_input,  # WHY: mirrors legacy field
             prefix_input=prefix_input,  # WHY: mirrors legacy field
             vrf_input=vrf_input,  # WHY: mirrors legacy field

--- a/src/network/routing_utils.py
+++ b/src/network/routing_utils.py
@@ -169,7 +169,7 @@ class RoutingUtils:
         """Configure logging for debug mode if enabled."""
         if debug_mode:  # WHY: only elevate logger when debug requested
             logging.getLogger().setLevel(logging.DEBUG)  # WHY: hoist root logger to DEBUG
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] DEBUG MODE ENABLED")  # WHY: user-visible confirmation
 
     def _get_device_info(
@@ -202,7 +202,7 @@ class RoutingUtils:
             None,
         )
         if device_info and debug_mode:  # WHY: emit metadata only when both present
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug(
                 "[DEBUG] Device type: %s, model: %s, name: %s",
                 device_info.get("type"),
@@ -215,16 +215,16 @@ class RoutingUtils:
         """Emit user-facing warning and optional debug trace for device lookup failure."""
         logging.warning("Could not verify device compatibility: %s", error)  # WHY: audit trail
         if debug_mode:  # WHY: extra visibility when troubleshooting
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] Device check failed: %s", error)  # WHY: expose exception message
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("   -> Proceeding with standard command")  # WHY: reassure operator
 
     def _connect_websocket(self, site_id: str, device_id: str, debug_mode: bool) -> Any | None:
         """Establish WebSocket connection and subscribe to channel."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n-> Executing show forwarding table on device %s...", device_id)  # WHY: user progress
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> Establishing WebSocket connection...")  # WHY: signal WS phase start
         websocket_manager = self._init_websocket_manager(debug_mode)  # WHY: build + connect
         if not websocket_manager:  # WHY: bail on connection failure
@@ -236,7 +236,7 @@ class RoutingUtils:
             debug_mode,
         ):
             return None
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> WebSocket connected and subscribed")  # WHY: confirm success
         time.sleep(1)  # WHY: give server a beat before command dispatch
         return websocket_manager  # WHY: hand back live handle
@@ -245,14 +245,14 @@ class RoutingUtils:
         """Create the WebSocket manager and establish the transport connection."""
         websocket_manager = self.websocket_manager_factory(self.apisession)  # WHY: instantiate via factory
         if debug_mode:  # WHY: trace lifecycle
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] WebSocketManager initialized")  # WHY: confirm object built
         if not websocket_manager.connect():  # WHY: attempt TCP/TLS handshake
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Failed to establish WebSocket connection")  # WHY: user-facing failure
             return None  # WHY: signal caller to abort
         if debug_mode:  # WHY: trace lifecycle
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] WebSocket connection established")  # WHY: confirm handshake success
         return websocket_manager  # WHY: caller subscribes next
 
@@ -263,15 +263,15 @@ class RoutingUtils:
         device_id: str,
         debug_mode: bool,
     ) -> bool:
-        """Subscribe to the device command channel; returns False on failure."""
+        """Subscribe to the device command channel. Returns False on failure."""
         command_channel = f"/sites/{site_id}/devices/{device_id}/cmd"  # WHY: per-device command topic
         if not websocket_manager.subscribe_to_channel(command_channel):  # WHY: attempt subscription
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! Failed to subscribe to device command channel")  # WHY: user-facing failure
             websocket_manager.disconnect()  # WHY: clean up partial connection
             return False  # WHY: caller aborts flow
         if debug_mode:  # WHY: trace subscription success
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] Subscribed to channel: %s", command_channel)  # WHY: confirm channel name
         return True  # WHY: caller may proceed with dispatch
 
@@ -282,7 +282,7 @@ class RoutingUtils:
         available = self._collect_debug_fields(result)  # WHY: filter to non-standard keys
         if not available:  # WHY: skip banner when nothing to show
             return
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("\n[DEBUG] OTHER AVAILABLE FIELDS: %s", available)  # WHY: banner + key list
         self._dump_debug_field_values(result, available)  # WHY: emit per-field values
 
@@ -297,7 +297,7 @@ class RoutingUtils:
         """Print each non-empty extra field on its own debug line."""
         for field in available:  # WHY: iterate discovered extras
             if result.get(field):  # WHY: skip empty/None values
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.debug("[DEBUG] %s: %s", field, result.get(field))  # WHY: expose value for triage
 
     def _display_no_data_message(self, result: dict[str, Any], label: str) -> None:
@@ -305,9 +305,9 @@ class RoutingUtils:
         raw_output = result.get("raw", "")  # WHY: primary payload slot
         output_fields = result.get("Output", "")  # WHY: secondary payload slot
         if not raw_output and not output_fields:  # WHY: both empty means nothing came back
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("! No %s data received", label)  # WHY: user-facing summary
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("Available result keys: %s", list(result.keys()))  # WHY: aid triage
 
     def _log_command_completion(
@@ -330,11 +330,11 @@ class RoutingUtils:
     ) -> None:
         """Handle exceptions during routing operations."""
         error_message = f"WebSocket {operation_name} operation failed: {error}"  # WHY: formatted context
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("! %s", error_message)  # WHY: user-facing failure
         logging.error(error_message)  # WHY: persist in log
         if debug_mode:  # WHY: dump traceback only under debug
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] Exception details:")  # WHY: banner
             import traceback  # WHY: lazy import to avoid unused cost in hot paths
 
@@ -345,10 +345,10 @@ class RoutingUtils:
         try:  # WHY: never let cleanup escalate to caller
             if websocket_manager is not None:  # WHY: skip when never connected
                 websocket_manager.disconnect()  # WHY: release socket
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.info("-> WebSocket connection closed")  # WHY: user confirmation
                 if debug_mode:  # WHY: trace lifecycle end
-                    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                     logger.debug("[DEBUG] WebSocket cleanup completed")  # WHY: confirm cleanup step
         except Exception as cleanup_error:  # WHY: swallow to guarantee finally-safety
             logging.warning("WebSocket cleanup error: %s", cleanup_error)  # WHY: audit trail

--- a/src/org/org_config_migration_manager.py
+++ b/src/org/org_config_migration_manager.py
@@ -415,7 +415,7 @@ class OrgConfigMigrationManager:  # Org config migration manager.
 
     @staticmethod
     def _existing_overlaps_new(new_net, existing: dict, new_subnet: str) -> dict | None:  # type: ignore[no-untyped-def]
-        """Return a conflict dict if ``existing``'s subnet overlaps ``new_net``; else None (also on parse error)."""
+        """Return a conflict dict if ``existing``'s subnet overlaps ``new_net``. Else None (also on parse error)."""
         existing_subnet = existing.get("subnet")  # Existing CIDR
         if not existing_subnet:  # Skip un-subnetted existing entries
             return None
@@ -522,7 +522,7 @@ class OrgConfigMigrationManager:  # Org config migration manager.
         """Remap network and VPN IDs in gateway template config."""
         networks = obj.get("networks", {})  # Gateway template networks section
         if isinstance(networks, dict):  # Verify expected dict structure
-            for net_config in networks.values():  # Iterate each network reference; keys unused here
+            for net_config in networks.values():  # Iterate each network reference. Keys unused here
                 if isinstance(net_config, dict) and "id" in net_config:  # Has remappable ID
                     old_id = net_config["id"]  # Capture source org's ID
                     net_config["id"] = self._remap_table.get(old_id, old_id)  # Swap to dest ID

--- a/src/org/org_synthetic_probes_manager.py
+++ b/src/org/org_synthetic_probes_manager.py
@@ -8,13 +8,13 @@ Why:
     Operators need a single-command way to keep the Zscaler reachability
     probe fleet in sync with their VLAN topology. Hand-maintaining the
     probe block against Zscaler's evolving Cloud Enforcement Node list is
-    error-prone; this module treats the JSON in ``data/`` as the source of
+    error-prone. This module treats the JSON in ``data/`` as the source of
     truth, and marks every probe it writes with the ``zcc-`` name prefix
     so a follow-up run can safely merge or swap without disturbing
     probes authored elsewhere.
 
 Module-import must remain side-effect free (--help guard):
-    Only ``import`` statements at module scope; all I/O, prompts, and API
+    Only ``import`` statements at module scope. All I/O, prompts, and API
     calls live inside functions invoked from the menu dispatch table.
 """
 
@@ -123,7 +123,7 @@ _COUNTRY_CODE_TO_REGION: dict[str, str] = {
     "VC": "americas",  # Saint Vincent and the Grenadines
     "VG": "americas",  # British Virgin Islands
     "VI": "americas",  # United States Virgin Islands
-    # China + SARs + Taiwan hit ``.com.cn`` endpoints; EMEA fallback uses
+    # China + SARs + Taiwan hit ``.com.cn`` endpoints. EMEA fallback uses
     # ``.com`` so they must be routed to the china role explicitly.
     "CN": "china",  # China (mainland)
     "HK": "china",  # Hong Kong SAR
@@ -287,7 +287,7 @@ _COUNTRY_CODE_INTENTIONAL_GAPS: frozenset[str] = frozenset(
         "SM",  # San Marino
         "UA",  # Ukraine
         "VA",  # Vatican City
-        # Central Asia (EMEA today; no China routing)
+        # Central Asia (EMEA today. No China routing)
         "AM",  # Armenia
         "AZ",  # Azerbaijan
         "KG",  # Kyrgyzstan
@@ -303,7 +303,7 @@ _COUNTRY_CODE_INTENTIONAL_GAPS: frozenset[str] = frozenset(
         "MV",  # Maldives
         "NP",  # Nepal
         "PK",  # Pakistan
-        # Southeast Asia (EMEA today; not classified as China)
+        # Southeast Asia (EMEA today. Not classified as China)
         "BN",  # Brunei
         "ID",  # Indonesia
         "KH",  # Cambodia
@@ -315,7 +315,7 @@ _COUNTRY_CODE_INTENTIONAL_GAPS: frozenset[str] = frozenset(
         "TH",  # Thailand
         "TL",  # Timor-Leste
         "VN",  # Vietnam
-        # Northeast Asia (EMEA today; not classified as China)
+        # Northeast Asia (EMEA today. Not classified as China)
         "JP",  # Japan
         "KP",  # North Korea
         "KR",  # South Korea
@@ -426,7 +426,7 @@ def _is_vpn_host(fqdn: str, cenr_source: dict[str, Any]) -> bool:
 
     Returns:
         True when the FQDN appears anywhere in a ``vpn_hostnames`` list
-        (top-level or under ``by_city[*]``); False otherwise.
+        (top-level or under ``by_city[*]``). False otherwise.
     """
     if _fqdn_in_vpn_bag(cenr_source.get("vpn_hostnames"), fqdn):
         return True
@@ -453,7 +453,7 @@ def _probe_type_for_target(target: str, _role_type: str | None = None) -> str:
         could re-attach the ``application`` label to a bare-hostname
         VPN target and reintroduce the pre-1024 fake-L4 failure mode
         (INV-2, INV-3). ``role_type`` is retained in the signature for
-        backwards compatibility with all three callsites; its value is
+        backwards compatibility with all three callsites. Its value is
         NOT consulted for the decision.
 
     Args:
@@ -471,21 +471,21 @@ def _probe_type_for_target(target: str, _role_type: str | None = None) -> str:
         (bare hostname — the post-1024 VPN emission shape).
     """
     # Scheme detection: case-sensitive prefix match. Targets emitted by
-    # this codebase are always lowercase; no normalisation required.
+    # this codebase are always lowercase. No normalisation required.
     if target.startswith(("http://", "https://")):
         decision = "application"
     else:
         # Port detection: look for ":" AFTER the last "." — a bare host
         # has no ":", a host:port has exactly one ":" after the last dot.
         # This avoids false positives on hypothetical IPv6-literal targets
-        # (unsupported by Mist Marvis Minis today; revisit if support arrives).
+        # (unsupported by Mist Marvis Minis today. Revisit if support arrives).
         last_dot = target.rfind(".")
         if last_dot != -1 and ":" in target[last_dot:]:
             decision = "application"
         else:
             # Bare hostname — the post-1024 VPN reachability shape.
             decision = "reachability"
-    # Debug trace only per contract §Logging; the emitting callsite
+    # Debug trace only per contract §Logging. The emitting callsite
     # handles higher-severity logging per Principle VII. Logger is
     # constructed here (not module-scoped) to match the local-scope
     # pattern used by peers like ``_probe_target``.
@@ -541,12 +541,12 @@ def _lookup_v3_observation(fqdn: str, cenr_source: dict[str, Any]) -> dict[str, 
         ..., "observed_port": ..., "last_probed": ...}``), otherwise
         ``None`` when the FQDN is absent from every bag.
     """
-    # Top-level bags are the common case; iterate them first so the fast
+    # Top-level bags are the common case. Iterate them first so the fast
     # path exits before descending into by_city.
     hit = _find_host_in_bags(cenr_source, fqdn)
     if hit is not None:
         return hit
-    # by_city bags carry the same shape (per cenr_cache_schema_v3.md); walk
+    # by_city bags carry the same shape (per cenr_cache_schema_v3.md). Walk
     # them last because the top-level bags dominate the hit rate.
     by_city = cenr_source.get("by_city")
     if isinstance(by_city, dict):
@@ -567,7 +567,7 @@ def _extract_observed_protocol_port(
     Why:
         Extracted from :func:`_probe_target` so its dispatch body stays under
         the Radon CC gate. The type guards mirror the schema: string protocol
-        and integer port; anything else collapses to ``None`` so the caller's
+        and integer port. Anything else collapses to ``None`` so the caller's
         Branch 3 fallback triggers.
 
     Args:
@@ -632,7 +632,7 @@ def _dispatch_observed_target(
     is_udp = observed_protocol == "UDP" or observed_protocol.startswith("UDP/")
     is_non_443_tcp = observed_protocol.startswith("TCP/") and observed_protocol != "TCP/443"
     if (is_udp or is_non_443_tcp) and observed_port is not None:
-        # Bare host:port form; NO scheme so Mist runs a raw probe
+        # Bare host:port form. NO scheme so Mist runs a raw probe
         # rather than trying TLS on a UDP/IKE endpoint.
         target = f"{fqdn}:{observed_port}"
         logger.debug("probe_target: %s -> %s (obs=%s)", fqdn, target, observed_protocol)
@@ -650,8 +650,8 @@ def _resolve_fallback_probe(
         Split out of :func:`_build_fallback_target` so the protocol
         normalisation and port coercion do not push the parent above the
         Radon CC gate. ``tunnel_zen`` still delegates to
-        ``cenr_source["probe_default"]``; unknown protocols still coerce to
-        ``https``; non-integer port values still fall back to the scheme
+        ``cenr_source["probe_default"]``. Unknown protocols still coerce to
+        ``https``. Non-integer port values still fall back to the scheme
         default.
 
     Args:
@@ -669,7 +669,7 @@ def _resolve_fallback_probe(
         # convention retained from the pre-1023 implementation).
         probe = cenr_source.get("probe_default") or {}
     protocol = str(probe.get("protocol") or "https").lower()
-    # Mist targets are URLs; raw TCP has no URL scheme, so upgrade to HTTPS
+    # Mist targets are URLs. Raw TCP has no URL scheme, so upgrade to HTTPS
     # which exercises the same TCP/443 handshake path.
     if protocol == "tcp":
         protocol = "https"
@@ -694,14 +694,14 @@ def _build_fallback_target(
     Why:
         Extracted from :func:`_probe_target` so the fallback logic is
         testable in isolation. The VPN pre-check and Branches 1/2 already
-        handled everything else; this only fires for non-VPN hosts with
+        handled everything else. This only fires for non-VPN hosts with
         missing / unrecognised observations.
 
     Args:
         fqdn: Hostname to render.
         role: Role dict passed through to :func:`_resolve_fallback_probe`.
         cenr_source: Loaded v3 CENR document.
-        observed_protocol: Original observation value (may be ``None``); used
+        observed_protocol: Original observation value (may be ``None``). Used
             only in the debug log line.
 
     Returns:
@@ -760,7 +760,7 @@ def _probe_target(fqdn: str, role: dict[str, Any], cenr_source: dict[str, Any]) 
         fqdn: The hostname to render into a probe target string. Callers
             strip wildcards before invoking this helper.
         role: The role dict from the probe source file. Retained for
-            signature parity with previous versions; Branch 3's fallback
+            signature parity with previous versions. Branch 3's fallback
             still respects ``role["probe"]`` when present so
             role-specific overrides in the ZCC catalogue continue to
             work.
@@ -773,14 +773,14 @@ def _probe_target(fqdn: str, role: dict[str, Any], cenr_source: dict[str, Any]) 
         (Branch 1) or ``"https://host"`` (Branch 2, default 443 elided)
         or the catalogue default (Branch 3).
     """
-    logger = logging.getLogger(__name__)  # module-scoped logger; matches _warn spec in contract
+    logger = logging.getLogger(__name__)  # module-scoped logger. Matches _warn spec in contract
 
     # --- VPN pre-check (feature 1024) ---------------------------------------
     # MUST run before the non-VPN 3-branch dispatch so that a host present
     # in a ``vpn_hostnames`` bag AND also observed on TCP/443 (Zscaler admin
     # console) is emitted as a VPN reachability probe. Bag membership wins
     # per contract vpn_probe_target_shape.md §Ordering Contract. Pre-1024
-    # this branch returned ``f"{fqdn}:500"``; that fake-L4 shape produced
+    # this branch returned ``f"{fqdn}:500"``. That fake-L4 shape produced
     # 100% guaranteed-fail probes because Mist cannot speak IKEv2.
     if _is_vpn_host(fqdn, cenr_source):
         logger.info("probe_target(vpn): %s -> bare (reachability)", fqdn)
@@ -807,7 +807,7 @@ def manage_org_synthetic_probes(mist_session: Any, org_id: str) -> None:
 
     Why:
         Single public API surface for the feature. The menu dispatch table
-        calls this exact callable; keeping it thin and delegating to the
+        calls this exact callable. Keeping it thin and delegating to the
         ``_``-prefixed helpers below preserves testability -- each helper
         can be exercised directly without stubbing the whole flow.
 
@@ -852,7 +852,7 @@ def manage_org_synthetic_probes(mist_session: Any, org_id: str) -> None:
     )
     # NOTE(1025-US2): companion dedup state for the load-time
     # country_code warning lives here so its lifetime is bounded by the invocation
-    # (data-model.md §3 INV-D1; FR-012 requires re-emission across
+    # (data-model.md §3 INV-D1. FR-012 requires re-emission across
     # back-to-back operator runs). Emission itself is delegated to
     # ``_prompt_and_apply_site_overrides`` because that is where the site
     # list is materialised via ``_list_org_sites`` -- the site list is
@@ -1004,7 +1004,7 @@ def _collect_cenr_observed_hosts(cenr_source: dict[str, Any]) -> frozenset[str]:
         (defensive against mid-migration flat strings that slipped past the
         loader adapter).
     """
-    observed: set[str] = set()  # accumulator; frozen at return time for immutability
+    observed: set[str] = set()  # accumulator. Frozen at return time for immutability
     _add_observed_hosts_from_container(cenr_source, observed)
     # by_city bags carry the same shape per cenr_cache_schema_v3.md.
     by_city = cenr_source.get("by_city")
@@ -1036,7 +1036,7 @@ def _collect_catalogue_hosts(probes_source: dict[str, Any]) -> frozenset[str]:
     Returns:
         Frozen set of every non-wildcard catalogue FQDN.
     """
-    catalogue: set[str] = set()  # accumulator; frozen at return time
+    catalogue: set[str] = set()  # accumulator. Frozen at return time
     for role in probes_source.get("roles", []) or []:  # each catalogue role
         role_name = role.get("role")  # role slug string
         if role_name == _TUNNEL_ZEN_ROLE:  # tunnel_zen sources FQDNs from CENR itself
@@ -1156,7 +1156,7 @@ def _compute_unmapped_country_codes(
         regardless of how many sites share each code (FR-004, FR-010).
         Codes appearing in ``gap_set`` are silently classified (they are
         deliberately EMEA today by contract INV-COVER-2) and therefore never
-        surface here; only truly-new codes bubble up so the operator gets a
+        surface here. Only truly-new codes bubble up so the operator gets a
         signal, not noise.
 
     Args:
@@ -1186,7 +1186,7 @@ def _compute_unmapped_country_codes(
     seen: set[str] = set()  # accumulator for unique codes across all sites
     for site in sites:  # single pass over the site list
         raw = site.get("country_code")  # optional field per Mist site schema
-        if not isinstance(raw, str):  # non-string / missing -> skip; region resolver handles it
+        if not isinstance(raw, str):  # non-string / missing -> skip. Region resolver handles it
             continue
         code = raw.strip().upper()  # normalise like _build_region_probes at line 1068
         if not code:  # blank string after normalisation -> skip
@@ -1227,7 +1227,7 @@ def _emit_load_time_country_code_warning(
         warned_unmapped_codes: Per-invocation dedup set (mutated in place).
             Codes added here are skipped on any subsequent call within the
             same invocation. FR-012: caller supplies a fresh empty set per
-            run; state MUST NOT persist across runs.
+            run. State MUST NOT persist across runs.
     """
     logging.info(  # Constitution VII: BEFORE the emission decision
         "evaluating country_code load-time warning: unmapped=%s already_warned=%s",
@@ -1299,7 +1299,7 @@ def _validate_vlan_input(raw: str) -> tuple[bool, str, list[int]]:
         are 802.1Q-reserved and 4095 is priority-tagged frames), so any
         out-of-range value would produce a red-banner error on the org
         setting push. Operators frequently paste condensed lists like
-        ``"3-6, 10, 200-203"``; expanding ranges here lets them use the
+        ``"3-6, 10, 200-203"``. Expanding ranges here lets them use the
         same shorthand they use in switch configs. Invalid tokens
         (non-integer, out-of-range endpoints, reversed ranges) are
         silently dropped rather than failing the whole entry so a single
@@ -1335,7 +1335,7 @@ def _prompt_vlan_list() -> list[int]:
     """Prompt the operator for a comma-separated VLAN id list.
 
     Why:
-        The VLAN list is the only per-invocation parameter; validating
+        The VLAN list is the only per-invocation parameter. Validating
         the range at prompt time avoids surfacing an opaque API-side
         rejection later. Accepts ranges (``3-6`` expands to ``3,4,5,6``)
         because operators paste condensed lists from switch configs.
@@ -1457,7 +1457,7 @@ def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
         standard closed-form solution: no external dep, no earth-model
         approximation error large enough to affect ranking at the
         continental scale we care about (Zscaler cities are hundreds of
-        kilometres apart; sub-percent radius error is invisible).
+        kilometres apart. Sub-percent radius error is invisible).
 
     Args:
         lat1: First point latitude in decimal degrees.
@@ -1507,7 +1507,7 @@ def _iter_role_fqdns(role: dict[str, Any], cenr: dict[str, Any]) -> list[str]:
     """Yield the concrete FQDN list for a single role, expanding CENR.
 
     Why:
-        Only the ``tunnel_zen`` role expands via the CENR file; every
+        Only the ``tunnel_zen`` role expands via the CENR file. Every
         other role carries its FQDNs inline. Centralising the branch
         keeps ``_build_probe_set`` readable.
 
@@ -1545,7 +1545,7 @@ def _emit_probes_for_role(
         role: One role entry from ``probes_source["roles"]``.
         cenr_source: Loaded CENR document (for FQDN expansion + target
             resolution).
-        result: Aggregating map; probes are inserted under their
+        result: Aggregating map. Probes are inserted under their
             ``zcc-<role>-<slug>`` keys.
 
     Returns:
@@ -1630,7 +1630,7 @@ def _build_probe_set(
 
     Args:
         sources: The ``(probes, cenr)`` tuple from ``_load_probe_sources``.
-        vlan_ids: Kept for signature/back-compat with the caller; ignored
+        vlan_ids: Kept for signature/back-compat with the caller. Ignored
             when building probe bodies because VLAN scoping belongs on
             the ``tests[]`` row that references the probe, not on the
             ``custom_probes`` definition itself (matches Mist's own
@@ -1672,7 +1672,7 @@ def _build_region_probes(
         wasteful noise. The site-override flow calls this helper instead so
         each picked site only receives the ELM role matching its own
         ``country_code``. Unmapped or missing country codes fall back to
-        EMEA (the broadest surface); the operator-visible WARNING for the
+        EMEA (the broadest surface). The operator-visible WARNING for the
         unmapped set is now emitted once at load time by
         ``_emit_load_time_country_code_warning`` (1025-US2, FR-004 / FR-010)
         rather than once per site here, so this helper stays silent on the
@@ -1681,14 +1681,14 @@ def _build_region_probes(
     Args:
         sources: The ``(probes, cenr)`` tuple from ``_load_probe_sources``.
         country_code: ISO 3166-1 alpha-2 code from the site dict (case-
-            insensitive; may be ``None`` or an unmapped code -- both fall
-            through to EMEA silently; see ``_emit_load_time_country_code_warning``
+            insensitive. May be ``None`` or an unmapped code -- both fall
+            through to EMEA silently. See ``_emit_load_time_country_code_warning``
             for the operator-visible surface).
 
     Returns:
         A ``{probe_name: probe_body}`` map for the one matching role.
         Empty dict if the probe source file does not ship a role for the
-        resolved region (defensive; the shipped catalogue has all three).
+        resolved region (defensive. The shipped catalogue has all three).
     """
     probes_source, _ = sources
     normalised = (country_code or "").strip().upper()
@@ -1722,7 +1722,7 @@ def _build_regional_elm_probes(
 
     Args:
         role: The matched Samsung ELM role dict from ``probes_source``.
-        sources: The ``(probes, cenr)`` tuple; only ``cenr`` (index 1) is
+        sources: The ``(probes, cenr)`` tuple. Only ``cenr`` (index 1) is
             passed through to ``_probe_target`` for probe-body wiring.
         target_role_name: Precomputed ``samsung_elm_activation_<region>``
             slug so the probe-name builder does not have to reconstruct
@@ -1770,7 +1770,7 @@ def _is_concrete_probe_fqdn(fqdn: Any) -> bool:
 
     Returns:
         ``True`` if ``fqdn`` is a ``str`` and does not start with
-        ``"*."``; otherwise ``False``.
+        ``"*."``. Otherwise ``False``.
     """
     return isinstance(fqdn, str) and not fqdn.startswith("*.")
 
@@ -1941,7 +1941,7 @@ def _resolve_zen_cities_for_site(
           deduped by location (so same-city pairs count once).
         - Country has more but site lacks ``latlng`` -> return the
           country's ZENs anyway (better to over-probe within-country than
-          to skip; operators can trim later).
+          to skip. Operators can trim later).
         - Site has no country match AND has ``latlng`` -> nearest globally.
         - No country match AND no latlng -> empty list + warn.
 
@@ -2125,7 +2125,7 @@ def _merge_probes(
         new_probes: Freshly-built probe set. Used to look up the
             authoritative ``aggressiveness`` (and ``type``/``target``
             when normalising legacy bodies) for each matching probe.
-        extra_vlans: Ignored; retained for caller signature back-compat.
+        extra_vlans: Ignored. Retained for caller signature back-compat.
 
     Returns:
         Merged probe map. Bodies conform to the mini-* shape:
@@ -2135,7 +2135,7 @@ def _merge_probes(
     del extra_vlans
     merged: dict[str, dict[str, Any]] = {}
     for name, probe in existing_tool.items():
-        # Prefer freshly-built type/target (new source of truth); fall back
+        # Prefer freshly-built type/target (new source of truth). Fall back
         # to on-org values when the probe is not in ``new_probes``.
         template = new_probes.get(name, probe)
         # Resolve target first because the ``type`` classification depends
@@ -2337,7 +2337,7 @@ def _prompt_confirm(summary: str) -> bool:
     Why:
         Isolated so tests can patch ``input`` without touching the rest
         of the flow. Only exact ``y`` / ``yes`` (case-insensitive)
-        answers proceed; anything else aborts as safe-default.
+        answers proceed. Anything else aborts as safe-default.
 
     Args:
         summary: Multi-line pre-PUT summary from ``_summarise``.
@@ -2422,7 +2422,7 @@ def _clean_test_row(row: Any) -> dict[str, Any] | None:
     probes_field = cleaned.get("probes")
     if isinstance(probes_field, list):
         filtered = [p for p in probes_field if not (isinstance(p, str) and p.startswith(_TOOL_NAME_PREFIX))]
-        # Row that only held zcc-* names is a prior injection; drop so
+        # Row that only held zcc-* names is a prior injection. Drop so
         # re-injection is authoritative.
         if probes_field and not filtered:
             return None
@@ -2554,7 +2554,7 @@ def _merge_zcc_criticals_into_tests(
             with its own ``vlan_ids`` exists.
         extra_regular_names: Optional additional ``zcc-*`` probe names
             to schedule at regular (non-critical) priority. Deduplicated
-            against the critical set; ordering-stable via sort. Rows are
+            against the critical set. Ordering-stable via sort. Rows are
             emitted with the same shape/template as critical rows -- the
             tests[] row itself carries no aggressiveness (that lives on
             the probe body in ``custom_probes``).
@@ -2681,7 +2681,7 @@ def _prompt_and_apply_site_overrides(
             target.
         resulting_tool: The tool-authored probe map just written to the
             org. Used as the source of truth (name/target/type/
-            aggressiveness) to push into each chosen site; each probe's
+            aggressiveness) to push into each chosen site. Each probe's
             ``vlan_ids`` is replaced with the freshly-prompted list.
         sources: The ``(probes, cenr)`` tuple from ``_load_probe_sources``.
             Passed through to ``_apply_to_site`` so per-region Samsung
@@ -2777,7 +2777,7 @@ def _sort_sites_for_picker(sites: list[dict[str, Any]]) -> list[dict[str, Any]]:
         gate. Unnamed sites sink to the end (secondary key = 1) so the
         named entries operators actually think about lead the list;
         name comparison is case-folded so ``ACME`` and ``acme`` sort
-        together; id is the final tie-break to keep the ordering stable
+        together. Id is the final tie-break to keep the ordering stable
         across invocations.
 
     Args:
@@ -2909,7 +2909,7 @@ def _prompt_site_indexes(sites: list[dict[str, Any]]) -> list[dict[str, Any]]:
         indexed prompt eliminates that class of typo entirely and lets
         the operator eyeball site names before committing. The list is
         sorted by human-readable site name (case-insensitive) so the
-        picker matches how operators think about their fleet; unnamed
+        picker matches how operators think about their fleet. Unnamed
         sites sink to the bottom. Full site dicts are returned (not just
         ids) so downstream code can read per-site fields like
         ``country_code`` without a second API round-trip. Accepts range
@@ -3086,7 +3086,7 @@ def _apply_to_site(
     if not isinstance(existing_tests, list):
         existing_tests = []
     # Region and ZEN probes are auto-priority, so the default critical-only
-    # filter would not schedule them; pass their names explicitly so each
+    # filter would not schedule them. Pass their names explicitly so each
     # gets a tests[] row and actually runs.
     synthetic["tests"] = _merge_zcc_criticals_into_tests(
         existing_tests,

--- a/src/org/org_ticket_manager.py
+++ b/src/org/org_ticket_manager.py
@@ -383,7 +383,7 @@ class OrgTicketManager:  # Support ticket operations.
 
     @staticmethod
     def _fetch_tickets_for_selection(org_id: str) -> list:
-        """Fetch ticket summaries for selection; print + return [] on error/empty."""
+        """Fetch ticket summaries for selection. Print + return [] on error/empty."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of mistapi + apisession.
         logging.info("Fetching ticket list for selection (org %s)", org_id)  # Log before API call
         try:
@@ -420,7 +420,7 @@ class OrgTicketManager:  # Support ticket operations.
 
     @staticmethod
     def _resolve_ticket_choice(choice: str, tickets: list) -> str:
-        """Parse numeric choice into ticket ID; print error + return '' on bad input."""
+        """Parse numeric choice into ticket ID. Print error + return '' on bad input."""
         try:
             idx = int(choice) - 1  # Convert 1-based to 0-based index
         except ValueError:  # Non-numeric input that was not 'm'

--- a/src/org_data_collector.py
+++ b/src/org_data_collector.py
@@ -107,8 +107,8 @@ class Operation:  # WHY: Immutable slotted bundle replaces per-entry dict[str, A
     api_call: Callable[..., Any]  # WHY: mistapi function reference invoked by _run_single
     data_type: str  # WHY: Human-readable label for filenames, logging, and progress lines
     category: str  # WHY: Grouping banner printed once per contiguous run of same-category ops
-    sort_key: str | None = None  # WHY: Result sort field; None falls back to _DEFAULT_SORT_KEY
-    paginated: bool = True  # WHY: Paginated endpoints receive limit=_DEFAULT_LIMIT; others pass None
+    sort_key: str | None = None  # WHY: Result sort field. None falls back to _DEFAULT_SORT_KEY
+    paginated: bool = True  # WHY: Paginated endpoints receive limit=_DEFAULT_LIMIT. Others pass None
     api_kwargs: dict[str, Any] = field(default_factory=dict)  # WHY: Extra kwargs (for example distinct=mac)
 
 
@@ -616,7 +616,7 @@ def _split_elapsed(elapsed: float) -> tuple[int, int]:
 
 def _print_summary_banner(total: int, totals: _RunTotals, minutes: int, seconds: int) -> None:
     """Emit the operator-facing summary banner for the completed run."""  # WHY: Pure console output helper
-    logging.warning(  # WHY: Summary banner via logger; single call preserves block cohesion.
+    logging.warning(  # WHY: Summary banner via logger. Single call preserves block cohesion.
         "\n%s\n  Org Data Collection Complete\n%s\n"
         "  Total:     %s\n"
         "  Succeeded: %s\n"

--- a/src/refactors/anomaly_metrics_discovery.py
+++ b/src/refactors/anomaly_metrics_discovery.py
@@ -2,7 +2,7 @@
 
 Discovers site-scoped anomaly metrics from ConstInsightMetrics.csv for
 AI/ML analysis. Originally defined as ``AnomalyMetricsDiscovery`` inside
-MistHelper.py; extracted here per initiative 1011 to shrink the monolith.
+MistHelper.py. Extracted here per initiative 1011 to shrink the monolith.
 
 Runtime dependency ``FilePathUtils`` still lives inside MistHelper.py and
 is resolved lazily via the ``_MH`` module-level proxy so this module keeps

--- a/src/refactors/connection_pool_executor.py
+++ b/src/refactors/connection_pool_executor.py
@@ -7,7 +7,7 @@ helper chain (MistHelper.py:7374-7542), and re-lands them as
 carry-forward. All 7 known callsites (3 in MistHelper.py + 2 in the
 gateway export utilities + 1 in the override device fetcher + 1 in the
 serial-CC helper) are rewritten in the same PR to reference the extracted
-class method; no wrapper shim remains in MistHelper.py after this extraction.
+class method. No wrapper shim remains in MistHelper.py after this extraction.
 
 FR-015 sibling-helpers-travel-with-parent: the full 11-helper chain moves
 together to preserve behavior. Splitting the chain would leave orphaned
@@ -40,10 +40,10 @@ def _resolve_fast_mode_env() -> tuple[bool, int, int]:  # Late-bind MistHelper m
     src/refactors/fast_mode_constants.py per initiative 1015 T-02, and
     FAST_MODE_USE_CONNECTION_AWARE_THREADING is imported from the same
     module per T-03 (both bypass the ``MistHelper.SYMBOL`` module-attribute
-    hop); FAST_MODE_FALLBACK_THREADS remains on MistHelper pending later
+    hop). FAST_MODE_FALLBACK_THREADS remains on MistHelper pending later
     extraction.
     """
-    import MistHelper  # Late-binding import; MistHelper is fully loaded by the time methods run
+    import MistHelper  # Late-binding import. MistHelper is fully loaded by the time methods run
     from src.refactors.fast_mode_constants import (
         FAST_MODE_MAX_CONCURRENT_CONNECTIONS,  # Direct import of the extracted concurrent-connection cap (post-T-02)
         FAST_MODE_USE_CONNECTION_AWARE_THREADING,  # Direct import of the threading-strategy toggle (post-T-03)
@@ -106,7 +106,7 @@ class ConnectionPoolExecutor:  # Class-body seam for the connection-pool-managed
             if result:  # Truthy result means the worker succeeded and returned data
                 return "success", result  # Hand the successful result back to the caller
             return "failed", item  # Falsy result (empty/None) -- treat the item as failed for retry
-        except Exception as exc:  # Worker threw an exception; log and track as failed
+        except Exception as exc:  # Worker threw an exception. Log and track as failed
             logging.error(  # Emit error log with item context for post-mortem debugging
                 "! Future exception for %s %s: %s", config.batch_description.rstrip("s"), item, exc
             )
@@ -115,7 +115,7 @@ class ConnectionPoolExecutor:  # Class-body seam for the connection-pool-managed
     @staticmethod
     def _pool_advance_progress_bar(pbar: Any) -> None:
         """Advance a tqdm progress bar by one, isolating any tqdm.update error so it cannot mask real results."""
-        try:  # tqdm.update can fail in some environments; isolate that error
+        try:  # tqdm.update can fail in some environments. Isolate that error
             pbar.update(1)  # Advance progress bar by one item for each completed future
         except Exception as upd_err:  # Progress bar update failure should not mask the real work result
             logging.error("! Progress bar update failed: %s", upd_err)  # Log progress bar failure for debugging
@@ -186,7 +186,7 @@ class ConnectionPoolExecutor:  # Class-body seam for the connection-pool-managed
     @staticmethod
     def _pool_emit_traceback_lines(batch_exc: Exception) -> None:  # Emit traceback lines to log
         """Format batch exception traceback and emit each line as an error record (best-effort)."""
-        try:  # Best-effort capture; serialization failure must not suppress the re-raise
+        try:  # Best-effort capture. Serialization failure must not suppress the re-raise
             import traceback as _tb2  # Local import to avoid affecting module namespace
 
             formatted = "".join(  # Format the exception into a multi-line string for line-by-line emission
@@ -287,7 +287,7 @@ class ConnectionPoolExecutor:  # Class-body seam for the connection-pool-managed
         # WHY: extracted so execute() drops from 39 lines to <25 per STRUCT-LENGTH.
         if not (failed_items and retry_function):  # Fast-exit when nothing to retry
             return failed_items  # Return unchanged failure list
-        return ConnectionPoolExecutor._pool_apply_retry(  # Retry failed items; merge recoveries in place
+        return ConnectionPoolExecutor._pool_apply_retry(  # Retry failed items. Merge recoveries in place
             failed_items, retry_function, batch_config.connection_semaphore, successful_results, batch_description
         )
 
@@ -303,7 +303,7 @@ class ConnectionPoolExecutor:  # Class-body seam for the connection-pool-managed
             batch_description,
             len(failed_items),
         )
-        logging.debug(  # AFTER: pool run finished; log final counts
+        logging.debug(  # AFTER: pool run finished. Log final counts
             "[POOL-EXECUTE] Pool execution finished: %s successful, %s failed",
             len(successful_results),
             len(failed_items),

--- a/src/refactors/data_directory_checker.py
+++ b/src/refactors/data_directory_checker.py
@@ -96,58 +96,58 @@ class DataDirectoryChecker:
 
     def _print_error_header(self) -> None:  # Display error banner with path
         """Print the error header with path information."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("\n%s", "=" * 70)  # Print separator to visually isolate error message
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("ERROR: Data directory is not writable!")  # Print main error message
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("%s", "=" * 70)  # Print closing separator
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("\nPath: %s", os.path.abspath(self.data_dir))  # Print absolute path
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("\nMistHelper cannot write logs or data to the data/ directory.")  # Explain impact
 
     def _print_container_guidance(self) -> None:  # Display container-specific remediation
         """Print guidance specific to container deployments."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n[CONTAINER DETECTED]")  # Indicate container environment detected
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "The container runs as non-root user 'misthelper' for security."
         )  # Explain why permissions are restricted
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("The mounted data/ directory must have write permissions.")  # State the requirement
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nTo fix this, run the following on your HOST machine:")  # Provide context for the fix
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n    chmod -R 777 data/")  # Show command to grant write permissions
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nThen restart the container:")  # Explain next step
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("    podman stop misthelper && podman rm misthelper")  # Show stop and remove command
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "    podman run -d --name misthelper -p 2200:2200 -p 8050:8050 \\"
         )  # Show container restart with port mapping
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             '        -v "${PWD}/data:/app/data:rw" -v "${PWD}/.env:/app/.env:ro" \\'
         )  # Show volume mount with correct permissions
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("        ghcr.io/jmorrison-juniper/misthelper:latest")  # Show container image URI
 
     def _print_local_guidance(self) -> None:  # Display local environment remediation
         """Print guidance for local (non-container) environments."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nTo fix this, ensure the data/ directory is writable:")  # Provide context for local fix
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n    chmod -R 755 data/")  # Show command to set directory permissions
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("    # Or if you own the directory:")  # Provide alternative if ownership is an issue
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("    chown -R $(whoami) data/")  # Show command to change ownership to current user
 
     def _print_error_footer(self) -> None:  # Display error footer separator
         """Print the closing separator line."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("\n%s", "=" * 70)  # Print separator line to visually isolate error message

--- a/src/refactors/device_config_template_cloner_manager.py
+++ b/src/refactors/device_config_template_cloner_manager.py
@@ -3,7 +3,7 @@
 Thin adapter around ``src.gateway.device_template_cloner`` that wires
 runtime dependencies (API session, input wrapper, path/data helpers,
 config utils) into the extracted implementation. Originally defined
-inline in MistHelper.py; hoisted here per initiative 1011 to shrink the
+inline in MistHelper.py. Hoisted here per initiative 1011 to shrink the
 monolith.
 
 Runtime dependencies (``apisession``, ``InputUtils``, ``FilePathUtils``,

--- a/src/refactors/device_data_fetcher.py
+++ b/src/refactors/device_data_fetcher.py
@@ -1,7 +1,7 @@
 """DeviceDataFetcher extracted from MistHelper.
 
 Interactive device data fetcher for single-device operations. Originally
-defined as ``DeviceDataFetcher`` inside MistHelper.py; extracted here per
+defined as ``DeviceDataFetcher`` inside MistHelper.py. Extracted here per
 initiative 1011 to shrink the monolith.
 
 Runtime dependencies (``PromptUtils``, ``DataProcessingUtils``,
@@ -34,8 +34,8 @@ class DeviceFetchConfig:
     filename: str  # Output filename for the exported data
     description: str  # Human-readable description shown to the user during the fetch
     device_type: str = "all"  # Device type filter (all/ap/switch/gateway); 'all' avoids the AP-only API default
-    site_id: str | None = None  # Optional site scope; None means an org-wide fetch
-    device_id: str | None = None  # Optional single-device scope; None means all matching devices
+    site_id: str | None = None  # Optional site scope. None means an org-wide fetch
+    device_id: str | None = None  # Optional single-device scope. None means all matching devices
 
 
 class _MistHelperProxy:  # Attribute forwarder to MistHelper module attributes
@@ -89,14 +89,14 @@ class DeviceDataFetcher:
 
     def _resolve_site_id(self) -> bool:
         """Resolve site ID from parameter or user prompt."""
-        if self.site_id:  # Caller may have pre-supplied the site; reuse it verbatim
+        if self.site_id:  # Caller may have pre-supplied the site. Reuse it verbatim
             return True  # Already resolved
         self.site_id = _MH.PromptUtils.select_site_id_from_csv()  # Interactive site selection from CSV inventory
         return bool(self.site_id)  # False when the user cancelled or no sites exist
 
     def _resolve_device_id(self) -> bool:
         """Resolve device ID from parameter or user prompt."""
-        if self.device_id:  # Caller may have pre-supplied the device; reuse it verbatim
+        if self.device_id:  # Caller may have pre-supplied the device. Reuse it verbatim
             return True  # Already resolved
         assert self.site_id is not None, "Site ID must be resolved before device ID"  # nosec B101
         self.device_id = _MH.PromptUtils.select_device_id_from_inventory(  # Interactive device selection

--- a/src/refactors/endpoint_primary_key_strategies.py
+++ b/src/refactors/endpoint_primary_key_strategies.py
@@ -2296,7 +2296,7 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "BLE beacon statistics per site (composite key: beacon id + site)",
     },
-    # --- composite_pk (no single stable UUID; identity is multi-field) ---
+    # --- composite_pk (no single stable UUID. Identity is multi-field) ---
     "getSiteCurrentChannelPlanning": {
         "type": "composite_pk",
         "primary_key": ["ap", "band"],

--- a/src/refactors/fast_mode_backoff_multiplier.py
+++ b/src/refactors/fast_mode_backoff_multiplier.py
@@ -5,7 +5,7 @@ module scope in MistHelper.py, and re-lands it as a class-level
 attribute on `FastModeBackoffMultiplier` per FR-005 / FR-015. Both
 MistHelper callsites (`_handle_site_port_stats_retry` at line ~9899 and
 the fast-retry helper at line ~15328) are rewritten in the same PR to
-reference the extracted class attribute; no wrapper shim remains in
+reference the extracted class attribute. No wrapper shim remains in
 MistHelper.py after this extraction.
 
 The value is the exponential-backoff growth factor applied to the

--- a/src/refactors/fast_mode_constants.py
+++ b/src/refactors/fast_mode_constants.py
@@ -3,7 +3,7 @@
 Home for bare module-level constants that tune the fast-mode concurrent-execution
 pipeline in MistHelper. Kept as plain module-level names (not class attributes) per
 the T-02 landing-target decision: single co-location file for the fast-mode
-env-derived constants (T-02 added the connection cap; T-03 folded in the
+env-derived constants (T-02 added the connection cap. T-03 folded in the
 connection-aware threading toggle) to avoid per-constant module proliferation. No
 wrapper class, no facade, no shim -- all callers import the bare name directly
 from this module.
@@ -24,7 +24,7 @@ FAST_MODE_MAX_CONCURRENT_CONNECTIONS: int = int(  # Cap on simultaneous API conn
 
 # WHAT: Toggle selecting the threading strategy for fast-mode batch executors.
 # WHY: When True, ThreadPoolExecutor sizing tracks FAST_MODE_MAX_CONCURRENT_CONNECTIONS
-#      (connection-aware mode); when False, executors fall back to CPU-aware sizing
+#      (connection-aware mode). When False, executors fall back to CPU-aware sizing
 #      (os.cpu_count() or FAST_MODE_FALLBACK_THREADS). Sourced from the
 #      FAST_MODE_USE_CONNECTION_AWARE_THREADING env var (default "true") at import time.
 FAST_MODE_USE_CONNECTION_AWARE_THREADING: bool = (  # Whether to size threads based on connection limits

--- a/src/refactors/fast_mode_devices_per_thread.py
+++ b/src/refactors/fast_mode_devices_per_thread.py
@@ -5,13 +5,13 @@ module scope in MistHelper.py, and re-lands it as a class-level
 attribute on `FastModeDevicesPerThread` per FR-005 / FR-015. The sole
 MistHelper callsite (batch-size sizing in `_pool_configure` at line
 ~7392) is rewritten in the same PR to reference the extracted class
-attribute; no wrapper shim remains in MistHelper.py after this
+attribute. No wrapper shim remains in MistHelper.py after this
 extraction.
 
 The value is the number of devices each worker thread handles in
 fast-mode workflows -- multiplied by `max_threads` to yield the effective
 batch size. Source of truth remains the `FAST_MODE_DEVICES_PER_THREAD`
-environment variable (default 10); the class-body evaluation preserves
+environment variable (default 10). The class-body evaluation preserves
 the original `os.getenv` semantics.
 """
 

--- a/src/refactors/fast_mode_sequential_max_retries.py
+++ b/src/refactors/fast_mode_sequential_max_retries.py
@@ -7,7 +7,7 @@ MistHelper callsites -- `_gw_retry_configs` at line ~6294 (which
 previously called `os.getenv` inline) and the sequential-fallback
 `fetch_synthetic_test_stats_with_retry` invocation at line ~15476 --
 are rewritten in the same PR to reference the extracted class
-attribute; no wrapper shim remains in MistHelper.py after this
+attribute. No wrapper shim remains in MistHelper.py after this
 extraction.
 
 The value is the retry ceiling for the sequential fallback pass in

--- a/src/refactors/initialize_mist_session.py
+++ b/src/refactors/initialize_mist_session.py
@@ -5,7 +5,7 @@ as the top-level `initialize_mist_session` function in MistHelper.py, and
 re-lands it as a class-body method per FR-005. The two MistHelper
 callsites (entrypoint `_establish_mist_session` token path and TUI
 guard `_ensure_tui_api_session`) are rewritten in the same PR to invoke
-the class method; no wrapper shim remains in MistHelper.py after this
+the class method. No wrapper shim remains in MistHelper.py after this
 extraction.
 
 MistHelper module-globals (`apisession`, `mistapi`) and helper functions

--- a/src/refactors/initialize_mist_session_interactive.py
+++ b/src/refactors/initialize_mist_session_interactive.py
@@ -5,7 +5,7 @@ top-level `initialize_mist_session_interactive` function in MistHelper.py,
 and re-lands it as a class-body method per FR-005. The three MistHelper
 callsites (login retry after args, session-switch flow, entrypoint
 `_establish_mist_session`) are rewritten in the same PR to invoke the
-class method; no wrapper shim remains in MistHelper.py after this
+class method. No wrapper shim remains in MistHelper.py after this
 extraction.
 
 MistHelper module-globals (`apisession`, `mistapi`, `msp_privileges`,

--- a/src/refactors/inventory_csvcomparator.py
+++ b/src/refactors/inventory_csvcomparator.py
@@ -3,7 +3,7 @@
 Thin adapter around ``src.inventory.csv_comparator`` that wires runtime
 dependencies (API session, path utils, cache helpers, address validation
 classes) into the extracted implementation. Originally defined inline in
-MistHelper.py; hoisted here per initiative 1011 to shrink the monolith.
+MistHelper.py. Hoisted here per initiative 1011 to shrink the monolith.
 
 Runtime dependencies (``apisession``, ``FilePathUtils``, ``CacheUtils``,
 ``OrgInventoryExporter``, ``ConfigUtils``, ``DeviceUtils``,

--- a/src/refactors/main_entrypoint.py
+++ b/src/refactors/main_entrypoint.py
@@ -4,7 +4,7 @@ Owns the top-level `main` entry function originally defined at module
 scope in MistHelper.py, and re-lands it as a class-body method per
 FR-005. The sole MistHelper callsite (the `__main__` guard invocation
 at the bottom of the module) is rewritten in the same PR to invoke the
-class method; no wrapper shim remains in MistHelper.py after this
+class method. No wrapper shim remains in MistHelper.py after this
 extraction.
 
 All six pipeline dependencies (`_initialize_deferred_imports`,

--- a/src/refactors/marvis_data_utils.py
+++ b/src/refactors/marvis_data_utils.py
@@ -6,7 +6,7 @@ defined at module scope in MistHelper.py, and re-lands it on a
 MistHelper callsite (the ClientTroubleshootingManager dependency-
 injection kwarg `marvis_data_utils=marvis_data_utils` at line 15656) is
 rewritten in the same PR to invoke the factory's `instance` class
-method; no wrapper shim remains in MistHelper.py after this extraction.
+method. No wrapper shim remains in MistHelper.py after this extraction.
 
 The concrete `MarvisDataUtils` class continues to live at
 `src.marvis.marvis_utils` -- this seam owns only the wired-up singleton.

--- a/src/refactors/mist_site_exclude_prefix.py
+++ b/src/refactors/mist_site_exclude_prefix.py
@@ -10,7 +10,7 @@ probe configuration, Menu #167 WAN probe device overrides).
 Landing per E-14 as a **bare module-level constant** -- no wrapper
 class, no getter function. The value is captured once at import time
 from ``os.getenv`` with an empty-string default (no defaults per the
-original comment; missing env var means "no sites excluded").
+original comment. Missing env var means "no sites excluded").
 
 ``MistHelper.py`` re-exports the constant so historical
 ``MistHelper.MIST_SITE_EXCLUDE_PREFIX`` / ``mh.MIST_SITE_EXCLUDE_PREFIX``

--- a/src/refactors/mist_wan_target_ports.py
+++ b/src/refactors/mist_wan_target_ports.py
@@ -6,13 +6,13 @@ attribute on `MistWanTargetPorts` per FR-005 / FR-015 (assignment ->
 class-body attribute). The sole MistHelper callsite -- the DI kwarg
 `mist_wan_target_ports=MIST_WAN_TARGET_PORTS` in
 `_gateway_export_dependency_kwargs` at line ~15568 -- is rewritten in
-the same PR to reference the extracted class attribute; no wrapper
+the same PR to reference the extracted class attribute. No wrapper
 shim remains in MistHelper.py after this extraction.
 
 The value is the operator-configured, comma-separated list of WAN port
 names to target for gateway-override analysis. Source of truth remains
 the `MIST_WAN_TARGET_PORTS` environment variable (no default -- an
-unset env yields an empty list); the class-body evaluation preserves
+unset env yields an empty list). The class-body evaluation preserves
 the original CSV-parsing semantics.
 
 FR-019 note: The local DI slots named `MIST_WAN_TARGET_PORTS` in
@@ -20,7 +20,7 @@ FR-019 note: The local DI slots named `MIST_WAN_TARGET_PORTS` in
 `src/gateway/overrides/_deps.py:17` are local module-level variables
 that receive their value at runtime via the injected `deps` struct.
 They are not references to the deleted MistHelper.py symbol and remain
-unchanged by this extraction; the cross-file audit trail verifies the
+unchanged by this extraction. The cross-file audit trail verifies the
 sole external-file caller path continues to flow through the DI kwarg.
 """
 

--- a/src/refactors/msp_privilege_detection.py
+++ b/src/refactors/msp_privilege_detection.py
@@ -21,7 +21,7 @@ Callsites rewritten in this PR:
   module-global cache.
 - ``src/refactors/initialize_mist_session_interactive.py`` already passed the
   session and returned the list to the LoginOrchestrator, which stashes it
-  into the state bag; no change required beyond signature (session now
+  into the state bag. No change required beyond signature (session now
   required, no default).
 - ``src/export/msp_inventory_exporter.py`` explicitly assigns the return
   value to ``MistHelper.msp_privileges`` after detection.
@@ -52,7 +52,7 @@ def _fetch_msp_name(msp_id: str, session: Any) -> str | None:
     if session is None:  # No active session to query with
         logging.debug("_fetch_msp_name: no session, returning None")  # AFTER: no-session trace
         return None  # Cannot look anything up
-    try:  # API call and payload parsing may fail; degrade to None on any error
+    try:  # API call and payload parsing may fail. Degrade to None on any error
         import mistapi.api.v1.msps.msps as msps_api  # noqa: PLC0415  # Lazy import of MSP details endpoint
 
         response = msps_api.getMspDetails(session, msp_id)  # Fetch the MSP record by ID via the shared session
@@ -81,7 +81,7 @@ def _msp_parse_one_privilege(priv: Any, session: Any) -> dict[str, Any] | None:
     logging.debug("_msp_parse_one_privilege: entry")  # BEFORE: trace parse entry
     if not (isinstance(priv, dict) and priv.get("msp_id")):  # Only MSP-scoped dict grants qualify.
         logging.debug("_msp_parse_one_privilege: not an MSP grant, returning None")  # AFTER: non-msp trace
-        return None  # Not an MSP grant; skip it.
+        return None  # Not an MSP grant. Skip it.
     logging.debug(
         "MSP privilege found: scope=%s, role=%s", priv.get("scope"), priv.get("role")
     )  # Log the grant details.
@@ -143,7 +143,7 @@ def detect_msp_privileges(session: Any) -> list[dict[str, Any]]:
 
     ``session`` is REQUIRED (an authenticated mistapi session). Returns the list of MSP
     privilege dicts (msp_id, msp_name, role, scope), or [] when there is no MSP access or
-    detection fails. This function does NOT touch any module-global; the caller is
+    detection fails. This function does NOT touch any module-global. The caller is
     responsible for publishing the result to ``MistHelper.msp_privileges`` if desired.
     """
     logging.info(

--- a/src/refactors/package_import_map.py
+++ b/src/refactors/package_import_map.py
@@ -4,7 +4,7 @@ Owns the `PACKAGE_IMPORT_MAP` constant originally defined at module
 scope in MistHelper.py, and re-lands it on a lightweight
 `PackageImportMapManager` seam per FR-005 / FR-015. The sole MistHelper
 callsite (`_early_dependency_check` bootstrap wiring) is rewritten in
-the same PR to import the extracted constant; no wrapper shim remains
+the same PR to import the extracted constant. No wrapper shim remains
 in MistHelper.py after this extraction.
 
 The mapping keys are pip distribution names and values are the

--- a/src/refactors/serial_cc/import_initialization_service.py
+++ b/src/refactors/serial_cc/import_initialization_service.py
@@ -37,7 +37,7 @@ class ImportInitializationService:
                 required=required,
                 skip_deps=skip_deps,
                 skip_upgrade=True,
-            )  # Attempt the import (no upgrade here; upgrades happen in the dependency phase)
+            )  # Attempt the import (no upgrade here. Upgrades happen in the dependency phase)
             if result:  # Import succeeded
                 logging.info("  [OK] %s: Available", module_name)  # Trace availability
             elif required:  # Required import failed - this is an error

--- a/src/refactors/serial_cc/security_events.py
+++ b/src/refactors/serial_cc/security_events.py
@@ -17,7 +17,7 @@ from src.dataclasses.progress_event import (
     ProgressContext,
 )  # Bundles progress identity for emit_progress_* (issue #470).
 
-_OUTPUT_FILES: tuple[str, ...] = (  # Files the service produces; also drives fast-mode freshness.
+_OUTPUT_FILES: tuple[str, ...] = (  # Files the service produces. Also drives fast-mode freshness.
     "OrgSecurityPolicies.csv",  # Flattened org security policies dataset.
     "OrgSecIntelProfiles.csv",  # Flattened org security intelligence profiles dataset.
     "OrgRogueData.csv",  # Combined rogue APs and rogue clients dataset.
@@ -88,18 +88,18 @@ class SecurityEventsService:
             logging.info(
                 "Fast mode cache hit: All security data CSVs are fresh; skipping fetch."
             )  # Trace short-circuit.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("* Fast mode: Using cached security data (all files fresh)")
-            return  # No fetch needed; the cached CSVs are still valid.
+            return  # No fetch needed. The cached CSVs are still valid.
         SecurityEventsService._run_export_workflow(deps)  # Delegate the actual export to keep this entrypoint short.
 
     @staticmethod
     def _run_export_workflow(deps: SimpleNamespace) -> None:
         """Execute the three security exports and emit progress bookends."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Export Organization Security Data:")
         logging.info("Starting export of organization security policies, intelligence profiles, and rogue data...")
-        emitter = deps.PROGRESS_EMITTER  # Optional; None disables progress emission.
+        emitter = deps.PROGRESS_EMITTER  # Optional. None disables progress emission.
         if emitter:
             emitter.emit_progress_start(
                 _PROGRESS_ISSUE_ID, _PROGRESS_STAGE, _PROGRESS_TOTAL
@@ -109,7 +109,7 @@ class SecurityEventsService:
         for spec in SecurityEventsService._build_flattened_specs(deps, current_org_id):  # Loop over datasets.
             SecurityEventsService._export_flattened_dataset(deps, spec)  # Fetch + flatten + export one dataset.
         SecurityEventsService._export_rogue_data(deps)  # Third file: combined rogue export.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Security data export completed (3 files generated)")
         logging.info("Completed security policies, intelligence profiles, and rogue data export aggregate.")
         if emitter:
@@ -123,7 +123,7 @@ class SecurityEventsService:
     @staticmethod
     def _all_outputs_fresh(deps: SimpleNamespace, output_files: list[str]) -> bool:
         """Return True when every expected CSV exists and is still fresh."""
-        for output_file in output_files:  # Every file must pass; a single miss falsifies the check.
+        for output_file in output_files:  # Every file must pass. A single miss falsifies the check.
             try:
                 path = deps.FilePathUtils.get_csv_path(output_file)  # Resolve absolute path via the util.
                 if not os.path.exists(path):  # Missing file means no cache to trust.
@@ -131,7 +131,7 @@ class SecurityEventsService:
                 age_minutes = (time.time() - os.path.getmtime(path)) / 60.0  # Convert mtime delta to minutes.
                 if age_minutes >= deps.csv_freshness_minutes:  # Stale => refetch is required.
                     return False
-            except Exception:  # Any filesystem error means we cannot prove freshness; fall through to refetch.
+            except Exception:  # Any filesystem error means we cannot prove freshness. Fall through to refetch.
                 return False
         return True  # All files exist and are within the freshness window.
 
@@ -166,7 +166,7 @@ class SecurityEventsService:
         """Fetch, flatten, and export a single org dataset described by ``spec``."""
         dataset = SecurityEventsService._fetch_dataset(deps, spec)  # Isolate the try/except paging in a helper.
         if not dataset:  # Guard clause: write an empty file and note the miss for observability.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(
                 "! 0 %s exported to %s %s",
                 spec.data_label,
@@ -179,7 +179,7 @@ class SecurityEventsService:
         processed = deps.DataProcessingUtils.flatten_nested_fields(dataset)  # Flatten nested API structures.
         processed = deps.DataProcessingUtils.escape_multiline(processed)  # Escape multiline fields for CSV safety.
         deps.DataExporter.write_with_format_selection(processed, spec.output_file)  # Emit the CSV/XLSX file.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "! %d %s exported to %s",
             len(processed),
@@ -197,7 +197,7 @@ class SecurityEventsService:
             dataset = deps.mistapi.get_all(response=response, mist_session=deps.apisession) or []  # Page all rows.
             logging.debug("%s fetched: %d", spec.data_label.capitalize(), len(dataset))  # Trace row count.
             return dataset
-        except Exception as error:  # Fetch failure is non-fatal; we still write an empty export downstream.
+        except Exception as error:  # Fetch failure is non-fatal. We still write an empty export downstream.
             logging.warning("Failed to fetch %s: %s", spec.start_label, error)  # Trace the failure cause.
             return []
 
@@ -225,7 +225,7 @@ class SecurityEventsService:
     def _fetch_site_rogue(
         deps: SimpleNamespace, site_id: str, site_name: str, rogue_duration: str
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-        """Fetch tagged rogue APs and rogue clients for one site; return ([],[]) on failure."""
+        """Fetch tagged rogue APs and rogue clients for one site. Return ([],[]) on failure."""
         try:  # Per-site failures are non-fatal for the whole export.
             aps = SecurityEventsService._fetch_tagged_rogue(
                 deps, site_id, site_name, rogue_duration, _ROGUE_KINDS[0]
@@ -250,7 +250,7 @@ class SecurityEventsService:
     ) -> Iterator[tuple[list[dict[str, Any]], list[dict[str, Any]]]]:
         """Yield (aps, clients) tuples per valid site, honoring the stop signal."""
         site_list_path = deps.FilePathUtils.get_csv_path(_SITE_LIST_CSV)  # Resolve the cached site list path.
-        with open(site_list_path, encoding="utf-8") as file_handle:  # Site list is small; read fully.
+        with open(site_list_path, encoding="utf-8") as file_handle:  # Site list is small. Read fully.
             sites = list(csv.DictReader(file_handle))  # Materialize rows so tqdm can size the bar.
         for site in deps.tqdm(sites, desc="Sites", unit="site"):  # Progress bar wraps the site loop.
             if deps.ConfigUtils.check_stop_signal():  # Honor a cooperative user cancel.
@@ -264,8 +264,8 @@ class SecurityEventsService:
     @staticmethod
     def _export_rogue_combined(deps: SimpleNamespace, all_rogue_data: list[dict[str, Any]]) -> None:
         """Flatten + export combined rogue data, or write an empty file when nothing was found."""
-        if not all_rogue_data:  # Guard: no rogue devices anywhere; still emit an empty file for consistency.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        if not all_rogue_data:  # Guard: no rogue devices anywhere. Still emit an empty file for consistency.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! 0 rogue devices exported to OrgRogueData.csv (no rogue devices found)")
             logging.info("No rogue devices found across all sites (OrgRogueData.csv written empty).")  # Trace empty.
             deps.DataExporter.write_with_format_selection([], _ROGUE_OUTPUT)  # Consistent empty export.
@@ -273,7 +273,7 @@ class SecurityEventsService:
         processed = deps.DataProcessingUtils.flatten_nested_fields(all_rogue_data)  # Flatten nested rogue fields.
         processed = deps.DataProcessingUtils.escape_multiline(processed)  # Escape multiline fields for CSV.
         deps.DataExporter.write_with_format_selection(processed, _ROGUE_OUTPUT)  # Write the combined rogue export.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("! %d rogue devices exported to OrgRogueData.csv", len(processed))
         logging.info("Exported %d rogue devices to OrgRogueData.csv", len(processed))  # Trace export volume.
 
@@ -289,7 +289,7 @@ class SecurityEventsService:
         deps.CacheUtils.check_and_generate_csv(_SITE_LIST_CSV, deps.OrgSiteExporter.sites)  # Ensure site list exists.
         all_rogue_aps: list[dict[str, Any]] = []  # Accumulates tagged rogue APs across sites.
         all_rogue_clients: list[dict[str, Any]] = []  # Accumulates tagged rogue clients across sites.
-        try:  # Guard site-list reading + iteration; failure here aborts this export only.
+        try:  # Guard site-list reading + iteration. Failure here aborts this export only.
             for aps, clients in SecurityEventsService._iterate_site_rogue(deps, rogue_duration):  # Per-site fan-out.
                 all_rogue_aps.extend(aps)  # Accumulate rogue APs.
                 all_rogue_clients.extend(clients)  # Accumulate rogue clients.

--- a/src/refactors/serial_cc/site_client_insights.py
+++ b/src/refactors/serial_cc/site_client_insights.py
@@ -97,12 +97,12 @@ class _ExportContext:
 
 def _emit_preview_rows(clients: list[dict[str, Any]], site_name: str) -> None:
     """Print the client-count summary and the first _PREVIEW_LIMIT rows (kept CC low)."""
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info(_MSG_FOUND_TMPL, len(clients), site_name)  # WHY: Summary count line
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info(_MSG_PREVIEW_HEADER)  # WHY: Preview header
     for index, client in enumerate(clients[:_PREVIEW_LIMIT]):  # WHY: Show only the first few rows
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             _MSG_PREVIEW_ROW_TMPL,
             index,
@@ -131,7 +131,7 @@ class SiteClientInsightsService:
     @staticmethod
     def _resolve_site_name(deps: SimpleNamespace, site_id: str) -> str:
         """Resolve the human-readable site name, falling back to the site id on failure."""
-        try:  # WHY: Site name lookup is best-effort; any failure falls back to the id
+        try:  # WHY: Site name lookup is best-effort. Any failure falls back to the id
             response = deps.mistapi.api.v1.sites.listSites(deps.apisession, site_id)  # WHY: Fetch site metadata
             sites = deps.mistapi.get_all(response=response, mist_session=deps.apisession)  # WHY: Page all sites
             return next((site[_KEY_NAME] for site in sites if site[_KEY_ID] == site_id), site_id)  # WHY: Match id->name
@@ -140,8 +140,8 @@ class SiteClientInsightsService:
 
     @staticmethod
     def _list_and_display_clients(deps: SimpleNamespace, site_id: str, site_name: str) -> list[dict[str, Any]]:
-        """Fetch wireless clients for the site and print a short preview; return the client list."""
-        try:  # WHY: Client listing is best-effort; failures are warned and yield an empty list
+        """Fetch wireless clients for the site and print a short preview. Return the client list."""
+        try:  # WHY: Client listing is best-effort. Failures are warned and yield an empty list
             response = deps.mistapi.api.v1.sites.stats.listSiteWirelessClientsStats(
                 deps.apisession, site_id
             )  # WHY: Query wireless clients for the site
@@ -152,33 +152,33 @@ class SiteClientInsightsService:
         if clients:  # WHY: Found at least one client - show a short preview
             _emit_preview_rows(clients, site_name)  # WHY: Delegate preview emission
         else:  # WHY: No clients returned for the site
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_MSG_NO_CLIENTS_TMPL, site_name)  # WHY: Inform the user
         return clients  # WHY: Hand back whatever clients were found (possibly empty)
 
     @staticmethod
     def _resolve_client_mac(client_input: str, clients: list[dict[str, Any]]) -> str | None:
-        """Resolve a client MAC from raw input; return None to abort (message already printed)."""
+        """Resolve a client MAC from raw input. Return None to abort (message already printed)."""
         if not client_input.isdigit():  # WHY: Non-numeric input is treated as a literal MAC string
             return client_input  # WHY: Use the input directly as the MAC
         try:  # WHY: Numeric input is an index into the displayed client list
             index = int(client_input)  # WHY: Parse the index
         except (ValueError, IndexError):  # WHY: Parsing failed despite isdigit (defensive)
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_MSG_INVALID_INDEX_TMPL, client_input)  # WHY: Inform the user
             return None  # WHY: Abort - message already printed
         if not (0 <= index < len(clients)):  # WHY: Index must reference an existing client
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_MSG_INDEX_RANGE_TMPL, index, len(clients) - 1)  # WHY: Inform the user
             return None  # WHY: Abort - message already printed
         client_mac = str(clients[index].get(_KEY_MAC, ""))  # WHY: Resolve MAC (may be empty)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(_MSG_SELECTED_TMPL, client_mac)  # WHY: Echo the selection
         return client_mac  # WHY: Return the resolved MAC (possibly empty string)
 
     @staticmethod
     def _fetch_single_metric(deps: SimpleNamespace, context: _ExportContext, metric: str) -> dict[str, Any] | None:
-        """Fetch one client-scope insight metric; return the tagged record or None on empty/failure."""
+        """Fetch one client-scope insight metric. Return the tagged record or None on empty/failure."""
         try:  # WHY: Per-metric failures are non-fatal and skip to the next metric
             response = deps.mistapi.api.v1.sites.insights.getSiteInsightMetricsForClient(
                 deps.apisession, context.site_id, context.client_mac, metrics=metric
@@ -197,7 +197,7 @@ class SiteClientInsightsService:
     def _collect_client_metrics(
         cls, deps: SimpleNamespace, context: _ExportContext, client_metrics: list[str]
     ) -> tuple[list[dict[str, Any]], int]:
-        """Fetch every client-scope insight metric; return (collected records, retrieved count)."""
+        """Fetch every client-scope insight metric. Return (collected records, retrieved count)."""
         all_client_data: list[dict[str, Any]] = []  # WHY: Accumulator for tagged records
         for metric in client_metrics:  # WHY: Iterate every client-scope metric
             record = cls._fetch_single_metric(deps, context, metric)  # WHY: Fetch one metric (None on empty/failure)
@@ -215,7 +215,7 @@ class SiteClientInsightsService:
     ) -> None:
         """Flatten and export collected client insight data, or write an empty file when none."""
         if not all_client_data:  # WHY: No data collected for any metric - write empty for consistency
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_MSG_EXPORT_EMPTY_TMPL, filename)  # WHY: User summary
             logging.warning(_MSG_EXPORT_EMPTY_LOG, site_name)  # WHY: Warn on empty run
             deps.DataExporter.write_with_format_selection([], filename)  # WHY: Write empty export file
@@ -223,7 +223,7 @@ class SiteClientInsightsService:
         processed = deps.DataProcessingUtils.flatten_nested_fields(all_client_data)  # WHY: Flatten nested structures
         processed = deps.DataProcessingUtils.escape_multiline(processed)  # WHY: Escape multiline fields for CSV
         deps.DataExporter.write_with_format_selection(processed, filename)  # WHY: Write the export file
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(_MSG_EXPORT_OK_TMPL, metrics_retrieved, filename)  # WHY: User summary
         logging.info(_MSG_EXPORT_OK_LOG, metrics_retrieved, site_name, filename)  # WHY: Trace successful export
 
@@ -237,7 +237,7 @@ class SiteClientInsightsService:
     @staticmethod
     def _read_client_input(deps: SimpleNamespace) -> str:
         """Prompt for the client MAC/index and return the trimmed input string."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(_MSG_PROMPT_HEADER)  # WHY: Prompt header
         raw = deps.InputUtils.safe_input(_PROMPT_CLIENT, context=_CTX_CLIENT)  # WHY: Read raw client selection
         return str(raw).strip()  # WHY: str-cast narrows Any for downstream str consumers
@@ -246,17 +246,17 @@ class SiteClientInsightsService:
     def _resolve_normalized_mac(
         cls, deps: SimpleNamespace, client_input: str, clients: list[dict[str, Any]]
     ) -> str | None:
-        """Resolve MAC from input, validate/normalize; return the normalized MAC or None to abort."""
+        """Resolve MAC from input, validate/normalize. Return the normalized MAC or None to abort."""
         client_mac = cls._resolve_client_mac(client_input, clients)  # WHY: Resolve MAC from input (None = abort)
         if client_mac is None:  # WHY: Invalid index/value - helper already printed the reason
             return None  # WHY: Abort silently
         if not client_mac:  # WHY: Resolved to an empty MAC (selected client had no MAC)
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_MSG_NO_MAC)  # WHY: Inform the user
             return None  # WHY: Abort
         normalized = deps.SiteClientExporter._normalize_client_mac_or_none(client_mac)  # WHY: Validate/normalize
         if not normalized:  # WHY: MAC failed format validation
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_MSG_INVALID_MAC_TMPL, client_mac)  # WHY: Inform the user
             logging.error(_MSG_INVALID_MAC_LOG, client_mac)  # WHY: Trace the failure
             return None  # WHY: Abort
@@ -268,7 +268,7 @@ class SiteClientInsightsService:
         client_metrics = deps.InsightMetricsUtils.get_by_scope(_CLIENT_SCOPE)  # WHY: Client-scope metric list
         if client_metrics:  # WHY: At least one metric configured
             return list(client_metrics)  # WHY: Freeze return type (list[str])
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning(_MSG_NO_METRICS)  # WHY: Inform the user of misconfiguration
         logging.error(_MSG_NO_METRICS_LOG)  # WHY: Trace the misconfiguration
         deps.DataExporter.write_with_format_selection([], filename)  # WHY: Write an empty export for consistency
@@ -276,7 +276,7 @@ class SiteClientInsightsService:
 
     @classmethod
     def _run_collect_and_export(cls, deps: SimpleNamespace, context: _ExportContext, client_metrics: list[str]) -> None:
-        """Guarded collect+export path; writes an empty file if the top-level fetch fails."""
+        """Guarded collect+export path. Writes an empty file if the top-level fetch fails."""
         try:  # WHY: Guard the fetch+export so failures still write an empty file
             all_client_data, metrics_retrieved = cls._collect_client_metrics(
                 deps, context, client_metrics
@@ -285,7 +285,7 @@ class SiteClientInsightsService:
                 deps, all_client_data, metrics_retrieved, context.filename, context.site_name
             )  # WHY: Export results
         except Exception as exception:  # WHY: Unexpected top-level failure
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error(_MSG_ERROR_TMPL, exception)  # WHY: User-facing error
             logging.error(_MSG_ERROR_LOG, context.site_name, exception)  # WHY: Trace the failure
             deps.DataExporter.write_with_format_selection([], context.filename)  # WHY: Write empty export on failure
@@ -293,23 +293,23 @@ class SiteClientInsightsService:
     @staticmethod
     def _print_intro_and_refresh(deps: SimpleNamespace) -> None:
         """Emit the banner + refresh notice and run the canonical metric refresh."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(_BANNER)  # WHY: User-facing banner
         logging.info(_MSG_START)  # WHY: Trace workflow start
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(_MSG_REFRESH)  # WHY: Inform about the metric refresh
         deps.ConstDefinitionsExporter(deps.apisession).export_all()  # WHY: Regenerate ConstInsightMetrics.csv
 
     @classmethod
     def _resolve_export_context(cls, deps: SimpleNamespace, site_id: str) -> _ExportContext | None:
-        """Resolve site context + client + normalized MAC into an _ExportContext; None aborts."""
+        """Resolve site context + client + normalized MAC into an _ExportContext. None aborts."""
         site_context = cls._prepare_site_context(deps, site_id)  # WHY: Resolve display + sanitized name
         clients = cls._list_and_display_clients(
             deps, site_context.site_id, site_context.site_name
         )  # WHY: Fetch + preview
         client_input = cls._read_client_input(deps)  # WHY: Prompt for the client selection
         if not client_input:  # WHY: User pressed Enter to skip
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_MSG_SKIP_EMPTY)  # WHY: Inform the user
             return None  # WHY: Abort the workflow
         normalized_mac = cls._resolve_normalized_mac(deps, client_input, clients)  # WHY: Resolve normalized MAC
@@ -340,6 +340,6 @@ class SiteClientInsightsService:
         client_metrics = cls._load_client_metrics_or_empty(deps, context.filename)  # WHY: Load metric list
         if client_metrics is None:  # WHY: No metrics configured (empty file already written)
             return  # WHY: Abort the workflow
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(_MSG_RETRIEVING_TMPL, len(client_metrics))  # WHY: Progress info line
         cls._run_collect_and_export(deps, context, client_metrics)  # WHY: Guarded fetch + export

--- a/src/refactors/serial_cc/sle_metrics.py
+++ b/src/refactors/serial_cc/sle_metrics.py
@@ -120,7 +120,7 @@ class SLEMetricsService:
     def _fetch_sites_aggregated(
         deps: SimpleNamespace, org_id: str, metric: str, config: SimpleNamespace, all_sle_data: list[Any]
     ) -> int:
-        """Fetch per-category sites SLE data for a worst-sites/sites-sle metric; return retrieved count."""
+        """Fetch per-category sites SLE data for a worst-sites/sites-sle metric. Return retrieved count."""
         retrieved = 0  # Successful per-category fetches for this metric
         for sle_category in config.sle_categories:  # Iterate each service category for this aggregated metric
             try:  # Per-category failures are non-fatal and skip to the next category
@@ -138,7 +138,7 @@ class SLEMetricsService:
     def _fetch_single_sle(
         deps: SimpleNamespace, org_id: str, metric: str, config: SimpleNamespace, all_sle_data: list[Any]
     ) -> tuple[int, int]:
-        """Fetch a single org-level specialized SLE metric; return (retrieved, failed) deltas."""
+        """Fetch a single org-level specialized SLE metric. Return (retrieved, failed) deltas."""
         response = deps.mistapi.api.v1.orgs.insights.getOrgSle(
             deps.apisession, org_id, metric, duration=config.duration_value
         )  # Query the single specialized org SLE metric
@@ -172,7 +172,7 @@ class SLEMetricsService:
         all_sle_data: list[Any],
         progress: "_SleProgressTracker",
     ) -> tuple[int, int]:
-        """Run the specialized-metrics loop; return cumulative (retrieved, failed)."""
+        """Run the specialized-metrics loop. Return cumulative (retrieved, failed)."""
         retrieved = 0  # Cumulative successful specialized fetches
         failed = 0  # Cumulative failed specialized fetches
         for metric in config.specialized_metrics:  # First loop: specialized org metrics
@@ -193,7 +193,7 @@ class SLEMetricsService:
     def _fetch_aggregated_category(
         deps: SimpleNamespace, org_id: str, sle_category: str, config: SimpleNamespace, all_sle_data: list[Any]
     ) -> tuple[int, int]:
-        """Fetch org-aggregated SLE data for one category; return (retrieved, failed) deltas."""
+        """Fetch org-aggregated SLE data for one category. Return (retrieved, failed) deltas."""
         response = deps.mistapi.api.v1.orgs.insights.getOrgSitesSle(
             deps.apisession, org_id, sle=sle_category, duration=config.duration_value, limit=1000
         )  # Query org sites SLE for this category
@@ -224,7 +224,7 @@ class SLEMetricsService:
         all_sle_data: list[Any],
         progress: "_SleProgressTracker",
     ) -> tuple[int, int]:
-        """Run the per-category aggregation loop; return cumulative (retrieved, failed)."""
+        """Run the per-category aggregation loop. Return cumulative (retrieved, failed)."""
         retrieved = 0  # Cumulative successful category fetches
         failed = 0  # Cumulative failed category fetches
         for sle_category in config.sle_categories:  # Second loop: aggregated SLE by category
@@ -248,7 +248,7 @@ class SLEMetricsService:
             processed = deps.DataProcessingUtils.flatten_nested_fields(all_sle_data)  # Flatten nested SLE structures
             processed = deps.DataProcessingUtils.escape_multiline(processed)  # Escape multiline fields for CSV
             deps.DataExporter.write_with_format_selection(processed, "OrgSLEMetrics.csv")  # Write the export file
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(
                 "! %s organization SLE data sources exported to OrgSLEMetrics.csv", metrics_retrieved
             )  # User summary
@@ -258,7 +258,7 @@ class SLEMetricsService:
                 metrics_retrieved,
             )  # Trace export volume
         else:  # No data collected from any source
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(
                 "! 0 organization SLE metrics exported to OrgSLEMetrics.csv (no data available)"
             )  # User summary
@@ -276,21 +276,21 @@ class SLEMetricsService:
         all_sle_data: list[Any],
         progress: "_SleProgressTracker",
     ) -> None:
-        """Run both retrieval loops and export; write empty CSV on any top-level failure."""
+        """Run both retrieval loops and export. Write empty CSV on any top-level failure."""
         # WHY: extracted from execute so execute stays under the 25-line STRUCT-LENGTH limit.
         try:  # Guard the whole retrieval+export so progress always completes
             spec_ok, spec_fail = cls._run_specialized_loop(deps, org_id, config, all_sle_data, progress)  # Loop 1
             cat_ok, cat_fail = cls._run_category_loop(deps, org_id, config, all_sle_data, progress)  # Loop 2
             metrics_retrieved = spec_ok + cat_ok  # Total successful fetches
             metrics_failed = spec_fail + cat_fail  # Total failed fetches
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info(
                 "! SLE data retrieval completed: %s successful, %s failed", metrics_retrieved, metrics_failed
             )  # Summary
             logging.info("Org SLE data: %s retrieved successfully, %s failed", metrics_retrieved, metrics_failed)
             cls._export_results(deps, all_sle_data, metrics_retrieved)  # Flatten + export (or write empty)
         except Exception as exception:  # Any unexpected top-level failure still writes an empty export
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("! Error exporting organization SLE metrics: %s", exception)  # User-facing error
             logging.error("Failed to export org SLE metrics: %s", exception)  # Trace the failure
             deps.DataExporter.write_with_format_selection([], "OrgSLEMetrics.csv")  # Write empty export on failure
@@ -299,7 +299,7 @@ class SLEMetricsService:
     def execute(cls, fast: bool = False) -> None:
         """Run the organization SLE metrics export workflow."""
         deps = _resolve_runtime_dependencies()  # Resolve MistHelper collaborators at call time
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("Export Organization SLE Metrics:")  # User-facing banner
         logging.info("Starting export of organization SLE metrics...")  # Trace workflow start
         org_id = deps.ConfigUtils.get_cached_or_prompted_org_id()  # Resolve target org (cached or prompted)
@@ -308,7 +308,7 @@ class SLEMetricsService:
         progress = _SleProgressTracker(deps.PROGRESS_EMITTER, total_items)  # Encapsulate progress + items-done counter
         progress.start()  # Emit the progress-start event
         all_sle_data: list[Any] = []  # Accumulates every SLE record across both loops
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(
             "! Retrieving organization SLE data using %s service categories...", len(config.sle_categories)
         )  # Info

--- a/src/refactors/serial_cc/start_site_client_capture_wireless.py
+++ b/src/refactors/serial_cc/start_site_client_capture_wireless.py
@@ -112,7 +112,7 @@ class _Helpers:
 
 @dataclass(frozen=True, slots=True)
 class _Settings:
-    """Frozen bundle of all user-gathered capture settings; hands off to payload/summary/dispatch."""
+    """Frozen bundle of all user-gathered capture settings. Hands off to payload/summary/dispatch."""
 
     client_mac: str  # WHY: Target wireless client MAC (normalized)
     ap_mac: str | None  # WHY: Optional AP MAC filter (None disables filter)
@@ -131,15 +131,15 @@ class SiteWirelessClientCaptureService:
     @staticmethod
     def _print_intro() -> None:
         """Print the wireless client capture configuration banner."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", _DIVIDER_DASH)  # WHY: Top divider
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _INTRO_TITLE)  # WHY: Section title
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _DIVIDER_DASH)  # WHY: Bottom divider
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _INTRO_PURPOSE)  # WHY: Purpose line
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _INTRO_GUIDANCE)  # WHY: Guidance toward the alternate capture type
 
     @staticmethod
@@ -148,7 +148,7 @@ class SiteWirelessClientCaptureService:
         if choice == _CLIENT_MODE_LIST:  # WHY: Pick from the connected-clients list
             client_mac = helpers.prompt_client_utils.select_client_mac(site_id)  # WHY: Interactive picker
             if not client_mac:  # WHY: Nothing selected
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("%s", _NO_CLIENT_MSG)  # WHY: Inform the user
                 return None  # WHY: Abort
             return str(client_mac)  # WHY: Return picker result
@@ -156,12 +156,12 @@ class SiteWirelessClientCaptureService:
 
     @classmethod
     def _select_client_mac(cls, manager: Any, helpers: _Helpers, site_id: str) -> str | None:
-        """Select and validate the target client MAC; return None to abort (message printed)."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        """Select and validate the target client MAC. Return None to abort (message printed)."""
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _CLIENT_HEADER)  # WHY: Prompt header
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _CLIENT_OPT_LIST)  # WHY: Option 1 (list picker)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _CLIENT_OPT_MANUAL)  # WHY: Option 2 (manual entry)
         choice = helpers.input_utils.safe_input(
             _PROMPT_CLIENT_CHOICE, default_value=_CLIENT_MODE_LIST, context="client_select"
@@ -170,14 +170,14 @@ class SiteWirelessClientCaptureService:
         if client_mac is None:  # WHY: Selection aborted (message printed)
             return None  # WHY: Propagate abort
         if not manager.validate_mac_address(client_mac):  # WHY: Reject malformed MACs
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_INVALID_CLIENT_MAC_MSG, client_mac)  # WHY: Inform the user
             return None  # WHY: Abort
         return str(manager.normalize_mac_address(client_mac))  # WHY: Return normalized MAC
 
     @staticmethod
     def _select_ap_from_list(manager: Any, helpers: _Helpers, site_id: str) -> str | None:
-        """Interactive AP picker path; returns normalized AP MAC or None when nothing chosen."""
+        """Interactive AP picker path. Returns normalized AP MAC or None when nothing chosen."""
         expand_port_range_fn = getattr(manager, "expand_port_range_string", lambda value: [value])  # WHY: Range fn
         prompt_utils = helpers.prompt_network_device_utils(
             manager.mist_session, helpers.input_utils.safe_input, expand_port_range_fn
@@ -189,24 +189,24 @@ class SiteWirelessClientCaptureService:
 
     @staticmethod
     def _select_ap_manual(manager: Any, helpers: _Helpers) -> tuple[str | None, bool]:
-        """Manual AP MAC entry path; returns (mac, ok) where ok=False signals abort."""
+        """Manual AP MAC entry path. Returns (mac, ok) where ok=False signals abort."""
         ap_mac = helpers.input_utils.safe_input(_PROMPT_AP_MAC, context="ap_mac")  # WHY: Read AP MAC
         if not manager.validate_mac_address(ap_mac):  # WHY: Reject malformed AP MACs
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(_INVALID_AP_MAC_MSG, ap_mac)  # WHY: Inform the user
             return None, False  # WHY: Abort
         return str(manager.normalize_mac_address(ap_mac)), True  # WHY: Normalized MAC + continue
 
     @classmethod
     def _select_ap_filter(cls, manager: Any, helpers: _Helpers, site_id: str) -> tuple[str | None, bool]:
-        """Optionally select an AP filter; return (ap_mac, ok) where ok=False signals abort."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        """Optionally select an AP filter. Return (ap_mac, ok) where ok=False signals abort."""
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _AP_HEADER)  # WHY: Prompt header
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _AP_OPT_LIST)  # WHY: Option 1 (list)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _AP_OPT_MANUAL)  # WHY: Option 2 (manual)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _AP_OPT_SKIP)  # WHY: Option 3 (skip)
         ap_choice = helpers.input_utils.safe_input(
             _PROMPT_AP_CHOICE, default_value="3", context="ap_filter"
@@ -219,17 +219,17 @@ class SiteWirelessClientCaptureService:
 
     @staticmethod
     def _prompt_bounded_int(input_utils: Any, spec: SimpleNamespace) -> int | None:
-        """Prompt for an integer within spec bounds; return None to abort (message printed)."""
+        """Prompt for an integer within spec bounds. Return None to abort (message printed)."""
         raw = input_utils.safe_input(spec.prompt, default_value=spec.default, context=spec.context)  # WHY: Read raw
         try:  # WHY: Validate that the input parses as an integer
             value = int(raw)  # WHY: Parse the integer
         except ValueError:  # WHY: Non-numeric input
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("\n! Invalid %s: %s", spec.invalid_label, raw)  # WHY: Inform the user
             return None  # WHY: Abort
         if value < spec.low or value > spec.high:  # WHY: Enforce the inclusive bounds
             for line in spec.range_lines:  # WHY: Print each range-error line
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("%s", line)  # WHY: Inform the user
             return None  # WHY: Abort
         return value  # WHY: Validated integer
@@ -237,11 +237,11 @@ class SiteWirelessClientCaptureService:
     @staticmethod
     def _prompt_loop_mode(input_utils: Any) -> bool:
         """Prompt whether to enable continuous loop mode."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _LOOP_HEADER)  # WHY: Section header
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _LOOP_LINE1)  # WHY: Explanation line 1
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _LOOP_LINE2)  # WHY: Explanation line 2
         loop_mode = input_utils.safe_input(
             _PROMPT_LOOP, default_value="n", context="loop_mode"
@@ -250,7 +250,7 @@ class SiteWirelessClientCaptureService:
 
     @classmethod
     def _collect_bounded_ints(cls, input_utils: Any) -> tuple[int, ...] | None:
-        """Run the three bounded-int prompts (duration, packets, max_pkt_len); None aborts."""
+        """Run the three bounded-int prompts (duration, packets, max_pkt_len). None aborts."""
         values: list[int] = []  # WHY: Accumulator for validated integers
         for spec in _BOUNDED_INT_SPECS:  # WHY: Table-driven sequential prompting
             value = cls._prompt_bounded_int(input_utils, spec)  # WHY: Prompt one bounded int
@@ -261,7 +261,7 @@ class SiteWirelessClientCaptureService:
 
     @classmethod
     def _gather_settings(cls, manager: Any, helpers: _Helpers, site_id: str) -> _Settings | None:
-        """Collect all user-provided settings for the capture; return None to abort workflow."""
+        """Collect all user-provided settings for the capture. Return None to abort workflow."""
         client_mac = cls._select_client_mac(manager, helpers, site_id)  # WHY: Resolve client MAC
         if not client_mac:  # WHY: Client selection aborted
             return None  # WHY: Abort workflow
@@ -275,7 +275,7 @@ class SiteWirelessClientCaptureService:
 
     @classmethod
     def _read_trailing_toggles(cls, manager: Any, helpers: _Helpers) -> tuple[bool, str, str, bool]:
-        """Read (includes_mcast, tcpdump_expr, capture_format, enable_loop); trims _finalize_settings."""
+        """Read (includes_mcast, tcpdump_expr, capture_format, enable_loop). Trims _finalize_settings."""
         mcast_raw = helpers.input_utils.safe_input(
             _PROMPT_MCAST, default_value="n", context="includes_mcast"
         )  # WHY: Read the multicast choice
@@ -334,7 +334,7 @@ class SiteWirelessClientCaptureService:
 
     @classmethod
     def _summary_rows(cls, settings: _Settings) -> list[tuple[str, str]]:
-        """Return ordered (label, value) rows for the summary table; keeps _print_summary CC low."""
+        """Return ordered (label, value) rows for the summary table. Keeps _print_summary CC low."""
         filter_display = settings.tcpdump_expr if settings.tcpdump_expr else _FILTER_NONE_LABEL  # WHY: None label
         packets_hint = _PACKETS_HINT_MAP[settings.num_packets == 0]  # WHY: Table-driven hint (no ternary branch)
         rows: list[tuple[str, str]] = [
@@ -358,16 +358,16 @@ class SiteWirelessClientCaptureService:
     @classmethod
     def _print_summary(cls, settings: _Settings) -> None:
         """Print the capture configuration summary using table-driven rendering."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", _DIVIDER_EQUAL)  # WHY: Top divider
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _SUMMARY_TITLE)  # WHY: Section title
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _DIVIDER_EQUAL)  # WHY: Divider
         for label, value in cls._summary_rows(settings):  # WHY: Uniform label-value rendering
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  %s: %s", label, value)  # WHY: One row per iteration (no branching)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _DIVIDER_EQUAL)  # WHY: Bottom divider
 
     @staticmethod

--- a/src/refactors/serial_cc/start_site_scan_capture.py
+++ b/src/refactors/serial_cc/start_site_scan_capture.py
@@ -6,7 +6,7 @@ import importlib  # WHY: Late-bound MistHelper import avoids circular src->MistH
 import logging  # WHY: Structured trace for workflow start/site abort events
 from dataclasses import dataclass  # WHY: Frozen slotted state bundles keep execute() CC low
 from types import SimpleNamespace  # WHY: SimpleNamespace preserves bounded-int spec shape used in tests
-from typing import Any, cast  # WHY: Manager/prompt helpers are dynamic MistHelper attrs; cast narrows AP MAC
+from typing import Any, cast  # WHY: Manager/prompt helpers are dynamic MistHelper attrs. Cast narrows AP MAC
 
 # Module-level constants - dividers, banner text, prompts, and event log strings extracted so
 # every method has fixed CC and no repeated string literals appear inline.
@@ -132,7 +132,7 @@ class _Helpers:
 
 @dataclass(frozen=True, slots=True)
 class _Settings:
-    """Frozen bundle of all user-gathered scan capture settings; hands off to payload/summary/dispatch."""
+    """Frozen bundle of all user-gathered scan capture settings. Hands off to payload/summary/dispatch."""
 
     ap_mac: str  # WHY: Target AP MAC (normalized) for single-AP path
     band: str  # WHY: Radio band code ("24", "5", "6")
@@ -150,14 +150,14 @@ class SiteScanCaptureService:
     @staticmethod
     def _print_intro() -> None:
         """Print the scan radio capture configuration banner."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", _DIVIDER_DASH)  # WHY: Top divider
         logger.info("%s", _INTRO_TITLE)  # WHY: Section title
         logger.info("%s", _DIVIDER_DASH)  # WHY: Bottom divider
 
     @staticmethod
     def _select_ap(manager: Any, helpers: _Helpers, site_id: str) -> tuple[str | None, str]:
-        """Select the target AP; return (ap_mac, mode) where mode is 'single', 'all', or 'abort'."""
+        """Select the target AP. Return (ap_mac, mode) where mode is 'single', 'all', or 'abort'."""
         logger.debug("Prompting for AP selection from site inventory")  # WHY: Trace the AP prompt
         prompt_utils = helpers.prompt_network_device_utils(
             manager.mist_session, helpers.input_utils.safe_input, helpers.device_utils.expand_port_range_string
@@ -175,9 +175,9 @@ class SiteScanCaptureService:
 
     @staticmethod
     def _select_band(input_utils: Any) -> str:
-        """Prompt for the radio band; return the resolved band code (defaults to 5 GHz)."""
+        """Prompt for the radio band. Return the resolved band code (defaults to 5 GHz)."""
         logger.debug("Prompting for band selection")  # WHY: Trace the band prompt
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _BAND_HEADER)  # WHY: Prompt header
         logger.info("%s", _BAND_OPT_24)  # WHY: 2.4 GHz option
         logger.info("%s", _BAND_OPT_5)  # WHY: 5 GHz option (default)
@@ -191,7 +191,7 @@ class SiteScanCaptureService:
 
     @staticmethod
     def _prompt_channel(input_utils: Any, band: str) -> int | None:
-        """Prompt for a band-appropriate channel; return None to abort (message printed)."""
+        """Prompt for a band-appropriate channel. Return None to abort (message printed)."""
         logger.debug("Prompting for channel")  # WHY: Trace the channel prompt
         prompt_text, default_value = _CHANNEL_PROMPTS[band]  # WHY: Table-driven per-band prompt
         channel_str = input_utils.safe_input(
@@ -200,7 +200,7 @@ class SiteScanCaptureService:
         try:  # WHY: Validate the channel parses as an integer
             channel = int(channel_str)  # WHY: Parse the channel
         except ValueError:  # WHY: Non-numeric channel
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("\n! Invalid channel: %s", channel_str)  # WHY: Inform the user
             logger.error("Invalid channel value: %s", channel_str)  # WHY: Trace the failure
             return None  # WHY: Abort
@@ -210,7 +210,7 @@ class SiteScanCaptureService:
     @staticmethod
     def _print_bandwidth_menu(band: str) -> None:
         """Emit the bandwidth menu rows (base + per-band extras) with fixed CC."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _BW_HEADER)  # WHY: Prompt header
         logger.info("%s", _BW_OPT_20)  # WHY: 20 MHz option
         logger.info("%s", _BW_OPT_40)  # WHY: 40 MHz option
@@ -219,7 +219,7 @@ class SiteScanCaptureService:
 
     @classmethod
     def _select_bandwidth(cls, input_utils: Any, band: str) -> str | None:
-        """Prompt for a band-appropriate bandwidth; return None to abort (message printed)."""
+        """Prompt for a band-appropriate bandwidth. Return None to abort (message printed)."""
         logger.debug("Prompting for bandwidth")  # WHY: Trace the bandwidth prompt
         cls._print_bandwidth_menu(band)  # WHY: Emit the menu rows via a helper (keeps CC low)
         bw_choice = input_utils.safe_input(
@@ -228,7 +228,7 @@ class SiteScanCaptureService:
         bandwidth = _BANDWIDTH_MAP.get(bw_choice, "20")  # WHY: Map to MHz, defaulting to 20 MHz
         logger.debug("Bandwidth selected: %s MHz (choice: %s)", bandwidth, bw_choice)  # WHY: Trace the value
         if band == "24" and bandwidth not in _BW_ALLOWED_24:  # WHY: 2.4 GHz only supports 20/40 MHz
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("%s", _INVALID_BW_24_MSG.format(value=bandwidth))  # WHY: Inform the user
             logger.error(_LOG_INVALID_BW_24, bandwidth)  # WHY: Trace the failure
             return None  # WHY: Abort
@@ -236,18 +236,18 @@ class SiteScanCaptureService:
 
     @staticmethod
     def _prompt_bounded_int(input_utils: Any, spec: SimpleNamespace) -> int | None:
-        """Prompt for an integer within spec bounds; return None to abort (message printed)."""
+        """Prompt for an integer within spec bounds. Return None to abort (message printed)."""
         raw = input_utils.safe_input(spec.prompt, default_value=spec.default, context=spec.context)  # WHY: Read raw
         try:  # WHY: Validate that the input parses as an integer
             value = int(raw)  # WHY: Parse the integer
         except ValueError:  # WHY: Non-numeric input
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("\n! Invalid %s: %s", spec.invalid_label, raw)  # WHY: Inform the user
             logger.error("Invalid %s value: %s", spec.invalid_label, raw)  # WHY: Trace the failure
             return None  # WHY: Abort
         if value < spec.low or value > spec.high:  # WHY: Enforce the inclusive bounds
             for line in spec.range_lines:  # WHY: Print each range-error line
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("%s", line)  # WHY: Inform the user
             logger.error("%s out of range: %s", spec.invalid_label, value)  # WHY: Trace the range failure
             return None  # WHY: Abort
@@ -256,7 +256,7 @@ class SiteScanCaptureService:
 
     @classmethod
     def _collect_bounded_ints(cls, input_utils: Any) -> tuple[int, ...] | None:
-        """Run the bounded-int prompts (duration, packets); None aborts."""
+        """Run the bounded-int prompts (duration, packets). None aborts."""
         values: list[int] = []  # WHY: Accumulator for validated integers
         for spec in _BOUNDED_INT_SPECS:  # WHY: Table-driven sequential prompting
             value = cls._prompt_bounded_int(input_utils, spec)  # WHY: Prompt one bounded int
@@ -268,7 +268,7 @@ class SiteScanCaptureService:
     @staticmethod
     def _prompt_loop_mode(input_utils: Any) -> bool:
         """Prompt whether to enable continuous loop mode."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _LOOP_HEADER)  # WHY: Section header
         logger.info("%s", _LOOP_LINE1)  # WHY: Explanation line 1
         logger.info("%s", _LOOP_LINE2)  # WHY: Explanation line 2
@@ -296,7 +296,7 @@ class SiteScanCaptureService:
 
     @staticmethod
     def _summary_rows(settings: _Settings) -> list[tuple[str, str]]:
-        """Return ordered (label, value) rows for the summary table; keeps _print_summary CC low."""
+        """Return ordered (label, value) rows for the summary table. Keeps _print_summary CC low."""
         return [
             ("Capture Type", "Scan Radio"),
             ("AP MAC", settings.ap_mac),
@@ -311,7 +311,7 @@ class SiteScanCaptureService:
     @classmethod
     def _print_summary(cls, settings: _Settings) -> None:
         """Print the scan capture configuration summary using table-driven rendering."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", _DIVIDER_EQUAL)  # WHY: Top divider
         logger.info("%s", _SUMMARY_TITLE)  # WHY: Section title
         logger.info("%s", _DIVIDER_EQUAL)  # WHY: Divider
@@ -326,7 +326,7 @@ class SiteScanCaptureService:
 
     @classmethod
     def _list_existing_captures(cls, helpers: _Helpers, manager: Any, site_id: str) -> list[dict[str, Any]] | None:
-        """Fetch the site's existing captures; None means the pre-check failed (warn and proceed)."""
+        """Fetch the site's existing captures. None means the pre-check failed (warn and proceed)."""
         try:  # WHY: Pre-check API failures are non-fatal - warn and proceed
             response = helpers.mistapi.api.v1.sites.pcaps.listSitePacketCaptures(
                 manager.mist_session, site_id
@@ -350,18 +350,18 @@ class SiteScanCaptureService:
     def _print_conflict_warning() -> None:
         """Emit the multi-line existing-capture warning banner."""
         for line in _WARN_LINES:  # WHY: Table-driven emission keeps CC fixed
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("%s", line)  # WHY: One warning line per iteration
 
     @classmethod
     def _confirm_conflict_override(cls, input_utils: Any) -> bool:
-        """Prompt whether to continue past an existing capture; False cancels."""
+        """Prompt whether to continue past an existing capture. False cancels."""
         cls._print_conflict_warning()  # WHY: Show the warning banner
         proceed = input_utils.safe_input(
             _PROMPT_OVERRIDE, default_value="n", context="capture_conflict_confirmation"
         ).lower()  # WHY: Read the override choice
         if proceed != _YES:  # WHY: User declined to proceed
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("%s", _CANCEL_MSG)  # WHY: Inform the user
             logger.info(_LOG_USER_CANCEL)  # WHY: Trace the cancel
             return False  # WHY: Signal cancel
@@ -369,8 +369,8 @@ class SiteScanCaptureService:
 
     @classmethod
     def _check_existing_captures(cls, manager: Any, helpers: _Helpers, site_id: str, ap_mac: str) -> bool:
-        """Warn on an existing capture for the AP; return False if the user cancels."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        """Warn on an existing capture for the AP. Return False if the user cancels."""
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _PRE_CHECK_MSG.format(ap_mac=ap_mac))  # WHY: Inform the user of the pre-check
         existing_captures = cls._list_existing_captures(helpers, manager, site_id)  # WHY: Fetch existing captures
         if existing_captures is None:  # WHY: Pre-check API failure (already logged) - proceed
@@ -381,7 +381,7 @@ class SiteScanCaptureService:
 
     @classmethod
     def _gather_prompted_values(cls, manager: Any, helpers: _Helpers, ap_mac: str) -> _Settings | None:
-        """Run band/channel/bandwidth/bounded-ints/format/loop prompts; None aborts."""
+        """Run band/channel/bandwidth/bounded-ints/format/loop prompts. None aborts."""
         band = cls._select_band(helpers.input_utils)  # WHY: Resolve the radio band
         channel = cls._prompt_channel(helpers.input_utils, band)  # WHY: Resolve a band-appropriate channel
         if channel is None:  # WHY: Invalid channel (message already printed)
@@ -405,7 +405,7 @@ class SiteScanCaptureService:
 
     @classmethod
     def _select_ap_or_dispatch(cls, manager: Any, helpers: _Helpers, site_id: str) -> str | None:
-        """Select the AP and handle abort/all-APs modes; return normalized MAC or None to stop."""
+        """Select the AP and handle abort/all-APs modes. Return normalized MAC or None to stop."""
         ap_mac, mode = cls._select_ap(manager, helpers, site_id)  # WHY: Interactive AP selection
         if mode == _MODE_ABORT:  # WHY: AP selection failed (message already traced)
             return None  # WHY: Abort the workflow

--- a/src/refactors/serial_cc/switch_vc_stats.py
+++ b/src/refactors/serial_cc/switch_vc_stats.py
@@ -138,7 +138,7 @@ class SwitchVcStatsService:
 
     @staticmethod
     def _build_preview_table(all_vc_stats: list[dict[str, Any]]) -> str:
-        """Assemble a PrettyTable summary string from VC rows; raises on malformed payloads."""
+        """Assemble a PrettyTable summary string from VC rows. Raises on malformed payloads."""
         from prettytable import PrettyTable  # Lazy import to match existing MistHelper display behavior
 
         table = PrettyTable()  # Build compact summary table for debug readability
@@ -151,8 +151,8 @@ class SwitchVcStatsService:
 
     @classmethod
     def _render_preview_table(cls, all_vc_stats: list[dict[str, Any]]) -> None:
-        """Log a PrettyTable summary; swallow rendering errors so export never fails on preview."""
-        try:  # PrettyTable may fail if columns are malformed; keep preview non-fatal
+        """Log a PrettyTable summary. Swallow rendering errors so export never fails on preview."""
+        try:  # PrettyTable may fail if columns are malformed. Keep preview non-fatal
             logging.debug("\n%s", cls._build_preview_table(all_vc_stats))  # Emit rendered summary to debug log
         except Exception as preview_error:  # Never fail export because preview generation failed
             logging.debug("Skipping VC stats PrettyTable preview due to error: %s", preview_error)  # Trace skip cause

--- a/src/refactors/serial_cc/test_results_by_site.py
+++ b/src/refactors/serial_cc/test_results_by_site.py
@@ -5,7 +5,7 @@ import importlib  # Late-import MistHelper to avoid circular src<->MistHelper de
 import logging  # Emit action-level tracing required by coding standards
 import time  # Measure elapsed duration for fast-mode summary and rate-limit delay
 from types import SimpleNamespace  # Bundle runtime dependencies without a formal dataclass
-from typing import Any  # MistHelper surface is dynamic; typed as Any at the boundary
+from typing import Any  # MistHelper surface is dynamic. Typed as Any at the boundary
 
 from src.refactors.connection_pool_executor import ConnectionPoolExecutor  # Pool executor extracted per 1012 SC-003
 
@@ -75,7 +75,7 @@ class GatewayTestResultsService:
             return []  # Return empty list so caller accumulates cleanly
         results: list[dict[str, Any]] = (
             response.data.get("results", []) if isinstance(response.data, dict) else []
-        )  # Extract result list from dict payload; empty list for unexpected shapes
+        )  # Extract result list from dict payload. Empty list for unexpected shapes
         for result in results:  # Tag every row with its source site_id for downstream joins
             result["site_id"] = site_id  # Tag every row with its source site_id
         return results  # Hand back the tagged rows to the caller
@@ -108,7 +108,7 @@ class GatewayTestResultsService:
             work_items=site_ids,
             worker_function=lambda site_id, sem: cls._fetch_site_tests(deps, site_id, sem),
             batch_description="sites",
-        )  # Distribute site fetches across the connection pool; lambda avoids ARCH-DELEGATE inner function
+        )  # Distribute site fetches across the connection pool. Lambda avoids ARCH-DELEGATE inner function
         flattened: list[dict[str, Any]] = []  # Accumulates flattened results from all site lists
         for site_list in successful_results:  # successful_results is a list-of-lists
             if isinstance(site_list, list):  # Defensive guard for unexpected pool result shapes
@@ -129,7 +129,7 @@ class GatewayTestResultsService:
         """Collect results sequentially with adaptive rate limiting (standard path)."""
         logging.info("Starting sequential fetch for %d sites with gateways", len(site_ids))  # Log before loop
         all_results: list[dict[str, Any]] = []  # Accumulates results across all sites
-        smoothed = None  # Adaptive rate-limit smoothing state; reset at the start of each run
+        smoothed = None  # Adaptive rate-limit smoothing state. Reset at the start of each run
         for site_id in deps.tqdm(site_ids, desc="Sites", unit="site"):  # Iterate with progress bar
             results = cls._fetch_site_tests(deps, site_id, connection_semaphore=None)  # Fetch site results
             if results:  # Only extend when the site returned data
@@ -145,7 +145,7 @@ class GatewayTestResultsService:
 
     @staticmethod
     def _export_results(deps: SimpleNamespace, all_results: list[dict[str, Any]], fast: bool) -> None:
-        """Flatten, sanitise, and persist results; emit user-facing summary."""
+        """Flatten, sanitise, and persist results. Emit user-facing summary."""
         if not all_results:  # No results found across all sites
             logging.warning("No test results found; CSV not created")  # Warn so operator can investigate
             # User-facing empty-result message
@@ -197,10 +197,10 @@ class GatewayTestResultsService:
                 if site_ids:  # Cache hit
                     return site_ids  # Return cache-derived site IDs
                 logging.warning("Fast-mode cache empty; falling back to API discovery")  # Warn about fallback
-            except Exception as exception:  # Cache failure is non-fatal; fall back to API
+            except Exception as exception:  # Cache failure is non-fatal. Fall back to API
                 logging.warning("Fast-mode site derivation failed (%s); falling back to API", exception)  # Trace
         logging.info("Discovering site IDs via API for org %s", org_id)  # Log before API call
-        raw = deps.GatewayExportUtils._get_site_ids_with_devices(org_id)  # Full API discovery; returns Any
+        raw = deps.GatewayExportUtils._get_site_ids_with_devices(org_id)  # Full API discovery. Returns Any
         site_ids = list(raw) if raw else []  # Cast Any->list[str] for mypy (GatewayExportUtils returns list)
         logging.debug("API discovery returned %d site IDs", len(site_ids))  # Log after API call
         return site_ids  # Return API-discovered site IDs

--- a/src/refactors/service_ping_launcher.py
+++ b/src/refactors/service_ping_launcher.py
@@ -102,7 +102,7 @@ class ServicePingLauncher:
             ServicePingManager as ExternalServicePingManager,
         )
 
-        manager = ExternalServicePingManager()  # Canonical class; constructor pulls wired module globals
+        manager = ExternalServicePingManager()  # Canonical class. Constructor pulls wired module globals
         logging.debug("ServicePingLauncher: ServicePingManager instantiated successfully")  # Log build finish
         return manager  # Return the ready-to-run manager to launch()
 

--- a/src/refactors/sqlite_database_writer.py
+++ b/src/refactors/sqlite_database_writer.py
@@ -5,7 +5,7 @@ SQLite database using natural business keys wherever possible and falling
 back to auto-increment when the endpoint has no natural key.
 
 Runtime dependencies (`DATABASE_PATH`, `DatabaseSchemaUtils`,
-`DataProcessingUtils`) are still owned by MistHelper.py; they are resolved
+`DataProcessingUtils`) are still owned by MistHelper.py. They are resolved
 lazily via `importlib.import_module` to keep the extracted module import-
 graph flat and to preserve monkeypatch-friendly test hooks that address
 `MistHelper.DATABASE_PATH` directly.
@@ -362,7 +362,7 @@ class SQLiteDatabaseWriter:  # Upsert records into SQLite.
         values = []  # Collect string values.
         for field_name in self.fields:  # In field order.
             value = row.get(field_name, "")  # Default missing fields.
-            values.append("" if value is None else str(value))  # Stringify; None -> empty.
+            values.append("" if value is None else str(value))  # Stringify. None -> empty.
         values.extend([current_time, current_time])  # Append audit timestamps.
         return values  # Return the value list.
 
@@ -375,7 +375,7 @@ class SQLiteDatabaseWriter:  # Upsert records into SQLite.
         """Build parameterized INSERT SQL statement."""
         placeholders = ", ".join(["?"] * value_count)  # Bind placeholders.
         safe_table_name = self._get_safe_table_name()  # Sanitize the table name.
-        return (  # nosec B608 - identifiers are sanitised above; values are bound via placeholders
+        return (  # nosec B608 - identifiers are sanitised above. Values are bound via placeholders
             f"{insert_mode} INTO {safe_table_name} ({', '.join(safe_fields)}) VALUES ({placeholders})"
         )
 

--- a/src/refactors/switch_to_interactive_login.py
+++ b/src/refactors/switch_to_interactive_login.py
@@ -45,7 +45,7 @@ class SwitchToInteractiveLoginManager:
     MSP/org selection to the corresponding ``_*_switch_login_*`` /
     ``_*_interactive_login_*`` helpers that remain in MistHelper.
 
-    SECURITY: Prompts the user for credentials; on failure the previous
+    SECURITY: Prompts the user for credentials. On failure the previous
     ``apisession`` and ``org_id`` globals are rolled back inside the
     helper ``_attempt_interactive_login_with_rollback``.
 
@@ -87,7 +87,7 @@ class SwitchToInteractiveLoginManager:
         logging.info("SwitchToInteractiveLoginManager: attempting rollback-guarded login")  # Log attempt entry
         old_session = getattr(misthelper, "apisession", None)  # Preserve current session for rollback
         old_org_id = getattr(misthelper, "org_id", None)  # Preserve current org for rollback
-        if not misthelper._attempt_interactive_login_with_rollback(  # Try login; restores on failure
+        if not misthelper._attempt_interactive_login_with_rollback(  # Try login. Restores on failure
             old_session, old_org_id
         ):
             logging.debug(  # Log rollback path for postmortem tracing

--- a/src/refactors/tui_launcher.py
+++ b/src/refactors/tui_launcher.py
@@ -78,9 +78,9 @@ class TUILauncher:  # Launch TUI mode from interactive menu.
 
     def _print_welcome(self) -> None:
         """Print TUI activation messages."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\n>> Terminal User Interface mode activated")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(">> Use arrow keys to navigate, Enter to select, Q to quit")
 
     def _ensure_api_session(self) -> bool:
@@ -90,17 +90,17 @@ class TUILauncher:  # Launch TUI mode from interactive menu.
             logging.debug("TUI_MODE: apisession already initialized; reusing existing session")  # Log reuse
             return True  # Signal caller that session is ready
 
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(">> Initializing Mist API session...")
         misthelper_module = self._deps.misthelper_module  # Cache the module handle for both calls below
         if not misthelper_module.initialize_mist_session():  # Delegate to MistHelper's session bootstrap
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logging.info("[ERROR] Failed to initialize Mist API session")
             logging.error("TUI_MODE: Could not initialize API session")  # Log the failure with error level
             return False  # Signal caller that session initialization failed
 
-        # initialize_mist_session mutates MistHelper.apisession; no additional sync needed since we read via getattr
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # initialize_mist_session mutates MistHelper.apisession. No additional sync needed since we read via getattr
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info(">> API session initialized successfully")
         logging.debug("TUI_MODE: apisession initialized successfully")  # Log after successful init
         return True  # Signal caller that session is ready
@@ -143,13 +143,13 @@ class TUILauncher:  # Launch TUI mode from interactive menu.
     def _handle_keyboard_interrupt(self) -> None:
         """Handle user Ctrl+C interruption."""
         logging.info("TUI_MODE: User interrupted with Ctrl+C")  # Log the intentional keyboard abort
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\n[EXIT] TUI mode stopped by user")
 
     def _handle_fatal_error(self, error: Exception) -> None:
         """Handle fatal TUI errors."""
         logging.error("TUI_MODE: Fatal error - %s", error, exc_info=True)  # Log with traceback for postmortem
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\n[ERROR] TUI mode crashed: %s", error)
 
     def _restore_console_logging(self) -> None:
@@ -169,5 +169,5 @@ class TUILauncher:  # Launch TUI mode from interactive menu.
             logging.debug("TUI_DEBUG: [%s] TUI_MODE function completed - returning to caller", timestamp)  # Trace
 
         logging.info("TUI_MODE: TUI mode completed successfully")  # Success-path summary log
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logging.info("\n>> Returned from TUI mode to main menu")

--- a/src/refactors/wan2_migration_launcher.py
+++ b/src/refactors/wan2_migration_launcher.py
@@ -112,7 +112,7 @@ class WAN2MigrationLauncher:
             WAN2MigrationManager,  # noqa: PLC0415 - lazy import mirrors _wire_dependencies
         )
 
-        manager = WAN2MigrationManager()  # Canonical class; constructor pulls wired module globals
+        manager = WAN2MigrationManager()  # Canonical class. Constructor pulls wired module globals
         logging.debug("WAN2MigrationLauncher: WAN2MigrationManager instantiated successfully")  # Log build finish
         return manager  # Return the ready-to-run manager to launch()
 

--- a/src/refactors/wan_probe_device_override_manager.py
+++ b/src/refactors/wan_probe_device_override_manager.py
@@ -5,7 +5,7 @@ Owns Menu #167 orchestration originally defined as the top-level
 dependency-wiring that used to live in the MistHelper delegation wrapper.
 
 The heavy implementation continues to live in
-`src/gateway/wan_probe_device_override_manager.py`; this refactor module
+`src/gateway/wan_probe_device_override_manager.py`. This refactor module
 is the thin orchestration seam that wires MistHelper globals into that
 implementation. Wiring targets (apisession, ConfigUtils, CacheUtils,
 OrgSiteExporter, GatewayExportUtils, FilePathUtils, InputUtils,

--- a/src/refactors/wanprobe_config_manager.py
+++ b/src/refactors/wanprobe_config_manager.py
@@ -96,7 +96,7 @@ class WANProbeConfigManager:  # WAN probe config manager (Menu 166 destructive e
         logging.info("Menu #166: No WAN interfaces found in selected templates")  # Log it.
 
     def _prepare_templates_with_changes(self) -> list[dict[str, Any]] | None:
-        """Run all init/load/select/analyze guard steps; return analyzed list or None to signal abort."""
+        """Run all init/load/select/analyze guard steps. Return analyzed list or None to signal abort."""
         if not self._initialize():  # Org id resolution
             return None
         if not self._load_data():  # Sites + templates load
@@ -219,7 +219,7 @@ class WANProbeConfigManager:  # WAN probe config manager (Menu 166 destructive e
         return selected
 
     def _select_templates(self) -> list[dict[str, Any]]:  # Select templates.
-        """Display templates and get user selection; returns selected templates."""
+        """Display templates and get user selection. Returns selected templates."""
         templates_sorted = sorted(self.templates, key=lambda t: t.get("name", "").lower())  # Sort by name.
         template_list = self._render_template_list(templates_sorted)  # Show menu + collect rows.
         print("\n  Template Selection:")  # Selection header.
@@ -335,7 +335,7 @@ class WANProbeConfigManager:  # WAN probe config manager (Menu 166 destructive e
 
     def _show_preview(self, templates_with_changes: list[dict[str, Any]], dry_run: bool) -> None:
         """Display preview of changes to be made."""
-        del dry_run  # Kept in signature for API-compat with sibling _apply_changes; not used in preview.
+        del dry_run  # Kept in signature for API-compat with sibling _apply_changes. Not used in preview.
         total_interfaces = sum(len(t["wan_interfaces"]) for t in templates_with_changes)  # Sum across all
         total_sites = sum(t["site_count"] for t in templates_with_changes)  # Sum site reach
         print("\n  Preview of Changes:")  # Section header
@@ -400,7 +400,7 @@ class WANProbeConfigManager:  # WAN probe config manager (Menu 166 destructive e
 
     @staticmethod
     def _blank_template_result(template: dict[str, Any]) -> dict[str, Any]:  # Pre-fill the per-template result
-        """Build the per-template result skeleton (identity fields set; status/error/updates start empty)."""
+        """Build the per-template result skeleton (identity fields set. Status/error/updates start empty)."""
         return {
             "template_name": template["name"],  # Template name for the report.
             "template_id": template["id"],  # Template id for the report.
@@ -411,7 +411,7 @@ class WANProbeConfigManager:  # WAN probe config manager (Menu 166 destructive e
         }
 
     def _apply_wan_probe_overrides(self, template: dict[str, Any], port_config: dict[str, Any]) -> list[str]:
-        """Set wan_probe_override on each WAN interface present in port_config; return the modified port names."""
+        """Set wan_probe_override on each WAN interface present in port_config. Return the modified port names."""
         interfaces_modified: list[str] = []  # Track modified ports.
         template_name = template["name"]  # Template name for trace logging.
         for wan_if in template["wan_interfaces"]:  # Walk WAN ports.
@@ -432,7 +432,7 @@ class WANProbeConfigManager:  # WAN probe config manager (Menu 166 destructive e
         dry_run: bool,
         interfaces_modified: list[str],
     ) -> tuple[str, str]:
-        """Commit the template config (dry-run logs only, else calls the API); return (status, error)."""
+        """Commit the template config (dry-run logs only, else calls the API). Return (status, error)."""
         template_name = template["name"]  # Template name for logging.
         if dry_run:  # Dry-run.
             logging.info("DRY-RUN: Would update template %s interfaces: %s", template_name, interfaces_modified)

--- a/src/refactors/wlanradius_timer_manager.py
+++ b/src/refactors/wlanradius_timer_manager.py
@@ -16,7 +16,7 @@ from __future__ import annotations  # Enable postponed evaluation for forward-re
 
 import importlib  # Late-import MistHelper module to avoid circular src<->MistHelper dependency
 import logging  # Structured action logging required by coding standards
-from typing import Any, cast  # Loose typing for late-bound MistHelper attributes; cast for Any-narrowing returns
+from typing import Any, cast  # Loose typing for late-bound MistHelper attributes. Cast for Any-narrowing returns
 
 import mistapi  # Direct dependency: Mist API SDK used throughout the class body
 
@@ -79,30 +79,30 @@ class WLANRadiusTimerManager:  # Menu 148 entrypoint for WLAN RADIUS timer edits
 
     def _discover_radius_wlans(self) -> bool:  # Aggregates site/org/template lookups + filtering
         """Prepare org/site context, fetch all WLANs, filter to RADIUS-only. Return False to abort the workflow."""
-        if not self._select_site():  # Prompt for a site; abort if none chosen
+        if not self._select_site():  # Prompt for a site. Abort if none chosen
             return False  # No site selected -- nothing to manage
-        if not self._get_org_id():  # Resolve the org ID; abort if it cannot be determined
+        if not self._get_org_id():  # Resolve the org ID. Abort if it cannot be determined
             return False  # Without an org ID we cannot fetch templates
-        if not self._fetch_site_info():  # Load site details; abort on failure
+        if not self._fetch_site_info():  # Load site details. Abort on failure
             return False  # Site info is required for template resolution
         self._fetch_all_wlans()  # Gather WLANs from site, template, and org sources
         self._filter_radius_wlans()  # Reduce to only RADIUS/RadSec WLANs
         if not self.all_radius_wlans:  # No RADIUS WLANs were found
             self._print_no_wlans_message()  # Tell the user there is nothing to modify
             return False  # Exit -- no candidates to change
-        return True  # Discovery complete; ready for interactive edit
+        return True  # Discovery complete. Ready for interactive edit
 
     def manage(self) -> None:  # Public menu entrypoint invoked by MistHelper menu action 148
         """Main entry point - orchestrates the WLAN timer management workflow."""
         logging.info("Starting WLAN RADIUS authentication timer management")  # Announce the workflow start
         self._enable_debug_if_requested()  # Start verbose logging if the user asked for it
-        if not self._discover_radius_wlans():  # Site + org + WLAN discovery; bail on abort.
+        if not self._discover_radius_wlans():  # Site + org + WLAN discovery. Bail on abort.
             return  # Discovery aborted -- nothing further to do
         self._display_wlans()  # Show the user the candidate WLANs and their timers
-        if not self._prompt_wlan_selection():  # Ask which WLAN to modify; abort if cancelled
+        if not self._prompt_wlan_selection():  # Ask which WLAN to modify. Abort if cancelled
             return  # User declined to pick a WLAN
         self._display_current_config()  # Show the selected WLAN's current timer config
-        if not self._prompt_new_values():  # Collect new timer values; abort if cancelled
+        if not self._prompt_new_values():  # Collect new timer values. Abort if cancelled
             return  # User declined to enter new values
         self._display_behavior_impact()  # Explain how the new values change behavior
         self._display_proposed_changes()  # Show a before/after diff of the settings

--- a/src/reports/e911_bssid.py
+++ b/src/reports/e911_bssid.py
@@ -10,7 +10,7 @@ import time  # WHY: measure wall-clock elapsed for report telemetry
 from collections.abc import Callable  # WHY: type-annotate injected input/write callbacks
 from dataclasses import dataclass, field  # WHY: bundle 7+ related params into ≤5-param call signatures
 from datetime import datetime, timedelta  # WHY: timestamp checkpoints and predict rate-limit reset window
-from typing import Any, ClassVar  # WHY: mistapi returns untyped JSON dicts; ClassVar for typed static tables
+from typing import Any, ClassVar  # WHY: mistapi returns untyped JSON dicts. ClassVar for typed static tables
 
 
 @dataclass  # WHY: promote plain class into an auto-init dataclass
@@ -287,7 +287,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         for ap_entry in radio_macs_data:  # WHY: each entry is one AP with its radio MACs
             all_radios = ap_entry.get("radio_mac", [])  # WHY: default empty list guards missing key
             if len(all_radios) < 2:  # WHY: 1-radio APs (BLE-only?) have no broadcast radios to map
-                continue  # WHY: skip; no bands to infer
+                continue  # WHY: skip. No bands to infer
             broadcast_radios = all_radios[:-1]  # WHY: last MAC is always the scanning radio (Mist convention)
             bands = band_orders.get(len(broadcast_radios), [])  # WHY: pick canonical order for this count
             for index, radio_mac in enumerate(broadcast_radios):  # WHY: pair each broadcast MAC to a band
@@ -318,7 +318,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
 
     @staticmethod
     def _write_checkpoint_file(checkpoint: dict[str, Any], completed_count: int) -> None:
-        """Write checkpoint JSON to disk; log OS errors without raising.
+        """Write checkpoint JSON to disk. Log OS errors without raising.
 
         WHY: extracted so `_save_checkpoint` stays under the 25-line ceiling
         and error-handling is isolated from checkpoint-shape construction.
@@ -537,7 +537,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         """
         if not wlan.get("enabled", False):  # WHY: disabled WLANs never broadcast
             return  # WHY: skip disabled record
-        ssid_name = wlan.get("ssid", "")  # WHY: required field; skip if missing
+        ssid_name = wlan.get("ssid", "")  # WHY: required field. Skip if missing
         if not ssid_name:  # WHY: empty SSID cannot appear on air
             return  # WHY: skip malformed record
         band_field = wlan.get("band") or ""  # WHY: normalise None to empty string for resolver
@@ -638,7 +638,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         missing = E911BSSIDReportGenerator._first_missing_field(ap_info)  # WHY: table lookup replaces if-chain
         if missing:  # WHY: first missing field wins
             return missing  # WHY: propagate to caller
-        map_id = ap_info.get("map_id") or ""  # WHY: already known present; re-fetch for lookup check
+        map_id = ap_info.get("map_id") or ""  # WHY: already known present. Re-fetch for lookup check
         if map_id not in lookups["maps"]:  # WHY: map id present but stale/deleted
             return "Map ID not found"  # WHY: distinct label for operator triage
         return ""  # WHY: empty string means "no gap"
@@ -691,7 +691,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         """
         band_info = lookups["radio_bands"].get(radio_mac)  # WHY: skip scanning/BLE radios (no band info)
         if not band_info:  # WHY: no band -> not a broadcast radio -> no rows
-            return  # WHY: silently skip; noise is handled at build-lookup time
+            return  # WHY: silently skip. Noise is handled at build-lookup time
         ssids = E911BSSIDReportGenerator._resolve_ssid_label(ap_ctx["site_id"], band_info, lookups)  # WHY: cell text
         band_label = band_info.get("band", "Unknown")  # WHY: default label preserves row shape
         E911BSSIDReportGenerator._emit_bssid_rows(radio_mac, band_label, ssids, ap_ctx, rows)  # WHY: fan-out 16 rows
@@ -725,7 +725,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         WHY: extracted so `_append_radio_rows` stays ≤25 lines.
         """
         for bssid in E911BSSIDReportGenerator._format_bssid(radio_mac):  # WHY: 16 BSSIDs per radio
-            rows.append(  # WHY: append to shared mutable list; single flat row schema
+            rows.append(  # WHY: append to shared mutable list. Single flat row schema
                 {
                     "Site Name": ap_ctx["site_name"],
                     "Site Address": ap_ctx["site_address"],
@@ -750,7 +750,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
             return "Unassigned", "", "Unassigned"  # WHY: consistent labels for compliance report
         site_info = lookups["sites"].get(site_id, {})  # WHY: empty dict when site_id is stale
         site_name = site_info.get("name") or "Unassigned"  # WHY: default label when name is blank
-        site_address = site_info.get("address", "")  # WHY: address optional; empty allowed
+        site_address = site_info.get("address", "")  # WHY: address optional. Empty allowed
         if not map_id:  # WHY: valid site but no floor plan
             return site_name, site_address, "Unassigned"  # WHY: separate map-level label
         if map_id not in lookups["maps"]:  # WHY: map id stale/deleted
@@ -897,7 +897,7 @@ class E911BSSIDReportGenerator:  # WHY: static-method namespace for the Menu 160
         batch: SiteBatchContext,
         index: int,
     ) -> bool | None:
-        """Process a single site; return False on rate-limit, None otherwise.
+        """Process a single site. Return False on rate-limit, None otherwise.
 
         WHY: extracted from `_process_site_batch` to keep parent ≤25 lines and complexity ≤5.
         """

--- a/src/reports/global_wired_client_report_generator.py
+++ b/src/reports/global_wired_client_report_generator.py
@@ -131,7 +131,7 @@ class GlobalWiredClientReportGenerator:
                 org_id,
                 **remote_params,
             )
-            records = mistapi.get_all(response=response, mist_session=mh.apisession) or []  # Page all; default empty.
+            records = mistapi.get_all(response=response, mist_session=mh.apisession) or []  # Page all. Default empty.
             logging.info("Retrieved %s wired client records", len(records))  # Log the count.
             logging.warning(
                 "  Retrieved %s wired client records", len(records)

--- a/src/reports/offline_device_reporter.py
+++ b/src/reports/offline_device_reporter.py
@@ -20,7 +20,7 @@ from __future__ import annotations  # WHY: PEP 604 unions for future annotations
 import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
 import logging  # WHY: structured trace + info/warn/error logging.
 import time  # WHY: wall-time epoch + elapsed timing.
-from datetime import datetime  # WHY: format epoch to human timestamp; timestamp CSV filename.
+from datetime import datetime  # WHY: format epoch to human timestamp. Timestamp CSV filename.
 from typing import Any  # WHY: device dicts carry heterogeneous values.
 
 from prettytable import PrettyTable  # WHY: render offline device rows as a table.
@@ -45,7 +45,7 @@ class OfflineDeviceReporter:  # Offline device inventory report.
 
     @staticmethod
     def _parse_threshold_attempt(raw: str) -> int | None:
-        """Parse one user attempt; return validated hours or None to retry."""
+        """Parse one user attempt. Return validated hours or None to retry."""
         try:
             hours = int(raw)  # Coerce to int.
             min_h = OfflineDeviceReporter.MIN_THRESHOLD_HOURS  # Local alias for line length.
@@ -156,7 +156,7 @@ class OfflineDeviceReporter:  # Offline device inventory report.
     def _maybe_build_offline_record(
         device: dict, site_lookup: dict[str, str], now: float, threshold_seconds: int
     ) -> dict | None:
-        """Return offline record for device if it qualifies as offline; None to skip."""
+        """Return offline record for device if it qualifies as offline. None to skip."""
         if device.get("status") == "connected":  # Skip currently-connected devices
             return None
         last_seen_epoch = OfflineDeviceReporter._parse_last_seen_epoch(device)  # Float epoch (0.0 = never seen)
@@ -236,7 +236,7 @@ class OfflineDeviceReporter:  # Offline device inventory report.
 
     @staticmethod
     def _save_offline_csv(offline_records: list[dict[str, str]], total_count: int) -> None:
-        """Build CSV rows and persist via shared exporter; log + print result."""
+        """Build CSV rows and persist via shared exporter. Log + print result."""
         mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of DataExporter.
         fields = OfflineDeviceReporter._OFFLINE_DISPLAY_FIELDS  # Column order.
         csv_records = [{f: record.get(f, "") for f in fields} for record in offline_records]  # Strip helper keys.

--- a/src/reports/wired_client_manufacturer_report_generator.py
+++ b/src/reports/wired_client_manufacturer_report_generator.py
@@ -57,7 +57,7 @@ class WiredClientManufacturerReportGenerator:
                 org_id,
                 limit=1000,
             )
-            records = mistapi.get_all(response=response, mist_session=mh.apisession) or []  # Page all; default empty.
+            records = mistapi.get_all(response=response, mist_session=mh.apisession) or []  # Page all. Default empty.
             logging.info("Retrieved %s wired client records", len(records))  # Log the count.
             logging.warning(
                 "  Retrieved %s wired client records", len(records)

--- a/src/site/address_audit/__init__.py
+++ b/src/site/address_audit/__init__.py
@@ -5,7 +5,7 @@ device serial number, enriches with SNMP location data, and resolves/validates
 the address through free tiers (internal comparison -> Nominatim -> optional
 Mist-dashboard UI automation). READ-ONLY in v1: no Mist site record is written.
 
-``AddressAuditEngine`` is the menu entry point; the remaining classes are its
+``AddressAuditEngine`` is the menu entry point. The remaining classes are its
 collaborators. ``AddressCorrector`` is an inert, unregistered write-back stub.
 """
 

--- a/src/site/address_audit/address_corrector.py
+++ b/src/site/address_audit/address_corrector.py
@@ -21,7 +21,7 @@ from __future__ import annotations  # PEP 604 union syntax on Python 3.13.
 import logging  # Action logging before/after every operation (project NON-NEGOTIABLE).
 from typing import Any  # Loose typing for the Mist API session/records.
 
-import mistapi  # Mist API SDK (sole Mist interface; hard dependency of MistHelper).
+import mistapi  # Mist API SDK (sole Mist interface. Hard dependency of MistHelper).
 
 from src.site.address_audit.models import AuditResult, CorrectionOutcome  # Shared dataclasses.
 from src.utils.input_utils import InputUtils  # EOF-safe operator prompts.
@@ -61,10 +61,10 @@ class AddressCorrector:
         return suggestion.lower() != current.lower()  # Only when the suggestion actually differs.
 
     def review_and_apply(self, results: list[AuditResult]) -> list[CorrectionOutcome]:
-        """Per-site BEFORE/AFTER + ``[y/N]``; push the accepted ones; return all outcomes."""
+        """Per-site BEFORE/AFTER + ``[y/N]``. Push the accepted ones. Return all outcomes."""
         targets = self.correctable(results)  # Rows eligible for write-back.
         if not targets:  # Nothing to push.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("No correctable addresses to push.")
             return []  # Empty outcome list.
         logging.info("Reviewing %d correctable address(es) for write-back", len(targets))  # Action-log start.
@@ -86,32 +86,32 @@ class AddressCorrector:
         return self._push(site.site_name or "-", site.site_id or "", before, after)  # Accepted -> push.
 
     def _push(self, name: str, site_id: str, before: str, after: str) -> CorrectionOutcome:
-        """Write the corrected address to one Mist site; never raises."""
+        """Write the corrected address to one Mist site. Never raises."""
         logging.info("Pushing corrected address to site %s (%s)", site_id, name)  # Action-log the write.
         try:
             ok = self._update_site_address(site_id, after)  # Fetch-modify-PUT the site record.
         except Exception as exc:  # noqa: BLE001 -- one failed write must not abort the batch.
             logging.warning("Write-back failed for site %s: %s", site_id, exc)  # Surface the cause.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("  FAILED: %s", exc)
             return CorrectionOutcome(name, site_id, before, after, "failed", str(exc))
         if ok:  # Mist accepted the update.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  PUSHED.")
             return CorrectionOutcome(name, site_id, before, after, "pushed")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("  FAILED: Mist rejected the update (check token permissions).")
         return CorrectionOutcome(name, site_id, before, after, "failed", "update rejected")
 
     def _update_site_address(self, site_id: str, address: str) -> bool:
-        """Fetch the full site, replace only ``address``, and PUT it back; return success."""
+        """Fetch the full site, replace only ``address``, and PUT it back. Return success."""
         logging.debug("Fetching site %s before write-back", site_id)  # Trace the read.
         current = mistapi.api.v1.sites.sites.getSiteInfo(self._api, site_id)  # Full current site record.
         site = current.data if isinstance(current.data, dict) else {}  # Guard against list/empty payloads.
         if not site:  # No usable site record returned.
             logging.warning("Site %s returned no record; cannot write back", site_id)  # Trace the miss.
             return False  # Treat as a failed update.
-        site["address"] = address  # Replace ONLY the address; everything else is preserved.
+        site["address"] = address  # Replace ONLY the address. Everything else is preserved.
         updated = mistapi.api.v1.sites.sites.updateSiteInfo(self._api, site_id, site)  # PUT the full record.
         success = updated.status_code in (200, 201)  # 2xx => Mist accepted the change.
         logging.debug("Write-back for site %s status=%s", site_id, updated.status_code)  # Trace the result.
@@ -120,19 +120,19 @@ class AddressCorrector:
     @staticmethod
     def _print_intro(count: int) -> None:
         """Print a clear banner before any Mist write occurs."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n--- Address write-back: %d site(s) to review ---", count)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("This WRITES to your Mist sites. Confirm each site with y/N (default No).\n")
 
     @staticmethod
     def _show(name: str, before: str, after: str) -> None:
         """Display one site's current vs corrected address side by side."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Site: %s", name)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  BEFORE: %s", before or "(empty)")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("  AFTER:  %s", after)
 
     @staticmethod
@@ -141,5 +141,5 @@ class AddressCorrector:
         pushed = sum(1 for o in outcomes if o.action == "pushed")  # Successful writes.
         skipped = sum(1 for o in outcomes if o.action == "skipped")  # Operator declines.
         failed = sum(1 for o in outcomes if o.action == "failed")  # API failures.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\nWrite-back complete: %d pushed, %d skipped, %d failed.", pushed, skipped, failed)

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -4,7 +4,7 @@ Resolves the best canonical address for one site WITHOUT any paid or non-existen
 API. Order of resolution:
 
   * Tier 1 (internal, no network): compare the Mist address against the CSV
-    address and the SNMP location; when an internal candidate clearly carries a
+    address and the SNMP location. When an internal candidate clearly carries a
     suite/unit the Mist address lacks, that candidate is the suggestion.
   * Tier 2 (Nominatim, free, <=1 req/sec): reuse the existing
     ``NominatimValidator`` to validate the base street and produce a canonical
@@ -51,7 +51,7 @@ class AddressResolver:
         """Store cache path, build the reused Nominatim config, and init counters."""
         self._db_path = db_path or _DB_RELATIVE_PATH  # Cache DB path (injectable for tests).
         self._nominatim_config = AddressValidationConfig(skip_ssl_verify=skip_ssl_verify)  # Reused validator cfg.
-        self._ui_geocoder = ui_geocoder  # Optional MistUIGeocoder (Tier 3); None disables it.
+        self._ui_geocoder = ui_geocoder  # Optional MistUIGeocoder (Tier 3). None disables it.
         self._perf = perf or PhaseTimer()  # Timing sink (own no-op timer when the caller passes none).
         self.cache_hits = 0  # Count of cache hits this run (feeds AuditCounters).
         self.external_calls = 0  # Count of Nominatim/UI calls actually made.
@@ -79,7 +79,7 @@ class AddressResolver:
             with self._perf.phase("tier2_nominatim"):  # Time OSM validation incl. its rate-limit sleep.
                 osm = self._validate_nominatim(candidates, query)  # Tier 2: OpenStreetMap street validation.
             with self._perf.phase("tier3_ui"):  # Time the browser tier incl. typing/read/politeness.
-                ui = self._maybe_ui(candidates, query)  # Tier 3: Google-via-Mist authority (gated; fail-soft).
+                ui = self._maybe_ui(candidates, query)  # Tier 3: Google-via-Mist authority (gated. Fail-soft).
             return self._combine(internal, osm, ui, candidates, query)  # Merge the tiers into one result.
         except Exception as exc:  # noqa: BLE001 -- one row must never abort the audit.
             logging.warning("Resolve failed for key derived from '%s': %s", query, exc)  # Log and continue.
@@ -96,8 +96,8 @@ class AddressResolver:
         """Merge results with the web (Tier 3) as the authority for the true suite.
 
         Priority: a confident Tier-3 (Google-via-Mist) suggestion WINS because it is
-        the only source that knows the real suite; otherwise the internal suite
-        candidate (street cross-checked by OSM); otherwise OSM's validated street;
+        the only source that knows the real suite. Otherwise the internal suite
+        candidate (street cross-checked by OSM). Otherwise OSM's validated street;
         otherwise NO_RESULT. Tier 3 only overrides when it actually returned an
         address, so a missing/failed browser never makes results worse.
         """
@@ -129,7 +129,7 @@ class AddressResolver:
     ) -> bool:  # WHY: tier identity dictates how the street-validated flag is derived.
         """Return the street_validated flag for the winning tier, respecting OSM cross-check."""
         osm_present = osm is not None  # WHY: cache the presence check so both branches read cleanly.
-        if winner is ui:  # WHY: Tier 3 may already carry its own validated flag; OR with OSM cross-check.
+        if winner is ui:  # WHY: Tier 3 may already carry its own validated flag. OR with OSM cross-check.
             return winner.street_validated or osm_present  # WHY: never demote an already-validated UI answer.
         if winner is osm:  # WHY: OSM itself is the external validator when it wins.
             return True  # WHY: OSM's presence *is* the confirmation.
@@ -145,16 +145,16 @@ class AddressResolver:
         """
         mist_street = candidates.mist_address.get("address", "")  # Mist street line (the clean base).
         if re.search(_SUITE_PATTERN, mist_street, flags=re.IGNORECASE):  # Mist already carries a suite.
-            return None  # No discrepancy to surface; defer to Tier 2.
+            return None  # No discrepancy to surface. Defer to Tier 2.
         suite = self._pick_internal_suite(candidates)  # WHY: fold the authority/CSV/SNMP fallback chain into a helper.
         if not suite:  # Neither internal source supplies a suite Mist lacks.
-            return None  # Nothing to add; defer to Tier 2.
+            return None  # Nothing to add. Defer to Tier 2.
         clean = self._build_clean_suggestion(candidates.mist_address, suite)  # Mist base + suite, no pollution.
         logging.debug("Tier 1 internal suggestion (suite=%s): %s", suite, clean)  # Trace the internal hit.
         return ResolverResult(query="", canonical_address=clean, source="internal", confidence=0.7)
 
     def _pick_internal_suite(self, candidates: ResolveCandidates) -> str:  # WHY: keep suite fallback out of Tier 1.
-        """Return the first available suite token: authority > CSV > SNMP; empty string when none."""
+        """Return the first available suite token: authority > CSV > SNMP. Empty string when none."""
         for source in (candidates.authoritative_address, candidates.csv_address):  # WHY: authority-first preference.
             suite = self._extract_suite(source.get("address", ""))  # WHY: normalized suite token or empty.
             if suite:  # WHY: first non-empty match wins.
@@ -180,7 +180,7 @@ class AddressResolver:
 
     @staticmethod
     def _build_locality(mist_address: dict[str, Any]) -> str:  # WHY: isolate the state/zip join so CC stays under 5.
-        """Return a "STATE ZIP" pair built from Mist fields; empty string when both are absent."""
+        """Return a "STATE ZIP" pair built from Mist fields. Empty string when both are absent."""
         zip_value = mist_address.get("zip") or mist_address.get("zipcode", "")  # WHY: either zip key may be populated.
         tokens = (mist_address.get("state", ""), str(zip_value))  # WHY: state first, ZIP second per US postal order.
         return " ".join(token for token in tokens if token).strip()  # WHY: filter empties so lone components stand.
@@ -225,7 +225,7 @@ class AddressResolver:
     def _nominatim_canonical(self, candidates: ResolveCandidates, comparison: dict[str, Any]) -> str:
         """Return a clean suggestion for an OSM-validated row from Mist's own address.
 
-        OpenStreetMap validates only the *street*; its ``display_name`` is verbose
+        OpenStreetMap validates only the *street*. Its ``display_name`` is verbose
         and noisy (``Business, 1200, Northwest 87th Avenue, Doral, Miami-Dade
         County, Florida, 33172, United States``). Since OSM merely confirms the
         street is real, the cleanest, most useful suggestion is Mist's own
@@ -259,7 +259,7 @@ class AddressResolver:
         return result  # May be None / empty (fail-soft) -> caller falls back to Tier 1/2.
 
     def _ui_lookup_with_fallback(self, candidates: ResolveCandidates, query: str) -> ResolverResult | None:
-        """Geocode the business-prefixed query; if it yields nothing, retry the plain address.
+        """Geocode the business-prefixed query. If it yields nothing, retry the plain address.
 
         A business-name prefix (``T-Mobile <addr>``) helps Google return the exact
         store unit, but when no store sits at that number Google returns unrelated
@@ -341,7 +341,7 @@ class AddressResolver:
 
         The Mist address, SNMP location, customer CSV, and optional business
         authority CSV are all hints, and any single one can be wrong. Voting on
-        house number means one bad hint cannot hijack the geocoding query; the
+        house number means one bad hint cannot hijack the geocoding query. The
         agreed-upon, cleanest, suite-bearing source wins.
         """
         hints = self._gather_hints(candidates)  # [(label, text, house_no, has_suite), ...].
@@ -378,7 +378,7 @@ class AddressResolver:
         return leaders > 1  # WHY: two or more leaders => tied => no majority.
 
     def _gather_hints(self, candidates: ResolveCandidates) -> list[tuple[str, str, str, bool]]:
-        """Normalize each hint into (label, text, house_number, has_suite); drop empties."""
+        """Normalize each hint into (label, text, house_number, has_suite). Drop empties."""
         raw = [  # Source label -> raw text (authority/CSV first so ties prefer customer-provided business data).
             ("authority", self._format_address(candidates.authoritative_address)),
             ("csv", self._format_address(candidates.csv_address)),
@@ -441,7 +441,7 @@ class AddressResolver:
             address.get("state", ""),  # State code.
             str(address.get("zip", address.get("zipcode", ""))),  # ZIP (either key).
         ]
-        return " ".join(part for part in parts if part).strip()  # Skip blanks; trim.
+        return " ".join(part for part in parts if part).strip()  # Skip blanks. Trim.
 
     @staticmethod
     def _strip_suite_from_dict(address: dict[str, Any]) -> dict[str, Any]:

--- a/src/site/address_audit/audit_engine.py
+++ b/src/site/address_audit/audit_engine.py
@@ -4,7 +4,7 @@
 matches each row to a Mist site (serial golden key, fuzzy fallback), enriches with
 SNMP location, resolves/validates the address through the free tiers, classifies
 each row into one of eleven states, renders the comparison table, and offers to save
-the results to CSV. The audit itself is read-only; afterwards the operator may
+the results to CSV. The audit itself is read-only. Afterwards the operator may
 opt in to push corrected addresses back to Mist via ``AddressCorrector``, gated by
 a batch confirmation and a per-site ``[y/N]`` before/after review.
 
@@ -25,7 +25,7 @@ from contextlib import contextmanager  # Scope the console-log suppression to on
 from dataclasses import dataclass  # Frozen bundle for audit context (STRUCT-PARAMS fix).
 from typing import Any, TypeVar  # Loose typing for Mist API records + generic collaborator default.
 
-import mistapi  # Mist API SDK (sole Mist interface; hard dependency of MistHelper).
+import mistapi  # Mist API SDK (sole Mist interface. Hard dependency of MistHelper).
 
 from src.site.address_audit.address_corrector import AddressCorrector  # Optional Mist write-back.
 from src.site.address_audit.address_resolver import AddressResolver  # Tiered resolver.
@@ -87,7 +87,7 @@ class _AuditContext:
     Groups the three read-only inputs (business-name prefix, Tier-3 enablement,
     business-authoritative index) that previously travelled as three positional
     arguments through ``_audit_rows``, ``_resolve_and_classify`` and
-    ``_build_audit_result``; bundling them keeps every function within the
+    ``_build_audit_result``. Bundling them keeps every function within the
     five-parameter limit while preserving intent at each call site.
     """
 
@@ -100,7 +100,7 @@ class _AddressAuditConsoleFilter(logging.Filter):
     """Console filter that drops log records emitted from the address_audit package.
 
     The address audit talks to the operator through ``print`` (the comparison
-    table, the post-table prompts, the write-back confirmations); every
+    table, the post-table prompts, the write-back confirmations). Every
     ``logging.*`` call it makes is a diagnostic trail destined for
     ``data/script.log``. Attached to the root logger's CONSOLE handlers (and only
     for the duration of a run), this filter keeps that diagnostic noise -- for example the
@@ -126,7 +126,7 @@ class AddressAuditEngine:
         renderer: ComparisonTableRenderer | None = None,
         reporter: AddressAuditReporter | None = None,
     ) -> None:
-        """Store collaborators (injectable for tests; sensible defaults otherwise)."""
+        """Store collaborators (injectable for tests. Sensible defaults otherwise)."""
         self._ingester = self._default(ingester, CSVAddressIngester)  # CSV parser (default or injected).
         self._authority_ingester = self._default(authority_ingester, BusinessAuthorityIngester)  # Authority parser.
         self._enricher = self._default(enricher, SNMPLocationEnricher)  # SNMP enrichment (default or injected).
@@ -151,7 +151,7 @@ class AddressAuditEngine:
         wrapped so this feature's diagnostic logging goes to ``data/script.log``
         only, never the terminal (keeps the progress bar clean).
         """
-        with self._console_logs_to_file_only():  # Address-audit logs -> file only; console stays clean.
+        with self._console_logs_to_file_only():  # Address-audit logs -> file only. Console stays clean.
             self._run_pipeline(apisession, org_id)  # Drive the actual audit pipeline.
 
     def _run_pipeline(self, apisession: Any, org_id: str) -> None:
@@ -160,12 +160,12 @@ class AddressAuditEngine:
         logger.info("Starting site address audit (tier3_geocode=%s)", ui_geocode)  # Action-log start.
         csv_path = self._select_csv_file()  # Pick the customer CSV from data/.
         if csv_path is None:  # No CSV present -> nothing to audit.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("No CSV/TSV files found in data/. Drop your address file there and retry.")
             return  # Clean early return.
         rows, failures = self._ingester.load(csv_path)  # Parse the CSV into rows.
         if not rows:  # Every row was malformed/empty-serial.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("No valid rows parsed from %s (%s skipped).", csv_path, failures)
             return  # Nothing further to do.
         business_csv_path = self._select_business_csv_file(csv_path)  # Optional second prompt for authoritative CSV.
@@ -231,7 +231,7 @@ class AddressAuditEngine:
         return results  # Hand the classified results back to the pipeline.
 
     def _select_csv_file(self) -> str | None:
-        """Find CSV/TSV files in data/; auto-pick one, prompt when several, else None."""
+        """Find CSV/TSV files in data/. Auto-pick one, prompt when several, else None."""
         candidates = sorted(glob.glob(os.path.join(_DATA_DIR, "*.csv")) + glob.glob(os.path.join(_DATA_DIR, "*.tsv")))
         if not candidates:  # No files at all.
             logger.debug("No CSV/TSV files found in %s", _DATA_DIR)  # Trace the empty case.
@@ -242,11 +242,11 @@ class AddressAuditEngine:
         return self._prompt_csv_choice(candidates)  # Multiple -> ask the operator.
 
     def _prompt_csv_choice(self, candidates: list[str]) -> str | None:
-        """Prompt the operator to choose one CSV from a numbered list; empty input aborts."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        """Prompt the operator to choose one CSV from a numbered list. Empty input aborts."""
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Available CSV files in data/:")  # Header for the choices.
         for index, path in enumerate(candidates, start=1):  # Enumerate options 1..N.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  [%s] %s", index, os.path.basename(path))  # Show each filename.
         while True:  # Loop until a valid selection is made or the operator/EOF aborts.
             raw = InputUtils.safe_input("Select file number: ", context="address_audit_csv_pick").strip()
@@ -254,14 +254,14 @@ class AddressAuditEngine:
                 not raw
             ):  # Empty response (blank Enter or EOF sentinel from safe_input) -> abort so we cannot infinite-loop under non-interactive stdin (for example --test).  # noqa: E501
                 logger.info("No CSV selection made (empty input); skipping address audit")  # Action-log the abort.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.info(
                     "No CSV selected. Skipping address audit."
                 )  # Inform the operator (also covers non-TTY --test).
                 return None  # Caller treats None as "nothing to audit".
             if raw.isdigit() and 1 <= int(raw) <= len(candidates):  # Valid in-range integer.
                 return candidates[int(raw) - 1]  # Return the chosen path.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("Invalid selection. Please enter a number between 1 and %s: ", len(candidates))  # Re-prompt.
 
     def _select_business_csv_file(self, primary_csv_path: str) -> str | None:
@@ -280,13 +280,13 @@ class AddressAuditEngine:
     @staticmethod
     def _print_business_csv_menu(candidates: list[str], primary_csv_path: str) -> None:
         """Print the numbered business-authoritative CSV menu with a primary-file marker."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "\nOptional: select business-authoritative CSV file in data/ (or q to skip):"
         )  # Second prompt header.
         for index, path in enumerate(candidates, start=1):  # Enumerate options 1..N.
             marker = " (primary file)" if path == primary_csv_path else ""  # Guard hint when selecting same file.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("  [%s] %s%s", index, os.path.basename(path), marker)  # Show indexed filename choice.
 
     def _read_business_csv_selection(self, candidates: list[str]) -> str | None:
@@ -309,7 +309,7 @@ class AddressAuditEngine:
             picked = self._parse_business_csv_choice(raw, candidates)  # Interpret the raw operator entry.
             if picked is not _INVALID_CHOICE:  # Valid choice (path) or explicit skip (None) -> exit the retry loop.
                 return picked  # type: ignore[no-any-return]  # Sentinel guarantees str|None here.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning(
                 "Invalid selection. Enter 1-%s or q to skip.", len(candidates)
             )  # One-line validation message.
@@ -356,7 +356,7 @@ class AddressAuditEngine:
         configured = os.environ.get("BUSINESS_NAME", "").strip()  # Preferred .env source.
         if configured:  # Already configured -> use it silently.
             return configured  # Business name from environment.
-        return InputUtils.safe_input(  # Otherwise prompt once; Enter skips the prefix.
+        return InputUtils.safe_input(  # Otherwise prompt once. Enter skips the prefix.
             'Enter business name for geocoding queries (e.g. "Starbucks"), or press Enter to skip: ',
             context="address_audit_business_name",
         ).strip()
@@ -385,7 +385,7 @@ class AddressAuditEngine:
     def _match_sites(
         self, rows: list[AddressRow], matcher: SiteMatchingEngine, sites_list: list[dict[str, Any]]
     ) -> list[MatchedSite]:
-        """Match each row by serial; fall back to fuzzy address match on a miss."""
+        """Match each row by serial. Fall back to fuzzy address match on a miss."""
         matched: list[MatchedSite] = []  # Per-row match outcomes.
         for row in rows:  # Walk every parsed CSV row.
             result = matcher.match_serial(row.serial)  # Try the golden-key serial match first.
@@ -431,11 +431,11 @@ class AddressAuditEngine:
 
         ``ADDRESS_AUDIT_GEOCODE`` accepts: ``off`` (disable Tier 3), ``auto``
         (default -- take over a debuggable browser if present, else spawn one and
-        guide login), ``attach`` (take over only; operator pre-started Edge), or
+        guide login), ``attach`` (take over only. Operator pre-started Edge), or
         ``launch`` (Playwright launches a fresh Edge). Unknown values fall back to
         ``auto`` so a typo never disables suite discovery.
         """
-        raw = os.environ.get("ADDRESS_AUDIT_GEOCODE", "auto").strip().lower()  # Single env knob; default auto.
+        raw = os.environ.get("ADDRESS_AUDIT_GEOCODE", "auto").strip().lower()  # Single env knob. Default auto.
         if raw in ("off", "0", "no", "false", "none", "disabled"):  # Any disable token.
             return "off"  # Tier 3 turned off.
         if raw in ("attach", "launch", "auto"):  # Explicit, recognized mode.
@@ -460,7 +460,7 @@ class AddressAuditEngine:
         SSL inspection, whose MITM cert otherwise breaks the OpenStreetMap call.
         Set ``MIST_SKIP_SSL_VERIFY=false`` to enforce verification (non-Zscaler hosts).
         """
-        raw = os.environ.get("MIST_SKIP_SSL_VERIFY", "true").strip().lower()  # Env override; default on.
+        raw = os.environ.get("MIST_SKIP_SSL_VERIFY", "true").strip().lower()  # Env override. Default on.
         return raw not in ("false", "0", "no", "off")  # Any falsey token re-enables verification.
 
     @staticmethod
@@ -470,7 +470,7 @@ class AddressAuditEngine:
 
         geocoder = MistUIGeocoder(AddressAuditEngine._ui_config(), perf=perf)  # Env-driven config + shared timer.
         if not geocoder.connect():  # Establish the browser session (fail-soft).
-            logger.info(  # No browser is the normal case; degrade quietly to Tier 1/2.
+            logger.info(  # No browser is the normal case. Degrade quietly to Tier 1/2.
                 "Tier-3 web geocoder not available; using internal + OpenStreetMap hints only. "
                 "Set ADDRESS_AUDIT_GEOCODE=off to skip, or 'launch' to force a fresh Edge."
             )
@@ -482,7 +482,7 @@ class AddressAuditEngine:
     def _ui_config() -> UIGeocoderConfig:
         """Build a ``UIGeocoderConfig`` from environment overrides (with safe defaults)."""
         config = UIGeocoderConfig()  # Start from the Zscaler-safe defaults.
-        config.connect_mode = AddressAuditEngine._geocode_mode()  # off is filtered earlier; auto/attach/launch here.
+        config.connect_mode = AddressAuditEngine._geocode_mode()  # off is filtered earlier. Auto/attach/launch here.
         config.dashboard_url = os.environ.get("MIST_DASHBOARD_URL", config.dashboard_url).strip()  # Cloud region.
         config.per_lookup_timeout_s = AddressAuditEngine._env_float(  # Per-lookup timeout override.
             "UI_GEOCODE_TIMEOUT_SECONDS", config.per_lookup_timeout_s
@@ -640,7 +640,7 @@ class AddressAuditEngine:
             matched_site=site,  # Keep the three hint columns visible for manual review.
             issue_type="CONFLICTING_HINTS",  # Never enters the correctable/push set.
             source="-",  # No single trustworthy source to credit.
-            suggested_address="",  # Decline to recommend; operator compares Mist/CSV/SNMP by hand.
+            suggested_address="",  # Decline to recommend. Operator compares Mist/CSV/SNMP by hand.
         )
 
     def _compose_audit_result(
@@ -821,7 +821,7 @@ class AddressAuditEngine:
 
         Includes alphabetic words (``jefferson``) AND ordinal/alphanumeric street
         names (``107th``, ``a1a``) so a numeric-named street still matches when
-        Google spells out ``NW``/``Avenue``; the pure-digit house number is
+        Google spells out ``NW``/``Avenue``. The pure-digit house number is
         excluded so two different streets at the same number never match on it.
         """
         without_suite = re.sub(_SUITE_PATTERN, " ", text.lower())  # Drop the suite token.
@@ -888,11 +888,11 @@ class AddressAuditEngine:
         """Save the report (operator's choice), then optionally write corrections back to Mist."""
         action = self._renderer.prompt_post_table(results)  # Ask save vs quit.
         if action != "save":  # Operator quit without saving.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("No file saved. Exiting address audit.")  # Quit branch confirmation.
             return  # No write-back when nothing was saved.
         path = self._reporter.save(results)  # Write the timestamped comparison CSV.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Saved to %s", path)  # Confirm the written path.
         self._offer_write_back(results, apisession)  # Offer to push corrections to Mist.
 
@@ -906,7 +906,7 @@ class AddressAuditEngine:
         prompt = f"\nPush corrected addresses back to Mist for up to {len(targets)} site(s)? [y/N]: "
         choice = InputUtils.safe_input(prompt, context="address_audit_writeback_gate").strip().lower()
         if choice not in ("y", "yes"):  # Operator declined the whole batch.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("Skipped write-back. No Mist changes made.")  # Confirm no writes.
             return  # Audit ends here.
         outcomes = corrector.review_and_apply(results)  # Per-site review + push.
@@ -924,11 +924,11 @@ class AddressAuditEngine:
             .lower()
         )
         if choice not in ("y", "yes"):  # Operator declined the report.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("No correction report saved.")  # Confirm the skip.
             return  # Done.
         path = self._reporter.save_corrections(outcomes)  # Write the before/after CSV.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Saved correction report to %s", path)  # Confirm the written path.
 
     @staticmethod
@@ -956,7 +956,7 @@ class AddressAuditEngine:
     def _csv_text(row: AddressRow) -> str:
         """Join a CSV row's address parts into a single fuzzy-match query string."""
         parts = [row.address, row.city, row.state]  # Address components for fuzzy matching.
-        return " ".join(part for part in parts if part).strip()  # Skip blanks; trim.
+        return " ".join(part for part in parts if part).strip()  # Skip blanks. Trim.
 
     @staticmethod
     def _format_address(address: dict[str, Any]) -> str:
@@ -967,10 +967,10 @@ class AddressAuditEngine:
             address.get("state", ""),  # State.
             str(address.get("zip", "")),  # ZIP.
         ]
-        return " ".join(part for part in parts if part).strip()  # Skip blanks; trim.
+        return " ".join(part for part in parts if part).strip()  # Skip blanks. Trim.
 
     def apply_corrections(self, *args: Any, **kwargs: Any) -> None:
-        """Deferred write-back surface (OQ-003); intentionally not menu-registered."""
+        """Deferred write-back surface (OQ-003). Intentionally not menu-registered."""
         logger.info(  # Action-log the attempt (and reference args/kwargs for the deferred signature).
             "apply_corrections invoked with %d args / %d kwargs (feature disabled)", len(args), len(kwargs)
         )

--- a/src/site/address_audit/audit_reporter.py
+++ b/src/site/address_audit/audit_reporter.py
@@ -38,7 +38,7 @@ class AddressAuditReporter:
     """Write the audit results to a timestamped CSV file in ``data/``."""
 
     def save(self, results: list[AuditResult], output_dir: str = "data") -> str:
-        """Write ``results`` to ``data/address_audit_<UTC timestamp>.csv``; return the path."""
+        """Write ``results`` to ``data/address_audit_<UTC timestamp>.csv``. Return the path."""
         logging.info("Saving address-audit report (%d rows)", len(results))  # Action-log start.
         os.makedirs(output_dir, exist_ok=True)  # Ensure the output directory exists.
         stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")  # UTC timestamp for the filename.
@@ -65,7 +65,7 @@ class AddressAuditReporter:
         ]
 
     def save_corrections(self, outcomes: list[CorrectionOutcome], output_dir: str = "data") -> str:
-        """Write the before/after write-back outcomes to a timestamped CSV; return the path."""
+        """Write the before/after write-back outcomes to a timestamped CSV. Return the path."""
         logging.info("Saving address-correction report (%d outcome rows)", len(outcomes))  # Action-log start.
         os.makedirs(output_dir, exist_ok=True)  # Ensure the output directory exists.
         stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")  # UTC timestamp for the filename.
@@ -89,10 +89,10 @@ class AddressAuditReporter:
             address.get("state", ""),  # State code.
             str(address.get("zip", "")),  # ZIP.
         ]
-        return " ".join(part for part in parts if part).strip()  # Skip blanks; trim.
+        return " ".join(part for part in parts if part).strip()  # Skip blanks. Trim.
 
     @staticmethod
     def _format_csv_address(row) -> str:
         """Join a CSV ``AddressRow`` into a single line."""
         parts = [row.address, row.city, row.state, row.zip_code]  # CSV address components.
-        return " ".join(part for part in parts if part).strip()  # Skip blanks; trim.
+        return " ".join(part for part in parts if part).strip()  # Skip blanks. Trim.

--- a/src/site/address_audit/business_authority_ingester.py
+++ b/src/site/address_audit/business_authority_ingester.py
@@ -110,7 +110,7 @@ class BusinessAuthorityIngester:
         return {}  # No unique mapping -> fail-safe empty (never bind a row to a wrong authority record).
 
     def _parse_row(self, raw: dict[str, str]) -> BusinessAuthorityRow | None:
-        """Normalize one authority CSV row; skip rows with no usable street/city/state/zip."""
+        """Normalize one authority CSV row. Skip rows with no usable street/city/state/zip."""
         site_name = (raw.get("Name") or "").strip()  # Business storefront name (may be blank on some exports).
         street = (raw.get("Address") or "").strip()  # Base street line from authority export.
         space = (raw.get("Space #") or "").strip()  # Separate suite/unit column in T-Builder exports.
@@ -118,7 +118,7 @@ class BusinessAuthorityIngester:
         state = (raw.get("State") or "").strip()  # State/region field.
         zip_code = (raw.get("Zip") or "").strip()  # ZIP/postal field.
         if not street or not city or not state:  # Reject rows missing basic geocoding identity.
-            return None  # Skip incomplete rows; caller keeps ingestion fail-soft.
+            return None  # Skip incomplete rows. Caller keeps ingestion fail-soft.
         merged = self._merge_street_and_space(street, space)  # Build one street line with space/suite included.
         return BusinessAuthorityRow(site_name=site_name, address=merged, city=city, state=state, zip_code=zip_code)
 

--- a/src/site/address_audit/comparison_display.py
+++ b/src/site/address_audit/comparison_display.py
@@ -3,7 +3,7 @@
 Renders the audited rows as a 7-column terminal table (current Mist address on
 the left, the suggested correction on the right) and, afterwards, prompts the
 operator to either save the full results to CSV or quit. The terminal view
-truncates the two widest columns for readability; the saved CSV keeps full
+truncates the two widest columns for readability. The saved CSV keeps full
 values (handled by ``AddressAuditReporter``).
 """
 
@@ -40,7 +40,7 @@ class ComparisonTableRenderer:
         for result in results:  # Add one terminal row per audited CSV row.
             table.add_row(self._build_row(result))  # Append the (truncated) row cells.
         rendered = table.get_string()  # Materialize the table as a string.
-        # WHY: preserve operator-facing table render; route through logger for capture/redirection.
+        # WHY: preserve operator-facing table render. Route through logger for capture/redirection.
         logging.info("%s", rendered)
         logging.debug("Comparison table rendered (%d rows)", len(results))  # Action-log completion.
         return rendered  # Return for tests/callers.
@@ -76,7 +76,7 @@ class ComparisonTableRenderer:
     def prompt_post_table(self, results: list[AuditResult]) -> str:
         """Print a one-line summary, then loop until the operator picks save/quit."""
         logging.info("Prompting operator for post-table action")  # Action-log start.
-        # WHY: preserve operator-facing summary + menu; route through logger for capture/redirection.
+        # WHY: preserve operator-facing summary + menu. Route through logger for capture/redirection.
         logging.info("%s", self._summary_line(results))
         logging.info("\n[1] Save comparison as CSV to data/ for review")
         logging.info("[q] Quit without saving")
@@ -88,7 +88,7 @@ class ComparisonTableRenderer:
             if choice == "q":  # Operator chose to quit.
                 logging.debug("Operator selected quit")  # Trace the choice.
                 return "quit"  # Engine exits without saving.
-            # WHY: preserve invalid-choice feedback verbatim; route through logger for capture/redirection.
+            # WHY: preserve invalid-choice feedback verbatim. Route through logger for capture/redirection.
             logging.warning("Invalid choice. Enter 1 to save or q to quit.")
 
     def _summary_line(self, results: list[AuditResult]) -> str:
@@ -115,10 +115,10 @@ class ComparisonTableRenderer:
             address.get("state", ""),  # State code.
             str(address.get("zip", "")),  # ZIP.
         ]
-        return " ".join(part for part in parts if part).strip()  # Skip blanks; trim.
+        return " ".join(part for part in parts if part).strip()  # Skip blanks. Trim.
 
     @staticmethod
     def _format_csv_address(row) -> str:
         """Join a CSV ``AddressRow`` into a single line."""
         parts = [row.address, row.city, row.state, row.zip_code]  # CSV address components.
-        return " ".join(part for part in parts if part).strip()  # Skip blanks; trim.
+        return " ".join(part for part in parts if part).strip()  # Skip blanks. Trim.

--- a/src/site/address_audit/csv_ingester.py
+++ b/src/site/address_audit/csv_ingester.py
@@ -81,7 +81,7 @@ class CSVAddressIngester:
         for candidate in _CANDIDATE_DELIMITERS:  # Probe each candidate delimiter.
             count = len(sample.split(candidate))  # Field count this delimiter would produce.
             if count >= _MIN_COLUMNS and candidate == "\t":  # A tab that yields >=6 wins outright.
-                return candidate  # Tab is the documented format; prefer it when it fits.
+                return candidate  # Tab is the documented format. Prefer it when it fits.
             if count > best_count:  # Otherwise track the delimiter giving the most fields.
                 best_count = count  # Remember the new best field count.
                 best_delimiter = candidate  # Remember the delimiter that produced it.

--- a/src/site/address_audit/models.py
+++ b/src/site/address_audit/models.py
@@ -23,9 +23,9 @@ from typing import Any  # Loose typing for the raw tier payload.
 class AddressRow:
     """One parsed, sanitized CSV row (tab-delimited, header-less customer file)."""
 
-    serial: str  # Col 0: Juniper device serial (numeric string); required, non-empty.
-    model: str  # Col 1: device model (for example SSR130); display only.
-    address: str  # Col 2: street address; sanitized (newlines removed, ws collapsed).
+    serial: str  # Col 0: Juniper device serial (numeric string). Required, non-empty.
+    model: str  # Col 1: device model (for example SSR130). Display only.
+    address: str  # Col 2: street address. Sanitized (newlines removed, ws collapsed).
     city: str  # Col 3: city name.
     state: str  # Col 4: 2-letter state code.
     zip_code: str  # Col 5: 5-digit ZIP.
@@ -35,12 +35,12 @@ class AddressRow:
 class MatchedSite:
     """A CSV row resolved (or not) to a Mist site, optionally SNMP-enriched."""
 
-    site_id: str | None = None  # Mist site UUID; None when unmatched.
-    site_name: str | None = None  # Display name; None when unmatched.
+    site_id: str | None = None  # Mist site UUID. None when unmatched.
+    site_name: str | None = None  # Display name. None when unmatched.
     mist_address: dict[str, Any] = field(default_factory=dict)  # {address,city,state,zip} from the site.
-    snmp_location: str | None = None  # Filled by SNMPLocationEnricher; None/(none) when absent.
+    snmp_location: str | None = None  # Filled by SNMPLocationEnricher. None/(none) when absent.
     match_strategy: str = "unmatched"  # One of: serial | fuzzy | unmatched.
-    match_confidence: float = 0.0  # 1.0 serial; rapidfuzz score/100 fuzzy; 0.0 unmatched.
+    match_confidence: float = 0.0  # 1.0 serial. Rapidfuzz score/100 fuzzy; 0.0 unmatched.
 
 
 @dataclass
@@ -68,13 +68,13 @@ class AuditResult:
     matched_site: MatchedSite  # Match outcome (+ SNMP enrichment).
     resolver_result: ResolverResult | None = None  # None for UNMATCHED rows (no resolution attempted).
     issue_type: str = "UNMATCHED"  # Exactly one of the eleven classification states.
-    suggested_address: str = ""  # Best correction to display (full value; truncated only in terminal).
+    suggested_address: str = ""  # Best correction to display (full value. Truncated only in terminal).
     source: str = "-"  # Source column label (Internal/Internal+OSM/Nominatim/Google (Mist UI)/Cache/-).
 
 
 @dataclass
 class AuditCounters:
-    """Lightweight run-summary counters (fresh per run; not persisted)."""
+    """Lightweight run-summary counters (fresh per run. Not persisted)."""
 
     total_rows: int = 0  # CSV rows emitted by the ingester.
     parse_failures: int = 0  # Rows skipped (empty/non-numeric serial).
@@ -106,7 +106,7 @@ class UIGeocoderConfig:
 
     connect_mode: str = "auto"  # "auto" (take over else spawn), "attach" (CDP only), or "launch" (fresh Edge).
     cdp_endpoint: str = "http://127.0.0.1:9222"  # DevTools endpoint (127.0.0.1, not localhost: avoids IPv6 ::1).
-    browser_channel: str = "msedge"  # System browser channel; avoids the Zscaler-blocked Chromium CDN.
+    browser_channel: str = "msedge"  # System browser channel. Avoids the Zscaler-blocked Chromium CDN.
     dashboard_url: str = "https://manage.mist.com/"  # Regional Mist cloud login/landing URL (override per cloud).
     headless: bool = False  # Must be visible so the operator can log in / observe the takeover.
     per_lookup_timeout_s: float = 20.0  # Hard per-lookup ceiling (UI_GEOCODE_TIMEOUT_SECONDS).

--- a/src/site/address_audit/perf.py
+++ b/src/site/address_audit/perf.py
@@ -36,7 +36,7 @@ class PhaseTimer:  # WHY: single-purpose timing container for audit phases
 
     def add(self, label: str, seconds: float) -> None:  # WHY: manual timing entry
         """Add a single ``seconds`` occurrence to ``label`` (safe for manual timing)."""
-        slot = self._phases.setdefault(label, [0.0, 0.0])  # [count, total]; created on first use.
+        slot = self._phases.setdefault(label, [0.0, 0.0])  # [count, total]. Created on first use.
         slot[0] += 1.0  # One more occurrence of this phase.
         slot[1] += max(0.0, seconds)  # Accumulate a non-negative duration (guards clock skew).
 

--- a/src/site/address_audit/site_matcher.py
+++ b/src/site/address_audit/site_matcher.py
@@ -97,7 +97,7 @@ class SiteMatchingEngine:
             site_name=site.get("name"),  # Human-readable site name.
             mist_address=self._extract_mist_address(site),  # Current Mist address dict.
             match_strategy=strategy,  # serial | fuzzy.
-            match_confidence=confidence,  # 1.0 serial; score/100 fuzzy.
+            match_confidence=confidence,  # 1.0 serial. Score/100 fuzzy.
         )
 
     @staticmethod

--- a/src/site/address_audit/snmp_enricher.py
+++ b/src/site/address_audit/snmp_enricher.py
@@ -21,7 +21,7 @@ import re  # Strip the leading SAP store-code prefix.
 from typing import Any  # Loose typing for the Mist site record dict.
 
 # Leading SAP store code: 3-7 alphanumerics followed by a hyphen separator, anchored at start.
-# Matches "S2SJB - ", "08806 - ", "0542E - ", "T000I - "; never strips a real street number
+# Matches "S2SJB - ", "08806 - ", "0542E - ", "T000I - ". Never strips a real street number
 # because a bare house number is not followed by " - " in these records.
 _SAP_PREFIX = re.compile(r"^\s*[A-Za-z0-9]{3,7}\s*-\s*")  # WHY: precompiled once at import time
 
@@ -56,14 +56,14 @@ class SNMPLocationEnricher:  # WHY: single-purpose class extracting SNMP locatio
 
     @staticmethod
     def _read_var_location(site_record: dict[str, Any]) -> str | None:  # WHY: read snmp_location site variable
-        """Read and trim ``vars["snmp_location"]``; return ``None`` if absent/blank."""
+        """Read and trim ``vars["snmp_location"]``. Return ``None`` if absent/blank."""
         site_vars = site_record.get("vars") or {}  # Site variables dict (may be missing/None).
         value = (site_vars.get("snmp_location") or "").strip()  # Trim the variable's value.
         return value or None  # Normalize empty string to None.
 
     @staticmethod
     def _read_config_location(site_record: dict[str, Any]) -> str | None:  # WHY: read snmp_config.location
-        """Read and trim ``snmp_config.location``; return ``None`` if absent/blank."""
+        """Read and trim ``snmp_config.location``. Return ``None`` if absent/blank."""
         snmp_config = site_record.get("snmp_config") or {}  # SNMP config block (may be missing/None).
         value = (snmp_config.get("location") or "").strip()  # Trim the standard SNMP location.
         return value or None  # Normalize empty string to None.

--- a/src/site/address_audit/suite_patterns.py
+++ b/src/site/address_audit/suite_patterns.py
@@ -16,7 +16,7 @@ hash form (in the classification patterns) requires a leading digit.
 from __future__ import annotations  # WHY: PEP 604 union syntax on Python 3.13
 
 # Single source of truth for suite/unit keywords. ``sute`` is a common misspelling
-# of ``suite`` seen in real customer data; a trailing period (``Ste.``) is matched
+# of ``suite`` seen in real customer data. A trailing period (``Ste.``) is matched
 # by the ``\.?`` in the patterns below, and ``ste`` already covers the abbreviation.
 # ``suit`` is deliberately excluded -- it would match ``lawsuit`` / ``pursuit``.
 SUITE_KEYWORDS = r"ste|suite|sute|unit|apt|apartment|bldg|building|space|spc|rm|room|lot"  # WHY: suite/unit vocabulary

--- a/src/site/address_audit/ui_geocoder.py
+++ b/src/site/address_audit/ui_geocoder.py
@@ -10,13 +10,13 @@ Three connection modes (all proven to work behind Zscaler SSL inspection, where
 Playwright CANNOT download its own Chromium):
 
   * ``auto`` (default) -- take over an already-running debuggable browser if one
-    is present; otherwise spawn a debuggable Edge for the operator, wait for them
+    is present. Otherwise spawn a debuggable Edge for the operator, wait for them
     to log into Mist and open a site's settings page, then take it over. This is
     the zero-setup path: the operator never has to start Edge with debug flags.
 
   * ``attach`` -- take over an already-running, already logged-in browser via the
     Chrome DevTools Protocol. The operator starts a debuggable browser (see
-    ``spawn_debuggable_browser``) and logs into Mist once; we reuse that live SSO
+    ``spawn_debuggable_browser``) and logs into Mist once. We reuse that live SSO
     session. No bundled browser download, no stored credentials.
 
   * ``launch`` -- Playwright launches the system Edge channel
@@ -60,7 +60,7 @@ try:  # Optional dependency: Playwright may not be installed in every environmen
 except ImportError:  # pragma: no cover -- exercised only on hosts without Playwright.
     sync_playwright = None  # type: ignore[assignment]  # Sentinel; is_available() keys off this.
 
-_KEY_JITTER = secrets.SystemRandom()  # Per-keystroke delay source; unpredictable cadence dodges bot heuristics.
+_KEY_JITTER = secrets.SystemRandom()  # Per-keystroke delay source. Unpredictable cadence dodges bot heuristics.
 _THINKING_PAUSE_EVERY = 7  # Add an occasional longer "thinking" pause every N characters while typing.
 _SUITE_GRACE_S = 2.0  # Extra seconds (after the house number matches) to let a typed suite/unit land in the dropdown.
 _POLL_INTERVAL_MS = 200  # WHY: cooperative pause between suggestion-list re-reads while waiting for a fresh row.
@@ -77,7 +77,7 @@ _EDGE_INSTALL_TAIL = (
 )  # WHY: path tail under each ProgramFiles root.
 _PROFILE_PREFIX = "misthelper-edge-"  # WHY: throwaway profile dir prefix so we never touch the operator's real profile.
 
-# --- Selector constants (captured 2026-06-29; re-verify if the Mist dashboard UI changes) ---
+# --- Selector constants (captured 2026-06-29. Re-verify if the Mist dashboard UI changes) ---
 # Google Places Autocomplete attaches ``pac-target-input`` to the bound input and
 # renders suggestions in a ``.pac-container`` of ``.pac-item`` rows. These Google
 # classes are stable across sites, so we anchor on them rather than Mist's markup.
@@ -116,7 +116,7 @@ class MistUIGeocoder:
         return available  # Callers gate Tier-3 on this before connect().
 
     def connect(self) -> bool:
-        """Establish the browser per ``connect_mode``; return success (never raises)."""
+        """Establish the browser per ``connect_mode``. Return success (never raises)."""
         if not self.is_available():  # Playwright missing -> Tier-3 is simply unavailable.
             logging.warning("Playwright not installed; Tier-3 UI geocoding unavailable")  # Inform operator.
             return False  # Audit continues on Tier-1/Tier-2 results.
@@ -142,7 +142,7 @@ class MistUIGeocoder:
         return self._connect_auto()  # Default: take over if possible, else spawn one for the operator.
 
     def _connect_auto(self) -> bool:
-        """Take over a debuggable browser if present; otherwise spawn one and take it over."""
+        """Take over a debuggable browser if present. Otherwise spawn one and take it over."""
         if self._try_attach():  # A debuggable browser is already running -> reuse it.
             return True  # Attached to the operator's existing session.
         logging.info("No debuggable browser found; spawning one for login")  # Action-log the spawn path.
@@ -211,7 +211,7 @@ class MistUIGeocoder:
         logging.info("Operator confirmed dashboard login; proceeding with UI geocoding")  # Action-log gate pass.
 
     def ensure_location_field_ready(self, max_prompts: int = 3) -> bool:
-        """Probe for the Location Search field; guide the operator until it appears (fail-soft).
+        """Probe for the Location Search field. Guide the operator until it appears (fail-soft).
 
         Tier-3 can only read Google's suggestions when the active tab is on a page
         that renders the Location Search input. We probe, and if it is missing we
@@ -230,7 +230,7 @@ class MistUIGeocoder:
                 context="ui_geocoder_navigate",
             )
         logging.info("Location Search field not found after %d prompts; Tier-3 will fail-soft", max_prompts)
-        return False  # Lookups will return None; the audit still completes on Tier 1/2.
+        return False  # Lookups will return None. The audit still completes on Tier 1/2.
 
     def _field_present(self, page: Any) -> bool:
         """Return True when any Location Search input selector matches on ``page``."""
@@ -243,7 +243,7 @@ class MistUIGeocoder:
         return False  # No candidate matched on the current page.
 
     def geocode_via_ui(self, query: str) -> ResolverResult | None:
-        """Resolve one address via the dashboard autocomplete; fail-soft to ``None``."""
+        """Resolve one address via the dashboard autocomplete. Fail-soft to ``None``."""
         if not self._connected:  # Guard: connect() must succeed first.
             logging.warning("geocode_via_ui called before a successful connect(); returning None")  # Misuse.
             return None  # Nothing to drive.
@@ -374,7 +374,7 @@ class MistUIGeocoder:
         """Decide whether the fresh top row is final, starts/extends the suite grace, or is skipped.
 
         Returns ``(resolved, house_ok_at)``. When ``resolved`` is not ``None`` the
-        caller must return it immediately; when it is ``None`` the caller keeps
+        caller must return it immediately. When it is ``None`` the caller keeps
         polling with the (possibly updated) ``house_ok_at`` timestamp.
         """
         if not expected_suite or self._reflects_suite(
@@ -382,7 +382,7 @@ class MistUIGeocoder:
         ):  # WHY: suite satisfied or none required.
             return texts, house_ok_at  # Finalize on the top row.
         if house_ok_at is None:  # WHY: first fresh house-number sighting -- start the grace clock.
-            return None, time.monotonic()  # Keep polling; anchor the suite grace at now.
+            return None, time.monotonic()  # Keep polling. Anchor the suite grace at now.
         if time.monotonic() - house_ok_at >= grace:  # WHY: grace expired -- accept the base street.
             logging.info("Suite '%s' not shown within grace; using base street", expected_suite)  # Action-log fallback.
             return texts, house_ok_at  # _build_result re-appends the unit we typed.
@@ -411,7 +411,7 @@ class MistUIGeocoder:
 
     @staticmethod
     def _house_number(text: str) -> str:
-        """Return the first digit-run (the house number); names like 'T-Mobile' have none."""
+        """Return the first digit-run (the house number). Names like 'T-Mobile' have none."""
         match = re.search(r"\d+", text)  # First run of digits in the query.
         return match.group(0) if match else ""  # House number or empty when none present.
 
@@ -534,7 +534,7 @@ class MistUIGeocoder:
         query_house = MistUIGeocoder._house_number(query)  # House number we asked about.
         sugg_house = MistUIGeocoder._house_number(suggestion)  # House number Google returned.
         if not query_house or not sugg_house:  # WHY: unknown on either side -- do not treat as different.
-            return False  # Cannot rule out same-building; defer to other guards.
+            return False  # Cannot rule out same-building. Defer to other guards.
         return query_house != sugg_house  # WHY: both known -- disagreement means a different building.
 
     @staticmethod
@@ -565,7 +565,7 @@ class MistUIGeocoder:
         and digits trigger a split, never a generic lowercase->uppercase boundary.
         The leading house number may be hyphenated (Hawaii's ``74-5450`` grid
         addresses), so the anchor accepts an optional ``-<digits>`` run before the
-        street; without this the glued business name survives (``T-Mobile74-5450``).
+        street. Without this the glued business name survives (``T-Mobile74-5450``).
         """
         s = text.strip()  # Normalize surrounding whitespace.
         s = re.sub(r",?\s*(?:USA|United States)\s*$", "", s, flags=re.IGNORECASE).strip()  # Drop trailing country.
@@ -577,7 +577,7 @@ class MistUIGeocoder:
         return cleaned.strip().strip(",").strip() or text.strip()  # Never return empty.
 
     def close(self) -> None:
-        """Tear down browser and driver handles; never raises."""
+        """Tear down browser and driver handles. Never raises."""
         logging.debug("Closing MistUIGeocoder browser resources")  # Action-log teardown.
         try:
             if self._browser is not None:  # Disconnect/close the browser if open.
@@ -612,7 +612,7 @@ class MistUIGeocoder:
 
         Returns the ``Popen`` handle (caller owns its lifecycle) or ``None`` when
         Edge cannot be located. Uses a throwaway profile so the operator's normal
-        Edge profile is never touched; the operator logs into Mist in this window
+        Edge profile is never touched. The operator logs into Mist in this window
         once, then ``connect_mode="attach"`` reuses that session.
         """
         edge = MistUIGeocoder._edge_executable()  # Locate the system Edge binary.
@@ -622,7 +622,7 @@ class MistUIGeocoder:
         profile = tempfile.mkdtemp(prefix=_PROFILE_PREFIX)  # WHY: dedicated dir so the operator's profile is untouched.
         args = MistUIGeocoder._debuggable_edge_args(edge, cdp_port, profile, dashboard_url)  # Build the CLI flags.
         logging.info("Spawning debuggable Edge on port %d (profile=%s)", cdp_port, profile)  # Action-log spawn.
-        proc = subprocess.Popen(args)  # Launch Edge; the operator logs in, then we attach.
+        proc = subprocess.Popen(args)  # Launch Edge. The operator logs in, then we attach.
         logging.debug("Debuggable Edge started (pid=%s)", proc.pid)  # Trace the PID.
         return proc  # Caller terminates it when the audit finishes.
 

--- a/src/site/bulk_radius_wlan_config_manager.py
+++ b/src/site/bulk_radius_wlan_config_manager.py
@@ -4,7 +4,7 @@ Extracted from MistHelper.py during initiative 1013 (Cat B, position 15).
 Scans org WLANs, filters those using RADIUS/RadSec auth, and offers bulk
 update of auth_servers_timeout, auth_servers_retries, and fast_dot1x_timers.
 All non-static methods keep instance state (org_id, WLAN buckets, change
-records); callers continue to reach the class through the
+records). Callers continue to reach the class through the
 ``MistHelper.BulkRadiusWLANConfigManager`` re-export alias.
 
 FR-008 remediation applied during extraction:
@@ -226,7 +226,7 @@ class BulkRadiusWLANConfigManager:
             wlan["_inheritance_source"] = "Org-Level WLAN"
 
     def _build_combined_wlan_rows(self) -> list[tuple[dict[str, Any], int | None]]:
-        """Pair WLANs with display indices: selectable WLANs get 1-based numbers; compliant ones get None."""
+        """Pair WLANs with display indices: selectable WLANs get 1-based numbers. Compliant ones get None."""
         display_index = 1  # Running 1-based number for selectable WLANs
         combined: list[tuple[dict[str, Any], int | None]] = []  # Output pairs
         for wlan in self.radius_wlans:  # Selectable WLANs that need configuration
@@ -274,11 +274,11 @@ class BulkRadiusWLANConfigManager:
 
     @staticmethod
     def _parse_range_part(part: str) -> tuple[int, int] | None:
-        """Parse a 'start-end' range piece into 0-based (start, end), swapping reversed bounds; None if invalid."""
+        """Parse a 'start-end' range piece into 0-based (start, end), swapping reversed bounds. None if invalid."""
         try:  # Non-numeric range pieces are skipped.
             range_parts = part.split("-")  # Split into start and end.
             if len(range_parts) != 2:  # Only a well-formed two-ended range is valid.
-                return None  # Malformed range; skip it.
+                return None  # Malformed range. Skip it.
             start = int(range_parts[0].strip()) - 1  # Convert start to 0-based.
             end = int(range_parts[1].strip()) - 1  # Convert end to 0-based.
             if start > end:  # Tolerate reversed ranges like '7-3'.
@@ -299,7 +299,7 @@ class BulkRadiusWLANConfigManager:
 
     @staticmethod
     def _add_index(idx: int, max_count: int, selected_indices: list[int]) -> None:
-        """Append idx to selected_indices when valid and not already chosen; warn when it is out of range."""
+        """Append idx to selected_indices when valid and not already chosen. Warn when it is out of range."""
         if 0 <= idx < max_count and idx not in selected_indices:  # Valid and not already chosen.
             selected_indices.append(idx)  # Add this index.
         elif idx >= max_count:  # Index beyond the list.
@@ -496,11 +496,11 @@ class BulkRadiusWLANConfigManager:
             "num_auth_servers": len(wlan.get("auth_servers", []) or []),  # How many RADIUS servers are configured
             "radsec_enabled": radsec.get("enabled", False) if isinstance(radsec, dict) else False,  # RadSec on/off
             "auth_servers_timeout": wlan.get("auth_servers_timeout", 5),  # Actual value (5 = the check's own default)
-            "auth_servers_timeout_present": "auth_servers_timeout" in wlan,  # True => real value; False => defaulted
+            "auth_servers_timeout_present": "auth_servers_timeout" in wlan,  # True => real value. False => defaulted
             "auth_servers_retries": wlan.get("auth_servers_retries", 2),  # Actual value (2 = the check's own default)
-            "auth_servers_retries_present": "auth_servers_retries" in wlan,  # True => real value; False => defaulted
+            "auth_servers_retries_present": "auth_servers_retries" in wlan,  # True => real value. False => defaulted
             "fast_dot1x_timers": wlan.get("fast_dot1x_timers", False),  # Actual value (False = the check's own default)
-            "fast_dot1x_timers_present": "fast_dot1x_timers" in wlan,  # True => real value; False => defaulted
+            "fast_dot1x_timers_present": "fast_dot1x_timers" in wlan,  # True => real value. False => defaulted
             "target_timeout": self.target_timeout,  # Target timeout this run compared against
             "target_retries": self.target_retries,  # Target retries this run compared against
             "target_fast_dot1x": self.target_fast_dot1x,  # Target fast-timer flag this run compared against
@@ -524,7 +524,7 @@ class BulkRadiusWLANConfigManager:
     ]
 
     def _write_audit_csv(self, filepath: str) -> None:
-        """Write self.change_records to a CSV at filepath; log success or surface failure to the user."""
+        """Write self.change_records to a CSV at filepath. Log success or surface failure to the user."""
         try:
             with open(filepath, "w", newline="", encoding="utf-8") as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=self._AUDIT_TRAIL_FIELDNAMES)
@@ -566,9 +566,9 @@ class BulkRadiusWLANConfigManager:
     def _scan_and_prepare(self) -> bool:
         """Display config, fetch + filter WLANs, persist snapshot. Return False on failure."""
         self._display_config()  # Show the target settings the user configured.
-        if not self._get_org_id():  # Resolve the org ID; abort if unavailable.
+        if not self._get_org_id():  # Resolve the org ID. Abort if unavailable.
             return False  # Cannot proceed without an org.
-        if not self._scan_org_wlans():  # Fetch all org WLANs; abort on failure.
+        if not self._scan_org_wlans():  # Fetch all org WLANs. Abort on failure.
             return False  # Cannot proceed without WLAN data.
         self._filter_radius_wlans()  # Split WLANs into selectable vs already-compliant buckets.
         self._export_scan_snapshot()  # Persist the pulled settings for post-run examination.

--- a/src/site/site_config_manager.py
+++ b/src/site/site_config_manager.py
@@ -121,7 +121,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
             logging.info("Loaded %s sites from CSV file", len(sites_data))  # WHY: audit successful load.
             print(f"\n Loaded {len(sites_data)} sites from CSV file")  # WHY: operator feedback on scope.
             return sites_data  # WHY: hand parsed rows back to caller.
-        except OSError as read_error:  # WHY: narrow to filesystem errors; do not swallow programmer errors.
+        except OSError as read_error:  # WHY: narrow to filesystem errors. Do not swallow programmer errors.
             logging.error("Failed to read CSV file: %s", read_error)  # WHY: audit read failure with detail.
             print(f" ERROR: Failed to read CSV file: {read_error}")  # WHY: surface reason to operator.
             return None  # WHY: signal read-failure to caller.
@@ -130,7 +130,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
     def _copy_optional_fields(site_data: dict[str, Any], payload: dict[str, Any]) -> None:  # WHY: mutate helper.
         """Copy present, non-empty optional fields from CSV row into payload."""
         for key in ("address", "country_code", "timezone", "notes"):  # WHY: single source of truth for keys.
-            value = site_data.get(key)  # WHY: fetch once; None + "" both mean absent.
+            value = site_data.get(key)  # WHY: fetch once. None + "" both mean absent.
             if value:  # WHY: only copy truthy values so we do not send blanks to API.
                 payload[key] = value.strip()  # WHY: strip whitespace per API hygiene.
 
@@ -148,7 +148,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
 
     @staticmethod
     def _build_site_payload(site_data: dict[str, Any]) -> dict[str, Any] | None:  # WHY: payload builder.
-        """Build API payload from a single site CSV row; None when name is missing."""
+        """Build API payload from a single site CSV row. None when name is missing."""
         site_name = site_data.get("name", "").strip()  # WHY: name is the only mandatory field.
         if not site_name:  # WHY: reject nameless rows so caller can record row-level failure.
             return None  # WHY: signal invalid row so caller can log failure.
@@ -339,7 +339,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
     def _group_sites_by_country(  # WHY: bucket helper isolates single-pass grouping logic.
         sites: list[dict[str, Any]],
     ) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
-        """Bucket sites by uppercase country code; collect empty-country sites separately."""
+        """Bucket sites by uppercase country code. Collect empty-country sites separately."""
         logging.info("Grouping %d sites by country code", len(sites))  # WHY: audit grouping start.
         sites_by_country: dict[str, list[dict[str, Any]]] = {}  # WHY: country -> site descriptors.
         sites_without_country: list[dict[str, Any]] = []  # WHY: sites missing country info.
@@ -371,7 +371,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
 
     @staticmethod
     def _fetch_existing_rf_templates(org_id: str) -> dict[str, str] | None:  # WHY: fetch existing templates.
-        """Fetch existing RF templates as a {name: id} map; return None on API error."""
+        """Fetch existing RF templates as a {name: id} map. Return None on API error."""
         print("\n  Step 2: Checking for existing RF templates...")  # WHY: legacy step header preserved.
         logging.info("Fetching existing RF templates for org_id=%s", org_id)  # WHY: audit start.
         try:
@@ -665,7 +665,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
 
     @staticmethod
     def _fetch_org_ap_inventory(org_id: str) -> list[dict[str, Any]] | None:
-        """Fetch org AP inventory list; return None on error or empty."""
+        """Fetch org AP inventory list. Return None on error or empty."""
         try:
             deps = _deps()  # WHY: local ref simplifies call.
             inventory_response = deps.mistapi.api.v1.orgs.inventory.getOrgInventory(  # WHY: SDK inventory call.
@@ -757,7 +757,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
     @staticmethod
     def _confirm_profile_creation(to_create: list[dict[str, Any]], to_skip: list[dict[str, Any]]) -> bool:
         """Confirm device profile creation with user."""
-        _ = to_skip  # WHY: preserve legacy signature; count is already reported by planner.
+        _ = to_skip  # WHY: preserve legacy signature. Count is already reported by planner.
         print("\n  " + "!" * 66)  # WHY: destructive banner open.
         print("  WARNING: DESTRUCTIVE OPERATION")  # WHY: warning line.
         print("  " + "!" * 66)  # WHY: banner divider.
@@ -912,7 +912,7 @@ class SiteConfigManager:  # WHY: umbrella namespace for the four menu entrypoint
 
     @staticmethod
     def _fetch_profile_map(org_id: str) -> dict[str, str] | None:
-        """Fetch device profiles and return name->id mapping; None on error/empty."""
+        """Fetch device profiles and return name->id mapping. None on error/empty."""
         print("\n  Step 2: Fetching existing Device Profiles...")  # WHY: legacy header preserved.
         try:
             deps = _deps()  # WHY: local ref.

--- a/src/ssh/batch/batch_executor.py
+++ b/src/ssh/batch/batch_executor.py
@@ -104,7 +104,7 @@ class BatchExecutor:
     # ------------------------------------------------------------------
     @staticmethod
     def run(request: BatchRunRequest) -> bool:  # WHY: single-request public entrypoint.
-        """Execute the batch session described by *request*; return success bool."""
+        """Execute the batch session described by *request*. Return success bool."""
         logger = logging.getLogger(_SSH_LOGGER_NAME)  # WHY: unified SSH logger for all executors.
         BatchExecutor._log_session_start(request, logger)  # WHY: emit start banner + debug details.
         log_ctx = BatchExecutor._setup_host_log(request, logger)  # WHY: build runner + log writer.
@@ -137,7 +137,7 @@ class BatchExecutor:
         logger: logging.Logger,
     ) -> bool:
         """Guarded session flow: catch fatal errors and always write the footer."""
-        overall_success = True  # WHY: default optimistic; flipped on any failure or exception.
+        overall_success = True  # WHY: default optimistic. Flipped on any failure or exception.
         try:
             overall_success = BatchExecutor._execute_with_connection(request, log_ctx, logger)  # WHY: real run.
             return overall_success  # WHY: propagate session outcome to the caller.
@@ -146,7 +146,7 @@ class BatchExecutor:
             overall_success = False  # WHY: guarantee failure state before finally-writes footer.
             return False  # WHY: signal caller that the batch failed.
         finally:
-            log_ctx.runner._disconnect()  # WHY: teardown; safe when client may be None.
+            log_ctx.runner._disconnect()  # WHY: teardown. Safe when client may be None.
             logger.debug("[%s] SSH multi-command session completed", request.hostname)  # WHY: parity log.
             BatchExecutor._write_footer(log_ctx.writer, overall_success, log_ctx.log_file, logger)  # WHY: footer.
 
@@ -171,7 +171,7 @@ class BatchExecutor:
     # ------------------------------------------------------------------
     @staticmethod
     def _setup_host_log(request: BatchRunRequest, logger: logging.Logger) -> _LogContext:
-        """Build the runner, create the per-host log file, write the header; return helpers."""
+        """Build the runner, create the per-host log file, write the header. Return helpers."""
         from src.ssh.ssh_runner import EnhancedSSHRunner  # WHY: local import avoids circular module load.
 
         runner = EnhancedSSHRunner(timeout=request.timeout, logger=logger)  # WHY: owns timeout + client.
@@ -202,9 +202,9 @@ class BatchExecutor:
         log_ctx: _LogContext,
         logger: logging.Logger,
     ) -> bool:
-        """Open SSH connection, iterate commands; return overall success bool."""
+        """Open SSH connection, iterate commands. Return overall success bool."""
         client = BatchExecutor._connect_client(request, log_ctx, logger)  # WHY: real connect step.
-        if client is None:  # WHY: connection failed; connector logged the reason already.
+        if client is None:  # WHY: connection failed. Connector logged the reason already.
             return False  # WHY: propagate failure sentinel to _run_guarded.
         logger.debug("SSH connected to %s, executing %d commands", request.hostname, len(request.commands))
         log_ctx.writer(f"\n>> Executing {len(request.commands)} commands sequentially...")  # WHY: verbatim status.
@@ -220,7 +220,7 @@ class BatchExecutor:
         log_ctx: _LogContext,
         logger: logging.Logger,
     ) -> Any:
-        """Perform the real SSH connect + wire the client into the runner; return client or None."""
+        """Perform the real SSH connect + wire the client into the runner. Return client or None."""
         logger.info(  # WHY: pre-connect log line for post-mortem correlation.
             "Connecting via SshConnector for multi-command session to %s:%s",
             request.hostname,
@@ -231,7 +231,7 @@ class BatchExecutor:
             request.hostname, request.username, request.password, request.port
         )
         logger.debug("Multi-command connect returned client=%s", bool(client))  # WHY: post-connect log.
-        if client is None:  # WHY: connection failed; write the verbatim error line.
+        if client is None:  # WHY: connection failed. Write the verbatim error line.
             error_msg = f"Failed to connect to {request.hostname}"  # WHY: verbatim error text.
             logger.error("SSH connection failed: %s:%s", request.hostname, request.port)  # WHY: log level.
             log_ctx.writer(f"X  {error_msg}")  # WHY: verbatim error line on the per-host log.
@@ -273,7 +273,7 @@ class BatchExecutor:
         ctx: _CommandContext,
         logger: logging.Logger,
     ) -> _StepResult:
-        """Run one command; convert KeyboardInterrupt into a stop flag."""
+        """Run one command. Convert KeyboardInterrupt into a stop flag."""
         try:
             step_ok = BatchExecutor._run_one_command(log_ctx.runner, ctx, log_ctx.writer, logger)  # WHY: run.
             return _StepResult(stop=False, ok=step_ok)  # WHY: normal path returns the command's success.
@@ -288,7 +288,7 @@ class BatchExecutor:
         writer: Callable[[str], None],
         logger: logging.Logger,
     ) -> bool:
-        """Execute one command, write the per-command log block; return success bool."""
+        """Execute one command, write the per-command log block. Return success bool."""
         BatchExecutor._write_command_header(ctx, writer)  # WHY: verbatim header block for the command.
         success, stdout, stderr = runner._execute_command(  # WHY: real per-command execution call.
             ctx.command, use_shell=ctx.use_shell, hostname=ctx.hostname
@@ -385,7 +385,7 @@ class BatchExecutor:
         host_log_file: str,
         logger: logging.Logger,
     ) -> None:
-        """Write the session footer; fall back to a minimal footer on any error."""
+        """Write the session footer. Fall back to a minimal footer on any error."""
         try:
             final_success = overall_success if isinstance(overall_success, bool) else False  # WHY: type guard.
             writer(BatchExecutor._build_footer(final_success, host_log_file))  # WHY: verbatim footer.

--- a/src/ssh/batch/host_runner.py
+++ b/src/ssh/batch/host_runner.py
@@ -195,7 +195,7 @@ class HostRunner:
         if cmd_lower in _PRIV_ESC_KEYWORDS or cmd_lower.startswith(_PRIV_ESC_PREFIX):  # WHY: match tokens.
             logger.debug("[%s] Interactive mode needed: detected '%s' command", hostname, command)  # WHY: trace.
             return True  # WHY: this command alone justifies interactive mode.
-        return False  # WHY: normal command; not a trigger.
+        return False  # WHY: normal command. Not a trigger.
 
     @staticmethod
     def _is_password_reply(

--- a/src/ssh/batch/interactive_batch_executor.py
+++ b/src/ssh/batch/interactive_batch_executor.py
@@ -165,7 +165,7 @@ def _persist_log_line(host_log_file: str, safe_message: str) -> None:  # WHY: ow
     """Append one already-sanitized line to the per-host log with owner-only perms."""
     with open(host_log_file, "a", encoding="utf-8") as log_file:  # WHY: append preserves history.
         # lgtm[py/clear-text-storage-sensitive-data] - messages are pre-scrubbed by
-        # _build_scrubbing_writer; CodeQL cannot model str.replace as a sanitizer.
+        # _build_scrubbing_writer. CodeQL cannot model str.replace as a sanitizer.
         log_file.write(f"{safe_message}\n")  # WHY: newline-terminated log record.
         log_file.flush()  # WHY: guarantee flush before chmod tightens perms.
     if hasattr(os, "chmod"):  # WHY: best-effort owner-only permission on POSIX.
@@ -252,7 +252,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
     # ------------------------------------------------------------------
     @staticmethod
     def run(request: InteractiveSessionRequest) -> bool:  # WHY: single-request public entrypoint.
-        """Execute the interactive session described by *request*; return success bool."""
+        """Execute the interactive session described by *request*. Return success bool."""
         logger = logging.getLogger("ssh_runner_v2")  # WHY: unified SSH logger for all executors.
         logger.info(  # WHY: session start line for post-mortem log review.
             "InteractiveBatchExecutor.run starting for %s@%s:%s (%d steps)",
@@ -280,7 +280,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         logger: logging.Logger,
     ) -> bool:
         """Guarded session flow: catch fatal errors and always write the footer."""
-        overall_success = True  # WHY: default to success; flipped on any failed step or error.
+        overall_success = True  # WHY: default to success. Flipped on any failed step or error.
         try:
             overall_success = InteractiveBatchExecutor._execute_session(request, log_ctx, logger)  # WHY: run session.
             return overall_success  # WHY: propagate session outcome to caller.
@@ -291,7 +291,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
             overall_success = False  # WHY: guarantee failure state before finally-writes footer.
             return False  # WHY: signal caller that the session failed.
         finally:
-            log_ctx.runner._disconnect()  # WHY: teardown; safe when client may be None.
+            log_ctx.runner._disconnect()  # WHY: teardown. Safe when client may be None.
             logger.debug("[%s] SSH interactive session completed", request.hostname)  # WHY: parity log line.
             InteractiveBatchExecutor._write_footer(
                 log_ctx.writer, overall_success, log_ctx.log_file, logger
@@ -334,7 +334,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
 
     @staticmethod
     def _build_log_path(hostname: str, logger: logging.Logger) -> str:  # WHY: sanitised per-host log path.
-        """Construct the sanitised per-host log file path; fall back on chmod errors."""
+        """Construct the sanitised per-host log file path. Fall back on chmod errors."""
         from src.ssh.ssh_runner import EnhancedSSHRunner  # WHY: local import avoids circular load.
 
         timestamp = datetime.now().strftime(_TS_FMT_FILE)  # WHY: verbatim filename timestamp format.
@@ -353,7 +353,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         """Wrap *inner_writer* so each message has *password* replaced with ``***REDACTED***``.
 
         Returning a new callable keeps the password reference confined to this
-        helper's closure; the inner writer never receives the credential value
+        helper's closure. The inner writer never receives the credential value
         as a parameter, satisfying the minimum-scope rule for sensitive data.
         """
         if not password:  # WHY: no credential to scrub - callers get the raw writer.
@@ -388,7 +388,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         log_ctx: _LogContext,
         logger: logging.Logger,
     ) -> bool:
-        """Open connection + shell, run all steps, write final status; return success bool."""
+        """Open connection + shell, run all steps, write final status. Return success bool."""
         shell = InteractiveBatchExecutor._connect_and_open_shell(request, log_ctx, logger)  # WHY: real connect.
         if shell is None:  # WHY: connection or shell setup failed (already logged by helper).
             return False
@@ -428,12 +428,12 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         log_ctx: _LogContext,
         logger: logging.Logger,
     ) -> Any | None:
-        """Run SshConnector.connect and wire the client into the runner; return client or None."""
+        """Run SshConnector.connect and wire the client into the runner. Return client or None."""
         logger.info(  # WHY: session-connect line preserved for log parity.
             "Connecting via SshConnector for interactive session to %s:%s", request.hostname, request.port
         )
         connector = SshConnector(timeout=log_ctx.runner.timeout, logger=logger)  # WHY: real connector (no facade).
-        client, kh_path = connector.connect(  # WHY: real connect; failures return (None, None).
+        client, kh_path = connector.connect(  # WHY: real connect. Failures return (None, None).
             request.hostname, request.username, request.password, request.port
         )
         logger.debug("Interactive connect returned client=%s", bool(client))  # WHY: debug diag.
@@ -466,7 +466,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         writer: Callable[[str], None],
         logger: logging.Logger,
     ) -> bool:
-        """Walk the step list; return overall success bool. Each step is one helper call."""
+        """Walk the step list. Return overall success bool. Each step is one helper call."""
         overall_success = True  # WHY: flipped to False on any failed step or interrupt.
         total = len(commands)  # WHY: total step count cached for the loop guard + pause helper.
         command_index = 0  # WHY: manual index because blank entries are skipped by helper.
@@ -489,7 +489,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         command_index: int,
         total: int,
     ) -> _StepContext | None:
-        """Return a per-step context for non-blank entries; None signals a blank-line skip."""
+        """Return a per-step context for non-blank entries. None signals a blank-line skip."""
         current_item = commands[command_index].strip()  # WHY: strip once so downstream code is simple.
         if not current_item:  # WHY: skip blank entries (verbatim behaviour) - no pause needed.
             return None
@@ -521,7 +521,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         writer: Callable[[str], None],
         logger: logging.Logger,
     ) -> tuple[bool, bool]:
-        """Run one step; return (stop_flag, step_success). Handles Ctrl+C + step exceptions."""
+        """Run one step. Return (stop_flag, step_success). Handles Ctrl+C + step exceptions."""
         try:
             step_ok = InteractiveBatchExecutor._run_one_step(shell, step_ctx, writer, logger)  # WHY: run step.
             return False, step_ok
@@ -573,7 +573,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         writer: Callable[[str], None],
         logger: logging.Logger,
     ) -> bool:
-        """Send one command/response, capture reply, log block; return step success bool."""
+        """Send one command/response, capture reply, log block. Return step success bool."""
         InteractiveBatchExecutor._write_step_header(step_ctx, writer, logger)  # WHY: verbatim header block.
         shell.send((step_ctx.command + "\n").encode("utf-8"))  # WHY: send the command/response line.
         time.sleep(_STEP_SEND_PAUSE)  # WHY: brief pause so device registers input (verbatim).
@@ -741,7 +741,7 @@ class InteractiveBatchExecutor:  # WHY: static-method container for the interact
         host_log_file: str,
         logger: logging.Logger,
     ) -> None:
-        """Write the session footer; fall back to a minimal footer on any error."""
+        """Write the session footer. Fall back to a minimal footer on any error."""
         try:
             writer(_build_footer_text(overall_success, host_log_file))  # WHY: verbatim footer block.
         except Exception as footer_error:  # noqa: BLE001 - footer is best-effort (verbatim)

--- a/src/ssh/batch/multi_host_runner.py
+++ b/src/ssh/batch/multi_host_runner.py
@@ -38,7 +38,7 @@ _SUMMARY_DIVIDER = "=" * 60  # WHY: verbatim console divider from the pre-refact
 class MultiHostRunRequest:  # WHY: immutable bundle collapses MultiHostRunner.run to a single param.
     """Immutable request describing one multi-host SSH fan-out."""
 
-    hosts: tuple[str, ...] = ()  # WHY: ordered target host list; empty allowed.
+    hosts: tuple[str, ...] = ()  # WHY: ordered target host list. Empty allowed.
     username: str = ""  # WHY: shared SSH login account applied to every host.
     password: str = ""  # WHY: shared SSH login secret (never logged verbatim).
     commands: tuple[str, ...] = ()  # WHY: ordered commands executed on each host.
@@ -112,7 +112,7 @@ class MultiHostRunner:
 
     @staticmethod
     def run(request: MultiHostRunRequest) -> dict[str, Any]:
-        """Execute commands on each host concurrently; return per-host result summary."""
+        """Execute commands on each host concurrently. Return per-host result summary."""
         logger = logging.getLogger(_SSH_LOGGER_NAME)  # WHY: unified SSH logger for the whole run.
         MultiHostRunner._log_invocation(request, logger)  # WHY: emit verbatim [TRACE] lines (debug only).
         MultiHostRunner._log_startup(request, logger)  # WHY: verbatim banner + info/debug context lines.
@@ -133,7 +133,7 @@ class MultiHostRunner:
     @staticmethod
     def _log_startup(request: MultiHostRunRequest, logger: logging.Logger) -> None:
         """Emit the verbatim startup banner + info/debug context lines."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(
             "\n>> Starting SSH execution on %d hosts (%d threads)",
             len(request.hosts),
@@ -183,7 +183,7 @@ class MultiHostRunner:
     # ------------------------------------------------------------------
     @staticmethod
     def _dispatch_hosts(request: MultiHostRunRequest, logger: logging.Logger) -> _FanOutState:
-        """Submit one HostRunner.run task per host; return the collected fan-out state."""
+        """Submit one HostRunner.run task per host. Return the collected fan-out state."""
         state = _FanOutState()  # WHY: mutable collector shared across submit/collect helpers.
         with concurrent.futures.ThreadPoolExecutor(  # WHY: bounded worker pool with named threads.
             max_workers=request.max_threads, thread_name_prefix=_THREAD_NAME_PREFIX
@@ -197,7 +197,7 @@ class MultiHostRunner:
         request: MultiHostRunRequest,
         executor: concurrent.futures.ThreadPoolExecutor,
     ) -> dict[concurrent.futures.Future[tuple[str, bool, str]], str]:
-        """Submit one HostRunner.run task per host; return future -> host map."""
+        """Submit one HostRunner.run task per host. Return future -> host map."""
         return {  # WHY: preserve future -> host mapping for post-hoc lookup on error.
             executor.submit(
                 HostRunner.run,
@@ -220,7 +220,7 @@ class MultiHostRunner:
         state: _FanOutState,
         logger: logging.Logger,
     ) -> None:
-        """Drain futures via wait() loop; record per-host success/failure (original UX)."""
+        """Drain futures via wait() loop. Record per-host success/failure (original UX)."""
         try:
             pending = set(future_to_host.keys())  # WHY: working set drained by FIRST_COMPLETED wait().
             iteration = 0  # WHY: trace counter for the verbatim per-iteration debug lines.
@@ -318,25 +318,25 @@ class MultiHostRunner:
         logger: logging.Logger,
     ) -> None:
         """Print the multi-host execution summary block (verbatim)."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n%s", _SUMMARY_DIVIDER)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("[STATUS] EXECUTION SUMMARY")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("%s", _SUMMARY_DIVIDER)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Total hosts: %d", len(hosts))
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Successful: %d [OK]", len(state.successful_hosts))
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Failed: %d [ERROR]", len(state.failed_hosts))
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("Per-host logs: per-host-logs/ssh_output_<hostname>_<timestamp>.log")
         if state.successful_hosts:  # WHY: skip empty success block for cleaner output.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n[OK] Successful hosts: %s", ", ".join(state.successful_hosts))
         if state.failed_hosts:  # WHY: skip empty failure block for cleaner output.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("\n[ERROR] Failed hosts: %s", ", ".join(state.failed_hosts))
         logger.info(  # WHY: final info line summarizing the run outcome.
             "Multi-host execution completed: %d/%d successful", len(state.successful_hosts), len(hosts)

--- a/src/ssh/cli_shell_manager.py
+++ b/src/ssh/cli_shell_manager.py
@@ -119,7 +119,7 @@ class CLIShellManager:
         if debug:  # Verbose troubleshooting output is enabled.
             logging.debug("[DEBUG] Raw recv: %r", data)  # WHY: trace raw received payload (was print()).
         if data and isinstance(data, str):  # We have a non-empty text frame to render.
-            # WHY: cast narrows Any->str for mypy strict (no-any-return); runtime check above ensures str.
+            # WHY: cast narrows Any->str for mypy strict (no-any-return). Runtime check above ensures str.
             return str(data)  # Renderable text.
         return None  # Nothing to render for this frame.
 
@@ -148,7 +148,7 @@ class CLIShellManager:
     @staticmethod
     def _shell_send_key(ws: Any, debug: bool, key: str) -> None:
         """Map and send one keystroke to the remote PTY; '~' closes the session."""
-        if not ws.connected:  # Socket already closed; nothing to send.
+        if not ws.connected:  # Socket already closed. Nothing to send.
             return  # Drop the keystroke.
         if key == "~":  # Exit key.
             CLIShellManager._shell_handle_exit_key(ws)  # Close the socket (issue #431: no obsolete stop_listening).
@@ -189,7 +189,7 @@ class CLIShellManager:
         CLIShellManager._shell_resize_terminal(ws, debug)  # Send initial terminal dimensions to the remote PTY.
         CLIShellManager._shell_start_receiver(ws, stream, screen, debug)  # Start the background receiver thread.
         time.sleep(1)  # Wait for connect before waking the prompt.
-        ws.send_binary(bytes(map(ord, "\00\n\n")))  # Send a wakeup; bytes (not bytearray) matches send_binary.
+        ws.send_binary(bytes(map(ord, "\00\n\n")))  # Send a wakeup. Bytes (not bytearray) matches send_binary.
         if debug:  # Debug mode.
             logging.debug("[DEBUG] Sent wakeup sequence to Juniper SSRs")  # WHY: trace wakeup handshake (was print()).
         mh.KeyboardListener().listen(  # Block on keyboard input, forwarding each key to the PTY.

--- a/src/ssh/command/command_runner.py
+++ b/src/ssh/command/command_runner.py
@@ -48,7 +48,7 @@ class SingleCommandRequest:  # WHY: immutable request bundle collapses the multi
     hostname: str  # WHY: SSH target host for the session.
     username: str  # WHY: SSH login user for the target host.
     password: str  # WHY: SSH login secret (never logged verbatim).
-    command: str = ""  # WHY: shell/exec command; empty string preserves original permissive behavior.
+    command: str = ""  # WHY: shell/exec command. Empty string preserves original permissive behavior.
     port: int = 22  # WHY: TCP port used for the SSH connection.
     timeout: int = 30  # WHY: connection + per-command timeout in seconds.
     use_shell: bool = False  # WHY: exec-vs-shell channel toggle passed to the runner.
@@ -71,7 +71,7 @@ class SingleCommandRequest:  # WHY: immutable request bundle collapses the multi
             hostname=config.hostname,  # WHY: propagate connection hostname.
             username=config.username,  # WHY: propagate connection username.
             password=config.password,  # WHY: propagate connection secret.
-            command=command,  # WHY: explicit command; config carries no command field.
+            command=command,  # WHY: explicit command. Config carries no command field.
             port=config.port,  # WHY: propagate connection port.
             timeout=config.timeout,  # WHY: propagate connection timeout.
             use_shell=config.use_shell,  # WHY: propagate the exec-vs-shell flag.
@@ -106,7 +106,7 @@ class SingleCommandRunner:
     # ------------------------------------------------------------------
     @staticmethod
     def run(request: SingleCommandRequest) -> bool:  # WHY: single-request public entrypoint.
-        """Execute the session described by *request*; return success bool."""
+        """Execute the session described by *request*. Return success bool."""
         logger = logging.getLogger(_SSH_LOGGER_NAME)  # WHY: unified SSH logger for all executors.
         SingleCommandRunner._log_session_start(request, logger)  # WHY: emit start banner + debug details.
         log_ctx = SingleCommandRunner._setup_host_log(request, logger)  # WHY: build runner + log writer.
@@ -138,7 +138,7 @@ class SingleCommandRunner:
         logger: logging.Logger,
     ) -> bool:
         """Guarded session flow: catch fatal errors and always write the footer."""
-        single_cmd_success = False  # WHY: default False; flipped only on confirmed success.
+        single_cmd_success = False  # WHY: default False. Flipped only on confirmed success.
         try:
             single_cmd_success = SingleCommandRunner._execute_with_connection(  # WHY: real run.
                 request, log_ctx, logger
@@ -148,7 +148,7 @@ class SingleCommandRunner:
             SingleCommandRunner._handle_run_error(request.hostname, run_error, log_ctx, logger)  # WHY: log path.
             return False  # WHY: signal caller that the command failed.
         finally:
-            log_ctx.runner._disconnect()  # WHY: teardown; safe when client may be None.
+            log_ctx.runner._disconnect()  # WHY: teardown. Safe when client may be None.
             logger.debug("[%s] SSH single command session completed", request.hostname)  # WHY: parity log.
             SingleCommandRunner._write_footer(log_ctx, single_cmd_success, logger)  # WHY: footer always runs.
 
@@ -173,7 +173,7 @@ class SingleCommandRunner:
     # ------------------------------------------------------------------
     @staticmethod
     def _setup_host_log(request: SingleCommandRequest, logger: logging.Logger) -> _LogContext:
-        """Build the runner, create the per-host log file, write the header; return helpers."""
+        """Build the runner, create the per-host log file, write the header. Return helpers."""
         from src.ssh.ssh_runner import EnhancedSSHRunner  # WHY: local import avoids circular module load.
 
         runner = EnhancedSSHRunner(timeout=request.timeout, logger=logger)  # WHY: owns timeout + client.
@@ -207,7 +207,7 @@ class SingleCommandRunner:
     ) -> bool:
         """Connect via SshConnector, execute the command, write results, return success."""
         client = SingleCommandRunner._connect_client(request, log_ctx, logger)  # WHY: real connect step.
-        if client is None:  # WHY: connection failed; connector logged the reason already.
+        if client is None:  # WHY: connection failed. Connector logged the reason already.
             return False  # WHY: propagate failure sentinel to _run_guarded.
         logger.debug("SSH connected to %s, executing single command", request.hostname)  # WHY: parity log.
         success, stdout, stderr = log_ctx.runner._execute_command(  # WHY: dispatcher remains on EnhancedSSHRunner.
@@ -230,7 +230,7 @@ class SingleCommandRunner:
         log_ctx: _LogContext,
         logger: logging.Logger,
     ) -> Any:
-        """Perform the real SSH connect + wire the client into the runner; return client or None."""
+        """Perform the real SSH connect + wire the client into the runner. Return client or None."""
         connector = SshConnector(timeout=log_ctx.runner.timeout, logger=logger)  # WHY: real collaborator.
         logger.info(  # WHY: pre-connect log line for post-mortem correlation.
             "SingleCommandRunner: connecting via SshConnector to %s:%s", request.hostname, request.port
@@ -239,7 +239,7 @@ class SingleCommandRunner:
             request.hostname, request.username, request.password, request.port
         )
         logger.debug("SingleCommandRunner: connect returned client=%s", bool(client))  # WHY: post-connect log.
-        if client is None:  # WHY: connection failed; write the verbatim error line.
+        if client is None:  # WHY: connection failed. Write the verbatim error line.
             error_msg = f"Failed to connect to {request.hostname}"  # WHY: verbatim error text.
             logger.error("SSH connection failed: %s:%s", request.hostname, request.port)  # WHY: log level.
             log_ctx.writer(f"X  {error_msg}")  # WHY: verbatim error line on the per-host log.
@@ -316,7 +316,7 @@ class SingleCommandRunner:
         single_cmd_success: bool,
         logger: logging.Logger,
     ) -> None:
-        """Write the session footer; fall back to a minimal footer on any error."""
+        """Write the session footer. Fall back to a minimal footer on any error."""
         try:
             final_success = single_cmd_success if isinstance(single_cmd_success, bool) else False  # WHY: type guard.
             log_ctx.writer(SingleCommandRunner._build_footer(final_success, log_ctx.log_file))  # WHY: verbatim.

--- a/src/ssh/config/command_parser.py
+++ b/src/ssh/config/command_parser.py
@@ -39,7 +39,7 @@ class CommandListParser:
     def _truncate_oversize(commands_str: str) -> str:
         """Truncate the raw command string if it exceeds the safety cap."""
         if len(commands_str) > _MAX_INPUT_LEN:  # Length check to prevent DoS
-            # WHY: Preserve user-facing string; emit through logger for structured output.
+            # WHY: Preserve user-facing string. Emit through logger for structured output.
             logger.warning("[WARNING] Command list too long, truncating to first 50000 characters")
             return commands_str[:_MAX_INPUT_LEN]  # Return truncated copy
         return commands_str  # No truncation needed
@@ -66,7 +66,7 @@ class CommandListParser:
         if not invalid:  # Clean input — nothing to warn about
             return  # No-op
         sample = ", ".join(invalid[:3])  # Original showed first 3 entries in the warning
-        # WHY: Preserve user-facing string verbatim; emit via logger.
+        # WHY: Preserve user-facing string verbatim. Emit via logger.
         logger.warning("[WARNING] Skipping %d invalid commands: %s", len(invalid), sample)
         if len(invalid) > 3:  # Indicate further truncation
             # WHY: Preserve user-facing string verbatim.
@@ -76,7 +76,7 @@ class CommandListParser:
     def _enforce_command_cap(commands: list[str]) -> list[str]:
         """Trim to the per-run command cap and warn if truncation happens."""
         if len(commands) > _MAX_COMMANDS:  # Resource exhaustion guard
-            # WHY: Preserve user-facing string verbatim; emit via logger.
+            # WHY: Preserve user-facing string verbatim. Emit via logger.
             logger.warning(
                 "[WARNING] Too many commands (%d), limiting to first %d",
                 len(commands),

--- a/src/ssh/config/csv_loader.py
+++ b/src/ssh/config/csv_loader.py
@@ -38,7 +38,7 @@ class CommandCsvLoader:
         if not os.path.exists(legacy_path):  # Legacy file also missing
             return None  # Give up
         # Preserve original user-facing string verbatim (informational note about legacy location)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("X  Using legacy SSH commands file at %s; move it to data/ for consistency.", legacy_path)
         return legacy_path  # Use the legacy file as a fallback
 
@@ -52,7 +52,7 @@ class CommandCsvLoader:
                 for row_num, row in enumerate(reader, 1):  # 1-based row index for warning messages
                     self._consume_csv_row(row, row_num, commands, invalid)  # Per-row dispatch
         except Exception as error:  # noqa: BLE001 - mirror original broad catch
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("[WARNING] Warning: Could not read %s: %s", csv_file_path, error)
             return []  # Bail out cleanly on read failure
         self._warn_invalid_rows(invalid, csv_file_path)  # User-facing warning preserved from original
@@ -91,20 +91,20 @@ class CommandCsvLoader:
         """Print warnings for any rejected CSV rows."""
         if not invalid:  # Clean file — nothing to warn about
             return  # No-op
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("[WARNING] Skipping %s invalid commands from %s:", len(invalid), csv_file_path)
         for invalid_cmd in invalid[:3]:  # Original shows first 3 entries
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("    %s", invalid_cmd)
         if len(invalid) > 3:  # Indicate further truncation
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("    ... and %s more", len(invalid) - 3)
 
     @staticmethod
     def _enforce_command_cap(commands: list[str], csv_file_path: str) -> list[str]:
         """Trim to the per-run command cap and warn if truncation happens."""
         if len(commands) > _MAX_COMMANDS:  # Resource exhaustion guard
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info(
                 "[WARNING] Too many commands in %s (%s), limiting to first %s",
                 csv_file_path,

--- a/src/ssh/config/env_loader.py
+++ b/src/ssh/config/env_loader.py
@@ -16,7 +16,7 @@ from src.ssh.config.command_parser import CommandListParser  # SSH_COMMANDS pars
 from src.ssh.config.host_parser import HostListParser  # SSH_HOST parsing
 from src.ssh.config.validators import validate_username  # SSH_USER validation
 
-# python-dotenv is optional; mirror the legacy availability flag pattern.
+# python-dotenv is optional. Mirror the legacy availability flag pattern.
 try:
     from dotenv import load_dotenv  # Preferred parser when installed
 
@@ -87,7 +87,7 @@ class EnvSshConfigLoader:
     def _is_safe_env_path(env_file: str) -> bool:
         """Reject path-traversal or absolute paths up front."""
         if not env_file or ".." in env_file or env_file.startswith("/") or "\\" in env_file:
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] Invalid .env file path: %s", env_file)
             return False  # Path is unsafe
         return True  # Path looks acceptable
@@ -98,11 +98,11 @@ class EnvSshConfigLoader:
         try:
             file_size = os.path.getsize(env_file)  # Single stat call
         except OSError as error:  # Permission denied / vanished and so on
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] Cannot access .env file: %s", error)
             return False  # Treat as unloadable
         if file_size > _MAX_ENV_BYTES:  # 1MB defensive cap
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] .env file too large (%s bytes), skipping", file_size)
             return False  # Refuse oversized files
         return True  # Within limits
@@ -120,7 +120,7 @@ class EnvSshConfigLoader:
             if ssh_commands:  # Only parse when present
                 config["commands"] = self._command_parser.parse(ssh_commands)  # Validated command list
         except Exception as error:  # noqa: BLE001 - mirror original broad catch
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] Error loading .env with python-dotenv: %s", error)
 
     def _populate_via_manual_parse(self, env_file: str, config: dict[str, Any]) -> None:
@@ -129,13 +129,13 @@ class EnvSshConfigLoader:
             with open(env_file, encoding="utf-8", errors="ignore") as file_handle:  # Tolerate decode errors
                 self._read_and_apply_lines(file_handle, config)  # Delegated read+cap+dispatch loop
         except UnicodeDecodeError as error:  # Should be rare due to errors="ignore" but kept for parity
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] .env file encoding error: %s", error)
         except OSError as error:  # Filesystem-level errors
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] Error reading %s: %s", env_file, error)
         except Exception as error:  # noqa: BLE001 - mirror original broad catch
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] Unexpected error reading %s: %s", env_file, error)
 
     def _read_and_apply_lines(self, file_handle: Any, config: dict[str, Any]) -> None:
@@ -143,7 +143,7 @@ class EnvSshConfigLoader:
         # WHY: extracting the loop drops _populate_via_manual_parse CC from 6 to 4.
         for line_count, raw_line in enumerate(file_handle, 1):  # 1-based for the cap comparison
             if line_count > _MAX_MANUAL_LINES:  # Stop runaway files defensively
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("[WARNING] .env file has too many lines, stopping at 1000")
                 return  # Exit early once the cap is exceeded
             self._apply_env_line(raw_line, config)  # Delegated single-line handler
@@ -178,18 +178,18 @@ class EnvSshConfigLoader:
         elif key == "SSH_USER":  # Login username
             self._set_username(config, value)  # Shared username application logic
         elif key == "SSH_PASSWORD":  # Password (verbatim)
-            config["password"] = value  # Store as-is; never logged
+            config["password"] = value  # Store as-is. Never logged
         elif key == "SSH_COMMANDS":  # Comma-separated command list
             config["commands"] = self._command_parser.parse(value)  # Validated command list
         # Unknown keys are intentionally ignored to keep the loader minimal
 
     @staticmethod
     def _set_username(config: dict[str, Any], username: str | None) -> None:
-        """Apply a username to ``config`` only after validation; warn otherwise."""
+        """Apply a username to ``config`` only after validation. Warn otherwise."""
         if not username:  # Missing/empty values are silently ignored
             return  # No-op
         if validate_username(username):  # Shared validation
             config["username"] = username  # Accept the username
             return  # Done
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("[WARNING] Invalid username format in .env file: %s", username)

--- a/src/ssh/config/host_parser.py
+++ b/src/ssh/config/host_parser.py
@@ -31,7 +31,7 @@ class HostListParser:
     def _truncate_oversize(hosts_str: str) -> str:
         """Truncate the raw host string if it exceeds the safety cap."""
         if len(hosts_str) > _MAX_INPUT_LEN:  # Length check to prevent DoS
-            # WHY: Preserve user-facing string; emit through logger for structured output.
+            # WHY: Preserve user-facing string. Emit through logger for structured output.
             logger.warning("[WARNING] Host list too long, truncating to first 10000 characters")
             return hosts_str[:_MAX_INPUT_LEN]  # Return truncated copy
         return hosts_str  # No truncation needed
@@ -57,7 +57,7 @@ class HostListParser:
         if not invalid:  # Nothing to warn about
             return  # No-op for clean inputs
         sample = ", ".join(invalid[:5])  # Show only the first 5 to keep output bounded
-        # WHY: Preserve user-facing string verbatim; emit via logger.
+        # WHY: Preserve user-facing string verbatim. Emit via logger.
         logger.warning("[WARNING] Skipping %d invalid hosts: %s", len(invalid), sample)
         if len(invalid) > 5:  # Indicate truncation only when extra entries exist
             # WHY: Preserve user-facing string verbatim.
@@ -67,7 +67,7 @@ class HostListParser:
     def _enforce_host_cap(hosts: list[str]) -> list[str]:
         """Trim to the per-run host cap and warn if truncation happens."""
         if len(hosts) > _MAX_HOSTS:  # Enforce resource cap
-            # WHY: Preserve user-facing string; emit via logger.
+            # WHY: Preserve user-facing string. Emit via logger.
             logger.warning(
                 "[WARNING] Too many hosts (%d), limiting to first %d",
                 len(hosts),

--- a/src/ssh/config/validators.py
+++ b/src/ssh/config/validators.py
@@ -1,6 +1,6 @@
 """Pure validation helpers for SSH inputs (hostnames, usernames, commands).
 
-Module-level functions; no class state. Extracted from EnhancedSSHRunner's
+Module-level functions. No class state. Extracted from EnhancedSSHRunner's
 private ``_validate_*`` static methods so the new config submodule and the
 remaining ssh_runner internals share a single, importable source of truth.
 """

--- a/src/ssh/connection/connector.py
+++ b/src/ssh/connection/connector.py
@@ -76,7 +76,7 @@ class SshConnector:
     """
 
     def __init__(self, timeout: int = _DEFAULT_TIMEOUT_SEC, logger: logging.Logger | None = None) -> None:
-        """Capture timeout and logger; defer all SSH work until :meth:`connect`."""
+        """Capture timeout and logger. Defer all SSH work until :meth:`connect`."""
         self.timeout = timeout  # WHY: connection + handshake timeout in seconds.
         self.logger = logger or logging.getLogger(_LOGGER_NAME)  # WHY: reuse the unified SSH logger.
         self.managed_known_hosts_path: str | None = None  # WHY: populated once the KH file is ensured.
@@ -116,7 +116,7 @@ class SshConnector:
         if not self._paramiko_available():  # WHY: hard requirement — paramiko import must have succeeded.
             return False  # WHY: paramiko-missing message already printed.
         self.logger.info("Attempting SSH connection to %s:%s as %s", hostname, port, username)  # WHY: audit.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.info(">> Connecting to %s:%s as %s...", hostname, port, username)
         return True  # WHY: preflight passed, connect flow may proceed.
 
@@ -142,7 +142,7 @@ class SshConnector:
     def _fail_input(self, error_msg: str) -> None:
         """Standard "log error + print bracketed ERROR" used for every input failure."""
         self.logger.error(error_msg)  # WHY: persistent record in script.log.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.error("[ERROR] %s", error_msg)
 
     @staticmethod
@@ -156,9 +156,9 @@ class SshConnector:
         if SSHClient is not None and paramiko is not None:  # WHY: paramiko import succeeded at load.
             return True  # WHY: normal production path — nothing to warn about.
         logging.getLogger(_LOGGER_NAME).error(_PARAMIKO_MISSING_MSG)  # WHY: audit-log the missing import.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("[ERROR] %s", _PARAMIKO_MISSING_MSG)
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error(_PARAMIKO_INSTALL_HINT)
         return False  # WHY: paramiko unavailable, connect cannot continue.
 
@@ -176,7 +176,7 @@ class SshConnector:
             self._trust_host_on_first_use(client, hostname, port)  # WHY: enroll first-seen key into managed store.
         except Exception as enroll_error:  # noqa: BLE001 - broad catch: log then translate to connection failure.
             self.logger.exception("TOFU enrollment failed for %s:%s: %s", hostname, port, enroll_error)  # WHY: audit.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             self.logger.error("[ERROR] Host key enrollment failed: %s", enroll_error)
             return None  # WHY: caller treats None as a hard connection failure.
         return client  # WHY: client is ready to attempt authentication.
@@ -276,7 +276,7 @@ class SshConnector:
         self._save_host_keys(client)  # WHY: persist the new entry to the managed file.
         fingerprint = self._format_host_key_fingerprint(remote_host_key)  # WHY: compute display fingerprint.
         self.logger.warning("TOFU enrolled new SSH host key for %s (%s)", entry_name, fingerprint)  # WHY: audit.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.info("[INFO] Trusted first-seen SSH host key for %s (%s)", entry_name, fingerprint)
 
     # ------------------------------------------------------------------
@@ -323,7 +323,7 @@ class SshConnector:
         """Log verbatim success traces and print the [OK] user-facing line."""
         self.logger.debug("SSH connection established in %.2f seconds", connection_time)  # WHY: verbatim.
         self.logger.info("Successfully connected to %s in %.2f seconds", hostname, connection_time)  # WHY: audit.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.info("[OK] Successfully connected to %s", hostname)
 
     def _handle_connect_exception(
@@ -347,7 +347,7 @@ class SshConnector:
     def _log_dns_error(self, error: BaseException, hostname: str, _port: int, _username: str) -> None:
         """Handler row: DNS resolution failure (socket.gaierror)."""
         self.logger.error("DNS Resolution Error for %s: %s", hostname, error)  # WHY: audit DNS miss.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.error("[ERROR] DNS Resolution Error: %s", error)
 
     def _log_timeout_error(self, _error: BaseException, hostname: str, port: int, _username: str) -> None:
@@ -355,29 +355,29 @@ class SshConnector:
         self.logger.error(  # WHY: audit timeout with host/port/timeout context.
             "Connection timeout to %s:%s after %s seconds", hostname, port, self.timeout
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.error("[ERROR] Connection timeout after %s seconds", self.timeout)
 
     def _log_bad_host_key(self, error: BaseException, hostname: str, _port: int, _username: str) -> None:
         """Handler row: mismatched known host key (paramiko.BadHostKeyException)."""
         self.logger.error("Host key verification failed for %s: %s", hostname, error)  # WHY: audit.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.error(_BAD_HOST_KEY_MSG)
 
     def _log_auth_failure(self, error: BaseException, hostname: str, _port: int, username: str) -> None:
         """Handler row: authentication failure (paramiko.AuthenticationException)."""
         self.logger.error("Authentication failed for %s@%s: %s", username, hostname, error)  # WHY: audit.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.error(_AUTH_FAILURE_MSG)
 
     def _log_ssh_error(self, error: BaseException, hostname: str, _port: int, _username: str) -> None:
         """Handler row: generic paramiko.SSHException with known-hosts specialisation."""
         self.logger.error("SSH Error connecting to %s: %s", hostname, error)  # WHY: audit generic SSH failure.
         if _KNOWN_HOSTS_MARKER in str(error):  # WHY: specialized message when the SSH error names known_hosts.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             self.logger.error(_UNTRUSTED_HOST_KEY_MSG)
             return  # WHY: specialised message already printed.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.error("[ERROR] SSH Error: %s", error)
 
     def _log_unknown_error(self, error: BaseException, hostname: str) -> None:
@@ -389,7 +389,7 @@ class SshConnector:
             error,
             exc_info=True,
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.error("[ERROR] Unexpected error: %s", error)
 
 

--- a/src/ssh/runtime/app_runner.py
+++ b/src/ssh/runtime/app_runner.py
@@ -119,7 +119,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
 
     @staticmethod
     def _install_line_tracer(logger: logging.Logger) -> tuple[bool, Any]:  # WHY: optional debug-only line trace.
-        """Install a debug-only line tracer; return (installed_flag, prior_tracer)."""
+        """Install a debug-only line tracer. Return (installed_flag, prior_tracer)."""
         if not logger.isEnabledFor(logging.DEBUG):  # Tracer only useful under DEBUG verbosity
             return False, None  # Skip install entirely
         try:  # Tracer installation is best-effort and never fatal
@@ -148,7 +148,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
         """Load credentials/commands from .env when use_env is True."""
         env_config: dict[str, Any] = {}  # Default empty when --no-env supplied
         if not use_env:  # Caller opted out via --no-env
-            return env_config  # Return empty dict; downstream treats missing keys as unset
+            return env_config  # Return empty dict. Downstream treats missing keys as unset
         logger.info("Loading SSH credentials from .env file (default behavior)")  # Before-action log
         env_config = EnvSshConfigLoader().load()  # Real call to extracted loader
         if any([env_config.get("hosts"), env_config.get("username"), env_config.get("password")]):  # Summarize
@@ -175,7 +175,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
 
     @staticmethod
     def _prompt_password(user: str, hosts: list[str]) -> str | None:  # WHY: interactive fallback prompt.
-        """Prompt for a password securely; an empty response becomes None (hard failure)."""
+        """Prompt for a password securely. An empty response becomes None (hard failure)."""
         label = _host_display_label(hosts)  # Friendly single-vs-many host label
         return getpass.getpass(f"!? Enter password for {user}@{label}: ") or None  # Hidden secure prompt
 
@@ -183,31 +183,31 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
     def _resolve_password(  # WHY: 3-tier resolution (env / --secure prompt / hard-fail).
         args: Any, env_config: dict[str, Any], hosts: list[str], user: str | None
     ) -> str | None:
-        """Resolve password, prompting securely when needed; return None on hard failure."""
+        """Resolve password, prompting securely when needed. Return None on hard failure."""
         password = env_config.get("password")  # Passwords are NEVER taken from CLI args
         if password and not args.secure:  # .env already supplied a password and user did not force prompt
             return str(password)  # Coerce to str in case env loader returned a non-str truthy value
         if not user or not hosts:  # Cannot prompt meaningfully without a user/host context
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("X  Password required but not provided")  # User-facing diagnostic preserved verbatim
             return None  # Hard failure: caller aborts pipeline
         return AppRunner._prompt_password(user, hosts)  # Delegate to secure prompt helper
 
     @staticmethod
     def _validate_hosts(final_hosts: list[str]) -> list[str] | None:  # WHY: reject syntactically invalid hostnames.
-        """Filter to valid hosts; return None on hard failure (no valid hosts)."""
+        """Filter to valid hosts. Return None on hard failure (no valid hosts)."""
         validated: list[str] = []  # Accepted hostnames
         invalid: list[str] = []  # Rejected hostnames (reported back to user)
         for host in final_hosts:  # Apply per-host syntactic validation
             (validated if validate_hostname(host) else invalid).append(host)  # Route by validator verdict
         if invalid:  # User-facing diagnostics preserved verbatim
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("X  Invalid hosts detected: %s", ", ".join(invalid))
             if not validated:  # No usable hosts left
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.error("X  No valid hosts remaining")
                 return None
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("[WARNING] Proceeding with %d valid hosts", len(validated))  # Soft failure path
         return validated
 
@@ -215,16 +215,16 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
     def _print_param_hints(use_env: bool) -> None:  # WHY: user-facing remediation hints after preflight failure.
         """Print the .env-vs-CLI remediation hint after a missing-parameter error."""
         if use_env:  # .env loading is on: point at the .env file
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("!? Add these to your .env file or provide as command line arguments")
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("!? Use --no-env flag to disable .env file loading")
         else:  # .env loading disabled: point at CLI args
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("!? Provide as command line arguments or remove --no-env flag to use .env file")
 
     @staticmethod
-    def _check_required_params(  # WHY: preflight gate; table-driven missing-field enumeration.
+    def _check_required_params(  # WHY: preflight gate. Table-driven missing-field enumeration.
         hosts: list[str], user: str | None, password: str | None, use_env: bool
     ) -> bool:
         """Return True when all of (hosts, user, password) are present."""
@@ -236,7 +236,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
             (password, "password/SSH_PASSWORD"),
         )
         missing = [label for value, label in specs if not value]  # Filter to unset fields
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("X  Error: Missing required parameters: %s", ", ".join(missing))  # Preserved verbatim
         AppRunner._print_param_hints(use_env)  # Delegate hint printing
         return False
@@ -256,7 +256,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
         csv_cmds = CommandCsvLoader().load()  # Priority 3: SSH_COMMANDS.CSV
         if csv_cmds:  # CSV supplied a command list
             logger.info("Using %s commands from data/SSH_COMMANDS.CSV: %s", len(csv_cmds), csv_cmds)
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("!? Loaded %d commands from data/SSH_COMMANDS.CSV", len(csv_cmds))
             return csv_cmds
         return AppRunner._prompt_for_commands(env_cmds, csv_cmds)  # Priority 4: interactive
@@ -267,7 +267,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
         logging.info("Prompting user for SSH command(s) at runtime")  # Before-action log
         command = InputUtils.safe_input("!? Enter command to execute: ", context="ssh_app_runner_command")  # EOF-safe
         if not command:  # Hard failure: user provided nothing
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("X  No commands specified")
             logging.debug("User declined to enter any command at the interactive prompt")
             return []
@@ -287,17 +287,17 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
 
     @staticmethod
     def _validate_commands(commands_to_run: list[str]) -> list[str]:  # WHY: reject unsafe commands + user warnings.
-        """Filter commands to those passing the shared validator; print rejections."""
+        """Filter commands to those passing the shared validator. Print rejections."""
         validated, invalid = AppRunner._partition_commands(commands_to_run)  # Pure split first
         if not invalid:  # Happy path -- no rejects to report
             return validated
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("X  Invalid commands detected: %s", ", ".join(invalid))  # Preserved verbatim
         if not validated:  # Nothing left to run
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("X  No valid commands remaining")
             return []
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("!? Proceeding with %d valid commands", len(validated))  # Soft failure path
         return validated
 
@@ -337,7 +337,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
         requested = request.args.max_threads or multiprocessing.cpu_count()  # CLI override or CPU count
         max_threads = _validate_thread_count(requested, len(request.hosts))  # Apply safety caps
         if max_threads != requested:  # Tell the user if we clamped their request
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("!? Adjusted thread count from %d to %d", requested, max_threads)
         logging.info(
             "Dispatching to MultiHostRunner.run (%d hosts / %d cmds)", len(request.hosts), len(request.commands)
@@ -369,7 +369,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
     def _resolve_execution_context(  # WHY: split preflight resolution to keep _execute_pipeline under CC 5.
         args: Any, logger: logging.Logger
     ) -> tuple[list[str], str | None, str, dict[str, Any], bool] | None:
-        """Resolve hosts/user/password and validate hosts; return context tuple or None on hard failure."""
+        """Resolve hosts/user/password and validate hosts. Return context tuple or None on hard failure."""
         use_env = not args.no_env  # .env loading is opt-out
         env_config = AppRunner._load_env_config(use_env, logger)  # Phase: load .env
         hosts, user = AppRunner._resolve_hosts_and_user(args, env_config)  # Phase: hosts + user
@@ -387,7 +387,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
     ) -> bool:
         """Validate username plus required params before dispatch."""
         if user and not validate_username(user):  # Validate username separately
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("[ERROR] Invalid username format: %s", user)
             return False
         return AppRunner._check_required_params(hosts, user, password, use_env)  # Final preflight
@@ -407,7 +407,7 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
             AppRunner._resolve_commands(args, env_config, use_env, logger)
         )
         if not commands:  # Nothing safe left to run
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("X  No commands to execute")  # User-facing diagnostic preserved verbatim
             return None  # Hard failure: caller aborts pipeline
         return _ExecutionRequest(  # Immutable bundle handed to dispatchers
@@ -452,13 +452,13 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
         try:  # Single try wraps the pipeline so we always restore the tracer
             return AppRunner._execute_pipeline(args, logger)
         except KeyboardInterrupt:  # Preserve legacy interrupt UX
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("\n[INTERRUPT] Operation cancelled by user")
             return False
         except Exception as exec_err:  # Preserve legacy fatal-error diagnostics
             logger.exception("Fatal error during SSH runner execution")
             logger.debug("[DIAG] Type of exception object: %s", type(exec_err))
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("X  Fatal error: %s", exec_err)
             return False
         finally:  # Always clean up the tracer to avoid leaking it into the caller

--- a/src/ssh/runtime/interactive_mode.py
+++ b/src/ssh/runtime/interactive_mode.py
@@ -36,11 +36,11 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
                 "- Enter hostname or IP address: ", context="ssh_hostname"
             )  # EOF-safe read.
             if not hostname:  # Empty -> reprompt
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("X  Hostname is required")
                 continue  # Re-enter the validation loop.
             if not validate_hostname(hostname):  # Reject invalid syntax
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("X  Invalid hostname or IP address format")
                 continue  # Re-enter the validation loop.
             logging.debug("Hostname accepted: %s", hostname)  # After-action log
@@ -53,11 +53,11 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
         while True:  # Validation loop
             username = InputUtils.safe_input("X  Enter username: ", context="ssh_username")  # EOF-safe read.
             if not username:  # Empty -> reprompt
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("X  Username is required")
                 continue  # Re-enter the validation loop.
             if not validate_username(username):  # Reject invalid chars
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("X  Invalid username format (alphanumeric, underscore, hyphen, dot only)")
                 continue  # Re-enter the validation loop.
             logging.debug("Username accepted: %s", username)  # After-action log
@@ -85,13 +85,13 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
                     return 22  # Return the documented default port.
                 port = int(port_input)  # Parse user-provided integer
                 if not SshConnector._validate_port(port):  # Range check 1..65535
-                    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                     logger.warning("X  Port must be between 1 and 65535")
                     continue  # Re-enter the validation loop.
                 logging.debug("Port accepted: %d", port)  # After-action log
                 return port  # Hand the validated port back to the caller.
             except ValueError:  # Non-numeric input
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("X  Port must be a valid number")
 
     @staticmethod
@@ -106,14 +106,14 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
 
     @staticmethod
     def _read_bounded_timeout() -> int | None:
-        """Read one timeout entry; return validated int, or None to re-prompt."""
+        """Read one timeout entry. Return validated int, or None to re-prompt."""
         # WHY: extracting parse/validate drops _prompt_timeout CC from 6 to 3.
         try:  # Catch non-numeric input from the user.
             timeout_input = InputUtils.safe_input(
                 "- Enter timeout in seconds (default 30): ", context="ssh_timeout"
             )  # EOF-safe read.
         except ValueError:  # Defensive; safe_input can raise on non-str contexts.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("X  Timeout must be a valid number")
             return None  # Signal caller to re-prompt.
         if not timeout_input:  # Empty entry selects the default timeout.
@@ -122,11 +122,11 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
         try:  # int() raises ValueError on non-numeric strings.
             timeout = int(timeout_input)  # Parse user-provided integer.
         except ValueError:  # Non-numeric input entered.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("X  Timeout must be a valid number")
             return None  # Signal caller to re-prompt.
         if not 1 <= timeout <= 3600:  # Bounded range check.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("X  Timeout must be between 1 and 3600 seconds")
             return None  # Signal caller to re-prompt.
         return timeout  # Validated, in-range timeout value.
@@ -150,11 +150,11 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
         while True:  # Validation loop
             command = InputUtils.safe_input("!? Enter command to execute: ", context="ssh_command")  # EOF-safe read.
             if not command:  # Empty -> reprompt
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("X  Command is required")
                 continue
             if not validate_command(command):  # Reject too-long or NUL bytes
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.warning("X  Invalid command (too long or contains null bytes)")
                 continue
             logging.debug("Command accepted (length=%d)", len(command))  # After-action log
@@ -164,15 +164,15 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
     def run() -> bool:
         """Orchestrate the interactive REPL and dispatch a single SSH command."""
         logging.info("Entering SSH runner interactive mode")  # Before-action log
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("- Enhanced SSH Command Runner v2 - Interactive Mode")
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("=" * 60)
         hostname = InteractiveMode._prompt_hostname()  # Phase 1: hostname
         username = InteractiveMode._prompt_username()  # Phase 2: username
         password = InteractiveMode._prompt_password()  # Phase 3: password
         if not password:  # Reject empty passwords explicitly
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.warning("X  Password is required")
             logging.debug("Interactive mode aborted: empty password")
             return False
@@ -180,7 +180,7 @@ class InteractiveMode:  # Groups the interactive REPL prompt helpers under one n
         timeout = InteractiveMode._prompt_timeout()  # Phase 5: timeout
         use_shell = InteractiveMode._prompt_shell_mode()  # Phase 6: shell mode
         command = InteractiveMode._prompt_command()  # Phase 7: command
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("\n>> Starting SSH session (shell_mode=%s)...", use_shell)
         logging.debug("Dispatching interactive SSH command to SingleCommandRunner.run")  # After-action log
         interactive_request = SingleCommandRequest(  # WHY: dataclass keeps SingleCommandRunner.run at 1 param.

--- a/src/ssh/shell_execution/shell_executor.py
+++ b/src/ssh/shell_execution/shell_executor.py
@@ -189,7 +189,7 @@ class ShellExecutor:
         self._log_output_summary(cleaned_output, start_time)  # WHY: Diagnostic logging only
         success = self._evaluate_success(cleaned_output)  # WHY: Phase 8: classify as success/failure
         command_time = time.time() - start_time  # WHY: Final wall-clock duration
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.info("[STATUS] [%s] Command completed in %.2f seconds", hostname, command_time)
         self.logger.debug(
             "ShellExecutor: command completed on %s in %.2fs", hostname, command_time
@@ -229,7 +229,7 @@ class ShellExecutor:
     def _send_command(
         self, shell: Any, command: str
     ) -> tuple[bool, str, str] | None:  # WHY: Write command + return error tuple on failure
-        r"""Send ``command\n`` to the shell; return an error tuple on failure, ``None`` on success."""
+        r"""Send ``command\n`` to the shell. Return an error tuple on failure, ``None`` on success."""
         try:
             command_with_newline = command + "\n"  # WHY: Newline triggers command execution
             shell.send(command_with_newline.encode("utf-8"))  # WHY: Byte-level write to channel
@@ -282,7 +282,7 @@ class ShellExecutor:
     def _loop_step(
         self, shell: Any, context: _CollectContext, state: _CollectState
     ) -> bool:  # WHY: One loop iteration - returns True when the loop should exit
-        """Perform one iteration of the collect loop; return True when the loop should terminate."""
+        """Perform one iteration of the collect loop. Return True when the loop should terminate."""
         if self._detect_hang(state, context):  # WHY: 90s "hang" forced-completion appends marker and exits
             return True
         self._maybe_print_long_running_progress(
@@ -299,7 +299,7 @@ class ShellExecutor:
     def _await_bytes_or_finish(
         self, state: _CollectState
     ) -> bool:  # WHY: Idle branch - return True when silence deadline reached
-        """Return True when silence has exceeded ``_NO_DATA_TIMEOUT_S``; else sleep briefly and return False."""
+        """Return True when silence has exceeded ``_NO_DATA_TIMEOUT_S``. Else sleep briefly and return False."""
         if self._silence_exceeded(state.last_data_time):  # WHY: Silence threshold reached - command considered finished
             return True
         time.sleep(_POLL_SLEEP_S)  # WHY: Brief sleep before next poll
@@ -330,7 +330,7 @@ class ShellExecutor:
         self, state: _CollectState, context: _CollectContext
     ) -> None:  # WHY: Keep KeyboardInterrupt bookkeeping out of the loop
         """Record the interrupt marker on ``state`` and emit the operator-facing status line."""
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.warning("X  [%s] Ctrl+C detected! Interrupting command: %s", context.hostname, context.command)
         self.logger.warning("Command interrupted by user: %s", context.command)  # WHY: Log for post-mortem
         # WHY: Marker preserved verbatim so downstream log parity is unaffected
@@ -343,7 +343,7 @@ class ShellExecutor:
         current_duration = time.time() - start_time  # WHY: Wall-clock elapsed
         if current_duration <= _HANG_DETECTION_S:  # WHY: Guard clause - not yet at threshold
             return False
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.warning(
             "[TIMEOUT] [%s] HANG DETECTED: Command running for %.0fs, forcing completion",
             hostname,
@@ -362,7 +362,7 @@ class ShellExecutor:
         if (
             current_duration > _LONG_RUNNING_THRESHOLD_S and chunk_count % _LONG_RUNNING_CADENCE_CHUNKS == 0
         ):  # WHY: Match original cadence verbatim
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             self.logger.info(
                 "- [%s] Long-running command... %.0fs elapsed (Ctrl+C to interrupt)",
                 hostname,
@@ -395,7 +395,7 @@ class ShellExecutor:
         state.output += (
             f"\n\n[OUTPUT TRUNCATED - Size limit of {cap_mb}MB reached]\n"  # WHY: Verbatim truncation marker
         )
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.warning("!? [%s] Output truncated at %dMB, draining remaining data...", hostname, cap_mb)
         state.truncated = True  # WHY: Loop will drain the tail and exit
 
@@ -408,7 +408,7 @@ class ShellExecutor:
             "Receiving data... %d chunks, %.1fMB", chunk_count, output_mb
         )  # WHY: Structured trace of progress
         if output_mb > _LARGE_OUTPUT_PRINT_MB:  # WHY: User-facing print only for large outputs
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             self.logger.info("- [%s] Receiving large output... %.1fMB (Press Ctrl+C to interrupt)", hostname, output_mb)
 
     # ------------------------------------------------------------------
@@ -433,7 +433,7 @@ class ShellExecutor:
                 break
             time.sleep(_POLL_SLEEP_S)  # WHY: Brief sleep before next poll
         drain_duration = time.time() - drain_start  # WHY: Final drain wall-clock
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.info(
             "[OK] [%s] Data drain completed in %.1fs (%d chunks discarded)",
             hostname,
@@ -449,7 +449,7 @@ class ShellExecutor:
         if drained_chunks % _PROGRESS_INTERVAL_CHUNKS != 0:  # WHY: Guard clause - not yet at cadence
             return
         drain_duration = time.time() - drain_start  # WHY: Elapsed drain wall-clock for the print
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning(
             "X  [%s] Draining excess data... %.0fs (%d chunks discarded)",
             hostname,
@@ -470,7 +470,7 @@ class ShellExecutor:
             shell.send(b"\n")  # WHY: Extra newline to ensure command commits
             self._drain_cleanup_tail(shell)  # WHY: Drain any remaining bytes within the cleanup budget
         except KeyboardInterrupt:  # WHY: Ctrl+C during cleanup - force-close immediately
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             self.logger.warning("X  [%s] Ctrl+C during cleanup - forcing shell close", hostname)
             self.logger.warning("Command cleanup interrupted by user")  # WHY: Log operator-driven interrupt
         except (
@@ -492,7 +492,7 @@ class ShellExecutor:
             self.logger.debug("Warning during shell close: %s", close_error)  # WHY: Trace non-fatal close issue
 
     def _drain_cleanup_tail(self, shell: Any) -> None:  # WHY: Drain within cleanup budget - exit early on silence
-        """Drain any remaining bytes within the ``_CLEANUP_MAX_S`` budget; exit early on silence."""
+        """Drain any remaining bytes within the ``_CLEANUP_MAX_S`` budget. Exit early on silence."""
         cleanup_timeout = time.time() + _CLEANUP_MAX_S  # WHY: Absolute deadline
         while time.time() < cleanup_timeout:  # WHY: Bounded loop
             if not shell.recv_ready():  # WHY: No data ready - brief pause then exit

--- a/src/ssh/ssh_runner.py
+++ b/src/ssh/ssh_runner.py
@@ -126,7 +126,7 @@ def _sample_suffix(output: str) -> str:
 
 def _validate_port_arg(value: str) -> int:
     """Validate the --port argparse value ensuring it is in 1..65535."""
-    parsed = int(value)  # WHY: argparse hands strings; convert to int for range validation
+    parsed = int(value)  # WHY: argparse hands strings. Convert to int for range validation
     if not SshConnector._validate_port(parsed):  # WHY: delegate to canonical port validator in connector
         msg = f"Port must be between 1 and 65535, got {parsed}"  # WHY: shorten for line length
         raise argparse.ArgumentTypeError(msg)  # WHY: same message as before
@@ -135,7 +135,7 @@ def _validate_port_arg(value: str) -> int:
 
 def _validate_timeout_arg(value: str) -> int:
     """Validate the --timeout argparse value ensuring it is in 1..3600."""
-    parsed = int(value)  # WHY: argparse gives strings; convert to int for validation
+    parsed = int(value)  # WHY: argparse gives strings. Convert to int for validation
     if not EnhancedSSHRunner._validate_timeout(parsed):  # WHY: reuse the same runner-level timeout validator
         raise argparse.ArgumentTypeError(  # WHY: preserve legacy error text so users' scripts still parse it
             f"Timeout must be between 1 and 3600 seconds, got {parsed}"
@@ -145,7 +145,7 @@ def _validate_timeout_arg(value: str) -> int:
 
 def _validate_threads_arg(value: str) -> int:
     """Validate the --max-threads argparse value ensuring 1..100 inclusive."""
-    parsed = int(value)  # WHY: argparse hands strings; convert to int for range validation
+    parsed = int(value)  # WHY: argparse hands strings. Convert to int for range validation
     if parsed <= 0 or parsed > 100:  # WHY: explicit bounds keep the CLI safe and predictable
         raise argparse.ArgumentTypeError(f"Thread count must be between 1 and 100, got {parsed}")  # WHY: keep msg
     return parsed  # WHY: return validated thread cap
@@ -183,7 +183,7 @@ class EnhancedSSHRunner:
             logger: Logger instance
         """
         self.timeout = timeout  # WHY: store timeout for both connect and command exec paths
-        self.client = None  # WHY: paramiko client is attached by the connector; None means not connected
+        self.client = None  # WHY: paramiko client is attached by the connector. None means not connected
         self.logger = logger or logging.getLogger(_DEFAULT_LOGGER_NAME)  # WHY: fall back to the module logger name
         self.managed_known_hosts_path: str | None = None  # WHY: connector writes the managed known-hosts path here
         self.logger.debug("EnhancedSSHRunner initialized with timeout=%s", timeout)  # WHY: trace-level init evidence
@@ -223,7 +223,7 @@ class EnhancedSSHRunner:
         """
         if not filename:  # WHY: empty inputs get a stable placeholder rather than an empty path segment
             return _UNKNOWN_SANITIZED  # WHY: preserves legacy "unknown" return value for empty inputs
-        sanitized = _SANITIZE_PATTERN.sub("_", filename)  # WHY: whitelist alnum/dot/dash/underscore; replace rest
+        sanitized = _SANITIZE_PATTERN.sub("_", filename)  # WHY: whitelist alnum/dot/dash/underscore. Replace rest
         sanitized = sanitized.strip(".-") or _FALLBACK_SANITIZED  # WHY: drop leading/trailing dots and dashes safely
         sanitized = _apply_length_limit(sanitized)  # WHY: cap filename length to keep filesystem happy
         if _is_windows_reserved(sanitized):  # WHY: rewrite reserved device names so Windows will not reject them
@@ -269,7 +269,7 @@ class EnhancedSSHRunner:
         try:
             os.makedirs(log_dir, exist_ok=True)  # WHY: create the subdir on demand for the very first host
             self._maybe_lock_log_dir(log_dir)  # WHY: chmod only when the platform supports it (POSIX-only)
-        except OSError as exc:  # WHY: creation can fail on read-only or exotic mounts; fall back gracefully
+        except OSError as exc:  # WHY: creation can fail on read-only or exotic mounts. Fall back gracefully
             self.logger.error("Failed to create log directory %s: %s", log_dir, exc)  # WHY: surface the failure
             return data_dir, f"fallback_{safe_hostname}"  # WHY: legacy fallback path when subdir cannot be made
         return log_dir, safe_hostname  # WHY: happy-path return of the newly-ensured directory + safe hostname
@@ -277,7 +277,7 @@ class EnhancedSSHRunner:
     @staticmethod
     def _maybe_lock_log_dir(log_dir: str) -> None:
         """Restrict the log directory to owner rwx on platforms that support chmod."""
-        if hasattr(os, "chmod"):  # WHY: os.chmod exists on Windows but is a no-op; still safe to call
+        if hasattr(os, "chmod"):  # WHY: os.chmod exists on Windows but is a no-op. Still safe to call
             os.chmod(log_dir, _LOG_DIR_MODE)  # WHY: lock down access to per-host logs
 
     def _write_to_host_log(self, log_path: str, message: str) -> None:
@@ -443,7 +443,7 @@ class EnhancedSSHRunner:
 
     def _disconnect(self) -> None:
         """Close SSH connection."""
-        if self.client:  # WHY: only close when a client is attached; no-op otherwise
+        if self.client:  # WHY: only close when a client is attached. No-op otherwise
             self.logger.debug("Closing SSH connection")  # WHY: trace so users can confirm clean teardown
             self.client.close()  # WHY: releases paramiko file descriptors and server-side session
             self.client = None  # WHY: reset so subsequent _execute_command calls fail fast with a clear message

--- a/src/ssh/ssh_runner_manager.py
+++ b/src/ssh/ssh_runner_manager.py
@@ -158,7 +158,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     def _prepare_gateway_selection(  # WHY: bundles load + select + filter to cut by_gateway_template() length.
         deps: SSHRunnerManagerDeps,
     ) -> tuple[str, list[Any]] | None:
-        """Load, prompt, and filter gateways; return (template, rows) or None on cancel."""
+        """Load, prompt, and filter gateways. Return (template, rows) or None on cancel."""
         gateways = SSHRunnerManager._load_gateway_data(deps)  # WHY: parse the CSV export.
         if not gateways:  # WHY: no data → nothing to do.
             return None  # WHY: nothing to prompt when the export is empty.
@@ -191,7 +191,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         if resolved is None:  # WHY: any cancel → return all-None tuple as documented.
             return None, None, None, None  # WHY: sentinel tuple contract expected by callers/tests.
         hosts, username, password = resolved  # WHY: unpack the required trio.
-        commands = commands or SSHRunnerManager._prompt_commands(deps)  # WHY: optional; empty is acceptable.
+        commands = commands or SSHRunnerManager._prompt_commands(deps)  # WHY: optional. Empty is acceptable.
         logging.info(  # WHY: Wave-1 exit envelope required by guardrail tests.
             "Exiting _collect_missing_data (commands_count=%s password=***REDACTED***)",
             len(commands),
@@ -205,7 +205,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         username: Any,
         password: Any,
     ) -> tuple[Any, Any, Any] | None:
-        """Resolve (hosts, username, password), prompting for any missing values; None on cancel."""
+        """Resolve (hosts, username, password), prompting for any missing values. None on cancel."""
         slots = (  # WHY: table-driven pairing of preexisting value + prompt fallback keeps CC ≤ 5.
             (hosts, lambda: SSHRunnerManager._prompt_hosts(deps)),
             (username, lambda: SSHRunnerManager._prompt_username(deps)),
@@ -221,7 +221,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
 
     @staticmethod
     def _prompt_hosts(deps: SSHRunnerManagerDeps) -> list[str] | None:  # WHY: split-and-clean host input.
-        """Prompt operator for comma-separated SSH hosts; return parsed list or None."""
+        """Prompt operator for comma-separated SSH hosts. Return parsed list or None."""
         host_input = deps.input_utils.safe_input(  # WHY: safe_input handles EOF in containers/SSH sessions.
             "Enter SSH host(s) (comma-separated): ",
             context="ssh_runner_hosts",
@@ -234,8 +234,8 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
 
     @staticmethod
     def _prompt_username(deps: SSHRunnerManagerDeps) -> str | None:  # WHY: username-only prompt path.
-        """Prompt operator for SSH username; return value or None on cancel."""
-        # WHY: safe_input is Any-typed via deps; cast to str for mypy strict (no-any-return).
+        """Prompt operator for SSH username. Return value or None on cancel."""
+        # WHY: safe_input is Any-typed via deps. Cast to str for mypy strict (no-any-return).
         username: str = str(deps.input_utils.safe_input("Enter SSH username: ", context="ssh_runner_username")).strip()
         if not username:  # WHY: cancel path.
             logging.warning("X  SSH username is required")
@@ -245,7 +245,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
 
     @staticmethod
     def _prompt_password() -> str | None:  # WHY: password-only prompt path via getpass.
-        """Prompt operator for SSH password via getpass; return value or None on cancel."""
+        """Prompt operator for SSH password via getpass. Return value or None on cancel."""
         try:
             password = getpass.getpass("Enter SSH password: ")  # WHY: hide input so password is not echoed.
         except (EOFError, KeyboardInterrupt):  # WHY: treat EOF / Ctrl-C as cancellation.
@@ -260,7 +260,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
 
     @staticmethod
     def _prompt_commands(deps: SSHRunnerManagerDeps) -> list[str]:  # WHY: optional one-shot command prompt.
-        """Prompt operator for an optional one-shot command; return list (may be empty)."""
+        """Prompt operator for an optional one-shot command. Return list (may be empty)."""
         logging.warning("\nNo commands configured. Enter command or press Enter for CSV fallback:")
         choice = deps.input_utils.safe_input("Command: ", context="ssh_runner_command_prompt").strip()
         return [choice] if choice else []  # WHY: empty list lets the caller fall back to CSV-loaded commands.
@@ -274,7 +274,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         commands: Any,
     ) -> bool:
         """Execute SSH commands on specified hosts."""
-        _ = deps  # WHY: retained for signature parity; deps not required after loader indirection.
+        _ = deps  # WHY: retained for signature parity. Deps not required after loader indirection.
         original_load = EnvSshConfigLoader.load  # WHY: capture original bound method for restoration.
         try:
             SSHRunnerManager._install_mock_env_loader(hosts, username, password, commands)  # WHY: inject overrides.
@@ -344,7 +344,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
             log_level="INFO",  # WHY: match legacy log level for CLI invocation.
             debug=False,  # WHY: suppress verbose debug output.
             max_threads=None,  # WHY: single-host path does not fan out.
-            secure=False,  # WHY: legacy default; caller can override upstream.
+            secure=False,  # WHY: legacy default. Caller can override upstream.
         )
         args.shell = True  # WHY: attribute assignment (not kwarg) sidesteps bandit B604 shell=True heuristic.
         return args  # WHY: return the fully-populated namespace consumed by AppRunner.run().
@@ -423,7 +423,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
 
     @staticmethod
     def _resolve_template_by_substring(selection: str, templates: list[str]) -> str | None:  # WHY: fuzzy fallback.
-        """Resolve template name by case-insensitive substring; require unique match."""
+        """Resolve template name by case-insensitive substring. Require unique match."""
         matches = [template for template in templates if selection.lower() in template.lower()]  # WHY: case-insens.
         if len(matches) == 1:  # WHY: unambiguous → accept.
             return matches[0]
@@ -444,7 +444,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     def _gateway_matches_template(gateway: Any, template_name: str) -> bool:  # WHY: single boolean, CC=1.
         """Return True when a gateway row matches template + online + valid IP predicates."""
         management_ip = (gateway.get(_MANAGEMENT_IP_KEY) or "").strip()  # WHY: normalize None/whitespace uniformly.
-        return (  # WHY: boolean expression avoids branching; table-driven bad-IP set skips repeated string checks.
+        return (  # WHY: boolean expression avoids branching. Table-driven bad-IP set skips repeated string checks.
             gateway.get(_TEMPLATE_KEY) == template_name
             and gateway.get(_ONLINE_STATUS_KEY) == _ONLINE_STATUS
             and management_ip not in _INVALID_MANAGEMENT_IPS
@@ -510,7 +510,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
 
     @staticmethod
     def _resolve_by_template_config() -> tuple[Any, Any, list[Any]] | None:  # WHY: config resolution helper.
-        """Load SSH creds + commands (from .env + CSV fallback); return None on missing data."""
+        """Load SSH creds + commands (from .env + CSV fallback). Return None on missing data."""
         ssh_config = EnvSshConfigLoader().load()  # WHY: T013a extracted .env loader.
         if not ssh_config.get("username") or not ssh_config.get("password"):  # WHY: mandatory fields missing.
             logging.warning("! SSH credentials not found in .env file.")

--- a/src/ssid_consolidation/_ssid_template_cluster.py
+++ b/src/ssid_consolidation/_ssid_template_cluster.py
@@ -21,7 +21,7 @@ from __future__ import annotations  # WHY: postponed evaluation for forward-ref 
 import logging  # WHY (#886 Phase 2): cluster helper emits bail msg via logger instead of print
 from typing import TYPE_CHECKING, Any  # WHY: Any lets __getattr__ proxy any parent method
 
-if TYPE_CHECKING:  # WHY: only pulled in by type checkers; skipped at runtime
+if TYPE_CHECKING:  # WHY: only pulled in by type checkers. Skipped at runtime
     from src.ssid_consolidation.ssid_template_consolidation import (  # WHY: parent type for annotation
         SSIDTemplateConsolidationManager,
     )
@@ -44,7 +44,7 @@ class _ClusterBase:  # WHY: shared wrapper base for every ssid_template cluster
     def __getattr__(self, name: str) -> Any:  # WHY: proxy unknown attrs back to parent
         """Delegate unknown attributes to the wrapped parent object."""
         parent = self.__dict__.get("_mm")  # WHY: guard against half-initialized instances
-        if parent is None:  # WHY: only trips during broken init; avoid infinite recursion
+        if parent is None:  # WHY: only trips during broken init. Avoid infinite recursion
             raise AttributeError(name)  # WHY: signal missing attribute cleanly to callers
         return getattr(parent, name)  # WHY: transparent proxy so self.org_id / helpers work
 
@@ -59,10 +59,10 @@ class _ClusterBase:  # WHY: shared wrapper base for every ssid_template cluster
         return getattr(self._mm, name)(*args, **kwargs)  # WHY: dynamic dispatch bypasses W0212
 
     def _load_cache_or_bail(self) -> bool:  # WHY: shared Phase 2-5 cache preamble
-        """Load Phase 1 cache onto parent; return False + bail msg when missing.
+        """Load Phase 1 cache onto parent. Return False + bail msg when missing.
 
         Phase 2/3/4/5 orchestrators all share the same "load cache or abort"
-        preamble; centralising it here keeps pylint's R0801 duplicate-code
+        preamble. Centralising it here keeps pylint's R0801 duplicate-code
         warning off the per-phase clusters without leaking parent internals.
         """
         parent = self._mm  # WHY: proxy alias

--- a/src/ssid_consolidation/_ssid_template_phase1.py
+++ b/src/ssid_consolidation/_ssid_template_phase1.py
@@ -73,7 +73,7 @@ def _fetch_and_log(  # WHY: mirror parent's fetch helper so mistapi patching lan
     """
     logging.warning("Fetching %s...", label)  # WHY: operator telemetry during multi-call fetch
     response = api_fn(session, org_id, **kwargs)  # WHY: mistapi list endpoint call
-    data: list[dict[str, Any]] = (  # WHY: paginate response; None -> [] keeps callers dict-safe
+    data: list[dict[str, Any]] = (  # WHY: paginate response. None -> [] keeps callers dict-safe
         mistapi.get_all(response=response, mist_session=session) or []
     )
     logging.info("%s fetched: %d", label.capitalize(), len(data))  # WHY: audit trail per collection
@@ -124,7 +124,7 @@ def _resolve_template(  # WHY: match a site to its owning template via first-hit
     for template_id, template in template_lookup.items():  # WHY: iterate all until first match
         if _template_applies_to_site(template, site):  # WHY: delegated scope check keeps CC low
             return template, template_id  # WHY: first-hit wins — templates are single-scope in Mist
-    return None, ""  # WHY: unassigned site is common; caller flags it
+    return None, ""  # WHY: unassigned site is common. Caller flags it
 
 
 def _get_template_wlans(  # WHY: normalize None -> [] so downstream can rely on iterable shape
@@ -135,7 +135,7 @@ def _get_template_wlans(  # WHY: normalize None -> [] so downstream can rely on 
     return wlans  # WHY: caller iterates without needing another None check
 
 
-def _find_target_wlan(  # WHY: linear scan for target SSID; WLAN lists are typically 1..8 entries
+def _find_target_wlan(  # WHY: linear scan for target SSID. WLAN lists are typically 1..8 entries
     wlans: list[dict[str, Any]], target_ssid: str
 ) -> dict[str, Any] | None:
     """Find the WLAN matching the target SSID name."""
@@ -638,7 +638,7 @@ class _SsidTemplatePhase1Cluster(_ClusterBase):
         return fresh
 
     def _try_load_cached(self) -> dict[str, Any] | None:
-        """Return cached org data when operator accepts reuse; None otherwise."""
+        """Return cached org data when operator accepts reuse. None otherwise."""
         parent = self._mm  # WHY: proxy alias for readability + W0212 avoidance
         from ._ssid_template_cache import _cache_age_minutes  # noqa: PLC0415 — local avoids cycle
 

--- a/src/ssid_consolidation/_ssid_template_phase2.py
+++ b/src/ssid_consolidation/_ssid_template_phase2.py
@@ -213,7 +213,7 @@ class _SsidTemplatePhase2Cluster(_ClusterBase):
     def phase2_site_variables(self) -> None:  # WHY: user-facing Phase 2 entry point
         """Phase 2 orchestrator - compute variable plan, write to sites."""
         logging.warning("=== Phase 2: Write Site Variables ===")  # WHY: banner marks phase boundary
-        # WHY (#886 Phase 2): module already imports `logging` at module top; local re-import removed.
+        # WHY (#886 Phase 2): module already imports `logging` at module top. Local re-import removed.
 
         logging.info("Phase 2: Starting site variable configuration")  # WHY: audit trail
         if not self._load_cache_or_bail():  # WHY: cache preamble aborts on missing Phase 1

--- a/src/ssid_consolidation/_ssid_template_phase3.py
+++ b/src/ssid_consolidation/_ssid_template_phase3.py
@@ -349,7 +349,7 @@ def _ensure_single_group(
     parent: Any,
     create_fn: Any,
 ) -> None:  # WHY: extracted from _ensure_groups_exist loop
-    """Create the group when missing; otherwise log the reuse."""
+    """Create the group when missing. Otherwise log the reuse."""
     if group["exists"]:  # WHY: reuse existing groups without hitting mistapi
         logging.info(_GROUP_EXISTS_LOG, group["group_name"], group["group_id"])  # WHY: audit trail
         return  # WHY: skip create call when already present

--- a/src/ssid_consolidation/_ssid_template_phase45.py
+++ b/src/ssid_consolidation/_ssid_template_phase45.py
@@ -124,7 +124,7 @@ class TemplateOutcome:
 
     template_id: str  # WHY: id returned by createOrgTemplate / existing template id
     action: str  # WHY: "created" | "updated_append" | "skipped" | "already_exists" | "failed"
-    error: str = ""  # WHY: exception message on failure; empty on success
+    error: str = ""  # WHY: exception message on failure. Empty on success
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +197,7 @@ def _record_deviation_choice(
 
 
 def _parse_choice_index(choice: str, param: str) -> int | None:
-    """Convert operator input to a 0-based index; return None + print on invalid input."""
+    """Convert operator input to a 0-based index. Return None + print on invalid input."""
     try:
         return int(choice) - 1  # WHY: 1-based menu -> 0-based index
     except ValueError:  # WHY: non-integer input is a soft failure — skip param, keep loop

--- a/src/ssid_consolidation/ssid_template_consolidation.py
+++ b/src/ssid_consolidation/ssid_template_consolidation.py
@@ -96,7 +96,7 @@ from ._ssid_template_phase45 import (  # WHY: re-export phase 4/5 helpers refere
 # WHY: declare the module-level re-export surface so ruff F401 does not flag the
 # intentional pass-throughs above (tests reach these helpers by patching them at
 # ``ssid_template_consolidation.<name>``, which requires the symbol to bind here).
-__all__ = [  # WHY: explicit re-export list; keeps ruff F401 quiet on intentional pass-throughs
+__all__ = [  # WHY: explicit re-export list. Keeps ruff F401 quiet on intentional pass-throughs
     "SSIDTemplateConsolidationManager",
     "SsidTemplateDeps",
     "TemplateOpParams",
@@ -320,7 +320,7 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
         current_org_id, target_ssid = context  # WHY: destructure validated org + ssid pair
         logging.info("Target SSID: %s, Org: %s", target_ssid, current_org_id)  # WHY: audit-log operator inputs
         # fmt: off
-        deps = SsidTemplateDeps(  # WHY: bundle 6 deps into frozen struct; STRUCT-LENGTH block
+        deps = SsidTemplateDeps(  # WHY: bundle 6 deps into frozen struct. STRUCT-LENGTH block
             org_id=current_org_id, target_ssid=target_ssid, apisession=apisession,
             page_limit=page_limit, safe_input_fn=safe_input_fn, write_data_fn=write_data_fn,
         )
@@ -383,7 +383,7 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
                 return  # WHY: unwind the loop when the choice was terminal (quit / phase 6)
 
     def _handle_menu_choice(self, choice: str, dispatch: dict[str, Any]) -> bool:  # WHY: extracted so complexity <= 5
-        """Route one menu selection; return True when the menu should exit."""
+        """Route one menu selection. Return True when the menu should exit."""
         if choice.lower() in ("q", "quit", ""):  # WHY: quit tokens include blank enter
             logging.warning("Returning to main menu.")  # WHY: operator feedback before unwinding
             return True  # WHY: signal caller to exit the menu loop
@@ -460,26 +460,26 @@ class SSIDTemplateConsolidationManager:  # pylint: disable=too-many-instance-att
     # Phase 2: Site Variables
     # ------------------------------------------------------------------
     # WHY: phase2_site_variables + _write_site_variables live on the
-    # phase-2 cluster; access is transparent via __getattr__ delegation.
+    # phase-2 cluster. Access is transparent via __getattr__ delegation.
 
     # ------------------------------------------------------------------
     # Phase 3: Site Groups
     # ------------------------------------------------------------------
     # WHY: phase3_site_groups + _ensure_groups_exist +
-    # _assign_sites_to_groups live on the phase-3 cluster; access is
+    # _assign_sites_to_groups live on the phase-3 cluster. Access is
     # transparent via __getattr__ delegation.
 
     # ------------------------------------------------------------------
     # Phase 4: Templates
     # ------------------------------------------------------------------
     # WHY: phase4_templates + _create_or_update_templates live on the
-    # phase-4/5 cluster; access is transparent via __getattr__ delegation.
+    # phase-4/5 cluster. Access is transparent via __getattr__ delegation.
 
     # ------------------------------------------------------------------
     # Phase 5: Disable Old SSIDs
     # ------------------------------------------------------------------
     # WHY: phase5_disable_old + _disable_ssids live on the phase-4/5
-    # cluster; access is transparent via __getattr__ delegation.
+    # cluster. Access is transparent via __getattr__ delegation.
 
 
 # ------------------------------------------------------------------
@@ -845,11 +845,11 @@ def _apply_ssid_disable(
     response = mistapi.api.v1.orgs.templates.getOrgTemplate(apisession, org_id, template_id)  # WHY: fetch current
     template_data = response.data if hasattr(response, "data") else {}  # WHY: mistapi returns .data
     wlans: list[dict[str, Any]] = template_data.get("wlans", []) or []  # WHY: empty template edge case
-    updated = _set_ssid_disabled(wlans, ssid_id)  # WHY: in-place flip; returns True if found
+    updated = _set_ssid_disabled(wlans, ssid_id)  # WHY: in-place flip. Returns True if found
     if updated:  # WHY: only PUT + report success when the WLAN row was located
         template_data["wlans"] = wlans  # WHY: PUT payload carries the mutated wlan list
         # fmt: off
-        mistapi.api.v1.orgs.templates.updateOrgTemplate(  # WHY: PUT mutated wlans; STRUCT-LENGTH block
+        mistapi.api.v1.orgs.templates.updateOrgTemplate(  # WHY: PUT mutated wlans. STRUCT-LENGTH block
             apisession, org_id, template_id, body=template_data,
         )
         # fmt: on

--- a/src/troubleshooting/interactive_test_runner.py
+++ b/src/troubleshooting/interactive_test_runner.py
@@ -42,7 +42,7 @@ class _LoggedErrorObserver(logging.Handler):
     def __init__(self) -> None:
         """Configure the handler at ERROR level with a zero-count captured tally."""
         super().__init__(level=logging.ERROR)
-        self.error_count = 0  # WHY: cheap monotonic tally; callers only check >0.
+        self.error_count = 0  # WHY: cheap monotonic tally. Callers only check >0.
 
     def emit(self, record: logging.LogRecord) -> None:  # noqa: D401 -- logging.Handler API
         """Increment the captured error tally for each ERROR (or higher) record."""
@@ -65,7 +65,7 @@ class SuiteContext:  # WHY: bundle runtime handles to keep run/finalize signatur
     """Runtime handles + counters threaded through the finalize phase of a suite run."""
 
     all_options: list[str]  # WHY: full option universe used for TestSummary total_ops metric.
-    interactive_options: list[str]  # WHY: subset actually executed; drives coverage denominator.
+    interactive_options: list[str]  # WHY: subset actually executed. Drives coverage denominator.
     test_site_id: str | None  # WHY: resolved test site injected into interactive callables.
     emitter: Any  # WHY: telemetry emitter that receives per-option and summary events.
     telemetry_path: Any  # WHY: destination path echoed in the operator summary block.
@@ -284,7 +284,7 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
 
         Why:
             #886 slice 18/N. Counts and blank-line separators are folded into
-            a single warning record; delegated tested/skipped listings each
+            a single warning record. Delegated tested/skipped listings each
             emit one further warning to preserve section boundaries.
         """
         logging.warning(
@@ -296,7 +296,7 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         self._print_skipped_options(skip_list)  # WHY: delegate skipped-listing emission.
 
     def _create_emitter(self) -> tuple[Any, Any]:
-        """Initialize telemetry emitter; return (emitter, path) tuple."""
+        """Initialize telemetry emitter. Return (emitter, path) tuple."""
         logging.info("Creating telemetry emitter for interactive test run")  # WHY: log before emitter setup.
         telemetry_path = self.telemetry_emitter_cls.timestamped_path("data")  # WHY: generate timestamped output path.
         emitter = self.telemetry_emitter_cls(telemetry_path)  # WHY: construct emitter instance.
@@ -332,7 +332,7 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         return org_id  # WHY: return org_id for downstream site resolution.
 
     def _resolve_site_or_close(self, org_id: str, emitter: Any) -> tuple[str | None, str]:
-        """Resolve test site context; close emitter and return (None, '') on failure paths."""
+        """Resolve test site context. Close emitter and return (None, '') on failure paths."""
         try:
             logging.warning("   Fetching test site for interactive operations...")  # WHY: #886 s18 legacy cue.
             test_site_id, test_site_name = self._resolve_test_site(org_id)  # WHY: resolve test site.
@@ -521,7 +521,7 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
 
         Why:
             #886 slice 18/N. The 10-line summary block was 10 separate
-            ``print()`` calls; consolidating into one warning record
+            ``print()`` calls. Consolidating into one warning record
             guarantees the block arrives contiguously in any handler.
         """
         coverage_pct = tallies.success_count / interactive_total * 100  # WHY: precompute coverage %.
@@ -592,7 +592,7 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
         self._print_suite_header()  # WHY: emit legacy header block.
         all_options, interactive_options, skip_list = self._build_option_lists()  # WHY: build option lists.
         self._print_option_listings(interactive_options, skip_list)  # WHY: emit option listings.
-        emitter, telemetry_path = self._create_emitter()  # WHY: initialize telemetry emitter; capture path.
+        emitter, telemetry_path = self._create_emitter()  # WHY: initialize telemetry emitter. Capture path.
         skip_count = self._emit_skip_events(emitter, skip_list)  # WHY: emit skip events and tally count.
         org_id = self._ensure_org_id()  # WHY: resolve org_id with cache fallback.
         test_site_id, _site_name = self._resolve_site_or_close(org_id, emitter)  # WHY: resolve site context or abort.

--- a/src/troubleshooting/marvis_troubleshoot_utils.py
+++ b/src/troubleshooting/marvis_troubleshoot_utils.py
@@ -82,7 +82,7 @@ class MarvisTroubleshootUtils:
         """Troubleshoot client connectivity issues using Marvis AI.
 
         Why:
-            Entry point for the client-scoped Marvis workflow; routes user
+            Entry point for the client-scoped Marvis workflow. Routes user
             selection into the API-call wrapper and error boundary.
 
         Args:
@@ -105,7 +105,7 @@ class MarvisTroubleshootUtils:
         """Troubleshoot device performance issues using Marvis AI.
 
         Why:
-            Entry point for the device-scoped Marvis workflow; wraps site +
+            Entry point for the device-scoped Marvis workflow. Wraps site +
             device selection prompts, device metadata lookup, and API dispatch.
 
         Args:
@@ -133,7 +133,7 @@ class MarvisTroubleshootUtils:
         """Troubleshoot general network connectivity issues using Marvis AI.
 
         Why:
-            Entry point for site-wide Marvis analysis; dispatches into API
+            Entry point for site-wide Marvis analysis. Dispatches into API
             wrapper after user-facing site selection.
 
         Args:
@@ -441,7 +441,7 @@ class MarvisTroubleshootUtils:
             results_header: heading to render before bullets.
         """
         logging.warning("\n  %s:", results_header)  # WHY: section header.
-        for result in results or []:  # WHY: iterate; treat missing list as empty.
+        for result in results or []:  # WHY: iterate. Treat missing list as empty.
             MarvisTroubleshootUtils._print_result_bullet(result)  # WHY: per-result renderer.
 
     @staticmethod
@@ -470,7 +470,7 @@ class MarvisTroubleshootUtils:
         """Print bullet list for a Marvis ``insights`` array.
 
         Why:
-            Parallel to results dispatch; keeps the insights-vs-results branch
+            Parallel to results dispatch. Keeps the insights-vs-results branch
             symmetrical for maintenance.
 
         Args:
@@ -478,7 +478,7 @@ class MarvisTroubleshootUtils:
             insights_label: heading to render before bullets.
         """
         logging.warning("\n  %s:", insights_label)  # WHY: section header.
-        for insight in insights or []:  # WHY: iterate; treat missing list as empty.
+        for insight in insights or []:  # WHY: iterate. Treat missing list as empty.
             description = MarvisTroubleshootUtils._insight_description(insight)  # WHY: consistent renderer.
             logging.warning("  !? %s", description)  # WHY: bullet output.
 
@@ -523,7 +523,7 @@ class MarvisTroubleshootUtils:
         """Print a bounded stringified preview of a non-dict Marvis response body.
 
         Why:
-            Non-dict payloads still deserve visibility; truncation avoids
+            Non-dict payloads still deserve visibility. Truncation avoids
             flooding the log with huge bodies.
 
         Args:
@@ -539,7 +539,7 @@ class MarvisTroubleshootUtils:
 
         Why:
             Collapses the failure banner + guidance bullets into one atomic
-            record; callers optionally prepend a workflow-specific failure
+            record. Callers optionally prepend a workflow-specific failure
             message so users see the error and remediation together.
 
         Args:
@@ -586,7 +586,7 @@ class MarvisTroubleshootUtils:
 
         Why:
             Users need a visible confirmation of which client is about to be
-            analysed; a paired structured log captures the same context for
+            analysed. A paired structured log captures the same context for
             operators reading the logs.
 
         Args:
@@ -614,7 +614,7 @@ class MarvisTroubleshootUtils:
 
         Why:
             Users need a visible confirmation of which device is about to be
-            analysed; a paired structured log captures the same context for
+            analysed. A paired structured log captures the same context for
             operators reading the logs.
 
         Args:
@@ -641,7 +641,7 @@ class MarvisTroubleshootUtils:
 
         Why:
             Users need a visible confirmation of which site is about to be
-            analysed; a paired structured log captures the same context for
+            analysed. A paired structured log captures the same context for
             operators reading the logs.
 
         Args:
@@ -655,10 +655,10 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _lookup_device(deps: MarvisTroubleshootDeps, site_id: str, device_id: str) -> tuple[str, str] | None:
-        """Fetch a device record and return (mac, name); print + return None on failure.
+        """Fetch a device record and return (mac, name). Print + return None on failure.
 
         Why:
-            Marvis needs a MAC to run; the device lookup lives in its own
+            Marvis needs a MAC to run. The device lookup lives in its own
             helper so the entry point stays small and testable.
 
         Args:
@@ -851,7 +851,7 @@ class MarvisTroubleshootUtils:
         Returns:
             Tuple of ``(display_name, zero_arg_callable)`` pairs.
         """
-        return (  # WHY: single entry today; tuple keeps future additions localised.
+        return (  # WHY: single entry today. Tuple keeps future additions localised.
             (
                 _SITES_SLE_ENDPOINT,
                 lambda: deps.mistapi.api.v1.orgs.insights.getOrgSitesSle(deps.apisession, org_id),
@@ -860,7 +860,7 @@ class MarvisTroubleshootUtils:
 
     @staticmethod
     def _try_insight_endpoint(endpoint_name: str, endpoint_func: Any, deps: MarvisTroubleshootDeps) -> bool:
-        """Invoke one insight endpoint and process its response; return True if data was rendered.
+        """Invoke one insight endpoint and process its response. Return True if data was rendered.
 
         Why:
             Per-endpoint try/except keeps the iteration loop resilient — a
@@ -937,7 +937,7 @@ class MarvisTroubleshootUtils:
         """Return the best-effort description string for an insight payload.
 
         Why:
-            The Marvis SDK returns heterogeneous shapes; this helper picks
+            The Marvis SDK returns heterogeneous shapes. This helper picks
             the most informative field available.
 
         Args:
@@ -956,7 +956,7 @@ class MarvisTroubleshootUtils:
         """Return CSV-ready rows using the SLE-specific formatter when applicable.
 
         Why:
-            SLE data has a dedicated formatter; every other endpoint gets a
+            SLE data has a dedicated formatter. Every other endpoint gets a
             generic flatten + escape pass.
 
         Args:

--- a/src/troubleshooting/troubleshoot_utils.py
+++ b/src/troubleshooting/troubleshoot_utils.py
@@ -20,7 +20,7 @@ from __future__ import annotations  # WHY: PEP 604 unions for future annotations
 
 import importlib  # WHY: lazy MistHelper import avoids circular load at module init.
 import logging  # WHY: structured trace for menu-dispatch lifecycle events.
-from typing import Any  # WHY: MarvisTroubleshootDeps is resolved lazily; annotate as Any.
+from typing import Any  # WHY: MarvisTroubleshootDeps is resolved lazily. Annotate as Any.
 
 from src.data.data_processing_utils import (
     DataProcessingUtils,

--- a/src/ui/display_utils.py
+++ b/src/ui/display_utils.py
@@ -44,7 +44,7 @@ class DisplayUtils:
     def dict_list_as_pretty_table(
         data: list[dict[str, Any]], fields: list[str] | None = None, sortby: str | None = None
     ) -> None:
-        """Render a PrettyTable from a list of dicts; debug-log the result. No-op if data is empty."""
+        """Render a PrettyTable from a list of dicts. Debug-log the result. No-op if data is empty."""
         if not data:  # Nothing to render
             return
         if fields is None:

--- a/src/ui/execution/debug_saver.py
+++ b/src/ui/execution/debug_saver.py
@@ -20,7 +20,7 @@ class DebugResultSaver:  # Owns the debug artifact write path for one API result
         self._tui = tui  # Back-reference for function_params
 
     def save(self, func_name: str, raw_result: Any, parsed_data: Any) -> None:  # Public entry point.
-        """Persist the debug artifact for one API call; logs on failure only."""
+        """Persist the debug artifact for one API call. Logs on failure only."""
         logging.info("TUI: saving debug artifact for %s", func_name)  # Action log before write
         try:
             filepath = self._build_filepath(func_name)  # Compose artifact path under DEBUG_DIR
@@ -85,7 +85,7 @@ class _Serializer:  # Internal utility: recursive JSON-safe conversion.
     @classmethod
     def _dict_to_jsonable(cls, obj: dict[Any, Any]) -> dict[Any, Any]:
         """Recursively serialize each value in a mapping."""
-        return {k: cls.to_jsonable(v) for k, v in obj.items()}  # Preserve keys; recurse on values.
+        return {k: cls.to_jsonable(v) for k, v in obj.items()}  # Preserve keys. Recurse on values.
 
     @classmethod
     def _sequence_to_jsonable(cls, obj: Any) -> list[Any]:

--- a/src/ui/execution/function_executor.py
+++ b/src/ui/execution/function_executor.py
@@ -48,7 +48,7 @@ class FunctionExecutor:  # WHY: extracted from MistHelperTUI to own Live-mode ex
         self._begin_collection_or_execute()  # Branch on whether params remain
 
     def _prepare_parameter_list(self, func: Any) -> None:  # WHY: signature probe + autofill dispatcher
-        """Inspect ``func``'s signature; build param_list + auto-fill known names."""
+        """Inspect ``func``'s signature. Build param_list + auto-fill known names."""
         tui = self._tui  # Local alias
         sig = inspect.signature(func)  # Signature object
         tui.param_list = []  # Reset collection list
@@ -93,7 +93,7 @@ class FunctionExecutor:  # WHY: extracted from MistHelperTUI to own Live-mode ex
         return True  # WHY: .env value injected
 
     def _begin_collection_or_execute(self) -> None:
-        """Start prompting when params remain; otherwise execute immediately."""
+        """Start prompting when params remain. Otherwise execute immediately."""
         tui = self._tui  # Local alias
         if tui.param_list:  # Prompt mode if any params remain
             tui.execution_state = "prompting"

--- a/src/ui/execution/item_executor.py
+++ b/src/ui/execution/item_executor.py
@@ -2,7 +2,7 @@
 
 This is the legacy fall-out-of-Live ``input()``-prompt path used outside the
 in-TUI prompting flow. Decomposed here so every helper is CC <= 5 and every
-function is <= 25 LoC; state is bundled in frozen slotted dataclasses and
+function is <= 25 LoC. State is bundled in frozen slotted dataclasses and
 result-preview branches are driven by a table-of-handlers dispatch.
 """
 
@@ -129,7 +129,7 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
         logging.exception(_LOG_FAIL, func_name, error)  # WHY: include traceback for triage
 
     def _validated_selection(self) -> dict[str, Any] | None:  # WHY: bounds + type guard
-        """Return the selected item iff it is a function; otherwise ``None``."""
+        """Return the selected item iff it is a function. Otherwise ``None``."""
         tui = self._tui  # WHY: local alias
         if not 0 <= tui.current_selection < len(tui.current_items):  # WHY: bounds check
             return None  # WHY: index out of range, not runnable
@@ -141,7 +141,7 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
     def _restore_terminal_for_prompt(self) -> None:  # WHY: switch stdin to cooked mode on Unix
         """Switch the Unix terminal back to cooked mode for ``input()``."""
         tui = self._tui  # WHY: local alias
-        if tui.IS_WINDOWS:  # WHY: Windows uses msvcrt; nothing to do
+        if tui.IS_WINDOWS:  # WHY: Windows uses msvcrt. Nothing to do
             return
         tui.termios.tcsetattr(
             sys.stdin, tui.termios.TCSADRAIN, tui.old_terminal_settings
@@ -168,7 +168,7 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
     def _collect_one_param(  # WHY: single-param table-driven dispatch (session -> env -> prompt)
         self, param_name: str, param: Any, params: dict[str, Any]
     ) -> str:
-        """Collect a single parameter; returns ``_OUTCOME_ABORT`` on hard error, else ``_OUTCOME_OK``."""
+        """Collect a single parameter. Returns ``_OUTCOME_ABORT`` on hard error, else ``_OUTCOME_OK``."""
         outcome = self._session_autofill_outcome(param_name, params)  # WHY: mist_session / apisession branch
         if outcome is not None:  # WHY: session branch handled the param
             return outcome
@@ -199,7 +199,7 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
     def _prompt_outcome(
         self, param_name: str, param: Any, params: dict[str, Any]
     ) -> str:  # WHY: interactive prompt branch
-        """Prompt the user for ``param_name``; abort when required-and-empty."""
+        """Prompt the user for ``param_name``. Abort when required-and-empty."""
         has_default = param.default != inspect.Parameter.empty  # WHY: required-vs-optional flag
         value = self._prompt_for_value(param_name, param.default, has_default)  # WHY: EOF-safe stdin read
         if not value and not has_default:  # WHY: required-but-empty - hard error
@@ -237,7 +237,7 @@ class ItemExecutor:  # WHY: extracted from MistHelperTUI to own the synchronous 
     def _invoke_and_display(  # WHY: call, capture, and render a bounded preview
         self, func: Any, func_name: str, params: dict[str, Any]
     ) -> None:
-        """Invoke ``func`` with ``params``; render a safe preview to stdout."""
+        """Invoke ``func`` with ``params``. Render a safe preview to stdout."""
         tui = self._tui  # WHY: local alias
         redacted = {k: _redact(k, v) for k, v in params.items()}  # WHY: redact secrets before logging
         logging.info(_LOG_CALL, func_name, redacted)  # WHY: log the redacted call site

--- a/src/ui/execution/output_formatter.py
+++ b/src/ui/execution/output_formatter.py
@@ -16,7 +16,7 @@ class APIResponseParser:
     """Extract the ``data`` attribute from mistapi ``APIResponse`` objects."""
 
     def parse(self, result: Any) -> Any:
-        """Return ``result.data`` when present; otherwise ``result`` unchanged."""
+        """Return ``result.data`` when present. Otherwise ``result`` unchanged."""
         if hasattr(result, "data"):  # mistapi APIResponse shape
             logging.debug("TUI_DEBUG: Detected APIResponse object, extracting data attribute")
             return result.data
@@ -67,7 +67,7 @@ class HierarchicalFormatter:
             self._render_dict_entry(child_key, child_value, output, indent)
 
     def _render_dict_entry(self, key: str, child_value: Any, output: list[str], indent: int) -> None:
-        """Emit a single key from a dict; recurse into nested structures."""
+        """Emit a single key from a dict. Recurse into nested structures."""
         if isinstance(child_value, (dict, list)):  # Recurse for nested structures
             self._render(child_value, output, indent + 1, key_name=key)
             return
@@ -96,7 +96,7 @@ class HierarchicalFormatter:
             output.append(f"{indent_str}  ... {item_count - display_count} more items")
 
     def _render_sequence_item(self, item: Any, output: list[str], indent: int, idx: int) -> None:
-        """Emit one item of a sequence; recurse for nested types."""
+        """Emit one item of a sequence. Recurse for nested types."""
         indent_str = "  " * indent  # Indent for the item line
         if isinstance(item, dict):  # Dict item -> show key sample
             output.append(f"{indent_str}  [{idx}]: dict ({len(item)} keys)")

--- a/src/ui/execution/parameter_collector.py
+++ b/src/ui/execution/parameter_collector.py
@@ -20,7 +20,7 @@ class ParameterCollector:  # WHY: extracted from MistHelperTUI._submit_parameter
         self._executor = executor  # Used to run when collection is done
 
     def submit(self) -> None:  # WHY: user pressed Enter on the parameter prompt
-        """Submit the current parameter value; advance index or run the call."""
+        """Submit the current parameter value. Advance index or run the call."""
         tui = self._tui  # Local alias
         if tui.current_param_index >= len(tui.param_list):  # Guard: nothing pending
             return  # WHY: idempotent no-op when collection already complete
@@ -42,7 +42,7 @@ class ParameterCollector:  # WHY: extracted from MistHelperTUI._submit_parameter
         return self._capture_nonempty(param_info, value)  # Non-empty value branch
 
     def _capture_empty(self, param_info: dict[str, Any]) -> bool:  # WHY: required->error, optional->default/None
-        """Handle empty input: required -> error; optional -> default/None."""
+        """Handle empty input: required -> error. Optional -> default/None."""
         tui = self._tui  # Local alias
         param_name = param_info["name"]  # Used in messages
         if not param_info["has_default"]:  # Required parameter must have a value

--- a/src/ui/input_handlers/key_poller.py
+++ b/src/ui/input_handlers/key_poller.py
@@ -25,7 +25,7 @@ _WINDOWS_SPECIAL_KEYS: dict[bytes, str] = {
 }
 
 # Dispatch table for Unix CSI sequences (ESC [ X ...).
-# Only the simple single-letter terminators are mapped here; the "5~" / "6~"
+# Only the simple single-letter terminators are mapped here. The "5~" / "6~"
 # page sequences are handled inline in _parse_unix_csi because they require
 # inspecting the third byte.
 _UNIX_CSI_LETTERS: dict[str, str] = {

--- a/src/ui/input_handlers/keyboard_dispatch.py
+++ b/src/ui/input_handlers/keyboard_dispatch.py
@@ -49,7 +49,7 @@ class KeyboardDispatchTable:  # WHY: replaces handle_input (was CC=65) with O(1)
     # ---- shared helpers --------------------------------------------------
 
     def _dispatch_with(self, table: dict[str, Callable[[], None]], key: str, mode: str) -> None:  # WHY: shared O(1)
-        """Invoke ``table[key]`` if present; otherwise debug-log the unhandled key."""
+        """Invoke ``table[key]`` if present. Otherwise debug-log the unhandled key."""
         handler = table.get(key)  # O(1) dispatch lookup
         if handler is None:  # Unknown key for this mode
             if self._tui.debug_mode:  # WHY: only trace unhandled keys in debug mode
@@ -122,7 +122,7 @@ class KeyboardDispatchTable:  # WHY: replaces handle_input (was CC=65) with O(1)
         self._tui.result_row_scroll = max(0, self._tui.result_row_scroll - 10)  # WHY: clamp at top row
 
     def _results_row_down(self) -> None:  # WHY: bound handler for down-arrow in results view
-        """Scroll down 10 rows; ResultsGridBuilder clamps the upper bound."""
+        """Scroll down 10 rows. ResultsGridBuilder clamps the upper bound."""
         self._tui.result_row_scroll += 10  # Builder handles bounds
 
     def _results_page_up(self) -> None:  # WHY: bound handler for page-up in results view
@@ -140,7 +140,7 @@ class KeyboardDispatchTable:  # WHY: replaces handle_input (was CC=65) with O(1)
     def _results_jump_end(self) -> None:  # WHY: bound handler for 'e' shortcut
         """Jump to the end of the current result (builder caps the value)."""
         if self._safe_results():  # Only jump if there is data
-            self._tui.result_row_scroll = 999999  # Sentinel; builder clamps
+            self._tui.result_row_scroll = 999999  # Sentinel. Builder clamps
 
     def _results_close(self) -> None:  # WHY: bound handler for escape/q in results view
         """Exit the results-view state and return to navigation."""
@@ -213,7 +213,7 @@ class KeyboardDispatchTable:  # WHY: replaces handle_input (was CC=65) with O(1)
         logging.info("TUI: Navigated into module: %s", module_name)
 
     def _nav_back(self) -> None:
-        """Escape: pop one level off the path; quit when already at root."""
+        """Escape: pop one level off the path. Quit when already at root."""
         tui = self._tui  # Local alias
         if not tui.current_path:  # Already at root -> escape quits
             tui.running = False

--- a/src/ui/layout/results_grid_builder.py
+++ b/src/ui/layout/results_grid_builder.py
@@ -11,7 +11,7 @@ import logging  # WHY: structured action logging for build lifecycle
 from typing import Any  # WHY: TUI hooks + payload values are heterogeneous
 
 MAX_VISIBLE_ROWS = 25  # WHY: hard cap on visible rows so wide payloads stay legible
-UUID_LEN = 36  # WHY: canonical hyphenated UUID length; used by _is_uuid_like
+UUID_LEN = 36  # WHY: canonical hyphenated UUID length. Used by _is_uuid_like
 SIMPLE_LIST_TYPES = (str, int, float, bool, type(None))  # WHY: primitives render inline
 SEPARATOR_ROW_TYPE = "separator"  # WHY: sentinel row type read by _populate_table
 _SEPARATOR_FIELD = "[dim]" + "-" * 40 + "[/dim]"  # WHY: pre-built dashed field cell

--- a/src/ui/prompt_utils.py
+++ b/src/ui/prompt_utils.py
@@ -106,7 +106,7 @@ class PromptUtils:  # General prompt helpers.
 
     @staticmethod
     def _resolve_device_selection(user_input: str, index_to_device: dict, name_to_device: dict) -> str | None:
-        """Resolve ``user_input`` to a device id by index or name; return None on miss."""
+        """Resolve ``user_input`` to a device id by index or name. Return None on miss."""
         normalized = user_input[1:] if user_input.startswith(".") else user_input  # Strip leading dot.
         if normalized.isdigit():  # Numeric index path.
             idx = int(normalized)  # Parse index.
@@ -125,7 +125,7 @@ class PromptUtils:  # General prompt helpers.
 
     @staticmethod
     def select_site_id_from_csv(csv_file: str = "SiteList.csv") -> str | None:  # Prompt site id from CSV.
-        """Prompt user to select a site by index or name from csv_file; returns the site ID or None."""
+        """Prompt user to select a site by index or name from csv_file. Returns the site ID or None."""
         mh = importlib.import_module("MistHelper")
         CacheUtils.check_and_generate_csv(csv_file, OrgSiteExporter.sites)  # Ensure site CSV exists/fresh.
         index_to_site, name_to_site = PromptUtils._load_site_csv_maps(csv_file)  # Read CSV into index/name maps.
@@ -162,7 +162,7 @@ class PromptUtils:  # General prompt helpers.
 
     @staticmethod
     def _pick_site_by_index(idx: int, index_to_site: dict[int, dict]) -> str | None:  # type: ignore[type-arg]
-        """Resolve a numeric site index to a site_id; print/log selection or invalid-index message."""
+        """Resolve a numeric site index to a site_id. Print/log selection or invalid-index message."""
         if idx not in index_to_site:  # Validate index exists.
             # WHY (#886 Phase 2): collapse paired print+logger into a single logging.warning so
             # the invalid-index banner reaches the operator via the same handler chain.
@@ -177,7 +177,7 @@ class PromptUtils:  # General prompt helpers.
 
     @staticmethod
     def _pick_site_by_name(name: str, name_to_site: dict[str, dict]) -> str | None:  # type: ignore[type-arg]
-        """Resolve a site name to a site_id; print/log the selection."""
+        """Resolve a site name to a site_id. Print/log the selection."""
         site_id = name_to_site[name].get("id")  # Read site id by name.
         # WHY (#886 Phase 2): retire print() in favor of logging.warning so operator sees the
         # confirmation banner on the default root-logger config (INFO is suppressed by default).
@@ -355,7 +355,7 @@ class PromptUtils:  # General prompt helpers.
 
     @staticmethod
     def _display_client_table(all_clients: list[dict], sites_cache: dict[str, str]) -> dict[int, dict]:  # type: ignore[type-arg]
-        """Render the client selection table and a summary line; return an index-to-client map for selection."""
+        """Render the client selection table and a summary line. Return an index-to-client map for selection."""
         table = PromptUtils._build_client_table_skeleton()  # Build empty table with columns + alignment
         for idx, client in enumerate(all_clients):  # Enumerate clients for rows
             row = PromptUtils._format_client_row(idx, client, sites_cache)  # Format a client row

--- a/src/ui/runtime/dotenv_loader.py
+++ b/src/ui/runtime/dotenv_loader.py
@@ -17,7 +17,7 @@ class DotenvLoader:  # WHY: extracted from MistHelperTUI._load_dotenv_only (was 
         self._tui = tui  # Back-reference for debug flag
 
     def load(self) -> dict[str, str]:  # WHY: read .env once at startup
-        """Return ``{key: value}`` parsed from ``.env``; empty dict on failure."""
+        """Return ``{key: value}`` parsed from ``.env``. Empty dict on failure."""
         logging.info("TUI: loading .env values")  # Action log before read
         if not os.path.exists(DOTENV_FILENAME):  # No file -> empty result
             return {}  # WHY: absent .env is not an error, just an empty result

--- a/src/ui/runtime/level_discoverer.py
+++ b/src/ui/runtime/level_discoverer.py
@@ -18,7 +18,7 @@ class LevelDiscoverer:
         self._tui = tui  # Back-reference for TUI state
 
     def discover(self) -> None:
-        """Discover modules + functions at the current path; update TUI state."""
+        """Discover modules + functions at the current path. Update TUI state."""
         tui = self._tui  # Local alias
         tui.current_items = []  # Reset items list
         module_path = self._compose_module_path()  # Build "mistapi.api.v1[...]" path
@@ -46,7 +46,7 @@ class LevelDiscoverer:
         return "mistapi.api.v1." + ".".join(path)  # Deeper level joined with dots
 
     def _import_module(self, module_path: str) -> Any:
-        """Import ``module_path``; set error item on failure and return None."""
+        """Import ``module_path``. Set error item on failure and return None."""
         try:
             module = importlib.import_module(module_path)  # Try the import
         except ImportError as error:  # Module not found -> show error

--- a/src/ui/runtime/tui_runner.py
+++ b/src/ui/runtime/tui_runner.py
@@ -43,7 +43,7 @@ class TuiRunner:  # WHY: extracted from MistHelperTUI.run (was CC=33)
     def _setup_terminal(self) -> None:  # WHY: enter cbreak so keys read w/o Enter
         """Put the Unix terminal into raw (cbreak) mode for keypress capture."""
         tui = self._tui  # Local alias
-        if tui.IS_WINDOWS:  # Windows uses msvcrt; nothing to prepare
+        if tui.IS_WINDOWS:  # Windows uses msvcrt. Nothing to prepare
             return  # WHY: no-op on Windows
         tui.old_terminal_settings = tui.termios.tcgetattr(sys.stdin)  # Save current termios for restore
         tui.tty.setcbreak(sys.stdin.fileno())  # Enter cbreak mode

--- a/src/ui/tui.py
+++ b/src/ui/tui.py
@@ -6,7 +6,7 @@ mistapi SDK hierarchy interactively.
 
 Internally this class is now a *thin orchestrator* that composes focused
 collaborators (input, layout, execution, runtime) under ``src/ui/``. All
-heavy logic lives in those collaborator modules; this class wires them
+heavy logic lives in those collaborator modules. This class wires them
 together and exposes the original public surface unchanged.
 """
 
@@ -207,7 +207,7 @@ class MistHelperTUI:  # WHY: public TUI entrypoint composing all collaborators
         max_items: int = 5,
     ) -> None:
         """Recursively format ``value`` into ``output`` (delegate)."""
-        # ``max_items`` is preserved in the signature for back-compat; the collaborator
+        # ``max_items`` is preserved in the signature for back-compat. The collaborator
         # uses its own MAX_SAMPLE_ITEMS constant.
         del max_items  # Explicitly acknowledge unused param
         self._hier_formatter._render(value, output, indent, key_name)  # Reuse the internal renderer

--- a/src/utils/address_utils.py
+++ b/src/utils/address_utils.py
@@ -16,7 +16,7 @@ import re  # WHY: regex normalization of addresses, zip codes, and business suff
 import time  # WHY: rate-limit + retry backoff around Nominatim API calls
 import traceback  # WHY: capture exception context in geocode debug logs
 import unicodedata  # WHY: NFKD normalization strips diacritics before comparison
-from collections.abc import Callable  # WHY: Any for opaque JSON payloads; Callable for dispatch map
+from collections.abc import Callable  # WHY: Any for opaque JSON payloads. Callable for dispatch map
 from dataclasses import dataclass, field  # WHY: config + address/skip bundling for STRUCT-PARAMS compliance
 from difflib import SequenceMatcher  # WHY: string-ratio helper used by org-name similarity
 from typing import Any
@@ -34,12 +34,12 @@ except ImportError:  # pragma: no cover  # WHY: absence is non-fatal
     urllib3 = None  # type: ignore[assignment]  # WHY: sentinel checked before disabling warnings
     _has_urllib3 = False  # WHY: skip suppression path when the module is missing
 
-try:  # WHY: rapidfuzz is optional; degrade to difflib on absence
+try:  # WHY: rapidfuzz is optional. Degrade to difflib on absence
     from rapidfuzz import fuzz  # WHY: faster token-sort ratio when available
 except ImportError:  # pragma: no cover  # WHY: keep import graph optional
     fuzz = None  # type: ignore[assignment]  # WHY: sentinel checked before use
 
-try:  # WHY: scourgify is optional; heuristic parser handles the rest
+try:  # WHY: scourgify is optional. Heuristic parser handles the rest
     from scourgify import normalize_address_record  # WHY: high-quality USPS-style parse
 except ImportError:  # pragma: no cover  # WHY: fall back to heuristic parser
     normalize_address_record = None  # WHY: sentinel checked before use
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover  # WHY: fall back to heuristic parser
 class AddressValidationConfig:
     """Configuration for address validation with Nominatim."""
 
-    timeout: int = 5  # WHY: seconds per HTTP attempt; retries add linear back-off
+    timeout: int = 5  # WHY: seconds per HTTP attempt. Retries add linear back-off
     debug: bool = False  # WHY: enables verbose parse + geocode logging
     skip_ssl_verify: bool = False  # WHY: internal MITM proxies sometimes need this
     org_name: str | None = None  # WHY: powers the org-name similarity tiebreaker
@@ -338,7 +338,7 @@ class AddressUtils:
     @staticmethod
     def _empty_parse_result(address_string: str | None) -> dict[str, Any]:
         """Return the base (all-unset) parsed-address result skeleton."""
-        return {  # WHY: every field starts unset; parser fills them on success
+        return {  # WHY: every field starts unset. Parser fills them on success
             "address": None,  # WHY: street line, None until parsed
             "city": None,  # WHY: city component, None until parsed
             "state": None,  # WHY: state/region, None until parsed
@@ -640,7 +640,7 @@ def _count_field_matches(
     skip_fields: list[str],
 ) -> int:
     """Count how many non-empty skip fields match comparison fields."""
-    return sum(  # WHY: sum booleans; only non-empty skip fields with equal comp count
+    return sum(  # WHY: sum booleans. Only non-empty skip fields with equal comp count
         bool(skip_val and comp_val == skip_val)  # WHY: skip field must be populated to count
         for comp_val, skip_val in zip(comp_fields, skip_fields, strict=True)  # WHY: strict=True catches shape drift
     )
@@ -686,7 +686,7 @@ def _check_parse_status(
     field_weights: dict[str, float],
 ) -> dict[str, Any]:
     """Check if addresses are parseable."""
-    status: dict[str, Any] = {  # WHY: default both sides parseable; downgrade on placeholder tokens
+    status: dict[str, Any] = {  # WHY: default both sides parseable. Downgrade on placeholder tokens
         "mist_parseable": True,  # WHY: assume valid until proven otherwise
         "comparison_parseable": True,  # WHY: assume valid until proven otherwise
         "mist_reason": "valid",  # WHY: default status label

--- a/src/utils/environment_utils.py
+++ b/src/utils/environment_utils.py
@@ -40,7 +40,7 @@ class EnvironmentUtils:
             if value in EnvironmentUtils.TRUE_VALUES:  # Operator forced container mode on.
                 logging.debug("Container detection: override via %s=%s", explicit_var, value)  # Trace the override.
                 return True  # Short-circuit: treat as a container.
-        return None  # No override set; defer to other detectors.
+        return None  # No override set. Defer to other detectors.
 
     @staticmethod
     def _check_dockerenv_file() -> bool:  # Detect Docker's /.dockerenv sentinel file.
@@ -57,7 +57,7 @@ class EnvironmentUtils:
             if os.environ.get(env_var):  # Any non-empty value signals a container.
                 logging.debug("Container detection: environment variable %s present", env_var)  # Trace which one.
                 return True  # Treat as containerized.
-        return False  # None present; inconclusive here.
+        return False  # None present. Inconclusive here.
 
     @staticmethod
     def _check_cgroup_markers() -> bool:
@@ -126,7 +126,7 @@ class EnvironmentUtils:
 
     @staticmethod
     def _run_container_detectors() -> bool:
-        """Run the ordered fallback container detectors; return True if any positive."""
+        """Run the ordered fallback container detectors. Return True if any positive."""
         checks = [  # Ordered fallback detectors in reliability order
             EnvironmentUtils._check_dockerenv_file,
             EnvironmentUtils._check_container_env_vars,

--- a/src/utils/file_path_utils.py
+++ b/src/utils/file_path_utils.py
@@ -38,7 +38,7 @@ class FilePathUtils:
         """
         # Ensure data directory exists
         data_dir = "data"  # All exports are confined to the data/ directory.
-        os.makedirs(data_dir, exist_ok=True)  # Create data/ on first use; no error if it exists.
+        os.makedirs(data_dir, exist_ok=True)  # Create data/ on first use. No error if it exists.
 
         # If filename already includes a path, use it as-is
         if os.path.dirname(filename):  # Caller supplied an explicit directory.
@@ -52,7 +52,7 @@ class FilePathUtils:
         filename: str, headers: list[str] | None = None, sample_data: list[list[str]] | None = None
     ) -> str:  # Create an empty CSV placeholder with optional headers.
         """Create an empty CSV under data/ with optional header row; sample_data is intentionally ignored."""
-        del sample_data  # Kept in signature for API compatibility; explicitly discard so linters do not flag it.
+        del sample_data  # Kept in signature for API compatibility. Explicitly discard so linters do not flag it.
         file_path = FilePathUtils.get_csv_path(filename)  # Normalize the destination under data/.
         try:
             with open(file_path, "w", newline="", encoding="utf-8") as f:  # Truncate/create the file.

--- a/src/utils/filter_operator_engine.py
+++ b/src/utils/filter_operator_engine.py
@@ -58,7 +58,7 @@ class FilterOperatorEngine:  # Filter operator evaluation engine.
         """Remove delimiters and lowercase for delimiter-insensitive comparison."""
         if not mac_value:  # Empty input.
             return ""  # Return empty.
-        return re.sub(r"[:\-.]", "", mac_value).lower()  # Strip separators; lowercase.
+        return re.sub(r"[:\-.]", "", mac_value).lower()  # Strip separators. Lowercase.
 
     @staticmethod
     def normalize_text(text_value: str) -> str:  # Normalize free text.

--- a/src/utils/input_utils.py
+++ b/src/utils/input_utils.py
@@ -32,14 +32,14 @@ class InputUtils:
 
     @staticmethod
     def ensure_tqdm_available() -> bool:
-        """Return True when the real ``tqdm`` package is active; False when the wrapper's fallback is in use.
+        """Return True when the real ``tqdm`` package is active. False when the wrapper's fallback is in use.
 
         The rebind dance that lived in ``MistHelper.InputUtils`` before
         initiative 1015 T-09 is no longer needed: T-14 made
         ``src.utils.tqdm_wrapper`` resolve the real ``tqdm`` at import
         time and expose a no-op iterable-passthrough when the package is
         missing. Callers still invoke this probe for its logging side
-        effect; the return value is informational.
+        effect. The return value is informational.
         """
         if hasattr(_tqdm, "__module__") and _tqdm.__module__.startswith("tqdm"):  # Real tqdm package is active.
             logging.debug("ensure_tqdm_available: real tqdm package is active")  # Action-log the healthy path.

--- a/src/utils/logger_utils.py
+++ b/src/utils/logger_utils.py
@@ -38,7 +38,7 @@ def redact_secret(value: str) -> str:
         logging.debug("Using credential: %s", redact_secret(password))
         # → "Using credential: ***REDACTED***"
     """
-    _ = value  # Accept the value so callers do not need to gate on None; discard it
+    _ = value  # Accept the value so callers do not need to gate on None. Discard it
     return REDACTED_PLACEHOLDER  # Return placeholder instead of the real value
 
 
@@ -63,7 +63,7 @@ def redact_if_sensitive(key: str, value: str) -> str:
     """
     if _SENSITIVE_KEY_PATTERNS.search(key):  # Key matches a credential pattern
         return REDACTED_PLACEHOLDER  # Discard value and return placeholder
-    return value  # Key is not credential-like; return value unchanged
+    return value  # Key is not credential-like. Return value unchanged
 
 
 class SensitiveFilter(logging.Filter):
@@ -111,5 +111,5 @@ class SensitiveFilter(logging.Filter):
                 record.msg = sanitized  # Replace the message with the sanitized version
                 record.args = ()  # Clear args so getMessage() uses the new msg directly
         except Exception:  # noqa: BLE001 — never crash a logging filter
-            pass  # Silently ignore filter errors; logging must not interrupt execution
-        return True  # Always pass the record on; we only sanitize, never suppress
+            pass  # Silently ignore filter errors. Logging must not interrupt execution
+        return True  # Always pass the record on. We only sanitize, never suppress

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -16,7 +16,7 @@ websocket        Requires WebSocket + interactive selection
 continuous_loop  Never terminates without user stop
 interactive      Needs user input not automatable
 unregistered     Fail-closed fallback (feature 1020) -- returned by ``get`` for any option
-                 absent from ``_REGISTRY``; a SKIP_CATEGORIES member, never written into
+                 absent from ``_REGISTRY``. A SKIP_CATEGORIES member, never written into
                  ``_REGISTRY`` by hand, so an unclassified option is never auto-run.
 """
 
@@ -32,7 +32,7 @@ _OptionEntry = dict[str, str]
 def _natural_option_sort_key(option: str) -> float:
     """Sort key that treats an ``aN`` suffix as a decimal so ``26a`` sorts just after ``26``.
 
-    The legacy inline sort used ``float(x.replace("a", ".1"))``; keeping the same key preserves
+    The legacy inline sort used ``float(x.replace("a", ".1"))``. Keeping the same key preserves
     the historical ordering the guardrail tests rely on.
     """
     return float(option.replace("a", ".1"))
@@ -289,8 +289,8 @@ class OperationRegistry:
         # 60 previously-unregistered menu_actions keys. Each category was
         # decided from the handler's real read-only versus state-changing
         # behavior (see research.md R1). Read-only exporters are "safe";
-        # heavy sweeps are "resource_intensive"; write/create operations are
-        # "destructive"; ticket viewing prompts for a selection so it is
+        # heavy sweeps are "resource_intensive". Write/create operations are
+        # "destructive". Ticket viewing prompts for a selection so it is
         # "interactive". This removes reliance on the fail-closed default for
         # any currently-reachable option.
         # ------------------------------------------------------------------
@@ -390,7 +390,7 @@ class OperationRegistry:
 
     # Wave 1 deterministic safety-boundary baseline used by classification guardrails.
     # Feature 1020: the former "9999" sentinel was a key absent from menu_actions that only
-    # read True under the old fail-open default; replaced with real safe key "13" now that the
+    # read True under the old fail-open default. Replaced with real safe key "13" now that the
     # default is fail-closed (an unregistered key like "9999" is now correctly is_safe()==False).
     WAVE1_SAFETY_CLASSIFICATION_BASELINE: dict[str, list[str]] = {
         "safe_true": ["26", "58", "13"],

--- a/src/utils/rate_limiting.py
+++ b/src/utils/rate_limiting.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass  # WHY: bundle PID inputs into a frozen slot o
 from datetime import UTC, datetime  # WHY: UTC-anchored hour-boundary detection.
 from typing import Any  # WHY: typed dict payloads flowing through file I/O helpers.
 
-try:  # WHY: numpy is optional; fall back to pure-Python stdev when absent.
+try:  # WHY: numpy is optional. Fall back to pure-Python stdev when absent.
     import numpy as np  # WHY: vectorised std-dev calculation when available.
 
     _has_numpy = True  # WHY: gate numpy branches on import success.
@@ -63,9 +63,9 @@ _MICRO_DIVISOR = 1_000_000  # WHY: microsecond-to-second divisor for subsecond p
 def _get_tuning_data_file_path() -> str:  # WHY: build absolute tuning-data path with graceful fallback.
     """Determine the tuning data file path, preferring data/ directory."""
     data_dir = os.path.join(os.getcwd(), _DATA_DIR)  # WHY: build absolute data/ path once.
-    try:  # WHY: creation may fail on read-only filesystems; fall back cleanly.
+    try:  # WHY: creation may fail on read-only filesystems. Fall back cleanly.
         os.makedirs(data_dir, exist_ok=True)  # WHY: ensure data/ exists idempotently.
-    except OSError:  # WHY: narrow to filesystem errors; other exceptions must bubble.
+    except OSError:  # WHY: narrow to filesystem errors. Other exceptions must bubble.
         return os.path.join(os.getcwd(), _TUNING_FILENAME)  # WHY: cwd fallback keeps writes possible.
     return os.path.join(data_dir, _TUNING_FILENAME)  # WHY: preferred data/ path when writable.
 
@@ -103,7 +103,7 @@ def _defaults() -> dict[str, Any]:  # WHY: single source of truth for cold-start
 
 def _is_finite_number(value: Any) -> bool:  # WHY: shared predicate for input sanitisation across helpers.
     """Return True when value is a finite int/float (bool excluded)."""
-    if isinstance(value, bool):  # WHY: bool is int subclass; excluded to avoid True==1.0 pollution.
+    if isinstance(value, bool):  # WHY: bool is int subclass. Excluded to avoid True==1.0 pollution.
         return False  # WHY: reject boolean sentinel as non-numeric.
     if not isinstance(value, (int, float)):  # WHY: only numeric samples participate in PID math.
         return False  # WHY: reject non-numeric input types.
@@ -125,7 +125,7 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
 
     @staticmethod
     def _read_tuning_file() -> dict[str, Any] | None:  # WHY: split I/O from parsing so caller handles None default.
-        """Read raw tuning-data JSON; return None on any I/O or decode error."""
+        """Read raw tuning-data JSON. Return None on any I/O or decode error."""
         if not os.path.exists(tuning_data_file):  # WHY: absence is the common cold-start case.
             logging.debug("File I/O: %s does not exist, using defaults", tuning_data_file)  # WHY: trace missing file.
             return None  # WHY: signal cold-start to caller.
@@ -159,11 +159,11 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
         """Save PID tuning data to file with comprehensive logging."""
         keys = list(data.keys()) if data else []  # WHY: log summary avoids leaking full payload.
         logging.debug("ENTRY: RateLimitingUtils._save_pid_tuning_data(data_keys=%s)", keys)  # WHY: entry trace.
-        try:  # WHY: caller expects OSError on unwritable paths; keep raise.
+        try:  # WHY: caller expects OSError on unwritable paths. Keep raise.
             with open(tuning_data_file, "w") as file_handle:  # WHY: overwrite prior tuning snapshot atomically.
                 json.dump(data, file_handle, indent=2)  # WHY: indent keeps file diff-friendly.
             logging.debug("File I/O: Successfully wrote PID tuning data to %s", tuning_data_file)  # WHY: success log.
-        except OSError as write_error:  # WHY: narrow catch; upstream re-raise preserved.
+        except OSError as write_error:  # WHY: narrow catch. Upstream re-raise preserved.
             logging.error("File I/O: Error writing to %s: %s", tuning_data_file, write_error)  # WHY: surface failure.
             raise  # WHY: contract requires caller to see write failures.
 
@@ -184,10 +184,10 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
         errors: list[float], min_alpha: float = _ALPHA_MIN, max_alpha: float = _ALPHA_MAX
     ) -> float:  # WHY: adaptive smoothing responds to error dispersion.
         """Compute a dynamic smoothing factor alpha based on error standard deviation."""
-        if len(errors) < 2:  # WHY: std-dev undefined for <2 samples; use safe fallback.
+        if len(errors) < 2:  # WHY: std-dev undefined for <2 samples. Use safe fallback.
             return _ALPHA_FALLBACK  # WHY: default smoothing when history is insufficient.
 
-        try:  # WHY: numpy path may still raise on exotic inputs; be defensive.
+        try:  # WHY: numpy path may still raise on exotic inputs. Be defensive.
             standard_deviation = RateLimitingUtils._calculate_std_dev(errors[-_ADJUST_WINDOW:])  # WHY: window std-dev.
             normalized = min(standard_deviation / _STDDEV_NORMALISER, 1.0)  # WHY: cap at 1.0 for bounded interpolation.
             return round(min_alpha + (max_alpha - min_alpha) * normalized, 3)  # WHY: rounded for stable logs.
@@ -209,10 +209,10 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
         """Resolve the metrics log file path into the data/ directory."""
         if filename != _METRICS_FILENAME:  # WHY: only the canonical filename is auto-relocated.
             return filename  # WHY: caller-supplied filenames pass through unchanged.
-        try:  # WHY: makedirs may fail on read-only FS; keep original name if so.
+        try:  # WHY: makedirs may fail on read-only FS. Keep original name if so.
             os.makedirs(_DATA_DIR, exist_ok=True)  # WHY: ensure data/ exists idempotently.
             return os.path.join(_DATA_DIR, filename)  # WHY: relocated path prefers data/ dir.
-        except OSError as directory_error:  # WHY: narrow catch; fall back to bare filename.
+        except OSError as directory_error:  # WHY: narrow catch. Fall back to bare filename.
             logging.error("File I/O: Failed to ensure data directory: %s", directory_error)  # WHY: surface FS issue.
             return filename  # WHY: fallback to bare filename when data/ unwritable.
 
@@ -221,7 +221,7 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
         """Read existing JSONL entries from a metrics log file."""
         if not os.path.exists(filepath):  # WHY: absence just means empty history.
             return []  # WHY: no prior entries to preserve.
-        try:  # WHY: partial corruption should not crash the pipeline; discard and start fresh.
+        try:  # WHY: partial corruption should not crash the pipeline. Discard and start fresh.
             entries: list[dict[str, Any]] = []  # WHY: accumulator for decoded rows.
             with open(filepath, encoding="utf-8") as file_handle:  # WHY: explicit utf-8 for portability.
                 for line in file_handle:  # WHY: line-oriented so we can skip blanks.
@@ -282,7 +282,7 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
         apisession: Any, api_usage_cache: dict[str, Any], current_time: float
     ) -> None:  # WHY: authoritative refresh from the Mist usage endpoint.
         """Refresh API usage data from the Mist API."""
-        try:  # WHY: mistapi may be absent or the call may fail; swallow gracefully.
+        try:  # WHY: mistapi may be absent or the call may fail. Swallow gracefully.
             import mistapi  # WHY: lazy import keeps module import cheap and testable.
 
             usage = mistapi.api.v1.self.usage.getSelfApiUsage(apisession).data  # WHY: canonical usage endpoint.
@@ -294,7 +294,7 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
             logging.debug(
                 "API usage refreshed: %d/%d requests", api_usage_cache["used"], api_usage_cache["limit"]
             )  # WHY: trace successful refresh.
-        except Exception as api_error:  # WHY: mistapi may raise anything; log and continue with cached values.
+        except Exception as api_error:  # WHY: mistapi may raise anything. Log and continue with cached values.
             logging.warning("Failed to refresh API usage data: %s. Using cached values.", api_error)  # WHY: warn.
 
     @staticmethod
@@ -561,7 +561,7 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
             return RateLimitingUtils._run_pid_pipeline(
                 apisession, api_usage_cache, tuning_data, smoothed_delay
             )  # WHY: happy path.
-        except Exception as rate_error:  # WHY: safety net; log and use fallback delay for any unexpected failure.
+        except Exception as rate_error:  # WHY: safety net. Log and use fallback delay for any unexpected failure.
             logging.error(
                 "Failed to calculate dynamic delay: %s. Using 500ms fallback.", rate_error
             )  # WHY: surface failure.
@@ -586,7 +586,7 @@ class RateLimitingUtils:  # WHY: static-method facade groups rate-limit helpers 
         logging.debug("ENTRY: get_rate_limited_delay(smoothed_delay=%s)", smoothed_delay)  # WHY: trace entry.
         if api_usage_cache is None:  # WHY: fail-safe when caller omits the shared cache.
             logging.warning("api_usage_cache not provided, using fallback delay")  # WHY: surface missing cache.
-            return smoothed_delay, _FALLBACK_DELAY  # WHY: cannot run PID without cache; return safe fallback.
+            return smoothed_delay, _FALLBACK_DELAY  # WHY: cannot run PID without cache. Return safe fallback.
 
         tuning_data = RateLimitingUtils._load_pid_tuning_data()  # WHY: seed tuning state from disk.
         RateLimitingUtils._reset_gains_if_needed(tuning_data)  # WHY: coerce corrupt gains before math.

--- a/src/utils/subprocess_runner.py
+++ b/src/utils/subprocess_runner.py
@@ -75,7 +75,7 @@ class SubprocessRunner:
             timeout: Positive finite float seconds; ``None`` and non-positive
                 values raise :class:`ValueError` before any process spawn.
             check: When ``True`` (default) a non-zero exit raises
-                :class:`subprocess.CalledProcessError`; the caller may set
+                :class:`subprocess.CalledProcessError`. The caller may set
                 ``False`` to inspect ``returncode`` manually.
 
         Returns:
@@ -100,9 +100,9 @@ class SubprocessRunner:
             result = subprocess.run(  # nosec B603  # Audited: argv validated, no shell, capture pinned.
                 list(argv),  # Copy to a plain list so callers cannot mutate the sequence mid-flight.
                 capture_output=True,  # Always capture stdout/stderr for callers that inspect them.
-                text=True,  # Always decode as text; every existing call site expected str output.
+                text=True,  # Always decode as text. Every existing call site expected str output.
                 timeout=timeout,  # Bound the child so a hung process cannot stall MistHelper startup.
-                check=check,  # Honour caller's check policy; default True matches most call sites.
+                check=check,  # Honour caller's check policy. Default True matches most call sites.
             )
         except subprocess.TimeoutExpired:  # Timeouts propagate; exc.__str__ contains argv, so log timeout only.
             logger.error("SubprocessRunner timed out %s after %ss", executable, timeout)  # Principle VII: error log.
@@ -115,7 +115,7 @@ class SubprocessRunner:
 
     @classmethod
     def _validate_argv(cls, argv: Sequence[str]) -> None:
-        """Validate argv shape and every element; raises :class:`ValueError` on failure."""
+        """Validate argv shape and every element. Raises :class:`ValueError` on failure."""
         if not argv:  # Empty sequence is never a legitimate command.
             raise ValueError("argv must be a non-empty sequence")  # Fail closed before any spawn.
         executable = argv[0]  # First element is the program to run.

--- a/src/utils/tqdm_wrapper.py
+++ b/src/utils/tqdm_wrapper.py
@@ -5,7 +5,7 @@ MistHelper.py:774-780 as a no-op fallback that was later overridden
 with the real ``tqdm`` package during import initialization.
 
 This module resolves the tension at import time: it tries to import the
-real ``tqdm`` package and re-exports it under the name ``tqdm``; when
+real ``tqdm`` package and re-exports it under the name ``tqdm``. When
 the package is not installed, it falls back to an iterable pass-through
 that preserves caller code unchanged. Callers therefore always get a
 callable named ``tqdm`` that accepts the same signature regardless of
@@ -33,7 +33,7 @@ except ImportError:  # tqdm not installed -- fall back to a no-op pass-through.
     logging.info("tqdm_wrapper: real tqdm not installed; using no-op fallback.")  # Info envelope: fallback path.
 
     def tqdm(iterable: Iterable[Any], *_args: Any, **_kwargs: Any) -> Iterable[Any]:  # No-op fallback.
-        """Return the iterable unchanged; used when the real tqdm is unavailable.
+        """Return the iterable unchanged. Used when the real tqdm is unavailable.
 
         This preserves the caller signature so code that expects a
         progress-bar wrapper keeps working -- there is simply no visible

--- a/src/utils/zscaler_catalogue.py
+++ b/src/utils/zscaler_catalogue.py
@@ -15,7 +15,7 @@ Why:
     cache and logs a warning rather than blocking the menu.
 
     The 8h TTL, single-file flat-merged layout, and full-fleet validation
-    scope are locked design decisions from the approved plan; do not tighten
+    scope are locked design decisions from the approved plan. Do not tighten
     the TTL or shard the file without re-opening that discussion.
 """
 
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any
 
 # Local repo imports. ``attach_city_metadata`` lives in scripts/ so the
-# CLI variant can keep its strict SystemExit; the library form here always
+# CLI variant can keep its strict SystemExit. The library form here always
 # returns warnings instead of raising, which is what the auto-refresh path
 # needs to stay non-fatal.
 from scripts.build_zen_city_metadata import attach_city_metadata
@@ -82,7 +82,7 @@ def _promote_host_entry(entry: str | dict[str, Any]) -> dict[str, Any]:
         "observed_port": int|None, "last_probed": str|None}]`` so downstream
         consumers (``_probe_target`` in menu 206) can dispatch on the last
         observed reachability protocol. Existing on-disk caches were written
-        as flat strings; a load-time promotion keeps them usable without
+        as flat strings. A load-time promotion keeps them usable without
         forcing a refresh. FR-006 forbids reading a v2 cache from crashing.
 
     Args:
@@ -97,7 +97,7 @@ def _promote_host_entry(entry: str | dict[str, Any]) -> dict[str, Any]:
     """
     if isinstance(entry, str):
         # Legacy v2 shape: single hostname string with no observation state.
-        # Wrap into the minimal v3 object; observation fields intentionally
+        # Wrap into the minimal v3 object. Observation fields intentionally
         # omitted so downstream callers see them as absent/None per contract.
         return {"host": entry}
     if isinstance(entry, dict):
@@ -128,7 +128,7 @@ def _promote_cenr_document(doc: dict[str, Any]) -> dict[str, Any]:
     for bag_key in ("proxy_hostnames", "vpn_hostnames"):
         bag = doc.get(bag_key)
         if isinstance(bag, list):
-            # Rebuild the bag so every element is a v3 host dict; preserves
+            # Rebuild the bag so every element is a v3 host dict. Preserves
             # element order (matters for deterministic diff-friendly writes).
             doc[bag_key] = [_promote_host_entry(entry) for entry in bag]
     by_city = doc.get("by_city")
@@ -140,7 +140,7 @@ def _promote_cenr_document(doc: dict[str, Any]) -> dict[str, Any]:
                 bag = city_slot.get(bag_key)
                 if isinstance(bag, list):
                     # Per-city bags follow the same v2 -> v3 shape rule as
-                    # the top-level bags; keep the two paths in lockstep.
+                    # the top-level bags. Keep the two paths in lockstep.
                     city_slot[bag_key] = [_promote_host_entry(entry) for entry in bag]
     return doc
 
@@ -164,7 +164,7 @@ def _promote_zcc_document(doc: dict[str, Any]) -> dict[str, Any]:
     roles = doc.get("roles")
     # The on-disk ZCC schema stores ``roles`` as a list of role objects (each
     # with its own ``fqdns`` bag). Older/hand-authored variants may store it as
-    # a dict keyed by role name; support both so promotion is shape-agnostic.
+    # a dict keyed by role name. Support both so promotion is shape-agnostic.
     role_bodies: list[Any] = []
     if isinstance(roles, list):
         role_bodies = list(roles)
@@ -175,7 +175,7 @@ def _promote_zcc_document(doc: dict[str, Any]) -> dict[str, Any]:
             continue
         fqdns = role_body.get("fqdns")
         if isinstance(fqdns, list):
-            # Same promotion rule as CENR bags; keeps the FQDN element
+            # Same promotion rule as CENR bags. Keeps the FQDN element
             # shape uniform across both cache files so downstream code
             # can treat any host entry as ``{"host": <fqdn>, ...}``.
             role_body["fqdns"] = [_promote_host_entry(entry) for entry in fqdns]
@@ -336,7 +336,7 @@ def promote_cache_document(doc: dict[str, Any], *, kind: str) -> dict[str, Any]:
 
     Args:
         doc: Parsed JSON document from disk. Mutated in place when promotion
-            fires; unmodified when already v3.
+            fires. Unmodified when already v3.
         kind: Either ``"cenr"`` (top-level proxy/vpn bags plus by_city) or
             ``"zcc"`` (roles[*].fqdns). Any other value is a caller bug and
             is treated as a no-op so a typo cannot silently drop data.
@@ -352,12 +352,12 @@ def promote_cache_document(doc: dict[str, Any], *, kind: str) -> dict[str, Any]:
     # prior writer bug produced ``schema_version=3`` documents with flat-
     # string bags, and a stamp-only short-circuit stranded every downstream
     # v3-dict walker. If the stamp says v3 AND the bags actually look v3,
-    # we skip; otherwise fall through and (re)promote silently.
+    # we skip. Otherwise fall through and (re)promote silently.
     needs_promotion = (
         _cenr_needs_promotion(doc) if kind == "cenr" else _zcc_needs_promotion(doc) if kind == "zcc" else False
     )
     if isinstance(detected, int) and detected >= _SCHEMA_VERSION and not needs_promotion:
-        # Already v3 in both stamp and shape -> skip promotion entirely; do
+        # Already v3 in both stamp and shape -> skip promotion entirely. Do
         # NOT log so steady-state loads stay quiet at INFO.
         return doc
     if kind == "cenr":
@@ -422,7 +422,7 @@ def _pick_observation_from_probe_result(
         signal that the endpoint is fully alive from the customer's edge.
         UDP/500 (IKE main) is picked before UDP/4500 (NAT-T) because the two
         are always probed together and 500 is the semantically primary IKE
-        port; picking 500 first also keeps observation output stable across
+        port. Picking 500 first also keeps observation output stable across
         NAT-fronted and non-NAT-fronted sites. Any remaining open TCP port
         wins over a null observation so probing effort never gets discarded.
 
@@ -499,7 +499,7 @@ def _merge_observations_into_cenr(
                 continue
             protocol, port, ts = obs
             # Always write all three observation keys together so a stale
-            # value never survives next to a fresh one; matches contract
+            # value never survives next to a fresh one. Matches contract
             # cenr_cache_schema_v3.md §"Observation triplet". When the host
             # was silent (no responding protocol), the whole triplet is None
             # so the "no observation" branch stays distinguishable on disk.
@@ -529,7 +529,7 @@ def _merge_observations_into_zcc(
     Why:
         Mirror of :func:`_merge_observations_into_cenr` but for the client-
         connector probes file. Kept separate from the CENR walker because
-        the outer shape differs (roles list/dict vs top-level bags); merging
+        the outer shape differs (roles list/dict vs top-level bags). Merging
         the two into one recursive walker would obscure both paths.
 
     Args:
@@ -596,7 +596,7 @@ def _stamp_zcc_entry(
 
     Args:
         entry: Candidate ``fqdns[]`` item. Only dict entries with a
-            string ``host`` are eligible; every other shape is skipped.
+            string ``host`` are eligible. Every other shape is skipped.
         observations: The ``fqdn -> (protocol, port, iso8601_utc)`` map
             passed through from :func:`_merge_observations_into_zcc`.
 
@@ -737,7 +737,7 @@ def _cloud_root_trees(cloud: str, doc: dict[str, Any]) -> list[dict[str, Any]]:
         Extracted from ``merge_clouds`` so the parent stays under the
         CI cyclomatic-complexity gate. The interesting tree normally
         hangs off a top-level key equal to the cloud slug (Zscaler's
-        canonical shape); on unexpected shapes we walk every dict-valued
+        canonical shape). On unexpected shapes we walk every dict-valued
         top-level key so a partially-broken feed still contributes what
         it can. ``svpnIPs`` is excluded because it is a metadata list,
         not a continent tree.
@@ -795,7 +795,7 @@ def _seed_slot_host_sets(slot: dict[str, Any]) -> tuple[set[str], set[str]]:
         first.
 
     Args:
-        slot: The per-city slot dict; may hold legacy strings or v3 dicts.
+        slot: The per-city slot dict. May hold legacy strings or v3 dicts.
 
     Returns:
         A ``(proxy_hosts, vpn_hosts)`` tuple of hostname sets, ready to
@@ -822,11 +822,11 @@ def _ingest_record(
         records`` loop.
 
     Args:
-        record: Raw CENR record; skipped when not a dict.
-        proxies: Global proxy-hostname dedup set; mutated in place.
-        vpns: Global vpn-hostname dedup set; mutated in place.
-        slot_proxies: Per-city proxy-hostname set; mutated in place.
-        slot_vpns: Per-city vpn-hostname set; mutated in place.
+        record: Raw CENR record. Skipped when not a dict.
+        proxies: Global proxy-hostname dedup set. Mutated in place.
+        vpns: Global vpn-hostname dedup set. Mutated in place.
+        slot_proxies: Per-city proxy-hostname set. Mutated in place.
+        slot_vpns: Per-city vpn-hostname set. Mutated in place.
     """
     if not isinstance(record, dict):
         return
@@ -850,7 +850,7 @@ def _finalize_slot(
 
     Why:
         Emit v3 dicts (not flat strings) so the on-disk shape stays
-        consistent with ``schema_version=3``; writing flat strings under
+        consistent with ``schema_version=3``. Writing flat strings under
         a v3 stamp previously broke the loader's idempotency
         short-circuit. ``seen_in_clouds`` lets operators auditing the
         merged file trace an entry back to a specific feed.
@@ -889,9 +889,9 @@ def _absorb_city_records(
         records: Raw record list from the city bucket.
         cloud: Cloud slug that supplied these records (recorded under
             ``seen_in_clouds`` on the slot).
-        proxies: Global proxy-hostname dedup set; mutated in place.
-        vpns: Global vpn-hostname dedup set; mutated in place.
-        by_city: Merged-by-city map; the target slot is mutated in place.
+        proxies: Global proxy-hostname dedup set. Mutated in place.
+        vpns: Global vpn-hostname dedup set. Mutated in place.
+        by_city: Merged-by-city map. The target slot is mutated in place.
     """
     slot = by_city.setdefault(city, {"proxy_hostnames": [], "vpn_hostnames": []})
     slot_proxies, slot_vpns = _seed_slot_host_sets(slot)
@@ -918,9 +918,9 @@ def _walk_city_map(
     Args:
         city_map: One continent's dict of city buckets.
         cloud: Cloud slug supplying these buckets.
-        proxies: Global proxy-hostname dedup set; mutated in place.
-        vpns: Global vpn-hostname dedup set; mutated in place.
-        by_city: Merged-by-city map; mutated in place.
+        proxies: Global proxy-hostname dedup set. Mutated in place.
+        vpns: Global vpn-hostname dedup set. Mutated in place.
+        by_city: Merged-by-city map. Mutated in place.
     """
     for city_key, records in city_map.items():
         if not isinstance(records, list):
@@ -950,7 +950,7 @@ def merge_clouds(per_cloud: dict[str, dict[str, Any]]) -> dict[str, Any]:
     Args:
         per_cloud: Mapping of cloud slug -> parsed CENR JSON dict. The dict's
             top-level normally contains one key equal to the cloud slug
-            (holding the continent tree) plus a ``svpnIPs`` list; both are
+            (holding the continent tree) plus a ``svpnIPs`` list. Both are
             optional. Clouds that fetched successfully but returned no
             hostnames still contribute their URL to ``source_urls``.
 
@@ -1006,7 +1006,7 @@ def _atomic_write_json(path: Path, doc: dict[str, Any]) -> None:
 
     Why:
         The CENR file is read concurrently by menu 206 and the background
-        refresh; a partial write during a crash would poison the next menu
+        refresh. A partial write during a crash would poison the next menu
         invocation. ``os.replace`` on the same filesystem is atomic on both
         POSIX and Windows, so a same-directory temp file guarantees readers
         either see the old or the new document, never a half-written one.
@@ -1048,7 +1048,7 @@ def _load_stale_cenr_cache(cenr_path: Path, warnings: list[str]) -> dict[str, An
 
     Args:
         cenr_path: Path to ``data/zscaler_cenr_hostnames.json``. May not
-            exist; a missing file is a packaging error, not a crash.
+            exist. A missing file is a packaging error, not a crash.
         warnings: Mutable warning list from the caller. Appended in place
             with any read or decode failure so the caller can log them.
 
@@ -1080,7 +1080,7 @@ def refresh_cenr(cenr_path: Path) -> tuple[dict[str, Any], list[str]]:
 
     Args:
         cenr_path: Path to ``data/zscaler_cenr_hostnames.json``. Must exist
-            already for the fail-open fallback to work; a missing file is a
+            already for the fail-open fallback to work. A missing file is a
             packaging error and surfaces as a warning with an empty dict.
 
     Returns:
@@ -1128,7 +1128,7 @@ def _run_probe_validation(
     cenr_path: Path,
     fresh: dict[str, Any],
 ) -> tuple[dict[str, Any], list[ProbeResult]]:
-    """Best-effort probe run; returns ``(probes_v3_dict, results)``.
+    """Best-effort probe run. Returns ``(probes_v3_dict, results)``.
 
     Why:
         Extracted from ``ensure_fresh`` so the caller stays under Radon
@@ -1139,7 +1139,7 @@ def _run_probe_validation(
         can subsequently stamp observations into it.
 
     Args:
-        cenr_path: Path to the CENR cache; probes cache is resolved as a
+        cenr_path: Path to the CENR cache. Probes cache is resolved as a
             sibling ``zscaler_client_connector_probes.json``.
         fresh: Freshly-refreshed CENR document.
 
@@ -1285,7 +1285,7 @@ def ensure_fresh(cenr_path: Path, cenr: dict[str, Any]) -> dict[str, Any]:
 
     Returns:
         The fresh dict (either the passthrough when in-TTL, or the refreshed
-        merged dict when stale). Never raises; always returns *some* dict so
+        merged dict when stale). Never raises. Always returns *some* dict so
         the caller can proceed.
     """
     # Promote legacy v2 CENR flat-string bags into v3 dict entries so every
@@ -1305,12 +1305,12 @@ def ensure_fresh(cenr_path: Path, cenr: dict[str, Any]) -> dict[str, Any]:
         logger.warning("zscaler_catalogue: %s", warning)
 
     if not fresh:
-        # Total-failure path returned empty dict; fall back to whatever the
+        # Total-failure path returned empty dict. Fall back to whatever the
         # caller already loaded so downstream code keeps a usable shape.
         logger.warning("zscaler_catalogue: refresh returned empty document; using in-memory copy")
         return cenr
 
-    # Best-effort probe run; validation failures do not block the return.
+    # Best-effort probe run. Validation failures do not block the return.
     probes, results = _run_probe_validation(cenr_path, fresh)
 
     # T028/T029: write persisted observations back onto both cache files so a

--- a/src/utils/zscaler_probe.py
+++ b/src/utils/zscaler_probe.py
@@ -79,7 +79,7 @@ class ProbeResult:
             customer-impact-critical.
         ip (str | None): First A-record returned by ``getaddrinfo``; ``None``
             if DNS failed.
-        dns_error (str | None): Formatted DNS failure text; only populated on
+        dns_error (str | None): Formatted DNS failure text. Only populated on
             lookup error.
         icmp_ok (bool): Whether a single OS ``ping`` succeeded within the
             timeout.
@@ -100,10 +100,10 @@ class ProbeResult:
             the TLS handshake.
         tls_issuer (str | None): Peer certificate issuer CN/O captured on the
             TLS handshake.
-        tls_error (str | None): Formatted TLS error text; only populated on
+        tls_error (str | None): Formatted TLS error text. Only populated on
             handshake failure.
         responding_protocols (list[str]): Compact list of protocols we
-            confirmed live (for example ``["ICMP", "TCP/443", "HTTPS"]``); used by
+            confirmed live (for example ``["ICMP", "TCP/443", "HTTPS"]``). Used by
             the log summary.
         server_class (str): Category inferred from FQDN + headers + cert
             issuer.
@@ -242,11 +242,11 @@ def _build_ike_sa_init() -> bytes:
     next_payload = 0  # 0 = "no next payload" per RFC 7296 (probe-only)
     version = 0x20  # major=2 minor=0 (IKEv2)
     exchange_type = 34  # IKE_SA_INIT per IANA IKEv2 exchange types
-    flags = 0x08  # Initiator flag set; Response/Version cleared
+    flags = 0x08  # Initiator flag set. Response/Version cleared
     message_id = 0  # first message in the exchange
-    length = 28  # header-only; no payloads included in the probe
+    length = 28  # header-only. No payloads included in the probe
     # ``!`` selects network (big-endian) byte order as required by RFC 7296.
-    # B/B/B/B/I = 1+1+1+1+4 bytes = 8 bytes; combined with the two 8-byte SPIs
+    # B/B/B/B/I = 1+1+1+1+4 bytes = 8 bytes. Combined with the two 8-byte SPIs
     # this yields the 28-byte header the responder expects.
     return (
         initiator_spi
@@ -268,7 +268,7 @@ def _udp_check(host: str, port: int, timeout: float) -> str:
 
     Why:
         Zscaler VPN gateways answer IKE on UDP/500 and NAT-T-encapsulated
-        UDP/4500 rather than any TCP port; TCP-only probing silently
+        UDP/4500 rather than any TCP port. TCP-only probing silently
         mislabels them dead. The three-value return vocabulary matches
         :func:`_tcp_check` so downstream reporting can share code paths.
         Port 4500 requires a four-byte non-ESP marker (0x00000000) prefix
@@ -279,7 +279,7 @@ def _udp_check(host: str, port: int, timeout: float) -> str:
         host: Target hostname or IP address.
         port: Either ``500`` or ``4500`` (any other value is accepted but
             will not carry the non-ESP marker).
-        timeout: Wall-clock recvfrom timeout in seconds; also bounds how
+        timeout: Wall-clock recvfrom timeout in seconds. Also bounds how
             long a silent-drop firewall can stall the probe thread.
 
     Returns:
@@ -424,7 +424,7 @@ def _pick_cn(rdns: Any) -> str | None:
 
     Why:
         ``ssl.SSLSocket.getpeercert`` returns RDNs as a nested tuple of
-        ``((key, value), ...)`` pairs; we prefer ``commonName`` and fall back
+        ``((key, value), ...)`` pairs. We prefer ``commonName`` and fall back
         to ``organizationName`` because a handful of Zscaler CAs omit CN.
 
     Args:
@@ -453,7 +453,7 @@ def _classify_zscaler_subrule(fqdn: str) -> str:
         fqdn: Lower-cased hostname of the endpoint under classification.
 
     Returns:
-        A short human-readable Zscaler sub-class label; falls back to
+        A short human-readable Zscaler sub-class label. Falls back to
         ``"Zscaler service"`` when no more specific rule matches.
     """
     if "pac" in fqdn:
@@ -567,7 +567,7 @@ def _probe_http_stack(
         timeout: Per-probe timeout in seconds.
         declared_ports: Ports the catalogue declared for this role. Only 8080
             probes emit when 8080 is both open and declared.
-        result: Mutated in place; HTTP/HTTPS fields and
+        result: Mutated in place. HTTP/HTTPS fields and
             ``responding_protocols`` are populated on success, ``notes`` on
             failure.
     """
@@ -596,7 +596,7 @@ def _probe_http_stack(
             result.notes.append(f"HTTPS :443 error: {err}")
 
     if result.tcp.get(8080) == "open" and 8080 in declared_ports:
-        # ZEN nodes listen on 8080 for explicit-proxy CONNECT; a raw HTTP GET
+        # ZEN nodes listen on 8080 for explicit-proxy CONNECT. A raw HTTP GET
         # is usually refused (400/407), but the TCP handshake alone confirms
         # the port is live.
         result.responding_protocols.append("TCP/8080 (proxy)")
@@ -616,7 +616,7 @@ def _probe_udp_ike_if_needed(
         function under the CC threshold.
 
     Args:
-        fqdn: Hostname; the ``"-vpn."`` substring is the catalogue-agnostic
+        fqdn: Hostname. The ``"-vpn."`` substring is the catalogue-agnostic
             hint that this is a VPN endpoint.
         timeout: Per-probe timeout in seconds.
         result: Mutated in place; ``udp`` and ``responding_protocols`` are
@@ -649,13 +649,13 @@ def _probe_fqdn(
 
     Args:
         fqdn: Hostname to probe.
-        role: Catalogue role dict; only ``role``, ``description``, ``ports``,
+        role: Catalogue role dict. Only ``role``, ``description``, ``ports``,
             and ``critical`` are consumed.
         timeout: Per-probe timeout in seconds.
 
     Returns:
         A fully populated :class:`ProbeResult`. On DNS failure the result is
-        returned early with ``ip=None`` and ``dns_error`` set; no downstream
+        returned early with ``ip=None`` and ``dns_error`` set. No downstream
         probes run.
     """
     declared_ports = list(role.get("ports") or [])
@@ -761,8 +761,8 @@ def _collect_zcc_probe_entries(
 
     Args:
         probes: Parsed ``zscaler_client_connector_probes.json`` document.
-        seen: Deduplication set for FQDNs already queued; mutated in place.
-        entries: Probe queue tuples ``(fqdn, role)``; mutated in place.
+        seen: Deduplication set for FQDNs already queued. Mutated in place.
+        entries: Probe queue tuples ``(fqdn, role)``. Mutated in place.
     """
     for role in probes.get("roles", []) or []:
         if not isinstance(role, dict):
@@ -811,7 +811,7 @@ def _log_probe_failures(results: list[ProbeResult]) -> None:
 
     Why:
         Kept at DEBUG (not INFO) so a batch of transient timeouts during
-        an 8-hour refresh window does not spam operator logs; the caller
+        an 8-hour refresh window does not spam operator logs. The caller
         still emits one INFO summary. Extracted so the parent's CC drops
         under the gate.
 
@@ -845,7 +845,7 @@ def run_full_validation(
         :mod:`src.utils.zscaler_catalogue`). Full-fleet coverage was chosen
         over sampling because the run only fires every 8 hours, amortising
         the cost. Per-endpoint failures are logged at DEBUG so a batch of
-        transient timeouts does not spam INFO; a single INFO summary line is
+        transient timeouts does not spam INFO. A single INFO summary line is
         always emitted.
 
     Args:

--- a/src/validation/validation_utils.py
+++ b/src/validation/validation_utils.py
@@ -65,7 +65,7 @@ class ValidationUtils:
         try:  # WHY: a literal IP address is always a valid target.
             ipaddress.ip_address(target)  # WHY: parse as a literal IP.
             return True  # WHY: valid IP target.
-        except ValueError:  # WHY: not an IP; fall through to hostname validation.
+        except ValueError:  # WHY: not an IP. Fall through to hostname validation.
             pass  # WHY: hostname check happens below.
         return ValidationUtils._is_valid_hostname(target)  # WHY: accept only well-formed hostnames.
 

--- a/src/wan_hub_group_manager.py
+++ b/src/wan_hub_group_manager.py
@@ -64,7 +64,7 @@ _POD_LABEL_PREFIX = "Pod: "  # WHY: shared prefix for uniform display.
 _POD_MIXED_PREFIX = "Pod: MIXED "  # WHY: warns operator that paths disagree on pod value.
 
 # --- Confirmation semantics ---------------------------------------------
-_CONFIRM_YES = "y"  # WHY: only case-insensitive 'y' proceeds; anything else cancels.
+_CONFIRM_YES = "y"  # WHY: only case-insensitive 'y' proceeds. Anything else cancels.
 _QUIT_CHAR = "q"  # WHY: canonical cancel key for the profile picker.
 
 
@@ -393,7 +393,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
     def _confirm(self, prompt: str, context: str) -> bool:  # WHY: y/N gate reused for set + clear flows.
         """Return True only when the operator explicitly answers 'y' (case-insensitive)."""
         answer = self._safe_input(prompt, context=context)  # WHY: reuse injected safe-input for testability.
-        return answer.lower() == _CONFIRM_YES  # WHY: y/Y proceeds; anything else cancels.
+        return answer.lower() == _CONFIRM_YES  # WHY: y/Y proceeds. Anything else cancels.
 
     # ------------------------------------------------------------------
     # Core operations
@@ -451,7 +451,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
             if vpn_id not in vpn_map:  # WHY: first path for this vpn seeds the entry.
                 vpn_map[vpn_id] = {"name": vpn_name, "paths": []}  # WHY: cache friendly name + empty list.
             vpn_map[vpn_id]["paths"].append(path_key)  # WHY: aggregate path keys per VPN.
-        _ = new_pod  # WHY: parameter reserved for future per-VPN branching; kept for API stability.
+        _ = new_pod  # WHY: parameter reserved for future per-VPN branching. Kept for API stability.
         return vpn_map  # WHY: caller iterates once per VPN.
 
     def _apply_vpn_updates(
@@ -480,7 +480,7 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         info: dict[str, Any],
         new_pod: int,
     ) -> int | None:  # WHY: return None on failure so caller can short-circuit.
-        """Update a single VPN and log outcome; return count or None on error."""
+        """Update a single VPN and log outcome. Return count or None on error."""
         vpn_name = info["name"]  # WHY: friendlier reference in messages.
         path_keys = info["paths"]  # WHY: exact set of keys to overwrite.
         try:  # WHY: isolate per-VPN failure from the loop.
@@ -555,4 +555,4 @@ class WanHubGroupNumberManager:  # WHY: single public surface consumed by Menu 1
         """
         from src.utils.input_utils import InputUtils  # WHY: local import avoids import cycle at module load.
 
-        return InputUtils.safe_input(prompt, context=_CTX_FALLBACK)  # WHY: EOF-safe; returns '' on EOF.
+        return InputUtils.safe_input(prompt, context=_CTX_FALLBACK)  # WHY: EOF-safe. Returns '' on EOF.

--- a/src/wan_vpn_builder.py
+++ b/src/wan_vpn_builder.py
@@ -15,7 +15,7 @@ from __future__ import annotations  # WHY: enable PEP 563 postponed annotations 
 import logging  # WHY: structured operator diagnostics (info/debug/exception) for CLI workflow.
 import re  # WHY: regex extraction of trailing pod digits from profile names.
 from collections.abc import Callable  # WHY: precise typing for injected safe_input callable.
-from typing import Any  # WHY: mistapi returns opaque dicts; Any keeps boundary honest without leaking types.
+from typing import Any  # WHY: mistapi returns opaque dicts. Any keeps boundary honest without leaking types.
 
 import mistapi  # WHY: shared API session helper (get_all pagination).
 import mistapi.api.v1.orgs.deviceprofiles  # WHY: gateway device profile list/get/update endpoints.
@@ -93,7 +93,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     # Main workflow (US1 + US2 + US3 orchestration)
     # ------------------------------------------------------------------
 
-    def run(self) -> None:  # WHY: top-level orchestrator; kept small by delegating to focused helpers.
+    def run(self) -> None:  # WHY: top-level orchestrator. Kept small by delegating to focused helpers.
         """Main workflow: fetch, display, build, preview, create."""
         logging.warning(
             "\n=== WAN Hub-Spoke VPN Builder ==="
@@ -101,12 +101,12 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         logging.info("Starting WAN Hub-Spoke VPN Builder")  # WHY: capture entry timestamp for troubleshooting.
 
         profiles = self._load_profiles_or_none()  # WHY: fetch profiles and short-circuit on empty inventory.
-        if profiles is None:  # WHY: helper already emitted operator message; nothing more to do.
+        if profiles is None:  # WHY: helper already emitted operator message. Nothing more to do.
             return  # WHY: propagate abort without further prompts.
 
         vpn_name = self._prompt_name_after_display(profiles)  # WHY: show existing VPNs then collect unique name.
         if vpn_name is None:  # WHY: user cancelled the name prompt.
-            return  # WHY: silent return; helper already printed the cancel message.
+            return  # WHY: silent return. Helper already printed the cancel message.
 
         assignments = self._collect_role_and_pod_assignments(profiles)  # WHY: gather full role+pod set in one step.
         if assignments is None:  # WHY: cancelled during role or pod prompts.
@@ -120,7 +120,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         self._create_and_optionally_update(vpn_name, vpn_body, assignments)  # WHY: perform side-effects together.
 
     def _load_profiles_or_none(self) -> list[Any] | None:  # WHY: split so run() stays short and testable.
-        """Fetch gateway profiles; return None and warn if inventory is empty."""
+        """Fetch gateway profiles. Return None and warn if inventory is empty."""
         profiles = self._fetch_profiles()  # WHY: API call is isolated for test-time monkeypatch.
         if not profiles:  # WHY: empty list means org has no gateway profiles -> abort with hint.
             logging.warning(
@@ -142,7 +142,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     def _collect_role_and_pod_assignments(  # WHY: chains role prompt then pod prompt, propagates cancel.
         self, profiles: list[Any]
     ) -> list[dict[str, Any]] | None:
-        """Run role prompt then pod prompt; propagate None on cancellation."""
+        """Run role prompt then pod prompt. Propagate None on cancellation."""
         assignments = self._prompt_role_assignments(profiles)  # WHY: collect Hub/Spoke/Skip per profile.
         if assignments is None:  # WHY: user aborted after all-skipped retry prompt.
             return None  # WHY: no assignments means nothing to prompt pods for.
@@ -170,7 +170,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_wan_suffix(interface_name: str) -> str:  # WHY: pure helper; safe to call from any thread.
+    def _extract_wan_suffix(interface_name: str) -> str:  # WHY: pure helper. Safe to call from any thread.
         """Extract the suffix after the last underscore.
 
         Examples:
@@ -190,7 +190,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         Returns (wan_list, lan_list) where each item is the
         interface name string.
         """
-        wan_interfaces: list[str] = []  # WHY: collect WAN uplinks; order established by sort() below.
+        wan_interfaces: list[str] = []  # WHY: collect WAN uplinks. Order established by sort() below.
         lan_interfaces: list[str] = []  # WHY: collect LAN interfaces separately for hub/spoke logic.
         for name, config in port_config.items():  # WHY: single-pass classification over configured ports.
             usage = config.get("usage", "")  # WHY: default empty means neither WAN nor LAN -> ignored.
@@ -311,7 +311,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         """Return path dict for one assignment (empty for skip)."""
         if assignment["role"] == ROLE_SKIP:  # WHY: skipped profiles contribute nothing to the VPN body.
             return {}  # WHY: empty dict merges as a no-op.
-        profile = assignment["profile"]  # WHY: extract once; used for name + port_config lookups.
+        profile = assignment["profile"]  # WHY: extract once. Used for name + port_config lookups.
         profile_name = profile.get("name", "")  # WHY: name feeds every generated path key.
         port_config = profile.get("port_config", {})  # WHY: default empty avoids KeyError on partial API objects.
         wan_list, lan_list = self._classify_interfaces(port_config)  # WHY: classifier reused across generators.
@@ -513,7 +513,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             return assignments  # WHY: return the fully-populated assignment list to the caller.
         return self._handle_all_skipped(profiles)  # WHY: dedicated branch handles retry/cancel messaging.
 
-    def _prompt_role_for_profile(  # WHY: per-profile role loop; keeps the caller's list-comp clean.
+    def _prompt_role_for_profile(  # WHY: per-profile role loop. Keeps the caller's list-comp clean.
         self, index: int, profile: dict[str, Any]
     ) -> dict[str, Any]:
         """Loop until the operator supplies a valid H/S/K response for one profile."""
@@ -577,7 +577,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             suggested = self._suggest_pod(profile_name, fallback_counter)  # WHY: use trailing digits if present.
             assignment["pod"] = self._prompt_single_pod(profile_name, suggested)  # WHY: focused per-profile loop.
             fallback_counter += 1  # WHY: bump fallback so successive digit-less profiles get unique pods.
-        return assignments  # WHY: mutation happens in-place; return for chaining convenience.
+        return assignments  # WHY: mutation happens in-place. Return for chaining convenience.
 
     def _prompt_single_pod(self, profile_name: str, suggested: int) -> int:  # WHY: single pod prompt loop.
         """Prompt until the operator provides a valid integer pod (or accepts the suggestion)."""
@@ -589,7 +589,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
             if not raw:  # WHY: empty input means "accept suggested value".
                 return suggested  # WHY: hand back the pre-computed suggestion.
             value = self._parse_pod_value(raw)  # WHY: parse helper handles both format and range.
-            if value is not None:  # WHY: parser returns None on invalid input; error already printed.
+            if value is not None:  # WHY: parser returns None on invalid input. Error already printed.
                 return value  # WHY: validated pod integer returned to caller.
 
     def _parse_pod_value(self, raw: str) -> int | None:  # WHY: reusable validator with printed feedback.
@@ -625,7 +625,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
         Returns dict of {PathName.VPNName: {key: N, role: role}} entries.
         """
         vpn_paths: dict[str, dict[str, Any]] = {}  # WHY: mapping of path-ref -> {key, role}.
-        is_wan = True  # WHY: preserved from original behavior; WAN interfaces get cross-connects when hub.
+        is_wan = True  # WHY: preserved from original behavior. WAN interfaces get cross-connects when hub.
         direct_key = f"{profile_name}-{interface_name}"  # WHY: direct path key (no suffix segment).
         vpn_ref = f"{direct_key}.{vpn_name}"  # WHY: dotted path.vpn form matches Mist expectations.
         vpn_paths[vpn_ref] = {"key": 0, "role": role}  # WHY: direct entry is always key index 0.
@@ -696,15 +696,15 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     ) -> None:
         """Union-merge new vpn_paths entries into an existing port_config entry."""
         existing = port_config[interface_name].get("vpn_paths", {})  # WHY: preserve entries from other VPNs.
-        existing.update(new_entries)  # WHY: additive; never removes references to unrelated VPNs.
+        existing.update(new_entries)  # WHY: additive. Never removes references to unrelated VPNs.
         port_config[interface_name]["vpn_paths"] = existing  # WHY: assign back so partial dicts get promoted.
 
     def _push_profile_update(self, profile_id: str, body: dict[str, Any]) -> None:  # WHY: PUT wrapper for tests.
         """Send the mutated profile body back to Mist (retained for external test patchability)."""
-        # WHY: keep this method so downstream monkeypatches keep working; body/id are validated here.
+        # WHY: keep this method so downstream monkeypatches keep working. Body/id are validated here.
         if not isinstance(profile_id, str) or not profile_id:  # WHY: reject empty ids pre-HTTP.
             raise ValueError("profile_id must be a non-empty string")  # WHY: fast failure protects the org.
-        if not isinstance(body, dict):  # WHY: mistapi expects a dict body; caller mistakes get caught early.
+        if not isinstance(body, dict):  # WHY: mistapi expects a dict body. Caller mistakes get caught early.
             raise TypeError("body must be a dict")  # WHY: explicit type feedback beats a mistapi trace.
         mistapi.api.v1.orgs.deviceprofiles.updateOrgDeviceProfile(  # WHY: performs the actual REST PUT.
             self.apisession,  # WHY: authenticated Mist session.
@@ -749,7 +749,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     def _run_profile_updates(  # WHY: performs the actual per-profile update loop and tallies results.
         self, vpn_name: str, non_skip: list[dict[str, Any]]
     ) -> tuple[int, int]:
-        """Iterate assignments, calling _update_single_profile; return (success, fail) tally."""
+        """Iterate assignments, calling _update_single_profile. Return (success, fail) tally."""
         suffixes = self._collect_wan_suffixes(non_skip)  # WHY: cross-connect vpn_paths need the global suffix set.
         success_count = 0  # WHY: tally successful profile PUTs.
         fail_count = 0  # WHY: tally per-profile failures without aborting the loop.
@@ -769,7 +769,7 @@ class WanVpnBuilder:  # WHY: class encapsulates all per-run state (session, org,
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _fallback_input(prompt: str, **_kwargs: Any) -> str:  # WHY: default injected input; used when no wrapper.
+    def _fallback_input(prompt: str, **_kwargs: Any) -> str:  # WHY: default injected input. Used when no wrapper.
         """Fallback input when safe_input is not provided.
 
         Delegates to the canonical EOF-safe wrapper instead of a second hand-rolled

--- a/src/websocket/commands.py
+++ b/src/websocket/commands.py
@@ -61,7 +61,7 @@ class MacTableCommand:  # WHY: Namespace grouping the show_mac_table workflow he
 
     @staticmethod
     def _run_workflow(deps: WebSocketCmdDeps, debug_mode: bool) -> WebSocketManager | None:  # WHY: Body helper.
-        """Perform target selection, WS connect, RPC trigger, and result display; return WS manager for cleanup."""
+        """Perform target selection, WS connect, RPC trigger, and result display. Return WS manager for cleanup."""
         targets = MacTableCommand._resolve_targets(deps, debug_mode)  # WHY: Prompt operator for site + switch.
         if targets is None:  # WHY: Guard clause — operator abort short-circuits workflow before WS open.
             return None  # WHY: Operator aborted target selection — nothing left to clean up.
@@ -72,13 +72,13 @@ class MacTableCommand:  # WHY: Namespace grouping the show_mac_table workflow he
 
         websocket_manager = MacTableCommand._open_websocket(deps, site_id, device_id, debug_mode)  # WHY: WS setup.
         if websocket_manager is None:  # WHY: Guard clause — no WS means RPC/response phases must be skipped.
-            return None  # WHY: Connect failure already logged inside helper; nothing to display.
+            return None  # WHY: Connect failure already logged inside helper. Nothing to display.
 
         session_id = MacTableCommand._trigger_rpc(  # WHY: Start REST RPC that produces the WS session id.
             deps, websocket_manager, site_id, device_id, debug_mode
         )
         if session_id is None:  # WHY: Guard clause — RPC helper already disconnected WS on failure.
-            return websocket_manager  # WHY: RPC helper disconnected on failure; return manager for cleanup finalize.
+            return websocket_manager  # WHY: RPC helper disconnected on failure. Return manager for cleanup finalize.
 
         MacTableCommand._announce_session(session_id, debug_mode)  # WHY: Emit legacy progress + debug detail lines.
         MacTableCommand._await_and_display(websocket_manager, session_id, debug_mode)  # WHY: Block on WS result.

--- a/src/websocket/diagnostics/arp_executor.py
+++ b/src/websocket/diagnostics/arp_executor.py
@@ -71,7 +71,7 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
     def _run_workflow(  # WHY: drive site+device prompts, compat check, and ARP dispatch.
         self, deps: WebSocketCmdDeps, debug_mode: bool
     ) -> WebSocketManager | None:
-        """Prompt for site+device, check compatibility, run ARP; returns WS for cleanup."""
+        """Prompt for site+device, check compatibility, run ARP. Returns WS for cleanup."""
         site_id = select_ws_site(deps, debug_mode)  # WHY: interactive site picker.
         if site_id is None:  # WHY: user cancelled site selection.
             return None  # WHY: skip rest of workflow.
@@ -95,7 +95,7 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
         device_id: str,
         debug_mode: bool,
     ) -> dict[str, Any] | None:
-        """Look up device record for type/model context; return None if unavailable."""
+        """Look up device record for type/model context. Return None if unavailable."""
         logging.debug("Fetching device record for ARP target device=%s", device_id)  # WHY: log.
         device_info = self._lookup_device_record(deps, site_id, device_id, debug_mode)  # WHY: API.
         if device_info and debug_mode:  # WHY: legacy debug echo of resolved attributes.
@@ -110,7 +110,7 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
         device_id: str,
         debug_mode: bool,
     ) -> dict[str, Any] | None:
-        """Call the device list API and pick the matching record; None on failure."""
+        """Call the device list API and pick the matching record. None on failure."""
         try:  # WHY: legacy swallows errors so ARP attempt still proceeds.
             rawdata = deps.list_devices_fn(deps.apisession, site_id, type="all").data  # WHY: API.
         except Exception as device_check_error:  # noqa: BLE001  # WHY: match legacy broad catch.
@@ -142,7 +142,7 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
         deps: WebSocketCmdDeps,
         device_info: dict[str, Any] | None,
     ) -> bool:
-        """Print device-type compatibility notes; ask switches to confirm. Returns proceed."""
+        """Print device-type compatibility notes. Ask switches to confirm. Returns proceed."""
         if not device_info:  # WHY: no metadata means proceed (legacy behavior).
             return True  # WHY: proceed unconditionally to preserve legacy behavior.
         device_type = device_info.get("type", "unknown")  # WHY: branch by device type.
@@ -196,7 +196,7 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
         session_id = self._post_arp_command(  # WHY: POST + demux session id.
             deps, websocket_manager, site_id, device_id, debug_mode
         )
-        if session_id is None:  # WHY: POST failed; helpers already disconnected.
+        if session_id is None:  # WHY: POST failed. Helpers already disconnected.
             return websocket_manager  # WHY: hand to finally for cleanup.
         self._await_and_render(  # WHY: wait for the WS result then render to console.
             websocket_manager, session_id, device_info, device_id, debug_mode
@@ -204,13 +204,13 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
         return websocket_manager  # WHY: hand to finally for cleanup.
 
     @staticmethod
-    def _connect_ws(  # WHY: build WS manager and subscribe; None on connect failure.
+    def _connect_ws(  # WHY: build WS manager and subscribe. None on connect failure.
         deps: WebSocketCmdDeps,
         site_id: str,
         device_id: str,
         debug_mode: bool,
     ) -> WebSocketManager | None:
-        """Build a WebSocketManager and subscribe to the device; None returns skip caller."""
+        """Build a WebSocketManager and subscribe to the device. None returns skip caller."""
         print(f"\n-> Executing ARP command on device {device_id}...")  # WHY: legacy banner.
         print("-> Establishing WebSocket connection...")  # WHY: legacy banner preserved.
         websocket_manager = WebSocketManager(deps.apisession)  # WHY: per-run WS manager.
@@ -235,14 +235,14 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
         credentials = prepare_command_credentials(  # WHY: pull + validate Mist host/token.
             deps.apisession, websocket_manager, debug_mode
         )
-        if credentials is None:  # WHY: credential lookup failed; helper disconnected.
+        if credentials is None:  # WHY: credential lookup failed. Helper disconnected.
             return None  # WHY: caller aborts the workflow.
         mist_host, mist_apitoken = credentials  # WHY: unpack into local variables.
         arp_url, headers = self._build_arp_request(  # WHY: build request tuple.
             mist_host, mist_apitoken, site_id, device_id
         )
         arp_response = post_device_command(arp_url, headers, {}, debug_mode, "ARP")  # WHY: POST.
-        if arp_response is None:  # WHY: defensive; helper currently never returns None.
+        if arp_response is None:  # WHY: defensive. Helper currently never returns None.
             return None  # WHY: treat as POST failure.
         return extract_command_session(arp_response, websocket_manager, "ARP")  # WHY: demux.
 
@@ -397,7 +397,7 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
         device_info: dict[str, Any] | None,
         debug_mode: bool,
     ) -> None:
-        """Render raw output; if gateway JSON, dispatch to table renderer."""
+        """Render raw output. If gateway JSON, dispatch to table renderer."""
         is_gateway = device_info is not None and device_info.get("type") == "gateway"  # WHY: gate.
         looks_like_json = raw_output.strip().startswith("{")  # WHY: cheap JSON sniff.
         if is_gateway and looks_like_json:  # WHY: try tabulate for gateway JSON responses.
@@ -407,10 +407,10 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
         print("-" * 40)  # WHY: legacy section underline preserved.
         print(raw_output)  # WHY: show captured raw text verbatim.
 
-    def _render_gateway_table_or_fallback(  # WHY: parse gateway JSON; fall back on failure.
+    def _render_gateway_table_or_fallback(  # WHY: parse gateway JSON. Fall back on failure.
         self, raw_output: str, debug_mode: bool
     ) -> None:
-        """Parse gateway JSON ARP response; tabulate on success, fall back on failure."""
+        """Parse gateway JSON ARP response. Tabulate on success, fall back on failure."""
         logging.debug("Attempting to parse gateway ARP JSON payload")  # WHY: log before parse.
         try:  # WHY: match legacy fallback phrasing on JSON parse failure.
             gateway_data = json.loads(raw_output)  # WHY: decode the JSON document.
@@ -451,7 +451,7 @@ class ArpDeviceExecutor:  # WHY: orchestrates ARP-over-WebSocket diagnostic work
     ) -> None:
         """Render the parsed gateway ARP response as an aligned text table."""
         columns = gateway_data.get("columns", [])  # WHY: column metadata describing rows.
-        if not columns:  # WHY: no descriptors means cannot tabulate; fall back.
+        if not columns:  # WHY: no descriptors means cannot tabulate. Fall back.
             print("No column information available in gateway response")  # WHY: legacy phrasing.
             self._echo_raw_fallback(raw_output)  # WHY: emit legacy raw echo block.
             return  # WHY: done with fallback path.

--- a/src/websocket/diagnostics/common.py
+++ b/src/websocket/diagnostics/common.py
@@ -34,9 +34,9 @@ def post_device_command(
 ) -> requests.Response | None:
     """POST a device-command to the Mist REST API and return the raw Response."""
     if debug_mode:  # Surface request metadata for the operator before sending
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("[DEBUG] POST URL = %s", url)  # Print target URL exactly as the legacy code did
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info(  # Print headers but never the real token value (security)
             "[DEBUG] Headers = {'Authorization': 'Token [REDACTED]', 'Content-Type': 'application/json'}"
         )
@@ -46,9 +46,9 @@ def post_device_command(
         "%s POST completed with status=%s", command_label, response.status_code
     )
     if debug_mode:  # Mirror legacy debug prints of full response
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("[DEBUG] HTTP Response Status = %s", response.status_code)  # Show numeric status
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("[DEBUG] HTTP Response Body = %s", response.text)  # Show raw body for diagnosis
     return response  # Caller inspects status/body and decides next step
 
@@ -60,9 +60,9 @@ def extract_command_session(
 ) -> str | None:
     """Return the session id from a command response or disconnect+None on failure."""
     if response.status_code != 200:  # Any non-200 is a hard failure for the command
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("! Failed to issue %s command: %s", command_label, response.status_code)  # User-facing error
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("! Response: %s", response.text)  # Show body for operator triage
         websocket_manager.disconnect()  # Free the WS since we will not consume results
         logging.warning(  # Action log after failure path
@@ -72,7 +72,7 @@ def extract_command_session(
     response_payload = response.json()  # Parse JSON body returned by the API
     session_id = response_payload.get("session")  # Pull the session identifier used for demux
     if not session_id:  # API contract requires a session id for result correlation
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("! No session ID returned from %s command", command_label)  # User-facing error
         websocket_manager.disconnect()  # Free the WS since we cannot demux results
         logging.warning("%s command returned no session id", command_label)  # Action log
@@ -107,9 +107,9 @@ def print_extra_result_fields(
 ) -> None:
     """Print any result keys outside the well-known ones (raw, Output, session)."""
     extra_keys = [key for key in result_payload if key not in excluded_keys]  # Anything novel
-    if not extra_keys:  # Nothing to show; keep output clean
+    if not extra_keys:  # Nothing to show. Keep output clean
         return  # Early return preserves prior visual layout
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.info("\nOTHER AVAILABLE FIELDS: %s", extra_keys)  # Header matches legacy phrasing
     _print_extra_field_values(result_payload, extra_keys)  # Extracted so CC stays <=5
 
@@ -123,5 +123,5 @@ def _print_extra_field_values(
     for field_name in extra_keys:  # Walk each unexpected key for visibility
         field_value = result_payload.get(field_name)  # Look up the actual value
         if field_value:  # Skip empty/falsey values per legacy behavior
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("%s: %s", field_name, field_value)  # Show the value verbatim

--- a/src/websocket/diagnostics/ping_executor.py
+++ b/src/websocket/diagnostics/ping_executor.py
@@ -90,7 +90,7 @@ class PingDeviceExecutor:  # WHY: orchestrates ping-over-WebSocket diagnostic wo
         logging.debug("ENTER: ping_device_websocket")  # WHY: trace marker kept verbatim.
 
     def _run_workflow(self, deps: WebSocketCmdDeps, debug_mode: bool) -> WebSocketManager | None:
-        """Prompt user, dispatch ping, render output; return WS manager for cleanup."""
+        """Prompt user, dispatch ping, render output. Return WS manager for cleanup."""
         site_id = select_ws_site(deps, debug_mode)  # WHY: interactive site picker.
         if site_id is None:  # WHY: user cancelled site selection.
             return None  # WHY: skip rest of workflow.
@@ -98,7 +98,7 @@ class PingDeviceExecutor:  # WHY: orchestrates ping-over-WebSocket diagnostic wo
         if device_id is None:  # WHY: user cancelled or no devices available.
             return None  # WHY: skip rest of workflow.
         target_host = self._prompt_target_host(deps, debug_mode)  # WHY: validated ping target.
-        if target_host is None:  # WHY: validation failed; message already printed.
+        if target_host is None:  # WHY: validation failed. Message already printed.
             return None  # WHY: skip rest of workflow.
         ping_count = self._prompt_ping_count(deps, debug_mode)  # WHY: clamped packet count.
         request = _PingRequest(  # WHY: bundle all inputs into a frozen record.
@@ -123,7 +123,7 @@ class PingDeviceExecutor:  # WHY: orchestrates ping-over-WebSocket diagnostic wo
         return device_id  # WHY: caller uses the id for downstream calls.
 
     def _prompt_target_host(self, deps: WebSocketCmdDeps, debug_mode: bool) -> str | None:
-        """Ask user for ping target; return validated host string or None on rejection."""
+        """Ask user for ping target. Return validated host string or None on rejection."""
         target_input = deps.safe_input_fn(  # WHY: EOF-safe input wrapper.
             _PROMPT_TARGET, context=_INPUT_CONTEXT
         ).strip()  # WHY: drop incidental whitespace from prompt response.
@@ -139,7 +139,7 @@ class PingDeviceExecutor:  # WHY: orchestrates ping-over-WebSocket diagnostic wo
         return target_host  # WHY: validated host returned to caller.
 
     def _prompt_ping_count(self, deps: WebSocketCmdDeps, debug_mode: bool) -> int:
-        """Ask user for ping packet count; return clamped int with legacy defaults."""
+        """Ask user for ping packet count. Return clamped int with legacy defaults."""
         raw_count = deps.safe_input_fn(  # WHY: EOF-safe input wrapper.
             _PROMPT_COUNT, context=_INPUT_CONTEXT
         ).strip()  # WHY: drop incidental whitespace from prompt response.
@@ -148,10 +148,10 @@ class PingDeviceExecutor:  # WHY: orchestrates ping-over-WebSocket diagnostic wo
 
     @staticmethod
     def _parse_ping_count(raw_count: str) -> int:
-        """Parse and range-check ping count input; fall back to legacy default."""
+        """Parse and range-check ping count input. Fall back to legacy default."""
         if not raw_count:  # WHY: empty input means accept default count.
             return _DEFAULT_PING_COUNT  # WHY: legacy fallback preserved.
-        try:  # WHY: parse user input as integer; revert to default on failure.
+        try:  # WHY: parse user input as integer. Revert to default on failure.
             parsed_count = int(raw_count)  # WHY: raises ValueError on non-numeric input.
         except ValueError:  # WHY: match legacy behavior of warning + default.
             print(_MSG_INVALID_COUNT)  # WHY: legacy phrasing preserved.
@@ -181,7 +181,7 @@ class PingDeviceExecutor:  # WHY: orchestrates ping-over-WebSocket diagnostic wo
         logging.debug("WebSocket connect+subscribe succeeded for ping")  # WHY: log on success.
         context = _PostContext(request=request, websocket_manager=websocket_manager)  # WHY: bundle.
         session_id = self._post_ping_command(context)  # WHY: POST + demux session id.
-        if session_id is None:  # WHY: POST failed; helper already disconnected.
+        if session_id is None:  # WHY: POST failed. Helper already disconnected.
             return websocket_manager  # WHY: hand to finally for cleanup.
         self._await_and_render(  # WHY: wait for WS result then render.
             websocket_manager, session_id, request.target_host, request.debug_mode
@@ -211,7 +211,7 @@ class PingDeviceExecutor:  # WHY: orchestrates ping-over-WebSocket diagnostic wo
         credentials = prepare_command_credentials(  # WHY: pull + validate Mist host/token.
             request.deps.apisession, context.websocket_manager, request.debug_mode
         )
-        if credentials is None:  # WHY: credential lookup failed; helper disconnected.
+        if credentials is None:  # WHY: credential lookup failed. Helper disconnected.
             return None  # WHY: caller aborts the workflow.
         mist_host, mist_apitoken = credentials  # WHY: unpack into local variables.
         ping_url, headers = self._build_ping_request(  # WHY: assemble URL + headers.
@@ -221,7 +221,7 @@ class PingDeviceExecutor:  # WHY: orchestrates ping-over-WebSocket diagnostic wo
         ping_response = post_device_command(  # WHY: POST and capture full response.
             ping_url, headers, payload, request.debug_mode, "ping"
         )
-        if ping_response is None:  # WHY: defensive; helper currently never returns None.
+        if ping_response is None:  # WHY: defensive. Helper currently never returns None.
             return None  # WHY: treat as POST failure.
         return extract_command_session(  # WHY: demux session id for WS wait.
             ping_response, context.websocket_manager, "ping"

--- a/src/websocket/manager.py
+++ b/src/websocket/manager.py
@@ -16,7 +16,7 @@ from src.websocket.polling.result_collector import ResultCollector  # WHY: wait_
 
 logger = logging.getLogger(__name__)  # WHY: module-scoped logger for #886 print-to-logger migration.
 
-try:  # WHY: websocket-client is a hard runtime dep; fail loudly if missing.
+try:  # WHY: websocket-client is a hard runtime dep. Fail loudly if missing.
     import websocket  # WHY: Actual client library import (may raise ImportError).
 except ImportError as _ws_err:  # WHY: Convert to project-branded ImportError with install hint.
     raise ImportError(  # WHY: Re-raise with actionable install command for operators.
@@ -47,11 +47,11 @@ def _is_debug_env_flag_set() -> bool:
 
 def log_ws_error(error_message: str, debug_mode: bool) -> None:
     """Print and log a WebSocket operation error with optional debug traceback."""
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.error("! %s", error_message)  # WHY: User-visible error banner via logger.
     logging.error(error_message)  # WHY: Persist error to configured logging sinks.
     if debug_mode:  # WHY: Only emit stack trace when the operator asked for detail.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("[DEBUG] Exception details:")  # WHY: Marker line preceding the traceback dump.
         traceback.print_exc()  # WHY: Full traceback for interactive debugging sessions.
 
@@ -61,10 +61,10 @@ def cleanup_ws_connection(ws_manager: Any, debug_mode: bool = False) -> None:
     try:  # WHY: Cleanup must never propagate — it runs from `finally` blocks.
         if ws_manager is not None:  # WHY: Callers may pass None if construction failed.
             ws_manager.disconnect()  # WHY: Release socket + clear internal state.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("-> WebSocket connection closed")  # WHY: User confirmation via logger.
             if debug_mode:  # WHY: Extra diagnostic breadcrumb only for debug runs.
-                # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+                # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
                 logger.debug("[DEBUG] WebSocket cleanup completed")  # WHY: Marks end of teardown.
     except Exception as cleanup_error:  # WHY: Broad catch — teardown must be resilient.
         logging.warning("WebSocket cleanup error: %s", cleanup_error)  # WHY: Warn but do not fail.
@@ -81,14 +81,14 @@ def dump_ws_debug_state(ws_mgr: Any, debug_mode: bool) -> None:
     """Print WebSocket manager debug state when debug mode is active."""
     if not debug_mode:  # WHY: Guard clause avoids nested block for non-debug runs.
         return  # WHY: No side effects when debug is off.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Checking WebSocket manager state...")  # WHY: Section marker for debug dump.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Connected = %s", ws_mgr.connected)  # WHY: Surfaces socket-open flag.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Subscribed channels = %s", ws_mgr.subscribed_channels)  # WHY: Reveals routing state.
     with ws_mgr.results_lock:  # WHY: Snapshot pending results under the shared lock.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("[DEBUG] Pending results = %s", list(ws_mgr.command_results.keys()))  # WHY: In-flight sessions.
 
 
@@ -96,20 +96,20 @@ def select_ws_site(deps: Any, debug_mode: bool) -> str | None:
     """Prompt for site selection, returning None and printing a message if cancelled."""
     site_id: str | None = deps.select_site_fn() or None  # WHY: Normalise falsy return to None.
     if not site_id:  # WHY: Cancellation path — surface a clear message to the operator.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("! No site selected. Operation cancelled.")  # WHY: Explains why nothing runs next.
         return None  # WHY: Callers detect None to abort the workflow.
     if debug_mode:  # WHY: Only echo the selected id when detail is requested.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("[DEBUG] Selected site_id = %s", site_id)  # WHY: Traceable id for later log correlation.
     return site_id  # WHY: Successful selection propagated to caller.
 
 
 def _log_credential_debug(mist_host: str, mist_apitoken: str) -> None:
     """Emit debug lines describing which credentials the manager will use."""
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] mist_host = %s", mist_host)  # WHY: Confirms target Mist cloud region.
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] API token length = %d", len(mist_apitoken))  # WHY: Token itself never printed.
 
 
@@ -119,16 +119,16 @@ def check_mist_credentials(
     mist_apitoken: str | None,
     debug_mode: bool,
 ) -> bool:
-    """Validate Mist host and token; disconnect ws_mgr and return False if invalid."""
+    """Validate Mist host and token. Disconnect ws_mgr and return False if invalid."""
     if not (mist_host and mist_apitoken):  # WHY: Combined guard shrinks branch count.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.error("! Mist host or API token not found in session or environment")  # WHY: Actionable hint.
         if ws_mgr is not None:  # WHY: Only tear down when a manager was actually constructed.
             ws_mgr.disconnect()  # WHY: Prevent leaked socket when we bail out early.
         return False  # WHY: Signals caller to abort the workflow.
     if debug_mode:  # WHY: Only dump credential shape when the operator requested detail.
         _log_credential_debug(mist_host, mist_apitoken)  # WHY: Encapsulates debug prints.
-    return True  # WHY: Credentials are usable; caller may proceed.
+    return True  # WHY: Credentials are usable. Caller may proceed.
 
 
 class WebSocketManager:
@@ -214,31 +214,31 @@ class WebSocketManager:
     def _debug_print(self, message: str, debug_mode: bool) -> None:
         """Print a `[DEBUG] ...` line only when debug_mode is truthy."""
         if debug_mode:  # WHY: Guard keeps quiet mode noise-free.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.debug("[DEBUG] %s", message)  # WHY: Uniform debug marker.
 
     def _subscribe_command_channel(self, site_id: str, device_id: str, debug_mode: bool) -> bool:
         """Subscribe to the site/device command channel and log the outcome."""
         command_channel = f"/sites/{site_id}/devices/{device_id}/cmd"  # WHY: Mist channel convention.
         if not self.subscribe_to_channel(command_channel):  # WHY: Delegates the wire message.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Failed to subscribe to device command channel")  # WHY: User-visible error banner.
             self.disconnect()  # WHY: Release the socket if subscribe failed.
             return False  # WHY: Caller must abort the workflow.
         self._debug_print(f"Subscribed to channel: {command_channel}", debug_mode)  # WHY: Trace success.
-        return True  # WHY: Subscription in place; ready for command POST.
+        return True  # WHY: Subscription in place. Ready for command POST.
 
     def connect_and_subscribe(self, site_id: str, device_id: str, debug_mode: bool) -> bool:
         """Connect to WebSocket and subscribe to the device command channel."""
         self._debug_print("WebSocketManager initialized", debug_mode)  # WHY: Trace lifecycle start.
         if not self.connect():  # WHY: Handshake is a hard precondition for subscribe.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("! Failed to establish WebSocket connection")  # WHY: User-visible failure.
             return False  # WHY: Cannot proceed without a live socket.
         self._debug_print("WebSocket connection established", debug_mode)  # WHY: Trace handshake success.
         if not self._subscribe_command_channel(site_id, device_id, debug_mode):  # WHY: Second precondition.
             return False  # WHY: Subscribe helper already emitted its own error banner.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.info("-> WebSocket connected and subscribed")  # WHY: Positive user-facing confirmation.
         time.sleep(_WS_STABILIZE_SLEEP_SECONDS)  # WHY: Brief settle before first command POST.
         return True  # WHY: Manager is ready for command traffic.
@@ -263,7 +263,7 @@ class WebSocketManager:
         """Log a subscription-lifecycle debug line to both logger and stdout."""
         if not debug_mode:  # WHY: Guard keeps quiet mode noise-free.
             return  # WHY: Nothing to log in non-debug runs.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("[DEBUG] %s: %s", action, channel_path)  # WHY: Debug echo for interactive debug.
 
     def _poll_subscription_confirmed(self, channel_path: str, timeout_seconds: float) -> bool:
@@ -272,7 +272,7 @@ class WebSocketManager:
         while time.time() - start_time < timeout_seconds:  # WHY: Elapsed check against caller's cap.
             if channel_path in self.confirmed_subscriptions:  # WHY: Router populates this set on ack.
                 return True  # WHY: Confirmation received — caller may proceed.
-            time.sleep(_WS_SUBSCRIPTION_POLL_SECONDS)  # WHY: Yield to reader; avoid busy-wait.
+            time.sleep(_WS_SUBSCRIPTION_POLL_SECONDS)  # WHY: Yield to reader. Avoid busy-wait.
         return False  # WHY: Deadline exceeded without confirmation.
 
     def wait_for_subscription_confirmation(

--- a/src/websocket/polling/completion_detector.py
+++ b/src/websocket/polling/completion_detector.py
@@ -119,7 +119,7 @@ class CompletionDetector:  # WHY: Bundles indicator matchers + shared logger/deb
         last_activity: float,
         check_count: int,
     ) -> str | None:
-        """Run every indicator strategy in priority order; return first match."""
+        """Run every indicator strategy in priority order. Return first match."""
         self.logger.info("Running completion-indicator scan (check #%s)", check_count)  # WHY: Pre-action observability.
         lowered = all_raw_content.lower()  # WHY: Case-insensitive matching across all strategies.
         strategies = self._build_strategies(collected_output, last_activity, check_count)  # WHY: Ordered strategy list.
@@ -330,7 +330,7 @@ class CompletionDetector:  # WHY: Bundles indicator matchers + shared logger/deb
     def _trace_mac_missing_header(self, lowered: str, check_count: int) -> None:  # WHY: Diagnostic-only helper.
         """Emit periodic trace while waiting for MAC-table header (verbatim)."""
         if self.debug_mode and check_count % _TRACE_PERIOD_MAC == 1:  # WHY: Throttle noisy output.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             self.logger.debug("MAC table: checking for completion pattern in %s chars", len(lowered))
 
     def _trace_mac_idle_pending(  # WHY: Diagnostic-only helper.
@@ -339,7 +339,7 @@ class CompletionDetector:  # WHY: Bundles indicator matchers + shared logger/deb
         """Emit periodic trace while waiting for MAC-table idle timeout (verbatim)."""
         if self.debug_mode and check_count % _TRACE_PERIOD_MAC == 1:  # WHY: Throttle noisy output.
             idle = time.time() - last_activity  # WHY: Diagnostic idle window.
-            # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             self.logger.debug("MAC table: found %s entries, idle for %.1fs", entry_count, idle)
 
     def _mac_table_repeated_tail(self, collected_output: list[dict[str, Any]]) -> str | None:  # WHY: Tail-repetition.
@@ -424,15 +424,15 @@ class CompletionDetector:  # WHY: Bundles indicator matchers + shared logger/deb
         """Emit the periodic ARP-pattern debug trace preserved verbatim."""
         if not self.debug_mode or check_count % _TRACE_PERIOD_SERVICE != 1:  # WHY: Throttle noisy output.
             return  # WHY: Silent path when tracing gate is closed.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.debug("ARP pattern analysis: found %s/%s patterns", pattern_count, len(_ARP_COLUMN_PATTERNS))
         found_patterns = [p for p in _ARP_COLUMN_PATTERNS if p in lowered]  # WHY: Surface which columns matched.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.debug("Found ARP patterns: %s", found_patterns)
 
     def _log_arp_hit(self, pattern_count: int) -> None:  # WHY: Preserve original debug messaging.
         """Emit debug trace when ARP-structure completion matches (verbatim)."""
         if not self.debug_mode:  # WHY: Guard preserves original silent path.
             return  # WHY: Silent path when debug is off.
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         self.logger.debug("FOUND ARP table completion: %s patterns detected", pattern_count)

--- a/src/websocket/polling/message_router.py
+++ b/src/websocket/polling/message_router.py
@@ -54,7 +54,7 @@ class MessageRouter:  # WHY: Public API preserved for WebSocketManager collabora
 
         Why:
             The original ``WebSocketManager._on_message`` passed five loose
-            arguments each call; packing them into a frozen dataclass makes
+            arguments each call. Packing them into a frozen dataclass makes
             attribute access cheaper (slots) and prevents accidental mutation
             by dispatch handlers while preserving the constructor signature
             expected by manager-side wiring.
@@ -65,7 +65,7 @@ class MessageRouter:  # WHY: Public API preserved for WebSocketManager collabora
             results_lock: Threading lock that serializes writes to
                 ``command_results``.
             confirmed_subscriptions: Set of channel names that have received
-                a confirmation frame; used to gate downstream dispatch.
+                a confirmation frame. Used to gate downstream dispatch.
             logger: Logger used for parity trace lines (preserved verbatim
                 from the pre-extraction ``_on_message`` code path).
             debug_mode: Verbose-trace toggle propagated from the manager.
@@ -124,7 +124,7 @@ def _trace_raw(ctx: _RouterCtx, message: Any) -> None:  # WHY: Emit verbatim [DE
 
 
 def _parse(ctx: _RouterCtx, message: Any) -> dict[str, Any] | None:  # WHY: Dispatch by message type.
-    """Parse a string or dict message into a dict; return None to skip."""
+    """Parse a string or dict message into a dict. Return None to skip."""
     if isinstance(message, str):  # WHY: JSON-string path handled separately.
         return _parse_string(ctx, message)  # WHY: Delegate JSON-decode path.
     if isinstance(message, dict):  # WHY: Pre-parsed dict path handled separately.
@@ -149,7 +149,7 @@ def _log_unexpected_type(ctx: _RouterCtx, message: Any) -> None:  # WHY: Warn ab
 
 
 def _parse_string(ctx: _RouterCtx, message: str) -> dict[str, Any] | None:  # WHY: JSON string path.
-    """Decode JSON string; return None on decode failure or non-dict result."""
+    """Decode JSON string. Return None on decode failure or non-dict result."""
     data = _json_load(ctx, message)  # WHY: Isolate try/except in a helper.
     if data is _SKIP:  # WHY: Decode failed and was already logged.
         return None  # WHY: Decode already logged inside _json_load.
@@ -276,7 +276,7 @@ def _unwrap_payload(ctx: _RouterCtx, data_payload: Any) -> Any:  # WHY: Normaliz
 
 
 def _unwrap_string(ctx: _RouterCtx, data_payload: str) -> Any:  # WHY: Decode nested JSON strings.
-    """Parse a JSON-string data field; return _SKIP if not JSON."""
+    """Parse a JSON-string data field. Return _SKIP if not JSON."""
     try:  # WHY: Isolate nested JSON decode.
         parsed = json.loads(data_payload)  # WHY: Standard library JSON decode.
     except json.JSONDecodeError:  # WHY: Non-JSON string is only logged, not raised.

--- a/src/websocket/polling/result_collector.py
+++ b/src/websocket/polling/result_collector.py
@@ -19,7 +19,7 @@ from src.websocket.polling.result_combiner import CombineRequest, combine_segmen
 # Circuit-breaker constant preserved verbatim from the original implementation.
 _MAX_CHECK_ITERATIONS = 10000  # WHY: Hard cap on polling iterations to avoid infinite loops.
 _DEFAULT_ACTIVITY_TIMEOUT = 2  # WHY: Default idle-window seconds before declaring completion.
-_POLL_INTERVAL = 0.1  # WHY: 100 ms sleep throttles the polling loop; DO NOT REMOVE.
+_POLL_INTERVAL = 0.1  # WHY: 100 ms sleep throttles the polling loop. DO NOT REMOVE.
 _PERF_LOG_INTERVAL = 5.0  # WHY: Periodic [PERF] logging cadence in seconds.
 _TRACE_MODULUS = 50  # WHY: Emit verbose diagnostic traces every N poll iterations.
 _TRACE_REMAINDER = 1  # WHY: Offset chosen so first trace fires on iteration 1.
@@ -46,7 +46,7 @@ class _CollectorDeps:  # WHY: Bundle the 4 constructor args to keep signatures w
     debug: bool  # WHY: Verbose print toggle propagated from the manager.
 
 
-@dataclass(slots=True)  # WHY: Mutable per-call state; frozen would block field updates.
+@dataclass(slots=True)  # WHY: Mutable per-call state. Frozen would block field updates.
 class _CollectorContext:  # WHY: Groups poll-loop state to stay within 5-param limit.
     """Mutable per-call state threaded through the poll loop helpers."""
 
@@ -209,12 +209,12 @@ class ResultCollector:  # WHY: Public API preserved for WebSocketManager collabo
         detector: CompletionDetector,
         timeout_seconds: int,
     ) -> list[dict[str, Any]]:  # WHY: Central polling driver invoked by collect().
-        """Main wait loop; returns the collected segment list on completion or timeout."""
+        """Main wait loop. Returns the collected segment list on completion or timeout."""
         while time.time() - ctx.start_time < timeout_seconds:  # WHY: Absolute timeout guard.
             result = self._poll_once(ctx, detector)  # WHY: Delegate per-iteration work.
             if result is not None:  # WHY: Helper returned finalized segments.
                 return result  # WHY: Indicator or activity timeout succeeded.
-            time.sleep(_POLL_INTERVAL)  # WHY: 100ms throttle; DO NOT REMOVE.
+            time.sleep(_POLL_INTERVAL)  # WHY: 100ms throttle. DO NOT REMOVE.
         return self._drain_on_timeout(ctx)  # WHY: Absolute timeout fell through.
 
     def _poll_once(
@@ -222,7 +222,7 @@ class ResultCollector:  # WHY: Public API preserved for WebSocketManager collabo
         ctx: _CollectorContext,
         detector: CompletionDetector,
     ) -> list[dict[str, Any]] | None:  # WHY: Single-iteration worker keeps _poll_loop short.
-        """Perform one poll iteration; returns segments when the loop should stop."""
+        """Perform one poll iteration. Returns segments when the loop should stop."""
         ctx.perf_monitor.check_iteration(self._deps.debug)  # WHY: Periodic perf + circuit breaker.
         ctx.check_count += 1  # WHY: Count this poll for downstream telemetry.
         self._maybe_emit_progress(ctx)  # WHY: Periodic 5-second progress trace.
@@ -231,14 +231,14 @@ class ResultCollector:  # WHY: Public API preserved for WebSocketManager collabo
             return done  # WHY: Return finalized segments to caller.
         if ctx.check_count > _MAX_CHECK_ITERATIONS:  # WHY: Defensive secondary breaker.
             return self._emergency_drain(ctx)  # WHY: Drain buffer and abort loop.
-        return self._try_activity_timeout(ctx)  # WHY: None keeps loop going; list stops it.
+        return self._try_activity_timeout(ctx)  # WHY: None keeps loop going. List stops it.
 
     def _try_completion(
         self,
         ctx: _CollectorContext,
         detector: CompletionDetector,
     ) -> list[dict[str, Any]] | None:  # WHY: Indicator-driven completion path.
-        """Inspect collected output; if an indicator fires, pop and return the segments."""
+        """Inspect collected output. If an indicator fires, pop and return the segments."""
         with self._deps.lock:  # WHY: Snapshot under lock to keep the dict stable.
             collected = self._results_for(ctx)  # WHY: Guard clause when session absent.
             if collected is None:  # WHY: No entry yet for this session id.
@@ -265,7 +265,7 @@ class ResultCollector:  # WHY: Public API preserved for WebSocketManager collabo
         """Update activity timestamps when new messages have arrived since last poll."""
         current_count = len(collected)  # WHY: Snapshot list length once.
         if current_count <= ctx.last_message_count:  # WHY: No new messages this iteration.
-            return  # WHY: Nothing changed; skip trace + bookkeeping.
+            return  # WHY: Nothing changed. Skip trace + bookkeeping.
         ctx.last_activity = time.time()  # WHY: Anchor new idle window.
         self._maybe_emit_new_activity(ctx, current_count)  # WHY: Trace before overwriting count.
         ctx.last_message_count = current_count  # WHY: Advance edge detector cursor.

--- a/src/websocket/polling/result_combiner.py
+++ b/src/websocket/polling/result_combiner.py
@@ -29,7 +29,7 @@ class CombineRequest:  # Immutable transport of the six caller inputs
 
 
 def combine_segments(request: CombineRequest) -> dict[str, Any] | None:  # Public entrypoint
-    """Combine message segments into a single result; mirror original print/log output."""
+    """Combine message segments into a single result. Mirror original print/log output."""
     segments = request.final_results  # Local alias improves readability of guard block
     request.logger.info("Combining %s WebSocket result segments", len(segments))  # Pre-action log
     if not segments:  # Guard: nothing to combine
@@ -60,11 +60,11 @@ def _emit_debug_header(request: CombineRequest) -> None:  # Verbose header emitt
     request.logger.debug("Combining %s result segments", count)  # Logger mirror line
     request.logger.debug("Total wait time: %.2f seconds", request.elapsed)  # Wall time
     request.logger.debug("Total checks performed: %s", request.check_count)  # Poll iterations
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Combining %s result segments", count)
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Total wait time: %.2f seconds", request.elapsed)
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Total checks performed: %s", request.check_count)
 
 
@@ -74,20 +74,20 @@ def _emit_debug_trailer(  # Verbose trailer emitter
     """Emit the trailing debug block including head/tail previews and completion banner."""
     if not request.debug_mode:  # Guard: skip entirely when quiet mode is active
         return  # Nothing to emit when debug is off
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Final combined result length: %s characters", len(combined_raw))
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Final result fields: %s", list(final_result.keys()))
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] First 150 chars of final result: %r", combined_raw[:_PREVIEW_CHARS])
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Last 150 chars of final result: %r", combined_raw[-_PREVIEW_CHARS:])
     if len(combined_raw) == 0:  # Empty payload sentinel
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.warning("[DEBUG] WARNING: Final result is empty - this may indicate an issue")
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] Session %s result collection complete", request.session_id)
-    # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+    # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
     logger.debug("[DEBUG] %s", _TRAILER_BAR)
 
 
@@ -111,7 +111,7 @@ def _absorb_raw_chunk(  # Per-segment raw handler
         return  # Empty chunk contributes nothing to buffer or trace
     buffer.append(raw_content)  # Defer join to caller for single allocation
     if verbose:  # Emit per-segment trace when verbose mode is precomputed on
-        # WHY: preserve operator notice verbatim; route through logger for capture/redirection.
+        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
         logger.debug("[DEBUG] Segment %s: %s chars", index + 1, len(raw_content))
 
 

--- a/src/websocket/service_ping_discovery.py
+++ b/src/websocket/service_ping_discovery.py
@@ -231,7 +231,7 @@ class ServicePingDiscoveryMixin:  # WHY: define ServicePingDiscoveryMixin type.
 
     @staticmethod
     def _collect_named_items(items: list[Any], sink: set[str]) -> None:  # WHY: define _collect_named_items helper.
-        """Add name field of dict items to sink; skip non-dicts and empty names."""
+        """Add name field of dict items to sink. Skip non-dicts and empty names."""
         for entry in items:  # WHY: iterate raw list entries defensively.
             if not isinstance(entry, dict):  # WHY: skip non-dict entries.
                 continue

--- a/src/websocket/service_ping_manager.py
+++ b/src/websocket/service_ping_manager.py
@@ -388,7 +388,7 @@ class ServicePingManager(ServicePingDiscoveryMixin):  # WHY: define ServicePingM
 
     def _display_timeout_results(self, payload: dict[str, Any]) -> None:  # WHY: timeout hint flow.
         """Display timeout guidance when websocket results are not received."""
-        del payload  # WHY: payload unused after refactor; kept in signature for back-compat.
+        del payload  # WHY: payload unused after refactor. Kept in signature for back-compat.
         print("\nNo Service Ping results received within timeout period.")  # WHY: primary message.
         if not self.device_info:  # WHY: bail out with a minimal log when we lack device metadata.
             logging.warning("Service ping timeout - no results received for device %s", self.device_id)


### PR DESCRIPTION
## Summary

Phase 2 of the `src/` Simplified Technical English (STE) cleanup (feature 1030).
This splits prose semicolons in `src/` comments and docstrings into separate
sentences. It changes no code behavior. Every edit stays in a comment or a
docstring.

Part of #1687. Phase 1 (mechanical fixes) merged in #1688.

## What changed

The STE semicolon rule (STE-S8-SEMICOLON) flags a sentence that joins two ideas
with a semicolon. STE asks for one idea per sentence.

- 2086 prose semicolons split into separate sentences.
- The count across `src/` drops from 2139 to 86 (96 percent reduction).

Example:

```text
before:  # Walk sites; values are looked up per-site as needed.
after:   # Walk sites. Values are looked up per-site as needed.

before:  """Delete each candidate cache file; return (deleted, errors)."""
after:   """Delete each candidate cache file. Return (deleted, errors)."""
```

## Why 86 semicolons remain

The remaining 86 are not prose. A sentence break would capitalize a code
identifier and change its meaning. These are left unchanged on purpose:

- Module references: `MistHelper.py provides a top-level re-export`
- Dunder references: `` ``__getattr__`` delegates lookups``
- Attribute or call references: `pipe.execute() is one round-trip`, `sys.exit on failure`
- Keyword arguments: `slots=True stops attribute drift`
- Index expressions: `argv[1:] is never empty`
- Lines that start with a digit, a quote, or a backtick

A two-pass fixer applied the safe splits. The first pass handled the clear
cases. The second pass used a stricter rule that capitalizes the next word only
when it is a plain English word, and skips a genuine code reference.

## Scope and safety

- Comments and docstrings only. No code line changed.
- The change is length-neutral (`; ` becomes `. `), so no line exceeds the limit.
- Black reports 967 files unchanged, which confirms no code reformatting.

## Verification

All gates run from the worktree with the project virtual environment:

- `ruff check .` -> All checks passed
- `black --check .` -> 967 files unchanged
- `mypy src/` -> Success, no issues in 329 source files
- `radon cc src/ -n C` -> no blocks over the threshold
- STE semicolon re-scan -> 2139 down to 86
- `pytest tests/unit` -> 8852 passed (the one machine-load-dependent timing
  meta-test is deselected here; it passes on an idle CI runner)

## Conformance

- [x] Links to the Spec Issue (#1687)
- [x] Comments and docstrings only, no code behavior change
- [x] No secrets added or logged
- [x] Ruff, Black, mypy, radon pass
- [x] Unit tests pass
