### PR TITLE
docs(1030): Phase 3 targeted tense fixes in src/ docstrings

### DIFF
--- a/src/capture/_packet_capture_exec.py
+++ b/src/capture/_packet_capture_exec.py
@@ -235,7 +235,7 @@ class PacketCaptureExec:
         expected_duration: int,
         progress: tuple[float, int],
     ) -> bool | None:
-        """Check if a specific capture has completed."""
+        """Check if a specific capture is complete."""
         elapsed, poll_attempt = progress  # WHY: unpack progress tuple for readability
         match = self._find_capture_record(captures, capture_id)  # WHY: locate our capture row
         if match is None:  # WHY: not seen in this poll

--- a/src/maps/_maps_clone.py
+++ b/src/maps/_maps_clone.py
@@ -375,7 +375,7 @@ class _MapsClone:
         )  # Bundle write outputs for the summary phase.
 
     def _finalize_clone(self, site_id: str, source_map_id: str, prep: _ClonePrep, result: _CloneWriteResult) -> None:
-        """Emit the summary block and audit log once the write phase has succeeded."""
+        """Emit the summary block and audit log after the write phase succeeds."""
         summary = MapCloneSummary(
             source_map=prep.source_map,
             new_name=prep.new_name,


### PR DESCRIPTION
## Summary

Phase 3 (final) of the `src/` Simplified Technical English (STE) cleanup
(feature 1030). This applies the two genuine tense improvements found in `src/`
and documents why the remaining passive, length, and tense flags are left
unchanged. It changes no code behavior.

Part of #1687. Phases 1 and 2 merged in #1688 and #1689.

## What changed

Two present-perfect docstrings become simple present:

```text
before:  """Check if a specific capture has completed."""
after:   """Check if a specific capture is complete."""

before:  """Emit the summary block and audit log once the write phase has succeeded."""
after:   """Emit the summary block and audit log after the write phase succeeds."""
```

## Why only two fixes

The judgment rules (passive, length, tense) flagged 1782 lines. A rigorous
review found the safe, genuine subset is very small. The measured breakdown:

| Rule | Flags | Finding |
| - | - | - |
| Passive | 1199 | Natural technical prose: `is required`, `is enabled`, `is set`, `are logged`. Active voice would add words and invent a meaningless actor. |
| Length | 401 | Every one is a multi-line wrapped docstring fragment. None is a single-line sentence that can be split in place. |
| Tense | 182 | 69 are false positives (adjectival `-ing`/`-ed` such as `missing`, `selected`). The rest are natural present-perfect (`has elapsed`, `have arrived`) or possessive (`has metadata`). Only two are genuine simple-present improvements. |

Forcing the rest would break the project rule that values readable text over a
perfect score. The two fixes here are the complete genuine set.

## Feature 1030 result

| Phase | Rule group | Fixes | PR |
| - | - | - | - |
| 1 | Mechanical (Latin, contraction, phrasal, warning, paragraph, gender) | 309 | #1688 |
| 2 | Prose semicolons | 2086 | #1689 |
| 3 | Genuine tense | 2 | this PR |

Total: 2397 real STE fixes across `src/`, comments and docstrings only, no code
behavior change.

## Verification

- `ruff check` -> All checks passed
- `black --check` -> unchanged
- The two flagged tense lines now read in simple present.

## Conformance

- [x] Links to the Spec Issue (#1687)
- [x] Comments and docstrings only, no code behavior change
- [x] No secrets added or logged
- [x] Ruff and Black pass
