### PR TITLE
docs: set STE precedence over caveman compression and add an ste-writing skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,12 @@ All documentation, code comments, pull request text, error messages, user-facing
 
 Core defaults: one word = one meaning; one term per concept, reused consistently (no synonym swapping); active voice; simple tenses; short sentences (<=20 words for instructions, <=25 for descriptions); imperative for instructions with one action per step and the condition first ("If X, do Y"); no semicolons, slang, jargon, phrasal verbs, or Latin abbreviations (e.g./i.e./etc.); American spelling; never alter quoted strings or identifiers. Warnings lead with a signal word (Warning = harm/irreversible; Caution = recoverable) and state the specific consequence. These rules reinforce the existing NON-NEGOTIABLE inline-comment and action-logging conventions.
 
+### Precedence: STE outranks caveman
+
+STE outranks the caveman compression rules in `.github/instructions/caveman.instructions.md`. If the two rule sets conflict, obey STE. STE is NON-NEGOTIABLE. Caveman is a preference.
+
+Caveman may remove filler, pleasantries, and hedging. Caveman must not drop an article, write a fragment, swap a synonym, or use slang. Use the caveman `lite` level, because it is the only level that obeys STE. Use a higher caveman level only when the user states that STE is suspended for the session.
+
 ---
 
 ## Core Architecture

--- a/.github/instructions/caveman.instructions.md
+++ b/.github/instructions/caveman.instructions.md
@@ -5,26 +5,53 @@ applyTo: "**"
 
 # Caveman Mode (Repo)
 
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
+Respond terse. Keep all the technical substance. Remove only the fluff.
+
+## Precedence: STE outranks caveman
+
+Simplified Technical English (STE) outranks caveman compression. If the two rule
+sets conflict, obey STE. STE is NON-NEGOTIABLE. Caveman is a preference.
+
+- STE controls all documentation, code comments, commit messages, pull request
+  text, error messages, printed output, and agent chat output.
+- Caveman applies only after STE. Caveman removes filler, pleasantries, and
+  hedging. Caveman must not break an STE rule.
+- Resolve each known conflict as follows:
+  - Keep the articles `a`, `an`, and `the` (STE Rule 4.5).
+  - Write complete sentences. Do not write fragments (STE Rule 4.2).
+  - Use one term for each concept, every time (STE Rule 1.11).
+  - Use plain words. Do not use slang or jargon (STE Rule 1.10).
+  - Use the active voice and simple tenses (STE Rules 3.2 and 3.6).
+  - Do not use a semicolon (STE Rule 8.1).
+- Caveman keeps the cut of filler, pleasantries, and hedging. Caveman loses the
+  permission to drop articles, to write fragments, and to swap synonyms.
+
+Full rules: `documentation/ASD-STE100_writing-guide.md`.
 
 ## Rules
 
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging.
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
-- Pattern: `[thing] [action] [reason]. [next step].`
-- Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
+Apply these rules only where they do not conflict with STE. See Precedence above.
+
+- Drop the filler (just/really/basically), the pleasantries, and the hedging.
+- Keep the articles and the complete sentences. STE Rules 4.5 and 4.2 require them.
+- Keep the technical terms exact. Keep the code blocks unchanged.
+- Use one term for each concept. Do not swap synonyms (STE Rule 1.11).
+- Not: "Sure! I would be happy to help you with that."
+- Yes: "The auth middleware has a bug. Change the token expiry check to `<=`."
 
 ## Levels
 
-User say `/caveman lite|full|ultra|wenyan` -> switch level. Default: `full`.
+Default: `lite`. The `lite` level is the only level that obeys STE.
 
-- **lite**: drop filler only.
-- **full**: caveman default (this file).
-- **ultra**: telegraphic, max compression.
-- **wenyan**: classical Chinese style, shortest.
+- **lite**: Drop the filler only. Keep the articles and the complete sentences.
+- **full**, **ultra**, **wenyan**: These levels drop articles and permit
+  fragments. They break STE Rules 4.2 and 4.5. Do not use them for agent output.
 
-Stop: "stop caveman" or "normal mode". Resume on next request unless user say off.
+If a user asks for `full`, `ultra`, or `wenyan`, tell the user about the conflict.
+Then use `lite`. Use a higher level only when the user states that STE is
+suspended for the session.
+
+Stop: "stop caveman" or "normal mode".
 
 ## Auto-Clarity (override caveman)
 
@@ -45,7 +72,12 @@ Resume caveman after.
 
 ## Interaction with Repo Instructions
 
-Repo-level `.github/copilot-instructions.md` and project `agents.md` take precedence
-for **code artifacts** (inline comments, action logging, 5-Item Rule, etc.).
-Caveman only compresses **chat prose** -- explanations, status updates, summaries
-between tool calls. All NON-NEGOTIABLE code conventions remain in full.
+The order of precedence is:
+
+1. `documentation/ASD-STE100_writing-guide.md` (STE). STE wins every conflict.
+2. `.github/copilot-instructions.md` and `agents.md`. These files control the
+   code artifacts, such as the inline comments, the action logging, and the
+   5-Item Rule.
+3. This file (caveman). Caveman compresses the chat prose only.
+
+All NON-NEGOTIABLE conventions remain in full.

--- a/.github/skills/ste-writing/SKILL.md
+++ b/.github/skills/ste-writing/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: ste-writing
+description: >-
+  Apply the Simplified Technical English rules of ASD-STE100 to the text this project ships.
+  Use it for the documentation, the README prose, the Markdown files, and the docstrings.
+  Use it for the inline code comments, the log messages, and the error messages.
+  Use it for the commit messages, the pull request text, the issue text, and the chat replies.
+  Use it when the STE linter reports a violation. Use it when a file scores below 80.
+  Use it when a user asks for text that a junior engineer can read without help.
+  The skill states the core rules and the repair for each linter rule identifier.
+  It also states the precedence above caveman compression and the self-check command.
+---
+
+# STE writing
+
+Simplified Technical English (STE) is a controlled subset of English. STE makes
+technical text clear and unambiguous for every reader. This repository treats
+STE as NON-NEGOTIABLE.
+
+This skill holds the rules you need for most text. The full rule set is in
+[the STE writing guide](../../../documentation/ASD-STE100_writing-guide.md) at
+`documentation/ASD-STE100_writing-guide.md`. Read that guide when you need a
+rule that this skill does not state.
+
+## Precedence
+
+STE outranks every other style rule in this repository. If another rule set
+conflicts with STE, obey STE.
+
+The caveman compression rules are the known conflict. Caveman removes filler,
+pleasantries, and hedging. Caveman must not drop an article, write a fragment,
+swap a synonym, or use slang. The caveman `lite` level is the only level that
+obeys STE.
+
+## The eight defaults
+
+Apply these defaults to every sentence you write.
+
+1. Use one word for one meaning. Use one term for each concept, every time.
+2. Use the active voice. Make the actor the subject of the sentence.
+3. Use simple tenses. Do not use a perfect form or a progressive form.
+4. Keep an instruction to 20 words. Keep a description to 25 words.
+5. Write one instruction for each sentence. Start the sentence with the verb.
+6. State the condition first, then the command. Write `If X, do Y`.
+7. Keep the articles. Write complete sentences.
+8. Use American spelling. Never change a quoted string or an identifier.
+
+## Repair each linter violation
+
+The linter reports a rule identifier for each violation. Apply the matching
+repair.
+
+| Rule identifier | Problem | Repair |
+| - | - | - |
+| STE-S1-WORD | The word is not in the approved dictionary. | Use the plain word that the linter suggests. If the word is a correct technical term, add it to `allowlist` under `[tool.ste_linter]` in `pyproject.toml`. |
+| STE-S1-POS | The word is not used as its approved part of speech. | Do not use a noun as a verb. Write `Apply oil to the surface`, not `Oil the surface`. |
+| STE-S2-NOUNCLUSTER | A multi-word noun stacks more than three words. | Break the stack with `of`, `on`, `in`, or `for`. Write `the handler that refreshes the token`, not `the token refresh handler`. |
+| STE-S3-PASSIVE | The sentence uses the passive voice. | Name the actor and make the actor the subject. Write `The parser reads the file`, not `The file is read by the parser`. |
+| STE-S3-TENSE | The sentence uses a complex tense. | Use a simple tense. Write `The parser read the file`, not `The parser has been reading the file`. |
+| STE-S4-LEN | The sentence is too long. | Split the sentence into two sentences. |
+| STE-S4-CONTRACTION | The text uses a contraction. | Write the full form. Use `do not`, `is not`, and `are not`. |
+| STE-S6-PARA | The paragraph has more than six sentences. | Split the paragraph where the topic changes. |
+| STE-S7-WARNING | A warning has no signal word or no stated consequence. | Start with `Warning` or with `Caution`. State the exact consequence. |
+| STE-S8-SEMICOLON | The text uses a semicolon. | Write two sentences instead. |
+| STE-S9-LATIN | The text uses a Latin abbreviation. | Write `for example`, `that is`, or `and so on`. |
+| STE-S9-PHRASAL | The text uses a phrasal verb. | Use one precise verb. Write `start`, not `kick off`. |
+| STE-S9-GENDER | The text uses a gendered word. | Use a neutral term such as `the operator` or `the engineer`. |
+
+## Write a warning in three parts
+
+A warning tells the reader about a risk. Build every warning from three parts.
+
+1. Start with the signal word. Use `Warning` for harm, for data loss, or for an
+   irreversible action. Use `Caution` for a recoverable action.
+2. Give the command or the condition.
+3. State the exact consequence.
+
+Correct: `Warning: do not run this command on production. The command deletes
+the users table, and no backup exists.`
+
+Wrong: `Be careful with this command.`
+
+## Check the text before you finish
+
+Run the linter on every file you changed. The threshold is 80.
+
+```powershell
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 <file>
+```
+
+These flags help:
+
+- `--quiet` prints only the score line.
+- `--format json` prints a machine-readable report.
+- `--ignore STE-S3-PASSIVE` turns off one rule.
+- `--select STE-S8-SEMICOLON` runs one rule alone.
+
+The pre-commit hook grades every `*.md` file and every `*.py` file at the same
+threshold. The `ste-lint` workflow grades the writing guide and the linter
+README on each pull request.
+
+## Scope
+
+STE controls this text:
+
+- The documentation, the README prose, and the specification prose.
+- The inline code comments and the docstrings.
+- The commit messages, the pull request text, and the issue text.
+- The log messages, the error messages, and the printed output.
+- The agent chat output.
+
+STE never changes this text:
+
+- A quoted string, an identifier, a file path, or a URL.
+- A code block, a command, or a log line that you copy word for word.
+- The name of a product or the name of a third party.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Set STE precedence over caveman compression and add an `ste-writing` skill (issue #1714)
+
+- **Writing standards (Changed)**: added the same precedence block to every
+  file that states a caveman rule or a Simplified Technical English rule.
+  Simplified Technical English now outranks caveman compression in every
+  conflict. Caveman keeps its cut of filler, pleasantries, and hedging, and
+  loses the permission to drop an article, to write a fragment, or to swap a
+  synonym. Files changed: `.github/copilot-instructions.md`,
+  `.github/instructions/caveman.instructions.md`, `agents.md`, `CLAUDE.md`,
+  and `documentation/ASD-STE100_writing-guide.md`.
+- **Caveman default level (Changed)**: the default level moves from `full` to
+  `lite`. The `lite` level is the only level that keeps the articles and the
+  complete sentences that Simplified Technical English Rules 4.5 and 4.2
+  require.
+- **Agent skill (Added)**: `.github/skills/ste-writing/SKILL.md` holds the
+  eight core rules, the repair for each of the 13 linter rule identifiers, the
+  three-part warning structure, and the self-check command. Before this change,
+  the 700-line writing guide loaded only when an agent chose to open it.
+- **Verification**: every changed Markdown file passes
+  `python -m tools.ste_linter --min-score 80`.
+
 ### #887 slice 4/N: drop `capture` from pydocstyle `match-dir` exclusion (issue #887)
 
 - **Pydocstyle scope narrowing (Changed)**: removed `capture` from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,4 +55,14 @@ phrasal verbs, or Latin abbreviations (e.g./i.e./etc.); American spelling; never
 alter quoted strings or identifiers. Warnings lead with a signal word (Warning =
 harm/irreversible; Caution = recoverable) and state the specific consequence.
 
+### Precedence: STE outranks caveman
+
+STE outranks the caveman compression rules in
+`.github/instructions/caveman.instructions.md`. If the two rule sets conflict,
+obey STE. STE is NON-NEGOTIABLE. Caveman is a preference.
+
+Caveman may remove filler, pleasantries, and hedging. Caveman must not drop an
+article, write a fragment, swap a synonym, or use slang. Use the caveman `lite`
+level, because it is the only level that obeys STE.
+
 <!-- MANUAL ADDITIONS END -->

--- a/agents.md
+++ b/agents.md
@@ -78,6 +78,11 @@ git checkout main && git pull origin main
   the condition first ("If X, do Y"); no semicolons, slang, jargon, or Latin
   abbreviations (e.g./i.e./etc.); American spelling; never alter quoted
   strings/identifiers. Warnings lead with a signal word and state the consequence.
+  STE outranks the caveman rules in `.github/instructions/caveman.instructions.md`.
+  If the two rule sets conflict, obey STE. Caveman may cut filler, pleasantries,
+  and hedging. Caveman must not drop an article, write a fragment, or swap a
+  synonym. Use the caveman `lite` level, because it is the only level that obeys
+  STE.
 
 ## External Resources
 

--- a/documentation/ASD-STE100_writing-guide.md
+++ b/documentation/ASD-STE100_writing-guide.md
@@ -23,6 +23,23 @@
 
 ---
 
+## Precedence over other style rules
+
+This guide outranks every other style rule in this repository. If another rule
+set conflicts with this guide, obey this guide. This guide is NON-NEGOTIABLE.
+
+The caveman compression rules are the known conflict. Those rules appear in
+`.github/instructions/caveman.instructions.md` and in `.agents/skills/caveman/`.
+They tell the writer to drop the articles, to write fragments, and to swap
+synonyms. Rules 4.5, 4.2, and 1.11 of this guide forbid all three. Obey Rules
+4.5, 4.2, and 1.11.
+
+The caveman rules keep one permission. They remove filler, pleasantries, and
+hedging. That removal does not break a rule in this guide. The caveman `lite`
+level is the only level that obeys this guide.
+
+---
+
 ## Core Principles (General Introduction)
 
 Simplified Technical English (STE) is a **controlled natural language**: a subset


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1714

## What changed

Two rule sets claimed the same text and gave opposite orders. The caveman instruction files told an agent to drop articles, to write fragments, and to swap in short synonyms. The Simplified Technical English rules require complete sentences and articles, forbid synonym rotation, and are marked NON-NEGOTIABLE. Nothing stated which set wins.

This pull request states the order. Simplified Technical English outranks caveman compression in every conflict.

The same precedence block now appears in every file that states either rule set. Each file resolves the six known conflicts the same way:

| Conflict | Resolution | Rule |
| - | - | - |
| Articles | Keep `a`, `an`, and `the` | 4.5 |
| Fragments | Write complete sentences | 4.2 |
| Synonyms | Use one term for each concept | 1.11 |
| Slang | Use plain words | 1.10 |
| Voice and tense | Use the active voice and simple tenses | 3.2, 3.6 |
| Semicolon | Do not use one | 8.1 |

Caveman keeps its cut of filler, pleasantries, and hedging. That cut breaks no Simplified Technical English rule.

The default caveman level moves from `full` to `lite`, because `lite` is the only level that keeps the articles and the complete sentences.

## New agent skill

Before this change, Simplified Technical English had a 700-line guide that loaded only when an agent chose to open it. Caveman had seven skills. The asymmetry meant an agent received the four-sentence summary and never the full rules.

`.github/skills/ste-writing/SKILL.md` closes that gap. It holds the eight core rules, the repair for each of the 13 linter rule identifiers, the three-part warning structure, the scope list, and the self-check command. The `name` field matches the parent directory, so the skill loads.

## Acceptance Criteria

- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification

## Quality

- [x] Tests added or updated for all changed functionality — not applicable. No executable code changed.
- [x] Coverage meets or exceeds 70% threshold — unchanged. No executable code changed.
- [x] No new Ruff lint violations (`ruff check .`) — no Python file changed.
- [x] Code formatted with Ruff (`ruff format --check .`) — no Python file changed.
- [x] mypy passes (`mypy MistHelper.py`) — no Python file changed.

### Simplified Technical English verification

Every changed Markdown file passes `python -m tools.ste_linter --min-score 80`.

| File | Score |
| - | - |
| `documentation/ASD-STE100_writing-guide.md` | 96 |
| `.github/skills/ste-writing/SKILL.md` | 98 |
| `.github/instructions/caveman.instructions.md` | 98 |
| `.github/copilot-instructions.md` | 96 |
| `agents.md` | 93 |
| `CLAUDE.md` | 91 |
| `CHANGELOG.md` | 90 |

The `ste-lint` workflow grades `documentation/ASD-STE100_writing-guide.md`. That file scores 96 and passes.

## Security

- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings — no Python file changed.
- [x] pip-audit clean — no dependency changed.
- [x] Sensitive data handled via `.env` / environment variables only

## Deployment

- [x] Dry-run verified locally — not applicable. Documentation only.
- [x] `.env` changes documented in `deploy/.env.example` — not applicable. No new variable.
- [x] Container builds successfully — not applicable. The `Containerfile` did not change.

## UI / E2E Testing

Not applicable. No web UI changed.

## Documentation

- [x] README.md updated — not applicable. No user-facing behavior changed.
- [x] Changelog entry added

## Files

| File | Change |
| - | - |
| `.github/copilot-instructions.md` | New precedence subsection |
| `.github/instructions/caveman.instructions.md` | New precedence section. Rules, Levels, and interaction sections aligned |
| `agents.md` | Precedence added to the writing-style bullet |
| `CLAUDE.md` | New precedence subsection |
| `documentation/ASD-STE100_writing-guide.md` | New "Precedence over other style rules" section |
| `.github/skills/ste-writing/SKILL.md` | New file |
| `CHANGELOG.md` | Entry under Unreleased |

Closes #1714
