### PR TITLE
security: remove both pip-audit --ignore-vuln entries after review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,10 +249,20 @@ jobs:
           cache: pip
       - run: pip install pip-audit
       - name: Run pip-audit
-        # CVE-2026-4539: false positive in cryptography (see linked issue)
-        # PYSEC-2025-183 / CVE-2025-45768: disputed by PyJWT upstream -- relates to app-level
-        # key length choices, not a library defect; no fix version exists; tracked in issue #346
-        run: pip-audit -r requirements.txt --ignore-vuln CVE-2026-4539 --ignore-vuln PYSEC-2025-183
+        # Reviewed 2026-07-28 under issue #890. Both historical --ignore-vuln entries
+        # are removed. `pip-audit -r requirements.txt` with no ignore flags reports
+        # "No known vulnerabilities found" against the current dependency set, which
+        # resolves cryptography 49.0.0 and PyJWT 2.13.0. Both packages are transitive.
+        # cryptography arrives through paramiko.
+        #   CVE-2026-4539  -- was recorded as a false positive in cryptography.
+        #                     pip-audit no longer reports it.
+        #   PYSEC-2025-183 -- also tracked as CVE-2025-45768. PyJWT upstream disputed it.
+        #                     Closed issue #346 holds the dispute record. pip-audit no
+        #                     longer reports it.
+        # Before you add a new --ignore-vuln entry, record three facts in a comment:
+        # the date of the review, a link to the upstream tracker, and the condition
+        # that triggers the next review.
+        run: pip-audit -r requirements.txt
 
   # ──────────────────────────────────────────────────────────────
   # CODE QUALITY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Remove both pip-audit `--ignore-vuln` entries after review (issue #890)
+
+- **CVE suppression review (Removed)**: deleted `--ignore-vuln CVE-2026-4539`
+  and `--ignore-vuln PYSEC-2025-183` from the pip-audit step in
+  `.github/workflows/ci.yml`. A run of `pip-audit -r requirements.txt` with no
+  ignore flags reports "No known vulnerabilities found" against the current
+  dependency set, which resolves cryptography 49.0.0 and PyJWT 2.13.0. Both
+  packages are transitive, and cryptography arrives through paramiko. Neither
+  suppressed identifier fires any longer, so both entries were dead weight that
+  could have masked a future finding under the same identifier.
+- **Review policy (Added)**: the replacement comment states the review date and
+  the evidence, and it requires three facts before anyone adds a new
+  `--ignore-vuln` entry. Those facts are the date of the review, a link to the
+  upstream tracker, and the condition that triggers the next review.
+
 ### Set STE precedence over caveman compression and add an `ste-writing` skill (issue #1714)
 
 - **Writing standards (Changed)**: added the same precedence block to every


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #890

## What changed

`.github/workflows/ci.yml` ran pip-audit with two hard-coded suppressions:

```
pip-audit -r requirements.txt --ignore-vuln CVE-2026-4539 --ignore-vuln PYSEC-2025-183
```

Both are removed. The step now reads:

```
pip-audit -r requirements.txt
```

## Evidence

I ran pip-audit against the current `requirements.txt` with no ignore flags:

```
$ uvx pip-audit -r requirements.txt
Installed 28 packages in 7.18s
No known vulnerabilities found
```

Exit code 0. Neither identifier fires any longer.

Resolved versions of the two packages in question:

| Package | Version | How it enters the tree |
| - | - | - |
| cryptography | 49.0.0 | Transitive, through `paramiko` |
| PyJWT | 2.13.0 | Transitive |

Neither package appears as a direct requirement. `requirements.txt` names `cryptography` only inside a comment that lists transitive packages.

## Why removal is the right outcome

A stale suppression is worse than no suppression. Each `--ignore-vuln` entry silences an identifier permanently. If upstream later files a real, exploitable finding under `CVE-2026-4539` or `PYSEC-2025-183`, the old entries would have hidden it and CI would have stayed green.

The historical rationale for each entry no longer applies:

- **CVE-2026-4539** was recorded as a false positive in cryptography. The description noted that no linked issue was ever written inline. pip-audit no longer reports the identifier at all.
- **PYSEC-2025-183**, also tracked as CVE-2025-45768, was disputed by PyJWT upstream. Issue #346 held that dispute and is now closed. pip-audit no longer reports the identifier.

## Policy for the future

The replacement comment states the review date and the evidence. It also states what a contributor must record before adding a new entry:

1. The date of the review.
2. A link to the upstream tracker.
3. The condition that triggers the next review.

## Acceptance Criteria

From issue #890:

- [x] Both `--ignore-vuln` entries reviewed with current upstream status documented in `ci.yml` comments
- [x] Any ignore whose upstream disposition has changed is removed — both were removed
- [x] Remaining ignores have a review-by date and a link to upstream tracking — no ignore remains. The policy for future entries is documented in the comment.
- [x] CI green

## Quality

- [x] Tests added or updated — not applicable. No executable code changed.
- [x] Coverage meets or exceeds threshold — unchanged. No executable code changed.
- [x] No new Ruff lint violations — no Python file changed.
- [x] Code formatted — no Python file changed.
- [x] mypy passes — no Python file changed.
- [x] Workflow YAML parses. Verified with `yaml.safe_load`, and the resolved step is `pip-audit -r requirements.txt`.
- [x] `CHANGELOG.md` passes the STE linter at the threshold of 80.

## Security

- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings — no Python file changed.
- [x] pip-audit clean — verified above with no ignore flags, which is a stricter check than before this pull request.
- [x] Sensitive data handled via `.env` / environment variables only

This pull request **increases** security coverage. CI now fails on any finding under either previously-suppressed identifier.

## Deployment

- [x] Dry-run verified locally — pip-audit run locally, shown above.
- [x] `.env` changes documented — not applicable.
- [x] Container builds successfully — not applicable. The `Containerfile` did not change.

## UI / E2E Testing

Not applicable. No web UI changed.

## Documentation

- [x] README.md updated — not applicable. No user-facing behavior changed.
- [x] Changelog entry added

## Follow-up

Issue #890 suggested a monthly cron that runs pip-audit without ignores. Its own Non-goals section defers vulnerability triage automation to a follow-up, so this pull request does not add it.

Closes #890
