### PR TITLE
ci: lower the vulture confidence floor from 90 to 70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ on:
         default: '90'
       vulture-confidence:
         type: string
-        default: '90'
+        default: '70'
       create-issues:
         type: boolean
         default: true
@@ -48,7 +48,10 @@ env:
   COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold || '80' }}
   PYLINT_THRESHOLD: ${{ inputs.pylint-threshold || '9.5' }}
   INTERROGATE_THRESHOLD: ${{ inputs.interrogate-threshold || '90' }}
-  VULTURE_CONFIDENCE: ${{ inputs.vulture-confidence || '90' }}
+  # Vulture reports 0 findings at 90, at 80, and at 70. The cliff sits at 60, which
+  # reports 306. The floor stops at 70 for issue #892, because 70 removes the maximum
+  # value without hiding a finding. A move to 60 needs its own issue and its own triage.
+  VULTURE_CONFIDENCE: ${{ inputs.vulture-confidence || '70' }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 # Execution is staged by observed runtime so quick feedback lands first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Lower the vulture confidence floor to 70 (issue #892)
+
+- **Dead code floor (Changed)**: lowered the vulture confidence floor from 90 to
+  70 in `.github/workflows/ci.yml`. The file holds that value at two sites. Line
+  35 is the `workflow_call` input default and line 51 is the `env` fallback.
+  Both sites now read `'70'`. A caller that uses `workflow_call` therefore runs
+  the same floor as a pull request.
+- **Measurement (Recorded)**: this checkout reports 0 findings at confidence 90,
+  0 at 80, 0 at 70, and 306 at 60. The floor stops at 70, because the step from
+  70 to 60 crosses a false positive cliff. Issue #1703 removes the dynamic
+  `mh.*` lookup that drives most of that rate. A later slice re-measures
+  confidence 60 after that issue lands.
+- **Repeat delivery (Fixed)**: the entry below this one recorded the same change
+  for pull request #1723, but that change never reached `main`. The revert of
+  the issue #891 work restored the whole `ci.yml` file, which silently undid
+  this floor change in the same file. The squash merge still read `Closes #892`
+  and closed the issue. This entry records the real delivery, on a branch that
+  carries this issue alone.
+
 ### Resolve the Redis time-series entity identifier from a fallback list (issue #990)
 
 - **Entity identifier (Fixed)**: `RedisTimeSeriesWriter` read the entity
@@ -37,16 +56,16 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   stays in place. Issue #891 now carries the correct measurement and the real
   remaining work, which is to raise the Linux score above 9.5 before the flag
   can come off. A local run is not a safe proxy for this gate.
-- **Dead code floor (Changed)**: lowered the vulture confidence floor from 90
-  to 70 in `.github/workflows/ci.yml`. The file holds that value at two sites.
-  Line 35 is the `workflow_call` input default and line 51 is the `env`
-  fallback. Both sites now read `'70'`. A caller that uses `workflow_call`
-  therefore runs the same floor as a pull request. A measurement on this
-  checkout reports 0 findings at confidence 90, 0 findings at confidence 70,
-  and 306 findings at confidence 60. The floor stops at 70, because the step
-  from 70 to 60 crosses a false positive cliff. Issue #1703 removes the dynamic
-  `mh.*` lookup that drives most of that rate. A later slice re-measures
-  confidence 60 after that issue lands.
+- **Dead code floor (Attempted and lost)**: this entry claimed that the vulture
+  confidence floor moved from 90 to 70. The claim is wrong. The change never
+  reached `main`. The revert of the pylint work restored the whole `ci.yml`
+  file, and that revert undid this floor change too, because both changes edit
+  the same file. The `ci.yml` change that pull request #1723 delivered is nine
+  added comment lines and no deleted line. The squash merge still read
+  `Closes #892` from the first commit message and closed the issue. The entry at
+  the top of this release records the real delivery. The lesson is that a
+  file level revert reverts every change in that file, so a partial revert needs
+  a line level edit.
 - **CodeQL exclusions (Removed)**: deleted the whole `query-filters` block from
   `.github/codeql/codeql-config.yml`. The block excluded
   `py/clear-text-logging-sensitive-data` and `py/stack-trace-exposure`. The


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #892
**Spec**: `specs/1033-ci-gate-silencer-removal/spec.md` (issue #892 slice)

## Why this pull request exists at all

Pull request #1723 claimed this change and closed this issue. **The change never reached `main`.**

Read the `ci.yml` diff that pull request #1723 actually delivered:

```
.github/workflows/ci.yml | 9 +++++++++
1 file changed, 9 insertions(+)
```

Nine added comment lines. Zero deleted lines. No value changed in that file.

### The cause

Pull request #1723 carried three issues: #891, #892, and #893. The Linux pylint gate failed, so I reverted the issue #891 work. I reverted **the file**, not **the lines**. That restored the pylint `--ignore` flag, which I intended, and it also restored the vulture floor to `90`, which I did not intend and did not notice.

The issue #893 change survived only because it edits a different file, `.github/codeql/codeql-config.yml`.

The squash merge then read `Closes #892` from the first commit message and closed this issue. The same mechanism wrongly closed issue #891.

**The lesson: a file level revert reverts every change in that file. A partial revert needs a line level edit.**

The specification grouped three issues into one branch to avoid a merge conflict on line 291. That decision traded a visible, cheap problem for an invisible, expensive one. This branch carries one issue.

## The change

| Line | Before | After |
| - | - | - |
| 35, `workflow_call` input default | `'90'` | `'70'` |
| 54, `env` fallback | `'90'` | `'70'` |

Both sites change together. A caller that reaches this workflow through `workflow_call` would otherwise keep the old floor, so the two sites must agree.

A comment above the `env` line records the measurement and names the stopping point, so the next reader does not repeat the search.

## Measurement

Re-measured on this checkout today:

| Confidence floor | Findings |
| - | - |
| 90 (before) | 0 |
| 80 | 0 |
| **70 (this change)** | **0** |
| 60 | 306 |

The floor stops at 70. The step from 70 to 60 crosses a false positive cliff. Issue #1703 removes the dynamic `mh.*` lookup that drives most of that rate, and a later slice can re-measure 60 once that lands.

### This claim does not depend on the platform

I state this because I got it wrong on issue #891. There I read a local Windows pylint score, called the change free, and the Linux runner disagreed by 0.30 points and failed.

Vulture is different in kind. It reports a **static count of findings**, not a score compared against a threshold. The count does not vary by operating system, and the gate passes whenever the count is 0. The local run is a safe proxy here. The CI Vulture check on this pull request confirms it rather than assuming it.

## Quality

| Gate | Result |
| - | - |
| `yaml.safe_load` on `ci.yml` | PASS |
| STE linter on `CHANGELOG.md` | PASS, 90/100 |
| Vulture at the new floor | 0 findings |

No Python file changes, so ruff, black, and mypy have nothing to read here.

## Documentation

- [x] Changelog entry added for the real delivery
- [x] **The earlier changelog entry is corrected.** It claimed the floor moved. It did not. The bullet now reads `Attempted and lost` and explains the revert, so the file does not carry a false record.

## Security

- [x] No secrets, tokens, or credentials
- [x] No production or runtime code touched

Closes #892
