### PR TITLE
chore: narrow pylint W0613/W0718 and mypy override cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,12 @@ specs/**/evidence/.tmp_*
 # uv lockfile — project uses pip via hatchling, not uv
 uv.lock
 
+# SpecKit Companion extension (local dev tool, re-installable)
+# The payload holds 15 third-party Python scripts. The repo-wide gates
+# (black, bandit, CodeQL) do not exclude .specify, so the payload stays untracked.
+# To install, run: specify extension add companion --from <release-url>
+# The .github patterns are scoped, because both folders hold tracked spec-kit files.
+.specify/extensions/companion/
+.github/agents/speckit.companion.*
+.github/prompts/speckit.companion.*
+

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -1,4 +1,5 @@
-installed: []
+installed:
+- companion
 settings:
   auto_execute_hooks: true
 hooks:
@@ -90,6 +91,15 @@ hooks:
     prompt: Commit specification changes?
     description: Auto-commit after specification
     condition: null
+  - extension: companion
+    command: speckit.companion.after-specify
+    enabled: true
+    optional: false
+    priority: 10
+    prompt: Execute speckit.companion.after-specify?
+    description: Record specify completion (currentStep=specify, status=specified)
+      into .spec-context.json
+    condition: null
   after_clarify:
   - extension: git
     command: speckit.git.commit
@@ -106,6 +116,14 @@ hooks:
     prompt: Commit plan changes?
     description: Auto-commit after implementation planning
     condition: null
+  - extension: companion
+    command: speckit.companion.after-plan
+    enabled: true
+    optional: false
+    priority: 10
+    prompt: Execute speckit.companion.after-plan?
+    description: Record plan completion (currentStep=plan, status=planned) into .spec-context.json
+    condition: null
   after_tasks:
   - extension: git
     command: speckit.git.commit
@@ -114,6 +132,15 @@ hooks:
     prompt: Commit task changes?
     description: Auto-commit after task generation
     condition: null
+  - extension: companion
+    command: speckit.companion.after-tasks
+    enabled: true
+    optional: false
+    priority: 10
+    prompt: Execute speckit.companion.after-tasks?
+    description: Record tasks completion (currentStep=tasks, status=ready-to-implement)
+      into .spec-context.json
+    condition: null
   after_implement:
   - extension: git
     command: speckit.git.commit
@@ -121,6 +148,15 @@ hooks:
     optional: true
     prompt: Commit implementation changes?
     description: Auto-commit after implementation
+    condition: null
+  - extension: companion
+    command: speckit.companion.after-implement
+    enabled: true
+    optional: false
+    priority: 10
+    prompt: Execute speckit.companion.after-implement?
+    description: Per-task journaling on implement (currentStep=implement; status=implemented
+      when all tasks checked)
     condition: null
   after_checklist:
   - extension: git

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -18,6 +18,37 @@
       },
       "registered_skills": [],
       "installed_at": "2026-05-07T16:09:35.300270+00:00"
+    },
+    "companion": {
+      "version": "0.20.1",
+      "source": "local",
+      "manifest_hash": "sha256:63daca72903a36c35450c900bb0ea3084ac91a19b235bb199dfb0c202a578f07",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "copilot": [
+          "speckit.companion.after-specify",
+          "speckit.companion.after-plan",
+          "speckit.companion.after-tasks",
+          "speckit.companion.after-implement",
+          "speckit.companion.status",
+          "speckit.companion.resume",
+          "speckit.companion.specify",
+          "speckit.companion.plan",
+          "speckit.companion.tasks",
+          "speckit.companion.implement",
+          "speckit.companion.classify",
+          "speckit.companion.mark-complete",
+          "speckit.companion.auto",
+          "speckit.companion.living-adopt",
+          "speckit.companion.living-move",
+          "speckit.companion.living-drift",
+          "speckit.companion.living-coverage",
+          "speckit.companion.living-sync"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-08-03T16:44:03.390488+00:00"
     }
   }
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs\\990-redis-entity-id"}
+{"feature_directory":"specs\\887-pylint-unused-argument"}

--- a/specs/887-pylint-unused-argument/checklists/requirements.md
+++ b/specs/887-pylint-unused-argument/checklists/requirements.md
@@ -1,0 +1,63 @@
+# Specification Quality Checklist: Narrow the pylint W0613 unused-argument suppression
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Feature-Specific Validation
+
+- [x] All 21 measured findings appear in the site inventory
+- [x] Every inventory row names a file, a line, a function, and a parameter
+- [x] The three triage outcomes are defined with entry conditions
+- [x] The spec forbids a file-wide and a repository-wide suppression
+- [x] The spec forbids a silent parameter deletion at an Outcome C site
+- [x] The spec requires the removal of `W0613` from the `disable` list as the final step
+- [x] The spec requires a Linux continuous integration run to confirm the score
+- [x] The spec states that a local Windows pylint run is not a safe proxy
+- [x] The spec excludes `W0718` and the mypy `src.db` override
+- [x] The spec records the maps clone confirmation-text observation without expanding scope
+- [x] The spec records the inline-comment, Simplified Technical English, no-wrapper, and no-shim conventions
+
+## Notes
+
+### Content Quality justification
+
+This feature changes a static-analysis configuration. The rule identifier `W0613`, the
+configuration file `pyproject.toml`, and the threshold `9.5` are the subject of the
+feature, not incidental implementation choices. The spec names them because a reader
+cannot verify the outcome without them. The Success Criteria section still states the
+outcomes in tool-neutral language.
+
+### Open items carried into planning
+
+- The triage must re-measure the baseline. The count of 21 is correct at commit `45c7b8d`
+  on `main`. Other work may change it.
+- Sixteen of the 21 findings have no verified outcome yet. The plan must schedule the
+  per-site code reading.
+- Two companion issues are expected. One covers the maps clone confirmation text. Any
+  Outcome C site raises one more.

--- a/specs/887-pylint-unused-argument/contracts/pylint-gate.md
+++ b/specs/887-pylint-unused-argument/contracts/pylint-gate.md
@@ -1,0 +1,141 @@
+# Contract: The pylint gate configuration
+
+**Feature Directory**: `specs/887-pylint-unused-argument/`
+
+**Date**: 2026-07-29
+
+This file records the gate that the feature changes. The gate is the interface
+between the source tree and the continuous integration job. The change is one
+line plus a comment block.
+
+---
+
+## 1. The configuration today
+
+**File**: `pyproject.toml`
+
+```toml
+[tool.pylint.main]
+fail-under = 9.5
+
+[tool.pylint."messages control"]
+# ... comment block ...
+disable = ["C0114", "C0115", "C0116", "W0613", "W0718"]
+```
+
+**File**: `.github/workflows/ci.yml`, job `pylint`
+
+```yaml
+- name: Run Pylint
+  run: pylint ${{ env.SRC_PATH }} --fail-under=${{ env.PYLINT_THRESHOLD }} --ignore=maps,ssh,ui
+```
+
+The environment variable `PYLINT_THRESHOLD` holds `9.5`. The runner is
+`ubuntu-latest`.
+
+---
+
+## 2. The configuration after the change
+
+```toml
+disable = ["C0114", "C0115", "C0116", "W0718"]
+```
+
+The entry `"W0613"` is absent. Every other entry keeps its position.
+
+The comment block above the list must no longer state that `W0613` is disabled.
+The replacement text must state three facts.
+
+1. `W0613` is enforced from this change onward.
+2. The audit record sits at `specs/887-pylint-unused-argument/research.md`.
+3. Six sites hold a site-local disable, and each one carries a reason.
+
+---
+
+## 3. What must not change
+
+FR-027, FR-028, and FR-029 forbid these changes.
+
+| Item | Rule |
+| - | - |
+| `"W0718"` in the `disable` list | Must stay. It is a separate slice of issue #887. |
+| `"C0114"`, `"C0115"`, `"C0116"` | Must stay. Another tool enforces docstrings. |
+| `fail-under = 9.5` | Must stay. FR-024 forbids a lower threshold. |
+| `--ignore=maps,ssh,ui` | Must stay. Issue #891 owns that flag. |
+| The mypy `src.db` override | Must stay. It is a separate slice of issue #887. |
+
+---
+
+## 4. Ordering rule
+
+FR-019 makes the `disable` list edit the **final** source change.
+
+Rationale: The moment the entry leaves the list, every open branch inherits the
+new gate. A branch that still holds an unused argument then fails. The team must
+resolve all 21 findings first.
+
+Sequence:
+
+1. Resolve every Outcome A site and every cascade level.
+2. Add every Outcome B comment and the Outcome C comment.
+3. Confirm that `pylint src/ --disable=all --enable=W0613` reports zero findings.
+4. Only then edit `pyproject.toml`.
+
+---
+
+## 5. Acceptance commands
+
+Run each command from the repository root.
+
+| Purpose | Command | Expected result |
+| - | - | - |
+| Count the findings (FR-021) | `.venv\Scripts\python.exe -m pylint src/ --disable=all --enable=W0613 --score=n` | No output. Zero findings. |
+| Reproduce the gate locally | `.venv\Scripts\python.exe -m pylint src/ --fail-under=9.5 --ignore=maps,ssh,ui` | Exit code 0. |
+| Confirm the ignored packages (FR-004) | `.venv\Scripts\python.exe -m pylint src/maps src/ssh --disable=all --enable=W0613 --score=n` | No output. Zero findings. |
+
+The third command is the manual scan that the spec assumptions require. The gate
+cannot prove those files, because the `--ignore` flag hides them.
+
+---
+
+## 6. Proof of the gate result (FR-022, FR-023)
+
+Warning: A local Windows run is not proof. Issue #891 measured 9.71 on Windows
+and 9.41 on the `ubuntu-latest` runner for the same commit. The Linux run
+failed the 9.5 threshold.
+
+The only accepted proof is a continuous integration run on the pushed branch.
+Read the result of the job named "Pylint (score gate)".
+
+Measured estimate from the current tree, for information only:
+
+| Condition | Local Windows score |
+| - | - |
+| Today | 9.77 |
+| With `W0613` enabled | 9.77 |
+
+The delta is smaller than the reported resolution of 0.01.
+
+---
+
+## 7. Rollback position
+
+If the Linux score falls below 9.5, take these steps in order.
+
+1. Read the runner log. List every message type that the run reports, with a
+   count for each type.
+2. Confirm that the drop comes from `W0613`. Compare the count of `W0613`
+   messages against zero. FR-021 requires zero.
+3. If any `W0613` message remains, fix that site. The audit missed it. This is
+   the expected cause, because the measured delta is near zero.
+4. If zero `W0613` messages remain, the drop comes from another message type on
+   Linux. That is a platform difference, not a regression from this feature.
+   Record the message types and open a separate issue.
+5. Do not lower `fail-under`. FR-024 forbids it.
+6. Do not restore `"W0613"` to the `disable` list. FR-024 forbids it.
+7. If the score cannot reach 9.5 in this feature, revert the `pyproject.toml`
+   commit only. Keep every source fix and keep the triage record. The source
+   tree stays clean, and the gate change waits for a follow-up branch.
+
+Step 7 is the safe stopping point. The source work holds its value without the
+gate change.

--- a/specs/887-pylint-unused-argument/contracts/signature-changes.md
+++ b/specs/887-pylint-unused-argument/contracts/signature-changes.md
@@ -1,0 +1,284 @@
+# Contract: Signature changes
+
+**Feature Directory**: `specs/887-pylint-unused-argument/`
+
+**Date**: 2026-07-29
+
+This file is the authoritative list of every signature that the feature
+changes. A function signature is an internal interface. This contract records
+the shape before the change and the shape after the change. It also names every
+call site that must change in the same task.
+
+A row marked **cascade** is not in the measured baseline. Pylint reports it only
+after the level below it loses the parameter. Section 3 of `research.md`
+explains the rule.
+
+Warning: a removal in group 4, group 7, and group 8 shifts a positional
+argument. If you drop the parameter and leave a call site unchanged, the
+remaining arguments bind to the wrong parameters. Change the signature and every
+call site in the same edit.
+
+---
+
+## Group 1. `src/capture/packet_capture.py`
+
+| Item | Value |
+| - | - |
+| Before | `def _multi_ap_gather_params(self, ap_macs: list[str]) -> dict[str, Any] \| None:` |
+| After | `def _multi_ap_gather_params(self) -> dict[str, Any] \| None:` |
+| Call site | `packet_capture.py:1018`, `self._multi_ap_gather_params(ap_macs)` becomes `self._multi_ap_gather_params()` |
+| Tests to update | None |
+| Cascade | None. The caller still passes `ap_macs` to `_multi_ap_confirm_and_launch`. |
+
+---
+
+## Group 2. `src/firmware/bulk_ap_upgrader.py`
+
+| Item | Value |
+| - | - |
+| Before | `def _upgrade_version_group(self, site_id: str, site_name: str, version: str, version_info: dict[str, Any], mistapi: Any) -> None:` |
+| After | Drop the final parameter `mistapi`. |
+| Call site | `bulk_ap_upgrader.py:1479` |
+| Tests to update | `tests/unit/test_bulk_ap_upgrader.py:1724` |
+
+**Cascade level 1**
+
+| Item | Value |
+| - | - |
+| Before | `def _execute_multi_version_upgrade(self, site_id: str, site_name: str, site_data: dict[str, Any], mistapi: Any) -> None:` |
+| After | Drop the final parameter `mistapi`. |
+| Call site | `bulk_ap_upgrader.py:1399`, inside `_execute_site_upgrade` |
+| Tests to update | `tests/unit/test_bulk_ap_upgrader.py:1702` |
+
+**Stop condition**: `_execute_site_upgrade` keeps its `mistapi` parameter. It
+also calls `_execute_single_version_upgrade`, which uses `mistapi`.
+
+---
+
+## Group 3. `src/firmware/org_ap_upgrader.py`
+
+| Item | Value |
+| - | - |
+| Before | `def _display_org_list(self, orgs: list[Any], msp_name: str) -> None:` |
+| After | `def _display_org_list(self, orgs: list[Any]) -> None:` |
+| Call site | `org_ap_upgrader.py:617` |
+| Tests to update | None |
+| Cascade | None. The caller still passes `msp_name` to `_collect_org_selection` and to the error log. |
+
+---
+
+## Group 4. `src/inventory/inventory_summary/version_per_model_fetcher.py`
+
+Warning: `target_org_id` is the first positional parameter in both functions.
+Every call site passes it positionally.
+
+| Item | Value |
+| - | - |
+| Before | `def _rows_for_model(target_org_id: str, model_row: dict, switch_records: list[dict], gateway_records: list[dict]) -> list[dict]:` |
+| After | Drop the first parameter `target_org_id`. |
+| Call site | `version_per_model_fetcher.py:25` |
+| Tests to update | `tests/unit/inventory/test_version_per_model_fetcher_wave3.py` lines 117, 123, 129, 136, and 142 |
+
+**Cascade level 1**
+
+| Item | Value |
+| - | - |
+| Before | `def _expand_model_rows(target_org_id: str, model_rows: list[dict], switch_records: list[dict], gateway_records: list[dict]) -> list[dict]:` |
+| After | Drop the first parameter `target_org_id`. |
+| Call site | `version_per_model_fetcher.py:72`, inside `fetch` |
+| Tests to update | `tests/unit/inventory/test_version_per_model_fetcher_wave3.py:320` |
+
+**Stop condition**: `fetch` keeps `target_org_id`. It uses the value for
+`_prefetch_switches`, for `_prefetch_gateways`, for `_append_bulk_rows`, and for
+two log calls.
+
+---
+
+## Group 5. `src/maps/_maps_clone.py`
+
+| Item | Value |
+| - | - |
+| Before | `def _confirm_clone(self, source_map: dict, new_name: str, source_zones_count: int, clone_payload: dict) -> bool:` |
+| After | Drop the final parameter `clone_payload`. |
+| Call site | `_maps_clone.py:352` |
+| Tests to update | None |
+
+Caution: `src/gateway/template_config.py` holds a different method with the same
+name and a different signature. Tests in
+`tests/unit/test_template_config.py` target that other method. Do not change
+them.
+
+---
+
+## Group 6. `src/maps/maps_manager.py`
+
+Warning: `site_name` is the first positional parameter.
+
+| Item | Value |
+| - | - |
+| Before | `def _render_site_maps_table(site_name: str, maps: list) -> None:` |
+| After | `def _render_site_maps_table(maps: list) -> None:` |
+| Call site | `maps_manager.py:559` |
+| Tests to update | None |
+| Cascade | None. The caller `list_site_maps` still prints `site_name` and logs it. |
+
+---
+
+## Group 7. `src/site/address_audit/address_resolver.py`
+
+Warning: `candidates` is the fourth parameter of five. Removing it shifts
+`query`.
+
+| Item | Value |
+| - | - |
+| Before | `def _combine(self, internal, osm, ui, candidates: ResolveCandidates, query: str) -> ResolverResult:` |
+| After | Drop `candidates`. The parameter `query` moves into the fourth slot. |
+| Call site | `address_resolver.py:83`, `self._combine(internal, osm, ui, candidates, query)` becomes `self._combine(internal, osm, ui, query)` |
+| Tests to update | None |
+
+---
+
+## Group 8. `src/ssh/runtime/app_runner.py`
+
+| Item | Value |
+| - | - |
+| Before | `def _prompt_for_commands(env_cmds: list[str], csv_cmds: list[str]) -> list[str]:` |
+| After | `def _prompt_for_commands() -> list[str]:` |
+| Call site | `app_runner.py:262` |
+| Tests to update | None |
+| Cascade | None. The caller `_resolve_commands` still tests both lists in an `if` block. |
+
+This group resolves two findings, because the site holds two unused parameters.
+
+---
+
+## Group 9. `src/ssid_consolidation/_ssid_template_cache.py`
+
+| Item | Value |
+| - | - |
+| Before | `def _offer_resume(self, phase: int, results: list[dict[str, Any]]) -> tuple[bool, list[dict[str, Any]]]:` |
+| After | `def _offer_resume(self, phase: int) -> tuple[bool, list[dict[str, Any]]]:` |
+| Call sites | `_ssid_template_phase2.py:238`, `_ssid_template_phase3.py:276`, `_ssid_template_phase45.py:610` |
+| Tests to update | `tests/unit/test_ssid_template_consolidation.py:2027` |
+
+Every call site passes a literal empty list today.
+
+Note: the manager class reaches this method through `__getattr__` proxy
+delegation. No base class fixes the signature.
+
+Note: `tests/unit/test_ssid_template_consolidation.py` lines 3283 and 3339 use
+`patch.object(mgr, "_offer_resume", ...)`. A patch by name survives a signature
+change. Do not edit those two lines.
+
+Also delete the dead comment `# noqa: ARG002 - signature preserved for tests`.
+
+---
+
+## Group 10. `src/ssid_consolidation/_ssid_template_phase1.py`
+
+| Item | Value |
+| - | - |
+| Before | `def _resolve_template(site, template_lookup, sitegroup_lookup) -> tuple[dict[str, Any] \| None, str]:` |
+| After | Drop the final parameter `sitegroup_lookup`. |
+| Call site | `_ssid_template_phase1.py:289` |
+| Tests to update | `tests/unit/test_ssid_template_consolidation.py` lines 423, 434, and 445 |
+
+**Cascade level 1**
+
+| Item | Value |
+| - | - |
+| Before | `def _resolve_site_wlan(site, target_ssid: str, template_lookup, sitegroup_lookup) -> tuple[...]:` |
+| After | Drop the final parameter `sitegroup_lookup`. |
+| Call site | `_ssid_template_phase1.py:351`, inside `_build_site_row` |
+| Tests to update | None |
+
+**Stop condition**: `_build_site_row` passes `lookups.sitegroup_lookup`. That is
+a dataclass field, not a parameter. Pylint does not report a field.
+
+Also delete the dead comment `# noqa: ARG001 - signature preserved for tests`.
+
+Do not remove the `_SiteLookups.sitegroup_lookup` field. Do not remove
+`_build_sitegroup_lookup`. Both become dead after this change. A companion issue
+records that work, because the module re-exports the function for back-compat.
+
+---
+
+## Group 11. `src/utils/address_utils.py`, the `debug` parameter
+
+| Item | Value |
+| - | - |
+| Before | `def apply_business_context_rules(mist_result, comparison_result, debug: bool = False) -> str:` |
+| After | Drop the final parameter `debug`. |
+| Call sites | None. No caller in the repository passes `debug`. |
+| Tests to update | None. Each of the four tests passes two arguments already. |
+
+Also delete the dead comment
+`# noqa: ARG004 - signature preserved for callers passing debug`. The comment
+states a claim that no call site supports.
+
+---
+
+## Group 12. `src/utils/address_utils.py`, the `source` thread
+
+This is the widest thread. Five methods lose the parameter. Change all five in
+one task.
+
+| Level | Before | After | Call site |
+| - | - | - | - |
+| Leaf | `def _make_api_request(self, address_string: str, source: str) -> Any \| None:` | Drop `source`. | `address_utils.py:1058` |
+| Leaf | `def _calculate_component_match(self, address_parts: list[str], display_name: str, source: str) -> float:` | Drop `source`. | `address_utils.py:1017` |
+| Leaf | `def _calculate_quality_boost(self, result: dict[str, Any], source: str) -> float:` | Drop `source`. | `address_utils.py:1018` |
+| Cascade | `def _calculate_confidence(self, result: dict[str, Any], address_parts: list[str], source: str) -> float:` | Drop `source`. | `address_utils.py:1035` |
+| Cascade | `def _parse_geocode_response(self, response: Any, address_parts: list[str], source: str) -> dict[str, Any]:` | Drop `source`. | `address_utils.py:1061` |
+
+**Stop condition**: `_geocode_address` keeps `source`. It uses the value in two
+`logging.debug` calls in the exception path.
+
+**Tests to update** in `tests/unit/test_address_utils.py`: lines 728, 734, 740,
+744, 751, 773, 778, 790, 798, 806, 813, 819, 827, and 844. Read the whole
+`NominatimValidator` test class before you edit. The list above holds the calls
+that the search found. Run the test file after the edit to catch any call that
+the search missed.
+
+Also delete the three dead `# noqa: ARG002` comments.
+
+---
+
+## Group 13. Outcome B sites, no signature change
+
+These five sites keep the parameter. Add the comment only.
+
+| File | Line | Function |
+| - | - | - |
+| `src/org/org_synthetic_probes_manager.py` | 1619 | `_build_probe_set` |
+| `src/websocket/manager.py` | 318 | `WebSocketManager._on_open` |
+| `src/websocket/manager.py` | 323 | `WebSocketManager._on_message` |
+| `src/websocket/manager.py` | 336 | `WebSocketManager._on_error` |
+| `src/websocket/manager.py` | 343 | `WebSocketManager._on_close` |
+
+Section 8 of `research.md` holds the exact comment text for each site.
+
+---
+
+## Group 14. Outcome C site, no signature change
+
+| File | Line | Function | Parameter |
+| - | - | - | - |
+| `src/ssid_consolidation/_ssid_template_phase45.py` | 267 | `_build_template_config` | `resolutions` |
+
+Warning: Do not remove this parameter. FR-015 forbids the removal. The
+parameter is the seam that the future fix needs. Add the comment that names the
+companion issue.
+
+---
+
+## Summary of the change surface
+
+| Measure | Count |
+| - | - |
+| Functions that lose a parameter | 19 |
+| Of those, cascade functions not in the baseline | 5 |
+| Production call sites to edit | 17 |
+| Test call sites to edit | 24 |
+| Sites that gain a suppression comment | 6 |
+| Dead `noqa` comments to delete | 6 |

--- a/specs/887-pylint-unused-argument/data-model.md
+++ b/specs/887-pylint-unused-argument/data-model.md
@@ -1,0 +1,158 @@
+# Data Model: Narrow the pylint W0613 unused-argument suppression
+
+**Feature Directory**: `specs/887-pylint-unused-argument/`
+
+**Date**: 2026-07-29
+
+This feature stores no runtime data. It changes source code and one
+configuration file. The entities below are documentation records and code
+constructs. The triage record in `research.md` is the instance store.
+
+---
+
+## 1. Finding
+
+One pylint `W0613` message.
+
+| Field | Type | Rule |
+| - | - | - |
+| `file` | Path relative to the repository root | Required. Always inside `src/`. |
+| `line` | Integer | Required. Points at the function definition. |
+| `function` | Qualified name | Required. Holds the class name when the function is a method. |
+| `parameter` | Identifier | Required. Names the unused argument. |
+| `gate_sees_it` | Boolean | Derived. False when the file sits in `src/maps`, `src/ssh`, or `src/ui`. |
+| `outcome` | Enum `A`, `B`, `C` | Required. FR-001 forbids an empty value. |
+| `justification` | One sentence | Required by FR-002. |
+
+**Cardinality**: The measured baseline holds 21 findings.
+
+**Validation**: A finding without an outcome fails SC-001.
+
+---
+
+## 2. Site
+
+One function that holds one or more findings.
+
+| Field | Type | Rule |
+| - | - | - |
+| `function` | Qualified name | Required. |
+| `findings` | List of Finding | One or more. |
+
+**Cardinality**: The baseline holds 20 sites and 21 findings.
+
+**Note**: `AppRunner._prompt_for_commands` is the only site with two findings.
+The site holds the parameters `env_cmds` and `csv_cmds`.
+
+---
+
+## 3. Parameter thread
+
+A chain of functions that pass the same parameter down without reading it.
+
+| Field | Type | Rule |
+| - | - | - |
+| `parameter` | Identifier | Required. |
+| `levels` | Ordered list of functions | The leaf comes first. |
+| `stops_at` | Qualified name | Required. Names the first function that reads the parameter. |
+
+**State transitions**: A thread moves through three states.
+
+1. **Reported**: Pylint reports the leaf only.
+2. **Partly removed**: The leaf loses the parameter. Pylint now reports the next
+   level. The count of findings does not fall.
+3. **Resolved**: Every level below `stops_at` loses the parameter. Pylint
+   reports nothing for the thread.
+
+**Validation rule**: A change must never leave a thread in the "partly removed"
+state at the end of a task. That state adds a finding that the baseline does
+not hold.
+
+**Instances**: `research.md` section 3 lists four threads.
+
+---
+
+## 4. Outcome
+
+One of three decisions. The enum is closed.
+
+| Value | Meaning | Required action | Forbidden action |
+| - | - | - | - |
+| `A` | The argument is a refactor leftover. | Remove the parameter from the signature and from every call site. Update every test that calls the signature. | Leave a call site behind. |
+| `B` | A contract mandates the signature. | Add a site-local `# pylint: disable=W0613` comment with a specific reason. | Add a file-wide or module-wide disable. |
+| `C` | The argument should have been used. | Record the defect, file a companion issue, take the safest minimal action. | Delete the parameter. |
+
+**Validation rule for `B`**: FR-013 rejects a generic reason. The reason must
+name a library, an override contract, a documented promise, or an issue number.
+
+---
+
+## 5. Suppression
+
+A `# pylint: disable=W0613` comment.
+
+| Field | Type | Rule |
+| - | - | - |
+| `scope` | Enum `line`, `function` | FR-012 forbids `file`, `module`, and `repository`. |
+| `position` | Enum `same line`, `line above` | FR-011 allows these two positions only. |
+| `reason` | One line | Required. Names a specific contract or an issue. |
+
+**Cardinality**: Six suppressions after the change. Five belong to Outcome B.
+One belongs to Outcome C.
+
+---
+
+## 6. Dead ruff suppression
+
+A `# noqa: ARG00x` comment that guards a parameter this feature removes.
+
+| Field | Type | Rule |
+| - | - | - |
+| `code` | Enum `ARG001`, `ARG002`, `ARG004` | Ruff reports the unused argument under these codes. |
+| `stated_reason` | Text | Recorded for the audit trail. |
+
+**Validation rule**: When the feature removes the parameter, the feature deletes
+the comment in the same change. A comment that guards a parameter that no longer
+exists is dead text.
+
+**Cardinality**: Six comments. `research.md` section 4 lists them.
+
+---
+
+## 7. Companion issue
+
+A GitHub issue that records work outside this feature.
+
+| Field | Type | Rule |
+| - | - | - |
+| `title` | Text | Required. States the defect or the observation. |
+| `type_label` | Enum `bug`, `chore` | Required by the repository issue policy. |
+| `scope_label` | Text | Required by the repository issue policy. |
+| `linked_from` | Triage record row | Required by FR-017 for an Outcome C row. |
+
+**Cardinality**: Three issues. One is mandatory under FR-017. Two record
+observations that the spec names.
+
+---
+
+## 8. Gate configuration
+
+The pylint settings that the continuous integration job reads.
+
+| Field | Location | Value today | Value after the change |
+| - | - | - | - |
+| `disable` list | `pyproject.toml`, `[tool.pylint."messages control"]` | `["C0114", "C0115", "C0116", "W0613", "W0718"]` | `["C0114", "C0115", "C0116", "W0718"]` |
+| Comment block | Directly above the `disable` list | Names `W0613` as disabled | Must not claim that `W0613` is disabled |
+| `fail-under` | `pyproject.toml`, `[tool.pylint.main]` | `9.5` | `9.5`, unchanged |
+| `--ignore` flag | `.github/workflows/ci.yml` | `maps,ssh,ui` | `maps,ssh,ui`, unchanged |
+
+**Validation rule**: FR-019 makes the `disable` list edit the final source
+change. FR-027 and FR-029 forbid a change to `W0718` and to the `--ignore` flag.
+
+**State transition**: The gate holds two states.
+
+1. **Hidden**: `W0613` sits in the `disable` list. A new unused argument passes.
+2. **Enforced**: `W0613` is absent. A new unused argument lowers the score.
+
+The move to "Enforced" is safe only when the finding count is zero. FR-021
+states that rule.

--- a/specs/887-pylint-unused-argument/plan.md
+++ b/specs/887-pylint-unused-argument/plan.md
@@ -1,0 +1,295 @@
+# Implementation Plan: Narrow the pylint W0613 unused-argument suppression
+
+**Branch**: `887-pylint-unused-argument` (not created. This plan creates no branch and no commit.)
+
+**Date**: 2026-07-29
+
+**Spec**: [spec.md](spec.md)
+
+**Source Issue**: #887, part 1 of 3
+
+**Input**: Feature specification from `specs/887-pylint-unused-argument/spec.md`
+
+---
+
+## Summary
+
+The file `pyproject.toml` disables the pylint check `W0613` for the whole
+repository. The committed reason covers WebSocket protocol callbacks only. Every
+other unused argument stays hidden.
+
+This feature triages all 21 findings, fixes the source tree, and then removes
+`W0613` from the `disable` list.
+
+The triage is complete. It is not deferred to implementation. Section 5 of
+[research.md](research.md) holds one final outcome for each of the 21 findings.
+
+| Outcome | Count | Meaning |
+| - | - | - |
+| A | 15 | Remove the parameter and every call site. |
+| B | 5 | Keep the parameter with a site-local disable and a specific reason. |
+| C | 1 | A real defect. Record it, file an issue, keep the parameter. |
+
+The technical approach has three parts.
+
+1. **Resolve each parameter thread as one unit.** The research found four
+   threads where a caller passes a parameter down without reading it. A partial
+   removal moves the finding up one level instead of clearing it. Five cascade
+   functions that the baseline does not report must change with their leaves.
+2. **Reject the "preserved for tests" reason.** Six parameters already carry a
+   ruff `ARG` suppression. Each reason names a test or a future plan. FR-013
+   needs a real contract, so these six take Outcome A. The feature updates the
+   tests and deletes the dead comments.
+3. **Change the gate last.** The edit to `pyproject.toml` is the final source
+   change. An earlier edit turns the gate red for every open branch.
+
+---
+
+## Technical Context
+
+**Language/Version**: Python 3.13 or newer. The constitution binds this minimum.
+The measured environment used Python 3.13.3.
+
+**Primary Dependencies**: None added. The feature uses pylint 4.0.6 and astroid
+4.0.4 as the measuring tool. It touches no runtime dependency.
+
+**Storage**: N/A. The feature stores no runtime data. It changes source files
+and one configuration file.
+
+**Testing**: pytest. The feature updates 24 existing test call sites. It adds no
+test and removes no test.
+
+**Target Platform**: The source runs on Windows for local development and on
+Linux inside the container. The gate runs on `ubuntu-latest`.
+
+**Project Type**: A single Python project. The package tree sits under `src/`.
+
+**Performance Goals**: N/A. No runtime path changes behavior.
+
+**Constraints**:
+
+- FR-025 forbids a runtime behavior change at any Outcome A site and at any
+  Outcome B site.
+- FR-019 makes the `pyproject.toml` edit the final source change.
+- FR-023 rejects a local Windows score as proof. Only a run on the Linux runner
+  proves the gate.
+- FR-024 forbids a lower threshold and forbids a restored repository-wide
+  disable.
+
+**Scale/Scope**: 21 findings across 13 files. 19 functions lose a parameter. 17
+production call sites and 24 test call sites change. 6 sites gain a comment. 6
+dead `noqa` comments go away. One line of `pyproject.toml` changes.
+
+**Tooling note**: Use `.venv\Scripts\python.exe` for every Python command. The
+global interpreter on the development machine is broken, and the virtual
+environment holds no `pip`.
+
+---
+
+## Constitution Check
+
+*Gate: this section passed before Phase 0. It passed again after Phase 1.*
+
+| Principle | Status | Evidence |
+| - | - | - |
+| I. Five-Item Rule | Improves | The feature only removes parameters. Two functions drop from six parameters to five. `BulkAPFirmwareUpgrader._upgrade_version_group` and `AddressResolver._combine` both move into the limit. |
+| II. Class-Based Architecture, No Wrappers | Pass | FR-032 forbids a wrapper. FR-033 forbids a shim. The feature updates real call sites instead. |
+| III. Safety-First | Pass | `AppRunner._prompt_for_commands` keeps its `InputUtils.safe_input` call. No destructive operation changes. No input validation changes. |
+| IV. Full Deployment Pipeline | Pass | The pipeline runs after merge, as it does for every change. |
+| V. Observability and Logging | Pass | No log call is removed. The `source` thread keeps its two `logging.debug` calls, because `_geocode_address` keeps the parameter. |
+| VI. Inline Comments | Pass | FR-030 requires a why-comment on every changed line. The tasks phase must budget for this work. |
+| VII. Action Logging | Pass with a note | See Complexity Tracking, row 1. |
+| Fix Over Suppress | Pass | The feature deletes six dead `noqa` comments and adds only six narrow, reasoned disables. FR-012 forbids a wide disable. |
+| Simplified Technical English | Pass | FR-031 covers the plan, the research, the comments, the issues, and the pull request text. Step 12 of the quickstart holds the check command. |
+
+No principle is violated. One principle needs a written note.
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/887-pylint-unused-argument/
+├── spec.md                          # Input
+├── plan.md                          # This file
+├── research.md                      # Phase 0 output. Holds the triage record.
+├── data-model.md                    # Phase 1 output
+├── quickstart.md                    # Phase 1 output. Holds the validation steps.
+├── contracts/
+│   ├── signature-changes.md         # Phase 1 output. Every before and after signature.
+│   └── pylint-gate.md               # Phase 1 output. The gate contract and the rollback.
+├── checklists/
+│   └── requirements.md              # Existing
+└── tasks.md                         # Phase 2 output. Not created by this command.
+```
+
+### Source Code (repository root)
+
+The feature touches these paths only.
+
+```text
+pyproject.toml                       # The disable list. Changed last.
+
+src/
+├── capture/packet_capture.py
+├── firmware/bulk_ap_upgrader.py
+├── firmware/org_ap_upgrader.py
+├── inventory/inventory_summary/version_per_model_fetcher.py
+├── maps/_maps_clone.py
+├── maps/maps_manager.py
+├── org/org_synthetic_probes_manager.py
+├── site/address_audit/address_resolver.py
+├── ssh/runtime/app_runner.py
+├── ssid_consolidation/_ssid_template_cache.py
+├── ssid_consolidation/_ssid_template_phase1.py
+├── ssid_consolidation/_ssid_template_phase2.py     # Call site only
+├── ssid_consolidation/_ssid_template_phase3.py     # Call site only
+├── ssid_consolidation/_ssid_template_phase45.py
+├── utils/address_utils.py
+└── websocket/manager.py
+
+tests/unit/
+├── inventory/test_version_per_model_fetcher_wave3.py
+├── test_address_utils.py
+├── test_bulk_ap_upgrader.py
+└── test_ssid_template_consolidation.py
+```
+
+**Structure Decision**: The feature keeps the existing single-project layout. It
+adds no module, no package, and no directory. Sixteen source files change and
+four test files change.
+
+---
+
+## Work Sequence
+
+FR-019 fixes the last step. The order below also groups the work so that each
+step ends with a clean finding count.
+
+| Step | Work | Ends with |
+| - | - | - |
+| 1 | Re-measure the baseline. Confirm 21 findings. | A confirmed start point. |
+| 2 | Apply the five simple Outcome A removals with no cascade: groups 1, 3, 5, 6, and 8 of the signature contract. | 6 findings cleared. |
+| 3 | Apply the single-level Outcome A removals: groups 7 and 9. | 2 more findings cleared. |
+| 4 | Apply the cascade threads one at a time: groups 2, 4, 10, and 12. Finish each thread before you start the next. | 7 more findings cleared. |
+| 5 | Apply group 11, the `debug` parameter. | 1 more finding cleared. Total 16 cleared. |
+| 6 | Add the five Outcome B comments. | 5 findings suppressed with a reason. |
+| 7 | File the three companion issues. Add the Outcome C comment with the issue number. | 1 finding suppressed with an issue link. Zero findings remain. |
+| 8 | Run every quality gate. Run the manual scan of `src/maps` and `src/ssh`. | A clean tree. |
+| 9 | Remove `"W0613"` from `pyproject.toml`. Update the comment block. | The gate is enforced. |
+| 10 | Push the branch. Read the Linux runner result. | Proof of the score. |
+
+Warning: Do not reorder step 9. If the entry leaves the `disable` list before
+step 8 reports zero findings, the gate turns red for every open branch in the
+repository.
+
+Caution: Steps 2 through 5 each change a finding count. Run the count command
+after every step. The count must fall. A rise means an unfinished cascade.
+
+---
+
+## Risk Register
+
+### Risk 1. The Linux score falls below 9.5
+
+**This is the risk that broke issue #891.** A Windows checkout reported 9.71 for
+a commit. The `ubuntu-latest` runner reported 9.41 for the same commit and
+failed the threshold.
+
+**Measured evidence for this feature**: The team measured the local Windows
+score with the gate flags in place. The score is 9.77 today. The score is 9.77
+with `W0613` enabled. The delta is smaller than the reported resolution of 0.01.
+Seventeen extra warnings do not move the score, because the `src/` tree holds a
+large statement count.
+
+**Why the #891 gap is not expected here**: The #891 measurement removed the
+`--ignore=maps,ssh,ui` flag and added three unaudited packages to the run. This
+feature keeps that flag. Both runs cover the same package set that passes today.
+
+**Mitigation**:
+
+- Require a real run on the pushed branch. FR-023 and step 10 hold this rule.
+- Read the job named "Pylint (score gate)". Record the score in the pull request
+  body.
+- Do not add the `auto-merge` label until that job and CodeQL both pass.
+
+**Rollback position**: Section 7 of [contracts/pylint-gate.md](contracts/pylint-gate.md)
+holds the full procedure. The short form is:
+
+1. Confirm that zero `W0613` messages remain. If any remain, fix that site.
+2. Do not lower `fail-under`. Do not restore the repository-wide disable.
+3. If the score still cannot reach 9.5, revert the `pyproject.toml` commit only.
+   Keep every source fix and keep the triage record. The gate change then waits
+   for a follow-up branch, and the source work holds its value.
+
+### Risk 2. A cascade adds a finding that the baseline does not hold
+
+Five functions read a parameter only to pass it down. They are not in the
+baseline. They become findings after their leaf changes.
+
+**Mitigation**: The signature contract marks each one as a cascade level and
+names the stop condition. Step 4 of the work sequence treats each thread as one
+unit. The count command after each step catches a partial removal.
+
+### Risk 3. A positional removal binds an argument to the wrong parameter
+
+Four removals are not at the end of a signature.
+
+| Function | Position of the removed parameter |
+| - | - |
+| `VersionPerModelFetcher._rows_for_model` | First of four |
+| `VersionPerModelFetcher._expand_model_rows` | First of four |
+| `MapsManager._render_site_maps_table` | First of two |
+| `AddressResolver._combine` | Fourth of five |
+
+**Mitigation**: The research checked every call site. No caller passes any
+Outcome A parameter by keyword, so no caller raises a `TypeError`. The signature
+contract names every call site for these four functions. Change the signature
+and every call site in one edit.
+
+### Risk 4. Four findings sit in packages that the gate hides
+
+`src/maps` and `src/ssh` hold four findings. The `--ignore` flag hides them, so
+the gate cannot prove them.
+
+**Mitigation**: Step 4 of the quickstart runs a manual scan of those two
+packages. FR-004 requires the triage anyway, and the research assigned an
+outcome to all four.
+
+### Risk 5. The baseline drifts before the work starts
+
+**Mitigation**: Step 1 re-measures. The team re-measured on 2026-07-29 and found
+no drift. If a later measurement differs, add each new finding to the triage
+record and assign an outcome before you continue.
+
+### Risk 6. A test asserts a signature that the feature changes
+
+**Mitigation**: The research searched every changed function name. The signature
+contract lists 24 test call sites. Two usages in
+`tests/unit/test_ssid_template_consolidation.py` use `patch.object` by name.
+A patch by name survives a signature change, so those two lines stay unchanged.
+Step 6 of the quickstart runs the full suite to catch any call that the search
+missed.
+
+---
+
+## Complexity Tracking
+
+| Item | Why it is needed | Simpler alternative rejected because |
+| - | - | - |
+| Principle VII asks the team to add action logging to a touched block that lacks it. This feature adds none. | Every edit in this feature is a signature edit or a comment edit. It adds no action, removes no action, and changes no data flow. Principle VII binds a "meaningful action". No new action appears. FR-025 also forbids a behavior change, and new output at a touched line risks a test that asserts captured output. | Adding a log line to each touched block would widen the change beyond the audit, raise the review cost, and put FR-025 at risk for no observability gain. |
+| Row 13 keeps an unused parameter behind a disable comment instead of a removal. | FR-015 forbids a removal at an Outcome C site. The parameter is the seam that the future fix needs. Deleting it hides an operator-facing defect. | Removing `resolutions` would clear the finding and hide the fact that Phase 4 discards every operator answer. |
+| Group 10 leaves `_build_sitegroup_lookup` and the `_SiteLookups.sitegroup_lookup` field in place, although both lose their last reader. | Removing a dataclass field and a back-compat re-export is dead-code work. The Out of Scope list excludes it, and the module re-exports the function by name. | Removing them inside this feature would change a documented back-compat surface without a specification for that change. |
+| The feature deletes six `noqa: ARG00x` comments rather than converting them into pylint disables. | The stated reasons name a test or a future plan. FR-013 needs a real contract. FR-026 requires the test update instead. The `debug` reason is also factually wrong, because no caller passes `debug`. | Converting them would keep 6 dead parameters and would set a precedent that a test freezes a private signature. |
+
+---
+
+## Phase Status
+
+| Phase | Output | Status |
+| - | - | - |
+| Phase 0, research | [research.md](research.md) | Complete. All 21 findings hold a final outcome. Zero items read "NEEDS CLARIFICATION". |
+| Phase 1, design | [data-model.md](data-model.md), [contracts/signature-changes.md](contracts/signature-changes.md), [contracts/pylint-gate.md](contracts/pylint-gate.md), [quickstart.md](quickstart.md) | Complete. |
+| Phase 2, tasks | `tasks.md` | Not started. The `/speckit.tasks` command creates it. |

--- a/specs/887-pylint-unused-argument/quickstart.md
+++ b/specs/887-pylint-unused-argument/quickstart.md
@@ -1,0 +1,251 @@
+# Quickstart: Validate the W0613 narrowing
+
+**Feature Directory**: `specs/887-pylint-unused-argument/`
+
+**Date**: 2026-07-29
+
+This guide shows how to validate the feature. It covers the checks that prove
+each user story. It does not hold implementation code. The signature changes sit
+in `contracts/signature-changes.md`. The outcomes sit in `research.md`.
+
+---
+
+## Prerequisites
+
+1. Open a PowerShell prompt at the repository root.
+2. Use `.venv\Scripts\python.exe` for every Python command. The global Python
+   interpreter on this machine is broken, and the virtual environment holds no
+   `pip`.
+3. Confirm the tool version. The baseline used pylint 4.0.6 and astroid 4.0.4.
+
+```powershell
+.venv\Scripts\python.exe -m pylint --version
+```
+
+If the version differs, re-measure the baseline before you start. A version
+change can add or remove findings.
+
+---
+
+## Step 1. Validate User Story 1, the triage record
+
+No code change is needed for this step.
+
+1. Open `research.md`.
+2. Read section 5.
+3. Confirm that the table holds 21 rows.
+4. Confirm that every row holds a file, a line, a function, a parameter, an
+   outcome, and a justification.
+5. Confirm that no cell in the outcome column reads "To triage".
+
+**Expected result**: 15 rows hold Outcome A. 5 rows hold Outcome B. 1 row holds
+Outcome C. The total is 21.
+
+This satisfies SC-001.
+
+---
+
+## Step 2. Re-measure the baseline
+
+Run this command before you change any code.
+
+```powershell
+.venv\Scripts\python.exe -m pylint src/ --disable=all --enable=W0613 --score=n
+```
+
+**Expected result**: 21 findings. Every file and line matches the table in
+`research.md`.
+
+If the count differs, other work landed on `main`. Add each new finding to the
+triage record and assign an outcome before you continue. FR-003 requires this
+step.
+
+---
+
+## Step 3. Validate User Story 2, the source tree
+
+Run this command after every task that changes code.
+
+```powershell
+.venv\Scripts\python.exe -m pylint src/ --disable=all --enable=W0613 --score=n
+```
+
+**Expected result during the work**: The count falls after each task. The count
+never rises.
+
+Caution: A rise means a cascade. You removed a parameter at one level and left
+the caller unchanged. Read section 3 of `research.md`, then finish the thread.
+
+**Expected result at the end**: No output. Zero findings. This satisfies FR-021
+and SC-002.
+
+---
+
+## Step 4. Validate the ignored packages
+
+The gate hides `src/maps` and `src/ssh`. Four findings sit there. Prove them by
+hand.
+
+```powershell
+.venv\Scripts\python.exe -m pylint src/maps src/ssh --disable=all --enable=W0613 --score=n
+```
+
+**Expected result**: No output. Zero findings.
+
+This satisfies FR-004.
+
+---
+
+## Step 5. Confirm that no suppression is too wide
+
+```powershell
+.venv\Scripts\python.exe -m tools.ste_linter --help
+Select-String -Path "pyproject.toml","setup.cfg" -Pattern "W0613" -ErrorAction SilentlyContinue
+Get-ChildItem -Path src -Recurse -Filter *.py | Select-String -Pattern "pylint: disable=.*W0613"
+```
+
+**Expected result for the second command**: No match after Step 8. A match
+before Step 8 is normal.
+
+**Expected result for the third command**: Exactly six matches. Five belong to
+Outcome B. One belongs to Outcome C. Each match sits on a parameter line or on
+the line above it.
+
+Read each of the six lines. Confirm that the reason names a library, a
+back-compat promise, or an issue number. A generic phrase fails FR-013 and
+SC-006.
+
+This satisfies FR-011 and FR-012.
+
+---
+
+## Step 6. Run the quality gates
+
+Run each command exactly as the continuous integration job runs it. Scope the
+run to the whole repository where the job does, not to the changed files only.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check .
+.venv\Scripts\python.exe -m black --check .
+.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml
+.venv\Scripts\python.exe -m radon cc src/ -nc
+.venv\Scripts\python.exe -m pytest
+```
+
+**Expected result**: Every command exits with code 0. The radon command must
+report no block above complexity 10.
+
+Caution: Removing a parameter lowers the parameter count. It does not raise
+complexity. A radon failure therefore points at an unrelated edit.
+
+This satisfies FR-026 and SC-005.
+
+---
+
+## Step 7. Confirm the test count
+
+Record the test count before the work and after the work.
+
+```powershell
+.venv\Scripts\python.exe -m pytest -q
+```
+
+**Expected result**: The pass count matches the count before the change. The
+feature updates 24 test call sites, but it adds no test and removes no test.
+
+This satisfies SC-005.
+
+---
+
+## Step 8. Change the gate, last
+
+Do not start this step until Step 3 reports zero findings.
+
+1. Open `pyproject.toml`.
+2. Remove `"W0613"` from the `disable` list under
+   `[tool.pylint."messages control"]`.
+3. Update the comment block above the list. See section 2 of
+   `contracts/pylint-gate.md` for the three facts that the new text must state.
+
+Reproduce the gate locally.
+
+```powershell
+.venv\Scripts\python.exe -m pylint src/ --fail-under=9.5 --ignore=maps,ssh,ui
+```
+
+**Expected result**: Exit code 0. The reported score is near 9.77 on Windows.
+
+Warning: This local result is not proof. Go to Step 9.
+
+---
+
+## Step 9. Validate User Story 3, the runner result
+
+1. Push the branch.
+2. Open the continuous integration run for the branch.
+3. Read the job named "Pylint (score gate)".
+4. Confirm that the job passed.
+5. Record the score from the job log in the pull request body.
+
+**Expected result**: The job passes at the 9.5 threshold on `ubuntu-latest`.
+
+Warning: Do not add the `auto-merge` label until this job and CodeQL both pass.
+
+If the job fails, follow section 7 of `contracts/pylint-gate.md`. That section
+holds the rollback position.
+
+This satisfies FR-022, FR-023, and SC-004.
+
+---
+
+## Step 10. Confirm the companion issues
+
+1. Open the three issues that section 7 of `research.md` names.
+2. Confirm that each issue holds a type label and a scope label.
+3. Confirm that the triage record links the Outcome C issue by number.
+4. Confirm that the Outcome C comment in the source names the same number.
+
+This satisfies FR-017 and SC-007.
+
+---
+
+## Step 11. Prove the gate reports a new defect
+
+This step proves SC-008. Do not commit the temporary change.
+
+1. Add an unused parameter to any function under `src/`.
+2. Run the gate command from Step 8.
+3. Confirm that pylint reports a `W0613` message for the new parameter.
+4. Undo the temporary change.
+5. Run the gate command again and confirm that it passes.
+
+---
+
+## Step 12. Check the prose
+
+Run the linter on every document that the feature writes or changes.
+
+```powershell
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/plan.md
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/research.md
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/data-model.md
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/quickstart.md
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/contracts/signature-changes.md
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/contracts/pylint-gate.md
+```
+
+**Expected result**: Every file scores 80 or higher.
+
+Run the linter on the pull request body and on each issue body too. FR-031
+covers all prose.
+
+---
+
+## Validation summary
+
+| Story | Step | Success criterion |
+| - | - | - |
+| User Story 1 | Step 1 | SC-001 |
+| User Story 2 | Steps 3, 4, 5, 6, 7 | SC-002, SC-005, SC-006, SC-009 |
+| User Story 3 | Steps 8, 9, 11 | SC-003, SC-004, SC-008 |
+| Companion work | Step 10 | SC-007 |

--- a/specs/887-pylint-unused-argument/research.md
+++ b/specs/887-pylint-unused-argument/research.md
@@ -1,0 +1,284 @@
+# Research: Narrow the pylint W0613 unused-argument suppression
+
+**Feature Directory**: `specs/887-pylint-unused-argument/`
+
+**Date**: 2026-07-29
+
+**Status**: Complete. Every finding holds a final outcome.
+
+This document is the triage record that FR-002 requires. It holds one row for
+each measured finding. It also holds the call-site evidence, the cascade
+analysis, and the score measurement.
+
+---
+
+## 1. Baseline re-measurement (FR-003)
+
+The team re-measured the baseline in the current working tree.
+
+**Command**:
+
+```powershell
+.venv\Scripts\python.exe -m pylint src/ --disable=all --enable=W0613 --score=n
+```
+
+**Tool versions**: pylint 4.0.6, astroid 4.0.4, Python 3.13.3 on Windows.
+
+**Result**: 21 findings. The count matches the spec. Every file and every line
+number matches the spec table. The baseline did not drift.
+
+**Decision**: Keep the 21-row site inventory from the spec. No new rows are
+needed.
+
+---
+
+## 2. Score measurement and risk evidence
+
+The largest risk is a score drop below the 9.5 threshold. The team measured the
+delta on Windows.
+
+**Commands**:
+
+```powershell
+.venv\Scripts\python.exe -m pylint src/ --ignore=maps,ssh,ui --exit-zero
+.venv\Scripts\python.exe -m pylint src/ --ignore=maps,ssh,ui --enable=W0613 --exit-zero
+```
+
+| Condition | Local Windows score |
+| - | - |
+| Today, `W0613` disabled | 9.77 |
+| Simulated, `W0613` enabled | 9.77 |
+
+**Finding**: The 17 gate-visible findings do not move the score at the
+reported resolution of 0.01. The measured delta is below 0.01.
+
+**Rationale**: The pylint score divides the message count by the statement
+count. The `src/` tree holds a large statement count. Seventeen extra warnings
+produce a change smaller than the reported resolution.
+
+**Caution**: This is a Windows measurement. Issue #891 measured a 0.30 gap
+between Windows and Linux for the same commit. That gap appeared when the run
+included `src/maps`, `src/ssh`, and `src/ui`. This feature keeps the
+`--ignore=maps,ssh,ui` flag, so the two runs cover the same package set that
+passes today. The gap is therefore expected to be smaller. The team still
+treats the Windows number as an estimate only. FR-023 requires a real run on
+the Linux runner.
+
+**Decision**: Proceed. Confirm the score with a continuous integration run on
+the pushed branch before merge.
+
+**Alternative considered and rejected**: Lower the threshold below 9.5.
+FR-024 forbids this action.
+
+**Alternative considered and rejected**: Keep the repository-wide disable and
+document the findings only. This action delivers no gate. SC-008 requires the
+gate to report a new unused argument on the first run.
+
+---
+
+## 3. Cascade analysis (the main research finding)
+
+Nine of the 21 findings sit at the end of a parameter thread. A caller accepts
+the same parameter and passes it down. The caller reads the parameter for no
+other purpose.
+
+When the feature removes the parameter from the callee, the caller parameter
+becomes unused. Pylint then reports a **new** W0613 finding at the caller. The
+new finding did not exist in the baseline.
+
+**Consequence**: An Outcome A change is not always a single-site edit. The
+feature must walk the thread up until it reaches a function that reads the
+parameter for a real purpose.
+
+**Decision**: Treat each thread as one unit of work. Remove the parameter at
+every level of the thread in the same change. Stop at the first level that
+reads the parameter.
+
+The table lists every cascade. The "Stops at" column names the function that
+reads the parameter for a real purpose.
+
+| Thread | Levels to change | Stops at | Reason the thread stops |
+| - | - | - | - |
+| `mistapi` in `bulk_ap_upgrader.py` | `_upgrade_version_group`, `_execute_multi_version_upgrade` | `_execute_site_upgrade` | It also calls `_execute_single_version_upgrade`, which uses `mistapi`. |
+| `target_org_id` in `version_per_model_fetcher.py` | `_rows_for_model`, `_expand_model_rows` | `fetch` | It uses `target_org_id` for two prefetch calls and for logging. |
+| `sitegroup_lookup` in `_ssid_template_phase1.py` | `_resolve_template`, `_resolve_site_wlan` | `_build_site_row` | It reads a dataclass field, not a parameter. Pylint does not report a field. |
+| `source` in `address_utils.py` | `_make_api_request`, `_calculate_component_match`, `_calculate_quality_boost`, `_calculate_confidence`, `_parse_geocode_response` | `_geocode_address` | It uses `source` in two debug log calls. |
+
+The `source` thread is the widest. Two of the five methods,
+`_calculate_confidence` and `_parse_geocode_response`, are not in the baseline.
+They read `source` only to pass it down. They become findings after the leaf
+methods change.
+
+---
+
+## 4. Existing ruff suppressions that this feature must resolve
+
+Six parameters already carry a ruff `ARG` suppression. The stated reason is
+"signature preserved for tests" or "reserved for future logging".
+
+| File | Parameter | Existing comment |
+| - | - | - |
+| `_ssid_template_cache.py` | `results` | `# noqa: ARG002 - signature preserved for tests` |
+| `_ssid_template_phase1.py` | `sitegroup_lookup` | `# noqa: ARG001 - signature preserved for tests` |
+| `address_utils.py` (3 sites) | `source` | `# noqa: ARG002` with a "future logging" reason |
+| `address_utils.py` | `debug` | `# noqa: ARG004 - signature preserved for callers passing debug` |
+
+**Decision**: None of these reasons meets the FR-013 bar. FR-013 requires a
+specific contract. A test is not an external contract. FR-026 requires the
+feature to update any test that calls a changed signature. A future plan for
+logging is not a contract either.
+
+**Evidence against the `debug` reason**: The comment claims that callers pass
+`debug`. A search of the whole repository found no caller that passes `debug`.
+The only callers are four tests, and each test passes two arguments. The stated
+reason is factually wrong.
+
+**Action**: These six parameters take Outcome A. The feature removes each
+parameter and deletes the now-dead `noqa` comment in the same change.
+
+---
+
+## 5. Triage record (FR-001, FR-002)
+
+The table holds one row for each of the 21 findings. The "Call sites" column
+counts the production call sites and the test call sites that need an edit.
+
+| # | File | Line | Function | Parameter | Gate sees it | Outcome | Justification | Call sites |
+| - | - | - | - | - | - | - | - | - |
+| 1 | `src/capture/packet_capture.py` | 911 | `PacketCaptureManager._multi_ap_gather_params` | `ap_macs` | Yes | A | The body calls three prompt helpers. None of them needs the AP list. The sibling helpers `_multi_ap_print_summary` and `_multi_ap_build_payload` do use the list, so the parameter is a copy-paste leftover. | 1 production, 0 test |
+| 2 | `src/firmware/bulk_ap_upgrader.py` | 1487 | `BulkAPFirmwareUpgrader._upgrade_version_group` | `mistapi` | Yes | A | The deeper helper `_invoke_upgrade_api` performs a lazy `import mistapi` of its own. The threaded module is dead. Cascades one level to `_execute_multi_version_upgrade`. | 2 production, 2 test |
+| 3 | `src/firmware/org_ap_upgrader.py` | 675 | `OrgLevelAPFirmwareUpgrader._display_org_list` | `msp_name` | Yes | A | The body prints the org list and the selection help. It never names the MSP. The caller already prints the MSP name in the step banner. | 1 production, 0 test |
+| 4 | `src/inventory/inventory_summary/version_per_model_fetcher.py` | 188 | `VersionPerModelFetcher._rows_for_model` | `target_org_id` | Yes | A | The method dispatches on `device_type` and reads only the prefetched record lists. The org id is no longer needed after the prefetch refactor. Cascades one level to `_expand_model_rows`. | 2 production, 6 test |
+| 5 | `src/maps/_maps_clone.py` | 149 | `_MapsClone._confirm_clone` | `clone_payload` | No | A | Verified in the spec. The method prints a plan and prompts for confirmation. It never reads the payload. | 1 production, 0 test |
+| 6 | `src/maps/maps_manager.py` | 532 | `MapsManager._render_site_maps_table` | `site_name` | No | A | The table header prints the map count and the column titles only. The caller already prints the site name before the call, so the operator does not lose information. | 1 production, 0 test |
+| 7 | `src/org/org_synthetic_probes_manager.py` | 1619 | `_build_probe_set` | `vlan_ids` | Yes | B | Verified in the spec. The docstring documents a back-compat promise to the caller. VLAN scoping belongs on the `tests[]` row, not on the `custom_probes` definition. | 0 |
+| 8 | `src/site/address_audit/address_resolver.py` | 93 | `AddressResolver._combine` | `candidates` | Yes | A | Verified in the spec. The body delegates to `_pick_tier_winner` and `_resolve_validated`. Neither helper needs the candidate list. The parameter sits fourth of five, so the removal shifts `query`. | 1 production, 0 test |
+| 9 | `src/ssh/runtime/app_runner.py` | 265 | `AppRunner._prompt_for_commands` | `env_cmds` | No | A | The caller reaches this line only after both lists tested empty. The caller passes two empty lists. The body prompts the operator and ignores both. | 1 production, 0 test |
+| 10 | `src/ssh/runtime/app_runner.py` | 265 | `AppRunner._prompt_for_commands` | `csv_cmds` | No | A | Same evidence as row 9. Both parameters are always empty at the single call site. | 1 production, 0 test |
+| 11 | `src/ssid_consolidation/_ssid_template_cache.py` | 193 | `_SsidTemplateCacheCluster._offer_resume` | `results` | Yes | A | All three production call sites pass a literal empty list. The body loads the prior results from disk instead. The manager reaches this method through `__getattr__` proxy delegation, so no base class fixes the signature. | 3 production, 1 test |
+| 12 | `src/ssid_consolidation/_ssid_template_phase1.py` | 121 | `_resolve_template` | `sitegroup_lookup` | Yes | A | The scope check `_template_applies_to_site` reads `site["sitegroup_ids"]` directly. The lookup map is never needed. Cascades one level to `_resolve_site_wlan`. | 2 production, 3 test |
+| 13 | `src/ssid_consolidation/_ssid_template_phase45.py` | 267 | `_build_template_config` | `resolutions` | Yes | **C** | See section 6. The operator answers a deviation prompt for each cluster and parameter. The answers never reach the template. | Do not remove |
+| 14 | `src/utils/address_utils.py` | 494 | `AddressUtils.apply_business_context_rules` | `debug` | Yes | A | No caller in the repository passes `debug`. The parameter carries a default value, so the removal cannot raise a `TypeError` at any caller. | 0 production, 4 test |
+| 15 | `src/utils/address_utils.py` | 902 | `NominatimValidator._make_api_request` | `source` | Yes | A | The body builds the query parameters and retries the request. It never reads `source`. Part of the five-level `source` thread. | 1 production, 4 test |
+| 16 | `src/utils/address_utils.py` | 947 | `NominatimValidator._calculate_component_match` | `source` | Yes | A | The body scores address parts against the display name. It never reads `source`. Part of the five-level `source` thread. | 1 production, 3 test |
+| 17 | `src/utils/address_utils.py` | 977 | `NominatimValidator._calculate_quality_boost` | `source` | Yes | A | The body sums two boost helpers. It never reads `source`. Part of the five-level `source` thread. | 1 production, 3 test |
+| 18 | `src/websocket/manager.py` | 318 | `WebSocketManager._on_open` | `websocket_connection` | Yes | B | Verified in the spec. The `websocket-client` library calls the callback with the connection as the first argument. | 0 |
+| 19 | `src/websocket/manager.py` | 323 | `WebSocketManager._on_message` | `websocket_connection` | Yes | B | Same library protocol as row 18. | 0 |
+| 20 | `src/websocket/manager.py` | 336 | `WebSocketManager._on_error` | `websocket_connection` | Yes | B | Same library protocol as row 18. | 0 |
+| 21 | `src/websocket/manager.py` | 343 | `WebSocketManager._on_close` | `websocket_connection` | Yes | B | Same library protocol as row 18. | 0 |
+
+### Outcome totals
+
+| Outcome | Count | Rows |
+| - | - | - |
+| A, remove the parameter | 15 | 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 14, 15, 16, 17 |
+| B, keep with a narrow suppression | 5 | 7, 18, 19, 20, 21 |
+| C, a real defect | 1 | 13 |
+| **Total** | **21** | |
+
+Zero findings stay unassigned. SC-001 is satisfied by this table.
+
+---
+
+## 6. Outcome C detail, row 13
+
+**Site**: `src/ssid_consolidation/_ssid_template_phase45.py:267`,
+`_build_template_config`, parameter `resolutions`.
+
+**The chain**:
+
+1. `_phase4_preflight` calls `_resolve_deviations`. That function prompts the
+   operator once for each deviating cluster and parameter.
+2. `_resolve_deviations` records each answer in `resolutions`, keyed by the
+   cluster name and the parameter name.
+3. `_phase4_preflight` passes `resolutions` to `_build_all_template_configs`.
+4. `_build_all_template_configs` passes `resolutions` to
+   `_build_template_config`.
+5. `_build_template_config` never reads `resolutions`. It calls
+   `_cluster_deviation_params` instead, and it writes a
+   `{{MISTHELPER_<PARAM>}}` placeholder for each deviating parameter.
+
+**Evidence**: A search of the whole module found 15 uses of the name
+`resolutions`. Every use belongs to the build-and-pass chain above. No code
+writes `resolutions` to a file. No code reads a value out of the map.
+
+**Why this is a defect**: The operator answers an interactive prompt for each
+deviation. The answers change nothing. The generated template holds a
+placeholder in every case. The prompt therefore misleads the operator.
+
+**Action (FR-015, FR-018)**: Do not delete the parameter. Deleting it hides the
+defect and removes the seam that the fix needs. Add a site-local
+`# pylint: disable=W0613` comment. The reason names the companion issue and
+states that the parameter stays until the fix lands.
+
+**Companion issue (FR-017)**: File an issue with the title
+"Phase 4 discards the operator deviation resolutions". Use the labels `bug` and
+`MistHelper.py` scope equivalent for `src/ssid_consolidation`. The issue body
+holds the five-step chain above.
+
+**Rationale for the minimal action**: The correct fix reads a resolved value
+out of `resolutions` and writes the concrete value into the config instead of
+the placeholder. That change alters the generated Mist template. It needs its
+own specification, its own tests, and its own operator review. It is larger
+than this feature.
+
+---
+
+## 7. Companion issues and observations
+
+| Source | Observation | Required action |
+| - | - | - |
+| Row 13 | Phase 4 discards the operator deviation resolutions. | File an issue. FR-017 requires it. |
+| Row 5 | The maps clone confirmation prints a static capability list. The text does not describe the real payload. | File an issue. The spec requires it. Do not redesign the text. |
+| Row 12 cascade | After the change, `_build_sitegroup_lookup` and the `_SiteLookups.sitegroup_lookup` field have no reader. The module also re-exports `_build_sitegroup_lookup` for back-compat. | File an issue. Removal of a dataclass field and a public re-export is dead-code work, and the Out of Scope list excludes it. |
+
+---
+
+## 8. Outcome B suppression text
+
+FR-011 requires a site-local comment. FR-013 requires a specific contract. The
+table holds the exact reason text for each Outcome B site.
+
+| Row | Reason text |
+| - | - |
+| 7 | `# pylint: disable=W0613 - back-compat contract with the caller. VLAN scope belongs on the tests[] row.` |
+| 18 | `# pylint: disable=W0613 - websocket-client library passes the connection to on_open.` |
+| 19 | `# pylint: disable=W0613 - websocket-client library passes the connection to on_message.` |
+| 20 | `# pylint: disable=W0613 - websocket-client library passes the connection to on_error.` |
+| 21 | `# pylint: disable=W0613 - websocket-client library passes the connection to on_close.` |
+| 13 | `# pylint: disable=W0613 - kept as the seam for issue <N>. Phase 4 must apply this map.` |
+
+Each comment names a specific contract or a specific issue. No comment uses a
+generic phrase.
+
+---
+
+## 9. Positional-shift check (FR-008, FR-009)
+
+FR-008 forbids a removal that shifts another positional argument into the wrong
+slot. The team checked every Outcome A call site.
+
+| Risk class | Rows | Finding |
+| - | - | - |
+| The parameter is last in the signature | 1, 2, 3, 5, 9, 10, 11, 12, 14, 15, 16, 17 | The removal cannot shift a later argument, because no later argument exists. Rows 9 and 10 empty the signature. |
+| The parameter is first or in the middle | 4, 6, 8 | Every call site passes the parameter positionally. Every call site must drop it in the same edit. Row 4 sits first of four. Row 6 sits first of two. Row 8 sits fourth of five and shifts `query`. |
+
+Section 5 names every call site for rows 4, 6, and 8. The signature contract
+repeats them with a warning.
+
+No caller passes any Outcome A parameter by keyword. FR-009 is satisfied.
+
+Row 14 carries a default value. FR-009 needs a keyword check for that row. No
+caller passes `debug` at all, so no keyword call site exists.
+
+---
+
+## 10. Decisions summary
+
+| Decision | Rationale | Alternative rejected |
+| - | - | - |
+| Resolve each parameter thread as one unit. | A partial removal creates a new finding at the caller. | Fix only the reported line. This leaves the gate red. |
+| Treat "signature preserved for tests" as insufficient. | FR-013 requires a specific contract. FR-026 requires a test update. | Convert the ruff `noqa` into a pylint disable. This keeps dead parameters. |
+| Keep row 13 and file an issue. | FR-015 forbids a delete. The defect must stay visible. | Delete `resolutions`. This hides a real operator-facing defect. |
+| Change `pyproject.toml` last. | An early change turns the gate red for every open branch. | Change the configuration first. This blocks the whole team. |
+| Confirm the score on the Linux runner. | Issue #891 measured a 0.30 platform gap. | Accept the local Windows score. FR-023 forbids this. |

--- a/specs/887-pylint-unused-argument/spec.md
+++ b/specs/887-pylint-unused-argument/spec.md
@@ -1,0 +1,291 @@
+# Feature Specification: Narrow the pylint W0613 unused-argument suppression
+
+**Feature Directory**: `specs/887-pylint-unused-argument/`
+
+**Feature Branch**: not created. This spec creates no branch and no commit.
+
+**Created**: 2026-07-29
+
+**Status**: Draft
+
+**Source Issue**: #887, part 1 of 3
+
+**Input**: Narrow the repository-wide pylint `W0613` (unused-argument) suppression so that unused arguments in ordinary functions are flagged again. Cover `W0613` only.
+
+---
+
+## Context
+
+The file `pyproject.toml` holds this line in the `[tool.pylint."messages control"]` table:
+
+```toml
+disable = ["C0114", "C0115", "C0116", "W0613", "W0718"]
+```
+
+The committed rationale for `W0613` is: "unused-argument -- WebSocket callback signatures are protocol-mandated". That rationale covers protocol callbacks only. The disable covers the whole repository. Any unused argument in any ordinary function is therefore hidden.
+
+Issue #887 asks the team to narrow the suppression. This feature covers `W0613` only.
+
+### Measured baseline
+
+The command `pylint src/ --disable=all --enable=W0613` reports 21 findings. The findings sit in 20 functions across 13 files. One function, `AppRunner._prompt_for_commands`, holds 2 of the 21 findings. The team measured this baseline on `main` at commit `45c7b8d`.
+
+### Gate behavior
+
+The continuous integration job runs this command:
+
+```text
+pylint src/ --fail-under=9.5 --ignore=maps,ssh,ui
+```
+
+The `--ignore` flag hides `src/maps`, `src/ssh`, and `src/ui`. Four of the 21 findings sit inside `src/maps` and `src/ssh`. Those four findings do not change the gate score today. Issue #891 tracks the removal of the `--ignore` flag. This feature does not change that flag.
+
+### Prior failure to avoid
+
+Issue #891 recorded a score disagreement. A Windows checkout reported 9.71. The `ubuntu-latest` runner reported 9.41 for the same commit and failed the 9.5 threshold. A local Windows run is therefore not a safe proxy for this gate. This feature must confirm the score on the runner.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Record a decision for every finding (Priority: P1)
+
+A maintainer needs to know which unused arguments are dead code and which are bound by a contract. The maintainer reviews each of the 21 findings, reads the surrounding code, and assigns one outcome to each finding. The maintainer writes the decision and the evidence into a triage record.
+
+**Why this priority**: The triage record is the foundation. Without it, a code change is a guess. The record alone gives the team value, because it separates dead parameters from contract-bound parameters.
+
+**Independent Test**: Read the triage record. Confirm that it holds 21 rows. Confirm that every row names a file, a line, a function, a parameter, an outcome, and a justification. No code change is needed for this test.
+
+**Acceptance Scenarios**:
+
+1. **Given** the measured baseline of 21 findings, **When** the maintainer completes the triage, **Then** the record holds one outcome for each of the 21 findings.
+2. **Given** a finding with no clear contract, **When** the maintainer inspects the function body and the call sites, **Then** the record states Outcome A and names every call site.
+3. **Given** a finding in a library callback, **When** the maintainer inspects the library contract, **Then** the record states Outcome B and names the contract.
+4. **Given** a finding where the argument should have been used, **When** the maintainer inspects the intended behavior, **Then** the record states Outcome C and links a companion issue.
+
+---
+
+### User Story 2 - Make the code match the triage (Priority: P2)
+
+A maintainer applies the recorded outcomes to the source tree. The maintainer removes each Outcome A parameter from the signature and from every call site. The maintainer adds a site-local suppression with a one-line reason to each Outcome B parameter. The maintainer takes the safest minimal action for each Outcome C site.
+
+**Why this priority**: The code change makes the source tree honest. A reviewer can then read one line and learn why an argument stays.
+
+**Independent Test**: Run `pylint src/ --disable=all --enable=W0613`. Confirm that it reports zero findings. Run the full test suite. Confirm that it passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Outcome A parameter, **When** the maintainer removes it, **Then** every call site drops the argument and the test suite passes.
+2. **Given** an Outcome A parameter that a caller passes positionally, **When** the maintainer removes it, **Then** the remaining arguments still bind to the correct parameters.
+3. **Given** an Outcome B parameter, **When** the maintainer adds the suppression, **Then** the comment names the contract that mandates the parameter.
+4. **Given** any Outcome A or Outcome B site, **When** the maintainer completes the change, **Then** the runtime behavior is the same as before the change.
+5. **Given** a test that calls a changed signature, **When** the maintainer changes the signature, **Then** the maintainer updates the test in the same change.
+
+---
+
+### User Story 3 - Turn the gate back on (Priority: P3)
+
+A maintainer removes `W0613` from the `disable` list in `pyproject.toml`. The maintainer updates the comment block above the list. The continuous integration run on the branch confirms that the pylint gate still passes at the 9.5 threshold.
+
+**Why this priority**: The gate is the durable outcome. From this point, the gate reports any new unused argument on the first run.
+
+**Independent Test**: Read the continuous integration result for the branch. Confirm that the pylint job passed. Confirm that `W0613` is absent from the `disable` list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a triaged and clean source tree, **When** the maintainer removes `W0613` from the `disable` list, **Then** the pylint gate passes on the Linux runner at the 9.5 threshold.
+2. **Given** a merged change, **When** a developer adds a new unused argument, **Then** the pylint gate reports it on the first run.
+3. **Given** a local Windows pylint score above 9.5, **When** the maintainer reports the result, **Then** the maintainer still waits for the Linux runner result before merge.
+
+---
+
+### Edge Cases
+
+- A parameter is unused in one method but is mandated because the method overrides a base-class method. Removing the parameter breaks the override contract.
+- A caller passes an Outcome A parameter positionally. Removing the parameter shifts every later argument to the wrong slot.
+- An Outcome A parameter carries a default value. A caller passes it by keyword. Removing the parameter raises a `TypeError` at that caller.
+- A test calls a changed signature. The test fails until the maintainer updates it.
+- A parameter is unused in the body but a decorator or a framework reads the signature.
+- Removing the `W0613` entry from the `disable` list makes hidden messages visible and lowers the pylint score below 9.5 on Linux.
+- Four findings sit in packages that the gate ignores. Those findings never change the score, so the gate cannot prove that they are fixed.
+- The baseline count drifts because other work lands on `main` before this feature starts.
+- A site is an Outcome C defect and the correct fix is larger than this feature. The team must not hide the defect by deleting the parameter.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Triage
+
+- **FR-001**: The feature MUST assign exactly one outcome to each of the 21 measured findings. The outcome set is A, B, and C.
+- **FR-002**: The triage record MUST name the file, the line, the function, the parameter, the outcome, and a one-sentence justification for each finding.
+- **FR-003**: The feature MUST re-measure the baseline before the triage starts. If the count differs from 21, the feature MUST record the new count and triage every finding in the new list.
+- **FR-004**: The feature MUST triage the four findings that sit in `src/maps` and `src/ssh`, even though the gate ignores those packages today.
+
+#### Outcome A, remove the parameter
+
+- **FR-005**: Outcome A applies when the argument is a refactor leftover and no contract requires it.
+- **FR-006**: An Outcome A change MUST remove the parameter from the signature and from every call site.
+- **FR-007**: Before an Outcome A removal, the feature MUST locate every call site in the source tree and in the test tree.
+- **FR-008**: The feature MUST confirm that no caller passes the parameter positionally in a way that shifts another argument.
+- **FR-009**: The feature MUST confirm that no caller passes the parameter by keyword.
+
+#### Outcome B, keep with a narrow suppression
+
+- **FR-010**: Outcome B applies when an external library protocol, an override contract, or a documented back-compat promise mandates the signature.
+- **FR-011**: An Outcome B change MUST add a site-local `# pylint: disable=W0613` comment with a one-line reason. The comment MUST sit on the same line or on the line directly above.
+- **FR-012**: The feature MUST NOT add a file-wide, module-wide, or repository-wide disable for `W0613`.
+- **FR-013**: The Outcome B reason MUST name the specific contract. A generic phrase such as "signature required" is not sufficient.
+
+#### Outcome C, a real defect
+
+- **FR-014**: Outcome C applies when the argument should have been used and the omission is a defect.
+- **FR-015**: The feature MUST NOT resolve an Outcome C site by deleting the parameter.
+- **FR-016**: The feature MUST record each Outcome C site in the triage record.
+- **FR-017**: The feature MUST file a companion GitHub issue for each Outcome C site and MUST link that issue from the triage record.
+- **FR-018**: The feature MUST take the safest minimal action at each Outcome C site and MUST state that action in the record.
+
+#### Gate change
+
+- **FR-019**: The feature MUST remove `"W0613"` from the `disable` list in `pyproject.toml`. This MUST be the final source change.
+- **FR-020**: The feature MUST update the comment block above the `disable` list so that it no longer claims that `W0613` is disabled.
+- **FR-021**: After the change, `pylint src/ --disable=all --enable=W0613` MUST report zero findings.
+- **FR-022**: The continuous integration pylint job MUST pass with `--fail-under=9.5` on the `ubuntu-latest` runner.
+- **FR-023**: The feature MUST confirm the score with a real continuous integration run on the branch. A local Windows pylint run MUST NOT be accepted as proof.
+- **FR-024**: If the Linux score falls below 9.5, the feature MUST raise the score by removing findings. The feature MUST NOT lower the threshold and MUST NOT restore the repository-wide disable.
+
+#### Safety
+
+- **FR-025**: The runtime behavior MUST NOT change at any Outcome A or Outcome B site.
+- **FR-026**: Every existing test MUST still pass. The feature MUST update any test that calls a changed signature in the same change.
+- **FR-027**: The feature MUST NOT change the `W0718` suppression.
+- **FR-028**: The feature MUST NOT change the mypy `src.db` override.
+- **FR-029**: The feature MUST NOT change the `--ignore=maps,ssh,ui` flag on the pylint gate.
+
+#### Project conventions
+
+- **FR-030**: Every changed line MUST carry an inline comment that explains why the line exists, not what the line does.
+- **FR-031**: All prose MUST follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md`.
+- **FR-032**: The feature MUST NOT add a wrapper function.
+- **FR-033**: The feature MUST NOT add a legacy compatibility shim, a pass-through alias, or a fallback compatibility path.
+
+---
+
+### Key Entities
+
+- **Finding**: One pylint `W0613` message. A finding names a file, a line, a function, and a parameter.
+- **Site**: One function that holds one or more findings. The baseline holds 20 sites and 21 findings.
+- **Outcome**: One of three decisions. Outcome A removes the parameter. Outcome B keeps the parameter with a narrow suppression. Outcome C records a defect.
+- **Triage record**: The document that maps every finding to an outcome, a justification, and evidence.
+- **Suppression**: A `# pylint: disable=W0613` comment that covers one line or one function. A suppression always carries a reason.
+
+---
+
+## Site Inventory
+
+The table lists the measured baseline. The outcome column is empty for every row that the team has not verified. The triage must fill every empty cell.
+
+| # | File | Line | Function | Parameter | Gate sees it | Outcome |
+| - | - | - | - | - | - | - |
+| 1 | `src/capture/packet_capture.py` | 911 | `PacketCaptureManager._multi_ap_gather_params` | `ap_macs` | Yes | To triage |
+| 2 | `src/firmware/bulk_ap_upgrader.py` | 1487 | `BulkAPFirmwareUpgrader._upgrade_version_group` | `mistapi` | Yes | To triage |
+| 3 | `src/firmware/org_ap_upgrader.py` | 675 | `OrgLevelAPFirmwareUpgrader._display_org_list` | `msp_name` | Yes | To triage |
+| 4 | `src/inventory/inventory_summary/version_per_model_fetcher.py` | 188 | `VersionPerModelFetcher._rows_for_model` | `target_org_id` | Yes | To triage |
+| 5 | `src/maps/_maps_clone.py` | 149 | `_MapsClone._confirm_clone` | `clone_payload` | No | Outcome A, verified |
+| 6 | `src/maps/maps_manager.py` | 532 | `MapsManager._render_site_maps_table` | `site_name` | No | To triage |
+| 7 | `src/org/org_synthetic_probes_manager.py` | 1619 | `_build_probe_set` | `vlan_ids` | Yes | Outcome B, verified |
+| 8 | `src/site/address_audit/address_resolver.py` | 93 | `AddressResolver._combine` | `candidates` | Yes | Outcome A, verified |
+| 9 | `src/ssh/runtime/app_runner.py` | 265 | `AppRunner._prompt_for_commands` | `env_cmds` | No | To triage |
+| 10 | `src/ssh/runtime/app_runner.py` | 265 | `AppRunner._prompt_for_commands` | `csv_cmds` | No | To triage |
+| 11 | `src/ssid_consolidation/_ssid_template_cache.py` | 193 | `_SsidTemplateCacheCluster._offer_resume` | `results` | Yes | To triage |
+| 12 | `src/ssid_consolidation/_ssid_template_phase1.py` | 121 | `_resolve_template` | `sitegroup_lookup` | Yes | To triage |
+| 13 | `src/ssid_consolidation/_ssid_template_phase45.py` | 267 | `_build_template_config` | `resolutions` | Yes | To triage |
+| 14 | `src/utils/address_utils.py` | 494 | `AddressUtils.apply_business_context_rules` | `debug` | Yes | To triage |
+| 15 | `src/utils/address_utils.py` | 902 | `NominatimValidator._make_api_request` | `source` | Yes | To triage |
+| 16 | `src/utils/address_utils.py` | 947 | `NominatimValidator._calculate_component_match` | `source` | Yes | To triage |
+| 17 | `src/utils/address_utils.py` | 977 | `NominatimValidator._calculate_quality_boost` | `source` | Yes | To triage |
+| 18 | `src/websocket/manager.py` | 318 | `WebSocketManager._on_open` | `websocket_connection` | Yes | Outcome B, verified |
+| 19 | `src/websocket/manager.py` | 323 | `WebSocketManager._on_message` | `websocket_connection` | Yes | Outcome B, verified |
+| 20 | `src/websocket/manager.py` | 336 | `WebSocketManager._on_error` | `websocket_connection` | Yes | Outcome B, verified |
+| 21 | `src/websocket/manager.py` | 343 | `WebSocketManager._on_close` | `websocket_connection` | Yes | Outcome B, verified |
+
+"Gate sees it" is "No" when the file sits in `src/maps` or `src/ssh`. The `--ignore=maps,ssh,ui` flag hides those packages from the score.
+
+---
+
+## Verified Observations
+
+The team already read the code at five of the 21 findings. The notes below are evidence for the triage. The triage must still record them in the triage record.
+
+### Rows 18 to 21, `src/websocket/manager.py`
+
+The four methods are callbacks for the `websocket-client` library. The library calls each method with the connection object as the first argument. The signature is protocol-mandated. These four findings match the committed rationale. Expected outcome: B.
+
+### Row 7, `src/org/org_synthetic_probes_manager.py`
+
+The docstring of `_build_probe_set` already documents the ignore. The text states that the parameter is kept for signature and back-compat with the caller, and that VLAN scoping belongs on the `tests[]` row that references the probe, not on the `custom_probes` definition. This is a deliberate, documented ignore. It is not a defect. Expected outcome: B.
+
+### Row 8, `src/site/address_audit/address_resolver.py`
+
+The parameter `candidates` is a leftover. The body of `_combine` delegates to `_pick_tier_winner(ui, internal, osm)` and to `_resolve_validated(winner, ui, osm)`. Neither helper needs `candidates`. A previous refactor extracted those helpers and left the parameter behind. The removal is safe. Expected outcome: A.
+
+### Row 5, `src/maps/_maps_clone.py`
+
+The method `_confirm_clone` prints a clone plan and prompts for confirmation. It never reads `clone_payload`. The minimal correct change is to remove the parameter. Expected outcome: A.
+
+**Companion observation, not in scope**: the plan text prints a static capability list, "Will copy: dimensions, orientation, location data, wayfinding, walls". The text does not describe the actual payload. The confirmation prompt may therefore not match what the operation sends. The feature MUST file a companion issue for this observation. The feature MUST NOT redesign the confirmation text.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The triage record covers every finding in the measured baseline. Zero findings are unassigned.
+- **SC-002**: A scan of the source tree for unused arguments reports zero findings after the change.
+- **SC-003**: The repository-wide suppression entry for unused arguments is absent from the project configuration file.
+- **SC-004**: The continuous integration quality-score gate passes on the Linux runner at the 9.5 threshold. A run on the branch confirms the result.
+- **SC-005**: The full test suite passes. The pass count matches the count before the change, apart from tests that the feature updated for a changed signature.
+- **SC-006**: Every retained argument carries a one-line reason that names a specific contract. A reviewer reads that reason without opening another file.
+- **SC-007**: Every recorded defect has a companion issue. The triage record links each issue.
+- **SC-008**: A new unused argument added after this change is reported by the quality gate on the first run.
+- **SC-009**: Zero behavior changes are observed at any Outcome A or Outcome B site.
+
+---
+
+## Out of Scope
+
+The items below belong to other issues. This feature MUST NOT change them.
+
+- `W0718` (broad-exception-caught). The repository holds 507 sites. This is a separate slice of issue #887.
+- The mypy `src.db` override. This is a separate slice of issue #887.
+- The `--ignore=maps,ssh,ui` flag on the pylint gate. Issue #891 tracks that work.
+- The `C0114`, `C0115`, and `C0116` docstring suppressions.
+- The redesign of the maps clone confirmation text. The feature records the observation and files a companion issue only.
+- Any raise or lowering of the `fail-under` threshold.
+
+---
+
+## Assumptions
+
+- The measured baseline of 21 findings holds at commit `45c7b8d` on `main`. Other work may land first and change the count. The feature re-measures before the triage starts.
+- The pylint version on the runner matches the version that produced the baseline. A version change can add or remove findings.
+- The four `src/websocket/manager.py` callbacks are expected to be Outcome B. The triage still records the evidence rather than assuming the result.
+- The `src/org/org_synthetic_probes_manager.py` site is expected to be Outcome B, because the docstring already documents the ignore.
+- Companion issues use the repository issue templates and the standard labels. Each issue carries a type label and a scope label.
+- The team accepts a longer review for this feature, because a signature change needs a call-site search for each removal.
+- The 4 findings in the ignored packages still get the full triage. The gate cannot prove that they are fixed, so a manual scan of those files confirms the result.
+
+---
+
+## Non-Negotiable Project Conventions
+
+The conventions below apply to every change in this feature.
+
+- **Inline comments**: every changed line carries an inline comment that explains why the line exists. A comment that restates the code is not sufficient.
+- **Simplified Technical English**: all documentation, code comments, commit text, pull request text, and issue text follow `documentation/ASD-STE100_writing-guide.md`.
+- **No wrappers**: the feature adds no wrapper function that only delegates to another function.
+- **No legacy shims**: the feature adds no compatibility alias, adapter, or fallback path that exists only to keep an old call site working. The feature updates the real call sites.
+- **Action logging**: the feature keeps the existing logging at every touched block. If a touched block lacks logging, the feature adds it.

--- a/specs/887-pylint-unused-argument/tasks.md
+++ b/specs/887-pylint-unused-argument/tasks.md
@@ -1,0 +1,310 @@
+# Tasks: Narrow the pylint W0613 unused-argument suppression
+
+**Input**: Design documents from `specs/887-pylint-unused-argument/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/signature-changes.md](contracts/signature-changes.md), [contracts/pylint-gate.md](contracts/pylint-gate.md), [quickstart.md](quickstart.md)
+
+**Tests**: The feature adds no test and removes no test. It updates 24 existing test call sites. Each update sits inside the source task that changes the signature. FR-026 requires that pairing.
+
+**Organization**: The tasks below group by user story. Inside User Story 2, the tasks group by cascade thread, not by file. Section 3 of `research.md` explains the cascade rule.
+
+**Source Issue**: #887, part 1 of 3.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: The task can run in parallel. It touches a file that no other `[P]` task in the same group touches, and it holds no cascade relationship with those tasks.
+- **[Story]**: The user story that owns the task. The values are `US1`, `US2`, and `US3`.
+- Every task names the exact file paths that it touches.
+
+## Path Conventions
+
+The repository holds a single Python project. The package tree sits under `src/`. The test tree sits under `tests/`. Paths are relative to the repository root.
+
+---
+
+## Standing rules for every task
+
+Read these rules once. They bind every task below.
+
+1. **Use the virtual environment interpreter.** Run every Python command as `.venv\Scripts\python.exe -m <module>`. The global interpreter on the development machine is broken.
+2. **Comment every changed line.** FR-030 and the project conventions require an inline comment that states why the line exists. Add the comment to each line that you touch and to each adjacent uncommented line in the same block.
+3. **Change no runtime behavior.** FR-025 forbids a behavior change at any Outcome A site and at any Outcome B site. Remove no log call. Add no log call.
+4. **Add no wrapper and no shim.** FR-032 forbids a wrapper function. FR-033 forbids a pass-through alias and a fallback path. Change the real call sites.
+5. **Finish a cascade thread inside one task.** A partial removal moves the finding up one level and holds the count flat. Data model section 3 names that state "partly removed". No task may end in that state.
+6. **Run the count command after every source task.**
+
+   ```powershell
+   .venv\Scripts\python.exe -m pylint src/ --disable=all --enable=W0613 --score=n
+   ```
+
+   Caution: The count must fall or hold. A rise means an unfinished cascade thread.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm that the measuring tool matches the tool that produced the baseline.
+
+- [ ] T001 Confirm the pylint version with `.venv\Scripts\python.exe -m pylint --version`. The baseline used pylint 4.0.6 and astroid 4.0.4 on Python 3.13.3. If the version differs, record the new version in `specs/887-pylint-unused-argument/research.md` section 1 before you continue. A version change can add a finding or remove a finding.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the two numbers that every later checkpoint compares against.
+
+**Warning**: No source task may start until T002 confirms the finding count.
+
+- [ ] T002 Re-measure the baseline (FR-003). Run `.venv\Scripts\python.exe -m pylint src/ --disable=all --enable=W0613 --score=n` from the repository root. Confirm 21 findings. Confirm that every file and every line matches the table in `specs/887-pylint-unused-argument/research.md` section 5. If the count differs, add each new finding to that table and assign an outcome before you continue.
+- [ ] T003 [P] Record the test pass count before the work. Run `.venv\Scripts\python.exe -m pytest -q`. Write the pass count into the pull request draft. SC-005 compares the final count against this number.
+
+**Checkpoint**: The baseline holds 21 findings. The triage record covers all 21. User story work can begin.
+
+---
+
+## Phase 3: User Story 1 - Record a decision for every finding (Priority: P1)
+
+**Goal**: Prove that the triage record assigns one outcome to each of the 21 findings.
+
+**Independent Test**: Read `specs/887-pylint-unused-argument/research.md` section 5. Confirm 21 rows. Confirm that every row names a file, a line, a function, a parameter, an outcome, and a justification. No code change is needed for this test.
+
+- [ ] T004 [US1] Validate the triage record in `specs/887-pylint-unused-argument/research.md`. Confirm that section 5 holds 21 rows. Confirm that the outcome totals read 15 for Outcome A, 5 for Outcome B, and 1 for Outcome C. Confirm that no cell in the outcome column reads "To triage". Confirm that section 8 holds the exact suppression text for all six retained parameters. This satisfies SC-001.
+
+**Checkpoint**: User Story 1 is complete. The record alone delivers value, because it separates a dead parameter from a contract-bound parameter.
+
+---
+
+## Phase 4: User Story 2 - Make the code match the triage (Priority: P2)
+
+**Goal**: Apply the recorded outcome to every site. The finding count reaches zero.
+
+**Independent Test**: Run `.venv\Scripts\python.exe -m pylint src/ --disable=all --enable=W0613 --score=n`. Confirm zero output. Run `.venv\Scripts\python.exe -m pytest`. Confirm that the suite passes.
+
+### Phase 4a: Outcome A removals with no cascade
+
+**Purpose**: Clear six findings. Each task changes one leaf function and its call sites. No caller inherits the parameter.
+
+- [ ] T005 [P] [US2] Group 1. Remove the parameter `ap_macs` from `PacketCaptureManager._multi_ap_gather_params` in `src/capture/packet_capture.py`. The signature becomes `def _multi_ap_gather_params(self) -> dict[str, Any] | None:`. Update the single call site at `src/capture/packet_capture.py:1018` from `self._multi_ap_gather_params(ap_macs)` to `self._multi_ap_gather_params()`. Do not change the later call that passes `ap_macs` to `_multi_ap_confirm_and_launch`. No test changes.
+- [ ] T006 [P] [US2] Group 3. Remove the parameter `msp_name` from `OrgLevelAPFirmwareUpgrader._display_org_list` in `src/firmware/org_ap_upgrader.py`. The signature becomes `def _display_org_list(self, orgs: list[Any]) -> None:`. Update the single call site at `src/firmware/org_ap_upgrader.py:617`. Do not change the calls that pass `msp_name` to `_collect_org_selection` or to the error log. No test changes.
+- [ ] T007 [P] [US2] Group 5. Remove the final parameter `clone_payload` from `_MapsClone._confirm_clone` in `src/maps/_maps_clone.py`. Update the single call site at `src/maps/_maps_clone.py:352`. Caution: `src/gateway/template_config.py` holds a different method with the same name. Do not change that method and do not change `tests/unit/test_template_config.py`. No test changes.
+- [ ] T008 [P] [US2] Group 6. Remove the first parameter `site_name` from `MapsManager._render_site_maps_table` in `src/maps/maps_manager.py`. The signature becomes `def _render_site_maps_table(maps: list) -> None:`. Update the single call site at `src/maps/maps_manager.py:559` in the same edit. Warning: `site_name` sits first of two. If you change the signature and leave the call site, the argument `maps` binds to the wrong slot. Do not change the `list_site_maps` code that prints and logs `site_name`. No test changes.
+- [ ] T009 [P] [US2] Group 8. Remove both parameters `env_cmds` and `csv_cmds` from `AppRunner._prompt_for_commands` in `src/ssh/runtime/app_runner.py`. The signature becomes `def _prompt_for_commands() -> list[str]:`. Update the single call site at `src/ssh/runtime/app_runner.py:262`. Keep the `InputUtils.safe_input` call in the body unchanged. Do not change the `if` block in `_resolve_commands` that tests both lists. This task clears two findings. No test changes.
+- [ ] T010 [US2] Checkpoint 4a. Run the count command. The count must read 15. A count above 15 means that a call site still passes a removed argument.
+
+### Phase 4b: Outcome A removals with one production file plus tests
+
+**Purpose**: Clear two more findings. Each task deletes a dead ruff suppression as well.
+
+- [ ] T011 [P] [US2] Group 7. Remove the parameter `candidates` from `AddressResolver._combine` in `src/site/address_audit/address_resolver.py`. The signature becomes `def _combine(self, internal, osm, ui, query: str) -> ResolverResult:`. Update the single call site at `src/site/address_audit/address_resolver.py:83` from `self._combine(internal, osm, ui, candidates, query)` to `self._combine(internal, osm, ui, query)`. Warning: `candidates` sits fourth of five. The parameter `query` moves into the fourth slot. Change the signature and the call site in the same edit. No test changes.
+- [ ] T012 [P] [US2] Group 9. Remove the parameter `results` from `_SsidTemplateCacheCluster._offer_resume` in `src/ssid_consolidation/_ssid_template_cache.py`. The signature becomes `def _offer_resume(self, phase: int) -> tuple[bool, list[dict[str, Any]]]:`. Delete the dead comment `# noqa: ARG002 - signature preserved for tests` in the same edit. Update the three call sites at `src/ssid_consolidation/_ssid_template_phase2.py:238`, `src/ssid_consolidation/_ssid_template_phase3.py:276`, and `src/ssid_consolidation/_ssid_template_phase45.py:610`. Each site passes a literal empty list today. Update the test call site at `tests/unit/test_ssid_template_consolidation.py:2027`. Do not change `tests/unit/test_ssid_template_consolidation.py` lines 3283 and 3339. Those two lines use `patch.object` by name, and a patch by name survives a signature change.
+- [ ] T013 [US2] Checkpoint 4b. Run the count command. The count must read 13.
+
+### Phase 4c: Cascade threads
+
+**Purpose**: Clear seven more findings. Section 3 of `research.md` names four threads. Each thread is one task. The task changes the leaf and every cascade level in the same edit, so the count never rises.
+
+- [ ] T014 [P] [US2] Group 2, the `mistapi` thread. In `src/firmware/bulk_ap_upgrader.py`, remove the final parameter `mistapi` from `BulkAPFirmwareUpgrader._upgrade_version_group` and from the cascade level `BulkAPFirmwareUpgrader._execute_multi_version_upgrade`. Update the call sites at `src/firmware/bulk_ap_upgrader.py:1479` and `src/firmware/bulk_ap_upgrader.py:1399`. Update the test call sites at `tests/unit/test_bulk_ap_upgrader.py:1724` and `tests/unit/test_bulk_ap_upgrader.py:1702`. Stop condition: `_execute_site_upgrade` keeps its `mistapi` parameter, because it also calls `_execute_single_version_upgrade`, which uses the value. Do not change `_invoke_upgrade_api`, which performs a lazy `import mistapi` of its own.
+- [ ] T015 [P] [US2] Group 4, the `target_org_id` thread. In `src/inventory/inventory_summary/version_per_model_fetcher.py`, remove the first parameter `target_org_id` from `VersionPerModelFetcher._rows_for_model` and from the cascade level `VersionPerModelFetcher._expand_model_rows`. Update the call sites at `src/inventory/inventory_summary/version_per_model_fetcher.py:25` and `src/inventory/inventory_summary/version_per_model_fetcher.py:72`. Update the test call sites at `tests/unit/inventory/test_version_per_model_fetcher_wave3.py` lines 117, 123, 129, 136, 142, and 320. Warning: `target_org_id` sits first of four in both functions, and every call site passes it positionally. Change both signatures and all call sites in the same edit. Stop condition: `fetch` keeps `target_org_id` for `_prefetch_switches`, for `_prefetch_gateways`, for `_append_bulk_rows`, and for two log calls.
+- [ ] T016 [US2] Group 10, the `sitegroup_lookup` thread. In `src/ssid_consolidation/_ssid_template_phase1.py`, remove the final parameter `sitegroup_lookup` from `_resolve_template` and from the cascade level `_resolve_site_wlan`. Delete the dead comment `# noqa: ARG001 - signature preserved for tests` in the same edit. Update the call sites at `src/ssid_consolidation/_ssid_template_phase1.py:289` and `src/ssid_consolidation/_ssid_template_phase1.py:351`. Update the test call sites at `tests/unit/test_ssid_template_consolidation.py` lines 423, 434, and 445. Stop condition: `_build_site_row` passes `lookups.sitegroup_lookup`, which is a dataclass field, and pylint does not report a field. Do not remove the `_SiteLookups.sitegroup_lookup` field. Do not remove `_build_sitegroup_lookup`. T024 files the issue that records that dead code. This task carries no `[P]` marker, because it edits `tests/unit/test_ssid_template_consolidation.py`, which T012 also edits.
+- [ ] T017 [P] [US2] Group 12, the `source` thread. This is the widest thread. In `src/utils/address_utils.py`, remove the parameter `source` from all five methods of `NominatimValidator`: the three leaves `_make_api_request`, `_calculate_component_match`, and `_calculate_quality_boost`, and the two cascade levels `_calculate_confidence` and `_parse_geocode_response`. Update the call sites at `src/utils/address_utils.py` lines 1017, 1018, 1035, 1058, and 1061. Delete the three dead `# noqa: ARG002` comments that name future logging. Update the test call sites in `tests/unit/test_address_utils.py` at lines 728, 734, 740, 744, 751, 773, 778, 790, 798, 806, 813, 819, 827, and 844. Read the whole `NominatimValidator` test class before you edit, then run `tests/unit/test_address_utils.py` to catch a call that the search missed. Stop condition: `_geocode_address` keeps `source`, because it uses the value in two `logging.debug` calls in the exception path.
+- [ ] T018 [US2] Group 11, the `debug` parameter. Remove the final parameter `debug` from `AddressUtils.apply_business_context_rules` in `src/utils/address_utils.py`. Delete the dead comment `# noqa: ARG004 - signature preserved for callers passing debug`. That comment states a claim that no call site supports. No production caller passes `debug`. The four tests already pass two arguments, so `tests/unit/test_address_utils.py` needs no change for this group. This task carries no `[P]` marker, because it edits `src/utils/address_utils.py`, which T017 also edits.
+- [ ] T019 [US2] Checkpoint 4c. Run the count command. The count must read 6. Those six are the five Outcome B sites and the one Outcome C site. All 15 Outcome A findings are now clear.
+
+### Phase 4d: Suppressions and companion issues
+
+**Purpose**: Add six narrow suppressions with a specific reason. File three companion issues.
+
+- [ ] T020 [P] [US2] Outcome B, row 7. Add a site-local suppression to `_build_probe_set` in `src/org/org_synthetic_probes_manager.py` at line 1619. Use the exact text from `research.md` section 8: `# pylint: disable=W0613 - back-compat contract with the caller. VLAN scope belongs on the tests[] row.` Place the comment on the parameter line or on the line directly above. Keep the parameter `vlan_ids`. Change no other line.
+- [ ] T021 [P] [US2] Outcome B, rows 18 to 21. Add four site-local suppressions in `src/websocket/manager.py` at lines 318, 323, 336, and 343, on `WebSocketManager._on_open`, `_on_message`, `_on_error`, and `_on_close`. Use the four exact reason texts from `research.md` section 8. Each reason names the `websocket-client` library callback that passes the connection. Keep the parameter `websocket_connection` at all four sites.
+- [ ] T022 [P] [US2] File the Outcome C companion issue with `gh issue create`. Title: "Phase 4 discards the operator deviation resolutions". Labels: `bug` and the scope label for `src/ssid_consolidation`. Body: the five-step chain from `research.md` section 6, which shows that `_resolve_deviations` records each operator answer in `resolutions`, that `_phase4_preflight` passes the map to `_build_all_template_configs`, that `_build_all_template_configs` passes it to `_build_template_config`, and that `_build_template_config` writes a `{{MISTHELPER_<PARAM>}}` placeholder instead. State that the parameter stays as the fix seam. Record the returned issue number. T025 needs that number.
+- [ ] T023 [P] [US2] File the maps clone companion issue with `gh issue create`. Title: "The maps clone confirmation prints a static capability list". Labels: `bug` and the scope label for `src/maps`. Body: `_MapsClone._confirm_clone` in `src/maps/_maps_clone.py` prints the fixed text "Will copy: dimensions, orientation, location data, wayfinding, walls". The text does not describe the real payload that the operation sends, so the prompt can mislead the operator. State that the redesign of the confirmation text is out of scope for feature 887 and that this issue records the observation only.
+- [ ] T024 [P] [US2] File the dead-code companion issue with `gh issue create`. Title: "Remove the unread sitegroup lookup after the W0613 narrowing". Labels: `chore` and the scope label for `src/ssid_consolidation`. Body: after T016, `_build_sitegroup_lookup` and the `_SiteLookups.sitegroup_lookup` field in `src/ssid_consolidation/_ssid_template_phase1.py` hold no reader. The module also re-exports `_build_sitegroup_lookup` for back-compat, so the removal changes a documented surface and needs its own specification.
+- [ ] T025 [US2] Outcome C, row 13. Add a site-local suppression to `_build_template_config` in `src/ssid_consolidation/_ssid_template_phase45.py` at line 267. Warning: Do not remove the parameter `resolutions`. FR-015 forbids the removal, because the parameter is the seam that the future fix needs. Use the text from `research.md` section 8 and replace the placeholder with the number that T022 returned: `# pylint: disable=W0613 - kept as the seam for issue <N>. Phase 4 must apply this map.` The reason must name the defect and point at the companion issue. This task depends on T022.
+- [ ] T026 [US2] Link the three issue numbers into the triage record at `specs/887-pylint-unused-argument/research.md`. Update section 6 with the Outcome C issue number. Update the three rows of section 7 with the matching issue numbers. Update the row 13 text in section 8 so that it holds the same number as the source comment. FR-017 requires this link.
+- [ ] T027 [US2] Checkpoint 4d. Run the count command. The count must read 0. This satisfies FR-021 and SC-002. Do not start Phase 5 until this checkpoint reads zero.
+
+### Phase 4e: Verification of the source tree
+
+**Purpose**: Prove the source work before the gate changes. Run each gate exactly as the continuous integration job runs it.
+
+- [ ] T028 [P] [US2] Scan the two ignored packages by hand (FR-004). Run `.venv\Scripts\python.exe -m pylint src/maps src/ssh --disable=all --enable=W0613 --score=n`. Expect no output. The gate cannot prove these files, because the `--ignore=maps,ssh,ui` flag hides them.
+- [ ] T029 [P] [US2] Confirm that no suppression is too wide and that no dead ruff comment survives (FR-012, SC-006). Run `Get-ChildItem -Path src -Recurse -Filter *.py | Select-String -Pattern "pylint: disable=.*W0613"` and confirm exactly six matches. Five belong to Outcome B and one belongs to Outcome C. Read each reason and confirm that it names a library, a back-compat promise, or an issue number. Reject a generic phrase. Then run `Select-String -Path "src/ssid_consolidation/_ssid_template_cache.py","src/ssid_consolidation/_ssid_template_phase1.py","src/utils/address_utils.py" -Pattern "noqa: ARG00"` and confirm zero matches. All six dead ruff comments are gone.
+- [ ] T030 [US2] Run the full gate suite from the repository root. Scope each command to the whole repository where the continuous integration job does. Every command must exit with code 0.
+
+  ```powershell
+  .venv\Scripts\python.exe -m ruff check .
+  .venv\Scripts\python.exe -m black --check .
+  .venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml
+  .venv\Scripts\python.exe -m radon cc src/ -j | .venv\Scripts\python.exe -c "import json,sys; d=json.load(sys.stdin); bad=[(f,b['name'],b['complexity']) for f,bs in d.items() if isinstance(bs,list) for b in bs if b['complexity']>10]; print(bad or 'OK'); sys.exit(1 if bad else 0)"
+  .venv\Scripts\python.exe -m pytest
+  ```
+
+  The radon command must report no block above complexity 10. Compare the pytest pass count against the number that T003 recorded. The counts must match, because the feature adds no test and removes no test. Caution: A radon failure points at an unrelated edit, because removing a parameter lowers the parameter count and does not raise complexity.
+
+**Checkpoint**: User Story 2 is complete. The source tree holds zero unused arguments, and every gate passes.
+
+---
+
+## Phase 5: User Story 3 - Turn the gate back on (Priority: P3)
+
+**Goal**: Remove the repository-wide suppression and prove the score on the Linux runner.
+
+**Independent Test**: Read the continuous integration result for the branch. Confirm that the job named "Pylint (score gate)" passed. Confirm that `W0613` is absent from the `disable` list in `pyproject.toml`.
+
+- [ ] T031 [US3] **This is the last source task.** Edit `pyproject.toml`. Remove the entry `"W0613"` from the `disable` list under `[tool.pylint."messages control"]`. The list becomes `disable = ["C0114", "C0115", "C0116", "W0718"]`. Keep every other entry in its position. Rewrite the comment block above the list so that it states three facts: `W0613` is enforced from this change onward, the audit record sits at `specs/887-pylint-unused-argument/research.md`, and six sites hold a site-local disable with a reason. Warning: Do not start this task until T027 reports zero findings. The moment the entry leaves the list, every open branch inherits the new gate, and a branch that still holds an unused argument fails. Do not change `"W0718"`. Do not change `"C0114"`, `"C0115"`, or `"C0116"`. Do not change `fail-under = 9.5`. Do not change the mypy `src.db` override. Do not change the `--ignore=maps,ssh,ui` flag in `.github/workflows/ci.yml`.
+- [ ] T032 [US3] Reproduce the gate locally. Run `.venv\Scripts\python.exe -m pylint src/ --fail-under=9.5 --ignore=maps,ssh,ui` from the repository root. Expect exit code 0 and a score near 9.77. Warning: This local Windows result is an estimate only. It is not proof. T034 holds the proof.
+- [ ] T033 [US3] Prove that the gate reports a new defect (SC-008). Add an unused parameter to any function under `src/`. Run the command from T032. Confirm that pylint reports a `W0613` message for the new parameter. Undo the temporary change. Run the command again and confirm that it passes. Do not commit the temporary change.
+- [ ] T034 [US3] **Confirm the score on the real continuous integration run.** Push the branch. Open the run for the branch. Read the job named "Pylint (score gate)". Confirm that the job passed at the 9.5 threshold on `ubuntu-latest`. Record the reported score in the pull request body. Warning: A local Windows run is **not** acceptable proof. FR-023 forbids it. Issue #891 measured 9.71 on Windows and 9.41 on the `ubuntu-latest` runner for the same commit, and the Linux run failed the threshold. Warning: Do not add the `auto-merge` label until this job and CodeQL both pass. If the job fails, follow the rollback position in section 7 of `contracts/pylint-gate.md`:
+  1. Read the runner log and list every message type with a count.
+  2. Confirm that the drop comes from `W0613`. Compare the `W0613` count against zero.
+  3. If any `W0613` message remains, fix that site. The audit missed it. This is the expected cause.
+  4. If zero `W0613` messages remain, the drop comes from another message type on Linux. Record the message types and open a separate issue.
+  5. Do not lower `fail-under`. FR-024 forbids it.
+  6. Do not restore `"W0613"` to the `disable` list. FR-024 forbids it.
+  7. If the score cannot reach 9.5 in this feature, revert the `pyproject.toml` commit only. Keep every source fix and keep the triage record. The gate change then waits for a follow-up branch, and the source work holds its value.
+
+**Checkpoint**: All three user stories are complete. The gate reports any new unused argument on the first run.
+
+---
+
+## Phase 6: Polish and Cross-Cutting Concerns
+
+- [ ] T035 [P] Update `CHANGELOG.md`. Add an entry under the `## [Unreleased]` heading. Follow the style of the entries above it: a level-three heading that names the change and the issue number, then bullets that lead with a bold label and a state word in parentheses. Suggested heading: `### Narrow the pylint W0613 unused-argument suppression (issue #887)`. Cover four points. Name the 21 triaged findings and the 15 parameters that the feature removed (Removed). Name the six site-local suppressions that replace the repository-wide entry (Changed). Name the six dead `noqa: ARG00x` comments that the feature deleted (Removed). Name the three companion issues (Recorded). State that no runtime behavior changed and that the test count held.
+- [ ] T036 Run the Simplified Technical English linter at the 80 threshold on every Markdown file that the feature changes and on every document that the feature wrote. Every file must score 80 or higher.
+
+  ```powershell
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 CHANGELOG.md
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/tasks.md
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/research.md
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/spec.md
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/plan.md
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/data-model.md
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/quickstart.md
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/contracts/signature-changes.md
+  .venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs/887-pylint-unused-argument/contracts/pylint-gate.md
+  ```
+
+  Run the linter on the pull request body and on the three issue bodies as well. FR-031 covers all prose.
+- [ ] T037 Walk `specs/887-pylint-unused-argument/quickstart.md` from Step 1 to Step 12 and confirm each expected result. Confirm Step 10: open the three issues, confirm that each holds a type label and a scope label, and confirm that the triage record and the source comment name the same Outcome C issue number. Write the pull request body. Link the spec issue, state `Closes #887` only when the whole of issue #887 is complete, and otherwise reference the issue without the closing keyword, because this feature covers part 1 of 3. Record the Linux pylint score from T034 in the body. Tick every conformance box in the pull request template.
+
+---
+
+## Dependencies and Execution Order
+
+### Phase dependencies
+
+| Phase | Depends on | Reason |
+| - | - | - |
+| Phase 1, Setup | Nothing | The version check reads the environment only. |
+| Phase 2, Foundational | Phase 1 | A version change can move the baseline. |
+| Phase 3, User Story 1 | Phase 2 | The record must cover the measured count. |
+| Phase 4, User Story 2 | Phase 3 | The code follows the record. |
+| Phase 5, User Story 3 | Phase 4e | FR-019 makes the `pyproject.toml` edit the final source change. |
+| Phase 6, Polish | Phase 5 | The changelog states the delivered result. |
+
+### Dependencies inside User Story 2
+
+The sub-phases run in order. Each one ends with a checkpoint that reads a lower count.
+
+| Sub-phase | Tasks | Ends with |
+| - | - | - |
+| 4a | T005 to T010 | 15 findings |
+| 4b | T011 to T013 | 13 findings |
+| 4c | T014 to T019 | 6 findings |
+| 4d | T020 to T027 | 0 findings |
+| 4e | T028 to T030 | A clean tree and green gates |
+
+Task-level dependencies:
+
+- T016 follows T012. Both edit `tests/unit/test_ssid_template_consolidation.py`.
+- T018 follows T017. Both edit `src/utils/address_utils.py`.
+- T025 follows T022. The suppression text needs the issue number.
+- T026 follows T022, T023, and T024. The record needs all three numbers.
+- T031 follows T027. The gate edit needs a zero count.
+- T034 follows T031. The runner needs the pushed change.
+
+### Cascade threads, one task each
+
+The count never rises, because each task changes the leaf and every cascade level together.
+
+| Thread | Task | Levels changed | Stops at |
+| - | - | - | - |
+| `mistapi` | T014 | `_upgrade_version_group`, `_execute_multi_version_upgrade` | `_execute_site_upgrade` |
+| `target_org_id` | T015 | `_rows_for_model`, `_expand_model_rows` | `fetch` |
+| `sitegroup_lookup` | T016 | `_resolve_template`, `_resolve_site_wlan` | `_build_site_row` |
+| `source` | T017 | `_make_api_request`, `_calculate_component_match`, `_calculate_quality_boost`, `_calculate_confidence`, `_parse_geocode_response` | `_geocode_address` |
+
+### Positional-shift tasks
+
+These three tasks remove a parameter that is not last. Change the signature and every call site in the same edit.
+
+| Task | Function | Position of the removed parameter |
+| - | - | - |
+| T008 | `MapsManager._render_site_maps_table` | First of two |
+| T011 | `AddressResolver._combine` | Fourth of five |
+| T015 | `_rows_for_model` and `_expand_model_rows` | First of four |
+
+### The six dead ruff suppressions
+
+`research.md` section 4 records that none of these reasons meets the FR-013 bar. Each comment is false after the parameter goes, so the task deletes it in the same edit.
+
+| Comment | File | Task |
+| - | - | - |
+| `# noqa: ARG002 - signature preserved for tests` | `src/ssid_consolidation/_ssid_template_cache.py` | T012 |
+| `# noqa: ARG001 - signature preserved for tests` | `src/ssid_consolidation/_ssid_template_phase1.py` | T016 |
+| `# noqa: ARG002`, three sites, future logging reason | `src/utils/address_utils.py` | T017 |
+| `# noqa: ARG004 - signature preserved for callers passing debug` | `src/utils/address_utils.py` | T018 |
+
+T029 confirms that zero `noqa: ARG00` comments survive in those three files.
+
+### Parallel opportunities
+
+| Group | Tasks that can run together | Files |
+| - | - | - |
+| Phase 2 | T003 runs beside T002 | Both read only. |
+| Phase 4a | T005, T006, T007, T008, T009 | Five different production files. No cascade between them. |
+| Phase 4b | T011, T012 | `address_resolver.py` and the SSID template files. No shared file. |
+| Phase 4c | T014, T015, T017 | `bulk_ap_upgrader.py`, `version_per_model_fetcher.py`, and `address_utils.py`, plus their own test files. |
+| Phase 4d | T020, T021, T022, T023, T024 | Two different source files and three separate issue creations. |
+| Phase 4e | T028, T029 | Two read-only scans. |
+| Phase 6 | T035 runs beside the review of T034 | `CHANGELOG.md` only. |
+
+T016, T018, T025, T026, T027, T030, and every Phase 5 task carry no `[P]` marker. Each one shares a file with an earlier task or depends on an earlier result.
+
+---
+
+## Implementation Strategy
+
+### Minimum viable increment
+
+User Story 1 alone delivers value. The triage record separates a dead parameter from a contract-bound parameter, and a reviewer can read it without a code change. T004 proves it.
+
+### Incremental delivery
+
+1. Complete Phase 1 and Phase 2. The baseline is confirmed.
+2. Complete Phase 3. The record is proven. Stop here for a record-only increment.
+3. Complete Phase 4. The source tree holds zero unused arguments. Stop here for a source-only increment. The gate change can wait for a follow-up branch. Section 7 of `contracts/pylint-gate.md` names this the safe stopping point.
+4. Complete Phase 5. The gate is enforced.
+5. Complete Phase 6. The changelog and the prose are current.
+
+### Safe stopping point
+
+If the Linux score falls below 9.5 and step 3 of the rollback finds no remaining `W0613` message, revert the `pyproject.toml` commit only. Keep every source fix and keep the triage record.
+
+---
+
+## Task summary
+
+| Measure | Count |
+| - | - |
+| Total tasks | 37 |
+| Setup and Foundational | 3 |
+| User Story 1 | 1 |
+| User Story 2 | 26 |
+| User Story 3 | 4 |
+| Polish | 3 |
+| Tasks marked `[P]` | 19 |
+| Source files changed | 16 |
+| Test files changed | 4 |
+| Configuration files changed | 1 |
+| Companion issues filed | 3 |

--- a/src/capture/packet_capture.py
+++ b/src/capture/packet_capture.py
@@ -908,7 +908,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         bandwidth = self._prompt_scan_bandwidth(band)  # WHY: width also band-dependent
         return {"band": band, "channel": channel, "bandwidth": bandwidth}  # WHY: return radio triplet
 
-    def _multi_ap_gather_params(self, ap_macs: list[str]) -> dict[str, Any] | None:
+    def _multi_ap_gather_params(self) -> dict[str, Any] | None:  # WHY: prompts read no AP list, so the parameter went
         """Prompt user for common multi-AP scan parameters.
 
         Returns:
@@ -1015,7 +1015,7 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         ap_macs = self._multi_ap_preflight(site_id)  # WHY: enumerate APs and print preflight banner
         if ap_macs is None:  # WHY: preflight aborted because site had no APs
             return  # WHY: cancel gracefully
-        params = self._multi_ap_gather_params(ap_macs)  # WHY: cluster prompts into one call
+        params = self._multi_ap_gather_params()  # WHY: cluster prompts into one call. The helper reads no AP list
         if params is None:  # WHY: user cancelled somewhere in the prompt chain
             return  # WHY: bail without side effects
         self._multi_ap_confirm_and_launch(site_id, ap_macs, params)  # WHY: summary+confirm+launch cluster

--- a/src/firmware/bulk_ap_upgrader.py
+++ b/src/firmware/bulk_ap_upgrader.py
@@ -1396,7 +1396,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
             if len(versions) == 1:  # WHY: guard on condition
                 self._execute_single_version_upgrade(site_id, site_name, site_data, mistapi)  # WHY: instance state
             else:
-                self._execute_multi_version_upgrade(site_id, site_name, site_data, mistapi)  # WHY: instance state
+                self._execute_multi_version_upgrade(site_id, site_name, site_data)  # WHY: callee needs no mistapi
             self._log_upgrade_results(site_id, site_name, site_data, "Upgrade Initiated")  # WHY: instance state
         except Exception as error:  # WHY: recover from failure
             print(f"      Failed: {error}")  # WHY: user-facing feedback
@@ -1461,8 +1461,7 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
         self,
         site_id: str,
         site_name: str,
-        site_data: dict[str, Any],
-        mistapi: Any,
+        site_data: dict[str, Any],  # WHY: the only callee below imports mistapi lazily, so the module stops here
     ) -> None:
         """Execute upgrade when devices use different versions."""
         print("      Multiple versions - grouping by target version...")  # WHY: user-facing feedback
@@ -1476,15 +1475,14 @@ class BulkAPFirmwareUpgrader:  # pylint: disable=too-many-instance-attributes
             devices_by_version[version]["models"].append(model)  # WHY: workflow step
 
         for version, version_info in devices_by_version.items():  # WHY: iterate collection
-            self._upgrade_version_group(site_id, site_name, version, version_info, mistapi)  # WHY: instance state
+            self._upgrade_version_group(site_id, site_name, version, version_info)  # WHY: callee imports mistapi itself
 
     def _upgrade_version_group(  # WHY: helper definition (see docstring)
         self,
         site_id: str,
         site_name: str,
         version: str,
-        version_info: dict[str, Any],
-        mistapi: Any,
+        version_info: dict[str, Any],  # WHY: _invoke_upgrade_api imports mistapi lazily, so no module is threaded in
     ) -> None:
         """Upgrade a group of devices sharing the same target version (PCPP orchestrator)."""
         devices = version_info["devices"]  # WHY: extract group's device list from the tuple/dict

--- a/src/firmware/org_ap_upgrader.py
+++ b/src/firmware/org_ap_upgrader.py
@@ -614,7 +614,7 @@ class OrgLevelAPFirmwareUpgrader:
             orgs = self._fetch_msp_orgs(msp_id, msp_name)  # WHY: hit Mist API for MSP -> orgs
             if not orgs:  # WHY: guard empty result
                 return []  # WHY: nothing to display
-            self._display_org_list(orgs, msp_name)  # WHY: show user picking list
+            self._display_org_list(orgs)  # WHY: show user picking list. The banner already named the MSP
             return self._collect_org_selection(orgs, msp_name)  # WHY: capture user choice
         except Exception as error:  # WHY: broad guard preserves pre-refactor behavior
             print(f"  X Error fetching organizations: {error}")  # WHY: user-visible error
@@ -672,7 +672,7 @@ class OrgLevelAPFirmwareUpgrader:
             return [raw]  # WHY: caller iterates a list, wrap scalar to keep loop uniform
         return []  # WHY: None / empty -> caller-visible empty inventory
 
-    def _display_org_list(self, orgs: list[Any], msp_name: str) -> None:  # WHY: declare private helper _display_org_lis
+    def _display_org_list(self, orgs: list[Any]) -> None:  # WHY: the body prints no MSP name, so the parameter went
         """Display numbered organization list."""
         print("")  # WHY: surface user-facing message
         print("  Organizations:")  # WHY: surface user-facing message

--- a/src/inventory/inventory_summary/version_per_model_fetcher.py
+++ b/src/inventory/inventory_summary/version_per_model_fetcher.py
@@ -12,8 +12,7 @@ class VersionPerModelFetcher:  # WHY: namespace for the decomposed version-per-m
 
     @staticmethod
     def _expand_model_rows(  # Walks model_rows and produces per-model expansion via helper
-        target_org_id: str,
-        model_rows: list[dict],
+        model_rows: list[dict],  # WHY: the callee stopped needing the org id, so this level drops it too
         switch_records: list[dict],
         gateway_records: list[dict],
     ) -> list[dict]:
@@ -23,8 +22,7 @@ class VersionPerModelFetcher:  # WHY: namespace for the decomposed version-per-m
             if model_row.get("device_type") == "ap":  # APs are expanded in bulk from inventory
                 continue  # Skip here so AP counts are not produced twice
             rows = VersionPerModelFetcher._rows_for_model(
-                target_org_id,
-                model_row,
+                model_row,  # WHY: model_row now sits first, because the org id left the signature
                 switch_records,
                 gateway_records,
             )  # Delegate per-row expansion to a small helper
@@ -70,8 +68,8 @@ class VersionPerModelFetcher:  # WHY: namespace for the decomposed version-per-m
         switch_records = VersionPerModelFetcher._prefetch_switches(target_org_id, model_rows)  # switches once
         gateway_records = VersionPerModelFetcher._prefetch_gateways(target_org_id, model_rows)  # gateways once
         all_rows = VersionPerModelFetcher._expand_model_rows(
-            target_org_id, model_rows, switch_records, gateway_records
-        )  # Per-model expansion (non-AP)
+            model_rows, switch_records, gateway_records
+        )  # Per-model expansion (non-AP). The org id stops at this orchestrator
         VersionPerModelFetcher._append_bulk_rows(
             target_org_id, all_rows, ap_records, unassigned_records
         )  # Adds AP + unassigned rows in-place
@@ -185,8 +183,7 @@ class VersionPerModelFetcher:  # WHY: namespace for the decomposed version-per-m
 
     @staticmethod
     def _rows_for_model(
-        target_org_id: str,
-        model_row: dict,
+        model_row: dict,  # WHY: the body dispatches on prefetched records only, so the org id left the signature
         switch_records: list[dict],
         gateway_records: list[dict],
     ) -> list[dict]:

--- a/src/maps/_maps_clone.py
+++ b/src/maps/_maps_clone.py
@@ -146,7 +146,7 @@ class _MapsClone:
             logging.debug("Could not fetch zone count for clone plan: %s", zone_error)  # Debug-only breadcrumb.
         return 0  # Default to zero so the plan text still reads sensibly.
 
-    def _confirm_clone(self, source_map: dict, new_name: str, source_zones_count: int, clone_payload: dict) -> bool:
+    def _confirm_clone(self, source_map: dict, new_name: str, source_zones_count: int) -> bool:
         """Display the clone plan and prompt user to confirm. Return True to proceed."""
         print(f"\n{'-' * 80}")  # Divider above the plan block.
         print("Clone Plan:")  # Section title for the pre-flight summary.
@@ -349,7 +349,7 @@ class _MapsClone:
             return None
         clone_payload = self._build_clone_payload(source_map, new_name)  # Assemble POST body.
         zones_count = self._fetch_source_zone_count(site_id, source_map_id)  # Pre-count for plan display.
-        if not self._confirm_clone(source_map, new_name, zones_count, clone_payload):  # Interactive confirm.
+        if not self._confirm_clone(source_map, new_name, zones_count):  # Interactive confirm. The plan text is static.
             return None  # User declined.
         return _ClonePrep(
             source_map=source_map,

--- a/src/maps/maps_manager.py
+++ b/src/maps/maps_manager.py
@@ -528,9 +528,7 @@ class MapsManager:  # WHY: declare MapsManager class
         return f"{map_name:<35} {map_type:<15} {dimensions:<20} {has_image:<8}"  # WHY: return computed result
 
     @staticmethod
-    def _render_site_maps_table(
-        site_name: str, maps: list
-    ) -> None:  # WHY: declare private helper _render_site_maps_table
+    def _render_site_maps_table(maps: list) -> None:  # WHY: the table prints no site name, so the parameter went
         """Print the header + all rows for the site-map summary table."""
         print(f"\n{'-' * 80}")  # WHY: surface user-facing message
         print(f"Total Maps Found: {len(maps)}")  # WHY: surface user-facing message
@@ -556,7 +554,7 @@ class MapsManager:  # WHY: declare MapsManager class
         if not maps:  # WHY: guard against missing precondition
             print(f"\n! No maps found for site: {site_name}")  # WHY: surface user-facing message
             return  # WHY: return early
-        self._render_site_maps_table(site_name, maps)  # WHY: advance computation
+        self._render_site_maps_table(maps)  # WHY: advance computation. The caller above already printed the site name
         logging.info("Listed %s maps for site %s", len(maps), site_name)  # WHY: action-log before operation
 
     @staticmethod

--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -80,7 +80,7 @@ class AddressResolver:
                 osm = self._validate_nominatim(candidates, query)  # Tier 2: OpenStreetMap street validation.
             with self._perf.phase("tier3_ui"):  # Time the browser tier incl. typing/read/politeness.
                 ui = self._maybe_ui(candidates, query)  # Tier 3: Google-via-Mist authority (gated. Fail-soft).
-            return self._combine(internal, osm, ui, candidates, query)  # Merge the tiers into one result.
+            return self._combine(internal, osm, ui, query)  # Merge the tiers into one result. Candidates are unused.
         except Exception as exc:  # noqa: BLE001 -- one row must never abort the audit.
             logging.warning("Resolve failed for key derived from '%s': %s", query, exc)  # Log and continue.
             return ResolverResult(query=query, canonical_address=None, source="internal", confidence=0.0)
@@ -90,8 +90,7 @@ class AddressResolver:
         internal: ResolverResult | None,
         osm: ResolverResult | None,
         ui: ResolverResult | None,
-        candidates: ResolveCandidates,
-        query: str,
+        query: str,  # WHY: candidates left the signature, so query now sits in the fourth slot.
     ) -> ResolverResult:  # WHY: fan-in point where the three tiers collapse to one authoritative answer.
         """Merge results with the web (Tier 3) as the authority for the true suite.
 

--- a/src/ssh/runtime/app_runner.py
+++ b/src/ssh/runtime/app_runner.py
@@ -259,10 +259,10 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
             # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.info("!? Loaded %d commands from data/SSH_COMMANDS.CSV", len(csv_cmds))
             return csv_cmds
-        return AppRunner._prompt_for_commands(env_cmds, csv_cmds)  # Priority 4: interactive
+        return AppRunner._prompt_for_commands()  # Priority 4: interactive. Both earlier lists are empty at this line
 
     @staticmethod
-    def _prompt_for_commands(env_cmds: list[str], csv_cmds: list[str]) -> list[str]:  # WHY: last-resort prompt.
+    def _prompt_for_commands() -> list[str]:  # WHY: last-resort prompt. It reads no earlier command list.
         """Interactive command-source picker used when no other source supplied commands."""
         logging.info("Prompting user for SSH command(s) at runtime")  # Before-action log
         command = InputUtils.safe_input("!? Enter command to execute: ", context="ssh_app_runner_command")  # EOF-safe

--- a/src/ssid_consolidation/_ssid_template_cache.py
+++ b/src/ssid_consolidation/_ssid_template_cache.py
@@ -189,8 +189,7 @@ class _SsidTemplateCacheCluster(_ClusterBase):  # WHY: proxy cluster grouping ca
 
     def _offer_resume(
         self,
-        phase: int,
-        results: list[dict[str, Any]],  # noqa: ARG002 — signature preserved for tests
+        phase: int,  # WHY: the prior results load from disk below, so no caller supplies them.
     ) -> tuple[bool, list[dict[str, Any]]]:
         """Detect partial run and offer to resume or restart."""
         parent = self._mm  # WHY: proxy alias — reused thrice below

--- a/src/ssid_consolidation/_ssid_template_phase1.py
+++ b/src/ssid_consolidation/_ssid_template_phase1.py
@@ -117,8 +117,7 @@ def _template_applies_to_site(  # WHY: direct-scope + group-scope check used by 
 
 def _resolve_template(  # WHY: match a site to its owning template via first-hit iteration
     site: dict[str, Any],
-    template_lookup: dict[str, dict[str, Any]],
-    sitegroup_lookup: dict[str, dict[str, Any]],  # noqa: ARG001 — signature preserved for tests
+    template_lookup: dict[str, dict[str, Any]],  # WHY: the scope check reads site["sitegroup_ids"] directly instead
 ) -> tuple[dict[str, Any] | None, str]:
     """Find the WLAN template assigned to a site via applies scope."""
     for template_id, template in template_lookup.items():  # WHY: iterate all until first match
@@ -282,11 +281,10 @@ def _assemble_site_row(**inputs: Any) -> dict[str, Any]:
 def _resolve_site_wlan(  # WHY: bundles template + wlans + matched lookup into a single 4-tuple
     site: dict[str, Any],
     target_ssid: str,
-    template_lookup: dict[str, dict[str, Any]],
-    sitegroup_lookup: dict[str, dict[str, Any]],
+    template_lookup: dict[str, dict[str, Any]],  # WHY: the callee stopped taking the group map, so this level drops it
 ) -> tuple[dict[str, Any] | None, str, list[dict[str, Any]], dict[str, Any] | None]:
     """Resolve the assigned template + matched WLAN for a site."""
-    template, template_id = _resolve_template(site, template_lookup, sitegroup_lookup)  # WHY: scope
+    template, template_id = _resolve_template(site, template_lookup)  # WHY: scope check needs the template map only
     wlans = _get_template_wlans(template) if template else []  # WHY: guard None template
     matched_wlan = _find_target_wlan(wlans, target_ssid)  # WHY: locate target SSID in list
     return template, template_id, wlans, matched_wlan
@@ -349,7 +347,7 @@ def _build_site_row(  # WHY: 5-param signature (lookups bundled) preserves test-
     if not site.get("id", ""):  # WHY: unidentifiable site cannot be reported
         return None
     resolution = _resolve_site_wlan(  # WHY: bundle template + wlans + matched into one tuple
-        site, target_ssid, lookups.template_lookup, lookups.sitegroup_lookup
+        site, target_ssid, lookups.template_lookup  # WHY: the group map left the callee signature in issue #887
     )
     _, _, wlans, matched_wlan = resolution  # WHY: extract fields needed for classify/tunnel steps
     classification = _classify_site(  # WHY: five-way classification result

--- a/src/ssid_consolidation/_ssid_template_phase2.py
+++ b/src/ssid_consolidation/_ssid_template_phase2.py
@@ -235,7 +235,7 @@ class _SsidTemplatePhase2Cluster(_ClusterBase):
     def _execute_phase2_plan(self, plan: list[dict[str, Any]]) -> None:  # WHY: post-confirm coordinator
         """Run resume + write + persist + summary in one flow."""
         parent = self._mm  # WHY: proxy alias for readability + W0212 avoidance
-        resuming, prior_results = parent._offer_resume(2, [])  # noqa: SLF001
+        resuming, prior_results = parent._offer_resume(2)  # noqa: SLF001
         results = self._call("_write_site_variables", plan, prior_results if resuming else [])
         parent._save_phase_results(2, results)  # noqa: SLF001
         parent.write_data_fn(  # WHY: persist to org-scoped sink for later phases

--- a/src/ssid_consolidation/_ssid_template_phase3.py
+++ b/src/ssid_consolidation/_ssid_template_phase3.py
@@ -273,7 +273,7 @@ class _SsidTemplatePhase3Cluster(_ClusterBase):  # WHY: exported for parent __in
         _log_phase3_start()  # WHY: emit banner + telemetry once
         if not self._load_cache_or_bail():  # WHY: shared preamble — abort when Phase 1 skipped
             return  # WHY: cache preamble already printed the bail message
-        resuming, prior_results = parent._offer_resume(_PHASE_ID, [])  # noqa: SLF001
+        resuming, prior_results = parent._offer_resume(_PHASE_ID)  # noqa: SLF001
         group_plan = _compute_group_plan(parent.cache)  # WHY: derive plan from Phase 1 cache
         _display_group_plan(group_plan)  # WHY: user preview before confirming
         prompt = f"Create/assign {len(group_plan['groups'])} site groups?"  # WHY: confirmation prompt copy

--- a/src/ssid_consolidation/_ssid_template_phase45.py
+++ b/src/ssid_consolidation/_ssid_template_phase45.py
@@ -607,7 +607,7 @@ class _SsidTemplatePhase45Cluster(_ClusterBase):
         parent = self._mm  # WHY: proxy alias
         if not self._load_cache_or_bail():  # WHY: shared preamble — abort when Phase 1 skipped
             return None  # WHY: cache preamble already printed the bail message
-        resuming, prior_results = parent._offer_resume(_PHASE5_ID, [])  # noqa: SLF001
+        resuming, prior_results = parent._offer_resume(_PHASE5_ID)  # noqa: SLF001
         plan = _build_disable_plan(parent.cache)  # WHY: shape the per-site disable plan
         to_disable = [entry for entry in plan if entry["status"] == _STATUS_TO_DISABLE]  # WHY: actionable slice
         _display_disable_plan(plan)  # WHY: user preview before confirming

--- a/src/utils/address_utils.py
+++ b/src/utils/address_utils.py
@@ -490,8 +490,7 @@ class AddressUtils:
     @staticmethod
     def apply_business_context_rules(
         mist_result: dict[str, Any],
-        comparison_result: dict[str, Any],
-        debug: bool = False,  # noqa: ARG004  # WHY: signature preserved for callers passing debug
+        comparison_result: dict[str, Any],  # WHY: no caller ever passed a debug flag, so the parameter went
     ) -> str:
         """Apply business context rules for address tiebreaking."""
         mist_biz, mist_res = AddressUtils._classify_place_type(mist_result.get("place_type", ""))  # WHY: mist tags
@@ -898,8 +897,7 @@ class NominatimValidator:
 
     def _make_api_request(
         self,
-        address_string: str,
-        source: str,  # noqa: ARG002  # WHY: kept for tests + future log context
+        address_string: str,  # WHY: the body builds the query from this string alone, so source left the signature
     ) -> Any | None:
         """Make Nominatim API request with retry logic."""
         if requests is None:  # WHY: missing dependency -> no-op
@@ -943,8 +941,7 @@ class NominatimValidator:
     def _calculate_component_match(
         self,
         address_parts: list[str],
-        display_name: str,
-        source: str,  # noqa: ARG002  # WHY: retained for future logging + test signature stability
+        display_name: str,  # WHY: the score reads the parts and the display name only, so source left the signature
     ) -> float:
         """Calculate match score based on address component matching."""
         total = len(address_parts)  # WHY: number of address parts to score against display name
@@ -973,8 +970,7 @@ class NominatimValidator:
 
     def _calculate_quality_boost(
         self,
-        result: dict[str, Any],
-        source: str,  # noqa: ARG002  # WHY: reserved for future logging
+        result: dict[str, Any],  # WHY: both boost helpers read the result only, so source left the signature
     ) -> float:
         """Calculate quality boost from place type and address details."""
         return self._place_type_boost(result) + self._address_detail_boost(result)  # WHY: sum the two boost sources
@@ -1007,23 +1003,21 @@ class NominatimValidator:
     def _calculate_confidence(
         self,
         result: dict[str, Any],
-        address_parts: list[str],
-        source: str,
+        address_parts: list[str],  # WHY: both callees below stopped taking source, so this level drops it too
     ) -> float:
         """Calculate overall confidence score for geocode result."""
         importance = float(result.get("importance", 0.0))  # WHY: Nominatim's own importance score
         if importance > 0.01:  # WHY: trust importance when it is non-trivial
             return min(1.0, importance * 2.0)  # WHY: scale + cap at 1.0
         display_name = result.get("display_name", "")  # WHY: cache to shorten next call
-        component = self._calculate_component_match(address_parts, display_name, source)  # WHY: fallback match
-        boost = self._calculate_quality_boost(result, source)  # WHY: quality boost adds to component score
+        component = self._calculate_component_match(address_parts, display_name)  # WHY: fallback match
+        boost = self._calculate_quality_boost(result)  # WHY: quality boost adds to component score
         return min(1.0, component + boost)  # WHY: bound confidence to [0, 1]
 
     def _parse_geocode_response(
         self,
         response: Any,
-        address_parts: list[str],
-        source: str,
+        address_parts: list[str],  # WHY: the only callee below stopped taking source, so this level drops it too
     ) -> dict[str, Any]:
         """Parse successful geocode response."""
         if response.status_code != 200:  # WHY: any non-200 is a failure
@@ -1032,7 +1026,7 @@ class NominatimValidator:
         if not results:  # WHY: empty result list = no geocode match
             return self._create_empty_result("No results found")  # WHY: canonical no-match error
         result = results[0]  # WHY: use only the top match
-        confidence = self._calculate_confidence(result, address_parts, source)  # WHY: score the match
+        confidence = self._calculate_confidence(result, address_parts)  # WHY: score the match
         return {  # WHY: canonical success shape
             "valid": True,  # WHY: geocode succeeded
             "confidence": confidence,  # WHY: 0-1 score
@@ -1055,10 +1049,10 @@ class NominatimValidator:
             addr_str, parts = self._build_address_string(address_dict)  # WHY: derive query string + parts list
             if not addr_str:  # WHY: nothing to geocode
                 return self._create_empty_result("Empty address")  # WHY: canonical empty-input error
-            response = self._make_api_request(addr_str, source)  # WHY: run the retryable HTTP call
+            response = self._make_api_request(addr_str)  # WHY: run the retryable HTTP call. It logs no source label
             if response is None:  # WHY: all retries failed
                 return self._create_empty_result("No response received")  # WHY: canonical no-response error
-            return self._parse_geocode_response(response, parts, source)  # WHY: shape the successful body
+            return self._parse_geocode_response(response, parts)  # WHY: shape the successful body
         except Exception as exc:  # WHY: never let a geocode bubble kill validation
             if self.debug:  # WHY: only log full traceback in debug mode
                 logging.debug("GEOCODE [%s]: %s", source, exc)
@@ -1142,7 +1136,7 @@ class NominatimValidator:
     ) -> tuple[str, str]:
         """Apply business context rules as final tiebreaker."""
         # WHY: biz/res + conf blend as the final recommendation
-        rec = AddressUtils.apply_business_context_rules(mist_result, comp_result, self.debug)
+        rec = AddressUtils.apply_business_context_rules(mist_result, comp_result)
         if rec == "mist":  # WHY: rule preferred the mist side
             return "mist", f"Mist more business-appropriate ({mist_result.get('place_type', 'unknown')})"
         if rec == "comparison":  # WHY: rule preferred the ref side

--- a/tests/unit/inventory/test_version_per_model_fetcher_wave3.py
+++ b/tests/unit/inventory/test_version_per_model_fetcher_wave3.py
@@ -114,32 +114,32 @@ class TestRowsForModel:
 
     def test_blank_model_returns_empty_list(self) -> None:
         """Rows with an empty model name are skipped before any dispatch."""
-        result = VersionPerModelFetcher._rows_for_model(_ORG_ID, {"device_type": "switch"}, [], [])  # WHY: blank.
+        result = VersionPerModelFetcher._rows_for_model({"device_type": "switch"}, [], [])  # WHY: blank.
         assert result == []  # WHY: no output emitted for blank-model rows.
 
     def test_ap_device_type_returns_empty_list(self) -> None:
         """AP device type falls through to the trailing return."""
         row = {"device_type": "ap", "model": "AP45"}  # WHY: AP dispatch is handled in bulk elsewhere.
-        assert VersionPerModelFetcher._rows_for_model(_ORG_ID, row, [], []) == []  # WHY: dispatcher skips.
+        assert VersionPerModelFetcher._rows_for_model(row, [], []) == []  # WHY: dispatcher skips.
 
     def test_switch_dispatch_returns_switch_rows(self) -> None:
         """The switch branch produces per-model rows via the switch helper."""
         row = {"device_type": "switch", "model": "EX4300"}  # WHY: minimal model row.
         switch_records = [{"model": "EX4300", "version": "22.4", "num_members": 1}]  # WHY: one matching record.
-        rows = VersionPerModelFetcher._rows_for_model(_ORG_ID, row, switch_records, [])  # WHY: dispatch.
+        rows = VersionPerModelFetcher._rows_for_model(row, switch_records, [])  # WHY: dispatch.
         assert len(rows) == 1 and rows[0]["device_type"] == "switch"  # WHY: dispatch reached _switch_rows.
 
     def test_gateway_dispatch_returns_gateway_rows(self) -> None:
         """The gateway branch produces per-model rows via the gateway helper."""
         row = {"device_type": "gateway", "model": "SRX300"}  # WHY: minimal model row.
         gateway_records = [{"model": "SRX300", "version": "23.2"}]  # WHY: one matching record.
-        rows = VersionPerModelFetcher._rows_for_model(_ORG_ID, row, [], gateway_records)  # WHY: dispatch.
+        rows = VersionPerModelFetcher._rows_for_model(row, [], gateway_records)  # WHY: dispatch.
         assert len(rows) == 1 and rows[0]["device_type"] == "gateway"  # WHY: dispatch reached _gateway_rows.
 
     def test_unknown_device_type_returns_empty_list(self) -> None:
         """An unrecognized device_type hits the trailing return."""
         row = {"device_type": "mystery", "model": "X"}  # WHY: forces final ``return []`` line.
-        assert VersionPerModelFetcher._rows_for_model(_ORG_ID, row, [], []) == []  # WHY: no dispatch match.
+        assert VersionPerModelFetcher._rows_for_model(row, [], []) == []  # WHY: no dispatch match.
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +318,7 @@ class TestExpandModelRows:
         switch_records = [{"model": "EX4300", "version": "22.4", "num_members": 1}]  # WHY: one match.
         gateway_records = [{"model": "SRX300", "version": "23.2"}]  # WHY: one match.
         rows = VersionPerModelFetcher._expand_model_rows(  # WHY: exercise iteration + AP skip.
-            _ORG_ID, model_rows, switch_records, gateway_records
+            model_rows, switch_records, gateway_records  # WHY: the org id left both signatures in issue #887.
         )
         by_type = sorted(row["device_type"] for row in rows)  # WHY: order-agnostic assertion.
         assert by_type == ["gateway", "switch"]  # WHY: proves AP row was skipped; other two dispatched.

--- a/tests/unit/test_address_utils.py
+++ b/tests/unit/test_address_utils.py
@@ -725,57 +725,53 @@ class TestNominatimValidatorHelpers:
         assert "springfield" in key
 
     def test_calculate_component_match_empty(self):
-        score = self.validator._calculate_component_match([], "Some Display", "test")
+        score = self.validator._calculate_component_match([], "Some Display")  # WHY: source left the signature
         assert score == 0.0
 
     def test_calculate_component_match_full(self):
         parts = ["123 Main St", "Springfield", "Illinois"]
         display = "123 Main St, Springfield, Illinois, USA"
-        score = self.validator._calculate_component_match(parts, display, "test")
+        score = self.validator._calculate_component_match(parts, display)  # WHY: source left the signature
         assert score > 0.0
 
     def test_calculate_component_match_partial(self):
         parts = ["123 Main St", "Springfield"]
         display = "Main St, Different City, IL"
-        score = self.validator._calculate_component_match(parts, display, "test")
+        score = self.validator._calculate_component_match(parts, display)  # WHY: source left the signature
         assert 0.0 < score < 1.0
 
     def test_calculate_quality_boost_high(self):
-        boost = self.validator._calculate_quality_boost(
+        boost = self.validator._calculate_quality_boost(  # WHY: source left the signature
             {"type": "building", "class": "building", "address": {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}},
-            "test",
         )
         assert boost >= 0.5  # 0.3 type + 0.2 details
 
     def test_calculate_quality_boost_medium(self):
-        boost = self.validator._calculate_quality_boost(
+        boost = self.validator._calculate_quality_boost(  # WHY: source left the signature
             {"type": "residential", "class": "other", "address": {"a": 1}},
-            "test",
         )
         assert boost == 0.2
 
     def test_calculate_quality_boost_class(self):
-        boost = self.validator._calculate_quality_boost(
+        boost = self.validator._calculate_quality_boost(  # WHY: source left the signature
             {"type": "other", "class": "place", "address": {}},
-            "test",
         )
         assert boost == 0.1
 
     def test_calculate_quality_boost_none(self):
-        boost = self.validator._calculate_quality_boost(
+        boost = self.validator._calculate_quality_boost(  # WHY: source left the signature
             {"type": "other", "class": "other"},
-            "test",
         )
         assert boost == 0.0
 
     def test_calculate_confidence_with_importance(self):
         result = {"importance": 0.6}
-        conf = self.validator._calculate_confidence(result, [], "test")
+        conf = self.validator._calculate_confidence(result, [])  # WHY: source left the signature
         assert conf > 0.0
 
     def test_calculate_confidence_no_importance(self):
         result = {"importance": 0.0, "display_name": "123 Main St", "type": "house", "class": "building", "address": {}}
-        conf = self.validator._calculate_confidence(result, ["123 Main St"], "test")
+        conf = self.validator._calculate_confidence(result, ["123 Main St"])  # WHY: source left the signature
         assert conf > 0.0
 
 
@@ -787,7 +783,7 @@ class TestNominatimValidatorAPI:
 
     def test_make_api_request_no_requests(self):
         with patch("src.utils.address_utils.requests", None):
-            result = self.validator._make_api_request("123 Main", "test")
+            result = self.validator._make_api_request("123 Main")  # WHY: source left the signature
             assert result is None
 
     def test_make_api_request_success(self):
@@ -795,7 +791,7 @@ class TestNominatimValidatorAPI:
         mock_resp.status_code = 200
         with patch("src.utils.address_utils.requests") as mock_req:
             mock_req.get.return_value = mock_resp
-            result = self.validator._make_api_request("123 Main", "test")
+            result = self.validator._make_api_request("123 Main")  # WHY: source left the signature
             assert result is not None
 
     def test_make_api_request_retry_then_success(self):
@@ -803,20 +799,20 @@ class TestNominatimValidatorAPI:
         with patch("src.utils.address_utils.requests") as mock_req:
             mock_req.get.side_effect = [Exception("timeout"), mock_resp]
             with patch("time.sleep"):
-                result = self.validator._make_api_request("123 Main", "test")
+                result = self.validator._make_api_request("123 Main")  # WHY: source left the signature
                 assert result is mock_resp
 
     def test_make_api_request_all_retries_fail(self):
         with patch("src.utils.address_utils.requests") as mock_req:
             mock_req.get.side_effect = Exception("timeout")
             with patch("time.sleep"):
-                result = self.validator._make_api_request("123 Main", "test")
+                result = self.validator._make_api_request("123 Main")  # WHY: source left the signature
                 assert result is None
 
     def test_parse_geocode_response_not_200(self):
         mock_resp = MagicMock()
         mock_resp.status_code = 404
-        result = self.validator._parse_geocode_response(mock_resp, [], "test")
+        result = self.validator._parse_geocode_response(mock_resp, [])  # WHY: source left the signature
         assert result["valid"] is False
         assert "404" in result["error"]
 
@@ -824,7 +820,7 @@ class TestNominatimValidatorAPI:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = []
-        result = self.validator._parse_geocode_response(mock_resp, [], "test")
+        result = self.validator._parse_geocode_response(mock_resp, [])  # WHY: source left the signature
         assert result["valid"] is False
 
     def test_parse_geocode_response_success(self):
@@ -841,7 +837,7 @@ class TestNominatimValidatorAPI:
                 "address": {},
             }
         ]
-        result = self.validator._parse_geocode_response(mock_resp, ["Springfield"], "test")
+        result = self.validator._parse_geocode_response(mock_resp, ["Springfield"])  # WHY: source left the signature
         assert result["valid"] is True
         assert result["lat"] == 39.78
 

--- a/tests/unit/test_bulk_ap_upgrader.py
+++ b/tests/unit/test_bulk_ap_upgrader.py
@@ -1699,7 +1699,7 @@ class TestStep8ExecuteExtended:
             },
         }
         with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
-            upgrader._execute_multi_version_upgrade("site-001", "HQ", site_data, _mock_mistapi)
+            upgrader._execute_multi_version_upgrade("site-001", "HQ", site_data)  # WHY: mistapi left the signature
         assert upgrader.successful_upgrades == 2
 
     def test_upgrade_version_group_non_dry_run(self):
@@ -1721,7 +1721,9 @@ class TestStep8ExecuteExtended:
         mock_resp.data = {"upgrade_id": "upgrade-xyz"}
         with patch.dict(sys.modules, {"mistapi": _mock_mistapi}):
             _mock_mistapi.api.v1.sites.devices.upgradeSiteDevices.return_value = mock_resp
-            upgrader._upgrade_version_group("site-001", "HQ", "0.14.123", version_info, _mock_mistapi)
+            upgrader._upgrade_version_group(  # WHY: Keep position arguments to match upstream method signature.
+                "site-001", "HQ", "0.14.123", version_info
+            )
         assert upgrader.successful_upgrades == 1
         assert "upgrade-xyz" in upgrader.upgrade_ids
 

--- a/tests/unit/test_ssid_template_consolidation.py
+++ b/tests/unit/test_ssid_template_consolidation.py
@@ -420,7 +420,7 @@ class TestResolveTemplate:
                 "applies": {"site_ids": ["site-1"], "sitegroup_ids": []},
             }
         }
-        tmpl, tid = _resolve_template(site, lookup, {})
+        tmpl, tid = _resolve_template(site, lookup)  # WHY: sitegroup_lookup left the signature in issue #887.
         assert tid == "tmpl-1"
 
     def test_sitegroup_match(self) -> None:
@@ -431,7 +431,7 @@ class TestResolveTemplate:
                 "applies": {"site_ids": [], "sitegroup_ids": ["g1"]},
             }
         }
-        tmpl, tid = _resolve_template(site, lookup, {})
+        tmpl, tid = _resolve_template(site, lookup)  # WHY: sitegroup_lookup left the signature in issue #887.
         assert tid == "tmpl-1"
 
     def test_no_match(self) -> None:
@@ -442,7 +442,7 @@ class TestResolveTemplate:
                 "applies": {"site_ids": ["site-2"], "sitegroup_ids": []},
             }
         }
-        tmpl, tid = _resolve_template(site, lookup, {})
+        tmpl, tid = _resolve_template(site, lookup)  # WHY: sitegroup_lookup left the signature in issue #887.
         assert tmpl is None
         assert tid == ""
 
@@ -2024,7 +2024,7 @@ class TestOfferResume:
             )
         )
         mgr._load_phase_results = MagicMock(return_value=None)  # type: ignore[method-assign]
-        resuming, results = mgr._offer_resume(2, [])
+        resuming, results = mgr._offer_resume(2)  # WHY: the results parameter left the signature in issue #887.
         assert resuming is False
         assert results == []
 


### PR DESCRIPTION
## Summary
- implement the issue #887 cleanup set across runtime, utility, and test modules
- add the SpecKit artifacts under specs/887-pylint-unused-argument/
- include the small follow-up fixes needed for branch quality gates (mypy call-arg and test lint line length)

## Validation
- python -m ruff check .
- python -m black --check --diff .
- python -m mypy src --config-file pyproject.toml
- python -m pytest --cov=src --cov-fail-under=80
- python -m pip_audit -r requirements.txt

## Notes
- local Windows bandit run reports known path-matching phantom findings (issue #1722); CI Linux bandit remains the source of truth.

Closes #887