### PR TITLE
feat: add getSiteBeacon menu operation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -111,6 +111,7 @@ per-host-logs/
 # Package manager artifacts
 *.lock
 uv.lock
+node_modules/
 
 # Archive and backup files
 *.tar

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -74,6 +74,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-03
 - N/A. The work changes two configuration files and one changelog file. (1033-ci-gate-silencer-removal)
 - Python 3.13 or newer. The project interpreter is `.venv\Scripts\python.exe`. The global `python` on this machine is broken. + The standard library only. The change adds `collections.Counter` and no package. (990-redis-entity-id)
 - Redis TimeSeries through the `redis-stack` service. The change adds no key, no index, and no migration. (990-redis-entity-id)
+- Python 3.13+ + `mistapi>=0.63.1`, `python-dotenv`, `PyYAML`, `structlog`, existing MistHelper utility modules (`InputUtils`, `DataExporter`) (671-mist-get-site-beacon)
+- CSV files under `data/`, SQLite (`data/mist_data.db`), optional ArangoDB + Redis through `DatabaseRouter` (671-mist-get-site-beacon)
 
 - Python 3.13+ + mistapi>=0.59.0, python-dotenv>=1.0.0 (001-radius-wlan-config)
 
@@ -93,9 +95,9 @@ cd src; pytest; ruff check .
 Python 3.13+: Follow standard conventions
 
 ## Recent Changes
+- 671-mist-get-site-beacon: Added Python 3.13+ + `mistapi>=0.63.1`, `python-dotenv`, `PyYAML`, `structlog`, existing MistHelper utility modules (`InputUtils`, `DataExporter`)
 - 990-redis-entity-id: Added an entity identifier fallback to `RedisTimeSeriesWriter`. The writer reads the strategy field first, then walks `device_id`, `site_id`, `org_id`, `mac`, `id`, and uses the `unknown` sentinel last.
 - 1033-ci-gate-silencer-removal: Added Python 3.13. The workstation interpreter is `.venv\Scripts\python.exe`. The global `python` on this machine is broken and must not run any gate command. + `pylint`, `vulture`, and the GitHub CodeQL Action v4. This work adds no dependency and pins no version.
-- 1032-bandit-severity-gate: Added Python 3.13 (`pyproject.toml` target `py313`) + `bandit[toml]` (no new runtime dependency)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs\\887-pylint-unused-argument"}
+{"feature_directory":"specs/671-mist-get-site-beacon"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ## [Unreleased]
 
+### Add menu operation 209 for getSiteBeacon (issue #1420, spec 671)
+
+- **New endpoint workflow (Added)**: added `SiteClientExporter.get_site_beacon`
+  and menu option `209` to execute
+  `mistapi.api.v1.sites.beacons.getSiteBeacon` with safe prompts for `site_id`
+  and `beacon_id`.
+- **Persistence contract (Added)**: normalized single-record payloads to a
+  list and persisted via
+  `DataExporter.write_with_format_selection(..., api_function_name="getSiteBeacon")`
+  using deterministic filenames per site/beacon pair.
+- **Resilience (Added)**: applied adaptive retry/backoff behavior for 429
+  responses via `RateLimitingUtils.get_rate_limited_delay` before retrying.
+- **Registry and key strategy (Added)**: registered menu option `209` as
+  `interactive_safe` in `OperationRegistry` and added `getSiteBeacon`
+  natural-key strategy (`id`) to
+  `ENDPOINT_PRIMARY_KEY_STRATEGIES`.
+- **Tests (Added)**: added unit coverage for prompt validation, happy path,
+  empty payload, 429 retry, and non-429 failure handling; added integration
+  menu dispatch smoke test for option `209`.
+
 ### Lower the vulture confidence floor to 70 (issue #892)
 
 - **Dead code floor (Changed)**: lowered the vulture confidence floor from 90 to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-14
 - No persistent state beyond the existing JSONL telemetry pattern; load-time dedup state is per-invocation `set[str]` in memory only (FR-012) (1025-probe-emission-log-fixes)
 - Python 3.13+ (per constitution binding minimum + `mistapi >= 0.63.1` (verified installed (1029-ap-profile-migration)
 - Local files under `data/` only. (1029-ap-profile-migration)
+- Python 3.13+ + `mistapi>=0.63.1`, `python-dotenv`, `PyYAML`, `structlog`, existing MistHelper utility modules (`InputUtils`, `DataExporter`) (671-mist-get-site-beacon)
+- CSV files under `data/`, SQLite (`data/mist_data.db`), optional ArangoDB + Redis through `DatabaseRouter` (671-mist-get-site-beacon)
 
 - Python 3.13 (matches project constitution binding minimum). (1019-test-quality-analyzer)
 
@@ -34,9 +36,9 @@ cd src; pytest; ruff check .
 Python 3.13 (matches project constitution binding minimum).: Follow standard conventions
 
 ## Recent Changes
+- 671-mist-get-site-beacon: Added Python 3.13+ + `mistapi>=0.63.1`, `python-dotenv`, `PyYAML`, `structlog`, existing MistHelper utility modules (`InputUtils`, `DataExporter`)
 - 1029-ap-profile-migration: Added menus 207 (migrate APs between device profiles) and 208 (revert); writes JSON backup and JSONL audit under `data/`.
 - 1025-probe-emission-log-fixes: Collapsed per-emission CENR + country_code WARNINGs into single load-time dedup emissions (`_emit_load_time_cenr_warning`, `_emit_load_time_country_code_warning`); extended `_COUNTRY_CODE_TO_REGION` LATAM/Caribbean mappings + added `_COUNTRY_CODE_INTENTIONAL_GAPS` frozenset; INV-1 byte-stability preserved
-- 1024-vpn-icmp-reachability: Added Python 3.13+ (`pyproject.toml` requires `>=3.13`; + Standard library only (`logging`, `pathlib`,
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -4013,6 +4013,10 @@ menu_actions: dict[str, tuple[Callable[..., Any], str]] = {
         SiteClientExporter.wan_client_events,
         "Search WAN client events for a selected site (spec 899 / issue #1407)",
     ),
+    "209": (
+        SiteClientExporter.get_site_beacon,
+        "Get site beacon detail by site_id + beacon_id (getSiteBeacon)",
+    ),
     "44": (OrgConfigExporter.psks, "Export PSK (Pre-Shared Key) information for the organization"),
     "45": (OrgConfigExporter.webhooks, "Export webhook configuration for the organization"),
     "46": (OrgConfigExporter.wlans, "Export WLAN configuration for the organization"),

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ flowchart LR
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 mindmap
-   root((MistHelper<br/>195 Operations))
+   root((MistHelper<br/>210 Operations))
     Safe Org Exports (60)
       Sites and Analysis 1-7
       Device Inventory 8-14
@@ -116,8 +116,8 @@ mindmap
       Config and Admin 42-50
       SLE and Insights 51-55
       Misc Exports 56-59
-    Interactive Safe (37)
-      Site Devices 60-72
+    Interactive Safe (38)
+      Site Devices 60-72, 209
       Site Insights 73-79
       Site Stats 80-91
       Viewers 92-96

--- a/documentation/menu_reference.md
+++ b/documentation/menu_reference.md
@@ -205,6 +205,7 @@ menu_actions = {
     "184": (SiteExportUtils.current_channel_planning, "Export current RRM channel & power plan per AP radio"),
     "185": (SelfExportUtils.audit_logs, "Export self (admin account) audit log"),
     "186": (GatewayHaExporter.ha_cluster_info, "Export HA gateway cluster info, stats & node pair for a site"),
+    "209": (SiteClientExporter.get_site_beacon, "Get site beacon detail by site_id + beacon_id (getSiteBeacon)"),
 }
 ```
 

--- a/specs/671-mist-get-site-beacon/contracts/get-site-beacon-contract.md
+++ b/specs/671-mist-get-site-beacon/contracts/get-site-beacon-contract.md
@@ -1,0 +1,50 @@
+# Contract: getSiteBeacon Menu Operation
+
+## Operation Identity
+
+- **Issue**: #1420
+- **Spec**: `/specs/671-mist-get-site-beacon/spec.md`
+- **operationId**: `getSiteBeacon`
+- **SDK Method**: `mistapi.api.v1.sites.beacons.getSiteBeacon`
+- **HTTP Path**: `GET /api/v1/sites/{site_id}/beacons/{beacon_id}`
+
+## Inputs
+
+### Required
+
+- `site_id` (string UUID)
+- `beacon_id` (string UUID)
+
+### Input acquisition contract
+
+- All prompts must use `safe_input()`.
+- EOF/interrupt must not raise traceback; operation exits cleanly.
+- Empty/invalid values must be validated before API call when possible.
+
+## Execution Contract
+
+1. Log `INFO` before API invocation.
+2. Call `getSiteBeacon` exactly once for one validated `(site_id, beacon_id)` pair.
+3. On success, normalize payload to list form for exporter compatibility.
+4. Log `DEBUG` with row/count summary after response handling.
+
+## Persistence Contract
+
+- Must call:
+  - `DataExporter.write_with_format_selection(data, filename, api_function_name='getSiteBeacon')`
+- Backend expectations:
+  - CSV output under `data/`
+  - SQLite upsert using `ENDPOINT_PRIMARY_KEY_STRATEGIES['getSiteBeacon']`
+  - ArangoDB/Redis routing enabled when configured
+
+## Error Contract
+
+- 404 and other API errors: surfaced as structured logs/warnings, no traceback crash.
+- 429: adaptive rate-limit handling engaged per existing delay metrics and retry system.
+
+## Documentation Contract
+
+Implementation PR for this issue must also update:
+- README menu table (new operation entry + count)
+- CHANGELOG entry
+- Endpoint key strategy registry with `getSiteBeacon`

--- a/specs/671-mist-get-site-beacon/contracts/get-site-beacon-response.schema.json
+++ b/specs/671-mist-get-site-beacon/contracts/get-site-beacon-response.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://misthelper/specs/671/contracts/get-site-beacon-response.schema.json",
+  "title": "getSiteBeaconResponse",
+  "type": "object",
+  "required": ["id", "site_id"],
+  "properties": {
+    "id": { "type": "string", "description": "Beacon UUID" },
+    "site_id": { "type": "string", "description": "Site UUID" },
+    "org_id": { "type": "string" },
+    "map_id": { "type": "string" },
+    "name": { "type": "string" },
+    "type": { "type": "string", "enum": ["eddystone-uid", "eddystone-url", "ibeacon"] },
+    "mac": { "type": "string" },
+    "x": { "type": "number" },
+    "y": { "type": "number" },
+    "power": { "type": "integer", "minimum": -12, "maximum": 100 },
+    "for_site": { "type": "boolean" },
+    "ibeacon_uuid": { "type": ["string", "null"] },
+    "ibeacon_major": { "type": ["integer", "null"], "minimum": 1, "maximum": 65535 },
+    "ibeacon_minor": { "type": ["integer", "null"], "minimum": 1, "maximum": 65535 },
+    "eddystone_namespace": { "type": "string" },
+    "eddystone_instance": { "type": "string" },
+    "eddystone_url": { "type": "string" },
+    "created_time": { "type": "number" },
+    "modified_time": { "type": "number" }
+  },
+  "additionalProperties": true
+}

--- a/specs/671-mist-get-site-beacon/data-model.md
+++ b/specs/671-mist-get-site-beacon/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: getSiteBeacon
+
+## 1) BeaconLookupRequest
+
+Represents validated operator input before SDK invocation.
+
+- `org_id` (string, required when org-scoped prompt flow is used)
+- `site_id` (UUID string, required)
+- `beacon_id` (UUID string, required)
+- `invoked_operation` (string, fixed: `getSiteBeacon`)
+- `requested_at_epoch` (number, generated)
+
+### Validation Rules
+
+- `site_id` and `beacon_id` must be non-empty after `safe_input().strip()`.
+- Reject obvious invalid UUID syntax early when validator exists; otherwise rely on API 404 and log warning.
+- EOF/interrupt from `safe_input()` returns default/empty and exits operation cleanly with status 0.
+
+## 2) SiteBeaconRecord
+
+Canonical output record from Mist API response (`GET /sites/{site_id}/beacons/{beacon_id}`).
+
+Core fields (expected):
+- `id` (UUID, read-only, natural primary key)
+- `site_id` (UUID, read-only)
+- `org_id` (UUID, read-only)
+- `map_id` (UUID, optional)
+- `name` (string)
+- `type` (enum-like string: `eddystone-uid` | `eddystone-url` | `ibeacon`)
+- `mac` (string, optional)
+- `x`, `y` (number, optional position)
+- `power` (int, dBm)
+- `ibeacon_uuid`, `ibeacon_major`, `ibeacon_minor` (nullable beacon profile fields)
+- `eddystone_namespace`, `eddystone_instance`, `eddystone_url` (nullable beacon profile fields)
+- `created_time`, `modified_time` (epoch numbers)
+- `for_site` (boolean)
+
+### Validation Rules
+
+- `id` must exist for persistence/upsert.
+- Numeric fields (`x`, `y`, `power`, epoch values) must remain numeric after flattening.
+- Nullables must remain nullable; do not coerce null to placeholder strings.
+
+## 3) ExportEnvelope
+
+Normalized payload passed to exporter and backend router.
+
+- `records` (list[SiteBeaconRecord], usually length 1)
+- `api_function_name` (string, fixed: `getSiteBeacon`)
+- `filename_or_table` (string target for CSV/SQLite)
+- `raw_data` (optional original payload for polyglot routing)
+
+### Persistence Behavior
+
+- CSV: append/write operation-specific file in `data/`.
+- SQLite: upsert using `ENDPOINT_PRIMARY_KEY_STRATEGIES['getSiteBeacon']` (`natural_pk` on `id`).
+- ArangoDB/Redis (if enabled): routed through `DatabaseRouter` with same API function name.
+
+## Relationships
+
+- `BeaconLookupRequest (1)` -> `(0..1) SiteBeaconRecord`
+- `SiteBeaconRecord (1)` -> `(1) ExportEnvelope` during successful run
+
+## State Transitions
+
+1. `InputPending` -> `InputValidated`
+2. `InputValidated` -> `ApiRequested`
+3. `ApiRequested` -> `ApiSucceeded` | `ApiNotFound` | `ApiRateLimited` | `ApiError`
+4. `ApiSucceeded` -> `Exported`
+5. `ApiNotFound`/`ApiRateLimited`/`ApiError` -> `LoggedAndExitedCleanly`

--- a/specs/671-mist-get-site-beacon/plan.md
+++ b/specs/671-mist-get-site-beacon/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Mist API Read Operation -- getSiteBeacon
+
+**Branch**: `671-mist-get-site-beacon` | **Date**: 2026-08-03 | **Spec**: `/specs/671-mist-get-site-beacon/spec.md`
+
+**Input**: Feature specification from `/specs/671-mist-get-site-beacon/spec.md`
+
+## Summary
+
+Add a new MistHelper menu operation for `getSiteBeacon` (`GET /api/v1/sites/{site_id}/beacons/{beacon_id}`) that safely collects required IDs, executes the SDK call once per selected scope, and persists results via `DataExporter.write_with_format_selection(..., api_function_name='getSiteBeacon')` for CSV, SQLite, and ArangoDB/Redis workflows.
+
+## Technical Context
+
+**Language/Version**: Python 3.13+
+
+**Primary Dependencies**: `mistapi>=0.63.1`, `python-dotenv`, `PyYAML`, `structlog`, existing MistHelper utility modules (`InputUtils`, `DataExporter`)
+
+**Storage**: CSV files under `data/`, SQLite (`data/mist_data.db`), optional ArangoDB + Redis through `DatabaseRouter`
+
+**Testing**: `pytest` (unit + integration marker), `python -m py_compile MistHelper.py`, `python -m ruff check`, `python -m black --check`
+
+**Target Platform**: Windows dev environment + Podman container runtime (Linux) + SSH/container interactive sessions
+
+**Project Type**: Single-project Python CLI application with modular `src/` packages
+
+**Performance Goals**: Single endpoint fetch completes within 5 seconds under normal API latency; retries and backoff honor existing adaptive rate-limit controls
+
+**Constraints**:
+- Must use `safe_input()` handling for all interactive prompts
+- Must apply constitution-mandated inline comments and action logging patterns
+- Must keep operation read-only and non-destructive
+- Must update `ENDPOINT_PRIMARY_KEY_STRATEGIES`, README menu table, and CHANGELOG in same issue scope
+
+**Scale/Scope**: One new GET menu operation, one new endpoint PK strategy entry, focused docs updates, and regression-safe export path reuse
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Research Gate Review
+
+- **I. Five-Item Rule**: PASS — planned work is a small additive change with helper reuse, no large structural expansion.
+- **II. Class-Based Architecture**: PASS — implementation will extend existing class/module pathways; no wrapper-only functions.
+- **III. Safety-First**: PASS — prompt flow explicitly requires `safe_input()` and graceful EOF handling.
+- **IV. Full Deployment Pipeline**: PASS (execution-phase gate) — validation commands and deployment pipeline remain required after coding.
+- **V. Observability & Logging**: PASS — info-before/debug-after logging is included in handler design.
+- **VI. Inline Comments**: PASS (execution-phase gate) — all generated executable lines will require same-line comments.
+- **VII. Action Logging**: PASS — API call, transform, and export steps include before/after logging.
+
+**Gate Result (Pre-Research)**: PASS
+
+### Post-Design Gate Re-Check
+
+- Data model preserves natural key semantics (`id`) for beacon entities.
+- Contract design enforces safe input, bounded API invocation, and backend-consistent persistence.
+- Quickstart validation includes lint/syntax/test gates and run-path verification.
+
+**Gate Result (Post-Design)**: PASS
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/671-mist-get-site-beacon/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── get-site-beacon-contract.md
+│   └── get-site-beacon-response.schema.json
+└── tasks.md                 # created in /speckit.tasks phase
+```
+
+### Source Code (repository root)
+
+```text
+MistHelper.py
+src/
+├── refactors/
+│   └── endpoint_primary_key_strategies.py
+├── utils/
+│   └── input_utils.py
+├── export/
+│   └── data_exporter.py
+└── db/
+    └── arango_writer.py
+
+documentation/
+├── MIST_API_MISSING_ENDPOINTS.md
+└── api/sites/
+
+tests/
+├── unit/
+└── integration/
+```
+
+**Structure Decision**: Use the existing single-project CLI structure. Implement `getSiteBeacon` by extending current menu/endpoint dispatch flow, reusing `InputUtils.safe_input`, exporter plumbing, and endpoint strategy configuration without introducing new top-level packages.
+
+## Phase 0: Research Plan
+
+1. Confirm request/response semantics for `getSiteBeacon` (required path params, non-paginated response, 404/429 behavior).
+2. Select primary key strategy for `getSiteBeacon` aligned with existing beacon endpoint conventions.
+3. Validate integration pattern for menu prompt -> SDK call -> data export -> backend routing.
+
+**Output**: `research.md`
+
+## Phase 1: Design Plan
+
+1. Define request/result/export entities and validation rules in `data-model.md`.
+2. Define user-facing operation contract and response schema in `contracts/`.
+3. Define operator validation workflow in `quickstart.md`.
+4. Refresh agent context from finalized plan metadata.
+
+**Output**: `data-model.md`, `contracts/*`, `quickstart.md`
+
+## Complexity Tracking
+
+No constitution violations expected; table not required.

--- a/specs/671-mist-get-site-beacon/quickstart.md
+++ b/specs/671-mist-get-site-beacon/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart Validation: getSiteBeacon
+
+## Purpose
+
+Validate the new Issue #1420 menu operation for `getSiteBeacon` end-to-end across input handling, API execution, and output persistence.
+
+## Prerequisites
+
+1. Python 3.13+ environment with project dependencies installed.
+2. Valid Mist API token in `.env`.
+3. Known valid `site_id` and `beacon_id` pair in target org.
+4. Writable `data/` directory (and container permissions if running in Podman).
+
+## Validation Scenario A: Static checks
+
+Run from repo root:
+
+1. `python -m py_compile MistHelper.py`
+2. `python -m ruff check`
+3. `python -m black --check .`
+
+Expected:
+- All commands exit 0.
+
+## Validation Scenario B: Interactive menu happy path
+
+1. Launch: `python MistHelper.py`
+2. Select the new menu number for `getSiteBeacon`.
+3. Enter required identifiers when prompted.
+4. Complete run.
+
+Expected:
+- No traceback.
+- Info log before API request; debug log with response count after request.
+- Export artifact written under `data/`.
+
+## Validation Scenario C: Non-interactive/EOF safety
+
+1. Run the menu in an SSH/container context.
+2. Trigger EOF during one prompt (or provide empty stream).
+
+Expected:
+- `safe_input()` handles EOF.
+- Operation exits cleanly (status 0) without unhandled exception.
+
+## Validation Scenario D: Repeat-run upsert behavior (SQLite)
+
+1. Set SQLite output mode.
+2. Run the same `site_id` + `beacon_id` twice.
+3. Inspect resulting SQLite table row count for the same beacon `id`.
+
+Expected:
+- No duplicate rows for the same natural primary key.
+
+## Validation Scenario E: Error handling
+
+### Unknown beacon/site
+
+- Use invalid `site_id` or `beacon_id`.
+- Expect warning/error log with controlled exit (no traceback).
+
+### Rate limit
+
+- Simulate/observe 429 path.
+- Expect retry/backoff behavior consistent with existing adaptive delay controls.
+
+## Related Artifacts
+
+- Data shape + keys: `data-model.md`
+- Interface constraints: `contracts/get-site-beacon-contract.md`
+- Response schema: `contracts/get-site-beacon-response.schema.json`

--- a/specs/671-mist-get-site-beacon/research.md
+++ b/specs/671-mist-get-site-beacon/research.md
@@ -1,0 +1,32 @@
+# Research: getSiteBeacon
+
+## Decision 1: SDK invocation pattern
+
+- **Decision**: Use `mistapi.api.v1.sites.beacons.getSiteBeacon(apisession, site_id=..., beacon_id=...)` as a single-record read operation with no pagination loop.
+- **Rationale**: Official API docs for `/api/v1/sites/{site_id}/beacons/{beacon_id}` define a single object response and no query params; this avoids unnecessary iteration complexity.
+- **Alternatives considered**:
+  - Reusing list endpoint (`listSiteBeacons`) and filtering client-side — rejected because it over-fetches and can miss exact server-side semantics.
+  - Raw HTTP request wrapper — rejected because constitution and project constraints prefer `mistapi` SDK when method exists.
+
+## Decision 2: Primary key strategy
+
+- **Decision**: Register `getSiteBeacon` in `ENDPOINT_PRIMARY_KEY_STRATEGIES` as `natural_pk` with primary key `id`.
+- **Rationale**: Beacon entities already use globally stable UUID `id` in existing strategy entries (`listSiteBeacons`), and get-by-id responses represent the same resource model.
+- **Alternatives considered**:
+  - Composite key (`site_id`, `id`) — rejected as redundant because `id` is unique and simpler for upsert behavior.
+  - Auto-increment strategy — rejected because it breaks natural-key consistency and repeat-run dedupe behavior.
+
+## Decision 3: Input, resilience, and export flow
+
+- **Decision**: Follow existing menu operation pattern: collect IDs with `safe_input()`, log before/after API calls, honor existing retry/rate-limit controls, and persist via `DataExporter.write_with_format_selection(..., api_function_name='getSiteBeacon')`.
+- **Rationale**: This directly satisfies FR-002/003/004/006 and maintains behavior parity across CSV, SQLite, and ArangoDB/Redis.
+- **Alternatives considered**:
+  - Custom exporter path for beacon-only output — rejected to avoid bypassing backend router and snapshot logic.
+  - Silent failures on 404/429 — rejected; operator-visible warnings are required for observability.
+
+## Decision 4: Documentation and menu registration scope
+
+- **Decision**: Keep scope limited to Issue #1420 by updating the next available menu entry plus README/CHANGELOG and endpoint strategy records only.
+- **Rationale**: Spec requires additive endpoint coverage without broader UI or architectural changes.
+- **Alternatives considered**:
+  - Bundle adjacent missing endpoint work in same change — rejected due to scope creep and issue isolation requirement.

--- a/specs/671-mist-get-site-beacon/tasks.md
+++ b/specs/671-mist-get-site-beacon/tasks.md
@@ -1,0 +1,130 @@
+---
+description: "Task list for [Spec 671] getSiteBeacon endpoint"
+---
+
+# Tasks: getSiteBeacon Menu Endpoint
+
+**Input**: Design documents from `specs/671-mist-get-site-beacon/`  
+**Prerequisites**: `plan.md`, `spec.md`  
+**Branch**: `671-mist-get-site-beacon`
+
+**Tests**: Tests are required for this feature (explicit request + spec acceptance checklist).
+
+**Organization**: Tasks are grouped by user story so implementation and validation can be completed independently.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare menu slot, test files, and endpoint-specific scaffolding.
+
+- [X] T001 Confirm and reserve the next sequential menu option for `getSiteBeacon` in `MistHelper.py`
+- [X] T002 [P] Add/extend `getSiteBeacon` unit-test scaffolding in `tests/unit/export/test_site_client_exporter.py`
+- [X] T003 [P] Create menu smoke-test scaffold for the new operation in `tests/integration/test_menu_site_beacon_detail.py`
+
+**Checkpoint**: Menu slot and test harness scaffolding are ready.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared endpoint metadata and dispatch prerequisites required before story implementation.
+
+**⚠️ CRITICAL**: Complete this phase before implementing user-story behavior.
+
+- [X] T004 Add `getSiteBeacon` entry to `ENDPOINT_PRIMARY_KEY_STRATEGIES` in `src/refactors/endpoint_primary_key_strategies.py`
+- [X] T005 Add operation-registry classification for the new menu option in `src/utils/operation_registry.py`
+- [X] T006 Add reusable site/beacon prompt-and-validation helper flow in `src/export/site_client_exporter.py`
+
+**Checkpoint**: PK strategy, operation classification, and prompt/validation scaffolding are in place.
+
+---
+
+## Phase 3: User Story 1 - Read-only data retrieval (Priority: P1) 🎯 MVP
+
+**Goal**: A NOC engineer can run a new menu action that calls `mistapi.api.v1.sites.beacons.getSiteBeacon()` and exports the response to configured backends.
+
+**Independent Test**: Run `python MistHelper.py --menu <new_id>` with known site/beacon IDs; verify output under `data/`, verify SQLite upsert behavior (no duplicate PK rows), and confirm graceful exit on EOF input.
+
+### Tests for User Story 1
+
+- [X] T007 [P] [US1] Add happy-path unit test for `getSiteBeacon` API invocation and export call in `tests/unit/export/test_site_client_exporter.py`
+- [X] T008 [P] [US1] Add prompt/validation and `safe_input()` EOF handling unit tests in `tests/unit/export/test_site_client_exporter.py`
+- [X] T009 [P] [US1] Add empty-response and API-error path unit tests in `tests/unit/export/test_site_client_exporter.py`
+- [X] T010 [US1] Add menu-dispatch integration smoke test for the new menu option in `tests/integration/test_menu_site_beacon_detail.py`
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Implement `getSiteBeacon` export workflow (site/beacon prompts, logging, SDK call) in `src/export/site_client_exporter.py`
+- [X] T012 [US1] Wire `DataExporter.write_with_format_selection(..., api_function_name="getSiteBeacon")` and deterministic filename logic in `src/export/site_client_exporter.py`
+- [X] T013 [US1] Register the new menu handler/label mapping in `MistHelper.py`
+- [X] T014 [US1] Ensure adaptive retry/rate-limit behavior is applied to `getSiteBeacon` call path in `src/export/site_client_exporter.py`
+- [X] T015 [US1] Align interactive-safe routing for the new menu option in `src/utils/operation_registry.py`
+
+**Checkpoint**: US1 is end-to-end functional and independently testable.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, release notes, and final validation.
+
+- [X] T016 [P] Update menu documentation and operation count for the new endpoint in `README.md`
+- [X] T017 [P] Update menu reference entry for the new endpoint in `documentation/menu_reference.md`
+- [X] T018 [P] Add `[Spec 671] getSiteBeacon` release note entry in `CHANGELOG.md`
+- [X] T019 Run targeted regression tests for touched endpoint wiring in `tests/unit/export/test_site_client_exporter.py` and `tests/integration/test_menu_site_beacon_detail.py`
+- [X] T020 Run acceptance validation commands (`py_compile`, `ruff`, `black --check`, `--menu` smoke run) against `MistHelper.py`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies.
+- **Phase 2 (Foundational)**: Depends on Phase 1; blocks all story work.
+- **Phase 3 (US1)**: Depends on Phase 2 completion.
+- **Phase 4 (Polish)**: Depends on US1 completion.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Foundational; no dependency on other user stories.
+
+### Within US1
+
+- Write tests first (T007-T010), verify they fail, then implement.
+- Implement endpoint workflow before final menu registration.
+- Keep operation-registry classification synchronized with menu wiring.
+
+### Parallel Opportunities
+
+- Setup: T002 and T003 can run in parallel.
+- US1 tests: T007, T008, and T009 can run in parallel.
+- Polish docs: T016, T017, and T018 can run in parallel.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Parallel test authoring for US1:
+Task: "T007 [US1] happy-path unit test in tests/unit/export/test_site_client_exporter.py"
+Task: "T008 [US1] safe_input/EOF unit tests in tests/unit/export/test_site_client_exporter.py"
+Task: "T009 [US1] empty/error-path unit tests in tests/unit/export/test_site_client_exporter.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Setup (Phase 1)
+2. Complete Foundational (Phase 2)
+3. Complete US1 (Phase 3)
+4. Validate with CLI `--menu` smoke run and backend output checks
+
+### Incremental Delivery
+
+1. Deliver endpoint metadata + routing prerequisites
+2. Deliver US1 endpoint behavior and tests
+3. Deliver docs/changelog updates
+4. Run validation gates before merge

--- a/src/export/site_client_exporter.py
+++ b/src/export/site_client_exporter.py
@@ -10,6 +10,7 @@ from __future__ import annotations  # WHY: enable PEP 604 unions on Python 3.9+.
 
 import importlib  # WHY: lazy MistHelper import to reach live helper classes without circular load.
 import logging  # WHY: structured trace for export lifecycle events.
+import time  # WHY: adaptive retry backoff sleep for rate-limited endpoint calls.
 from typing import Any  # WHY: raw client rows are duck-typed dicts from mistapi.
 
 import mistapi  # WHY: direct SDK access for listSiteWirelessClientsStats + beacons endpoints.
@@ -25,6 +26,10 @@ from src.export.wifi_clients_exporter import WifiClientsExporter  # Extracted Wi
 from src.utils.tqdm_wrapper import (
     tqdm,
 )  # WHY: 1015 T-14 -- import directly from canonical wrapper (eliminates mh.tqdm).
+
+_GET_SITE_BEACON_API_FUNCTION_NAME = "getSiteBeacon"  # WHY: operation id for PK routing.
+_GET_SITE_BEACON_FILENAME_PREFIX = "SiteBeacon"  # WHY: deterministic prefix keeps per-request artifacts discoverable.
+_GET_SITE_BEACON_FALLBACK_RETRIES = 2  # WHY: bounded fallback retry count when runtime retry config is unavailable.
 
 
 class SiteClientExporter:
@@ -170,3 +175,176 @@ class SiteClientExporter:
         )._export_data(  # Shared export scaffolding handles prompting + CSV write.
             api_call=mistapi.api.v1.sites.beacons.listSiteBeacons, data_type="beacons", sort_key="name"
         )
+
+    @staticmethod
+    def _prompt_site_beacon_identifiers() -> tuple[str, str] | None:
+        """Prompt for site/beacon IDs through safe_input and reject empty responses."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of InputUtils keeps module import acyclic.
+        logging.info("Prompting operator for site_id required by getSiteBeacon")  # WHY: action log before first prompt.
+        site_id = mh.InputUtils.safe_input(  # WHY: safe_input enforces EOF/interrupt-safe prompting semantics.
+            "Enter Site ID for getSiteBeacon: ",  # WHY: explicit site-id prompt.
+            allow_empty=False,  # WHY: empty identifiers are invalid for the API path contract.
+            context="site_client_exporter.getSiteBeacon.site_id",  # WHY: prompt context tag.
+        ).strip()  # WHY: strip whitespace so accidental spaces do not bypass empty-input validation.
+        logging.debug(
+            "Completed site_id prompt for getSiteBeacon with value_present=%s",
+            bool(site_id),
+        )  # WHY: prompt result trace.
+        if not site_id:  # WHY: blank/EOF/interrupt should abort cleanly before any API call.
+            logging.error("No site_id provided for getSiteBeacon. Exiting.")  # WHY: abort reason.
+            logging.info("! No site selected. Exiting.")  # WHY: user-facing cancel line.
+            return None  # WHY: signal caller to terminate flow without side effects.
+        logging.info("Prompting operator for beacon_id required by getSiteBeacon")  # WHY: pre-prompt log.
+        beacon_id = mh.InputUtils.safe_input(  # WHY: safe_input keeps beacon prompt EOF-safe in SSH/container sessions.
+            "Enter Beacon ID for getSiteBeacon: ",  # WHY: explicit beacon-id prompt.
+            allow_empty=False,  # WHY: empty beacon identifiers are invalid for the endpoint contract.
+            context="site_client_exporter.getSiteBeacon.beacon_id",  # WHY: prompt context tag.
+        ).strip()  # WHY: trim accidental whitespace before validation and filename generation.
+        logging.debug(
+            "Completed beacon_id prompt for getSiteBeacon with value_present=%s",
+            bool(beacon_id),
+        )  # WHY: prompt result trace.
+        if not beacon_id:  # WHY: blank/EOF/interrupt should abort before reaching SDK call.
+            logging.error("No beacon_id provided for getSiteBeacon. Exiting.")  # WHY: abort reason.
+            logging.info("! No beacon selected. Exiting.")  # WHY: user-facing cancel line.
+            return None  # WHY: signal caller to stop without invoking the API.
+        return site_id, beacon_id  # WHY: both required identifiers are now validated and ready for API invocation.
+
+    @staticmethod
+    def _normalize_site_beacon_payload(response_payload: Any) -> list[dict[str, Any]]:
+        """Normalize getSiteBeacon response payload to list-of-dicts for exporter compatibility."""
+        if response_payload is None:  # WHY: empty payload should flow through as an empty export dataset.
+            return []  # WHY: callers rely on list semantics for empty-result handling.
+        if isinstance(response_payload, list):  # WHY: defensive support for list payloads from wrappers/mocks.
+            normalized_rows = [row for row in response_payload if isinstance(row, dict)]  # WHY: keep only dict rows.
+            logging.debug(
+                "Normalized list payload for getSiteBeacon to %d dict rows",
+                len(normalized_rows),
+            )  # WHY: coercion trace.
+            return normalized_rows  # WHY: list payload already matches exporter shape after dict filtering.
+        if isinstance(response_payload, dict):  # WHY: expected SDK path returns one beacon object as a dict.
+            logging.debug("Normalized dict payload for getSiteBeacon to single-row list")  # WHY: coercion trace.
+            return [response_payload]  # WHY: DataExporter expects iterable rows; wrap single dict into list.
+        logging.warning(
+            "Unexpected getSiteBeacon payload type %s; treating as empty result",
+            type(response_payload).__name__,
+        )  # WHY: diagnose odd payload.
+        return []  # WHY: safest fallback for unsupported payload types is an empty dataset.
+
+    @staticmethod
+    def _build_site_beacon_filename(site_id: str, beacon_id: str) -> str:
+        """Build deterministic per-request export filename for getSiteBeacon output."""
+        sanitized_site_id = site_id.replace("-", "_")  # WHY: normalize punctuation for filenames.
+        sanitized_beacon_id = beacon_id.replace("-", "_")  # WHY: keep identifier formatting consistent.
+        filename = (  # WHY: deterministic artifact naming.
+            f"{_GET_SITE_BEACON_FILENAME_PREFIX}_{sanitized_site_id}_{sanitized_beacon_id}.csv"
+        )
+        logging.debug("Built deterministic getSiteBeacon filename: %s", filename)  # WHY: artifact trace.
+        return filename  # WHY: caller persists output using this stable filename.
+
+    @staticmethod
+    def _fetch_site_beacon_with_retry(site_id: str, beacon_id: str) -> list[dict[str, Any]]:
+        """Fetch one site beacon with adaptive delay retries on 429-style failures."""
+        mh = importlib.import_module("MistHelper")  # WHY: fetch runtime retry/delay globals lazily.
+        retry_limit = getattr(  # WHY: resolve configured retry cap while preserving behavior when setting is absent.
+            getattr(mh, "FastModeSequentialMaxRetries", None),  # WHY: tolerate missing retry config.
+            "VALUE",  # WHY: project standard stores retry count on VALUE class attribute.
+            _GET_SITE_BEACON_FALLBACK_RETRIES,  # WHY: fallback keeps retries bounded when config object is missing.
+        )
+        smoothed_delay = None  # WHY: seed RateLimitingUtils smoothing state for adaptive-delay retries.
+        for attempt in range(retry_limit + 1):  # WHY: include initial attempt plus configured retry attempts.
+            logging.info(
+                "Calling getSiteBeacon for site_id=%s beacon_id=%s (attempt %d/%d)",
+                site_id,
+                beacon_id,
+                attempt + 1,
+                retry_limit + 1,
+            )  # WHY: pre-call log.
+            try:  # WHY: isolate request failures so 429 can trigger adaptive retry path.
+                response = mistapi.api.v1.sites.beacons.getSiteBeacon(  # WHY: SDK get-by-id call.
+                    mh.apisession,  # WHY: authenticated API session required by mistapi endpoint functions.
+                    site_id=site_id,  # WHY: endpoint path parameter selecting the site container.
+                    beacon_id=beacon_id,  # WHY: endpoint path parameter selecting the specific beacon resource.
+                )
+                payload = getattr(response, "data", response)  # WHY: support object and dict responses.
+                rows = SiteClientExporter._normalize_site_beacon_payload(payload)  # WHY: normalize to list rows.
+                logging.debug(
+                    "getSiteBeacon call succeeded with %d normalized rows",
+                    len(rows),
+                )  # WHY: post-call summary.
+                return rows  # WHY: successful fetch ends retry loop immediately.
+            except Exception as exception:  # WHY: capture API failures for retry/abort decisioning.
+                logging.error(
+                    "getSiteBeacon API call failed on attempt %d/%d: %s",
+                    attempt + 1,
+                    retry_limit + 1,
+                    exception,
+                )  # WHY: failure details.
+                if "429" not in str(exception):  # WHY: only rate-limit errors should enter adaptive retry delay path.
+                    raise  # WHY: non-rate-limit exceptions should bubble to caller for immediate handling.
+                if attempt >= retry_limit:  # WHY: avoid sleeping when no retries remain.
+                    raise  # WHY: propagate exhausted-rate-limit failure after final attempt.
+                logging.info(  # WHY: pre-delay log.
+                    "Rate-limit signal detected; calculating adaptive delay before retry"
+                )
+                delay_helper = mh.RateLimitingUtils.get_rate_limited_delay  # WHY: adaptive delay helper reference.
+                (
+                    smoothed_delay,
+                    delay_seconds,
+                ) = delay_helper(  # type: ignore[no-untyped-call]
+                    smoothed_delay,  # WHY: keep smoothing state across retries.
+                    mh.apisession,  # WHY: RateLimitingUtils inspects API usage counters through live session object.
+                    mh._api_usage_cache,  # WHY: shared mutable cache stores usage snapshots across calls.
+                )
+                logging.debug(
+                    "Adaptive retry delay resolved to %.3f seconds for getSiteBeacon",
+                    delay_seconds,
+                )  # WHY: delay summary.
+                time.sleep(delay_seconds)  # WHY: enforce adaptive backoff interval before retrying the API call.
+        return []  # WHY: unreachable safety fallback keeps static analyzers aware of list return type.
+
+    @staticmethod
+    def get_site_beacon() -> None:
+        """Run getSiteBeacon prompt -> fetch -> export workflow."""
+        mh = importlib.import_module("MistHelper")  # WHY: lazy fetch of runtime deps.
+        logging.info("Export Site Beacon Detail:")  # WHY: operator-facing header for new menu operation.
+        logging.info("Starting getSiteBeacon workflow...")  # WHY: start boundary log for observability timelines.
+        identifiers = SiteClientExporter._prompt_site_beacon_identifiers()  # WHY: gather validated identifiers.
+        if identifiers is None:  # WHY: prompt helper already logged cancellation/EOF details.
+            return  # WHY: stop cleanly when required identifiers were not provided.
+        site_id, beacon_id = identifiers  # WHY: unpack validated identifiers for API request and filename construction.
+        try:  # WHY: top-level guard keeps menu operation from crashing on API/runtime failures.
+            rows = SiteClientExporter._fetch_site_beacon_with_retry(  # WHY: fetch with 429 retry path.
+                site_id,
+                beacon_id,
+            )
+        except Exception as exception:  # WHY: error path should surface clear logs and exit gracefully.
+            logging.error(
+                "! Error fetching site beacon detail for site_id=%s beacon_id=%s: %s",
+                site_id,
+                beacon_id,
+                exception,
+            )  # WHY: structured failure context.
+            logging.info("! Error fetching site beacon detail: %s", exception)  # WHY: user-facing error line.
+            return  # WHY: do not attempt export after fetch failure.
+        if not rows:  # WHY: empty payload should end cleanly without writing empty artifacts.
+            logging.warning(
+                "! getSiteBeacon returned no data for site_id=%s beacon_id=%s",
+                site_id,
+                beacon_id,
+            )  # WHY: no-data warning.
+            logging.info("! No beacon data found for the specified identifiers.")  # WHY: user-facing no-data line.
+            return  # WHY: skip export when endpoint returns no rows.
+        filename = SiteClientExporter._build_site_beacon_filename(site_id, beacon_id)  # WHY: deterministic filename.
+        logging.info("Persisting %d getSiteBeacon row(s) to %s", len(rows), filename)  # WHY: pre-write log.
+        mh.DataExporter.write_with_format_selection(  # WHY: canonical multi-backend write path.
+            rows,  # WHY: normalized row payload from endpoint response.
+            filename,  # WHY: deterministic export filename derived from site+beacon identifiers.
+            api_function_name=_GET_SITE_BEACON_API_FUNCTION_NAME,  # WHY: explicit operation id for PK strategy.
+        )
+        logging.debug(
+            "Persisted getSiteBeacon payload with row_count=%d filename=%s",
+            len(rows),
+            filename,
+        )  # WHY: post-write summary.
+        logging.info("! Exported site beacon detail to %s", filename)  # WHY: user-facing success message.

--- a/src/refactors/endpoint_primary_key_strategies.py
+++ b/src/refactors/endpoint_primary_key_strategies.py
@@ -319,6 +319,13 @@ ENDPOINT_PRIMARY_KEY_STRATEGIES = {
         "unique_constraints": [],
         "description": "BLE beacons deployed on site maps",
     },
+    "getSiteBeacon": {
+        "type": "natural_pk",
+        "primary_key": ["id"],
+        "indexes": ["site_id", "map_id", "name", "type"],
+        "unique_constraints": [],
+        "description": "Single BLE beacon detail by site + beacon identifier",
+    },
     "listSiteVBeacons": {
         "type": "natural_pk",
         "primary_key": ["id"],

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -268,6 +268,7 @@ class OperationRegistry:
         "201": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "202": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "203": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
+        "209": {"category": "interactive_safe", "skip_reason": "Requires site and beacon selection"},
         "186": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Deletes all generated cache CSV files"},
         "58": {"category": "safe"},
         "187": {"category": "destructive", "skip_reason": "DESTRUCTIVE: Creates config objects in destination org"},

--- a/tests/integration/test_menu_site_beacon_detail.py
+++ b/tests/integration/test_menu_site_beacon_detail.py
@@ -1,0 +1,43 @@
+"""Integration smoke tests for menu item 209 getSiteBeacon wiring."""
+
+import pytest  # WHY: skip guard and assertions use pytest helpers.
+
+import MistHelper  # WHY: integration target exposes the runtime menu_actions mapping.
+
+_HAS_MENU_WIRING = all(  # WHY: skip in stripped test environments.
+    hasattr(MistHelper, attr_name) for attr_name in ("menu_actions", "SiteClientExporter")
+)
+pytestmark = pytest.mark.skipif(  # WHY: guard avoids false failures when menu wiring is unavailable.
+    not _HAS_MENU_WIRING,  # WHY: condition expression for environment-based skip.
+    reason="MistHelper menu wiring unavailable in this test environment",  # WHY: explicit skip reason.
+)
+
+
+def test_menu_209_dispatches_to_get_site_beacon(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Menu key 209 should invoke SiteClientExporter.get_site_beacon through menu_actions tuple dispatch."""
+    called = {"value": False}  # WHY: mutable sentinel proves the dispatch target executed.
+
+    def exporter_stub() -> None:
+        called["value"] = True  # WHY: toggle sentinel when patched menu callable runs.
+
+    (
+        _original_callable,
+        description,
+    ) = MistHelper.menu_actions[
+        "209"
+    ]  # WHY: preserve description while swapping callable.
+    monkeypatch.setitem(  # WHY: menu tuple holds callable by value.
+        MistHelper.menu_actions,  # WHY: dispatch dictionary under test.
+        "209",  # WHY: new getSiteBeacon menu key.
+        (exporter_stub, description),  # WHY: preserve description while injecting observable callable.
+    )
+    action_callable, _description = MistHelper.menu_actions["209"]  # WHY: read patched tuple from runtime map.
+    action_callable()  # WHY: execute dispatch surface exactly as runtime menu handler does.
+
+    assert called["value"] is True  # WHY: sentinel confirms menu dispatch reached the expected callable.
+
+
+def test_menu_209_description_mentions_get_site_beacon() -> None:
+    """Menu key 209 should carry a readable description for operators and docs."""
+    _action_callable, description = MistHelper.menu_actions["209"]  # WHY: inspect production tuple entry.
+    assert "getsitebeacon" in description.lower()  # WHY: operation label should expose endpoint identity for operators.

--- a/tests/unit/export/test_site_client_exporter.py
+++ b/tests/unit/export/test_site_client_exporter.py
@@ -18,6 +18,9 @@ Covers every branch of ``SiteClientExporter`` static methods:
 - ``beacons``: constructs SiteExportUtils with every kwarg wired to
   MistHelper globals then invokes ``_export_data`` with the beacons
   api_call + data_type + sort_key contract.
+- ``get_site_beacon``: prompts for site/beacon identifiers via
+  ``safe_input``, retries 429 with adaptive delay, normalizes payload,
+  and persists via ``api_function_name="getSiteBeacon"``.
 
 Every collaborator (DataProcessingUtils, mistapi, WifiClientsExporter,
 SiteExportUtils, MistHelper.* globals) is monkeypatched. No live
@@ -87,6 +90,11 @@ def wired_deps(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     is_debug_mode = MagicMock(name="IsDebugMode")  # WHY: .check attribute forwarded into SiteExportUtils.
     pretty_table = MagicMock(name="PrettyTable")  # WHY: forwarded into SiteExportUtils.
     mh_mistapi = MagicMock(name="mh_mistapi")  # WHY: forwarded into SiteExportUtils constructor separately.
+    input_utils = MagicMock(name="InputUtils")  # WHY: safe_input collaborator used by get_site_beacon prompts.
+    rate_limiting_utils = MagicMock(name="RateLimitingUtils")  # WHY: adaptive delay helper for 429 retry flow.
+    api_usage_cache = {"used": 1, "limit": 5000}  # WHY: mutable cache passed into RateLimitingUtils during retries.
+    retry_config = MagicMock(name="FastModeSequentialMaxRetries")  # WHY: retry limit config for SUT.
+    retry_config.VALUE = 1  # WHY: keep retry-loop expectations deterministic for unit assertions.
 
     monkeypatch.setattr("MistHelper.DataExporter", data_exporter, raising=False)  # WHY: proxy lookup.
     monkeypatch.setattr("MistHelper.apisession", apisession, raising=False)  # WHY: proxy lookup.
@@ -108,6 +116,14 @@ def wired_deps(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setattr("MistHelper.IsDebugMode", is_debug_mode, raising=False)  # WHY: proxy lookup.
     monkeypatch.setattr("MistHelper.PrettyTable", pretty_table, raising=False)  # WHY: proxy lookup.
     monkeypatch.setattr("MistHelper.mistapi", mh_mistapi, raising=False)  # WHY: proxy lookup (distinct from module).
+    monkeypatch.setattr("MistHelper.InputUtils", input_utils, raising=False)  # WHY: prompt helper lookup.
+    monkeypatch.setattr("MistHelper.RateLimitingUtils", rate_limiting_utils, raising=False)  # WHY: delay helper lookup.
+    monkeypatch.setattr("MistHelper._api_usage_cache", api_usage_cache, raising=False)  # WHY: delay cache lookup.
+    monkeypatch.setattr(
+        "MistHelper.FastModeSequentialMaxRetries",
+        retry_config,
+        raising=False,
+    )  # WHY: retry config lookup.
 
     return {
         "DataProcessingUtils": data_processing,
@@ -131,6 +147,10 @@ def wired_deps(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         "IsDebugMode": is_debug_mode,
         "PrettyTable": pretty_table,
         "mh_mistapi": mh_mistapi,
+        "InputUtils": input_utils,
+        "RateLimitingUtils": rate_limiting_utils,
+        "api_usage_cache": api_usage_cache,
+        "FastModeSequentialMaxRetries": retry_config,
     }
 
 
@@ -366,3 +386,130 @@ class TestBeacons:
             ),
             call.write([{"mac": "aa"}], "SiteClients_N.csv"),
         ]
+
+
+class TestGetSiteBeacon:
+    """Cover prompt, success, empty-response, and retry/error branches of get_site_beacon."""
+
+    def test_happy_path_prompts_fetches_and_persists(self, wired_deps: dict[str, Any]) -> None:
+        """Validated identifiers trigger one SDK call and one DataExporter write_with_format_selection call."""
+        wired_deps["InputUtils"].safe_input.side_effect = [  # WHY: prompt helper asks for site_id then beacon_id.
+            "site-123",
+            "beacon-456",
+        ]
+        wired_deps["mistapi"].api.v1.sites.beacons.getSiteBeacon.return_value = {  # WHY: dict payload -> one row.
+            "id": "beacon-456",
+            "site_id": "site-123",
+            "name": "Lobby Beacon",
+        }
+
+        SiteClientExporter.get_site_beacon()  # WHY: execute full getSiteBeacon workflow.
+
+        wired_deps["InputUtils"].safe_input.assert_has_calls(  # WHY: validate prompt sequencing + safe_input usage.
+            [
+                call(
+                    "Enter Site ID for getSiteBeacon: ",
+                    allow_empty=False,
+                    context="site_client_exporter.getSiteBeacon.site_id",
+                ),
+                call(
+                    "Enter Beacon ID for getSiteBeacon: ",
+                    allow_empty=False,
+                    context="site_client_exporter.getSiteBeacon.beacon_id",
+                ),
+            ]
+        )
+        (
+            wired_deps["mistapi"].api.v1.sites.beacons.getSiteBeacon
+        ).assert_called_once_with(  # WHY: endpoint gets validated ids.
+            wired_deps["apisession"],
+            site_id="site-123",
+            beacon_id="beacon-456",
+        )
+        (
+            wired_deps["DataExporter"].write_with_format_selection
+        ).assert_called_once_with(  # WHY: persistence contract check.
+            [{"id": "beacon-456", "site_id": "site-123", "name": "Lobby Beacon"}],
+            "SiteBeacon_site_123_beacon_456.csv",
+            api_function_name="getSiteBeacon",
+        )
+
+    def test_eof_or_blank_site_id_aborts_without_api_call(
+        self, wired_deps: dict[str, Any], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Blank site_id (safe_input EOF fallback) exits cleanly without invoking SDK or exporter."""
+        wired_deps["InputUtils"].safe_input.return_value = ""  # WHY: simulate EOF/default blank safe_input return.
+
+        with caplog.at_level(logging.INFO, logger="root"):  # WHY: capture user-facing cancellation log message.
+            SiteClientExporter.get_site_beacon()  # WHY: execute cancellation path.
+
+        (
+            wired_deps["mistapi"].api.v1.sites.beacons.getSiteBeacon
+        ).assert_not_called()  # WHY: no API call without site id.
+        wired_deps["DataExporter"].write_with_format_selection.assert_not_called()  # WHY: no persistence on cancel.
+        assert any(  # WHY: cancel message emitted.
+            "No site selected. Exiting." in record.message for record in caplog.records
+        )
+
+    def test_empty_payload_skips_export(self, wired_deps: dict[str, Any], caplog: pytest.LogCaptureFixture) -> None:
+        """None payload from SDK is normalized to empty rows and does not write artifacts."""
+        wired_deps["InputUtils"].safe_input.side_effect = ["site-123", "beacon-456"]  # WHY: satisfy both prompts.
+        (wired_deps["mistapi"].api.v1.sites.beacons.getSiteBeacon).return_value = (
+            None  # WHY: exercise normalize(None)->[].
+        )
+
+        with caplog.at_level(logging.INFO, logger="root"):  # WHY: capture no-data user-facing message.
+            SiteClientExporter.get_site_beacon()  # WHY: execute empty-response branch.
+
+        wired_deps["DataExporter"].write_with_format_selection.assert_not_called()  # WHY: no export on empty payload.
+        assert any("No beacon data found" in record.message for record in caplog.records)  # WHY: empty-result notice.
+
+    def test_rate_limit_retry_uses_adaptive_delay_then_succeeds(
+        self, wired_deps: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """429-like failure triggers RateLimitingUtils delay and retries once before successful export."""
+        wired_deps["InputUtils"].safe_input.side_effect = ["site-123", "beacon-456"]  # WHY: provide required ids.
+        wired_deps["mistapi"].api.v1.sites.beacons.getSiteBeacon.side_effect = [  # WHY: first 429, then success.
+            RuntimeError("429 Too Many Requests"),
+            {"id": "beacon-456", "site_id": "site-123"},
+        ]
+        (wired_deps["RateLimitingUtils"].get_rate_limited_delay).return_value = (
+            0.25,
+            0.5,
+        )  # WHY: deterministic delay tuple.
+        sleep_spy = MagicMock(name="sleep_spy")  # WHY: observe delay application without real waiting.
+        monkeypatch.setattr(
+            "src.export.site_client_exporter.time.sleep",
+            sleep_spy,
+            raising=True,
+        )  # WHY: intercept sleep.
+
+        SiteClientExporter.get_site_beacon()  # WHY: execute retry success path.
+
+        assert wired_deps["mistapi"].api.v1.sites.beacons.getSiteBeacon.call_count == 2  # WHY: one retry after 429.
+        wired_deps["RateLimitingUtils"].get_rate_limited_delay.assert_called_once_with(  # WHY: retry uses delay helper.
+            None,
+            wired_deps["apisession"],
+            wired_deps["api_usage_cache"],
+        )
+        sleep_spy.assert_called_once_with(0.5)  # WHY: adaptive delay duration applied before retry.
+        (
+            wired_deps["DataExporter"].write_with_format_selection
+        ).assert_called_once_with(  # WHY: successful retry persists payload.
+            [{"id": "beacon-456", "site_id": "site-123"}],
+            "SiteBeacon_site_123_beacon_456.csv",
+            api_function_name="getSiteBeacon",
+        )
+
+    def test_non_rate_limit_error_does_not_retry(self, wired_deps: dict[str, Any]) -> None:
+        """Non-429 API error logs and exits without calling adaptive delay helper or exporter."""
+        wired_deps["InputUtils"].safe_input.side_effect = ["site-123", "beacon-456"]  # WHY: satisfy prompts.
+        (wired_deps["mistapi"].api.v1.sites.beacons.getSiteBeacon).side_effect = RuntimeError(
+            "500 Internal Server Error"
+        )  # WHY: non-429 should not retry.
+
+        SiteClientExporter.get_site_beacon()  # WHY: execute non-rate-limit failure path.
+
+        wired_deps["RateLimitingUtils"].get_rate_limited_delay.assert_not_called()  # WHY: adaptive delay only on 429.
+        wired_deps["DataExporter"].write_with_format_selection.assert_not_called()  # WHY: failed fetch never persists.
+        wired_deps["mistapi"].api.v1.sites.beacons.getSiteBeacon.assert_called_once()  # WHY: no retries on non-429.


### PR DESCRIPTION
## Summary
- implement issue #1420 ([Spec 671]) for getSiteBeacon endpoint
- add menu operation 209 and interactive prompts for site_id and eacon_id
- add endpoint PK strategy and operation classification
- add unit and integration tests
- update docs and changelog

## Validation
- python -m pytest tests/unit/export/test_site_client_exporter.py tests/integration/test_menu_site_beacon_detail.py -q
- python -m py_compile MistHelper.py
- python -m ruff check .
- python -m black --check .

Closes #1420