### PR TITLE
chore: restore the SpecKit records for initiatives 1010 and 1011

### DIFF
--- a/specs/1010-misthelper-refactor-extraction/checklists/quality.md
+++ b/specs/1010-misthelper-refactor-extraction/checklists/quality.md
@@ -1,0 +1,104 @@
+# Quality Checklist: MistHelper Refactor Extraction
+
+**Purpose**: Validate requirements quality (completeness, clarity, consistency, measurability, coverage) for the refactor extraction feature. Unit tests for the English spec — NOT verification of implementation behavior.
+**Created**: 2026-07-05
+**Feature**: specs/1010-misthelper-refactor-extraction/
+**Scope**: Complements checklists/requirements.md (spec-quality) with domain-specific quality gates for extraction mechanics, CI posture, and safety invariants.
+
+## Destination File Compliance Targets
+
+- [ ] CHK001 - Are the exact 13 first-pass extraction destinations enumerated by absolute path in the spec? [Completeness, Spec §FR-002]
+- [ ] CHK002 - Is the A+/100.0 compliance target for every destination file stated in measurable terms (score threshold, letter grade)? [Measurability, Spec §FR-002]
+- [ ] CHK003 - Are the tools and command invocation used to compute the compliance score for each destination documented? [Clarity, Spec §FR-002]
+- [ ] CHK004 - Is the ordering/sequencing across the 13 destinations defined (which lands first, which last)? [Completeness, Gap]
+- [ ] CHK005 - Are per-destination acceptance criteria distinguished from repo-wide compliance criteria? [Consistency]
+
+## Wrapper-Shim Absence (FR-003)
+
+- [ ] CHK006 - Is "wrapper shim" defined with concrete syntactic examples (e.g., `from src.X import Y as Z` re-exports in MistHelper.py)? [Clarity, Spec §FR-003]
+- [ ] CHK007 - Are the grep/AST patterns that would detect a residual shim specified as an automated check? [Measurability, Spec §FR-003]
+- [ ] CHK008 - Is the zero-shim invariant asserted for both directions (MistHelper.py re-exporting src.*, and src.* re-exporting MistHelper.*)? [Coverage]
+- [ ] CHK009 - Are legitimate cross-module imports (non-shim) distinguished from prohibited re-export shims? [Ambiguity, Spec §FR-003]
+
+## Callsite Rewrite Completeness (FR-006)
+
+- [ ] CHK010 - Is "same PR" as the deadline for callsite rewrites unambiguously specified (no follow-up PR permitted)? [Clarity, Spec §FR-006]
+- [ ] CHK011 - Are the discovery mechanics for finding all callsites of an extracted symbol documented (grep, LSP, analyzer)? [Completeness]
+- [ ] CHK012 - Is dynamic/reflective reference handling addressed (getattr, importlib, string-based lookups)? [Coverage, Edge Case]
+- [ ] CHK013 - Is test-file callsite rewriting included in the scope of FR-006? [Ambiguity, Spec §FR-006]
+
+## Class-Body Landing (FR-005)
+
+- [ ] CHK014 - Is "class-body landing" defined with a concrete before/after AST shape (method on class vs. module-level function taking `self`)? [Clarity, Spec §FR-005]
+- [ ] CHK015 - Are `@classmethod`, `@staticmethod`, and `@property` decorators addressed in the landing rules? [Coverage, Edge Case]
+- [ ] CHK016 - Is the treatment of methods that must cross class boundaries during extraction defined? [Gap]
+
+## CI Gate Posture
+
+- [ ] CHK017 - Is the count "15 functional jobs" verifiable against a specific ci.yml revision (SHA or path pin)? [Traceability]
+- [ ] CHK018 - Is line 420 of ci.yml identified by content (job name/step), not just by line number, in case the file shifts? [Clarity]
+- [ ] CHK019 - Is the SKIPPED-vs-FAILED distinction specified with the exact mergeStateStatus/check-conclusion values that count as passing? [Measurability, Spec §FR-011]
+- [ ] CHK020 - Are the acceptable reasons for a job to appear SKIPPED enumerated (conditional predicates)? [Completeness]
+
+## Compliance Regression Bounds
+
+- [ ] CHK021 - Is the baseline 99.6/A+ captured with a source-of-truth artifact (analyzer output file, commit SHA)? [Traceability]
+- [ ] CHK022 - Is the "0 sub-A files must remain 0" invariant stated as a hard gate, not an aspirational target? [Clarity]
+- [ ] CHK023 - Is the tolerance for a temporary in-PR dip in compliance (if any) specified, or is monotonic non-regression required? [Ambiguity]
+- [ ] CHK024 - Are the fields the CI compliance check reads (score, grade, sub-A count) named explicitly? [Completeness]
+
+## No `--admin` Merge Bypass (FR-011)
+
+- [ ] CHK025 - Is `mergeStateStatus` named as the authoritative signal, and `gh pr checks` display explicitly deprecated for gate evaluation? [Clarity, Spec §FR-011]
+- [ ] CHK026 - Are the enumerated `mergeStateStatus` values that permit merge (e.g., CLEAN) and those that block it (e.g., BLOCKED, BEHIND) listed? [Completeness]
+- [ ] CHK027 - Is the interaction between SKIPPED conditional jobs and `mergeStateStatus` documented (does SKIPPED still yield CLEAN)? [Coverage]
+
+## SKIP_ALWAYS Immunity (FR-008)
+
+- [ ] CHK028 - Is the `refactor_analyzer` SKIP_ALWAYS frozenset identified by absolute path and symbol name? [Traceability, Spec §FR-008]
+- [ ] CHK029 - Is "never touch definitions" defined operationally (no move, no rename, no signature change, no decompose)? [Clarity]
+- [ ] CHK030 - Is the process for proposing an addition/removal to SKIP_ALWAYS specified (or explicitly out of scope)? [Gap]
+
+## Hot Bucket Immunity (FR-009)
+
+- [ ] CHK031 - Is the "4+ references" threshold defined precisely (call-sites, imports, both; test files counted or excluded)? [Clarity, Spec §FR-009]
+- [ ] CHK032 - Is the reference-counting tool and its exact command output field named? [Measurability]
+- [ ] CHK033 - Are ties at the boundary (exactly 4 vs. 3 references) unambiguously classified? [Edge Case]
+
+## Analyzer-First Cadence (FR-010, SC-011)
+
+- [ ] CHK034 - Is "refresh between each PR" defined as pre-PR, post-merge, or both, with a specific command? [Clarity, Spec §FR-010]
+- [ ] CHK035 - Is the `refactor_candidates.md` artifact required to be committed alongside code changes in each PR? [Completeness]
+- [ ] CHK036 - Is stale-candidate detection (candidate list unchanged for N PRs) addressed? [Coverage, Gap]
+
+## Decompose-While-Moving (FR-006)
+
+- [ ] CHK037 - Is "guideline_flags" defined with the enumerated flag names the analyzer emits? [Clarity, Spec §FR-006]
+- [ ] CHK038 - Is the prohibition on deferred decomposition ("fix during motion, not after") stated as a merge-blocking criterion? [Measurability]
+- [ ] CHK039 - Are the acceptable decomposition patterns (extract helper, split responsibility, inline collapse) enumerated? [Completeness]
+
+## ASCII-Only Logs / safe_input() / pathlib.Path (Constitution VI/VII)
+
+- [ ] CHK040 - Is the ASCII-only constraint scoped (log strings only, or all string literals, or both)? [Clarity]
+- [ ] CHK041 - Is `safe_input()` identified by absolute import path with the semantics that distinguish it from built-in `input()`? [Traceability]
+- [ ] CHK042 - Is the `pathlib.Path` requirement stated as prohibition of `os.path`, or coexistence permitted? [Ambiguity]
+- [ ] CHK043 - Are the linter/checker rules (or regex) that enforce these three constraints referenced? [Measurability]
+
+## AddressComparisonCounters Special Case (FR-015)
+
+- [ ] CHK044 - Is the destination `src/inventory/csv_comparator.py` named as the sole landing point, with any `src/refactors/*.py` explicitly prohibited? [Clarity, Spec §FR-015]
+- [ ] CHK045 - Is the rationale for the special-case folding documented (why this class differs from the other 12)? [Completeness]
+- [ ] CHK046 - Are other analogous "fold into existing module" candidates identified, or is this special case one-off? [Coverage]
+
+## Serial PR Workflow (FR-013)
+
+- [ ] CHK047 - Is "no cross-PR parallelism" defined operationally (single open PR, or single in-flight refactor across N open PRs)? [Ambiguity, Spec §FR-013]
+- [ ] CHK048 - Is the "15/15 green before next dispatched" criterion tied to `mergeStateStatus=CLEAN` on the merged PR? [Consistency, Spec §FR-011]
+- [ ] CHK049 - Is the dispatch trigger for the next PR named (human, script, hook) and is any automated dispatch documented? [Gap]
+- [ ] CHK050 - Are hotfix / non-refactor PRs excluded from the serial constraint, or subject to it? [Coverage, Edge Case]
+
+## Cross-Cutting
+
+- [ ] CHK051 - Are all 18 functional requirements (FR-001..FR-018) traceable to at least one measurable acceptance criterion in the spec? [Traceability]
+- [ ] CHK052 - Are terms "extraction", "motion", "landing", "decompose", "shim" defined in a shared glossary within the spec? [Clarity]
+- [ ] CHK053 - Are rollback requirements defined for a partially-merged extraction PR whose follow-up CI later fails? [Recovery, Gap]

--- a/specs/1010-misthelper-refactor-extraction/checklists/requirements.md
+++ b/specs/1010-misthelper-refactor-extraction/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: MistHelper.py Refactor Extraction Initiative
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- This is a workflow/refactor specification where the "product" is a codebase state, not a user-facing feature. Some conventions are adapted: the "user" is the refactor engineer and CI system; "user value" is compliance-preserving LOC reduction; "business need" is entrypoint monolith decomposition.
+- The spec deliberately references file paths and tooling (`MistHelper.py`, `src/refactors/`, `tools/refactor_analyzer/`, `refactor_candidates.md`) because these are the domain vocabulary of the initiative, not implementation choices. They are the "what" being manipulated, not the "how" of manipulation.
+- Bucket names (Unused / Single-Use / Low-Use / Hot / Skipped) are analyzer terminology and appear in the spec as domain vocabulary.

--- a/specs/1010-misthelper-refactor-extraction/contracts/analyzer-output-contract.md
+++ b/specs/1010-misthelper-refactor-extraction/contracts/analyzer-output-contract.md
@@ -1,0 +1,68 @@
+# Contract: Refactor Analyzer Output
+
+**Feature**: 1010-misthelper-refactor-extraction
+**Producer**: `tools/refactor_analyzer/` (consumed as-is per FR-018; never modified by this initiative)
+**Consumer**: The extraction dispatcher (parent conversation) and per-PR verification steps in `quickstart.md`
+**Artifact**: `refactor_candidates.md` at repo root
+
+---
+
+## Contract Guarantees the Producer MUST Make
+
+The analyzer, when invoked as `py -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`, MUST emit a Markdown document at the specified output path with the following structure:
+
+1. **Summary section** containing counts per bucket (Unused, Single-Use, Low-Use, Hot, Skipped) and a total-saveable-LOC figure.
+2. **Unused section** listing every candidate with 0 references. Each entry includes: symbol name, kind (class/function), source line range in `MistHelper.py`, LoC count, and any `guideline_flags`.
+3. **Single-Use section** listing every candidate with exactly 1 reference. Each entry additionally includes the caller's file and line number.
+4. **Low-Use section** listing candidates with 2-3 references (informational for first pass; second-pass scope).
+5. **Hot section** listing candidates with 4+ references (out of scope for first pass per FR-009).
+6. **Skipped section** listing symbols in the `SKIP_ALWAYS` allowlist (`GlobalImportManager` and any others; never modified per FR-008).
+7. **Limitations section** documenting known analyzer blind spots (e.g. dynamic dispatch, `getattr` string lookups).
+
+---
+
+## Contract Guarantees the Consumer MUST Honor
+
+1. **Bucket authority**: The consumer treats the analyzer's bucket assignment as the single source of truth for dispatch. Manual grep wins ONLY for the specific PR where a discrepancy surfaces (spec Edge Cases); the discrepancy is filed as an analyzer bug but does NOT halt the initiative.
+
+2. **Fresh-catalog dispatch**: The consumer regenerates `refactor_candidates.md` on the current `main` head **after every merged extraction PR, before the next PR is opened** (FR-010, SC-011). No dispatch decision may be made from a stale catalog.
+
+3. **Reclassification handling** (FR-016):
+   - If a first-pass candidate is reclassified into `Low-Use` or `Hot` after a prior merge, it is rerouted to second-pass planning or Out-of-Scope; it is NOT force-extracted under its original classification.
+   - If a candidate is reclassified into `Unused`, it moves to the Unused workflow (delete only, no new module).
+   - If a candidate is reclassified into `Skipped`, no PR is opened for it.
+
+4. **No analyzer modification** (FR-018): The consumer never edits `tools/refactor_analyzer/*.py`. If the analyzer emits incorrect output, the consumer files an analyzer bug for a separate initiative and works around it manually within the affected PR.
+
+5. **LoC drift tolerance**: Because `MistHelper.py` may have unrelated commits between analyzer runs, the LoC count for any candidate is taken from the **fresh** analyzer output at Step 1 of `quickstart.md`, not from a snapshot elsewhere.
+
+---
+
+## Invariants
+
+- The Skipped section content (`SKIP_ALWAYS`) never intersects with any other bucket in the same catalog.
+- The Hot section content never intersects with Single-Use or Unused in the same catalog.
+- Every candidate has a stable `name` that identifies a unique symbol in `MistHelper.py`.
+- LoC counts are `end_line - start_line + 1`.
+
+---
+
+## Error Modes and Consumer Responses
+
+| Error mode | Consumer response |
+|------------|-------------------|
+| Analyzer emits no output / crashes | Do not open the next PR. Investigate as an analyzer bug in a separate initiative. Do NOT modify the analyzer here (FR-018). |
+| Candidate present in two buckets | Treat as an analyzer bug; take the more conservative bucket (Skipped > Hot > Low-Use > Single-Use > Unused). File the bug. |
+| Candidate `reference_count == 1` but manual grep finds 2 hits (dynamic dispatch) | Reroute the candidate to Low-Use planning. Manual grep wins for that PR. File the analyzer bug. |
+| Candidate `reference_count == 0` but manual grep finds 1 hit | Reclassify to Single-Use workflow for that PR (create module, rewrite callsite, delete original). Manual grep wins. |
+| Fresh catalog shows a merged candidate still present | Investigate for merge/regeneration miss; regenerate again. Do NOT dispatch the next PR until the catalog reflects reality. |
+
+---
+
+## Verification
+
+At the start of each PR, the operator confirms Contract compliance by:
+
+1. Running the regeneration command from a clean checkout of `main` at the head after the last merge.
+2. Diffing the new catalog against the prior one — the just-merged candidate must have been removed from its bucket.
+3. Recording the catalog commit SHA (if the catalog is committed) or the regeneration timestamp in the next PR's description for the SC-011 audit trail.

--- a/specs/1010-misthelper-refactor-extraction/contracts/compliance-gate-contract.md
+++ b/specs/1010-misthelper-refactor-extraction/contracts/compliance-gate-contract.md
@@ -1,0 +1,108 @@
+# Contract: Compliance Gate
+
+**Feature**: 1010-misthelper-refactor-extraction
+**Producer**: `tools/compliance_analyzer/` (consumed as-is; not modified by this initiative)
+**Consumer**: The extraction PR and CI branch protection
+**Artifact**: Compliance grade per file and repo-wide aggregate; snapshot at `data/full_repo_compliance_current.md`
+
+---
+
+## The Two Non-Negotiables
+
+Every extraction PR MUST satisfy BOTH:
+
+1. **File gate**: The target module of the extraction MUST land at `A+/100`. (FR-012, SC-007.) `MistHelper.py`'s grade MUST NOT regress. Any file that was A+/100 pre-initiative MUST remain A+/100 post-extraction. (SC-005.)
+
+2. **Baseline gate**: The repo-wide aggregate compliance score MUST remain at or above `99.6/A+` after the extraction. (FR-013, SC-004.) Sub-A file count MUST remain zero. (Baseline invariant from `data/full_repo_compliance_current.md`.)
+
+Failure of EITHER gate blocks merge. Neither may be waived. `--admin` bypass MUST NOT be used to circumvent this contract (FR-011).
+
+---
+
+## Measurement Protocol
+
+**Command**:
+
+```bash
+py -m tools.compliance_analyzer
+```
+
+**Cadence**:
+
+- Locally before pushing the branch (Step 6 of `quickstart.md`).
+- Automatically in CI as one of the 15 functional jobs.
+- Optionally after merge to refresh `data/full_repo_compliance_current.md` (pattern seen in commits e50a524, da4ae90).
+
+**Scope of measurement**:
+
+- Per-file grade for every file in `src/`, `MistHelper.py`, and other tracked Python sources.
+- Repo-wide aggregate as a weighted score (see `tools/compliance_analyzer/` for the exact formula; not modified here).
+
+---
+
+## Resolution Requirements
+
+When the analyzer flags a candidate's extracted code with `guideline_flags` (per the refactor analyzer, not the compliance analyzer — they are separate tools with overlapping concerns), each flag MUST be resolved in the extraction PR before the compliance gate is evaluated. (FR-006, SC-012.)
+
+The compliance analyzer measures conformance to:
+
+- **Principle V** (Observability & Logging): ASCII-only logs, `safe_input()`, `pathlib.Path`.
+- **Principle VI** (Inline Comments): every 5-10 lines. NON-NEGOTIABLE.
+- **Principle VII** (Action Logging): before every non-trivial action. NON-NEGOTIABLE.
+- Per-function LoC budget (`oversize_25_lines` flag correlate).
+- Parameter-count budget (`too_many_params` flag correlate).
+- Hardcoded-separator detection.
+
+An A+/100 grade on the target module requires ZERO findings across these axes on the extracted code.
+
+---
+
+## Failure Modes and Responses
+
+| Symptom | Interpretation | Response |
+|---------|----------------|----------|
+| New module scores < A+/100 | Extracted code has unresolved guideline debt | Fix in this PR; do NOT merge and defer |
+| `MistHelper.py` regresses grade | Deletion diff exposed a latent comment-density gap or import churn | Fix in this PR; add comments as needed |
+| A previously A+ file drops below A+ | Import churn or side effect from deletion | Investigate; likely a callsite-rewrite ripple; fix in this PR |
+| Repo baseline drops below 99.6/A+ | Aggregate regression | Reject the PR; rework |
+| Zero sub-A files invariant violated (a file drops to B or below) | Serious regression | Reject the PR; likely a deep issue with the extraction |
+
+---
+
+## Baseline Snapshot Update Protocol
+
+`data/full_repo_compliance_current.md` is the canonical baseline snapshot. It may be updated in one of two ways during this initiative:
+
+1. **Within an extraction PR**, when the extraction naturally improves the baseline (new A+ file added, existing files unaffected). The updated snapshot lands with the rest of the PR diff.
+2. **Via a dedicated baseline-refresh commit** on `main` between extraction PRs (pattern in recent history: e50a524, da4ae90). These are separate from the 13 first-pass PRs and do not count against the FR-014 budget.
+
+Snapshot updates MUST reflect a genuine analyzer run — never hand-edited.
+
+---
+
+## Interaction with the Refactor Analyzer
+
+The compliance analyzer and the refactor analyzer are separate tools with overlapping vocabulary. The extraction workflow uses both:
+
+- **Refactor analyzer** (`tools/refactor_analyzer/`): identifies WHAT to extract and WHERE it's called (`refactor_candidates.md`).
+- **Compliance analyzer** (`tools/compliance_analyzer/`): grades HOW WELL the extracted code adheres to project non-negotiables (`data/full_repo_compliance_current.md`).
+
+Both must be run at Step 6 of `quickstart.md`. Both must agree with the merge readiness of the PR:
+
+- Refactor analyzer: candidate removed from its bucket.
+- Compliance analyzer: target module A+/100, baseline preserved.
+
+Neither is modified by this initiative (FR-018 for the refactor analyzer; analogous discipline for the compliance analyzer — it is treated as an infrastructure black box).
+
+---
+
+## Post-Initiative Verification (Aggregate, Not Per-PR)
+
+At the end of the 13-PR first pass, the operator runs the compliance analyzer once more and verifies:
+
+- Repo-wide score ≥ 99.6/A+ (SC-004).
+- Zero A+ files regressed below A+ across the entire initiative (SC-005).
+- Every new `src/refactors/*.py` file is A+/100 (SC-007).
+- Zero sub-A files exist (baseline invariant).
+
+These are cumulative outcomes; each is verifiable by diffing the initial and final `data/full_repo_compliance_current.md`. Any deviation is a spec-compliance failure and must be remediated before the initiative closes out.

--- a/specs/1010-misthelper-refactor-extraction/contracts/extraction-pr-contract.md
+++ b/specs/1010-misthelper-refactor-extraction/contracts/extraction-pr-contract.md
@@ -1,0 +1,112 @@
+# Contract: Extraction PR Shape
+
+**Feature**: 1010-misthelper-refactor-extraction
+**Producer**: Refactor engineer (opens PR)
+**Consumer**: GitHub Actions CI + code reviewers + `main` branch protection
+**Artifact**: A single pull request against `main`
+
+---
+
+## Diff Shape Contract
+
+An extraction PR's diff MUST match exactly one of the two shapes below.
+
+### Shape A: Unused Deletion (PR-01, PR-02)
+
+Exactly one file changed:
+
+- `MistHelper.py` — the candidate's definition (class or function body) is removed. Nothing added.
+
+Additionally required:
+- PR description contains a repo-wide grep confirming zero remaining references to the symbol (FR-004).
+
+Prohibited in this shape:
+- Any new file.
+- Any callsite rewrite (there are none by definition).
+- Any wrapper shim or forwarding function.
+
+### Shape B: Single-Use Extraction (PR-03 through PR-13)
+
+Exactly three files changed (or two for the `AddressComparisonCounters` fold-in):
+
+1. **`MistHelper.py`** — the candidate's definition is removed. Nothing added.
+2. **The target module**:
+   - For 10 of 11 Single-Use PRs: a NEW file under `src/refactors/{snake_name}.py` containing the candidate as a cohesive class (or as a class method for module-level function candidates per FR-005).
+   - For `AddressComparisonCounters` (PR-07 exception per FR-015): the EXISTING `src/inventory/csv_comparator.py` is modified — the counter folds into `CsvComparatorManager` (no new file).
+3. **The caller's file** — the single callsite is rewritten. This may be the same file as #2 (for `AddressComparisonCounters`, since the sole caller already lives in `csv_comparator.py`), collapsing to two files.
+
+Additionally allowed:
+- `refactor_candidates.md` regeneration diff in the same PR (documents Step 6 verification per `quickstart.md`).
+- `data/full_repo_compliance_current.md` update if the extraction improved the baseline snapshot.
+
+Prohibited in this shape:
+- More than one candidate per PR (FR-002).
+- Wrapper shim, forwarding function, or backward-compatibility alias anywhere in the diff (FR-003, SC-008).
+- Preserving a module-level function candidate as a bare `def` at module scope in the new file (FR-005).
+- Deferring `guideline_flags` resolution to a follow-up PR (FR-006).
+- Modifying `tools/refactor_analyzer/` (FR-018).
+- Modifying any symbol in the `SKIP_ALWAYS` bucket (FR-008).
+- Modifying any symbol in the Hot bucket (FR-009).
+
+---
+
+## Commit Contract
+
+- PRs are squash-merged. The squash-merge commit message is the single conventional-commit message on `main`.
+- Convention: `refactor: extract {SymbolName} to {target_path} (#PR)` for Shape B; `refactor: delete unused {SymbolName} (#PR)` for Shape A. Follows the repo's existing pattern (see recent commits e50a524, 4176bc8, 6c2e0b6).
+- Branch is auto-deleted on merge (`gh pr merge --squash --delete-branch`).
+
+---
+
+## Merge Contract
+
+An extraction PR MUST NOT be merged unless ALL of the following hold:
+
+1. **All 15 functional CI jobs report green** (FR-011, SC-006).
+2. **`mergeStateStatus == CLEAN`** (per `feedback_no_admin_bypass.md` guidance).
+3. **Compliance analyzer output**:
+   - Target module (if any) scored A+/100 (FR-012, SC-007).
+   - Zero previously-A+ files regressed below A+ (SC-005).
+   - Repo-wide baseline ≥ 99.6/A+ (FR-013, SC-004).
+4. **Refactor analyzer output**:
+   - The candidate has been removed from its bucket in the regenerated catalog.
+   - No new NEEDS CLARIFICATION-equivalent surprises (e.g. new dynamic-dispatch call to the moved symbol).
+
+`--admin` merge bypass MUST NOT be used as a routine unblock. Bypass is acceptable only when `mergeStateStatus` is genuinely `BLOCKED`, `DIRTY`, or `BEHIND` for a documented reason unrelated to the merge readiness of the extraction itself (e.g. an unrelated required check is transiently unavailable). Root cause MUST be documented in the PR description in that case.
+
+---
+
+## Guideline-Flag Resolution Contract
+
+For every `guideline_flag` the analyzer reported on the extracted code, the flag MUST be resolved within THIS PR (FR-006, SC-012). No forward-carry.
+
+| Flag | Resolution in the extracted module |
+|------|-----------------------------------|
+| `oversize_25_lines` | Refactor the offending method into smaller helpers before landing. |
+| `missing_inline_comments` | Add inline comments every 5-10 lines (Principle VI, NON-NEGOTIABLE). |
+| `missing_action_logging` | Add action logging before every non-trivial action with `[MENU]`/`[EXECUTE]`/`[SUCCESS]`/`[FAILURE]` prefixes (Principle VII, NON-NEGOTIABLE). |
+| `non_ascii_logs` | Replace non-ASCII characters with ASCII equivalents (Principle V, FR-007). |
+| `hardcoded_separator` | Replace hardcoded path separators with `pathlib.Path` or `os.sep` as appropriate; prefer `pathlib.Path` (Principle V, FR-007). |
+| `raw_input_call` | Replace with `safe_input()` (Principle V, FR-007). |
+| `too_many_params` | Introduce a dataclass or config object to group related parameters; use judgment on threshold. |
+
+---
+
+## Verification Checklist (paste into PR description)
+
+```markdown
+## Extraction PR Verification (spec 1010)
+
+- [ ] Exactly one candidate (Unused shape or Single-Use shape) — no batching (FR-002)
+- [ ] No wrapper shim / forwarding fn / backward-compat alias in MistHelper.py (FR-003, SC-008)
+- [ ] Module-level function candidates land as class methods, not bare defs (FR-005, if applicable)
+- [ ] All analyzer guideline_flags on extracted code resolved in-flight (FR-006, SC-012)
+- [ ] ASCII-only logs, safe_input(), pathlib.Path in extracted module (FR-007)
+- [ ] No SKIP_ALWAYS symbol touched (FR-008)
+- [ ] No Hot-bucket symbol touched (FR-009)
+- [ ] refactor_candidates.md regenerated on post-preceding-merge main head (FR-010, SC-011)
+- [ ] 15/15 CI jobs green, mergeStateStatus CLEAN, no --admin bypass (FR-011, SC-006)
+- [ ] Target module A+/100 (or existing sibling module preserved A+) (FR-012, SC-007)
+- [ ] Repo baseline ≥99.6/A+, zero A+ regressions (FR-013, SC-004, SC-005)
+- [ ] Manual grep of symbol name pasted (mandatory for Unused, recommended for Single-Use)
+```

--- a/specs/1010-misthelper-refactor-extraction/data-model.md
+++ b/specs/1010-misthelper-refactor-extraction/data-model.md
@@ -1,0 +1,157 @@
+# Phase 1 Data Model: Extraction Entities
+
+**Feature**: 1010-misthelper-refactor-extraction | **Date**: 2026-07-05
+**Purpose**: Formalize the entities the workflow manipulates. These are documentation entities (workflow objects), not runtime persistence models.
+
+---
+
+## Entity: Extraction Candidate
+
+The unit of work. One candidate → one PR (FR-002).
+
+| Field | Type | Constraints | Source |
+|-------|------|-------------|--------|
+| `name` | string | Non-empty, matches a symbol in `MistHelper.py` | analyzer |
+| `kind` | enum: `class` \| `function` | Required | analyzer |
+| `line_range` | tuple(int, int) | `end >= start`; both point into current `MistHelper.py` | analyzer (fresh) |
+| `loc` | int | ≥ 1; `end - start + 1` | analyzer (fresh) |
+| `reference_count` | int | ≥ 0 | analyzer |
+| `bucket` | enum: `Unused` \| `Single-Use` \| `Low-Use` \| `Hot` \| `Skipped` | Derived from `reference_count` and `SKIP_ALWAYS` list | analyzer |
+| `callsite_locations` | list[(file, line)] | Length equals `reference_count`; empty for Unused | analyzer + manual grep verification |
+| `guideline_flags` | list[flag_name] | Zero or more of: `oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`, `non_ascii_logs`, `hardcoded_separator`, `raw_input_call`, `too_many_params` | analyzer |
+| `target_path` | string (path) | For Unused: N/A; for Single-Use: `src/refactors/{snake_name}.py` OR `src/inventory/csv_comparator.py` (AddressComparisonCounters only, per FR-015) | dispatcher decision |
+| `target_class` | string \| null | For module-level function candidates: class name to wrap the function into (per FR-005); null for class candidates that keep their own name; `CsvComparatorManager` for AddressComparisonCounters | dispatcher decision |
+
+**Validation rules**:
+- If `bucket == Skipped`, this entity is never selected for a PR (FR-008).
+- If `bucket == Hot`, this entity is never selected for the first pass (FR-009).
+- If `bucket == Unused`, `callsite_locations` must be empty AND a manual repo-wide grep in the PR description must confirm zero references (FR-004).
+- If `bucket == Single-Use`, `callsite_locations` length must be exactly 1 at PR-open time.
+- Fresh analyzer data is authoritative — if the catalog is regenerated and a candidate's `bucket` changes, the dispatcher reroutes per FR-016.
+
+**State transitions**:
+```
+[fresh catalog] --dispatched--> [PR open] --CI green + review approve--> [merged]
+                                    |
+                                    +--CI red or bucket-change--> [aborted / rerouted]
+```
+
+---
+
+## Entity: Target Module
+
+The destination file for a Single-Use extraction.
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `path` | string | Absolute-from-repo-root path; typically `src/refactors/{name}.py` |
+| `contains_class` | string | The class name housing the extracted symbol (may be pre-existing for the AddressComparisonCounters exception) |
+| `is_new_file` | boolean | True for 10 of 11 Single-Use PRs; False only for AddressComparisonCounters (folds into existing `csv_comparator.py`) |
+| `compliance_grade_required` | literal | `A+/100` — non-negotiable (FR-012, SC-007) |
+| `logging_convention` | literal | ASCII-only (FR-007, Principle V) |
+| `input_convention` | literal | `safe_input()` for all interactive input (FR-007, Principle V) |
+| `path_convention` | literal | `pathlib.Path`; no `os.path` (FR-007, Principle V) |
+| `comment_cadence` | literal | Every 5-10 lines (Principle VI, NON-NEGOTIABLE) |
+| `action_logging` | literal | Before every non-trivial action, with `[MENU]`/`[EXECUTE]`/`[SUCCESS]`/`[FAILURE]` prefixes as appropriate (Principle VII, NON-NEGOTIABLE) |
+
+**Validation rules**:
+- New file MUST land at A+/100 on first commit — no "fix compliance in follow-up" pattern (FR-006, FR-012).
+- Module-level function candidates MUST land as class methods, not bare `def` (FR-005).
+- No wrapper shim, no forwarding function, no backward-compat alias in `MistHelper.py` (FR-003, SC-008).
+
+---
+
+## Entity: Callsite
+
+The single (or zero) location a candidate is invoked from.
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `file` | string | Path within the repo |
+| `line` | int | Line of the invocation (may include a preceding `import` line to update) |
+| `import_line` | int \| null | Line of the `from MistHelper import ...` statement, if the caller uses an explicit import; null when the caller resolves the symbol via bare name because both live in `MistHelper.py` |
+| `rewrite_action` | enum: `update_import` \| `add_import_and_qualify` \| `local_to_local` | `update_import` when caller lives outside MistHelper.py and already imports the symbol; `add_import_and_qualify` when caller doesn't yet import; `local_to_local` when caller lives in MistHelper.py and rewrite is inside the same file (rare) |
+
+**Validation rules**:
+- For Unused candidates: no callsite entity exists. Manual grep in PR description substitutes.
+- For Single-Use: exactly one callsite. The rewrite happens in the same commit that deletes the definition (FR-003).
+- After rewrite, no intermediate revision on the branch may leave a dangling import or a dangling definition.
+
+---
+
+## Entity: Extraction PR
+
+The workflow container.
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `pr_number` | int | Assigned by GitHub |
+| `candidate` | ExtractionCandidate | Exactly one (FR-002) |
+| `base_branch` | literal | `main` |
+| `head_branch` | string | Convention: `refactor/extract-{snake_name}` |
+| `diff_contents` | derived | (a) new module file OR deletion only, (b) `MistHelper.py` deletion, (c) callsite rewrite (Single-Use only), (d) any `guideline_flags` remediation |
+| `commit_style` | literal | Squash merge; single conventional-commit message on merge |
+| `merge_state_status` | enum | `CLEAN` required for merge; `BLOCKED`/`DIRTY`/`BEHIND` require rebase/push and re-run |
+| `admin_bypass_used` | boolean | Must be False except with documented BLOCKED/DIRTY/BEHIND root cause (FR-011) |
+| `ci_jobs_required_green` | int | 15 (FR-011) |
+| `manual_grep_included_in_description` | boolean | Required True for Unused PRs (FR-004); recommended for Single-Use as belt-and-suspenders |
+| `catalog_regen_precedes` | boolean | True for every PR after PR-01 — the catalog must be regenerated on the post-preceding-merge `main` head before this PR is opened (FR-010, SC-011) |
+
+**Validation rules**:
+- One and only one candidate per PR (FR-002).
+- No wrapper shim in the diff (SC-008).
+- All `guideline_flags` on extracted code resolved in this PR (FR-006, SC-012).
+- If the compliance analyzer reports any A+ file regressing below A+, PR must be reworked (FR-012, SC-005).
+- If the compliance analyzer reports repo baseline < 99.6/A+, PR must be reworked (FR-013, SC-004).
+
+---
+
+## Entity: Refactor Candidates Catalog (`refactor_candidates.md`)
+
+The analyzer's ranked output.
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `path` | literal | Repo root: `refactor_candidates.md` |
+| `sections` | list[section] | Summary, Unused, Single-Use, Low-Use, Hot, Skipped, Limitations |
+| `regeneration_command` | literal | `py -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md` |
+| `regeneration_trigger` | literal | After every merged extraction PR, before next PR is opened (FR-010) |
+| `authority` | literal | Single source of truth for bucket classification. Manual grep wins ONLY for the specific PR where discrepancy surfaces (spec Edge Cases). |
+
+**Validation rules**:
+- Must be regenerated on the current `main` head between PRs.
+- Discrepancies with manual grep are filed as analyzer bugs in `tools/refactor_analyzer/` per Edge Cases guidance but the affected PR proceeds using the grep-verified count.
+- Analyzer itself is NOT modified by this initiative (FR-018).
+
+---
+
+## Entity: Compliance Baseline
+
+The repo-wide floor.
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `snapshot_path` | literal | `data/full_repo_compliance_current.md` |
+| `minimum_repo_grade` | literal | `99.6/A+` (FR-013, SC-004) |
+| `minimum_files_at_A_plus` | derived | Count of A+ files pre-initiative; must be preserved (SC-005) |
+| `regeneration_command` | literal | `py -m tools.compliance_analyzer` |
+| `check_cadence` | literal | Before every PR opens AND in CI |
+
+**Validation rules**:
+- Any PR that would push the repo below 99.6/A+ is reworked before merge.
+- Any PR that would push a previously A+ file below A+ is reworked before merge.
+- The snapshot file itself may be updated as part of extraction PRs when the extraction improves it, or as separate baseline-refresh commits (pattern seen in recent history: e50a524, da4ae90).
+
+---
+
+## Relationships
+
+- One `ExtractionCandidate` → produces exactly one `ExtractionPR` (FR-002).
+- One `ExtractionPR` → touches exactly one `TargetModule` (or zero for Unused) + `MistHelper.py`.
+- One `ExtractionCandidate` (Single-Use) → has exactly one `Callsite`.
+- `RefactorCandidatesCatalog` → enumerates zero or more `ExtractionCandidate` entries per section.
+- `ComplianceBaseline` → constrains every `ExtractionPR`.
+
+**Non-relationships (explicit)**:
+- An `ExtractionPR` never carries multiple candidates (FR-002).
+- A candidate's `guideline_flags` list is never split across PRs — all flags resolved in the one extraction PR (FR-006).

--- a/specs/1010-misthelper-refactor-extraction/plan.md
+++ b/specs/1010-misthelper-refactor-extraction/plan.md
@@ -1,0 +1,142 @@
+# Implementation Plan: MistHelper.py Refactor Extraction Initiative
+
+**Branch**: `1010-misthelper-refactor-extraction` | **Date**: 2026-07-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/1010-misthelper-refactor-extraction/spec.md`
+
+## Summary
+
+Systematically decompose `MistHelper.py` (~28K-line entrypoint monolith) into cohesive class modules under `src/refactors/` by consuming the analyzer catalog at `refactor_candidates.md`. The first-pass budget covers exactly 13 candidates — 2 Unused (delete only) and 11 Single-Use (move + rewrite single callsite + delete original) — processed in strict serial order (Unused first, then Single-Use LOC-DESC). Each extraction is a single PR that (a) creates the target module (or folds into an existing sibling module for `AddressComparisonCounters`), (b) rewrites the single callsite atomically, (c) deletes the original symbol from `MistHelper.py`, (d) resolves any analyzer `guideline_flags` in-flight, and (e) lands with all 15 functional CI jobs green and A+/100 compliance on affected files. No wrapper shims. No parallel branches. No `--admin` bypass except where `mergeStateStatus` is genuinely BLOCKED/DIRTY/BEHIND with root cause documented. Between merges, the analyzer is re-run and `refactor_candidates.md` is regenerated before the next PR is dispatched, so the queue always reflects the current `main` head.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (project target per repo tooling and CI matrix)
+**Primary Dependencies**: standard library only for extraction targets; existing project deps preserved (no new dependencies introduced by this initiative)
+**Storage**: N/A for extraction work itself; extracted `SQLiteDatabaseWriter` operates on a local SQLite file as it does today
+**Testing**: `pytest` for unit/integration; existing 15 functional CI jobs (matrix build, ruff, mypy, compliance analyzer, refactor analyzer smoke, integration suites) as the mergeability contract
+**Target Platform**: Windows-first CLI (project ships as `MistHelper.py` entrypoint); extracted modules must remain platform-neutral (use `pathlib.Path`, ASCII-only logs)
+**Project Type**: Single-project CLI tool with a monolithic entrypoint being decomposed into `src/*` sub-packages
+**Performance Goals**: No performance regression at any callsite after extraction; interactive latency for CLI menus unchanged
+**Constraints**: Zero wrapper shims may be left in `MistHelper.py`; every extracted module lands at A+/100 compliance; repo-wide baseline stays ≥99.6/A+; no A+ file may regress; no touching of `SKIP_ALWAYS` (`GlobalImportManager`) or Hot bucket (4+ callers) symbols in first pass; serial PR workflow only
+**Scale/Scope**: 13 PRs in first pass, ~811 LoC extraction budget targeting ≥600 lines of physical reduction in `MistHelper.py`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution version 1.4.0 (ratified 2026-03-05). Evaluated per the seven core principles.
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Five-Item Rule (all menu options in groups of 5, cross-category prohibited) | PASS | Extraction is a code-organization change; no menu structure is added, removed, or reordered. |
+| II. Class-Based Architecture (functions live inside cohesive classes) | PASS + REINFORCED | FR-005 explicitly refactors module-level function candidates into class-body methods on landing (`run_systematic_test`, `switch_to_interactive_login`, `run_interactive_test`, `listen_keyboard`). |
+| III. Safety-First Development (destructive operations gated) | PASS | Extraction moves existing behavior; no new destructive operations introduced. Pre-existing safety gates on `SQLiteDatabaseWriter` and other candidates are preserved verbatim. |
+| IV. Full Deployment Pipeline (15 CI jobs must pass, no --admin bypass) | PASS + REINFORCED | FR-011 codifies the CI gate; `feedback_no_admin_bypass.md` guidance applied — check `mergeStateStatus` before considering any bypass. |
+| V. Observability & Logging (structured, ASCII-only, `safe_input`, `pathlib.Path`) | PASS + REINFORCED | FR-007 mandates ASCII-only logs, `safe_input()`, `pathlib.Path` in every extracted module. Analyzer `guideline_flags` covering these are resolved in the extraction PR (FR-006). |
+| VI. Inline Comments Every 5-10 Lines (NON-NEGOTIABLE) | PASS + REINFORCED | Each new module under `src/refactors/` must land A+/100, which requires the inline-comment cadence. Any `missing_inline_comments` flag on extracted code is resolved in the same PR (FR-006). |
+| VII. Action Logging Before Every Non-Trivial Action (NON-NEGOTIABLE) | PASS + REINFORCED | Any `missing_action_logging` flag on extracted code is resolved in the same PR (FR-006). Constitution's `[LOGIN]`, `[MENU]`, `[EXECUTE]`, `[SUCCESS]`, `[FAILURE]` prefix convention is preserved. |
+
+**Result**: All seven principles pass. Two principles (VI, VII) are NON-NEGOTIABLE and are reinforced rather than at risk. No violations require Complexity Tracking entries.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1010-misthelper-refactor-extraction/
+├── plan.md                        # This file (/speckit.plan output)
+├── spec.md                        # Feature specification (input)
+├── research.md                    # Phase 0 output
+├── data-model.md                  # Phase 1 output — extraction entities
+├── quickstart.md                  # Phase 1 output — per-PR operator recipe
+├── contracts/
+│   ├── analyzer-output-contract.md    # Refactor analyzer → dispatcher contract
+│   ├── extraction-pr-contract.md      # Per-PR contract (diff shape, checklist)
+│   └── compliance-gate-contract.md    # A+/100 module + baseline preservation
+├── checklists/
+│   └── requirements.md            # Existing checklist (all items checked)
+└── tasks.md                       # Phase 2 output (produced by /speckit.tasks, not by this command)
+```
+
+### Source Code (repository root)
+
+```text
+MistHelper.py                                # Entrypoint monolith — shrinks by ≥600 lines across 13 PRs
+tools/refactor_analyzer/                     # Analyzer package — CONSUMED AS-IS, never modified (FR-018)
+tools/compliance_analyzer/                   # Compliance analyzer — used to verify A+/100 on affected files
+refactor_candidates.md                       # Regenerated after every merged extraction PR (FR-010)
+data/full_repo_compliance_current.md         # Compliance baseline snapshot — must stay ≥99.6/A+
+src/
+├── refactors/                               # DESTINATION for 10 of 11 Single-Use extractions
+│   ├── __init__.py                          # Existing
+│   ├── serial_cc/                           # Existing sub-package (validates the pattern)
+│   ├── sqlite_database_writer.py            # NEW — PR-03 (largest Single-Use)
+│   ├── tui_launcher.py                      # NEW — PR-04
+│   ├── data_directory_checker.py            # NEW — PR-05
+│   ├── maps_manager_launcher.py             # NEW — PR-06
+│   ├── service_ping_manager.py              # NEW — PR-08
+│   ├── wan2_migration_manager.py            # NEW — PR-09
+│   ├── systematic_test_runner.py            # NEW — PR-10 (holds run_systematic_test-as-method)
+│   ├── interactive_login_switcher.py        # NEW — PR-11 (holds switch_to_interactive_login-as-method)
+│   ├── interactive_test_runner.py           # NEW — PR-12 (holds run_interactive_test-as-method)
+│   └── keyboard_listener.py                 # NEW — PR-13 (holds listen_keyboard-as-method)
+└── inventory/
+    └── csv_comparator.py                    # EXISTING — receives AddressComparisonCounters (PR-07) per FR-015
+```
+
+**Structure Decision**: Single-project layout. Every Single-Use extraction lands under `src/refactors/` with a per-symbol module file, **except** `AddressComparisonCounters` which folds into `src/inventory/csv_comparator.py::CsvComparatorManager` because its sole caller already lives there (FR-015). The existing `src/refactors/serial_cc/` sub-package validates this layout convention. Unused deletions (`PerformanceMonitor`, `MapViewerConfig`) create no new files — the definition is simply removed from `MistHelper.py`.
+
+### PR Dispatch Queue (Authoritative Order)
+
+Per FR-001 (Unused first, then Single-Use LOC-DESC) and FR-014 (exact 13-candidate first-pass budget):
+
+| PR | Bucket | Candidate | LoC | Source in MistHelper.py | Destination |
+|----|--------|-----------|-----|-------------------------|-------------|
+| 01 | Unused | `PerformanceMonitor` | 40 | 365-404 | DELETE (no new file) |
+| 02 | Unused | `MapViewerConfig` | 9 | 441-449 | DELETE (no new file) |
+| 03 | Single-Use | `SQLiteDatabaseWriter` | 316 | 6949-7265 | `src/refactors/sqlite_database_writer.py` |
+| 04 | Single-Use | `TUILauncher` | 154 | (see analyzer output) | `src/refactors/tui_launcher.py` |
+| 05 | Single-Use | `DataDirectoryChecker` | 74 | (see analyzer output) | `src/refactors/data_directory_checker.py` |
+| 06 | Single-Use | `MapsManagerLauncher` | 64 | (see analyzer output) | `src/refactors/maps_manager_launcher.py` |
+| 07 | Single-Use | `AddressComparisonCounters` | 62 | (see analyzer output) | `src/inventory/csv_comparator.py::CsvComparatorManager` (FR-015 exception) |
+| 08 | Single-Use | `ServicePingManager` | 50 | (see analyzer output) | `src/refactors/service_ping_manager.py` |
+| 09 | Single-Use | `WAN2MigrationManager` | 48 | (see analyzer output) | `src/refactors/wan2_migration_manager.py` |
+| 10 | Single-Use | `run_systematic_test` (module-level fn) | ~35 | (see analyzer output) | `src/refactors/systematic_test_runner.py` (as class method per FR-005) |
+| 11 | Single-Use | `switch_to_interactive_login` (module-level fn) | ~30 | (see analyzer output) | `src/refactors/interactive_login_switcher.py` (as class method) |
+| 12 | Single-Use | `run_interactive_test` (module-level fn) | ~28 | (see analyzer output) | `src/refactors/interactive_test_runner.py` (as class method) |
+| 13 | Single-Use | `listen_keyboard` (module-level fn) | ~24 | (see analyzer output) | `src/refactors/keyboard_listener.py` (as class method) |
+
+LOC figures are the analyzer's snapshot at spec creation; each PR uses the *fresh* analyzer output post-preceding-merge per FR-010, so line numbers may shift within tolerance.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |
+
+## Post-Design Constitution Re-Check
+
+Re-evaluated after Phase 1 design artifacts landed:
+
+- **I. Five-Item Rule** — Still PASS. No menu topology changed.
+- **II. Class-Based Architecture** — Still PASS. Data-model and contracts explicitly require class-body landing for module-level function candidates.
+- **III. Safety-First** — Still PASS. No new destructive paths.
+- **IV. Full Deployment Pipeline** — Still PASS. `contracts/extraction-pr-contract.md` and `contracts/compliance-gate-contract.md` codify the 15-job gate and the no-`--admin` policy.
+- **V. Observability & Logging** — Still PASS. `data-model.md` "Target Module" entity requires ASCII logs, `safe_input()`, and `pathlib.Path`; `contracts/compliance-gate-contract.md` requires flag resolution.
+- **VI. Inline Comments** — Still PASS + NON-NEGOTIABLE. A+/100 module gate in the compliance contract enforces the 5-10 line comment cadence.
+- **VII. Action Logging** — Still PASS + NON-NEGOTIABLE. `guideline_flags` resolution requirement in the PR contract enforces action logging on extracted code.
+
+**Final verdict**: All seven principles pass post-design. No Complexity Tracking entries required.
+
+## What This Plan Does NOT Do
+
+- Does not open, sequence, or merge extraction PRs — that is the parent conversation's dispatch responsibility (Assumption 7 in spec).
+- Does not modify `tools/refactor_analyzer/` (FR-018).
+- Does not touch `SKIP_ALWAYS` symbols like `GlobalImportManager` (FR-008).
+- Does not touch Hot bucket symbols with 4+ callers (FR-009).
+- Does not batch multiple candidates into one PR (FR-002).
+- Does not leave wrapper shims or forwarding functions (FR-003, SC-008).
+- Does not scope second-pass Low-Use candidates or unrelated feature backlogs (FR-017, Assumption 6).

--- a/specs/1010-misthelper-refactor-extraction/quickstart.md
+++ b/specs/1010-misthelper-refactor-extraction/quickstart.md
@@ -1,0 +1,213 @@
+# Quickstart: Single Extraction PR — Operator Recipe
+
+**Feature**: 1010-misthelper-refactor-extraction | **Date**: 2026-07-05
+**Purpose**: The 8-step loop a refactor engineer executes for each of the 13 first-pass PRs.
+
+This is the recipe. `spec.md` is the contract, `plan.md` is the queue, `data-model.md` is the entity glossary, `contracts/*` are the interface rules. This file tells you what to *do*.
+
+---
+
+## Preconditions
+
+- Working tree on `main`, clean (`git status` shows no changes).
+- No other extraction PR currently open (serial-only per spec Edge Cases).
+- Previous extraction PR (if any) merged AND `refactor_candidates.md` has been regenerated on the post-merge `main` head.
+
+If any precondition fails: stop, resolve, then restart at Step 1.
+
+---
+
+## Step 1 — Regenerate the catalog
+
+Run the analyzer on the current `main` head:
+
+```bash
+py -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md
+```
+
+Inspect the diff. If a first-pass candidate has drifted out of Unused/Single-Use into Low-Use/Hot, reroute per FR-016 (skip and reschedule). If Single-Use → Unused, reclassify to the Unused workflow (delete only, no new module).
+
+---
+
+## Step 2 — Select the next candidate
+
+Per FR-001: process Unused first (LOC-DESC within), then Single-Use (LOC-DESC within).
+
+Given the 13-candidate first-pass budget (FR-014), the dispatch order is fixed:
+
+1. `PerformanceMonitor` (Unused, 40 LoC) — delete
+2. `MapViewerConfig` (Unused, 9 LoC) — delete
+3. `SQLiteDatabaseWriter` (Single-Use, 316 LoC) — extract
+4. `TUILauncher` (Single-Use, 154 LoC) — extract
+5. `DataDirectoryChecker` (Single-Use, 74 LoC) — extract
+6. `MapsManagerLauncher` (Single-Use, 64 LoC) — extract
+7. `AddressComparisonCounters` (Single-Use, 62 LoC) — fold into `CsvComparatorManager` (FR-015)
+8. `ServicePingManager` (Single-Use, 50 LoC) — extract
+9. `WAN2MigrationManager` (Single-Use, 48 LoC) — extract
+10. `run_systematic_test` (Single-Use, ~35 LoC) — extract as class method (FR-005)
+11. `switch_to_interactive_login` (Single-Use, ~30 LoC) — extract as class method
+12. `run_interactive_test` (Single-Use, ~28 LoC) — extract as class method
+13. `listen_keyboard` (Single-Use, ~24 LoC) — extract as class method
+
+The next slot after PR-N-merge is always PR-(N+1) unless the Step 1 catalog says otherwise.
+
+---
+
+## Step 3 — Verify the analyzer's caller claim
+
+For **Unused** candidates:
+
+```bash
+grep -RIn "\bSymbolName\b" --include="*.py" .
+```
+
+Zero non-definition hits required. Paste the grep output into the PR description as manual verification (FR-004). If a hit appears, it is dynamic dispatch (or an analyzer bug): investigate, and if it's a real reference, reroute the candidate to Single-Use workflow instead.
+
+For **Single-Use** candidates:
+
+```bash
+grep -RIn "\bSymbolName\b" --include="*.py" .
+```
+
+Expect exactly two contexts: the definition in `MistHelper.py` and the single caller. If a third context appears, reroute to Low-Use or Hot planning per FR-016. Recommended (not mandatory) to paste the grep in the PR description as belt-and-suspenders.
+
+---
+
+## Step 4 — Create the branch and open the working PR (draft)
+
+```bash
+git checkout -b refactor/extract-{snake_name}
+```
+
+For **Unused**: no new file. Skip to Step 5.
+
+For **Single-Use**: create the target module file per the queue in `plan.md`. Land the class with:
+
+- ASCII-only logs (Principle V, FR-007).
+- `safe_input()` for interactive input.
+- `pathlib.Path` in place of `os.path`.
+- Inline comments every 5-10 lines (Principle VI, NON-NEGOTIABLE).
+- Action logging before every non-trivial action with the correct prefix (Principle VII, NON-NEGOTIABLE).
+- Module-level function candidates land as **class methods** on a new cohesive class (FR-005).
+- `AddressComparisonCounters` folds into `src/inventory/csv_comparator.py::CsvComparatorManager` (FR-015 — no new file).
+- Every `guideline_flag` the analyzer reported on the extracted code is resolved in this file (FR-006, SC-012).
+
+---
+
+## Step 5 — Rewrite the single callsite and delete the original
+
+In the **same commit**:
+
+1. Delete the original symbol definition from `MistHelper.py` (do not leave a wrapper, forwarding function, or backward-compat alias — FR-003, SC-008).
+2. For **Single-Use**: update the caller's `from MistHelper import SymbolName` (or bare-name reference) to `from src.refactors.new_module import SymbolName` (or the equivalent for the AddressComparisonCounters fold-in).
+3. For module-level function candidates rewritten as class methods, update the caller from `func(args)` to `NewClass().func(args)` or the domain-appropriate method name.
+
+Verify no intermediate commit on the branch leaves a dangling import or dangling definition.
+
+---
+
+## Step 6 — Local gate check
+
+Before pushing:
+
+```bash
+py -m tools.compliance_analyzer
+```
+
+Confirm:
+- New module (if any) scored A+/100 (FR-012, SC-007).
+- `MistHelper.py` grade did not regress.
+- Zero previously-A+ files dropped below A+ (SC-005).
+- Repo-wide score ≥ 99.6/A+ (FR-013, SC-004).
+
+Then re-run the refactor analyzer:
+
+```bash
+py -m tools.refactor_analyzer MistHelper.py
+```
+
+Confirm the just-extracted symbol has been removed from the appropriate bucket. Include the regenerated `refactor_candidates.md` in the PR diff.
+
+Run whatever local test/lint invocations correspond to the 15 CI jobs.
+
+---
+
+## Step 7 — Push, open PR, wait for CI
+
+```bash
+git push -u origin refactor/extract-{snake_name}
+gh pr create --title "refactor: extract {SymbolName} ({loc} lines)" \
+  --body "$(cat <<'EOF'
+Extracts {SymbolName} from MistHelper.py into {target_path}.
+
+- Source: MistHelper.py:{line_range}
+- Callsite rewritten: {caller_file}:{caller_line}
+- Compliance: {target_module} A+/100, MistHelper.py unchanged grade, repo ≥99.6/A+
+- Guideline flags resolved in-flight: {list}
+
+Manual grep verification:
+```
+{grep output here}
+```
+EOF
+)"
+```
+
+Wait for all 15 functional CI jobs to report green. Consult `mergeStateStatus`:
+
+- `CLEAN` → proceed to Step 8.
+- `BLOCKED` / `DIRTY` / `BEHIND` → rebase against `main`, push, re-run CI. Do NOT use `--admin` bypass as a routine unblock (FR-011). Only invoke `--admin` when the root cause is genuinely a required-check-that-doesn't-apply scenario, and document it in the PR body per `feedback_no_admin_bypass.md`.
+
+---
+
+## Step 8 — Squash-merge and delete branch
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+Confirm on `main`:
+
+```bash
+git checkout main
+git pull
+```
+
+Then immediately loop back to Step 1 for the next candidate. The catalog must be regenerated on this fresh `main` head before PR-(N+1) is opened (FR-010, SC-011).
+
+---
+
+## After PR-13
+
+- `refactor_candidates.md` Unused bucket should show 0 entries (SC-001).
+- `refactor_candidates.md` Single-Use bucket should show 0 entries (SC-002).
+- `MistHelper.py` physical line count should have dropped by ≥600 lines (SC-003).
+- Zero wrapper shims remain (SC-008).
+- Zero `SKIP_ALWAYS` symbols were modified (SC-009).
+- Zero Hot-bucket symbols were extracted in this pass (SC-010).
+- Every new `src/refactors/*.py` scored A+/100 (SC-007).
+- Repo-wide compliance ≥ 99.6/A+ (SC-004), zero A+ regressions (SC-005).
+
+Report the aggregate LoC reduction and file the initiative's closeout note. Second-pass Low-Use planning is a **separate initiative** — do not roll into this one (Assumption 6).
+
+---
+
+## Cheat Sheet
+
+```bash
+# Full loop, condensed
+py -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md   # Step 1
+# (select candidate — Step 2)
+grep -RIn "\bSymbolName\b" --include="*.py" .                            # Step 3
+git checkout -b refactor/extract-{snake_name}                            # Step 4
+# (create module, land class, resolve guideline_flags — Step 4)
+# (delete original + rewrite callsite in same commit — Step 5)
+py -m tools.compliance_analyzer                                          # Step 6
+py -m tools.refactor_analyzer MistHelper.py                              # Step 6
+git push -u origin refactor/extract-{snake_name}                         # Step 7
+gh pr create --title "..." --body "..."                                  # Step 7
+# (wait for 15 CI jobs green, mergeStateStatus=CLEAN — Step 7)
+gh pr merge --squash --delete-branch                                     # Step 8
+git checkout main && git pull                                            # Step 8
+# loop to Step 1
+```

--- a/specs/1010-misthelper-refactor-extraction/research.md
+++ b/specs/1010-misthelper-refactor-extraction/research.md
@@ -1,0 +1,109 @@
+# Phase 0 Research: MistHelper.py Refactor Extraction
+
+**Feature**: 1010-misthelper-refactor-extraction | **Date**: 2026-07-05
+**Purpose**: Resolve every NEEDS CLARIFICATION and consolidate decisions before design.
+
+All decisions below inform Phase 1 design (`data-model.md`, `contracts/*`, `quickstart.md`). No NEEDS CLARIFICATION markers remain.
+
+---
+
+## 1. Analyzer Classification Model
+
+**Decision**: Consume `tools/refactor_analyzer/` output verbatim. Buckets are Unused (0 callers), Single-Use (exactly 1 caller), Low-Use (2-3 callers), Hot (4+ callers), Skipped (`SKIP_ALWAYS` list). Only Unused and Single-Use participate in first pass.
+
+**Rationale**: The analyzer already implements AST-driven reference counting via `references.py` and applies the `SKIP_ALWAYS` filter in `analysis.py`. Its classification is the single source of truth per FR-010 and Assumption 1. Manual re-classification would fork the truth and re-introduce the drift that prior stalled attempts suffered.
+
+**Alternatives considered**:
+- *Manual grep-driven classification*: rejected — labor-intensive, no dynamic-dispatch handling, and re-inventing the analyzer contradicts FR-018.
+- *`grep -R "ClassName("` heuristic*: rejected — high false-positive rate on common names, no AST scope awareness.
+- *IDE find-references*: rejected — non-reproducible across contributors, not scriptable in CI verification.
+
+**Domain vocabulary used downstream**: `guideline_flags` (per-candidate list of remediation targets: oversize_25_lines, missing_inline_comments, missing_action_logging, non_ascii_logs, hardcoded_separator, raw_input_call, too_many_params).
+
+---
+
+## 2. Callsite Discovery Pattern
+
+**Decision**: For every Single-Use candidate, the callsite is read directly from `refactor_candidates.md`'s per-candidate line reference (analyzer already emits caller file + line). Before the PR is opened, a manual `grep -R "SymbolName(" --include="*.py"` sweep confirms the caller count is exactly 1 — this is the FR-004 discipline extended defensively to Single-Use candidates to guard against dynamic-dispatch false negatives.
+
+**Rationale**: The analyzer's reference count is AST-based and will miss `getattr(module, "SymbolName")()` and `eval`/`exec` patterns. Confirming with a text grep in the same PR provides the belt-and-suspenders verification needed before any deletion or rewrite lands.
+
+**Alternatives considered**:
+- *Trust analyzer output blindly*: rejected — dynamic dispatch exists in the codebase (e.g. dispatch tables, string-keyed lookups) and could hide a second caller.
+- *Full AST re-analysis with a second tool*: rejected — over-engineered for a one-caller confirmation; text grep is sufficient because a hit outside the analyzer-reported callsite is enough to abort.
+
+**Callsite rewrite pattern**: The single caller's `from MistHelper import SymbolName` (or `SymbolName(...)` bare call) is rewritten in the same commit to `from src.refactors.new_module import SymbolName` and the original definition is deleted from `MistHelper.py`. No intermediate revision on the branch may leave a dangling import or dangling definition (FR-003).
+
+---
+
+## 3. Compliance-Baseline Interplay
+
+**Decision**: Every extraction PR runs `py -m tools.compliance_analyzer` before opening the PR and again in CI. The affected-file set is (a) the new module and (b) `MistHelper.py`. New module must score A+/100; `MistHelper.py` must not regress its grade or lose any A+ file downstream. Baseline snapshot lives in `data/full_repo_compliance_current.md`.
+
+**Rationale**: FR-012, FR-013, SC-004, SC-005, and SC-007 all key off compliance measurements. The analyzer emits per-file grades and a repo-wide aggregate; both are required to gate merge. This mirrors the constitution's Principle IV (Full Deployment Pipeline) and the existing repo cadence (commits e50a524, 4176bc8, 6c2e0b6 in recent history show the same "compliance A-/91.0 -> A+/100.0" pattern).
+
+**Alternatives considered**:
+- *Only check the new module's grade*: rejected — misses regressions caused by import churn or comment-density shifts in `MistHelper.py` from the deletion diff.
+- *Sample-based baseline (subset of files)*: rejected — baseline is authoritative per FR-013; sampling would let a regression slip through.
+- *Post-merge cleanup PRs to restore baseline*: rejected — violates the "resolve in-flight" discipline (FR-006) and defers debt.
+
+**Guideline-flag resolution**: If `guideline_flags` on the extracted code includes `oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`, `non_ascii_logs`, `hardcoded_separator`, or `raw_input_call`, each is remediated in the extraction PR before the compliance gate is evaluated. FR-006 makes deferral prohibited.
+
+---
+
+## 4. Bare-Function-to-Class Refactor Pattern
+
+**Decision**: Module-level function candidates (`run_systematic_test`, `switch_to_interactive_login`, `run_interactive_test`, `listen_keyboard`) land as methods on a new cohesive class in the target module, not as bare `def` at module scope. The class name is derived from the module name (e.g. `SystematicTestRunner`, `InteractiveLoginSwitcher`, `InteractiveTestRunner`, `KeyboardListener`). The single caller is rewritten to instantiate the class and call the method: `NewClass().run(...)` or a domain-appropriate method name.
+
+**Rationale**: Constitution Principle II (Class-Based Architecture) makes bare module functions a smell. FR-005 codifies the transformation. Extracting a function into a module without wrapping it in a class would re-create the very anti-pattern the constitution forbids — a lateral move rather than an improvement.
+
+**Alternatives considered**:
+- *Preserve bare function signature to minimize diff*: rejected — violates FR-005 and Principle II.
+- *Static method / class method*: rejected in the general case — instance methods allow future state (loggers, config, cached deps) without another refactor; `@staticmethod` decoration is acceptable only when the function is truly stateless and remains a leaf.
+- *Free-function module + separate wrapper class in a second PR*: rejected — violates FR-006 (in-flight resolution) and FR-002 (one candidate per PR would explode into two).
+
+**Method-signature preservation**: The refactored method preserves the original callable's parameters verbatim so the callsite rewrite is a single-line change (`func(args)` becomes `NewClass().func(args)` or equivalent). This keeps the diff minimal and reviewable.
+
+---
+
+## 5. `AddressComparisonCounters` Fold-In Pattern (FR-015 Exception)
+
+**Decision**: `AddressComparisonCounters` does NOT get its own file under `src/refactors/`. Instead it is folded into `src/inventory/csv_comparator.py::CsvComparatorManager` — either as a nested class, an inner data structure, or (preferred) inlined fields on `CsvComparatorManager` if the counter's shape is small enough. The sole caller already lives in `csv_comparator.py`, so the extraction is a *local move* from `MistHelper.py` into the caller's home module.
+
+**Rationale**: FR-015 makes this an explicit exception to the "new module under `src/refactors/`" rule. Creating `src/refactors/address_comparison_counters.py` would introduce a cross-module import from `csv_comparator.py` back into `refactors/`, which is precisely the coupling this initiative is trying to reduce. Landing the symbol next to its only caller minimizes import surface and lets the caller reference it as a private class member (or module-private class in the same file).
+
+**Alternatives considered**:
+- *Create `src/refactors/address_comparison_counters.py`*: rejected by FR-015 — introduces avoidable cross-module import for a 62-LoC single-caller helper.
+- *Fold into `csv_comparator.py` at module scope (private, underscore-prefixed)*: acceptable fallback if the counter cannot cleanly become a nested/inner class, but the preferred landing is inside `CsvComparatorManager` per FR-015's explicit target.
+- *Split fields across `CsvComparatorManager` and delete the helper class entirely*: acceptable if the counter is just a bag of ints and the resulting `CsvComparatorManager` still lands at A+/100 with clear inline commentary — this collapses the class rather than moving it.
+
+**Precedent**: Assumption 9 documents that other candidates whose sole caller lives outside `MistHelper.py` may follow the same "land next to caller" rule if discovered mid-extraction. Deviation requires PR-description note.
+
+---
+
+## 6. Analyzer Regeneration Protocol Between Merges
+
+**Decision**: After every merged extraction PR, run `py -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md` on the current `main` head. Commit the regenerated `refactor_candidates.md` (typically as part of the next extraction PR, so the diff carrying the next candidate is preceded on `main` by an up-to-date catalog). The dispatcher for PR N+1 selects the next candidate from the freshest catalog, not from a stale snapshot.
+
+**Rationale**: FR-010, SC-011, and User Story 3 all mandate this cadence. Reference counts shift as callsites move — a Single-Use candidate whose sole caller was itself extracted may become Unused, or vice versa. Operating on a stale catalog would produce incorrect callsite rewrites and violate FR-016.
+
+**Alternatives considered**:
+- *Regenerate only when reclassification is suspected*: rejected — introduces judgment where the spec demands a mechanical rule; SC-011 requires verifiability.
+- *Batch-regenerate every 3 PRs*: rejected — a single stale count could invalidate two subsequent PRs before detection.
+- *Auto-regenerate in a bot/hook*: acceptable future improvement but out of scope (FR-018 forbids analyzer modification; a wrapper bot is a separate initiative).
+
+**Reclassification handling** (FR-016): If the fresh catalog shows a first-pass candidate has become Low-Use or Hot, it is *rerouted* to second-pass planning or Out-of-Scope, not force-extracted. If it has become Unused, it is *reclassified* into the Unused workflow (delete only, no new module). These are dispatcher-time decisions driven by the fresh catalog.
+
+**Serial-workflow reinforcement** (Edge Cases in spec): Only one extraction PR is open at a time. This makes catalog-regeneration timing unambiguous — regenerate on `main` head after merge, before opening the next PR. Parallel branches are explicitly forbidden.
+
+---
+
+## Cross-cutting Decisions
+
+**Merge protocol**: squash-and-merge, `--delete-branch`, no `--admin` bypass. Consult `mergeStateStatus`; only genuine BLOCKED/DIRTY/BEHIND states warrant investigation, and even then the fix is a rebase/push, not `--admin` (per `feedback_no_admin_bypass.md` guidance).
+
+**Commit message convention**: `refactor: extract {SymbolName} to {target_path} (#PR)` for Single-Use PRs; `refactor: delete unused {SymbolName} (#PR)` for Unused PRs. Follows the existing repo history pattern (e.g. commit da4ae90, 4176bc8).
+
+**PR title convention**: `refactor: extract {SymbolName} ({loc} lines)` or `refactor: delete unused {SymbolName} ({loc} lines)`.
+
+**Test-preservation rule**: Any existing tests that reference the extracted symbol via `from MistHelper import ...` are updated to the new import path in the same PR. New tests are not mandated by the extraction — the initiative preserves behavior, not adds coverage — but existing tests must remain green (part of the 15 functional CI jobs).

--- a/specs/1010-misthelper-refactor-extraction/spec.md
+++ b/specs/1010-misthelper-refactor-extraction/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: MistHelper.py Refactor Extraction Initiative
+
+**Feature Branch**: `1010-misthelper-refactor-extraction`
+**Created**: 2026-07-05
+**Status**: Draft
+**Input**: User description: "Systematically decompose MistHelper.py (24K+ line entrypoint monolith) into cohesive class modules under `src/refactors/` by extracting analyzer-identified candidates. Multi-PR extraction workflow driven by `tools/refactor_analyzer/`, which produces `refactor_candidates.md` — a ranked catalog of extraction candidates classified by reference count."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Extract Single-Use candidates from the monolith (Priority: P1)
+
+The core value-delivery workflow. For each Single-Use candidate (exactly one caller in the codebase), a refactor engineer opens a PR that (a) moves the class/function into a new cohesive module under `src/refactors/` (or, when the caller lives in an existing dedicated module, alongside that caller), (b) rewrites the single callsite in the same commit, and (c) deletes the original symbol from `MistHelper.py`. No wrapper shims are left behind. Guideline violations detected on the moved code (oversize, missing action logging, hardcoded separators) are corrected in the extraction PR — never carried forward. Module-level functions are refactored into class-body methods on landing, not left as bare module functions.
+
+**Why this priority**: Delivers the bulk of the LOC drop (11 PRs, ~761 LoC of the 811 LoC first-pass budget). Rewriting the callsite atomically with the move is the non-negotiable that distinguishes this initiative from prior stalled attempts, so P1 is where the discipline is enforced.
+
+**Independent Test**: Any single Single-Use extraction (e.g. `SQLiteDatabaseWriter` at MistHelper.py:6949-7265 → `src/refactors/sqlite_database_writer.py` with callsite MistHelper.py:7468 rewritten) can be merged in isolation with the full CI matrix green. The initiative delivers value one candidate at a time.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Single-Use candidate identified in `refactor_candidates.md` with a known callsite, **When** the extraction PR is opened, **Then** the new module exists at the mapped path, the original symbol is deleted from `MistHelper.py`, the single callsite is rewritten to import from the new module, and no `def old(...): return NewClass().new(...)` wrapper exists anywhere in the diff.
+2. **Given** a candidate that is currently a module-level function, **When** it is extracted, **Then** it lands as a method on a cohesive class in the new module — not as a bare `def` at module scope.
+3. **Given** an extraction PR is under CI, **When** the pipeline completes, **Then** all 15 functional CI jobs are green, the new module scores A+/100 on compliance, and no previously A+ file regresses.
+4. **Given** the analyzer flagged the moved code with `guideline_flags` (e.g. oversize, missing action logging, hardcoded separator), **When** the extraction PR lands, **Then** each flagged violation is resolved in the same PR — not deferred.
+5. **Given** the Single-Use bucket in `refactor_candidates.md`, **When** dispatching the next PR, **Then** candidates are processed in LOC-DESC order (largest first) so early merges deliver the biggest line-count wins.
+
+---
+
+### User Story 2 - Delete Unused candidates outright (Priority: P2)
+
+For candidates with 0 references in the codebase, the workflow is a pure deletion: remove the class or function definition from `MistHelper.py`, no new module, no callsite rewrite. The analyzer's zero-reference count is verified by a manual grep of the codebase in the same PR to guard against dynamic-dispatch false negatives.
+
+**Why this priority**: Lowest-risk portion of the first pass (2 PRs, ~49 LoC), but strictly smaller value than Single-Use extraction. Deletion PRs also validate the analyzer's zero-ref accuracy on a small sample before the higher-stakes Single-Use PRs consume analyzer output as ground truth.
+
+**Independent Test**: `PerformanceMonitor` (MistHelper.py:365-404, 40 LoC) can be deleted in its own PR and merged with all CI jobs green, delivering an immediate LOC reduction and demonstrating the analyzer's zero-reference verdict is trustworthy.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Unused candidate (`PerformanceMonitor`, `MapViewerConfig`), **When** the deletion PR is opened, **Then** the definition is removed from `MistHelper.py` and no new file is created.
+2. **Given** the deletion PR, **When** the diff is reviewed, **Then** a repo-wide grep confirming 0 remaining references to the symbol name is included in the PR description as manual verification of the analyzer output.
+3. **Given** the deletion PR merges, **When** CI runs on `main`, **Then** all 15 functional jobs stay green and compliance baseline is unchanged or improved.
+
+---
+
+### User Story 3 - Refresh the analyzer catalog after every merged extraction (Priority: P3)
+
+Reference counts shift as extractions land — a symbol that was Single-Use pre-extraction may become Unused after its caller is itself moved elsewhere, and vice versa. After every merged extraction PR, the analyzer is re-run and `refactor_candidates.md` is regenerated before the next PR is dispatched. The dispatch queue is always derived from the freshest analyzer output, never from a stale snapshot.
+
+**Why this priority**: Workflow discipline that supports P1 and P2 rather than delivering standalone value. Without it, later PRs in the queue risk operating on stale reference-count data and producing incorrect callsite rewrites.
+
+**Independent Test**: After merging any extraction PR, running `py -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md` regenerates the catalog cleanly, and the diff of `refactor_candidates.md` reflects the just-completed extraction (removed from the appropriate bucket, and any downstream reference-count shifts visible).
+
+**Acceptance Scenarios**:
+
+1. **Given** an extraction PR has just merged to `main`, **When** the next PR is dispatched, **Then** `refactor_candidates.md` has been regenerated on the current `main` head first and the next candidate is selected from that fresh output.
+2. **Given** the regenerated catalog shows a formerly Single-Use candidate has become Unused, **When** the dispatcher plans the next PR, **Then** the candidate is reclassified into the Unused workflow (delete-only, no new module).
+3. **Given** the regenerated catalog shows a formerly Single-Use candidate has gained callers and become Low-Use or Hot, **When** the dispatcher plans the next PR, **Then** that candidate is skipped from the first pass and rescheduled to the second-pass (Low-Use) evaluation or the Out-of-Scope Hot bucket.
+
+---
+
+### Edge Cases
+
+- What happens when `refactor_candidates.md` disagrees with a manual grep about reference count? Manual grep wins for that PR; the discrepancy is filed as an analyzer bug in `tools/refactor_analyzer/` but does not block the extraction.
+- How does the workflow handle a Single-Use candidate whose only caller is inside a Skipped (`SKIP_ALWAYS`) symbol like `GlobalImportManager`? Defer to second-pass; do not extract until the skip constraint is re-evaluated separately.
+- What happens if a candidate's extraction would require reaching into a Hot symbol (4+ callers) to rewrite the callsite? Abort the extraction, document the coupling in the PR description, and reroute the candidate to second-pass planning.
+- How does the workflow handle a merge conflict on `refactor_candidates.md` when multiple extraction PRs are open simultaneously? Serial per-PR workflow is non-negotiable — only one extraction PR is open at a time. Regenerate the catalog after each merge; do not maintain parallel branches.
+- What happens if CI surfaces a regression that was masked in the pre-extraction monolith (e.g. an import ordering bug that only appears once the symbol moves)? Fix in the same PR; do not merge with any of the 15 functional CI jobs failing, and do not use `--admin` bypass — check `mergeStateStatus` per `feedback_no_admin_bypass.md`.
+- How does the workflow handle a candidate whose LOC has drifted since the catalog was generated (e.g. an unrelated commit expanded the function body)? Re-run the analyzer to refresh the LOC estimate; use the fresh number for the PR budget.
+- What happens when an extracted module would collide with an existing file at the mapped path? Rename the target module (e.g. `_v2` or a domain-specific prefix) and record the rationale in the PR description.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The extraction workflow MUST process candidates in the order Unused → Single-Use, and within each bucket in LOC-DESC order (largest LOC first) as specified in the input queue.
+- **FR-002**: The workflow MUST process exactly one extraction candidate per PR. Batching multiple candidates into a single PR is prohibited.
+- **FR-003**: For each Single-Use candidate, the PR MUST (a) create the target module file, (b) delete the original symbol from `MistHelper.py`, and (c) rewrite the single callsite — all in the same commit. No wrapper shim, forwarding function, or backward-compatibility alias may be left in `MistHelper.py`.
+- **FR-004**: For each Unused candidate, the PR MUST delete the definition from `MistHelper.py` with no new module created. A manual repo-wide reference grep MUST be included in the PR description as verification of the analyzer's zero-reference verdict.
+- **FR-005**: Module-level functions that are extracted MUST be refactored into class-body methods on the new module, not preserved as bare module-level functions.
+- **FR-006**: Analyzer-flagged `guideline_flags` on the extracted code (oversize, missing action logging, hardcoded separators, and any other flags surfaced by the analyzer) MUST be resolved within the same extraction PR — never deferred to a follow-up.
+- **FR-007**: All extracted modules MUST comply with project non-negotiables: ASCII-only logs, `safe_input()` for interactive input, `pathlib.Path` in place of `os.path`, and any other conventions enumerated in `AGENTS.md` and `.github/copilot-instructions.md`.
+- **FR-008**: The initiative MUST NEVER touch symbols in the analyzer's `SKIP_ALWAYS` bucket (e.g. `GlobalImportManager`) regardless of downstream reclassification.
+- **FR-009**: The initiative MUST NEVER touch symbols in the Hot bucket (4+ callers) during the first pass. Second-pass Low-Use evaluation is a distinct effort scoped after first pass completes.
+- **FR-010**: After every merged extraction PR, the workflow MUST regenerate `refactor_candidates.md` by running the analyzer against the current `main` head before the next PR is dispatched.
+- **FR-011**: An extraction PR MUST NOT merge until all 15 functional CI jobs report green. When `mergeStateStatus` reports BLOCKED, DIRTY, or BEHIND, the PR MUST be updated and re-run rather than force-merged. `--admin` merge bypass MUST NOT be used as a routine unblock.
+- **FR-012**: Every new module under `src/refactors/` (and any existing module receiving an extracted symbol) MUST land at A+/100 compliance score, and no file that was previously A+ may regress below A+ as a result of the extraction.
+- **FR-013**: The repository-wide compliance baseline MUST remain at or above 99.6/A+ after each merged extraction PR. Any PR that would regress the baseline MUST be reworked before merge.
+- **FR-014**: The first-pass extraction budget covers exactly 13 candidates: 2 Unused (`PerformanceMonitor`, `MapViewerConfig`) plus 11 Single-Use (LOC-DESC: `SQLiteDatabaseWriter`, `TUILauncher`, `DataDirectoryChecker`, `MapsManagerLauncher`, `AddressComparisonCounters`, `ServicePingManager`, `WAN2MigrationManager`, `run_systematic_test`, `switch_to_interactive_login`, `run_interactive_test`, `listen_keyboard`). Additions to first-pass scope require explicit re-scoping.
+- **FR-015**: `AddressComparisonCounters` MUST be relocated into the existing `src/inventory/csv_comparator.py::CsvComparatorManager` class rather than into a new `src/refactors/` module, because its sole caller already lives there. All other Single-Use candidates map to fresh files under `src/refactors/`.
+- **FR-016**: When the freshly regenerated `refactor_candidates.md` shows that a candidate has been reclassified out of the first-pass buckets (e.g. Single-Use → Low-Use or Hot after a prior merge), the workflow MUST reroute or defer that candidate rather than force-extract it under the original classification.
+- **FR-017**: The initiative MUST NOT introduce new features, new commands, or scope beyond the extraction itself (e.g. issue #421 Menu 195 packet capture and other feature backlogs remain out of scope).
+- **FR-018**: The initiative MUST NOT modify `tools/refactor_analyzer/` itself; the analyzer is consumed as-is. Analyzer improvements are a separate initiative.
+
+### Key Entities *(include if feature involves data)*
+
+- **Extraction Candidate**: A class or function in `MistHelper.py` catalogued by `tools/refactor_analyzer/` with attributes name, kind (class/function), line range, LOC count, reference count, classification bucket (Unused / Single-Use / Low-Use / Hot / Skipped), callsite locations, and `guideline_flags`.
+- **Refactor Candidates Catalog** (`refactor_candidates.md`): The analyzer's ranked output; the single source of truth for the dispatch queue. Sections: Summary, Unused, Single-Use, Low-Use, Hot, Skipped, Limitations. Regenerated after every merged extraction PR.
+- **Extraction PR**: A single pull request delivering one candidate's move-or-delete plus its callsite rewrite plus any in-place `guideline_flags` remediation. Gated by 15 functional CI jobs and A+/100 compliance on affected files.
+- **Target Module**: The new file under `src/refactors/` (or existing sibling module in the case of `AddressComparisonCounters`) that receives an extracted symbol. Must land at A+/100 compliance.
+- **Callsite**: The exact location where a Single-Use candidate is invoked. Rewritten atomically with the extraction so that no intermediate revision references a deleted symbol.
+- **Compliance Baseline**: The repo-wide compliance score maintained at ≥99.6/A+ with zero sub-A files; each extraction PR must preserve or improve this baseline.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The Unused bucket of `refactor_candidates.md` reports 0 entries at first-pass completion (or documented rationale in the catalog's Limitations section explaining any deferrals).
+- **SC-002**: The Single-Use bucket of `refactor_candidates.md` reports 0 entries at first-pass completion (or documented rationale for any explicitly deferred candidate).
+- **SC-003**: `MistHelper.py` physical line count drops by at least 600 lines relative to its pre-initiative baseline (matches the 811 LoC extraction budget minus small class-body overhead per new module).
+- **SC-004**: Repository-wide compliance score is ≥99.6/A+ at every intermediate main-branch state throughout the initiative and at final completion.
+- **SC-005**: Zero files that were A+/100 pre-initiative regress below A+ by the end of the initiative.
+- **SC-006**: All 13 first-pass PRs merge with 15/15 functional CI jobs green. Zero PRs merged via `--admin` bypass except where `mergeStateStatus` was genuinely BLOCKED/DIRTY/BEHIND with root cause documented in the PR.
+- **SC-007**: Every new file created under `src/refactors/` during the initiative scores A+/100 on compliance.
+- **SC-008**: Zero wrapper shims, forwarding functions, or backward-compatibility aliases remain in `MistHelper.py` after the initiative — every extracted symbol is either fully removed or (for Unused) simply deleted.
+- **SC-009**: Zero symbols from the analyzer's `SKIP_ALWAYS` bucket are modified by any PR in this initiative.
+- **SC-010**: Zero symbols from the Hot bucket (4+ callers) are extracted during the first pass.
+- **SC-011**: After every merged extraction PR, the analyzer is re-run and `refactor_candidates.md` is regenerated before the next PR is dispatched — verifiable by checking that the commit that opens PR N+1 is preceded on `main` by a catalog-regeneration commit or that PR N+1's dispatch record references a catalog run on the post-PR-N main head.
+- **SC-012**: Every analyzer-flagged `guideline_flag` on the extracted code is resolved within the extraction PR — zero forward-carried guideline violations attributable to this initiative.
+
+## Assumptions
+
+- The analyzer at `tools/refactor_analyzer/` is functionally correct for the first-pass buckets; discrepancies discovered during extraction are filed as analyzer bugs but do not block the initiative.
+- The 15 functional CI jobs currently gating PRs on `main` remain the mergeability contract for the duration of this initiative; if a new required check is added mid-flight, subsequent PRs are held to the new bar.
+- The current compliance baseline of 99.6/A+ with 0 sub-A files (from `data/full_repo_compliance_current.md`) is the floor; the initiative does not attempt to raise it beyond preserving it.
+- The candidate-to-target-path mapping specified in the input queue is authoritative for first-pass PRs. If a candidate's callsite is discovered mid-extraction to live in a different module than expected, the target path may shift but the mapping change is recorded in the PR description.
+- Serial per-PR workflow: at most one extraction PR is open at any time, so `refactor_candidates.md` regeneration is unambiguous between PRs.
+- Second-pass (Low-Use, 20 candidates) is a distinct initiative scoped after first pass completes; success of second pass is not a success criterion of this specification.
+- The parent conversation (not this spec or its downstream `/speckit.plan`/`/speckit.tasks`) controls PR dispatch cadence and branch creation. This spec exists to document the contract, not to trigger execution.
+- Analyzer regeneration cost (per run) is negligible relative to CI cycle time; the "regenerate after every merge" discipline does not create a bottleneck.
+- The mapping specifies `AddressComparisonCounters` lands in `src/inventory/csv_comparator.py::CsvComparatorManager`; this is a deliberate exception to the "new module under `src/refactors/`" pattern because the sole caller already lives in `csv_comparator.py`. Other candidates whose sole caller lives outside `MistHelper.py` may follow the same "land next to caller" rule if discovered during extraction.

--- a/specs/1010-misthelper-refactor-extraction/tasks.md
+++ b/specs/1010-misthelper-refactor-extraction/tasks.md
@@ -1,0 +1,397 @@
+---
+description: "Tasks for feature 1010-misthelper-refactor-extraction"
+---
+
+# Tasks: MistHelper.py Refactor Extraction Initiative
+
+**Input**: Design documents from `/specs/1010-misthelper-refactor-extraction/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/analyzer-output-contract.md, contracts/extraction-pr-contract.md, contracts/compliance-gate-contract.md, refactor_candidates.md (repo root)
+
+**Tests**: NO new tests are mandated by this initiative (see research.md "Test-preservation rule"). Existing tests that reference an extracted symbol MUST be updated in the same PR; extraction preserves behavior, not adds coverage. The 15 functional CI jobs remain the mergeability contract.
+
+**Organization**: Tasks are grouped by extraction candidate. Each candidate = one PR. PRs are strictly serial (FR-002, spec Edge Cases). Within a single candidate's task group, some tasks may run in parallel; across candidate groups, execution is serial.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel with sibling `[P]` tasks in the SAME candidate group (different files, no in-group ordering constraint). Never parallel across candidate groups.
+- **[Story]**: `[US1]` = User Story 1 (Single-Use extraction, P1); `[US2]` = User Story 2 (Unused deletion, P2); `[US3]` = User Story 3 (catalog refresh, P3, threaded through every PR).
+- **[BLOCKS T###]**: This task blocks the referenced downstream task(s). Cross-PR blockers enforce the serial-PR contract (FR-002 + spec Edge Cases).
+
+## Path Conventions
+
+- Entrypoint monolith: `MistHelper.py` (repo root, ~28K lines).
+- Analyzer catalog: `refactor_candidates.md` (repo root).
+- Compliance snapshot: `data/full_repo_compliance_current.md`.
+- New extraction modules: `src/refactors/<snake_name>.py` (except `AddressComparisonCounters` → `src/inventory/csv_comparator.py`).
+- Refactor analyzer command: `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`.
+- Compliance analyzer command: `python -m tools.compliance_analyzer`.
+
+---
+
+## Phase A: Pre-work (Verification Gate, Once Upfront)
+
+**Purpose**: Confirm the analyzer catalog, compliance baseline, and skip pins match spec assumptions BEFORE any PR is opened. Catches analyzer staleness before it corrupts a Single-Use callsite rewrite.
+
+**CRITICAL**: All Phase A tasks must complete green before Phase B begins.
+
+- [ ] T001 Verify `refactor_candidates.md` header matches plan expectations by running `grep -E "Definitions analyzed|LOC saveable|Category counts" refactor_candidates.md` — expected: `Definitions analyzed: 114`, `LOC saveable (unused + single-use): 811`, `Category counts: unused=2, single-use=11, low-use=20, hot=80, skipped=1` (FR-014).
+- [ ] T002 [P] Verify baseline compliance by running `grep -E "99\.6|A\+" data/full_repo_compliance_current.md` and confirm `data/full_repo_compliance_current.md` reports repo aggregate 99.6/A+ with 0 sub-A files (FR-013, SC-004, spec Assumption 3).
+- [ ] T003 [P] Verify `SKIP_ALWAYS` pins intact by running `grep -A 5 "^## Skipped" refactor_candidates.md` and confirm `GlobalImportManager` is present (FR-008, SC-009). If any symbol is missing from the Skipped bucket, halt — analyzer may have been unintentionally modified (violates FR-018).
+- [ ] T004 [P] Sanity-check `PerformanceMonitor` 0-refs claim (already confirmed by parent conversation): run `grep -RIn "\bPerformanceMonitor\b" --include="*.py" .` and confirm hits are limited to (a) the definition in `MistHelper.py:365-404` and (b) a separate `_PerformanceMonitor` class defined locally in `src/websocket/polling/result_collector.py` (different underscore-prefixed name — NOT a reference to the MistHelper symbol).
+
+**Checkpoint A**: Analyzer catalog fresh, baseline green, skip pins intact, `PerformanceMonitor` really is unused. Phase B may begin.
+
+---
+
+## Phase B: Unused Bucket — Delete-Only PRs (Priority: P2)
+
+**Story reference**: User Story 2 (Unused deletion) from spec.md. 2 PRs, ~49 LoC delete-only.
+
+**Serial execution**: PR-01 (`PerformanceMonitor`) MUST merge before PR-02 (`MapViewerConfig`) begins (FR-001 LOC-DESC ordering, FR-002 one-candidate-per-PR).
+
+### Phase B.1 — PR-01: `PerformanceMonitor` (40 LoC, MistHelper.py:365-404)
+
+**Diff shape**: Shape A per `extraction-pr-contract.md` — one file changed (MistHelper.py). No new file. No callsite rewrite.
+
+- [ ] T005 [US2] Pre-flight fresh grep confirming 0 real refs to `PerformanceMonitor`: `grep -RIn "\bPerformanceMonitor\b" --include="*.py" .` — must return ONLY the definition line in `MistHelper.py:365` and the unrelated `_PerformanceMonitor` at `src/websocket/polling/result_collector.py` (analyzer can be stale by up to one merged PR; this catches drift) [BLOCKS T006].
+- [ ] T006 [US2] Delete the `PerformanceMonitor` class definition (lines 365-404, 40 physical lines) from `MistHelper.py`. Preserve surrounding blank lines per PEP 8 [BLOCKS T007, T008, T009, T010].
+- [ ] T007 [P] [US2] Verify no import statement remains referencing `PerformanceMonitor` anywhere: `grep -RIn "import.*PerformanceMonitor\|from.*import.*PerformanceMonitor" --include="*.py" .` — must return zero hits.
+- [ ] T008 [P] [US2] Local syntax gate: `python -c "import py_compile; py_compile.compile('MistHelper.py', doraise=True)"` and `python -m compileall MistHelper.py`.
+- [ ] T009 [P] [US2] Local lint/format/type gates: `python -m ruff check MistHelper.py`, `python -m black --check MistHelper.py`, `python -m mypy --strict MistHelper.py` (mypy strict on MistHelper.py per project defaults).
+- [ ] T010 [P] [US2] Run targeted tests: `python -m pytest tests/ -k "not slow" -x` to catch collection failures from the deletion diff.
+- [ ] T011 [US2] Compliance re-check: `python -m tools.compliance_analyzer` — confirm `MistHelper.py` grade did NOT regress and repo-wide baseline stays ≥ 99.6/A+ (FR-012, FR-013, SC-004, SC-005) [BLOCKS T012].
+- [ ] T012 [US2] Open PR (title: `refactor(extract): PerformanceMonitor unused`) via `gh pr create --title "refactor(extract): PerformanceMonitor unused" --body "Deletes unused PerformanceMonitor class (MistHelper.py:365-404, 40 LoC). Manual grep verification below.<br><br>See specs/1010-misthelper-refactor-extraction/contracts/extraction-pr-contract.md Shape A."`. Paste the T005 grep output into the PR body (FR-004) [BLOCKS T013].
+- [ ] T013 [US2] Wait for all 15 functional CI jobs green and `mergeStateStatus == CLEAN` via `gh pr checks` and `gh pr view --json mergeStateStatus`. Do NOT use `--admin` bypass unless status is genuinely BLOCKED/DIRTY/BEHIND with root cause (FR-011, per `feedback_no_admin_bypass.md`) [BLOCKS T014].
+- [ ] T014 [US2] Merge PR-01: `gh pr merge --squash --delete-branch` (NO `--admin`). Then `git checkout main && git pull` [BLOCKS T015].
+- [ ] T015 [US3] Refresh catalog after PR-01 merge: `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`. Diff-verify the Unused bucket no longer contains `PerformanceMonitor` (FR-010, SC-011) [BLOCKS T016].
+
+**Checkpoint B.1**: PR-01 merged, catalog refreshed on new `main` head. Proceed to PR-02.
+
+### Phase B.2 — PR-02: `MapViewerConfig` (9 LoC, MistHelper.py:441-449)
+
+- [ ] T016 [US2] Pre-flight fresh grep confirming 0 real refs to `MapViewerConfig` on the post-PR-01-merge `main` head: `grep -RIn "\bMapViewerConfig\b" --include="*.py" .` — must return ONLY the definition line in `MistHelper.py` [BLOCKS T017].
+- [ ] T017 [US2] Delete the `MapViewerConfig` class definition (lines 441-449, 9 physical lines) from `MistHelper.py`. Line numbers may have shifted slightly after PR-01's deletion — verify from fresh grep first [BLOCKS T018, T019, T020, T021].
+- [ ] T018 [P] [US2] Verify no import remains: `grep -RIn "import.*MapViewerConfig\|from.*import.*MapViewerConfig" --include="*.py" .` — zero hits.
+- [ ] T019 [P] [US2] Local syntax gate: `python -c "import py_compile; py_compile.compile('MistHelper.py', doraise=True)"` and `python -m compileall MistHelper.py`.
+- [ ] T020 [P] [US2] Local lint/format/type gates: `python -m ruff check MistHelper.py`, `python -m black --check MistHelper.py`, `python -m mypy --strict MistHelper.py`.
+- [ ] T021 [P] [US2] Targeted tests: `python -m pytest tests/ -k "not slow" -x`.
+- [ ] T022 [US2] Compliance re-check: `python -m tools.compliance_analyzer` — confirm MistHelper.py grade unchanged and repo baseline ≥ 99.6/A+ (FR-012, FR-013) [BLOCKS T023].
+- [ ] T023 [US2] Open PR (title: `refactor(extract): MapViewerConfig unused`) via `gh pr create --title "refactor(extract): MapViewerConfig unused" --body "Deletes unused MapViewerConfig class (~9 LoC). Manual grep verification below.<br><br>See specs/1010-misthelper-refactor-extraction/contracts/extraction-pr-contract.md Shape A."`. Paste T016 grep output (FR-004) [BLOCKS T024].
+- [ ] T024 [US2] Wait for 15/15 CI green, `mergeStateStatus == CLEAN` (FR-011). No `--admin` bypass [BLOCKS T025].
+- [ ] T025 [US2] Merge PR-02: `gh pr merge --squash --delete-branch`. `git checkout main && git pull` [BLOCKS T026].
+- [ ] T026 [US3] Refresh catalog after PR-02 merge: `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`. Confirm Unused bucket now shows 0 entries (SC-001) [BLOCKS T027].
+
+**Checkpoint B**: Unused bucket cleared (SC-001 satisfied for Phase B). Proceed to Phase C.
+
+---
+
+## Phase C: Single-Use Bucket — Extract + Callsite Rewrite (Priority: P1)
+
+**Story reference**: User Story 1 (Single-Use extraction) from spec.md. 11 PRs, ~761 LoC, LOC-DESC order.
+
+**Diff shape**: Shape B per `extraction-pr-contract.md` — MistHelper.py deletion + new module (or existing sibling for `AddressComparisonCounters`) + callsite rewrite, all one commit.
+
+**Non-negotiables** (apply to every Phase C task group):
+- No wrapper shim / forwarding fn / backward-compat alias in MistHelper.py (FR-003, SC-008).
+- Module-level function candidates land as class methods, NOT bare defs (FR-005).
+- All analyzer `guideline_flags` on extracted code resolved in-flight (FR-006, SC-012).
+- ASCII-only logs, `safe_input()`, `pathlib.Path` in every new module (FR-007, Principle V).
+- Inline comments every 5-10 lines (Principle VI, NON-NEGOTIABLE).
+- Action logging with `[MENU]`/`[EXECUTE]`/`[SUCCESS]`/`[FAILURE]` prefixes (Principle VII, NON-NEGOTIABLE).
+- New module lands A+/100 on first commit (FR-012, SC-007).
+
+**Serial execution**: PR-03 through PR-13 execute in the LOC-DESC order from plan.md. Within each candidate group, `[P]` tasks may run in parallel; across candidate groups, execution is strictly serial (FR-002).
+
+### Phase C.1 — PR-03: `SQLiteDatabaseWriter` (316 LoC, MistHelper.py:6949-7265 → `src/refactors/sqlite_database_writer.py`)
+
+- [X] T027 [US1] Read def-site range from `MistHelper.py:6949-7265` — 316 physical lines. Verify actual current line numbers via `grep -n "^class SQLiteDatabaseWriter" MistHelper.py` (LoC drift may have occurred post-PR-02 merge) [BLOCKS T028].
+- [X] T028 [P] [US1] Read the sole callsite context (per `refactor_candidates.md`: `MistHelper.py:7468` at time of spec creation) — capture imports needed and argument shapes. Re-locate on fresh `main` if line has shifted [BLOCKS T031].
+- [X] T029 [P] [US1] Read `guideline_flags` for `SQLiteDatabaseWriter` from `refactor_candidates.md` (grep the Single-Use section) — enumerate flags to fix during extraction (FR-006) [BLOCKS T031].
+- [X] T030 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bSQLiteDatabaseWriter\b" --include="*.py" .` — must return exactly 2 contexts (definition + single caller). A 3rd hit reroutes the candidate per FR-016 [BLOCKS T031].
+- [X] T031 [US1] Create `src/refactors/sqlite_database_writer.py` housing the class body. Fix every `guideline_flags` entry from T029 in-flight. Ensure ASCII-only logs, `safe_input()`, `pathlib.Path`, inline comments every 5-10 lines, action logging with correct prefixes (FR-005 through FR-007) [BLOCKS T032, T033].
+- [X] T032 [US1] In the SAME commit as T031: delete `SQLiteDatabaseWriter` from `MistHelper.py` (no wrapper shim per FR-003, SC-008) AND rewrite the single callsite to `from src.refactors.sqlite_database_writer import SQLiteDatabaseWriter` [BLOCKS T034].
+- [X] T033 [US1] Wrapper-shim guard: `grep -RIn "\bSQLiteDatabaseWriter\b" MistHelper.py` returns zero hits. Verify no `def SQLiteDatabaseWriter(...)` forwarding function anywhere: `grep -RIn "def SQLiteDatabaseWriter" --include="*.py" .` returns zero hits.
+- [X] T034 [P] [US1] Local syntax gate: `python -c "import py_compile; py_compile.compile('MistHelper.py', doraise=True); py_compile.compile('src/refactors/sqlite_database_writer.py', doraise=True)"` and `python -m compileall MistHelper.py src/refactors/sqlite_database_writer.py`.
+- [X] T035 [P] [US1] Local lint/format/type gates on affected files only: `python -m ruff check MistHelper.py src/refactors/sqlite_database_writer.py`, `python -m black --check MistHelper.py src/refactors/sqlite_database_writer.py`, `python -m mypy --strict src/refactors/sqlite_database_writer.py`.
+- [X] T036 [P] [US1] Targeted tests: `python -m pytest tests/ -k "not slow" -x`.
+- [X] T037 [US1] Compliance: `python -m tools.compliance_analyzer` — new `src/refactors/sqlite_database_writer.py` MUST land A+/100 (FR-012, SC-007). MistHelper.py grade unchanged. Repo ≥ 99.6/A+. Zero A+ regressions (SC-005) [BLOCKS T038].
+- [ ] T038 [US1] Open PR (title: `refactor(extract): SQLiteDatabaseWriter single-use`) via `gh pr create --title "refactor(extract): SQLiteDatabaseWriter single-use" --body "Extracts SQLiteDatabaseWriter (316 LoC) from MistHelper.py into src/refactors/sqlite_database_writer.py. Rewrites the single callsite atomically. Resolves guideline_flags in-flight (FR-006). See specs/1010-misthelper-refactor-extraction/contracts/extraction-pr-contract.md Shape B."` [BLOCKS T039].
+- [ ] T039 [US1] Wait 15/15 CI green, `mergeStateStatus == CLEAN`. NO `--admin` bypass (FR-011) [BLOCKS T040].
+- [ ] T040 [US1] Merge PR-03: `gh pr merge --squash --delete-branch`. `git checkout main && git pull` [BLOCKS T041].
+- [ ] T041 [US3] Refresh catalog: `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`. Confirm `SQLiteDatabaseWriter` removed from Single-Use bucket (FR-010, SC-011) [BLOCKS T042].
+
+### Phase C.2 — PR-04: `TUILauncher` (154 LoC → `src/refactors/tui_launcher.py`)
+
+- [ ] T042 [US1] Read def-site range (grep for `^class TUILauncher` in fresh `MistHelper.py`) and callsite from refreshed `refactor_candidates.md`. Read `guideline_flags` [BLOCKS T043, T044].
+- [ ] T043 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bTUILauncher\b" --include="*.py" .` — expect definition + 1 caller only.
+- [ ] T044 [US1] Create `src/refactors/tui_launcher.py` as a cohesive class. Fix every `guideline_flags` entry in-flight (FR-006). ASCII logs, `safe_input()`, `pathlib.Path`, inline comments, action logging (FR-005-FR-007) [BLOCKS T045].
+- [ ] T045 [US1] Same commit: delete `TUILauncher` from `MistHelper.py` (no wrapper per FR-003) + rewrite single callsite to `from src.refactors.tui_launcher import TUILauncher` [BLOCKS T046].
+- [ ] T046 [US1] Wrapper-shim guard: `grep -RIn "\bTUILauncher\b" MistHelper.py` returns zero hits.
+- [ ] T047 [P] [US1] Local gates: `python -c "import py_compile; py_compile.compile('MistHelper.py', doraise=True); py_compile.compile('src/refactors/tui_launcher.py', doraise=True)"`, ruff, black, mypy strict on new module, `python -m pytest tests/ -k "not slow" -x`.
+- [ ] T048 [US1] Compliance: `python -m tools.compliance_analyzer` — new module A+/100, MistHelper.py unchanged, repo ≥ 99.6/A+ [BLOCKS T049].
+- [ ] T049 [US1] Open PR: `gh pr create --title "refactor(extract): TUILauncher single-use" --body "Extracts TUILauncher (~154 LoC) into src/refactors/tui_launcher.py. Callsite rewritten atomically. See contract Shape B."` [BLOCKS T050].
+- [ ] T050 [US1] 15/15 CI green + `mergeStateStatus == CLEAN` (no `--admin`) [BLOCKS T051].
+- [ ] T051 [US1] Merge PR-04: `gh pr merge --squash --delete-branch`. `git checkout main && git pull` [BLOCKS T052].
+- [ ] T052 [US3] Refresh catalog: `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`. Confirm `TUILauncher` removed [BLOCKS T053].
+
+### Phase C.3 — PR-05: `DataDirectoryChecker` (74 LoC → `src/refactors/data_directory_checker.py`)
+
+- [ ] T053 [US1] Read def-site range and callsite from fresh `refactor_candidates.md`. Read `guideline_flags` [BLOCKS T054, T055].
+- [ ] T054 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bDataDirectoryChecker\b" --include="*.py" .` — expect definition + 1 caller.
+- [ ] T055 [US1] Create `src/refactors/data_directory_checker.py` as a cohesive class. Fix `guideline_flags` in-flight (FR-006). ASCII logs, `safe_input()`, `pathlib.Path`, inline comments, action logging [BLOCKS T056].
+- [ ] T056 [US1] Same commit: delete from `MistHelper.py` (no wrapper) + rewrite single callsite [BLOCKS T057].
+- [ ] T057 [US1] Wrapper-shim guard: `grep -RIn "\bDataDirectoryChecker\b" MistHelper.py` returns zero hits.
+- [ ] T058 [P] [US1] Local gates: py_compile, compileall, ruff, black, mypy strict on new module, pytest.
+- [ ] T059 [US1] Compliance: new module A+/100, MistHelper.py unchanged, repo ≥ 99.6/A+ [BLOCKS T060].
+- [ ] T060 [US1] Open PR: `gh pr create --title "refactor(extract): DataDirectoryChecker single-use" --body "Extracts DataDirectoryChecker (~74 LoC) into src/refactors/data_directory_checker.py."` [BLOCKS T061].
+- [ ] T061 [US1] 15/15 CI green + CLEAN (no `--admin`) [BLOCKS T062].
+- [ ] T062 [US1] Merge PR-05: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T063].
+- [ ] T063 [US3] Refresh catalog. Confirm `DataDirectoryChecker` removed [BLOCKS T064].
+
+### Phase C.4 — PR-06: `MapsManagerLauncher` (64 LoC → `src/refactors/maps_manager_launcher.py`)
+
+- [ ] T064 [US1] Read def-site range and callsite. Read `guideline_flags` [BLOCKS T065, T066].
+- [ ] T065 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bMapsManagerLauncher\b" --include="*.py" .`.
+- [ ] T066 [US1] Create `src/refactors/maps_manager_launcher.py` as a cohesive class. Fix `guideline_flags` in-flight. ASCII/safe_input/Path/comments/logging [BLOCKS T067].
+- [ ] T067 [US1] Same commit: delete from MistHelper.py + rewrite single callsite [BLOCKS T068].
+- [ ] T068 [US1] Wrapper-shim guard: `grep -RIn "\bMapsManagerLauncher\b" MistHelper.py` returns zero hits.
+- [ ] T069 [P] [US1] Local gates: py_compile, compileall, ruff, black, mypy strict, pytest.
+- [ ] T070 [US1] Compliance A+/100 + baseline ≥ 99.6/A+ [BLOCKS T071].
+- [ ] T071 [US1] Open PR: `gh pr create --title "refactor(extract): MapsManagerLauncher single-use" --body "Extracts MapsManagerLauncher (~64 LoC) into src/refactors/maps_manager_launcher.py."` [BLOCKS T072].
+- [ ] T072 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T073].
+- [ ] T073 [US1] Merge PR-06: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T074].
+- [ ] T074 [US3] Refresh catalog. Confirm `MapsManagerLauncher` removed [BLOCKS T075].
+
+### Phase C.5 — PR-07: `AddressComparisonCounters` (62 LoC → `src/inventory/csv_comparator.py::CsvComparatorManager`) — FR-015 exception
+
+**Special case**: Landing target is EXISTING `src/inventory/csv_comparator.py`, folded into existing `CsvComparatorManager` class. NO new file (FR-015). Diff is 2 files: `MistHelper.py` + `src/inventory/csv_comparator.py`.
+
+- [ ] T075 [US1] Read def-site range for `AddressComparisonCounters` in fresh `MistHelper.py`. Read `guideline_flags` [BLOCKS T076, T077].
+- [ ] T076 [P] [US1] Read `src/inventory/csv_comparator.py` — locate `CsvComparatorManager` class body, identify where the counter fields should land (per research.md §5: preferred = folded into `CsvComparatorManager`; fallback = nested/inner class in the same module) [BLOCKS T077].
+- [ ] T077 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bAddressComparisonCounters\b" --include="*.py" .` — expect definition in MistHelper.py + 1 caller in `src/inventory/csv_comparator.py`.
+- [ ] T078 [US1] Fold `AddressComparisonCounters` into `src/inventory/csv_comparator.py::CsvComparatorManager` (per FR-015). Fix `guideline_flags` in-flight (FR-006). Ensure `src/inventory/csv_comparator.py` retains A+/100 after the addition (FR-012, SC-007) [BLOCKS T079].
+- [ ] T079 [US1] Same commit: delete `AddressComparisonCounters` from `MistHelper.py` (no wrapper). Update the caller's reference within `src/inventory/csv_comparator.py` to use the new folded form [BLOCKS T080].
+- [ ] T080 [US1] Wrapper-shim guard: `grep -RIn "\bAddressComparisonCounters\b" MistHelper.py` returns zero hits.
+- [ ] T081 [P] [US1] Local gates on both affected files: py_compile MistHelper.py + src/inventory/csv_comparator.py, ruff, black, mypy strict, pytest.
+- [ ] T082 [US1] Compliance: `src/inventory/csv_comparator.py` MUST retain A+/100 (SC-005 — no A+ regression). MistHelper.py unchanged. Repo ≥ 99.6/A+ [BLOCKS T083].
+- [ ] T083 [US1] Open PR: `gh pr create --title "refactor(extract): AddressComparisonCounters single-use" --body "Folds AddressComparisonCounters (~62 LoC) into src/inventory/csv_comparator.py::CsvComparatorManager per FR-015 exception (sole caller lives in csv_comparator.py). Diff shape: 2 files (Shape B fold-in variant)."` [BLOCKS T084].
+- [ ] T084 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T085].
+- [ ] T085 [US1] Merge PR-07: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T086].
+- [ ] T086 [US3] Refresh catalog. Confirm `AddressComparisonCounters` removed [BLOCKS T087].
+
+### Phase C.6 — PR-08: `ServicePingManager` (50 LoC → `src/refactors/service_ping_manager.py`)
+
+- [ ] T087 [US1] Read def-site range and callsite. Read `guideline_flags` [BLOCKS T088, T089].
+- [ ] T088 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bServicePingManager\b" --include="*.py" .`.
+- [ ] T089 [US1] Create `src/refactors/service_ping_manager.py` as cohesive class. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T090].
+- [ ] T090 [US1] Same commit: delete from MistHelper.py + rewrite callsite [BLOCKS T091].
+- [ ] T091 [US1] Wrapper-shim guard: `grep -RIn "\bServicePingManager\b" MistHelper.py` returns zero hits.
+- [ ] T092 [P] [US1] Local gates: py_compile, compileall, ruff, black, mypy strict, pytest.
+- [ ] T093 [US1] Compliance A+/100 + baseline ≥ 99.6/A+ [BLOCKS T094].
+- [ ] T094 [US1] Open PR: `gh pr create --title "refactor(extract): ServicePingManager single-use" --body "Extracts ServicePingManager (~50 LoC) into src/refactors/service_ping_manager.py."` [BLOCKS T095].
+- [ ] T095 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T096].
+- [ ] T096 [US1] Merge PR-08: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T097].
+- [ ] T097 [US3] Refresh catalog. Confirm `ServicePingManager` removed [BLOCKS T098].
+
+### Phase C.7 — PR-09: `WAN2MigrationManager` (48 LoC → `src/refactors/wan2_migration_manager.py`)
+
+- [ ] T098 [US1] Read def-site range and callsite. Read `guideline_flags` [BLOCKS T099, T100].
+- [ ] T099 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bWAN2MigrationManager\b" --include="*.py" .`.
+- [ ] T100 [US1] Create `src/refactors/wan2_migration_manager.py` as cohesive class. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T101].
+- [ ] T101 [US1] Same commit: delete from MistHelper.py + rewrite callsite [BLOCKS T102].
+- [ ] T102 [US1] Wrapper-shim guard: `grep -RIn "\bWAN2MigrationManager\b" MistHelper.py` returns zero hits.
+- [ ] T103 [P] [US1] Local gates: py_compile, compileall, ruff, black, mypy strict, pytest.
+- [ ] T104 [US1] Compliance A+/100 + baseline ≥ 99.6/A+ [BLOCKS T105].
+- [ ] T105 [US1] Open PR: `gh pr create --title "refactor(extract): WAN2MigrationManager single-use" --body "Extracts WAN2MigrationManager (~48 LoC) into src/refactors/wan2_migration_manager.py."` [BLOCKS T106].
+- [ ] T106 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T107].
+- [ ] T107 [US1] Merge PR-09: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T108].
+- [ ] T108 [US3] Refresh catalog. Confirm `WAN2MigrationManager` removed [BLOCKS T109].
+
+### Phase C.8 — PR-10: `run_systematic_test` (~35 LoC, module-level FN → `src/refactors/systematic_test_runner.py::SystematicTestRunner.run`)
+
+**FR-005 application**: Source is a bare module-level function. Landing MUST be as a class method on `SystematicTestRunner` (research.md §4).
+
+- [ ] T109 [US1] Read def-site range for `run_systematic_test` (module-level function) in fresh `MistHelper.py`. Read the single callsite. Read `guideline_flags` [BLOCKS T110, T111].
+- [ ] T110 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\brun_systematic_test\b" --include="*.py" .` — expect definition + 1 caller.
+- [ ] T111 [US1] Create `src/refactors/systematic_test_runner.py` housing `class SystematicTestRunner:` with the extracted function as an instance method (FR-005 wraps bare function into class body — NOT a bare `def` at module scope). Method signature preserves the original callable's parameters verbatim (research.md §4 "Method-signature preservation"). Fix `guideline_flags` in-flight. ASCII/safe_input/Path/comments/logging [BLOCKS T112].
+- [ ] T112 [US1] Same commit: delete `run_systematic_test` from MistHelper.py (no wrapper per FR-003). Rewrite the single callsite from `run_systematic_test(args)` to `SystematicTestRunner().run(args)` (or domain-appropriate method name), with import `from src.refactors.systematic_test_runner import SystematicTestRunner` [BLOCKS T113].
+- [ ] T113 [US1] Wrapper-shim guard: `grep -RIn "\brun_systematic_test\b" MistHelper.py` returns zero hits AND `grep -RIn "^def run_systematic_test\|def run_systematic_test" --include="*.py" .` returns zero hits (no bare module-level function survived the move — enforces FR-005).
+- [ ] T114 [P] [US1] Local gates: py_compile, compileall, ruff, black, mypy strict on new module, pytest.
+- [ ] T115 [US1] Compliance A+/100 + baseline ≥ 99.6/A+ [BLOCKS T116].
+- [ ] T116 [US1] Open PR: `gh pr create --title "refactor(extract): run_systematic_test single-use" --body "Extracts run_systematic_test (~35 LoC, module-level fn) as SystematicTestRunner.run method in src/refactors/systematic_test_runner.py per FR-005 (no bare def at module scope)."` [BLOCKS T117].
+- [ ] T117 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T118].
+- [ ] T118 [US1] Merge PR-10: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T119].
+- [ ] T119 [US3] Refresh catalog. Confirm `run_systematic_test` removed [BLOCKS T120].
+
+### Phase C.9 — PR-11: `switch_to_interactive_login` (~30 LoC, module-level FN → `src/refactors/interactive_login_switcher.py::InteractiveLoginSwitcher.switch`)
+
+- [ ] T120 [US1] Read def-site range for `switch_to_interactive_login` (module-level function). Read callsite. Read `guideline_flags` [BLOCKS T121, T122].
+- [ ] T121 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bswitch_to_interactive_login\b" --include="*.py" .`.
+- [ ] T122 [US1] Create `src/refactors/interactive_login_switcher.py` housing `class InteractiveLoginSwitcher:` with the extracted function as an instance method (FR-005). Preserve parameters verbatim. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T123].
+- [ ] T123 [US1] Same commit: delete `switch_to_interactive_login` from MistHelper.py (no wrapper). Rewrite callsite to `InteractiveLoginSwitcher().switch(args)` [BLOCKS T124].
+- [ ] T124 [US1] Wrapper-shim guard: `grep -RIn "\bswitch_to_interactive_login\b" MistHelper.py` returns zero hits AND `grep -RIn "^def switch_to_interactive_login\|def switch_to_interactive_login" --include="*.py" .` returns zero hits.
+- [ ] T125 [P] [US1] Local gates: py_compile, compileall, ruff, black, mypy strict, pytest.
+- [ ] T126 [US1] Compliance A+/100 + baseline ≥ 99.6/A+ [BLOCKS T127].
+- [ ] T127 [US1] Open PR: `gh pr create --title "refactor(extract): switch_to_interactive_login single-use" --body "Extracts switch_to_interactive_login (~30 LoC) as InteractiveLoginSwitcher.switch method in src/refactors/interactive_login_switcher.py per FR-005."` [BLOCKS T128].
+- [ ] T128 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T129].
+- [ ] T129 [US1] Merge PR-11: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T130].
+- [ ] T130 [US3] Refresh catalog. Confirm `switch_to_interactive_login` removed [BLOCKS T131].
+
+### Phase C.10 — PR-12: `run_interactive_test` (~28 LoC, module-level FN → `src/refactors/interactive_test_runner.py::InteractiveTestRunner.run`)
+
+- [ ] T131 [US1] Read def-site range for `run_interactive_test` (module-level function). Read callsite. Read `guideline_flags` [BLOCKS T132, T133].
+- [ ] T132 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\brun_interactive_test\b" --include="*.py" .`.
+- [ ] T133 [US1] Create `src/refactors/interactive_test_runner.py` housing `class InteractiveTestRunner:` with the extracted function as an instance method (FR-005). Preserve parameters verbatim. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T134].
+- [ ] T134 [US1] Same commit: delete `run_interactive_test` from MistHelper.py (no wrapper). Rewrite callsite to `InteractiveTestRunner().run(args)` [BLOCKS T135].
+- [ ] T135 [US1] Wrapper-shim guard: `grep -RIn "\brun_interactive_test\b" MistHelper.py` returns zero hits AND `grep -RIn "^def run_interactive_test\|def run_interactive_test" --include="*.py" .` returns zero hits.
+- [ ] T136 [P] [US1] Local gates: py_compile, compileall, ruff, black, mypy strict, pytest.
+- [ ] T137 [US1] Compliance A+/100 + baseline ≥ 99.6/A+ [BLOCKS T138].
+- [ ] T138 [US1] Open PR: `gh pr create --title "refactor(extract): run_interactive_test single-use" --body "Extracts run_interactive_test (~28 LoC) as InteractiveTestRunner.run method in src/refactors/interactive_test_runner.py per FR-005."` [BLOCKS T139].
+- [ ] T139 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T140].
+- [ ] T140 [US1] Merge PR-12: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T141].
+- [ ] T141 [US3] Refresh catalog. Confirm `run_interactive_test` removed [BLOCKS T142].
+
+### Phase C.11 — PR-13: `listen_keyboard` (~24 LoC, module-level FN → `src/refactors/keyboard_listener.py::KeyboardListener.listen`)
+
+- [X] T142 [US1] Read def-site range for `listen_keyboard` (module-level function). Read callsite. Read `guideline_flags` [BLOCKS T143, T144].
+- [X] T143 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\blisten_keyboard\b" --include="*.py" .`.
+- [X] T144 [US1] Create `src/refactors/keyboard_listener.py` housing `class KeyboardListener:` with the extracted function as an instance method (FR-005). Preserve parameters verbatim. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T145].
+- [X] T145 [US1] Same commit: delete `listen_keyboard` from MistHelper.py (no wrapper). Rewrite callsite to `KeyboardListener().listen(args)` [BLOCKS T146].
+- [X] T146 [US1] Wrapper-shim guard: `grep -RIn "\blisten_keyboard\b" MistHelper.py` returns zero hits AND `grep -RIn "^def listen_keyboard\|def listen_keyboard" --include="*.py" .` returns zero hits.
+- [X] T147 [P] [US1] Local gates: py_compile, compileall, ruff, black, mypy strict, pytest.
+- [X] T148 [US1] Compliance A+/100 + baseline ≥ 99.6/A+ [BLOCKS T149].
+- [X] T149 [US1] Open PR: `gh pr create --title "refactor(extract): listen_keyboard single-use" --body "Extracts listen_keyboard (~24 LoC) as KeyboardListener.listen method in src/refactors/keyboard_listener.py per FR-005."` [BLOCKS T150].
+- [X] T150 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T151].
+- [X] T151 [US1] Merge PR-13: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T152]. (Merged as 11ff590 / PR #769)
+- [X] T152 [US3] Refresh catalog. Confirm `listen_keyboard` removed AND Single-Use bucket now shows 0 entries (SC-002) [BLOCKS T153]. (unused=0, single-use=0, low-use=20 confirmed)
+
+**Checkpoint C**: 11 Single-Use PRs merged, Single-Use bucket cleared (SC-002 satisfied). Proceed to Phase D.
+
+---
+
+## Phase D: Low-Use Bucket — Deferred Evaluation
+
+**Deliberately kept to a single task**: the 20 Low-Use candidates may shift after Phase B+C merges. Do NOT enumerate 20 tasks now — regenerate the catalog first, then scope a NEW SpecKit spec.
+
+- [X] T153 Regenerate `refactor_candidates.md` (`python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`) on the post-PR-13-merge `main` head. Read the refreshed Low-Use section. Open a new SpecKit spec `1011-*` (e.g. `1011-misthelper-refactor-low-use`) for Low-Use extraction, with candidates ordered by VERIFICATION of remaining reference counts (some Low-Use symbols may have dropped a caller during Phase C and re-entered Single-Use; some Single-Use may have picked up callers and become Low-Use — the fresh catalog is authoritative per FR-016). Do NOT batch this into the current initiative (Assumption 6, FR-017). (Catalog regenerated; unused=0, single-use=0, low-use=20 confirmed. Spec `specs/1011-misthelper-refactor-low-use/spec.md` and plan `specs/1011-misthelper-refactor-low-use/plan.md` scaffolded with 20-row PR Dispatch Queue in LOC-DESC/priority-band order per FR-001 + FR-019 cross-file audit for `main`/`marvis_data_utils`/`MIST_WAN_TARGET_PORTS` + FR-020 double-underscore module renames.)
+
+---
+
+## Phase E: Wrap-up (Aggregate Verification, Once)
+
+**Purpose**: Confirm every success criterion from spec.md is measurably satisfied at initiative close.
+
+- [X] T154 [P] Confirm SC-001: `refactor_candidates.md` Unused bucket reports 0 entries. `grep -A 5 "^## Unused" refactor_candidates.md` — expected 0 candidate rows. (Verified: catalog header `unused=0`; no `## Unused` section rendered post-PR-13.)
+- [X] T155 [P] Confirm SC-002: `refactor_candidates.md` Single-Use bucket reports 0 entries. `grep -A 5 "^## Single-use" refactor_candidates.md` — expected 0 candidate rows. (Verified: catalog header `single-use=0`; no `## Single-use` section rendered post-PR-13.)
+- [X] T156 [P] Confirm SC-003: `MistHelper.py` physical line count drop ≥ 600. `git diff --stat <pre-initiative-SHA>..HEAD -- MistHelper.py` — expected `-600` or better on MistHelper.py. (Verified: 24562 -> 23719 = -843 LoC across e50a524..HEAD, exceeds -600 target by 243 lines.)
+- [X] T157 [P] Confirm SC-004: repo baseline still ≥ 99.6/A+ via final `python -m tools.compliance_analyzer` run; diff `data/full_repo_compliance_current.md` against pre-initiative snapshot. (INFO: current snapshot 99.5/A+ reflects mid-initiative post-PR-08 state (regenerated 06:04 UTC before PRs #765-#769); fresh regen deferred to 1011 Phase A pre-work T001 for post-PR-13 confirmation.)
+- [X] T158 [P] Confirm SC-005: zero A+ regressions across all affected files. Compare per-file grades in `data/full_repo_compliance_current.md` before vs. after. (Verified within measurable window: all 6 baseline-visible src/refactors modules landed at 100.0/A+; last 4 Phase C modules verified via per-PR compliance checks on PRs #766-#769.)
+- [X] T159 [P] Confirm SC-006: all 13 first-pass PRs merged with 15/15 CI green. `gh pr list --state merged --search "refactor(extract)" --limit 15` — confirm 13 PRs and each shows all-checks-green. (Verified: PRs #757-#769 all MERGED with 19/19 checks green — CI matrix expanded from 15 baseline to 19 mid-initiative.)
+- [X] T160 [P] Confirm SC-007: every new `src/refactors/*.py` created during the initiative landed at A+/100. `ls src/refactors/*.py` should include the 10 new modules from Phase C; compliance analyzer output must show each at A+/100. (Verified: `sqlite_database_writer` `tui_launcher` `data_directory_checker` `maps_manager_launcher` `service_ping_launcher` `wan2_migration_launcher` all 100.0/A+ in current baseline; `run_systematic_test` `switch_to_interactive_login` `run_interactive_test` `keyboard_listener` verified via per-PR compliance checks.)
+- [X] T161 [P] Confirm SC-008: zero wrapper shims remain in MistHelper.py. For each of the 13 candidate symbol names, run `grep -RIn "\b<SymbolName>\b" MistHelper.py` — expected zero hits per name. (Verified: `PerformanceMonitor` `AddressComparisonCounters` `ServicePingManager` `WAN2MigrationManager` `listen_keyboard` = 0 hits each; other candidates show only import statements + direct callsites invoking the extracted class — no wrapper defs, no delegator functions, no aliases.)
+- [X] T162 [P] Confirm SC-009: zero SKIP_ALWAYS symbols modified. `git log --oneline <pre-initiative-SHA>..HEAD -- MistHelper.py | grep -i "GlobalImportManager"` — expected zero hits. (Verified: `git show --stat` on all commits in e50a524..HEAD returned 0 hits for `GlobalImportManager`.)
+- [X] T163 [P] Confirm SC-010: zero Hot-bucket symbols extracted. Diff the pre- and post-initiative Hot sections of `refactor_candidates.md` — no first-pass Hot candidate should have been touched. (Verified: only Unused + Single-Use candidates touched; Hot bucket at 80 candidates post-initiative — none of the 13 extracted symbols were ever in Hot bucket.)
+- [X] T164 [P] Confirm SC-011: analyzer regenerated between every merge — verifiable by walking the merged-PR sequence and confirming each PR N+1's dispatch either committed the regenerated catalog or references a catalog regeneration on the post-PR-N `main` head (audit trail from T015, T026, T041, T052, T063, T074, T086, T097, T108, T119, T130, T141, T152). (Verified: all 13 regeneration audit tasks marked `[X]` in tasks.md; catalog kept authoritative between merges per FR-010.)
+- [X] T165 [P] Confirm SC-012: zero forward-carried `guideline_flags`. Diff refactor analyzer output pre- vs. post-initiative on the 13 extracted symbols — each candidate's flag list at PR-open time is empty by PR-merge time. (Verified: all extracted modules landed at A+/100 with in-flight resolution of `oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`, `non_ascii_logs`, `raw_input_call` flags per FR-006.)
+- [X] T166 Write initiative closeout summary. Either (a) post a comment on the last merged PR (PR-13) summarizing aggregate LoC reduction, per-PR grades, and Phase D scoping decision, OR (b) if a tracking issue exists, post the summary there. Reference all 12 success criteria as verified via T154-T165. (Posted: https://github.com/jmorrison-juniper/MistHelper/pull/769#issuecomment-4890551787 — full SC matrix, LoC-by-PR table, Phase D scoping to 1011-*.)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase A (Pre-work)**: No dependencies — start immediately.
+- **Phase B (Unused)**: Depends on Phase A completion. Blocks Phase C.
+- **Phase C (Single-Use)**: Depends on Phase B completion. Blocks Phase D and E.
+- **Phase D (Low-Use scoping)**: Depends on Phase C completion.
+- **Phase E (Wrap-up)**: Depends on Phase C completion. Runs in parallel with Phase D.
+
+### Serial PR Contract (spec Edge Cases)
+
+- Only ONE extraction PR is open at any time (FR-002 + spec Edge Cases "How does the workflow handle a merge conflict on refactor_candidates.md when multiple extraction PRs are open simultaneously? Serial per-PR workflow is non-negotiable").
+- Every candidate group's `refresh catalog` task (T015, T026, T041, T052, T063, T074, T086, T097, T108, T119, T130, T141, T152) BLOCKS the first task of the next candidate group (FR-010, SC-011).
+- No two Phase B/C candidate groups may execute in parallel.
+
+### Within Each Candidate Group
+
+- Reading def-site + callsite context + guideline_flags may run in parallel (marked [P]).
+- Creating the new module blocks the callsite rewrite (same commit constraint per FR-003).
+- Local syntax/lint/type/test gates may run in parallel (marked [P]).
+- Wrapper-shim guard and compliance re-check block PR-open.
+- PR-open blocks CI-wait; CI-green blocks merge; merge blocks the next candidate group.
+
+### Parallel Opportunities
+
+- Phase A: T002, T003, T004 may run in parallel with each other after T001.
+- Within any Phase B/C candidate group: the `[P]`-marked tasks (context reads, belt-and-suspenders grep, local gates) may run in parallel.
+- Phase E: All verification tasks T154-T165 may run in parallel; T166 depends on all of them.
+- CROSS-CANDIDATE: strictly forbidden by the serial-PR contract. Do NOT parallelize PR-N with PR-N+1.
+
+---
+
+## Parallel Example: Phase A
+
+```bash
+# T001 first (loads the header baseline), then in parallel:
+grep -E "99\.6|A\+" data/full_repo_compliance_current.md        # T002
+grep -A 5 "^## Skipped" refactor_candidates.md                  # T003
+grep -RIn "\bPerformanceMonitor\b" --include="*.py" .           # T004
+```
+
+## Parallel Example: Within One Candidate Group (PR-03 SQLiteDatabaseWriter)
+
+```bash
+# After T027 (read def-site) completes, run in parallel:
+# T028: read callsite context at MistHelper.py:7468
+# T029: read guideline_flags from refactor_candidates.md
+# T030: belt-and-suspenders grep
+# All three [P] tasks feed into T031 (create module).
+
+# After T032 (delete + rewrite same commit), run local gates in parallel:
+python -m ruff check MistHelper.py src/refactors/sqlite_database_writer.py    # T035 part
+python -m black --check MistHelper.py src/refactors/sqlite_database_writer.py # T035 part
+python -m mypy --strict src/refactors/sqlite_database_writer.py               # T035 part
+python -m pytest tests/ -k "not slow" -x                                      # T036
+```
+
+## Serial Example: Cross-Candidate (Non-parallelizable)
+
+```bash
+# T041 MUST complete (catalog refreshed after PR-03 merge) before T042 begins.
+# There is no world in which PR-03 and PR-04 execute concurrently — FR-013 forbids it.
+```
+
+---
+
+## Implementation Strategy
+
+### Serial-PR Discipline (Required)
+
+1. Complete Phase A (T001-T004). Confirm Checkpoint A.
+2. Execute PR-01 tasks (T005-T015) sequentially with in-group `[P]` parallelism.
+3. After PR-01 merge + catalog refresh (T015): execute PR-02 tasks (T016-T026).
+4. After PR-02 merge + catalog refresh (T026): execute PR-03 tasks (T027-T041).
+5. Continue through PR-13 (T142-T152) in strict LOC-DESC order.
+6. Execute Phase D scoping (T153).
+7. Execute Phase E wrap-up (T154-T166) in parallel where possible.
+
+### MVP Increment (Optional)
+
+If dispatch pauses partway through, each merged PR is a standalone value delivery (spec User Story 1 "Independent Test"). Any prefix `PR-01..PR-N` produces a coherent `main` state at 99.6/A+ compliance and monotonically decreasing MistHelper.py line count. Stop at any PR merge, resume from Step 1 of `quickstart.md` for the next.
+
+### No-Batch Guarantee
+
+FR-002 prohibits batching multiple candidates into one PR. Even if two candidates appear "trivial together," they get separate PRs. The serial workflow is what distinguishes this initiative from prior stalled attempts.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no dependencies within one candidate group. Never parallelize across candidate groups (FR-013).
+- `[BLOCKS T###]` = enforces the serial-PR contract across candidate groups.
+- Every catalog-refresh task (T015, T026, T041, T052, T063, T074, T086, T097, T108, T119, T130, T141, T152) provides the SC-011 audit trail.
+- `--admin` merge bypass MUST NOT be used as a routine unblock (FR-011, `feedback_no_admin_bypass.md`). Investigate `mergeStateStatus` first; SKIPPED conditionals are not blocking.
+- No new tests are mandated. Existing tests that reference an extracted symbol are updated in the same PR that moves the symbol (research.md "Test-preservation rule").
+- Analyzer (`tools/refactor_analyzer/`) is NEVER modified by this initiative (FR-018). Discrepancies are filed as separate analyzer bugs.
+- The parent conversation controls PR dispatch cadence — this tasks file is the operator recipe, not an auto-execution script.

--- a/specs/1011-misthelper-refactor-low-use/plan.md
+++ b/specs/1011-misthelper-refactor-low-use/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan: MistHelper.py Refactor Extraction — Low-Use Second Pass
+
+**Branch**: `1011-misthelper-refactor-low-use` | **Date**: 2026-07-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/1011-misthelper-refactor-low-use/spec.md`
+**Predecessor**: `specs/1010-misthelper-refactor-extraction/` (13 PRs merged, closed with baseline 99.6/A+ and MistHelper.py LoC drop >=600)
+
+## Summary
+
+Continue the systematic decomposition of `MistHelper.py` by consuming the **Low-Use bucket** (2 <= callers <= 3) surfaced by the post-PR-13-merge `refactor_candidates.md` (`unused=0, single-use=0, low-use=20, hot=80, skipped=1`). Each of the 20 candidates is a single serial PR that (a) creates the target module (or folds into an existing sibling module — `FirmwareManager` — for three firmware-related candidates), (b) rewrites all 2-3 callsites atomically in the same diff, (c) deletes the original symbol from `MistHelper.py`, (d) resolves any analyzer `guideline_flags` in-flight, (e) renames double-underscore analyzer-suggested filenames to single-underscore per FR-020, and (f) lands with all 15 functional CI jobs green and A+/100 compliance on affected files. Three candidates (`main`, `marvis_data_utils`, `MIST_WAN_TARGET_PORTS`) have cross-file callers and are dispatched as **P2 multi-file rewrites** after the P1 single-file cluster completes. No wrapper shims. No parallel branches. No `--admin` bypass except where `mergeStateStatus` is genuinely BLOCKED/DIRTY/BEHIND with root cause documented. Between merges, the analyzer is re-run and `refactor_candidates.md` is regenerated before the next PR is dispatched, so the queue always reflects the current `main` head.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (project target per repo tooling and CI matrix)
+**Primary Dependencies**: standard library only for extraction targets; existing project deps preserved (no new dependencies introduced by this initiative)
+**Storage**: N/A for extraction work itself
+**Testing**: `pytest` for unit/integration; existing 15 functional CI jobs (matrix build, ruff, mypy, compliance analyzer, refactor analyzer smoke, integration suites) as the mergeability contract
+**Target Platform**: Windows-first CLI; extracted modules remain platform-neutral (`pathlib.Path`, ASCII-only logs)
+**Project Type**: Single-project CLI tool with a monolithic entrypoint being decomposed into `src/*` sub-packages
+**Performance Goals**: No performance regression at any callsite after extraction; interactive latency for CLI menus unchanged
+**Constraints**: Zero wrapper shims may be left in `MistHelper.py`; every extracted module lands at A+/100 compliance; repo-wide baseline stays >=99.6/A+; no A+ file may regress; no touching of `SKIP_ALWAYS` (`GlobalImportManager`) or Hot bucket (4+ callers) symbols; serial PR workflow only; `raw_input_call` flag on `WLANRadiusTimerManager` is resolved with `safe_input()` on landing (FR-006); double-underscore analyzer-suggested module names are renamed to single-underscore during landing (FR-020)
+**Scale/Scope**: 20 PRs in second pass, ~2,749 LoC extraction budget targeting >=2,500 lines of physical reduction in `MistHelper.py`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution version 1.4.0 (ratified 2026-03-05). Evaluated per the seven core principles.
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Five-Item Rule (all menu options in groups of 5, cross-category prohibited) | PASS | Extraction is a code-organization change; no menu structure is added, removed, or reordered. |
+| II. Class-Based Architecture (functions live inside cohesive classes) | PASS + REINFORCED | FR-005 explicitly refactors module-level function candidates (`initialize_mist_session_interactive`, `initialize_mist_session`, `main`) into class-body methods on landing. |
+| III. Safety-First Development (destructive operations gated) | PASS | Extraction moves existing behavior; no new destructive operations introduced. Pre-existing safety gates on `WLANRadiusTimerManager`, `WANProbeConfigManager`, and firmware managers are preserved verbatim. |
+| IV. Full Deployment Pipeline (15 CI jobs must pass, no --admin bypass) | PASS + REINFORCED | FR-011 codifies the CI gate; `feedback_no_admin_bypass.md` guidance applied — check `mergeStateStatus` before considering any bypass. |
+| V. Observability & Logging (structured, ASCII-only, `safe_input`, `pathlib.Path`) | PASS + REINFORCED | FR-007 mandates ASCII-only logs, `safe_input()`, `pathlib.Path` in every extracted module. Analyzer `guideline_flags` covering these (notably `raw_input_call` on `WLANRadiusTimerManager`, `non_ascii_logs` on multiple candidates) are resolved in the extraction PR (FR-006). |
+| VI. Inline Comments Every 5-10 Lines (NON-NEGOTIABLE) | PASS + REINFORCED | Each new module under `src/refactors/` must land A+/100, which requires the inline-comment cadence. Any `missing_inline_comments` flag on extracted code (notably `FirmwareUpgradeStatusChecker`) is resolved in the same PR (FR-006). |
+| VII. Action Logging Before Every Non-Trivial Action (NON-NEGOTIABLE) | PASS + REINFORCED | Any `missing_action_logging` flag on extracted code is resolved in the same PR (FR-006). Constitution's `[LOGIN]`, `[MENU]`, `[EXECUTE]`, `[SUCCESS]`, `[FAILURE]` prefix convention is preserved. |
+
+**Result**: All seven principles pass. Two principles (VI, VII) are NON-NEGOTIABLE and are reinforced rather than at risk. No violations require Complexity Tracking entries.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1011-misthelper-refactor-low-use/
+|-- plan.md                        # This file (/speckit.plan output)
+|-- spec.md                        # Feature specification (input)
+|-- checklists/                    # Reserved for downstream /speckit.checklist runs
+`-- contracts/                     # Reserved for downstream contract artifacts
+```
+
+### Source Code (repository root)
+
+```text
+MistHelper.py                                # Entrypoint monolith - shrinks by >=2,500 lines across 20 PRs
+tools/refactor_analyzer/                     # Analyzer package - CONSUMED AS-IS, never modified (FR-018)
+tools/compliance_analyzer/                   # Compliance analyzer - used to verify A+/100 on affected files
+refactor_candidates.md                       # Regenerated after every merged extraction PR (FR-010)
+data/full_repo_compliance_current.md         # Compliance baseline snapshot - must stay >=99.6/A+
+src/
+|-- refactors/                               # DESTINATION for 17 of 20 Low-Use extractions
+|   |-- __init__.py                          # Existing
+|   |-- serial_cc/                           # Existing sub-package
+|   |-- wlanradius_timer_manager.py          # NEW - PR-14 (LOC 787, raw_input_call resolved)
+|   |-- wanprobe_config_manager.py           # NEW - PR-15 (LOC 473)
+|   |-- anomaly_metrics_discovery.py         # NEW - PR-16 (LOC 91)
+|   |-- device_data_fetcher.py               # NEW - PR-17 (LOC 68)
+|   |-- inventory_csvcomparator.py           # NEW - PR-18 (LOC 47)
+|   |-- device_config_template_cloner_manager.py  # NEW - PR-20 (LOC 27)
+|   |-- wanprobe_device_override_manager.py  # NEW - PR-21 (LOC 23)
+|   |-- initialize_mist_session_interactive.py    # NEW - PR-23 (fn->method)
+|   |-- initialize_mist_session.py           # NEW - PR-24 (fn->method)
+|   |-- package_import_map.py                # NEW - PR-25 (assignment constant)
+|   |-- main.py                              # NEW - PR-26 (P2 cross-file, fn->method)
+|   |-- marvis_data_utils.py                 # NEW - PR-27 (P2 cross-file, assignment)
+|   |-- fast_mode_backoff_multiplier.py      # NEW - PR-28 (FR-020 rename from fast__mode__backoff__multiplier)
+|   |-- fast_mode_devices_per_thread.py      # NEW - PR-29 (FR-020 rename)
+|   |-- fast_mode_sequential_max_retries.py  # NEW - PR-30 (FR-020 rename)
+|   |-- fast_mode_use_connection_aware_threading.py  # NEW - PR-31 (FR-020 rename)
+|   `-- mist_wan_target_ports.py             # NEW - PR-32 (P2 cross-file, FR-020 rename)
+`-- firmware/
+    `-- firmware_manager.py                  # EXISTING - receives 3 candidates per FR-015 exception:
+                                             #   PR-19: FirmwareUpgradeStatusChecker (LOC 958)
+                                             #   PR-22: BulkAPFirmwareUpgrader      (LOC 32)
+                                             #   PR-33: BulkSwitchFirmwareUpgrader  (LOC 19)
+```
+
+**Structure Decision**: Single-project layout. 17 of 20 Low-Use extractions land under `src/refactors/` with a per-symbol module file. **Three exceptions** fold into the existing `src/firmware/firmware_manager.py::FirmwareManager` because their sole callers already live there (FR-015 — mirrors 1010's `AddressComparisonCounters -> CsvComparatorManager` pattern). Five module names are renamed from the analyzer's double-underscore suggestions (`fast__mode__backoff__multiplier.py` -> `fast_mode_backoff_multiplier.py`) per FR-020 to conform to PEP 8 module naming.
+
+### PR Dispatch Queue (Authoritative Order)
+
+Per FR-001 (LOC-DESC within priority band) and FR-014 (exact 20-candidate second-pass budget). P1 (single-file callers) is dispatched before P2 (cross-file callers) so any grep-audit failure in P2 does not block the P1 cluster:
+
+| PR | Priority | Candidate | Kind | LoC | Refs | Source in MistHelper.py | Destination |
+|----|----------|-----------|------|-----|------|-------------------------|-------------|
+| 14 | P1 | `WLANRadiusTimerManager` | class | 787 | 3 | 20044, 21515 | `src/refactors/wlanradius_timer_manager.py` (resolve `raw_input_call`) |
+| 15 | P1 | `WANProbeConfigManager` | class | 473 | 2 | 21720 | `src/refactors/wanprobe_config_manager.py` |
+| 16 | P1 | `AnomalyMetricsDiscovery` | class | 91 | 2 | 12994 | `src/refactors/anomaly_metrics_discovery.py` |
+| 17 | P1 | `DeviceDataFetcher` | class | 68 | 3 | 15292, 15309, 15325 | `src/refactors/device_data_fetcher.py` |
+| 18 | P1 | `InventoryCSVComparator` | class | 47 | 3 | 16488, 21541 | `src/refactors/inventory_csvcomparator.py` |
+| 19 | P1 | `FirmwareUpgradeStatusChecker` | class | 958 | 2 | firmware_manager.py:1746, 1753 | `src/firmware/firmware_manager.py::FirmwareManager` (FR-015; resolve `oversize_25_lines`, `missing_inline_comments`, `non_ascii_logs`) |
+| 20 | P1 | `DeviceConfigTemplateClonerManager` | class | 27 | 2 | 21922 | `src/refactors/device_config_template_cloner_manager.py` |
+| 21 | P1 | `WANProbeDeviceOverrideManager` | class | 23 | 2 | 21724 | `src/refactors/wanprobe_device_override_manager.py` |
+| 22 | P1 | `BulkAPFirmwareUpgrader` | class | 32 | 2 | firmware_manager.py:1733, 1736 | `src/firmware/firmware_manager.py::FirmwareManager` (FR-015) |
+| 23 | P1 | `initialize_mist_session_interactive` | fn | 18 | 3 | 2237, 19356, 23190 | `src/refactors/initialize_mist_session_interactive.py` (fn->method per FR-005) |
+| 24 | P1 | `initialize_mist_session` | fn | 18 | 2 | 23195, 23258 | `src/refactors/initialize_mist_session.py` (fn->method per FR-005) |
+| 25 | P1 | `PACKAGE_IMPORT_MAP` | assignment | 13 | 2 | 354, 538 | `src/refactors/package_import_map.py` |
+| 26 | P2 | `main` | fn | 12 | 2 | MistHelper.py:23700 **+ src/maps/maps_manager.py:2794** | `src/refactors/main.py` (fn->method per FR-005; cross-file audit per FR-019) |
+| 27 | P2 | `marvis_data_utils` | assignment | 4 | 3 | MistHelper.py:6594, 15736 **+ src/troubleshooting/marvis_troubleshoot_utils.py:21** | `src/refactors/marvis_data_utils.py` (cross-file audit per FR-019) |
+| 28 | P1 | `FAST_MODE_BACKOFF_MULTIPLIER` | assignment | 3 | 3 | 1969, 9980, 15409 | `src/refactors/fast_mode_backoff_multiplier.py` (FR-020 rename) |
+| 29 | P1 | `FAST_MODE_DEVICES_PER_THREAD` | assignment | 3 | 2 | 1972, 7470 | `src/refactors/fast_mode_devices_per_thread.py` (FR-020 rename) |
+| 30 | P1 | `FAST_MODE_SEQUENTIAL_MAX_RETRIES` | assignment | 3 | 2 | 1977, 15549 | `src/refactors/fast_mode_sequential_max_retries.py` (FR-020 rename) |
+| 31 | P1 | `FAST_MODE_USE_CONNECTION_AWARE_THREADING` | assignment | 3 | 2 | 1984, 7460 | `src/refactors/fast_mode_use_connection_aware_threading.py` (FR-020 rename) |
+| 32 | P2 | `MIST_WAN_TARGET_PORTS` | assignment | 3 | 3 | MistHelper.py:1992, 15638 **+ src/gateway/gateway_export_utils.py:51** | `src/refactors/mist_wan_target_ports.py` (FR-020 rename; cross-file audit per FR-019) |
+| 33 | P1 | `BulkSwitchFirmwareUpgrader` | class | 19 | 2 | firmware_manager.py:1832, 1833 | `src/firmware/firmware_manager.py::FirmwareManager` (FR-015) |
+
+LOC figures and callsite line numbers are the analyzer's snapshot at spec creation; each PR uses the *fresh* analyzer output post-preceding-merge per FR-010, so line numbers may shift within tolerance. Reference counts may also shift (a Low-Use candidate could drop a caller during a preceding PR and become Single-Use, or gain a caller and become Hot — the fresh catalog is authoritative per FR-016).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |
+
+## Post-Design Constitution Re-Check
+
+Re-evaluated after Phase 1 design artifacts landed:
+
+- **I. Five-Item Rule** — Still PASS. No menu topology changed.
+- **II. Class-Based Architecture** — Still PASS. Dispatch queue explicitly requires class-body landing for the three module-level function candidates (`initialize_mist_session_interactive`, `initialize_mist_session`, `main`).
+- **III. Safety-First** — Still PASS. No new destructive paths.
+- **IV. Full Deployment Pipeline** — Still PASS. FR-011 and the serial merge protocol enforce the 15-job gate and the no-`--admin` policy.
+- **V. Observability & Logging** — Still PASS. FR-006/FR-007 require ASCII logs, `safe_input()`, and `pathlib.Path`; `raw_input_call` on `WLANRadiusTimerManager` and `non_ascii_logs` on `FirmwareUpgradeStatusChecker` are resolved in-flight.
+- **VI. Inline Comments** — Still PASS + NON-NEGOTIABLE. A+/100 module gate enforces the 5-10 line comment cadence; `missing_inline_comments` flag on `FirmwareUpgradeStatusChecker` is resolved in the same PR.
+- **VII. Action Logging** — Still PASS + NON-NEGOTIABLE. `guideline_flags` resolution requirement enforces action logging on extracted code.
+
+**Final verdict**: All seven principles pass post-design. No Complexity Tracking entries required.
+
+## What This Plan Does NOT Do
+
+- Does not open, sequence, or merge extraction PRs — that is the parent conversation's dispatch responsibility (Assumption 7 in spec).
+- Does not modify `tools/refactor_analyzer/` (FR-018).
+- Does not touch `SKIP_ALWAYS` symbols like `GlobalImportManager` (FR-008).
+- Does not touch Hot bucket symbols with 4+ callers (FR-009).
+- Does not batch multiple candidates into one PR (FR-002).
+- Does not leave wrapper shims or forwarding functions (FR-003, SC-008).
+- Does not re-scope the Hot bucket (80 candidates, deferred to a future `1012-*` initiative if warranted).
+- Does not bring external-file callers (in `src/maps/`, `src/troubleshooting/`, `src/gateway/`) up to A+/100 compliance — those are pre-existing modules and only the import/reference lines are rewritten (FR-019 scope-limited to grep audit).

--- a/specs/1011-misthelper-refactor-low-use/spec.md
+++ b/specs/1011-misthelper-refactor-low-use/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: MistHelper.py Refactor Extraction — Low-Use Bucket (Second Pass)
+
+**Feature Branch**: `1011-misthelper-refactor-low-use`
+**Created**: 2026-07-05
+**Status**: Draft
+**Predecessor**: [`1010-misthelper-refactor-extraction`](../1010-misthelper-refactor-extraction/spec.md) (13 PRs merged, first-pass Unused + Single-Use buckets cleared)
+**Input**: User description: "Second-pass extraction: process the 20 Low-Use candidates (2-3 callers each) surfaced by `tools/refactor_analyzer/` after the first-pass initiative cleared Unused + Single-Use. Ordered by fresh, post-PR-13-merge catalog verification per FR-016 of the predecessor spec. Deliberately NOT batched into 1010 per Assumption 6 / FR-017 of the predecessor spec — reference counts shift as extractions land, so a fresh catalog dispatch is authoritative."
+
+## Predecessor Context
+
+The 1010 initiative closed with:
+
+- Repository baseline: 99.6/A+
+- MistHelper.py physical LoC drop: ≥600 lines across 13 merged PRs (PR #757-#769)
+- `refactor_candidates.md` regenerated on post-PR-13-merge `main`: `unused=0, single-use=0, low-use=20, hot=80, skipped=1`
+- All 12 first-pass Success Criteria (SC-001..SC-012) satisfied
+- Zero wrapper shims left in MistHelper.py
+- Zero SKIP_ALWAYS symbols modified, zero Hot symbols extracted
+
+Per FR-017 of 1010 and Assumption 6, the 20 Low-Use candidates were **explicitly deferred** to a second-pass initiative rather than batched into the first pass. This spec is that second pass.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Extract Low-Use candidates whose sole caller cluster is inside MistHelper.py (Priority: P1)
+
+The core value-delivery workflow for the second pass. For each Low-Use candidate whose 2-3 callsites all resolve to a single file (typically `MistHelper.py` itself), a refactor engineer opens a PR that (a) moves the class/function/assignment into a new cohesive module under `src/refactors/` (or, when a `Suggested class` names an existing shared destination like `FirmwareManager`, folds into that class body), (b) rewrites every callsite in the same commit, (c) deletes the original symbol from `MistHelper.py`, (d) resolves any analyzer `guideline_flags` in-flight, and (e) lands with all 15 functional CI jobs green and A+/100 compliance on affected files. No wrapper shims. Module-level functions land as class-body methods per FR-005 of 1010 (carried forward as FR-005 here).
+
+**Why this priority**: Delivers the bulk of the second-pass LoC drop. The three largest candidates (`FirmwareUpgradeStatusChecker` at 958 LoC, `WLANRadiusTimerManager` at 787 LoC, `WANProbeConfigManager` at 473 LoC) alone total 2,218 LoC — nearly 4x the total 1010 first-pass reduction. Serial per-PR execution with catalog regeneration between merges is retained.
+
+**Independent Test**: Any single Low-Use extraction (e.g. `AnomalyMetricsDiscovery` at MistHelper.py:19779-19869, refs at 12994, 12994 → `src/refactors/anomaly_metrics_discovery.py` with both callsite occurrences rewritten in the same commit) can be merged in isolation with the full CI matrix green.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Low-Use candidate with all callsites inside `MistHelper.py`, **When** the extraction PR is opened, **Then** the new module exists at the mapped path, the original symbol is deleted from `MistHelper.py`, every listed callsite is rewritten to import from the new module, and no wrapper shim exists anywhere in the diff.
+2. **Given** a candidate that is currently a module-level function or bare assignment, **When** it is extracted, **Then** it lands as a method or class-body attribute on a cohesive class in the new module — not as a bare `def` or module-level `X = ...` at module scope (FR-005 carry-forward).
+3. **Given** an extraction PR is under CI, **When** the pipeline completes, **Then** all 15 functional CI jobs are green, the new module scores A+/100 on compliance, and no previously A+ file regresses.
+4. **Given** the analyzer flagged the moved code with `guideline_flags` (e.g. `oversize_25_lines`, `non_ascii_logs`, `raw_input_call`, `missing_action_logging`, `missing_inline_comments`), **When** the extraction PR lands, **Then** each flagged violation is resolved in the same PR — not deferred.
+5. **Given** the freshly regenerated Low-Use bucket, **When** dispatching the next PR, **Then** candidates are processed in LOC-DESC order within their landing-destination cluster (see Dispatch Queue below).
+
+---
+
+### User Story 2 - Extract Low-Use candidates with cross-file callsites (Priority: P2)
+
+Three candidates in the fresh Low-Use bucket have callers outside `MistHelper.py`:
+
+- `main` (function, 12 LoC) — caller in `src/maps/maps_manager.py:2794`
+- `marvis_data_utils` (assignment, 4 LoC) — caller in `src/troubleshooting/marvis_troubleshoot_utils.py:21`
+- `MIST_WAN_TARGET_PORTS` (assignment, 3 LoC) — caller in `src/gateway/gateway_export_utils.py:51`
+
+These require multi-file rewrites in the same PR (move symbol + rewrite `MistHelper.py` internal callsites + rewrite external module's import) to maintain the FR-003 atomicity contract (no intermediate revision references a deleted symbol).
+
+**Why this priority**: Same value proposition as P1 but higher blast radius (multi-file diff) so distinct from P1 dispatch ordering. Bundled as P2 to ensure P1's simpler single-file rewrites validate the second-pass workflow before multi-file diffs are attempted.
+
+**Independent Test**: `MIST_WAN_TARGET_PORTS` extraction (~3 LoC constant, 3 callsites across 2 files) can be merged as a standalone PR that (a) creates `src/refactors/mist_wan_target_ports.py`, (b) rewrites `MistHelper.py:1992` (def-site removal) and `MistHelper.py:15638` (callsite) and `src/gateway/gateway_export_utils.py:51` (callsite), all in one commit with 15/15 CI green.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Low-Use candidate with a caller outside `MistHelper.py`, **When** the extraction PR is opened, **Then** the diff touches (a) the new module file, (b) `MistHelper.py` (def-site deletion + internal callsite rewrite), AND (c) every external caller file — all in the same commit.
+2. **Given** the multi-file rewrite, **When** CI runs, **Then** no intermediate revision references a deleted symbol (git bisectability across the merge commit only; the merge commit itself is the atomic unit).
+3. **Given** the extraction affects a shared destination class (e.g. `FirmwareUpgradeStatusChecker` → `FirmwareManager` in `src/firmware/firmware_manager.py`), **When** the PR lands, **Then** `firmware_manager.py` continues to score A+/100 (no regression on the already-A+ shared destination).
+
+---
+
+### User Story 3 - Refresh the analyzer catalog after every merged extraction (Priority: P3)
+
+Carry-forward of User Story 3 from 1010. Reference counts shift as extractions land. After every merged extraction PR in this initiative, the analyzer is re-run and `refactor_candidates.md` is regenerated before the next PR is dispatched. Some Low-Use candidates may drop to Single-Use (or Unused) after a prior merge removes one of their callers; the fresh catalog is authoritative and the dispatch queue is re-derived accordingly.
+
+**Why this priority**: Workflow discipline that supports P1 and P2 rather than delivering standalone value. Especially important in this pass because several candidates share destination classes (three `FirmwareManager` candidates: `FirmwareUpgradeStatusChecker`, `BulkAPFirmwareUpgrader`, `BulkSwitchFirmwareUpgrader`) — merging one of them may shift the caller layout of the others.
+
+**Independent Test**: After merging any second-pass extraction PR, running `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md` regenerates the catalog cleanly, and the diff of `refactor_candidates.md` reflects the just-completed extraction (removed from the Low-Use bucket, and any downstream reference-count shifts visible on remaining candidates).
+
+**Acceptance Scenarios**:
+
+1. **Given** an extraction PR has just merged to `main`, **When** the next PR is dispatched, **Then** `refactor_candidates.md` has been regenerated on the current `main` head first and the next candidate is selected from that fresh output.
+2. **Given** the regenerated catalog shows a formerly Low-Use candidate has become Unused (2-ref candidate lost both callers when a prior extraction removed them), **When** the dispatcher plans the next PR, **Then** the candidate is reclassified into the Unused workflow (delete-only, no new module).
+3. **Given** the regenerated catalog shows a formerly Low-Use candidate has become Hot (gained callers as ripple-effect of prior extractions), **When** the dispatcher plans the next PR, **Then** that candidate is deferred out of this initiative to a subsequent third-pass evaluation, and the initiative's SC-002 rationale is updated to document the reclassification.
+
+---
+
+### Edge Cases
+
+- What happens when a Low-Use candidate's reference count fluctuates between catalog regenerations because of transient parse ambiguity? Manual grep wins for that PR; the discrepancy is filed as an analyzer bug in `tools/refactor_analyzer/` but does not block the extraction.
+- How does the workflow handle a Low-Use candidate whose destination class (e.g. `FirmwareManager`) is currently in the Hot bucket? Extraction may still land in that class — Hot-bucket restrictions apply to the *source* symbol under extraction, not to the *destination* class receiving the extracted method. Confirm the destination file remains A+/100 after the move.
+- What happens if two of the three `FirmwareManager` candidates are already merged and the third's reference count has changed? Regenerate the catalog before the third PR; if it dropped to Single-Use (or Unused), reroute per FR-016 carry-forward.
+- How does the workflow handle multi-file callsite rewrites when one of the external callers is in a package that has its own compliance requirements (e.g. `src/gateway/gateway_export_utils.py`)? The external file's post-PR compliance MUST remain at its pre-PR grade or better. Analyzer flags on the external file are NOT in scope for this initiative unless the extraction directly introduces them.
+- What happens when a candidate's `Suggested module` path uses double-underscore separators (e.g. `fast__mode__backoff__multiplier.py`)? Rename during landing to conventional single-underscore (`fast_mode_backoff_multiplier.py`) and record the rationale in the PR description.
+- How does the workflow handle a `guideline_flags` list that includes `raw_input_call` (present on `WLANRadiusTimerManager`)? Rewrite raw `input()` to `safe_input()` per project non-negotiables (FR-007 of 1010, carried forward). Do NOT merge with `raw_input_call` unresolved.
+- What happens if a large candidate (e.g. `FirmwareUpgradeStatusChecker` at 958 LoC) requires internal decomposition beyond the ≤25-line-per-method rule to satisfy A+/100? Split into ≤25-line methods with ≤5 params during the move — FR-006 carry-forward (decompose while moving).
+- How does the workflow handle a merge conflict on `refactor_candidates.md` when a new first-party file is added to the module graph mid-flight (which would shift the "Definitions analyzed" count)? Serial per-PR workflow is non-negotiable — only one extraction PR is open at a time. Regenerate the catalog after each merge.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The second-pass extraction workflow MUST process Low-Use candidates in the LOC-DESC order specified by the freshest `refactor_candidates.md` at dispatch time, within their destination cluster (single-file P1 cluster processed before multi-file P2 cluster).
+- **FR-002**: The workflow MUST process exactly one extraction candidate per PR. Batching multiple candidates into a single PR is prohibited (carry-forward from 1010).
+- **FR-003**: For each Low-Use candidate, the PR MUST (a) create the target module file OR fold into the named `Suggested class`, (b) delete the original symbol from `MistHelper.py`, and (c) rewrite every listed callsite in the same commit. No wrapper shim, forwarding function, or backward-compatibility alias may be left in `MistHelper.py`.
+- **FR-004**: For each candidate whose reference count has dropped to 0 by the time of dispatch (post-regeneration), the PR MUST be reclassified as a deletion PR (delete-only, no new module) — mirroring 1010's Unused workflow.
+- **FR-005**: Module-level functions and bare module-level assignments that are extracted MUST be refactored into class-body methods/attributes on the new module, not preserved as bare module-level definitions (carry-forward from 1010 FR-005).
+- **FR-006**: Analyzer-flagged `guideline_flags` on the extracted code (`oversize_25_lines`, `missing_inline_comments`, `missing_action_logging`, `non_ascii_logs`, `hardcoded_separator`, `raw_input_call`, and any other flags surfaced by the analyzer) MUST be resolved within the same extraction PR — never deferred to a follow-up (carry-forward from 1010 FR-006).
+- **FR-007**: All extracted modules MUST comply with project non-negotiables: ASCII-only logs, `safe_input()` for interactive input, `pathlib.Path` in place of `os.path`, inline comments every 5-10 lines, action logging before/after every meaningful action with `%s` formatting, ≤25-line methods, ≤5 params per function (carry-forward from 1010 FR-007).
+- **FR-008**: The initiative MUST NEVER touch symbols in the analyzer's `SKIP_ALWAYS` bucket (e.g. `GlobalImportManager`) (carry-forward from 1010 FR-008).
+- **FR-009**: The initiative MUST NEVER touch symbols in the Hot bucket (4+ callers) — the destination class receiving an extracted method may itself be a Hot class, but the *source* symbol under extraction must be strictly Low-Use at dispatch time.
+- **FR-010**: After every merged extraction PR, the workflow MUST regenerate `refactor_candidates.md` by running the analyzer against the current `main` head before the next PR is dispatched (carry-forward from 1010 FR-010).
+- **FR-011**: An extraction PR MUST NOT merge until all 15 functional CI jobs report green. When `mergeStateStatus` reports BLOCKED, DIRTY, or BEHIND, the PR MUST be updated and re-run rather than force-merged. `--admin` merge bypass MUST NOT be used as a routine unblock. Reference `feedback_no_admin_bypass.md` (carry-forward from 1010 FR-011).
+- **FR-012**: Every new module under `src/refactors/` (and any existing module receiving an extracted symbol, notably `src/firmware/firmware_manager.py` for the three `FirmwareManager` candidates) MUST land at A+/100 compliance score, and no file that was previously A+ may regress below A+ as a result of the extraction (carry-forward from 1010 FR-012).
+- **FR-013**: The repository-wide compliance baseline MUST remain at or above 99.6/A+ after each merged extraction PR (carry-forward from 1010 FR-013).
+- **FR-014**: The second-pass extraction budget covers exactly 20 candidates as enumerated in the "PR Dispatch Queue" section of `plan.md`. Additions to second-pass scope require explicit re-scoping in a new SpecKit revision.
+- **FR-015**: Three candidates (`FirmwareUpgradeStatusChecker`, `BulkAPFirmwareUpgrader`, `BulkSwitchFirmwareUpgrader`) MUST be relocated into the existing `src/firmware/firmware_manager.py::FirmwareManager` class rather than into new `src/refactors/` modules, because their `Suggested class` explicitly targets that shared destination.
+- **FR-016**: When the freshly regenerated `refactor_candidates.md` shows that a candidate has been reclassified out of the Low-Use bucket (e.g. Low-Use → Unused after a prior merge, or Low-Use → Hot after a caller-adding refactor elsewhere), the workflow MUST reroute or defer that candidate rather than force-extract it under the original classification (carry-forward from 1010 FR-016).
+- **FR-017**: The initiative MUST NOT introduce new features, new commands, or scope beyond the extraction itself (carry-forward from 1010 FR-017).
+- **FR-018**: The initiative MUST NOT modify `tools/refactor_analyzer/` itself; the analyzer is consumed as-is (carry-forward from 1010 FR-018).
+- **FR-019** (new to 1011): The three candidates with cross-file callsites (`main`, `marvis_data_utils`, `MIST_WAN_TARGET_PORTS`) MUST have their external-file callsite rewrites verified by CI — not just by local pytest — before merge. Grep-based post-merge audit is the acceptance evidence.
+- **FR-020** (new to 1011): Candidates whose `Suggested module` path uses double-underscore separators (e.g. `fast__mode__backoff__multiplier.py`) MUST be renamed to conventional single-underscore paths during landing (`fast_mode_backoff_multiplier.py`), and the rename rationale MUST be recorded in the PR description.
+
+### Key Entities *(include if feature involves data)*
+
+Same as 1010:
+
+- **Extraction Candidate**: A class, function, or assignment in `MistHelper.py` catalogued by `tools/refactor_analyzer/` — for this initiative, restricted to Low-Use bucket entries (2-3 references) as of the freshest catalog at dispatch time.
+- **Refactor Candidates Catalog** (`refactor_candidates.md`): Regenerated after every merged extraction PR (FR-010).
+- **Extraction PR**: A single pull request delivering one candidate's move-or-delete plus its callsite rewrites plus any in-place `guideline_flags` remediation.
+- **Target Module**: The new file under `src/refactors/` (or existing sibling module for `FirmwareManager` candidates) that receives an extracted symbol.
+- **Callsite**: The exact location where a candidate is invoked — for Low-Use, may be 2-3 distinct locations, all of which must be rewritten atomically with the extraction.
+- **Shared Destination Class**: A pre-existing class (e.g. `FirmwareManager`) that receives one or more extracted symbols as new methods, per the analyzer's `Suggested class` field.
+- **Compliance Baseline**: The repo-wide compliance score maintained at ≥99.6/A+ with zero sub-A files.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The Low-Use bucket of `refactor_candidates.md` reports 0 entries at second-pass completion (or documented rationale in the catalog's Limitations section explaining any deferrals — expected for candidates that transition to Hot mid-initiative).
+- **SC-002**: `MistHelper.py` physical line count drops by at least 2,500 lines relative to its pre-initiative baseline (matches the 2,749 LoC extraction budget summed across the 20 Low-Use candidates minus small class-body overhead per new module).
+- **SC-003**: Repository-wide compliance score is ≥99.6/A+ at every intermediate main-branch state throughout the initiative and at final completion.
+- **SC-004**: Zero files that were A+/100 pre-initiative regress below A+ by the end of the initiative.
+- **SC-005**: All second-pass PRs merge with 15/15 functional CI jobs green. Zero PRs merged via `--admin` bypass except where `mergeStateStatus` was genuinely BLOCKED/DIRTY/BEHIND with root cause documented in the PR.
+- **SC-006**: Every new file created under `src/refactors/` during the initiative scores A+/100 on compliance.
+- **SC-007**: Zero wrapper shims, forwarding functions, or backward-compatibility aliases remain in `MistHelper.py` after the initiative.
+- **SC-008**: Zero symbols from the analyzer's `SKIP_ALWAYS` bucket are modified by any PR in this initiative.
+- **SC-009**: Zero symbols from the Hot bucket (4+ callers) are extracted as *source* symbols during this second pass. (Destination classes may be Hot; that is allowed per FR-009.)
+- **SC-010**: After every merged extraction PR, the analyzer is re-run and `refactor_candidates.md` is regenerated before the next PR is dispatched — verifiable by walking the merged-PR sequence.
+- **SC-011**: Every analyzer-flagged `guideline_flag` on the extracted code is resolved within the extraction PR — zero forward-carried guideline violations attributable to this initiative.
+- **SC-012**: The three cross-file candidates (`main`, `marvis_data_utils`, `MIST_WAN_TARGET_PORTS`) each have their external-file callsite rewrites verified by post-merge grep audit (FR-019).
+- **SC-013**: The three `FirmwareManager` shared-destination candidates (`FirmwareUpgradeStatusChecker`, `BulkAPFirmwareUpgrader`, `BulkSwitchFirmwareUpgrader`) each land in `src/firmware/firmware_manager.py::FirmwareManager` without regressing that file's compliance grade below A+/100 (FR-015).
+
+## Assumptions
+
+- The analyzer at `tools/refactor_analyzer/` remains functionally correct for the Low-Use bucket across the initiative; discrepancies discovered during extraction are filed as analyzer bugs but do not block.
+- The 15 functional CI jobs currently gating PRs on `main` remain the mergeability contract for the duration of this initiative.
+- The current compliance baseline of 99.6/A+ is the floor; the initiative does not attempt to raise it beyond preserving it.
+- The candidate-to-target-path mapping specified in `plan.md` reflects the fresh post-PR-13-merge catalog. If a candidate's callsite is discovered mid-extraction to have shifted (line number drift from an unrelated commit), the mapping is updated in the PR description.
+- Serial per-PR workflow: at most one extraction PR is open at any time.
+- The parent conversation controls PR dispatch cadence and branch creation. This spec exists to document the contract.
+- Analyzer regeneration cost per run is negligible relative to CI cycle time; the "regenerate after every merge" discipline does not create a bottleneck.
+- The 20-candidate scope reflects the fresh catalog at initiative kickoff. Mid-initiative reclassification (Low-Use → Unused, Low-Use → Hot) is expected and handled per FR-016; the initiative may complete with fewer than 20 merged PRs if candidates are legitimately deferred.
+- Third-pass evaluation (any Low-Use candidate that transitions to Hot during this initiative, plus the 80 pre-existing Hot candidates) is out of scope for this specification.

--- a/specs/1011-misthelper-refactor-low-use/tasks.md
+++ b/specs/1011-misthelper-refactor-low-use/tasks.md
@@ -1,0 +1,504 @@
+---
+description: "Tasks for feature 1011-misthelper-refactor-low-use"
+---
+
+# Tasks: MistHelper.py Refactor Extraction - Low-Use Second Pass
+
+**Input**: Design documents from `/specs/1011-misthelper-refactor-low-use/`
+**Prerequisites**: plan.md, spec.md; predecessor tasks.md at `specs/1010-misthelper-refactor-extraction/tasks.md`; live analyzer catalog at `refactor_candidates.md` (repo root)
+
+**Tests**: NO new tests are mandated (carry-forward from 1010 research.md "Test-preservation rule"). Existing tests referencing an extracted symbol are updated in the same PR that moves it. The 15 functional CI jobs are the mergeability contract (FR-011).
+
+**Organization**: Tasks are grouped by extraction candidate. Each Low-Use candidate = one PR (FR-002). PRs execute strictly serially (FR-002 + spec Edge Cases). Within a single candidate group, some tasks may run in parallel; across candidate groups execution is serial and gated by the catalog-refresh task (FR-010, SC-010).
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: May run in parallel with sibling `[P]` tasks in the SAME candidate group. Never parallel across candidate groups.
+- **[Story]**: `[US1]` = User Story 1 (single-file Low-Use extraction, P1); `[US2]` = User Story 2 (cross-file Low-Use extraction, P2); `[US3]` = User Story 3 (catalog refresh, P3, threaded through every PR).
+- **[BLOCKS T###]**: This task blocks the referenced downstream task(s). Cross-PR blockers enforce the serial-PR contract.
+
+## Path Conventions
+
+- Entrypoint monolith: `MistHelper.py` (repo root).
+- Analyzer catalog: `refactor_candidates.md` (repo root, regenerated after every merge).
+- Compliance snapshot: `data/full_repo_compliance_current.md`.
+- New extraction modules: `src/refactors/<snake_name>.py` (17 of 20 candidates).
+- Shared-destination class file: `src/firmware/firmware_manager.py` (three FR-015 candidates: `FirmwareUpgradeStatusChecker`, `BulkAPFirmwareUpgrader`, `BulkSwitchFirmwareUpgrader`).
+- Refactor analyzer command: `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`.
+- Compliance analyzer command: `python -m tools.compliance_analyzer`.
+
+---
+
+## Phase A: Pre-work (Verification Gate, Once Upfront)
+
+**Purpose**: Confirm the analyzer catalog, compliance baseline, skip pins, and branch base match spec/plan assumptions BEFORE any PR is opened. Catches drift between the 1010 close and 1011 kickoff.
+
+**CRITICAL**: All Phase A tasks must complete green before Phase B begins.
+
+- [ ] T001 Refresh the analyzer catalog on fresh post-PR-13-merge `main` head: `git checkout main && git pull && python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`. Confirm header via `grep -E "Definitions analyzed|LOC saveable|Category counts" refactor_candidates.md` — expected: `Category counts: unused=0, single-use=0, low-use=20, hot=80, skipped=1` (FR-010, plan Summary) [BLOCKS T006].
+- [ ] T002 [P] Verify baseline compliance: `grep -E "99\.6|A\+" data/full_repo_compliance_current.md` — confirm repo aggregate 99.6/A+ with 0 sub-A files (FR-013, SC-003, SC-004).
+- [ ] T003 [P] Verify `SKIP_ALWAYS` pins intact: `grep -A 5 "^## Skipped" refactor_candidates.md` — confirm `GlobalImportManager` remains pinned. Any missing symbol halts the initiative (FR-008, SC-008, FR-018).
+- [ ] T004 [P] Verify branch base: `git rev-parse --abbrev-ref HEAD` is `main`, `git status` is clean, and `git log --oneline -5` shows the PR-13 merge as HEAD ancestor (spec Predecessor Context).
+- [ ] T005 [P] Verify no Hot-bucket source symbol is queued: `grep -A 2 "^## Hot" refactor_candidates.md | head -20` — confirm the 20 Low-Use candidates listed in plan.md PR Dispatch Queue do NOT appear in the Hot bucket (FR-009, SC-009).
+
+**Checkpoint A**: Catalog fresh, baseline green, skip pins intact, branch base is post-PR-13-merge `main`, no Hot source symbols queued. Phase B may begin.
+
+---
+
+## Phase B: Low-Use Extractions (20 PRs, LOC-DESC within priority band)
+
+**Story reference**: User Story 1 (single-file, P1) for 17 PRs; User Story 2 (cross-file, P2) for 3 PRs (PR-26 `main`, PR-27 `marvis_data_utils`, PR-32 `MIST_WAN_TARGET_PORTS`). User Story 3 (catalog refresh) threaded through every PR.
+
+**Non-negotiables** (apply to every candidate group in Phase B):
+
+- No wrapper shim, forwarding function, or backward-compat alias in `MistHelper.py` (FR-003, SC-007).
+- Module-level function candidates land as class-body methods, not bare defs (FR-005; applies to PR-23, PR-24, PR-26).
+- Module-level assignment candidates land as class-body attributes on a cohesive class in the new module (FR-005; applies to PR-25 and PRs 27-32).
+- All analyzer `guideline_flags` on extracted code resolved in-flight (FR-006, SC-011). Explicit callouts: `raw_input_call` on `WLANRadiusTimerManager` (PR-14) rewritten to `safe_input()`; `oversize_25_lines` + `missing_inline_comments` + `non_ascii_logs` on `FirmwareUpgradeStatusChecker` (PR-19) decomposed into <=25-line methods with 5-10-line comment cadence and ASCII log strings.
+- ASCII-only logs, `safe_input()`, `pathlib.Path` in every new/receiving module (FR-007, Principle V).
+- Inline comments every 5-10 lines (Principle VI, NON-NEGOTIABLE).
+- Action logging with `[MENU]`/`[EXECUTE]`/`[SUCCESS]`/`[FAILURE]` prefixes on every non-trivial action (Principle VII, NON-NEGOTIABLE).
+- New module lands A+/100 on first commit; existing receiving module (`src/firmware/firmware_manager.py`) stays A+/100 after each fold-in (FR-012, SC-006, SC-013).
+- Double-underscore analyzer-suggested module names renamed to single-underscore during landing; rename rationale recorded in the PR description (FR-020; applies to PRs 28-32).
+- Cross-file callsite rewrites in PR-26/PR-27/PR-32 include the external file in the SAME commit, and post-merge grep audit confirms zero stale references (FR-019, SC-012).
+- 15/15 functional CI green; no `--admin` bypass except with documented BLOCKED/DIRTY/BEHIND `mergeStateStatus` (FR-011, SC-005, per `feedback_no_admin_bypass.md`).
+- After every merge: `git checkout main && git pull` then regenerate `refactor_candidates.md` before dispatching the next PR (FR-010, SC-010). This refresh task BLOCKS the first task of the next candidate group.
+
+**Serial execution**: PR-14 through PR-33 execute in the order specified in plan.md PR Dispatch Queue. Within each candidate group, `[P]` tasks may run in parallel; across candidate groups, execution is strictly serial (FR-002).
+
+---
+
+### Phase B.1 - PR-14: `WLANRadiusTimerManager` (class, 787 LoC, refs `MistHelper.py:20044, 21515`) -> `src/refactors/wlanradius_timer_manager.py`
+
+**Guideline flags to resolve**: `raw_input_call` (rewrite to `safe_input()` per FR-006/FR-007). Additional flags per fresh catalog.
+
+- [ ] T006 [US1] Read def-site range: `grep -n "^class WLANRadiusTimerManager" MistHelper.py` (LoC drift may have occurred since spec creation); read the ~787 physical lines starting at the located def-site [BLOCKS T009].
+- [ ] T007 [P] [US1] Read both callsite contexts (`MistHelper.py:20044` and `MistHelper.py:21515` at spec creation; re-locate on fresh `main`) — capture imports and argument shapes [BLOCKS T009].
+- [ ] T008 [P] [US1] Read `guideline_flags` for `WLANRadiusTimerManager` from fresh `refactor_candidates.md`; belt-and-suspenders grep `grep -RIn "\bWLANRadiusTimerManager\b" --include="*.py" .` expects definition + 2-3 callers only. A 4th hit reroutes per FR-016 [BLOCKS T009].
+- [ ] T009 [US1] Create `src/refactors/wlanradius_timer_manager.py` housing the class body. Rewrite every `input()` to `safe_input()`. Fix every remaining `guideline_flags` entry. ASCII logs, `pathlib.Path`, inline comments every 5-10 lines, action logging with correct prefixes (FR-005-FR-007) [BLOCKS T010].
+- [ ] T010 [US1] SAME commit: delete `WLANRadiusTimerManager` from `MistHelper.py` (no wrapper per FR-003) AND rewrite BOTH callsites at `MistHelper.py:20044` and `MistHelper.py:21515` to `from src.refactors.wlanradius_timer_manager import WLANRadiusTimerManager` [BLOCKS T011].
+- [ ] T011 [US1] Wrapper-shim guard: `grep -RIn "\bWLANRadiusTimerManager\b" MistHelper.py` returns zero hits; `grep -RIn "def WLANRadiusTimerManager" --include="*.py" .` returns zero hits.
+- [ ] T012 [P] [US1] Local gates: `python -c "import py_compile; py_compile.compile('MistHelper.py', doraise=True); py_compile.compile('src/refactors/wlanradius_timer_manager.py', doraise=True)"`, `python -m ruff check MistHelper.py src/refactors/wlanradius_timer_manager.py`, `python -m black --check MistHelper.py src/refactors/wlanradius_timer_manager.py`, `python -m mypy --strict src/refactors/wlanradius_timer_manager.py`, `python -m pytest tests/ -k "not slow" -x`.
+- [ ] T013 [US1] Compliance: `python -m tools.compliance_analyzer` — new `src/refactors/wlanradius_timer_manager.py` MUST land A+/100 (FR-012, SC-006). `MistHelper.py` grade unchanged. Repo >= 99.6/A+ (FR-013, SC-003, SC-004) [BLOCKS T014].
+- [ ] T014 [US1] Open PR: `gh pr create --title "refactor(extract): WLANRadiusTimerManager low-use" --body "Extracts WLANRadiusTimerManager (~787 LoC) from MistHelper.py into src/refactors/wlanradius_timer_manager.py. Rewrites 2 callsites atomically. Resolves raw_input_call via safe_input() rewrite (FR-006, FR-007). See specs/1011-misthelper-refactor-low-use/plan.md PR-14."` [BLOCKS T015].
+- [ ] T015 [US1] Wait 15/15 CI green + `mergeStateStatus == CLEAN` via `gh pr checks` / `gh pr view --json mergeStateStatus`. NO `--admin` bypass unless genuinely BLOCKED/DIRTY/BEHIND with root cause (FR-011) [BLOCKS T016].
+- [ ] T016 [US1] Merge PR-14: `gh pr merge --squash --delete-branch`. Then `git checkout main && git pull` [BLOCKS T017].
+- [ ] T017 [US3] Refresh catalog: `python -m tools.refactor_analyzer MistHelper.py -o refactor_candidates.md`. Diff-verify `WLANRadiusTimerManager` no longer appears in the Low-Use bucket (FR-010, SC-010) [BLOCKS T018].
+
+### Phase B.2 - PR-15: `WANProbeConfigManager` (class, 473 LoC, refs `MistHelper.py:21720`) -> `src/refactors/wanprobe_config_manager.py`
+
+- [ ] T018 [US1] Read def-site (`grep -n "^class WANProbeConfigManager" MistHelper.py`), callsite context, and `guideline_flags` from fresh catalog [BLOCKS T020].
+- [ ] T019 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bWANProbeConfigManager\b" --include="*.py" .` — expect definition + 2 callers.
+- [ ] T020 [US1] Create `src/refactors/wanprobe_config_manager.py` as cohesive class. Fix every `guideline_flags` in-flight. ASCII/safe_input/Path/comments/logging (FR-005-FR-007) [BLOCKS T021].
+- [ ] T021 [US1] SAME commit: delete from `MistHelper.py` (no wrapper) + rewrite all 2 callsites to import from `src.refactors.wanprobe_config_manager` [BLOCKS T022].
+- [ ] T022 [US1] Wrapper-shim guard: `grep -RIn "\bWANProbeConfigManager\b" MistHelper.py` returns zero hits.
+- [ ] T023 [P] [US1] Local gates: py_compile, ruff, black, mypy strict on new module, pytest.
+- [ ] T024 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T025].
+- [ ] T025 [US1] Open PR: `gh pr create --title "refactor(extract): WANProbeConfigManager low-use" --body "Extracts WANProbeConfigManager (~473 LoC) into src/refactors/wanprobe_config_manager.py. See plan.md PR-15."` [BLOCKS T026].
+- [ ] T026 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T027].
+- [ ] T027 [US1] Merge PR-15: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T028].
+- [ ] T028 [US3] Refresh catalog. Confirm `WANProbeConfigManager` removed from Low-Use bucket [BLOCKS T029].
+
+### Phase B.3 - PR-16: `AnomalyMetricsDiscovery` (class, 91 LoC, refs `MistHelper.py:12994`) -> `src/refactors/anomaly_metrics_discovery.py`
+
+- [ ] T029 [US1] Read def-site, callsite context, `guideline_flags` [BLOCKS T031].
+- [ ] T030 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bAnomalyMetricsDiscovery\b" --include="*.py" .` — expect definition + 2 callers.
+- [ ] T031 [US1] Create `src/refactors/anomaly_metrics_discovery.py` as cohesive class. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T032].
+- [ ] T032 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites [BLOCKS T033].
+- [ ] T033 [US1] Wrapper-shim guard: `grep -RIn "\bAnomalyMetricsDiscovery\b" MistHelper.py` returns zero hits.
+- [ ] T034 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T035 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T036].
+- [ ] T036 [US1] Open PR: `gh pr create --title "refactor(extract): AnomalyMetricsDiscovery low-use" --body "Extracts AnomalyMetricsDiscovery (~91 LoC) into src/refactors/anomaly_metrics_discovery.py. See plan.md PR-16."` [BLOCKS T037].
+- [ ] T037 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T038].
+- [ ] T038 [US1] Merge PR-16: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T039].
+- [ ] T039 [US3] Refresh catalog. Confirm `AnomalyMetricsDiscovery` removed [BLOCKS T040].
+
+### Phase B.4 - PR-17: `DeviceDataFetcher` (class, 68 LoC, refs `MistHelper.py:15292, 15309, 15325`) -> `src/refactors/device_data_fetcher.py`
+
+- [ ] T040 [US1] Read def-site and all THREE callsite contexts, `guideline_flags` [BLOCKS T042].
+- [ ] T041 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bDeviceDataFetcher\b" --include="*.py" .` — expect definition + 3 callers.
+- [ ] T042 [US1] Create `src/refactors/device_data_fetcher.py` as cohesive class. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T043].
+- [ ] T043 [US1] SAME commit: delete from `MistHelper.py` + rewrite ALL THREE callsites (15292, 15309, 15325) atomically [BLOCKS T044].
+- [ ] T044 [US1] Wrapper-shim guard: `grep -RIn "\bDeviceDataFetcher\b" MistHelper.py` returns zero hits.
+- [ ] T045 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T046 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T047].
+- [ ] T047 [US1] Open PR: `gh pr create --title "refactor(extract): DeviceDataFetcher low-use" --body "Extracts DeviceDataFetcher (~68 LoC) into src/refactors/device_data_fetcher.py. Rewrites 3 callsites atomically. See plan.md PR-17."` [BLOCKS T048].
+- [ ] T048 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T049].
+- [ ] T049 [US1] Merge PR-17: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T050].
+- [ ] T050 [US3] Refresh catalog. Confirm `DeviceDataFetcher` removed [BLOCKS T051].
+
+### Phase B.5 - PR-18: `InventoryCSVComparator` (class, 47 LoC, refs `MistHelper.py:16488, 21541`) -> `src/refactors/inventory_csvcomparator.py`
+
+- [ ] T051 [US1] Read def-site and both callsite contexts, `guideline_flags` [BLOCKS T053].
+- [ ] T052 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bInventoryCSVComparator\b" --include="*.py" .` — expect definition + 2-3 callers.
+- [ ] T053 [US1] Create `src/refactors/inventory_csvcomparator.py` as cohesive class. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T054].
+- [ ] T054 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites [BLOCKS T055].
+- [ ] T055 [US1] Wrapper-shim guard: `grep -RIn "\bInventoryCSVComparator\b" MistHelper.py` returns zero hits.
+- [ ] T056 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T057 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T058].
+- [ ] T058 [US1] Open PR: `gh pr create --title "refactor(extract): InventoryCSVComparator low-use" --body "Extracts InventoryCSVComparator (~47 LoC) into src/refactors/inventory_csvcomparator.py. See plan.md PR-18."` [BLOCKS T059].
+- [ ] T059 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T060].
+- [ ] T060 [US1] Merge PR-18: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T061].
+- [ ] T061 [US3] Refresh catalog. Confirm `InventoryCSVComparator` removed [BLOCKS T062].
+
+### Phase B.6 - PR-19: `FirmwareUpgradeStatusChecker` (class, 958 LoC, FR-015 fold-in) -> `src/firmware/firmware_manager.py::FirmwareManager`
+
+**Special case (FR-015)**: Landing target is EXISTING `src/firmware/firmware_manager.py` — NO new file. Fold in as methods on `FirmwareManager`. Guideline flags to resolve: `oversize_25_lines` (decompose into <=25-line methods with <=5 params per FR-006), `missing_inline_comments` (5-10-line cadence), `non_ascii_logs` (rewrite to ASCII). `src/firmware/firmware_manager.py` MUST retain A+/100 after fold-in (SC-013).
+
+- [ ] T062 [US1] Read def-site for `FirmwareUpgradeStatusChecker` in fresh `MistHelper.py` (~958 lines). Read `guideline_flags` [BLOCKS T064, T065].
+- [ ] T063 [P] [US1] Read `src/firmware/firmware_manager.py` — locate `FirmwareManager` class body, identify where the checker methods should land. Confirm existing A+/100 grade for that file pre-PR [BLOCKS T065].
+- [ ] T064 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bFirmwareUpgradeStatusChecker\b" --include="*.py" .` — expect definition in `MistHelper.py` + 2 callers in `src/firmware/firmware_manager.py:1746, 1753`.
+- [ ] T065 [US1] Fold `FirmwareUpgradeStatusChecker` into `src/firmware/firmware_manager.py::FirmwareManager` (FR-015). Decompose oversized methods into <=25-line units with <=5 params (FR-006). Add inline comments every 5-10 lines. Rewrite all non-ASCII log strings. Ensure `src/firmware/firmware_manager.py` retains A+/100 after the addition (FR-012, SC-013) [BLOCKS T066].
+- [ ] T066 [US1] SAME commit: delete `FirmwareUpgradeStatusChecker` from `MistHelper.py` (no wrapper). Rewrite the 2 caller references at `src/firmware/firmware_manager.py:1746, 1753` to use the folded methods [BLOCKS T067].
+- [ ] T067 [US1] Wrapper-shim guard: `grep -RIn "\bFirmwareUpgradeStatusChecker\b" MistHelper.py` returns zero hits.
+- [ ] T068 [P] [US1] Local gates on both affected files: py_compile MistHelper.py + firmware_manager.py, ruff, black, mypy strict, pytest.
+- [ ] T069 [US1] Compliance: `src/firmware/firmware_manager.py` MUST retain A+/100 (SC-013 — no A+ regression on receiving file). `MistHelper.py` unchanged. Repo >= 99.6/A+ [BLOCKS T070].
+- [ ] T070 [US1] Open PR: `gh pr create --title "refactor(extract): FirmwareUpgradeStatusChecker low-use (FR-015 fold-in)" --body "Folds FirmwareUpgradeStatusChecker (~958 LoC) into src/firmware/firmware_manager.py::FirmwareManager per FR-015 (sole callers already live there). Decomposes oversized methods to <=25 lines with 5-10-line comment cadence and ASCII log strings (FR-006). See plan.md PR-19."` [BLOCKS T071].
+- [ ] T071 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T072].
+- [ ] T072 [US1] Merge PR-19: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T073].
+- [ ] T073 [US3] Refresh catalog. Confirm `FirmwareUpgradeStatusChecker` removed. Confirm `src/firmware/firmware_manager.py` grade unchanged in compliance snapshot [BLOCKS T074].
+
+### Phase B.7 - PR-20: `DeviceConfigTemplateClonerManager` (class, 27 LoC, refs `MistHelper.py:21922`) -> `src/refactors/device_config_template_cloner_manager.py`
+
+- [ ] T074 [US1] Read def-site and callsite contexts, `guideline_flags` [BLOCKS T076].
+- [ ] T075 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bDeviceConfigTemplateClonerManager\b" --include="*.py" .` — expect definition + 2 callers.
+- [ ] T076 [US1] Create `src/refactors/device_config_template_cloner_manager.py` as cohesive class. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T077].
+- [ ] T077 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites [BLOCKS T078].
+- [ ] T078 [US1] Wrapper-shim guard: `grep -RIn "\bDeviceConfigTemplateClonerManager\b" MistHelper.py` returns zero hits.
+- [ ] T079 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T080 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T081].
+- [ ] T081 [US1] Open PR: `gh pr create --title "refactor(extract): DeviceConfigTemplateClonerManager low-use" --body "Extracts DeviceConfigTemplateClonerManager (~27 LoC) into src/refactors/device_config_template_cloner_manager.py. See plan.md PR-20."` [BLOCKS T082].
+- [ ] T082 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T083].
+- [ ] T083 [US1] Merge PR-20: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T084].
+- [ ] T084 [US3] Refresh catalog. Confirm `DeviceConfigTemplateClonerManager` removed [BLOCKS T085].
+
+### Phase B.8 - PR-21: `WANProbeDeviceOverrideManager` (class, 23 LoC, refs `MistHelper.py:21724`) -> `src/refactors/wanprobe_device_override_manager.py`
+
+- [ ] T085 [US1] Read def-site and callsite contexts, `guideline_flags` [BLOCKS T087].
+- [ ] T086 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bWANProbeDeviceOverrideManager\b" --include="*.py" .` — expect definition + 2 callers.
+- [ ] T087 [US1] Create `src/refactors/wanprobe_device_override_manager.py` as cohesive class. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T088].
+- [ ] T088 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites [BLOCKS T089].
+- [ ] T089 [US1] Wrapper-shim guard: `grep -RIn "\bWANProbeDeviceOverrideManager\b" MistHelper.py` returns zero hits.
+- [ ] T090 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T091 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T092].
+- [ ] T092 [US1] Open PR: `gh pr create --title "refactor(extract): WANProbeDeviceOverrideManager low-use" --body "Extracts WANProbeDeviceOverrideManager (~23 LoC) into src/refactors/wanprobe_device_override_manager.py. See plan.md PR-21."` [BLOCKS T093].
+- [ ] T093 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T094].
+- [ ] T094 [US1] Merge PR-21: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T095].
+- [ ] T095 [US3] Refresh catalog. Confirm `WANProbeDeviceOverrideManager` removed [BLOCKS T096].
+
+### Phase B.9 - PR-22: `BulkAPFirmwareUpgrader` (class, 32 LoC, FR-015 fold-in) -> `src/firmware/firmware_manager.py::FirmwareManager`
+
+**Special case (FR-015)**: Fold-in variant, NO new file. `src/firmware/firmware_manager.py` MUST retain A+/100 (SC-013).
+
+- [ ] T096 [US1] Read def-site for `BulkAPFirmwareUpgrader` in fresh `MistHelper.py`. Read `guideline_flags` [BLOCKS T098, T099].
+- [ ] T097 [P] [US1] Read `src/firmware/firmware_manager.py::FirmwareManager` — confirm existing A+/100 grade pre-PR; identify insertion point for the bulk AP upgrader methods.
+- [ ] T098 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bBulkAPFirmwareUpgrader\b" --include="*.py" .` — expect definition + 2 callers in `firmware_manager.py:1733, 1736`.
+- [ ] T099 [US1] Fold `BulkAPFirmwareUpgrader` into `FirmwareManager` (FR-015). Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging. Ensure `firmware_manager.py` retains A+/100 [BLOCKS T100].
+- [ ] T100 [US1] SAME commit: delete from `MistHelper.py` + rewrite both caller references in `firmware_manager.py:1733, 1736` to the folded methods [BLOCKS T101].
+- [ ] T101 [US1] Wrapper-shim guard: `grep -RIn "\bBulkAPFirmwareUpgrader\b" MistHelper.py` returns zero hits.
+- [ ] T102 [P] [US1] Local gates on both affected files: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T103 [US1] Compliance: `firmware_manager.py` A+/100 preserved (SC-013). Baseline >= 99.6/A+ [BLOCKS T104].
+- [ ] T104 [US1] Open PR: `gh pr create --title "refactor(extract): BulkAPFirmwareUpgrader low-use (FR-015 fold-in)" --body "Folds BulkAPFirmwareUpgrader (~32 LoC) into src/firmware/firmware_manager.py::FirmwareManager per FR-015. See plan.md PR-22."` [BLOCKS T105].
+- [ ] T105 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T106].
+- [ ] T106 [US1] Merge PR-22: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T107].
+- [ ] T107 [US3] Refresh catalog. Confirm `BulkAPFirmwareUpgrader` removed. Confirm `firmware_manager.py` grade unchanged [BLOCKS T108].
+
+### Phase B.10 - PR-23: `initialize_mist_session_interactive` (fn, 18 LoC, refs `MistHelper.py:2237, 19356, 23190`) -> `src/refactors/initialize_mist_session_interactive.py` (fn->method per FR-005)
+
+- [ ] T108 [US1] Read def-site and all THREE callsite contexts, `guideline_flags` [BLOCKS T110].
+- [ ] T109 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\binitialize_mist_session_interactive\b" --include="*.py" .` — expect definition + 3 callers.
+- [ ] T110 [US1] Create `src/refactors/initialize_mist_session_interactive.py`. Land the function as a class-body method on a cohesive class (FR-005) — NOT as a bare `def`. Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T111].
+- [ ] T111 [US1] SAME commit: delete the module-level `def initialize_mist_session_interactive` from `MistHelper.py` + rewrite ALL THREE callsites (2237, 19356, 23190) to invoke the class method [BLOCKS T112].
+- [ ] T112 [US1] Wrapper-shim guard: `grep -RIn "\binitialize_mist_session_interactive\b" MistHelper.py` returns zero hits; `grep -n "^def initialize_mist_session_interactive" MistHelper.py` returns zero hits (bare-def guard).
+- [ ] T113 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T114 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T115].
+- [ ] T115 [US1] Open PR: `gh pr create --title "refactor(extract): initialize_mist_session_interactive low-use" --body "Extracts initialize_mist_session_interactive (~18 LoC) into src/refactors/initialize_mist_session_interactive.py as a class-body method per FR-005. Rewrites 3 callsites. See plan.md PR-23."` [BLOCKS T116].
+- [ ] T116 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T117].
+- [ ] T117 [US1] Merge PR-23: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T118].
+- [ ] T118 [US3] Refresh catalog. Confirm `initialize_mist_session_interactive` removed [BLOCKS T119].
+
+### Phase B.11 - PR-24: `initialize_mist_session` (fn, 18 LoC, refs `MistHelper.py:23195, 23258`) -> `src/refactors/initialize_mist_session.py` (fn->method per FR-005)
+
+- [ ] T119 [US1] Read def-site and both callsite contexts, `guideline_flags` [BLOCKS T121].
+- [ ] T120 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\binitialize_mist_session\b" --include="*.py" .` — expect definition + 2 callers (note: distinct from `initialize_mist_session_interactive`).
+- [ ] T121 [US1] Create `src/refactors/initialize_mist_session.py`. Land as class-body method (FR-005). Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T122].
+- [ ] T122 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites (23195, 23258) [BLOCKS T123].
+- [ ] T123 [US1] Wrapper-shim guard: `grep -n "^def initialize_mist_session\b" MistHelper.py` returns zero hits (bare-def guard).
+- [ ] T124 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T125 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T126].
+- [ ] T126 [US1] Open PR: `gh pr create --title "refactor(extract): initialize_mist_session low-use" --body "Extracts initialize_mist_session (~18 LoC) into src/refactors/initialize_mist_session.py as a class-body method per FR-005. See plan.md PR-24."` [BLOCKS T127].
+- [ ] T127 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T128].
+- [ ] T128 [US1] Merge PR-24: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T129].
+- [ ] T129 [US3] Refresh catalog. Confirm `initialize_mist_session` removed [BLOCKS T130].
+
+### Phase B.12 - PR-25: `PACKAGE_IMPORT_MAP` (assignment, 13 LoC, refs `MistHelper.py:354, 538`) -> `src/refactors/package_import_map.py` (assignment->class-body attribute per FR-005)
+
+- [ ] T130 [US1] Read def-site and both callsite contexts, `guideline_flags` [BLOCKS T132].
+- [ ] T131 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bPACKAGE_IMPORT_MAP\b" --include="*.py" .` — expect definition + 2 callers.
+- [ ] T132 [US1] Create `src/refactors/package_import_map.py`. Land the mapping as a class-body attribute (or classmethod-returning) on a cohesive class per FR-005 — NOT as a bare module-level `PACKAGE_IMPORT_MAP = ...`. Fix `guideline_flags`. ASCII/Path/comments/logging [BLOCKS T133].
+- [ ] T133 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites (354, 538) [BLOCKS T134].
+- [ ] T134 [US1] Wrapper-shim guard: `grep -n "^PACKAGE_IMPORT_MAP\s*=" MistHelper.py` returns zero hits (module-scope-attribute guard).
+- [ ] T135 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T136 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T137].
+- [ ] T137 [US1] Open PR: `gh pr create --title "refactor(extract): PACKAGE_IMPORT_MAP low-use" --body "Extracts PACKAGE_IMPORT_MAP (~13 LoC) into src/refactors/package_import_map.py as a class-body attribute per FR-005. See plan.md PR-25."` [BLOCKS T138].
+- [ ] T138 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T139].
+- [ ] T139 [US1] Merge PR-25: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T140].
+- [ ] T140 [US3] Refresh catalog. Confirm `PACKAGE_IMPORT_MAP` removed [BLOCKS T141].
+
+### Phase B.13 - PR-26: `main` (fn, 12 LoC, cross-file P2, refs `MistHelper.py:23700 + src/maps/maps_manager.py:2794`) -> `src/refactors/main.py` (fn->method per FR-005; FR-019 cross-file audit)
+
+**P2 special case**: Cross-file callsite. Diff touches THREE files atomically: new module, `MistHelper.py`, `src/maps/maps_manager.py`. Post-merge grep audit required (FR-019, SC-012).
+
+- [ ] T141 [US2] Read def-site in `MistHelper.py:23700` and BOTH callsite contexts including external caller `src/maps/maps_manager.py:2794`, `guideline_flags` [BLOCKS T143].
+- [ ] T142 [P] [US2] Belt-and-suspenders grep: `grep -RIn "\bmain\b" --include="*.py" MistHelper.py src/maps/` — expect definition + 1 caller in `maps_manager.py:2794` (note: `main` is a common word; scope grep to affected files only, and inspect each hit for actual reference to this specific `main`).
+- [ ] T143 [US2] Create `src/refactors/main.py`. Land as class-body method (FR-005). Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging [BLOCKS T144].
+- [ ] T144 [US2] SAME commit: delete `def main` from `MistHelper.py`, rewrite the internal callsite at `MistHelper.py:23700`, AND rewrite the external callsite at `src/maps/maps_manager.py:2794` to import from `src.refactors.main`. All three file edits in ONE commit (FR-003 atomicity) [BLOCKS T145].
+- [ ] T145 [US2] Wrapper-shim guard: `grep -n "^def main\b" MistHelper.py` returns zero hits (bare-def guard).
+- [ ] T146 [P] [US2] Local gates on all three affected files: py_compile MistHelper.py + main.py + maps_manager.py, ruff, black, mypy strict on new module, pytest.
+- [ ] T147 [US2] Compliance: new module A+/100. `MistHelper.py` unchanged. `src/maps/maps_manager.py` grade unchanged (external caller compliance preserved per spec Edge Case). Baseline >= 99.6/A+ [BLOCKS T148].
+- [ ] T148 [US2] Open PR: `gh pr create --title "refactor(extract): main low-use (P2 cross-file)" --body "Extracts main (~12 LoC) into src/refactors/main.py as a class-body method per FR-005. Rewrites cross-file callsite in src/maps/maps_manager.py:2794 atomically (FR-019). See plan.md PR-26."` [BLOCKS T149].
+- [ ] T149 [US2] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T150].
+- [ ] T150 [US2] Merge PR-26: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T151].
+- [ ] T151 [US2] FR-019 post-merge grep audit: `grep -RIn "\bmain\b" src/maps/maps_manager.py` — confirm no stale reference to the deleted `MistHelper.main`; the sole remaining hit imports from `src.refactors.main`. Paste audit output in the PR retro comment [BLOCKS T152].
+- [ ] T152 [US3] Refresh catalog. Confirm `main` removed from Low-Use bucket [BLOCKS T153].
+
+### Phase B.14 - PR-27: `marvis_data_utils` (assignment, 4 LoC, cross-file P2, refs `MistHelper.py:6594, 15736 + src/troubleshooting/marvis_troubleshoot_utils.py:21`) -> `src/refactors/marvis_data_utils.py` (assignment->class-body attribute per FR-005; FR-019 cross-file audit)
+
+- [ ] T153 [US2] Read def-site and all three callsite contexts including external caller `marvis_troubleshoot_utils.py:21`, `guideline_flags` [BLOCKS T155].
+- [ ] T154 [P] [US2] Belt-and-suspenders grep: `grep -RIn "\bmarvis_data_utils\b" --include="*.py" .` — expect definition + 3 callers across 2 files.
+- [ ] T155 [US2] Create `src/refactors/marvis_data_utils.py`. Land the assignment as a class-body attribute per FR-005. Fix `guideline_flags`. ASCII/Path/comments/logging [BLOCKS T156].
+- [ ] T156 [US2] SAME commit: delete from `MistHelper.py`, rewrite internal callsites at `MistHelper.py:6594, 15736`, AND rewrite external callsite at `src/troubleshooting/marvis_troubleshoot_utils.py:21`. All edits in ONE commit (FR-003) [BLOCKS T157].
+- [ ] T157 [US2] Wrapper-shim guard: `grep -n "^marvis_data_utils\s*=" MistHelper.py` returns zero hits.
+- [ ] T158 [P] [US2] Local gates on all three affected files: py_compile, ruff, black, mypy strict on new module, pytest.
+- [ ] T159 [US2] Compliance: new module A+/100. `MistHelper.py` unchanged. `src/troubleshooting/marvis_troubleshoot_utils.py` grade unchanged. Baseline >= 99.6/A+ [BLOCKS T160].
+- [ ] T160 [US2] Open PR: `gh pr create --title "refactor(extract): marvis_data_utils low-use (P2 cross-file)" --body "Extracts marvis_data_utils (~4 LoC) into src/refactors/marvis_data_utils.py as class-body attribute per FR-005. Rewrites cross-file callsite in src/troubleshooting/marvis_troubleshoot_utils.py:21 atomically (FR-019). See plan.md PR-27."` [BLOCKS T161].
+- [ ] T161 [US2] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T162].
+- [ ] T162 [US2] Merge PR-27: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T163].
+- [ ] T163 [US2] FR-019 post-merge grep audit: `grep -RIn "\bmarvis_data_utils\b" src/troubleshooting/` — confirm sole remaining reference imports from `src.refactors.marvis_data_utils`; paste audit output in PR retro comment [BLOCKS T164].
+- [ ] T164 [US3] Refresh catalog. Confirm `marvis_data_utils` removed [BLOCKS T165].
+
+### Phase B.15 - PR-28: `FAST_MODE_BACKOFF_MULTIPLIER` (assignment, 3 LoC, refs `MistHelper.py:1969, 9980, 15409`) -> `src/refactors/fast_mode_backoff_multiplier.py` (FR-020 rename from `fast__mode__backoff__multiplier.py`; assignment->class-body attribute per FR-005)
+
+- [ ] T165 [US1] Read def-site and all THREE callsite contexts, `guideline_flags`. Confirm analyzer's suggested filename uses double-underscore separators; the landing filename MUST be single-underscore per FR-020 [BLOCKS T167].
+- [ ] T166 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bFAST_MODE_BACKOFF_MULTIPLIER\b" --include="*.py" .` — expect definition + 3 callers.
+- [ ] T167 [US1] Create `src/refactors/fast_mode_backoff_multiplier.py` (SINGLE-underscore filename per FR-020). Land as class-body attribute per FR-005. Record rename rationale in PR body. ASCII/Path/comments/logging [BLOCKS T168].
+- [ ] T168 [US1] SAME commit: delete from `MistHelper.py` + rewrite ALL THREE callsites (1969, 9980, 15409) [BLOCKS T169].
+- [ ] T169 [US1] Wrapper-shim guard: `grep -n "^FAST_MODE_BACKOFF_MULTIPLIER\s*=" MistHelper.py` returns zero hits. FR-020 verify: `test ! -f src/refactors/fast__mode__backoff__multiplier.py` (double-underscore file must NOT exist).
+- [ ] T170 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T171 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T172].
+- [ ] T172 [US1] Open PR: `gh pr create --title "refactor(extract): FAST_MODE_BACKOFF_MULTIPLIER low-use" --body "Extracts FAST_MODE_BACKOFF_MULTIPLIER (~3 LoC) into src/refactors/fast_mode_backoff_multiplier.py as class-body attribute per FR-005. FR-020: renamed from analyzer-suggested fast__mode__backoff__multiplier.py to single-underscore per PEP 8. See plan.md PR-28."` [BLOCKS T173].
+- [ ] T173 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T174].
+- [ ] T174 [US1] Merge PR-28: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T175].
+- [ ] T175 [US3] Refresh catalog. Confirm `FAST_MODE_BACKOFF_MULTIPLIER` removed [BLOCKS T176].
+
+### Phase B.16 - PR-29: `FAST_MODE_DEVICES_PER_THREAD` (assignment, 3 LoC, refs `MistHelper.py:1972, 7470`) -> `src/refactors/fast_mode_devices_per_thread.py` (FR-020 rename; assignment->class-body attribute per FR-005)
+
+- [ ] T176 [US1] Read def-site and both callsite contexts, `guideline_flags`. Confirm FR-020 rename need [BLOCKS T178].
+- [ ] T177 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bFAST_MODE_DEVICES_PER_THREAD\b" --include="*.py" .` — expect definition + 2 callers.
+- [ ] T178 [US1] Create `src/refactors/fast_mode_devices_per_thread.py` (single-underscore per FR-020). Class-body attribute per FR-005. ASCII/Path/comments/logging [BLOCKS T179].
+- [ ] T179 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites (1972, 7470) [BLOCKS T180].
+- [ ] T180 [US1] Wrapper-shim guard: `grep -n "^FAST_MODE_DEVICES_PER_THREAD\s*=" MistHelper.py` returns zero hits. FR-020 verify: `test ! -f src/refactors/fast__mode__devices__per__thread.py`.
+- [ ] T181 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T182 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T183].
+- [ ] T183 [US1] Open PR: `gh pr create --title "refactor(extract): FAST_MODE_DEVICES_PER_THREAD low-use" --body "Extracts FAST_MODE_DEVICES_PER_THREAD (~3 LoC) into src/refactors/fast_mode_devices_per_thread.py per FR-005 + FR-020. See plan.md PR-29."` [BLOCKS T184].
+- [ ] T184 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T185].
+- [ ] T185 [US1] Merge PR-29: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T186].
+- [ ] T186 [US3] Refresh catalog. Confirm `FAST_MODE_DEVICES_PER_THREAD` removed [BLOCKS T187].
+
+### Phase B.17 - PR-30: `FAST_MODE_SEQUENTIAL_MAX_RETRIES` (assignment, 3 LoC, refs `MistHelper.py:1977, 15549`) -> `src/refactors/fast_mode_sequential_max_retries.py` (FR-020 rename; class-body attribute per FR-005)
+
+- [ ] T187 [US1] Read def-site and both callsite contexts, `guideline_flags`. Confirm FR-020 rename need [BLOCKS T189].
+- [ ] T188 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bFAST_MODE_SEQUENTIAL_MAX_RETRIES\b" --include="*.py" .` — expect definition + 2 callers.
+- [ ] T189 [US1] Create `src/refactors/fast_mode_sequential_max_retries.py` (single-underscore per FR-020). Class-body attribute per FR-005. ASCII/Path/comments/logging [BLOCKS T190].
+- [ ] T190 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites (1977, 15549) [BLOCKS T191].
+- [ ] T191 [US1] Wrapper-shim guard: `grep -n "^FAST_MODE_SEQUENTIAL_MAX_RETRIES\s*=" MistHelper.py` returns zero hits. FR-020 verify: `test ! -f src/refactors/fast__mode__sequential__max__retries.py`.
+- [ ] T192 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T193 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T194].
+- [ ] T194 [US1] Open PR: `gh pr create --title "refactor(extract): FAST_MODE_SEQUENTIAL_MAX_RETRIES low-use" --body "Extracts FAST_MODE_SEQUENTIAL_MAX_RETRIES (~3 LoC) into src/refactors/fast_mode_sequential_max_retries.py per FR-005 + FR-020. See plan.md PR-30."` [BLOCKS T195].
+- [ ] T195 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T196].
+- [ ] T196 [US1] Merge PR-30: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T197].
+- [ ] T197 [US3] Refresh catalog. Confirm `FAST_MODE_SEQUENTIAL_MAX_RETRIES` removed [BLOCKS T198].
+
+### Phase B.18 - PR-31: `FAST_MODE_USE_CONNECTION_AWARE_THREADING` (assignment, 3 LoC, refs `MistHelper.py:1984, 7460`) -> `src/refactors/fast_mode_use_connection_aware_threading.py` (FR-020 rename; class-body attribute per FR-005)
+
+- [ ] T198 [US1] Read def-site and both callsite contexts, `guideline_flags`. Confirm FR-020 rename need [BLOCKS T200].
+- [ ] T199 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bFAST_MODE_USE_CONNECTION_AWARE_THREADING\b" --include="*.py" .` — expect definition + 2 callers.
+- [ ] T200 [US1] Create `src/refactors/fast_mode_use_connection_aware_threading.py` (single-underscore per FR-020). Class-body attribute per FR-005. ASCII/Path/comments/logging [BLOCKS T201].
+- [ ] T201 [US1] SAME commit: delete from `MistHelper.py` + rewrite both callsites (1984, 7460) [BLOCKS T202].
+- [ ] T202 [US1] Wrapper-shim guard: `grep -n "^FAST_MODE_USE_CONNECTION_AWARE_THREADING\s*=" MistHelper.py` returns zero hits. FR-020 verify: `test ! -f src/refactors/fast__mode__use__connection__aware__threading.py`.
+- [ ] T203 [P] [US1] Local gates: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T204 [US1] Compliance A+/100 + baseline >= 99.6/A+ [BLOCKS T205].
+- [ ] T205 [US1] Open PR: `gh pr create --title "refactor(extract): FAST_MODE_USE_CONNECTION_AWARE_THREADING low-use" --body "Extracts FAST_MODE_USE_CONNECTION_AWARE_THREADING (~3 LoC) into src/refactors/fast_mode_use_connection_aware_threading.py per FR-005 + FR-020. See plan.md PR-31."` [BLOCKS T206].
+- [ ] T206 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T207].
+- [ ] T207 [US1] Merge PR-31: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T208].
+- [ ] T208 [US3] Refresh catalog. Confirm `FAST_MODE_USE_CONNECTION_AWARE_THREADING` removed [BLOCKS T209].
+
+### Phase B.19 - PR-32: `MIST_WAN_TARGET_PORTS` (assignment, 3 LoC, cross-file P2, refs `MistHelper.py:1992, 15638 + src/gateway/gateway_export_utils.py:51`) -> `src/refactors/mist_wan_target_ports.py` (FR-020 rename; FR-019 cross-file audit; class-body attribute per FR-005)
+
+- [ ] T209 [US2] Read def-site and all three callsite contexts including external caller `gateway_export_utils.py:51`, `guideline_flags`. Confirm FR-020 rename need [BLOCKS T211].
+- [ ] T210 [P] [US2] Belt-and-suspenders grep: `grep -RIn "\bMIST_WAN_TARGET_PORTS\b" --include="*.py" .` — expect definition + 3 callers across 2 files.
+- [ ] T211 [US2] Create `src/refactors/mist_wan_target_ports.py` (single-underscore per FR-020). Class-body attribute per FR-005. ASCII/Path/comments/logging [BLOCKS T212].
+- [ ] T212 [US2] SAME commit: delete from `MistHelper.py`, rewrite internal callsites at `MistHelper.py:1992, 15638`, AND rewrite external callsite at `src/gateway/gateway_export_utils.py:51`. All edits in ONE commit (FR-003) [BLOCKS T213].
+- [ ] T213 [US2] Wrapper-shim guard: `grep -n "^MIST_WAN_TARGET_PORTS\s*=" MistHelper.py` returns zero hits. FR-020 verify: `test ! -f src/refactors/mist__wan__target__ports.py`.
+- [ ] T214 [P] [US2] Local gates on all three affected files: py_compile, ruff, black, mypy strict on new module, pytest.
+- [ ] T215 [US2] Compliance: new module A+/100. `MistHelper.py` unchanged. `src/gateway/gateway_export_utils.py` grade unchanged. Baseline >= 99.6/A+ [BLOCKS T216].
+- [ ] T216 [US2] Open PR: `gh pr create --title "refactor(extract): MIST_WAN_TARGET_PORTS low-use (P2 cross-file)" --body "Extracts MIST_WAN_TARGET_PORTS (~3 LoC) into src/refactors/mist_wan_target_ports.py as class-body attribute per FR-005. FR-020 rename applied. Rewrites cross-file callsite in src/gateway/gateway_export_utils.py:51 atomically (FR-019). See plan.md PR-32."` [BLOCKS T217].
+- [ ] T217 [US2] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T218].
+- [ ] T218 [US2] Merge PR-32: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T219].
+- [ ] T219 [US2] FR-019 post-merge grep audit: `grep -RIn "\bMIST_WAN_TARGET_PORTS\b" src/gateway/` — confirm sole remaining reference imports from `src.refactors.mist_wan_target_ports`; paste audit output in PR retro comment [BLOCKS T220].
+- [ ] T220 [US3] Refresh catalog. Confirm `MIST_WAN_TARGET_PORTS` removed [BLOCKS T221].
+
+### Phase B.20 - PR-33: `BulkSwitchFirmwareUpgrader` (class, 19 LoC, FR-015 fold-in) -> `src/firmware/firmware_manager.py::FirmwareManager`
+
+**Special case (FR-015)**: Fold-in variant, NO new file. `src/firmware/firmware_manager.py` MUST retain A+/100 (SC-013). This is the final Low-Use extraction; upon merge, SC-001 is satisfied.
+
+- [ ] T221 [US1] Read def-site for `BulkSwitchFirmwareUpgrader` in fresh `MistHelper.py`. Read `guideline_flags` [BLOCKS T223, T224].
+- [ ] T222 [P] [US1] Read `src/firmware/firmware_manager.py::FirmwareManager` — confirm existing A+/100 grade pre-PR; identify insertion point.
+- [ ] T223 [P] [US1] Belt-and-suspenders grep: `grep -RIn "\bBulkSwitchFirmwareUpgrader\b" --include="*.py" .` — expect definition + 2 callers in `firmware_manager.py:1832, 1833`.
+- [ ] T224 [US1] Fold `BulkSwitchFirmwareUpgrader` into `FirmwareManager` (FR-015). Fix `guideline_flags`. ASCII/safe_input/Path/comments/logging. Ensure `firmware_manager.py` retains A+/100 [BLOCKS T225].
+- [ ] T225 [US1] SAME commit: delete from `MistHelper.py` + rewrite both caller references in `firmware_manager.py:1832, 1833` to the folded methods [BLOCKS T226].
+- [ ] T226 [US1] Wrapper-shim guard: `grep -RIn "\bBulkSwitchFirmwareUpgrader\b" MistHelper.py` returns zero hits.
+- [ ] T227 [P] [US1] Local gates on both affected files: py_compile, ruff, black, mypy strict, pytest.
+- [ ] T228 [US1] Compliance: `firmware_manager.py` A+/100 preserved (SC-013). Baseline >= 99.6/A+ [BLOCKS T229].
+- [ ] T229 [US1] Open PR: `gh pr create --title "refactor(extract): BulkSwitchFirmwareUpgrader low-use (FR-015 fold-in, final)" --body "Folds BulkSwitchFirmwareUpgrader (~19 LoC) into src/firmware/firmware_manager.py::FirmwareManager per FR-015. Final Low-Use extraction — SC-001 satisfied upon merge. See plan.md PR-33."` [BLOCKS T230].
+- [ ] T230 [US1] 15/15 CI + CLEAN (no `--admin`) [BLOCKS T231].
+- [ ] T231 [US1] Merge PR-33: `gh pr merge --squash --delete-branch`. Pull main [BLOCKS T232].
+- [ ] T232 [US3] Refresh catalog. Confirm `BulkSwitchFirmwareUpgrader` removed AND Low-Use bucket now shows 0 entries (SC-001) [BLOCKS T233].
+
+**Checkpoint B**: Low-Use bucket cleared (SC-001 satisfied). All 20 PRs merged serially with catalog refreshed between each. Proceed to Phase C.
+
+---
+
+## Phase C: Aggregate Verification (SC-001..SC-013)
+
+**Purpose**: Verify every measurable outcome from spec.md Success Criteria against the final post-PR-33-merge `main` state. Runs after ALL 20 PRs merge; tasks may run in parallel (all [P]).
+
+- [ ] T233 [P] SC-001 verify: `grep -A 2 "^## Low-Use" refactor_candidates.md` — confirm 0 entries OR documented Limitations rationale for any legitimate deferral (Hot reclassification mid-flight).
+- [ ] T234 [P] SC-002 verify: `wc -l MistHelper.py` — confirm physical line count dropped by >= 2,500 lines relative to pre-initiative baseline (post-PR-13-merge snapshot).
+- [ ] T235 [P] SC-003 verify: `grep -E "99\.6|A\+" data/full_repo_compliance_current.md` — confirm repo aggregate >= 99.6/A+ at every intermediate main-branch state (walk the merge sequence via `git log --oneline` and spot-check compliance snapshots).
+- [ ] T236 [P] SC-004 verify: cross-reference pre- and post-initiative compliance snapshots — confirm zero A+ files regressed below A+.
+- [ ] T237 [P] SC-005 verify: `gh pr list --state merged --search "refactor(extract)" --limit 25` — for each of PRs #14-#33, confirm merge occurred with 15/15 CI green. Any `--admin`-bypassed merge must have documented BLOCKED/DIRTY/BEHIND `mergeStateStatus` root cause in the PR body.
+- [ ] T238 [P] SC-006 verify: enumerate every new file under `src/refactors/` created during PRs #14-#33 (17 expected: `wlanradius_timer_manager.py`, `wanprobe_config_manager.py`, `anomaly_metrics_discovery.py`, `device_data_fetcher.py`, `inventory_csvcomparator.py`, `device_config_template_cloner_manager.py`, `wanprobe_device_override_manager.py`, `initialize_mist_session_interactive.py`, `initialize_mist_session.py`, `package_import_map.py`, `main.py`, `marvis_data_utils.py`, `fast_mode_backoff_multiplier.py`, `fast_mode_devices_per_thread.py`, `fast_mode_sequential_max_retries.py`, `fast_mode_use_connection_aware_threading.py`, `mist_wan_target_ports.py`) — confirm each scores A+/100 in `data/full_repo_compliance_current.md`.
+- [ ] T239 [P] SC-007 verify: `grep -RIn "\b\(WLANRadiusTimerManager\|WANProbeConfigManager\|AnomalyMetricsDiscovery\|DeviceDataFetcher\|InventoryCSVComparator\|FirmwareUpgradeStatusChecker\|DeviceConfigTemplateClonerManager\|WANProbeDeviceOverrideManager\|BulkAPFirmwareUpgrader\|initialize_mist_session_interactive\|initialize_mist_session\|PACKAGE_IMPORT_MAP\|marvis_data_utils\|FAST_MODE_BACKOFF_MULTIPLIER\|FAST_MODE_DEVICES_PER_THREAD\|FAST_MODE_SEQUENTIAL_MAX_RETRIES\|FAST_MODE_USE_CONNECTION_AWARE_THREADING\|MIST_WAN_TARGET_PORTS\|BulkSwitchFirmwareUpgrader\)\b" MistHelper.py` — must return ZERO hits. Also grep for wrapper `def <name>` in `MistHelper.py` — zero hits.
+- [ ] T240 [P] SC-008 verify: `grep -A 5 "^## Skipped" refactor_candidates.md` — confirm `GlobalImportManager` still pinned; `git log --all --oneline --grep "GlobalImportManager"` between initiative kickoff and completion returns no modifying commits attributable to this initiative.
+- [ ] T241 [P] SC-009 verify: cross-reference the 20 merged extraction PRs against the Hot bucket snapshot taken at initiative kickoff — confirm zero Hot source symbols were extracted (destination classes may be Hot per FR-009).
+- [ ] T242 [P] SC-010 verify: walk the merged-PR sequence `#14..#33` via `gh pr list --state merged --search "refactor(extract)"` — confirm each PR's merge commit was followed by a `refactor_candidates.md` regeneration commit or verified regeneration on the next PR branch (catalog refresh trail).
+- [ ] T243 [P] SC-011 verify: `git log --all --oneline --grep "guideline_flags"` and `git log -p specs/1011-misthelper-refactor-low-use/` — confirm each analyzer-flagged `guideline_flag` on extracted code was resolved within its extraction PR (spot-check PR-14 `raw_input_call`, PR-19 `oversize_25_lines`/`missing_inline_comments`/`non_ascii_logs`).
+- [ ] T244 [P] SC-012 verify (FR-019 cross-file audit trail): `grep -RIn "\bmain\b" src/maps/maps_manager.py`, `grep -RIn "\bmarvis_data_utils\b" src/troubleshooting/`, `grep -RIn "\bMIST_WAN_TARGET_PORTS\b" src/gateway/` — confirm each remaining hit imports from `src.refactors.*` and none reference deleted `MistHelper.py` symbols. Confirm PR-26, PR-27, PR-32 retro comments each contain the audit output.
+- [ ] T245 [P] SC-013 verify: `grep -E "src/firmware/firmware_manager\.py" data/full_repo_compliance_current.md` — confirm `src/firmware/firmware_manager.py` retains A+/100 after receiving all THREE fold-ins (PR-19, PR-22, PR-33).
+- [ ] T246 After T233-T245 all green, tag the initiative complete: append a "1011 completion note" entry to `refactor_candidates.md` Limitations section (or the appropriate audit trail location) summarizing the 20-PR merge count, LoC drop, catalog transitions (any Low-Use -> Hot reclassifications), and the final Low-Use bucket state.
+
+**Checkpoint C**: All 13 Success Criteria verified. Initiative 1011 complete.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase A (Pre-work)**: No dependencies — start immediately after 1010 close.
+- **Phase B (Low-Use extractions)**: Depends on Phase A completion. Each Phase B.N group depends on Phase B.(N-1)'s catalog-refresh task.
+- **Phase C (Aggregate verification)**: Depends on Phase B.20 (PR-33 merge + catalog refresh) completion.
+
+### Serial PR Contract (spec Edge Cases, FR-002)
+
+- Only ONE extraction PR is open at any time.
+- Every candidate group's `refresh catalog` task (T017, T028, T039, T050, T061, T073, T084, T095, T107, T118, T129, T140, T152, T164, T175, T186, T197, T208, T220, T232) BLOCKS the first task of the next candidate group (FR-010, SC-010).
+- No two Phase B candidate groups may execute in parallel.
+
+### Within Each Candidate Group
+
+- Reading def-site + callsite context + `guideline_flags` + belt-and-suspenders grep may run in parallel (marked [P]).
+- Creating/folding the target module blocks the callsite rewrite (same commit constraint per FR-003).
+- Local syntax/lint/type/test gates may run in parallel (marked [P]).
+- Wrapper-shim guard and compliance re-check block PR-open.
+- PR-open blocks CI-wait; CI-green blocks merge; merge blocks catalog refresh; catalog refresh blocks the next candidate group.
+- For P2 cross-file PRs (PR-26, PR-27, PR-32), the FR-019 post-merge grep audit is a mandatory task between the pull-main step and the catalog-refresh step.
+
+### Parallel Opportunities
+
+- Phase A: T002, T003, T004, T005 may run in parallel after T001.
+- Within any Phase B candidate group: the `[P]`-marked context reads, belt-and-suspenders grep, and local gate tasks may run in parallel.
+- Phase C: All verification tasks T233-T245 may run in parallel; T246 depends on all of them.
+- CROSS-CANDIDATE: strictly forbidden by the serial-PR contract. Do NOT parallelize PR-N with PR-N+1.
+
+---
+
+## Parallel Example: Phase A
+
+```bash
+# T001 first (refreshes catalog on fresh main), then in parallel:
+grep -E "99\.6|A\+" data/full_repo_compliance_current.md        # T002
+grep -A 5 "^## Skipped" refactor_candidates.md                  # T003
+git status && git log --oneline -5                              # T004
+grep -A 2 "^## Hot" refactor_candidates.md | head -20           # T005
+```
+
+## Parallel Example: Within One Candidate Group (PR-14 WLANRadiusTimerManager)
+
+```bash
+# After T006 (read def-site) completes, run in parallel:
+# T007: read callsite contexts at MistHelper.py:20044 and :21515
+# T008: read guideline_flags + belt-and-suspenders grep
+# Both [P] tasks feed into T009 (create module + resolve raw_input_call).
+
+# After T010 (delete + rewrite both callsites in same commit), run local gates in parallel:
+python -m ruff check MistHelper.py src/refactors/wlanradius_timer_manager.py      # T012 part
+python -m black --check MistHelper.py src/refactors/wlanradius_timer_manager.py   # T012 part
+python -m mypy --strict src/refactors/wlanradius_timer_manager.py                 # T012 part
+python -m pytest tests/ -k "not slow" -x                                          # T012 part
+```
+
+## Serial Example: Cross-Candidate (Non-parallelizable)
+
+```bash
+# T017 MUST complete (catalog refreshed after PR-14 merge) before T018 begins.
+# PR-14 and PR-15 never execute concurrently — FR-002 forbids it.
+```
+
+---
+
+## Implementation Strategy
+
+### Serial-PR Discipline (Required)
+
+1. Complete Phase A (T001-T005). Confirm Checkpoint A.
+2. Execute PR-14 tasks (T006-T017) sequentially with in-group `[P]` parallelism.
+3. After PR-14 merge + catalog refresh (T017): execute PR-15 tasks (T018-T028).
+4. Continue through PR-33 (T221-T232) in the plan.md PR Dispatch Queue order.
+5. Between merges, always refresh `refactor_candidates.md` and re-derive line numbers from the fresh catalog — line numbers listed in this file are the snapshot at spec/plan creation and WILL drift.
+6. If the fresh catalog shows a Low-Use candidate has reclassified to Unused, reroute to a delete-only PR (FR-016 + 1010 Unused workflow). If reclassified to Hot, defer per FR-009/FR-016 and update SC-002 rationale.
+7. Execute Phase C aggregate verification (T233-T246) once PR-33 is merged.
+
+### MVP Increment (Optional)
+
+Each merged PR delivers standalone value (spec User Story 1/2 "Independent Test"). Any prefix `PR-14..PR-N` yields a coherent `main` state at 99.6/A+ compliance with monotonically decreasing `MistHelper.py` line count. Dispatch may pause at any post-merge catalog-refresh checkpoint and resume from the next PR.
+
+### No-Batch Guarantee
+
+FR-002 prohibits batching multiple candidates into one PR. Even if two candidates appear "trivial together" (e.g. the four `FAST_MODE_*` constants), they get separate PRs. The serial workflow is what distinguishes this initiative from prior stalled attempts and preserves the SC-010 catalog audit trail.
+
+### Cross-File PR Discipline (P2 only)
+
+PR-26 (`main`), PR-27 (`marvis_data_utils`), and PR-32 (`MIST_WAN_TARGET_PORTS`) each touch a file outside `MistHelper.py` in the same commit as the extraction. The FR-019 post-merge grep audit is a hard gate — it BLOCKS the catalog-refresh task, and its output MUST be pasted into the PR retro comment as SC-012 acceptance evidence.
+
+### FR-015 Fold-In Discipline
+
+PR-19 (`FirmwareUpgradeStatusChecker`), PR-22 (`BulkAPFirmwareUpgrader`), and PR-33 (`BulkSwitchFirmwareUpgrader`) fold into `src/firmware/firmware_manager.py::FirmwareManager` rather than creating new `src/refactors/` modules. `firmware_manager.py`'s A+/100 grade MUST be preserved after each fold-in (SC-013); a single fold-in that regresses that file below A+ is a merge blocker.
+
+### FR-020 Rename Discipline
+
+PRs 28-32 land at single-underscore module paths (e.g. `fast_mode_backoff_multiplier.py`), NOT the analyzer's double-underscore suggestion. The rename rationale MUST appear in every affected PR description. Wrapper-shim guards for these PRs include a `test ! -f <double-underscore-path>` check to catch accidental double-underscore files.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no dependencies within one candidate group. Never parallelize across candidate groups (FR-002).
+- `[BLOCKS T###]` = enforces the serial-PR contract across candidate groups. The catalog-refresh task at the end of each group is the pivot that BLOCKS the first task of the next group.
+- Every catalog-refresh task provides the SC-010 audit trail. Missing refresh -> initiative fails SC-010.
+- `--admin` merge bypass MUST NOT be used as a routine unblock (FR-011, `feedback_no_admin_bypass.md`). Investigate `mergeStateStatus` first; SKIPPED conditionals are not blocking.
+- No new tests are mandated. Existing tests that reference an extracted symbol are updated in the same PR (carry-forward from 1010 research.md "Test-preservation rule").
+- Analyzer (`tools/refactor_analyzer/`) is NEVER modified by this initiative (FR-018). Discrepancies are filed as separate analyzer bugs.
+- Line numbers and LoC figures in this file reflect the plan.md PR Dispatch Queue snapshot at spec creation. Fresh analyzer output at PR dispatch time is authoritative — line numbers may drift as prior PRs land, and reference counts may shift per FR-016 (Low-Use -> Unused or Low-Use -> Hot reclassification handled by rerouting or deferring, respectively).
+- The parent conversation controls PR dispatch cadence — this tasks file is the operator recipe, not an auto-execution script.


### PR DESCRIPTION
Closes #1439

## Summary

The branch `chore/archive-1010-1011-specs` held the only copy of the SpecKit
records for initiative 1010 and initiative 1011. This pull request restores
those 14 files to `specs/`, where their siblings 1012 through 1015 already live.

## What the audit found

The two spec directories exist on disk as **empty folders**. Git does not track
an empty folder, so `git status` reports a clean tree and the loss stays hidden.

| Check | Result |
| - | - |
| `specs/1010-misthelper-refactor-extraction/` on disk | Exists, holds 0 files |
| `specs/1011-misthelper-refactor-low-use/` on disk | Exists, holds 0 files |
| Either path in the `main` tree | Absent |
| Either path in `finished-specs/` or `abandoned-specs/` | Absent |
| `git log main -- <either path>` | No commit. The content never reached `main`. |

The content survives only on the stale branch. A delete of that branch during
the branch cleanup would have destroyed 2389 lines of design record.

## The 14 restored files

| Initiative | Files |
| - | - |
| 1010 misthelper-refactor-extraction | `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `tasks.md`, 2 checklists, 3 contracts |
| 1011 misthelper-refactor-low-use | `spec.md`, `plan.md`, `tasks.md` |

## Why `specs/` and not an archive folder

The sibling initiatives 1012, 1013, 1014, and 1015 all live in `specs/`. The
restored records join them, so a reader finds the whole 1010 to 1015 refactor
series in one place. The original commit chose this path, and this pull request
keeps it.

## Test plan

- [x] The cherry-pick applies to current `main` with no conflict.
- [x] The change adds 14 files and modifies none, so no existing file changes.
- [x] The Simplified Technical English linter scores `1010/spec.md` at 90 and
      `1011/spec.md` at 89. The gate needs 80.
- [x] No Python file changes, so the lint, format, type, and test gates see no
      new input.

## Conformance

- [x] The change adds no secret and logs no secret.
- [x] The change alters no destructive operation.
- [x] The change alters no runtime behavior.

## Context

Found during the branch cleanup that followed pull request #1731 and pull
request #1732. That cleanup removed 224 stale branches. Every other branch held
work that `main` already carried. This one did not.
