### PR TITLE
docs: sync README, wiki, and menu reference with the source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Network Operations & Data Export Tool for Juniper Mist Cloud
 [![Quality Gates](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/ci.yml)
 [![Container Build](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml/badge.svg)](https://github.com/jmorrison-juniper/MistHelper/actions/workflows/container-build.yml)
 
-**Operation Count:** The code currently defines 194 actionable menu entries (1-194), organized into 31 logical groups with no gaps. Exit is menu 0.
+**Operation Count:** The code defines 209 actionable menu entries, numbered 1 to
+209 with no gaps. Exit is menu 0, so the registry holds 210 entries in total.
+The [Menu Reference](#menu-reference) section lists every category and range.
 
 MistHelper is a production-focused Python application that streamlines large-scale Juniper Mist Cloud data extraction, enrichment, transformation, and limited lifecycle operations. It supports both interactive (menu) and fully automated CLI execution, with flexible output to CSV files, a local SQLite database, or a polyglot backend (ArangoDB for documents, Redis for time-series and JSON caching) using natural/composite business keys (no artificial surrogate IDs for core entities). The codebase emphasizes safety, transparency, and predictable behavior-aligned with the included internal Agents Guide and NASA/JPL style defensive programming practices.
 
@@ -12,15 +14,31 @@ MistHelper is a production-focused Python application that streamlines large-sca
 
 ## Quality Gates
 
-Every PR runs these checks in parallel via GitHub Actions:
+Every pull request runs these 13 checks in parallel through GitHub Actions. The
+workflow is `.github/workflows/ci.yml`. A caller can override each threshold
+through a `workflow_call` input. The table lists the default.
 
 | Gate | Tool | Threshold |
 |------|------|-----------|
 | Lint | Ruff | Zero violations |
-| Type Check | mypy --strict | Phased enforcement |
-| Tests | pytest + coverage | >= 70% |
-| Security | Bandit | Zero findings |
-| Dependencies | pip-audit | Zero vulnerabilities |
+| Format | Black | Zero files need reformatting |
+| Type check | mypy | Zero errors under the `pyproject.toml` settings |
+| Tests | pytest with coverage | Coverage >= 80 percent |
+| Security | Bandit | Zero findings at any severity |
+| Dependencies | pip-audit | Zero known vulnerabilities |
+| Code quality | Pylint | Score >= 9.5 |
+| Complexity | Radon | No block above cyclomatic complexity 10 |
+| Dead code | Vulture | Zero findings at confidence 70 |
+| Docstring style | pydocstyle | Zero violations |
+| Docstring coverage | interrogate | Coverage >= 90 percent |
+| Diagram references | `tools/diagram_lint` | Every diagram reference resolves |
+| Browser tests | Playwright | Every end-to-end test passes |
+
+CodeQL runs in a separate workflow, `.github/workflows/codeql.yml`. A code pull
+request must wait for CodeQL before it takes the `auto-merge` label.
+
+A gate that fails on `main` opens an issue with the `quality-gate` label. The
+same gate closes that issue when it passes again.
 
 ## Deployment Options
 
@@ -105,34 +123,43 @@ flowchart LR
 }}}%%
 mindmap
    root((MistHelper<br/>210 Operations))
-    Safe Org Exports (60)
+    Safe Org Exports (61)
       Sites and Analysis 1-7
-      Device Inventory 8-14
-      Device Stats 15-19
+      Device Inventory 8-13
+      Device Stats 15-17
       Events and Logs 20-26
       Client Stats 27-30
       Gateway Ops 31-36
       Templates 37-41
       Config and Admin 42-50
       SLE and Insights 51-55
-      Misc Exports 56-59
-    Interactive Safe (38)
-      Site Devices 60-72, 209
+      Misc Exports 56-58
+      Support and Assets 188, 193
+      Address and License 195-196
+      JSI and Mist Edge 204-205
+    Interactive Safe (45)
+      Site Devices 60-72
       Site Insights 73-79
       Site Stats 80-91
       Viewers 92-96
-    Resource Intensive (6)
+      Site Searches 197-203
+      Site Beacon 209
+    Resource Intensive (10)
+      Heavy Inventory 14, 18-19
+      Bulk Exports 59
       Long-Running 97-101
-      Bulk 153
+      Bulk Upgrade 153
     WebSocket (22)
       Show Commands 102-115
       Diagnostics 116-123
-    Interactive (27)
+    Interactive (29)
+      Exit 0
       Device Diag 124-127
       Device Mgmt 128-133
       Packet Capture 134-135
       Tools 136-147
       Config Mgmt 148-150
+      Ticket Viewer 192
     Continuous (2)
       Loops 151-152
     Destructive (41)
@@ -145,8 +172,10 @@ mindmap
       Test Data 171-174
       SSH Runners 175-176
       Clear Reset 177-187
-      Support Tickets 188-193
+      Support Tickets 189-191
       Gateway Template 194
+      Synthetic Probes 206
+      AP Profile Migration 207-208
 ```
 
 > See [full operations reference](documentation/diagrams/operations/operations-reference.md) with lifecycle states, NOC engineer journey, and safety requirements.
@@ -176,8 +205,9 @@ mindmap
 
 | Path | Purpose |
 |------|---------|
-| `MistHelper.py` | Legacy entrypoint -- actively being decomposed into `src/` modules (see Architecture Evolution below) |
-| `src/` | Extracted modules mirroring the Mist API / mistapi hierarchy (db, output, constants, WAN builders) |
+| `MistHelper.py` | Runtime entrypoint and menu registry. The decomposition moved most logic into `src/`. |
+| `src/` | Extracted modules that mirror the Mist API and mistapi hierarchy |
+| `tools/ste_linter/` | Simplified Technical English compliance linter and dictionary extractor |
 | `data/` | SQLite DB (`mist_data.db`), generated CSV outputs, derived artifacts; polyglot backends run in containers |
 | `CombinedInventory_ByWeek/` | Time-series weekly inventory snapshots |
 | `data/SSH_COMMANDS.CSV` | Fallback SSH command list (legacy root path still supported) |
@@ -193,7 +223,24 @@ All export CSVs are now written inside `data/` (the code enforces a data directo
 
 ## Architecture Evolution
 
-MistHelper started as a single-file script (`MistHelper.py`) and is being incrementally decomposed into a modular `src/` package. The target structure mirrors both the **Mist Cloud API hierarchy** (from the OpenAPI spec) and **Thomas Munzer's mistapi library** (`tmunzer/mistapi_python`), so that MistHelper's internal organization matches the APIs it consumes.
+MistHelper started as a single-file script (`MistHelper.py`). The decomposition
+moved most logic into a modular `src/` package. The target structure mirrors
+both the **Mist Cloud API hierarchy** (from the OpenAPI spec) and **Thomas
+Munzer's mistapi library** (`tmunzer/mistapi_python`), so that the internal
+organization matches the APIs that the tool consumes.
+
+### Size Facts
+
+Measured on 2026-08-04.
+
+| Area | Python lines | Files |
+|------|--------------|-------|
+| `MistHelper.py` | 6,054 | 1 |
+| `src/` | 123,785 | 360 |
+| `tests/` | 129,364 | -- |
+
+The entrypoint held roughly 28,000 lines before the decomposition. It now holds
+6,054. The test suite is now larger than the source it covers.
 
 ### Current `src/` Layout
 
@@ -203,10 +250,14 @@ src/
 ├── api/                    # API operation modules (orgs, sites, const)
 ├── audit/                  # Audit log operations
 ├── auth/                   # Authentication and session management
+├── bootstrap/              # Dependency checks and package installation
 ├── cache/                  # Caching utilities
 ├── capture/                # Packet capture workflows and download management
+├── config/                 # Configuration loading and resolution
+├── data/                   # Shared data helpers
+├── dataclasses/            # Structured payload definitions
 ├── db/                     # Database backends (ArangoDB, Redis, retention, routing)
-├── device/                 # Device utility operations
+├── device/                 # Device utility operations and AP profile migration
 ├── export/                 # Site data export and insights extraction
 ├── firmware/               # Firmware management operations
 ├── gateway/                # Gateway exports, stats, overrides, WAN migration
@@ -214,16 +265,21 @@ src/
 ├── inventory/              # Device inventory summary, MSP orchestration, CSV comparison
 ├── maps/                   # Maps manager operations
 ├── marvis/                 # Marvis AI integration
+├── menu/                   # Menu system and option dispatch
 ├── network/                # Network configuration operations
+├── org/                    # Organization operations and synthetic probes
 ├── org_data_collector.py   # Org-level data collection
 ├── output/                 # Output formatting (writer)
+├── refactors/              # Extraction targets from the decomposition waves
 ├── reports/                # Report generation
 ├── site/                   # Site configuration management (test sites, RF, profiles)
 ├── ssh/                    # SSH runner and execution management
 ├── ssid_consolidation/     # SSID consolidation operations
+├── time/                   # Time and lookback window utilities
 ├── troubleshooting/        # Marvis troubleshooting workflows
 ├── ui/                     # Web portal components
-├── utils/                  # Shared utility functions
+├── utils/                  # Shared utilities and the operation registry
+├── validation/             # Input validation
 ├── wan_hub_group_manager.py  # WAN hub/group operations
 ├── wan_vpn_builder.py      # WAN VPN builder
 ├── websocket/              # WebSocket commands, diagnostics, service ping
@@ -280,6 +336,16 @@ Compatibility surface preserved: `MistHelper.py` remains the runtime entrypoint 
 ---
 
 ## Installation and Setup
+
+### Requirements
+
+| Item | Minimum |
+|------|---------|
+| Python | 3.13 |
+| mistapi | 0.63.1 |
+| Container runtime | Podman (primary) or Docker |
+
+`requirements.txt` and `pyproject.toml` hold the full dependency list.
 
 ### Step 1: Get the Code
 ```powershell
@@ -420,23 +486,58 @@ Interactive fallback occurs if no `-M/--menu` is supplied.
 
 ## Menu Reference
 
-This README is intentionally lean. The full, up-to-date menu reference (each option, description, safety level, and usage examples) is maintained in the repository documentation and the GitHub Wiki:
+This README stays lean. The full menu reference names each option, its
+description, its safety level, and a usage example.
 
-- Repository copy (authoritative, auto-generated): documentation/menu_reference.md
-- GitHub Wiki mirror: https://github.com/jmorrison-juniper/MistHelper/wiki/Menu-Reference
+- Repository copy, which is authoritative: `documentation/menu_reference.md`
+- Wiki mirror: <https://github.com/jmorrison-juniper/MistHelper/wiki/Menu-Reference>
 
-For quick category guidance, see the Wiki Menu Reference page linked above.
+### Categories and ranges
 
-- New in this branch: Menu `196` exports org async license-claim status summary and optional per-device detail rows.
-- New in this branch: Menu `197` interactively downloads client packet captures grouped by VLAN (site -> client -> VLAN -> `data/packet_captures/<mac>/vlan_<id>/`).
-- New in this branch: Menu `198` searches site WAN usage records (`searchSiteWanUsage`) and exports them to `SiteWanUsages_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
-- New in this branch: Menu `199` searches site webhook delivery attempts (`searchSiteWebhooksDeliveries`) and exports them to `SiteWebhookDeliveries_<site>_<webhook>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
-- New in this branch: Menu `200` searches site guest authorization records (`searchSiteGuestAuthorization`) and exports them to `SiteGuestAuthorizations_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
-- New in this branch: Menu `201` searches site Mist Edge events (`searchSiteMistEdgeEvents`) and exports them to `SiteMistEdgeEvents_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
-- New in this branch: Menu `202` searches site NAC client events (`searchSiteNacClientEvents`) and exports them to `SiteNacClientEvents_<site>.csv` (CSV/SQLite/ArangoDB via `DataExporter`).
-- New in this branch: Menu `203` searches WAN client events for a selected site via `searchSiteWanClientEvents` (spec 899 / issue #1407) and persists paginated results to `SiteWanClientEvents.CSV` (or the configured SQLite/ArangoDB backend).
-- New in this branch: Menu `204` searches org JSI assets and contract coverage via `searchOrgJsiAssetsAndContracts` (spec 865 / issue #1373) and exports the paginated results to `OrgJsiAssets.CSV` (CSV/SQLite/ArangoDB via `DataExporter`).
-- New in this branch: Menu `205` searches org-wide Mist Edge events via `searchOrgMistEdgeEvents` (spec 866 / issue #1374) -- org-scope peer of the site-scoped Menu `201` -- and persists paginated results to `OrgMistEdgeEvents.CSV` (CSV/SQLite/ArangoDB via `DataExporter`).
+`src/utils/operation_registry.py` classifies every menu number. The classifier
+fails closed, so `--test` skips any option that the registry does not name
+`safe` or `interactive_safe`. Counts were measured on 2026-08-04.
+
+| Category | Count | Menu numbers | Behavior under `--test` |
+|----------|-------|--------------|-------------------------|
+| `safe` | 61 | 1-13, 15-17, 20-58, 188, 193, 195-196, 204-205 | Runs |
+| `interactive_safe` | 45 | 60-96, 197-203, 209 | Runs under `--testinteractive` |
+| `destructive` | 41 | 154-187, 189-191, 194, 206-208 | Never runs |
+| `interactive` | 29 | 0, 124-150, 192 | Never runs |
+| `websocket` | 22 | 102-123 | Never runs |
+| `resource_intensive` | 10 | 14, 18-19, 59, 97-101, 153 | Never runs |
+| `continuous_loop` | 2 | 151-152 | Never runs |
+| **Total** | **210** | 0-209, no gaps | Menu 0 is Exit |
+
+Warning: A destructive operation changes the Mist cloud configuration. Read
+`documentation/menu_reference.md` before you run one.
+
+### Recent additions
+
+| Menu | Operation | Category |
+|------|-----------|----------|
+| 195 | Audit site addresses from a CSV file. Read-only. | `safe` |
+| 196 | Export the async organization license claim status | `safe` |
+| 197 | Download client packet captures grouped by VLAN | `interactive_safe` |
+| 198 | Search site WAN usages (`searchSiteWanUsage`) | `interactive_safe` |
+| 199 | Search site webhook deliveries (`searchSiteWebhooksDeliveries`) | `interactive_safe` |
+| 200 | Search site guest authorization (`searchSiteGuestAuthorization`) | `interactive_safe` |
+| 201 | Search site Mist Edge events (`searchSiteMistEdgeEvents`) | `interactive_safe` |
+| 202 | Search site NAC client events (`searchSiteNacClientEvents`) | `interactive_safe` |
+| 203 | Search site WAN client events (`searchSiteWanClientEvents`) | `interactive_safe` |
+| 204 | Search organization JSI assets and contracts | `safe` |
+| 205 | Search organization Mist Edge events. Org peer of menu 201. | `safe` |
+| 206 | Manage organization Zscaler synthetic probes | `destructive` |
+| 207 | Migrate access points between device profiles | `destructive` |
+| 208 | Revert an access point profile migration from a backup | `destructive` |
+| 209 | Get the site beacon detail (`getSiteBeacon`) | `interactive_safe` |
+
+Menu 197 writes to `data/packet_captures/<mac>/vlan_<id>/`. Every other
+operation in the table writes through `DataExporter`, so it honors the CSV,
+SQLite, and ArangoDB backends.
+
+---
+
 ## Security & Safety
 
 | Area | Practice |

--- a/documentation/diagrams/core/architecture-overview.md
+++ b/documentation/diagrams/core/architecture-overview.md
@@ -23,7 +23,7 @@ flowchart TB
     ci_system(["CI/CD System<br/>GitHub Actions"])
 
     subgraph misthelper["MistHelper"]
-        mh["Python CLI tool<br/>194 operations"]
+        mh["Python CLI tool<br/>209 operations"]
     end
 
     mist_cloud["Juniper Mist Cloud<br/>REST API + WebSocket"]

--- a/documentation/diagrams/core/database-strategy.md
+++ b/documentation/diagrams/core/database-strategy.md
@@ -6,7 +6,7 @@ Hybrid primary key system and PK strategy decision flowchart for MistHelper's SQ
 
 ## Entity Relationship Diagram
 
-Representative tables showing the three PK strategies used across MistHelper's 194 operations.
+Representative tables showing the three PK strategies used across MistHelper's 209 operations.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {

--- a/documentation/diagrams/operations/metrics-and-analytics.md
+++ b/documentation/diagrams/operations/metrics-and-analytics.md
@@ -6,7 +6,7 @@ Operation distribution, rate limiting behavior, data flow volumes, and version h
 
 ## Operation Category Distribution
 
-How MistHelper's 194 operations break down by safety classification.
+How MistHelper's 209 operations break down by safety classification.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -177,7 +177,7 @@ timeline
                 : Auto-merge workflow
                 : Web portal (Gunicorn)
     section Current
-        2026 : 194 operations
+        2026 : 209 operations
              : 30-group menu reorg (issue #368)
              : SpecKit integration
              : Mermaid documentation suite

--- a/documentation/menu_reference.md
+++ b/documentation/menu_reference.md
@@ -1,214 +1,249 @@
-# Menu Reference (Auto-generated)
+# Menu Reference
 
-This file was generated from the canonical `menu_actions` mapping in `MistHelper.py`.
-It is intended as an authoritative, code-aligned reference for all interactive menu options.
+This page is generated. Run `python scripts/generate_menu_wiki.py` after any
+change to `menu_actions` in `MistHelper.py` or to `src/utils/operation_registry.py`.
 
-Note: Descriptions may contain safety flags like `DESTRUCTIVE`. Refer to the code for exact behavior and required confirmations.
+MistHelper defines **209 actionable menu entries**, numbered
+1 to 209 with no gaps.
+Menu 0 is Exit, so the registry holds 210 entries in total.
 
----
+The Safety column reads from `src/utils/operation_registry.py`, which is the
+single source of truth. The classifier fails closed, so an unregistered option
+never runs in an automated test pass.
 
-```python
-menu_actions = {
-    "0": (lambda: sys.exit(0), "Exit MistHelper"),
-    "1": (OrgAlarmEventExporter.alarms, "Export all organization alarms from the past day"),
-    "2": (OrgAlarmEventExporter.device_events, "Export all device events from the past 24 hours"),
-    "3": (
-        lambda: OrgExportUtils.audit_logs(full_history=False),
-        "Export audit logs for the organization (last 24 hours)",
-    ),
-    "4": (
-        lambda fast=False: GatewayExportUtils.management_ips(fast=fast),
-        "Export gateway management overlay IPs grouped by template association",
-    ),
-    "5": (WebSocketCommands.show_mac_table, "Show MAC table on switch device via WebSocket (Layer 2 switching table)"),
-    "6": (
-        WebSocketCommands.show_forwarding_table,
-        "Show forwarding table on gateway device via WebSocket (Layer 3 routing table)",
-    ),
-    "7": (
-        WebSocketCommands.show_routing_table,
-        "Show routing table on switches via WebSocket (Switch L3 routing - BGP/OSPF/Static)",
-    ),
-    "8": (
-        WebSocketCommands.show_ssr_routes,
-        "Show SSR/SRX routing table via dedicated API (128T/SRX gateways - Advanced BGP analysis)",
-    ),
-    "9": (
-        lambda: PacketCaptureManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).start_site_packet_capture(),
-        "Start Site Packet Capture - Wireless/Wired/Gateway/Scan captures with WebSocket streaming",
-    ),
-    "10": (
-        lambda: PacketCaptureManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).start_org_packet_capture(),
-        "Start Organization Packet Capture - MxEdge captures for org-level Mist Edges only",
-    ),
-    "11": (OrgSiteExporter.sites, "Export a list of all sites in the organization"),
-    "12": (OrgInventoryExporter.inventory, "Export the full inventory of devices in the organization"),
-    "13": (OrgDeviceStatsExporter.device_stats, "Export statistics for all devices in the organization"),
-    "14": (OrgDeviceStatsExporter.device_port_stats, "Export port-level statistics for switches and gateways"),
-    "15": (OrgDeviceStatsExporter.vpn_peer_stats, "Export VPN peer path statistics for the organization"),
-    "16": (GatewayTestExporter.synthetic_tests, "Export synthetic test results for all gateways"),
-    "17": (OrgInventoryExporter.devices, "Export a list of all devices in the organization"),
-    "18": (SiteConfigExporter.settings, "Export configuration settings for all sites"),
-    "19": (GatewayTestExporter.test_results_by_site, "Export all synthetic test results (including speed tests) for gateways"),
-    "20": (OrgSiteExporter.sites_with_location, "Export a list of sites with location and timezone info"),
-    "21": (OrgInventoryExporter.gateways_with_site_info, "Export a list of gateways with associated site and address info"),
-    "22": (OrgInventoryExporter.devices_with_site_info, "Export a list of all devices with associated site and address info"),
-    "23": (lambda: (OrgSiteExporter.current_guests(), OrgSiteExporter.historical_guests()), "Export all current guest users and last 7 days of historical guests to CSV"),
-    "24": (OrgDeviceStatsExporter.switch_vc_stats, "Export all switch virtual chassis (VC/stacking) stats to CSV"),
-    "25": (OrgInventoryExporter.combined_inventory_with_site_info, "Export combined inventory with site and address info by calendar week"),
-    "26": (GatewayExportUtils.templates, "Export gateway templates from the organization"),
-    "27": (OrgSiteExporter.sites_list_api, "Export all sites using the 'list' sites API endpoint (to SiteList_ListAPI.csv, only if not already present)"),
-    "28": (lambda fast=False: GatewayExportUtils.with_wan_overrides(fast=fast), "Find gateway ports overridden from template (outliers for compliance correction)"),
-    "29": (SiteDeviceExporter.port_stats, "Export port statistics for a selected site"),
-    "30": (SiteClientExporter.clients, "Export client statistics for a selected site"),
-    "31": (SiteDeviceExporter.devices, "Export device list for a selected site"),
-    "32": (SiteDeviceExporter.device_stats, "Export device statistics for a selected site"),
-    "33": (SiteDeviceExporter.device_virtual_chassis, "Export virtual chassis information for a selected switch device"),
-    "34": (SiteClientExporter.wifi_clients, "Export currently connected WiFi clients and session data for a selected site to SiteWiFiClients.CSV"),
-    "35": (OrgTemplateExporter.all_templates, "Export all organization templates (gateway, network, RF, site, AP)"),
-    "36": (OrgTemplateExporter.network_templates, "Export network template information for the organization"),
-    "37": (OrgTemplateExporter.rf_templates, "Export RF template information for the organization"),
-    "38": (OrgTemplateExporter.ap_templates, "Export AP template information for the organization"),
-    "39": (OrgTemplateExporter.switch_templates, "Export switch template information for the organization"),
-    "40": (OrgClientSecurityExporter.wireless_clients, "Export wireless client statistics for the organization"),
-    "41": (OrgClientSecurityExporter.wired_clients, "Export wired client statistics for the organization"),
-    "42": (OrgClientSecurityExporter.security_events, "Export security events for the organization"),
-    "43": (OrgClientSecurityExporter.rogue_clients, "Export rogue client detections for the organization"),
-    "44": (OrgClientSecurityExporter.rogue_aps, "Export rogue AP detections for the organization"),
-    "45": (OrgAdminExporter.licenses, "Export license information for the organization"),
-    "46": (OrgConfigExporter.psks, "Export PSK (Pre-Shared Key) information for the organization"),
-    "47": (OrgConfigExporter.webhooks, "Export webhook configuration for the organization"),
-    "48": (OrgConfigExporter.wlans, "Export WLAN configuration for the organization"),
-    "49": (SiteConfigExporter.wlans, "Export WLAN configuration for a selected site"),
-    "50": (SiteClientExporter.beacons, "Export beacon information for a selected site"),
-    "51": (SiteConfigExporter.maps, "Export map information for a selected site"),
-    "52": (SiteConfigExporter.zones, "Export zone information for a selected site"),
-    "53": (SiteExportUtils.insights, "Export SLE (Service Level Experience) metrics insights for a selected site"),
-    "54": (OrgAdminExporter.api_tokens, "Export API token information for the organization"),
-    "55": (OrgAdminExporter.admins, "Export administrator information for the organization"),
-    "56": (OrgConfigExporter.msp, "MSP (Managed Service Provider) info - Displays guidance only (MSP data requires MSP-level API access, not org-level)"),
-    "57": (OrgAdminExporter.sso, "Export SSO (Single Sign-On) information for the organization"),
-    "58": (OrgAdminExporter.usage, "Export license usage information for the organization"),
-    "59": (OrgConfigExporter.mx_edges, "Export MX Edge information for the organization"),
-    "60": (lambda: FirmwareManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).check_firmware_upgrade_status(), "Check current firmware upgrade status across organization with detailed progress monitoring and export to CSV"),
-    "61": (lambda fast=False, address_check=False, debug=False, skip_ssl_verify=False: InventoryCSVComparator(fast=fast, address_check=address_check, debug=debug, skip_ssl_verify=skip_ssl_verify).execute(), "Compare inventory data with external CSV file using configurable address similarity threshold (ADDRESS_MATCH_THRESHOLD in .env)"),
-    "62": (TroubleshootUtils.launch_interactive, "Interactive Marvis (VNA) AI troubleshooting - guided client, device, and network analysis"),
-    "63": (OrgAlarmEventExporter.device_events_52w, "Export all org device events from the last 52 weeks (streaming with checkpoint/resume)"),
-    "64": (lambda: OrgExportUtils.audit_logs(full_history=True, duration="52w"), "Export ALL audit logs for the organization (last 52 weeks)"),
-    "65": (GatewayExportUtils.device_configs, "Export configuration details for all gateway devices across all sites"),
-    "70": (PromptUtils.select_site_with_logging, "Select a site (used by other functions)"),
-    "71": (InteractiveDisplayUtils.site_inventory, "View device inventory for a selected site"),
-    "72": (InteractiveDisplayUtils.device_stats, "View statistics for a selected device at a site"),
-    "73": (InteractiveDisplayUtils.device_tests, "View synthetic test stats for a selected gateway device"),
-    "74": (InteractiveDisplayUtils.device_config, "View configuration details for a selected device"),
-    "75": (DataCollectionManager.continuous_loop, "Loop refresh of core datasets (site list, inventory, stats, ports, VPN) Stop with CTRL+C or create 'stop_loop.txt'"),
-    "76": (DataCollectionManager.continuous_loop, "Run continuous data collection loop (5 core API calls with rate limiting)"),
-    "77": (SFPTransceiverDataProcessor.merge_transceiver_data, "Process and merge CSV files of SFP Module locations into a single CSV file"),
-    "78": (DataCollectionManager.generate_support_packages, "Generate support package for each site"),
-    "79": (CLIShellManager.launch, "Interactively execute a CLI command on a gateway or switch (exit with ~)"),
-    "80": (ARPCommandManager.execute, "Run ARP command on an AP and receive output via WebSocket"),
-    "90": (lambda: FirmwareManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_firmware_upgrade_with_mode_selection(), " DESTRUCTIVE: Advanced AP firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment"),
-    "91": (DeviceRebootManager.by_gateway_template_list, " DESTRUCTIVE: Reboot all devices associated with templates listed in GatewayTemplateRebootList.CSV and log results"),
-    "92": (lambda dry_run=False: VirtualChassisManager.convert_single(dry_run=dry_run), " DESTRUCTIVE: Convert a virtual chassis switch to virtual MAC (interactive, supports --dry-run)"),
-    "93": (VirtualChassisManager.convert_by_site_list, " DESTRUCTIVE: Convert all virtual chassis switches in sites listed in VCConvert.CSV (bulk operation)"),
-    "94": (VirtualChassisManager.check_status, "Check virtual chassis to virtual MAC conversion status for all switches"),
-    "95": (lambda fast=False: GatewayStatsExporter.device_stats_with_freshness(fast=fast), "Export detailed device statistics for all gateways (with freshness check)"),
-    "96": (GatewayStatsExporter.wan_port_conflicts, "Check and export gateways with duplicate WAN port IP addresses (0/0/0, 0/0/1, 0/0/2)"),
-    "97": (SSHRunnerManager.interactive, "Enhanced SSH Command Runner - Execute commands on remote network devices via SSH"),
-    "98": (SSHRunnerManager.by_gateway_template, "SSH Runner - Target gateways by template name (online gateways with management IPs only)"),
-    "99": (lambda: FirmwareManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_switch_firmware_upgrade_with_mode_selection(), " DESTRUCTIVE: Advanced Switch firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment"),
-    "100": (lambda: FirmwareManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_ssr_firmware_upgrade_with_mode_selection(), " DESTRUCTIVE: Advanced SSR firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment"),
-    "101": (lambda: TUILauncher().launch(), "Launch Terminal User Interface (TUI) mode - Visual navigation of Mist API library with interactive exploration"),
-    "102": (lambda: WLANRadiusTimerManager().manage(), "Manage WLAN RADIUS Authentication Timers - Configure auth_servers_timeout, auth_servers_retries, auth_server_selection, and fast_dot1x_timers for site or template WLANs"),
-    "103": (lambda: WAN2MigrationManager().set_site_variable(), "Set WAN2 Interface Site Variable - Configure 'wan2_interface' site variable for template-based WAN migration (Reports sites with ge-0/0/1 overrides)"),
-    "104": (lambda fast=False, dry_run=False: update_gateway_templates_wan2_variable(fast=fast, dry_run=dry_run), " DESTRUCTIVE: Update Gateway Templates to Use WAN2 Variable - Replace hardcoded 'ge-0/0/1' references with {{wan2_interface}} variable (Requires uppercase 'MIGRATE' confirmation, supports --dry-run)"),
-    "105": (GatewayTemplateConfigManager.extract, "Extract Gateway Template Configuration (DIA_Pico, Picocell) - Save specific configs to JSON for replication"),
-    "106": (GatewayTemplateConfigManager.apply, " DESTRUCTIVE: Apply Gateway Template Configuration - Replicate extracted configs to other templates (Requires uppercase 'APPLY' confirmation)"),
-    "107": (SiteConfigManager.create_test_sites_from_csv, " DESTRUCTIVE: Create 137 test sites from NorthAmericanTestSites.csv - Real landmarks across 13 North American countries (Requires uppercase 'CREATE' confirmation)"),
-    "108": (SiteConfigManager.create_country_rf_templates_and_assign, " DESTRUCTIVE: Create country-specific RF templates and assign sites to matching templates (Requires uppercase 'CREATE' confirmation)"),
-    "109": (SiteConfigManager.create_ap_model_device_profiles, " DESTRUCTIVE: Create AP model device profiles per AP model (Requires uppercase 'CREATE' confirmation)"),
-    "110": (SiteConfigManager.assign_aps_to_matching_device_profiles, " DESTRUCTIVE: Assign APs to Device Profiles matching their model type (AP-{model}) - Skips APs without matching profiles (Requires uppercase 'ASSIGN' confirmation)"),
-    "111": (GatewayTemplateConfigManager.clone_by_location, " DESTRUCTIVE: Clone Gateway Template by State and Country - Create state/country-specific templates and assign sites (Requires uppercase 'CLONE' confirmation)"),
-    "112": (lambda: MapsManagerLauncher().launch(), "Maps Manager - Interactive site floorplan and map operations (sub-menu)"),
-    "113": (lambda dry_run=False: WANProbeConfigManager.configure(dry_run=dry_run), " DESTRUCTIVE: Configure WAN Probe Override on Gateway Templates - Set ICMP probe IPs and profile for all WAN interfaces (Requires uppercase 'APPLY' confirmation, supports --dry-run)"),
-    "114": (lambda dry_run=False: WANProbeDeviceOverrideManager.configure(dry_run=dry_run), " DESTRUCTIVE: Configure WAN Probe on Device Port Overrides - Set ICMP probe on device-level WAN overrides only (Requires uppercase 'APPLY' confirmation, supports --dry-run)"),
-    "115": (switch_to_interactive_login, "Switch to interactive login (email/password) - Enables MSP-level API access for current session"),
-    "116": (OrgLevelAPFirmwareUpgrader.run, " DESTRUCTIVE: Org-Level AP Firmware Upgrade - Efficient multi-site upgrade using org-level API (1 call per version vs 1 per site), MSP multi-org support, supports --dry-run"),
-    "117": (MSPInventoryExporter.execute, "MSP Inventory Export - Export device inventory across all MSPs and all organizations to CSV (requires MSP privileges via --login)"),
-    "118": (SiteAutoUpgradeConfigurator.execute, "Site Auto-Upgrade Configuration - Configure AP auto-upgrade settings for sites with MSP multi-org support (supports --dry-run)"),
-    "119": (ZoneConfigurationAnalyzer.analyze, "Site Config Analysis - Scan all sites for zone, engagement dwell tag, and occupancy setting deviations"),
-    "120": (SiteAnalyticsConfigurator.execute, " DESTRUCTIVE: Site Analytics Configuration - Apply standard RTSA/Rogue/Engagement/Occupancy settings to deviating sites"),
-    "121": (SiteInventoryHealthAnalyzer.analyze, "Site Inventory Health Analysis - Find sites with APs missing switches/gateways, or with offline infrastructure"),
-    "122": (lambda dry_run=False: BulkRadiusWLANConfigManager().manage(dry_run=dry_run), "Bulk RADIUS WLAN Configuration - Configure auth_servers_timeout, auth_servers_retries, fast_dot1x_timers for org-level RADIUS WLANs"),
-    "123": (DeviceUtilityCommands.traceroute, "Traceroute from device to destination host (AP/Switch/Gateway)"),
-    "124": (DeviceUtilityCommands.show_ospf_neighbors, "Show OSPF Neighbors on SSR/SRX Gateway"),
-    "125": (DeviceUtilityCommands.show_ospf_interfaces, "Show OSPF Interfaces on SSR/SRX Gateway"),
-    "126": (DeviceUtilityCommands.show_ospf_database, "Show OSPF Database on SSR/SRX Gateway"),
-    "127": (DeviceUtilityCommands.show_ospf_summary, "Show OSPF Summary on SSR/SRX Gateway"),
-    "128": (DeviceUtilityCommands.show_session, "Show Sessions on SSR/SRX Gateway"),
-    "129": (DeviceUtilityCommands.show_service_path, "Show Service Path on SSR Gateway"),
-    "130": (DeviceUtilityCommands.show_bgp_summary, "Show BGP Summary on Switch or Gateway"),
-    "131": (DeviceUtilityCommands.show_arp_table, "Show ARP Table on Switch or Gateway"),
-    "132": (DeviceUtilityCommands.show_dhcp_leases, "Show DHCP Leases on Switch or Gateway"),
-    "133": (DeviceUtilityCommands.show_dot1x, "Show 802.1X Table on Switch"),
-    "134": (DeviceUtilityCommands.show_evpn_database, "Show EVPN Database on Switch or Gateway"),
-    "135": (DeviceUtilityCommands.resolve_dns, "Test DNS Resolution on SSR Gateway"),
-    "136": (DeviceUtilityCommands.monitor_traffic, "Monitor Traffic on Switch/SRX Port (streaming, Ctrl+C to stop)"),
-    "137": (DeviceUtilityCommands.run_top, "Run Top Command on Switch/SRX (streaming, Ctrl+C to stop)"),
-    "138": (DeviceUtilityCommands.locate_device, "Locate Device - Blink LED on AP or Switch"),
-    "139": (DeviceUtilityCommands.unlocate_device, "Unlocate Device - Stop LED Blinking on AP or Switch"),
-    "140": (DeviceUtilityCommands.bounce_port, " Bounce Switch/Gateway Port (y/N confirmation)"),
-    "141": (DeviceUtilityCommands.cable_test, "Cable Test on Switch Port"),
-    "142": (DeviceUtilityCommands.reprovision_device, " Reprovision Switch/Gateway (y/N confirmation)"),
-    "143": (DeviceUtilityCommands.readopt_device, "Re-adopt Switch Device"),
-    "144": (DeviceUtilityCommands.get_ztp_password, "Get ZTP Password for Switch/Gateway (console only)"),
-    "145": (DeviceUtilityCommands.get_config_commands, "Get Config CLI Commands for Switch Adoption"),
-    "146": (DeviceUtilityCommands.upload_support_file, "Upload Support File from Switch/Gateway"),
-    "147": (DeviceUtilityCommands.clear_arp_cache, " DESTRUCTIVE: Clear ARP Cache (type CLEAR)"),
-    "148": (DeviceUtilityCommands.clear_bgp_routes, " DESTRUCTIVE: Clear BGP Routes (type CLEAR)"),
-    "149": (DeviceUtilityCommands.clear_session, " DESTRUCTIVE: Clear Session on SSR/SRX (type CLEAR)"),
-    "150": (DeviceUtilityCommands.clear_mac_table, " DESTRUCTIVE: Clear MAC Table (type CLEAR)"),
-    "151": (DeviceUtilityCommands.clear_bpdu_error, " DESTRUCTIVE: Clear BPDU Errors on Switch (type CLEAR)"),
-    "152": (DeviceUtilityCommands.clear_learned_macs, " DESTRUCTIVE: Clear Learned MACs from Switch Port (type CLEAR)"),
-    "153": (DeviceUtilityCommands.clear_policy_hit_count, " DESTRUCTIVE: Clear Policy Hit Count on SSR (type CLEAR)"),
-    "154": (DeviceUtilityCommands.release_dhcp_lease, " Release DHCP Lease on Switch/Gateway (y/N)"),
-    "155": (DeviceUtilityCommands.release_dhcp_ssr, " Release DHCP Lease on SSR/SRX (y/N)"),
-    "156": (DeviceUtilityCommands.poll_switch_stats, "Poll Fresh Statistics from Switch"),
-    "157": (DeviceUtilityCommands.create_device_snapshot, "Create Device Snapshot on Switch"),
-    "158": (OfflineDeviceReporter.execute, "Offline Device Report"),
-    "159": (SSIDTemplateConsolidationManager.execute, "SSID Template Consolidation (5-Phase Guided Workflow)"),
-    "160": (E911BSSIDReportGenerator.execute, "E911 BSSID Compliance Report"),
-    "161": (GlobalWiredClientReportGenerator.execute, "Global Wired Client Report (operator-based MAC/MFG filtering)"),
-    "162": (WiredClientManufacturerReportGenerator.execute, "Wired Client Manufacturer Report (browse & select)"),
-    "163": (WanHubGroupNumberManager.execute, "WAN Hub Group Number Manager"),
-    "164": (WanVpnBuilder.execute, "WAN Hub-Spoke VPN Builder"),
-    "165": (OrgDataCollector.execute, "Bulk Org Data Collection (populate ArangoDB/Redis/SQLite with all org-level APIs)"),
-    "166": (OrgExportUtils.e911_report, "Export E911 report for the organization"),
-    "167": (OrgExportUtils.jsi_pbn, "Export JSI PBN (Product Bulletin Notifications) data"),
-    "168": (OrgExportUtils.jsi_sirt, "Export JSI SIRT (Security Incident Response) advisories"),
-    "169": (OrgExportUtils.ospf_stats, "Export OSPF adjacency statistics for the organization"),
-    "170": (SiteExportUtils.ospf_stats, "Export OSPF adjacency statistics for a selected site"),
-    "171": (SiteExportUtils.mxedge_upgrade_status, "Export MxEdge upgrade status for a selected site"),
-    "172": (SiteExportUtils.auto_map_assignment_status, "Export auto-map assignment status for a selected site"),
-    "173": (SitesByAPModelExporter.export_sites_by_ap_model, "Export sites by AP model with site address (CSV)"),
-    "174": (AuditAnalysisOps.audit_log_analysis, "Audit Log Analysis - Mermaid timeline + interactive HTML report"),
-    "175": (CacheUtils.clear_cache, "Clear CSV Cache Files (delete all generated cache CSVs)"),
-    "176": (OrgConfigMigrationManager.export_config, "Export Org WAN/Gateway Config (JSON bundle for cross-org migration)"),
-    "177": (OrgConfigMigrationManager.import_config, "Import Org WAN/Gateway Config (cross-org migration with conflict detection)"),
-    # Site Stats, Metrics & Channel Planning
-    "178": (SiteExportUtils.site_stats, "Export site aggregate health & capacity statistics"),
-    "179": (SiteExportUtils.gateway_metrics, "Export site gateway performance metrics summary"),
-    "180": (SiteExportUtils.switches_metrics, "Export site switch performance metrics summary"),
-    "181": (SiteExportUtils.beacons_stats, "Export site BLE beacon statistics"),
-    "182": (SiteExportUtils.wxrules_usage, "Export site WxLAN rule usage statistics"),
-    "183": (SiteExportUtils.assets_stats, "Export site asset statistics"),
-    "184": (SiteExportUtils.current_channel_planning, "Export current RRM channel & power plan per AP radio"),
-    "185": (SelfExportUtils.audit_logs, "Export self (admin account) audit log"),
-    "186": (GatewayHaExporter.ha_cluster_info, "Export HA gateway cluster info, stats & node pair for a site"),
-    "209": (SiteClientExporter.get_site_beacon, "Get site beacon detail by site_id + beacon_id (getSiteBeacon)"),
-}
-```
+## Important Notes
 
----
+- Options 14, 18-19, 59, 97-101, 153 are resource intensive. They can run for a long time on a large org.
+- Options 154-187, 189-191, 194, 206-208 are destructive. They change the Mist cloud configuration.
+- Warning: Do not script a destructive option unattended. Each one needs a typed
+  confirmation from a human operator.
 
-This file should be considered the single source of truth for menu numbering and short descriptions. If any menu behavior or description changes in code, regenerate or update this file accordingly.
+## Operation Categories
+
+| Menu numbers | Category | Summary |
+|---|---|---|
+| 1-13, 15-17, 20-58, 188, 193, 195-196, 204-205 | Safe org exports | 61 operations. Read-only org exports. The --test run includes them. |
+| 60-96, 197-203, 209 | Interactive safe | 45 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
+| 154-187, 189-191, 194, 206-208 | Destructive | 41 operations. They change the Mist cloud configuration. Each one needs a typed confirmation. |
+| 0, 124-150, 192 | Interactive | 29 operations. They prompt the operator, so no automated run includes them. |
+| 102-123 | WebSocket | 22 operations. They open a WebSocket stream to a device. |
+| 14, 18-19, 59, 97-101, 153 | Resource intensive | 10 operations. They run long or fetch a large payload. |
+| 151-152 | Continuous loop | 2 operations. They loop until the operator stops them. |
+
+## Full Menu Table
+
+| Menu ID | Short description | Safety | Callable/Handler |
+|---:|---|---|---|
+| 0 | Exit MistHelper | Interactive | `lambda: sys.exit(0)` |
+| 1 | Export a list of all sites in the organization | Safe org exports | `OrgSiteExporter.sites` |
+| 2 | Export a list of sites with location and timezone info | Safe org exports | `OrgSiteExporter.sites_with_location` |
+| 3 | Export all sites using the 'list' sites API endpoint (to SiteList_ListAPI.csv, only if not already present) | Safe org exports | `OrgSiteExporter.sites_list_api` |
+| 4 | Export all current guest users and last 7 days of historical guests to CSV | Safe org exports | `lambda: (OrgSiteExporter.current_guests(), OrgSiteExporter.historical_guests())` |
+| 5 | Export E911 report for the organization | Safe org exports | `OrgExportUtils.e911_report` |
+| 6 | Site Config Analysis - Scan all sites for zone, engagement dwell tag, and occupancy setting deviations | Safe org exports | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).zone_config_analysis()` |
+| 7 | Site Inventory Health Analysis - Find sites with APs missing switches/gateways, or with offline infrastructure | Safe org exports | `lambda: ExtractedSiteInventoryHealthAnalyzer.analyze(SiteInventoryHealthAnalyzerDeps(apisession=apisession, mistapi=mistapi, get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id, all_sites_fn=APICoreFetchUtils.all_sites_with_limit, save_data_fn=DataExporter.write_with_format_selection))` |
+| 8 | Export the full inventory of devices in the organization | Safe org exports | `OrgInventoryExporter.inventory` |
+| 9 | Export a list of all devices in the organization | Safe org exports | `OrgInventoryExporter.devices` |
+| 10 | Export a list of all devices with associated site and address info | Safe org exports | `OrgInventoryExporter.devices_with_site_info` |
+| 11 | Export a list of gateways with associated site and address info | Safe org exports | `OrgInventoryExporter.gateways_with_site_info` |
+| 12 | Export combined inventory with site and address info by calendar week | Safe org exports | `OrgInventoryExporter.combined_inventory_with_site_info` |
+| 13 | Export org device model counts, firmware version distribution, and versions per model (MSP-aware) | Safe org exports | `OrgDeviceInventorySummary.dispatch` |
+| 14 | Check virtual chassis to virtual MAC conversion status for all switches | Resource intensive | `lambda: _configure_virtual_chassis_manager().launch_check_status()` |
+| 15 | Export statistics for all devices in the organization | Safe org exports | `OrgDeviceStatsExporter.device_stats` |
+| 16 | Export VPN peer path statistics for the organization | Safe org exports | `OrgDeviceStatsExporter.vpn_peer_stats` |
+| 17 | Export all switch virtual chassis (VC/stacking) stats to CSV | Safe org exports | `OrgDeviceStatsExporter.switch_vc_stats` |
+| 18 | Export detailed device statistics for all gateways (with freshness check) | Resource intensive | `lambda fast=False: _dispatch_gateway_stats_device_stats_with_freshness(fast=fast)` |
+| 19 | Export port-level statistics for switches and gateways | Resource intensive | `OrgDeviceStatsExporter.device_port_stats` |
+| 20 | Export all organization alarms from the past day | Safe org exports | `OrgAlarmEventExporter.alarms` |
+| 21 | Export all device events from the past 24 hours | Safe org exports | `OrgAlarmEventExporter.device_events` |
+| 22 | Export audit logs for the organization (last 24 hours) | Safe org exports | `lambda: OrgExportUtils.audit_logs(full_history=False)` |
+| 23 | Export self (admin account) audit log | Safe org exports | `SelfExportUtils.audit_logs` |
+| 24 | Export security events for the organization | Safe org exports | `OrgClientSecurityExporter.security_events` |
+| 25 | Audit Log Analysis - Mermaid timeline + interactive HTML report | Safe org exports | `AuditAnalysisOps.audit_log_analysis` |
+| 26 | Offline Device Report | Safe org exports | `OfflineDeviceReporter.execute` |
+| 27 | Export wireless client statistics for the organization | Safe org exports | `OrgClientSecurityExporter.wireless_clients` |
+| 28 | Export wired client statistics for the organization | Safe org exports | `OrgClientSecurityExporter.wired_clients` |
+| 29 | Export rogue client detections for the organization | Safe org exports | `OrgClientSecurityExporter.rogue_clients` |
+| 30 | Export rogue AP detections for the organization | Safe org exports | `OrgClientSecurityExporter.rogue_aps` |
+| 31 | Export gateway management overlay IPs grouped by template association | Safe org exports | `_dispatch_gateway_management_ips` |
+| 32 | Export gateway templates from the organization | Safe org exports | `_dispatch_gateway_templates` |
+| 33 | Export synthetic test results for all gateways | Safe org exports | `GatewayTestExporter.synthetic_tests` |
+| 34 | Export all synthetic test results (including speed tests) for gateways | Safe org exports | `GatewayTestExporter.test_results_by_site` |
+| 35 | Find gateway ports overridden from template (outliers for compliance correction) | Safe org exports | `_dispatch_gateway_with_wan_overrides` |
+| 36 | Check and export gateways with duplicate WAN port IP addresses (0/0/0, 0/0/1, 0/0/2) | Safe org exports | `_dispatch_gateway_stats_wan_port_conflicts` |
+| 37 | Export all organization templates (gateway, network, RF, site, AP) | Safe org exports | `OrgTemplateExporter.all_templates` |
+| 38 | Export network template information for the organization | Safe org exports | `OrgTemplateExporter.network_templates` |
+| 39 | Export RF template information for the organization | Safe org exports | `OrgTemplateExporter.rf_templates` |
+| 40 | Export AP template information for the organization | Safe org exports | `OrgTemplateExporter.ap_templates` |
+| 41 | Export switch template information for the organization | Safe org exports | `OrgTemplateExporter.switch_templates` |
+| 42 | Export license information for the organization | Safe org exports | `OrgAdminExporter.licenses` |
+| 43 | Export license usage information for the organization | Safe org exports | `OrgAdminExporter.usage` |
+| 44 | Export PSK (Pre-Shared Key) information for the organization | Safe org exports | `OrgConfigExporter.psks` |
+| 45 | Export webhook configuration for the organization | Safe org exports | `OrgConfigExporter.webhooks` |
+| 46 | Export WLAN configuration for the organization | Safe org exports | `OrgConfigExporter.wlans` |
+| 47 | Export API token information for the organization | Safe org exports | `OrgAdminExporter.api_tokens` |
+| 48 | Export administrator information for the organization | Safe org exports | `OrgAdminExporter.admins` |
+| 49 | Export SSO (Single Sign-On) information for the organization | Safe org exports | `OrgAdminExporter.sso` |
+| 50 | Export MX Edge information for the organization | Safe org exports | `OrgConfigExporter.mx_edges` |
+| 51 | Export Organization SLE Metrics (Service Level Experience) | Safe org exports | `OrgExportUtils.sle_metrics` |
+| 52 | Export SLE summary metrics for all sites in the organization | Safe org exports | `OrgExportUtils.sites_sle_summary` |
+| 53 | Export Organization Insight Metrics (comprehensive operational insights) | Safe org exports | `OrgExportUtils.insight_metrics` |
+| 54 | Export all available const definitions from the Mist API (comprehensive endpoint coverage) | Safe org exports | `lambda: ConstDefinitionsExporter(apisession).export_all()` |
+| 55 | Export OSPF adjacency statistics for the organization | Safe org exports | `OrgExportUtils.ospf_stats` |
+| 56 | Export JSI PBN (Product Bulletin Notifications) data | Safe org exports | `OrgExportUtils.jsi_pbn` |
+| 57 | Export JSI SIRT (Security Incident Response) advisories | Safe org exports | `OrgExportUtils.jsi_sirt` |
+| 58 | Export Org WAN/Gateway Config (JSON bundle for cross-org migration) | Safe org exports | `lambda: cast(Any, OrgConfigMigrationManager)(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input).export_config()` |
+| 59 | Export configuration settings for all sites | Resource intensive | `SiteConfigExporter.settings` |
+| 60 | Export device list for a selected site | Interactive safe | `SiteDeviceExporter.devices` |
+| 61 | Export device statistics for a selected site | Interactive safe | `SiteDeviceExporter.device_stats` |
+| 62 | Export port statistics for a selected site | Interactive safe | `SiteDeviceExporter.port_stats` |
+| 63 | Export virtual chassis information for a selected switch device | Interactive safe | `SiteDeviceExporter.device_virtual_chassis` |
+| 64 | Export currently connected WiFi clients and session data for a selected site to SiteWiFiClients.CSV | Interactive safe | `SiteClientExporter.wifi_clients` |
+| 65 | Export client statistics for a selected site | Interactive safe | `SiteClientExporter.clients` |
+| 66 | Export beacon information for a selected site | Interactive safe | `SiteClientExporter.beacons` |
+| 67 | Export map information for a selected site | Interactive safe | `SiteConfigExporter.maps` |
+| 68 | Export zone information for a selected site | Interactive safe | `SiteConfigExporter.zones` |
+| 69 | Export WLAN configuration for a selected site | Interactive safe | `SiteConfigExporter.wlans` |
+| 70 | Export OSPF adjacency statistics for a selected site | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).ospf_stats()` |
+| 71 | Export MxEdge upgrade status for a selected site | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).mxedge_upgrade_status()` |
+| 72 | Export auto-map assignment status for a selected site | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).auto_map_assignment_status()` |
+| 73 | Export SLE (Service Level Experience) metrics insights for a selected site | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).insights()` |
+| 74 | Export general insight metrics for a selected site | Interactive safe | `lambda: SiteMetricOperation(apisession=apisession, PromptUtils=PromptUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, mistapi=mistapi).execute()` |
+| 75 | Export client-specific insight metrics for a selected site | Interactive safe | `SiteClientExporter.client_insights` |
+| 76 | Export device-specific insight metrics for a selected site | Interactive safe | `lambda: DeviceMetricOperation(apisession=apisession, PromptUtils=PromptUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, mistapi=mistapi).execute()` |
+| 77 | Export Site Anomaly Events (dynamic discovery of all anomaly-related metrics from Mist API) | Interactive safe | `SiteAnomalyExporter.anomaly_events` |
+| 78 | Export Site Device Anomaly Events (device-specific anomaly detection) | Interactive safe | `SiteAnomalyExporter.device_anomaly_events` |
+| 79 | Export Site Client Anomaly Events (client-specific anomaly detection: connectivity, roaming, throughput) | Interactive safe | `SiteAnomalyExporter.client_anomaly_events` |
+| 80 | Export site aggregate health & capacity statistics | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).site_stats()` |
+| 81 | Export site gateway performance metrics summary | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).gateway_metrics()` |
+| 82 | Export site switch performance metrics summary | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).switches_metrics()` |
+| 83 | Export site BLE beacon statistics | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).beacons_stats()` |
+| 84 | Export site WxLAN rule usage statistics | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).wxrules_usage()` |
+| 85 | Export site asset statistics | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).assets_stats()` |
+| 86 | Export current RRM channel & power plan per AP radio | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).current_channel_planning()` |
+| 87 | Export HA gateway cluster info, stats & node pair for a site | Interactive safe | `GatewayHaExporter.ha_cluster_info` |
+| 88 | Export sites by AP model with site address (CSV) | Interactive safe | `SitesByAPModelExporter.export_sites_by_ap_model` |
+| 89 | E911 BSSID Compliance Report | Interactive safe | `OrgExportUtils.e911_bssid_compliance_report` |
+| 90 | Global Wired Client Report (operator-based MAC/MFG filtering) | Interactive safe | `GlobalWiredClientReportGenerator.execute` |
+| 91 | Wired Client Manufacturer Report (browse & select) | Interactive safe | `WiredClientManufacturerReportGenerator.execute` |
+| 92 | Select a site (used by other functions) | Interactive safe | `PromptUtils.select_site_with_logging` |
+| 93 | View device inventory for a selected site | Interactive safe | `InteractiveDisplayUtils.site_inventory` |
+| 94 | View statistics for a selected device at a site | Interactive safe | `InteractiveDisplayUtils.device_stats` |
+| 95 | View synthetic test stats for a selected gateway device | Interactive safe | `InteractiveDisplayUtils.device_tests` |
+| 96 | View configuration details for a selected device | Interactive safe | `InteractiveDisplayUtils.device_config` |
+| 97 | Export all org device events from the last 52 weeks (streaming with checkpoint/resume) | Resource intensive | `OrgAlarmEventExporter.device_events_52w` |
+| 98 | Export ALL audit logs for the organization (last 52 weeks) | Resource intensive | `lambda: OrgExportUtils.audit_logs(full_history=True, duration='52w')` |
+| 99 | Export configuration details for all gateway devices across all sites | Resource intensive | `_dispatch_gateway_device_configs` |
+| 100 | Process and merge CSV files of SFP Module locations into a single CSV file | Resource intensive | `SFPTransceiverDataProcessor.merge_transceiver_data` |
+| 101 | Generate support package for each site | Resource intensive | `DataCollectionManager.generate_support_packages` |
+| 102 | Show MAC table on switch device via WebSocket (Layer 2 switching table) | WebSocket | `lambda: MacTableCommand.execute(_ws_cmd_deps())` |
+| 103 | Show forwarding table on gateway device via WebSocket (Layer 3 routing table) | WebSocket | `lambda: RoutingUtils(RoutingDeps(apisession=apisession, select_site_fn=PromptUtils.select_site_id_from_csv, select_device_fn=lambda site_id, dtype: PromptUtils.select_device_id_from_inventory(site_id, device_type=dtype), safe_input_fn=InputUtils.safe_input, websocket_manager_factory=WebSocketManager, check_fn=IsDebugMode.check)).execute_show_forwarding_table()` |
+| 104 | Show routing table on switches via WebSocket (Switch L3 routing - BGP/OSPF/Static) | WebSocket | `lambda: RoutingUtils(RoutingDeps(apisession=apisession, select_site_fn=PromptUtils.select_site_id_from_csv, select_device_fn=lambda site_id, dtype: PromptUtils.select_device_id_from_inventory(site_id, device_type=dtype), safe_input_fn=InputUtils.safe_input, websocket_manager_factory=WebSocketManager, check_fn=IsDebugMode.check)).execute_show_routing_table()` |
+| 105 | Show SSR/SRX routing table via dedicated API (128T/SRX gateways - Advanced BGP analysis) | WebSocket | `lambda: RoutingUtils(RoutingDeps(apisession=apisession, select_site_fn=PromptUtils.select_site_id_from_csv, select_device_fn=lambda site_id, dtype: PromptUtils.select_device_id_from_inventory(site_id, device_type=dtype), safe_input_fn=InputUtils.safe_input, websocket_manager_factory=WebSocketManager, check_fn=IsDebugMode.check)).execute_show_ssr_routes()` |
+| 106 | Show OSPF Neighbors on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_ospf_neighbors()` |
+| 107 | Show OSPF Interfaces on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_ospf_interfaces()` |
+| 108 | Show OSPF Database on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_ospf_database()` |
+| 109 | Show OSPF Summary on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_ospf_summary()` |
+| 110 | Show Sessions on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_session()` |
+| 111 | Show Service Path on SSR Gateway | WebSocket | `lambda: _get_duc_instance().show_service_path()` |
+| 112 | Show BGP Summary on Switch or Gateway | WebSocket | `lambda: _get_duc_instance().show_bgp_summary()` |
+| 113 | Show ARP Table on Switch or Gateway | WebSocket | `lambda: _get_duc_instance().show_arp_table()` |
+| 114 | Show DHCP Leases on Switch or Gateway | WebSocket | `lambda: _get_duc_instance().show_dhcp_leases()` |
+| 115 | Show 802.1X Table on Switch | WebSocket | `lambda: _get_duc_instance().show_dot1x()` |
+| 116 | Show EVPN Database on Switch or Gateway | WebSocket | `lambda: _get_duc_instance().show_evpn_database()` |
+| 117 | Test DNS Resolution on SSR Gateway | WebSocket | `lambda: _get_duc_instance().resolve_dns()` |
+| 118 | WebSocket Device Ping - Execute ping command on device via WebSocket stream (real-time output) | WebSocket | `lambda: PingDeviceExecutor().execute(_ws_cmd_deps())` |
+| 119 | WebSocket Device ARP - Execute ARP command on device via WebSocket stream (real-time output) | WebSocket | `lambda: ArpDeviceExecutor().execute(_ws_cmd_deps())` |
+| 120 | WebSocket Service Ping - Execute service-specific ping on SSR gateways via WebSocket stream (real-time output) | WebSocket | `lambda: ServicePingLauncher().launch()` |
+| 121 | Run ARP command on an AP and receive output via WebSocket | WebSocket | `ARPCommandManager.execute` |
+| 122 | Cable Test on Switch Port | WebSocket | `lambda: _get_duc_instance().cable_test()` |
+| 123 | Traceroute from device to destination host (AP/Switch/Gateway) | WebSocket | `lambda: _get_duc_instance().traceroute()` |
+| 124 | Monitor Traffic on Switch/SRX Port (streaming, Ctrl+C to stop) | Interactive | `lambda: _get_duc_instance().monitor_traffic()` |
+| 125 | Run Top Command on Switch/SRX (streaming, Ctrl+C to stop) | Interactive | `lambda: _get_duc_instance().run_top()` |
+| 126 | Poll Fresh Statistics from Switch | Interactive | `lambda: _get_duc_instance().poll_switch_stats()` |
+| 127 | Create Device Snapshot on Switch | Interactive | `lambda: _get_duc_instance().create_device_snapshot()` |
+| 128 | Locate Device - Blink LED on AP or Switch | Interactive | `lambda: _get_duc_instance().locate_device()` |
+| 129 | Unlocate Device - Stop LED Blinking on AP or Switch | Interactive | `lambda: _get_duc_instance().unlocate_device()` |
+| 130 | Re-adopt Switch Device | Interactive | `lambda: _get_duc_instance().readopt_device()` |
+| 131 | Get ZTP Password for Switch/Gateway (console only) | Interactive | `lambda: _get_duc_instance().get_ztp_password()` |
+| 132 | Get Config CLI Commands for Switch Adoption | Interactive | `lambda: _get_duc_instance().get_config_commands()` |
+| 133 | Upload Support File from Switch/Gateway | Interactive | `lambda: _get_duc_instance().upload_support_file()` |
+| 134 | Start Site Packet Capture - Wireless/Wired/Gateway/Scan captures with WebSocket streaming | Interactive | `lambda: PacketCaptureManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).start_site_packet_capture()` |
+| 135 | Start Organization Packet Capture - MxEdge captures for org-level Mist Edges only | Interactive | `lambda: PacketCaptureManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).start_org_packet_capture()` |
+| 136 | MSP (Managed Service Provider) info - Displays guidance only (MSP data requires MSP-level API access, not org-level) | Interactive | `OrgConfigExporter.msp` |
+| 137 | Check current firmware upgrade status across organization with detailed progress monitoring and export to CSV | Interactive | `lambda: _build_firmware_manager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).check_firmware_upgrade_status()` |
+| 138 | Compare inventory data with external CSV file using configurable address similarity threshold (ADDRESS_MATCH_THRESHOLD in .env) | Interactive | `lambda fast=False, address_check=False, debug=False, skip_ssl_verify=False: InventoryCSVComparator(fast=fast, address_check=address_check, debug=debug, skip_ssl_verify=skip_ssl_verify).execute()` |
+| 139 | Interactive Marvis (VNA) AI troubleshooting - guided client, device, and network analysis | Interactive | `TroubleshootUtils.launch_interactive` |
+| 140 | Interactively execute a CLI command on a gateway or switch (exit with ~) | Interactive | `CLIShellManager.launch` |
+| 141 | Launch Terminal User Interface (TUI) mode - Visual navigation of Mist API library with interactive exploration | Interactive | `lambda: TUILauncher().launch()` |
+| 142 | Maps Manager - Interactive site floorplan and map operations (sub-menu) | Interactive | `lambda: MapsManagerLauncher().launch()` |
+| 143 | Switch to interactive login (email/password) - Enables MSP-level API access for current session | Interactive | `lambda: SwitchToInteractiveLoginManager().run()` |
+| 144 | MSP Inventory Export - Export device inventory across all MSPs and all organizations to CSV (requires MSP privileges via --login) | Interactive | `MSPInventoryExporter.execute` |
+| 145 | SSID Template Consolidation (5-Phase Guided Workflow) | Interactive | `OrgExportUtils.ssid_template_consolidation` |
+| 146 | WAN Hub Group Number Manager | Interactive | `lambda: WanHubGroupNumberManager.execute(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input)` |
+| 147 | WAN Hub-Spoke VPN Builder | Interactive | `lambda: WanVpnBuilder.execute(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input)` |
+| 148 | Manage WLAN RADIUS Authentication Timers - Configure auth_servers_timeout, auth_servers_retries, auth_server_selection, and fast_dot1x_timers for site or template WLANs | Interactive | `lambda: WLANRadiusTimerManager().manage()` |
+| 149 | Set WAN2 Interface Site Variable - Configure 'wan2_interface' site variable for template-based WAN migration (Reports sites with ge-0/0/1 overrides) | Interactive | `lambda: WAN2MigrationLauncher().launch()` |
+| 150 | Extract Gateway Template Configuration (DIA_Pico, Picocell) - Save specific configs to JSON for replication | Interactive | `lambda: GatewayTemplateConfigManager(org_id=ConfigUtils.get_cached_or_prompted_org_id(), apisession=apisession, input_fn=InputUtils.safe_input, get_csv_path_fn=FilePathUtils.get_csv_path, save_data_fn=DataExporter.write_with_format_selection, check_and_generate_csv_fn=CacheUtils.check_and_generate_csv, generate_sites_fn=OrgSiteExporter.sites, sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename).extract()` |
+| 151 | Loop refresh of core datasets (site list, inventory, stats, ports, VPN) Stop with CTRL+C or create 'stop_loop.txt' | Continuous loop | `DataCollectionManager.continuous_loop` |
+| 152 | Run continuous data collection loop (5 core API calls with rate limiting) | Continuous loop | `DataCollectionManager.continuous_loop` |
+| 153 | Bulk Org Data Collection (populate ArangoDB/Redis/SQLite with all org-level APIs) | Resource intensive | `lambda: OrgDataCollector.execute(OrgExportUtils.export_data, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input)` |
+| 154 | DESTRUCTIVE: Advanced AP firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: _build_firmware_manager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_firmware_upgrade_with_mode_selection()` |
+| 155 | DESTRUCTIVE: Advanced Switch firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: _build_firmware_manager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_switch_firmware_upgrade_with_mode_selection()` |
+| 156 | DESTRUCTIVE: Advanced SSR firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: _build_firmware_manager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_ssr_firmware_upgrade_with_mode_selection()` |
+| 157 | DESTRUCTIVE: Org-Level AP Firmware Upgrade - Efficient multi-site upgrade using org-level API (1 call per version vs 1 per site), MSP multi-org support, supports --dry-run | Destructive | `lambda: _build_org_ap_upgrader().run()` |
+| 158 | DESTRUCTIVE: Reboot all devices associated with templates listed in GatewayTemplateRebootList.CSV and log results | Destructive | `DeviceRebootManager.by_gateway_template_list` |
+| 159 | Bounce Switch/Gateway Port (y/N confirmation) | Destructive | `lambda: _get_duc_instance().bounce_port()` |
+| 160 | Reprovision Switch/Gateway (y/N confirmation) | Destructive | `lambda: _get_duc_instance().reprovision_device()` |
+| 161 | DESTRUCTIVE: Convert a virtual chassis switch to virtual MAC (interactive, supports --dry-run) | Destructive | `lambda dry_run=False: _configure_virtual_chassis_manager().launch_convert_single(dry_run=dry_run)` |
+| 162 | DESTRUCTIVE: Convert all virtual chassis switches in sites listed in VCConvert.CSV (bulk operation) | Destructive | `lambda: _configure_virtual_chassis_manager().launch_convert_by_site_list()` |
+| 163 | DESTRUCTIVE: Update Gateway Templates to Use WAN2 Variable - Replace hardcoded 'ge-0/0/1' references with {{wan2_interface}} variable (Requires uppercase 'MIGRATE' confirmation, supports --dry-run) | Destructive | `_dispatch_gateway_wan2_variable_migration` |
+| 164 | DESTRUCTIVE: Apply Gateway Template Configuration - Replicate extracted configs to other templates (Requires uppercase 'APPLY' confirmation) | Destructive | `lambda: GatewayTemplateConfigManager(org_id=ConfigUtils.get_cached_or_prompted_org_id(), apisession=apisession, input_fn=InputUtils.safe_input, get_csv_path_fn=FilePathUtils.get_csv_path, save_data_fn=DataExporter.write_with_format_selection, check_and_generate_csv_fn=CacheUtils.check_and_generate_csv, generate_sites_fn=OrgSiteExporter.sites, sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename).apply()` |
+| 165 | DESTRUCTIVE: Clone Gateway Template by State and Country - Create state/country-specific templates and assign sites (Requires uppercase 'CLONE' confirmation) | Destructive | `lambda: GatewayTemplateConfigManager(org_id=ConfigUtils.get_cached_or_prompted_org_id(), apisession=apisession, input_fn=InputUtils.safe_input, get_csv_path_fn=FilePathUtils.get_csv_path, save_data_fn=DataExporter.write_with_format_selection, check_and_generate_csv_fn=CacheUtils.check_and_generate_csv, generate_sites_fn=OrgSiteExporter.sites, sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename).clone_by_location()` |
+| 166 | DESTRUCTIVE: Configure WAN Probe Override on Gateway Templates - Set ICMP probe IPs and profile for all WAN interfaces (Requires uppercase 'APPLY' confirmation, supports --dry-run) | Destructive | `lambda dry_run=False: WANProbeConfigManager.configure(dry_run=dry_run)` |
+| 167 | DESTRUCTIVE: Configure WAN Probe on Device Port Overrides - Set ICMP probe on device-level WAN overrides only (Requires uppercase 'APPLY' confirmation, supports --dry-run) | Destructive | `lambda dry_run=False: WANProbeDeviceOverrideManager.configure(dry_run=dry_run)` |
+| 168 | Site Auto-Upgrade Configuration - Configure AP auto-upgrade settings for sites with MSP multi-org support (supports --dry-run) | Destructive | `lambda: SiteAutoUpgradeConfigurator.execute(apisession=apisession, msp_privileges=msp_privileges if msp_privileges else [], safe_input_fn=InputUtils.safe_input, get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id, fetch_sites_fn=APICoreFetchUtils.all_sites_with_limit, check_stop_fn=ConfigUtils.check_stop_signal, dry_run=getattr(globals().get('args', None), 'dry_run', False), select_msps_fn=lambda: _build_org_ap_upgrader(org_id='')._select_msps(), select_orgs_fn=lambda msp: _build_org_ap_upgrader(org_id='')._select_orgs_from_msp(msp))` |
+| 169 | DESTRUCTIVE: Site Analytics Configuration - Apply standard RTSA/Rogue/Engagement/Occupancy settings to deviating sites | Destructive | `lambda: ExtractedSiteAnalyticsConfigurator.execute(SiteAnalyticsConfiguratorDeps(apisession=apisession, mistapi=mistapi, get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id, check_stop_fn=ConfigUtils.check_stop_signal, safe_input_fn=InputUtils.safe_input, all_sites_fn=APICoreFetchUtils.all_sites_with_limit, save_data_fn=DataExporter.write_with_format_selection, tqdm_fn=tqdm))` |
+| 170 | Bulk RADIUS WLAN Configuration - Configure auth_servers_timeout, auth_servers_retries, fast_dot1x_timers for org-level RADIUS WLANs | Destructive | `lambda dry_run=False: BulkRadiusWLANConfigManager().manage(dry_run=dry_run)` |
+| 171 | DESTRUCTIVE: Create 137 test sites from NorthAmericanTestSites.csv - Real landmarks across 13 North American countries (Requires uppercase 'CREATE' confirmation) | Destructive | `lambda: _configure_site_config_manager().create_test_sites_from_csv()` |
+| 172 | DESTRUCTIVE: Create country-specific RF templates and assign sites to matching templates (Requires uppercase 'CREATE' confirmation) | Destructive | `lambda: _configure_site_config_manager().create_country_rf_templates_and_assign()` |
+| 173 | DESTRUCTIVE: Scan org for AP models and create Device Profile per model with inherit/auto settings (Requires uppercase 'CREATE' confirmation) | Destructive | `lambda: _configure_site_config_manager().create_ap_model_device_profiles()` |
+| 174 | DESTRUCTIVE: Assign APs to Device Profiles matching their model type (AP-{model}) - Skips APs without matching profiles (Requires uppercase 'ASSIGN' confirmation) | Destructive | `lambda: _configure_site_config_manager().assign_aps_to_matching_device_profiles()` |
+| 175 | Enhanced SSH Command Runner - Execute commands on remote network devices via SSH | Destructive | `lambda: SSHRunnerManager.interactive(_build_ssh_runner_deps())` |
+| 176 | SSH Runner - Target gateways by template name (online gateways with management IPs only) | Destructive | `lambda: SSHRunnerManager.by_gateway_template(_build_ssh_runner_deps())` |
+| 177 | DESTRUCTIVE: Clear ARP Cache (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_arp_cache()` |
+| 178 | DESTRUCTIVE: Clear BGP Routes (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_bgp_routes()` |
+| 179 | DESTRUCTIVE: Clear Session on SSR/SRX (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_session()` |
+| 180 | DESTRUCTIVE: Clear MAC Table (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_mac_table()` |
+| 181 | DESTRUCTIVE: Clear BPDU Errors on Switch (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_bpdu_error()` |
+| 182 | DESTRUCTIVE: Clear Learned MACs from Switch Port (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_learned_macs()` |
+| 183 | DESTRUCTIVE: Clear Policy Hit Count on SSR (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_policy_hit_count()` |
+| 184 | Release DHCP Lease on Switch/Gateway (y/N) | Destructive | `lambda: _get_duc_instance().release_dhcp_lease()` |
+| 185 | Release DHCP Lease on SSR/SRX (y/N) | Destructive | `lambda: _get_duc_instance().release_dhcp_ssr()` |
+| 186 | Clear CSV Cache Files (delete all generated cache CSVs) | Destructive | `CacheUtils.clear_cache` |
+| 187 | Import Org WAN/Gateway Config (cross-org migration with conflict detection) | Destructive | `lambda: cast(Any, OrgConfigMigrationManager)(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input).import_config()` |
+| 188 | Export all organization support tickets to CSV | Safe org exports | `OrgTicketManager.list_tickets` |
+| 189 | Create a new organization support ticket | Destructive | `OrgTicketManager.create_ticket` |
+| 190 | Add a comment (with optional file attachment) to a support ticket | Destructive | `OrgTicketManager.add_comment` |
+| 191 | Update fields on an existing support ticket | Destructive | `OrgTicketManager.update_ticket` |
+| 192 | View a support ticket with full comments and history | Interactive | `OrgTicketManager.view_ticket` |
+| 193 | Export all tickets with full details and comments | Safe org exports | `OrgTicketManager.export_ticket_details` |
+| 194 | DESTRUCTIVE: Clone Device Config to Gateway Template - Select a gateway, extract its local config, and create a new org gateway template (Requires typing 'CREATE' to confirm) | Destructive | `DeviceConfigTemplateClonerManager.clone` |
+| 195 | Audit site addresses from CSV (data/) - fuse Mist + SNMP + CSV hints, verify vs. web; READ-ONLY, saves report. Tier-3 browser geocoding auto-engages when available (ADDRESS_AUDIT_GEOCODE=off to skip) | Safe org exports | `lambda: AddressAuditEngine().run(apisession, ConfigUtils.get_cached_or_prompted_org_id())` |
+| 196 | Export async organization license-claim status summary (and optional per-device details) | Safe org exports | `LicenseExportUtils.export_org_license_async_claim_status` |
+| 197 | Download client packet captures grouped by VLAN (site -> client -> VLAN -> data/packet_captures/) | Interactive safe | `lambda: ClientPacketCaptureDownloader(apisession).run()` |
+| 198 | Search Site WAN Usages (searchSiteWanUsage) - Export per-site WAN usage records to SiteWanUsages.csv | Interactive safe | `SiteWanUsageExporter.wan_usages` |
+| 199 | Search Site Webhook Deliveries (searchSiteWebhooksDeliveries) - Per site+webhook delivery audit CSV | Interactive safe | `SiteWebhookDeliveriesExporter.deliveries` |
+| 200 | Search Site Guest Authorization (searchSiteGuestAuthorization) - Per-site authorized guest CSV | Interactive safe | `SiteGuestAuthorizationExporter.guest_authorizations` |
+| 201 | Search Site Mist Edge Events (searchSiteMistEdgeEvents) - Per-site Mist Edge event CSV | Interactive safe | `SiteMistEdgeEventsExporter.mist_edge_events` |
+| 202 | Search Site NAC Client Events (searchSiteNacClientEvents) - Per-site NAC client event CSV | Interactive safe | `SiteNacClientEventsExporter.nac_client_events` |
+| 203 | Search WAN client events for a selected site (spec 899 / issue #1407) | Interactive safe | `SiteClientExporter.wan_client_events` |
+| 204 | Export JSI assets and contract search results | Safe org exports | `OrgExportUtils.jsi_assets` |
+| 205 | Export Org Mist Edge event search results | Safe org exports | `OrgExportUtils.mist_edge_events` |
+| 206 | DESTRUCTIVE: Manage org Zscaler synthetic probes - Build/merge/swap synthetic_test.custom_probes from curated Zscaler catalogue | Destructive | `lambda: manage_org_synthetic_probes(apisession, ConfigUtils.get_cached_or_prompted_org_id())` |
+| 207 | DESTRUCTIVE: Migrate APs between device profiles - Reassign every AP bound to a source device profile to a chosen target profile (Requires typing 'MIGRATE' or 'DRY-RUN' to confirm) | Destructive | `lambda: APProfileMigrationManager.migrate_aps_between_device_profiles(apisession)` |
+| 208 | DESTRUCTIVE: Revert an AP profile migration from a backup file - Reassign each listed AP back to its original device profile (Requires typing 'REVERT' to confirm) | Destructive | `lambda: APProfileMigrationManager.revert_ap_profile_migration(apisession)` |
+| 209 | Get site beacon detail by site_id + beacon_id (getSiteBeacon) | Interactive safe | `SiteClientExporter.get_site_beacon` |
+
+This page should be regenerated whenever `menu_actions` or the operation registry
+changes, so the wiki stays aligned with the code.

--- a/documentation/wiki/History.md
+++ b/documentation/wiki/History.md
@@ -2,7 +2,7 @@
 
 The previous README was partially outdated compared to the current codebase. Key discrepancies that were corrected:
 
-1. **Operation Count**: MistHelper now has 194 actionable menu entries (1-194)
+1. **Operation Count**: MistHelper now has 209 actionable menu entries (1-209)
 2. **File Naming**: Actual output files use names like `OrgApiTokens.csv`, `OrgPsks.csv`, etc. Weekly inventory is stored in `CombinedInventory_ByWeek/`
 3. **SSH Command Runner**: The Enhanced SSH Runner (option 97) uses a fallback CSV located at `data/SSH_COMMANDS.CSV`, not the root directory
 4. **Heavy Operations**: Options 14 (port stats for all sites) and 18 (site settings for all sites) are excluded from `--test` mode due to multi-hour runtime

--- a/documentation/wiki/Home.md
+++ b/documentation/wiki/Home.md
@@ -1,10 +1,10 @@
 # MistHelper Wiki
 
-Welcome to the MistHelper documentation wiki. MistHelper is a production-focused Python application for Juniper Mist Cloud network operations, providing 194 menu-driven operations for data extraction, device management, and firmware upgrades.
+Welcome to the MistHelper documentation wiki. MistHelper is a production-focused Python application for Juniper Mist Cloud network operations, providing 209 menu-driven operations for data extraction, device management, and firmware upgrades.
 
 ## Quick Links
 
-- [Menu Reference](Menu-Reference) - Complete list of all 194 menu operations
+- [Menu Reference](Menu-Reference) - Complete list of all 209 menu operations
 - [Data Model](Data-Model) - CSV, SQLite, and polyglot output details
 - [Testing](Testing) - Systematic test mode and CI pipeline
 - [Troubleshooting](Troubleshooting) - Common issues and solutions

--- a/documentation/wiki/Menu-Reference.md
+++ b/documentation/wiki/Menu-Reference.md
@@ -1,212 +1,249 @@
 # Menu Reference
 
-Operation Count: MistHelper currently defines 194 actionable menu entries (1-194).
+This page is generated. Run `python scripts/generate_menu_wiki.py` after any
+change to `menu_actions` in `MistHelper.py` or to `src/utils/operation_registry.py`.
 
-Below is the authoritative list derived directly from `menu_actions` in code. WIP = unstable schema, DESTRUCTIVE = requires explicit user confirmation.
+MistHelper defines **209 actionable menu entries**, numbered
+1 to 209 with no gaps.
+Menu 0 is Exit, so the registry holds 210 entries in total.
+
+The Safety column reads from `src/utils/operation_registry.py`, which is the
+single source of truth. The classifier fails closed, so an unregistered option
+never runs in an automated test pass.
 
 ## Important Notes
 
-- Options 14 and 18 are resource-intensive and may take a long time during large exports.
-- Options 63-65 are intentionally marked WIP and may evolve as the bulk-history workflows settle.
-- Destructive ranges should never be scripted unattended without explicit human review and confirmation.
+- Options 14, 18-19, 59, 97-101, 153 are resource intensive. They can run for a long time on a large org.
+- Options 154-187, 189-191, 194, 206-208 are destructive. They change the Mist cloud configuration.
+- Warning: Do not script a destructive option unattended. Each one needs a typed
+  confirmation from a human operator.
 
 ## Operation Categories
 
-| Range | Category | Summary |
+| Menu numbers | Category | Summary |
 |---|---|---|
-| 0 | Exit | Exit and session control |
-| 1-4 | Alarms & Definitions | Org alarms, device events, audit logs, and gateway management IPs |
-| 5-8 | WebSocket Commands | MAC table, forwarding table, routing table, and SSR/SRX routing tools |
-| 9-10 | Packet Capture | Site and org packet capture workflows with WebSocket streaming |
-| 11-15 | Org Inventory Core | Sites, inventory, device stats, port stats, and VPN peer stats |
-| 16-19 | Gateway Exports | Synthetic tests, device lists, site settings, and test results |
-| 20-28 | Location & Enrichment | Sites, gateways, devices, guests, VC stats, combined inventory, and WAN overrides |
-| 29-34 | Site-Scoped | Per-site ports, clients, devices, stats, VC, and Wi-Fi clients |
-| 35-39 | Template Bundles | All templates plus network, RF, AP, and switch subsets |
-| 40-44 | Clients & Security | Wireless and wired clients, security events, rogue clients, and rogue APs |
-| 45-53 | Configuration | Licenses, PSKs, webhooks, WLANs, beacons, maps, zones, and insights |
-| 54-59 | Admin & Org Mgmt | API tokens, admins, MSP info, SSO, usage, and MX Edge |
-| 60-62 | Monitoring / Analytics | Firmware status, inventory comparison, and Marvis troubleshooting |
-| 63-65 | WIP Bulk History | 52-week device events, 52-week audit logs, and gateway configs |
-| 66-69 | Insights API | Org SLE metrics, site summaries, site insights, and client insights |
-| 70-74 | Interactive Views | Site selection, inventory browser, device stats, tests, and config views |
-| 75-76 | Continuous Loops | Continuous collection and refresh loops |
-| 77-78 | Processing & Support | SFP merge and support package generation |
-| 79-80 | CLI / WebSocket | Interactive CLI shell and ARP via WebSocket |
-| 81-86 | Advanced Insights | Device insights and anomaly event exports |
-| 87-89 | WebSocket Device Commands | Real-time ping, ARP, and service ping streams |
-| 90-100 | Destructive Operations | Firmware upgrades, reboots, VC operations, SSH runner, and switch/SSR firmware |
-| 101-114 | Advanced Configuration | TUI, RADIUS timers, WAN2 migration, template config, test-site creation, WAN probe, and maps |
-| 115-121 | Access / MSP / Health | Interactive login, org firmware, MSP inventory, auto-upgrade, and health analysis |
-| 122-160 | Device Utilities & Reports | Bulk WLAN config, device commands, clear actions, DHCP, snapshots, offline reports, SSID consolidation, and E911 |
+| 1-13, 15-17, 20-58, 188, 193, 195-196, 204-205 | Safe org exports | 61 operations. Read-only org exports. The --test run includes them. |
+| 60-96, 197-203, 209 | Interactive safe | 45 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
+| 154-187, 189-191, 194, 206-208 | Destructive | 41 operations. They change the Mist cloud configuration. Each one needs a typed confirmation. |
+| 0, 124-150, 192 | Interactive | 29 operations. They prompt the operator, so no automated run includes them. |
+| 102-123 | WebSocket | 22 operations. They open a WebSocket stream to a device. |
+| 14, 18-19, 59, 97-101, 153 | Resource intensive | 10 operations. They run long or fetch a large payload. |
+| 151-152 | Continuous loop | 2 operations. They loop until the operator stops them. |
 
 ## Full Menu Table
 
 | Menu ID | Short description | Safety | Callable/Handler |
 |---:|---|---|---|
-| 0 | Exit MistHelper | Safe | `lambda: sys.exit(0)` |
-| 1 | Export all organization alarms from the past day | Safe | `OrgAlarmEventExporter.alarms` |
-| 2 | Export all device events from the past 24 hours | Safe | `OrgAlarmEventExporter.device_events` |
-| 3 | Export audit logs for the organization (last 24 hours) | Safe | `lambda: OrgExportUtils.audit_logs(full_history=False)` |
-| 4 | Export gateway management overlay IPs grouped by template association | Safe | `lambda fast=False: GatewayExportUtils.management_ips(fast=fast)` |
-| 5 | Show MAC table on switch device via WebSocket (Layer 2 switching table) | Safe | `WebSocketCommands.show_mac_table` |
-| 6 | Show forwarding table on gateway device via WebSocket (Layer 3 routing table) | Safe | `WebSocketCommands.show_forwarding_table` |
-| 7 | Show routing table on switches via WebSocket (Switch L3 routing - BGP/OSPF/Static) | Safe | `WebSocketCommands.show_routing_table` |
-| 8 | Show SSR/SRX routing table via dedicated API (128T/SRX gateways - Advanced BGP analysis) | Safe | `WebSocketCommands.show_ssr_routes` |
-| 9 | Start Site Packet Capture - Wireless/Wired/Gateway/Scan captures with WebSocket streaming | Interactive | `lambda: PacketCaptureManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).start_site_packet_capture()` |
-| 10 | Start Organization Packet Capture - MxEdge captures for org-level Mist Edges only | Safe | `lambda: PacketCaptureManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).start_org_packet_capture()` |
-| 11 | Export a list of all sites in the organization | Safe | `OrgSiteExporter.sites` |
-| 12 | Export the full inventory of devices in the organization | Safe | `OrgInventoryExporter.inventory` |
-| 13 | Export statistics for all devices in the organization | Safe | `OrgDeviceStatsExporter.device_stats` |
-| 14 | Export port-level statistics for switches and gateways | Safe | `OrgDeviceStatsExporter.device_port_stats` |
-| 15 | Export VPN peer path statistics for the organization | Safe | `OrgDeviceStatsExporter.vpn_peer_stats` |
-| 16 | Export synthetic test results for all gateways | Safe | `GatewayTestExporter.synthetic_tests` |
-| 17 | Export a list of all devices in the organization | Safe | `OrgInventoryExporter.devices` |
-| 18 | Export configuration settings for all sites | Safe | `SiteConfigExporter.settings` |
-| 19 | Export all synthetic test results (including speed tests) for gateways | Safe | `GatewayTestExporter.test_results_by_site` |
-| 20 | Export a list of sites with location and timezone info | Safe | `OrgSiteExporter.sites_with_location` |
-| 21 | Export a list of gateways with associated site and address info | Safe | `OrgInventoryExporter.gateways_with_site_info` |
-| 22 | Export a list of all devices with associated site and address info | Safe | `OrgInventoryExporter.devices_with_site_info` |
-| 23 | Export all current guest users and last 7 days of historical guests to CSV | Safe | `lambda: (OrgSiteExporter.current_guests(), OrgSiteExporter.historical_guests())` |
-| 24 | Export all switch virtual chassis (VC/stacking) stats to CSV | Safe | `OrgDeviceStatsExporter.switch_vc_stats` |
-| 25 | Export combined inventory with site and address info by calendar week | Safe | `OrgInventoryExporter.combined_inventory_with_site_info` |
-| 26 | Export gateway templates from the organization | Safe | `GatewayExportUtils.templates` |
-| 27 | Export all sites using the 'list' sites API endpoint (to SiteList_ListAPI.csv, only if not already present) | Safe | `OrgSiteExporter.sites_list_api` |
-| 28 | Find gateway ports overridden from template (outliers for compliance correction) | Safe | `lambda fast=False: GatewayExportUtils.with_wan_overrides(fast=fast)` |
-| 29 | Export port statistics for a selected site | Safe | `SiteDeviceExporter.port_stats` |
-| 30 | Export client statistics for a selected site | Safe | `SiteClientExporter.clients` |
-| 31 | Export device list for a selected site | Safe | `SiteDeviceExporter.devices` |
-| 32 | Export device statistics for a selected site | Safe | `SiteDeviceExporter.device_stats` |
-| 33 | Export virtual chassis information for a selected switch device | Safe | `SiteDeviceExporter.device_virtual_chassis` |
-| 34 | Export currently connected WiFi clients and session data for a selected site to SiteWiFiClients.CSV | Safe | `SiteClientExporter.wifi_clients` |
-| 35 | Export all organization templates (gateway, network, RF, site, AP) | Safe | `OrgTemplateExporter.all_templates` |
-| 36 | Export network template information for the organization | Safe | `OrgTemplateExporter.network_templates` |
-| 37 | Export RF template information for the organization | Safe | `OrgTemplateExporter.rf_templates` |
-| 38 | Export AP template information for the organization | Safe | `OrgTemplateExporter.ap_templates` |
-| 39 | Export switch template information for the organization | Safe | `OrgTemplateExporter.switch_templates` |
-| 40 | Export wireless client statistics for the organization | Safe | `OrgClientSecurityExporter.wireless_clients` |
-| 41 | Export wired client statistics for the organization | Safe | `OrgClientSecurityExporter.wired_clients` |
-| 42 | Export security events for the organization | Safe | `OrgClientSecurityExporter.security_events` |
-| 43 | Export rogue client detections for the organization | Safe | `OrgClientSecurityExporter.rogue_clients` |
-| 44 | Export rogue AP detections for the organization | Safe | `OrgClientSecurityExporter.rogue_aps` |
-| 45 | Export license information for the organization | Safe | `OrgAdminExporter.licenses` |
-| 46 | Export PSK (Pre-Shared Key) information for the organization | Safe | `OrgConfigExporter.psks` |
-| 47 | Export webhook configuration for the organization | Safe | `OrgConfigExporter.webhooks` |
-| 48 | Export WLAN configuration for the organization | Safe | `OrgConfigExporter.wlans` |
-| 49 | Export WLAN configuration for a selected site | Safe | `SiteConfigExporter.wlans` |
-| 50 | Export beacon information for a selected site | Safe | `SiteClientExporter.beacons` |
-| 51 | Export map information for a selected site | Safe | `SiteConfigExporter.maps` |
-| 52 | Export zone information for a selected site | Safe | `SiteConfigExporter.zones` |
-| 53 | Export SLE (Service Level Experience) metrics insights for a selected site | Safe | `SiteExportUtils.insights` |
-| 54 | Export API token information for the organization | Safe | `OrgAdminExporter.api_tokens` |
-| 55 | Export administrator information for the organization | Safe | `OrgAdminExporter.admins` |
-| 56 | MSP (Managed Service Provider) info - Displays guidance only (MSP data requires MSP-level API access, not org-level) | Safe | `OrgConfigExporter.msp` |
-| 57 | Export SSO (Single Sign-On) information for the organization | Safe | `OrgAdminExporter.sso` |
-| 58 | Export license usage information for the organization | Safe | `OrgAdminExporter.usage` |
-| 59 | Export MX Edge information for the organization | Safe | `OrgConfigExporter.mx_edges` |
-| 60 | Check current firmware upgrade status across organization with detailed progress monitoring and export to CSV | Safe | `lambda: FirmwareManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).check_firmware_upgrade_status()` |
-| 61 | Compare inventory data with external CSV file using configurable address similarity threshold (ADDRESS_MATCH_THRESHOLD in .env) | Safe | `lambda fast=False, address_check=False, debug=False, skip_ssl_verify=False: InventoryCSVComparator(fast=fast, address_check=address_check, debug=debug, skip_ssl_verify=skip_ssl_verify).execute()` |
-| 62 | Interactive Marvis (VNA) AI troubleshooting - guided client, device, and network analysis | Interactive | `TroubleshootUtils.launch_interactive` |
-| 63 | Export all org device events from the last 52 weeks (streaming with checkpoint/resume) | Interactive | `OrgAlarmEventExporter.device_events_52w` |
-| 64 | Export ALL audit logs for the organization (last 52 weeks) | Safe | `lambda: OrgExportUtils.audit_logs(full_history=True, duration='52w')` |
-| 65 | Export configuration details for all gateway devices across all sites | Safe | `GatewayExportUtils.device_configs` |
-| 66 | Export Organization SLE Metrics (Service Level Experience) | Safe | `OrgExportUtils.sle_metrics` |
-| 67 | Export SLE summary metrics for all sites in the organization | Safe | `OrgExportUtils.sites_sle_summary` |
-| 68 | Export general insight metrics for a selected site | Safe | `SiteExportUtils.insight_metrics` |
-| 69 | Export client-specific insight metrics for a selected site | Safe | `SiteClientExporter.client_insights` |
-| 70 | Select a site (used by other functions) | Safe | `PromptUtils.select_site_with_logging` |
-| 71 | View device inventory for a selected site | Interactive | `InteractiveDisplayUtils.site_inventory` |
-| 72 | View statistics for a selected device at a site | Interactive | `InteractiveDisplayUtils.device_stats` |
-| 73 | View synthetic test stats for a selected gateway device | Interactive | `InteractiveDisplayUtils.device_tests` |
-| 74 | View configuration details for a selected device | Interactive | `InteractiveDisplayUtils.device_config` |
-| 75 | Loop refresh of core datasets (site list, inventory, stats, ports, VPN) Stop with CTRL+C or create 'stop_loop.txt' | Safe | `DataCollectionManager.continuous_loop` |
-| 76 | Run continuous data collection loop (5 core API calls with rate limiting) | Safe | `DataCollectionManager.continuous_loop` |
-| 77 | Process and merge CSV files of SFP Module locations into a single CSV file | Safe | `SFPTransceiverDataProcessor.merge_transceiver_data` |
-| 78 | Generate support package for each site | Safe | `DataCollectionManager.generate_support_packages` |
-| 79 | Interactively execute a CLI command on a gateway or switch (exit with ~) | Interactive | `CLIShellManager.launch` |
-| 80 | Run ARP command on an AP and receive output via WebSocket | Safe | `ARPCommandManager.execute` |
-| 81 | Export device-specific insight metrics for a selected site | Safe | `SiteExportUtils.device_insights` |
-| 82 | Export all available const definitions from the Mist API (comprehensive endpoint coverage) | Safe | `lambda: ConstDefinitionsExporter(apisession).export_all()` |
-| 83 | Export Organization Insight Metrics (comprehensive operational insights) | Safe | `OrgExportUtils.insight_metrics` |
-| 84 | Export Site Anomaly Events (dynamic discovery of all anomaly-related metrics from Mist API) | Safe | `SiteAnomalyExporter.anomaly_events` |
-| 85 | Export Site Device Anomaly Events (device-specific anomaly detection) | Safe | `SiteAnomalyExporter.device_anomaly_events` |
-| 86 | Export Site Client Anomaly Events (client-specific anomaly detection: connectivity, roaming, throughput) | Safe | `SiteAnomalyExporter.client_anomaly_events` |
-| 87 | WebSocket Device Ping - Execute ping command on device via WebSocket stream (real-time output) | Interactive | `WebSocketNetworkDiagCommands.ping_device` |
-| 88 | WebSocket Device ARP - Execute ARP command on device via WebSocket stream (real-time output) | Interactive | `WebSocketNetworkDiagCommands.arp_device` |
-| 89 | WebSocket Service Ping - Execute service-specific ping on SSR gateways via WebSocket stream (real-time output) | Interactive | `WebSocketNetworkDiagCommands.service_ping_device` |
-| 90 | DESTRUCTIVE: Advanced AP firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: FirmwareManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_firmware_upgrade_with_mode_selection()` |
-| 91 | DESTRUCTIVE: Reboot all devices associated with templates listed in GatewayTemplateRebootList.CSV and log results | Destructive | `DeviceRebootManager.by_gateway_template_list` |
-| 92 | DESTRUCTIVE: Convert a virtual chassis switch to virtual MAC (interactive, supports --dry-run) | Destructive | `lambda dry_run=False: VirtualChassisManager.convert_single(dry_run=dry_run)` |
-| 93 | DESTRUCTIVE: Convert all virtual chassis switches in sites listed in VCConvert.CSV (bulk operation) | Destructive | `VirtualChassisManager.convert_by_site_list` |
-| 94 | Check virtual chassis to virtual MAC conversion status for all switches | Safe | `VirtualChassisManager.check_status` |
-| 95 | Export detailed device statistics for all gateways (with freshness check) | Safe | `lambda fast=False: GatewayStatsExporter.device_stats_with_freshness(fast=fast)` |
-| 96 | Check and export gateways with duplicate WAN port IP addresses (0/0/0, 0/0/1, 0/0/2) | Safe | `GatewayStatsExporter.wan_port_conflicts` |
-| 97 | Enhanced SSH Command Runner - Execute commands on remote network devices via SSH | Interactive | `SSHRunnerManager.interactive` |
-| 98 | SSH Runner - Target gateways by template name (online gateways with management IPs only) | Safe | `SSHRunnerManager.by_gateway_template` |
-| 99 | DESTRUCTIVE: Advanced Switch firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: FirmwareManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_switch_firmware_upgrade_with_mode_selection()` |
-| 100 | DESTRUCTIVE: Advanced SSR firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: FirmwareManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_ssr_firmware_upgrade_with_mode_selection()` |
-| 101 | Launch Terminal User Interface (TUI) mode - Visual navigation of Mist API library with interactive exploration | Interactive | `lambda: TUILauncher().launch()` |
-| 102 | Manage WLAN RADIUS Authentication Timers - Configure auth_servers_timeout, auth_servers_retries, auth_server_selection, and fast_dot1x_timers for site or template WLANs | Safe | `lambda: WLANRadiusTimerManager().manage()` |
-| 103 | Set WAN2 Interface Site Variable - Configure 'wan2_interface' site variable for template-based WAN migration (Reports sites with ge-0/0/1 overrides) | Safe | `lambda: WAN2MigrationManager().set_site_variable()` |
-| 104 | DESTRUCTIVE: Update Gateway Templates to Use WAN2 Variable - Replace hardcoded 'ge-0/0/1' references with {{wan2_interface}} variable (Requires uppercase 'MIGRATE' confirmation, supports --dry-run) | Destructive | `lambda fast=False, dry_run=False: update_gateway_templates_wan2_variable(fast=fast, dry_run=dry_run)` |
-| 105 | Extract Gateway Template Configuration (DIA_Pico, Picocell) - Save specific configs to JSON for replication | Safe | `GatewayTemplateConfigManager.extract` |
-| 106 | DESTRUCTIVE: Apply Gateway Template Configuration - Replicate extracted configs to other templates (Requires uppercase 'APPLY' confirmation) | Destructive | `GatewayTemplateConfigManager.apply` |
-| 107 | DESTRUCTIVE: Create 137 test sites from NorthAmericanTestSites.csv - Real landmarks across 13 North American countries (Requires uppercase 'CREATE' confirmation) | Destructive | `SiteConfigManager.create_test_sites_from_csv` |
-| 108 | DESTRUCTIVE: Create country-specific RF templates and assign sites to matching templates (Requires uppercase 'CREATE' confirmation) | Destructive | `SiteConfigManager.create_country_rf_templates_and_assign` |
-| 109 | DESTRUCTIVE: Scan org for AP models and create Device Profile per model with inherit/auto settings (Requires uppercase 'CREATE' confirmation) | Destructive | `SiteConfigManager.create_ap_model_device_profiles` |
-| 110 | DESTRUCTIVE: Assign APs to Device Profiles matching their model type (AP-{model}) - Skips APs without matching profiles (Requires uppercase 'ASSIGN' confirmation) | Destructive | `SiteConfigManager.assign_aps_to_matching_device_profiles` |
-| 111 | DESTRUCTIVE: Clone Gateway Template by State and Country - Create state/country-specific templates and assign sites (Requires uppercase 'CLONE' confirmation) | Destructive | `GatewayTemplateConfigManager.clone_by_location` |
-| 112 | Maps Manager - Interactive site floorplan and map operations (sub-menu) | Interactive | `lambda: MapsManagerLauncher().launch()` |
-| 113 | DESTRUCTIVE: Configure WAN Probe Override on Gateway Templates - Set ICMP probe IPs and profile for all WAN interfaces (Requires uppercase 'APPLY' confirmation, supports --dry-run) | Destructive | `lambda dry_run=False: WANProbeConfigManager.configure(dry_run=dry_run)` |
-| 114 | DESTRUCTIVE: Configure WAN Probe on Device Port Overrides - Set ICMP probe on device-level WAN overrides only (Requires uppercase 'APPLY' confirmation, supports --dry-run) | Destructive | `lambda dry_run=False: WANProbeDeviceOverrideManager.configure(dry_run=dry_run)` |
-| 115 | Switch to interactive login (email/password) - Enables MSP-level API access for current session | Interactive | `switch_to_interactive_login` |
-| 116 | DESTRUCTIVE: Org-Level AP Firmware Upgrade - Efficient multi-site upgrade using org-level API (1 call per version vs 1 per site), MSP multi-org support, supports --dry-run | Destructive | `OrgLevelAPFirmwareUpgrader.run` |
-| 117 | MSP Inventory Export - Export device inventory across all MSPs and all organizations to CSV (requires MSP privileges via --login) | Safe | `MSPInventoryExporter.execute` |
-| 118 | Site Auto-Upgrade Configuration - Configure AP auto-upgrade settings for sites with MSP multi-org support (supports --dry-run) | Safe | `SiteAutoUpgradeConfigurator.execute` |
-| 119 | Site Config Analysis - Scan all sites for zone, engagement dwell tag, and occupancy setting deviations | Safe | `ZoneConfigurationAnalyzer.analyze` |
-| 120 | DESTRUCTIVE: Site Analytics Configuration - Apply standard RTSA/Rogue/Engagement/Occupancy settings to deviating sites | Destructive | `SiteAnalyticsConfigurator.execute` |
-| 121 | Site Inventory Health Analysis - Find sites with APs missing switches/gateways, or with offline infrastructure | Safe | `SiteInventoryHealthAnalyzer.analyze` |
-| 122 | Bulk RADIUS WLAN Configuration - Configure auth_servers_timeout, auth_servers_retries, fast_dot1x_timers for org-level RADIUS WLANs | Safe | `lambda dry_run=False: BulkRadiusWLANConfigManager().manage(dry_run=dry_run)` |
-| 123 | Traceroute from device to destination host (AP/Switch/Gateway) | Safe | `DeviceUtilityCommands.traceroute` |
-| 124 | Show OSPF Neighbors on SSR/SRX Gateway | Safe | `DeviceUtilityCommands.show_ospf_neighbors` |
-| 125 | Show OSPF Interfaces on SSR/SRX Gateway | Safe | `DeviceUtilityCommands.show_ospf_interfaces` |
-| 126 | Show OSPF Database on SSR/SRX Gateway | Safe | `DeviceUtilityCommands.show_ospf_database` |
-| 127 | Show OSPF Summary on SSR/SRX Gateway | Safe | `DeviceUtilityCommands.show_ospf_summary` |
-| 128 | Show Sessions on SSR/SRX Gateway | Safe | `DeviceUtilityCommands.show_session` |
-| 129 | Show Service Path on SSR Gateway | Safe | `DeviceUtilityCommands.show_service_path` |
-| 130 | Show BGP Summary on Switch or Gateway | Safe | `DeviceUtilityCommands.show_bgp_summary` |
-| 131 | Show ARP Table on Switch or Gateway | Safe | `DeviceUtilityCommands.show_arp_table` |
-| 132 | Show DHCP Leases on Switch or Gateway | Safe | `DeviceUtilityCommands.show_dhcp_leases` |
-| 133 | Show 802.1X Table on Switch | Safe | `DeviceUtilityCommands.show_dot1x` |
-| 134 | Show EVPN Database on Switch or Gateway | Safe | `DeviceUtilityCommands.show_evpn_database` |
-| 135 | Test DNS Resolution on SSR Gateway | Safe | `DeviceUtilityCommands.resolve_dns` |
-| 136 | Monitor Traffic on Switch/SRX Port (streaming, Ctrl+C to stop) | Interactive | `DeviceUtilityCommands.monitor_traffic` |
-| 137 | Run Top Command on Switch/SRX (streaming, Ctrl+C to stop) | Interactive | `DeviceUtilityCommands.run_top` |
-| 138 | Locate Device - Blink LED on AP or Switch | Safe | `DeviceUtilityCommands.locate_device` |
-| 139 | Unlocate Device - Stop LED Blinking on AP or Switch | Safe | `DeviceUtilityCommands.unlocate_device` |
-| 140 | Bounce Switch/Gateway Port (y/N confirmation) | Safe | `DeviceUtilityCommands.bounce_port` |
-| 141 | Cable Test on Switch Port | Safe | `DeviceUtilityCommands.cable_test` |
-| 142 | Reprovision Switch/Gateway (y/N confirmation) | Safe | `DeviceUtilityCommands.reprovision_device` |
-| 143 | Re-adopt Switch Device | Safe | `DeviceUtilityCommands.readopt_device` |
-| 144 | Get ZTP Password for Switch/Gateway (console only) | Safe | `DeviceUtilityCommands.get_ztp_password` |
-| 145 | Get Config CLI Commands for Switch Adoption | Safe | `DeviceUtilityCommands.get_config_commands` |
-| 146 | Upload Support File from Switch/Gateway | Safe | `DeviceUtilityCommands.upload_support_file` |
-| 147 | DESTRUCTIVE: Clear ARP Cache (type CLEAR) | Destructive | `DeviceUtilityCommands.clear_arp_cache` |
-| 148 | DESTRUCTIVE: Clear BGP Routes (type CLEAR) | Destructive | `DeviceUtilityCommands.clear_bgp_routes` |
-| 149 | DESTRUCTIVE: Clear Session on SSR/SRX (type CLEAR) | Destructive | `DeviceUtilityCommands.clear_session` |
-| 150 | DESTRUCTIVE: Clear MAC Table (type CLEAR) | Destructive | `DeviceUtilityCommands.clear_mac_table` |
-| 151 | DESTRUCTIVE: Clear BPDU Errors on Switch (type CLEAR) | Destructive | `DeviceUtilityCommands.clear_bpdu_error` |
-| 152 | DESTRUCTIVE: Clear Learned MACs from Switch Port (type CLEAR) | Destructive | `DeviceUtilityCommands.clear_learned_macs` |
-| 153 | DESTRUCTIVE: Clear Policy Hit Count on SSR (type CLEAR) | Destructive | `DeviceUtilityCommands.clear_policy_hit_count` |
-| 154 | Release DHCP Lease on Switch/Gateway (y/N) | Safe | `DeviceUtilityCommands.release_dhcp_lease` |
-| 155 | Release DHCP Lease on SSR/SRX (y/N) | Safe | `DeviceUtilityCommands.release_dhcp_ssr` |
-| 156 | Poll Fresh Statistics from Switch | Safe | `DeviceUtilityCommands.poll_switch_stats` |
-| 157 | Create Device Snapshot on Switch | Safe | `DeviceUtilityCommands.create_device_snapshot` |
-| 158 | Offline Device Report | Safe | `OfflineDeviceReporter.execute` |
-| 159 | SSID Template Consolidation (5-Phase Guided Workflow) | Safe | `SSIDTemplateConsolidationManager.execute` |
-| 160 | E911 BSSID Compliance Report | Safe | `E911BSSIDReportGenerator.execute` |
-| 161 | Global Wired Client Report (operator-based MAC/MFG filtering) | Interactive Safe | `GlobalWiredClientReportGenerator.execute` |
-| 162 | Wired Client Manufacturer Report (browse & select) | Interactive Safe | `WiredClientManufacturerReportGenerator.execute` |
-| 163 | WAN Hub Group Number Manager | Interactive | `WanHubGroupNumberManager.execute` |
+| 0 | Exit MistHelper | Interactive | `lambda: sys.exit(0)` |
+| 1 | Export a list of all sites in the organization | Safe org exports | `OrgSiteExporter.sites` |
+| 2 | Export a list of sites with location and timezone info | Safe org exports | `OrgSiteExporter.sites_with_location` |
+| 3 | Export all sites using the 'list' sites API endpoint (to SiteList_ListAPI.csv, only if not already present) | Safe org exports | `OrgSiteExporter.sites_list_api` |
+| 4 | Export all current guest users and last 7 days of historical guests to CSV | Safe org exports | `lambda: (OrgSiteExporter.current_guests(), OrgSiteExporter.historical_guests())` |
+| 5 | Export E911 report for the organization | Safe org exports | `OrgExportUtils.e911_report` |
+| 6 | Site Config Analysis - Scan all sites for zone, engagement dwell tag, and occupancy setting deviations | Safe org exports | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).zone_config_analysis()` |
+| 7 | Site Inventory Health Analysis - Find sites with APs missing switches/gateways, or with offline infrastructure | Safe org exports | `lambda: ExtractedSiteInventoryHealthAnalyzer.analyze(SiteInventoryHealthAnalyzerDeps(apisession=apisession, mistapi=mistapi, get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id, all_sites_fn=APICoreFetchUtils.all_sites_with_limit, save_data_fn=DataExporter.write_with_format_selection))` |
+| 8 | Export the full inventory of devices in the organization | Safe org exports | `OrgInventoryExporter.inventory` |
+| 9 | Export a list of all devices in the organization | Safe org exports | `OrgInventoryExporter.devices` |
+| 10 | Export a list of all devices with associated site and address info | Safe org exports | `OrgInventoryExporter.devices_with_site_info` |
+| 11 | Export a list of gateways with associated site and address info | Safe org exports | `OrgInventoryExporter.gateways_with_site_info` |
+| 12 | Export combined inventory with site and address info by calendar week | Safe org exports | `OrgInventoryExporter.combined_inventory_with_site_info` |
+| 13 | Export org device model counts, firmware version distribution, and versions per model (MSP-aware) | Safe org exports | `OrgDeviceInventorySummary.dispatch` |
+| 14 | Check virtual chassis to virtual MAC conversion status for all switches | Resource intensive | `lambda: _configure_virtual_chassis_manager().launch_check_status()` |
+| 15 | Export statistics for all devices in the organization | Safe org exports | `OrgDeviceStatsExporter.device_stats` |
+| 16 | Export VPN peer path statistics for the organization | Safe org exports | `OrgDeviceStatsExporter.vpn_peer_stats` |
+| 17 | Export all switch virtual chassis (VC/stacking) stats to CSV | Safe org exports | `OrgDeviceStatsExporter.switch_vc_stats` |
+| 18 | Export detailed device statistics for all gateways (with freshness check) | Resource intensive | `lambda fast=False: _dispatch_gateway_stats_device_stats_with_freshness(fast=fast)` |
+| 19 | Export port-level statistics for switches and gateways | Resource intensive | `OrgDeviceStatsExporter.device_port_stats` |
+| 20 | Export all organization alarms from the past day | Safe org exports | `OrgAlarmEventExporter.alarms` |
+| 21 | Export all device events from the past 24 hours | Safe org exports | `OrgAlarmEventExporter.device_events` |
+| 22 | Export audit logs for the organization (last 24 hours) | Safe org exports | `lambda: OrgExportUtils.audit_logs(full_history=False)` |
+| 23 | Export self (admin account) audit log | Safe org exports | `SelfExportUtils.audit_logs` |
+| 24 | Export security events for the organization | Safe org exports | `OrgClientSecurityExporter.security_events` |
+| 25 | Audit Log Analysis - Mermaid timeline + interactive HTML report | Safe org exports | `AuditAnalysisOps.audit_log_analysis` |
+| 26 | Offline Device Report | Safe org exports | `OfflineDeviceReporter.execute` |
+| 27 | Export wireless client statistics for the organization | Safe org exports | `OrgClientSecurityExporter.wireless_clients` |
+| 28 | Export wired client statistics for the organization | Safe org exports | `OrgClientSecurityExporter.wired_clients` |
+| 29 | Export rogue client detections for the organization | Safe org exports | `OrgClientSecurityExporter.rogue_clients` |
+| 30 | Export rogue AP detections for the organization | Safe org exports | `OrgClientSecurityExporter.rogue_aps` |
+| 31 | Export gateway management overlay IPs grouped by template association | Safe org exports | `_dispatch_gateway_management_ips` |
+| 32 | Export gateway templates from the organization | Safe org exports | `_dispatch_gateway_templates` |
+| 33 | Export synthetic test results for all gateways | Safe org exports | `GatewayTestExporter.synthetic_tests` |
+| 34 | Export all synthetic test results (including speed tests) for gateways | Safe org exports | `GatewayTestExporter.test_results_by_site` |
+| 35 | Find gateway ports overridden from template (outliers for compliance correction) | Safe org exports | `_dispatch_gateway_with_wan_overrides` |
+| 36 | Check and export gateways with duplicate WAN port IP addresses (0/0/0, 0/0/1, 0/0/2) | Safe org exports | `_dispatch_gateway_stats_wan_port_conflicts` |
+| 37 | Export all organization templates (gateway, network, RF, site, AP) | Safe org exports | `OrgTemplateExporter.all_templates` |
+| 38 | Export network template information for the organization | Safe org exports | `OrgTemplateExporter.network_templates` |
+| 39 | Export RF template information for the organization | Safe org exports | `OrgTemplateExporter.rf_templates` |
+| 40 | Export AP template information for the organization | Safe org exports | `OrgTemplateExporter.ap_templates` |
+| 41 | Export switch template information for the organization | Safe org exports | `OrgTemplateExporter.switch_templates` |
+| 42 | Export license information for the organization | Safe org exports | `OrgAdminExporter.licenses` |
+| 43 | Export license usage information for the organization | Safe org exports | `OrgAdminExporter.usage` |
+| 44 | Export PSK (Pre-Shared Key) information for the organization | Safe org exports | `OrgConfigExporter.psks` |
+| 45 | Export webhook configuration for the organization | Safe org exports | `OrgConfigExporter.webhooks` |
+| 46 | Export WLAN configuration for the organization | Safe org exports | `OrgConfigExporter.wlans` |
+| 47 | Export API token information for the organization | Safe org exports | `OrgAdminExporter.api_tokens` |
+| 48 | Export administrator information for the organization | Safe org exports | `OrgAdminExporter.admins` |
+| 49 | Export SSO (Single Sign-On) information for the organization | Safe org exports | `OrgAdminExporter.sso` |
+| 50 | Export MX Edge information for the organization | Safe org exports | `OrgConfigExporter.mx_edges` |
+| 51 | Export Organization SLE Metrics (Service Level Experience) | Safe org exports | `OrgExportUtils.sle_metrics` |
+| 52 | Export SLE summary metrics for all sites in the organization | Safe org exports | `OrgExportUtils.sites_sle_summary` |
+| 53 | Export Organization Insight Metrics (comprehensive operational insights) | Safe org exports | `OrgExportUtils.insight_metrics` |
+| 54 | Export all available const definitions from the Mist API (comprehensive endpoint coverage) | Safe org exports | `lambda: ConstDefinitionsExporter(apisession).export_all()` |
+| 55 | Export OSPF adjacency statistics for the organization | Safe org exports | `OrgExportUtils.ospf_stats` |
+| 56 | Export JSI PBN (Product Bulletin Notifications) data | Safe org exports | `OrgExportUtils.jsi_pbn` |
+| 57 | Export JSI SIRT (Security Incident Response) advisories | Safe org exports | `OrgExportUtils.jsi_sirt` |
+| 58 | Export Org WAN/Gateway Config (JSON bundle for cross-org migration) | Safe org exports | `lambda: cast(Any, OrgConfigMigrationManager)(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input).export_config()` |
+| 59 | Export configuration settings for all sites | Resource intensive | `SiteConfigExporter.settings` |
+| 60 | Export device list for a selected site | Interactive safe | `SiteDeviceExporter.devices` |
+| 61 | Export device statistics for a selected site | Interactive safe | `SiteDeviceExporter.device_stats` |
+| 62 | Export port statistics for a selected site | Interactive safe | `SiteDeviceExporter.port_stats` |
+| 63 | Export virtual chassis information for a selected switch device | Interactive safe | `SiteDeviceExporter.device_virtual_chassis` |
+| 64 | Export currently connected WiFi clients and session data for a selected site to SiteWiFiClients.CSV | Interactive safe | `SiteClientExporter.wifi_clients` |
+| 65 | Export client statistics for a selected site | Interactive safe | `SiteClientExporter.clients` |
+| 66 | Export beacon information for a selected site | Interactive safe | `SiteClientExporter.beacons` |
+| 67 | Export map information for a selected site | Interactive safe | `SiteConfigExporter.maps` |
+| 68 | Export zone information for a selected site | Interactive safe | `SiteConfigExporter.zones` |
+| 69 | Export WLAN configuration for a selected site | Interactive safe | `SiteConfigExporter.wlans` |
+| 70 | Export OSPF adjacency statistics for a selected site | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).ospf_stats()` |
+| 71 | Export MxEdge upgrade status for a selected site | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).mxedge_upgrade_status()` |
+| 72 | Export auto-map assignment status for a selected site | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).auto_map_assignment_status()` |
+| 73 | Export SLE (Service Level Experience) metrics insights for a selected site | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).insights()` |
+| 74 | Export general insight metrics for a selected site | Interactive safe | `lambda: SiteMetricOperation(apisession=apisession, PromptUtils=PromptUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, mistapi=mistapi).execute()` |
+| 75 | Export client-specific insight metrics for a selected site | Interactive safe | `SiteClientExporter.client_insights` |
+| 76 | Export device-specific insight metrics for a selected site | Interactive safe | `lambda: DeviceMetricOperation(apisession=apisession, PromptUtils=PromptUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, mistapi=mistapi).execute()` |
+| 77 | Export Site Anomaly Events (dynamic discovery of all anomaly-related metrics from Mist API) | Interactive safe | `SiteAnomalyExporter.anomaly_events` |
+| 78 | Export Site Device Anomaly Events (device-specific anomaly detection) | Interactive safe | `SiteAnomalyExporter.device_anomaly_events` |
+| 79 | Export Site Client Anomaly Events (client-specific anomaly detection: connectivity, roaming, throughput) | Interactive safe | `SiteAnomalyExporter.client_anomaly_events` |
+| 80 | Export site aggregate health & capacity statistics | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).site_stats()` |
+| 81 | Export site gateway performance metrics summary | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).gateway_metrics()` |
+| 82 | Export site switch performance metrics summary | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).switches_metrics()` |
+| 83 | Export site BLE beacon statistics | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).beacons_stats()` |
+| 84 | Export site WxLAN rule usage statistics | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).wxrules_usage()` |
+| 85 | Export site asset statistics | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).assets_stats()` |
+| 86 | Export current RRM channel & power plan per AP radio | Interactive safe | `lambda: SiteExportUtils(apisession=apisession, PromptUtils=PromptUtils, ConfigUtils=ConfigUtils, DataProcessingUtils=DataProcessingUtils, DataExporter=DataExporter, TimeUtils=TimeUtils, EnhancedSSHRunner=EnhancedSSHRunner, InsightMetricsUtils=InsightMetricsUtils, PacketCaptureManager=PacketCaptureManager, APICoreFetchUtils=APICoreFetchUtils, check_fn=IsDebugMode.check, PrettyTable=PrettyTable, tqdm=tqdm, mistapi=mistapi).current_channel_planning()` |
+| 87 | Export HA gateway cluster info, stats & node pair for a site | Interactive safe | `GatewayHaExporter.ha_cluster_info` |
+| 88 | Export sites by AP model with site address (CSV) | Interactive safe | `SitesByAPModelExporter.export_sites_by_ap_model` |
+| 89 | E911 BSSID Compliance Report | Interactive safe | `OrgExportUtils.e911_bssid_compliance_report` |
+| 90 | Global Wired Client Report (operator-based MAC/MFG filtering) | Interactive safe | `GlobalWiredClientReportGenerator.execute` |
+| 91 | Wired Client Manufacturer Report (browse & select) | Interactive safe | `WiredClientManufacturerReportGenerator.execute` |
+| 92 | Select a site (used by other functions) | Interactive safe | `PromptUtils.select_site_with_logging` |
+| 93 | View device inventory for a selected site | Interactive safe | `InteractiveDisplayUtils.site_inventory` |
+| 94 | View statistics for a selected device at a site | Interactive safe | `InteractiveDisplayUtils.device_stats` |
+| 95 | View synthetic test stats for a selected gateway device | Interactive safe | `InteractiveDisplayUtils.device_tests` |
+| 96 | View configuration details for a selected device | Interactive safe | `InteractiveDisplayUtils.device_config` |
+| 97 | Export all org device events from the last 52 weeks (streaming with checkpoint/resume) | Resource intensive | `OrgAlarmEventExporter.device_events_52w` |
+| 98 | Export ALL audit logs for the organization (last 52 weeks) | Resource intensive | `lambda: OrgExportUtils.audit_logs(full_history=True, duration='52w')` |
+| 99 | Export configuration details for all gateway devices across all sites | Resource intensive | `_dispatch_gateway_device_configs` |
+| 100 | Process and merge CSV files of SFP Module locations into a single CSV file | Resource intensive | `SFPTransceiverDataProcessor.merge_transceiver_data` |
+| 101 | Generate support package for each site | Resource intensive | `DataCollectionManager.generate_support_packages` |
+| 102 | Show MAC table on switch device via WebSocket (Layer 2 switching table) | WebSocket | `lambda: MacTableCommand.execute(_ws_cmd_deps())` |
+| 103 | Show forwarding table on gateway device via WebSocket (Layer 3 routing table) | WebSocket | `lambda: RoutingUtils(RoutingDeps(apisession=apisession, select_site_fn=PromptUtils.select_site_id_from_csv, select_device_fn=lambda site_id, dtype: PromptUtils.select_device_id_from_inventory(site_id, device_type=dtype), safe_input_fn=InputUtils.safe_input, websocket_manager_factory=WebSocketManager, check_fn=IsDebugMode.check)).execute_show_forwarding_table()` |
+| 104 | Show routing table on switches via WebSocket (Switch L3 routing - BGP/OSPF/Static) | WebSocket | `lambda: RoutingUtils(RoutingDeps(apisession=apisession, select_site_fn=PromptUtils.select_site_id_from_csv, select_device_fn=lambda site_id, dtype: PromptUtils.select_device_id_from_inventory(site_id, device_type=dtype), safe_input_fn=InputUtils.safe_input, websocket_manager_factory=WebSocketManager, check_fn=IsDebugMode.check)).execute_show_routing_table()` |
+| 105 | Show SSR/SRX routing table via dedicated API (128T/SRX gateways - Advanced BGP analysis) | WebSocket | `lambda: RoutingUtils(RoutingDeps(apisession=apisession, select_site_fn=PromptUtils.select_site_id_from_csv, select_device_fn=lambda site_id, dtype: PromptUtils.select_device_id_from_inventory(site_id, device_type=dtype), safe_input_fn=InputUtils.safe_input, websocket_manager_factory=WebSocketManager, check_fn=IsDebugMode.check)).execute_show_ssr_routes()` |
+| 106 | Show OSPF Neighbors on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_ospf_neighbors()` |
+| 107 | Show OSPF Interfaces on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_ospf_interfaces()` |
+| 108 | Show OSPF Database on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_ospf_database()` |
+| 109 | Show OSPF Summary on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_ospf_summary()` |
+| 110 | Show Sessions on SSR/SRX Gateway | WebSocket | `lambda: _get_duc_instance().show_session()` |
+| 111 | Show Service Path on SSR Gateway | WebSocket | `lambda: _get_duc_instance().show_service_path()` |
+| 112 | Show BGP Summary on Switch or Gateway | WebSocket | `lambda: _get_duc_instance().show_bgp_summary()` |
+| 113 | Show ARP Table on Switch or Gateway | WebSocket | `lambda: _get_duc_instance().show_arp_table()` |
+| 114 | Show DHCP Leases on Switch or Gateway | WebSocket | `lambda: _get_duc_instance().show_dhcp_leases()` |
+| 115 | Show 802.1X Table on Switch | WebSocket | `lambda: _get_duc_instance().show_dot1x()` |
+| 116 | Show EVPN Database on Switch or Gateway | WebSocket | `lambda: _get_duc_instance().show_evpn_database()` |
+| 117 | Test DNS Resolution on SSR Gateway | WebSocket | `lambda: _get_duc_instance().resolve_dns()` |
+| 118 | WebSocket Device Ping - Execute ping command on device via WebSocket stream (real-time output) | WebSocket | `lambda: PingDeviceExecutor().execute(_ws_cmd_deps())` |
+| 119 | WebSocket Device ARP - Execute ARP command on device via WebSocket stream (real-time output) | WebSocket | `lambda: ArpDeviceExecutor().execute(_ws_cmd_deps())` |
+| 120 | WebSocket Service Ping - Execute service-specific ping on SSR gateways via WebSocket stream (real-time output) | WebSocket | `lambda: ServicePingLauncher().launch()` |
+| 121 | Run ARP command on an AP and receive output via WebSocket | WebSocket | `ARPCommandManager.execute` |
+| 122 | Cable Test on Switch Port | WebSocket | `lambda: _get_duc_instance().cable_test()` |
+| 123 | Traceroute from device to destination host (AP/Switch/Gateway) | WebSocket | `lambda: _get_duc_instance().traceroute()` |
+| 124 | Monitor Traffic on Switch/SRX Port (streaming, Ctrl+C to stop) | Interactive | `lambda: _get_duc_instance().monitor_traffic()` |
+| 125 | Run Top Command on Switch/SRX (streaming, Ctrl+C to stop) | Interactive | `lambda: _get_duc_instance().run_top()` |
+| 126 | Poll Fresh Statistics from Switch | Interactive | `lambda: _get_duc_instance().poll_switch_stats()` |
+| 127 | Create Device Snapshot on Switch | Interactive | `lambda: _get_duc_instance().create_device_snapshot()` |
+| 128 | Locate Device - Blink LED on AP or Switch | Interactive | `lambda: _get_duc_instance().locate_device()` |
+| 129 | Unlocate Device - Stop LED Blinking on AP or Switch | Interactive | `lambda: _get_duc_instance().unlocate_device()` |
+| 130 | Re-adopt Switch Device | Interactive | `lambda: _get_duc_instance().readopt_device()` |
+| 131 | Get ZTP Password for Switch/Gateway (console only) | Interactive | `lambda: _get_duc_instance().get_ztp_password()` |
+| 132 | Get Config CLI Commands for Switch Adoption | Interactive | `lambda: _get_duc_instance().get_config_commands()` |
+| 133 | Upload Support File from Switch/Gateway | Interactive | `lambda: _get_duc_instance().upload_support_file()` |
+| 134 | Start Site Packet Capture - Wireless/Wired/Gateway/Scan captures with WebSocket streaming | Interactive | `lambda: PacketCaptureManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).start_site_packet_capture()` |
+| 135 | Start Organization Packet Capture - MxEdge captures for org-level Mist Edges only | Interactive | `lambda: PacketCaptureManager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).start_org_packet_capture()` |
+| 136 | MSP (Managed Service Provider) info - Displays guidance only (MSP data requires MSP-level API access, not org-level) | Interactive | `OrgConfigExporter.msp` |
+| 137 | Check current firmware upgrade status across organization with detailed progress monitoring and export to CSV | Interactive | `lambda: _build_firmware_manager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).check_firmware_upgrade_status()` |
+| 138 | Compare inventory data with external CSV file using configurable address similarity threshold (ADDRESS_MATCH_THRESHOLD in .env) | Interactive | `lambda fast=False, address_check=False, debug=False, skip_ssl_verify=False: InventoryCSVComparator(fast=fast, address_check=address_check, debug=debug, skip_ssl_verify=skip_ssl_verify).execute()` |
+| 139 | Interactive Marvis (VNA) AI troubleshooting - guided client, device, and network analysis | Interactive | `TroubleshootUtils.launch_interactive` |
+| 140 | Interactively execute a CLI command on a gateway or switch (exit with ~) | Interactive | `CLIShellManager.launch` |
+| 141 | Launch Terminal User Interface (TUI) mode - Visual navigation of Mist API library with interactive exploration | Interactive | `lambda: TUILauncher().launch()` |
+| 142 | Maps Manager - Interactive site floorplan and map operations (sub-menu) | Interactive | `lambda: MapsManagerLauncher().launch()` |
+| 143 | Switch to interactive login (email/password) - Enables MSP-level API access for current session | Interactive | `lambda: SwitchToInteractiveLoginManager().run()` |
+| 144 | MSP Inventory Export - Export device inventory across all MSPs and all organizations to CSV (requires MSP privileges via --login) | Interactive | `MSPInventoryExporter.execute` |
+| 145 | SSID Template Consolidation (5-Phase Guided Workflow) | Interactive | `OrgExportUtils.ssid_template_consolidation` |
+| 146 | WAN Hub Group Number Manager | Interactive | `lambda: WanHubGroupNumberManager.execute(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input)` |
+| 147 | WAN Hub-Spoke VPN Builder | Interactive | `lambda: WanVpnBuilder.execute(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input)` |
+| 148 | Manage WLAN RADIUS Authentication Timers - Configure auth_servers_timeout, auth_servers_retries, auth_server_selection, and fast_dot1x_timers for site or template WLANs | Interactive | `lambda: WLANRadiusTimerManager().manage()` |
+| 149 | Set WAN2 Interface Site Variable - Configure 'wan2_interface' site variable for template-based WAN migration (Reports sites with ge-0/0/1 overrides) | Interactive | `lambda: WAN2MigrationLauncher().launch()` |
+| 150 | Extract Gateway Template Configuration (DIA_Pico, Picocell) - Save specific configs to JSON for replication | Interactive | `lambda: GatewayTemplateConfigManager(org_id=ConfigUtils.get_cached_or_prompted_org_id(), apisession=apisession, input_fn=InputUtils.safe_input, get_csv_path_fn=FilePathUtils.get_csv_path, save_data_fn=DataExporter.write_with_format_selection, check_and_generate_csv_fn=CacheUtils.check_and_generate_csv, generate_sites_fn=OrgSiteExporter.sites, sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename).extract()` |
+| 151 | Loop refresh of core datasets (site list, inventory, stats, ports, VPN) Stop with CTRL+C or create 'stop_loop.txt' | Continuous loop | `DataCollectionManager.continuous_loop` |
+| 152 | Run continuous data collection loop (5 core API calls with rate limiting) | Continuous loop | `DataCollectionManager.continuous_loop` |
+| 153 | Bulk Org Data Collection (populate ArangoDB/Redis/SQLite with all org-level APIs) | Resource intensive | `lambda: OrgDataCollector.execute(OrgExportUtils.export_data, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input)` |
+| 154 | DESTRUCTIVE: Advanced AP firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: _build_firmware_manager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_firmware_upgrade_with_mode_selection()` |
+| 155 | DESTRUCTIVE: Advanced Switch firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: _build_firmware_manager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_switch_firmware_upgrade_with_mode_selection()` |
+| 156 | DESTRUCTIVE: Advanced SSR firmware upgrade with mode selection - upgrade by site list/selection or by Gateway Template assignment | Destructive | `lambda: _build_firmware_manager(apisession, ConfigUtils.get_cached_or_prompted_org_id()).execute_ssr_firmware_upgrade_with_mode_selection()` |
+| 157 | DESTRUCTIVE: Org-Level AP Firmware Upgrade - Efficient multi-site upgrade using org-level API (1 call per version vs 1 per site), MSP multi-org support, supports --dry-run | Destructive | `lambda: _build_org_ap_upgrader().run()` |
+| 158 | DESTRUCTIVE: Reboot all devices associated with templates listed in GatewayTemplateRebootList.CSV and log results | Destructive | `DeviceRebootManager.by_gateway_template_list` |
+| 159 | Bounce Switch/Gateway Port (y/N confirmation) | Destructive | `lambda: _get_duc_instance().bounce_port()` |
+| 160 | Reprovision Switch/Gateway (y/N confirmation) | Destructive | `lambda: _get_duc_instance().reprovision_device()` |
+| 161 | DESTRUCTIVE: Convert a virtual chassis switch to virtual MAC (interactive, supports --dry-run) | Destructive | `lambda dry_run=False: _configure_virtual_chassis_manager().launch_convert_single(dry_run=dry_run)` |
+| 162 | DESTRUCTIVE: Convert all virtual chassis switches in sites listed in VCConvert.CSV (bulk operation) | Destructive | `lambda: _configure_virtual_chassis_manager().launch_convert_by_site_list()` |
+| 163 | DESTRUCTIVE: Update Gateway Templates to Use WAN2 Variable - Replace hardcoded 'ge-0/0/1' references with {{wan2_interface}} variable (Requires uppercase 'MIGRATE' confirmation, supports --dry-run) | Destructive | `_dispatch_gateway_wan2_variable_migration` |
+| 164 | DESTRUCTIVE: Apply Gateway Template Configuration - Replicate extracted configs to other templates (Requires uppercase 'APPLY' confirmation) | Destructive | `lambda: GatewayTemplateConfigManager(org_id=ConfigUtils.get_cached_or_prompted_org_id(), apisession=apisession, input_fn=InputUtils.safe_input, get_csv_path_fn=FilePathUtils.get_csv_path, save_data_fn=DataExporter.write_with_format_selection, check_and_generate_csv_fn=CacheUtils.check_and_generate_csv, generate_sites_fn=OrgSiteExporter.sites, sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename).apply()` |
+| 165 | DESTRUCTIVE: Clone Gateway Template by State and Country - Create state/country-specific templates and assign sites (Requires uppercase 'CLONE' confirmation) | Destructive | `lambda: GatewayTemplateConfigManager(org_id=ConfigUtils.get_cached_or_prompted_org_id(), apisession=apisession, input_fn=InputUtils.safe_input, get_csv_path_fn=FilePathUtils.get_csv_path, save_data_fn=DataExporter.write_with_format_selection, check_and_generate_csv_fn=CacheUtils.check_and_generate_csv, generate_sites_fn=OrgSiteExporter.sites, sanitize_filename_fn=EnhancedSSHRunner.sanitize_filename).clone_by_location()` |
+| 166 | DESTRUCTIVE: Configure WAN Probe Override on Gateway Templates - Set ICMP probe IPs and profile for all WAN interfaces (Requires uppercase 'APPLY' confirmation, supports --dry-run) | Destructive | `lambda dry_run=False: WANProbeConfigManager.configure(dry_run=dry_run)` |
+| 167 | DESTRUCTIVE: Configure WAN Probe on Device Port Overrides - Set ICMP probe on device-level WAN overrides only (Requires uppercase 'APPLY' confirmation, supports --dry-run) | Destructive | `lambda dry_run=False: WANProbeDeviceOverrideManager.configure(dry_run=dry_run)` |
+| 168 | Site Auto-Upgrade Configuration - Configure AP auto-upgrade settings for sites with MSP multi-org support (supports --dry-run) | Destructive | `lambda: SiteAutoUpgradeConfigurator.execute(apisession=apisession, msp_privileges=msp_privileges if msp_privileges else [], safe_input_fn=InputUtils.safe_input, get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id, fetch_sites_fn=APICoreFetchUtils.all_sites_with_limit, check_stop_fn=ConfigUtils.check_stop_signal, dry_run=getattr(globals().get('args', None), 'dry_run', False), select_msps_fn=lambda: _build_org_ap_upgrader(org_id='')._select_msps(), select_orgs_fn=lambda msp: _build_org_ap_upgrader(org_id='')._select_orgs_from_msp(msp))` |
+| 169 | DESTRUCTIVE: Site Analytics Configuration - Apply standard RTSA/Rogue/Engagement/Occupancy settings to deviating sites | Destructive | `lambda: ExtractedSiteAnalyticsConfigurator.execute(SiteAnalyticsConfiguratorDeps(apisession=apisession, mistapi=mistapi, get_org_id_fn=ConfigUtils.get_cached_or_prompted_org_id, check_stop_fn=ConfigUtils.check_stop_signal, safe_input_fn=InputUtils.safe_input, all_sites_fn=APICoreFetchUtils.all_sites_with_limit, save_data_fn=DataExporter.write_with_format_selection, tqdm_fn=tqdm))` |
+| 170 | Bulk RADIUS WLAN Configuration - Configure auth_servers_timeout, auth_servers_retries, fast_dot1x_timers for org-level RADIUS WLANs | Destructive | `lambda dry_run=False: BulkRadiusWLANConfigManager().manage(dry_run=dry_run)` |
+| 171 | DESTRUCTIVE: Create 137 test sites from NorthAmericanTestSites.csv - Real landmarks across 13 North American countries (Requires uppercase 'CREATE' confirmation) | Destructive | `lambda: _configure_site_config_manager().create_test_sites_from_csv()` |
+| 172 | DESTRUCTIVE: Create country-specific RF templates and assign sites to matching templates (Requires uppercase 'CREATE' confirmation) | Destructive | `lambda: _configure_site_config_manager().create_country_rf_templates_and_assign()` |
+| 173 | DESTRUCTIVE: Scan org for AP models and create Device Profile per model with inherit/auto settings (Requires uppercase 'CREATE' confirmation) | Destructive | `lambda: _configure_site_config_manager().create_ap_model_device_profiles()` |
+| 174 | DESTRUCTIVE: Assign APs to Device Profiles matching their model type (AP-{model}) - Skips APs without matching profiles (Requires uppercase 'ASSIGN' confirmation) | Destructive | `lambda: _configure_site_config_manager().assign_aps_to_matching_device_profiles()` |
+| 175 | Enhanced SSH Command Runner - Execute commands on remote network devices via SSH | Destructive | `lambda: SSHRunnerManager.interactive(_build_ssh_runner_deps())` |
+| 176 | SSH Runner - Target gateways by template name (online gateways with management IPs only) | Destructive | `lambda: SSHRunnerManager.by_gateway_template(_build_ssh_runner_deps())` |
+| 177 | DESTRUCTIVE: Clear ARP Cache (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_arp_cache()` |
+| 178 | DESTRUCTIVE: Clear BGP Routes (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_bgp_routes()` |
+| 179 | DESTRUCTIVE: Clear Session on SSR/SRX (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_session()` |
+| 180 | DESTRUCTIVE: Clear MAC Table (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_mac_table()` |
+| 181 | DESTRUCTIVE: Clear BPDU Errors on Switch (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_bpdu_error()` |
+| 182 | DESTRUCTIVE: Clear Learned MACs from Switch Port (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_learned_macs()` |
+| 183 | DESTRUCTIVE: Clear Policy Hit Count on SSR (type CLEAR) | Destructive | `lambda: _get_duc_instance().clear_policy_hit_count()` |
+| 184 | Release DHCP Lease on Switch/Gateway (y/N) | Destructive | `lambda: _get_duc_instance().release_dhcp_lease()` |
+| 185 | Release DHCP Lease on SSR/SRX (y/N) | Destructive | `lambda: _get_duc_instance().release_dhcp_ssr()` |
+| 186 | Clear CSV Cache Files (delete all generated cache CSVs) | Destructive | `CacheUtils.clear_cache` |
+| 187 | Import Org WAN/Gateway Config (cross-org migration with conflict detection) | Destructive | `lambda: cast(Any, OrgConfigMigrationManager)(apisession, ConfigUtils.get_cached_or_prompted_org_id, InputUtils.safe_input).import_config()` |
+| 188 | Export all organization support tickets to CSV | Safe org exports | `OrgTicketManager.list_tickets` |
+| 189 | Create a new organization support ticket | Destructive | `OrgTicketManager.create_ticket` |
+| 190 | Add a comment (with optional file attachment) to a support ticket | Destructive | `OrgTicketManager.add_comment` |
+| 191 | Update fields on an existing support ticket | Destructive | `OrgTicketManager.update_ticket` |
+| 192 | View a support ticket with full comments and history | Interactive | `OrgTicketManager.view_ticket` |
+| 193 | Export all tickets with full details and comments | Safe org exports | `OrgTicketManager.export_ticket_details` |
+| 194 | DESTRUCTIVE: Clone Device Config to Gateway Template - Select a gateway, extract its local config, and create a new org gateway template (Requires typing 'CREATE' to confirm) | Destructive | `DeviceConfigTemplateClonerManager.clone` |
+| 195 | Audit site addresses from CSV (data/) - fuse Mist + SNMP + CSV hints, verify vs. web; READ-ONLY, saves report. Tier-3 browser geocoding auto-engages when available (ADDRESS_AUDIT_GEOCODE=off to skip) | Safe org exports | `lambda: AddressAuditEngine().run(apisession, ConfigUtils.get_cached_or_prompted_org_id())` |
+| 196 | Export async organization license-claim status summary (and optional per-device details) | Safe org exports | `LicenseExportUtils.export_org_license_async_claim_status` |
+| 197 | Download client packet captures grouped by VLAN (site -> client -> VLAN -> data/packet_captures/) | Interactive safe | `lambda: ClientPacketCaptureDownloader(apisession).run()` |
+| 198 | Search Site WAN Usages (searchSiteWanUsage) - Export per-site WAN usage records to SiteWanUsages.csv | Interactive safe | `SiteWanUsageExporter.wan_usages` |
+| 199 | Search Site Webhook Deliveries (searchSiteWebhooksDeliveries) - Per site+webhook delivery audit CSV | Interactive safe | `SiteWebhookDeliveriesExporter.deliveries` |
+| 200 | Search Site Guest Authorization (searchSiteGuestAuthorization) - Per-site authorized guest CSV | Interactive safe | `SiteGuestAuthorizationExporter.guest_authorizations` |
+| 201 | Search Site Mist Edge Events (searchSiteMistEdgeEvents) - Per-site Mist Edge event CSV | Interactive safe | `SiteMistEdgeEventsExporter.mist_edge_events` |
+| 202 | Search Site NAC Client Events (searchSiteNacClientEvents) - Per-site NAC client event CSV | Interactive safe | `SiteNacClientEventsExporter.nac_client_events` |
+| 203 | Search WAN client events for a selected site (spec 899 / issue #1407) | Interactive safe | `SiteClientExporter.wan_client_events` |
+| 204 | Export JSI assets and contract search results | Safe org exports | `OrgExportUtils.jsi_assets` |
+| 205 | Export Org Mist Edge event search results | Safe org exports | `OrgExportUtils.mist_edge_events` |
+| 206 | DESTRUCTIVE: Manage org Zscaler synthetic probes - Build/merge/swap synthetic_test.custom_probes from curated Zscaler catalogue | Destructive | `lambda: manage_org_synthetic_probes(apisession, ConfigUtils.get_cached_or_prompted_org_id())` |
+| 207 | DESTRUCTIVE: Migrate APs between device profiles - Reassign every AP bound to a source device profile to a chosen target profile (Requires typing 'MIGRATE' or 'DRY-RUN' to confirm) | Destructive | `lambda: APProfileMigrationManager.migrate_aps_between_device_profiles(apisession)` |
+| 208 | DESTRUCTIVE: Revert an AP profile migration from a backup file - Reassign each listed AP back to its original device profile (Requires typing 'REVERT' to confirm) | Destructive | `lambda: APProfileMigrationManager.revert_ap_profile_migration(apisession)` |
+| 209 | Get site beacon detail by site_id + beacon_id (getSiteBeacon) | Interactive safe | `SiteClientExporter.get_site_beacon` |
 
-This page should be regenerated whenever `menu_actions` changes so the wiki stays aligned with `MistHelper.py`.
+This page should be regenerated whenever `menu_actions` or the operation registry
+changes, so the wiki stays aligned with the code.

--- a/scripts/generate_menu_wiki.py
+++ b/scripts/generate_menu_wiki.py
@@ -4,8 +4,31 @@
 from __future__ import annotations
 
 import ast
+import sys
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+
+# Display names and one-line explanations for each registry category.
+_CATEGORY_TITLES = {
+    "safe": "Safe org exports",
+    "interactive_safe": "Interactive safe",
+    "destructive": "Destructive",
+    "interactive": "Interactive",
+    "websocket": "WebSocket",
+    "resource_intensive": "Resource intensive",
+    "continuous_loop": "Continuous loop",
+}
+
+_CATEGORY_SUMMARIES = {
+    "safe": "Read-only org exports. The --test run includes them.",
+    "interactive_safe": "Read-only, but they prompt for a site or a device. The --testinteractive run includes them.",
+    "destructive": "They change the Mist cloud configuration. Each one needs a typed confirmation.",
+    "interactive": "They prompt the operator, so no automated run includes them.",
+    "websocket": "They open a WebSocket stream to a device.",
+    "resource_intensive": "They run long or fetch a large payload.",
+    "continuous_loop": "They loop until the operator stops them.",
+}
 
 
 @dataclass(frozen=True)
@@ -33,34 +56,51 @@ class WikiMenuReferenceGenerator:
     def __init__(self) -> None:
         self.repo_root = Path(__file__).resolve().parents[1]
         self.source_path = self.repo_root / "MistHelper.py"
-        self.output_path = self.repo_root / "documentation" / "wiki" / "Menu-Reference.md"
+        # Both files hold the same content, so the wiki and the repository copy cannot diverge.
+        self.output_paths = (
+            self.repo_root / "documentation" / "wiki" / "Menu-Reference.md",
+            self.repo_root / "documentation" / "menu_reference.md",
+        )
 
     def generate(self) -> None:
         source = self.source_path.read_text(encoding="utf-8")
         entries = self.extract_entries(source)
         categories = self.build_categories()
         markdown = self.render_markdown(entries, categories)
-        self.output_path.parent.mkdir(parents=True, exist_ok=True)
-        self.output_path.write_text(markdown, encoding="utf-8")
-        print(f"WROTE {self.output_path}")
+        for output_path in self.output_paths:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(markdown, encoding="utf-8")
+            print(f"WROTE {output_path}")
 
     def extract_entries(self, source: str) -> list[MenuEntry]:
         tree = ast.parse(source, filename=str(self.source_path))
         menu_dict = self.find_menu_actions(tree)
+        registry = self.load_registry()
         entries: list[MenuEntry] = []
         for key_node, value_node in zip(menu_dict.keys, menu_dict.values, strict=True):
             menu_id = self.extract_menu_id(key_node)
             handler, description = self.extract_value_pair(value_node)
-            entries.append(MenuEntry(menu_id, description, self.classify_safety(description, handler), handler))
+            category = registry.get(menu_id, "unregistered")
+            entries.append(MenuEntry(menu_id, description, _CATEGORY_TITLES.get(category, category), handler))
         return sorted(entries, key=lambda entry: entry.menu_id)
 
     def find_menu_actions(self, tree: ast.AST) -> ast.Dict:
         for node in ast.walk(tree):
+            # `menu_actions` carries a type annotation, so the node is AnnAssign, not Assign.
+            targets: list[ast.expr] = []
+            value: ast.expr | None = None
             if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if isinstance(target, ast.Name) and target.id == "menu_actions":
-                        if isinstance(node.value, ast.Dict):
-                            return node.value
+                targets = list(node.targets)
+                value = node.value
+            elif isinstance(node, ast.AnnAssign):
+                targets = [node.target]
+                value = node.value
+            else:
+                continue
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id == "menu_actions":
+                    if isinstance(value, ast.Dict):
+                        return value
         raise SystemExit("menu_actions not found")
 
     def extract_menu_id(self, key_node: ast.expr | None) -> int:
@@ -84,104 +124,81 @@ class WikiMenuReferenceGenerator:
             return " ".join(node.value.split())
         raise SystemExit("Unexpected description format")
 
-    def classify_safety(self, description: str, handler: str) -> str:
-        haystack = f"{description} {handler}".upper()
-        if "DESTRUCTIVE" in haystack:
-            return "Destructive"
-        if "INTERACTIVE" in haystack or "STREAM" in haystack:
-            return "Interactive"
-        return "Safe"
+    def load_registry(self) -> dict[int, str]:
+        """Return the menu number to category map from the single source of truth."""
+        sys.path.insert(0, str(self.repo_root))
+        from src.utils.operation_registry import OperationRegistry
+
+        return {
+            int(option): OperationRegistry.skip_category(option)
+            for option in OperationRegistry.registered_options()
+            if option.isdigit()
+        }
 
     def build_categories(self) -> list[CategorySummary]:
-        return [
-            CategorySummary("0", "Exit", "Exit and session control"),
-            CategorySummary(
-                "1-4", "Alarms & Definitions", "Org alarms, device events, audit logs, and gateway management IPs"
-            ),
-            CategorySummary(
-                "5-8", "WebSocket Commands", "MAC table, forwarding table, routing table, and SSR/SRX routing tools"
-            ),
-            CategorySummary("9-10", "Packet Capture", "Site and org packet capture workflows with WebSocket streaming"),
-            CategorySummary(
-                "11-15", "Org Inventory Core", "Sites, inventory, device stats, port stats, and VPN peer stats"
-            ),
-            CategorySummary(
-                "16-19", "Gateway Exports", "Synthetic tests, device lists, site settings, and test results"
-            ),
-            CategorySummary(
-                "20-28",
-                "Location & Enrichment",
-                "Sites, gateways, devices, guests, VC stats, combined inventory, and WAN overrides",
-            ),
-            CategorySummary("29-34", "Site-Scoped", "Per-site ports, clients, devices, stats, VC, and Wi-Fi clients"),
-            CategorySummary("35-39", "Template Bundles", "All templates plus network, RF, AP, and switch subsets"),
-            CategorySummary(
-                "40-44",
-                "Clients & Security",
-                "Wireless and wired clients, security events, rogue clients, and rogue APs",
-            ),
-            CategorySummary(
-                "45-53", "Configuration", "Licenses, PSKs, webhooks, WLANs, beacons, maps, zones, and insights"
-            ),
-            CategorySummary("54-59", "Admin & Org Mgmt", "API tokens, admins, MSP info, SSO, usage, and MX Edge"),
-            CategorySummary(
-                "60-62", "Monitoring / Analytics", "Firmware status, inventory comparison, and Marvis troubleshooting"
-            ),
-            CategorySummary(
-                "63-65", "WIP Bulk History", "52-week device events, 52-week audit logs, and gateway configs"
-            ),
-            CategorySummary(
-                "66-69", "Insights API", "Org SLE metrics, site summaries, site insights, and client insights"
-            ),
-            CategorySummary(
-                "70-74", "Interactive Views", "Site selection, inventory browser, device stats, tests, and config views"
-            ),
-            CategorySummary("75-76", "Continuous Loops", "Continuous collection and refresh loops"),
-            CategorySummary("77-78", "Processing & Support", "SFP merge and support package generation"),
-            CategorySummary("79-80", "CLI / WebSocket", "Interactive CLI shell and ARP via WebSocket"),
-            CategorySummary("81-86", "Advanced Insights", "Device insights and anomaly event exports"),
-            CategorySummary("87-89", "WebSocket Device Commands", "Real-time ping, ARP, and service ping streams"),
-            CategorySummary(
-                "90-100",
-                "Destructive Operations",
-                "Firmware upgrades, reboots, VC operations, SSH runner, and switch/SSR firmware",
-            ),
-            CategorySummary(
-                "101-114",
-                "Advanced Configuration",
-                "TUI, RADIUS timers, WAN2 migration, template config, test-site creation, WAN probe, and maps",
-            ),
-            CategorySummary(
-                "115-121",
-                "Access / MSP / Health",
-                "Interactive login, org firmware, MSP inventory, auto-upgrade, and health analysis",
-            ),
-            CategorySummary(
-                "122-160",
-                "Device Utilities & Reports",
-                "Bulk WLAN config, device commands, clear actions, DHCP, snapshots, offline reports, SSID consolidation, and E911",
-            ),
-        ]
+        """Build one summary row per registry category, with the spans computed from the data."""
+        buckets: dict[str, list[int]] = defaultdict(list)
+        for menu_id, category in self.load_registry().items():
+            buckets[category].append(menu_id)
+        rows: list[CategorySummary] = []
+        for category in sorted(buckets, key=lambda name: -len(buckets[name])):
+            numbers = sorted(buckets[category])
+            rows.append(
+                CategorySummary(
+                    menu_range=self.compact_spans(numbers),
+                    title=_CATEGORY_TITLES.get(category, category),
+                    summary=f"{len(numbers)} operations. {_CATEGORY_SUMMARIES.get(category, '')}".strip(),
+                )
+            )
+        return rows
+
+    def compact_spans(self, numbers: list[int]) -> str:
+        """Collapse a sorted number list into compact range notation such as ``1-13, 15-17``."""
+        spans: list[str] = []
+        start = previous = numbers[0]
+        for number in numbers[1:]:
+            if number == previous + 1:
+                previous = number
+                continue
+            spans.append(f"{start}-{previous}" if start != previous else f"{start}")
+            start = previous = number
+        spans.append(f"{start}-{previous}" if start != previous else f"{start}")
+        return ", ".join(spans)
 
     def render_markdown(self, entries: list[MenuEntry], categories: list[CategorySummary]) -> str:
+        registry = self.load_registry()
+        numbers = sorted(entry.menu_id for entry in entries)
+        actionable = [n for n in numbers if n != 0]
+        gaps = [n for n in range(numbers[0], numbers[-1] + 1) if n not in set(numbers)]
+        heavy = self.compact_spans(sorted(n for n, c in registry.items() if c == "resource_intensive"))
+        destructive = self.compact_spans(sorted(n for n, c in registry.items() if c == "destructive"))
         lines: list[str] = []
         lines.extend(
             [
                 "# Menu Reference",
                 "",
-                f"Operation Count: MistHelper currently defines {len(entries)} actionable menu entries (0-160) with some gaps for future expansion.",
+                "This page is generated. Run `python scripts/generate_menu_wiki.py` after any",
+                "change to `menu_actions` in `MistHelper.py` or to `src/utils/operation_registry.py`.",
                 "",
-                "Below is the authoritative list derived directly from `menu_actions` in code. WIP = unstable schema, DESTRUCTIVE = requires explicit user confirmation.",
+                f"MistHelper defines **{len(actionable)} actionable menu entries**, numbered",
+                f"{actionable[0]} to {actionable[-1]}"
+                + (f" with gaps at {self.compact_spans(gaps)}." if gaps else " with no gaps."),
+                f"Menu 0 is Exit, so the registry holds {len(numbers)} entries in total.",
+                "",
+                "The Safety column reads from `src/utils/operation_registry.py`, which is the",
+                "single source of truth. The classifier fails closed, so an unregistered option",
+                "never runs in an automated test pass.",
                 "",
                 "## Important Notes",
                 "",
-                "- Options 14 and 18 are resource-intensive and may take a long time during large exports.",
-                "- Options 63-65 are intentionally marked WIP and may evolve as the bulk-history workflows settle.",
-                "- Destructive ranges should never be scripted unattended without explicit human review and confirmation.",
+                f"- Options {heavy} are resource intensive. They can run for a long time on a large org.",
+                f"- Options {destructive} are destructive. They change the Mist cloud configuration.",
+                "- Warning: Do not script a destructive option unattended. Each one needs a typed",
+                "  confirmation from a human operator.",
                 "",
                 "## Operation Categories",
                 "",
-                "| Range | Category | Summary |",
+                "| Menu numbers | Category | Summary |",
                 "|---|---|---|",
             ]
         )
@@ -197,13 +214,14 @@ class WikiMenuReferenceGenerator:
             ]
         )
         for entry in entries:
-            lines.append(
-                f"| {entry.menu_id} | {self.escape(entry.description)} | {entry.safety} | `{self.escape(entry.handler)}` |"
-            )
+            description = self.escape(entry.description)
+            handler = self.escape(entry.handler)
+            lines.append(f"| {entry.menu_id} | {description} | {entry.safety} | `{handler}` |")
         lines.extend(
             [
                 "",
-                "This page should be regenerated whenever `menu_actions` changes so the wiki stays aligned with `MistHelper.py`.",
+                "This page should be regenerated whenever `menu_actions` or the operation registry",
+                "changes, so the wiki stays aligned with the code.",
             ]
         )
         return "\n".join(lines) + "\n"


### PR DESCRIPTION
Closes #1744

## Summary

The documentation drifted from the code by 15 operations and 8 quality gates.
This pull request corrects every number and fixes the root cause that let the
drift go unnoticed.

## Root cause: the generator was broken

`scripts/generate_menu_wiki.py` reads `menu_actions` from `MistHelper.py`
through the AST. It searched for an `ast.Assign` node. The declaration now
carries a type annotation:

```python
menu_actions: dict[str, tuple[Callable[..., Any], str]] = {
```

An annotated assignment parses as `ast.AnnAssign`, not `ast.Assign`. The
generator matched nothing and exited with `menu_actions not found`. Every
regeneration since that annotation landed produced no output, so the committed
reference froze on the pre-regrouping numbering. It listed menu 5 as
"Show MAC table via WebSocket". Menu 5 is a safe org export today.

## The generator is now self-maintaining

| Aspect | Before | After |
| - | - | - |
| Node match | `ast.Assign` only | `ast.Assign` and `ast.AnnAssign` |
| Safety label | Guessed from words in the description | Read from `OperationRegistry.skip_category()` |
| Category table | 24 hardcoded rows on the 0-160 numbering | Computed from `registered_options()` |
| Entry count | Hardcoded "0-160 with some gaps" | Computed, with real gaps |
| Resource-intensive note | Hardcoded "14 and 18" | Computed from the registry |
| Output files | 1 | 2, written from one render, so they cannot diverge |

The generator uses the public accessors `registered_options()` and
`skip_category()`. It does not touch the private registry dictionary.

## Measured facts

Taken from `menu_actions` and `OperationRegistry` on 2026-08-04.

| Category | Count | Menu numbers |
| - | - | - |
| `safe` | 61 | 1-13, 15-17, 20-58, 188, 193, 195-196, 204-205 |
| `interactive_safe` | 45 | 60-96, 197-203, 209 |
| `destructive` | 41 | 154-187, 189-191, 194, 206-208 |
| `interactive` | 29 | 0, 124-150, 192 |
| `websocket` | 22 | 102-123 |
| `resource_intensive` | 10 | 14, 18-19, 59, 97-101, 153 |
| `continuous_loop` | 2 | 151-152 |
| **Total** | **210** | 0-209, no gaps |

## README corrections

| Claim | Was | Now |
| - | - | - |
| Operation count | 194 entries, 31 groups | 209 actionable, 210 with Exit |
| Quality gates | 5 | 13, plus CodeQL |
| Coverage threshold | 70 percent | 80 percent |
| Type gate | "mypy --strict, phased" | mypy under the `pyproject.toml` settings |
| `src/` packages | 6 missing | complete |
| `tools/ste_linter/` | absent | listed |
| Python floor | unstated | 3.13 |
| `mistapi` floor | unstated | 0.63.1 |
| Size facts | absent | measured table |

The README contradicted itself before this change. The opening line read 194
while its own mindmap read 210.

### The 15 operations the README never named

Menus 195 through 209 now appear in a table with their category. Three are
destructive: 206 synthetic probes, 207 AP profile migration, and 208 the
revert.

## Size facts recorded

| Area | Python lines | Files |
| - | - | - |
| `MistHelper.py` | 6,054 | 1 |
| `src/` | 123,785 | 360 |
| `tests/` | 129,364 | -- |

The entrypoint held roughly 28,000 lines before the decomposition. It holds
6,054 now, a reduction near 78 percent. No document recorded that outcome. The
test suite is now larger than the source it covers.

## Test plan

| Gate | Result |
| - | - |
| `ruff check scripts/generate_menu_wiki.py` | All checks passed |
| `black --check scripts/generate_menu_wiki.py` | 1 file unchanged |
| `mypy scripts/generate_menu_wiki.py` | Success, no issues |
| `python scripts/lint_diagram_refs.py` | OK: 125 references validated across 16 diagram files |
| STE linter on all 8 changed markdown files | Lowest 88, highest 100. The gate needs 80. |
| Generated output covers menus 0-209 | Yes, no gaps |
| Both output files byte-identical | Yes |

## Conformance

- [x] The change adds no secret and logs no secret.
- [x] The change alters no destructive operation.
- [x] The change alters no runtime behavior. Only a documentation generator and
      markdown files change.
- [x] Every prose file follows Simplified Technical English.

## Follow-up

The wiki pages under `documentation/wiki/` are the repository source. Someone
with wiki write access must copy them to the GitHub wiki, or a workflow must
publish them. No automation does that today.
