### PR TITLE
fix(docs): make the menu wiki generator idempotent on Windows

### DIFF
--- a/scripts/generate_menu_wiki.py
+++ b/scripts/generate_menu_wiki.py
@@ -69,7 +69,8 @@ class WikiMenuReferenceGenerator:
         markdown = self.render_markdown(entries, categories)
         for output_path in self.output_paths:
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(markdown, encoding="utf-8")
+            # newline="\n" stops Windows from writing CRLF, which would show as a spurious diff.
+            output_path.write_text(markdown, encoding="utf-8", newline="\n")
             print(f"WROTE {output_path}")
 
     def extract_entries(self, source: str) -> list[MenuEntry]:


### PR DESCRIPTION
Refs #1744

## Problem

`scripts/generate_menu_wiki.py` writes its two output files with
`Path.write_text()`. That call opens the file in text mode. On Windows, text
mode translates every newline to CRLF. The committed files hold LF.

A contributor who runs the generator on Windows therefore sees both output
files reported as modified, even when no source changed:

```text
 M documentation/menu_reference.md
 M documentation/wiki/Menu-Reference.md
```

`git diff --ignore-cr-at-eol` reports nothing, which proves the content is
identical. Only the line endings differ.

## Why this matters

The noise hides a real regeneration. A contributor who sees two modified files
after every run learns to ignore that signal. The next time the generator picks
up a genuine menu change, the same two lines appear and nobody looks.

This is the same failure mode that let pull request #1745 exist. The generator
had been silently broken for months and nobody noticed.

## The change

One argument on the write call:

```python
output_path.write_text(markdown, encoding="utf-8", newline="\n")
```

## Test plan

| Check | Result |
| - | - |
| Run the generator twice on Windows, then `git status` | Clean tree |
| `ruff check scripts/generate_menu_wiki.py` | All checks passed |
| `black --check scripts/generate_menu_wiki.py` | 1 file unchanged |
| `mypy scripts/generate_menu_wiki.py` | Success, no issues |

## Conformance

- [x] The change adds no secret and logs no secret.
- [x] The change alters no destructive operation.
- [x] The change alters no runtime behavior of the tool.
- [x] The generated content does not change. Only the line endings do.
