### PR TITLE
ci: publish the wiki automatically and guard the menu reference generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,32 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: python scripts/lint_diagram_refs.py
 
+  menu_reference_drift:
+    name: "Menu reference drift"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      # The generator failed silently for months, so the committed pages froze on
+      # an old numbering. This step re-runs it and fails when the output moves.
+      - name: Regenerate the menu reference
+        run: python scripts/generate_menu_wiki.py
+      - name: Fail when the committed output is stale
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet -- documentation/menu_reference.md documentation/wiki/Menu-Reference.md; then
+            echo "The committed menu reference does not match the generator output."
+            echo "Run 'python scripts/generate_menu_wiki.py' and commit both files."
+            git --no-pager diff --stat -- documentation/menu_reference.md documentation/wiki/Menu-Reference.md
+            exit 1
+          fi
+          echo "The menu reference matches the generator output."
+
   playwright:
     name: "E2E smoke tests"
     needs:

--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -1,0 +1,86 @@
+name: Publish wiki
+
+# The repository holds the wiki source under documentation/wiki/. This workflow
+# copies those pages to the MistHelper.wiki.git repository.
+#
+# Trigger choice matters. GitHub does not start a workflow from an event that the
+# GITHUB_TOKEN created, and auto-merge.yml enables auto-merge with that token. A
+# push trigger alone would therefore miss every auto-merged pull request. The
+# schedule catches those. The push trigger gives an immediate publish for a merge
+# that a human performs. See issue #1749 for the measurements.
+
+on:
+  schedule:
+    # Every 6 hours. Catches an auto-merge, which starts no push event.
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'documentation/wiki/**'
+      - '.github/workflows/wiki-publish.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  # One publish at a time. A second run would race the wiki push.
+  group: wiki-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: "Sync documentation/wiki to the GitHub wiki"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Clone the wiki repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" wiki
+
+      - name: Copy the pages and report any live-only page
+        id: copy
+        run: |
+          set -euo pipefail
+          changed=0
+          # Copy every source page. Compare first so an identical file makes no commit.
+          for src in documentation/wiki/*.md; do
+            name="$(basename "$src")"
+            dest="wiki/${name}"
+            if [ ! -f "$dest" ] || ! cmp -s "$src" "$dest"; then
+              cp "$src" "$dest"
+              echo "updated ${name}"
+              changed=1
+            fi
+          done
+          # Never delete. A live-only page may hold content the repository lacks,
+          # which is exactly what happened to Development.md before issue #1747.
+          for live in wiki/*.md; do
+            name="$(basename "$live")"
+            if [ ! -f "documentation/wiki/${name}" ]; then
+              echo "::warning::${name} exists only on the live wiki. This workflow leaves it alone. Copy it into documentation/wiki/ to bring it under source control."
+            fi
+          done
+          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push
+        if: steps.copy.outputs.changed == '1'
+        working-directory: wiki
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- '*.md'
+          git commit -m "Sync the wiki from documentation/wiki at ${GITHUB_SHA}"
+          git push origin master
+
+      - name: Report a no-op run
+        if: steps.copy.outputs.changed != '1'
+        run: echo "The live wiki already matches documentation/wiki. No commit was made."


### PR DESCRIPTION
Closes #1749

## Summary

Two changes. One publishes the wiki without a human step. One stops the
generator from failing silently again.

## Why a push trigger alone would not work

GitHub does not start a workflow from an event that the `GITHUB_TOKEN` created.
`auto-merge.yml` enables auto-merge with that token, so an auto-merged pull
request starts nothing downstream.

Measured on 2026-08-04 and 2026-08-05:

| Pull request | Merged (UTC) | Method | Workflows on `main` after |
| - | - | - | - |
| #1509 | 23:14 | `gh pr merge` by a user | Quality Gates, CodeQL |
| #1745 | 23:23 | `auto-merge` label | **none** |
| #1746 | 23:37 | `auto-merge` label | **none** |
| #1748 | 01:07 | `auto-merge` label | **none** |

The last push-triggered run on `main` was 23:14. Three later merges started
nothing. This is also the root cause of issue #1742, where `close-linked-issues.yml`
never fires for an auto-merged pull request.

## 1. `wiki-publish.yml`

Three triggers cover every path:

| Trigger | Covers |
| - | - |
| `schedule`, every 6 hours | An auto-merge, which starts no event |
| `workflow_dispatch` | A maintainer publishing on demand |
| `push` on `main`, scoped to `documentation/wiki/**` | A human merge, published immediately |

Design points:

- **Compares before copying.** A run with no content difference makes no commit.
- **Never deletes.** A page that exists only on the live wiki gets a
  `::warning::` telling the maintainer to bring it under source control. It is
  left in place. `Development.md` was exactly this case: the live wiki held 18
  lines that the repository lacked, and a one-way publish would have destroyed
  them. Issue #1747 covers that recovery.
- **No new secret.** `GITHUB_TOKEN` with `contents: write` pushes to the wiki.
- **Concurrency group.** Two runs cannot race the wiki push.

## 2. `menu_reference_drift` job in `ci.yml`

`scripts/generate_menu_wiki.py` searched for `menu_actions` as an `ast.Assign`
node. The declaration gained a type annotation, which parses as `ast.AnnAssign`,
so the generator exited with `menu_actions not found` and produced nothing for
months. The committed pages froze on pre-regrouping numbering that listed menu 5
as a WebSocket command. Menu 5 is a safe org export.

Pull request #1745 fixed the parser. Nothing stopped a repeat until now.

The job regenerates the reference and fails when the committed files differ.

## Test plan

Both workflows parse as YAML.

The drift guard was tested in both directions:

| Scenario | Guard result | Correct |
| - | - | - |
| Clean tree, no source change | Passes | Yes |
| A menu entry added without regenerating the docs | **Fails** | Yes |

The second case injected a fake `"210"` entry into `menu_actions`, ran the
generator, and confirmed the job would exit 1. The tree was restored afterward.

My first attempt at that test was wrong and worth recording: it appended a line
to `menu_reference.md` and expected the guard to notice. The generator overwrites
that file, so the tampering vanished and the guard reported clean. The guard was
right and the test was wrong. The corrected test changes the source instead,
which is the real mistake a contributor makes.

## Note for the reviewer

The new job appears as a check on every pull request, but it does not block a
merge until someone adds it to the branch protection required checks. That is a
repository setting. The existing `diagram_lint` job has the same status, so this
change follows the current convention rather than changing it.

## Conformance

- [x] The change adds no secret and logs no secret.
- [x] The change alters no destructive operation.
- [x] The change alters no runtime behavior of the tool.
- [x] The wiki publish never deletes a page.
