### PR TITLE
fix(ci): sweep for linked issues that an auto-merge leaves open

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,19 +1,43 @@
 name: Close linked issues on merge
 
+# GitHub does not start a workflow from an event that the GITHUB_TOKEN created,
+# and auto-merge.yml enables auto-merge with that token. The pull_request trigger
+# below therefore never fires for an auto-merged pull request. Measured on
+# 2026-08-04: pull requests #1745, #1746, and #1748 all merged by the auto-merge
+# label and started nothing at all. The schedule below sweeps for those.
+# See issue #1742.
+
 on:
   pull_request:
     types: [closed]
+  schedule:
+    # Every 2 hours. Catches an auto-merge, which starts no pull_request event.
+    - cron: '43 */2 * * *'
+  workflow_dispatch:
+    inputs:
+      lookback-hours:
+        description: 'How many hours of merged pull requests to sweep'
+        required: false
+        default: '24'
 
 permissions:
   issues: write
+  pull-requests: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+concurrency:
+  # One sweep at a time. Two runs would race on the same issue.
+  group: close-linked-issues
+  cancel-in-progress: false
+
 jobs:
-  close-linked-issues:
-    if: github.event.pull_request.merged == true
+  close-from-event:
+    name: "Close issues linked by the merged pull request"
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Close issues referenced in PR body
         env:
@@ -37,3 +61,53 @@ jobs:
               echo "Issue #${ISSUE} is already ${STATE}, skipping."
             fi
           done
+
+  sweep-recent-merges:
+    name: "Sweep recently merged pull requests"
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Close issues linked by any recently merged pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOOKBACK_HOURS: ${{ github.event.inputs.lookback-hours || '24' }}
+        run: |
+          set -euo pipefail
+          SINCE=$(date -u -d "${LOOKBACK_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Sweeping pull requests merged since ${SINCE}."
+
+          # A merged pull request keeps its body, so this reads the same keywords
+          # the event path reads. The sweep is safe to repeat, because it skips
+          # any issue that is already closed.
+          PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state merged --limit 100 \
+                  --json number,body,mergedAt \
+                  --jq "[.[] | select(.mergedAt >= \"${SINCE}\")] | .[] | @base64")
+
+          if [ -z "$PRS" ]; then
+            echo "No pull request merged in the window."
+            exit 0
+          fi
+
+          CLOSED=0
+          for ROW in $PRS; do
+            PR_JSON=$(echo "$ROW" | base64 -d)
+            PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+            PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+
+            ISSUES=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | grep -oE '[0-9]+' | sort -u || true)
+            if [ -z "$ISSUES" ]; then
+              continue
+            fi
+
+            for ISSUE in $ISSUES; do
+              STATE=$(gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json state --jq '.state' 2>/dev/null || echo "MISSING")
+              if [ "$STATE" = "OPEN" ]; then
+                gh issue close "$ISSUE" --repo "$GITHUB_REPOSITORY" --reason completed \
+                  --comment "Automatically closed by the merge of PR #${PR_NUMBER}. The scheduled sweep found this link, because an auto-merged pull request starts no event. See issue #1742."
+                echo "Closed issue #${ISSUE} from PR #${PR_NUMBER}"
+                CLOSED=$((CLOSED + 1))
+              fi
+            done
+          done
+          echo "The sweep closed ${CLOSED} issue(s)."


### PR DESCRIPTION
Closes #1742

## Root cause

`close-linked-issues.yml` is correctly written. It simply never runs for an
auto-merged pull request.

GitHub does not start a workflow from an event that the `GITHUB_TOKEN` created.
`auto-merge.yml` enables auto-merge with that token, so the merge and the
resulting push both carry that identity and every downstream workflow stays
silent.

## Evidence

Measured on 2026-08-04 and 2026-08-05.

| Pull request | Merged (UTC) | Method | Workflows started |
| - | - | - | - |
| #1509 | 23:14 | `gh pr merge` by a user | Quality Gates, CodeQL, close-linked-issues |
| #1745 | 23:23 | `auto-merge` label | **none** |
| #1746 | 23:37 | `auto-merge` label | **none** |
| #1748 | 01:07 | `auto-merge` label | **none** |

The last push-triggered run on `main` was 23:14. Three later merges started
nothing. The last `close-linked-issues` run was 23:14 for the same reason.

## The change

The workflow now holds two jobs.

| Job | Trigger | Purpose |
| - | - | - |
| `close-from-event` | `pull_request: closed` | Unchanged behavior for a human merge |
| `sweep-recent-merges` | `schedule` every 2 hours, `workflow_dispatch` | Catches an auto-merge |

The sweep reads every pull request merged inside the lookback window, extracts
the same `Closes`, `Fixes`, and `Resolves` keywords, and closes any linked issue
that is still open. It skips an issue that is already closed, so a repeat run is
safe. `workflow_dispatch` accepts a `lookback-hours` input, which defaults to 24.

A `concurrency` group stops two runs from racing on the same issue.

## Why not a personal access token

A PAT on `auto-merge.yml` would make the merge carry a user identity and restore
every downstream trigger. That is the tidier fix, but it needs a new secret and
a rotation owner. The sweep needs neither and works today. If the repository
later gains a PAT or a GitHub App, the sweep stays useful as a safety net.

## Test plan

A dry run of the sweep logic against the live repository, using the same query
and the same keyword pattern the workflow uses:

```text
since: 2026-08-04T01:40:09Z

  PR #1750  -> issue #1749  WOULD CLOSE
  PR #1748  -> issue #1747  skip (CLOSED)
  PR #1745  -> issue #1744  WOULD CLOSE
  PR #1743  -> issue #1439  skip (CLOSED)
  PR #1732  -> issue #1710  skip (CLOSED)

pull requests in window with a closing keyword: 5
```

The run found two issues that an auto-merge had left open, #1744 and #1749. Both
are the defect this pull request fixes. It correctly skipped the three that a
human had already closed by hand.

| Check | Result |
| - | - |
| YAML parses, 2 jobs, 3 triggers | Pass |
| Sweep query returns the merged pull requests in the window | Pass |
| Keyword pattern extracts the linked issue numbers | Pass |
| Already-closed issues are skipped | Pass |

I left #1744 and #1749 open on purpose. The first scheduled sweep after this
merges should close both, which proves the fix end to end.

## Conformance

- [x] The change adds no secret and logs no secret.
- [x] The change alters no destructive operation.
- [x] The change alters no runtime behavior of the tool.
- [x] The sweep is idempotent.
