### PR TITLE
chore: remove the broken submodule gitlink and ignore agent scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,6 @@ uv.lock
 .github/agents/speckit.companion.*
 .github/prompts/speckit.companion.*
 
+
+# Claude Code agent scratch. A worktree here was committed as a broken gitlink once (issue #1752).
+.claude/


### PR DESCRIPTION
Closes #1752

## Problem

The index held one gitlink with no `.gitmodules` file:

```text
160000 3b7f1f794e8a0c52d5184fa286d24aa065ca391d 0  .claude/worktrees/1022-org-synthetic-probes
```

Git treats that path as a submodule it cannot resolve. Every `actions/checkout`
post-job cleanup logged a fatal line and an exit 128 warning:

```text
[command]/usr/bin/git submodule foreach --recursive sh -c "git config ..."
fatal: No url found for submodule path '.claude/worktrees/1022-org-synthetic-probes' in .gitmodules
##[warning]The process '/usr/bin/git' failed with exit code 128
```

## Why it matters

No job failed, because every workflow passes `submodules: false`. The defect is
still real:

1. Every run log carries a `fatal:` line. A reader who scans logs for trouble
   finds noise that means nothing, which trains them to ignore the word.
2. Any future workflow that needs `submodules: true` fails outright.
3. `git submodule` commands fail for a contributor on a fresh clone.

## Cause

Commit `28fdfe5`, merged as pull request #1662, added the entry. The path is a
Claude Code agent worktree. It is scratch state that was never meant to reach
the repository. `.gitignore` did not list `.claude/`, so nothing stopped it.

## The change

| Action | Effect |
| - | - |
| `git rm --cached .claude/worktrees/1022-org-synthetic-probes` | Removes the gitlink from the index |
| Add `.claude/` to `.gitignore` | Stops a repeat |

The directory stays on the contributor's disk. Only the tracking stops.

## Test plan

| Check | Before | After |
| - | - | - |
| `git ls-files --stage` entries with mode `160000` | 1 | **0** |
| `git check-ignore -v .claude/worktrees/1022-org-synthetic-probes` | no match | `.gitignore:296:.claude/` |
| Tracked files under `.claude/` | 1 | 0 |

After this merges, a checkout post-cleanup should log no `fatal:` line and no
exit 128 warning. That is visible in the next run of any workflow.

## Conformance

- [x] The change adds no secret and logs no secret.
- [x] The change alters no destructive operation.
- [x] The change alters no runtime behavior of the tool.
- [x] No file leaves the contributor's disk.

## Context

Found while verifying the new `wiki-publish.yml` workflow under issue #1749. The
run succeeded, but its log carried the warning. Worth noting that this had been
in every CI log since pull request #1662 merged and nobody had traced it.
