### PR TITLE
fix(tests): stop test modules leaking a mistapi stub into sys.modules

### DIFF
--- a/src/utils/input_utils.py
+++ b/src/utils/input_utils.py
@@ -59,9 +59,8 @@ class InputUtils:
         """Return trimmed user input, degrading to ``default_value`` on EOF/empty."""
         logging.debug("safe_input entered (context=%s)", context)  # Action-log entry per project rule.
         try:
-            user_input = input(
-                prompt
-            ).strip()  # noqa: STRUCT-PARAMS  # bare input() OK here -- this IS the safe wrapper.
+            # A bare input() is correct here, because this method IS the safe wrapper.
+            user_input = input(prompt).strip()
         except EOFError:  # Stream closed (Ctrl+D, broken pipe, SSH disconnect).
             return InputUtils._handle_eof(context, default_value)  # Degrade gracefully to the default.
         except KeyboardInterrupt:  # Operator pressed Ctrl+C to abort the prompt.

--- a/tests/unit/device/test_ap_profile_migration_manager.py
+++ b/tests/unit/device/test_ap_profile_migration_manager.py
@@ -1522,7 +1522,6 @@ def test_migrate_hermetic_no_wall_clock_sleep(
         """Record every pacing sleep argument so the test can sum them."""
         sleep_args.append(secs)
 
-    start = time.perf_counter()
     with (
         patch.object(APProfileMigrationManager, "_pick_ap_device_profile", side_effect=[src, tgt]),
         patch.object(APProfileMigrationManager, "_discover_aps_on_source_profile", return_value=aps),
@@ -1530,13 +1529,14 @@ def test_migrate_hermetic_no_wall_clock_sleep(
         patch("src.device.ap_profile_migration_manager.time.sleep", side_effect=_record_sleep),
     ):
         APProfileMigrationManager.migrate_aps_between_device_profiles(session=MagicMock())
-    elapsed = time.perf_counter() - start
 
-    # WHY: FR-A07 hermetic gate -- 100 APs run in well under half a second.
-    assert elapsed < 0.5, f"hermetic run exceeded 0.5 s wall clock: {elapsed:.3f} s"
     # WHY: pacing was actually invoked (not silently skipped).
     assert sum(sleep_args) > 0.0, "sleep sum is zero; pacing did not fire"
     assert len(sleep_args) >= 100, f"expected >=100 sleep calls, got {len(sleep_args)}"
+    # WHY: FR-A07 hermetic gate. The recorded total is the wall time the run WOULD have
+    # cost, so a large total proves the patched reference intercepted every real sleep.
+    # A direct wall-clock assertion here flaked under full-suite load. See issue #1738.
+    assert sum(sleep_args) >= 1.0, f"pacing total {sum(sleep_args):.3f} s is too low to prove interception"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/org/test_org_synthetic_probes_manager.py
+++ b/tests/unit/org/test_org_synthetic_probes_manager.py
@@ -3506,10 +3506,22 @@ def test_regression_runtime_under_budget(pytestconfig: pytest.Config) -> None:  
         f"1025 regression subset did not fully pass (pytest exit_code={exit_code}); "
         f"fix the failing tests before evaluating the runtime budget"
     )
-    # SC-007: wall-clock budget assertion.
-    budget_seconds = 5.0  # SC-007 canonical budget on the reference dev machine
-    assert elapsed < budget_seconds, (
-        f"1025 regression subset took {elapsed:.3f}s, exceeding the {budget_seconds:.1f}s "
-        f"SC-007 budget. Investigate slow fixtures or add a fresh justification if the "
-        f"budget must grow."
+    # SC-007 part 1: the deterministic guard. The real concern is subset creep, because
+    # each added node costs about 500 ms of fixed pytest-in-pytest overhead. A node count
+    # does not move with machine load, so this assertion is the one that must hold.
+    max_nodes = 8  # SC-007 canonical subset size; growing it is a conscious decision
+    assert len(subset) <= max_nodes, (
+        f"the 1025 regression subset holds {len(subset)} nodes, above the SC-007 cap of "
+        f"{max_nodes}. Each node costs about 500 ms. Trim the subset or raise the cap "
+        f"with a written justification."
+    )
+    # SC-007 part 2: a catastrophic-regression ceiling only. The former 5.0 s budget
+    # measured a nested pytest run, so it failed whenever the full suite loaded the
+    # machine. Measured alone it took 0.93 s and under full-suite load 22.99 s, with no
+    # code change between the two. See issue #1738. This ceiling catches a real runaway
+    # such as a fixture loop that scales with site count, and ignores scheduling noise.
+    ceiling_seconds = 120.0
+    assert elapsed < ceiling_seconds, (
+        f"1025 regression subset took {elapsed:.3f}s, above the {ceiling_seconds:.0f}s "
+        f"runaway ceiling. This is not scheduling noise. Investigate slow fixtures."
     )

--- a/tests/unit/test_bulk_switch_upgrader.py
+++ b/tests/unit/test_bulk_switch_upgrader.py
@@ -19,24 +19,34 @@ import pytest
 # ---------------------------------------------------------------------------
 # Mock mistapi before importing the module under test
 # ---------------------------------------------------------------------------
-_had_mistapi = "mistapi" in sys.modules
+# ---------------------------------------------------------------------------
+# Stub mistapi for the import, then restore sys.modules at once.
+# WHY: pytest imports every test module during collection but runs teardown_module only
+# for a module that has a selected test. A stub left in sys.modules therefore leaks for
+# the whole session and breaks mistapi's lazy subpackage import. See issue #1739.
+# ---------------------------------------------------------------------------
 _saved_mistapi = sys.modules.get("mistapi")
 _our_mock = MagicMock()
 sys.modules["mistapi"] = _our_mock
-
-from src.firmware.bulk_switch_upgrader import BulkSwitchFirmwareUpgrader
+try:
+    from src.firmware.bulk_switch_upgrader import BulkSwitchFirmwareUpgrader
+finally:
+    if _saved_mistapi is not None:
+        sys.modules["mistapi"] = _saved_mistapi
+    else:
+        sys.modules.pop("mistapi", None)
 
 
 def setup_module() -> None:
-    """Re-assert mocks in sys.modules before tests run."""
+    """Re-assert our stub for the duration of this module's tests."""
     sys.modules["mistapi"] = _our_mock
 
 
 def teardown_module() -> None:
-    """Restore sys.modules only if our mock is still installed."""
+    """Restore sys.modules only if our stub is still installed."""
     if sys.modules.get("mistapi") is not _our_mock:
-        return  # Another module replaced our mock; leave it alone
-    if _had_mistapi:
+        return  # Another module replaced our stub; leave it alone
+    if _saved_mistapi is not None:
         sys.modules["mistapi"] = _saved_mistapi
     else:
         sys.modules.pop("mistapi", None)

--- a/tests/unit/test_csv_comparator.py
+++ b/tests/unit/test_csv_comparator.py
@@ -11,31 +11,40 @@ import sys
 import tempfile
 from unittest.mock import MagicMock, patch
 
-# --- Module-level mistapi mock (identity-checked teardown) ---
-_had_mistapi = "mistapi" in sys.modules
+# --- Module-level mistapi stub, restored the moment the import finishes ---
+# WHY: pytest imports every test module during collection but runs teardown_module only
+# for a module that has a selected test. A stub left in sys.modules therefore leaks for
+# the whole session and breaks mistapi's lazy subpackage import. See issue #1739.
+# The module under test binds this stub in its own namespace at import time, so the
+# tests keep seeing it after sys.modules is restored.
 _saved_mistapi = sys.modules.get("mistapi")
 _our_mock = MagicMock()
 sys.modules["mistapi"] = _our_mock
-
-from src.inventory.csv_comparator import (
-    AddressComparisonCounters,
-    ComparatorDependencies,
-    ComparatorFlags,
-    InventoryCSVComparator,
-    RecordComparisonInputs,
-)
+try:
+    from src.inventory.csv_comparator import (
+        AddressComparisonCounters,
+        ComparatorDependencies,
+        ComparatorFlags,
+        InventoryCSVComparator,
+        RecordComparisonInputs,
+    )
+finally:
+    if _saved_mistapi is not None:
+        sys.modules["mistapi"] = _saved_mistapi
+    else:
+        sys.modules.pop("mistapi", None)
 
 
 def setup_module() -> None:
-    """Re-assert our mock in sys.modules before tests run."""
+    """Re-assert our stub for the duration of this module's tests."""
     sys.modules["mistapi"] = _our_mock
 
 
 def teardown_module() -> None:
-    """Restore sys.modules only if our mock is still installed."""
+    """Restore sys.modules only if our stub is still installed."""
     if sys.modules.get("mistapi") is not _our_mock:
         return
-    if _had_mistapi:
+    if _saved_mistapi is not None:
         sys.modules["mistapi"] = _saved_mistapi
     else:
         sys.modules.pop("mistapi", None)

--- a/tests/unit/test_device_utility_commands.py
+++ b/tests/unit/test_device_utility_commands.py
@@ -15,14 +15,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# --- Module-level mistapi mock (identity-checked teardown) ---
-_had_mistapi = "mistapi" in sys.modules
+# --- Module-level mistapi stub, restored the moment the import finishes ---
+# WHY: pytest imports every test module during collection but runs teardown_module only
+# for a module that has a selected test. A stub left in sys.modules therefore leaks for
+# the whole session and breaks mistapi's lazy subpackage import. See issue #1739.
 _saved_mistapi = sys.modules.get("mistapi")
 _our_mock = MagicMock()
 sys.modules["mistapi"] = _our_mock
-
-from src.device._utility_commands_websocket import ExportResultSpec, StreamWsSpec
-from src.device.utility_commands import DeviceUtilityCommands, UtilityCommandsDeps
+try:
+    from src.device._utility_commands_websocket import ExportResultSpec, StreamWsSpec
+    from src.device.utility_commands import DeviceUtilityCommands, UtilityCommandsDeps
+finally:
+    if _saved_mistapi is not None:
+        sys.modules["mistapi"] = _saved_mistapi
+    else:
+        sys.modules.pop("mistapi", None)
 
 _WS_LOGGER = "src.device._utility_commands_websocket"  # WHY: caplog target for #886 print-to-logger tests
 _SEL_LOGGER = "src.device._utility_commands_selection"  # WHY: caplog target for #886 print-to-logger tests
@@ -34,11 +41,11 @@ def setup_module() -> None:
 
 
 def teardown_module() -> None:
-    """Restore sys.modules only if our mock is still installed."""
+    """Restore sys.modules only if our stub is still installed."""
     if sys.modules.get("mistapi") is not _our_mock:
         return
-    if _had_mistapi:
-        sys.modules["mistapi"] = _saved_mistapi  # type: ignore[assignment]
+    if _saved_mistapi is not None:
+        sys.modules["mistapi"] = _saved_mistapi
     else:
         sys.modules.pop("mistapi", None)
 

--- a/tests/unit/test_no_mistapi_stub_leak.py
+++ b/tests/unit/test_no_mistapi_stub_leak.py
@@ -1,0 +1,34 @@
+"""Guard against a test module that leaves a mistapi stub in sys.modules.
+
+Some test modules put a MagicMock at ``sys.modules["mistapi"]``. This lets them import
+their subject without the real SDK.
+
+pytest imports every test module during collection. But pytest runs ``teardown_module``
+only for a module with a selected test. A stub from import time therefore stays for the
+whole session when pytest deselects the owner module, such as under ``-k``.
+
+The leak is silent. The real ``mistapi`` package finds its subpackages through
+``__getattr__``. That lookup reads ``sys.modules["mistapi"]`` to get the parent package.
+A stub has no ``__path__``, so the import fails. The error then names ``mistapi`` as
+"not a package" in an unrelated test. See issue #1739.
+
+Each stub module must restore sys.modules directly after its import.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def test_mistapi_in_sys_modules_is_the_real_package() -> None:
+    """Fail if collection left a stub in place of the real mistapi package."""
+    module = sys.modules.get("mistapi")  # Whatever collection left behind.
+    assert module is not None, "mistapi is absent from sys.modules. A test module removed it."
+
+    # A MagicMock stub has no __path__, so lazy subpackage imports fail.
+    assert hasattr(module, "__path__"), (
+        "sys.modules['mistapi'] holds a stub, not the real package. A test module "
+        "installed a mock at import time and did not restore it. Restore sys.modules "
+        "directly after the guarded import. teardown_module does not run for a "
+        "deselected module. See issue #1739."
+    )

--- a/tests/unit/test_routing_utils.py
+++ b/tests/unit/test_routing_utils.py
@@ -16,27 +16,33 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# --- Module-level mistapi mock (identity-checked teardown) ---
-_had_mistapi = "mistapi" in sys.modules
+# --- Module-level mistapi stub, restored the moment the import finishes ---
+# WHY: pytest imports every test module during collection but runs teardown_module only
+# for a module that has a selected test. A stub left in sys.modules therefore leaks for
+# the whole session and breaks mistapi's lazy subpackage import. See issue #1739.
 _saved_mistapi = sys.modules.get("mistapi")
 _our_mock = MagicMock()
 sys.modules["mistapi"] = _our_mock
-
-
-from src.network.routing_utils import RoutingDeps, RoutingTableContext, RoutingUtils, SsrRouteContext
+try:
+    from src.network.routing_utils import RoutingDeps, RoutingTableContext, RoutingUtils, SsrRouteContext
+finally:
+    if _saved_mistapi is not None:
+        sys.modules["mistapi"] = _saved_mistapi
+    else:
+        sys.modules.pop("mistapi", None)
 
 
 def setup_module() -> None:
-    """Re-assert our mock in sys.modules before tests run."""
+    """Re-assert our stub for the duration of this module's tests."""
     sys.modules["mistapi"] = _our_mock
 
 
 def teardown_module() -> None:
-    """Restore sys.modules only if our mock is still installed."""
+    """Restore sys.modules only if our stub is still installed."""
     if sys.modules.get("mistapi") is not _our_mock:
         return
-    if _had_mistapi:
-        sys.modules["mistapi"] = _saved_mistapi  # type: ignore[assignment]
+    if _saved_mistapi is not None:
+        sys.modules["mistapi"] = _saved_mistapi
     else:
         sys.modules.pop("mistapi", None)
 

--- a/tests/unit/test_ssid_template_consolidation.py
+++ b/tests/unit/test_ssid_template_consolidation.py
@@ -24,86 +24,124 @@ import pytest
 # Mock mistapi before importing the module under test
 # ---------------------------------------------------------------------------
 _mock_mistapi = MagicMock()
-# WHY: install mistapi mocks permanently in sys.modules so that any lazy
-# re-imports triggered by cluster methods (e.g. `from .ssid_template_consolidation
-# import _disable_single_ssid` inside _SsidTemplatePhase45Cluster) resolve the
-# same mocked mistapi.  A `with patch.dict(...)` block would REMOVE the fake
-# entries on exit, and the ssid_consolidation package itself, causing lazy
-# imports to trigger a real re-import with the real mistapi bound in globals.
-sys.modules["mistapi"] = _mock_mistapi
-sys.modules["mistapi.api"] = MagicMock()
-sys.modules["mistapi.api.v1"] = MagicMock()
-sys.modules["mistapi.api.v1.orgs"] = MagicMock()
-sys.modules["mistapi.api.v1.orgs.templates"] = MagicMock()
-sys.modules["mistapi.api.v1.orgs.wlans"] = MagicMock()
-sys.modules["mistapi.api.v1.orgs.sites"] = MagicMock()
-sys.modules["mistapi.api.v1.orgs.mxtunnels"] = MagicMock()
-sys.modules["mistapi.api.v1.orgs.sitegroups"] = MagicMock()
-sys.modules["mistapi.api.v1.sites"] = MagicMock()
-sys.modules["mistapi.api.v1.sites.sites"] = MagicMock()
-sys.modules["mistapi.get_all"] = MagicMock()
+# WHY: the cluster methods do lazy re-imports (for example `from
+# .ssid_template_consolidation import _disable_single_ssid` inside
+# _SsidTemplatePhase45Cluster). Those must resolve the same mocked mistapi, so the
+# stubs stay installed for the whole time this module's tests run. setup_module
+# re-installs them and teardown_module removes them again.
+_MISTAPI_STUBS: dict[str, MagicMock] = {
+    "mistapi": _mock_mistapi,
+    "mistapi.api": MagicMock(),
+    "mistapi.api.v1": MagicMock(),
+    "mistapi.api.v1.orgs": MagicMock(),
+    "mistapi.api.v1.orgs.templates": MagicMock(),
+    "mistapi.api.v1.orgs.wlans": MagicMock(),
+    "mistapi.api.v1.orgs.sites": MagicMock(),
+    "mistapi.api.v1.orgs.mxtunnels": MagicMock(),
+    "mistapi.api.v1.orgs.sitegroups": MagicMock(),
+    "mistapi.api.v1.sites": MagicMock(),
+    "mistapi.api.v1.sites.sites": MagicMock(),
+    "mistapi.get_all": MagicMock(),
+}
+_saved_mistapi_modules = {name: sys.modules.get(name) for name in _MISTAPI_STUBS}
 
-import src.ssid_consolidation.ssid_template_consolidation as _mod  # noqa: E402
-from src.ssid_consolidation.ssid_template_consolidation import (  # noqa: E402
-    SSIDTemplateConsolidationManager,
-    SsidTemplateDeps,
-    TemplateOpParams,
-    TemplateOutcome,
-    _add_pilot_group,
-    _append_drift_record,
-    _append_ssid_to_template,
-    _assign_matrix_sites,
-    _build_all_template_configs,
-    _build_cluster_groups,
-    _build_deviation_record,
-    _build_disable_base,
-    _build_disable_plan,
-    _build_mxtunnel_lookup,
-    _build_site_row,
-    _build_sitegroup_lookup,
-    _build_skip_entry,
-    _build_template_config,
-    _build_template_lookup,
-    _build_variable_entry,
-    _cache_age_minutes,
-    _check_cache_exists,
-    _check_prerequisite_for_all,
-    _classify_disable_entry,
-    _classify_site,
-    _collect_comparison_keys,
-    _collect_group_wlan_configs,
-    _collect_key_values,
-    _compute_group_plan,
-    _compute_variable_plan,
-    _create_new_template,
-    _create_site_group,
-    _detect_cross_cluster_drift,
-    _determine_target_group,
-    _display_disable_plan,
-    _display_group_plan,
-    _display_template_plan,
-    _display_variable_summary,
-    _extract_deviation_params,
-    _find_representative,
-    _find_target_wlan,
-    _get_cached_site_vars,
-    _get_existing_group_site_ids,
-    _get_template_wlans,
-    _group_by_target,
-    _group_entries_by_site,
-    _handle_completed_resume,
-    _handle_existing_non_misthelper,
-    _handle_partial_resume,
-    _load_group_plan_from_results,
-    _populate_from_representative,
-    _print_conflicts,
-    _print_phase1_summary,
-    _print_phase_summary,
-    _resolve_template,
-    _set_ssid_disabled,
-    _SiteLookups,
-    _template_result,
-)
+
+def _install_mistapi_stubs() -> None:
+    """Put every mistapi stub into sys.modules."""
+    sys.modules.update(_MISTAPI_STUBS)
+
+
+def _restore_mistapi_modules() -> None:
+    """Undo _install_mistapi_stubs for each entry we still own."""
+    for name, saved in _saved_mistapi_modules.items():
+        if sys.modules.get(name) is not _MISTAPI_STUBS[name]:
+            continue  # Another module replaced our stub; leave it alone.
+        if saved is not None:
+            sys.modules[name] = saved
+        else:
+            sys.modules.pop(name, None)
+
+
+# Restore the moment the import finishes. pytest imports every test module during
+# collection but runs teardown_module only for a module that has a selected test, so a
+# stub left here leaks for the whole session and breaks mistapi's lazy subpackage
+# import. See issue #1739.
+_install_mistapi_stubs()
+try:
+    import src.ssid_consolidation.ssid_template_consolidation as _mod  # noqa: E402
+    from src.ssid_consolidation.ssid_template_consolidation import (  # noqa: E402
+        SSIDTemplateConsolidationManager,
+        SsidTemplateDeps,
+        TemplateOpParams,
+        TemplateOutcome,
+        _add_pilot_group,
+        _append_drift_record,
+        _append_ssid_to_template,
+        _assign_matrix_sites,
+        _build_all_template_configs,
+        _build_cluster_groups,
+        _build_deviation_record,
+        _build_disable_base,
+        _build_disable_plan,
+        _build_mxtunnel_lookup,
+        _build_site_row,
+        _build_sitegroup_lookup,
+        _build_skip_entry,
+        _build_template_config,
+        _build_template_lookup,
+        _build_variable_entry,
+        _cache_age_minutes,
+        _check_cache_exists,
+        _check_prerequisite_for_all,
+        _classify_disable_entry,
+        _classify_site,
+        _collect_comparison_keys,
+        _collect_group_wlan_configs,
+        _collect_key_values,
+        _compute_group_plan,
+        _compute_variable_plan,
+        _create_new_template,
+        _create_site_group,
+        _detect_cross_cluster_drift,
+        _determine_target_group,
+        _display_disable_plan,
+        _display_group_plan,
+        _display_template_plan,
+        _display_variable_summary,
+        _extract_deviation_params,
+        _find_representative,
+        _find_target_wlan,
+        _get_cached_site_vars,
+        _get_existing_group_site_ids,
+        _get_template_wlans,
+        _group_by_target,
+        _group_entries_by_site,
+        _handle_completed_resume,
+        _handle_existing_non_misthelper,
+        _handle_partial_resume,
+        _load_group_plan_from_results,
+        _populate_from_representative,
+        _print_conflicts,
+        _print_phase1_summary,
+        _print_phase_summary,
+        _resolve_template,
+        _set_ssid_disabled,
+        _SiteLookups,
+        _template_result,
+    )
+finally:
+    _restore_mistapi_modules()
+
+
+def setup_module() -> None:
+    """Re-install the stubs for the duration of this module's tests."""
+    _install_mistapi_stubs()
+
+
+def teardown_module() -> None:
+    """Remove the stubs again after this module's tests finish."""
+    _restore_mistapi_modules()
+
 
 # ===================================================================
 # Helpers

--- a/tests/unit/test_template_config.py
+++ b/tests/unit/test_template_config.py
@@ -11,40 +11,47 @@ import sys
 import tempfile
 from unittest.mock import MagicMock, patch
 
-# --- Module-level mistapi mock (identity-checked teardown) ---
-_had_mistapi = "mistapi" in sys.modules
+# --- Module-level mistapi stub, restored the moment the import finishes ---
+# WHY: pytest imports every test module during collection but runs teardown_module only
+# for a module that has a selected test. A stub left in sys.modules therefore leaks for
+# the whole session and breaks mistapi's lazy subpackage import. See issue #1739.
 _saved_mistapi = sys.modules.get("mistapi")
 _our_mock = MagicMock()
 sys.modules["mistapi"] = _our_mock
-
-from src.gateway.template_config import (
-    GatewayTemplateConfigManager,
-    _filter_sites_with_location,
-    _find_existing_picocell_index,
-    _find_picocell_policy,
-    _infer_state_without_postal,  # private — used for edge-case coverage of line 1034
-    _insert_picocell_policy,
-    _merge_dia_pico,
-    _merge_picocell,
-    _parse_canadian_state,  # private — used for edge-case coverage of line 997
-    _parse_general_state,  # private — used for edge-case coverage of line 1016
-    _parse_state_comma_separated,
-    _parse_state_space_separated,
-    _parse_template_indices,
-    parse_state_from_address,
-)
+try:
+    from src.gateway.template_config import (
+        GatewayTemplateConfigManager,
+        _filter_sites_with_location,
+        _find_existing_picocell_index,
+        _find_picocell_policy,
+        _infer_state_without_postal,  # private — used for edge-case coverage of line 1034
+        _insert_picocell_policy,
+        _merge_dia_pico,
+        _merge_picocell,
+        _parse_canadian_state,  # private — used for edge-case coverage of line 997
+        _parse_general_state,  # private — used for edge-case coverage of line 1016
+        _parse_state_comma_separated,
+        _parse_state_space_separated,
+        _parse_template_indices,
+        parse_state_from_address,
+    )
+finally:
+    if _saved_mistapi is not None:
+        sys.modules["mistapi"] = _saved_mistapi
+    else:
+        sys.modules.pop("mistapi", None)
 
 
 def setup_module() -> None:
-    """Re-assert our mock in sys.modules before tests run."""
+    """Re-assert our stub for the duration of this module's tests."""
     sys.modules["mistapi"] = _our_mock
 
 
 def teardown_module() -> None:
-    """Restore sys.modules only if our mock is still installed."""
+    """Restore sys.modules only if our stub is still installed."""
     if sys.modules.get("mistapi") is not _our_mock:
         return
-    if _had_mistapi:
+    if _saved_mistapi is not None:
         sys.modules["mistapi"] = _saved_mistapi
     else:
         sys.modules.pop("mistapi", None)

--- a/tests/unit/test_wan2_variable.py
+++ b/tests/unit/test_wan2_variable.py
@@ -9,32 +9,35 @@ import sys
 import threading
 from unittest.mock import MagicMock
 
-# --- Module-level mistapi mock (identity-checked teardown) ---
-_had_mistapi = "mistapi" in sys.modules
+# --- Module-level mistapi stub, restored the moment the import finishes ---
+# WHY: pytest imports every test module during collection but runs teardown_module only
+# for a module that has a selected test. A stub left in sys.modules therefore leaks for
+# the whole session and breaks mistapi's lazy subpackage import. See issue #1739.
 _saved_mistapi = sys.modules.get("mistapi")
 _our_mock = MagicMock()
 sys.modules["mistapi"] = _our_mock
-
-from src.gateway._wan2_variable_device import _Wan2VariableDevice
-from src.gateway._wan2_variable_io import _Wan2VariableIO
-from src.gateway._wan2_variable_reporting import _Wan2VariableReporting
-from src.gateway.wan2_variable import GatewayWan2VariableMigrator, Wan2VariableDeps
+try:
+    from src.gateway._wan2_variable_device import _Wan2VariableDevice
+    from src.gateway._wan2_variable_io import _Wan2VariableIO
+    from src.gateway._wan2_variable_reporting import _Wan2VariableReporting
+    from src.gateway.wan2_variable import GatewayWan2VariableMigrator, Wan2VariableDeps
+finally:
+    if _saved_mistapi is not None:
+        sys.modules["mistapi"] = _saved_mistapi
+    else:
+        sys.modules.pop("mistapi", None)
 
 
 def setup_module() -> None:
-    """Re-assert our mock in sys.modules before tests run.
-
-    During pytest collection, other test files may overwrite sys.modules["mistapi"]
-    after our module-level setup but before our tests execute.
-    """
+    """Re-assert our stub for the duration of this module's tests."""
     sys.modules["mistapi"] = _our_mock
 
 
 def teardown_module() -> None:
-    """Restore sys.modules only if our mock is still installed."""
+    """Restore sys.modules only if our stub is still installed."""
     if sys.modules.get("mistapi") is not _our_mock:
         return
-    if _had_mistapi:
+    if _saved_mistapi is not None:
         sys.modules["mistapi"] = _saved_mistapi
     else:
         sys.modules.pop("mistapi", None)

--- a/tests/unit/test_zone_analyzer.py
+++ b/tests/unit/test_zone_analyzer.py
@@ -15,67 +15,76 @@ import pytest
 # ---------------------------------------------------------------------------
 _mock_mistapi = MagicMock()
 
-_MOCKED_MODULES = {
+# Mock tqdm too, to avoid import issues in CI.
+_mock_tqdm_mod = MagicMock()
+_mock_tqdm_mod.tqdm = lambda items, **_kw: items
+
+_MOCKED_MODULES: dict[str, Any] = {
     "mistapi": _mock_mistapi,
     "mistapi.api": _mock_mistapi.api,
     "mistapi.api.v1": _mock_mistapi.api.v1,
     "mistapi.api.v1.sites": _mock_mistapi.api.v1.sites,
     "mistapi.api.v1.sites.setting": _mock_mistapi.api.v1.sites.setting,
     "mistapi.api.v1.sites.zones": _mock_mistapi.api.v1.sites.zones,
+    "tqdm": _mock_tqdm_mod,
 }
 
-# Remember what was there before (if anything)
-_saved: dict[str, Any] = {}
-_absent: list[str] = []
-for _key, _val in _MOCKED_MODULES.items():
-    if _key in sys.modules:
-        _saved[_key] = sys.modules[_key]
-    else:
-        _absent.append(_key)
-    sys.modules[_key] = _val
+# Remember what was there before (if anything).
+_saved: dict[str, Any] = {key: sys.modules.get(key) for key in _MOCKED_MODULES}
 
-# Mock tqdm to avoid import issues in CI
-_mock_tqdm_mod = MagicMock()
-_mock_tqdm_mod.tqdm = lambda items, **_kw: items
-if "tqdm" not in sys.modules:
-    _absent.append("tqdm")
-elif "tqdm" in sys.modules:
-    _saved["tqdm"] = sys.modules["tqdm"]
-sys.modules["tqdm"] = _mock_tqdm_mod
 
-from src.analytics.zone_analyzer import (
-    ZoneConfigurationAnalyzer,
-    _build_one_summary_row,
-    _build_summary_rows,
-    _compute_zone_stats,
-    _dwell_config_key,
-    _empty_zone_entry,
-    _find_dwell_deviations,
-    _find_occupancy_deviations,
-    _find_sites_missing_common,
-    _find_sites_with_unique,
-    _find_zone_count_deviations,
-    _occupancy_config_key,
-    _track_custom_names,
-)
+def _install_stub_modules() -> None:
+    """Put every stub into sys.modules."""
+    sys.modules.update(_MOCKED_MODULES)
+
+
+def _restore_stub_modules() -> None:
+    """Undo _install_stub_modules for each entry we still own."""
+    for key, saved in _saved.items():
+        if sys.modules.get(key) is not _MOCKED_MODULES[key]:
+            continue  # Another module replaced our stub; leave it alone.
+        if saved is not None:
+            sys.modules[key] = saved
+        else:
+            sys.modules.pop(key, None)
+
+
+# Restore the moment the import finishes. pytest imports every test module during
+# collection but runs teardown_module only for a module that has a selected test, so a
+# stub left here leaks for the whole session and breaks mistapi's lazy subpackage
+# import. See issue #1739.
+_install_stub_modules()
+try:
+    from src.analytics.zone_analyzer import (
+        ZoneConfigurationAnalyzer,
+        _build_one_summary_row,
+        _build_summary_rows,
+        _compute_zone_stats,
+        _dwell_config_key,
+        _empty_zone_entry,
+        _find_dwell_deviations,
+        _find_occupancy_deviations,
+        _find_sites_missing_common,
+        _find_sites_with_unique,
+        _find_zone_count_deviations,
+        _occupancy_config_key,
+        _track_custom_names,
+    )
+finally:
+    _restore_stub_modules()
 
 
 # ---------------------------------------------------------------------------
 # Module setup/teardown -- ensure mocks survive pytest collection ordering
 # ---------------------------------------------------------------------------
 def setup_module() -> None:
-    """Re-assert mocks in sys.modules before tests run."""
-    for key, val in _MOCKED_MODULES.items():
-        sys.modules[key] = val
-    sys.modules["tqdm"] = _mock_tqdm_mod
+    """Re-install the stubs for the duration of this module's tests."""
+    _install_stub_modules()
 
 
 def teardown_module() -> None:
-    """Restore sys.modules to pre-test state."""
-    for key in _absent:
-        sys.modules.pop(key, None)
-    for key, val in _saved.items():
-        sys.modules[key] = val
+    """Remove the stubs again after this module's tests finish."""
+    _restore_stub_modules()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1738
Closes #1739
Closes #1740

## Problem

Eight test modules installed a `MagicMock` at `sys.modules["mistapi"]` at import time and removed it only in `teardown_module`.

pytest imports **every** test module during collection, but it runs `teardown_module` only for a module that has a **selected** test. Under `-k`, the stub therefore survived for the whole session.

The failure surfaced far from its cause. The real `mistapi` package resolves subpackages through `__getattr__`, and that lookup reads `sys.modules["mistapi"]` to find the parent package. A `MagicMock` has no `__path__`, so an unrelated test failed with:

```
ModuleNotFoundError: No module named 'mistapi.cli'; 'mistapi' is not a package
```

Reproduction before this change:

```
pytest tests/unit -q -k "token or session or credential or preflight"
=> 1 failed, 282 passed
```

## Fix

Each module now restores `sys.modules` directly after its guarded import:

```python
_saved_mistapi = sys.modules.get("mistapi")
_our_mock = MagicMock()
sys.modules["mistapi"] = _our_mock
try:
    from src.pkg.module import Thing
finally:
    if _saved_mistapi is not None:
        sys.modules["mistapi"] = _saved_mistapi
    else:
        sys.modules.pop("mistapi", None)
```

This is safe because the module under test binds `mistapi` in its own namespace at import time. The tests reference the local mock, never `sys.modules`, at run time.

Modules that do lazy re-imports during their own tests (`test_ssid_template_consolidation`, `test_zone_analyzer`) keep an identity-checked `setup_module` / `teardown_module` pair, so their stubs stay live while their tests run.

Files corrected: `test_bulk_switch_upgrader`, `test_csv_comparator`, `test_device_utility_commands`, `test_routing_utils`, `test_ssid_template_consolidation`, `test_template_config`, `test_wan2_variable`, `test_zone_analyzer`.

## Also in this change

- **#1740** — Replace an invalid `# noqa: STRUCT-PARAMS` code in [src/utils/input_utils.py](src/utils/input_utils.py) with a plain comment. Ruff reported it as an unknown rule.
- **#1738** — Remove two wall-clock assertions that made tests flaky on a loaded machine. `test_ap_profile_migration_manager` now asserts the summed sleep arguments. `test_org_synthetic_probes_manager` now asserts a node count and keeps a wide runaway ceiling.
- **New guard** — [tests/unit/test_no_mistapi_stub_leak.py](tests/unit/test_no_mistapi_stub_leak.py) asserts that `sys.modules["mistapi"]` still has `__path__`.

### The guard was proven to fail

A grep for `sys.modules["mistapi"` found only 7 of the 8 files. It missed `test_zone_analyzer.py`, which used a dict and a loop. The culprit was found with a temporary pytest plugin using `pytest_collectreport`.

To confirm the guard is not vacuous, it was run against a deliberately leaking throwaway module:

```
=== NEGATIVE test: guard must FAIL while a leaker is collected-but-deselected ===
FAILED tests/unit/test_no_mistapi_stub_leak.py::test_mistapi_in_sys_modules_is_the_real_package

=== POSITIVE test: guard passes once the leaker is gone ===
1 passed
```

## Verification

| Check | Result |
| - | - |
| `pytest tests/unit` | 8922 passed, 0 failed |
| Reproduction subset | 283 passed, 0 failed (was 1 failed) |
| `ruff check .` | All checks passed |
| `black --check .` | 974 files unchanged |
| `mypy src/` | Success, no issues in 331 source files |
| STE linter (new file) | 100/100 PASS |

## Conformance

- [x] Acceptance criteria met for #1738, #1739, #1740
- [x] Tests added or modified
- [x] No secrets added
- [x] Lint, format, and type gates pass locally
- [x] Regression guard added and proven to fail on the bug it guards
