### PR TITLE
docs(1034): specify the CodeQL clear-text logging remediation

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -76,6 +76,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-03
 - Redis TimeSeries through the `redis-stack` service. The change adds no key, no index, and no migration. (990-redis-entity-id)
 - Python 3.13+ + `mistapi>=0.63.1`, `python-dotenv`, `PyYAML`, `structlog`, existing MistHelper utility modules (`InputUtils`, `DataExporter`) (671-mist-get-site-beacon)
 - CSV files under `data/`, SQLite (`data/mist_data.db`), optional ArangoDB + Redis through `DatabaseRouter` (671-mist-get-site-beacon)
+- Python 3.13 or newer. The `pyproject.toml` file targets `py313`. + `mistapi>=0.63.1`. This feature adds no dependency. (1034-codeql-cleartext-logging)
+- No database change. The verdict register is a Markdown file under (1034-codeql-cleartext-logging)
 
 - Python 3.13+ + mistapi>=0.59.0, python-dotenv>=1.0.0 (001-radius-wlan-config)
 
@@ -95,9 +97,9 @@ cd src; pytest; ruff check .
 Python 3.13+: Follow standard conventions
 
 ## Recent Changes
+- 1034-codeql-cleartext-logging: Added Python 3.13 or newer. The `pyproject.toml` file targets `py313`. + `mistapi>=0.63.1`. This feature adds no dependency.
 - 671-mist-get-site-beacon: Added Python 3.13+ + `mistapi>=0.63.1`, `python-dotenv`, `PyYAML`, `structlog`, existing MistHelper utility modules (`InputUtils`, `DataExporter`)
 - 990-redis-entity-id: Added an entity identifier fallback to `RedisTimeSeriesWriter`. The writer reads the strategy field first, then walks `device_id`, `site_id`, `org_id`, `mac`, `id`, and uses the `unknown` sentinel last.
-- 1033-ci-gate-silencer-removal: Added Python 3.13. The workstation interpreter is `.venv\Scripts\python.exe`. The global `python` on this machine is broken and must not run any gate command. + `pylint`, `vulture`, and the GitHub CodeQL Action v4. This work adds no dependency and pins no version.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/671-mist-get-site-beacon"}
+{"feature_directory":"specs/1034-codeql-cleartext-logging"}

--- a/specs/1034-codeql-cleartext-logging/.spec-context.json
+++ b/specs/1034-codeql-cleartext-logging/.spec-context.json
@@ -1,0 +1,23 @@
+{
+  "workflow": "speckit",
+  "specName": "Resolve the open clear-text logging alerts",
+  "branch": "1034-codeql-cleartext-logging",
+  "currentStep": "plan",
+  "status": "planned",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-05T02:21:40.572Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "agent",
+      "at": "2026-08-05T02:47:32.178Z"
+    }
+  ]
+}

--- a/specs/1034-codeql-cleartext-logging/checklists/requirements.md
+++ b/specs/1034-codeql-cleartext-logging/checklists/requirements.md
@@ -1,0 +1,48 @@
+# Specification Quality Checklist: Resolve the open clear-text logging alerts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+
+**Created**: 2026-08-04
+
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- Two checklist items need a recorded exception. The subject of this feature is a set of
+  static analysis alerts, and each alert has a fixed source location. The specification
+  therefore names source files and line locations. Those names are the requirement subject,
+  not a design choice.
+- The specification names one mechanism, the terminal check `isatty()`. FR-009 states the
+  outcome first and names the check as an acceptable mechanism, not as the only mechanism.
+- SC-001 names the query `py/clear-text-logging-sensitive-data` and the GitHub security tab.
+  The alert count is the agreed primary metric for the feature, so the metric cannot avoid
+  the tool name.
+- The specification records no [NEEDS CLARIFICATION] marker. The address decision, the GPS
+  decision, and the MAC address decision are open on purpose. Each one is a required
+  outcome of the work, not a gap in the specification.

--- a/specs/1034-codeql-cleartext-logging/contracts/credential_console.md
+++ b/specs/1034-codeql-cleartext-logging/contracts/credential_console.md
@@ -1,0 +1,159 @@
+# Contract: `CredentialConsole`
+
+**Feature**: 1034-codeql-cleartext-logging
+
+**Owner module**: `src/utils/console.py`
+
+**Date**: 2026-08-05
+
+This contract states the behavior of the credential display primitive. The class serves
+user story 1 and satisfies requirements FR-009 through FR-014. The format follows the
+precedent of `specs/1031-warning-echo-refactor/contracts/echo_helper.md`.
+
+---
+
+## Purpose
+
+`CredentialConsole` shows a secret to an operator on an interactive terminal and withholds
+that secret from every other destination. The class exists because a redirected stream, a
+pipe, and a log file all keep a permanent copy of a credential.
+
+The class lives beside `echo()` in `src/utils/console.py`. The module already owns console
+output, so the new class needs no new module.
+
+---
+
+## C-1: The public surface is one method
+
+```python
+class CredentialConsole:
+    @staticmethod
+    def reveal(label: str, secret: str) -> bool: ...
+```
+
+The method returns `True` when it wrote the secret. The method returns `False` when it
+withheld the secret. A caller uses the return value for its own action logging.
+
+The parameter count is two. The five-item rule caps the count at five.
+
+---
+
+## C-2: The method writes with `sys.stdout.write()`
+
+The method never calls `print()` for the secret. Requirement FR-014 drives this clause.
+
+The ruff configuration in `pyproject.toml` does not select the `T20` rule family today. A
+comment in that file states the plan of issue #886. That plan enables `T20` and converts
+every `print()` call to a logging call across 5053 sites. A `sys.stdout.write()` call is not
+a `print()` call, so the migration never sees this line and never converts it.
+
+---
+
+## C-3: The method decides with `sys.stdout.isatty()`
+
+The method calls `sys.stdout.isatty()` once. A `True` answer selects the reveal path. A
+`False` answer selects the withhold path.
+
+The check blocks a redirected stream and a pipe. The check does not block a recorded
+session. Research note R-002 records the test that proves this limit.
+
+---
+
+## C-4: The reveal path warns before it shows
+
+The reveal path writes three parts in this order.
+
+1. The warning. The text names the capture risk of a session recording.
+2. The label and the secret.
+3. Nothing else.
+
+The warning comes first, so the operator reads the risk before the screen holds the secret.
+
+The warning text states the specific consequence. An example text follows.
+
+```text
+Warning: a session recording captures this screen. The next line holds a live credential.
+```
+
+---
+
+## C-5: The withhold path states the reason
+
+The withhold path writes the label, a withhold notice, and the reason. The path never writes
+the secret and never writes a partial secret.
+
+An example text follows.
+
+```text
+-> ZTP Password: withheld
+-> The output stream is not an interactive terminal, so the tool withheld the credential.
+-> Run the command on an interactive terminal to read the credential.
+```
+
+The notice tells the operator how to reach the value. A notice with no remedy leaves the
+operator stuck.
+
+---
+
+## C-6: The method never logs the secret
+
+The method emits one action log line before the write and one after the write. Constitution
+principle VII requires both lines.
+
+Neither line holds the `secret` value. Neither line holds any part of the `secret` value.
+Neither line holds a digest of the `secret` value.
+
+Pull request #1732 tried a SHA-256 fingerprint for a related alert. CodeQL rejected that
+change with the query `py/weak-sensitive-data-hashing` at high severity. Do not hash a
+credential for a log label.
+
+The log line names the label and the outcome.
+
+```python
+logging.info("Credential display requested for %s", label)
+logging.debug("Credential display outcome for %s: %s", label, outcome)
+```
+
+The `outcome` value is `revealed` or `withheld`.
+
+---
+
+## C-7: The caller keeps the comment honest
+
+The old comment in `src/device/_utility_commands_action.py` claimed that the tool never logs
+and never saves the password. Requirement FR-013 forbids a comment that claims a behavior
+that the code does not provide.
+
+The new comment states the true behavior in one line. The comment names the terminal check
+and names the recording limit.
+
+---
+
+## C-8: A guard test enforces clause C-2 and clause C-6
+
+The test file is `tests/unit/test_credential_console_contract.py`.
+
+The test reads the source of `src/utils/console.py` and the source of
+`src/device/_utility_commands_action.py`. The test fails on any of the conditions below.
+
+- The credential reveal path contains a `print(` call.
+- The credential reveal path contains a `logging.` call that takes the secret variable.
+- The module `src/device/_utility_commands_action.py` passes the credential to any callable
+  other than `CredentialConsole.reveal`.
+
+The test is the durable marker that FR-014 requires. A comment is advice. A test is
+enforcement. A mechanical migration under issue #886 fails the test instead of shipping a
+regression.
+
+---
+
+## C-9: The class adds no prompt
+
+The method asks the operator no question. The method needs no call to `safe_input()`.
+
+A typed confirmation was considered and rejected. The prompt does not remove the recording
+risk, because the operator still reads the secret on the recorded screen. The prompt also
+adds a step that acceptance scenario 1 of user story 1 does not describe.
+
+Any future prompt in this path must use `InputUtils.safe_input()`. Constitution principle
+III requires that wrapper for every input call.

--- a/specs/1034-codeql-cleartext-logging/contracts/verdict-register.md
+++ b/specs/1034-codeql-cleartext-logging/contracts/verdict-register.md
@@ -1,0 +1,154 @@
+# Contract: The verdict register
+
+**Feature**: 1034-codeql-cleartext-logging
+
+**Artifact**: `specs/1034-codeql-cleartext-logging/verdict-register.md`
+
+**Date**: 2026-08-05
+
+This contract states the binding format of the verdict register. A reviewer checks a
+register against the clauses below. A register that breaks any clause fails the review.
+
+---
+
+## C-1: The register holds one table with eleven columns
+
+The header row reads as follows.
+
+```markdown
+| Alert | Issue | File | Line | Anchor | Verdict | Reason | Author | Decided | Review | Trigger |
+| - | - | - | - | - | - | - | - | - | - | - |
+```
+
+The column order is fixed. A reader compares two revisions of the register with a plain
+text difference, so a column move breaks the comparison.
+
+---
+
+## C-2: The register holds nineteen data rows
+
+The row count equals the alert count. The count is 19. The `Alert` values run from 173
+through 191 with no gap and no repeat.
+
+A reviewer counts the rows with the command below.
+
+```bash
+grep -c '^| 1[78][0-9] |' specs/1034-codeql-cleartext-logging/verdict-register.md
+```
+
+The expected output is `19`.
+
+---
+
+## C-3: The `Verdict` column holds one of three values
+
+The allowed values are `fixed`, `false_positive`, and `accepted_with_rationale`. No other
+value passes the review. A blank cell fails the review.
+
+---
+
+## C-4: The `Reason` column holds a written sentence
+
+The sentence states why the verdict is correct. The sentence follows the Simplified
+Technical English rules. The cell is never blank and never reads `see above`.
+
+A row with the verdict `false_positive` states the evidence that the query misreads the
+value. A bare claim of a false positive fails the review, because requirement FR-005 makes a
+code fix the default action.
+
+---
+
+## C-5: A non-fixed row holds a review date and a trigger
+
+A row with the verdict `false_positive` or `accepted_with_rationale` fills the `Review`
+column and the `Trigger` column. Requirement FR-007 requires both fields.
+
+The `Review` value is an ISO date. The `Trigger` value names a concrete event. An example
+event is the merge of issue #886.
+
+A row with the verdict `fixed` writes `-` in both columns, because the code change removes
+the alert.
+
+---
+
+## C-6: The `Anchor` column survives a line move
+
+The anchor format follows entity E-004 in `data-model.md`.
+
+```text
+<file_path>::<qualified_symbol> :: "<log template fragment>"
+```
+
+The anchor holds no street address, no coordinate, no MAC address, and no credential. The
+anchor quotes the format string only.
+
+---
+
+## C-7: A dismissal reason matches the register reason
+
+The team dismisses each alert with the verdict `false_positive` or
+`accepted_with_rationale`. The dismissal comment repeats the register `Reason` text.
+
+The dismissal command follows.
+
+```bash
+gh api -X PATCH "repos/:owner/:repo/code-scanning/alerts/<alert_number>" \
+  -f state=dismissed \
+  -f dismissed_reason="<api_reason>" \
+  -f dismissed_comment="<register_reason>"
+```
+
+The `api_reason` value maps from the register verdict.
+
+| Register verdict | `api_reason` |
+| - | - |
+| `false_positive` | `false positive` |
+| `accepted_with_rationale` | `won't fix` |
+| `fixed` | No dismissal |
+
+---
+
+## C-8: The reconciliation command proves clause C-7
+
+A reviewer lists every dismissed alert and compares the output against the register.
+
+```bash
+gh api "repos/:owner/:repo/code-scanning/alerts?state=dismissed&per_page=100" \
+  --jq '.[] | select(.rule.id=="py/clear-text-logging-sensitive-data")
+        | "\(.number)|\(.dismissed_reason)|\(.dismissed_comment)"'
+```
+
+Each line of the output matches one register row. A line with no matching row fails the
+review. A register row with no matching line fails the review.
+
+---
+
+## C-9: The open alert count reaches zero
+
+The command below reports the open alert count for the query.
+
+```bash
+gh api "repos/:owner/:repo/code-scanning/alerts?state=open&per_page=100" \
+  --jq '[.[] | select(.rule.id=="py/clear-text-logging-sensitive-data")] | length'
+```
+
+The expected output at the end of the feature is `0`. The command returned `19` on
+2026-08-05, and that value is the baseline.
+
+---
+
+## C-10: The five tracking issues link to the register
+
+Each of the issues 1733, 1734, 1735, 1736, and 1737 holds a comment with the register path.
+The comment names the rows that belong to that issue. Requirement FR-003 requires the link.
+
+---
+
+## C-11: A reopened alert keeps its history
+
+A later scan can raise the same alert again after a code change. The register then adds a
+new row for the new alert number. The new row names the earlier alert number inside the
+`Reason` text.
+
+The team does not delete the earlier row. The register is an audit record, so the history
+stays.

--- a/specs/1034-codeql-cleartext-logging/data-model.md
+++ b/specs/1034-codeql-cleartext-logging/data-model.md
@@ -1,0 +1,175 @@
+# Phase 1 Data Model: Resolve the open clear-text logging alerts
+
+**Feature**: 1034-codeql-cleartext-logging
+
+**Date**: 2026-08-05
+
+This feature adds no database table and no API payload. The entities below describe
+documents and one small code object. The contract files in `contracts/` state the binding
+format for each one.
+
+---
+
+## E-001: Alert
+
+One CodeQL result for the query `py/clear-text-logging-sensitive-data`.
+
+| Field | Type | Source | Rule |
+| - | - | - | - |
+| `alert_number` | integer | GitHub code scanning API | Unique. The range is 173 to 191 |
+| `file_path` | string | GitHub code scanning API | A repository-relative path |
+| `line_number` | integer | GitHub code scanning API | Informational. The value drifts |
+| `anchor` | string | The author | See E-004. The anchor survives a line move |
+| `rule_id` | string | GitHub code scanning API | Always `py/clear-text-logging-sensitive-data` |
+| `severity` | string | GitHub code scanning API | Always `high` for this set |
+| `tracking_issue` | integer | The author | One of 1733, 1734, 1735, 1736, 1737 |
+
+**Relationship**: One alert holds exactly one verdict.
+
+**State**: The GitHub security tab holds the state. The values are `open`, `dismissed`, and
+`fixed`. The register does not copy the state, because a copy goes stale.
+
+---
+
+## E-002: Verdict
+
+The recorded decision for one alert.
+
+| Field | Type | Rule |
+| - | - | - |
+| `verdict` | enumeration | One of `fixed`, `false_positive`, `accepted_with_rationale` |
+| `reason` | string | A written sentence. The field must not be empty |
+| `author` | string | The GitHub user name of the decision owner |
+| `decision_date` | date | The ISO date of the decision |
+| `review_date` | date | Required when the verdict is not `fixed` |
+| `next_review_trigger` | string | Required when the verdict is not `fixed` |
+
+**Validation rules**:
+
+- A row holds exactly one verdict value. A blank verdict fails the review.
+- A verdict of `false_positive` states the evidence that the query misreads the value.
+  Requirement FR-005 forbids a bare claim.
+- A verdict of `fixed` needs no review date, because the code change removes the alert.
+- A verdict of `accepted_with_rationale` names a concrete trigger. An example trigger is
+  issue #886.
+
+**State transitions**:
+
+```text
+(no row) --> proposed --> recorded --> dismissed        [false_positive]
+(no row) --> proposed --> recorded --> dismissed        [accepted_with_rationale]
+(no row) --> proposed --> recorded --> closed by scan   [fixed]
+recorded --> reopened   [a later scan raises the same alert again]
+```
+
+The transition `recorded --> reopened` uses the anchor, not the line number. A reopened row
+keeps its history and gains a new decision date.
+
+---
+
+## E-003: Verdict register
+
+The single table that holds one verdict record for each alert.
+
+**Location**: `specs/1034-codeql-cleartext-logging/verdict-register.md`
+
+**Shape**: One Markdown table. The columns join E-001 and E-002.
+
+| Column | Entity |
+| - | - |
+| `Alert` | E-001 `alert_number` |
+| `Issue` | E-001 `tracking_issue` |
+| `File` | E-001 `file_path` |
+| `Line` | E-001 `line_number` |
+| `Anchor` | E-001 `anchor` |
+| `Verdict` | E-002 `verdict` |
+| `Reason` | E-002 `reason` |
+| `Author` | E-002 `author` |
+| `Decided` | E-002 `decision_date` |
+| `Review` | E-002 `review_date` |
+| `Trigger` | E-002 `next_review_trigger` |
+
+**Invariants**:
+
+- INV-1: The row count equals 19.
+- INV-2: Every `Alert` value appears once.
+- INV-3: Every row holds a non-empty `Reason`.
+- INV-4: A row with a verdict other than `fixed` holds a `Review` value and a `Trigger`
+  value.
+- INV-5: The `Reason` text of a dismissed row equals the `dismissed_comment` of the matching
+  alert in the GitHub security tab.
+
+---
+
+## E-004: Stable anchor
+
+A textual key that identifies a log call site after a line move.
+
+**Format**:
+
+```text
+<file_path>::<qualified_symbol> :: "<log template fragment>"
+```
+
+**Example**:
+
+```text
+src/ssh/ssh_runner_manager.py::SSHRunnerManager._echo_plan :: "!? Target hosts: %s"
+```
+
+**Rules**:
+
+- The qualified symbol names the class and the method. A module-level call names the module.
+- The template fragment quotes the literal format string. The fragment never quotes a value.
+- The anchor holds no personal data and no credential.
+- A reviewer finds the row with one text search on the fragment.
+
+---
+
+## E-005: Suppression justification
+
+The written note that accompanies a suppression marker in the source.
+
+| Field | Type | Rule |
+| - | - | - |
+| `alert_number` | integer | Names one alert. FR-008 forbids a file-wide marker |
+| `reason` | string | Matches the register `Reason` text |
+| `review_date` | date | The ISO date of the next review |
+| `next_review_trigger` | string | The event that forces the review |
+
+**Placement**: The note sits in an inline comment beside the suppressed line.
+
+**Template**:
+
+```python
+# CodeQL alert <number> dismissed as <verdict>. <reason>
+# Review by <review_date>. Trigger: <next_review_trigger>.
+```
+
+This feature adds no new `# noqa` marker and no new `# nosec` marker. The dismissal lives in
+the GitHub security tab, and the comment records the reason beside the code.
+
+---
+
+## E-006: Credential reveal request
+
+The small code object that carries a secret to the operator screen.
+
+**Owner**: `CredentialConsole` in `src/utils/console.py`.
+
+| Field | Type | Rule |
+| - | - | - |
+| `label` | string | A non-secret name such as `ZTP Password` |
+| `secret` | string | The credential. The object never logs this field |
+
+**Behavior**:
+
+| Destination | Action |
+| - | - |
+| An interactive terminal | Write the label, write the secret, write the recording warning |
+| Any other destination | Write the label, write the withhold notice, write the reason |
+
+**Logging rule**: The class logs the event and never logs the `secret` field. The log line
+names the label and the outcome. The outcome is `revealed` or `withheld`.
+
+The contract file `contracts/credential_console.md` states the full clause list.

--- a/specs/1034-codeql-cleartext-logging/plan.md
+++ b/specs/1034-codeql-cleartext-logging/plan.md
@@ -1,0 +1,250 @@
+# Implementation Plan: Resolve the open clear-text logging alerts
+
+**Branch**: `1034-codeql-cleartext-logging` | **Date**: 2026-08-05 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/1034-codeql-cleartext-logging/spec.md`
+
+## Summary
+
+The repository holds 19 open CodeQL alerts for the query
+`py/clear-text-logging-sensitive-data`. The alert numbers run from 173 through 191. Five
+GitHub issues track them. This feature records one verdict for each alert and fixes every
+alert that a code change can fix.
+
+The technical approach has four parts.
+
+1. Add a `CredentialConsole` class to `src/utils/console.py`. The class checks the output
+   destination, warns the operator, and withholds the ZTP credential from any destination
+   that is not an interactive terminal.
+2. Convert the two flagged SSH echo lines to the `echo()` helper that spec 1031 introduced.
+3. Apply one address policy to the ten address alerts. The policy keeps a street address out
+   of the information level and out of the warning level.
+4. Record every decision in a verdict register under the feature directory. Dismiss each
+   non-fixed alert in the GitHub security tab with the same written reason.
+
+Research note R-002 changed the design. A test proved that `sys.stdout.isatty()` returns
+`True` inside a recorded session. A terminal check alone therefore cannot protect the
+credential, and the design adds an operator warning to cover that gap.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 or newer. The `pyproject.toml` file targets `py313`.
+
+**Primary Dependencies**: `mistapi>=0.63.1`. This feature adds no dependency.
+
+**Storage**: No database change. The verdict register is a Markdown file under
+`specs/1034-codeql-cleartext-logging/`. The run log stays at `data/script.log`.
+
+**Testing**: pytest. Run every command through `.venv\Scripts\python.exe`. The global Python
+interpreter in this workspace is broken.
+
+**Target Platform**: Windows 11 for local development. A Podman container on Linux for the
+SSH service and the web portal.
+
+**Project Type**: A single command-line project with a menu registry and a `src/` package
+tree.
+
+**Performance Goals**: No performance target. Every change is a log call, a display call, or
+a document.
+
+**Constraints**:
+
+- A terminal check does not block a recorded SSH session. See research note R-002.
+- The container serves SSH on port 2200 with `PermitTTY yes` and a forced command launch.
+- Issue #886 will convert 5053 `print()` calls to logging calls. The credential protection
+  must survive that migration.
+- Issue #1721 edits `starlink_dashboard.py`. This feature must not edit that file at the
+  same time.
+
+**Scale/Scope**: 19 alerts across 5 source files. The feature touches 5 source files, adds
+5 test files, and adds 6 documents.
+
+## Constitution Check
+
+*GATE: This section passed before Phase 0 research. The section passed again after Phase 1
+design.*
+
+| Principle | Assessment | Result |
+| - | - | - |
+| I. Five-item rule | `CredentialConsole.reveal` takes 2 parameters and stays under 25 lines. The class holds 1 public method. The dataclass `ResolveCandidates` gains a seventh field, and the rule caps a parameter count, not a field count | Pass |
+| II. Class-based architecture | The new code lives in the `CredentialConsole` class. The class is not a wrapper, because it owns the terminal check and the warning text | Pass |
+| III. Safety-first | The feature exists to keep a credential out of a log. The design adds no input call, so it needs no `safe_input()` call. Contract clause C-9 records the rule for any future prompt | Pass |
+| IV. Full deployment pipeline | Each pull request runs the pipeline. See `quickstart.md` check 9 | Pass |
+| V. Observability and logging | Every new log call uses ASCII text and `%s` formatting. No new log call carries a secret | Pass |
+| VI. Inline comments | Every changed line gains an inline comment. Every touched block gains comments on its uncommented lines | Pass |
+| VII. Action logging | `CredentialConsole.reveal` logs before the write and after the write. Neither line holds the secret | Pass |
+| Fix over suppress | The default action is a code fix. The feature adds no new `# noqa` marker and no new `# nosec` marker. A dismissal carries evidence and a review trigger | Pass |
+
+The Complexity Tracking table below holds no entry, because the design raises no violation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1034-codeql-cleartext-logging/
+├── plan.md                          # This file
+├── spec.md                          # The authoritative input
+├── research.md                      # Phase 0 output. 14 research notes
+├── data-model.md                    # Phase 1 output. 6 entities
+├── quickstart.md                    # Phase 1 output. 12 validation checks
+├── verdict-register.md              # Created during implementation. 19 rows
+├── contracts/
+│   ├── verdict-register.md          # The register format. 11 clauses
+│   └── credential_console.md        # The credential primitive. 9 clauses
+└── tasks.md                         # Created by /speckit.tasks. Not part of this plan
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── utils/
+│   └── console.py                   # Holds echo(). Gains the CredentialConsole class
+├── device/
+│   └── _utility_commands_action.py  # Alert 173. Calls CredentialConsole.reveal
+├── ssh/
+│   ├── ssh_runner_manager.py        # Alerts 188 and 189. Converts to echo()
+│   └── runtime/
+│       └── app_runner.py            # Two extra "!?" echoes from the sweep
+├── site/
+│   └── address_audit/
+│       ├── address_resolver.py      # Alerts 174 through 183. Applies the address policy
+│       └── models.py                # ResolveCandidates gains a site_id field
+└── capture/
+    └── packet_capture.py            # Alerts 184 through 187. No code change
+
+starlink_dashboard.py                # Alerts 190 and 191. No code change
+
+tests/unit/
+├── test_credential_console_contract.py       # The guard test for issue #886
+├── test_credential_console_behavior.py       # The reveal branch and the withhold branch
+├── test_ssh_runner_echo_plan.py              # The echo() conversion
+├── test_address_resolver_log_redaction.py    # The address policy
+└── test_starlink_location_dump_guard.py      # The expiry guard for the GPS acceptance
+```
+
+**Structure Decision**: The feature keeps the existing single-project layout. The new class
+joins `src/utils/console.py`, because that module already owns console output. A new module
+would add a fifteenth file to `src/utils/`, and the existing module is the correct semantic
+home.
+
+## The order of work
+
+The feature ships as four pull requests. Research note R-012 records the reason.
+
+| Order | Pull request | Stories | Blocked by |
+| - | - | - | - |
+| 1 | ZTP credential guard | US1 | Nothing |
+| 2 | SSH echo conversion | US6 | Nothing |
+| 3 | Address and capture stance | US3, US5 | Nothing |
+| 4 | GPS stance and register close-out | US4, US2 | Issue #1721. See check 12 |
+
+User story 1 holds priority P1 and ships alone. The story is independently testable, it
+touches no file that another story touches, and it is the only story that protects a live
+credential.
+
+The remaining stories must not land as one pull request. Two reasons drive the split. User
+story 4 waits on a coordination check against issue #1721, and a wait must not block a
+security fix. CodeQL reports a result after a merge to `main`, so a smaller pull request
+returns a clearer signal for each decision.
+
+Each pull request adds its own rows to the verdict register. Pull request 4 checks the row
+count, runs the reconciliation command, and closes the five tracking issues.
+
+## The verdict register
+
+**Location**: `specs/1034-codeql-cleartext-logging/verdict-register.md`.
+
+**Columns**: `Alert`, `Issue`, `File`, `Line`, `Anchor`, `Verdict`, `Reason`, `Author`,
+`Decided`, `Review`, `Trigger`. Contract clause C-1 fixes the order.
+
+**Key**: The `Alert` column holds the GitHub alert number. The number is the only key that
+the security tab accepts for a dismissal.
+
+**Anchor**: The `Anchor` column holds the qualified symbol path and a quoted fragment of the
+log template. A line number drifts after an edit above the line. A symbol path does not.
+
+**Synchronization**: The register is the source of truth for the reason, the author, the
+date, and the anchor. The GitHub security tab is the source of truth for the open state and
+the dismissed state. One command reconciles the two. Contract clause C-8 states the command.
+
+## The proposed verdicts
+
+The register records the final decision. The table below states the proposal that each pull
+request confirms. Research notes R-006 through R-009 hold the evidence.
+
+| Alerts | File | Proposed verdict | Basis |
+| - | - | - | - |
+| 173 | `_utility_commands_action.py` | `fixed` | R-003. A terminal check and a warning replace the bare print |
+| 174, 175, 183 | `address_resolver.py` | `fixed` | R-006. The cache key is the address. The line logs the site identifier instead |
+| 176 | `address_resolver.py` | `fixed` | R-006. The warning keeps its level and logs the site identifier |
+| 177 through 182 | `address_resolver.py` | `fixed` | R-006. The lines move to the debug level |
+| 184, 185, 186 | `packet_capture.py` | `false_positive` | R-007. A MAC address is a device identifier that the tool exists to report |
+| 187 | `packet_capture.py` | `false_positive` | R-007. The payload holds a type, a MAC, a band, a packet length, a channel, a bandwidth, and a duration. No field holds a secret |
+| 188, 189 | `ssh_runner_manager.py` | `fixed` | R-009. The lines move to the `echo()` helper at the information level |
+| 190, 191 | `starlink_dashboard.py` | `accepted_with_rationale` | R-008. The lines print to an operator-invoked dump and reach no log. The acceptance expires when issue #886 converts them |
+
+## How to verify the result
+
+The full check list lives in `quickstart.md`. The single command that proves the outcome
+follows.
+
+```bash
+gh api "repos/:owner/:repo/code-scanning/alerts?state=open&per_page=100" \
+  --jq '[.[] | select(.rule.id=="py/clear-text-logging-sensitive-data")] | length'
+```
+
+The command returned `19` on 2026-08-05. That value is the baseline. The expected value at
+the end of the feature is `0`.
+
+The end state has four parts.
+
+1. The open alert count for the query is `0`.
+2. The register holds 19 rows, and every row holds a verdict and a reason.
+3. Every dismissed alert carries a comment that matches its register reason.
+4. The five tracking issues are closed.
+
+## Test strategy
+
+A CodeQL count is not a unit test. The count reflects a scan of `main` after a merge, and it
+proves the outcome of the whole feature. A unit test proves the branch logic of one change
+before the merge. The feature needs both.
+
+| Story | Automated test | What the test proves | What the test cannot prove |
+| - | - | - | - |
+| US1 | `test_credential_console_behavior.py` patches `sys.stdout.isatty` and asserts the two branches | The withhold branch writes no secret. The reveal branch writes the warning first | The real terminal path. A test harness has no terminal, so check 5 needs a human |
+| US1 | `test_credential_console_contract.py` reads the two source files | The reveal path holds no `print(` call and no `logging.` call that takes the secret | That a future migration honors the contract. The test fails the migration instead |
+| US2 | No automated test | Nothing | The register is a document. A reviewer counts the rows with check 2 and reconciles with check 3 |
+| US3 | `test_address_resolver_log_redaction.py` captures the log records | The information level and the warning level hold no street address. The debug level still holds one | That no other module logs the address. Check 7 covers the run |
+| US4 | `test_starlink_location_dump_guard.py` reads the source | The two lines still call `print()` and not `logging` | That the coordinates are safe. The test only enforces the stated expiry |
+| US5 | No automated test | Nothing | The verdict is a triage decision with no code change. Research note R-007 holds the evidence |
+| US6 | `test_ssh_runner_echo_plan.py` patches `echo` and captures the log | The method calls `echo()` and logs at the information level. The text is unchanged | The screen output of a live run. Check 6 covers that |
+
+The coverage gate needs 80 percent. Every new module carries a test, so the feature raises
+the covered line count and cannot lower the ratio.
+
+## Coordination duties
+
+**Issue #1721**: The issue reports that `starlink_dashboard.py` configures logging after the
+bootstrap. Run check 12 in `quickstart.md` immediately before any edit to that file. When
+the check prints an open pull request, stop and wait. Issue #1721 lands first in that case.
+Record the observed state and the date in the register. Requirement FR-023 requires the
+record.
+
+**Issue #886**: The issue plans a mechanical migration of 5053 `print()` calls to logging
+calls. This feature performs no part of that migration. The boundary is as follows. This
+feature owns the credential reveal path and the two GPS dump lines. Issue #886 owns every
+other `print()` call. The guard tests in `test_credential_console_contract.py` and
+`test_starlink_location_dump_guard.py` fail when the migration crosses that boundary. The
+register names the boundary. Requirement FR-024 requires the name.
+
+## Complexity Tracking
+
+> This section holds an entry only when the Constitution Check reports a violation.
+
+The Constitution Check reported no violation. This table is empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | Not applicable | Not applicable |

--- a/specs/1034-codeql-cleartext-logging/quickstart.md
+++ b/specs/1034-codeql-cleartext-logging/quickstart.md
@@ -1,0 +1,263 @@
+# Quickstart: Validate the clear-text logging work
+
+**Feature**: 1034-codeql-cleartext-logging
+
+**Date**: 2026-08-05
+
+This guide states the runnable checks that prove the feature works. Run every check before
+you open the final pull request. Each check names the requirement that it proves.
+
+---
+
+## Prerequisites
+
+Activate the project virtual environment. The global Python interpreter in this workspace
+is broken, so always use the virtual environment path.
+
+```powershell
+.venv\Scripts\Activate.ps1
+```
+
+Confirm that the GitHub command-line tool holds a token with the `security_events` scope.
+
+```powershell
+gh auth status
+```
+
+---
+
+## Check 1: The open alert count reaches zero
+
+**Proves**: SC-001 and SC-008.
+
+```powershell
+gh api "repos/:owner/:repo/code-scanning/alerts?state=open&per_page=100" `
+  --jq '[.[] | select(.rule.id==\"py/clear-text-logging-sensitive-data\")] | length'
+```
+
+**Expected output at the start**: `19`.
+
+**Expected output at the end**: `0`.
+
+**Limit**: This count reflects the last completed scan of `main`. A pull request branch
+shows a different count. Run the check again after the merge.
+
+---
+
+## Check 2: The register holds nineteen complete rows
+
+**Proves**: SC-002 and FR-002.
+
+```powershell
+Select-String -Path specs\1034-codeql-cleartext-logging\verdict-register.md `
+  -Pattern '^\| 1[78][0-9] \|' | Measure-Object | Select-Object -ExpandProperty Count
+```
+
+**Expected output**: `19`.
+
+Then read the table and confirm that no `Verdict` cell is blank and no `Reason` cell is
+blank. Contract clause C-3 and clause C-4 state the rule.
+
+---
+
+## Check 3: The dismissal reasons match the register
+
+**Proves**: SC-003 and contract clause C-8.
+
+```powershell
+gh api "repos/:owner/:repo/code-scanning/alerts?state=dismissed&per_page=100" `
+  --jq '.[] | select(.rule.id==\"py/clear-text-logging-sensitive-data\")
+        | \"\(.number)|\(.dismissed_reason)|\(.dismissed_comment)\"'
+```
+
+Compare each output line against the matching register row. A line with no matching row
+fails the check. A register row with no matching line fails the check.
+
+---
+
+## Check 4: The ZTP credential stays out of a redirected stream
+
+**Proves**: SC-005, FR-009, and FR-010.
+
+Run menu 144 with the output stream redirected to a file.
+
+```powershell
+python MistHelper.py --menu 144 > data\ztp_redirect_test.txt
+```
+
+Then search the file for the credential.
+
+```powershell
+Select-String -Path data\ztp_redirect_test.txt -Pattern 'ZTP Password:'
+```
+
+**Expected result**: The file holds the label and the withhold notice. The file holds no
+credential value.
+
+Delete the test file after the check.
+
+```powershell
+Remove-Item data\ztp_redirect_test.txt
+```
+
+**Warning**: This check calls the live Mist API and returns a real credential. Run the check
+against a laboratory device. Do not run the check against a production device.
+
+---
+
+## Check 5: The ZTP credential still reaches an interactive terminal
+
+**Proves**: FR-011 and acceptance scenario 1 of user story 1.
+
+Run menu 144 on an interactive terminal with no redirection.
+
+```powershell
+python MistHelper.py --menu 144
+```
+
+**Expected result**: The screen shows the recording warning first. The screen then shows the
+credential.
+
+**Limit**: This check needs a human. No automated test can prove the interactive path,
+because a test harness has no terminal. The unit test in check 8 covers the branch logic
+with a fake terminal answer.
+
+---
+
+## Check 6: The SSH plan echo keeps every line
+
+**Proves**: SC-010 and acceptance scenario 1 of user story 6.
+
+Start a bulk SSH run and stop at the plan echo.
+
+```powershell
+python MistHelper.py --menu 60
+```
+
+**Expected result**: The screen shows the target hosts, the user name, and the command
+count. The text matches the earlier text.
+
+Then read the log and confirm the level.
+
+```powershell
+Select-String -Path data\script.log -Pattern 'Target hosts' | Select-Object -Last 3
+```
+
+**Expected result**: The matching lines carry the `INFO` level and not the `WARNING` level.
+
+---
+
+## Check 7: The address audit log holds no street address
+
+**Proves**: FR-018 and acceptance scenario 2 of user story 3.
+
+Run the address audit at the default log level. Then search the log.
+
+```powershell
+Select-String -Path data\script.log -Pattern 'Resolving address \(key='
+```
+
+**Expected result**: No match. The replacement line names the site identifier.
+
+**Limit**: A raise of the log level to debug returns the address to the log. The recorded
+decision states that condition, so the check runs at the default level only.
+
+---
+
+## Check 8: The unit tests pass
+
+**Proves**: The branch logic of every code change.
+
+```powershell
+.venv\Scripts\python.exe -m pytest tests\unit -q
+```
+
+**Expected result**: Every test passes.
+
+The new tests are as follows.
+
+| Test file | Covers |
+| - | - |
+| `tests/unit/test_credential_console_contract.py` | Contract clause C-2, C-6, and C-8 |
+| `tests/unit/test_credential_console_behavior.py` | The reveal branch and the withhold branch |
+| `tests/unit/test_ssh_runner_echo_plan.py` | The `echo()` conversion of user story 6 |
+| `tests/unit/test_address_resolver_log_redaction.py` | The address policy of user story 3 |
+| `tests/unit/test_starlink_location_dump_guard.py` | The expiry guard of user story 4 |
+
+---
+
+## Check 9: The quality gates pass
+
+**Proves**: The merge readiness of every pull request.
+
+Run the gates exactly as the continuous integration workflow runs them. The scope of each
+command matters. A narrower scope hides a failure.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check .
+.venv\Scripts\python.exe -m black --check --diff .
+.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml
+.venv\Scripts\python.exe -m radon cc src/ -n C
+.venv\Scripts\python.exe -m bandit -r src/ MistHelper.py starlink_dashboard.py
+.venv\Scripts\python.exe -m pytest --cov --cov-fail-under=80
+```
+
+**Expected result**: Every command exits with the code `0`.
+
+**Warning**: The `radon` tool honors no suppression marker. A block above the complexity
+value of 10 fails the gate. Decompose the block. Do not annotate it.
+
+---
+
+## Check 10: The documents meet the writing standard
+
+**Proves**: SC-009 and FR-027.
+
+```powershell
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 `
+  specs\1034-codeql-cleartext-logging\plan.md `
+  specs\1034-codeql-cleartext-logging\research.md `
+  specs\1034-codeql-cleartext-logging\data-model.md `
+  specs\1034-codeql-cleartext-logging\quickstart.md `
+  specs\1034-codeql-cleartext-logging\verdict-register.md `
+  specs\1034-codeql-cleartext-logging\contracts\verdict-register.md `
+  specs\1034-codeql-cleartext-logging\contracts\credential_console.md
+```
+
+**Expected result**: Every file scores 80 or above.
+
+**Limit**: The `STE compliance` job grades a fixed file list under `documentation/`. A
+document under `specs/` never reaches that job, so this check runs by hand.
+
+---
+
+## Check 11: The `!?` sweep matches the register
+
+**Proves**: SC-006 and FR-017.
+
+```powershell
+Select-String -Path src\ssh\*.py, src\ssh\**\*.py -Pattern '!\?' |
+  ForEach-Object { "$($_.Path):$($_.LineNumber)" }
+```
+
+Compare the output against the sweep table in `research.md` under note R-009. Every listed
+line holds a recorded disposition. A new line with no disposition fails the check.
+
+---
+
+## Check 12: No concurrent edit collides with issue #1721
+
+**Proves**: FR-023.
+
+Run this check immediately before any edit to `starlink_dashboard.py`.
+
+```powershell
+gh pr list --state open --json number,title,headRefName,files `
+  --jq '.[] | select(.files[].path==\"starlink_dashboard.py\")
+        | \"#\(.number) \(.headRefName) \(.title)\"'
+```
+
+**Expected result**: No output.
+
+If the command prints a pull request, stop. Wait for that pull request to merge. Record the
+observed state and the date in the register.

--- a/specs/1034-codeql-cleartext-logging/research.md
+++ b/specs/1034-codeql-cleartext-logging/research.md
@@ -1,0 +1,414 @@
+# Phase 0 Research: Resolve the open clear-text logging alerts
+
+**Feature**: 1034-codeql-cleartext-logging
+
+**Date**: 2026-08-05
+
+**Input**: `specs/1034-codeql-cleartext-logging/spec.md`
+
+This document records the research that removes every unknown from the Technical Context.
+Each section states a decision, the reason for the decision, and the alternatives that the
+research rejected.
+
+---
+
+## R-001: The exact alert inventory
+
+**Decision**: The feature covers GitHub code scanning alerts 173 through 191. The count is
+19. Every alert carries the security severity `high`.
+
+**Evidence**: The command below ran against the repository on 2026-08-05 and returned 19.
+
+```bash
+gh api "repos/:owner/:repo/code-scanning/alerts?state=open&per_page=100" \
+  --jq '[.[] | select(.rule.id=="py/clear-text-logging-sensitive-data")] | length'
+```
+
+| Alert | File | Line | Tracking issue |
+| - | - | - | - |
+| 173 | `src/device/_utility_commands_action.py` | 283 | #1735 |
+| 174 | `src/site/address_audit/address_resolver.py` | 64 | #1733 |
+| 175 | `src/site/address_audit/address_resolver.py` | 71 | #1733 |
+| 176 | `src/site/address_audit/address_resolver.py` | 85 | #1733 |
+| 177 | `src/site/address_audit/address_resolver.py` | 152 | #1733 |
+| 178 | `src/site/address_audit/address_resolver.py` | 193 | #1733 |
+| 179 | `src/site/address_audit/address_resolver.py` | 202 | #1733 |
+| 180 | `src/site/address_audit/address_resolver.py` | 221 | #1733 |
+| 181 | `src/site/address_audit/address_resolver.py` | 275 | #1733 |
+| 182 | `src/site/address_audit/address_resolver.py` | 368 | #1733 |
+| 183 | `src/site/address_audit/address_resolver.py` | 478 | #1733 |
+| 184 | `src/capture/packet_capture.py` | 548 | #1734 |
+| 185 | `src/capture/packet_capture.py` | 637 | #1734 |
+| 186 | `src/capture/packet_capture.py` | 846 | #1734 |
+| 187 | `src/capture/packet_capture.py` | 890 | #1734 |
+| 188 | `src/ssh/ssh_runner_manager.py` | 110 | #1736 |
+| 189 | `src/ssh/ssh_runner_manager.py` | 111 | #1736 |
+| 190 | `starlink_dashboard.py` | 1343 | #1737 |
+| 191 | `starlink_dashboard.py` | 1344 | #1737 |
+
+**Alternatives rejected**: A manual read of the source files. A manual read misses the
+alert number, and the alert number is the only stable key that the GitHub security tab
+accepts for a dismissal.
+
+---
+
+## R-002: Does `isatty()` protect the ZTP credential inside a recorded SSH session?
+
+**Decision**: No. An `isatty()` guard blocks a redirected stream and a pipe. It does not
+block a recorded session. The guard is necessary. The guard is not sufficient.
+
+**Evidence**: Two tests ran in a POSIX environment on 2026-08-05.
+
+Test 1 redirected the output stream to a file.
+
+```text
+plain-redirect: False
+```
+
+Test 2 ran a child process under a pseudo-terminal while the parent wrote every byte to a
+file. The file recorded the child's own answer.
+
+```text
+RECORDED_FILE_HELD: child_isatty= True
+```
+
+The container configuration confirms that the second shape applies to the SSH service. The
+`Containerfile` writes `PermitTTY yes` and `ForceCommand /usr/local/bin/misthelper-session`
+into `/etc/ssh/sshd_config.d/misthelper.conf`. An interactive client requests a
+pseudo-terminal, so the server allocates one. The tool then sees an interactive terminal
+even when the client records the screen to a file.
+
+**Consequence**: The design must warn the operator on the interactive path. The warning is
+the only control that covers the recorded session. Requirement FR-011 already states this
+duty.
+
+**Alternatives rejected**: An assumption that a recorded session behaves like a redirected
+stream. The test above disproves that assumption.
+
+---
+
+## R-003: The mechanism that protects the ZTP credential
+
+**Decision**: Combine a terminal check with an operator warning. Write the credential with
+`sys.stdout.write()` from a new `CredentialConsole` class in `src/utils/console.py`. Do not
+write the credential to a file.
+
+**Reason**: The three candidates score as follows.
+
+| Candidate | Blocks a redirected stream | Blocks a recorded session | Creates a credential at rest | Verdict |
+| - | - | - | - | - |
+| Terminal check with `isatty()` | Yes | No | No | Keep |
+| Restricted file under `data/` | Yes | Yes | Yes | Reject |
+| Explicit operator warning | No | No | No | Keep |
+
+The restricted file fails for two reasons. First, the container documentation directs the
+operator to run `chmod -R 777 data/` before the first run, so the container makes the whole
+directory world readable. A file mode of `0600` cannot survive that instruction. Second,
+Windows does not honor a POSIX file mode, and Windows is the stated local development
+platform. The file would therefore hold a live credential in a readable location on both
+platforms. That result is worse than the current screen display.
+
+The terminal check and the operator warning cover different threats, so the design keeps
+both. The terminal check satisfies FR-009 and FR-010. The operator warning satisfies FR-011.
+
+**Alternatives rejected**:
+
+- A hash of the credential. Pull request #1732 tried a SHA-256 fingerprint for a related
+  alert. CodeQL rejected that change with the query `py/weak-sensitive-data-hashing` at high
+  severity. Do not hash a credential for a display label.
+- A typed confirmation prompt before the reveal. The prompt does not remove the recording
+  risk, because the operator still sees the credential on the recorded screen. The prompt
+  also adds a step that acceptance scenario 1 does not describe.
+
+---
+
+## R-004: How the ZTP protection survives the print-to-logging migration of issue #886
+
+**Decision**: Write the credential with `sys.stdout.write()`, not with `print()`. Add a
+guard test that fails when the reveal path gains a `logging` call or a `print()` call.
+
+**Reason**: The ruff configuration in `pyproject.toml` does not select the `T20` rule family
+today. A comment in that file states the plan for issue #886. The plan is to enable `T20`
+and to convert 5053 `print()` sites to logging calls. A `sys.stdout.write()` call is not a
+`print()` call, so the `T20` rule never flags it and the mechanical migration never sees it.
+
+The current `# noqa: T201` marker on line 283 is inert, because ruff does not select `T20`.
+A comment alone does not stop a mechanical migration. A test does. The guard test is the
+enforcement that FR-014 requires.
+
+**Alternatives rejected**:
+
+- A `# noqa: T201` marker with a longer comment. A marker is advice. A migration script can
+  drop the marker along with the `print()` call.
+- A per-file ignore in `pyproject.toml`. A per-file ignore silences the whole file, and
+  FR-008 forbids a suppression that covers a whole file.
+
+---
+
+## R-005: The travel path of the address audit log
+
+**Decision**: The site support package does not hold the address audit log. The street
+address in the log reaches `data/script.log` only.
+
+**Evidence**: Menu 101 maps to `DataCollectionManager.generate_support_packages`. The method
+`_generate_site_packages` builds one dictionary for each site. The dictionary holds the keys
+`alarms`, `events`, `devices`, `device_stats`, `port_stats`, and `speedtests`. The method
+then writes `SupportPackage_<site_id>.csv`. No step reads `data/script.log`, and no step
+copies the log into the package.
+
+**Consequence**: The spec assumption that the package can hold the audit log is wrong. The
+verdict register must record the corrected fact under FR-019. The exposure is narrower than
+the spec assumed. The exposure is still real, because an operator attaches `data/script.log`
+to a support case by hand.
+
+**Alternatives rejected**: A trust of the spec assumption without a read of the code. The
+code read changed the answer, and the register must state the true answer.
+
+---
+
+## R-006: The stance on the ten address alerts
+
+**Decision**: Record one policy. The policy is: no street address at the information level
+and no street address at the warning level. The debug level may hold a street address. Every
+demoted line gains a site identifier, so the operator keeps the ability to correlate.
+
+**Reason**: FR-018 offers three options. The single policy above combines the first option
+and the second option, and it covers all ten alerts with one rule. A single rule is easier
+to review than ten separate calls.
+
+The ten alerts split into two shapes.
+
+| Shape | Lines | Action |
+| - | - | - |
+| The log line carries the cache key, and the cache key is the address | 64, 71, 478 | Log the site identifier in place of the key |
+| The log line carries the address inside the message body | 85, 152, 193, 202, 221, 275, 368 | Move the line to the debug level |
+
+The method `AddressResolver._build_query_key` lowercases the query and collapses the
+whitespace. The method returns the address itself. The three `key=%s` lines therefore print
+the full street address. CodeQL is correct on those three lines.
+
+Line 85 is a warning that reports a failed resolve. A move to the debug level would hide an
+operator signal. Line 85 therefore keeps the warning level and gains the site identifier in
+place of the query.
+
+**Open dependency**: The dataclass `ResolveCandidates` holds no `site_id` field and no
+`site_name` field. The plan adds a `site_id` field to that dataclass. The audit engine
+already holds `site.site_id` at the call site, so the value is available. The five-item rule
+caps the parameter count of a function at five. The rule does not cap the field count of a
+configuration object, and `ResolveCandidates` already holds six fields.
+
+**Alternatives rejected**:
+
+- An acceptance with a written reason and no code change. The address is personal data, and
+  the project rule is fix over suppress.
+- A new hash of the address as the log key. A hash removes the ability of the operator to
+  correlate a log line with a site. The site identifier does that job better.
+
+---
+
+## R-007: The stance on the four capture alerts
+
+**Decision**: Record the verdict `false_positive` for the three MAC address alerts and for
+the payload alert.
+
+**Reason**: A MAC address is a device identifier. MistHelper exists to report device
+identifiers. The three lines read `logging.debug("Selected and normalized <type> MAC: %s",
+<var>)`. CodeQL matched the text `mac` in the variable name. The value is not private data.
+
+The payload alert is a separate case. The payload is built inside `_scan_single_ap_run`. The
+dictionary holds the keys `type`, `ap_mac`, `band`, `max_pkt_len`, and the keys that
+`_gather_scan_radio_params` returns. Those keys are the channel, the bandwidth, and the
+duration. No key holds a secret. The construction is local and closed, so the field list is
+complete.
+
+**Alternatives rejected**: A demotion of the three MAC lines to a lower level. The lines are
+already at the debug level, so no lower level exists.
+
+---
+
+## R-008: The stance on the two GPS alerts
+
+**Decision**: Record the verdict `accepted_with_rationale` with a stated expiry. The next
+review trigger is issue #886.
+
+**Reason**: The two lines sit inside `_dump_diagnostics_location`. The docstring names the
+method a diagnostics dump. Both lines call `print()`, so the value reaches the operator
+screen and reaches no log file. The CodeQL query assumes a log sink. That assumption does
+not hold today.
+
+The assumption will hold after issue #886 converts the two `print()` calls to logging calls.
+The acceptance therefore carries an expiry. A guard test enforces the expiry. The test fails
+when either line becomes a logging call.
+
+**Alternatives rejected**:
+
+- A permanent acceptance with no expiry. FR-007 requires a next review trigger, and a
+  permanent acceptance names none.
+- A reduction of the coordinate precision. The operator invokes the dump to read the exact
+  position, so a coarse value defeats the purpose of the command.
+
+---
+
+## R-009: The stance on the two SSH runner alerts
+
+**Decision**: Record the verdict `fixed`. Convert both lines to the `echo()` helper.
+
+**Reason**: The method `SSHRunnerManager._echo_plan` calls `logging.warning` three times.
+Each call carries the `!?` prefix. That prefix marks a legacy console echo. Spec 1031 added
+`echo()` in `src/utils/console.py`. The helper prints the message and logs it at the
+information level. The two flagged lines are exactly the shape that spec 1031 replaced.
+
+The third line in the same method reports a command count. That line carries no personal
+data, so CodeQL did not flag it. The conversion covers all three lines, because a mixed
+method would confuse the next reader.
+
+**Sweep result**: A search of `src/ssh/` found 18 occurrences of the `!?` prefix across 6
+files. The table below records the disposition of each group. FR-017 requires this record.
+
+| File | Lines | Disposition |
+| - | - | - |
+| `src/ssh/ssh_runner_manager.py` | 110, 111, 112 | Convert under this feature |
+| `src/ssh/ssh_runner_manager.py` | 307, 323 | Convert under this feature |
+| `src/ssh/batch/batch_executor.py` | 307 | Keep. The call already uses the information level |
+| `src/ssh/command/command_runner.py` | 282 | Keep. The call writes through an injected writer |
+| `src/ssh/runtime/app_runner.py` | 180, 268 | Keep. The prefix belongs to an input prompt |
+| `src/ssh/runtime/app_runner.py` | 219, 221, 224, 260 | Keep. The calls already use the information level |
+| `src/ssh/runtime/app_runner.py` | 301, 341 | Convert under this feature |
+| `src/ssh/runtime/interactive_mode.py` | 70, 151 | Keep. The prefix belongs to an input prompt |
+| `src/ssh/shell_execution/shell_executor.py` | 399 | Keep. The line reports a real truncation warning |
+
+**Alternatives rejected**: A change of the log level with no move to `echo()`. That change
+would drop the message from the screen, because the console handler runs at the warning
+level. Requirement SC-010 forbids the loss of any plan line.
+
+---
+
+## R-010: The location and the shape of the verdict register
+
+**Decision**: Store the register at
+`specs/1034-codeql-cleartext-logging/verdict-register.md`. Use one Markdown table with one
+row for each alert.
+
+**Reason**: FR-003 requires the feature directory. A Markdown table renders in the GitHub
+issue view, so a reviewer reads it without a download. The five tracking issues link to the
+file, and the link stays valid after the merge.
+
+The stable anchor is the qualified symbol path plus a quoted fragment of the log template. A
+line number drifts after any edit above the line. A symbol path survives a line move. The
+contract `contracts/verdict-register.md` states the full column list.
+
+**Alternatives rejected**:
+
+- A CSV file. A CSV file does not render in the GitHub issue view.
+- A GitHub project board. A board lives outside the repository, so a reader cannot audit the
+  decision from a checkout.
+
+---
+
+## R-011: How the register stays in step with the GitHub security tab
+
+**Decision**: Treat the register as the source of truth for the reason. Treat the security
+tab as the source of truth for the state. Reconcile the two with one command.
+
+**Reason**: The two stores hold different facts. The register holds the author, the date,
+the anchor, and the reason. The security tab holds the open state and the dismissed state.
+A single source cannot hold both, because the security tab has no field for an anchor.
+
+The reconciliation command lists every dismissed alert with its reason. A reviewer compares
+that output against the register.
+
+```bash
+gh api "repos/:owner/:repo/code-scanning/alerts?state=dismissed&per_page=100" \
+  --jq '.[] | select(.rule.id=="py/clear-text-logging-sensitive-data")
+        | "\(.number)|\(.dismissed_reason)|\(.dismissed_comment)"'
+```
+
+The GitHub API accepts three dismissal reasons. The register maps its verdicts as follows.
+
+| Register verdict | API `dismissed_reason` |
+| - | - |
+| `false_positive` | `false positive` |
+| `accepted_with_rationale` | `won't fix` |
+| `fixed` | No dismissal. The next scan closes the alert |
+
+**Alternatives rejected**: A manual dismissal through the web interface with no register
+entry. That path loses the anchor and the author, and FR-002 requires both.
+
+---
+
+## R-012: The pull request split
+
+**Decision**: Split the work across four pull requests. Land them in the stated order.
+
+**Reason**: Three forces drive the split.
+
+1. User story 1 is the only story that exposes a live credential. That fix must not wait for
+   a triage debate about a street address.
+2. User story 4 depends on a coordination check against issue #1721. A wait on that check
+   must not block the credential fix.
+3. CodeQL reports a new result after a merge to `main`. A smaller pull request returns a
+   faster and clearer verdict signal.
+
+| Order | Pull request | Stories | Files |
+| - | - | - | - |
+| 1 | ZTP credential guard | US1 | `src/utils/console.py`, `src/device/_utility_commands_action.py`, tests |
+| 2 | SSH echo conversion | US6 | `src/ssh/ssh_runner_manager.py`, `src/ssh/runtime/app_runner.py`, tests |
+| 3 | Address and capture stance | US3, US5 | `src/site/address_audit/`, register rows |
+| 4 | GPS stance and register close-out | US4, US2 | `starlink_dashboard.py`, register, issue closure |
+
+The register file receives rows in every pull request. The final pull request checks the
+count and closes the five issues.
+
+**Alternatives rejected**: One pull request for the whole feature. A single pull request
+would hold a credential fix behind a coordination wait, and it would give one coarse CodeQL
+signal for six independent decisions.
+
+---
+
+## R-013: The coordination check against issue #1721
+
+**Decision**: Run the check below immediately before any edit to `starlink_dashboard.py`.
+Stop when the check reports an open pull request that touches the file.
+
+```bash
+gh pr list --state open --json number,title,headRefName,files \
+  --jq '.[] | select(.files[].path=="starlink_dashboard.py")
+        | "#\(.number) \(.headRefName) \(.title)"'
+```
+
+**Reason**: Issue #1721 reports that `starlink_dashboard.py` configures logging after the
+bootstrap. That fix edits the module header. This feature edits
+`_dump_diagnostics_location` near line 1343. The two regions do not overlap today. A
+concurrent edit still creates a rebase conflict, so the order matters.
+
+**Agreed order**: Issue #1721 lands first when its pull request is open. This feature waits.
+This feature lands first when no such pull request is open. The register records the
+observed state and the date.
+
+**Alternatives rejected**: A merge of both changes in one pull request. The two changes have
+different owners and different tracking issues.
+
+---
+
+## R-014: The Simplified Technical English check
+
+**Decision**: Grade every document that this feature adds with the local linter. Use a
+minimum score of 80.
+
+```bash
+.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 `
+  specs/1034-codeql-cleartext-logging/plan.md `
+  specs/1034-codeql-cleartext-logging/research.md `
+  specs/1034-codeql-cleartext-logging/data-model.md `
+  specs/1034-codeql-cleartext-logging/quickstart.md `
+  specs/1034-codeql-cleartext-logging/verdict-register.md
+```
+
+**Reason**: The `STE compliance` job grades a fixed file list. That list holds
+`documentation/ASD-STE100_writing-guide.md` and `tools/ste_linter/README.md`. The job also
+triggers only on a change under `documentation/`. A document under `specs/` therefore never
+reaches the job. Requirement FR-027 still applies, so the author runs the linter by hand.
+
+**Alternatives rejected**: An extension of the graded file list in the workflow. That change
+edits a shared gate, and the spec places any CodeQL configuration change and any workflow
+change outside the scope of this feature.

--- a/specs/1034-codeql-cleartext-logging/spec.md
+++ b/specs/1034-codeql-cleartext-logging/spec.md
@@ -1,0 +1,380 @@
+# Feature Specification: Resolve the open clear-text logging alerts
+
+**Feature Branch**: `1034-codeql-cleartext-logging`
+
+**Created**: 2026-08-04
+
+**Status**: Draft
+
+**Input**: User description: "Create a feature specification for resolving all 19 open CodeQL `py/clear-text-logging-sensitive-data` alerts in the MistHelper repository."
+
+## Background
+
+Pull request #1723 removed the `py/clear-text-logging-sensitive-data` exclusion from
+`.github/codeql/codeql-config.yml` under issue #893. That exclusion hid real alerts. The
+changelog then made a wrong claim of zero alerts. A read of `refs/heads/main` found 21
+alerts. Pull request #1732 resolved the 2 alerts in `MistHelper.py`. It removed the partial
+token preview and used a position label such as `2/3` instead.
+
+19 alerts remain. Five GitHub issues track them. This feature covers all five issues.
+
+| Issue | File | Alerts | Data in the log line |
+| - | - | - | - |
+| #1733 | `src/site/address_audit/address_resolver.py` | 10 | Physical street addresses |
+| #1734 | `src/capture/packet_capture.py` | 4 | 3 MAC addresses and 1 constructed payload |
+| #1735 | `src/device/_utility_commands_action.py` | 1 | A live ZTP password on the console |
+| #1736 | `src/ssh/ssh_runner_manager.py` | 2 | A target host list and a user name |
+| #1737 | `starlink_dashboard.py` | 2 | A GPS latitude and a GPS longitude |
+
+An alert is not proof of a defect. A MAC address is a device identifier that this tool
+exists to report. A user name and a host list are operational facts that an operator needs
+before a bulk SSH run. This feature therefore records a verdict for each alert. It does not
+assume that each alert is a defect.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Protect the ZTP credential (Priority: P1)
+
+An operator asks for the ZTP password of a switch. The tool shows the password on the
+screen. The operator reads the password and uses it. The password does not reach any
+recording, any file, and any log.
+
+Today the tool prints the password with a direct console write. An inline comment claims
+that the tool never logs and never saves the password. That claim holds only on a live
+terminal. The claim fails in three known conditions. The container serves SSH on port 2200
+with a forced command launch, and a recorded SSH session captures the screen. A redirected
+output stream or a pipe captures the screen. Issue #886 plans a mechanical move of every
+console write to the logging framework, and that move would send the password to the log
+file.
+
+**Why this priority**: This alert is the only one that exposes a live credential. An
+attacker who reads a captured session gains device access. Every other alert exposes an
+identifier or a location, not a secret.
+
+**Independent Test**: Request the ZTP password with the output stream redirected to a file.
+Confirm that the file holds no password. Confirm that the tool states why it withheld the
+password. Then request the password on a live terminal and confirm that the password
+appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator runs the tool on a live terminal, **When** the operator requests a
+   ZTP password, **Then** the tool shows the password and shows a warning that names the
+   capture risk.
+2. **Given** an operator runs the tool with the output stream redirected to a file, **When**
+   the operator requests a ZTP password, **Then** the tool withholds the password from the
+   redirected stream and states the reason.
+3. **Given** a reviewer reads the source, **When** the reviewer reads the comment near the
+   password display, **Then** the comment states the true behavior and names the protection.
+
+---
+
+### User Story 2 - Record one verdict for each alert (Priority: P2)
+
+A security reviewer opens the verdict register. The register holds one row for each of the
+19 alerts. Each row holds one verdict of `fixed`, `false_positive`, or
+`accepted_with_rationale`. Each row holds a written reason. The reviewer closes the five
+issues with confidence, because no alert lacks a decision.
+
+**Why this priority**: The register makes the whole feature auditable. Without the register
+a later reader cannot tell a deliberate acceptance from a missed alert. The register also
+gates the other stories, because each story ends with a verdict.
+
+**Independent Test**: Count the rows in the register. Confirm the count is 19. Confirm that
+each row holds exactly one of the three verdict values and a written reason.
+
+**Acceptance Scenarios**:
+
+1. **Given** the register exists, **When** a reviewer counts the rows, **Then** the count
+   equals the alert count of 19.
+2. **Given** a row holds the verdict `false_positive`, **When** a reviewer opens the GitHub
+   security tab, **Then** the matching alert shows a dismissal with the same written reason.
+3. **Given** a row holds the verdict `fixed`, **When** the CodeQL scan runs on `main`,
+   **Then** the matching alert no longer appears.
+
+---
+
+### User Story 3 - Decide the stance on street addresses (Priority: P3)
+
+A support engineer receives a support package for a site. The package holds the run log of
+the address audit. The engineer expects the package to hold only the data that the support
+case needs. The team has made a written decision about whether a street address belongs in
+that log.
+
+The address audit exists to compare and correct site addresses, so the log holds addresses
+by design. The open question is the travel of that log. Menu 101 builds a support package
+for a site, and the package can leave the operator network.
+
+**Why this priority**: This issue holds 10 of the 19 alerts. The data is personal data, and
+it travels. The exposure is wider than the other remaining alerts, but the data is not a
+credential.
+
+**Independent Test**: Run the address audit. Read the resulting log at the default log
+level. Confirm that the log content matches the recorded decision.
+
+**Acceptance Scenarios**:
+
+1. **Given** the team recorded a decision, **When** a reviewer reads the register, **Then**
+   the register names the chosen option and the reason.
+2. **Given** the decision demotes the address lines to the debug level, **When** the audit
+   runs at the default level, **Then** the log holds no street address.
+3. **Given** the decision keeps the address lines, **When** a reviewer reads the register,
+   **Then** the register states the effect on the support package.
+
+---
+
+### User Story 4 - Decide the stance on GPS coordinates (Priority: P4)
+
+An operator reads the Starlink dashboard log. The log holds the position of a terminal. The
+team has made a written decision about whether a precise latitude and a precise longitude
+belong in that log.
+
+**Why this priority**: A precise coordinate pair identifies a physical location. The
+exposure is smaller than the address exposure, because the log holds 2 alerts and does not
+travel in the site support package.
+
+**Independent Test**: Run the dashboard. Read the log. Confirm that the log content matches
+the recorded decision.
+
+**Acceptance Scenarios**:
+
+1. **Given** the team recorded a decision, **When** a reviewer reads the register, **Then**
+   the register names the chosen option and the reason.
+2. **Given** a worker plans an edit to `starlink_dashboard.py`, **When** the worker reads
+   the register, **Then** the register names the coordination duty with issue #1721.
+
+---
+
+### User Story 5 - Decide the stance on capture identifiers (Priority: P5)
+
+A network engineer runs a packet capture. The log names the device under capture. The team
+has made a written decision for each of the 3 MAC address alerts and for the 1 constructed
+payload alert.
+
+The removed exclusion comment argued that CodeQL misreads a MAC address as private data,
+because the variable name holds the text `mac`. A MAC address is a device identifier that
+this tool exists to report. The constructed payload is a separate question, because a
+payload can hold fields that the log must not hold.
+
+**Why this priority**: The 3 MAC address alerts are the strongest false positive
+candidates, so the expected security gain is small. The payload alert still needs a real
+review, so the story stays in scope.
+
+**Independent Test**: Read the register rows for the 4 alerts. Confirm that each MAC row
+states why a device identifier is not private data. Confirm that the payload row names each
+field that the payload holds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a MAC address row holds the verdict `false_positive`, **When** a reviewer reads
+   the reason, **Then** the reason states that the value is a device identifier.
+2. **Given** the payload row exists, **When** a reviewer reads the reason, **Then** the
+   reason lists the fields of the payload and states whether any field holds a secret.
+
+---
+
+### User Story 6 - Restore the operator echo contract in the SSH runner (Priority: P6)
+
+An operator starts a bulk SSH run. The tool echoes the target host list, the user name, and
+the command count. The operator confirms the plan before the run starts. The echo reaches
+the screen through the standard echo path, and the log records the echo at the information
+level.
+
+The two flagged lines carry the `!?` prefix. That prefix marks a legacy console echo, and
+the lines still call the warning log level. Spec 1031, merged as pull request #1694,
+replaced about 170 such echoes with an `echo()` helper. The helper writes to the screen and
+logs at the information level. The sweep missed these two lines.
+
+**Why this priority**: The security risk is the lowest of the six stories, because a host
+list and a user name are operational facts. The story still corrects a real defect that the
+earlier sweep missed.
+
+**Independent Test**: Start a bulk SSH run. Confirm that the plan echo still appears on the
+screen with the same text. Confirm that the log records the echo at the information level.
+Then search `src/ssh/` for the `!?` prefix and confirm the result matches the register.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator starts a bulk SSH run, **When** the tool echoes the plan, **Then**
+   the screen text matches the earlier text.
+2. **Given** the echo runs, **When** a reviewer reads the log, **Then** the log holds the
+   echo at the information level and not at the warning level.
+3. **Given** the sweep of `src/ssh/` finishes, **When** a reviewer reads the register,
+   **Then** the register lists each remaining `!?` echo or states that none remain.
+
+---
+
+### Edge Cases
+
+- What happens when a worker records the verdict `false_positive` and a later code change
+  makes CodeQL raise the same alert again? The register must key each row on a stable
+  anchor, because a line number drifts.
+- What happens when the ZTP password request runs inside a recorded SSH session on port
+  2200? The session recording is a capture, so the tool must apply the same protection that
+  it applies to a redirected stream.
+- What happens when issue #886 moves the ZTP console write to the logging framework? The
+  protection must survive that move, or the migration must skip this call site by written
+  agreement.
+- What happens when a worker adds a suppression without a review date? The suppression is
+  incomplete, and the review must reject it.
+- What happens when an operator raises the log level to debug after the address lines move
+  to debug? The address returns to the log, so the decision must state that condition.
+- What happens when two workers edit `starlink_dashboard.py` at the same time under this
+  feature and under issue #1721? The edits collide, so the register must name the order.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Verdict record
+
+- **FR-001**: The team MUST record exactly one verdict for each of the 19 alerts. The
+  verdict MUST be `fixed`, `false_positive`, or `accepted_with_rationale`.
+- **FR-002**: Each verdict record MUST hold the alert identifier, the source file, the line
+  number, a stable anchor that survives a line move, the query name, the verdict, the
+  written reason, the author, and the decision date.
+- **FR-003**: The team MUST store the verdict register in the feature directory and MUST
+  link the register from each of the five tracking issues.
+- **FR-004**: For each alert with the verdict `false_positive` or `accepted_with_rationale`,
+  the team MUST dismiss the alert in the GitHub security tab. The dismissal reason MUST
+  match the written reason in the register.
+- **FR-005**: The default action for an alert MUST be a code fix. The team MUST NOT record
+  `false_positive` without evidence that the alert misreads the value.
+
+#### Suppression format
+
+- **FR-006**: The team MUST NOT add a bare suppression marker. Each suppression MUST carry a
+  written justification.
+- **FR-007**: Each suppression justification MUST state the reason, the review date, and the
+  next review trigger.
+- **FR-008**: A suppression MUST name the single alert that it silences. A suppression MUST
+  NOT silence a whole file or a whole rule.
+
+#### ZTP credential protection (issue #1735)
+
+- **FR-009**: The tool MUST NOT write the ZTP credential to an output destination that is
+  not an interactive terminal. A terminal check such as `isatty()` is an acceptable
+  mechanism.
+- **FR-010**: When the destination is not an interactive terminal, the tool MUST withhold
+  the credential and MUST state the reason to the operator.
+- **FR-011**: When the destination is an interactive terminal, the tool MUST show the
+  credential and MUST warn the operator that a session recording captures the screen.
+- **FR-012**: If the design writes the credential to a file under `data/`, the tool MUST
+  restrict the file permissions to the owner and MUST state the file path to the operator.
+- **FR-013**: The tool MUST NOT keep a comment that claims a behavior that the code does not
+  provide. The comment near the credential display MUST state the true behavior.
+- **FR-014**: The protection MUST hold after the print-to-logging migration of issue #886.
+  The feature MUST record the contract that the later migration must honor.
+
+#### SSH runner echo contract (issue #1736)
+
+- **FR-015**: The tool MUST send the target host echo and the user name echo through the
+  `echo()` helper that spec 1031 introduced.
+- **FR-016**: The converted echo MUST keep the operator-visible text and MUST log at the
+  information level instead of the warning level.
+- **FR-017**: The team MUST search `src/ssh/` for every remaining `!?` console echo. The
+  team MUST convert each one or MUST list each one in the register with a reason.
+
+#### Street address stance (issue #1733)
+
+- **FR-018**: The team MUST record one decision for the address audit log. The options are a
+  move from the information level to the debug level, a switch to a site identifier in place
+  of the address, and an acceptance with a written reason.
+- **FR-019**: The recorded decision MUST state the effect on the site support package that
+  menu 101 builds.
+
+#### Capture identifier stance (issue #1734)
+
+- **FR-020**: The team MUST record a verdict for each of the 3 MAC address alerts. A verdict
+  of `false_positive` MUST state that the value is a device identifier that the tool exists
+  to report.
+- **FR-021**: The team MUST review the constructed payload alert as a separate case. The
+  reason MUST list the fields that the payload holds and MUST state whether any field holds
+  a secret.
+
+#### GPS coordinate stance (issue #1737)
+
+- **FR-022**: The team MUST record one decision for the latitude value and the longitude
+  value in the Starlink dashboard log.
+
+#### Coordination
+
+- **FR-023**: The feature MUST NOT edit `starlink_dashboard.py` at the same time as issue
+  #1721. The register MUST name the agreed order of the two changes.
+- **FR-024**: The feature MUST NOT perform the print-to-logging migration of issue #886. The
+  register MUST name the boundary between this feature and that migration.
+
+#### Quality
+
+- **FR-025**: The feature MUST NOT introduce a new alert of the query
+  `py/clear-text-logging-sensitive-data`.
+- **FR-026**: A change that removes a value from a log line MUST keep the operator able to
+  identify the record. The change MUST supply a non-sensitive identifier in place of the
+  removed value.
+- **FR-027**: Every document that this feature adds MUST follow the Simplified Technical
+  English rules in `documentation/ASD-STE100_writing-guide.md`.
+
+### Key Entities
+
+- **Alert**: One CodeQL result for the query `py/clear-text-logging-sensitive-data`. Key
+  attributes are the alert identifier, the source file, the line number, a stable anchor,
+  and the tracking issue.
+- **Verdict**: The decision for one alert. The value is `fixed`, `false_positive`, or
+  `accepted_with_rationale`. A verdict holds a written reason, an author, and a date.
+- **Verdict register**: The table that holds one verdict record for each alert. The register
+  is the single audit record for the feature.
+- **Suppression justification**: The written note that accompanies a suppression marker in
+  the source. It holds the reason, the review date, and the next review trigger.
+
+## Out of Scope
+
+- The 2 alerts in `MistHelper.py`. Pull request #1732 already resolved them.
+- Issue #1721, which reports that `starlink_dashboard.py` configures logging after the
+  bootstrap. This feature only records the coordination duty.
+- The print-to-logging migration of issue #886. This feature only records the contract that
+  the migration must honor for the ZTP credential.
+- Any other CodeQL query. This feature covers one query only.
+- Any change to the CodeQL configuration file. The exclusion removal is already complete.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The open alert count for the query `py/clear-text-logging-sensitive-data` on
+  `main` reaches 0. A code change removes an alert with the verdict `fixed`. A dismissal in
+  the GitHub security tab removes an alert with the verdict `false_positive` or
+  `accepted_with_rationale`.
+- **SC-002**: 19 of 19 alerts hold exactly one verdict in the register.
+- **SC-003**: 100 percent of the dismissed alerts show a dismissal reason that matches the
+  register text.
+- **SC-004**: 100 percent of the surviving suppressions state a reason, a review date, and a
+  next review trigger.
+- **SC-005**: A ZTP password request with a redirected output stream produces 0 occurrences
+  of the credential in the captured output.
+- **SC-006**: `src/ssh/` holds 0 unconverted `!?` console echoes, or the register lists each
+  remaining one with a reason.
+- **SC-007**: All five tracking issues reach the closed state.
+- **SC-008**: The feature introduces 0 new alerts of the same query.
+- **SC-009**: Each document that this feature adds scores 80 or above with the Simplified
+  Technical English linter. The `STE compliance` job enforces that score for the documents
+  in its graded list.
+- **SC-010**: A bulk SSH run still shows the plan echo on the screen. The operator loses 0
+  lines of plan information.
+
+## Assumptions
+
+- The alert list and the line numbers are correct for `main` at the start of the feature.
+  Line numbers drift, so the register keys each row on a stable anchor in addition to the
+  line number.
+- A dismissal in the GitHub security tab is the recorded representation of the verdict
+  `false_positive` and of the verdict `accepted_with_rationale`.
+- The `echo()` helper that spec 1031 introduced is available to `src/ssh/` and is the correct
+  target for the two flagged lines.
+- Menu 101 builds the site support package, and that package can hold the address audit log.
+- The container serves SSH on port 2200 with a forced command launch, so a recorded session
+  can capture the console.
+- The project rule of fix over suppress comes from `.github/copilot-instructions.md` and
+  governs every verdict in this feature.
+- The `STE compliance` job triggers on changes under `documentation/` and grades a fixed
+  file list with a minimum score of 80. A document that this feature adds outside that list
+  still follows the same rules.

--- a/specs/1034-codeql-cleartext-logging/tasks.md
+++ b/specs/1034-codeql-cleartext-logging/tasks.md
@@ -1,0 +1,416 @@
+# Tasks: Resolve the open clear-text logging alerts
+
+**Feature**: `1034-codeql-cleartext-logging`
+
+**Branch**: `1034-codeql-cleartext-logging`
+
+**Date**: 2026-08-05
+
+**Input**: Design documents in `specs/1034-codeql-cleartext-logging/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`,
+`contracts/verdict-register.md`, `contracts/credential_console.md`
+
+---
+
+## Format
+
+`- [ ] [TaskID] [P?] [Story?] Description with the file path`
+
+- **[P]**: The task runs in parallel with the other `[P]` tasks in the same block. A `[P]`
+  task touches a different file, or the task only reads.
+- **[Story]**: The user story that owns the task. The setup phase, the foundational phase,
+  and the polish phase carry no story label.
+- **PENDING OPERATOR**: The task needs a live Mist organization, a live network host, a
+  human reader, or a GitHub write token. This session cannot run the task.
+
+---
+
+## The pull request grouping
+
+The feature ships as four pull requests. Research note R-012 records the reason. Each pull
+request is independently mergeable.
+
+| Pull request | Phases | Stories | Tasks | Closes |
+| - | - | - | - | - |
+| PR 1 | 1, 2, 3 | US1 | T001 to T016 | #1735 |
+| PR 2 | 4 | US6 | T017 to T027 | #1736 |
+| PR 3 | 5, 6 | US3, US5 | T028 to T049 | #1733, #1734 |
+| PR 4 | 7, 8, 9 | US4, US2 | T050 to T066 | #1737 |
+
+User story 2 spans all four pull requests. Each pull request appends its own rows to the
+verdict register. Pull request 4 counts the rows, reconciles the register with the GitHub
+security tab, and closes the five tracking issues.
+
+---
+
+## Repository rules that every task obeys
+
+1. Every executable line that a task adds carries an inline comment. The comment states the
+   intent of the line.
+2. Every action gains one `logging.info` call before the action and one `logging.debug`
+   call after the action. The second call states the result.
+3. Every prose file that a task changes passes the Simplified Technical English linter with
+   a score of 80 or above.
+4. Every command runs through `.venv\Scripts\python.exe`. The global interpreter in this
+   workspace is broken.
+5. No task hashes a secret. Pull request #1732 tried a SHA-256 digest, and CodeQL raised
+   `py/weak-sensitive-data-hashing` at high severity. A task removes the value, uses a
+   position label, or uses a count.
+
+---
+
+## Phase 1: Setup and baseline (PR 1)
+
+**Purpose**: Confirm the tooling and record the starting state.
+
+- [ ] T001 Verify the interpreter and the GitHub token. Run `.venv\Scripts\python.exe --version` and expect `Python 3.13` or a later version. Run `gh auth status` and expect a token with the `security_events` scope.
+- [ ] T002 [P] Record the baseline open alert count. Run the check 1 command from `specs/1034-codeql-cleartext-logging/quickstart.md`. Expect the output `19`. Write the value and the date into a scratch note for task T004.
+- [ ] T003 [P] Export the current alert list. Run `gh api "repos/:owner/:repo/code-scanning/alerts?state=open&per_page=100" --jq '.[] | select(.rule.id=="py/clear-text-logging-sensitive-data") | "\(.number)|\(.most_recent_instance.location.path)|\(.most_recent_instance.location.start_line)"'`. Expect 19 lines. Compare the output against the table in `specs/1034-codeql-cleartext-logging/research.md` under note R-001. A line difference means that a line drifted, so the anchor takes priority over the line number.
+
+**Checkpoint**: The tooling works and the baseline is recorded.
+
+---
+
+## Phase 2: Foundational (PR 1)
+
+**Purpose**: Create the register file. Every story appends rows to this file, so the file
+must exist first.
+
+**Blocking**: No story task that writes a register row can start until T004 completes.
+
+- [ ] T004 Create `specs/1034-codeql-cleartext-logging/verdict-register.md`. Write the eleven-column header exactly as contract clause C-1 states. The columns are `Alert`, `Issue`, `File`, `Line`, `Anchor`, `Verdict`, `Reason`, `Author`, `Decided`, `Review`, `Trigger`. Add a preamble that names the baseline count from T002, the baseline date, and the reconciliation command from contract clause C-8. Add no data row.
+
+**Checkpoint**: The register exists. Story work can start.
+
+---
+
+## Phase 3: User Story 1 - Protect the ZTP credential (Priority: P1) - PR 1 - MVP
+
+**Goal**: The tool shows the ZTP password on an interactive terminal with a warning. The
+tool withholds the password from every other destination.
+
+**Independent Test**: Request the ZTP password with the output stream redirected to a file.
+Confirm that the file holds no password. Then request the password on a live terminal and
+confirm that the password appears after the warning.
+
+**Covers**: FR-009 through FR-014, SC-005, alert 173, issue #1735.
+
+### Tests for User Story 1
+
+> Write these tests first. Confirm that they fail before the implementation starts.
+
+- [ ] T005 [P] [US1] Create `tests/unit/test_credential_console_behavior.py`. Patch `sys.stdout.isatty` to return `True` and assert that the written text holds the warning before the secret and that the method returns `True`. Patch `sys.stdout.isatty` to return `False` and assert that the written text holds the label, holds the withhold notice, holds no character of the secret, and that the method returns `False`. Capture the log records and assert that no record holds the secret.
+- [ ] T006 [P] [US1] Create `tests/unit/test_credential_console_contract.py`. The test reads the source of `src/utils/console.py` and the source of `src/device/_utility_commands_action.py`. The test fails when the reveal path holds a `print(` call, when the reveal path holds a `logging.` call that takes the secret variable, or when `_render_ztp_response` passes the credential to any callable other than `CredentialConsole.reveal`. This test is the durable marker for issue #886 that requirement FR-014 needs. Contract clauses C-2, C-6, and C-8 state the rules.
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Add the `CredentialConsole` class to `src/utils/console.py`. The class holds one public static method `reveal(label: str, secret: str) -> bool`. The method calls `sys.stdout.isatty()` once. The reveal branch writes the recording warning first and then writes the label and the secret. The withhold branch writes the label, the withhold notice, and the remedy. Every write uses `sys.stdout.write()`, because ruff does not select the `T20` rule family today and a `sys.stdout.write()` call therefore survives the mechanical migration of issue #886. The method logs `logging.info("Credential display requested for %s", label)` before the write and `logging.debug("Credential display outcome for %s: %s", label, outcome)` after the write. Neither log line holds the secret, any part of the secret, or a digest of the secret. Contract clauses C-1 through C-6 state the full behavior.
+- [ ] T008 [US1] Rewrite `_render_ztp_response` in `src/device/_utility_commands_action.py`. Replace the line `print(f"\n-> ZTP Password: {ztp_credential}")  # noqa: T201` with a call to `CredentialConsole.reveal("ZTP Password", ztp_credential)`. The inert `# noqa: T201` marker leaves the file with that line, because ruff does not select `T20` and the marker therefore silences nothing.
+- [ ] T009 [US1] Correct the comment block above the credential display in `src/device/_utility_commands_action.py`. Delete the claim that the tool never logs and never saves the password, because that claim holds only on a live terminal. Delete the line `print("-> (Password displayed on console only - not logged or saved)")`, because the new withhold notice and the new warning replace it. Write one comment line that names the terminal check and names the recording limit. Requirement FR-013 and contract clause C-7 state the rule.
+
+### Verification for User Story 1
+
+- [ ] T010 [US1] Append the register row for alert 173 to `specs/1034-codeql-cleartext-logging/verdict-register.md`. Set `Issue` to `1735`, `File` to `src/device/_utility_commands_action.py`, `Verdict` to `fixed`, `Review` to `-`, and `Trigger` to `-`. Set `Anchor` to `src/device/_utility_commands_action.py::UtilityCommandsAction._render_ztp_response :: "-> ZTP Password: "`. The reason states that a terminal check and an operator warning replace the bare console write.
+- [ ] T011 [US1] Run the new unit tests. Command: `.venv\Scripts\python.exe -m pytest tests\unit\test_credential_console_behavior.py tests\unit\test_credential_console_contract.py -q`. Expected output: every test passes and the exit code is `0`.
+- [ ] T012 [US1] PENDING OPERATOR. Run quickstart check 4. Command: `python MistHelper.py --menu 144 > data\ztp_redirect_test.txt`, then `Select-String -Path data\ztp_redirect_test.txt -Pattern 'ZTP Password:'`. Expected result: the file holds the label and the withhold notice, and the file holds no credential value. Delete the file after the check. This task needs a live Mist organization and a laboratory device. **Warning**: this check returns a real credential, so never run it against a production device.
+- [ ] T013 [US1] PENDING OPERATOR. Run quickstart check 5. Command: `python MistHelper.py --menu 144` on an interactive terminal with no redirection. Expected result: the screen shows the recording warning first and then shows the credential. This task needs a human reader, because a test harness has no terminal.
+- [ ] T014 [US1] Run the quality gates exactly as the workflow runs them. Commands: `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, `.venv\Scripts\python.exe -m radon cc src/ -n C`, `.venv\Scripts\python.exe -m bandit -r src/ MistHelper.py starlink_dashboard.py`, `.venv\Scripts\python.exe -m pytest --cov --cov-fail-under=80`. Expected result: every command exits with the code `0`. **Warning**: `radon` honors no suppression marker. A block above the complexity value of 10 fails the gate, so decompose the block instead of annotating it.
+- [ ] T015 [US1] Run the Simplified Technical English linter on the changed prose. Command: `.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs\1034-codeql-cleartext-logging\verdict-register.md`. Expected result: the score is 80 or above.
+- [ ] T016 [US1] PENDING OPERATOR. Open pull request 1 from the branch `1034-codeql-cleartext-logging`. The title names the ZTP credential guard. The body holds `Closes #1735` and a link to `specs/1034-codeql-cleartext-logging/verdict-register.md`. Wait for CodeQL to finish before you add the `auto-merge` label.
+
+**Checkpoint**: User story 1 is complete and independently shippable. The only live
+credential in the alert set is now protected.
+
+---
+
+## Phase 4: User Story 6 - Restore the operator echo contract (Priority: P6) - PR 2
+
+**Goal**: The SSH plan echo reaches the screen through the `echo()` helper and reaches the
+log at the information level.
+
+**Independent Test**: Start a bulk SSH run. Confirm that the plan echo still shows the same
+text on the screen. Confirm that the log records the echo at the information level.
+
+**Covers**: FR-015 through FR-017, SC-006, SC-010, alerts 188 and 189, issue #1736.
+
+**Reuse rule**: Use the existing `echo()` helper in `src/utils/console.py` that spec 1031
+added. Do not write a second helper.
+
+### Tests for User Story 6
+
+- [ ] T017 [P] [US6] Create `tests/unit/test_ssh_runner_echo_plan.py`. Patch the `echo` name that `src/ssh/ssh_runner_manager.py` imports. Call `SSHRunnerManager._echo_plan` with a host list, a user name, and a command list. Assert that the patched `echo` receives three calls. Assert that the message text matches the earlier text. Capture the log records and assert that every record carries the `INFO` level and that no record carries the `WARNING` level.
+
+### Implementation for User Story 6
+
+- [ ] T018 [US6] Convert the three echo calls in `SSHRunnerManager._echo_plan` in `src/ssh/ssh_runner_manager.py` at the lines 110, 111, and 112. Replace each `logging.warning("!? ...", ...)` call with an `echo("...", ...)` call. Drop the `!?` prefix, because the helper owns the console write. Keep the operator-visible words unchanged, because requirement SC-010 forbids the loss of a plan line. Alert 188 sits on line 110 and alert 189 sits on line 111. Line 112 carries no alert, and the task converts it anyway, because a mixed method confuses the next reader.
+- [ ] T019 [US6] Convert the two remaining echo calls in `src/ssh/ssh_runner_manager.py` at the lines 307 and 323. Both calls sit inside `_execute_multi_host`. Replace each `logging.warning("\n!? ...", ...)` call with an `echo("...", ...)` call. Note R-009 in `specs/1034-codeql-cleartext-logging/research.md` records this disposition.
+- [ ] T020 [P] [US6] Convert the two flagged echo calls in `src/ssh/runtime/app_runner.py` at the lines 301 and 341. Replace each `logger.warning("!? ...", ...)` call with an `echo("...", ...)` call. Leave the lines 180, 219, 221, 224, 260, and 268 unchanged, because note R-009 records those as an input prompt or as an existing information-level call.
+- [ ] T021 [US6] Run the sweep of `src/ssh/` and reconcile the result. Command: `Select-String -Path src\ssh\*.py, src\ssh\**\*.py -Pattern '!\?' | ForEach-Object { "$($_.Path):$($_.LineNumber)" }`. Compare the output against the sweep table in note R-009. Expected result: every remaining line matches a `Keep` row in that table. A line with no recorded disposition fails the check, so add a row for it. Requirement FR-017 needs this record.
+
+### Verification for User Story 6
+
+- [ ] T022 [US6] Append the register rows for alert 188 and alert 189 to `specs/1034-codeql-cleartext-logging/verdict-register.md`. Set `Issue` to `1736`, `File` to `src/ssh/ssh_runner_manager.py`, `Verdict` to `fixed`, `Review` to `-`, and `Trigger` to `-`. Set the anchor of alert 188 to `src/ssh/ssh_runner_manager.py::SSHRunnerManager._echo_plan :: "!? Target hosts: %s"`. Set the anchor of alert 189 to `src/ssh/ssh_runner_manager.py::SSHRunnerManager._echo_plan :: "!? Username: %s"`. The reason states that the line moved to the `echo()` helper at the information level. Add a note that names the sweep result from T021.
+- [ ] T023 [US6] Run the unit tests. Command: `.venv\Scripts\python.exe -m pytest tests\unit\test_ssh_runner_echo_plan.py -q`. Expected output: every test passes and the exit code is `0`.
+- [ ] T024 [US6] PENDING OPERATOR. Run quickstart check 6. Command: `python MistHelper.py --menu 60`, then `Select-String -Path data\script.log -Pattern 'Target hosts' | Select-Object -Last 3`. Expected result: the screen shows the target hosts, the user name, and the command count. The matching log lines carry the `INFO` level and not the `WARNING` level. This task needs live network hosts.
+- [ ] T025 [US6] Run the quality gates with the six commands from T014. Expected result: every command exits with the code `0`.
+- [ ] T026 [US6] Run the Simplified Technical English linter on `specs\1034-codeql-cleartext-logging\verdict-register.md` with a minimum score of 80.
+- [ ] T027 [US6] PENDING OPERATOR. Open pull request 2. The title names the SSH echo conversion. The body holds `Closes #1736`. Wait for CodeQL before you add the `auto-merge` label.
+
+**Checkpoint**: User story 6 is complete. The operator keeps every plan line, and the
+warning channel keeps its signal.
+
+---
+
+## Phase 5: User Story 3 - Decide the stance on street addresses (Priority: P3) - PR 3
+
+**Goal**: The address audit log holds no street address at the information level and no
+street address at the warning level. Each changed line names a site identifier instead.
+
+**Independent Test**: Run the address audit at the default log level. Read `data/script.log`
+and confirm that the log holds no street address.
+
+**Covers**: FR-018, FR-019, FR-026, alerts 174 through 183, issue #1733.
+
+**Policy**: Note R-006 records one policy for all ten alerts. No street address reaches the
+information level. No street address reaches the warning level. The debug level may hold a
+street address. Every changed line gains a site identifier, so the operator keeps the
+ability to correlate a log line with a site.
+
+### Correction and prerequisite for User Story 3
+
+- [ ] T028 [US3] Correct requirement FR-019 in `specs/1034-codeql-cleartext-logging/spec.md`. Note R-005 proves that `_generate_site_packages` never reads `data/script.log`, and a code search returns zero references. The site support package therefore does not hold the address audit log. Rewrite FR-019 to state that the decision records the true travel path, which is `data/script.log` only. Correct the matching assumption line that reads "Menu 101 builds the site support package, and that package can hold the address audit log." Correct the matching sentence in the user story 3 narrative.
+- [ ] T029 [US3] Add a `site_id` field to the `ResolveCandidates` dataclass in `src/site/address_audit/models.py`. Use the type `str` with the default `""`. Write an inline comment that states why the field exists, which is that the resolver logs a site identifier in place of a street address. The five-item rule caps a function parameter count at five. The rule does not cap the field count of a configuration object, and `ResolveCandidates` already holds six fields.
+- [ ] T030 [US3] Populate the new field at the single construction site. The site is `src/site/address_audit/audit_engine.py` near line 625. Pass the site identifier that the engine already holds. Add an inline comment on the new argument.
+
+### Tests for User Story 3
+
+- [ ] T031 [P] [US3] Create `tests/unit/test_address_resolver_log_redaction.py`. Build a `ResolveCandidates` object with a known street address and a known site identifier. Capture the log records at every level. Assert that no record at the information level holds the street address. Assert that no record at the warning level holds the street address. Assert that the changed records hold the site identifier. Assert that the debug level still carries the detail that an engineer needs.
+
+### Implementation for User Story 3
+
+- [ ] T032 [US3] Change the two log calls in `AddressResolver.resolve` in `src/site/address_audit/address_resolver.py` at the lines 64 and 71. The method `_build_query_key` lowercases the query and collapses the whitespace, so the cache key is the street address itself. Log `candidates.site_id` in place of `key`. Alert 174 sits on line 64 and alert 175 sits on line 71.
+- [ ] T033 [US3] Change the log call in `AddressResolver._from_cache` in `src/site/address_audit/address_resolver.py` at line 478. The call reads `logging.debug("cache hit for %s", key)`, and the key is the street address. Log the site identifier in place of the key. Alert 183 sits on this line.
+- [ ] T034 [US3] Change the log call in `AddressResolver._resolve_uncached` in `src/site/address_audit/address_resolver.py` at line 85. Keep the warning level, because the line reports a failed resolve and a demotion would hide an operator signal. Log the site identifier in place of the query string. Alert 176 sits on this line.
+- [ ] T035 [US3] Change the log call in `src/site/address_audit/address_resolver.py` at line 152. The call already uses the debug level. Remove the resolved address from the message body and log the site identifier and the suite value only. Alert 177 sits on this line.
+- [ ] T036 [US3] Change the two log calls in `src/site/address_audit/address_resolver.py` at the lines 193 and 202. Move both calls from the information level to the debug level. Log the site identifier in the message body. Alert 178 sits on line 193 and alert 179 sits on line 202.
+- [ ] T037 [US3] Change the log call in `src/site/address_audit/address_resolver.py` that starts at line 220 and carries alert 180 on line 221. Keep the warning level, because the call reports a real mismatch. Replace the street value with the site identifier.
+- [ ] T038 [US3] Change the log call in `src/site/address_audit/address_resolver.py` at line 275. Move the call from the information level to the debug level and log the site identifier. Alert 181 sits on this line.
+- [ ] T039 [US3] Change the log call in `src/site/address_audit/address_resolver.py` at line 368. The call logs the conflicting house numbers at the information level. Move the call to the debug level and log the site identifier and the count of the distinct values. Alert 182 sits on this line.
+
+### Verification for User Story 3
+
+- [ ] T040 [US3] Append the ten register rows for the alerts 174 through 183 to `specs/1034-codeql-cleartext-logging/verdict-register.md`. Set `Issue` to `1733` and `File` to `src/site/address_audit/address_resolver.py` on every row. Set the anchor of each row to the qualified symbol path and the quoted format string fragment, as entity E-004 states. The anchor holds no street address. Record the corrected travel path from T028 in the reason of at least one row, because requirement FR-019 needs that statement.
+- [ ] T041 [US3] Run the unit tests. Command: `.venv\Scripts\python.exe -m pytest tests\unit\test_address_resolver_log_redaction.py -q`. Expected output: every test passes and the exit code is `0`.
+- [ ] T042 [US3] PENDING OPERATOR. Run quickstart check 7. Run the address audit at the default log level, then run `Select-String -Path data\script.log -Pattern 'Resolving address \(key='`. Expected result: no match. This task needs a live Mist organization and the customer address file.
+- [ ] T043 [US3] Run the quality gates with the six commands from T014. Expected result: every command exits with the code `0`.
+- [ ] T044 [US3] Run the Simplified Technical English linter on the two changed prose files. Command: `.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs\1034-codeql-cleartext-logging\spec.md specs\1034-codeql-cleartext-logging\verdict-register.md`. Expected result: both files score 80 or above.
+
+**Checkpoint**: The address audit no longer prints a street address at an operator-visible
+log level.
+
+---
+
+## Phase 6: User Story 5 - Decide the stance on capture identifiers (Priority: P5) - PR 3
+
+**Goal**: The four capture alerts hold a recorded verdict with evidence.
+
+**Independent Test**: Read the four register rows. Confirm that each MAC row states why a
+device identifier is not private data. Confirm that the payload row lists every field.
+
+**Covers**: FR-020, FR-021, alerts 184 through 187, issue #1734.
+
+**Code change**: None. Note R-007 records the evidence.
+
+- [ ] T045 [P] [US5] Confirm the payload field list in `src/capture/packet_capture.py`. Read the dictionary that `_scan_single_ap_run` builds near line 890. Confirm the keys `type`, `ap_mac`, `band`, and `max_pkt_len`. Confirm the keys that `_gather_scan_radio_params` returns, which are the channel, the bandwidth, and the duration. Write the confirmed list into the reason of the row that task T047 creates. A new key that this task finds needs a fresh review before the verdict stands.
+- [ ] T046 [US5] Append the three register rows for the alerts 184, 185, and 186 to `specs/1034-codeql-cleartext-logging/verdict-register.md`. Set `Issue` to `1734`, `File` to `src/capture/packet_capture.py`, and `Verdict` to `false_positive`. The lines sit at 548, 637, and 846. Each line reads `logging.debug("Selected and normalized <type> MAC: %s", <var>)`. The reason states that the value is a device identifier that MistHelper exists to report, and that the query matched the text `mac` in the variable name. Set `Review` to a date one year ahead and set `Trigger` to a change of the log template on that line, because contract clause C-5 needs both fields.
+- [ ] T047 [US5] Append the register row for alert 187 to `specs/1034-codeql-cleartext-logging/verdict-register.md`. Set `Issue` to `1734`, `File` to `src/capture/packet_capture.py`, `Line` to `890`, and `Verdict` to `false_positive`. The reason lists every field from T045 and states that no field holds a secret. Set `Review` and `Trigger` as clause C-5 needs. Requirement FR-021 needs the field list.
+- [ ] T048 [US5] PENDING OPERATOR. Dismiss the alerts 184, 185, 186, and 187 in the GitHub security tab. Command per alert: `gh api -X PATCH "repos/:owner/:repo/code-scanning/alerts/<number>" -f state=dismissed -f dismissed_reason="false positive" -f dismissed_comment="<register reason>"`. The comment repeats the register reason exactly, because contract clause C-7 needs the match. This task needs a token with a write scope on the security events.
+- [ ] T049 [US5] PENDING OPERATOR. Open pull request 3. The title names the address stance and the capture stance. The body holds `Closes #1733` and `Closes #1734`. Wait for CodeQL before you add the `auto-merge` label.
+
+**Checkpoint**: Pull request 3 is complete. Fourteen of the nineteen alerts now hold a
+verdict.
+
+---
+
+## Phase 7: User Story 4 - Decide the stance on GPS coordinates (Priority: P4) - PR 4
+
+**Goal**: The two Starlink coordinate alerts hold a recorded acceptance with a stated
+expiry.
+
+**Independent Test**: Read the two register rows. Confirm that each row names the option,
+the reason, the review date, and the trigger.
+
+**Covers**: FR-022, FR-023, alerts 190 and 191, issue #1737.
+
+**Code change**: None to `starlink_dashboard.py`. The verdict is
+`accepted_with_rationale`, so the two `print()` calls stay. Phase 7 adds one guard test that
+only reads the file.
+
+- [ ] T050 [US4] Run the coordination check against issue #1721 before any task in this phase touches `starlink_dashboard.py`. Command: `gh pr list --state open --json number,title,headRefName,files --jq '.[] | select(.files[].path=="starlink_dashboard.py") | "#\(.number) \(.headRefName) \(.title)"'`. Expected result: no output. If the command prints a pull request, stop and wait for that pull request to merge. Issue #1721 lands first in that case. Quickstart check 12 states this rule.
+- [ ] T051 [US4] Record the T050 result in `specs/1034-codeql-cleartext-logging/verdict-register.md`. Write the observed state, the date, and the agreed order in a note below the table. Requirement FR-023 needs this record. State that the chosen verdict needs no edit to `starlink_dashboard.py`, so the collision risk is zero for this feature.
+- [ ] T052 [US4] Create `tests/unit/test_starlink_location_dump_guard.py`. The test reads the source of `starlink_dashboard.py` and finds the method `_dump_diagnostics_location`. The test asserts that the latitude line and the longitude line still call `print()`. The test fails when either line becomes a `logging` call. The test is the expiry enforcement that note R-008 needs, because the acceptance stands only while the value reaches no log sink.
+- [ ] T053 [US4] Append the register rows for alert 190 and alert 191 to `specs/1034-codeql-cleartext-logging/verdict-register.md`. Set `Issue` to `1737`, `File` to `starlink_dashboard.py`, and `Verdict` to `accepted_with_rationale`. The lines sit at 1343 and 1344. Set the anchor of alert 190 to `starlink_dashboard.py::StarlinkDashboard._dump_diagnostics_location :: "  - Latitude: "` and the anchor of alert 191 to the matching longitude fragment. The reason states that the operator invokes the dump, that both lines call `print()`, and that the value reaches no log file. Set `Trigger` to the merge of issue #886. Set `Review` to the ISO date that the team agrees.
+- [ ] T054 [US4] PENDING OPERATOR. Dismiss the alerts 190 and 191 in the GitHub security tab. Command per alert: `gh api -X PATCH "repos/:owner/:repo/code-scanning/alerts/<number>" -f state=dismissed -f dismissed_reason="won't fix" -f dismissed_comment="<register reason>"`. Note R-011 maps the verdict `accepted_with_rationale` to the API reason `won't fix`.
+- [ ] T055 [US4] Run the unit test and the quality gates. Command: `.venv\Scripts\python.exe -m pytest tests\unit\test_starlink_location_dump_guard.py -q`, then the six commands from T014. Expected result: every command exits with the code `0`.
+
+**Checkpoint**: All nineteen alerts now hold a verdict.
+
+---
+
+## Phase 8: User Story 2 - Record one verdict for each alert (Priority: P2) - PR 4
+
+**Goal**: The register holds one complete row for each of the nineteen alerts, and the
+GitHub security tab agrees with the register.
+
+**Independent Test**: Count the rows in the register. Confirm the count is 19. Confirm that
+each row holds exactly one of the three verdict values and a written reason.
+
+**Covers**: FR-001 through FR-008, FR-024, SC-002, SC-003, SC-004, SC-007.
+
+- [ ] T056 [US2] Run quickstart check 2. Command: `Select-String -Path specs\1034-codeql-cleartext-logging\verdict-register.md -Pattern '^\| 1[78][0-9] \|' | Measure-Object | Select-Object -ExpandProperty Count`. Expected output: `19`. Invariant INV-1 needs this count.
+- [ ] T057 [US2] Read every row and confirm the four contract clauses. Confirm that each `Verdict` cell holds `fixed`, `false_positive`, or `accepted_with_rationale`, per clause C-3. Confirm that no `Reason` cell is blank and that no cell reads `see above`, per clause C-4. Confirm that each non-fixed row holds a `Review` value and a `Trigger` value, per clause C-5. Confirm that no anchor holds a street address, a coordinate, a MAC address, or a credential, per clause C-6.
+- [ ] T058 [US2] Record the boundary with issue #886 in `specs/1034-codeql-cleartext-logging/verdict-register.md`. State that this feature owns the credential reveal path and the two GPS dump lines. State that issue #886 owns every other `print()` call. Name the two guard tests that fail when the migration crosses the boundary, which are `tests/unit/test_credential_console_contract.py` and `tests/unit/test_starlink_location_dump_guard.py`. Requirement FR-024 needs this record.
+- [ ] T059 [US2] PENDING OPERATOR. Run quickstart check 3 and reconcile the two stores. Command: `gh api "repos/:owner/:repo/code-scanning/alerts?state=dismissed&per_page=100" --jq '.[] | select(.rule.id=="py/clear-text-logging-sensitive-data") | "\(.number)|\(.dismissed_reason)|\(.dismissed_comment)"'`. Expected result: six lines that cover the alerts 184, 185, 186, 187, 190, and 191. Each line matches one register row. A line with no matching row fails the check, and a dismissed register row with no matching line fails the check.
+- [ ] T060 [US2] PENDING OPERATOR. Add a comment to each of the issues 1733, 1734, 1735, 1736, and 1737. The comment holds the register path and names the rows that belong to that issue. Contract clause C-10 and requirement FR-003 need the link.
+- [ ] T061 [US2] PENDING OPERATOR. Run quickstart check 1 after pull request 4 merges to `main` and after the next CodeQL scan completes. Command: the check 1 command from `quickstart.md`. Expected output: `0`. A pull request branch reports a different count, so run this check only after the merge.
+- [ ] T062 [US2] PENDING OPERATOR. Handle a residual alert from the address work. The query flags a logging call at every level, so a move to the debug level protects the operator log but may leave the alert open. If T061 reports a count above zero, read the residual alert numbers. For each residual address alert, either remove the value from the log template or change the register verdict from `fixed` to `accepted_with_rationale` with a review date and a trigger. Then dismiss the alert with the matching reason and rerun T061.
+- [ ] T063 [US2] PENDING OPERATOR. Close the issues 1733, 1734, 1735, 1736, and 1737 after T061 reports `0`. Success criterion SC-007 needs the closed state on all five issues.
+
+**Checkpoint**: The audit record is complete and matches the GitHub security tab.
+
+---
+
+## Phase 9: Polish and cross-cutting concerns - PR 4
+
+- [ ] T064 [P] Add the changelog entry to `CHANGELOG.md`. Use the `version YY.MM.DD.HH.MM` format with a UTC timestamp. Name the five issues and the four pull requests. State the resolved alert count.
+- [ ] T065 Run quickstart check 10 on every feature document. Command: `.venv\Scripts\python.exe -m tools.ste_linter --min-score 80 specs\1034-codeql-cleartext-logging\plan.md specs\1034-codeql-cleartext-logging\research.md specs\1034-codeql-cleartext-logging\data-model.md specs\1034-codeql-cleartext-logging\quickstart.md specs\1034-codeql-cleartext-logging\verdict-register.md specs\1034-codeql-cleartext-logging\tasks.md specs\1034-codeql-cleartext-logging\contracts\verdict-register.md specs\1034-codeql-cleartext-logging\contracts\credential_console.md`. Expected result: every file scores 80 or above.
+- [ ] T066 PENDING OPERATOR. Open pull request 4. The title names the GPS stance and the register close-out. The body holds `Closes #1737` and links the register. Wait for CodeQL before you add the `auto-merge` label.
+
+---
+
+## The alert to task map
+
+Every alert holds a code task or a verdict task and a register task. The table proves that
+no alert lacks a decision.
+
+| Alert | File | Issue | Code task | Register task | Verdict |
+| - | - | - | - | - | - |
+| 173 | `src/device/_utility_commands_action.py` | 1735 | T008, T009 | T010 | `fixed` |
+| 174 | `src/site/address_audit/address_resolver.py` | 1733 | T032 | T040 | `fixed` |
+| 175 | `src/site/address_audit/address_resolver.py` | 1733 | T032 | T040 | `fixed` |
+| 176 | `src/site/address_audit/address_resolver.py` | 1733 | T034 | T040 | `fixed` |
+| 177 | `src/site/address_audit/address_resolver.py` | 1733 | T035 | T040 | `fixed` |
+| 178 | `src/site/address_audit/address_resolver.py` | 1733 | T036 | T040 | `fixed` |
+| 179 | `src/site/address_audit/address_resolver.py` | 1733 | T036 | T040 | `fixed` |
+| 180 | `src/site/address_audit/address_resolver.py` | 1733 | T037 | T040 | `fixed` |
+| 181 | `src/site/address_audit/address_resolver.py` | 1733 | T038 | T040 | `fixed` |
+| 182 | `src/site/address_audit/address_resolver.py` | 1733 | T039 | T040 | `fixed` |
+| 183 | `src/site/address_audit/address_resolver.py` | 1733 | T033 | T040 | `fixed` |
+| 184 | `src/capture/packet_capture.py` | 1734 | None | T046 | `false_positive` |
+| 185 | `src/capture/packet_capture.py` | 1734 | None | T046 | `false_positive` |
+| 186 | `src/capture/packet_capture.py` | 1734 | None | T046 | `false_positive` |
+| 187 | `src/capture/packet_capture.py` | 1734 | T045 | T047 | `false_positive` |
+| 188 | `src/ssh/ssh_runner_manager.py` | 1736 | T018 | T022 | `fixed` |
+| 189 | `src/ssh/ssh_runner_manager.py` | 1736 | T018 | T022 | `fixed` |
+| 190 | `starlink_dashboard.py` | 1737 | None | T053 | `accepted_with_rationale` |
+| 191 | `starlink_dashboard.py` | 1737 | None | T053 | `accepted_with_rationale` |
+
+The alerts sit in five source files. Note R-009 reports six files for the `!?` console echo
+sweep, and that sweep is a separate count.
+
+---
+
+## Dependencies and execution order
+
+### Phase dependencies
+
+- Phase 1 has no dependency and starts at once.
+- Phase 2 depends on Phase 1. Phase 2 blocks every register write in every story.
+- Phase 3 depends on Phase 2. Phase 3 is the minimum viable product.
+- Phase 4 depends on Phase 2 only. Phase 4 does not depend on Phase 3.
+- Phase 5 depends on Phase 2 only.
+- Phase 6 depends on Phase 2 only.
+- Phase 7 depends on Phase 2 and on the T050 coordination check.
+- Phase 8 depends on Phase 3, Phase 4, Phase 5, Phase 6, and Phase 7. The register must hold
+  all nineteen rows before the count check runs.
+- Phase 9 depends on Phase 8.
+
+### Story dependencies
+
+- User story 1 depends on nothing. It ships first and alone.
+- User story 6 depends on nothing.
+- User story 3 depends on nothing.
+- User story 5 depends on nothing.
+- User story 4 depends on the issue #1721 coordination check.
+- User story 2 depends on every other story, because the register closes last.
+
+### Task dependencies inside a story
+
+- T005 and T006 run before T007, T008, and T009. Write the test first and watch it fail.
+- T007 runs before T008, because the call site needs the new class.
+- T029 and T030 run before T032 through T039, because the resolver reads the new field.
+- T031 runs before T032 through T039.
+- T045 runs before T047, because the row holds the confirmed field list.
+- T050 runs before every other Phase 7 task.
+- T056 runs after every register write task, which are T010, T022, T040, T046, T047, and
+  T053.
+
+### Parallel opportunities
+
+| Block | Tasks | Reason |
+| - | - | - |
+| Phase 1 | T002, T003 | Both tasks only read the GitHub API |
+| Phase 3 tests | T005, T006 | Two different new test files |
+| Phase 4 | T017, T020 | A new test file and a different source file |
+| Phase 5 | T031 | A new test file, separate from the source edits |
+| Phase 6 | T045 | A read-only confirmation |
+| Phase 9 | T064 | `CHANGELOG.md` touches no other task file |
+
+The source edits in Phase 5 from T032 through T039 all touch
+`src/site/address_audit/address_resolver.py`, so they run in sequence. The register writes
+all touch one file, so they run in sequence.
+
+Two workers can run Phase 4 and Phase 5 at the same time, because the two phases share no
+file.
+
+---
+
+## Implementation strategy
+
+### The minimum viable product
+
+Pull request 1 alone is a shippable increment. It protects the only live credential in the
+alert set. Stop after T016 and ship if the schedule needs a cut.
+
+### The incremental order
+
+1. Ship pull request 1. The credential risk closes first.
+2. Ship pull request 2. The defect that the spec 1031 sweep missed closes next.
+3. Ship pull request 3. The ten address alerts and the four capture alerts close.
+4. Ship pull request 4. The register closes and the five issues close.
+
+### Risks
+
+| Risk | Effect | Response |
+| - | - | - |
+| A move to the debug level may not close a CodeQL alert. The query flags a logging call at any level | The address alerts stay open after pull request 3 merges | T062 handles the residual. Remove the value from the template or change the verdict |
+| A recorded SSH session returns `True` from `isatty()` | The terminal check alone does not protect the credential | The reveal path writes the operator warning first. Note R-002 records the test |
+| Issue #886 converts the credential write to a logging call | The credential reaches `data/script.log` | T006 creates the guard test. `sys.stdout.write()` is not a `print()` call, so the migration does not see the line |
+| Issue #1721 edits `starlink_dashboard.py` at the same time | A rebase conflict | T050 gates Phase 7. This feature makes no edit to that file |
+| A line number drifts before a task runs | A task edits the wrong line | Find the call site with the anchor text, not with the line number |
+
+### The operator tasks
+
+This session cannot run the tasks below. They need a live Mist organization, a live network
+host, a human reader, or a GitHub write token.
+
+| Task | What it needs |
+| - | - |
+| T012 | A live Mist organization and a laboratory switch |
+| T013 | A human reader on an interactive terminal |
+| T016, T027, T049, T066 | A GitHub write token for the pull request |
+| T024 | Live network hosts for a bulk SSH run |
+| T042 | A live Mist organization and the customer address file |
+| T048, T054 | A GitHub token with a write scope on the security events |
+| T059, T060, T061, T062, T063 | A GitHub token and a completed scan of `main` |


### PR DESCRIPTION
Refs #1733
Refs #1734
Refs #1735
Refs #1736
Refs #1737

## Scope

This pull request adds **specification artifacts only**. It contains no source code changes and no behavior changes.

Per the request to "start a speckit workflow but stop short of implementation", the `specify`, `plan`, and `tasks` phases are complete. The `implement` phase has **not** run.

## Problem

CodeQL reports clear-text logging of potentially sensitive information across several call sites. Issues #1733 through #1737 each cover one cluster of findings. Handling them one at a time risks inconsistent redaction rules, so this spec defines a single shared approach first.

## Contents

| Artifact | Purpose |
| - | - |
| `spec.md` | Problem, goals, non-goals, acceptance criteria |
| `plan.md` | Technical approach and sequencing |
| `research.md` | CodeQL rule analysis and redaction options |
| `data-model.md` | Redaction categories and field classification |
| `quickstart.md` | How to verify a fix locally |
| `tasks.md` | 66 tasks, grouped into 4 follow-up pull requests |
| `contracts/` | Two interface contracts for the redaction helpers |
| `checklist.md` | Reviewer checklist |

## Key decisions recorded

- Never hash a secret to label it. CodeQL flags SHA-256 on sensitive data as `py/weak-sensitive-data-hashing` at HIGH severity. Only PBKDF2, bcrypt, scrypt, or Argon2 are acceptable for password storage, and none of those belong in a log line.
- Use a positional label such as `2/3` when a log line must identify which credential it means.
- 15 tasks are marked **pending-operator**. They need a decision from a human before implementation starts.

## Verification

- All 9 artifacts score 95 to 99 on the STE linter.
- No source files are touched, so the code gates are unaffected.

## Next step

Review and merge the spec. Implementation will follow in the 4 pull requests that `tasks.md` describes, each linked to its originating issue.

## Conformance

- [x] Spec artifacts complete through the `tasks` phase
- [x] STE compliant
- [x] No source changes
- [x] No secrets added
- [ ] Implementation (deliberately deferred)
