### PR TITLE
fix(docs): correct the mermaid diagrams and the counts they show

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ flowchart LR
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 mindmap
-   root((MistHelper<br/>210 Operations))
+   root((MistHelper<br/>230 Operations))
     Safe Org Exports (61)
       Sites and Analysis 1-7
       Device Inventory 8-13
@@ -137,13 +137,16 @@ mindmap
       Support and Assets 188, 193
       Address and License 195-196
       JSI and Mist Edge 204-205
-    Interactive Safe (45)
+    Interactive Safe (65)
       Site Devices 60-72
       Site Insights 73-79
       Site Stats 80-91
       Viewers 92-96
       Site Searches 197-203
-      Site Beacon 209
+      Site Beacon and Assets 209-213
+      Site Event Searches 214-220
+      Site Client and Device Searches 221-224
+      Site Stats and Zones 225-229
     Resource Intensive (10)
       Heavy Inventory 14, 18-19
       Bulk Exports 59

--- a/documentation/diagrams/core/architecture-overview.md
+++ b/documentation/diagrams/core/architecture-overview.md
@@ -23,7 +23,7 @@ flowchart TB
     ci_system(["CI/CD System<br/>GitHub Actions"])
 
     subgraph misthelper["MistHelper"]
-        mh["Python CLI tool<br/>209 operations"]
+        mh["Python CLI tool<br/>229 operations"]
     end
 
     mist_cloud["Juniper Mist Cloud<br/>REST API + WebSocket"]
@@ -166,7 +166,7 @@ flowchart TD
 
 | Subsystem | Primary Classes | Purpose |
 |-----------|----------------|---------|
-| Menu System | `OperationRegistry`, `MistHelperTUI` | 193-operation interactive/CLI menu |
+| Menu System | `OperationRegistry`, `MistHelperTUI` | 229-operation interactive/CLI menu |
 | API Layer | `APIFetchUtils`, `RateLimitingUtils` | Paginated API calls with adaptive rate limiting |
 | Data Exporters | `DataExporter`, `SQLiteDatabaseWriter`, `DatabaseRouter` | Multi-backend output (CSV/SQLite/ArangoDB/Redis) with business keys |
 | WebSocket | `WebSocketManager`, `WebSocketCommands`, `ServicePingManager` | Real-time device commands plus extracted service-ping orchestration |

--- a/documentation/diagrams/core/database-strategy.md
+++ b/documentation/diagrams/core/database-strategy.md
@@ -6,7 +6,7 @@ Hybrid primary key system and PK strategy decision flowchart for MistHelper's SQ
 
 ## Entity Relationship Diagram
 
-Representative tables showing the three PK strategies used across MistHelper's 209 operations.
+Representative tables showing the three PK strategies used across MistHelper's 229 operations.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {

--- a/documentation/diagrams/infrastructure/deployment-pipeline.md
+++ b/documentation/diagrams/infrastructure/deployment-pipeline.md
@@ -101,7 +101,7 @@ How feature branches flow through the auto-merge pipeline.
   'tertiaryColor': '#1A1A2E',
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
-gitgraph
+gitGraph
     commit id: "main"
     branch feature/new-operation
     checkout feature/new-operation

--- a/documentation/diagrams/operations/metrics-and-analytics.md
+++ b/documentation/diagrams/operations/metrics-and-analytics.md
@@ -6,7 +6,7 @@ Operation distribution, rate limiting behavior, data flow volumes, and version h
 
 ## Operation Category Distribution
 
-How MistHelper's 209 operations break down by safety classification.
+How MistHelper's 229 operations break down by safety classification.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -27,13 +27,13 @@ How MistHelper's 209 operations break down by safety classification.
   'pieTitleTextColor': '#E0E0E0',
   'pieSectionTextColor': '#E0E0E0'
 }, 'pie': {'textPosition': 0.75}}}%%
-pie title Operation Safety Classification (193 total)
-    "Safe (59)" : 59
-    "Destructive (40)" : 40
-    "Interactive Safe (37)" : 37
-    "Interactive (27)" : 27
+pie title Operation Safety Classification (229 actionable, menu 0 excluded)
+    "Interactive Safe (65)" : 65
+    "Safe (61)" : 61
+    "Destructive (41)" : 41
+    "Interactive (28)" : 28
     "WebSocket (22)" : 22
-    "Resource Intensive (6)" : 6
+    "Resource Intensive (10)" : 10
     "Continuous (2)" : 2
 ```
 
@@ -177,7 +177,7 @@ timeline
                 : Auto-merge workflow
                 : Web portal (Gunicorn)
     section Current
-        2026 : 209 operations
+        2026 : 229 operations
              : 30-group menu reorg (issue #368)
              : SpecKit integration
              : Mermaid documentation suite

--- a/documentation/diagrams/operations/operations-reference.md
+++ b/documentation/diagrams/operations/operations-reference.md
@@ -84,7 +84,10 @@ journey
 
 ## Destructive Operation Safety Requirements
 
-Requirements that MUST be met before any destructive operation (Menu 154-194) executes.
+Requirements that MUST be met before any destructive operation executes. The
+destructive set is menus 154-187, 189-191, 194, and 206-208. It is not one
+unbroken block, so do not treat any range boundary as a shortcut. Menus 188 and
+193 sit inside those numbers and are safe, and menu 192 is interactive.
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {
@@ -97,7 +100,7 @@ Requirements that MUST be met before any destructive operation (Menu 154-194) ex
   'fontFamily': 'ui-monospace, monospace'
 }}}%%
 flowchart TB
-    subgraph requirements["Safety Requirements - Menu 154-194"]
+    subgraph requirements["Safety Requirements - Menus 154-187, 189-191, 194, 206-208"]
         SAF001["SAF-001: Explicit Confirmation<br/>Type exact word to proceed<br/>Risk: HIGH | Verify: test"]
         SAF002["SAF-002: EOF Handling<br/>All input calls handle EOFError<br/>Risk: HIGH | Verify: inspection"]
         SAF003["SAF-003: No Blind Automation<br/>--menu flag requires confirmation<br/>Risk: HIGH | Verify: test"]


### PR DESCRIPTION
Audits every mermaid diagram in the repository against the source **and** against a real mermaid parser. 38 diagrams checked across 18 files.

## One diagram never rendered at all

`documentation/diagrams/infrastructure/deployment-pipeline.md` declared **`gitgraph`**. Mermaid requires **`gitGraph`**. The block failed to parse, so GitHub rendered an error box instead of the branch flow.

This was only found by running the diagrams through the actual mermaid library. No existing gate catches it — `scripts/lint_diagram_refs.py` validates that *references resolve*, not that diagrams *parse*.

Worth noting my first validation attempt reported **36 of 38 failing** with `DOMPurify.sanitize is not a function`. That was my harness lacking a DOM, not the diagrams. After adding jsdom the real count was 1. I mention it because "36 diagrams are broken" would have been a badly wrong conclusion to act on.

## One diagram stated a wrong destructive range

`operations-reference.md` said destructive operations are **"Menu 154-194"**. The real set is **154-187, 189-191, 194, 206-208**.

That matters for a NOC engineer:

| Menu | Old text implies | Actually |
| - | - | - |
| 188 | destructive | **safe** |
| 192 | destructive | interactive |
| 193 | destructive | **safe** |
| 206-208 | not destructive | **destructive** |

So it both over-warned on three safe operations and, more seriously, **omitted three genuinely destructive ones**. The heading and subgraph label now list the true set and state that it is not one unbroken block.

## Stale counts corrected

All measured from `MistHelper.menu_actions` and `OperationRegistry.skip_category`, not copied between documents.

| File | Was | Now |
| - | - | - |
| architecture-overview.md (node label) | 209 operations | 229 |
| architecture-overview.md (table row) | 193-operation menu | 229-operation |
| database-strategy.md | 209 operations | 229 |
| metrics-and-analytics.md (intro) | 209 operations | 229 |
| metrics-and-analytics.md (timeline) | 2026 : 209 | 229 |
| README.md mindmap root | 210 Operations | 230 |
| README.md Interactive Safe branch | 45 | 65 |

### The pie chart was the worst of them

It claimed **193 total** and every slice was wrong:

| Slice | Chart said | Actual |
| - | - | - |
| Safe | 59 | 61 |
| Destructive | 40 | 41 |
| Interactive Safe | 37 | **65** |
| Interactive | 27 | 28 |
| WebSocket | 22 | 22 |
| Resource Intensive | 6 | **10** |
| Continuous | 2 | 2 |

It was internally consistent, which is why it never looked obviously broken — it just described a much older codebase. Now shows measured values and states that menu 0 is excluded.

### README mindmap now adds up

The branch values previously summed to 210 while the code had 229 actionable entries. They now sum to **230**, matching the root and matching `menu_actions` including Exit. The Interactive Safe branch lists menus 209-229 rather than menu 209 alone.

## Verification

| Check | Result |
| - | - |
| mermaid 11 parse (jsdom DOM) | **38 of 38 parse, 0 failed** |
| `scripts/lint_diagram_refs.py` | 125 references validated across 16 files |
| Mindmap branch sum vs root | 230 = 230 |
| Category values vs `OperationRegistry` | all 7 match |

No build artifacts left behind — mermaid and jsdom were installed in a temp directory outside the repo, so no `node_modules` or `package.json` was added here.

## Conformance

- [x] Every number measured from source, not copied
- [x] All diagrams verified to parse with a real renderer
- [x] No secrets added
- [x] Diagram reference lint passes
