### PR TITLE
docs(specs): specify the two findings the widened report scope revealed

### DIFF
--- a/specs/1771-critical-complexity-scripts-tests/spec.md
+++ b/specs/1771-critical-complexity-scripts-tests/spec.md
@@ -1,0 +1,86 @@
+# Feature Specification: Critical Complexity in scripts/ and tests/ (#1771)
+
+**Branch**: `refactor/1771-critical-complexity-scripts-tests`
+**Created**: 2026-08-05
+**Issue**: <https://github.com/jmorrison-juniper/MistHelper/issues/1771>
+**Status**: Specified. Implementation not started.
+
+## Problem / Goal
+
+Three symbols carry critical cyclomatic complexity. All three sit in areas that
+no gate and no earlier spec covered.
+
+| Symbol | Location | Complexity | Target |
+| - | - | - | - |
+| `summarize` | `scripts/analyze_marvis_pcap.py:26` | 49 | <= 5 |
+| `test_v2_cache_promotes_to_v3_shape_in_memory` | `tests/unit/utils/test_zscaler_catalogue.py:509` | 49 | <= 5 |
+| `_render_section` | `scripts/probe_zscaler_endpoints.py:191` | 21 | <= 5 |
+
+They became visible on 2026-08-05, when the compliance analyzer first ran across
+the whole repository instead of `MistHelper.py` and `src` alone.
+
+### Goal
+
+Bring all three to a complexity the analyzer accepts, and decide whether the CI
+radon gate should cover the areas that hid them.
+
+### Non-goals
+
+- The 297 high-severity findings. Specs 1008 and 1009 already hold that backlog.
+- Any behavior change. Each symbol must produce the same output as before.
+
+## Why this is not already covered
+
+Spec `433-full-repo-compliance-sweep` set "5 critical violations to 0" as its
+Target D. Issue #433 is closed and its other targets are met:
+
+| Target | Then | Now |
+| - | - | - |
+| `src/firmware/site_auto_upgrade.py` | 27 / F | 100.0 / A+ |
+| `src/maps/maps_manager.py` | 40 / F | 100.0 / A+ |
+
+The `src/` work landed. These three were never in scope, because at the time
+nothing analyzed `scripts/` or `tests/`.
+
+## Interfaces & Behavior
+
+No public interface changes. `summarize` and `_render_section` are internal to
+their scripts. The test keeps its name, or splits into named cases.
+
+## Constraints
+
+- Output must not change. `summarize` and `_render_section` build reports that a
+  reader compares between runs.
+- The 5-Item Rule applies to every helper this work extracts.
+- The test case must stay deterministic.
+
+## Test Plan
+
+1. Capture the current output of both scripts on a fixed input. Compare byte for
+   byte after the refactor.
+2. Run the existing `test_zscaler_catalogue.py` suite before and after. The same
+   assertions must hold.
+3. Re-run the compliance analyzer repository-wide. Confirm 0 critical findings.
+
+## Open Questions
+
+1. Should the CI radon gate extend past `src/`? Without that, these can regress
+   silently. The gate currently runs `radon cc src/`.
+2. The test at complexity 49 branches 49 ways in one case. Split into separate
+   cases, or parametrize? A reader cannot currently tell which path ran when it
+   passes.
+3. Are `scripts/` and `tests/` held to the same 5-Item Rule as `src/`? The
+   analyzer applies it. No written decision records whether that is intended.
+
+## Acceptance Criteria
+
+- [ ] All three symbols report complexity <= 10, ideally <= 5.
+- [ ] The analyzer reports 0 critical STRUCT-COMPLEXITY findings repo-wide.
+- [ ] Script output is unchanged, proven by a captured comparison.
+- [ ] A recorded decision on the radon gate scope.
+
+## Next Step
+
+Run `speckit.plan`. Question 1 and question 3 need an answer before the task
+list can be written, because they decide whether this is a three-symbol fix or
+the first slice of a wider policy change.

--- a/specs/1772-test-quality-triage/spec.md
+++ b/specs/1772-test-quality-triage/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Triage the Test Quality Findings (#1772)
+
+**Branch**: `test/1772-test-quality-triage`
+**Created**: 2026-08-05
+**Issue**: <https://github.com/jmorrison-juniper/MistHelper/issues/1772>
+**Status**: Specified. Implementation not started.
+
+## Problem / Goal
+
+The test quality analyzer reports 1596 findings. None are triaged.
+
+Spec `1019-test-quality-analyzer` is complete at 60/60 tasks. It delivered the
+tool. It did not act on the output.
+
+| Severity | Count |
+| - | - |
+| high | 35 |
+| medium | 1561 |
+
+### Goal
+
+Turn 1596 raw findings into a small set of recorded decisions plus a short list
+of real work.
+
+### Non-goals
+
+- Fixing 1596 findings one at a time. The dominant rules collapse into a few
+  policy choices.
+- Changing the analyzer itself. Scope and baseline defects are tracked
+  separately.
+
+## Findings
+
+All 35 high findings are the single rule `untested_public_function`:
+
+| Area | Count |
+| - | - |
+| `tests/unit` | 21 |
+| `tests/integration` | 5 |
+| `tests/conftest.py` | 3 |
+| `tests/e2e` | 2 |
+| `tests/fixtures` | 2 |
+| other | 2 |
+
+The five largest medium rules:
+
+| Rule | Count |
+| - | - |
+| `weak_zero_assertions` | 698 |
+| `weak_is_not_none` | 230 |
+| `missing_ec_negative_value` | 119 |
+| `missing_ec_zero_value` | 85 |
+| `weak_bare_assert` | 73 |
+
+Those five are 1205 of the 1561 medium findings, so four or five decisions cover
+most of the set.
+
+## Reading the findings
+
+Six of the 35 high findings sit in `conftest.py` or `fixtures`. A fixture module
+is support code, not a subject under test, so `untested_public_function` there is
+likely rule noise rather than a coverage gap. Triage must therefore separate rule
+tuning from real gaps before anyone writes a test.
+
+`weak_zero_assertions` at 698 says a large share of the suite asserts that a
+count equals zero rather than asserting the specific outcome. That is a real
+weakness, because such an assertion passes when the code under test does nothing
+at all. It still needs one policy decision rather than 698 edits.
+
+## Constraints
+
+- No test may be weakened to clear a finding.
+- Any rule that is tuned must have the reason recorded, so a later reader does
+  not simply re-enable it.
+
+## Test Plan
+
+1. Re-run the analyzer after each decision and record the finding count.
+2. For every high finding marked as a real gap, add a test that fails before the
+   fix and passes after.
+3. Confirm the full unit suite still passes at each step.
+
+## Dependencies
+
+Two analyzer defects should settle first, because both change which findings
+exist:
+
+- Analyzer scope. The roots were widened from `tests` to include
+  `mist-ops-platform/tests` on 2026-08-05, which moved the count from 1530 to
+  1596.
+- Baseline drift. Six baseline entries can never match again, so the gate
+  compares against a drifted reference.
+
+Re-recording the baseline before the root set settles would only need doing
+twice.
+
+## Open Questions
+
+1. Are `conftest.py` and `fixtures` in scope for `untested_public_function`? Six
+   of 35 high findings depend on the answer.
+2. What replaces a `weak_zero_assertions` call site? A blanket rewrite risks
+   asserting the wrong thing 698 times.
+3. Is a finding count a gate, or a report? If it gates, the baseline must be
+   correct first.
+
+## Acceptance Criteria
+
+- [ ] Every high finding is fixed, or recorded as intentional with a reason.
+- [ ] A recorded decision on support-module scope.
+- [ ] A recorded policy for `weak_zero_assertions`.
+- [ ] The baseline reports 0 stale entries.
+
+## Next Step
+
+Run `speckit.clarify`. All three open questions are policy choices that a person
+must make. Writing a plan before they are answered would guess at the shape of
+the work.


### PR DESCRIPTION
Refs #1771
Refs #1772

Adds specifications for the two findings that only became visible when the report generator scope was widened in #1770. **Both stop at the `specify` phase**, as requested — no plan, no tasks, no implementation.

## Why only two issues, not more

The fresh compliance report lists **2,380 tasks**. Creating an issue per finding would have been noise. I checked the existing specs first, and most of that backlog is already owned:

| Existing spec | Tasks | Covers |
| - | - | - |
| `1008-top20-violations-remediation` | 0/167 | high-severity violations |
| `1009-compliance-backlog-remediation` | 1/115 | compliance backlog |
| `1016-misthelper-suppression-cleanup` | 0/75 | suppressions |
| `198-radon-complexity-decomposition` | 2/44 | complexity |
| `1028-ste-compliance-cleanup` | 0/19 | STE |

Those are unstarted, not missing. Duplicating them would have created competing plans for the same work. So this PR covers only what genuinely has no owner.

## Spec 1771 — critical complexity in `scripts/` and `tests/`

Three symbols at critical severity:

| Symbol | Location | Complexity |
| - | - | - |
| `summarize` | `scripts/analyze_marvis_pcap.py:26` | **49** |
| `test_v2_cache_promotes_to_v3_shape_in_memory` | `tests/unit/utils/test_zscaler_catalogue.py:509` | **49** |
| `_render_section` | `scripts/probe_zscaler_endpoints.py:191` | **21** |

**I checked whether spec 433 already owned this.** It set "5 critical violations to 0" as Target D. It turns out #433 is **closed and its other targets are met**:

| Target | Then | Now |
| - | - | - |
| `src/firmware/site_auto_upgrade.py` | 27 / F | **100.0 / A+** |
| `src/maps/maps_manager.py` | 40 / F | **100.0 / A+** |

The `src/` work landed. These three were never in scope because nothing analyzed `scripts/` or `tests/` at the time. The CI radon gate runs `radon cc src/`, so it does not reach them either — which is why they can regress silently, and why the spec asks for a decision on gate scope rather than assuming one.

Worth noting the test case: complexity 49 in a **single test**. A test that branches 49 ways does not tell the reader which path ran when it passes.

## Spec 1772 — triage 1596 test quality findings

Spec `1019-test-quality-analyzer` is complete at 60/60. It delivered the tool but never acted on the output.

The spec deliberately argues **against** treating this as 1596 units of work. Five rules account for **1205 of the 1561** medium findings, so it is a few policy decisions:

| Rule | Count |
| - | - |
| `weak_zero_assertions` | 698 |
| `weak_is_not_none` | 230 |
| `missing_ec_negative_value` | 119 |
| `missing_ec_zero_value` | 85 |
| `weak_bare_assert` | 73 |

And 6 of the 35 high findings sit in `conftest.py` or `fixtures` — support code, not subjects under test — so `untested_public_function` there is probably rule noise, not a coverage gap. Triage has to separate those before anyone writes 35 tests.

The spec also records a dependency: the analyzer's scope and baseline defects should settle first, since both change which findings exist. Re-recording the baseline now would only need doing twice.

## Why these stop at `specify`

Each spec lists open questions that are **policy choices a person must make**, not details I can infer:

- Should the radon gate extend past `src/`?
- Are `conftest.py` and `fixtures` in scope for `untested_public_function`?
- What replaces a `weak_zero_assertions` call site? A blanket rewrite risks asserting the wrong thing 698 times.

Answering these changes the shape of the work, so planning ahead of them would be guessing.

## Verification

| Check | Result |
| - | - |
| STE linter, spec 1771 | 97/100 PASS |
| STE linter, spec 1772 | 98/100 PASS |
| Existing spec overlap | checked, 5 owning specs identified and excluded |

## Conformance

- [x] Specs stop before implementation, as requested
- [x] Existing spec coverage checked before creating new work
- [x] Open questions recorded rather than guessed
- [x] No secrets added
