### PR TITLE
fix(test): stop --test blocking on menus 195 and 196

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -257,16 +257,16 @@ is_running_in_container()  # Checks /.dockerenv, /run/.containerenv
 
 ## Menu System & Operations
 
-### Menu Categories (Full Range: 1-209)
+### Menu Categories (Full Range: 0-234)
 
 `src/utils/operation_registry.py` is the single source of truth. Read it before
-you trust this table. Counts were measured on 2026-08-04. Run
+you trust this table. Counts were measured on 2026-08-05. Run
 `python scripts/generate_menu_wiki.py` to regenerate the full reference.
 
 | Category | Count | Menu numbers |
 | - | - | - |
-| `safe` | 61 | 1-13, 15-17, 20-58, 188, 193, 195-196, 204-205 |
-| `interactive_safe` | 45 | 60-96, 197-203, 209 |
+| `interactive_safe` | 67 | 60-96, 195-203, 209-229 |
+| `safe` | 64 | 1-13, 15-17, 20-58, 188, 193, 204-205, 230-234 |
 | `destructive` | 41 | 154-187, 189-191, 194, 206-208 |
 | `interactive` | 29 | 0, 124-150, 192 |
 | `websocket` | 22 | 102-123 |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ mindmap
       Address and License 195-196
       JSI and Mist Edge 204-205
       Org Searches 230-234
-    Interactive Safe (65)
+    Interactive Safe (67)
       Site Devices 60-72
       Site Insights 73-79
       Site Stats 80-91
@@ -504,8 +504,8 @@ fails closed, so `--test` skips any option that the registry does not name
 
 | Category | Count | Menu numbers | Behavior under `--test` |
 |----------|-------|--------------|-------------------------|
-| `safe` | 66 | 1-13, 15-17, 20-58, 188, 193, 195-196, 204-205, 230-234 | Runs |
-| `interactive_safe` | 65 | 60-96, 197-203, 209-229 | Runs under `--testinteractive` |
+| `safe` | 64 | 1-13, 15-17, 20-58, 188, 193, 204-205, 230-234 | Runs |
+| `interactive_safe` | 67 | 60-96, 195-203, 209-229 | Runs under `--testinteractive` |
 | `destructive` | 41 | 154-187, 189-191, 194, 206-208 | Never runs |
 | `interactive` | 29 | 0, 124-150, 192 | Never runs |
 | `websocket` | 22 | 102-123 | Never runs |

--- a/documentation/menu_reference.md
+++ b/documentation/menu_reference.md
@@ -22,8 +22,8 @@ never runs in an automated test pass.
 
 | Menu numbers | Category | Summary |
 |---|---|---|
-| 1-13, 15-17, 20-58, 188, 193, 195-196, 204-205, 230-234 | Safe org exports | 66 operations. Read-only org exports. The --test run includes them. |
-| 60-96, 197-203, 209-229 | Interactive safe | 65 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
+| 60-96, 195-203, 209-229 | Interactive safe | 67 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
+| 1-13, 15-17, 20-58, 188, 193, 204-205, 230-234 | Safe org exports | 64 operations. Read-only org exports. The --test run includes them. |
 | 154-187, 189-191, 194, 206-208 | Destructive | 41 operations. They change the Mist cloud configuration. Each one needs a typed confirmation. |
 | 0, 124-150, 192 | Interactive | 29 operations. They prompt the operator, so no automated run includes them. |
 | 102-123 | WebSocket | 22 operations. They open a WebSocket stream to a device. |
@@ -229,8 +229,8 @@ never runs in an automated test pass.
 | 192 | View a support ticket with full comments and history | Interactive | `OrgTicketManager.view_ticket` |
 | 193 | Export all tickets with full details and comments | Safe org exports | `OrgTicketManager.export_ticket_details` |
 | 194 | DESTRUCTIVE: Clone Device Config to Gateway Template - Select a gateway, extract its local config, and create a new org gateway template (Requires typing 'CREATE' to confirm) | Destructive | `DeviceConfigTemplateClonerManager.clone` |
-| 195 | Audit site addresses from CSV (data/) - fuse Mist + SNMP + CSV hints, verify vs. web; READ-ONLY, saves report. Tier-3 browser geocoding auto-engages when available (ADDRESS_AUDIT_GEOCODE=off to skip) | Safe org exports | `lambda: AddressAuditEngine().run(apisession, ConfigUtils.get_cached_or_prompted_org_id())` |
-| 196 | Export async organization license-claim status summary (and optional per-device details) | Safe org exports | `LicenseExportUtils.export_org_license_async_claim_status` |
+| 195 | Audit site addresses from CSV (data/) - fuse Mist + SNMP + CSV hints, verify vs. web; READ-ONLY, saves report. Tier-3 browser geocoding auto-engages when available (ADDRESS_AUDIT_GEOCODE=off to skip) | Interactive safe | `lambda: AddressAuditEngine().run(apisession, ConfigUtils.get_cached_or_prompted_org_id())` |
+| 196 | Export async organization license-claim status summary (and optional per-device details) | Interactive safe | `LicenseExportUtils.export_org_license_async_claim_status` |
 | 197 | Download client packet captures grouped by VLAN (site -> client -> VLAN -> data/packet_captures/) | Interactive safe | `lambda: ClientPacketCaptureDownloader(apisession).run()` |
 | 198 | Search Site WAN Usages (searchSiteWanUsage) - Export per-site WAN usage records to SiteWanUsages.csv | Interactive safe | `SiteWanUsageExporter.wan_usages` |
 | 199 | Search Site Webhook Deliveries (searchSiteWebhooksDeliveries) - Per site+webhook delivery audit CSV | Interactive safe | `SiteWebhookDeliveriesExporter.deliveries` |

--- a/documentation/wiki/Menu-Reference.md
+++ b/documentation/wiki/Menu-Reference.md
@@ -22,8 +22,8 @@ never runs in an automated test pass.
 
 | Menu numbers | Category | Summary |
 |---|---|---|
-| 1-13, 15-17, 20-58, 188, 193, 195-196, 204-205, 230-234 | Safe org exports | 66 operations. Read-only org exports. The --test run includes them. |
-| 60-96, 197-203, 209-229 | Interactive safe | 65 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
+| 60-96, 195-203, 209-229 | Interactive safe | 67 operations. Read-only, but they prompt for a site or a device. The --testinteractive run includes them. |
+| 1-13, 15-17, 20-58, 188, 193, 204-205, 230-234 | Safe org exports | 64 operations. Read-only org exports. The --test run includes them. |
 | 154-187, 189-191, 194, 206-208 | Destructive | 41 operations. They change the Mist cloud configuration. Each one needs a typed confirmation. |
 | 0, 124-150, 192 | Interactive | 29 operations. They prompt the operator, so no automated run includes them. |
 | 102-123 | WebSocket | 22 operations. They open a WebSocket stream to a device. |
@@ -229,8 +229,8 @@ never runs in an automated test pass.
 | 192 | View a support ticket with full comments and history | Interactive | `OrgTicketManager.view_ticket` |
 | 193 | Export all tickets with full details and comments | Safe org exports | `OrgTicketManager.export_ticket_details` |
 | 194 | DESTRUCTIVE: Clone Device Config to Gateway Template - Select a gateway, extract its local config, and create a new org gateway template (Requires typing 'CREATE' to confirm) | Destructive | `DeviceConfigTemplateClonerManager.clone` |
-| 195 | Audit site addresses from CSV (data/) - fuse Mist + SNMP + CSV hints, verify vs. web; READ-ONLY, saves report. Tier-3 browser geocoding auto-engages when available (ADDRESS_AUDIT_GEOCODE=off to skip) | Safe org exports | `lambda: AddressAuditEngine().run(apisession, ConfigUtils.get_cached_or_prompted_org_id())` |
-| 196 | Export async organization license-claim status summary (and optional per-device details) | Safe org exports | `LicenseExportUtils.export_org_license_async_claim_status` |
+| 195 | Audit site addresses from CSV (data/) - fuse Mist + SNMP + CSV hints, verify vs. web; READ-ONLY, saves report. Tier-3 browser geocoding auto-engages when available (ADDRESS_AUDIT_GEOCODE=off to skip) | Interactive safe | `lambda: AddressAuditEngine().run(apisession, ConfigUtils.get_cached_or_prompted_org_id())` |
+| 196 | Export async organization license-claim status summary (and optional per-device details) | Interactive safe | `LicenseExportUtils.export_org_license_async_claim_status` |
 | 197 | Download client packet captures grouped by VLAN (site -> client -> VLAN -> data/packet_captures/) | Interactive safe | `lambda: ClientPacketCaptureDownloader(apisession).run()` |
 | 198 | Search Site WAN Usages (searchSiteWanUsage) - Export per-site WAN usage records to SiteWanUsages.csv | Interactive safe | `SiteWanUsageExporter.wan_usages` |
 | 199 | Search Site Webhook Deliveries (searchSiteWebhooksDeliveries) - Per site+webhook delivery audit CSV | Interactive safe | `SiteWebhookDeliveriesExporter.deliveries` |

--- a/src/utils/operation_registry.py
+++ b/src/utils/operation_registry.py
@@ -260,7 +260,10 @@ class OperationRegistry:
         "72": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "88": {"category": "interactive_safe", "skip_reason": "Requires AP model selection"},
         "25": {"category": "safe"},
-        "196": {"category": "safe"},
+        "196": {
+            "category": "interactive_safe",
+            "skip_reason": "Prompts for the per-device detail preference",
+        },
         "197": {"category": "interactive_safe", "skip_reason": "Requires site + client + VLAN selection"},
         "198": {"category": "interactive_safe", "skip_reason": "Requires site selection"},
         "199": {"category": "interactive_safe", "skip_reason": "Requires site + webhook selection"},
@@ -375,7 +378,11 @@ class OperationRegistry:
         "205": {"category": "safe"},  # OrgExportUtils.mist_edge_events - read-only export (spec 866 / #1374).
         "188": {"category": "safe"},  # OrgTicketManager.list_tickets - read-only ticket list export (no selection).
         "193": {"category": "safe"},  # OrgTicketManager.export_ticket_details - read-only (exports all, no selection).
-        "195": {"category": "safe"},  # Site address audit - self-described READ-ONLY report.
+        # Read-only, but it prompts the operator to pick a CSV, so it is not unattended.
+        "195": {
+            "category": "interactive_safe",
+            "skip_reason": "Prompts the operator to choose a CSV file from data/",
+        },
         # --- heavy sweeps (resource_intensive) ------------------------------
         "14": {
             "category": "resource_intensive",

--- a/tests/unit/utils/test_prompting_menus_not_safe.py
+++ b/tests/unit/utils/test_prompting_menus_not_safe.py
@@ -1,0 +1,59 @@
+"""Guard the categories of the two operations that prompt during a sweep.
+
+Issue #1765. Menus 195 and 196 were classified `safe`, so `--test` invoked them
+unattended. Both call ``InputUtils.safe_input``. When stdin is a terminal,
+``input()`` blocks and the sweep never finishes. A live run stalled for 461
+seconds on menu 195 before an operator answered it.
+
+The README defines the two read-only categories by whether they prompt:
+
+- `safe` runs under ``--test`` and must not read stdin.
+- `interactive_safe` is read-only but prompts, and runs under
+  ``--testinteractive``.
+
+Both operations are read-only, so the read-only half was right. Both prompt, so
+the category was wrong.
+
+A general static guard is not practical here. A menu handler may be a lambda
+defined in ``MistHelper.py``, so the defining module of the handler is the
+entrypoint itself, and the entrypoint legitimately contains many prompts. A
+module-level scan would therefore flag almost every operation. The harness-level
+stdin guard proposed in issue #1765 is the general answer. This test locks the
+two known cases so they cannot silently regress.
+"""
+
+from __future__ import annotations  # WHY: PEP 604 unions on Python 3.10+.
+
+import pytest  # WHY: parametrized cases keep each menu reported separately.
+
+from src.utils.operation_registry import OperationRegistry
+
+# Each entry is a menu that prompts, with the prompt context recorded in the log.
+PROMPTING_MENUS = [
+    ("195", "address_audit_csv_pick"),
+    ("196", "org_license_claim_status:detail"),
+]
+
+
+class TestPromptingMenusAreNotSafe:
+    """A menu that reads stdin must never be classified `safe`."""
+
+    @pytest.mark.parametrize(("menu", "prompt_context"), PROMPTING_MENUS)
+    def test_menu_is_not_classified_safe(self, menu: str, prompt_context: str) -> None:
+        """`safe` means the sweep can run it unattended, which a prompt breaks."""
+        category = OperationRegistry.skip_category(menu)
+        assert category != "safe", (
+            f"Menu {menu} prompts at context '{prompt_context}', so classifying it 'safe' makes "
+            f"--test block on stdin. Use 'interactive_safe'. See issue #1765."
+        )
+
+    @pytest.mark.parametrize(("menu", "prompt_context"), PROMPTING_MENUS)
+    def test_menu_is_interactive_safe(self, menu: str, prompt_context: str) -> None:
+        """Both operations are read-only, so `interactive_safe` is the right category."""
+        assert OperationRegistry.skip_category(menu) == "interactive_safe"
+
+    @pytest.mark.parametrize(("menu", "prompt_context"), PROMPTING_MENUS)
+    def test_menu_records_why_the_sweep_skips_it(self, menu: str, prompt_context: str) -> None:
+        """A skip reason tells the next reader why the sweep passes the menu over."""
+        reason = OperationRegistry.skip_reason(menu)
+        assert reason, f"Menu {menu} needs a skip_reason naming the prompt."


### PR DESCRIPTION
Closes #1765

Both menus were classified `safe`, so the `--test` sweep invoked them unattended. Both call `InputUtils.safe_input`, and when stdin is a terminal `input()` blocks forever.

A live run against a real org **stalled for 461 seconds** on menu 195 before I answered the prompt by hand, then stalled again on menu 196.

| Menu | Prompt context | Was | Now |
| - | - | - | - |
| 195 | `address_audit_csv_pick` | safe | interactive_safe |
| 196 | `org_license_claim_status:detail` | safe | interactive_safe |

## Why it passed CI

The code has an EOF abort path, commented as covering non-TTY `--test`. That holds in CI, where stdin is closed and `safe_input` returns empty immediately. From an interactive terminal it blocks.

So `--test` was only unattended-safe when stdin happened to be closed: green in CI, hung on a laptop. That is the kind of assumption that survives every gate and fails the first person who runs it by hand.

The registry comment on 195 shows how it arose:

```python
"195": {"category": "safe"},  # Site address audit - self-described READ-ONLY report.
```

Classified on *does it write*, not *does it prompt*. Both operations are read-only, so that half was right. The README defines `interactive_safe` as "Read-only, but they prompt", which is exactly these two.

## On the general guard

I deliberately did not add a static scan. Menu 195's handler is a **lambda defined in `MistHelper.py`**, so its defining module is the entrypoint, which legitimately contains many prompts — a module-level scan would flag nearly every operation and be worse than useless.

The harness-level stdin guard proposed in #1765 is the real general answer: make a `safe` operation that reads stdin fail immediately with the operation named, rather than block. That is a change to the sweep loop and is left as follow-up. This test locks the two known cases against regression, and the test file records why the static approach was rejected.

## Verification

| Check | Result |
| - | - |
| New guard test | 6 passed |
| Registry guardrails | 48 passed |
| `ruff check .` | All checks passed |
| `black --check .` | 983 files unchanged |

## Effect

Unblocks running `--test` unattended, which is the precondition for exercising `--testinteractive` against a live site.

## Conformance

- [x] Root cause fixed, not suppressed
- [x] Regression test added
- [x] Rejected approach documented rather than silently skipped
- [x] No secrets added
