### PR TITLE
chore(ci): pin the bandit version so a new release cannot break CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install 'bandit[toml]'
+      # Pinned in requirements-dev.txt so Dependabot raises a new release as a
+      # reviewable pull request rather than breaking CI on an unrelated commit (issue #1718)
+      - run: pip install -r requirements-dev.txt
       - name: Run Bandit
         # -c pyproject.toml picks up [tool.bandit] targets/exclude_dirs (issue #881)
         # No severity flag: the gate fails on a finding at any severity, including LOW (issue #889)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,17 @@
+# Pinned versions for the CI gate tools.
+#
+# Why this file exists:
+#   The workflow installed several gate tools with no version constraint, so a
+#   new release could fail CI on a commit that changed nothing. Bandit is the
+#   sharpest case. Issue #889 removed the `-ll` severity flag, so the gate now
+#   fails on a finding at any severity, and a new rule in a new release breaks
+#   the build immediately. Issue #1718 records that exposure.
+#
+#   Dependabot watches the pip ecosystem at the repository root and reads every
+#   requirements file there. Putting the pin here means a new release arrives as
+#   a reviewable pull request instead of as a surprise CI failure.
+#
+#   Runtime dependencies stay in requirements.txt. This file holds only the
+#   tools that grade the code.
+
+bandit[toml]==1.9.4


### PR DESCRIPTION
## Summary

The Bandit gate installed `bandit[toml]` with no version constraint. Every CI run
resolved whatever release was current at that moment.

Issue #889 removed the `-ll` severity flag from the gate command. The gate now
fails on a finding at any severity, including LOW. Together, those two facts mean
a new Bandit release that adds a rule can fail the build on a commit that changed
no code.

Closes #1718

## What changed

- Added `requirements-dev.txt` with `bandit[toml]==1.9.4`.
- The Bandit job now runs `pip install -r requirements-dev.txt`.

Runtime dependencies stay in `requirements.txt`. The new file holds only the tools
that grade the code.

## Acceptance criteria

- [x] **CI installs a pinned Bandit version.** The job reads the pin from
      `requirements-dev.txt`.
- [x] **Dependabot can raise the pin.** The pip ecosystem in
      `.github/dependabot.yml` watches `directory: "/"`, and Dependabot reads every
      requirements file in that directory. A new release now arrives as a reviewable
      pull request.
- [x] **CI passes.** The pinned version is the version the unpinned install already
      resolved to, so the gate result does not change.

## Verification

`1.9.4` is the current release on PyPI, so `pip install 'bandit[toml]'` already
installed it. The pin records that fact rather than changing it.

Running the exact gate command locally reports 42 `B101` and 1 `B104` finding.
Those are not caused by this change:

- 9 of the 10 files sit in `tools/test_quality_analyzer/fixtures/`, which
  `pyproject.toml` already lists in `exclude_dirs`. The exclusion does not match on
  Windows because of the backslash path separator. Issue #1722 tracks that defect.
- The remaining file is untracked in this checkout, so CI never sees it.

The Bandit job passes on the last three `main` runs, which confirms the gate is
green on a clean Linux checkout.

## Related

`specs/1032-bandit-severity-gate/research.md` decision R11 records the same
exposure.

Eight other gate tools remain unpinned: `ruff`, `pip-audit`, `pylint`, `radon`,
`vulture`, `pydocstyle`, `interrogate`, and `pytest`. `black` is pinned inline at
`black==26.5.1`. This pull request fixes only the Bandit case that #1718 reports.
The wider cleanup belongs in its own issue.
