### PR TITLE
security: replace the inert ruff noqa S annotations with real suppressions

### DIFF
--- a/scripts/migrate_sqlite_to_polyglot.py
+++ b/scripts/migrate_sqlite_to_polyglot.py
@@ -116,7 +116,7 @@ class SqliteReader:
     def read_table(self, table_name: str) -> list[dict]:
         """Read all rows from a table as list of dicts."""
         cursor = self._connection.cursor()
-        cursor.execute(f'SELECT * FROM "{table_name}"')  # noqa: S608
+        cursor.execute(f'SELECT * FROM "{table_name}"')  # nosec B608 - name comes from sqlite_master
         columns = [desc[0] for desc in cursor.description]
         rows = []
         for row in cursor.fetchall():

--- a/src/gateway/_wan2_variable_device.py
+++ b/src/gateway/_wan2_variable_device.py
@@ -368,7 +368,7 @@ class _Wan2VariableDevice(_ClusterBase):
 
     def _migrate_devices_fast(self, devices: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Migrate devices using connection pool (fast mode)."""
-        assert self._pool_fn is not None  # noqa: S101  # nosec B101 - The use_fast gate proved the pool exists.
+        assert self._pool_fn is not None  # nosec B101 - The use_fast gate proved the pool exists.
 
         count = len(devices)  # WHY: banner count
         # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.

--- a/src/utils/zscaler_catalogue.py
+++ b/src/utils/zscaler_catalogue.py
@@ -677,7 +677,7 @@ def fetch_cloud(cloud: str, *, timeout: float = _FETCH_TIMEOUT) -> dict[str, Any
     url = _CENR_URL_TEMPLATE.format(cloud=cloud)
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "MistHelper-menu206/1.0"})
-        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 -- fixed HTTPS host  # nosec B310
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310 - the host is a fixed HTTPS URL
             status = getattr(resp, "status", 200)
             if status != 200:
                 logger.warning(

--- a/src/utils/zscaler_probe.py
+++ b/src/utils/zscaler_probe.py
@@ -181,7 +181,7 @@ def _icmp_ping(host: str, timeout: float) -> bool:
     timeout_val = str(int(timeout * 1000)) if is_win else str(int(timeout))
     cmd = ["ping", count_flag, "1", timeout_flag, timeout_val, host]
     try:
-        completed = subprocess.run(  # noqa: S603 - args are validated above
+        completed = subprocess.run(  # the argv parts are validated above
             cmd,  # nosec B603 - shell stays False, so host becomes one argv element and cannot start a program.
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

Ruff selects `["E", "F", "W", "I", "UP", "B", "G"]` in `pyproject.toml`. The `S`
family, which holds the flake8-bandit rules, is not in that list. Every
`# noqa: S...` annotation in the tree therefore suppressed nothing. Ruff never
raised the rule, and bandit reads `# nosec` only.

An annotation that suppresses nothing is worse than no annotation. A reader sees
`# noqa: S104` and believes somebody reviewed and accepted a security finding.
Nobody did.

Closes #1719

## What changed

A search of the whole tree found the annotation in 4 tracked files. Everything
else sits in `.venv` or in the `specs/1032-bandit-severity-gate/` documents that
describe this defect.

| File | Before | After | Reason |
| - | - | - | - |
| `src/gateway/_wan2_variable_device.py` | `# noqa: S101  # nosec B101 - ...` | `# nosec B101 - ...` | The `# nosec` half already worked. Removed the inert half. |
| `src/utils/zscaler_catalogue.py` | `# noqa: S310 -- fixed HTTPS host  # nosec B310` | `# nosec B310 - the host is a fixed HTTPS URL` | The `# nosec` half already worked. Kept the reason in the `# nosec` text. |
| `src/utils/zscaler_probe.py` | `# noqa: S603 - args are validated above` | `# the argv parts are validated above` | The working `# nosec B603` sits on the argument line below. Nothing to suppress here, so this is now a plain comment. |
| `scripts/migrate_sqlite_to_polyglot.py` | `# noqa: S608` | `# nosec B608 - name comes from sqlite_master` | Bandit never scanned the file, because `pyproject.toml` excludes `scripts`. A real suppression now protects the line if that exclusion changes. |

The `B608` case is a false positive. `table_name` comes from a `sqlite_master`
query at line 113 of the same file, not from a user.

## A detail worth reviewing

Each suppression stays on the line bandit reports. My first attempt used longer
justifications, and black then split the call and pushed the `# nosec` down to
the closing parenthesis, where it may no longer bind to the finding. Shorter
comments keep the annotation in place. Please keep that constraint in mind for
future edits to these lines.

## Verification

- Bandit reports 0 findings at every severity on the CI targets, exit code 0,
  with 78 suppressions still active.
- `ruff check .` passes on the whole repository.
- `black --check` leaves all 4 files unchanged.
- 279 unit tests covering these modules pass.

## Not in scope

**`mist-ops-platform/src/shared/config/settings.py:41`** carries
`api_host: str = "0.0.0.0"  # noqa: S104`, and issue #1719 names it. I did not
change it. Git does not track that file, because line 244 of `.gitignore`
matches it through the `config/` pattern. An edit there cannot be committed.

The surrounding project has 110 tracked files, so the broad `config/` rule looks
like an accident rather than a decision. That deserves its own issue, because
un-ignoring the file exposes a MEDIUM `B104` finding, and issue #889 removed the
severity flag that used to let a MEDIUM pass.

**Point 3 of the issue** asks whether ruff should select `S` at all. That
duplicates bandit and needs a decision from the team, so this pull request leaves
it open.
