### PR TITLE
ci: pin every gate tool version in requirements-dev.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install ruff
+      - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Ruff lint
         run: ruff check .
 
@@ -115,7 +115,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install black==26.5.1
+      - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Black format check
         run: black --check --diff .
 
@@ -154,7 +154,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install 'mypy<2.0' 'types-requests<2.33.0.20260503' types-paramiko types-tqdm
+          pip install -r requirements-dev.txt  # pinned mypy and stubs (issue #1779)
       - name: Run mypy
         run: mypy ${{ env.SRC_PATH }} --config-file pyproject.toml
 
@@ -188,7 +188,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest pytest-cov hypothesis
+          pip install -r requirements-dev.txt  # pinned pytest stack (issue #1779)
       - name: Run tests with coverage
         run: pytest --cov=${{ env.SRC_PATH }} --cov-fail-under=${{ env.COVERAGE_THRESHOLD }}
 
@@ -217,7 +217,7 @@ jobs:
           cache: pip
       # Pinned in requirements-dev.txt so Dependabot raises a new release as a
       # reviewable pull request rather than breaking CI on an unrelated commit (issue #1718)
-      - run: pip install -r requirements-dev.txt
+      - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Run Bandit
         # -c pyproject.toml picks up [tool.bandit] targets/exclude_dirs (issue #881)
         # No severity flag: the gate fails on a finding at any severity, including LOW (issue #889)
@@ -252,7 +252,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install pip-audit
+      - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Run pip-audit
         # Reviewed 2026-07-28 under issue #890. Both historical --ignore-vuln entries
         # are removed. `pip-audit -r requirements.txt` with no ignore flags reports
@@ -291,7 +291,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pylint
+          pip install -r requirements-dev.txt  # pinned pylint (issue #1779)
       # The package exclusion lives in [tool.pylint.main] ignore-paths in pyproject.toml,
       # not on this line. Issue #891 moved it there so one file holds the gate config.
       # That comment carries the reason, the measurements, and the removal plan.
@@ -310,7 +310,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install radon
+      - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Check cyclomatic complexity
         run: |
           radon cc ${{ env.SRC_PATH }} -a -nb
@@ -342,7 +342,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install vulture
+      - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Detect dead code
         run: vulture ${{ env.SRC_PATH }} --min-confidence ${{ env.VULTURE_CONFIDENCE }}
 
@@ -361,7 +361,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install "pydocstyle[toml]"
+      - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Check docstring conventions
         run: pydocstyle ${{ env.SRC_PATH }}
 
@@ -377,7 +377,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
-      - run: pip install interrogate
+      - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Check docstring coverage
         run: interrogate ${{ env.SRC_PATH }} --fail-under ${{ env.INTERROGATE_THRESHOLD }} -v
 
@@ -442,7 +442,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest pytest-timeout
+          pip install -r requirements-dev.txt  # pinned pytest and timeout plugin (issue #1779)
       - name: Run E2E smoke tests
         run: pytest tests/e2e/ -v --timeout=60
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,17 +1,54 @@
 # Pinned versions for the CI gate tools.
 #
 # Why this file exists:
-#   The workflow installed several gate tools with no version constraint, so a
-#   new release could fail CI on a commit that changed nothing. Bandit is the
-#   sharpest case. Issue #889 removed the `-ll` severity flag, so the gate now
-#   fails on a finding at any severity, and a new rule in a new release breaks
-#   the build immediately. Issue #1718 records that exposure.
+#   The workflow installed the gate tools with no version constraint, so a new
+#   release could fail CI on a commit that changed nothing. Each gate fails on a
+#   threshold or on a finding count, so a new rule, a new default, or a changed
+#   score moves the result without any change to this repository.
+#
+#   Two gates hold very little margin. Pylint scores 9.53 against a 9.5 floor.
+#   Radon fails when any block passes complexity 10. Bandit fails on a finding at
+#   any severity, because issue #889 removed the severity flag.
 #
 #   Dependabot watches the pip ecosystem at the repository root and reads every
-#   requirements file there. Putting the pin here means a new release arrives as
+#   requirements file there. Putting the pins here means a new release arrives as
 #   a reviewable pull request instead of as a surprise CI failure.
 #
-#   Runtime dependencies stay in requirements.txt. This file holds only the
-#   tools that grade the code.
+#   Issue #1718 started this file with bandit. Issue #1779 added the rest.
+#
+# How to change a pin:
+#   Let Dependabot raise it. If you raise one by hand, run the matching gate
+#   first and record the result in the pull request.
+#
+# Runtime dependencies stay in requirements.txt. This file holds only the tools
+# that grade the code. Every version below is the version CI already resolved, so
+# these pins do not change any gate result.
 
+# Lint and format
+ruff==0.16.1
+black==26.5.1
+
+# Type checking
+mypy==1.20.2
+types-requests==2.33.0.20260408
+types-paramiko==5.0.0.20260724
+types-tqdm==4.70.0.20260805
+
+# Tests and coverage
+pytest==9.1.1
+pytest-cov==7.1.0
+pytest-timeout==2.4.0
+hypothesis==6.165.2
+
+# Security
 bandit[toml]==1.9.4
+pip-audit==2.10.1
+
+# Code quality
+pylint==4.0.6
+radon==6.0.1
+vulture==2.16
+
+# Docstrings
+pydocstyle[toml]==6.3.0
+interrogate==1.7.0


### PR DESCRIPTION
## Summary

The workflow installed nine gate tools with no version constraint. A new release
of any one of them could fail the build on a commit that changed nothing.

Every gate fails on a threshold or on a finding count, so a new rule, a new
default, or a changed score moves the result without any change to this
repository. Two gates hold very little margin:

- **pylint** scores 9.53 against a 9.5 floor. One new check can fail it.
- **radon** fails when any block passes complexity 10. A change to how radon
  counts a construct moves every score at once.

Closes #1779

## What changed

`requirements-dev.txt` now pins every gate tool. Each gate job installs from that
file.

| Tool | Pin |
| - | - |
| ruff | 0.16.1 |
| black | 26.5.1 |
| mypy | 1.20.2 |
| types-requests | 2.33.0.20260408 |
| types-paramiko | 5.0.0.20260724 |
| types-tqdm | 4.70.0.20260805 |
| pytest | 9.1.1 |
| pytest-cov | 7.1.0 |
| pytest-timeout | 2.4.0 |
| hypothesis | 6.165.2 |
| bandit[toml] | 1.9.4 |
| pip-audit | 2.10.1 |
| pylint | 4.0.6 |
| radon | 6.0.1 |
| vulture | 2.16 |
| pydocstyle[toml] | 6.3.0 |
| interrogate | 1.7.0 |

The inline `black==26.5.1` pin moved into the same file, so one file now holds
every pin.

## No gate result should change

Every version above is the version CI **already resolved** on run
[31058942017](https://github.com/jmorrison-juniper/MistHelper/actions/runs/31058942017).
I read them from that run's `Successfully installed` lines rather than taking the
current PyPI release, so this change records what CI does today instead of moving
it.

The mypy step also loosens nothing. It previously read
`'mypy<2.0' 'types-requests<2.33.0.20260503'`, and the pins sit inside those
ranges.

## Conflict check

Only `pytest` and `hypothesis` appear in both requirements files. The pinned
versions satisfy the runtime ranges:

| Package | requirements.txt | requirements-dev.txt |
| - | - | - |
| hypothesis | `>=6.151.12` | `==6.165.2` |
| pytest | unconstrained | `==9.1.1` |

## Verification

- The workflow YAML parses, and all 16 jobs survive.
- Zero unpinned `pip install` lines remain.
- CI on this pull request is the real proof, because it installs the pins and
  runs every gate.

## Trade-off worth noting

Each gate job now installs the whole tool set rather than its one tool. That adds
a little install time per job. I chose it over a pip constraints file because a
constraints file cannot carry an extra, and `bandit[toml]` and `pydocstyle[toml]`
both need one. One file and one mechanism seemed worth the seconds.
