### PR TITLE
docs(specs): specs for the gitignore source leak (#1778) and the ruff S decision (#1780)

### DIFF
--- a/specs/1778-gitignore-source-leak/plan.md
+++ b/specs/1778-gitignore-source-leak/plan.md
@@ -1,0 +1,207 @@
+# Implementation Plan: Gitignore Source Leak Repair
+
+**Branch**: The implementation needs its own branch. This document sits on `docs/1778-1780-specs`. | **Date**: 2026-08-05 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1778-gitignore-source-leak/spec.md`
+
+**GitHub Issue**: [#1778](https://github.com/jmorrison-juniper/MistHelper/issues/1778)
+
+## Summary
+
+Line 244 of `.gitignore` holds an unanchored `config/` pattern. The pattern excludes three source directories inside two tracked projects. One excluded module holds a MEDIUM bandit result that CI never sees.
+
+This work narrows the pattern, clears the security result, and formats the new files. The three parts must land together. The ignore change alone stops the build on the bandit gate and on the black gate.
+
+The plan orders the work so that each gate risk closes before the files enter git. The commit that adds the files comes last.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 for the three new Python files. TypeScript for the 17 new React files.
+
+**Primary Dependencies**: None. The change adds no package.
+
+**Storage**: N/A. The change adds no schema and no data file.
+
+**Testing**: The existing suite must keep its pass count. The new files hold no test.
+
+**Target Platform**: CI runs on Linux. Developers work on Windows. Git applies the same ignore rules on both platforms.
+
+**Project Type**: repository hygiene and static analysis repair.
+
+**Performance Goals**: Every CI job must stay inside its current timeout. The bandit job holds a 5 minute timeout and finishes in about 10 seconds.
+
+**Constraints**:
+
+- The root `[tool.black]` table sets a line length of 120. The `mist-ops-platform/pyproject.toml` file sets 99. Black reads the root table for a whole repository run, so the new module needs the 120 character form.
+- The root ruff `extend-exclude` list holds `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`. Ruff therefore stays quiet on the new Python files.
+- The bandit `targets` list holds `mist-ops-platform`, so bandit reads the new Python files.
+- Mypy reads `src/` only, so the new files face no type check.
+- Git cannot re-include a file below an excluded directory. A negation needs two lines.
+
+**Scale/Scope**: 1 ignore rule, 3 matched directories, 20 source files, and 1 security result.
+
+### Measurement contract
+
+Run each command from the repository root. Use `.venv\Scripts\python.exe` on Windows, because the global interpreter cannot import the project.
+
+```powershell
+git check-ignore -v mist-ops-platform/src/shared/config/settings.py
+git ls-files mist-ops-platform | Measure-Object
+.venv\Scripts\python.exe -m bandit -c pyproject.toml -r . -f json -o "$env:TEMP\bandit_1778.json" -q
+.venv\Scripts\python.exe -m black --check --diff .
+.venv\Scripts\python.exe -m ruff check .
+```
+
+A Windows bandit run reports 43 results. It reports 42 of them under `tools/test_quality_analyzer/fixtures/`. The `[tool.bandit]` table lists that path in `exclude_dirs`, but a Windows scan does not apply the entry, because the configured path uses a forward slash and a Windows scan reports a backslash. Subtract those 42 by hand.
+
+| Filter step | Baseline count | Target count |
+| - | - | - |
+| Raw bandit results on Windows | 43 | 42 |
+| Minus the analyzer fixtures | 1 | 0 |
+| Results in tracked files | 0 | 0 |
+| Files that black would rewrite | 0 | 0 |
+
+The baseline reads 0 tracked results only because git hides the module. The target reads 0 with the module tracked.
+
+### Verified mechanics
+
+The implementer probed four behaviors before this plan. Each result shapes a task.
+
+1. **Git needs two negation lines.** Lines 246 to 249 of `.gitignore` already hold the pattern. A directory line comes first, and a file glob line comes second. A single glob line cannot escape an excluded parent directory.
+2. **Black reads `.gitignore`.** A run against the excluded directory reports "No Python files are present to be formatted". A forced run reports that black would rewrite `settings.py`. The formatter therefore stops the build after the file enters git.
+3. **The `# noqa: S104` annotation is latent.** A run of `ruff check --select S` on the module reports one result at line 27. The same run with `--ignore-noqa` reports a second result at line 41. The annotation already hides the `S104` result from ruff.
+4. **Ruff reads the subtree configuration for an explicit path.** The `mist-ops-platform/pyproject.toml` file selects the `RUF` family, so an explicit run reports `RUF100` on the latent annotation. A repository wide run never reaches the file, because the root `extend-exclude` list holds the subtree.
+
+### Discovered risk: the settings module holds a second security result
+
+Ruff reports `S105` at line 27 of the module.
+
+```python
+    vault_token: str = "dev-root-token"
+```
+
+Bandit does not report that line. The two tools disagree, because bandit handles an annotated assignment differently. The value is a documented local development token, not a production secret. The implementer must record that judgment in the pull request. The implementer must not add a `# noqa: S105` annotation, because a latent annotation is the exact defect that this work removes.
+
+### Discovered risk: the original rule may protect nothing
+
+The team wrote the `config/` rule for a local settings directory. No such directory exists in the working tree today. If the research phase finds no protected directory, the rule needs deletion, not narrowing. Deletion is simpler and removes the whole class of accident.
+
+## Constitution Check
+
+*GATE: The plan passes before Phase 0 research. The plan passes again after Phase 1 design.*
+
+| Principle | Status | Basis |
+| - | - | - |
+| I. Five-Item Rule | PASS | The change touches one line of a class body. It adds no function and no class. |
+| II. Class-Based Architecture (No Wrappers) | PASS | The change adds no wrapper. |
+| III. Safety-First | PASS with a gate | The implementer must read every new file for a credential before the first commit. Task T006 holds that gate. |
+| IV. Full Deployment Pipeline | ADAPTED | The work follows the branch and pull request flow. The container needs no rebuild, because no runtime behavior changes inside the container image. |
+| V. Observability and Logging | PASS | The change adds no log call. The one changed line is a settings default. |
+| VI. Inline Comments (NON-NEGOTIABLE) | PASS | The changed line and each new ignore line carry a comment that states the reason. |
+| VII. Action Logging (NON-NEGOTIABLE) | NOT APPLICABLE | The change adds no action. A settings default runs no operation. |
+| Security Findings: Fix Over Suppress (NON-NEGOTIABLE) | PASS with a gate | The plan prefers a named interface or an environment read. A `# nosec B104` comment stays available only with a stated reason. |
+
+### The bind address question
+
+The module sets `api_host` to `0.0.0.0`, which binds the service to every interface. Three answers exist.
+
+1. **Read the host from the environment.** The class already extends `BaseSettings`, so the field already reads an environment variable. Change the default to `127.0.0.1`. A container deployment then sets `API_HOST=0.0.0.0` on purpose. This answer removes the result and keeps the container working.
+2. **Bind to a named interface.** This answer breaks a container deployment, because the container needs a bind to every interface to accept outside traffic.
+3. **Keep the bind and add `# nosec B104` with a reason.** The repository already holds this pattern at `src/network/_routing_utils_display.py` line 454.
+
+The plan prefers answer 1. It removes the result at the root instead of hiding it. The implementer must confirm that no deployment file relies on the current default before the change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1778-gitignore-source-leak/
+├── spec.md              # The feature specification
+├── plan.md              # This file
+└── tasks.md             # The task list
+```
+
+### Source code (repository root)
+
+```text
+.gitignore                                          # Phase 2: narrow the config/ pattern at line 244
+
+mist-ops-platform/src/shared/config/
+├── __init__.py                                     # Phase 4: track. The file is empty.
+├── constants.py                                    # Phase 4: track. 127 lines, no security result.
+└── settings.py                                     # Phase 3: correct line 41, then format, then track.
+
+ops-portal/src/features/config/                     # Phase 5: 7 TypeScript files. Record a decision.
+ops-portal/src/pages/config/                        # Phase 5: 10 TypeScript files. Record a decision.
+```
+
+**Structure Decision**: The work adds no directory and no module. It corrects one ignore rule and one source line, then adds existing files to git.
+
+## Phased approach
+
+Each phase ends with a measurement. A phase that does not reach its target blocks the next phase.
+
+### Phase 0 - Research (no file change)
+
+- Find the local directory that the `config/` rule protects. Search the working tree and the deployment documents.
+- Read every one of the 20 files for a credential, a token, and a private key.
+- Read the deployment files of `mist-ops-platform` and record how each one sets the API host.
+- Decide the answer to the bind address question.
+- Decide whether the 17 TypeScript files belong in git.
+
+**Exit measurement**: The team records five decisions. No decision stays open.
+
+### Phase 1 - Correct the security result (no git change)
+
+- Change the `api_host` default in `settings.py` per the Phase 0 decision.
+- Delete the `# noqa: S104` annotation.
+- Add an inline comment that states why the default binds where it binds.
+
+**Exit measurement**: A forced ruff run with `--ignore-noqa` reports no `S104` result in the module.
+
+### Phase 2 - Correct the formatting (no git change)
+
+- Run black on the three Python files with the root configuration.
+- Confirm that the result matches the 120 character line length.
+
+**Exit measurement**: A forced black check reports zero files to rewrite.
+
+### Phase 3 - Narrow the ignore rule
+
+- Replace or narrow the `config/` pattern at line 244.
+- Add the two line negation for each directory that the team decided to track.
+- Add a comment above the rule that states which directory it protects.
+
+**Exit measurement**: `git check-ignore -v` prints no rule for the settings module. It still prints a rule for the protected local directory.
+
+### Phase 4 - Track the files and run every gate
+
+- Stage the new files. Read `git status` and confirm that no compiled file appears.
+- Run bandit, black, ruff, and mypy across the whole repository.
+
+**Exit measurement**: Every gate exits with code 0.
+
+### Phase 5 - Record the TypeScript decision
+
+- Track the 17 TypeScript files, or record why they stay out.
+- State the decision in the pull request body.
+
+**Exit measurement**: The pull request holds a decision for all three matched directories.
+
+## Complexity Tracking
+
+| Item | Why it is needed | Simpler option that the plan rejected |
+| - | - | - |
+| A two line negation per directory | Git cannot re-include a file below an excluded directory. Lines 246 to 249 already prove the need. | One glob line. It fails without a visible error. |
+| A forced black run before the commit | Black reads `.gitignore`, so a normal run skips the file and hides the failure. | A normal run. It reports success and the gate then stops the build. |
+| A separate pull request for issue #1780 | The two efforts touch different files and need different reviewers. | One combined pull request. It mixes a defect repair with a design decision. |
+
+## Risks
+
+| Risk | Effect | Control |
+| - | - | - |
+| The team narrows the rule and a local secret enters git. | A credential enters the history and needs a rotation. | Task T006 reads every new file before the first commit. |
+| The bind change breaks a container deployment. | The service stops accepting outside traffic. | Phase 0 reads every deployment file first. |
+| Issue #1780 selects the ruff `S` family first. | The latent annotation hides the MEDIUM result for good. | Requirement FR-019 states the order. The pull request repeats it. |
+| The 17 TypeScript files hold lint errors. | A future TypeScript job starts with a failure. | Non-goal NG-003 keeps that job outside this scope. The decision record names the debt. |

--- a/specs/1778-gitignore-source-leak/spec.md
+++ b/specs/1778-gitignore-source-leak/spec.md
@@ -1,0 +1,222 @@
+# Feature Specification: Gitignore Source Leak Repair
+
+**Feature Branch**: `docs/1778-1780-specs` (specification only. The implementation needs its own branch.)
+
+**GitHub Issue**: [#1778](https://github.com/jmorrison-juniper/MistHelper/issues/1778) - "security: a MEDIUM bandit finding hides in a source file that gitignore excludes by accident"
+
+**Created**: 2026-08-05
+
+**Status**: Specification. No code change exists yet.
+
+**Input**: A `config/` pattern in `.gitignore` excludes source directories by accident. One excluded module holds a MEDIUM bandit finding that CI never sees. Narrow the pattern, track the source, and clear every gate that the new files then meet.
+
+---
+
+## Background
+
+Line 244 of `.gitignore` holds the pattern `config/`. The pattern carries no anchor, so git applies it to a directory named `config` at any depth. The pattern was written for a local settings directory. It also matches source directories inside two tracked projects.
+
+The `mist-ops-platform` project holds 110 tracked files. The `config` directory under `src/shared/` is the only source directory that drops out. That imbalance shows that the exclusion is an accident, not a decision.
+
+One excluded module holds a security defect. The module is `mist-ops-platform/src/shared/config/settings.py`. Line 41 reads as follows.
+
+```python
+    api_host: str = "0.0.0.0"  # noqa: S104
+```
+
+Bandit reports the line as a MEDIUM `B104` finding, which is `hardcoded_bind_all_interfaces`. Issue [#889](https://github.com/jmorrison-juniper/MistHelper/issues/889) removed the `-ll` severity flag from the bandit gate. The gate now stops the build on a result at any severity. The gate therefore stops the build on the first run after the module enters git.
+
+The `# noqa: S104` annotation hides nothing today. Issue [#1719](https://github.com/jmorrison-juniper/MistHelper/issues/1719) states the reason. The root ruff configuration does not select the `S` family, and bandit reads `# nosec` only. A reader sees the annotation and believes that a person reviewed the line. No person reviewed the line.
+
+### Measured baseline
+
+A maintainer measured every claim on 2026-08-05 with bandit 1.9.4 and ruff 0.16.0.
+
+| Measurement | Command | Result |
+| - | - | - |
+| The rule that excludes the module | `git check-ignore -v mist-ops-platform/src/shared/config/settings.py` | `.gitignore:244:config/` |
+| Tracked files in the project | `git ls-files mist-ops-platform` | 110 |
+| The module in git | `git ls-files mist-ops-platform/src/shared/config/settings.py` | no output |
+| Raw bandit results | `bandit -c pyproject.toml -r .` | 43 |
+| Results under the analyzer fixtures | the same run | 42 |
+| Results that remain | the same run | 1 |
+| Results in tracked files | the same run | 0 |
+
+The one remaining result is the `B104` MEDIUM at line 41 of the settings module. Every claim in issue #1778 holds.
+
+### Three findings that issue #1778 does not state
+
+The measurement produced three facts that the issue text omits. Each fact widens the work.
+
+**Finding 1: the pattern hides three directories, not one.**
+
+```text
+.gitignore:244:config/  mist-ops-platform/src/shared/config/
+.gitignore:244:config/  ops-portal/src/features/config/
+.gitignore:244:config/  ops-portal/src/pages/config/
+```
+
+The three directories hold 20 source files in total.
+
+| Directory | Files | Type |
+| - | - | - |
+| `mist-ops-platform/src/shared/config/` | 3 | Python |
+| `ops-portal/src/features/config/` | 7 | TypeScript React |
+| `ops-portal/src/pages/config/` | 10 | TypeScript React |
+
+**Finding 2: the black gate also stops the build.**
+
+Black reads `.gitignore` and skips an ignored file. The settings module therefore never met the formatter. The module carries the 99 character line length of the `mist-ops-platform` subtree. The root black configuration sets 120 characters. A forced run reports that black would rewrite the module. CI runs `black --check --diff .`, so the gate stops the build the moment the module enters git.
+
+**Finding 3: the annotation is latent, not inert.**
+
+The `# noqa: S104` annotation activates the moment anybody selects the `S` family in ruff. A run of `ruff check --select S` on the module reports one result at line 27 and no result at line 41. The same run with `--ignore-noqa` reports both. The annotation therefore hides the MEDIUM defect from ruff already. Issue [#1780](https://github.com/jmorrison-juniper/MistHelper/issues/1780) asks whether to select the `S` family. If issue #1780 lands first, the annotation hides the defect for good.
+
+Warning: If a person selects the ruff `S` family before this work deletes the annotation, the `S104` defect becomes invisible to both tools. Delete the annotation first.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Track every source file that the project needs (Priority: P1)
+
+A maintainer clones the repository on a clean machine. The maintainer starts the `mist-ops-platform` service. The service imports its settings module and starts, because git holds every module that the service needs.
+
+**Why this priority**: The missing module is a correctness defect on its own. A clean clone cannot start the service today. The security defect in User Story 2 is a consequence, not the root cause.
+
+**Independent Test**: A reviewer runs `git ls-files mist-ops-platform/src/shared/config/settings.py` on the branch. The command prints the path.
+
+**Acceptance Scenarios**:
+
+1. **Given** the corrected ignore rule, **When** a reviewer runs `git check-ignore -v mist-ops-platform/src/shared/config/settings.py`, **Then** the command prints no rule and exits with code 1.
+2. **Given** the corrected ignore rule, **When** a reviewer runs `git ls-files mist-ops-platform/src/shared/config/`, **Then** the command lists `__init__.py`, `constants.py`, and `settings.py`.
+3. **Given** the corrected ignore rule, **When** a reviewer runs `git status --porcelain`, **Then** the output holds no compiled Python file from a `__pycache__` directory.
+4. **Given** the corrected ignore rule, **When** a reviewer runs `git check-ignore -v` against the local settings path that the original rule protected, **Then** the command still prints a rule.
+
+---
+
+### User Story 2 - Clear the security defect before the module enters git (Priority: P1)
+
+A security reviewer wants the tracked code to hold zero bandit results. The reviewer reads the corrected settings module. The module binds to a named interface or reads the host from the environment. No hidden defect enters the history.
+
+**Why this priority**: The gate stops the build on the first push that holds the module. This story and User Story 1 must land in one pull request, because either one alone breaks CI.
+
+**Independent Test**: A reviewer runs `bandit -c pyproject.toml -r .` on a Linux checkout of the branch. The command reports zero results and exits with code 0.
+
+**Acceptance Scenarios**:
+
+1. **Given** the corrected module, **When** CI runs `bandit -c pyproject.toml -r .`, **Then** the job reports zero results and succeeds.
+2. **Given** the corrected module, **When** a reviewer reads line 41, **Then** the line holds no `# noqa: S104` annotation.
+3. **Given** a bind to every interface that the team keeps, **When** a reviewer reads the line, **Then** the line holds a `# nosec B104` comment that states the reason.
+4. **Given** the corrected module, **When** a reviewer runs `ruff check --select S --ignore-noqa` against the module, **Then** the run reports no `S104` result.
+
+---
+
+### User Story 3 - Keep every other gate green (Priority: P2)
+
+A maintainer pushes the branch. Every CI job succeeds. No new file breaks the formatter, the linter, or the type checker.
+
+**Why this priority**: The formatter failure is certain and measured. The story protects the pull request from a second review cycle.
+
+**Independent Test**: A reviewer runs the full local gate set on the branch. Ruff, black, and mypy each exit with code 0.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new tracked files, **When** CI runs `black --check --diff .`, **Then** the job reports zero files to rewrite.
+2. **Given** the new tracked files, **When** CI runs `ruff check .`, **Then** the job reports zero results.
+3. **Given** the new tracked files, **When** CI runs `mypy src/ --config-file pyproject.toml`, **Then** the job reports no new error.
+4. **Given** the 17 TypeScript files that the corrected rule adds, **When** CI runs the full workflow, **Then** every job keeps the status that it held before the change.
+
+---
+
+### Edge Cases
+
+- A person narrows the rule but forgets the directory negation. Git cannot re-include a file below an excluded directory. The rule needs two lines, as lines 246 to 249 already show. A single glob line fails without a visible error.
+- A person adds the module without the black correction. The formatter job stops the build. The person must run `black` on the module before the first commit.
+- A person adds the module without the bandit correction. The security job stops the build, because issue #889 removed the severity filter.
+- A person narrows the rule and stages a `__pycache__` directory by accident. Line 80 of `.gitignore` holds the `__pycache__/` rule, so git catches the compiled files once it descends into the directory. The person must still read `git status` before the first commit.
+- The original `config/` rule protects a real local directory. A person must find that directory before the change. If no such directory exists, the rule needs deletion, not narrowing.
+- A person tracks the 17 TypeScript files and starts a lint job that the repository does not run today. The files then need their own cleanup. This specification keeps that work outside its scope.
+- A person selects the ruff `S` family under issue #1780 before this work lands. The latent annotation then hides the MEDIUM defect. The two efforts need an order.
+
+---
+
+## Requirements *(mandatory)*
+
+### Ignore rule requirements
+
+- **FR-001**: The `config/` pattern at line 244 of `.gitignore` MUST stop matching a directory inside a tracked project.
+- **FR-002**: The corrected rule MUST keep the exclusion that the original rule protects. The team MUST name that directory before the change.
+- **FR-003**: The corrected rule MUST follow the two line form that lines 246 to 249 already use. The first line re-includes the directory. The second line re-includes the files inside it.
+- **FR-004**: The corrected rule MUST NOT re-include a compiled Python file, a build output, or a local secret.
+- **FR-005**: The team MUST record a decision for each of the three matched directories. The decision is track or keep out.
+
+### Source tracking requirements
+
+- **FR-006**: Git MUST track `mist-ops-platform/src/shared/config/__init__.py`, `constants.py`, and `settings.py`, or the pull request MUST state why each file stays out.
+- **FR-007**: The team MUST record a decision for the 17 TypeScript files under `ops-portal/`. The decision MUST state the reason.
+- **FR-008**: The change MUST NOT add a file that holds a credential, a token, or a private key.
+
+### Security requirements
+
+- **FR-009**: The bandit gate MUST report zero results after the new files enter git.
+- **FR-010**: The `B104` result at line 41 of the settings module MUST receive one recorded decision. The decision MUST be a bind to a named interface, a read from the environment, or a `# nosec B104` comment that states the reason.
+- **FR-011**: The team MUST select the decision in this order. First, correct the root cause. Second, restructure to remove the pattern. Third, add a suppression comment for a result that a person verified as safe.
+- **FR-012**: The `# noqa: S104` annotation at line 41 MUST go, because the annotation hides the defect the moment anybody selects the `S` family.
+- **FR-013**: The team MUST search every new tracked file for a further security result before the first commit. The search MUST cover bandit and MUST cover `ruff check --select S --ignore-noqa`.
+
+### Quality requirements
+
+- **FR-014**: Every CI gate MUST hold its current status after the change.
+- **FR-015**: Black MUST report zero files to rewrite across the whole repository.
+- **FR-016**: Every changed Python line MUST carry an inline comment that states why the line exists.
+- **FR-017**: All prose, all code comments, and all commit text MUST follow the writing guide at `documentation/ASD-STE100_writing-guide.md`.
+- **FR-018**: The pull request MUST land the ignore rule change and the security correction together, because either change alone stops the build.
+
+### Coordination requirements
+
+- **FR-019**: This work MUST land before issue #1780 selects the ruff `S` family. The pull request MUST state that order.
+- **FR-020**: The pull request MUST reference issue #1719, which removed every other latent annotation of this kind.
+
+### Key Entities
+
+- **Ignore rule**: One line in `.gitignore`. It holds a pattern, and git applies it to a path.
+- **Matched directory**: One directory that the pattern excludes. It holds a track decision or a keep out decision.
+- **Bandit result**: One report entry. It holds a rule identifier, a severity, a file path, and a line number.
+- **Latent annotation**: A `# noqa` comment for a rule that no tool selects today. It starts to hide a result the moment a person selects that rule.
+
+---
+
+## Non-Goals
+
+- **NG-001**: This work does not select the ruff `S` family. Issue #1780 owns that decision.
+- **NG-002**: This work does not remove the `mist-ops-platform` entry from the root ruff `extend-exclude` list.
+- **NG-003**: This work does not add a TypeScript lint job or a TypeScript build job.
+- **NG-004**: This work does not audit the other patterns in `.gitignore`. It corrects the `config/` pattern only.
+- **NG-005**: This work does not restructure the settings module beyond the one line that holds the security defect.
+- **NG-006**: This work does not rotate a credential, because the measurement found no real credential in the new files.
+
+---
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `git check-ignore -v mist-ops-platform/src/shared/config/settings.py` prints no rule and exits with code 1.
+- **SC-002**: `git ls-files mist-ops-platform` reports 113 files or more, against the baseline of 110.
+- **SC-003**: `bandit -c pyproject.toml -r .` reports zero results outside the analyzer fixtures.
+- **SC-004**: `black --check --diff .` reports zero files to rewrite.
+- **SC-005**: `ruff check .` reports zero results.
+- **SC-006**: No line in the repository holds a `# noqa: S104` annotation.
+- **SC-007**: `ruff check --select S --ignore-noqa` reports no `S104` result in the new tracked files.
+- **SC-008**: The pull request records a track decision or a keep out decision for each of the three matched directories.
+- **SC-009**: `git status --porcelain` reports no compiled Python file.
+- **SC-010**: Every CI job that succeeded before the change succeeds after the change.
+
+---
+
+## Assumptions
+
+- The `mist-ops-platform` project stays in the repository. A plan to delete the project would cancel this work.
+- The original `config/` rule protects a local directory that a developer creates. The team confirms that directory during the research phase.
+- The bandit version stays at 1.9.4, which `requirements-dev.txt` pins.
+- The root ruff `extend-exclude` list keeps the `mist-ops-platform` entry, so ruff stays quiet on the new Python files.
+- The repository runs no lint job and no build job for TypeScript, so the 17 new TypeScript files add no gate risk.

--- a/specs/1778-gitignore-source-leak/tasks.md
+++ b/specs/1778-gitignore-source-leak/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: Gitignore Source Leak Repair
+
+**Feature**: `1778-gitignore-source-leak` | **Branch**: the implementation needs its own branch | **Date**: 2026-08-05
+
+**GitHub Issue**: [#1778](https://github.com/jmorrison-juniper/MistHelper/issues/1778)
+
+**Input**: Design documents from `specs/1778-gitignore-source-leak/`
+
+**Prerequisites**: [spec.md](spec.md), [plan.md](plan.md)
+
+**Tests**: The specification requests no new test. The existing suite must keep its pass count. Each phase ends with a measurement task, not with a new test file.
+
+**Branch rule**: Create a branch from `main` with the name `fix/1778-gitignore-source-leak`. Do not reuse the documentation branch.
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: The task can run in parallel with another task in the same phase. The tasks touch different files.
+- **[Story]**: The user story that owns the task. The value is `US1`, `US2`, or `US3`.
+- Each task names an exact file path.
+
+## Rules that apply to every task
+
+1. Use `.venv\Scripts\python.exe` for every Python command. The global interpreter cannot import the project.
+2. Every changed Python line carries an inline comment that states why the line exists. Principle VI requires this.
+3. Every prose line follows the writing guide at `documentation/ASD-STE100_writing-guide.md`.
+4. Do not add a `# noqa: S...` annotation. A latent annotation is the defect that this work removes.
+5. Run every gate across the whole repository. Do not scope a gate to the changed paths.
+6. Keep the ignore change, the security correction, and the format correction in one pull request.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the environment before any measurement.
+
+- [ ] T001 Create the branch with `git checkout -b fix/1778-gitignore-source-leak main`. Confirm the name with `git branch --show-current`.
+- [ ] T002 Confirm that `.venv\Scripts\python.exe -m bandit --version` reports `1.9.4` and that `.venv\Scripts\python.exe -m ruff --version` reports `0.16.0`. Install the pinned set with `pip install -r requirements-dev.txt` if a version differs.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prove the baseline and close every open decision. No edit starts until this phase closes.
+
+- [ ] T003 Capture the ignore baseline. Run `git check-ignore -v mist-ops-platform/src/shared/config/settings.py` and confirm that it prints `.gitignore:244:config/`. Run `git ls-files mist-ops-platform | Measure-Object` and confirm that it reports 110 files.
+- [ ] T004 Capture the bandit baseline. Run `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r . -f json -o "$env:TEMP\bandit_1778.json" -q`. Confirm 43 raw results, 42 under `tools/test_quality_analyzer/fixtures/`, and 1 remaining `B104` MEDIUM at `mist-ops-platform/src/shared/config/settings.py` line 41. Stop and re-derive the plan if a count differs.
+- [ ] T005 Find the local directory that the `config/` rule protects. Search the working tree, the `deploy/` directory, and every document under `documentation/`. Record the result in the pull request body. If no directory needs the rule, record that the rule needs deletion instead of narrowing.
+- [ ] T006 Read every one of the 20 files under the three matched directories. Search each file for a credential, a token, an API key, and a private key. Record the result. **Warning**: If a file holds a real credential, stop the work. Move the value to the environment and raise a rotation request before any file enters git.
+- [ ] T007 Read every deployment file of `mist-ops-platform` and record how each one sets the API host. Cover `deploy/`, `compose.yml`, `Containerfile`, and `Dockerfile`. This task decides whether a change to the `api_host` default breaks a running service.
+- [ ] T008 Decide the answer to the bind address question in [plan.md](plan.md). Record the decision and the reason. The plan prefers a default of `127.0.0.1` with an environment override.
+- [ ] T009 Decide whether git tracks the 17 TypeScript files under `ops-portal/src/features/config/` and `ops-portal/src/pages/config/`. Record the decision and the reason. Requirement FR-007 demands this record.
+
+**Checkpoint**: Five decisions are closed. The baseline reads 1 bandit result. Phase 3 can start.
+
+---
+
+## Phase 3: User Story 2 - Correct the security result (Priority: P1)
+
+**Goal**: Remove the `B104` result and the latent annotation from `mist-ops-platform/src/shared/config/settings.py` before the file enters git.
+
+**Independent Test**: A run of `.venv\Scripts\python.exe -m ruff check --select S --ignore-noqa mist-ops-platform/src/shared/config/settings.py` reports no `S104` result.
+
+- [ ] T010 [US2] Apply the T008 decision to line 41 of `mist-ops-platform/src/shared/config/settings.py`. Change the `api_host` default, or keep the bind and add a `# nosec B104` comment that states the reason. Add an inline comment that states why the default binds where it binds.
+- [ ] T011 [US2] Delete the `# noqa: S104` annotation from line 41 of `mist-ops-platform/src/shared/config/settings.py`. Requirement FR-012 demands this deletion, because the annotation hides the result the moment anybody selects the ruff `S` family.
+- [ ] T012 [US2] Record a judgment for the `S105` result at line 27 of `mist-ops-platform/src/shared/config/settings.py`. The value is `vault_token = "dev-root-token"`. Confirm that the value is a local development token and not a production secret. Do not add a `# noqa: S105` annotation. State the judgment in the pull request body.
+- [ ] T013 [US2] Verify User Story 2. Run `.venv\Scripts\python.exe -m ruff check --select S --ignore-noqa mist-ops-platform/src/shared/config/settings.py` and confirm that no `S104` result appears. Run `git grep -n "noqa: S104"` and confirm that the search returns nothing.
+
+**Checkpoint**: The security result is closed. Phase 4 can start.
+
+---
+
+## Phase 4: User Story 3 - Correct the formatting (Priority: P2)
+
+**Goal**: Format the three Python files to the root black configuration, so that the formatter gate stays green after the files enter git.
+
+**Independent Test**: A forced black check on the three files reports zero files to rewrite.
+
+**Caution**: Black reads `.gitignore` and skips an ignored file. A normal run reports success and hides the failure. Force the run.
+
+- [ ] T014 [US3] Run black on `mist-ops-platform/src/shared/config/settings.py` and `mist-ops-platform/src/shared/config/constants.py` with the root configuration. Use an explicit path so that black reads the file. The measurement shows that `settings.py` needs a rewrite of the `database_url` default to one line of 120 characters.
+- [ ] T015 [US3] Confirm the format. Run a forced black check on the three Python files and confirm zero files to rewrite. Confirm that the change touched only whitespace and line breaks, and that it changed no value.
+
+**Checkpoint**: The formatter is satisfied. Phase 5 can start.
+
+---
+
+## Phase 5: User Story 1 - Narrow the ignore rule (Priority: P1)
+
+**Goal**: Stop the `config/` pattern from matching a source directory, and keep the exclusion that the rule protects.
+
+**Independent Test**: `git check-ignore -v mist-ops-platform/src/shared/config/settings.py` prints no rule and exits with code 1.
+
+**Caution**: Git cannot re-include a file below an excluded directory. Each negation needs two lines. Lines 246 to 249 of `.gitignore` already hold the pattern.
+
+- [ ] T016 [US1] Edit line 244 of `.gitignore`. Apply the T005 decision. Either delete the `config/` pattern, or anchor it to the one directory it protects. Add a comment above the rule that names that directory and states the reason.
+- [ ] T017 [US1] Add the negation lines to `.gitignore` for each directory that T009 chose to track. Write the directory line first and the file glob line second, in the style of lines 246 to 249. Add a comment that names the project that owns each directory.
+- [ ] T018 [US1] Verify the ignore rule. Run `git check-ignore -v` against `mist-ops-platform/src/shared/config/settings.py`, against `ops-portal/src/features/config/RevisionDiff.tsx`, and against the local directory that T005 named. Confirm that each result matches the recorded decision.
+- [ ] T019 [US1] Confirm that git still ignores the compiled files. Run `git check-ignore -v mist-ops-platform/src/shared/config/__pycache__/settings.cpython-313.pyc` and confirm that the rule now reads `.gitignore:80:__pycache__/`.
+
+**Checkpoint**: The ignore rule is correct. Phase 6 can start.
+
+---
+
+## Phase 6: Track the files and run every gate
+
+**Goal**: Add the new files to git and prove that every gate stays green.
+
+**Independent Test**: Every local gate exits with code 0 on a staged working tree.
+
+- [ ] T020 Stage the new files with `git add`. Read `git status --porcelain` line by line. Confirm that no compiled Python file appears and that no local secret appears. Requirement FR-004 demands this reading.
+- [ ] T021 Run the bandit gate. Run `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r . -f json -o "$env:TEMP\bandit_1778_after.json" -q`. Confirm that the run reports 42 results and that all 42 sit under `tools/test_quality_analyzer/fixtures/`. Success criterion SC-003 compares against this count.
+- [ ] T022 Run the format gate and the lint gate. Run `.venv\Scripts\python.exe -m black --check --diff .` and `.venv\Scripts\python.exe -m ruff check .`. Confirm that each command exits with code 0.
+- [ ] T023 Run the type gate and the test suite. Run `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml` and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Confirm no new error and confirm that the pass count matches the count before the change.
+- [ ] T024 Confirm the file count. Run `git ls-files mist-ops-platform | Measure-Object` and confirm 113 files or more. Success criterion SC-002 compares against this count.
+
+**Checkpoint**: Every gate is green. Phase 7 can start.
+
+---
+
+## Phase 7: Polish and hand over
+
+**Goal**: Record every decision and state the order against issue #1780.
+
+- [ ] T025 Write the pull request body. Record the five decisions from Phase 2. Name the directory that the narrowed rule protects. State the judgment for the `S105` value at line 27.
+- [ ] T026 State the coordination order in the pull request body. Write that this work must merge before issue [#1780](https://github.com/jmorrison-juniper/MistHelper/issues/1780) selects the ruff `S` family. State the consequence of the other order, which is that the latent annotation hides the MEDIUM result for good. Requirement FR-019 demands this statement.
+- [ ] T027 Reference issue [#1719](https://github.com/jmorrison-juniper/MistHelper/issues/1719) in the pull request body. That issue removed every other latent annotation of this kind and left this one out of scope, because a person cannot commit an edit to an untracked file.
+- [ ] T028 Run the writing gate. Run `.venv\Scripts\python.exe -m tools.ste_linter` against every changed Markdown file and confirm a score of 80 or more.
+- [ ] T029 Open the pull request. Write `Closes #1778` in the body. Add the labels `security` and `chore`. Wait for CodeQL to report before adding the `auto-merge` label.
+
+---
+
+## Dependencies
+
+| Task | Depends on | Reason |
+| - | - | - |
+| T010 | T007, T008 | The bind change needs the deployment survey and the recorded decision. |
+| T014 | T010, T011 | Black must format the final content, not an intermediate form. |
+| T016 | T005 | The narrowed rule needs the name of the directory it protects. |
+| T017 | T009 | The negation lines need the TypeScript decision. |
+| T020 | T013, T015, T018 | The files enter git only after every gate risk closes. |
+| T024 | T020 | The file count changes only after the stage step. |
+
+## Parallel opportunities
+
+- T005, T006, and T007 read different files. Run them in parallel.
+- T021, T022, and T023 read the same working tree and change nothing. Run them in parallel.

--- a/specs/1780-ruff-s-family-decision/plan.md
+++ b/specs/1780-ruff-s-family-decision/plan.md
@@ -1,0 +1,207 @@
+# Implementation Plan: Ruff S Family Decision
+
+**Branch**: The implementation needs its own branch. This document sits on `docs/1778-1780-specs`. | **Date**: 2026-08-05 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1780-ruff-s-family-decision/spec.md`
+
+**GitHub Issue**: [#1780](https://github.com/jmorrison-juniper/MistHelper/issues/1780)
+
+## Summary
+
+The root ruff configuration does not select the `S` family. Every `# noqa: S...` annotation therefore has no effect. Issue #1780 asks the team to choose between three options and to record the reason.
+
+The research phase is complete. [research.md](research.md) holds the measured data for all three options. This plan turns that data into a decision, a written record, a contract update, and a guard that keeps the decision true.
+
+The plan recommends Option 2, which keeps the current select list. The recommendation rests on two measurements. Option 3 would leave 111 Python files with no security scan. Option 1 would buy 10 new results for a cost of 62 double suppression comments and one ignore block for 13,440 test asserts.
+
+## Technical Context
+
+**Language/Version**: Python 3.13. The change touches configuration and documentation only.
+
+**Primary Dependencies**: ruff 0.16.0 and bandit 1.9.4. Both versions come from `requirements-dev.txt`. The change adds no dependency.
+
+**Storage**: N/A.
+
+**Testing**: The guard in User Story 3 needs one new test. The existing suite must keep its pass count.
+
+**Target Platform**: CI runs on Linux. Developers work on Windows. Both platforms report the same ruff counts, because ruff normalizes the path separator.
+
+**Project Type**: static analysis policy and repository governance.
+
+**Performance Goals**: The ruff job runs in under 1 second. The bandit job runs in about 10 seconds. Both sit in the fast group of the workflow. Neither sets the total workflow time.
+
+**Constraints**:
+
+- The root ruff `extend-exclude` list holds `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`.
+- The bandit `exclude_dirs` list holds `tests`, `.venv`, `node_modules`, `scripts`, `specs`, and `tools/test_quality_analyzer/fixtures`.
+- The two lists do not match, so the two tools read different trees.
+- The test tree holds 13,440 `assert` statements. Pytest needs them.
+
+**Scale/Scope**: 1 decision, 1 record, 1 contract update, and 1 guard test.
+
+### Measurement contract
+
+Run each command from the repository root with `.venv\Scripts\python.exe`.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check --select S --statistics .
+.venv\Scripts\python.exe -m ruff check --select S --statistics --exclude tests .
+.venv\Scripts\python.exe -m ruff check --select S --ignore-noqa --statistics .
+.venv\Scripts\python.exe -m bandit -c pyproject.toml -r . -f json -o "$env:TEMP\bandit_1780.json" -q
+```
+
+| Measurement | Value on 2026-08-05 |
+| - | - |
+| Ruff `S` results, whole repository | 13,566 |
+| Ruff `S` results, no test tree | 121 |
+| Bandit results, tracked files | 0 |
+| Latent `# noqa: S...` annotations | 1 |
+
+The implementer must re-run every command before the decision. A count that differs means the code base moved, and the recommendation needs a fresh reading.
+
+### Verified mechanics
+
+The implementer probed four behaviors before this plan.
+
+1. **Ruff reads `# noqa` only.** It does not read `# nosec`. Bandit reads `# nosec` only. The two forms never overlap.
+2. **A `# noqa: S...` annotation is latent.** A run with `--ignore-noqa` reports a result that a normal run hides. Section R9 of [research.md](research.md) holds the proof.
+3. **Ruff can add a `# noqa` comment automatically.** A person who runs `--fix` after adding `S` can create thousands of annotations in one command. The plan forbids that path.
+4. **A subtree can hold its own ruff configuration.** The `mist-ops-platform/pyproject.toml` file selects a different rule set. The root `extend-exclude` entry means CI never reads it.
+
+### Discovered risk: the ordering against issue #1778
+
+Issue [#1778](https://github.com/jmorrison-juniper/MistHelper/issues/1778) removes a latent `# noqa: S104` annotation from an untracked settings module. Bandit reports that same line as a MEDIUM `B104`.
+
+Warning: If this work selects the `S` family before issue #1778 lands, the annotation activates and hides the MEDIUM result. The defect then stays invisible to both tools.
+
+The control is simple. Choose Option 2, which never selects `S`. If the team overrides the recommendation, run `ruff check --select S --ignore-noqa` first and triage every hidden result.
+
+### Discovered risk: the recommendation may not survive review
+
+The plan recommends Option 2. A reviewer can disagree. Two counter arguments deserve a written answer.
+
+1. **"Ruff finds 10 results that bandit misses."** True. Section R4 of [research.md](research.md) names all 10. Two of them are default passwords in `src/db/__init__.py`. The correct answer is a separate issue that corrects those 10 lines, not a second tool that reports 13,566 results to find them.
+2. **"Editors show ruff inline and never show bandit."** True. That is a real developer experience gain. It costs 62 double suppression comments and a permanent second comment form. A bandit editor extension solves the same problem with no repository change.
+
+The implementer must record the chosen answer even when the team overrides the recommendation.
+
+## Constitution Check
+
+*GATE: The plan passes before Phase 0 research. The plan passes again after Phase 1 design.*
+
+| Principle | Status | Basis |
+| - | - | - |
+| I. Five-Item Rule | PASS | The guard test holds one function. The configuration change touches one list. |
+| II. Class-Based Architecture (No Wrappers) | PASS | The work adds no wrapper. |
+| III. Safety-First | PASS | The work adds no input handling and no destructive operation. |
+| IV. Full Deployment Pipeline | ADAPTED | The work follows the branch and pull request flow. The container needs no rebuild, because no runtime behavior changes. |
+| V. Observability and Logging | PASS | The guard test uses ASCII only. |
+| VI. Inline Comments (NON-NEGOTIABLE) | PASS | Every line of the guard test carries a comment that states why the line exists. |
+| VII. Action Logging (NON-NEGOTIABLE) | NOT APPLICABLE | A test needs no action log. |
+| Security Findings: Fix Over Suppress (NON-NEGOTIABLE) | PASS with a statement | Option 2 keeps the current coverage. Requirement FR-018 demands a written statement if a choice reduces coverage. |
+
+### The coverage question
+
+The constitution prefers a correction over a suppression. Option 2 makes no correction and adds no coverage. That needs a defense.
+
+Option 2 does not reduce coverage. It keeps the bandit gate that issue #889 hardened, and that gate reports zero results in tracked files today. The 10 results that ruff would add are real, and the plan routes them to their own issue. That route delivers the same corrections without a second tool, a second comment form, and 13,440 ignored test results.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1780-ruff-s-family-decision/
+├── spec.md              # The feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output: the measured data for all three options
+└── tasks.md             # The task list
+```
+
+### Source code (repository root)
+
+The exact file list depends on the chosen option. The table states the file set for each option.
+
+```text
+specs/1780-ruff-s-family-decision/decision.md          # All options: the decision record
+
+specs/1032-bandit-severity-gate/contracts/
+└── suppression-comment.md                             # All options: state which comment form works
+
+tests/guardrails/
+└── test_no_latent_noqa_s.py                           # Option 2 only: the guard
+
+pyproject.toml                                         # Option 1 and Option 3 only: the select list
+.github/workflows/ci.yml                               # Option 3 only: delete the bandit job
+```
+
+**Structure Decision**: The work adds one decision record and one guard test. It changes one contract. Under Option 2 it changes no configuration, which is the point of the option.
+
+## Phased approach
+
+### Phase 0 - Re-measure (complete for the recorded date)
+
+[research.md](research.md) holds the full measurement from 2026-08-05. The implementer must re-run every command in the measurement contract and must compare the counts.
+
+**Exit measurement**: Every count matches [research.md](research.md), or the implementer records the drift and re-reads the recommendation.
+
+### Phase 1 - Decide
+
+- Read [research.md](research.md) section R10, which states the cost of each option.
+- Choose one option.
+- Write the decision record.
+
+**Exit measurement**: The record names the option, the reason, the date, and the tool versions.
+
+### Phase 2 - Update the suppression contract
+
+- State which comment form suppresses a security result.
+- State whether a `# noqa: S...` annotation has any effect.
+- Under Option 2, state that such an annotation is latent and state the consequence.
+
+**Exit measurement**: A reader learns the correct comment form from one document.
+
+### Phase 3 - Add the guard (Option 2 only)
+
+- Add a test that searches every tracked Python file for a `# noqa: S...` annotation.
+- The test reports the file and the line number for each hit.
+- The test must report zero hits at the time it lands.
+
+**Exit measurement**: The test passes. A deliberate annotation makes it fail.
+
+### Phase 4 - Apply the choice (Option 1 and Option 3 only)
+
+The plan does not recommend this phase. It states the steps so that the team can price the work.
+
+- Run `ruff check --select S --ignore-noqa` and triage every hidden result first.
+- Add an ignore rule for `S101` under `tests/` in `[tool.ruff.lint.per-file-ignores]`.
+- Add `S` to the select list.
+- Add a second annotation to each of the 62 lines that already hold a `# nosec` comment.
+- Under Option 3, delete the bandit job from `.github/workflows/ci.yml`, remove the `[tool.bandit]` table, remove `bandit` from `requirements-dev.txt`, and remove every one of the 117 `# nosec` comments.
+- Under Option 3, remove `mist-ops-platform`, `web_portal`, and `src/maps` from the ruff exclude list, or record that 111 Python files lose their security scan.
+
+**Exit measurement**: Every gate is green and no security result hides behind a latent annotation.
+
+### Phase 5 - Close the loop
+
+- Open a separate issue for the 10 production results in [research.md](research.md) section R4.
+- State the ordering against issue #1778 in the pull request body.
+
+**Exit measurement**: The new issue exists and the pull request names it.
+
+## Complexity Tracking
+
+| Item | Why it is needed | Simpler option that the plan rejected |
+| - | - | - |
+| A guard test under Option 2 | Issue #1719 removed the annotations once. Without a gate they return, and each one is a latent suppression. | A note in the contributing guide. A reader can miss a note. A gate cannot. |
+| A separate issue for the 10 results | The results are real and need a correction. They do not need a second tool. | Fold them into this work. That mixes a policy decision with a code correction. |
+| A written answer to each counter argument | A reviewer will raise them. An unwritten answer restarts the debate. | Record the choice only. The question then returns in six months. |
+
+## Risks
+
+| Risk | Effect | Control |
+| - | - | - |
+| The team selects `S` before issue #1778 lands. | The MEDIUM `B104` result hides for good. | Requirement FR-013 states the order. The pull request repeats it. |
+| A person runs `ruff --fix` after adding `S`. | The repository gains thousands of unreviewed annotations in one command. | Task T014 forbids the flag and states the reason. |
+| The team chooses Option 3 without reading section R6. | 111 Python files lose their security scan with no visible warning. | Success criterion SC-010 demands a written list of what the option gives up. |
+| The recommendation ages out. | A future ruff release closes the rule gap and changes the answer. | Requirement FR-005 demands that the record state what would change the decision. |

--- a/specs/1780-ruff-s-family-decision/research.md
+++ b/specs/1780-ruff-s-family-decision/research.md
@@ -1,0 +1,302 @@
+# Research: Ruff S Family Decision
+
+**Feature**: `1780-ruff-s-family-decision` | **Date**: 2026-08-05
+
+**GitHub Issue**: [#1780](https://github.com/jmorrison-juniper/MistHelper/issues/1780)
+
+**Purpose**: Issue #1780 asks the team to choose between three options. This document holds the measured data that the choice needs. Every number here comes from a command that a maintainer ran on 2026-08-05. No number here is an estimate.
+
+**Tool versions**: ruff 0.16.0, bandit 1.9.4, Python 3.13. Both versions come from `requirements-dev.txt`.
+
+---
+
+## R1: What does ruff report today?
+
+**Command**:
+
+```powershell
+.venv\Scripts\python.exe -m ruff check --select S --statistics .
+```
+
+**Output**:
+
+```text
+13440   S101    assert
+   39   S106    hardcoded-password-func-arg
+   25   S108    hardcoded-temp-file
+   22   S105    hardcoded-password-string
+   13   S603    subprocess-without-shell-equals-true
+   10   S110    try-except-pass
+    3   S310    suspicious-url-open-usage
+    3   S607    start-process-with-partial-path
+    3   S608    hardcoded-sql-expression
+    2   S104    hardcoded-bind-all-interfaces
+    2   S113    request-without-timeout
+    2   S605    start-process-with-a-shell
+    1   S112    try-except-continue
+    1   S606    start-process-with-no-shell
+Found 13566 errors.
+```
+
+**Finding**: The `S` family reports 13,566 results across the repository. One rule produces 99.1 percent of them. `S101` fires on every `assert` statement, and the test suite holds 13,440 of them.
+
+---
+
+## R2: Where do the results sit?
+
+**Commands**:
+
+```powershell
+.venv\Scripts\python.exe -m ruff check --select S --statistics --exclude tests .
+.venv\Scripts\python.exe -m ruff check --select S --statistics src
+```
+
+**Output without the test tree**:
+
+```text
+81      S101    assert
+ 9      S105    hardcoded-password-string
+ 8      S110    try-except-pass
+ 8      S603    subprocess-without-shell-equals-true
+ 3      S310    suspicious-url-open-usage
+ 3      S608    hardcoded-sql-expression
+ 2      S113    request-without-timeout
+ 2      S605    start-process-with-a-shell
+ 2      S607    start-process-with-partial-path
+ 1      S104    hardcoded-bind-all-interfaces
+ 1      S112    try-except-continue
+ 1      S606    start-process-with-no-shell
+Found 121 errors.
+```
+
+**Output for the `src/` tree only**: 62 results.
+
+**Finding**: The test tree holds 13,445 of the 13,566 results. The production code holds 121. Any option that selects `S` must ignore `S101` in the test tree, or the gate can never turn green.
+
+---
+
+## R3: How many results need a second suppression comment?
+
+A maintainer read the source line for each of the 121 non-test results and searched it for the text `# nosec`.
+
+| Group | Count |
+| - | - |
+| The line already holds a `# nosec` comment | 62 |
+| The line holds no `# nosec` comment | 59 |
+| Total | 121 |
+| Distinct files | 42 |
+
+**Finding**: 62 lines already carry a bandit suppression. Ruff reads `# noqa` and does not read `# nosec`. Each of those 62 lines therefore needs a second annotation on the same line. The result reads `# noqa: S603  # nosec B603`. Issue [#1719](https://github.com/jmorrison-juniper/MistHelper/issues/1719) removed that exact confusion.
+
+The repository holds 117 `# nosec` comments across 51 tracked Python files today.
+
+---
+
+## R4: Where do the 59 unsuppressed results sit?
+
+| Location | Count | Why bandit stays quiet |
+| - | - | - |
+| `tools/test_quality_analyzer/fixtures/` | 42 | The `[tool.bandit]` table lists the path in `exclude_dirs`. The files hold deliberately bad code that the analyzer reads as test material. |
+| `specs/010-endpoint-usage-audit/_validate_report.py` | 7 | The `[tool.bandit]` table lists `specs` in `exclude_dirs`. |
+| Production code | 10 | See the table below. |
+
+**The 10 production results that bandit does not report**:
+
+```text
+MistHelper.py:917                              S310  with urllib.request.urlopen(
+src/analytics/site_analytics_configurator.py:11 S105  _CONFIRM_TOKEN: str = "CONFIGURE"
+src/db/__init__.py:45                          S105  arango_password: str = "misthelper"
+src/db/__init__.py:48                          S105  redis_password: str = "misthelper"
+src/refactors/sqlite_database_writer.py:248    S101  assert (
+src/ssh/shell_execution/shell_executor.py:157  S101  assert (
+src/utils/logger_utils.py:113                  S110  except Exception:
+src/utils/zscaler_catalogue.py:679             S310  req = urllib.request.Request(url, ...)
+src/utils/zscaler_probe.py:184                 S603  completed = subprocess.run(
+src/utils/zscaler_probe.py:371                 S110  except Exception:
+```
+
+**Caution**: The search read the reported line only. Bandit accepts a `# nosec` comment on any line of a multi line statement. Some of these 10 results may already hold a suppression on an adjacent line. The implementer must read each statement before treating it as a new result.
+
+**Finding**: Two results look like real value. `src/db/__init__.py` lines 45 and 48 hold a default password of `misthelper` in an annotated assignment. Bandit does not report an annotated assignment under `B105`. Ruff does. That is one measured case where ruff finds a default credential that bandit misses.
+
+---
+
+## R5: What does bandit report today?
+
+**Command**:
+
+```powershell
+.venv\Scripts\python.exe -m bandit -c pyproject.toml -r . -f json -o "$env:TEMP\bandit_1780.json" -q
+```
+
+| Measurement | Count |
+| - | - |
+| Raw results on Windows | 43 |
+| Results under `tools/test_quality_analyzer/fixtures/` | 42 |
+| Results that remain | 1 |
+| Results in files that git tracks | 0 |
+
+The one remaining result is `mist-ops-platform/src/shared/config/settings.py` line 41, `B104`, MEDIUM. Git does not track that file. Issue [#1778](https://github.com/jmorrison-juniper/MistHelper/issues/1778) owns it.
+
+A Windows scan does not apply the `exclude_dirs` entry for the analyzer fixtures, because the configured path uses a forward slash and a Windows scan reports a backslash. CI runs on Linux and applies the entry.
+
+**Finding**: The bandit gate is clean. Issue [#889](https://github.com/jmorrison-juniper/MistHelper/issues/889) delivered that state. Any option that adds a second tool starts from 121 new results against a gate that reports zero today.
+
+---
+
+## R6: Do the two tools read the same files?
+
+**Ruff excludes** (root `pyproject.toml`, `[tool.ruff] extend-exclude`):
+
+```text
+mist-ops-platform, web_portal, scripts, src/maps
+```
+
+**Bandit excludes** (root `pyproject.toml`, `[tool.bandit] exclude_dirs`):
+
+```text
+tests, .venv, node_modules, scripts, specs, tools/test_quality_analyzer/fixtures
+```
+
+| Tree | Ruff reads it | Bandit reads it |
+| - | - | - |
+| `src/` except `src/maps` | Yes | Yes |
+| `src/maps` | No | Yes |
+| `mist-ops-platform` | No | Yes |
+| `web_portal` | No | Yes |
+| `tests` | Yes | No |
+| `specs` | Yes | No |
+| `tools/test_quality_analyzer/fixtures` | Yes | No |
+| `scripts` | No | No |
+
+**Finding**: The two coverage sets differ in both directions. Option 3 in issue #1780 asks the team to drop bandit. That option would leave `src/maps`, `mist-ops-platform`, and `web_portal` with no security scan at all. The three trees hold 111 Python files.
+
+The `mist-ops-platform` subtree holds its own `pyproject.toml` with a separate ruff configuration. That configuration selects `E`, `W`, `F`, `I`, `N`, `UP`, `B`, `A`, `C4`, `SIM`, `TCH`, `RUF`, and `PLR`. It does not select `S` either. The root `extend-exclude` entry means a repository wide ruff run never reads the subtree, so the subtree configuration has no effect in CI.
+
+---
+
+## R7: How large is the rule gap?
+
+**Commands**:
+
+```powershell
+.venv\Scripts\python.exe -m ruff rule --all --output-format json
+```
+
+The maintainer compared the ruff `S` codes against the bandit rule identifiers from `bandit.core.extension_loader`.
+
+| Measurement | Count |
+| - | - |
+| Ruff `S` rules | 73 |
+| Bandit rules (42 plugin tests plus 33 blacklist entries) | 75 |
+| Bandit rules with no ruff equivalent | 4 |
+| Ruff rules with no bandit equivalent | 2 |
+
+**The 4 bandit rules that ruff does not implement**:
+
+| Rule | Name |
+| - | - |
+| B613 | `trojansource` |
+| B614 | `pytorch_load` |
+| B615 | `huggingface_unsafe_download` |
+| B703 | `django_mark_safe` |
+
+**Finding**: The rule gap is small in count but not small in value. `B613` detects a Trojan Source attack, which uses a bidirectional Unicode control character to make source code read one way and run another way. No other gate in this repository detects that attack. Three of the four gaps cover frameworks that this project does not use, which are PyTorch, Hugging Face, and Django.
+
+The two ruff rules with no bandit number are `S320` and `S410`. Bandit removed both rules in an earlier release, so the gap is a version difference and not a capability difference.
+
+---
+
+## R8: What is the runtime cost?
+
+| Tool | Scope | Observed wall time |
+| - | - | - |
+| Ruff | Whole repository | Under 1 second |
+| Bandit | Whole repository | About 10 seconds |
+
+Both jobs sit in the fast group of the CI workflow, which the workflow comment records as 8 to 11 seconds. Neither tool sets the total workflow time. The slow group holds pytest, pylint, and black.
+
+**Finding**: The speed argument in issue #1780 is correct but small. The workflow saves about 10 seconds if it drops bandit. That saving does not change the developer experience, because the two jobs run in parallel.
+
+---
+
+## R9: The latent annotation problem
+
+This finding does not appear in issue #1780. It changes the risk of every option that selects `S`.
+
+**Commands**:
+
+```powershell
+.venv\Scripts\python.exe -m ruff check --select S mist-ops-platform/src/shared/config/settings.py
+.venv\Scripts\python.exe -m ruff check --select S --ignore-noqa mist-ops-platform/src/shared/config/settings.py
+```
+
+**Output without `--ignore-noqa`**: one result, `S105` at line 27.
+
+**Output with `--ignore-noqa`**: two results, `S105` at line 27 and `S104` at line 41.
+
+Line 41 reads as follows.
+
+```python
+    api_host: str = "0.0.0.0"  # noqa: S104
+```
+
+**Finding**: A `# noqa: S...` annotation is not inert. It is latent. It hides nothing while `S` stays out of the select list. It starts to hide a result the moment somebody adds `S`. Bandit reports that same line as a MEDIUM `B104`.
+
+Warning: If the team selects the ruff `S` family before issue #1778 deletes this annotation, the MEDIUM result becomes invisible to ruff and stays invisible to CI, because git does not track the file. Issue #1778 must land first.
+
+Issue #1719 removed every other annotation of this kind. This one stayed out of scope, because a person cannot commit an edit to an untracked file.
+
+---
+
+## R10: What would each option cost?
+
+The counts below come from R1 through R9. Each count is a measurement, not an estimate.
+
+### Option 1: Add `S` to the ruff select list and keep bandit
+
+| Item | Count or effect |
+| - | - |
+| New ruff results to clear | 13,566 |
+| Results the team must ignore by rule and path | 13,440 `S101` results in `tests/` |
+| Lines that need a second annotation next to an existing `# nosec` | 62 |
+| Production results with no current suppression | 10 |
+| Security coverage lost | None |
+| New security coverage gained | The 10 results in R4, which include 2 default passwords |
+| Suppression comment forms in the repository | 2 |
+
+### Option 2: Keep the select list as it is
+
+| Item | Count or effect |
+| - | - |
+| New ruff results to clear | 0 |
+| Lines that need a second annotation | 0 |
+| Security coverage lost | None |
+| New security coverage gained | None |
+| Suppression comment forms in the repository | 1 |
+| Latent `# noqa: S...` annotations that stay latent | 1, at `settings.py` line 41 |
+
+### Option 3: Select `S` in ruff and drop bandit
+
+| Item | Count or effect |
+| - | - |
+| New ruff results to clear | 13,566 |
+| Lines that lose their suppression and need a new one | 117 `# nosec` comments across 51 files |
+| Trees that lose every security scan | `src/maps`, `mist-ops-platform`, `web_portal` |
+| Python files in those trees | 111 |
+| Bandit rules lost | 4, including `B613` Trojan Source detection |
+| CI time saved | About 10 seconds, in a parallel job |
+| Suppression comment forms in the repository | 1 |
+
+---
+
+## Recommendation
+
+The data supports **Option 2 with two named corrections**. The plan states the reasoning. The corrections are as follows.
+
+1. Adopt a rule that forbids a `# noqa: S...` annotation while `S` stays out of the select list. A `RUF100` check can enforce the rule. The annotation is latent, not harmless.
+2. Open a separate issue for the 10 production results in R4. Two of them are default passwords in `src/db/__init__.py`. Bandit misses them because of an annotated assignment. Correct them under the bandit gate that already exists, and do not add a second tool to find them.
+
+Option 3 fails on the coverage data alone. It would leave 111 Python files with no security scan and would lose Trojan Source detection.
+
+Option 1 delivers 10 new results for a cost of 62 double suppressions, one new ignore block for 13,440 test asserts, and a second suppression comment form. The same 10 results cost far less through a single bandit pass, because bandit already reads 8 of those 10 files.

--- a/specs/1780-ruff-s-family-decision/spec.md
+++ b/specs/1780-ruff-s-family-decision/spec.md
@@ -1,0 +1,215 @@
+# Feature Specification: Ruff S Family Decision
+
+**Feature Branch**: `docs/1778-1780-specs` (specification only. The implementation needs its own branch.)
+
+**GitHub Issue**: [#1780](https://github.com/jmorrison-juniper/MistHelper/issues/1780) - "chore: decide whether ruff should select the S rule family that duplicates bandit"
+
+**Created**: 2026-08-05
+
+**Status**: Specification. The team has not made the decision yet.
+
+**Input**: The root ruff configuration does not select the `S` family, so every `# noqa: S...` annotation does nothing. Three options exist. Gather the data, choose one option, record the reason, and apply the choice.
+
+---
+
+## Background
+
+The root `pyproject.toml` file holds this select list.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G"]
+```
+
+The `S` family holds the flake8-bandit rules. The list does not hold it. A `# noqa: S105` annotation therefore changes nothing in a ruff run.
+
+Issue [#1719](https://github.com/jmorrison-juniper/MistHelper/issues/1719) removed every annotation that this absence made useless. That issue left the design question open on purpose, because the answer needs a team decision.
+
+Issue #1780 states the question. Should ruff select `S` at all?
+
+### The three options
+
+| Option | Description |
+| - | - |
+| 1 | Add `S` to the ruff select list and keep bandit. |
+| 2 | Keep the select list as it is. This is the current state. |
+| 3 | Select `S` in ruff and drop bandit. |
+
+### Measured baseline
+
+A maintainer measured every option on 2026-08-05 with ruff 0.16.0 and bandit 1.9.4. The document [research.md](research.md) holds the full output. The table below holds the numbers that drive the decision.
+
+| Measurement | Value |
+| - | - |
+| Ruff `S` results across the repository | 13,566 |
+| Ruff `S101` results in the test tree | 13,440 |
+| Ruff `S` results outside the test tree | 121 |
+| Results on a line that already holds a `# nosec` comment | 62 |
+| Production results that bandit does not report | 10 |
+| Bandit results in tracked files today | 0 |
+| Existing `# nosec` comments in the repository | 117 |
+| Files that hold a `# nosec` comment | 51 |
+| Ruff `S` rules | 73 |
+| Bandit rules | 75 |
+| Bandit rules with no ruff equivalent | 4 |
+| Python files that ruff excludes and bandit reads | 111 |
+
+### The finding that issue #1780 does not state
+
+The measurement produced one fact that changes the risk of Option 1 and Option 3.
+
+A `# noqa: S...` annotation is **latent**, not inert. It hides nothing while `S` stays out of the select list. It starts to hide a result the moment somebody adds `S`.
+
+The proof sits at `mist-ops-platform/src/shared/config/settings.py` line 41.
+
+```python
+    api_host: str = "0.0.0.0"  # noqa: S104
+```
+
+A run of `ruff check --select S` on that file reports one result at line 27 and no result at line 41. The same run with `--ignore-noqa` reports both. Bandit reports line 41 as a MEDIUM `B104`.
+
+Warning: If a person selects the ruff `S` family before issue [#1778](https://github.com/jmorrison-juniper/MistHelper/issues/1778) deletes that annotation, the MEDIUM result becomes invisible to ruff and stays invisible to CI. Issue #1778 must land first.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Read the decision without asking the author (Priority: P1)
+
+A new maintainer wonders why a `# noqa: S101` annotation appears in a pull request review but never fires. The maintainer opens the decision record. The record states the choice, the reason, and the measured data behind it. The maintainer needs no further conversation.
+
+**Why this priority**: The question returns every time somebody reads a suppression comment. A written decision ends the loop. This story delivers value even if the team keeps the current state.
+
+**Independent Test**: A reviewer opens the decision record and finds the chosen option, the date, the reason, and a link to the measured data.
+
+**Acceptance Scenarios**:
+
+1. **Given** the decision record, **When** a reviewer reads it, **Then** the record names one of the three options.
+2. **Given** the decision record, **When** a reviewer reads it, **Then** the record states the reason and links to the measurement that supports it.
+3. **Given** the decision record, **When** a reviewer reads it, **Then** the record names the date and the tool versions that produced the measurement.
+4. **Given** the decision record, **When** a reviewer reads it, **Then** the record states what would change the decision later.
+
+---
+
+### User Story 2 - Write the correct suppression comment on the first try (Priority: P1)
+
+A developer adds a subprocess call and sees a security result. The developer opens the suppression contract. The contract states which comment form works. The developer writes one comment and the gate turns green.
+
+**Why this priority**: A wrong suppression comment wastes a CI cycle and a review cycle. The contract removes the guess.
+
+**Independent Test**: A reviewer reads `specs/1032-bandit-severity-gate/contracts/suppression-comment.md` and finds a statement about the ruff `S` family.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated suppression contract, **When** a developer reads it, **Then** the contract states which comment form suppresses a security result.
+2. **Given** the updated suppression contract, **When** a developer reads it, **Then** the contract states whether a `# noqa: S...` annotation does anything.
+3. **Given** the updated suppression contract, **When** a developer reads it, **Then** the contract names the tool that owns each security rule.
+4. **Given** a security result on one line, **When** a developer applies the contract, **Then** the developer writes one comment and not two.
+
+---
+
+### User Story 3 - Stop a latent annotation from entering the code (Priority: P2)
+
+A reviewer reads a pull request that adds `# noqa: S603`. A gate rejects the annotation, because the `S` family stays out of the select list. The annotation never reaches `main`.
+
+**Why this priority**: This story protects the decision over time. Issue #1719 removed the annotations once. Without a gate, they return.
+
+**Independent Test**: A reviewer adds a `# noqa: S101` annotation to a tracked file and confirms that a gate reports it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pull request that adds a `# noqa: S...` annotation, **When** CI runs the lint gate, **Then** the gate reports the line and names the file.
+2. **Given** the current code base, **When** CI runs the lint gate, **Then** the gate reports zero latent annotations.
+3. **Given** a person who removes the `S` family from the select list later, **When** CI runs the lint gate, **Then** the gate reports every annotation that turns latent.
+
+---
+
+### Edge Cases
+
+- A person selects `S` without an ignore rule for the test tree. The gate then reports 13,440 `S101` results and can never turn green.
+- A person selects `S` and clears the results with `--fix`. Ruff can add a `# noqa` comment automatically, so the repository gains thousands of annotations in one command. A reviewer cannot read that diff.
+- A person drops bandit and does not remove the `mist-ops-platform` entry from the ruff exclude list. The subtree then holds 111 Python files with no security scan and no visible warning.
+- A person drops bandit and loses `B613`, which detects a Trojan Source attack. No other gate in this repository detects that attack.
+- A person selects `S` before issue #1778 lands. The latent annotation at `settings.py` line 41 then hides a MEDIUM result for good.
+- A future ruff release adds the four missing bandit rules. The gap analysis then needs a new measurement, and Option 3 becomes cheaper.
+- A future bandit release adds a rule. The team must triage the new result. The team must not restore a severity filter, per issue #889.
+
+---
+
+## Requirements *(mandatory)*
+
+### Decision requirements
+
+- **FR-001**: The team MUST choose one of the three options and MUST record the choice in the repository.
+- **FR-002**: The decision record MUST state the reason for the choice.
+- **FR-003**: The decision record MUST link to the measured data in [research.md](research.md).
+- **FR-004**: The decision record MUST name the tool versions and the date of the measurement.
+- **FR-005**: The decision record MUST state what evidence would change the decision later.
+- **FR-006**: The decision record MUST state which tool owns each security rule, or MUST state that the two tools overlap and MUST name the overlap.
+
+### Contract requirements
+
+- **FR-007**: The file `specs/1032-bandit-severity-gate/contracts/suppression-comment.md` MUST state which comment form suppresses a security result.
+- **FR-008**: The suppression contract MUST state whether a `# noqa: S...` annotation has any effect.
+- **FR-009**: If the team keeps the `S` family out of the select list, the contract MUST state that a `# noqa: S...` annotation is latent and MUST state the consequence.
+
+### Guard requirements
+
+- **FR-010**: If the team keeps the `S` family out of the select list, a gate MUST report any new `# noqa: S...` annotation.
+- **FR-011**: The guard MUST report the file and the line number, so that a developer can find the annotation without a search.
+- **FR-012**: The guard MUST report zero results against the current code base at the time it lands.
+
+### Coordination requirements
+
+- **FR-013**: This work MUST NOT add `S` to the select list before issue #1778 deletes the latent annotation at `mist-ops-platform/src/shared/config/settings.py` line 41.
+- **FR-014**: The pull request MUST reference issue #1719, which raised this question, and issue #1778, which holds the ordering risk.
+- **FR-015**: If the team chooses Option 1 or Option 3, the work MUST run `ruff check --select S --ignore-noqa` first and MUST triage every result that a latent annotation currently hides.
+
+### Quality requirements
+
+- **FR-016**: Every changed file MUST keep every CI gate green.
+- **FR-017**: All prose and all commit text MUST follow the writing guide at `documentation/ASD-STE100_writing-guide.md`.
+- **FR-018**: The decision MUST NOT reduce security coverage without a written statement of what it gives up.
+
+### Key Entities
+
+- **Rule family**: A group of ruff rules with a shared prefix. The `S` family holds the flake8-bandit rules.
+- **Latent annotation**: A `# noqa` comment for a rule that no configuration selects today. It starts to hide a result the moment somebody selects that rule.
+- **Suppression contract**: The document that states which comment form hides a security result.
+- **Decision record**: The document that states the chosen option, the reason, and the measured data.
+
+---
+
+## Non-Goals
+
+- **NG-001**: This work does not correct the 10 production results that [research.md](research.md) section R4 lists. Those need their own issue.
+- **NG-002**: This work does not change the bandit configuration, the bandit targets, or the bandit exclude list.
+- **NG-003**: This work does not remove any tree from the ruff exclude list.
+- **NG-004**: This work does not correct the gitignore defect in issue #1778. It records the ordering only.
+- **NG-005**: This work does not add a new security tool such as Semgrep.
+- **NG-006**: This work does not change the CodeQL workflow.
+- **NG-007**: This work does not select any other ruff rule family.
+
+---
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: The repository holds one document that names the chosen option and the reason.
+- **SC-002**: A reader finds the decision within two minutes and needs no conversation with the author.
+- **SC-003**: The suppression contract states which comment form works, and a reader needs no second document.
+- **SC-004**: The repository holds zero latent `# noqa: S...` annotations at the time the work lands.
+- **SC-005**: A gate reports any new latent annotation and names the file and the line.
+- **SC-006**: Every CI gate that was green before the change stays green.
+- **SC-007**: The bandit gate keeps its current result count of zero in tracked files.
+- **SC-008**: The pull request states the ordering against issue #1778.
+- **SC-009**: If the team chooses Option 1 or Option 3, the ruff `S` gate reports zero results on the branch.
+- **SC-010**: If the team chooses Option 3, the pull request names every tree that loses its security scan and names every bandit rule that the repository gives up.
+
+---
+
+## Assumptions
+
+- The team accepts a measured recommendation. [research.md](research.md) recommends Option 2 with two named corrections.
+- The tool versions stay pinned in `requirements-dev.txt`, so the measurement holds until Dependabot raises an update.
+- The `mist-ops-platform`, `web_portal`, and `src/maps` trees stay in the repository and stay in the ruff exclude list.
+- The test suite keeps its `assert` statements. Pytest needs them, so `S101` in the test tree can never be a real result.
+- CodeQL stays in place and covers a different rule set, so it does not replace either tool.

--- a/specs/1780-ruff-s-family-decision/tasks.md
+++ b/specs/1780-ruff-s-family-decision/tasks.md
@@ -1,0 +1,156 @@
+# Tasks: Ruff S Family Decision
+
+**Feature**: `1780-ruff-s-family-decision` | **Branch**: the implementation needs its own branch | **Date**: 2026-08-05
+
+**GitHub Issue**: [#1780](https://github.com/jmorrison-juniper/MistHelper/issues/1780)
+
+**Input**: Design documents from `specs/1780-ruff-s-family-decision/`
+
+**Prerequisites**: [spec.md](spec.md), [plan.md](plan.md), [research.md](research.md)
+
+**Tests**: The guard in User Story 3 needs one new test. The existing suite must keep its pass count.
+
+**Branch rule**: Create a branch from `main` with the name `chore/1780-ruff-s-family-decision`. Do not reuse the documentation branch.
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: The task can run in parallel with another task in the same phase. The tasks touch different files.
+- **[Story]**: The user story that owns the task. The value is `US1`, `US2`, or `US3`.
+- Each task names an exact file path.
+
+## Rules that apply to every task
+
+1. Use `.venv\Scripts\python.exe` for every Python command. The global interpreter cannot import the project.
+2. Every prose line follows the writing guide at `documentation/ASD-STE100_writing-guide.md`.
+3. Never run `ruff --fix` with the `S` family selected. The flag adds a `# noqa` comment for every result, and a reviewer cannot read that diff.
+4. Run every gate across the whole repository. Do not scope a gate to the changed paths.
+5. Do not add `S` to the select list before issue [#1778](https://github.com/jmorrison-juniper/MistHelper/issues/1778) lands. Requirement FR-013 states the order.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the environment before any measurement.
+
+- [ ] T001 Create the branch with `git checkout -b chore/1780-ruff-s-family-decision main`. Confirm the name with `git branch --show-current`.
+- [ ] T002 Confirm that `.venv\Scripts\python.exe -m ruff --version` reports `0.16.0` and that `.venv\Scripts\python.exe -m bandit --version` reports `1.9.4`. Install the pinned set with `pip install -r requirements-dev.txt` if a version differs.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Confirm that the recorded measurement still holds. No decision starts until this phase closes.
+
+- [ ] T003 Re-run the ruff measurement. Run `.venv\Scripts\python.exe -m ruff check --select S --statistics .` and confirm 13,566 results with 13,440 under `S101`. Run the same command with `--exclude tests` and confirm 121 results.
+- [ ] T004 Re-run the bandit measurement. Run `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r . -f json -o "$env:TEMP\bandit_1780.json" -q`. Confirm 43 raw results, 42 under `tools/test_quality_analyzer/fixtures/`, and 0 results in files that git tracks.
+- [ ] T005 Re-run the latent annotation search. Run `git grep -n "noqa: S"` across every tracked file. Confirm zero hits. Then run `.venv\Scripts\python.exe -m ruff check --select S --ignore-noqa --statistics .` and compare the total against T003. A higher total means a latent annotation exists.
+- [ ] T006 Read the status of issue #1778 with `gh issue view 1778`. Record whether the latent `# noqa: S104` annotation at `mist-ops-platform/src/shared/config/settings.py` line 41 still exists. Requirement FR-013 needs this record.
+- [ ] T007 Compare every count from T003 to T006 against [research.md](research.md). If a count differs, record the drift in [research.md](research.md) and read the recommendation again before Phase 3.
+
+**Checkpoint**: The measurement holds. Phase 3 can start.
+
+---
+
+## Phase 3: User Story 1 - Record the decision (Priority: P1)
+
+**Goal**: Choose one option and write a record that a new maintainer can read without a conversation.
+
+**Independent Test**: A reviewer opens the decision record and finds the option, the reason, the date, and a link to the data.
+
+- [ ] T008 [US1] Read [research.md](research.md) section R10, which states the cost of each option. Read the two counter arguments in [plan.md](plan.md). Choose one of the three options.
+- [ ] T009 [US1] Create `specs/1780-ruff-s-family-decision/decision.md`. State the chosen option, the date, and the tool versions. Requirements FR-001 and FR-004 demand these fields.
+- [ ] T010 [US1] Add the reason to `specs/1780-ruff-s-family-decision/decision.md`. Link to [research.md](research.md) and name the sections that support the reason. Requirements FR-002 and FR-003 demand these links.
+- [ ] T011 [US1] Add the rule ownership statement to `specs/1780-ruff-s-family-decision/decision.md`. Name the tool that owns each security rule, or state that the two tools overlap and name the overlap. Requirement FR-006 demands this statement.
+- [ ] T012 [US1] Add the review trigger to `specs/1780-ruff-s-family-decision/decision.md`. State what evidence would change the decision later. Name the four bandit rules that ruff does not implement, which are `B613`, `B614`, `B615`, and `B703`. Requirement FR-005 demands this statement.
+- [ ] T013 [US1] Add the written answer to each counter argument in [plan.md](plan.md). Cover the 10 results that ruff finds and bandit misses. Cover the inline editor argument. Requirement FR-018 demands a written statement of what the choice gives up.
+
+**Checkpoint**: The decision record is complete. Phase 4 can start.
+
+---
+
+## Phase 4: User Story 2 - Update the suppression contract (Priority: P1)
+
+**Goal**: State which comment form works, so that a developer writes one comment and not two.
+
+**Independent Test**: A reviewer reads `specs/1032-bandit-severity-gate/contracts/suppression-comment.md` and finds a statement about the ruff `S` family.
+
+- [ ] T014 [US2] Read `specs/1032-bandit-severity-gate/contracts/suppression-comment.md` and record what it states about the `S` family today.
+- [ ] T015 [US2] Add the comment form statement to `specs/1032-bandit-severity-gate/contracts/suppression-comment.md`. State that bandit reads `# nosec` and that ruff reads `# noqa`. State that the two forms never overlap. Requirement FR-007 demands this statement.
+- [ ] T016 [US2] Add the latent annotation warning to `specs/1032-bandit-severity-gate/contracts/suppression-comment.md`. State that a `# noqa: S...` annotation hides nothing today and starts to hide a result the moment somebody selects the `S` family. Link to [research.md](research.md) section R9, which holds the proof. Requirements FR-008 and FR-009 demand this warning.
+- [ ] T017 [US2] Add a link from `specs/1032-bandit-severity-gate/contracts/suppression-comment.md` to `specs/1780-ruff-s-family-decision/decision.md`, so that a reader finds the reason behind the rule.
+
+**Checkpoint**: The contract is correct. Phase 5 can start.
+
+---
+
+## Phase 5: User Story 3 - Add the guard (Priority: P2, Option 2 only)
+
+**Goal**: Stop a new latent annotation from reaching `main`.
+
+**Independent Test**: A reviewer adds a `# noqa: S101` annotation to a tracked file and confirms that the test fails and names the file and the line.
+
+**Skip condition**: If the team chooses Option 1 or Option 3, skip this phase. A selected `S` family makes every annotation active, so no latent annotation can exist.
+
+- [ ] T018 [US3] Create `tests/guardrails/test_no_latent_noqa_s.py`. Read the tracked Python file list with `git ls-files "*.py"`. Search each file for a `# noqa` comment that names an `S` code. Follow the existing guard test style in `tests/guardrails/`.
+- [ ] T019 [US3] Make the test report the file path and the line number for each hit. Requirement FR-011 demands both fields. Add an inline comment to every line of the test, per Principle VI.
+- [ ] T020 [US3] Run the test with `.venv\Scripts\python.exe -m pytest tests/guardrails/test_no_latent_noqa_s.py -q`. Confirm zero hits against the current code base. Requirement FR-012 demands this result.
+- [ ] T021 [US3] Prove that the test works. Add a `# noqa: S101` annotation to one tracked file, run the test, and confirm that it fails and names that file and that line. Remove the annotation afterward.
+
+**Checkpoint**: The guard holds. Phase 6 can start.
+
+---
+
+## Phase 6: Apply the choice (Option 1 and Option 3 only)
+
+**Goal**: Change the configuration when the team overrides the recommendation.
+
+**Skip condition**: If the team chooses Option 2, skip this phase. Option 2 changes no configuration.
+
+**Warning**: A change to the select list activates every latent annotation. Run task T022 first, or a hidden security result stays hidden for good.
+
+- [ ] T022 Triage every hidden result. Run `.venv\Scripts\python.exe -m ruff check --select S --ignore-noqa .` and compare the output against a run without the flag. Record a decision for each result that only the first run reports. Requirement FR-015 demands this triage.
+- [ ] T023 Add the test tree ignore rule to `pyproject.toml`. Add `S101` to the `tests/**` entry in `[tool.ruff.lint.per-file-ignores]`. The measurement shows 13,440 results without this rule. Add a comment that states the count and the reason.
+- [ ] T024 Add `S` to the `select` list in `[tool.ruff.lint]` of `pyproject.toml`. Add a comment that links to `specs/1780-ruff-s-family-decision/decision.md`.
+- [ ] T025 Add the second annotation to each of the 62 lines that already hold a `# nosec` comment. [research.md](research.md) section R3 holds the count. Write the ruff annotation first and the bandit comment second, so that both tools read their own form.
+- [ ] T026 Triage the 10 production results in [research.md](research.md) section R4. Two of them are default passwords in `src/db/__init__.py` lines 45 and 48. **Warning**: If a value is a real credential, move it to the environment and raise a rotation request. Do not add a suppression comment for a real secret.
+- [ ] T027 Under Option 3 only, delete the bandit job from `.github/workflows/ci.yml`. Delete the `[tool.bandit]` table from `pyproject.toml`. Remove `bandit` from `requirements-dev.txt`. Remove the bandit entry from `.pre-commit-config.yaml`.
+- [ ] T028 Under Option 3 only, remove every one of the 117 `# nosec` comments across the 51 files that hold one. A comment for a tool that no longer runs is dead text.
+- [ ] T029 Under Option 3 only, record what the repository gives up. Name `src/maps`, `mist-ops-platform`, and `web_portal`, which hold 111 Python files that ruff excludes. Name the four bandit rules with no ruff equivalent. Success criterion SC-010 demands this record.
+
+**Checkpoint**: The configuration matches the decision. Phase 7 can start.
+
+---
+
+## Phase 7: Verify and hand over
+
+**Goal**: Prove that every gate stays green and close the loop with the neighboring issues.
+
+- [ ] T030 Run the lint gate and the format gate. Run `.venv\Scripts\python.exe -m ruff check .` and `.venv\Scripts\python.exe -m black --check --diff .`. Confirm that each command exits with code 0.
+- [ ] T031 Run the security gate. Run `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r . -q` under Option 1 and Option 2 and confirm the count from T004. Skip this task under Option 3, because the gate no longer exists.
+- [ ] T032 Run the test suite. Run `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q` and confirm that the pass count matches the count before the change. Success criterion SC-006 compares against it.
+- [ ] T033 Open a separate issue for the 10 production results in [research.md](research.md) section R4. Name the two default passwords in `src/db/__init__.py`. Add the labels `security` and `chore`. Non-goal NG-001 keeps that work outside this scope.
+- [ ] T034 Write the pull request body. State the chosen option and link to `specs/1780-ruff-s-family-decision/decision.md`. State the ordering against issue #1778. Reference issue [#1719](https://github.com/jmorrison-juniper/MistHelper/issues/1719), which raised the question. Requirement FR-014 demands both references.
+- [ ] T035 Run the writing gate. Run `.venv\Scripts\python.exe -m tools.ste_linter` against every changed Markdown file and confirm a score of 80 or more.
+- [ ] T036 Open the pull request. Write `Closes #1780` in the body. Add the labels `chore` and `docs`. Wait for CodeQL to report before adding the `auto-merge` label.
+
+---
+
+## Dependencies
+
+| Task | Depends on | Reason |
+| - | - | - |
+| T008 | T007 | The choice needs a measurement that still holds. |
+| T009 to T013 | T008 | The record needs the chosen option. |
+| T015 to T017 | T008 | The contract text depends on the chosen option. |
+| T018 | T008 | The guard exists only under Option 2. |
+| T022 | T006 | The triage needs the status of issue #1778. |
+| T024 | T022, T023 | The select list changes only after the triage and the ignore rule. |
+| T034 | T009 | The pull request body links to the decision record. |
+
+## Parallel opportunities
+
+- T003, T004, and T005 read the same working tree and change nothing. Run them in parallel.
+- T009 to T013 write one file in sequence. Do not run them in parallel.
+- T030, T031, and T032 read the same working tree and change nothing. Run them in parallel.


### PR DESCRIPTION
## Summary

This pull request adds two specification sets. Neither one holds an implementation. Both stop at the task list on purpose, so the team can review the approach before any code changes.

- `specs/1778-gitignore-source-leak/` holds `spec.md`, `plan.md`, and `tasks.md`.
- `specs/1780-ruff-s-family-decision/` holds `spec.md`, `plan.md`, `tasks.md`, and `research.md`.

Refs #1778
Refs #1780

These specifications do not resolve either issue. Each issue closes when its own implementation pull request merges.

## Measured data

Every number below comes from a command that ran on 2026-08-05 with ruff 0.16.0 and bandit 1.9.4.

### Ruff S family statistics

```text
.venv\Scripts\python.exe -m ruff check --select S --statistics .

13440   S101    assert
   39   S106    hardcoded-password-func-arg
   25   S108    hardcoded-temp-file
   22   S105    hardcoded-password-string
   13   S603    subprocess-without-shell-equals-true
   10   S110    try-except-pass
    3   S310    suspicious-url-open-usage
    3   S607    start-process-with-partial-path
    3   S608    hardcoded-sql-expression
    2   S104    hardcoded-bind-all-interfaces
    2   S113    request-without-timeout
    2   S605    start-process-with-a-shell
    1   S112    try-except-continue
    1   S606    start-process-with-no-shell
Found 13566 errors.
```

| Scope | Results |
| - | - |
| Whole repository | 13,566 |
| Outside the test tree | 121 |
| Inside `src/` only | 62 |
| On a line that already holds a `# nosec` comment | 62 of the 121 |
| Bandit results in tracked files | 0 |

## Findings that the issues do not state

The research produced five facts that neither issue records. Each fact widens the work.

1. **The `config/` pattern hides three directories, not one.** It matches `mist-ops-platform/src/shared/config/`, `ops-portal/src/features/config/`, and `ops-portal/src/pages/config/`. Together they hold 20 source files. Issue #1778 names only the first.
2. **The black gate also stops the build.** Black reads `.gitignore` and skips an ignored file, so the settings module never met the formatter. It carries the 99 character line length of its subtree. The root configuration sets 120. A forced run confirms that black would rewrite the file. Issue #1778 names only the bandit gate.
3. **The `# noqa: S104` annotation is latent, not inert.** A run of `ruff check --select S` on the module reports one result at line 27 and no result at line 41. The same run with `--ignore-noqa` reports both. The annotation already hides the result from ruff. This changes the ordering of the two issues, and neither issue states it.
4. **The two tools read different trees.** Ruff excludes `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`. Bandit excludes `tests`, `specs`, `scripts`, and the analyzer fixtures. Option 3 in issue #1780 would leave 111 Python files with no security scan.
5. **The rule gap is 4 rules, not a vague subset.** Bandit holds 75 rules and ruff holds 73 `S` rules. The four with no ruff equivalent are `B613` `trojansource`, `B614` `pytorch_load`, `B615` `huggingface_unsafe_download`, and `B703` `django_mark_safe`. Only `B613` matters here, because this project does not use PyTorch, Hugging Face, or Django.

## Ordering warning

Issue #1778 must land before issue #1780 selects the ruff `S` family. If the select list changes first, the latent `# noqa: S104` annotation activates and hides the MEDIUM `B104` result from both tools. Both specifications record this order.

## Recommendation in the research document

The data supports Option 2, which keeps the current select list, with two named corrections. The suppression contract must state that a `# noqa: S...` annotation is latent. A separate issue must correct the 10 production results that ruff finds and bandit misses. Two of those 10 are default passwords in `src/db/__init__.py`.

The research document states the counter arguments and the answer to each one, so a reviewer can disagree with evidence rather than with opinion.

## Writing gate

Every file passes the Simplified Technical English linter. The gate is 80.

| File | Score |
| - | - |
| `specs/1778-gitignore-source-leak/spec.md` | 97 |
| `specs/1778-gitignore-source-leak/plan.md` | 98 |
| `specs/1778-gitignore-source-leak/tasks.md` | 96 |
| `specs/1780-ruff-s-family-decision/spec.md` | 98 |
| `specs/1780-ruff-s-family-decision/plan.md` | 98 |
| `specs/1780-ruff-s-family-decision/tasks.md` | 96 |
| `specs/1780-ruff-s-family-decision/research.md` | 98 |

## Scope

The change adds seven Markdown files under `specs/`. It touches no production code, no test, and no configuration.
