### PR TITLE
fix: call the canonical device prompt in the menu 76 operation

### DIFF
--- a/src/export/site_insights/device_metric_operation.py
+++ b/src/export/site_insights/device_metric_operation.py
@@ -80,7 +80,8 @@ class DeviceMetricOperation:
         if not site_id:
             logging.error("No site selected. Exiting.")  # WHY: Match legacy error log message verbatim
             return None
-        device_id = self.PromptUtils.select_device(site_id)  # WHY: Device prompt is scoped by site
+        # Issue #431 renamed select_device to select_device_id_from_inventory. This call site was missed.
+        device_id = self.PromptUtils.select_device_id_from_inventory(site_id)  # WHY: Device prompt is scoped by site
         if not device_id:
             logging.error("No device selected. Exiting.")  # WHY: Match legacy error log message verbatim
             return None

--- a/tests/unit/export/site_insights/test_device_metric_operation_wave3.py
+++ b/tests/unit/export/site_insights/test_device_metric_operation_wave3.py
@@ -34,7 +34,9 @@ from src.export.site_insights.device_metric_operation import (  # WHY: SUTs unde
 def _make_deps() -> dict:
     """Return the eight injected constructor kwargs as a fresh dict of MagicMocks."""
     apisession = MagicMock(name="apisession")  # WHY: opaque session object; passed through unchanged.
-    prompt_utils = MagicMock(name="PromptUtils")  # WHY: select_site/select_device stubs bound per-test.
+    prompt_utils = MagicMock(
+        name="PromptUtils"
+    )  # WHY: select_site/select_device_id_from_inventory stubs bound per-test.
     data_processing = MagicMock(name="DataProcessingUtils")  # WHY: flatten/escape helpers.
     data_exporter = MagicMock(name="DataExporter")  # WHY: write_with_format_selection observed.
     enhanced_ssh = MagicMock(name="EnhancedSSHRunner")  # WHY: sanitize_filename returns predictable token.
@@ -111,13 +113,13 @@ class TestExecute:
         with caplog.at_level(logging.INFO):  # WHY: capture starting log entry too.
             op.execute()  # WHY: exercise the top-level dispatcher.
         op.InsightMetricsUtils.export_const_insight_metrics.assert_called_once()  # WHY: refresh still ran.
-        op.PromptUtils.select_device.assert_not_called()  # WHY: cancelled before device prompt.
+        op.PromptUtils.select_device_id_from_inventory.assert_not_called()  # WHY: cancelled before device prompt.
 
     def test_execute_returns_when_context_fails(self, monkeypatch) -> None:
         """When _build_context returns None (bad MAC), execute() must skip _run_export."""
         op = _make_op()  # WHY: fresh SUT.
         op.PromptUtils.select_site.return_value = "site-xyz"  # WHY: happy prompt path.
-        op.PromptUtils.select_device.return_value = "dev-abc"  # WHY: device prompt succeeds.
+        op.PromptUtils.select_device_id_from_inventory.return_value = "dev-abc"  # WHY: device prompt succeeds.
         # WHY: force _build_context to return None so _run_export must never fire.
         monkeypatch.setattr(op, "_build_context", lambda *_args, **_kw: None)
         run_export = MagicMock(name="_run_export")  # WHY: assert we never enter the export pipeline.
@@ -129,7 +131,7 @@ class TestExecute:
         """When both helpers succeed, execute() must invoke _run_export with the built context."""
         op = _make_op()  # WHY: fresh SUT.
         op.PromptUtils.select_site.return_value = "site-xyz"  # WHY: happy prompt path.
-        op.PromptUtils.select_device.return_value = "dev-abc"  # WHY: device prompt succeeds.
+        op.PromptUtils.select_device_id_from_inventory.return_value = "dev-abc"  # WHY: device prompt succeeds.
         context = _make_context()  # WHY: canned frozen context handed downstream.
         monkeypatch.setattr(op, "_build_context", lambda *_a, **_kw: context)  # WHY: stub the builder.
         run_export = MagicMock(name="_run_export")  # WHY: observe the orchestrator call site.
@@ -164,14 +166,14 @@ class TestPromptSiteAndDevice:
         with caplog.at_level(logging.ERROR):
             result = op._prompt_site_and_device()  # WHY: exercise cancel-at-site branch.
         assert result is None  # WHY: contract: None means cancel.
-        op.PromptUtils.select_device.assert_not_called()  # WHY: never advance to device prompt.
+        op.PromptUtils.select_device_id_from_inventory.assert_not_called()  # WHY: never advance to device prompt.
         assert any("No site selected" in r.message for r in caplog.records)  # WHY: log preserved.
 
     def test_returns_none_when_device_falsy(self, caplog) -> None:
         """A falsy device_id after a good site_id also returns None."""
         op = _make_op()  # WHY: fresh SUT.
         op.PromptUtils.select_site.return_value = "site-xyz"  # WHY: first prompt succeeds.
-        op.PromptUtils.select_device.return_value = None  # WHY: user cancels at second prompt.
+        op.PromptUtils.select_device_id_from_inventory.return_value = None  # WHY: user cancels at second prompt.
         with caplog.at_level(logging.ERROR):
             result = op._prompt_site_and_device()  # WHY: exercise cancel-at-device branch.
         assert result is None  # WHY: contract: None means cancel.
@@ -181,7 +183,7 @@ class TestPromptSiteAndDevice:
         """When both prompts succeed, the helper returns (site_id, device_id)."""
         op = _make_op()  # WHY: fresh SUT.
         op.PromptUtils.select_site.return_value = "site-xyz"  # WHY: first prompt happy.
-        op.PromptUtils.select_device.return_value = "dev-abc"  # WHY: second prompt happy.
+        op.PromptUtils.select_device_id_from_inventory.return_value = "dev-abc"  # WHY: second prompt happy.
         assert op._prompt_site_and_device() == ("site-xyz", "dev-abc")  # WHY: contract shape.
 
 

--- a/tests/unit/ui/test_device_prompt_rename_guard.py
+++ b/tests/unit/ui/test_device_prompt_rename_guard.py
@@ -1,0 +1,89 @@
+"""Guard against call sites that survived the issue #431 device-prompt rename.
+
+Issue #431 removed ``PromptUtils.select_device`` and made
+``PromptUtils.select_device_id_from_inventory`` the one device prompt. One call
+site in ``src/export/site_insights/device_metric_operation.py`` kept the old
+name. No unit test covered it, so menu 76 raised ``AttributeError`` until a live
+``--testinteractive`` run found it.
+
+These tests fail if the old name comes back.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from src.ui.prompt_utils import PromptUtils
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCANNED_DIRS = ("src", "web_portal")
+REMOVED_NAME = "select_device"
+CANONICAL_NAME = "select_device_id_from_inventory"
+
+
+def _python_files() -> list[Path]:
+    """Return every Python file in the scanned source directories."""
+    files: list[Path] = []
+    for folder in SCANNED_DIRS:
+        root = REPO_ROOT / folder
+        if root.is_dir():
+            files.extend(root.rglob("*.py"))
+    return files
+
+
+def _attribute_calls(tree: ast.AST) -> list[str]:
+    """Return the attribute name of every call of the form ``something.name(...)``."""
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            names.append(node.func.attr)
+    return names
+
+
+def test_canonical_prompt_exists() -> None:
+    """The canonical device prompt must stay on PromptUtils."""
+    assert hasattr(PromptUtils, CANONICAL_NAME), f"PromptUtils lost {CANONICAL_NAME}"
+
+
+def test_removed_prompt_stays_removed() -> None:
+    """Issue #431 removed the old prompt. It must not come back."""
+    assert not hasattr(
+        PromptUtils, REMOVED_NAME
+    ), f"PromptUtils.{REMOVED_NAME} came back. Issue #431 replaced it with {CANONICAL_NAME}."
+
+
+def test_no_source_file_calls_the_removed_prompt() -> None:
+    """No source file may call the removed device prompt.
+
+    A call to the removed name raises AttributeError at runtime, and only an
+    interactive run reaches most of those code paths.
+    """
+    offenders: list[str] = []
+    for path in _python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # Not parseable, so not a call site.
+            continue
+        if REMOVED_NAME in _attribute_calls(tree):
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert not offenders, (
+        f"These files call the removed PromptUtils.{REMOVED_NAME}: {offenders}. "
+        f"Use {CANONICAL_NAME}(site_id, device_type=...) instead."
+    )
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    ["src/export/site_insights/device_metric_operation.py"],
+)
+def test_known_regression_site_uses_canonical_prompt(module_path: str) -> None:
+    """The menu 76 module must call the canonical prompt.
+
+    This file held the missed call site, so it gets its own check.
+    """
+    source = (REPO_ROOT / module_path).read_text(encoding="utf-8")
+    assert CANONICAL_NAME in source, f"{module_path} no longer calls {CANONICAL_NAME}"


### PR DESCRIPTION
## Summary

Menu 76, "Export device-specific insight metrics for a selected site", raised
`type object 'PromptUtils' has no attribute 'select_device'` on every run.

A live `--testinteractive` run against a real organization found it. No unit test
would ever have.

Closes #1783

## Cause

Issue #431 removed `PromptUtils.select_device` and made
`select_device_id_from_inventory` the one device prompt. That change updated every
call site but one.

`src/export/site_insights/device_metric_operation.py` line 83 kept the old name,
so the operation could never reach the device prompt.

`src/ui/prompt_utils.py` already carries the note that the method is gone.

## Why no test caught it

This is the part worth reading.

The existing test binds `PromptUtils` to a `MagicMock`:

```python
prompt_utils = MagicMock(name="PromptUtils")
```

A `MagicMock` answers to **any** attribute name. The test stubbed
`op.PromptUtils.select_device` and asserted against it, so it passed against code
that could never run. Seven references named the removed method.

The test did not just miss the defect. It asserted the defect.

## What changed

| File | Change |
| - | - |
| `src/export/site_insights/device_metric_operation.py` | Call `select_device_id_from_inventory(site_id)` |
| `tests/unit/export/site_insights/test_device_metric_operation_wave3.py` | Correct 7 stale mock references |
| `tests/unit/ui/test_device_prompt_rename_guard.py` | New guard, 4 tests |

The guard walks the AST of every file under `src/` and `web_portal/` and fails if
any file calls the removed name. It also asserts the removed name stays off the
class, so a revival of the method is caught too.

## Verification

- **The guard actually catches the regression.** I reintroduced the old call, and
  `test_no_source_file_calls_the_removed_prompt` failed. I restored the fix, and
  all 4 passed. A guard that has never failed is not a guard.
- A repository-wide search found **no other stale call site**.
- 254 unit tests pass in the affected areas.
- `ruff check .` and `black --check .` pass across all 984 files.

## Note on the wider run

The same `--testinteractive` run reported 11 failures out of 67. Ten of those are
an artifact of how I fed answers, not defects. I piped one repeated site index,
and ten operations prompt for something else, such as a device index, a beacon
identifier, or a zone type. Menu 76 is the only real defect in that set.

That points at a separate gap: `--testinteractive` has no way to run unattended,
because the answer it needs varies per operation. That deserves its own issue.
