### PR TITLE
fix: ignore third-party ERROR records in the interactive test observer

### DIFF
--- a/src/troubleshooting/interactive_test_runner.py
+++ b/src/troubleshooting/interactive_test_runner.py
@@ -26,6 +26,11 @@ class TestSiteSelectorUnresolved(RuntimeError):
     """
 
 
+_THIRD_PARTY_LOGGER_ROOTS = frozenset(
+    {"mistapi", "websocket", "urllib3", "requests", "paramiko"}
+)  # WHY: #1786 -- these libraries log a transport condition the caller may treat as normal.
+
+
 class _LoggedErrorObserver(logging.Handler):
     """Root-logger handler that counts ERROR (or higher) records emitted during an option run.
 
@@ -37,17 +42,31 @@ class _LoggedErrorObserver(logging.Handler):
         the ``_invoke_option`` call gives the runner a deterministic signal
         that a logged-error occurred without an exception being raised, so it
         can route to the failure emitter and keep the exit code accurate.
+
+        Issue #1786 — the handler sits on the root logger, so it also saw
+        records from third-party libraries. The ``mistapi`` SDK logs an ERROR
+        for every HTTP 404, and a probe-style operation treats a 404 as the
+        answer rather than a fault. Menu 74 asks for 61 insight metrics and a
+        site rarely carries them all, which produced 122 records and one false
+        failure. Only a MistHelper logger now counts, which keeps the whole
+        intent of #1636, because a handler that swallows its own logged error
+        still reports under a MistHelper logger name.
     """
 
     def __init__(self) -> None:
         """Configure the handler at ERROR level with a zero-count captured tally."""
         super().__init__(level=logging.ERROR)
         self.error_count = 0  # WHY: cheap monotonic tally. Callers only check >0.
+        self.ignored_count = 0  # WHY: #1786 -- third-party records, reported so they stay visible.
 
     def emit(self, record: logging.LogRecord) -> None:  # noqa: D401 -- logging.Handler API
         """Increment the captured error tally for each ERROR (or higher) record."""
-        if record.levelno >= logging.ERROR:
-            self.error_count += 1
+        if record.levelno < logging.ERROR:
+            return
+        if record.name.split(".", 1)[0] in _THIRD_PARTY_LOGGER_ROOTS:
+            self.ignored_count += 1  # WHY: #1786 -- the operation decides whether this matters.
+            return
+        self.error_count += 1
 
 
 @dataclass(frozen=True, slots=True)
@@ -458,6 +477,12 @@ class InteractiveTestRunner:  # WHY: dependency container avoids global module s
                 self._invoke_option(option, test_site_id)  # WHY: invoke the menu callable.
             finally:
                 root_logger.removeHandler(observer)  # WHY: detach before pass/fail emission to avoid self-count.
+            if observer.ignored_count:
+                logging.debug(
+                    "INTERACTIVE_TEST: option %s ignored %d third-party ERROR record(s)",
+                    option,
+                    observer.ignored_count,
+                )  # WHY: #1786 -- keep SDK transport errors visible without failing the option.
             if observer.error_count > 0:
                 # WHY: #1636 — logged error without an exception is still a failure.
                 synthesized = RuntimeError(f"operation logged {observer.error_count} error record(s) without raising")

--- a/tests/unit/troubleshooting/test_logged_error_observer_filter.py
+++ b/tests/unit/troubleshooting/test_logged_error_observer_filter.py
@@ -1,0 +1,95 @@
+"""Tests for the interactive-test error observer source filter.
+
+Issue #1636 made the runner fail an option that calls ``logging.error(...)`` and
+then returns None. Issue #1786 found that the observer sat on the root logger, so
+it also counted records from the ``mistapi`` SDK. The SDK logs an ERROR for every
+HTTP 404, and a probe-style operation treats a 404 as the answer rather than a
+fault.
+
+Menu 74 asks for 61 site insight metrics. A site rarely carries them all, so the
+SDK logged 122 records and the runner reported a false failure. Menu 196 failed
+the same way when an organization had no async claim job.
+
+These tests hold both halves of the contract. A third-party record must not fail
+an option, and a MistHelper record must still fail one.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from src.troubleshooting.interactive_test_runner import _LoggedErrorObserver
+
+
+def _record(logger_name: str, level: int = logging.ERROR) -> logging.LogRecord:
+    """Build a log record that claims to come from ``logger_name``."""
+    return logging.LogRecord(
+        name=logger_name,
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg="synthetic record",
+        args=(),
+        exc_info=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "logger_name",
+    ["mistapi", "websocket", "urllib3", "requests", "paramiko"],
+)
+def test_third_party_error_does_not_fail_the_option(logger_name: str) -> None:
+    """A third-party ERROR must not count toward the failure tally."""
+    observer = _LoggedErrorObserver()
+    observer.emit(_record(logger_name))
+    assert observer.error_count == 0, f"{logger_name} ERROR wrongly counted as an option failure"
+    assert observer.ignored_count == 1, "the ignored tally must stay visible"
+
+
+def test_child_logger_of_a_third_party_root_is_also_ignored() -> None:
+    """A dotted child of a third-party logger must follow its root."""
+    observer = _LoggedErrorObserver()
+    observer.emit(_record("mistapi.__api_response"))
+    assert observer.error_count == 0
+    assert observer.ignored_count == 1
+
+
+@pytest.mark.parametrize(
+    "logger_name",
+    ["src.export.site_insights", "MistHelper", "root", ""],
+)
+def test_misthelper_error_still_fails_the_option(logger_name: str) -> None:
+    """Issue #1636 must keep working. A MistHelper ERROR still fails the option."""
+    observer = _LoggedErrorObserver()
+    observer.emit(_record(logger_name))
+    assert observer.error_count == 1, f"{logger_name} ERROR must still fail the option"
+    assert observer.ignored_count == 0
+
+
+def test_below_error_level_is_never_counted() -> None:
+    """A WARNING must not fail an option."""
+    observer = _LoggedErrorObserver()
+    observer.emit(_record("src.export", level=logging.WARNING))
+    assert observer.error_count == 0
+    assert observer.ignored_count == 0
+
+
+def test_menu_74_probe_pattern_no_longer_fails() -> None:
+    """Reproduce the menu 74 shape: 61 missing metrics, two SDK records each."""
+    observer = _LoggedErrorObserver()
+    for _ in range(61):
+        observer.emit(_record("mistapi"))  # apirequest HTTP error
+        observer.emit(_record("mistapi"))  # apiresponse parse error
+    assert observer.ignored_count == 122, "the observed run logged exactly 122 records"
+    assert observer.error_count == 0, "menu 74 handled every 404, so it must pass"
+
+
+def test_a_real_error_beside_sdk_noise_still_fails() -> None:
+    """SDK noise must not mask a genuine swallowed error in the same option."""
+    observer = _LoggedErrorObserver()
+    observer.emit(_record("mistapi"))
+    observer.emit(_record("src.device.prompt_utils"))
+    assert observer.ignored_count == 1
+    assert observer.error_count == 1, "the MistHelper error must survive the filter"


### PR DESCRIPTION
## Summary

`--testinteractive` marked two healthy operations as failed, because the `mistapi`
SDK logs an ERROR record for every HTTP 404 that an operation deliberately
handles.

Closes #1786

## The evidence

**Menu 74** probes 61 site insight metrics one at a time. A site rarely carries
them all, so the API answers 404 for the rest and the operation moves on:

```text
ERROR - apirequest:mist_get:HTTP error: 404 Client Error: Not Found
ERROR - apiresponse:__init__:unable to process HTTP Response:
DEBUG - No data available for metric: num_clients
```

The SDK logs 2 records per missing metric. The run reported **122**, and 61 times
2 is exactly 122. Every one came from a probe that worked as designed.

**Menu 196** failed the same way on an organization with no async claim job. The
operation logged `No async claim job for org ...; exporting empty rows` and
carried on correctly.

## Cause

Issue #1636 added `_LoggedErrorObserver` to catch a handler that calls
`logging.error(...)` and then returns None. Its docstring states that intent, and
that intent is about **MistHelper's own** error logging.

The handler sits on the **root** logger, so it also counted records from
libraries the caller does not control.

## The fix

Count a record only when a MistHelper logger emits it. `mistapi` uses one named
logger, `logging.getLogger("mistapi")`, so the filter is exact. Records from
`websocket`, `urllib3`, `requests`, and `paramiko` follow the same rule.

This keeps the **whole** intent of #1636. A handler that swallows its own logged
error still fails, because that record carries a MistHelper logger name.

The observer keeps a separate `ignored_count`, and the runner logs it at DEBUG
level, so the SDK records stay visible rather than disappearing.

## Tests

13 tests hold both halves of the contract:

| Test | Holds |
| - | - |
| `test_third_party_error_does_not_fail_the_option` | 5 library names do not fail an option |
| `test_child_logger_of_a_third_party_root_is_also_ignored` | `mistapi.__api_response` follows its root |
| `test_misthelper_error_still_fails_the_option` | 4 MistHelper logger names still fail |
| `test_below_error_level_is_never_counted` | A WARNING never fails |
| `test_menu_74_probe_pattern_no_longer_fails` | Reproduces the exact 122-record shape |
| `test_a_real_error_beside_sdk_noise_still_fails` | SDK noise cannot mask a real error |

The last two matter most. One reproduces the reported failure, and one proves the
fix does not open a hole.

## Verification

- 13 new tests pass.
- 74 existing runner tests pass, so #1636 does not regress.
- `ruff check .`, `black --check .` on 985 files, and `mypy` all pass.
- A live `--testinteractive` run against the Morrison organization confirms menus
  74 and 196 now pass. I will post the before and after counts below.

## Why this mattered

The last run reported 56 passed and 11 failed. Two failures were this false
positive. That noise is not harmless: menu 76 held a real `AttributeError` in the
same run (issue #1783), and a familiar false failure trains a reader to skim the
list.
