### PR TITLE
ci: scope each quality gate to its widest passing set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,29 @@ env:
   # --- Customize per repo (overridden by workflow_call inputs) ---
   PYTHON_VERSION: ${{ inputs.python-version || '3.13' }}
   SRC_PATH: ${{ inputs.src-path || 'src/' }}
+  # Issue #888: SRC_PATH used to scope every gate to src/, so MistHelper.py, wsgi.py,
+  # web_portal, tools, and starlink_dashboard.py went unscanned. Each gate below now
+  # names the widest scope it passes today. The measurement date is 2026-08-05, and
+  # every exclusion states the count that blocks it. Widen a scope when its count
+  # reaches zero. SRC_PATH still drives the two gates whose scope changes their
+  # threshold arithmetic, which are the coverage gate and the pylint score gate.
+  #
+  # mypy: clean on src/, MistHelper.py, and wsgi.py under the strict settings.
+  # MistHelper.py is genuinely checked here, proved by injecting a type error and
+  # watching the gate catch it. Excludes starlink_dashboard.py (76 errors),
+  # web_portal (168), and tools (61). See [tool.mypy] exclude in pyproject.toml.
+  MYPY_PATHS: 'src/ MistHelper.py wsgi.py'
+  # radon: no block passes complexity 10 in src/, MistHelper.py, wsgi.py, or
+  # starlink_dashboard.py. Excludes web_portal (2 blocks) and tools (20 blocks).
+  RADON_PATHS: 'src/ MistHelper.py wsgi.py starlink_dashboard.py'
+  # vulture: 0 findings at confidence 70 everywhere except tools, which reports 6.
+  VULTURE_PATHS: 'src/ MistHelper.py wsgi.py starlink_dashboard.py web_portal'
+  # pydocstyle: 0 violations in src/, wsgi.py, and web_portal. Excludes
+  # MistHelper.py (3), starlink_dashboard.py (11), and tools (2).
+  PYDOCSTYLE_PATHS: 'src/ wsgi.py web_portal'
+  # interrogate: every target clears the 90 percent floor, so this gate covers the
+  # whole project. Lowest measured value is web_portal at 97.5 percent.
+  INTERROGATE_PATHS: 'src/ MistHelper.py wsgi.py starlink_dashboard.py web_portal tools'
   COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold || '80' }}
   PYLINT_THRESHOLD: ${{ inputs.pylint-threshold || '9.5' }}
   INTERROGATE_THRESHOLD: ${{ inputs.interrogate-threshold || '90' }}
@@ -156,7 +179,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt  # pinned mypy and stubs (issue #1779)
       - name: Run mypy
-        run: mypy ${{ env.SRC_PATH }} --config-file pyproject.toml
+        run: mypy ${{ env.MYPY_PATHS }} --config-file pyproject.toml
 
   # ──────────────────────────────────────────────────────────────
   # TESTS + COVERAGE
@@ -190,6 +213,10 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt  # pinned pytest stack (issue #1779)
       - name: Run tests with coverage
+        # Issue #888: this gate keeps SRC_PATH. Widening the measured scope adds
+        # uncovered lines to the denominator, so the percentage drops against the 80
+        # floor without any test changing. Widen it only together with the tests that
+        # cover the added code.
         run: pytest --cov=${{ env.SRC_PATH }} --cov-fail-under=${{ env.COVERAGE_THRESHOLD }}
 
   # ──────────────────────────────────────────────────────────────
@@ -295,6 +322,8 @@ jobs:
       # The package exclusion lives in [tool.pylint.main] ignore-paths in pyproject.toml,
       # not on this line. Issue #891 moved it there so one file holds the gate config.
       # That comment carries the reason, the measurements, and the removal plan.
+      # Issue #888: this gate keeps SRC_PATH. The score is 9.53 against a 9.5 floor, so
+      # a margin of 0.03 cannot absorb a new package. Widen it only with a measurement.
       - name: Run Pylint
         run: pylint ${{ env.SRC_PATH }} --fail-under=${{ env.PYLINT_THRESHOLD }}
 
@@ -313,8 +342,8 @@ jobs:
       - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Check cyclomatic complexity
         run: |
-          radon cc ${{ env.SRC_PATH }} -a -nb
-          radon cc ${{ env.SRC_PATH }} -j | python3 -c "
+          radon cc ${{ env.RADON_PATHS }} -a -nb
+          radon cc ${{ env.RADON_PATHS }} -j | python3 -c "
           import json, sys
           data = json.load(sys.stdin)
           bad = []
@@ -344,7 +373,7 @@ jobs:
           cache: pip
       - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Detect dead code
-        run: vulture ${{ env.SRC_PATH }} --min-confidence ${{ env.VULTURE_CONFIDENCE }}
+        run: vulture ${{ env.VULTURE_PATHS }} --min-confidence ${{ env.VULTURE_CONFIDENCE }}
 
   # ──────────────────────────────────────────────────────────────
   # DOCUMENTATION
@@ -363,7 +392,7 @@ jobs:
           cache: pip
       - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Check docstring conventions
-        run: pydocstyle ${{ env.SRC_PATH }}
+        run: pydocstyle ${{ env.PYDOCSTYLE_PATHS }}
 
   interrogate:
     name: "Interrogate (docstring coverage)"
@@ -379,7 +408,7 @@ jobs:
           cache: pip
       - run: pip install -r requirements-dev.txt  # pinned (issue #1779)
       - name: Check docstring coverage
-        run: interrogate ${{ env.SRC_PATH }} --fail-under ${{ env.INTERROGATE_THRESHOLD }} -v
+        run: interrogate ${{ env.INTERROGATE_PATHS }} --fail-under ${{ env.INTERROGATE_THRESHOLD }} -v
 
   # ──────────────────────────────────────────────────────────────
   # PROJECT-SPECIFIC (remove or adapt when copying to other repos)

--- a/MistHelper.py
+++ b/MistHelper.py
@@ -2413,7 +2413,7 @@ API_REQUEST_RETRY_DELAY = float(os.getenv("API_REQUEST_RETRY_DELAY", "5.0"))  # 
 FAST_MODE_MAX_RETRIES = int(os.getenv("FAST_MODE_MAX_RETRIES", "3"))  # Retry ceiling when --fast is active
 FAST_MODE_RETRY_DELAY = float(os.getenv("FAST_MODE_RETRY_DELAY", "0.5"))  # Shorter retry delay for fast mode
 
-org_id = None  # Active organization ID, populated after the user selects an org
+org_id: str | None = None  # Active organization ID, populated after the user selects an org
 
 # Additional Fast Mode Configuration from .env (continuing from earlier definitions)
 # NOTE: FAST_MODE_BACKOFF_MULTIPLIER extracted to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,12 +257,15 @@ explicit_package_bases = true
 #                            under a future Phase-2 tests-typing issue.
 #   scripts               -- 584 mypy errors at strict; out of scope for #884. Dev tooling
 #                            typing sweep will be tracked separately.
-#   tools                 -- 47 mypy errors; dev tooling with codemod fixtures whose bad/
+#   tools                 -- 61 mypy errors; dev tooling with codemod fixtures whose bad/
 #                            files deliberately embody anti-patterns. Track under a future
-#                            tools-typing sweep.
-#   MistHelper.py         -- monolith being refactored (Wave 2); 118 strict errors. Already
-#                            covered by follow_imports=silent (#883) for cross-module bug
-#                            catches. Shrinks as classes graduate out into src/*.
+#                            tools-typing sweep. Re-measured 2026-08-05 for #888.
+#   MistHelper.py         -- REMOVED from this list on 2026-08-05 for issue #888. The file
+#                            reported 118 strict errors when #884 wrote this note. It
+#                            reports 0 today, because the decomposition waves moved the
+#                            untyped code into src/. The CI mypy gate now scans it through
+#                            MYPY_PATHS in .github/workflows/ci.yml. Proved by injecting a
+#                            type error and confirming the gate caught it.
 #   starlink_dashboard.py -- standalone dashboard app; 76 strict errors. Needs its own
 #                            typing sweep — track separately.
 # Dropped from prior list in #884: ops-portal (0 .py files), maps_manager (never existed
@@ -274,7 +277,6 @@ exclude = [
     "tests",
     "scripts",
     "tools",
-    "MistHelper.py",
     "starlink_dashboard.py",
 ]
 

--- a/web_portal/__init__.py
+++ b/web_portal/__init__.py
@@ -1,2 +1,4 @@
-# web_portal - MistHelper Web Portal Interface
-# Flask-based web portal for browser access to MistHelper operations
+"""MistHelper web portal interface.
+
+A Flask web portal that gives browser access to the MistHelper operations.
+"""

--- a/web_portal/routes/__init__.py
+++ b/web_portal/routes/__init__.py
@@ -1,1 +1,1 @@
-# web_portal.routes - Flask route blueprints
+"""Flask route blueprints for the web portal."""

--- a/web_portal/services/__init__.py
+++ b/web_portal/services/__init__.py
@@ -1,1 +1,1 @@
-# web_portal.services - Business logic service classes
+"""Business logic service classes for the web portal."""


### PR DESCRIPTION
## Summary

`SRC_PATH` scoped every gate to `src/`, so `MistHelper.py`, `wsgi.py`,
`web_portal`, `tools`, and `starlink_dashboard.py` went unscanned. A file could
pass the whole pipeline as long as it lived outside `src/`.

Closes #888

## What each gate covers now

I measured every gate against every candidate path before changing anything. Each
scope below is the widest set that **passes today**, and every exclusion states
the count that blocks it.

| Gate | New scope | Excluded, with the blocking count |
| - | - | - |
| **mypy** | `src/`, `MistHelper.py`, `wsgi.py` | starlink_dashboard.py 76, web_portal 168, tools 61 |
| **radon** | `src/`, `MistHelper.py`, `wsgi.py`, `starlink_dashboard.py` | web_portal 2, tools 20 |
| **vulture** | `src/`, `MistHelper.py`, `wsgi.py`, `starlink_dashboard.py`, `web_portal` | tools 6 |
| **pydocstyle** | `src/`, `wsgi.py`, `web_portal` | MistHelper.py 3, starlink_dashboard.py 11, tools 2 |
| **interrogate** | **the whole project** | none, lowest value is web_portal at 97.5% |

## The headline: MistHelper.py now passes mypy

The exclusion note in `pyproject.toml` claimed **118 strict errors**. That was
true when issue #884 wrote it. The file reports **0** today, because the
decomposition waves moved the untyped code into `src/`.

Nobody saw that improvement, because the exclusion hid it. The same note claimed
47 errors for `tools`, and the real count is 61. Both numbers are corrected.

## I verified the gate really reads the file

An exclusion entry plus an explicit command-line path is ambiguous, so I did not
trust the passing result. I injected a type error into `MistHelper.py`:

```text
MistHelper.py:2416: error: Incompatible types in assignment
MistHelper.py:2505: error: Argument 1 to "set_cached_org_id" has incompatible type
```

The gate caught it, including a knock-on error 89 lines later. Removing the
injected error made it pass again. `MistHelper.py` is genuinely type-checked.

## One real fix

`wsgi.py` had a single error blocking it. The module-level `org_id` in
`MistHelper.py` carried no annotation, so mypy inferred `None` and rejected
`MistHelper.org_id = wsgi_org_id`. It now reads `org_id: str | None = None`.

## Two gates keep the narrow scope, and say why

Per the second acceptance criterion, both carry a comment on the line above:

- **coverage** — widening adds uncovered lines to the denominator, so the
  percentage drops against the 80 floor without any test changing.
- **pylint score** — the score is 9.53 against a 9.5 floor. A margin of 0.03
  cannot absorb a new package. Issue #891 holds that measurement.

## Verification

Every gate run locally at its new scope:

| Gate | Result |
| - | - |
| mypy | `Success: no issues found in 340 source files` |
| radon | 0 blocks over complexity 10 |
| vulture | 0 findings at confidence 70 |
| pydocstyle | 0 violations |
| interrogate | `PASSED (minimum: 90.0%, actual: 99.6%)` |
| ruff / black | pass across 985 files |
| pytest | 57 tests touching `org_id`, config, and wsgi pass |

## A note on how I got here

My first pass produced wrong numbers twice, and I want that on the record.
`pydocstyle` and `interrogate` were not installed in the local environment, so I
was counting zero lines from an error message. `mypy` reported 0 errors for four
paths that `[tool.mypy] exclude` was silently skipping. I only caught the second
one because mypy refused a directory with "no .py[i] files" while that directory
plainly held 16 Python files. Every number in this pull request comes from a run
that I confirmed actually scanned the files.
