### PR TITLE
docs(specs): add five lint debt specifications

### DIFF
--- a/specs/1792-unused-noqa-directives/plan.md
+++ b/specs/1792-unused-noqa-directives/plan.md
@@ -1,0 +1,190 @@
+# Implementation Plan: Unused Noqa Directive Removal
+
+**Branch**: `lint/1792-unused-noqa` (SpecKit feature directory `1792-unused-noqa-directives`) | **Date**: 2026-08-05 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1792-unused-noqa-directives/spec.md`
+
+**GitHub Issue**: [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792)
+
+## Summary
+
+Ruff reports 286 `# noqa` directives that suppress nothing. Ruff repairs all 286 without help. The whole repair is one command plus a careful read of the difference.
+
+The work then adds `RUF100` to the ruff `select` list, so that the count cannot return.
+
+This plan orders the work in three steps. Measure first. Repair second. Close the gate third. The gate step comes last, because the gate fails while any result remains.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (`pyproject.toml` target `py313`)
+
+**Primary Dependencies**: `ruff` 0.16.0. This work adds no dependency.
+
+**Storage**: Not applicable. The work changes comment text and one configuration line.
+
+**Testing**: `pytest` with `--cov=src/ --cov-fail-under=80`. The suite must keep its pass count.
+
+**Target Platform**: The CI runner uses Linux. A developer works on Windows. Ruff reports the same count on both, because the `extend-exclude` list uses paths that ruff normalizes.
+
+**Project Type**: Static analysis cleanup. The work adds no module and no class.
+
+**Performance Goals**: The lint gate must stay inside its current runtime. Ruff scans the repository in about two seconds today.
+
+**Constraints**:
+
+- The root ruff line length is 120 characters. The removal shortens lines, so no line grows.
+- `ruff check .` reads the whole repository. Its `extend-exclude` list drops `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`.
+- `black` formats the whole repository. A removed trailing comment can change the line width that `black` prefers, so `black` must run after the repair.
+- The repair touches one test file. The unit suite must run.
+
+**Scale/Scope**: 286 directives, 94 files, and one configuration line.
+
+### Measurement contract
+
+Run the command below to measure the baseline. Record the value before the first edit.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --extend-select RUF100 --statistics
+```
+
+The expected output holds one line.
+
+```text
+286     RUF100  [*] unused-noqa
+```
+
+The `[*]` marker states that ruff repairs the result without help.
+
+**Warning**: Do not measure with `--select RUF100`. That form turns off every other rule and reports 320 results. The extra 34 results name a code that the project selects, so each of those directives suppresses a real result. A repair with that form breaks the lint gate.
+
+If the count differs from 286, stop. Record the new count in this plan and continue with the new value. Do not change the specification text in silence. A maintainer measured 231 on 2026-08-05 and 286 on 2026-08-06, so the value moves.
+
+### Verified mechanics
+
+A maintainer probed the ruff behavior before this plan. Three results shape the tasks.
+
+1. `ruff check . --extend-select RUF100 --fix` removes each unused code from a directive. It removes the whole comment when no other text remains.
+2. A directive that names two codes keeps the code that produces a result. Ruff removes the other code and leaves the line.
+3. `--ignore-noqa` reveals the true count for any rule. The difference between the two counts equals the number of lines that a directive hides.
+
+### Discovered risk: 88 lines hide a real blind except block
+
+This risk is the most important finding in the whole plan.
+
+| Command | `BLE001` count |
+| - | - |
+| `ruff check . --select BLE001 --statistics` | 412 |
+| `ruff check . --select BLE001 --ignore-noqa --statistics` | 500 |
+
+The 88-line difference means that 88 lines carry a `# noqa: BLE001` directive and hold a real blind `except` block. Today the directive changes nothing, because the `select` list does not hold `BLE001`.
+
+The day the team selects `BLE001`, those 88 directives start to hide real results. The gate then reports 412 results and never reports the other 88. A team that clears 412 results believes the work is complete.
+
+This plan therefore states a hard order. This work lands first. Issue [#1794](https://github.com/jmorrison-juniper/MistHelper/issues/1794) starts second.
+
+The same trap applies to `DTZ005` at a smaller scale. Ruff reports 56 results by default and 57 with `--ignore-noqa`. One site hides. Issue [#1795](https://github.com/jmorrison-juniper/MistHelper/issues/1795) reads that number.
+
+## Constitution Check
+
+*GATE: The plan passes before Phase 0 research. The plan passes again after Phase 1 design.*
+
+| Principle | Status | Basis |
+| - | - | - |
+| I. Five-Item Rule | PASS | The work adds no function and changes no function body. |
+| II. Class-Based Architecture (No Wrappers) | PASS | The work adds no class and no wrapper. |
+| III. Safety-First | PASS | The work changes no input handling and no confirmation prompt. |
+| IV. Full Deployment Pipeline | ADAPTED | The work follows the branch and pull request workflow. The container needs no rebuild, because no runtime behavior changes. |
+| V. Observability and Logging | PASS | The work adds no log call. Every removed directive is ASCII text. |
+| VI. Inline Comments (NON-NEGOTIABLE) | PASS with a note | The work removes comment text and adds none. Principle VI asks for a comment on each changed line of code. This work changes no line of code. |
+| VII. Action Logging (NON-NEGOTIABLE) | PASS | The work adds no action and therefore adds no log call. |
+| Security Findings: Fix Over Suppress (NON-NEGOTIABLE) | PASS | The work removes suppressions. It adds none. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1792-unused-noqa-directives/
+├── spec.md              # The feature specification
+├── plan.md              # This file
+└── tasks.md             # The task list
+```
+
+### Source code (repository root)
+
+The repair touches 94 files. The list below names the eight files that hold 127 of the 286 directives. The other 86 files hold 1 to 6 directives each.
+
+```text
+pyproject.toml                                        # Step 3: add RUF100 to the select list
+
+src/
+├── device/ap_profile_migration_manager.py            # 67 directives
+├── site/address_audit/ui_geocoder.py                 # 10 directives
+├── export/site_export_utils.py                       #  9 directives
+├── firmware/firmware_manager.py                      #  9 directives
+├── ssid_consolidation/_ssid_template_phase45.py      #  9 directives
+├── reports/e911_bssid.py                             #  8 directives
+└── ssh/batch/interactive_batch_executor.py           #  7 directives
+
+tests/unit/refactors/test_fast_mode_small_seams.py    #  8 directives
+```
+
+**Structure Decision**: The work stays inside the current tree. It creates no file and deletes no file.
+
+## Phased approach
+
+The work runs in three phases. Each phase ends with a measurement.
+
+### Phase A - Measure and record
+
+Record the baseline count. Record the `BLE001` count with and without `--ignore-noqa`. Record the `DTZ005` count with and without `--ignore-noqa`.
+
+These three records prove the latent suppression claim. A later reader needs them.
+
+**Exit measurement**: The three records exist and the `RUF100` count reads 286.
+
+### Phase B - Repair
+
+Run one command. Read the whole difference.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --extend-select RUF100 --fix
+```
+
+**Warning**: Do not add any other rule to the `--extend-select` list in this command. A mixed repair hides the comment change inside a code change, and a reviewer then cannot confirm requirement FR-003. Do not use the `--select` form. That form deletes 34 live suppressions.
+
+Read the difference with `git diff`. Search for any changed line that does not start with a comment marker. The expected count of such lines is zero.
+
+The single file `src/device/ap_profile_migration_manager.py` holds 67 directives. Read that file difference on its own.
+
+**Exit measurement**: `ruff check . --extend-select RUF100` reports zero. The count of changed lines that are not comments reads zero.
+
+### Phase C - Close the gate
+
+Add `RUF100` to the `select` list in `pyproject.toml`.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G", "RUF100"]
+```
+
+Add a comment above the list that states why `RUF100` sits there. The comment must state that a directive with no matching result is a false record.
+
+**Warning**: This step must land in the same pull request as Phase B. A separate pull request would let the count grow between the two merges.
+
+**Exit measurement**: `ruff check .` passes with the new list. A test directive with no matching result fails the gate.
+
+## Risk register
+
+| Risk | Likelihood | Effect | Control |
+| - | - | - | - |
+| Ruff removes a comment that a reader needs | Low | A reader loses context | Task T008 reads the whole difference by hand |
+| The repair changes a line of code | Very low | A silent behavior change | Task T008 counts the changed lines that are not comments. The expected value is zero. |
+| A concurrent pull request adds a directive | Medium | The count changes | Task T012 measures the count again before the final push |
+| `black` wants to reformat a shortened line | Medium | The format gate fails | Task T009 runs `black` after the repair |
+| Issue #1794 starts before this work lands | Medium | 88 results disappear | Task T013 writes the warning into the pull request text and comments on issue #1794 |
+
+## Complexity Tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+| - | - | - |
+| Phase B and Phase C land in one pull request | The gate must close at the same moment that the count reaches zero | Two pull requests leave a window in which a contributor adds a new directive with no gate to stop it |

--- a/specs/1792-unused-noqa-directives/spec.md
+++ b/specs/1792-unused-noqa-directives/spec.md
@@ -1,0 +1,252 @@
+# Feature Specification: Unused Noqa Directive Removal
+
+**Feature Branch**: `docs/lint-debt-specs` (specification only). The implementation branch is `lint/1792-unused-noqa`.
+
+**GitHub Issue**: [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792) — "lint: 231 unused noqa directives claim suppressions that do not exist"
+
+**Created**: 2026-08-05
+
+**Status**: Specification only. No code change exists yet.
+
+**Input**: Remove the 286 `# noqa` directives that suppress nothing. Add the `RUF100` rule to the ruff `select` list, so that the count cannot grow again.
+
+---
+
+## Background
+
+A `# noqa` directive is a claim. It states that a person read a lint result, judged the result acceptable, and recorded that judgment on the line.
+
+The repository holds 286 directives that make this claim with no basis. Ruff reports each one under rule `RUF100`, which is named `unused-noqa`. No lint result sits behind any of them. The issue title states 231, because a maintainer measured that value one day earlier.
+
+### Why no gate reports this today
+
+The ruff `select` list in `pyproject.toml` line 164 reads as follows.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G"]
+```
+
+`RUF100` sits outside that list. The CI lint gate therefore never reports these directives. The count grows without limit and without notice.
+
+### Measured baseline
+
+**Correction on 2026-08-06.** A second maintainer measured the counts again at commit `08a75d2` with ruff 0.16.0. Two values changed. The correct command uses `--extend-select`, not `--select`. The correct count is 286, not 231.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --extend-select RUF100 --statistics
+```
+
+| Measurement | Value on 2026-08-05 | Value on 2026-08-06 |
+| - | - | - |
+| `RUF100` results under `--extend-select` | not measured | 286 |
+| `RUF100` results under `--select` | 231 | 320 |
+| Files that hold at least one directive | 110 | 94 under `--extend-select` |
+| Results that ruff repairs without help | 231 | 286 |
+
+**Warning**: The `--select RUF100` form disables every other rule. Ruff then reports 34 directives that suppress a real result under the project configuration. A repair that uses that form deletes those 34 directives and breaks the lint gate. The section "The isolated select trap" states the proof.
+
+The eight files below hold 127 of the directives.
+
+| File | Count |
+| - | - |
+| src/device/ap_profile_migration_manager.py | 67 |
+| src/site/address_audit/ui_geocoder.py | 10 |
+| src/export/site_export_utils.py | 9 |
+| src/firmware/firmware_manager.py | 9 |
+| src/ssid_consolidation/_ssid_template_phase45.py | 9 |
+| src/reports/e911_bssid.py | 8 |
+| tests/unit/refactors/test_fast_mode_small_seams.py | 8 |
+| src/ssh/batch/interactive_batch_executor.py | 7 |
+
+The directives name 12 rule codes. The six codes below cover 259 of the named codes. One directive can name more than one code, so the code total is larger than the directive total.
+
+| Named code | Count |
+| - | - |
+| BLE001 blind-except | 107 |
+| T201 print | 49 |
+| PLC0415 import-outside-top-level | 44 |
+| E402 module-import-not-at-top-of-file | 26 |
+| SLF001 private-member-access | 18 |
+| E501 line-too-long | 15 |
+
+### The isolated select trap
+
+**Warning**: A repair with the wrong command deletes 34 live suppressions and breaks the lint gate.
+
+Ruff decides that a directive is unused when the named code produces no result **in the current run**. The `--select RUF100` form turns off `E`, `F`, `W`, `I`, `UP`, `B`, and `G`. Ruff therefore reports every `# noqa: E501` and every `# noqa: E731` as unused, even where the directive hides a real result.
+
+| Command | `RUF100` results |
+| - | - |
+| `ruff check . --select RUF100` | 320 |
+| `ruff check . --extend-select RUF100` | 286 |
+
+A maintainer compared the two result sets on 2026-08-06. The 34 extra results all name a code that the project selects. The sample below shows four of them.
+
+| Site | Named code |
+| - | - |
+| src/export/org_inventory_exporter.py line 246 | E501 |
+| src/export/site_anomaly_exporter.py line 182 | E731 |
+| tests/maps/test_viewer_callbacks_wave_a.py line 46 | E402 |
+| starlink_dashboard.py line 98 | F401 |
+
+The repair must therefore use `--extend-select RUF100 --fix`.
+
+### The latent suppression trap
+
+This work must land before the team adds `BLE001` to the `select` list.
+
+Ruff reports 412 `BLE001` results when it reads the `# noqa` directives. Ruff reports 500 results when a maintainer adds `--ignore-noqa`.
+
+| Command | `BLE001` count |
+| - | - |
+| Default. Ruff reads each directive. | 412 |
+| With `--ignore-noqa`. Ruff skips each directive. | 500 |
+
+The difference is 88 lines. Each of those 88 lines carries a `# noqa: BLE001` directive **and** holds a real blind `except` block. The directive changes nothing today, because ruff does not select `BLE001`. The directive starts to work on the day the team selects the rule. Ruff then hides 88 real results, and the team never sees them.
+
+Issue [#1794](https://github.com/jmorrison-juniper/MistHelper/issues/1794) owns the blind `except` work. That issue depends on this one.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Remove every directive that suppresses nothing (Priority: P1)
+
+A reader opens a source file. Each `# noqa` directive that remains in that file suppresses a real lint result. No directive makes a false claim.
+
+**Why this priority**: This story delivers the whole value of the work. Ruff repairs all 286 results without help, so the cost is low and the benefit is immediate.
+
+**Independent Test**: A reviewer runs `ruff check . --extend-select RUF100`. The command exits with code 0 and reports zero results.
+
+**Acceptance Scenarios**:
+
+1. **Given** the branch holds the repair, **When** a reviewer runs `ruff check . --extend-select RUF100`, **Then** the command exits with code 0 and reports zero results.
+2. **Given** the branch holds the repair, **When** a reviewer reads the difference, **Then** the difference removes comment text only and changes no line of code.
+3. **Given** the branch holds the repair, **When** CI runs the full gate set, **Then** each gate stays green and the unit test suite keeps its pass count.
+
+---
+
+### User Story 2 - Stop the count from growing again (Priority: P2)
+
+A contributor adds a `# noqa` directive that suppresses nothing. The CI lint gate reports the directive and stops the pull request.
+
+**Why this priority**: This story protects the result of User Story 1. Without it, the count returns. The story cannot land first, because the gate fails while the 286 results remain.
+
+**Independent Test**: A reviewer adds one directive that suppresses nothing to a tracked file. The lint gate fails and names `RUF100`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated `select` list, **When** a reviewer searches the list, **Then** the list holds `RUF100`.
+2. **Given** the updated `select` list, **When** CI runs the lint gate on the clean branch, **Then** the gate succeeds.
+3. **Given** a pull request that adds one directive with no matching result, **When** CI runs the lint gate, **Then** the gate fails and the log names `RUF100` and the file.
+
+---
+
+### User Story 3 - Protect the blind except work from a silent loss (Priority: P1)
+
+A maintainer reads the pull request. The maintainer learns that 88 lines carried an inert `# noqa: BLE001` directive. The maintainer therefore knows that the true `BLE001` count is 500, not 412.
+
+**Why this priority**: This story shares the P1 rank with User Story 1, because the order of the two efforts decides whether 88 results survive. A wrong order loses them in silence.
+
+**Independent Test**: A reviewer runs `ruff check . --select BLE001 --statistics` on the branch after the repair. The count reads 500.
+
+**Acceptance Scenarios**:
+
+1. **Given** the branch holds the repair, **When** a reviewer runs `ruff check . --select BLE001 --statistics`, **Then** the count reads 500.
+2. **Given** the branch holds the repair, **When** a reviewer runs the same command with `--ignore-noqa`, **Then** the count reads 500 and matches the value above.
+3. **Given** the pull request text, **When** a maintainer of issue #1794 reads it, **Then** the text states the 88-line difference and states the correct order of the two efforts.
+
+---
+
+### Edge Cases
+
+- Ruff removes the whole comment when the directive is the only text in it. Ruff keeps the rest of the comment when other text follows the directive. A reviewer must confirm that no useful comment text disappears.
+- A directive names two codes. One code matches a real result and the other does not. Ruff removes the unused code and keeps the rest of the directive. The line stays.
+- The ruff `extend-exclude` list drops `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`. A directive inside one of those paths stays in place. The count of 286 does not cover them.
+- The repair touches `tests/unit/refactors/test_fast_mode_small_seams.py`. A test file change needs the same review care as a source file change.
+- A concurrent pull request adds a new directive while this work is open. The count then changes. The implementer must measure the count again before the final push.
+- `src/device/ap_profile_migration_manager.py` holds 67 of the 286 directives. That single file needs its own read, because it holds 23 percent of the work.
+
+---
+
+## Requirements *(mandatory)*
+
+### Repair requirements
+
+- **FR-001**: The repository MUST hold zero `RUF100` results after this work. The measurement command MUST use `--extend-select`.
+- **FR-002**: The implementer MUST use the ruff repair command `ruff check . --extend-select RUF100 --fix`. A hand edit is forbidden, because a hand edit invites a typing mistake across 94 files. The `--select RUF100 --fix` form is forbidden, because it deletes 34 live suppressions.
+- **FR-003**: The difference MUST remove comment text only. It MUST change zero lines of code.
+- **FR-004**: The implementer MUST read the whole difference and MUST record the count of changed lines that are not comments. The expected count is zero.
+- **FR-005**: The implementer MUST NOT run any other ruff repair in the same commit. A mixed repair hides the comment change inside a code change.
+
+### Gate requirements
+
+- **FR-006**: The ruff `select` list in `pyproject.toml` MUST hold `RUF100` after the repair lands.
+- **FR-007**: The `select` list change MUST land in the same pull request as the repair. A later change would allow the count to grow in between.
+- **FR-008**: The implementer MUST NOT add any other rule to the `select` list in this work.
+
+### Coordination requirements
+
+- **FR-009**: The pull request text MUST state that 88 lines carry an inert `# noqa: BLE001` directive.
+- **FR-010**: The pull request text MUST state that the true `BLE001` count is 500 and that the default ruff run reports 412.
+- **FR-011**: The pull request text MUST state that issue #1794 depends on this work and MUST NOT start before this work lands.
+
+### Quality requirements
+
+- **FR-012**: Every quality gate MUST stay green. The unit test suite MUST keep its pass count.
+- **FR-013**: All prose, all code comments, and all commit text MUST follow the Simplified Technical English guide at `documentation/ASD-STE100_writing-guide.md`.
+- **FR-014**: The commit text MUST name the count of removed directives and MUST name the count of touched files.
+
+### Key Entities
+
+- **Noqa directive**: A source comment that tells ruff to hide a result on that line. It names zero or more rule codes.
+- **Unused directive**: A directive that names a code which produces no result on that line. Ruff reports it under `RUF100`.
+- **Inert directive**: A directive that names a code which the `select` list does not hold. Ruff reports it under `RUF100` today. It starts to hide results on the day the team selects that code.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `ruff check . --extend-select RUF100` reports zero results and exits with code 0.
+- **SC-002**: The count of changed lines that are not comments is zero.
+- **SC-003**: The ruff `select` list in `pyproject.toml` holds `RUF100`.
+- **SC-004**: A pull request that adds one directive with no matching result fails the CI lint gate.
+- **SC-005**: `ruff check . --select BLE001 --statistics` and the same command with `--ignore-noqa` both report 500.
+- **SC-006**: Every quality gate stays green. The unit test suite keeps its pass count and adds no new failure.
+- **SC-007**: The pull request text states the 88-line latent suppression and names issue #1794.
+- **SC-008**: The work touches zero files under `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`.
+
+---
+
+## Non-Goals
+
+- **NG-001**: This work does not add `BLE001` to the `select` list. Issue #1794 owns that decision.
+- **NG-002**: This work does not add `T201`, `PLC0415`, or `SLF001` to the `select` list. Issue #886 owns the `T201` decision.
+- **NG-003**: This work does not repair any result that a removed directive used to name. Removal of the directive is the whole scope.
+- **NG-004**: This work does not review the directives that remain. A directive that suppresses a real result stays in place with no audit.
+- **NG-005**: This work does not change the ruff `extend-exclude` list. The four excluded paths keep their directives.
+- **NG-006**: This work does not touch a `# nosec` comment. Bandit reads those comments and ruff does not.
+- **NG-007**: This work does not touch a `# type: ignore` comment. Mypy reads those comments and ruff does not.
+- **NG-008**: This work does not add any lint suppression. It removes suppressions only. A contributor who meets a new result must repair the result.
+- **NG-009**: This work does not repair the 34 directives that the isolated run reports. Those directives suppress a real result and must stay in place.
+
+---
+
+## Assumptions
+
+- The ruff version stays at 0.16.0 during this work. A version change can add a rule and can change the count.
+- The 286 count reflects the branch tip at commit `08a75d2`. The implementer must measure the count again before the first commit. The count moved from 231 to 286 in one day, so the value is not stable.
+- Ruff repairs each result without help. The `[*]` marker in the statistics output states this.
+- No directive in the set carries useful comment text that a reader needs after the removal.
+- The team accepts a stricter lint gate. A new directive with no matching result becomes a build failure.
+
+---
+
+## Dependencies
+
+- Issue [#1794](https://github.com/jmorrison-juniper/MistHelper/issues/1794) depends on this work. It must not start before this work lands.
+- Issue [#1795](https://github.com/jmorrison-juniper/MistHelper/issues/1795) depends on this work for one `DTZ005` site that a directive hides.
+- Issue [#886](https://github.com/jmorrison-juniper/MistHelper/issues/886) covers the `T201` rule. 49 directives name that code. The two efforts must not edit the same lines at the same time.
+- The Simplified Technical English guide at `documentation/ASD-STE100_writing-guide.md` governs all prose in this work.

--- a/specs/1792-unused-noqa-directives/tasks.md
+++ b/specs/1792-unused-noqa-directives/tasks.md
@@ -1,0 +1,173 @@
+# Tasks: Unused Noqa Directive Removal
+
+**Feature**: `1792-unused-noqa-directives` | **Branch**: `lint/1792-unused-noqa` | **Date**: 2026-08-06
+
+**GitHub Issue**: [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792)
+
+**Input**: Design documents from `specs/1792-unused-noqa-directives/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md)
+
+**Tests**: The specification requests no new test. The existing suite must keep its pass count. Each phase ends with a measurement task, not with a new test file.
+
+**Branch rule**: Create `lint/1792-unused-noqa` from `main`. Do not branch from another feature branch.
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: The task can run in parallel with another task in the same phase. The tasks touch different files.
+- **[Story]**: The user story that owns the task. The value is `US1`, `US2`, or `US3`.
+- Each task names an exact file path or an exact command.
+
+## Rules that apply to every task
+
+1. Use `.venv\Scripts\python.exe` for every Python command. The global interpreter cannot import the project.
+2. Measure with `--extend-select RUF100`. Never measure with `--select RUF100`. The isolated form reports 34 directives that suppress a real result.
+3. Add no lint suppression. This work removes suppressions and adds none. Non-goal NG-008 states this rule.
+4. Follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` for every prose line.
+5. Keep the repair in one commit and keep the configuration change in a second commit. Both commits land in one pull request.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the environment before any measurement.
+
+- [ ] T001 Create the branch with `git checkout -b lint/1792-unused-noqa main`. Confirm the result with `git branch --show-current`. Stop if the command returns another value.
+- [ ] T002 Confirm the tool version with `.venv\Scripts\python.exe -m ruff --version`. The expected value is `ruff 0.16.0`. Record any other value in [plan.md](plan.md), because a version change moves every count.
+- [ ] T003 Confirm that `.venv\Scripts\python.exe -m pytest --version` runs. Every later test command uses this interpreter.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prove the baseline and record the two latent suppression counts. No edit starts until this phase closes.
+
+**Warning**: Task T007 protects 88 blind `except` results. If a contributor skips it, issue #1794 loses those results without any signal.
+
+- [ ] T004 Record the repair baseline. Run `.venv\Scripts\python.exe -m ruff check . --extend-select RUF100 --statistics`. Write the count into [plan.md](plan.md) under "Measurement contract". The expected value is 286.
+- [ ] T005 Record the isolated count. Run `.venv\Scripts\python.exe -m ruff check . --select RUF100 --statistics`. Write the count into [plan.md](plan.md). The expected value is 320. Subtract the T004 value and confirm that the difference reads 34.
+- [ ] T006 Prove that the 34 extra results suppress a real result. Compare the two result sets from T004 and T005 by file and by line. Read four of the extra sites and confirm that each names `E501`, `E731`, `E402`, or `F401`. Requirement FR-002 depends on this proof.
+- [ ] T007 Record the `BLE001` latent count. Run `.venv\Scripts\python.exe -m ruff check . --select BLE001 --statistics` and then the same command with `--ignore-noqa`. The expected values are 412 and 500. Write both into [plan.md](plan.md) and confirm that the difference reads 88.
+- [ ] T008 Record the `DTZ005` latent count. Run `.venv\Scripts\python.exe -m ruff check . --select DTZ005 --statistics` and then the same command with `--ignore-noqa`. The expected values are 56 and 57. Write both into [plan.md](plan.md). Issue #1795 reads this record.
+- [ ] T009 Record the pre-change gate baseline. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Save the unit test pass count, because SC-006 compares against it.
+
+**Checkpoint**: The baseline reads 286 repairs. The three latent records exist. Phase 3 can start.
+
+---
+
+## Phase 3: User Story 1 - Remove every directive that suppresses nothing (Priority: P1)
+
+**Goal**: Reduce the `RUF100` count to zero and change no line of code.
+
+**Independent Test**: A reviewer runs `ruff check . --extend-select RUF100`. The command exits with code 0 and reports zero results.
+
+**Warning**: Run the repair with `--extend-select`. The `--select RUF100 --fix` form deletes 34 live suppressions and breaks the lint gate on the next run.
+
+- [ ] T010 [US1] Run the repair. Use `.venv\Scripts\python.exe -m ruff check . --extend-select RUF100 --fix`. Add no other rule to the command. Requirement FR-005 forbids a mixed repair.
+- [ ] T011 [US1] Read the difference for the largest file on its own. Run `git diff -- src/device/ap_profile_migration_manager.py`. That file holds 67 of the 286 directives. Confirm that every removed line is a comment or a comment fragment.
+- [ ] T012 [US1] Count the changed lines that are not comments. Run `git diff -U0` and search each changed line for a leading `#` inside the comment position. The expected count is zero. Requirement FR-004 demands this record. Stop if the count is above zero.
+- [ ] T013 [US1] Confirm that no useful comment text disappeared. Read the difference for `src/site/address_audit/ui_geocoder.py`, `src/export/site_export_utils.py`, and `src/ssid_consolidation/_ssid_template_phase45.py`. Ruff keeps the rest of a comment when other text follows the directive, so a lost sentence signals a defect.
+- [ ] T014 [US1] Review the test file change. Read the difference for `tests/unit/refactors/test_fast_mode_small_seams.py`. A test file change needs the same care as a source file change.
+- [ ] T015 [US1] Run the formatter. Use `.venv\Scripts\python.exe -m black .`. A shortened line can change the width that the formatter prefers, so this step must follow the repair.
+- [ ] T016 [US1] Verify User Story 1. Run `.venv\Scripts\python.exe -m ruff check . --extend-select RUF100` and confirm zero results. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Confirm that the pass count matches T009.
+- [ ] T017 [US1] Commit the repair on its own. Write a Conventional Commits message that names the count of removed directives and the count of touched files. Requirement FR-014 demands both counts.
+
+**Checkpoint**: The `RUF100` count reads zero. SC-001 and SC-002 now hold. Phase 4 can start.
+
+---
+
+## Phase 4: User Story 3 - Protect the blind except work from a silent loss (Priority: P1)
+
+**Goal**: Prove that the true `BLE001` count is 500 and record the proof where issue #1794 reads it.
+
+**Independent Test**: A reviewer runs `ruff check . --select BLE001 --statistics` on the repaired branch. The count reads 500.
+
+**Note on the order**: This phase runs before User Story 2. The gate change is the final change, because the gate fails while any result remains.
+
+- [ ] T018 [US3] Measure `BLE001` again after the repair. Run `.venv\Scripts\python.exe -m ruff check . --select BLE001 --statistics` and the same command with `--ignore-noqa`. Both values must read 500. A lower value means that the repair missed a directive.
+- [ ] T019 [US3] Measure `DTZ005` again after the repair. Run `.venv\Scripts\python.exe -m ruff check . --select DTZ005 --statistics` and the same command with `--ignore-noqa`. Both values must read 57.
+- [ ] T020 [US3] Write the coordination text for the pull request body. State that 88 lines carried an inert `# noqa: BLE001` directive. State that the true count is 500 and that the earlier default run reported 412. State that issue #1794 must not start before this work lands. Requirements FR-009, FR-010, and FR-011 demand these three statements.
+- [ ] T021 [US3] Comment on issue [#1794](https://github.com/jmorrison-juniper/MistHelper/issues/1794) with `gh issue comment 1794 --body-file <file>`. Name the 88-line count and name this pull request. Delete the body file after the command returns.
+
+**Checkpoint**: The true `BLE001` count is on record. SC-005 and SC-007 now hold. Phase 5 can start.
+
+---
+
+## Phase 5: User Story 2 - Stop the count from growing again (Priority: P2)
+
+**Goal**: Add `RUF100` to the ruff `select` list, so that a new directive with no matching result fails the gate.
+
+**Independent Test**: A reviewer adds one directive with no matching result to a tracked file. The lint gate fails and names `RUF100`.
+
+**Warning**: Run this phase only after Phase 3 reports zero results. The gate fails on every push while any result remains.
+
+- [ ] T022 [US2] Change line 164 of `pyproject.toml` from `select = ["E", "F", "W", "I", "UP", "B", "G"]` to `select = ["E", "F", "W", "I", "UP", "B", "G", "RUF100"]`. Add no other rule, per FR-008.
+- [ ] T023 [US2] Add a comment above the `select` list in `pyproject.toml`. State that a directive with no matching result is a false record. Keep the comment inside 120 characters. Depends on T022, because both tasks edit the same file.
+- [ ] T024 [US2] Verify the gate. Run `.venv\Scripts\python.exe -m ruff check .` and confirm that it passes with the new list.
+- [ ] T025 [US2] Prove the negative case for SC-004. Add one temporary `# noqa: E501` directive to a short line in a tracked file under `src/`. Run `.venv\Scripts\python.exe -m ruff check .` and confirm that it reports `RUF100` and exits with code 1. Remove the line. Run `git status` and confirm that the tree holds no leftover change.
+- [ ] T026 [US2] Commit the configuration change. Requirement FR-007 demands that this commit land in the same pull request as the T017 commit.
+
+**Checkpoint**: The gate reports a false directive. SC-003 and SC-004 now hold.
+
+---
+
+## Phase 6: Polish and Final Validation
+
+**Purpose**: Prove every success criterion and open the pull request. These tasks change no source line.
+
+- [ ] T027 Run the full gate set exactly as CI runs it. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, `.venv\Scripts\python.exe -m pylint src/`, `.venv\Scripts\python.exe -m radon cc src/ -a -nb`, `.venv\Scripts\python.exe -m vulture src/ --min-confidence 80`, `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r .`, and `.venv\Scripts\python.exe -m pytest --cov=src/ --cov-fail-under=80`. Do not scope a gate to the changed files only. SC-006 depends on this run.
+- [ ] T028 [P] Prove SC-008. Run `git diff --name-only main...HEAD`. Confirm that the list holds no path under `mist-ops-platform`, `web_portal`, `scripts`, or `src/maps`.
+- [ ] T029 [P] Measure the count one last time before the push. Run `.venv\Scripts\python.exe -m ruff check . --extend-select RUF100 --statistics` and confirm zero results. A concurrent pull request can add a new directive while this work is open.
+- [ ] T030 Open the pull request against `main` from `lint/1792-unused-noqa`. Write `Closes #1792` in the body. Attach the T020 coordination text. Link `specs/1792-unused-noqa-directives/spec.md`. Complete the checklist in `.github/PULL_REQUEST_TEMPLATE.md`. Add the `auto-merge` label only after every check passes, including CodeQL.
+
+---
+
+## Dependencies and Execution Order
+
+### Phase order
+
+| Phase | Content | Starts after |
+| - | - | - |
+| 1 | Setup | Nothing |
+| 2 | Foundational baseline | Phase 1 |
+| 3 | US1, the repair | Phase 2 records all three baselines |
+| 4 | US3, the coordination record | Phase 3 reports zero results |
+| 5 | US2, the gate change | Phase 4 records the 500 count |
+| 6 | Polish and final validation | Phase 5 |
+
+### Why User Story 3 runs before User Story 2
+
+The template orders a phase by story priority. This feature runs User Story 3 in the middle. The `BLE001` proof needs the repaired tree, and the gate change must stay last. A gate change before the repair fails every push.
+
+### Same-file sequencing
+
+| Task | Depends on | Reason |
+| - | - | - |
+| T011 to T015 | T010 | Each task reads the difference that the repair produces. |
+| T023 | T022 | Both edit `pyproject.toml`. |
+| T026 | T022 and T023 | The commit needs both edits. |
+
+---
+
+## Parallel Opportunities
+
+| Phase | Parallel tasks | Reason |
+| - | - | - |
+| 2 | T007, T008 | The two commands read different rules. |
+| 6 | T028, T029 | The two commands read different data. |
+
+The repair itself holds no parallel opportunity. One command changes all 94 files at once.
+
+---
+
+## Implementation Strategy
+
+### Minimum viable delivery
+
+Phase 1 through Phase 3 deliver the whole repair. A reviewer can merge that state and still gain the value. The count returns over time without Phase 5, so treat Phase 5 as part of the same pull request.
+
+### Order of risk
+
+The repair carries a low risk, because ruff repairs every result without help and because the change removes comment text only. The two real risks are the wrong command form and a concurrent pull request. Task T006 controls the first risk. Task T029 controls the second risk.

--- a/specs/1793-root-logger-calls/plan.md
+++ b/specs/1793-root-logger-calls/plan.md
@@ -1,0 +1,213 @@
+# Implementation Plan: Module Logger Migration
+
+**Branch**: `refactor/1793-module-logger` (SpecKit feature directory `1793-root-logger-calls`) | **Date**: 2026-08-06 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1793-root-logger-calls/spec.md`
+
+**GitHub Issue**: [#1793](https://github.com/jmorrison-juniper/MistHelper/issues/1793)
+
+## Summary
+
+Ruff reports 4478 root logger calls in 223 files. Ruff repairs none of them. The rewrite is mechanical, but the volume forbids a single pull request.
+
+This plan splits the work into 14 slices. Each slice holds one area or one part of a large area. The slices land from the smallest area to the largest area, so that the pattern proves itself at a low cost.
+
+The gate change lands last, in its own pull request, after the last slice reports zero results.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (`pyproject.toml` target `py313`)
+
+**Primary Dependencies**: `ruff` 0.16.0 and the standard `logging` module. This work adds no dependency.
+
+**Storage**: Not applicable. The work changes call sites and one configuration line.
+
+**Testing**: `pytest` with `--cov=src/ --cov-fail-under=80`. The suite must keep its pass count for each slice.
+
+**Target Platform**: The CI runner uses Linux. A developer works on Windows. Ruff reports the same count on both.
+
+**Project Type**: Behavior-preserving refactor. The work adds no module and no class. It adds one module-level name to each converted module.
+
+**Performance Goals**: The lint gate must stay inside its current runtime. A named logger costs the same as a root logger call at run time.
+
+**Constraints**:
+
+- The root ruff line length is 120 characters. A rewrite from `logging.` to `logger.` shortens each line by two characters, so no line grows.
+- `ruff check .` and `black` read the whole repository. Its `extend-exclude` list drops `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`.
+- `mypy` now reads `MistHelper.py` as well as `src/`. Issue #888 widened that scope.
+- The action logging rule in `.github/copilot-instructions.md` is NON-NEGOTIABLE. The rewrite must keep every message and every level.
+
+**Scale/Scope**: 4478 calls, 223 files, 14 slices, and one configuration line.
+
+### Measurement contract
+
+Run the command below before each slice. Record the value in the slice pull request.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --select LOG015 --statistics
+```
+
+The expected output holds one line.
+
+```text
+4478    LOG015  root-logger-call
+```
+
+Ruff reports no repair marker, because `LOG015` has no automatic repair. Every edit is a hand edit or a scripted edit with a hand review.
+
+If the count differs from 4478, stop. Record the new count in this plan and continue with the new value.
+
+### Verified mechanics
+
+A maintainer probed the counts on 2026-08-06 at commit `08a75d2`. Three results shape the tasks.
+
+1. The area counts in the specification match the measured values exactly. No drift exists between the issue and the tree.
+2. Four files hold 779 of the 4478 calls. `MistHelper.py` holds 303, `src/firmware/firmware_manager.py` holds 228, `src/firmware/org_ap_upgrader.py` holds 143, and `src/firmware/bulk_ap_upgrader.py` holds 105.
+3. The `tests` area holds 134 calls, and 53 of them sit in one file. That file is `tests/unit/refactors/test_fast_mode_small_seams.py`.
+
+### Discovered risk: three files break the 500-line slice limit on their own
+
+`MistHelper.py`, `src/firmware/firmware_manager.py`, and `src/firmware/org_ap_upgrader.py` each hold more than 100 calls. A single file cannot split across two pull requests without a broken intermediate state, because the module logger definition must land with the first converted call.
+
+The control is a per-file slice. Each of those three files becomes its own pull request. The line count then reaches about 300 for the largest file, which stays inside the limit.
+
+### Discovered risk: the logging configuration module can recurse
+
+`src/utils/logger_utils.py` configures the logging system. A record that the configuration path emits can re-enter the same path. Specification `1032-bandit-severity-gate` already records one suppression in that module for the same reason.
+
+The control is a separate read. The implementer reads that module in full before any edit and confirms that the module logger does not sit inside a filter or a handler.
+
+## Constitution Check
+
+*GATE: The plan passes before Phase 0 research. The plan passes again after Phase 1 design.*
+
+| Principle | Status | Basis |
+| - | - | - |
+| I. Five-Item Rule | PASS | The work adds one module-level name to each module. It changes no function body structure. |
+| II. Class-Based Architecture (No Wrappers) | PASS | The work adds no class and no wrapper function. |
+| III. Safety-First | PASS | The work changes no input handling and no confirmation prompt. |
+| IV. Full Deployment Pipeline | ADAPTED | The work follows the branch and pull request workflow. The container needs a rebuild after the last slice, because the runtime code changes. |
+| V. Observability and Logging | PASS with a gain | The work improves observability. A record then carries the module name. Every message stays ASCII. |
+| VI. Inline Comments (NON-NEGOTIABLE) | PASS with a note | The module logger line receives an inline comment that states its purpose. A rewritten call keeps its existing comment. |
+| VII. Action Logging (NON-NEGOTIABLE) | PASS with a hard constraint | The rewrite keeps every message and every level. Requirements FR-004 through FR-007 state the constraint. A slice that changes a message fails the review. |
+| Security Findings: Fix Over Suppress (NON-NEGOTIABLE) | PASS | The work adds no suppression. Non-goal NG-001 states this rule. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1793-root-logger-calls/
+├── spec.md              # The feature specification
+├── plan.md              # This file
+└── tasks.md             # The task list
+```
+
+### Source code (repository root)
+
+The work touches 223 files. The list below names the slice boundary for each area.
+
+```text
+pyproject.toml                                        # Slice 14: add LOG015 to the select list
+
+MistHelper.py                                         # Slice 11: 303 calls, its own pull request
+
+src/
+├── export/                                           # Slices 12 and 13: 678 calls, split by file
+├── firmware/
+│   ├── firmware_manager.py                           # Slice 9: 228 calls, its own pull request
+│   ├── org_ap_upgrader.py                            # Slice 8: 143 calls, its own pull request
+│   └── (the rest of the area)                        # Slice 10: 130 calls
+├── refactors/                                        # Slice 7: 423 calls, split by file if needed
+├── gateway/                                          # Slice 6: 261 calls
+├── capture/                                          # Slice 5: 220 calls
+├── org/                                              # Slice 4: 191 calls
+├── device/                                           # Slice 3: 182 calls
+├── site/                                             # Slice 3: 156 calls
+├── troubleshooting/                                  # Slice 3: 150 calls
+├── auth/                                             # Slice 2: 131 calls
+├── inventory/                                        # Slice 2: 131 calls
+└── ui/                                               # Slice 2: 131 calls
+
+tests/                                                # Slice 1: 134 calls, the lowest risk
+```
+
+**Structure Decision**: The work stays inside the current tree. It creates no file and deletes no file. Each converted module gains one module-level line.
+
+## Phased approach
+
+The work runs in three stages. Every slice inside a stage follows the same steps.
+
+### Stage 1 - Prove the pattern on the lowest risk area
+
+Slice 1 converts the `tests` area. A test module carries no operator value in its log records, so a mistake there costs the least.
+
+The slice proves three facts. The `caplog` fixture still captures the records. The unit suite keeps its pass count. The difference holds only a logger object change.
+
+**Exit measurement**: The `LOG015` count drops by 134. The unit suite keeps its pass count.
+
+### Stage 2 - Convert the production areas from the smallest to the largest
+
+Slices 2 through 13 convert the production code. Each slice follows the same five steps.
+
+1. Search the area for an existing name `logger`. Record any collision.
+2. Add the module logger line to each file in the slice.
+3. Rewrite each root logger call in those files.
+4. Read the whole difference and confirm that only the logger object changed.
+5. Run the full gate set and the full unit suite.
+
+**Warning**: Do not change a message text and do not change a level. The action logging rule depends on both. A reviewer who finds one changed message must reject the slice.
+
+**Exit measurement**: The `LOG015` count reaches zero after slice 13.
+
+### Stage 3 - Close the gate
+
+Add `LOG015` to the `select` list in `pyproject.toml`.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G", "LOG015"]
+```
+
+**Warning**: This step must follow the last slice. The gate fails on every push while any call remains.
+
+**Exit measurement**: `ruff check .` passes with the new list. A test call to `logging.info` fails the gate.
+
+## Slice ledger
+
+| Slice | Scope | Calls | Files |
+| - | - | - | - |
+| 1 | tests | 134 | about 20 |
+| 2 | src/auth, src/inventory, src/ui | 393 | about 25 |
+| 3 | src/device, src/site, src/troubleshooting | 488 | about 30 |
+| 4 | src/org | 191 | about 10 |
+| 5 | src/capture | 220 | about 10 |
+| 6 | src/gateway | 261 | about 12 |
+| 7 | src/refactors | 423 | about 25 |
+| 8 | src/firmware/org_ap_upgrader.py | 143 | 1 |
+| 9 | src/firmware/firmware_manager.py | 228 | 1 |
+| 10 | src/firmware, the rest | 130 | about 10 |
+| 11 | MistHelper.py | 303 | 1 |
+| 12 | src/export, part one | about 340 | about 15 |
+| 13 | src/export, part two, and every remaining area | about 1624 | about 60 |
+| 14 | pyproject.toml | 0 | 1 |
+
+**Caution**: Slice 13 holds every area that the table above does not name. The implementer must split that slice further once the earlier slices land and the exact remainder is clear. No pull request may exceed 500 changed lines.
+
+## Risk register
+
+| Risk | Likelihood | Effect | Control |
+| - | - | - | - |
+| A slice changes a message text | Medium | An operator playbook breaks | The slice review reads every changed line. Task T012 states the check. |
+| A module already binds the name `logger` | Low | A name collision hides the real object | Each slice starts with a search. Task T008 states the search. |
+| A test asserts on the root logger | Medium | A test fails after the slice | Each slice runs the whole unit suite, not the area tests alone |
+| The logging configuration module recurses | Low | The process hangs or overflows the stack | Task T034 reads `src/utils/logger_utils.py` before any edit |
+| A slice exceeds 500 changed lines | Medium | A reviewer cannot read the difference | The slice ledger caps each slice. Task T009 counts the lines before the push. |
+| Issue #886 edits the same lines | Medium | A merge conflict | Task T005 checks the open pull requests for each area before the slice starts |
+
+## Complexity Tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+| - | - | - |
+| The work spans 14 pull requests | 4478 call sites cannot receive a real review in one difference | A single pull request would merge without a review, and the action logging rule needs a human check on every message |
+| Three files each take a whole pull request | The module logger line must land with the first converted call in that file | A split inside one file leaves an intermediate state in which the module holds both call forms |
+| The gate change lands in its own pull request | The gate fails while any call remains | A gate change inside the last slice would block every push during the slice review |

--- a/specs/1793-root-logger-calls/spec.md
+++ b/specs/1793-root-logger-calls/spec.md
@@ -1,0 +1,246 @@
+# Feature Specification: Module Logger Migration
+
+**Feature Branch**: `docs/1792-1796-lint-debt-specs` (specification only). The implementation branch is `refactor/1793-module-logger`.
+
+**GitHub Issue**: [#1793](https://github.com/jmorrison-juniper/MistHelper/issues/1793) — "refactor: 4478 logging calls use the root logger instead of a module logger"
+
+**Created**: 2026-08-06
+
+**Status**: Specification only. No code change exists yet.
+
+**Input**: Replace every root logger call with a named module logger. Add the `LOG015` rule to the ruff `select` list after the last slice lands.
+
+---
+
+## Background
+
+A call such as `logging.info("...")` sends the record to the root logger. A call such as `logger.info("...")` sends the record to a logger that carries the module name.
+
+The record from a root logger call carries no module name. The logging framework cannot route that record by module and cannot filter that record by module. An operator who wants debug output from the firmware path must raise the level on the root logger. The operator then receives debug output from every module at once.
+
+The repository holds 4478 root logger calls. Ruff reports each one under rule `LOG015`, which is named `root-logger-call`.
+
+### Why no gate reports this today
+
+The ruff `select` list in `pyproject.toml` line 164 reads as follows.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G"]
+```
+
+`LOG015` belongs to the `LOG` family. That family sits outside the `select` list. The CI lint gate therefore never reports these calls. The count grows without limit and without notice.
+
+### Measured baseline
+
+A maintainer measured the counts on 2026-08-06 at commit `08a75d2` with ruff 0.16.0.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --select LOG015 --statistics
+```
+
+| Measurement | Value |
+| - | - |
+| `LOG015` results | 4478 |
+| Files that hold at least one call | 223 |
+| Results that ruff repairs without help | 0 |
+
+The count matches the value in issue #1793 exactly.
+
+### The counts for each area
+
+| Area | Count |
+| - | - |
+| src/export | 678 |
+| src/firmware | 501 |
+| src/refactors | 423 |
+| MistHelper.py | 303 |
+| src/gateway | 261 |
+| src/capture | 220 |
+| src/org | 191 |
+| src/device | 182 |
+| src/site | 156 |
+| src/troubleshooting | 150 |
+| tests | 134 |
+| src/auth | 131 |
+| src/inventory | 131 |
+| src/ui | 131 |
+
+Every other area holds fewer than 131 calls.
+
+### The counts for the largest files
+
+| File | Count |
+| - | - |
+| MistHelper.py | 303 |
+| src/firmware/firmware_manager.py | 228 |
+| src/firmware/org_ap_upgrader.py | 143 |
+| src/firmware/bulk_ap_upgrader.py | 105 |
+| src/org/org_ticket_manager.py | 86 |
+| src/troubleshooting/marvis_troubleshoot_utils.py | 76 |
+| src/org/org_config_migration_manager.py | 60 |
+| src/ssh/ssh_runner_manager.py | 57 |
+| src/troubleshooting/interactive_test_runner.py | 57 |
+| src/device/prompt_utils.py | 56 |
+
+### The project rule that shapes this work
+
+The file `.github/copilot-instructions.md` states a NON-NEGOTIABLE rule for action logging. Each meaningful action logs before the action and logs after the action. Each message uses the lazy `%s` argument form that issue #429 delivered.
+
+This work must keep every one of those records. It changes the logger object and nothing else. A change to a level or to a message text would break the action logging rule and would break the operator playbooks that read the messages.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Filter the log output by module (Priority: P1)
+
+An operator debugs the firmware upgrade path. The operator raises the level for `src.firmware` alone. Every other module keeps its current level. The operator reads the firmware records without the other 3977 call sites.
+
+**Why this priority**: This story delivers the whole operator value. A named logger is the only way to route a record by module.
+
+**Independent Test**: An operator sets the level of the `src.firmware` logger to `DEBUG` and leaves the root logger at `INFO`. The operator then runs a firmware operation and reads debug records from the firmware modules only.
+
+**Acceptance Scenarios**:
+
+1. **Given** a converted module, **When** an operator raises the level for that module logger alone, **Then** the operator reads the debug records from that module and reads no debug record from another module.
+2. **Given** a converted module, **When** a record reaches a handler, **Then** the record carries the module name in the `name` field.
+3. **Given** a converted module, **When** a reviewer compares the message text against the earlier text, **Then** the two texts match byte for byte.
+4. **Given** a converted module, **When** a reviewer compares the log level of each call against the earlier level, **Then** the two levels match.
+
+---
+
+### User Story 2 - Land the change in slices that a reviewer can read (Priority: P1)
+
+A reviewer opens one pull request. The pull request holds one area. The reviewer reads the whole difference and confirms that only the logger object changed.
+
+**Why this priority**: This story shares the P1 rank, because 4478 call sites in one pull request cannot receive a real review. A review that nobody can perform delivers no safety.
+
+**Independent Test**: A reviewer counts the changed lines in any slice pull request. The count stays inside the stated limit.
+
+**Acceptance Scenarios**:
+
+1. **Given** any slice pull request, **When** a reviewer counts the changed lines, **Then** the count stays at or below 500.
+2. **Given** any slice pull request, **When** a reviewer reads the file list, **Then** every file belongs to one area.
+3. **Given** any slice pull request, **When** CI runs the gate set, **Then** every gate stays green and the unit test suite keeps its pass count.
+4. **Given** the slice order, **When** a reviewer reads the plan, **Then** the smallest area lands first and the largest area lands last.
+
+---
+
+### User Story 3 - Stop the count from growing again (Priority: P2)
+
+A contributor adds a root logger call. The CI lint gate reports the call and stops the pull request.
+
+**Why this priority**: This story protects the result of the first two stories. The story cannot land first, because the gate fails while any call remains.
+
+**Independent Test**: A reviewer adds one `logging.info(...)` call to a tracked file. The lint gate fails and names `LOG015`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated `select` list, **When** a reviewer searches the list, **Then** the list holds `LOG015`.
+2. **Given** the updated `select` list, **When** CI runs the lint gate on the clean branch, **Then** the gate succeeds.
+3. **Given** a pull request that adds one root logger call, **When** CI runs the lint gate, **Then** the gate fails and the log names `LOG015` and the file.
+
+---
+
+### Edge Cases
+
+- A module already binds the name `logger` to another object. The new module logger then collides with that name. The implementer must search each module for the name before the edit.
+- A test reads records with the `caplog` fixture. That fixture attaches to the root logger by default and still captures a record that a child logger sends. A test that asserts on `logging.getLogger()` directly can fail. The implementer must run the whole unit suite for each slice.
+- A module calls `logging.basicConfig` or `logging.getLogger()` with no argument. Those calls configure the root logger on purpose. Rule `LOG015` does not report them, and this work does not change them.
+- `src/utils/logger_utils.py` configures the logging system. A module logger inside the configuration path can recurse. The implementer must read that module before any edit.
+- `MistHelper.py` holds 303 calls in one file. The mypy gate now covers that file, so a wrong edit fails the type gate as well as the lint gate.
+- The `tests` area holds 134 calls. A test that logs through the root logger carries no operator value, so the same conversion applies with a lower risk.
+- Issue #886 converts `print()` calls into logging calls. Each new call must use a module logger from the start. The two efforts must not edit the same lines at the same time.
+
+---
+
+## Requirements *(mandatory)*
+
+### Conversion requirements
+
+- **FR-001**: Each converted module MUST define one module logger with `logger = logging.getLogger(__name__)`.
+- **FR-002**: The module logger definition MUST sit at module level, after the import block and before the first class or function.
+- **FR-003**: Each root logger call MUST become a call on the module logger. The rewrite covers `debug`, `info`, `warning`, `error`, `exception`, and `critical`.
+- **FR-004**: The rewrite MUST NOT change the log level of any call.
+- **FR-005**: The rewrite MUST NOT change the message text of any call.
+- **FR-006**: The rewrite MUST NOT change the argument list of any call. It MUST keep the lazy `%s` form that issue #429 delivered.
+- **FR-007**: The rewrite MUST NOT add a call and MUST NOT remove a call. The count of logging calls in each module stays the same.
+- **FR-008**: The implementer MUST search each module for an existing name `logger` before the edit. A collision MUST receive a rename of the other object, not a different logger name.
+- **FR-009**: The implementer MUST NOT change a `logging.basicConfig` call and MUST NOT change a `logging.getLogger()` call that takes no argument.
+
+### Slice requirements
+
+- **FR-010**: Each pull request MUST hold one area from the area table.
+- **FR-011**: Each pull request MUST hold at most 500 changed lines.
+- **FR-012**: An area above 500 calls MUST split into two or more pull requests by file. `src/export` and `src/firmware` need this split.
+- **FR-013**: The slices MUST land from the smallest area to the largest area. A small area proves the pattern at a low cost.
+- **FR-014**: Each slice MUST run the whole unit test suite, not the tests for that area alone.
+
+### Gate requirements
+
+- **FR-015**: The ruff `select` list in `pyproject.toml` MUST hold `LOG015` after the last slice lands.
+- **FR-016**: The `select` list change MUST land in its own pull request, after the last slice reports zero results.
+- **FR-017**: The implementer MUST NOT add any other rule to the `select` list in this work.
+
+### Quality requirements
+
+- **FR-018**: Every quality gate MUST stay green for each slice. The unit test suite MUST keep its pass count.
+- **FR-019**: All prose, all code comments, and all commit text MUST follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md`.
+- **FR-020**: Each pull request body MUST name the area, the count of converted calls, and the count of touched files.
+
+### Key Entities
+
+- **Root logger call**: A call on the `logging` module itself, such as `logging.info(...)`. The record carries no module name.
+- **Module logger**: A logger that `logging.getLogger(__name__)` returns. The record carries the module name.
+- **Slice**: One pull request that converts one area or one part of an area.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `ruff check . --select LOG015` reports zero results and exits with code 0.
+- **SC-002**: Every converted module defines `logger = logging.getLogger(__name__)` exactly once.
+- **SC-003**: The count of changed log levels is zero across every slice.
+- **SC-004**: The count of changed message texts is zero across every slice.
+- **SC-005**: The count of added logging calls is zero and the count of removed logging calls is zero.
+- **SC-006**: No slice pull request holds more than 500 changed lines.
+- **SC-007**: The ruff `select` list in `pyproject.toml` holds `LOG015`.
+- **SC-008**: A pull request that adds one root logger call fails the CI lint gate.
+- **SC-009**: Every quality gate stays green for every slice. The unit test suite keeps its pass count and adds no new failure.
+- **SC-010**: An operator raises the level for one module logger and reads records from that module alone.
+
+---
+
+## Non-Goals
+
+- **NG-001**: This work does not add any lint suppression. It adds no `# noqa` directive and no rule to the ruff `ignore` list. The whole point is a repair, not a hidden result.
+- **NG-002**: This work does not change the log level of any call. A level change would alter the operator output.
+- **NG-003**: This work does not change the message text of any call. The action logging rule in `.github/copilot-instructions.md` depends on the current text.
+- **NG-004**: This work does not add a logging call and does not remove one. A missing action log is a separate defect with a separate issue.
+- **NG-005**: This work does not convert a `print()` call into a logging call. Issue #886 owns that scope.
+- **NG-006**: This work does not change the logging configuration in `src/utils/logger_utils.py` beyond the conversion of the calls in that module.
+- **NG-007**: This work does not add a handler, a filter, or a formatter.
+- **NG-008**: This work does not change the `extend-exclude` list. The four excluded paths keep their root logger calls.
+- **NG-009**: This work does not add `LOG` rules other than `LOG015` to the `select` list.
+
+---
+
+## Assumptions
+
+- The ruff version stays at 0.16.0 during this work. A version change can add a rule and can move the count.
+- The 4478 count reflects the branch tip at commit `08a75d2`. The implementer must measure the count again before each slice.
+- The `caplog` fixture keeps working after the conversion, because it attaches to the root logger and a child logger propagates to it by default.
+- No module in scope sets `propagate = False` on a logger. The implementer must confirm this before the first slice.
+- The team accepts a stricter lint gate. A new root logger call becomes a build failure.
+- A reviewer can read a 500-line mechanical difference. A larger difference receives no real review.
+
+---
+
+## Dependencies
+
+- Issue [#886](https://github.com/jmorrison-juniper/MistHelper/issues/886) converts `print()` calls into logging calls. Each new call must use a module logger. The two efforts must not edit the same lines at the same time.
+- Issue [#429](https://github.com/jmorrison-juniper/MistHelper/issues/429) delivered the lazy `%s` argument form. This work must keep that form.
+- Issue [#1721](https://github.com/jmorrison-juniper/MistHelper/issues/1721) records a related defect. The Starlink dashboard configures logging after the bootstrap, so the startup records disappear.
+- The Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` govern all prose in this work.

--- a/specs/1793-root-logger-calls/tasks.md
+++ b/specs/1793-root-logger-calls/tasks.md
@@ -1,0 +1,220 @@
+# Tasks: Module Logger Migration
+
+**Feature**: `1793-root-logger-calls` | **Branch**: `refactor/1793-module-logger` | **Date**: 2026-08-06
+
+**GitHub Issue**: [#1793](https://github.com/jmorrison-juniper/MistHelper/issues/1793)
+
+**Input**: Design documents from `specs/1793-root-logger-calls/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md)
+
+**Tests**: The specification requests no new test. The existing suite must keep its pass count for each slice. Each slice ends with a measurement task and a gate task.
+
+**Branch rule**: Create one branch for each slice from `main`. Name the branch `refactor/1793-module-logger-<slice>`. Do not branch from another slice branch.
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: The task can run in parallel with another task in the same phase. The tasks touch different files.
+- **[Story]**: The user story that owns the task. The value is `US1`, `US2`, or `US3`.
+- Each task names an exact file path, an exact area, or an exact command.
+
+## Rules that apply to every edit task
+
+1. Use `.venv\Scripts\python.exe` for every Python command. The global interpreter cannot import the project.
+2. Change the logger object only. Do not change a level. Do not change a message text. Do not change an argument list. Requirements FR-004 through FR-006 state this rule.
+3. Add no lint suppression. Non-goal NG-001 forbids a `# noqa` directive and a new entry in the ruff `ignore` list.
+4. Add the module logger line with an inline comment that states its purpose. Principle VI requires the comment.
+5. Keep the lazy `%s` argument form that issue #429 delivered. Do not write an f-string.
+6. Follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` for every prose line.
+7. Keep each pull request at or below 500 changed lines. Requirement FR-011 states the limit.
+
+## The conversion pattern
+
+Each converted module gains one line after the import block.
+
+```python
+logger = logging.getLogger(__name__)  # Named logger lets an operator filter records by module.
+```
+
+Each call then changes its object and nothing else.
+
+```python
+logging.info("Fetching device list for site %s", site_id)   # Before
+logger.info("Fetching device list for site %s", site_id)    # After
+```
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the environment before any measurement.
+
+- [ ] T001 Confirm the tool version with `.venv\Scripts\python.exe -m ruff --version`. The expected value is `ruff 0.16.0`. Record any other value in [plan.md](plan.md), because a version change moves the count.
+- [ ] T002 Confirm that `.venv\Scripts\python.exe -m pytest --version` runs. Every later test command uses this interpreter.
+- [ ] T003 Record the pre-change gate baseline. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Save the unit test pass count, because SC-009 compares against it.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prove the baseline and remove the two coordination risks. No slice starts until this phase closes.
+
+- [ ] T004 Record the baseline. Run `.venv\Scripts\python.exe -m ruff check . --select LOG015 --statistics`. Write the count into [plan.md](plan.md) under "Measurement contract". The expected value is 4478.
+- [ ] T005 Check for an open pull request that touches the same areas. Run `gh pr list --json number,title,files`. Issue #886 converts `print()` calls and can edit the same lines. Record any overlap in [plan.md](plan.md).
+- [ ] T006 Search the whole tree for an existing module-level name `logger`. Run `.venv\Scripts\python.exe -m ruff check . --select LOG015 --output-format concise` to list the files, then search each file for `logger =`. Record every collision in [plan.md](plan.md). Requirement FR-008 depends on this record.
+- [ ] T007 Search the tree for a logger that sets `propagate = False`. A module with that setting does not send a record to the root logger, so the `caplog` fixture cannot see it. Record every site in [plan.md](plan.md).
+
+**Checkpoint**: The baseline reads 4478. The collision list and the propagate list exist. Slice 1 can start.
+
+---
+
+## Phase 3: User Story 1 and 2, Slice 1 - The tests area (Priority: P1)
+
+**Goal**: Convert the 134 calls in `tests/`. This area proves the pattern at the lowest cost.
+
+**Independent Test**: The `LOG015` count drops from 4478 to 4344. The unit suite keeps the T003 pass count.
+
+**Files**: about 20 files under `tests/`. The largest is `tests/unit/refactors/test_fast_mode_small_seams.py` with 53 calls.
+
+- [ ] T008 [US1] List the files in the slice. Run `.venv\Scripts\python.exe -m ruff check tests --select LOG015 --output-format concise`. Search each listed file for an existing name `logger`. Rename the other object if a collision exists, per FR-008.
+- [ ] T009 [US1] Add the module logger line to each file in the slice. Place the line after the import block and before the first class or function, per FR-002. Add the inline comment that Principle VI requires.
+- [ ] T010 [US1] Rewrite each root logger call in the slice. Change `logging.debug`, `logging.info`, `logging.warning`, `logging.error`, `logging.exception`, and `logging.critical` to the module logger form. Leave `logging.basicConfig` and `logging.getLogger()` unchanged, per FR-009.
+- [ ] T011 [US1] Confirm that the call count did not move. Count the logging calls in each changed file before and after the edit. The two counts must match, per FR-007.
+- [ ] T012 [US1] Read the whole difference. Confirm that each changed line differs by the object name alone. Count the changed levels and the changed message texts. Both counts must read zero, per SC-003 and SC-004.
+- [ ] T013 [US1] Confirm the slice size. Run `git diff --shortstat`. The changed line count must stay at or below 500, per FR-011.
+- [ ] T014 [US1] Verify the slice. Run `.venv\Scripts\python.exe -m ruff check . --select LOG015 --statistics` and confirm 4344. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Confirm that the pass count matches T003 and that the `caplog` assertions still pass.
+- [ ] T015 [US2] Open the slice pull request. Name the area, the count of converted calls, and the count of touched files in the body, per FR-020. Write `Refs #1793` and not `Closes #1793`, because 13 slices remain.
+
+**Checkpoint**: The count reads 4344. The pattern holds. Slice 2 can start.
+
+---
+
+## Phase 4: User Story 1 and 2, Slices 2 to 7 - The medium production areas (Priority: P1)
+
+**Goal**: Convert 1976 calls across six slices. Each slice repeats the T008 to T015 steps for its own scope.
+
+**Independent Test**: The `LOG015` count drops by the slice size after each slice. The unit suite keeps its pass count.
+
+**Warning**: Do not change a message text and do not change a level. A reviewer who finds one changed message must reject the slice.
+
+- [ ] T016 [US1] Convert slice 2. The scope is `src/auth`, `src/inventory`, and `src/ui`, which hold 393 calls. Repeat the T008 to T015 steps. Split the slice by area if the changed line count passes 500.
+- [ ] T017 [US1] Convert slice 3. The scope is `src/device`, `src/site`, and `src/troubleshooting`, which hold 488 calls. Read `src/troubleshooting/marvis_troubleshoot_utils.py` with care, because it holds 76 calls. Repeat the T008 to T015 steps.
+- [ ] T018 [P] [US1] Convert slice 4. The scope is `src/org`, which holds 191 calls. Read `src/org/org_ticket_manager.py` with care, because it holds 86 calls. Repeat the T008 to T015 steps.
+- [ ] T019 [P] [US1] Convert slice 5. The scope is `src/capture`, which holds 220 calls. Repeat the T008 to T015 steps.
+- [ ] T020 [P] [US1] Convert slice 6. The scope is `src/gateway`, which holds 261 calls. Repeat the T008 to T015 steps.
+- [ ] T021 [US1] Convert slice 7. The scope is `src/refactors`, which holds 423 calls. Split the slice by file if the changed line count passes 500. Repeat the T008 to T015 steps.
+
+**Checkpoint**: The count reads about 2368. Slice 8 can start.
+
+---
+
+## Phase 5: User Story 1 and 2, Slices 8 to 11 - The four largest files (Priority: P1)
+
+**Goal**: Convert 779 calls across four single-file slices. Each of these files exceeds 100 calls, so each takes its own pull request.
+
+**Independent Test**: The `LOG015` count drops by the file count after each slice. The mypy gate stays green.
+
+**Caution**: A single file cannot split across two pull requests. The module logger line must land with the first converted call in that file. A split leaves the module holding both call forms.
+
+- [ ] T022 [US1] Convert slice 8. The file is `src/firmware/org_ap_upgrader.py`, which holds 143 calls. Repeat the T008 to T015 steps for that file alone.
+- [ ] T023 [US1] Convert slice 9. The file is `src/firmware/firmware_manager.py`, which holds 228 calls. Repeat the T008 to T015 steps for that file alone.
+- [ ] T024 [US1] Convert slice 10. The scope is the rest of `src/firmware`, which holds 130 calls. `src/firmware/bulk_ap_upgrader.py` holds 105 of them. Repeat the T008 to T015 steps.
+- [ ] T025 [US1] Convert slice 11. The file is `MistHelper.py`, which holds 303 calls. Run `.venv\Scripts\python.exe -m mypy src/ MistHelper.py --config-file pyproject.toml` after the edit. Issue #888 widened the mypy scope to cover this file, so a wrong edit fails the type gate.
+
+**Checkpoint**: The count reads about 1589. Slice 12 can start.
+
+---
+
+## Phase 6: User Story 1 and 2, Slices 12 and 13 - The export area and the remainder (Priority: P1)
+
+**Goal**: Convert the last 1589 calls. `src/export` holds 678 of them, so that area splits into two or more slices.
+
+**Independent Test**: The `LOG015` count reaches zero.
+
+- [ ] T026 [US1] Split `src/export` into groups of at most 500 changed lines. List the files with `.venv\Scripts\python.exe -m ruff check src/export --select LOG015 --output-format concise` and record the group boundary in [plan.md](plan.md).
+- [ ] T027 [US1] Convert slice 12. The scope is the first `src/export` group. Repeat the T008 to T015 steps.
+- [ ] T028 [US1] Convert slice 13. The scope is the second `src/export` group. Repeat the T008 to T015 steps.
+- [ ] T029 [US1] List every area that the earlier slices did not cover. Run `.venv\Scripts\python.exe -m ruff check . --select LOG015 --output-format concise` and group the remaining files by area. Record the group boundary in [plan.md](plan.md).
+- [ ] T030 [US1] Convert each remaining group as its own slice. Repeat the T008 to T015 steps for each one. Keep every pull request at or below 500 changed lines.
+- [ ] T031 [US1] Verify the whole conversion. Run `.venv\Scripts\python.exe -m ruff check . --select LOG015 --statistics` and confirm zero results. SC-001 depends on this run.
+
+**Checkpoint**: The count reads zero. User Story 1 is complete. Phase 7 can start.
+
+---
+
+## Phase 7: User Story 3 - Stop the count from growing again (Priority: P2)
+
+**Goal**: Add `LOG015` to the ruff `select` list. This is the final change of the feature.
+
+**Independent Test**: A reviewer adds one `logging.info(...)` call to a tracked file. The lint gate fails and names `LOG015`.
+
+**Warning**: Run this phase only after Phase 6 reports zero results. The gate fails on every push while any call remains.
+
+- [ ] T032 [US3] Change line 164 of `pyproject.toml` from `select = ["E", "F", "W", "I", "UP", "B", "G"]` to `select = ["E", "F", "W", "I", "UP", "B", "G", "LOG015"]`. Add no other rule, per FR-017.
+- [ ] T033 [US3] Add a comment above the `select` list in `pyproject.toml`. State that a root logger record carries no module name and that an operator cannot filter it. Keep the comment inside 120 characters. Depends on T032, because both tasks edit the same file.
+- [ ] T034 [US3] Read `src/utils/logger_utils.py` in full. Confirm that the module logger does not sit inside a filter or a handler. A record from inside the logging path can re-enter that path and can recurse without end.
+- [ ] T035 [US3] Prove the negative case for SC-008. Add one temporary `logging.info("temp")` call to a tracked file under `src/`. Run `.venv\Scripts\python.exe -m ruff check .` and confirm that it reports `LOG015` and exits with code 1. Remove the line. Run `git status` and confirm that the tree holds no leftover change.
+
+**Checkpoint**: The gate reports a root logger call. SC-007 and SC-008 now hold.
+
+---
+
+## Phase 8: Polish and Final Validation
+
+**Purpose**: Prove every success criterion and close the issue. These tasks change no source line.
+
+- [ ] T036 Run the full gate set exactly as CI runs it. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, `.venv\Scripts\python.exe -m pylint src/`, `.venv\Scripts\python.exe -m radon cc src/ -a -nb`, `.venv\Scripts\python.exe -m vulture src/ --min-confidence 80`, `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r .`, and `.venv\Scripts\python.exe -m pytest --cov=src/ --cov-fail-under=80`. Do not scope a gate to the changed files only.
+- [ ] T037 [P] Prove SC-002. Search every converted module for `logging.getLogger(__name__)` and confirm exactly one match in each one.
+- [ ] T038 [P] Prove SC-010. Set the level of one module logger to `DEBUG` and leave the root logger at `INFO`. Run an operation that reaches that module. Confirm that the output holds debug records from that module and holds no debug record from another module.
+- [ ] T039 [P] Prove SC-005. Compare the count of logging calls in the tree before the first slice and after the last slice. The two counts must match.
+- [ ] T040 Open the final pull request for the gate change. Write `Closes #1793` in the body. Link `specs/1793-root-logger-calls/spec.md`. List every slice pull request number. Complete the checklist in `.github/PULL_REQUEST_TEMPLATE.md`. Add the `auto-merge` label only after every check passes, including CodeQL.
+
+---
+
+## Dependencies and Execution Order
+
+### Phase order
+
+| Phase | Content | Starts after |
+| - | - | - |
+| 1 | Setup | Nothing |
+| 2 | Foundational baseline | Phase 1 |
+| 3 | Slice 1, the tests area | Phase 2 records the baseline |
+| 4 | Slices 2 to 7, the medium areas | Phase 3 proves the pattern |
+| 5 | Slices 8 to 11, the largest files | Phase 4 |
+| 6 | Slices 12 and 13, the export area and the remainder | Phase 5 |
+| 7 | US3, the gate change | Phase 6 reports zero results |
+| 8 | Polish and final validation | Phase 7 |
+
+### Why slice 1 converts the test area first
+
+A test module carries no operator value in its records. A mistake there costs the least. Slice 1 also proves that the `caplog` fixture still captures a record from a named logger, which is the largest test risk in the whole feature.
+
+### Slice exit rule
+
+A slice must reduce the count by its own size and must move no other count. The unit suite must keep its pass count. A slice that fails either check does not merge.
+
+---
+
+## Parallel Opportunities
+
+| Phase | Parallel tasks | Reason |
+| - | - | - |
+| 4 | T018, T019, T020 | The three areas hold no shared file. |
+| 8 | T037, T038, T039 | The three checks read different data. |
+
+**Caution**: Two agents must not open a slice pull request for the same area at the same time. Claim the area on issue #1793 before the branch starts.
+
+---
+
+## Implementation Strategy
+
+### Minimum viable delivery
+
+Slice 1 alone delivers no operator value, because a test record reaches no operator. Slice 2 delivers the first real value, because an operator can then filter three production areas.
+
+### Order of risk
+
+The largest risk is a silent message change. The rewrite is mechanical, so a scripted edit is safe. A scripted edit that also touches a message is not safe. Task T012 is the control, and it runs in every slice.

--- a/specs/1794-blind-except-handlers/plan.md
+++ b/specs/1794-blind-except-handlers/plan.md
@@ -1,0 +1,223 @@
+# Implementation Plan: Blind Except Handler Audit
+
+**Branch**: `refactor/1794-blind-except` (SpecKit feature directory `1794-blind-except-handlers`) | **Date**: 2026-08-06 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1794-blind-except-handlers/spec.md`
+
+**GitHub Issue**: [#1794](https://github.com/jmorrison-juniper/MistHelper/issues/1794)
+
+## Summary
+
+Ruff reports 500 blind handlers once a maintainer removes the inert `# noqa` directives. Ruff repairs none of them, and no mechanical repair exists. Each site needs a judgment.
+
+This plan runs the work in three stages. It reconciles the baseline first. It then audits the sites in 15 slices, from the smallest area to the largest area. It closes both gates last.
+
+The plan treats the existing project judgment as a starting point, not as a conclusion. The comment at `pyproject.toml` line 475 states that 493 sites are intentional in cleanup handlers and error handlers. The audit tests that statement one site at a time.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (`pyproject.toml` target `py313`)
+
+**Primary Dependencies**: `ruff` 0.16.0 and `pylint` 4.0.6. This work adds no dependency.
+
+**Storage**: Not applicable. The work changes handler blocks, comments, and two configuration entries.
+
+**Testing**: `pytest` with `--cov=src/ --cov-fail-under=80`. The suite must keep its pass count for each slice.
+
+**Target Platform**: The CI runner uses Linux. A developer works on Windows. Both report the same ruff count.
+
+**Project Type**: Behavior-sensitive refactor. A narrowed exception type changes which errors propagate.
+
+**Performance Goals**: The lint gate must stay inside its current runtime. A narrow exception clause costs the same as a broad one at run time.
+
+**Constraints**:
+
+- The root ruff line length is 120 characters.
+- `ruff check .` reads the whole repository. Its `extend-exclude` list drops `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`.
+- `pylint` reads `MistHelper.py` and `src` only. The two roots differ, and that difference produces part of the count gap.
+- `radon` fails on any block above complexity 10. A narrowed type adds no branch, so the score stays flat. An added `if` inside a handler does add a branch.
+- The action logging rule in `.github/copilot-instructions.md` demands a log call on each meaningful action. Requirement FR-011 extends that rule to every handler that the code continues past.
+
+**Scale/Scope**: 500 sites, 161 files, 15 slices, and two configuration entries.
+
+### Measurement contract
+
+Run the three commands below before the first slice. Record all three values.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --select BLE001 --statistics
+.venv\Scripts\python.exe -m ruff check . --select BLE001 --ignore-noqa --statistics
+.venv\Scripts\python.exe -m pylint MistHelper.py src --disable=all --enable=W0718 --score=n
+```
+
+The expected values are 412, 500, and a value near 493.
+
+**Warning**: The scope uses the 500 count, not the 412 count. A scope built on 412 leaves 88 sites unaudited, and the gate never reports them.
+
+### Verified mechanics
+
+A maintainer probed the counts on 2026-08-06 at commit `08a75d2`. Four results shape the tasks.
+
+1. The default count reads 412 and the `--ignore-noqa` count reads 500. The gap is 88.
+2. The default run touches 122 files. The `--ignore-noqa` run touches 161 files. 39 files hold hidden sites only.
+3. `src/ssh` shows the largest hidden share. It reports 14 sites by default and 32 with `--ignore-noqa`.
+4. `starlink_dashboard.py` holds 8 sites. Pylint never reads that file, so those 8 sites sit inside the count gap between the two tools.
+
+### Discovered risk: the two tools disagree by 7 sites
+
+Ruff reports 500 with `--ignore-noqa`. The `pyproject.toml` comment records 493 for pylint. The gap is 7.
+
+The largest known cause is the root difference. Ruff reads `starlink_dashboard.py`, `tools/`, and `tests/`. Pylint reads `MistHelper.py` and `src` only. That difference alone covers more than 7 sites, so a second effect must run the other way. The likely second effect is the pylint scope in the current CI workflow, which the team changed in pull request #1788.
+
+The control is task T005. It measures the pylint count again on the current tree instead of trusting the recorded 493.
+
+### Discovered risk: a narrowed type can turn a caught error into a crash
+
+The audit narrows the exception type at some sites. A narrow clause lets an unexpected error propagate, which is the whole point. It also changes the behavior on any path that already raises that unexpected error today.
+
+The control is the full unit suite on each slice plus a read of the caller. A site whose caller cannot handle the propagated error receives a `keep` outcome with a log call instead of a `narrow` outcome.
+
+## Constitution Check
+
+*GATE: The plan passes before Phase 0 research. The plan passes again after Phase 1 design.*
+
+| Principle | Status | Basis |
+| - | - | - |
+| I. Five-Item Rule | PASS with a constraint | An added log call adds one line to a handler. Each touched function must stay inside 25 lines and 5 blocks. |
+| II. Class-Based Architecture (No Wrappers) | PASS | The work adds no class and no wrapper function. |
+| III. Safety-First | PASS with a gate | A narrowed type changes which errors reach the operator. Each `narrow` outcome needs a read of the caller. |
+| IV. Full Deployment Pipeline | ADAPTED | The work follows the branch and pull request workflow. The container needs a rebuild after the last slice. |
+| V. Observability and Logging | PASS with a gain | The work adds a log call to every handler that the code continues past. Every message stays ASCII. |
+| VI. Inline Comments (NON-NEGOTIABLE) | PASS | Each `keep` outcome carries a comment that states the reason. Each changed line carries an inline comment. |
+| VII. Action Logging (NON-NEGOTIABLE) | PASS with a gain | Requirement FR-011 adds the missing log call at every silent site. |
+| Security Findings: Fix Over Suppress (NON-NEGOTIABLE) | PASS with a gate | Requirement FR-013 forbids a `# noqa: BLE001` directive. A `keep` outcome uses a plain comment and needs a stated reason. |
+
+### The keep question
+
+This plan expects a `keep` outcome at most sites. That expectation needs a justification against the "fix over suppress" rule.
+
+A `keep` outcome is not a suppression. The site keeps the broad catch, gains a log call, and gains a comment that states the reason. The gate still reports the site, and the ruff `select` list still holds the rule, because a `keep` site holds no directive.
+
+**Warning**: A contributor who adds `# noqa: BLE001` to reach a green gate defeats the whole work. Requirement FR-013 forbids that action, and the review must reject it.
+
+A `keep` outcome therefore turns a silent handler into a loud one. That is the fix. The breadth is not the defect. The silence is the defect.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1794-blind-except-handlers/
+├── spec.md              # The feature specification
+├── plan.md              # This file
+└── tasks.md             # The task list
+```
+
+### Source code (repository root)
+
+The work touches 161 files. The list below names the slice boundary for each area. Each count uses the `--ignore-noqa` value.
+
+```text
+pyproject.toml                                        # Slice 15: the select list and the disable list
+
+MistHelper.py                                         # Slice 11: 33 sites, coordinate with issue #1709
+starlink_dashboard.py                                 # Slice 2: 8 sites, pylint never reads this file
+
+src/
+├── export/                                           # Slices 12 to 14: 94 sites, split by file
+├── firmware/                                         # Slices 9 and 10: 62 sites, split by file
+├── refactors/                                        # Slice 8: 43 sites, split if above 40
+├── device/                                           # Slice 7: 34 sites
+├── ssh/                                              # Slice 6: 32 sites, 18 of them hidden today
+├── gateway/                                          # Slice 5: 24 sites
+├── site/                                             # Slice 4: 18 sites
+├── db/                                               # Slice 4: 17 sites
+├── api/                                              # Slice 3: 16 sites
+├── utils/                                            # Slice 3: 14 sites
+├── websocket/                                        # Slice 3: 14 sites
+├── ui/                                               # Slice 2: 12 sites
+└── analytics/                                        # Slice 2: 10 sites
+```
+
+**Structure Decision**: The work stays inside the current tree. It creates no file and deletes no file.
+
+## Phased approach
+
+The work runs in three stages.
+
+### Stage 1 - Reconcile the baseline
+
+No edit starts before this stage closes. The stage produces one written record.
+
+The record states the three counts, names the root that each tool reads, and explains each site in the difference. Requirement FR-003 blocks the first slice until the record holds an explanation for every site.
+
+**Exit measurement**: The record exists. Issue #1792 has landed, and the default ruff count now equals the `--ignore-noqa` count at 500.
+
+### Stage 2 - Audit the sites in slices
+
+Slices 2 through 14 audit the sites. Each slice follows the same six steps.
+
+1. List the sites in the slice with `ruff check <area> --select BLE001 --output-format concise`.
+2. Read each site and its caller. Select an outcome of `delete`, `narrow`, or `keep`.
+3. Apply the outcome. Add a log call at every site that the code continues past.
+4. Record the outcome for each site in the pull request body.
+5. Read the whole difference and confirm that no `# noqa: BLE001` directive appeared.
+6. Run the full gate set and the full unit suite.
+
+**Caution**: A narrowed type changes behavior. Read the caller before the edit. A caller that cannot handle the propagated error needs a `keep` outcome instead.
+
+**Exit measurement**: The `BLE001` count reaches zero after the last slice.
+
+### Stage 3 - Close both gates
+
+Add `BLE001` to the ruff `select` list. Remove `W0718` from the pylint `disable` list. Rewrite the comment at `pyproject.toml` line 471, because it records a count and a judgment that this work replaces.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G", "BLE001"]
+disable = ["C0114", "C0115", "C0116", "W0613"]
+```
+
+**Warning**: Both configuration changes must land in one pull request. A split leaves a window in which one tool reports the pattern and the other does not.
+
+**Exit measurement**: `ruff check .` and the pylint gate both pass. A test handler that catches `Exception` fails both gates.
+
+## Slice ledger
+
+| Slice | Scope | Sites |
+| - | - | - |
+| 1 | Reconciliation only, no edit | 0 |
+| 2 | src/analytics, src/ui, starlink_dashboard.py | 30 |
+| 3 | src/api, src/utils, src/websocket | 44, split if needed |
+| 4 | src/site, src/db | 35 |
+| 5 | src/gateway | 24 |
+| 6 | src/ssh | 32 |
+| 7 | src/device | 34 |
+| 8 | src/refactors | 43, split into two |
+| 9 | src/firmware/firmware_manager.py | 28 |
+| 10 | src/firmware, the rest | 34 |
+| 11 | MistHelper.py | 33 |
+| 12 | src/export, part one | about 33 |
+| 13 | src/export, part two | about 33 |
+| 14 | src/export, part three, and every remaining area | the remainder |
+| 15 | pyproject.toml | 0 |
+
+**Caution**: Slice 14 holds every area that the table above does not name. The implementer must split that slice further once the earlier slices land. No pull request may audit more than 40 sites.
+
+## Risk register
+
+| Risk | Likelihood | Effect | Control |
+| - | - | - | - |
+| The work starts before issue #1792 lands | Medium | 88 sites stay unaudited and the gate hides them | Task T004 blocks the first slice until the two ruff counts match |
+| A contributor adds a `# noqa: BLE001` directive to reach a green gate | Medium | The gate reports a false clean state | Task T016 searches each difference for the directive. Requirement FR-013 forbids it. |
+| A narrowed type turns a caught error into a crash | Medium | An operator meets a new failure | Each slice reads the caller and runs the whole unit suite |
+| An added log call pushes a function above the complexity limit | Low | The radon gate fails | A log call adds no branch. Each slice runs `radon cc src/ -a -nb`. |
+| Issue #1709 edits the same lines in `MistHelper.py` | Medium | A merge conflict | Slice 11 checks the state of issue #1709 first |
+| The pylint count differs from the recorded 493 | High | The reconciliation record is wrong | Task T005 measures the count again instead of trusting the comment |
+
+## Complexity Tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+| - | - | - |
+| The work spans 15 pull requests | 500 sites each need a judgment, and a reviewer cannot judge 500 sites in one difference | A single pull request would merge without a real review, which defeats the purpose of an audit |
+| Most sites receive a `keep` outcome | The breadth is correct on a cleanup path and around an undocumented third-party call | A blanket narrowing would turn a caught error into a new crash across the whole tree |
+| The reconciliation stage produces no code change | A wrong baseline produces a wrong scope, and a wrong scope leaves sites unaudited in silence | An audit that starts from the 412 count misses 88 sites and reports a false clean state |

--- a/specs/1794-blind-except-handlers/spec.md
+++ b/specs/1794-blind-except-handlers/spec.md
@@ -1,0 +1,286 @@
+# Feature Specification: Blind Except Handler Audit
+
+**Feature Branch**: `docs/1792-1796-lint-debt-specs` (specification only). The implementation branch is `refactor/1794-blind-except`.
+
+**GitHub Issue**: [#1794](https://github.com/jmorrison-juniper/MistHelper/issues/1794) — "refactor: 412 blind except Exception handlers hide the failures they catch"
+
+**Created**: 2026-08-06
+
+**Status**: Specification only. No code change exists yet.
+
+**Input**: Audit every handler that catches the base `Exception` class. Separate the handler that protects the operator from the handler that hides a defect. Add the `BLE001` rule to the ruff `select` list after the last slice lands.
+
+---
+
+## Background
+
+A handler that catches `Exception` catches every error. It catches the error that the author expected. It also catches a name error, a type error, and an attribute error that the author never considered. The handler then returns a default value, and the defect disappears.
+
+Ruff reports each site under rule `BLE001`, which is named `blind-except`.
+
+### This work is not a blanket rewrite
+
+The project already studied this pattern once. The comment at `pyproject.toml` line 475 records the result.
+
+```toml
+# W0613 (unused-argument) and W0718 (broad-exception-caught) remain disabled
+# repo-wide; narrowing them is tracked as separate #887 follow-up slices --
+# ... and W0718 has 493 sites where broad `except Exception:` blocks
+# are intentional in cleanup/error handlers. Each needs a per-site audit.
+disable = ["C0114", "C0115", "C0116", "W0613", "W0718"]
+```
+
+That comment states two facts. The team counted 493 sites. The team judged the sites intentional in cleanup handlers and error handlers.
+
+This specification accepts the first fact and tests the second one. A cleanup handler that runs on a shutdown path has a real reason for the broad catch. A data export handler that returns an empty list has no such reason, because a name error there produces a silent empty report.
+
+The work therefore audits each site and records one of three outcomes. It does not rewrite every site to a narrow type.
+
+### Why no gate reports this today
+
+The ruff `select` list in `pyproject.toml` line 164 reads as follows.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G"]
+```
+
+`BLE001` belongs to the `BLE` family. That family sits outside the `select` list. Pylint reports the same pattern under rule `W0718`, and the project disables that rule. No gate reports the pattern today.
+
+### Measured baseline
+
+A maintainer measured the counts on 2026-08-06 at commit `08a75d2` with ruff 0.16.0.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --select BLE001 --statistics
+.venv\Scripts\python.exe -m ruff check . --select BLE001 --ignore-noqa --statistics
+```
+
+| Command | `BLE001` count | Files |
+| - | - | - |
+| Default. Ruff reads each `# noqa` directive. | 412 | 122 |
+| With `--ignore-noqa`. Ruff skips each directive. | 500 | 161 |
+| Pylint `W0718`, recorded in `pyproject.toml` | 493 | not recorded |
+
+Both ruff counts match the values in issue #1794 exactly.
+
+### The true count is 500, not 412
+
+The 88-site difference is the most important number in this specification.
+
+Those 88 lines carry a `# noqa: BLE001` directive **and** hold a real blind handler. The directive changes nothing today, because ruff does not select `BLE001`. The directive starts to work on the day the team selects the rule. Ruff then hides 88 real results, and a team that clears 412 sites believes the work is complete.
+
+Issue [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792) removes those inert directives. That work must land before this one starts.
+
+### The remaining gap of 7 sites
+
+Ruff reports 500 with `--ignore-noqa`. Pylint recorded 493. The gap is 7.
+
+The two tools read different roots. Pylint reads `MistHelper.py` and `src` only. Ruff reads the whole repository, and its `extend-exclude` list drops `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`. Ruff therefore reports 8 sites in `starlink_dashboard.py` that pylint never reads.
+
+The first task of this work reconciles the two counts and records the reason for each difference. A wrong baseline produces a wrong scope.
+
+### The counts for each area, with the directives removed
+
+| Area | Count with `--ignore-noqa` | Count by default |
+| - | - | - |
+| src/export | 94 | 75 |
+| src/firmware | 62 | 58 |
+| src/refactors | 43 | 38 |
+| src/device | 34 | 28 |
+| MistHelper.py | 33 | 33 |
+| src/ssh | 32 | 14 |
+| src/gateway | 24 | 22 |
+| src/site | 18 | 8 |
+| src/db | 17 | 17 |
+| src/api | 16 | 16 |
+| src/utils | 14 | 12 |
+| src/websocket | 14 | 11 |
+| src/ui | 12 | 12 |
+| src/analytics | 10 | 6 |
+
+The `src/ssh` area shows the largest hidden count. 18 of its 32 sites carry an inert directive today.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See the failure that a handler catches (Priority: P1)
+
+A contributor writes a defect inside a guarded block. The handler catches the error, logs it with the exception detail, and the log names the file and the error type. The contributor reads the log and finds the defect.
+
+**Why this priority**: This story delivers the whole value. A handler that logs the error stops the silent data loss, even where the broad catch stays in place.
+
+**Independent Test**: A reviewer injects a `NameError` into a guarded block. The reviewer runs the operation and reads a log record that names the error type and the module.
+
+**Acceptance Scenarios**:
+
+1. **Given** a handler that the audit keeps, **When** the block catches an error and the program continues, **Then** the code logs the error with the exception detail.
+2. **Given** a handler that the audit keeps, **When** a reader opens the source, **Then** a comment states why the broad catch is correct at that site.
+3. **Given** a handler that the audit narrows, **When** an unexpected error reaches the block, **Then** the error propagates instead of returning a default value.
+4. **Given** a handler that the audit deletes, **When** a reviewer reads the block, **Then** the reviewer confirms that no exception can reach it.
+
+---
+
+### User Story 2 - Trust the baseline before the first edit (Priority: P1)
+
+A maintainer reads one written record. The record states the true count, states the reason for every difference between the two tools, and names the roots that each tool reads.
+
+**Why this priority**: This story shares the P1 rank. A wrong baseline produces a wrong scope, and a wrong scope leaves sites unaudited without any signal.
+
+**Independent Test**: A reviewer reads the record and reproduces every count in it with the stated commands.
+
+**Acceptance Scenarios**:
+
+1. **Given** the written record, **When** a reviewer runs the stated ruff command, **Then** the output matches the recorded count.
+2. **Given** the written record, **When** a reviewer runs the stated pylint command, **Then** the output matches the recorded count.
+3. **Given** the written record, **When** a reviewer reads the reconciliation, **Then** the record explains each site in the difference between the two tools.
+4. **Given** the written record, **When** a reviewer checks the order, **Then** the record states that issue #1792 lands first.
+
+---
+
+### User Story 3 - Land the audit in slices that a reviewer can read (Priority: P2)
+
+A reviewer opens one pull request. The pull request holds one area and states the outcome for each site in that area.
+
+**Why this priority**: This story protects the review quality. Each site needs a judgment, not a mechanical edit, so a large pull request receives no real review.
+
+**Independent Test**: A reviewer counts the sites in any slice pull request. The count stays at or below 40.
+
+**Acceptance Scenarios**:
+
+1. **Given** any slice pull request, **When** a reviewer counts the audited sites, **Then** the count stays at or below 40.
+2. **Given** any slice pull request, **When** a reviewer reads the body, **Then** the body records the outcome for each site.
+3. **Given** any slice pull request, **When** CI runs the gate set, **Then** every gate stays green and the unit test suite keeps its pass count.
+
+---
+
+### Edge Cases
+
+- A handler sits on a shutdown path or a cleanup path. A raised error there can leave a resource open or can hide the first error. The broad catch is correct, and the audit keeps it with a comment.
+- A handler sits inside a logging filter. A log call from that block can re-enter the filter and can recurse without end. Specification `1032-bandit-severity-gate` already records this case for `src/utils/logger_utils.py`.
+- A handler wraps a third-party call that documents no exception type. A narrow type would miss an error that the library adds in a later release. The audit keeps the broad catch and states the library name.
+- A handler catches `Exception` and then re-raises. That site loses nothing, so the audit records it as safe with a short comment.
+- A handler returns an empty list or an empty dictionary. A caller then reports zero rows and reports no error. This is the highest risk category, and the audit must narrow or log every one of these sites.
+- The `starlink_dashboard.py` file holds 8 sites that pylint never reads. Those sites still need an audit, because ruff reads them.
+- Issue [#1709](https://github.com/jmorrison-juniper/MistHelper/issues/1709) asks the same question for `MistHelper.py` alone. That file holds 33 of the sites. The two efforts must not edit the same lines at the same time.
+- The bandit rule `B110`, which is named `try_except_pass`, reports a near neighbor. Specification `1032-bandit-severity-gate` covered 7 of those sites and closed them.
+
+---
+
+## Requirements *(mandatory)*
+
+### Reconciliation requirements
+
+- **FR-001**: The implementer MUST record the ruff count, the ruff count with `--ignore-noqa`, and the pylint `W0718` count before any edit.
+- **FR-002**: The record MUST name the root that each tool reads and MUST name the exclusion list that each tool applies.
+- **FR-003**: The record MUST explain every site in the difference between the two counts. A site with no explanation blocks the first slice.
+- **FR-004**: The implementer MUST NOT start any edit before issue #1792 lands. That work removes the 88 inert directives.
+- **FR-005**: The scope MUST use the count with `--ignore-noqa`, not the default count.
+
+### Audit requirements
+
+- **FR-006**: Each site MUST receive one recorded outcome. The outcome MUST be `delete`, `narrow`, or `keep`.
+- **FR-007**: A `delete` outcome MUST show that no exception can reach the block.
+- **FR-008**: A `narrow` outcome MUST name the specific exception class or classes that the block expects.
+- **FR-009**: A `keep` outcome MUST carry a source comment that states why the breadth is correct at that site. A bare `keep` is forbidden.
+- **FR-010**: The implementer MUST select the outcome in this order. First, delete the handler. Second, narrow the exception type. Third, keep the broad catch with a stated reason.
+- **FR-011**: A handler that the code continues past MUST log the exception. The log call MUST include the exception detail.
+- **FR-012**: A handler MUST NOT pass in silence. A `pass` with no log needs a `keep` comment that states why silence is correct.
+- **FR-013**: The implementer MUST NOT add a `# noqa: BLE001` directive to any site. A `keep` outcome uses a plain comment, not a suppression.
+
+### Slice requirements
+
+- **FR-014**: Each pull request MUST hold one area from the area table.
+- **FR-015**: Each pull request MUST audit at most 40 sites.
+- **FR-016**: An area above 40 sites MUST split into two or more pull requests by file.
+- **FR-017**: The slices MUST land from the smallest area to the largest area.
+- **FR-018**: Each pull request body MUST record the outcome for each audited site.
+
+### Gate requirements
+
+- **FR-019**: The ruff `select` list in `pyproject.toml` MUST hold `BLE001` after the last slice lands.
+- **FR-020**: The pylint `disable` list in `pyproject.toml` MUST NOT hold `W0718` after the last slice lands.
+- **FR-021**: The two configuration changes MUST land in the same pull request, so that no window opens in which one tool reports and the other does not.
+- **FR-022**: The comment at `pyproject.toml` line 471 MUST change, because it records a count and a judgment that this work replaces.
+
+### Quality requirements
+
+- **FR-023**: Every quality gate MUST stay green for each slice. The unit test suite MUST keep its pass count.
+- **FR-024**: All prose, all code comments, and all commit text MUST follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md`.
+- **FR-025**: Every changed Python line MUST carry an inline comment that explains why the line exists.
+
+### Key Entities
+
+- **Blind handler**: A `try` block whose `except` clause names the base `Exception` class or names no class at all.
+- **Inert directive**: A `# noqa: BLE001` comment that hides nothing today, because the `select` list does not hold the rule.
+- **Audit outcome**: The recorded decision for one site. The value is `delete`, `narrow`, or `keep`.
+- **Silent handler**: A handler that catches an error, returns a default value, and writes no log record. This is the pattern that the work targets first.
+
+---
+
+## Outcome policy by handler shape
+
+The table states the default outcome for each shape. A reviewer may choose a different outcome for one site. The reviewer must then record the reason in the pull request.
+
+| Handler shape | Default outcome | Escalate when |
+| - | - | - |
+| The block returns an empty collection or a default value and writes no log | Narrow the type and add a log call | The caller cannot act on the error. Then keep the broad catch and add a log call with a stated reason. |
+| The block re-raises after a log call | Keep with a comment | The narrow type is obvious from one line above. Then narrow the type. |
+| The block runs on a shutdown path or a cleanup path | Keep with a comment that names the resource | The block can run on a normal path. Then narrow the type. |
+| The block wraps a third-party call with no documented exception type | Keep with a comment that names the library | The library documents its exception types. Then narrow the type. |
+| The block sits inside a logging filter, a handler, or a formatter | Keep with a comment that states the recursion risk | Never. A log call from that block can recurse without end. |
+| The block holds `pass` and nothing else | Narrow the type and add a debug log | Silence is correct, such as a best-effort close. Then keep with a stated reason. |
+| The block catches an error that the code above cannot raise | Delete the handler | The call chain can raise it through a deeper frame. Then narrow the type. |
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A written record states the ruff count, the ruff count with `--ignore-noqa`, and the pylint count, and explains every difference between them.
+- **SC-002**: `ruff check . --select BLE001 --ignore-noqa` reports zero results and exits with code 0.
+- **SC-003**: The count of sites without a recorded outcome is zero.
+- **SC-004**: Every site with a `keep` outcome carries a source comment that states the reason.
+- **SC-005**: Every handler that the code continues past logs the exception detail.
+- **SC-006**: The count of `# noqa: BLE001` directives that this work adds is zero.
+- **SC-007**: No slice pull request audits more than 40 sites.
+- **SC-008**: The ruff `select` list holds `BLE001` and the pylint `disable` list does not hold `W0718`.
+- **SC-009**: A pull request that adds one blind handler fails the CI lint gate.
+- **SC-010**: Every quality gate stays green for every slice. The unit test suite keeps its pass count and adds no new failure.
+- **SC-011**: A reviewer who did not write the change reads any `keep` comment and states the reason in under one minute, without help from the author.
+
+---
+
+## Non-Goals
+
+- **NG-001**: This work does not add any lint suppression. It adds no `# noqa: BLE001` directive and adds no rule to the ruff `ignore` list. Requirement FR-013 states the rule. The whole point is a repair, not a hidden result.
+- **NG-002**: This work does not rewrite every site to a narrow type. The audit keeps a broad catch where the breadth is correct.
+- **NG-003**: This work does not restore the pylint `W0718` disable entry under another name.
+- **NG-004**: This work does not change the behavior that the test suite covers. A narrowed type must not turn a caught error into a new crash on a covered path.
+- **NG-005**: This work does not remove the inert `# noqa: BLE001` directives. Issue #1792 owns that scope.
+- **NG-006**: This work does not resolve issue #1709 in full. That issue covers `MistHelper.py`, which holds 33 sites.
+- **NG-007**: This work does not change the ruff `extend-exclude` list. The four excluded paths keep their handlers.
+- **NG-008**: This work does not add a new bandit suppression. Specification `1032-bandit-severity-gate` already closed the 7 `B110` sites.
+- **NG-009**: This work does not add `BLE` rules other than `BLE001` to the `select` list.
+
+---
+
+## Assumptions
+
+- Issue #1792 lands before this work starts. Without it, the gate hides 88 sites.
+- The ruff version stays at 0.16.0 during this work. A version change can move the count.
+- The 500 count reflects the branch tip at commit `08a75d2`. The implementer must measure the count again before each slice.
+- The recorded pylint count of 493 reflects an older tree. The implementer must measure it again, because the tree changed since that comment.
+- Most of the 500 sites receive a `keep` outcome. The team judged them intentional once already. The value of this work is the log call and the stated reason, not a mass rewrite.
+- A reviewer can judge 40 sites in one sitting. A larger pull request receives no real review.
+
+---
+
+## Dependencies
+
+- Issue [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792) must land first. It removes the 88 inert directives that hide real sites.
+- Issue [#1709](https://github.com/jmorrison-juniper/MistHelper/issues/1709) covers the 33 sites in `MistHelper.py`. Land it first or fold it into the `MistHelper.py` slice.
+- Issue [#887](https://github.com/jmorrison-juniper/MistHelper/issues/887) disabled `W0718` and recorded the 493-site count. This work reverses that decision.
+- Specification `1032-bandit-severity-gate` closed 7 `B110` sites, which are near neighbors of this pattern.
+- The Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` govern all prose in this work.

--- a/specs/1794-blind-except-handlers/tasks.md
+++ b/specs/1794-blind-except-handlers/tasks.md
@@ -1,0 +1,214 @@
+# Tasks: Blind Except Handler Audit
+
+**Feature**: `1794-blind-except-handlers` | **Branch**: `refactor/1794-blind-except` | **Date**: 2026-08-06
+
+**GitHub Issue**: [#1794](https://github.com/jmorrison-juniper/MistHelper/issues/1794)
+
+**Input**: Design documents from `specs/1794-blind-except-handlers/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md). Issue [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792) must land first.
+
+**Tests**: The specification requests no new test. The existing suite must keep its pass count for each slice.
+
+**Branch rule**: Create one branch for each slice from `main`. Name the branch `refactor/1794-blind-except-<slice>`. Do not branch from another slice branch.
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: The task can run in parallel with another task in the same phase. The tasks touch different files.
+- **[Story]**: The user story that owns the task. The value is `US1`, `US2`, or `US3`.
+- Each task names an exact area, an exact file path, or an exact command.
+
+## Rules that apply to every edit task
+
+1. Use `.venv\Scripts\python.exe` for every Python command. The global interpreter cannot import the project.
+2. Add no lint suppression. Requirement FR-013 forbids a `# noqa: BLE001` directive. A `keep` outcome uses a plain comment.
+3. Read the caller before any `narrow` outcome. A narrow clause lets an error propagate, and the caller must handle it.
+4. Add a log call at every site that the code continues past. The call must include the exception detail, per FR-011.
+5. Every changed Python line carries an inline comment that states why the line exists. Principle VI requires it.
+6. Follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` for every prose line.
+7. Audit at most 40 sites in one pull request. Requirement FR-015 states the limit.
+
+## The three outcomes
+
+| Outcome | When | What the site looks like afterward |
+| - | - | - |
+| `delete` | No exception can reach the block | The `try` and the `except` are gone. The body stays. |
+| `narrow` | One exception class or a small set can reach the block | The clause names the classes. The log call names the error. |
+| `keep` | The breadth is correct at that site | The clause still names `Exception`. A comment states the reason. A log call records the error. |
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the environment and the prerequisite before any measurement.
+
+- [ ] T001 Confirm the tool versions with `.venv\Scripts\python.exe -m ruff --version` and `.venv\Scripts\python.exe -m pylint --version`. The expected values are `ruff 0.16.0` and `pylint 4.0.6`.
+- [ ] T002 Confirm that `.venv\Scripts\python.exe -m pytest --version` runs. Every later test command uses this interpreter.
+- [ ] T003 Record the pre-change gate baseline. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Save the unit test pass count, because SC-010 compares against it.
+
+---
+
+## Phase 2: User Story 2 - Trust the baseline before the first edit (Priority: P1)
+
+**Purpose**: Produce the reconciliation record. No edit starts until this phase closes.
+
+**Warning**: Task T004 is a stop condition. If the two ruff counts differ, issue #1792 has not landed. Stop and wait. A start on the 412 count leaves 88 sites unaudited, and the gate never reports them.
+
+- [ ] T004 [US2] Confirm that issue #1792 landed. Run `.venv\Scripts\python.exe -m ruff check . --select BLE001 --statistics` and the same command with `--ignore-noqa`. Both values must read 500. Stop if the default value reads 412, because the inert directives still exist.
+- [ ] T005 [US2] Measure the pylint count on the current tree. Run `.venv\Scripts\python.exe -m pylint MistHelper.py src --disable=all --enable=W0718 --score=n` and count the reported lines. Do not trust the value of 493 in the `pyproject.toml` comment, because the tree changed since that comment.
+- [ ] T006 [US2] Record the root that each tool reads. Ruff reads the whole repository and drops `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`. Pylint reads `MistHelper.py` and `src` only. Write both lists into [plan.md](plan.md).
+- [ ] T007 [US2] Explain every site in the difference between the two counts. List the ruff sites outside the pylint root, such as the 8 sites in `starlink_dashboard.py` and every site under `tools/` and `tests/`. List the pylint sites outside the ruff root. Requirement FR-003 blocks the first slice until each site holds an explanation.
+- [ ] T008 [US2] Record the per-area counts with `--ignore-noqa`. Run `.venv\Scripts\python.exe -m ruff check . --select BLE001 --ignore-noqa --output-format concise` and group the results by area. Compare the result against the table in [spec.md](spec.md). Record any drift.
+- [ ] T009 [US2] Read the state of issue [#1709](https://github.com/jmorrison-juniper/MistHelper/issues/1709) with `gh issue view 1709`. That issue covers the 33 sites in `MistHelper.py`. Record the decision to land it first or to fold it into slice 11.
+
+**Checkpoint**: The reconciliation record exists and explains every difference. SC-001 now holds. Slice 2 can start.
+
+---
+
+## Phase 3: User Story 1 and 3, Slices 2 to 5 - The small areas (Priority: P1)
+
+**Goal**: Audit 133 sites across four slices. Each slice repeats the same six steps for its own scope.
+
+**Independent Test**: The `BLE001` count drops by the slice size after each slice. The unit suite keeps the T003 pass count.
+
+### The six steps that every slice repeats
+
+- [ ] T010 [US1] List the sites in the slice. Run `.venv\Scripts\python.exe -m ruff check <area> --select BLE001 --output-format concise`. Write each site into the pull request body with a blank outcome column.
+- [ ] T011 [US1] Read each site and its caller. Select `delete`, `narrow`, or `keep` from the policy table in [spec.md](spec.md). Apply the order in FR-010. Try `delete` first, then `narrow`, then `keep`.
+- [ ] T012 [US1] Apply each outcome. Add a log call with the exception detail at every site that the code continues past. Add a comment at every `keep` site that states why the breadth is correct.
+- [ ] T013 [US1] Record the outcome for each site in the pull request body. Requirement FR-018 demands one row for each site. A blank row blocks the merge.
+- [ ] T014 [US1] Read the whole difference. Confirm that no changed line adds a `# noqa: BLE001` directive. Requirement FR-013 forbids it and SC-006 measures it.
+- [ ] T015 [US1] Verify the slice. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, `.venv\Scripts\python.exe -m radon cc src/ -a -nb`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Confirm that the pass count matches T003 and that no block scores above 10.
+
+### The four small slices
+
+- [ ] T016 [US3] Run slice 2. The scope is `src/analytics`, `src/ui`, and `starlink_dashboard.py`, which hold 30 sites. Repeat the T010 to T015 steps. Note that pylint never reads `starlink_dashboard.py`, so those 8 sites need a ruff-only check.
+- [ ] T017 [US3] Run slice 3. The scope is `src/api`, `src/utils`, and `src/websocket`, which hold 44 sites. Split the slice by area, because 44 exceeds the limit of 40. Read `src/utils/logger_utils.py` with care, because a log call inside a logging filter can recurse without end.
+- [ ] T018 [P] [US3] Run slice 4. The scope is `src/site` and `src/db`, which hold 35 sites. Repeat the T010 to T015 steps.
+- [ ] T019 [P] [US3] Run slice 5. The scope is `src/gateway`, which holds 24 sites. Repeat the T010 to T015 steps.
+
+**Checkpoint**: The count reads about 367. Slice 6 can start.
+
+---
+
+## Phase 4: User Story 1 and 3, Slices 6 to 11 - The medium areas and the largest files (Priority: P1)
+
+**Goal**: Audit 206 sites across six slices.
+
+**Independent Test**: The `BLE001` count drops by the slice size after each slice.
+
+**Caution**: The `src/ssh` area holds 18 sites that the default ruff run hides today. Those sites received no earlier review at all.
+
+- [ ] T020 [US3] Run slice 6. The scope is `src/ssh`, which holds 32 sites. 18 of them carried an inert directive before issue #1792 landed. Read those 18 with extra care, because no earlier reviewer saw them.
+- [ ] T021 [US3] Run slice 7. The scope is `src/device`, which holds 34 sites. Read `src/device/virtual_chassis.py` with care, because it holds 10 sites.
+- [ ] T022 [US3] Run slice 8. The scope is `src/refactors`, which holds 43 sites. Split the slice into two pull requests, because 43 exceeds the limit of 40.
+- [ ] T023 [US3] Run slice 9. The file is `src/firmware/firmware_manager.py`, which holds 28 sites. Repeat the T010 to T015 steps for that file alone.
+- [ ] T024 [US3] Run slice 10. The scope is the rest of `src/firmware`, which holds 34 sites. `src/firmware/bulk_switch_upgrader.py` holds 10 and `src/firmware/bulk_ap_upgrader.py` holds 11.
+- [ ] T025 [US3] Run slice 11. The file is `MistHelper.py`, which holds 33 sites. Confirm the T009 decision about issue #1709 first. Run `.venv\Scripts\python.exe -m mypy src/ MistHelper.py --config-file pyproject.toml` after the edit, because issue #888 widened the mypy scope to cover this file.
+
+**Checkpoint**: The count reads about 161. Slice 12 can start.
+
+---
+
+## Phase 5: User Story 1 and 3, Slices 12 to 14 - The export area and the remainder (Priority: P1)
+
+**Goal**: Audit the last 161 sites. `src/export` holds 94 of them, so that area splits into three slices.
+
+**Independent Test**: The `BLE001` count reaches zero under `--ignore-noqa`.
+
+- [ ] T026 [US1] Split `src/export` into groups of at most 40 sites. List the files with `.venv\Scripts\python.exe -m ruff check src/export --select BLE001 --ignore-noqa --output-format concise` and record the group boundary in [plan.md](plan.md). Note that `src/export/const_definitions_exporter.py` holds 11 sites.
+- [ ] T027 [US1] Run slice 12. The scope is the first `src/export` group. Repeat the T010 to T015 steps. This area holds the highest defect risk, because an export handler that returns an empty list produces a silent empty report.
+- [ ] T028 [US1] Run slice 13. The scope is the second `src/export` group. Repeat the T010 to T015 steps.
+- [ ] T029 [US1] List every area that the earlier slices did not cover. Run `.venv\Scripts\python.exe -m ruff check . --select BLE001 --output-format concise` and group the remaining files by area. Record the group boundary in [plan.md](plan.md).
+- [ ] T030 [US1] Run slice 14 and every further slice that the remainder needs. Repeat the T010 to T015 steps for each one. Keep every pull request at or below 40 sites.
+- [ ] T031 [US1] Verify the whole audit. Run `.venv\Scripts\python.exe -m ruff check . --select BLE001 --ignore-noqa --statistics` and confirm zero results. SC-002 depends on this run.
+
+**Checkpoint**: The count reads zero. User Story 1 is complete. Phase 6 can start.
+
+---
+
+## Phase 6: Close both gates (Priority: P2)
+
+**Goal**: Add `BLE001` to the ruff `select` list and remove `W0718` from the pylint `disable` list. This is the final change of the feature.
+
+**Independent Test**: A reviewer adds one handler that catches `Exception`. Both the ruff gate and the pylint gate fail.
+
+**Warning**: Run this phase only after Phase 5 reports zero results. Both gates fail on every push while any site remains.
+
+- [ ] T032 Change line 164 of `pyproject.toml` from `select = ["E", "F", "W", "I", "UP", "B", "G"]` to `select = ["E", "F", "W", "I", "UP", "B", "G", "BLE001"]`. Add no other rule, per NG-009.
+- [ ] T033 Change line 481 of `pyproject.toml` from `disable = ["C0114", "C0115", "C0116", "W0613", "W0718"]` to `disable = ["C0114", "C0115", "C0116", "W0613"]`. Requirement FR-020 demands this change. Depends on T032, because both tasks edit the same file.
+- [ ] T034 Rewrite the comment block at `pyproject.toml` lines 471 to 480. Delete the sentence that states the 493-site count and the intentional judgment. Replace it with a reference to this specification and to the audit record. Requirement FR-022 demands this change.
+- [ ] T035 Verify both gates. Run `.venv\Scripts\python.exe -m ruff check .` and `.venv\Scripts\python.exe -m pylint src/`. Both must pass with the new configuration.
+- [ ] T036 Prove the negative case for SC-009. Add one temporary handler that catches `Exception` to a tracked file under `src/`. Run both gate commands and confirm that each one reports the site and exits with a non-zero code. Remove the handler. Run `git status` and confirm that the tree holds no leftover change.
+
+**Checkpoint**: Both gates report a blind handler. SC-008 and SC-009 now hold.
+
+---
+
+## Phase 7: Polish and Final Validation
+
+**Purpose**: Prove every success criterion and close the issue. These tasks change no source line.
+
+- [ ] T037 Run the full gate set exactly as CI runs it. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, `.venv\Scripts\python.exe -m pylint src/`, `.venv\Scripts\python.exe -m radon cc src/ -a -nb`, `.venv\Scripts\python.exe -m vulture src/ --min-confidence 80`, `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r .`, and `.venv\Scripts\python.exe -m pytest --cov=src/ --cov-fail-under=80`. Do not scope a gate to the changed files only.
+- [ ] T038 [P] Prove SC-003. Count the sites in every slice pull request body and confirm that the total reads 500 and that no row holds a blank outcome.
+- [ ] T039 [P] Prove SC-006. Run `git log -p main..HEAD` across every slice branch and search for an added `# noqa: BLE001` line. The expected count is zero.
+- [ ] T040 [P] Prove SC-005. List every site with a `keep` outcome and confirm that each one holds a log call with the exception detail.
+- [ ] T041 Prove SC-011. Ask a reviewer who did not write the change to read three `keep` comments. The reviewer must state the reason for each one in under one minute and without help from the author. This task needs a second person and an agent session cannot run it.
+- [ ] T042 Open the final pull request for the gate change. Write `Closes #1794` in the body. Link `specs/1794-blind-except-handlers/spec.md`. List every slice pull request number and attach the reconciliation record. Complete the checklist in `.github/PULL_REQUEST_TEMPLATE.md`. Add the `auto-merge` label only after every check passes, including CodeQL.
+
+---
+
+## Dependencies and Execution Order
+
+### Phase order
+
+| Phase | Content | Starts after |
+| - | - | - |
+| 1 | Setup | Nothing |
+| 2 | US2, the reconciliation record | Issue #1792 lands |
+| 3 | Slices 2 to 5, the small areas | Phase 2 explains every difference |
+| 4 | Slices 6 to 11, the medium areas and the largest files | Phase 3 |
+| 5 | Slices 12 to 14, the export area and the remainder | Phase 4 |
+| 6 | Both gate changes | Phase 5 reports zero results |
+| 7 | Polish and final validation | Phase 6 |
+
+### Why the reconciliation runs before any edit
+
+An audit that starts from the 412 count leaves 88 sites unaudited. The gate then reports a clean state that is not true. Task T004 is the stop condition, and it blocks every later phase.
+
+### Slice exit rule
+
+A slice must reduce the count by its own size and must move no other count. Each site in the slice must hold a recorded outcome. The unit suite must keep its pass count.
+
+### Cross-issue coordination
+
+| Issue | Overlap | Control |
+| - | - | - |
+| #1792 | Removes the 88 inert directives | Task T004 blocks the start until the two counts match |
+| #1709 | Covers the 33 sites in `MistHelper.py` | Task T009 records the decision. Task T025 applies it. |
+| #887 | Recorded the 493-site pylint count | Task T034 rewrites the comment that holds that count |
+
+---
+
+## Parallel Opportunities
+
+| Phase | Parallel tasks | Reason |
+| - | - | - |
+| 3 | T018, T019 | The two scopes hold no shared file. |
+| 7 | T038, T039, T040 | The three checks read different data. |
+
+**Caution**: Two agents must not open a slice pull request for the same area at the same time. Claim the area on issue #1794 before the branch starts.
+
+---
+
+## Implementation Strategy
+
+### Minimum viable delivery
+
+Slice 12 delivers the largest value on its own. The `src/export` area holds 94 sites, and an export handler that returns an empty collection produces a silent empty report. A reviewer who has time for one slice should pick that one.
+
+### Order of risk
+
+The largest risk is a false clean state. Two paths lead there. The first path starts the audit from the 412 count. The second path adds a `# noqa: BLE001` directive to reach a green gate. Task T004 controls the first path. Task T014 and task T039 control the second path.

--- a/specs/1795-small-correctness-rules/plan.md
+++ b/specs/1795-small-correctness-rules/plan.md
@@ -1,0 +1,251 @@
+# Implementation Plan: Small Correctness Rule Cleanup
+
+**Branch**: `lint/1795-small-correctness` (SpecKit feature directory `1795-small-correctness-rules`) | **Date**: 2026-08-06 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1795-small-correctness-rules/spec.md`
+
+**GitHub Issue**: [#1795](https://github.com/jmorrison-juniper/MistHelper/issues/1795)
+
+## Summary
+
+Six small rule families report 146 sites. Five families come from ruff and one family comes from pylint.
+
+This plan clears one family at a time, in order of risk. The family that names a real cross-platform defect lands first. The family that can change behavior lands last.
+
+Each family takes its own pull request. The gate change lands after every family reports zero results.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (`pyproject.toml` target `py313`)
+
+**Primary Dependencies**: `ruff` 0.16.0 and `pylint` 4.0.6. This work adds no dependency. It adds one standard-library import, which is `typing.ClassVar`, to several modules.
+
+**Storage**: Not applicable. The work changes call sites, annotations, and one configuration line.
+
+**Testing**: `pytest` with `--cov=src/ --cov-fail-under=80`. The suite must keep its pass count for each family.
+
+**Target Platform**: The CI runner uses Linux. A developer works on Windows. The `W1514` family exists because those two platforms use a different default encoding.
+
+**Project Type**: Static analysis cleanup with one behavior-sensitive family. The work adds no module and no class.
+
+**Performance Goals**: The lint gate must stay inside its current runtime.
+
+**Constraints**:
+
+- The root ruff line length is 120 characters. A `ClassVar` annotation and an `encoding` argument both make a line longer, so a long line can need a wrap.
+- `ruff check .` reads the whole repository. Its `extend-exclude` list drops `mist-ops-platform`, `web_portal`, `scripts`, and `src/maps`.
+- `mypy` reads `src/` and `MistHelper.py`. Every `RUF012` annotation faces that gate.
+- `pylint` reads `MistHelper.py` and `src` only. Pull request #1788 changed the job scope, so the implementer must confirm the current scope.
+
+**Scale/Scope**: 146 sites, 6 families, about 70 files, and one configuration line.
+
+### Measurement contract
+
+Run the two commands below before each family. Record the value in the family pull request.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --select DTZ005,ISC004,C408,RUF012,SIM103 --statistics
+.venv\Scripts\python.exe -m pylint MistHelper.py src --disable=all --enable=W1514 --score=n
+```
+
+The expected ruff output holds five lines.
+
+```text
+60      RUF012  mutable-class-default
+56      DTZ005  call-datetime-now-without-tzinfo
+13      ISC004  implicit-string-concatenation-in-collection-literal
+ 9      SIM103  needless-bool
+ 3      C408    unnecessary-collection-call
+```
+
+The expected pylint output holds 5 result lines.
+
+If any count differs, stop. Record the new count in this plan and continue with the new value.
+
+### Verified mechanics
+
+A maintainer probed the counts on 2026-08-06 at commit `08a75d2`. Four results shape the tasks.
+
+1. The five family counts in issue #1795 all match the measured values. The issue total of 137 is correct for its own family set.
+2. Ruff reports no automatic repair for these families under the safe setting. It offers 16 repairs under `--unsafe-fixes`. This plan does not use that flag.
+3. `DTZ005` reports 56 by default and 57 with `--ignore-noqa`. One site hides behind a directive that issue #1792 removes.
+4. `SIM103` reports 9 sites. That family sits outside the issue text, and the section "Correction" in [spec.md](spec.md) records the reason.
+
+### Discovered risk: two files carry sites in two families
+
+`src/firmware/firmware_manager.py` holds 5 `DTZ005` sites and 3 `RUF012` sites. `src/reports/e911_bssid.py` holds 3 of each.
+
+The two families land in two pull requests. A concurrent edit of the same file produces a merge conflict.
+
+The control is the order in requirement FR-010. The `RUF012` family lands before the `DTZ005` family, and neither family starts before the earlier one merges.
+
+### Discovered risk: an unsafe repair changes behavior
+
+Ruff reports 16 hidden repairs under `--unsafe-fixes`. The `DTZ005` repair sits in that set, because an aware value can change the result of a comparison.
+
+The control is a hand repair with a byte-identical proof. This plan forbids `--unsafe-fixes` for every family.
+
+## Constitution Check
+
+*GATE: The plan passes before Phase 0 research. The plan passes again after Phase 1 design.*
+
+| Principle | Status | Basis |
+| - | - | - |
+| I. Five-Item Rule | PASS | The work adds no function. A `SIM103` repair removes two blocks and adds one line, which lowers the block count. |
+| II. Class-Based Architecture (No Wrappers) | PASS | The work adds no class and no wrapper function. |
+| III. Safety-First | PASS with a gate | The `DTZ005` family changes a value that the code compares and prints. Requirement FR-007 demands a proof for each site. |
+| IV. Full Deployment Pipeline | ADAPTED | The work follows the branch and pull request workflow. The container needs a rebuild, because the runtime code changes. |
+| V. Observability and Logging | PASS with a note | A `DTZ005` change can alter a printed timestamp. The proof step covers the log text and the filename. |
+| VI. Inline Comments (NON-NEGOTIABLE) | PASS | Every changed line carries an inline comment. A `ClassVar` annotation states that the attribute is a class constant. |
+| VII. Action Logging (NON-NEGOTIABLE) | PASS | The work adds no action and therefore adds no log call. |
+| Security Findings: Fix Over Suppress (NON-NEGOTIABLE) | PASS | The work adds no suppression. Non-goal NG-001 states this rule. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1795-small-correctness-rules/
+├── spec.md              # The feature specification
+├── plan.md              # This file
+└── tasks.md             # The task list
+```
+
+### Source code (repository root)
+
+The work touches about 70 files across six families.
+
+```text
+pyproject.toml                                        # Family 6: add five rules to the select list
+
+MistHelper.py                                         # W1514 x2, ISC004 x4, C408 x2
+starlink_dashboard.py                                 # RUF012 x4
+
+src/
+├── analytics/site_analytics_configurator.py          # RUF012 x6
+├── api/api_data_fetcher.py                           # SIM103 x1
+├── audit/filter.py                                   # SIM103 x1
+├── cache/cache_utils.py                              # RUF012 x2, SIM103 x1
+├── config/config_utils.py                            # W1514 x1
+├── export/const_definitions_exporter.py              # RUF012 x3
+├── firmware/
+│   ├── bulk_switch_upgrader.py                       # DTZ005 x5
+│   ├── firmware_manager.py                           # DTZ005 x5, RUF012 x3
+│   └── org_ap_upgrader.py                            # DTZ005 x3
+├── reports/e911_bssid.py                             # DTZ005 x3, RUF012 x3
+├── site/bulk_radius_wlan_config_manager.py           # DTZ005 x4, RUF012 x3
+├── ssh/batch/interactive_batch_executor.py           # DTZ005 x4
+├── utils/
+│   ├── address_utils.py                              # RUF012 x4
+│   ├── operation_registry.py                         # RUF012 x3
+│   └── rate_limiting.py                              # W1514 x2
+└── websocket/
+    ├── diagnostics/arp_executor.py                   # ISC004 x1
+    └── service_ping_manager.py                       # SIM103 x1
+
+tools/
+├── codemod_logging_lazy.py                           # SIM103 x1
+├── compliance_analyzer/analyzers.py                  # SIM103 x1
+├── refactor_analyzer/reporting.py                    # ISC004 x8
+├── ste_linter/parsing/markdown.py                    # SIM103 x1
+└── test_quality_analyzer/discovery.py                # SIM103 x1
+
+tests/
+├── unit/org/test_org_synthetic_probes_manager.py     # SIM103 x1
+└── unit/troubleshooting/                             # C408 x1
+    └── test_marvis_troubleshoot_utils_extended.py
+```
+
+**Structure Decision**: The work stays inside the current tree. It creates no file and deletes no file.
+
+## Phased approach
+
+The work runs one family at a time. Each family ends with a measurement.
+
+### Family 1 - W1514, the cross-platform defect (5 sites, 4 files)
+
+This family lands first, because it is the only one that names a real defect.
+
+Add `encoding="utf-8"` to each `open()` call. Confirm the file mode first, because a binary mode takes no encoding argument.
+
+Then check the pylint job scope in `.github/workflows/ci.yml`. The job must read every file that holds a site. Pull request #1788 changed that scope.
+
+**Exit measurement**: The pylint `W1514` count reads 0.
+
+### Family 2 - C408, the smallest family (3 sites, 2 files)
+
+Replace each `dict()` call with a `{}` literal. The change is safe, because the two forms produce the same object.
+
+**Exit measurement**: `C408` reads 0.
+
+### Family 3 - SIM103, the boolean returns (9 sites, 9 files)
+
+Replace each `if` and `else` pair with a direct return of the condition.
+
+**Caution**: Confirm that the condition is a boolean. A condition that returns a truthy value changes the return type after the repair. Add `bool(...)` where the type is not certain.
+
+**Exit measurement**: `SIM103` reads 0.
+
+### Family 4 - ISC004, the implicit concatenation (13 sites, 3 files)
+
+Read each site first. A missing comma produces the same shape as a deliberate concatenation, and the two need a different repair.
+
+Record the count of sites that held a missing comma. Success criterion SC-005 reads that count. A value above zero names a real defect that this work repaired.
+
+**Exit measurement**: `ISC004` reads 0.
+
+### Family 5 - RUF012, the class constants (60 sites, 32 files)
+
+Add a `typing.ClassVar` annotation to each attribute. Add the import where the module does not hold it.
+
+**Warning**: Run mypy after each file. A wrong annotation changes the inferred type for every reader of that attribute, and the type gate then fails in a file that this work never touched.
+
+The family holds 60 sites in 32 files, so it needs two or three pull requests to stay reviewable.
+
+**Exit measurement**: `RUF012` reads 0 and the mypy gate stays green.
+
+### Family 6 - DTZ005, the naive datetime values (57 sites, 26 files)
+
+This family lands last, because it is the only one that can change behavior.
+
+**Warning**: This family must not start before issue #1792 lands. One site hides behind a `# noqa` directive, and the default run reports 56 instead of 57.
+
+Each site needs a byte-identical proof. Capture the printed output before the change and after the change. Compare the two captures. Pull request #1791 records the model for 4 sites.
+
+Check each comparison. A naive value and an aware value raise `TypeError` when they compare. The repair must convert both sides or neither.
+
+The family holds 57 sites in 26 files, so it needs two pull requests to stay reviewable.
+
+**Exit measurement**: `DTZ005` reads 0 with `--ignore-noqa` and every site holds a proof.
+
+### Family 7 - Close the gate (1 file)
+
+Add the five ruff rules to the `select` list.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G", "C408", "DTZ005", "ISC004", "RUF012", "SIM103"]
+```
+
+**Warning**: This step must follow every family. The gate fails on every push while any site remains.
+
+**Exit measurement**: `ruff check .` passes with the new list. A test site in each family fails the gate.
+
+## Risk register
+
+| Risk | Likelihood | Effect | Control |
+| - | - | - | - |
+| An `ISC004` site held a missing comma | Medium | The repair changes the list length and changes behavior | Task T017 reads each site before the edit |
+| A `RUF012` annotation names the wrong type | Medium | The mypy gate fails in another file | Task T021 runs mypy after each file |
+| A `DTZ005` change shifts a printed timestamp | High | An operator reads a different value | Task T025 captures the output before and after each site |
+| A `DTZ005` change breaks a comparison | Medium | The code raises `TypeError` at run time | Task T026 reads every comparison that reads the changed value |
+| The `DTZ005` family starts before issue #1792 lands | Medium | One site stays unrepaired and the gate hides it | Task T024 blocks the family until the two counts match |
+| Two families edit the same file at the same time | Medium | A merge conflict | The family order in FR-010 keeps them apart |
+| The pylint job does not read a `W1514` file | Medium | The gate reports a clean state that is not true | Task T009 reads the job scope in `.github/workflows/ci.yml` |
+
+## Complexity Tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+| - | - | - |
+| The work spans about 9 pull requests | The `RUF012` family and the `DTZ005` family each hold more sites than one reviewable difference | A single pull request would hold 146 sites across six families with six different risk profiles |
+| The `DTZ005` family needs a proof for each site | An aware value can change a printed timestamp and can break a comparison | A mechanical repair with no proof would ship a silent output change to every operator |
+| This plan forbids `--unsafe-fixes` | Ruff marks the repair unsafe because it can change behavior | An automatic repair would apply 16 behavior changes without a review |

--- a/specs/1795-small-correctness-rules/spec.md
+++ b/specs/1795-small-correctness-rules/spec.md
@@ -1,0 +1,302 @@
+# Feature Specification: Small Correctness Rule Cleanup
+
+**Feature Branch**: `docs/1792-1796-lint-debt-specs` (specification only). The implementation branch is `lint/1795-small-correctness`.
+
+**GitHub Issue**: [#1795](https://github.com/jmorrison-juniper/MistHelper/issues/1795) — "lint: five small correctness rule families report 137 findings that no gate sees"
+
+**Created**: 2026-08-06
+
+**Status**: Specification only. No code change exists yet.
+
+**Input**: Clear six small rule families. Add the ruff rules to the `select` list. One family names a real cross-platform defect.
+
+---
+
+## Background
+
+Six small rule families report findings across the repository. No quality gate reports any of them today. Five families come from ruff. One family comes from pylint.
+
+Each family is small enough to clear in one effort. One family names a real defect that changes the content of a file between Windows and Linux.
+
+### Why no gate reports this today
+
+The ruff `select` list in `pyproject.toml` line 164 reads as follows.
+
+```toml
+select = ["E", "F", "W", "I", "UP", "B", "G"]
+```
+
+`RUF012`, `DTZ005`, `ISC004`, `C408`, and `SIM103` all sit outside that list. The CI lint gate therefore never reports them.
+
+The pylint gate does read `W1514`. The CI pylint job passes today, so the 5 sites did not fail a build. The implementer must confirm the current pylint job scope before the work starts, because pull request #1788 changed that scope.
+
+### Measured baseline
+
+A maintainer measured the counts on 2026-08-06 at commit `08a75d2` with ruff 0.16.0 and pylint 4.0.6.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check . --select DTZ005,ISC004,C408,RUF012,SIM103 --statistics
+.venv\Scripts\python.exe -m pylint MistHelper.py src --disable=all --enable=W1514 --score=n
+```
+
+| Rule | Tool | Count | Files | Name |
+| - | - | - | - | - |
+| RUF012 | ruff | 60 | 32 | mutable-class-default |
+| DTZ005 | ruff | 56 | 26 | call-datetime-now-without-tzinfo |
+| ISC004 | ruff | 13 | 3 | implicit-string-concatenation-in-collection-literal |
+| SIM103 | ruff | 9 | 9 | needless-bool |
+| W1514 | pylint | 5 | 4 | unspecified-encoding |
+| C408 | ruff | 3 | 2 | unnecessary-collection-call |
+| **Total** | | **146** | | |
+
+### Correction: the issue names five families and the total is 137
+
+Issue #1795 names five families. Those five are `RUF012`, `DTZ005`, `ISC004`, `W1514`, and `C408`. Their total reads 60 + 56 + 13 + 5 + 3, which equals 137. That value is correct.
+
+A later verification command replaced `W1514` with `SIM103`. That command reports 60 + 56 + 13 + 9 + 3, which equals 141. Both totals describe a different family set.
+
+This specification covers all six families and states 146 as the total. The extra family is `SIM103`, which reports 9 sites. That family is small, mechanical, and shares the same gate change, so it belongs in the same effort.
+
+### W1514 names the real defect
+
+The `open()` function with no `encoding` argument uses the platform default encoding. Windows returns `cp1252`. Linux returns `utf-8`.
+
+MistHelper runs on a Windows workstation and inside a Linux container. A file that MistHelper writes on Windows under `cp1252` does not read back the same on Linux under `utf-8`. Any character above code point 127 changes or raises a decode error.
+
+The 5 sites are as follows.
+
+| File | Line |
+| - | - |
+| MistHelper.py | 777 |
+| MistHelper.py | 1154 |
+| src/config/config_utils.py | 84 |
+| src/utils/rate_limiting.py | 134 |
+| src/utils/rate_limiting.py | 163 |
+
+Two of these files hold state that moves between a workstation and a container. `src/utils/rate_limiting.py` reads and writes the adaptive delay metrics. `src/config/config_utils.py` reads the project configuration.
+
+### DTZ005 changes behavior, so it needs the most care
+
+The `datetime.now()` call returns a naive value with no time zone. Rule `DTZ005` asks for an aware value.
+
+A conversion from naive to aware can change the result of a comparison. Two naive values compare without error. A naive value and an aware value raise `TypeError` when they compare.
+
+Pull request #1791 converted 4 of these sites. The author proved that the printed output stayed byte identical after the change. This work applies the same proof to every remaining site.
+
+One further site hides behind a `# noqa` directive. Ruff reports 56 sites by default and 57 sites with `--ignore-noqa`. Issue #1792 removes that directive.
+
+The six files with the most sites are as follows.
+
+| File | Count |
+| - | - |
+| src/firmware/bulk_switch_upgrader.py | 5 |
+| src/firmware/firmware_manager.py | 5 |
+| src/site/bulk_radius_wlan_config_manager.py | 4 |
+| src/ssh/batch/interactive_batch_executor.py | 4 |
+| src/firmware/org_ap_upgrader.py | 3 |
+| src/reports/e911_bssid.py | 3 |
+
+### RUF012 is a typing rule, not a runtime defect
+
+Rule `RUF012` asks for a `ClassVar` annotation on a class attribute that holds a mutable default. A shared mutable default is a common Python trap. The 60 sites here are class constants, not instance state.
+
+The repair adds `typing.ClassVar` to each annotation. The change is mechanical. Run mypy after each file, because a wrong annotation changes the inferred type.
+
+The six files with the most sites are as follows.
+
+| File | Count |
+| - | - |
+| src/analytics/site_analytics_configurator.py | 6 |
+| src/utils/address_utils.py | 4 |
+| starlink_dashboard.py | 4 |
+| src/export/const_definitions_exporter.py | 3 |
+| src/firmware/firmware_manager.py | 3 |
+| src/reports/e911_bssid.py | 3 |
+
+### ISC004, SIM103, and C408 are small and mechanical
+
+Rule `ISC004` reports 13 sites in 3 files. The rule finds two string parts joined by an implicit concatenation inside a list or a tuple. A missing comma produces the same shape, so each site needs a read before the edit.
+
+| File | Count |
+| - | - |
+| tools/refactor_analyzer/reporting.py | 8 |
+| MistHelper.py | 4 |
+| src/websocket/diagnostics/arp_executor.py | 1 |
+
+Rule `SIM103` reports 9 sites in 9 files. Each site holds an `if` block that returns `True` and an `else` block that returns `False`. The repair returns the condition directly.
+
+| File | Line |
+| - | - |
+| src/api/api_data_fetcher.py | 163 |
+| src/audit/filter.py | 50 |
+| src/cache/cache_utils.py | 198 |
+| src/websocket/service_ping_manager.py | 416 |
+| tests/unit/org/test_org_synthetic_probes_manager.py | 2491 |
+| tools/codemod_logging_lazy.py | 276 |
+| tools/compliance_analyzer/analyzers.py | 935 |
+| tools/ste_linter/parsing/markdown.py | 89 |
+| tools/test_quality_analyzer/discovery.py | 64 |
+
+Rule `C408` reports 3 sites in 2 files. Each site calls `dict()` where a `{}` literal works.
+
+| File | Count |
+| - | - |
+| MistHelper.py | 2 |
+| tests/unit/troubleshooting/test_marvis_troubleshoot_utils_extended.py | 1 |
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Read a file the same way on both platforms (Priority: P1)
+
+An operator writes a metrics file on a Windows workstation. The operator then copies that file into a Linux container. The container reads every character without a change and without an error.
+
+**Why this priority**: This story removes the only real defect in the whole feature. The other five families report a style question or a typing question.
+
+**Independent Test**: A reviewer writes a file that holds a character above code point 127 on Windows. The reviewer reads that file inside a Linux container. The two contents match byte for byte.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repaired `open()` call, **When** a reviewer reads the source line, **Then** the call names `encoding="utf-8"`.
+2. **Given** a repaired module, **When** a reviewer runs `pylint --enable=W1514` on it, **Then** the command reports zero results.
+3. **Given** a metrics file that a Windows run writes, **When** a Linux container reads that file, **Then** every character matches.
+4. **Given** the whole tree, **When** a reviewer searches for an `open()` call with no encoding, **Then** the search returns zero matches.
+
+---
+
+### User Story 2 - Keep the printed output identical after a time zone change (Priority: P1)
+
+A reviewer converts a naive `datetime.now()` call to an aware call. The reviewer then runs the affected operation and compares the printed output against the earlier output. The two outputs match byte for byte.
+
+**Why this priority**: This story shares the P1 rank, because `DTZ005` is the only family that can change behavior. A wrong conversion raises `TypeError` on a comparison or shifts a printed timestamp.
+
+**Independent Test**: A reviewer captures the printed output of one affected operation before the change and after the change. The two captures match.
+
+**Acceptance Scenarios**:
+
+1. **Given** a converted site, **When** a reviewer compares the printed output before and after, **Then** the two outputs match byte for byte.
+2. **Given** a converted site, **When** the code compares that value against another datetime value, **Then** the comparison raises no `TypeError`.
+3. **Given** a converted site, **When** a reviewer reads the pull request body, **Then** the body records the proof for that site.
+4. **Given** the whole tree, **When** a reviewer runs `ruff check . --select DTZ005 --ignore-noqa`, **Then** the command reports zero results.
+
+---
+
+### User Story 3 - Stop the six families from growing again (Priority: P2)
+
+A contributor adds a naive `datetime.now()` call. The CI lint gate reports the call and stops the pull request.
+
+**Why this priority**: This story protects the result of the first two stories. The story cannot land first, because the gate fails while any result remains.
+
+**Independent Test**: A reviewer adds one naive `datetime.now()` call to a tracked file. The lint gate fails and names `DTZ005`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated `select` list, **When** a reviewer searches the list, **Then** the list holds `RUF012`, `DTZ005`, `ISC004`, `C408`, and `SIM103`.
+2. **Given** the updated `select` list, **When** CI runs the lint gate on the clean branch, **Then** the gate succeeds.
+3. **Given** a pull request that adds one site in any of the six families, **When** CI runs the gate set, **Then** a gate fails and the log names the rule and the file.
+
+---
+
+### Edge Cases
+
+- An `ISC004` site holds a missing comma instead of a deliberate concatenation. The repair then changes the list length and changes behavior. Each site needs a read before the edit.
+- A `RUF012` annotation names the wrong type. Mypy then infers a wrong type for every reader of that attribute. Run mypy after each file.
+- A `DTZ005` site feeds a value into a filename. An aware value prints a time zone offset, which changes the filename. The proof must cover the filename, not the log text alone.
+- A `DTZ005` site compares its value against a naive value from another module. The comparison then raises `TypeError`. The repair must convert both sides or neither.
+- A `SIM103` site returns the condition where the condition is not a boolean. The repair then changes the return type. Read each site and confirm that the condition is a boolean.
+- One `DTZ005` site hides behind a `# noqa` directive. Ruff reports 56 by default and 57 with `--ignore-noqa`. Issue #1792 removes the directive.
+- A `W1514` site opens a binary file. A binary mode takes no encoding argument, and the rule does not report it. Confirm the mode before the edit.
+- The `RUF012` and `DTZ005` families both touch `src/firmware/firmware_manager.py` and `src/reports/e911_bssid.py`. The two repairs must not run at the same time in the same file.
+
+---
+
+## Requirements *(mandatory)*
+
+### Repair requirements
+
+- **FR-001**: Every `open()` call in the tree MUST name an explicit encoding, or MUST use a binary mode.
+- **FR-002**: The `W1514` repair MUST use `encoding="utf-8"`. It MUST NOT use the platform default and MUST NOT use another encoding.
+- **FR-003**: Every `C408` site MUST use a literal instead of a `dict()` call.
+- **FR-004**: Every `ISC004` site MUST receive a read before the edit. The implementer MUST confirm that the author did not drop a comma.
+- **FR-005**: Every `SIM103` site MUST return a boolean after the repair. The implementer MUST confirm that the condition is a boolean.
+- **FR-006**: Every `RUF012` site MUST receive a `typing.ClassVar` annotation. The implementer MUST run mypy after each file.
+- **FR-007**: Every `DTZ005` site MUST receive a proof that the printed output stayed byte identical. Pull request #1791 records the model.
+- **FR-008**: A `DTZ005` repair MUST NOT leave a comparison between a naive value and an aware value.
+- **FR-009**: The `DTZ005` scope MUST use the count with `--ignore-noqa`, which reads 57.
+
+### Order requirements
+
+- **FR-010**: The families MUST land in order of risk. The order is `W1514`, then `C408`, then `SIM103`, then `ISC004`, then `RUF012`, then `DTZ005`.
+- **FR-011**: Each family MUST land in its own pull request.
+- **FR-012**: The `DTZ005` family MUST NOT start before issue #1792 lands, because one site hides behind a directive.
+- **FR-013**: The `RUF012` family and the `DTZ005` family MUST NOT edit the same file at the same time.
+
+### Gate requirements
+
+- **FR-014**: The ruff `select` list in `pyproject.toml` MUST hold `RUF012`, `DTZ005`, `ISC004`, `C408`, and `SIM103` after the last repair lands.
+- **FR-015**: The gate change MUST land in its own pull request, after every family reports zero results.
+- **FR-016**: The implementer MUST confirm the current pylint job scope in `.github/workflows/ci.yml` and MUST confirm that the job reads every file that holds a `W1514` site.
+- **FR-017**: The implementer MUST NOT add any other rule to the `select` list in this work.
+
+### Quality requirements
+
+- **FR-018**: Every quality gate MUST stay green for each family. The unit test suite MUST keep its pass count.
+- **FR-019**: All prose, all code comments, and all commit text MUST follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md`.
+- **FR-020**: Every changed Python line MUST carry an inline comment that explains why the line exists.
+
+### Key Entities
+
+- **Rule family**: One lint rule and the set of sites that it reports.
+- **Byte-identical proof**: A record that shows the printed output before a change and after a change, and states that the two match.
+- **Hidden site**: A site that a `# noqa` directive suppresses. Ruff reports it only with `--ignore-noqa`.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `ruff check . --select RUF012,DTZ005,ISC004,C408,SIM103 --ignore-noqa` reports zero results and exits with code 0.
+- **SC-002**: `pylint MistHelper.py src --disable=all --enable=W1514` reports zero results.
+- **SC-003**: A text search of the tree finds zero `open()` calls in text mode without an encoding argument.
+- **SC-004**: Every `DTZ005` change carries a written record that the printed output stayed the same.
+- **SC-005**: The count of `ISC004` sites that held a missing comma is recorded. The expected value is zero, and a value above zero names a real defect that the work repaired.
+- **SC-006**: The ruff `select` list holds all five ruff rules.
+- **SC-007**: A pull request that adds one site in any of the six families fails a CI gate.
+- **SC-008**: Every quality gate stays green. The unit test suite keeps its pass count and adds no new failure.
+- **SC-009**: A file that a Windows run writes reads back with identical content inside a Linux container.
+
+---
+
+## Non-Goals
+
+- **NG-001**: This work does not add any lint suppression. It adds no `# noqa` directive and adds no rule to the ruff `ignore` list or the pylint `disable` list. The whole point is a repair, not a hidden result.
+- **NG-002**: This work does not change the time zone that the code uses. It adds the time zone information to a naive value and keeps the same instant.
+- **NG-003**: This work does not convert a naive value that a third-party library returns. The scope covers the call sites in this repository.
+- **NG-004**: This work does not add the whole `DTZ` family, the whole `RUF` family, the whole `ISC` family, the whole `C4` family, or the whole `SIM` family to the `select` list. It adds the five named rules only.
+- **NG-005**: This work does not remove the `# noqa` directive that hides one `DTZ005` site. Issue #1792 owns that scope.
+- **NG-006**: This work does not change the ruff `extend-exclude` list. The four excluded paths keep their sites.
+- **NG-007**: This work does not change the encoding of any file that the repository already holds. It changes the code that reads and writes a file.
+- **NG-008**: This work does not change the pylint job scope in `.github/workflows/ci.yml`. It confirms the scope and records the result.
+
+---
+
+## Assumptions
+
+- The ruff version stays at 0.16.0 and the pylint version stays at 4.0.6 during this work. A version change can move any count.
+- The counts reflect the branch tip at commit `08a75d2`. The implementer must measure each count again before the family starts.
+- Every `W1514` site opens a text file. A binary site takes no encoding argument, and the rule does not report it.
+- Every `RUF012` site holds a class constant, not instance state. The implementer must confirm this before each annotation.
+- Every `SIM103` condition returns a boolean. The implementer must confirm this before each repair.
+- The `utf-8` encoding is correct for every file that MistHelper reads and writes. No file uses another encoding on purpose.
+- Pull request #1791 proved the byte-identical result for 4 `DTZ005` sites. The same method works for the other 53.
+
+---
+
+## Dependencies
+
+- Issue [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792) removes the `# noqa` directive that hides one `DTZ005` site. The `DTZ005` family must not start before that work lands.
+- Pull request #1791 converted 4 `DTZ005` sites and recorded the byte-identical proof. This work follows that model.
+- Pull request #1788 changed the pylint job scope. Requirement FR-016 demands a check of the current scope.
+- The Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` govern all prose in this work.

--- a/specs/1795-small-correctness-rules/tasks.md
+++ b/specs/1795-small-correctness-rules/tasks.md
@@ -1,0 +1,216 @@
+# Tasks: Small Correctness Rule Cleanup
+
+**Feature**: `1795-small-correctness-rules` | **Branch**: `lint/1795-small-correctness` | **Date**: 2026-08-06
+
+**GitHub Issue**: [#1795](https://github.com/jmorrison-juniper/MistHelper/issues/1795)
+
+**Input**: Design documents from `specs/1795-small-correctness-rules/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md). Issue [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792) must land before the `DTZ005` family starts.
+
+**Tests**: The specification requests no new test. The existing suite must keep its pass count for each family.
+
+**Branch rule**: Create one branch for each family from `main`. Name the branch `lint/1795-<rule>`. Do not branch from another family branch.
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: The task can run in parallel with another task in the same phase. The tasks touch different files.
+- **[Story]**: The user story that owns the task. The value is `US1`, `US2`, or `US3`.
+- Each task names an exact file path, an exact rule, or an exact command.
+
+## Rules that apply to every edit task
+
+1. Use `.venv\Scripts\python.exe` for every Python command. The global interpreter cannot import the project.
+2. Add no lint suppression. Non-goal NG-001 forbids a `# noqa` directive and a new entry in the ruff `ignore` list or the pylint `disable` list.
+3. Do not use `--unsafe-fixes`. Ruff marks 16 repairs unsafe because they can change behavior.
+4. Every changed Python line carries an inline comment that states why the line exists. Principle VI requires it.
+5. Follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` for every prose line.
+6. Land one family in one pull request. Requirement FR-011 states this rule.
+7. Keep every line inside 120 characters. An `encoding` argument and a `ClassVar` annotation both make a line longer.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the environment before any measurement.
+
+- [ ] T001 Confirm the tool versions with `.venv\Scripts\python.exe -m ruff --version` and `.venv\Scripts\python.exe -m pylint --version`. The expected values are `ruff 0.16.0` and `pylint 4.0.6`.
+- [ ] T002 Confirm that `.venv\Scripts\python.exe -m pytest --version` runs. Every later test command uses this interpreter.
+- [ ] T003 Record the pre-change gate baseline. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Save the unit test pass count, because SC-008 compares against it.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prove the baseline for all six families. No edit starts until this phase closes.
+
+- [ ] T004 Record the ruff baseline. Run `.venv\Scripts\python.exe -m ruff check . --select DTZ005,ISC004,C408,RUF012,SIM103 --statistics`. The expected values are `RUF012` 60, `DTZ005` 56, `ISC004` 13, `SIM103` 9, and `C408` 3. Write each value into [plan.md](plan.md).
+- [ ] T005 Record the pylint baseline. Run `.venv\Scripts\python.exe -m pylint MistHelper.py src --disable=all --enable=W1514 --score=n`. The expected count is 5. Write the value and the 5 file paths into [plan.md](plan.md).
+- [ ] T006 Record the `DTZ005` hidden site. Run `.venv\Scripts\python.exe -m ruff check . --select DTZ005 --ignore-noqa --statistics`. The expected value is 57. The one-site difference names the directive that issue #1792 removes.
+- [ ] T007 Record the site list for each family. Run `.venv\Scripts\python.exe -m ruff check . --select DTZ005,ISC004,C408,RUF012,SIM103 --output-format concise` and save the output. Every later task reads this list.
+
+**Checkpoint**: The six baselines exist. Family 1 can start.
+
+---
+
+## Phase 3: User Story 1, Family 1 - W1514, the cross-platform defect (Priority: P1)
+
+**Goal**: Add an explicit encoding to all 5 `open()` calls. This family carries the only real defect in the feature.
+
+**Independent Test**: `pylint MistHelper.py src --disable=all --enable=W1514` reports zero results.
+
+**Warning**: A file that MistHelper writes on Windows under `cp1252` does not read back the same on Linux under `utf-8`. Any character above code point 127 changes or raises a decode error.
+
+- [ ] T008 [US1] Read each of the 5 sites and confirm the file mode. The sites are `MistHelper.py` line 777, `MistHelper.py` line 1154, `src/config/config_utils.py` line 84, `src/utils/rate_limiting.py` line 134, and `src/utils/rate_limiting.py` line 163. A binary mode takes no encoding argument, so record any binary site and remove it from the scope.
+- [ ] T009 [US1] Read the pylint job scope in `.github/workflows/ci.yml`. Confirm that the job reads every file that holds a site. Pull request #1788 changed that scope. Record the result in [plan.md](plan.md). Requirement FR-016 demands this check.
+- [ ] T010 [US1] Add `encoding="utf-8"` to each text-mode site. Requirement FR-002 forbids the platform default and forbids another encoding. Add an inline comment on each changed line that states the cross-platform reason.
+- [ ] T011 [US1] Search the whole tree for a remaining `open()` call in text mode with no encoding argument. Requirement FR-001 and success criterion SC-003 demand zero matches. Include the paths that ruff excludes, because a defect there still reaches an operator.
+- [ ] T012 [US1] Prove SC-009. Write a file that holds a character above code point 127 through `src/utils/rate_limiting.py` on Windows. Read that file inside a Linux container. Confirm that the two contents match.
+- [ ] T013 [US1] Verify family 1. Run `.venv\Scripts\python.exe -m pylint MistHelper.py src --disable=all --enable=W1514 --score=n` and confirm zero results. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Confirm that the pass count matches T003.
+- [ ] T014 [US1] Open the family 1 pull request. Write `Refs #1795` and not `Closes #1795`, because five families remain. Record the T009 result and the T012 proof in the body.
+
+**Checkpoint**: The `W1514` count reads zero. SC-002 and SC-003 now hold. Family 2 can start.
+
+---
+
+## Phase 4: User Story 3, Families 2 to 4 - The mechanical repairs (Priority: P2)
+
+**Goal**: Clear 25 sites across three small families.
+
+**Independent Test**: `C408`, `SIM103`, and `ISC004` each report zero results.
+
+- [ ] T015 [P] [US3] Clear family 2, which is `C408`. Replace each `dict()` call with a `{}` literal. The 3 sites sit at 2 lines in `MistHelper.py` and 1 line in `tests/unit/troubleshooting/test_marvis_troubleshoot_utils_extended.py`. Verify with `.venv\Scripts\python.exe -m ruff check . --select C408` and open the pull request.
+- [ ] T016 [P] [US3] Clear family 3, which is `SIM103`. Replace each `if` and `else` pair with a direct return of the condition. The 9 sites sit in `src/api/api_data_fetcher.py`, `src/audit/filter.py`, `src/cache/cache_utils.py`, `src/websocket/service_ping_manager.py`, `tests/unit/org/test_org_synthetic_probes_manager.py`, `tools/codemod_logging_lazy.py`, `tools/compliance_analyzer/analyzers.py`, `tools/ste_linter/parsing/markdown.py`, and `tools/test_quality_analyzer/discovery.py`.
+- [ ] T017 [US3] Confirm the return type at each `SIM103` site. Requirement FR-005 demands a boolean return. Wrap the condition in `bool(...)` where the condition returns a truthy value instead of a boolean. Depends on T016, because both tasks read the same sites.
+- [ ] T018 [US3] Read each `ISC004` site before any edit. The 13 sites sit in `tools/refactor_analyzer/reporting.py` with 8, in `MistHelper.py` with 4, and in `src/websocket/diagnostics/arp_executor.py` with 1. Confirm at each site that the author joined two string parts on purpose and did not drop a comma. Requirement FR-004 demands this read.
+- [ ] T019 [US3] Clear family 4, which is `ISC004`. Join each deliberate concatenation into one string. Add the missing comma at any site that the T018 read found. Record the count of missing commas, because SC-005 reads that count.
+- [ ] T020 [US3] Verify families 2 to 4. Run `.venv\Scripts\python.exe -m ruff check . --select C408,SIM103,ISC004 --statistics` and confirm zero results. Run the full gate set and confirm that the unit suite keeps the T003 pass count.
+
+**Checkpoint**: Three families read zero. Family 5 can start.
+
+---
+
+## Phase 5: User Story 3, Family 5 - RUF012, the class constants (Priority: P2)
+
+**Goal**: Add a `typing.ClassVar` annotation to all 60 sites across 32 files.
+
+**Independent Test**: `ruff check . --select RUF012` reports zero results and the mypy gate stays green.
+
+**Warning**: A wrong annotation changes the inferred type for every reader of that attribute. The mypy gate then fails in a file that this work never touched.
+
+- [ ] T021 [US3] Split the 60 sites into two or three groups of at most 25 sites. Record the group boundary in [plan.md](plan.md). The largest file is `src/analytics/site_analytics_configurator.py` with 6 sites.
+- [ ] T022 [US3] Confirm that each site holds a class constant and not instance state. Read each attribute and each writer of that attribute. A site that the code writes at run time needs a different repair and moves out of scope.
+- [ ] T023 [US3] Add the `ClassVar` annotation to each site in the first group. Add the `from typing import ClassVar` import where the module does not hold it. Run `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml` after each file, per FR-006.
+- [ ] T024 [US3] Repeat T023 for each remaining group. Open one pull request for each group. Skip `src/firmware/firmware_manager.py`, `src/reports/e911_bssid.py`, and `src/site/bulk_radius_wlan_config_manager.py` in a group that runs at the same time as the `DTZ005` family, per FR-013.
+- [ ] T025 [US3] Verify family 5. Run `.venv\Scripts\python.exe -m ruff check . --select RUF012 --statistics` and confirm zero results. Run `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml` and confirm zero errors. Run the full gate set.
+
+**Checkpoint**: The `RUF012` count reads zero. Family 6 can start.
+
+---
+
+## Phase 6: User Story 2, Family 6 - DTZ005, the naive datetime values (Priority: P1)
+
+**Goal**: Convert all 57 sites and prove that the printed output stayed byte identical at each one.
+
+**Independent Test**: `ruff check . --select DTZ005 --ignore-noqa` reports zero results. Each site holds a written proof.
+
+**Warning**: This family changes behavior. An aware value can print a time zone offset, which changes a log line and can change a filename. A naive value and an aware value raise `TypeError` when they compare.
+
+- [ ] T026 [US2] Confirm that issue #1792 landed. Run `.venv\Scripts\python.exe -m ruff check . --select DTZ005 --statistics` and the same command with `--ignore-noqa`. Both values must read 57. Stop if the default value reads 56, because the directive still hides one site. Requirement FR-012 states this stop condition.
+- [ ] T027 [US2] Read pull request #1791 and record the proof method that its author used for 4 sites. This family repeats that method 57 times.
+- [ ] T028 [US2] Split the 57 sites into two groups of at most 30 sites. Record the group boundary in [plan.md](plan.md). The largest files are `src/firmware/bulk_switch_upgrader.py` and `src/firmware/firmware_manager.py` with 5 sites each.
+- [ ] T029 [US2] Capture the printed output for each site before the change. Run the operation that reaches the site and save the output. This capture is the reference for the proof.
+- [ ] T030 [US2] Convert each site in the first group. Pass the time zone to the `datetime.now()` call. Add an inline comment on each changed line that states why the value needs a time zone.
+- [ ] T031 [US2] Read every comparison that reads a converted value. Requirement FR-008 forbids a comparison between a naive value and an aware value. Convert both sides or neither. Depends on T030, because the comparison sites read the changed values.
+- [ ] T032 [US2] Capture the printed output for each converted site again. Compare the capture against the T029 reference. The two must match byte for byte. Requirement FR-007 and success criterion SC-004 demand this proof. Check the filename as well as the log text, because a printed offset can reach a filename.
+- [ ] T033 [US2] Repeat T029 through T032 for the second group. Open one pull request for each group and record the proof for each site in the body.
+- [ ] T034 [US2] Verify family 6. Run `.venv\Scripts\python.exe -m ruff check . --select DTZ005 --ignore-noqa --statistics` and confirm zero results. Run the full gate set and confirm that the unit suite keeps the T003 pass count.
+
+**Checkpoint**: Every family reads zero. SC-001 and SC-004 now hold. Phase 7 can start.
+
+---
+
+## Phase 7: User Story 3 - Close the gate (Priority: P2)
+
+**Goal**: Add the five ruff rules to the `select` list. This is the final change of the feature.
+
+**Independent Test**: A reviewer adds one site in any family. The lint gate fails and names the rule.
+
+**Warning**: Run this phase only after Phase 6 reports zero results. The gate fails on every push while any site remains.
+
+- [ ] T035 [US3] Change line 164 of `pyproject.toml` from `select = ["E", "F", "W", "I", "UP", "B", "G"]` to `select = ["E", "F", "W", "I", "UP", "B", "G", "C408", "DTZ005", "ISC004", "RUF012", "SIM103"]`. Add no other rule, per FR-017. Add no whole family, per NG-004.
+- [ ] T036 [US3] Add a comment above the `select` list in `pyproject.toml`. State that `DTZ005` protects a comparison and that `RUF012` protects a class constant. Keep the comment inside 120 characters. Depends on T035, because both tasks edit the same file.
+- [ ] T037 [US3] Verify the gate. Run `.venv\Scripts\python.exe -m ruff check .` and confirm that it passes with the new list.
+- [ ] T038 [US3] Prove the negative case for SC-007. Add one temporary naive `datetime.now()` call to a tracked file under `src/`. Run `.venv\Scripts\python.exe -m ruff check .` and confirm that it reports `DTZ005` and exits with code 1. Repeat with one temporary `dict()` call for `C408`. Remove both lines. Run `git status` and confirm that the tree holds no leftover change.
+
+**Checkpoint**: The gate reports every family. SC-006 and SC-007 now hold.
+
+---
+
+## Phase 8: Polish and Final Validation
+
+**Purpose**: Prove every success criterion and close the issue. These tasks change no source line.
+
+- [ ] T039 Run the full gate set exactly as CI runs it. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ --config-file pyproject.toml`, `.venv\Scripts\python.exe -m pylint src/`, `.venv\Scripts\python.exe -m radon cc src/ -a -nb`, `.venv\Scripts\python.exe -m vulture src/ --min-confidence 80`, `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r .`, and `.venv\Scripts\python.exe -m pytest --cov=src/ --cov-fail-under=80`. Do not scope a gate to the changed files only.
+- [ ] T040 [P] Prove SC-005. Read the T019 record and state the count of `ISC004` sites that held a missing comma. A value above zero names a real defect that this work repaired.
+- [ ] T041 [P] Prove SC-004. Count the `DTZ005` sites with a written proof and confirm that the count reads 57.
+- [ ] T042 [P] Confirm that this work added no suppression. Run `git log -p main..HEAD` across every family branch and search for an added `# noqa` line and for a new entry in the ruff `ignore` list. The expected count is zero, per NG-001.
+- [ ] T043 Open the final pull request for the gate change. Write `Closes #1795` in the body. Link `specs/1795-small-correctness-rules/spec.md`. List every family pull request number. State the correction that this specification records, because the issue names five families and this work covers six. Complete the checklist in `.github/PULL_REQUEST_TEMPLATE.md`. Add the `auto-merge` label only after every check passes, including CodeQL.
+
+---
+
+## Dependencies and Execution Order
+
+### Phase order
+
+| Phase | Content | Starts after |
+| - | - | - |
+| 1 | Setup | Nothing |
+| 2 | Foundational baseline | Phase 1 |
+| 3 | Family 1, `W1514` | Phase 2 records all six counts |
+| 4 | Families 2 to 4, the mechanical repairs | Phase 3 |
+| 5 | Family 5, `RUF012` | Phase 4 |
+| 6 | Family 6, `DTZ005` | Phase 5 and issue #1792 lands |
+| 7 | The gate change | Phase 6 reports zero results |
+| 8 | Polish and final validation | Phase 7 |
+
+### Why the order runs from the defect to the behavior change
+
+Family 1 names a real defect that changes file content between two platforms. It lands first, because it delivers value on its own.
+
+Family 6 changes behavior at every site. It lands last, because a mistake there reaches every operator and because it depends on issue #1792.
+
+### Same-file sequencing
+
+| File | Earlier family | Later family |
+| - | - | - |
+| MistHelper.py | 1 (`W1514`) | 2 (`C408`) and 4 (`ISC004`) |
+| src/cache/cache_utils.py | 3 (`SIM103`) | 5 (`RUF012`) |
+| src/firmware/firmware_manager.py | 5 (`RUF012`) | 6 (`DTZ005`) |
+| src/reports/e911_bssid.py | 5 (`RUF012`) | 6 (`DTZ005`) |
+| src/site/bulk_radius_wlan_config_manager.py | 5 (`RUF012`) | 6 (`DTZ005`) |
+
+---
+
+## Parallel Opportunities
+
+| Phase | Parallel tasks | Reason |
+| - | - | - |
+| 4 | T015, T016 | The two families share no file. |
+| 8 | T040, T041, T042 | The three checks read different data. |
+
+The `RUF012` family and the `DTZ005` family hold no parallel opportunity, because they share three files.
+
+---
+
+## Implementation Strategy
+
+### Minimum viable delivery
+
+Family 1 alone delivers real value. Five sites carry a cross-platform defect, and the repair takes one small pull request. A team with time for one family should pick that one.
+
+### Order of risk
+
+The largest risk is a silent output change from family 6. An aware datetime value prints a time zone offset, and that offset can reach a log line or a filename. Task T032 is the control, and it runs at every one of the 57 sites.

--- a/specs/1796-comment-sweep-safety/plan.md
+++ b/specs/1796-comment-sweep-safety/plan.md
@@ -1,0 +1,195 @@
+# Implementation Plan: Automated Sweep Safety Procedure
+
+**Branch**: `chore/1796-sweep-safety` (SpecKit feature directory `1796-comment-sweep-safety`) | **Date**: 2026-08-06 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1796-comment-sweep-safety/spec.md`
+
+**GitHub Issue**: [#1796](https://github.com/jmorrison-juniper/MistHelper/issues/1796)
+
+## Summary
+
+An automated sweep deleted a live declaration and stripped a comment marker. The mypy gate caught the first defect by luck, because issue #888 had widened that gate days earlier.
+
+This work removes the luck. It adds a symbol table tool, a written procedure, and a test that covers the `--fast` flag.
+
+The plan runs in three parts. The tool lands first, because the procedure names it. The procedure lands second. The test lands third, because it is independent of the other two.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (`pyproject.toml` target `py313`)
+
+**Primary Dependencies**: The standard `ast` module and the standard `subprocess` module. This work adds no third-party dependency.
+
+**Storage**: Not applicable. The tool reads a file and prints a report.
+
+**Testing**: `pytest` with `--cov=src/ --cov-fail-under=80`. The suite must keep its pass count and must gain the new tests.
+
+**Target Platform**: The CI runner uses Linux. A developer works on Windows. The tool must read a path on both, so it must use `pathlib` and must not hardcode a separator.
+
+**Project Type**: A new tool plus a documentation change plus a test. The tool adds one class under `tools/`.
+
+**Performance Goals**: The symbol table check must finish in under 5 seconds for a 6000-line file. `MistHelper.py` holds 6054 lines today.
+
+**Constraints**:
+
+- The root ruff line length is 120 characters.
+- `mypy` reads `src/`, `MistHelper.py`, and `wsgi.py`. It does not read `tools/`. The new tool therefore faces `ruff`, `black`, `bandit`, and the test suite.
+- The Five-Item Rule caps a function at 5 parameters, 5 blocks, and 25 lines. The tool must split its work across small methods.
+- The project forbids a wrapper function. The tool must hold its logic in a class.
+- `bandit` reports `B404` on an `import subprocess`. The tool needs `subprocess` to read a git revision, so that import needs a `# nosec` comment in the style of `MistHelper.py` line 47.
+
+**Scale/Scope**: One new tool module, one instruction section, and two or three new tests.
+
+### Measurement contract
+
+The reference case is pull request #1791. Its commit statistics read as follows.
+
+```text
+1 file changed, 53 insertions(+), 515 deletions(-)
+```
+
+Run the command below to replay the sweep and prove the tool.
+
+```powershell
+.venv\Scripts\python.exe -m tools.symbol_diff --base 08a75d2~1 MistHelper.py
+```
+
+The tool must report the lost name `FAST_MODE_ENABLED` when a reviewer replays the state before the repair. Success criterion SC-006 states this outcome.
+
+### Verified mechanics
+
+A maintainer probed the current tree on 2026-08-06 at commit `08a75d2`. Four results shape the tasks.
+
+1. `MistHelper.py` line 2382 holds the restored declaration `FAST_MODE_ENABLED: bool = False`.
+2. `MistHelper.py` line 112 names `FAST_MODE_ENABLED` inside an export list.
+3. `MistHelper.py` line 5101 holds the `global FAST_MODE_ENABLED` statement inside `_setup_runtime_flags`.
+4. A search of `tests/` finds two references to the name. Both sit in `tests/unit/serial_cc/test_switch_vc_stats.py` and both set an attribute on a test double. No test reads the module global.
+
+### Discovered risk: the declaration uses an annotated assignment
+
+The declaration reads `FAST_MODE_ENABLED: bool = False`. Python parses that statement as `ast.AnnAssign`, not as `ast.Assign`.
+
+A symbol table tool that matches `ast.Assign` alone misses every annotated module global. The tool would then report zero lost names on the exact defect that it exists to catch.
+
+The control is task T007. The tool must handle `ast.Assign`, `ast.AnnAssign`, `ast.FunctionDef`, `ast.AsyncFunctionDef`, `ast.ClassDef`, `ast.Import`, and `ast.ImportFrom`.
+
+**Warning**: This repository already lost a generator to this exact trap. `scripts/generate_menu_wiki.py` searched for `menu_actions` as an `ast.Assign` node. The declaration gained a type annotation, the node became `ast.AnnAssign`, and the generator produced nothing for months.
+
+### Discovered risk: the tool must read a file that does not compile
+
+Defect 2 left `MistHelper.py` in a state that `py_compile` rejected. A tool that imports the file to read its names cannot run in that state.
+
+The control is the `ast` module. It parses text and does not run it. The tool must catch `SyntaxError` and must print a clear message that names the file and the line. Requirement FR-018 and success criterion SC-007 state this outcome.
+
+## Constitution Check
+
+*GATE: The plan passes before Phase 0 research. The plan passes again after Phase 1 design.*
+
+| Principle | Status | Basis |
+| - | - | - |
+| I. Five-Item Rule | PASS with a constraint | The tool class must hold at most 5 public methods. Each method must stay inside 25 lines and 5 blocks. |
+| II. Class-Based Architecture (No Wrappers) | PASS | The tool holds one class named `SymbolTableComparator`. The module entry point calls one method on it. No wrapper function exists. |
+| III. Safety-First | PASS | The tool reads a file and prints a report. It writes no file and changes no state. |
+| IV. Full Deployment Pipeline | ADAPTED | The work follows the branch and pull request workflow. The container needs no rebuild, because the tool does not ship in the runtime path. |
+| V. Observability and Logging | PASS | The tool logs each read and each comparison. Every message stays ASCII. |
+| VI. Inline Comments (NON-NEGOTIABLE) | PASS | Every added line carries an inline comment. Requirement FR-023 states this rule. |
+| VII. Action Logging (NON-NEGOTIABLE) | PASS | Requirement FR-024 demands a log call before and after each read and each comparison. |
+| Security Findings: Fix Over Suppress (NON-NEGOTIABLE) | PASS with one suppression | The `import subprocess` line needs a `# nosec B404` comment. The comment names the seam and states that the tool passes a fixed argument list with no shell. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1796-comment-sweep-safety/
+├── spec.md              # The feature specification
+├── plan.md              # This file
+└── tasks.md             # The task list
+```
+
+### Source code (repository root)
+
+The work creates two files and changes two files.
+
+```text
+tools/
+└── symbol_diff/
+    ├── __init__.py                       # New: the module entry point
+    └── comparator.py                     # New: the SymbolTableComparator class
+
+.github/copilot-instructions.md           # Changed: add the sweep procedure section
+agents.md                                 # Changed: add a one-line pointer to the procedure
+
+tests/
+└── unit/
+    ├── test_fast_mode_flag.py            # New: the --fast flag tests
+    └── tools/
+        └── test_symbol_diff.py           # New: the tool tests
+```
+
+**Structure Decision**: The tool sits under `tools/`, next to `tools/ste_linter` and `tools/compliance_analyzer`. That location matches requirement FR-020 and matches the existing project layout. The tool takes a package directory, not a single file, because the Five-Item Rule caps one module at 5 top-level constructs.
+
+## Phased approach
+
+The work runs in three parts. Each part ends with a check.
+
+### Part A - The symbol table tool
+
+Build `SymbolTableComparator`. The class reads a file with the `ast` module, collects the module-level names, and compares two sets.
+
+The class holds five public methods at most.
+
+1. `collect_names(source: str) -> set[str]` reads the text and returns the module-level names.
+2. `read_revision(revision: str, path: Path) -> str` reads the file text at a git revision.
+3. `compare(before: set[str], after: set[str]) -> SymbolDelta` returns the lost names and the added names.
+4. `report(delta: SymbolDelta) -> int` prints the report and returns the exit code.
+5. `run(revision: str, paths: list[Path]) -> int` runs the whole check.
+
+**Warning**: `collect_names` must handle `ast.AnnAssign` as well as `ast.Assign`. A tool that misses the annotated form reports zero lost names on the exact defect from issue #1796.
+
+**Exit measurement**: The tool reports the lost `FAST_MODE_ENABLED` name when a reviewer replays the pull request #1791 sweep. It reads a file that does not compile without an unhandled error.
+
+### Part B - The written procedure
+
+Add a section to `.github/copilot-instructions.md`. The section states the four checks, each command, and each expected result.
+
+The section must also state three rules.
+
+1. A comment sweep deletes comment lines only. The expected count of other deletions is zero.
+2. A sweep pull request body records that count.
+3. A rebase repeats every check.
+
+Add a one-line pointer in `agents.md`. That file already points to `.github/copilot-instructions.md` as the canonical source, so it must not repeat the procedure text.
+
+**Exit measurement**: A search of the project instructions for the word "sweep" finds the procedure. The procedure names all four checks.
+
+### Part C - The fast flag test
+
+Add `tests/unit/test_fast_mode_flag.py`. The test proves three facts.
+
+1. The `--fast` flag sets the `MistHelper.FAST_MODE_ENABLED` module global to `True`.
+2. The absence of the flag leaves the module global at `False`.
+3. The test reads the module global on the `MistHelper` module itself, not on a test double.
+
+**Caution**: The test changes a module global. It must restore the earlier value after each run, or a later test reads a changed flag. Requirement FR-016 states this rule.
+
+**Exit measurement**: The test passes on the current tree. The test fails when a reviewer removes the declaration from `MistHelper.py`.
+
+## Risk register
+
+| Risk | Likelihood | Effect | Control |
+| - | - | - | - |
+| The tool misses an annotated assignment | High | The tool reports zero lost names on the exact defect it exists to catch | Task T007 handles `ast.AnnAssign`. Task T012 proves the case against pull request #1791. |
+| The tool cannot read a file that does not compile | Medium | The tool fails on defect 2 and hides defect 1 | Task T008 catches `SyntaxError` and prints a clear message |
+| The fast flag test leaks a changed global | Medium | A later test reads the wrong value and fails without a clear cause | Task T016 restores the earlier value in a fixture teardown |
+| A contributor skips the procedure | High | The next sweep repeats the defect | The procedure sits in the file that every agent session reads |
+| The `MYPY_PATHS` value narrows again | Low | One of the four checks stops working | The procedure reads the value from `.github/workflows/ci.yml` instead of repeating it |
+| The tool trips a bandit rule | Medium | The security gate fails | Task T009 adds a `# nosec B404` comment that names the seam |
+
+## Complexity Tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+| - | - | - |
+| The work adds a new tool | The mypy gate catches a lost name only where another module reads it. A private module global has no such reader. | A mypy-only check catches defect 1 by luck. The luck ran out once already, before issue #888 widened the gate. |
+| The tool takes a package directory, not one module | The Five-Item Rule caps one module at 5 top-level constructs, and the tool needs a class plus an entry point plus a result type | A single module would exceed the cap and would fail the structural review |
+| The procedure states a manual check, not a CI job | A sweep runs before the commit, and the check must stop the commit, not the merge | A CI job reports the defect after the push, and a reviewer then reads a red build instead of a clean difference |

--- a/specs/1796-comment-sweep-safety/spec.md
+++ b/specs/1796-comment-sweep-safety/spec.md
@@ -1,0 +1,246 @@
+# Feature Specification: Automated Sweep Safety Procedure
+
+**Feature Branch**: `docs/1792-1796-lint-debt-specs` (specification only). The implementation branch is `chore/1796-sweep-safety`.
+
+**GitHub Issue**: [#1796](https://github.com/jmorrison-juniper/MistHelper/issues/1796) — "chore: an automated comment sweep deleted a live declaration and broke the build"
+
+**Created**: 2026-08-06
+
+**Status**: Specification only. No code change exists yet.
+
+**Input**: Write a safety procedure for any automated comment sweep or code sweep. Add a test that covers the `--fast` command line flag.
+
+---
+
+## Background
+
+An automated sweep deleted a live declaration from `MistHelper.py`. The same sweep removed a comment marker from a separator line. The file then failed to compile.
+
+Issue [#1707](https://github.com/jmorrison-juniper/MistHelper/issues/1707) asked for the removal of the completed-migration `NOTE` comment blocks. Pull request #1791 carried the sweep. The commit statistics read as follows.
+
+```text
+1 file changed, 53 insertions(+), 515 deletions(-)
+```
+
+Two of the 515 deleted lines were not comments.
+
+### Defect 1: the sweep deleted a live module global
+
+`MistHelper.py` held the following declaration.
+
+```python
+FAST_MODE_ENABLED: bool = False  # Set to True via --fast CLI flag at startup
+```
+
+The declaration sat between two `NOTE` comment blocks. The sweep treated the whole span as comment text and removed the declaration with it.
+
+The function `_setup_runtime_flags` assigns to that name through a `global` statement at `MistHelper.py` line 5101. Without the declaration, the module holds no such global. The `--fast` flag then raises `NameError` at run time.
+
+### Defect 2: the sweep stripped a comment marker
+
+The sweep removed the leading `#` from a separator line. The remaining text was not valid Python. The `py_compile` step failed on the file.
+
+### Why no check caught the first defect
+
+Two gaps combined.
+
+1. **No test covers the `--fast` path.** A search of `tests/` finds two references to the name `FAST_MODE_ENABLED`. Both sit in `tests/unit/serial_cc/test_switch_vc_stats.py`, and both set an attribute on a test double. Neither reads the module global in `MistHelper.py`. No test observed the missing declaration.
+2. **The mypy gate reached `MistHelper.py` only days before.** Issue [#888](https://github.com/jmorrison-juniper/MistHelper/issues/888) widened the mypy scope. The `MYPY_PATHS` value in `.github/workflows/ci.yml` line 59 now reads `src/ MistHelper.py wsgi.py`. The wider gate reported the undefined global. Before that change, the defect would have reached the container.
+
+The compile failure is loud. The missing global is quiet. It fails only when an operator passes `--fast`.
+
+### Why this matters beyond one commit
+
+An automated sweep is a code change. It carries the same risk as a hand edit, and it carries more risk, because it changes many lines at once and because a reviewer reads it as a comment-only difference.
+
+A reviewer who sees "delete comments" in a pull request title does not look for a deleted declaration. The title sets the wrong expectation. A 515-line deletion holds two defects inside a difference that looks safe.
+
+### The sweeps that this repository still plans
+
+Four open efforts propose a mechanical change across many files.
+
+| Issue | Scope | Risk |
+| - | - | - |
+| [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792) | Remove 286 unused `# noqa` directives across 94 files | A repair with the wrong ruff flag deletes 34 live suppressions |
+| [#1793](https://github.com/jmorrison-juniper/MistHelper/issues/1793) | Rewrite 4478 logging calls across 223 files | A scripted rewrite can change a message text |
+| [#1795](https://github.com/jmorrison-juniper/MistHelper/issues/1795) | Repair 146 sites across about 70 files | An unsafe ruff repair can change behavior |
+| [#886](https://github.com/jmorrison-juniper/MistHelper/issues/886) | Convert `print()` calls into logging calls | A rewrite can drop an output line |
+
+Each of these efforts needs the procedure that this specification defines. The procedure must land before the first of them starts.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stop a sweep that deletes a live declaration (Priority: P1)
+
+A contributor runs an automated sweep. The sweep removes a line that is not a comment. The contributor runs the stated checks before the commit and finds the deleted line.
+
+**Why this priority**: This story prevents the exact defect that issue #1796 records. It also protects the four planned sweeps that the table above lists.
+
+**Independent Test**: A reviewer runs a sweep that deletes one declaration on purpose. The stated checks report the deletion before the commit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sweep that deletes a line which is not a comment, **When** a contributor runs the symbol table check, **Then** the check reports the lost name and states the file.
+2. **Given** a sweep that produces a file which does not compile, **When** a contributor runs the compile check, **Then** the check fails and names the file and the line.
+3. **Given** a completed sweep, **When** a contributor reads the procedure, **Then** the procedure states the exact count of deleted lines that are not comments.
+4. **Given** a sweep pull request, **When** a reviewer reads the body, **Then** the body states that count and the expected value is zero.
+
+---
+
+### User Story 2 - Prove that the fast flag still works (Priority: P1)
+
+A contributor removes the `FAST_MODE_ENABLED` declaration. The unit test suite fails and names the missing global.
+
+**Why this priority**: This story shares the P1 rank. The procedure catches a sweep defect at commit time. The test catches the same defect at every later change, including a hand edit.
+
+**Independent Test**: A reviewer removes the declaration from `MistHelper.py`. The reviewer runs the unit suite and reads a failure that names the flag.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new test, **When** a contributor runs the unit suite on the current tree, **Then** the test passes.
+2. **Given** the new test, **When** a contributor removes the `FAST_MODE_ENABLED` declaration, **Then** the test fails and the message names the flag.
+3. **Given** the new test, **When** a contributor passes the `--fast` flag, **Then** the test proves that the module global receives the value `True`.
+4. **Given** the new test, **When** a contributor omits the `--fast` flag, **Then** the test proves that the module global holds the value `False`.
+
+---
+
+### User Story 3 - Find the procedure without asking a maintainer (Priority: P2)
+
+A contributor plans an automated sweep. The contributor opens the project instructions and finds the procedure. The contributor does not need to ask a maintainer.
+
+**Why this priority**: This story protects the value of the first two stories over time. A written rule that nobody can find has no effect.
+
+**Independent Test**: A contributor who never met this issue searches the project instructions for the word "sweep" and finds the procedure.
+
+**Acceptance Scenarios**:
+
+1. **Given** the project instructions, **When** a contributor searches for the sweep procedure, **Then** the search finds it in `.github/copilot-instructions.md`.
+2. **Given** the project instructions, **When** a contributor reads the procedure, **Then** the procedure states each command and each expected result.
+3. **Given** the procedure, **When** a contributor reads it, **Then** the procedure names the pull request body statement that a sweep must hold.
+
+---
+
+### Edge Cases
+
+- A sweep runs on a file that the mypy gate does not read. The type check then reports nothing. The symbol table check still reports the lost name, so the procedure must not depend on mypy alone.
+- A sweep deletes a name that no other module reads. Mypy reports nothing, because no reader exists. The symbol table check still reports the loss.
+- A sweep adds a name instead of deleting one. The symbol table check must report an added name as well as a lost name, because an added name can shadow an import.
+- A sweep changes only whitespace inside a comment. The symbol table stays the same and the compile check passes. The procedure records zero deleted lines that are not comments, and the sweep proceeds.
+- A sweep touches a file that holds no Python code, such as a Markdown file or a YAML file. The compile check does not apply. The procedure must state which check applies to which file type.
+- A sweep runs across many files. The compile check must cover every changed file, not the largest one alone.
+- A contributor runs the sweep and the checks, then rebases onto a changed `main`. The rebase can reintroduce the defect. The procedure must run again after any rebase.
+
+---
+
+## Requirements *(mandatory)*
+
+### Procedure requirements
+
+- **FR-001**: The project instructions MUST hold a written procedure for an automated sweep. The location MUST be `.github/copilot-instructions.md`.
+- **FR-002**: The procedure MUST state a compile check. The command MUST be `.venv\Scripts\python.exe -m py_compile <file>` for every changed Python file.
+- **FR-003**: The procedure MUST state a lint check. The command MUST be `.venv\Scripts\python.exe -m ruff check .` across the whole repository, not across the changed files alone.
+- **FR-004**: The procedure MUST state a type check. The command MUST use the `MYPY_PATHS` value from `.github/workflows/ci.yml`, which reads `src/ MistHelper.py wsgi.py`.
+- **FR-005**: The procedure MUST state a symbol table check. The check MUST compare the module-level names before the sweep against the module-level names after the sweep.
+- **FR-006**: The symbol table check MUST report a lost name and MUST report an added name.
+- **FR-007**: The procedure MUST state a difference read. The contributor MUST count every changed line that is not a comment.
+- **FR-008**: The procedure MUST state that a comment sweep deletes comment lines only. The expected count of other deletions is zero.
+- **FR-009**: The procedure MUST state that a sweep pull request body records that count.
+- **FR-010**: The procedure MUST state that a rebase repeats every check, because a rebase can reintroduce the defect.
+- **FR-011**: The procedure MUST state that a sweep pull request title names the sweep. A title such as "delete comments" sets the wrong expectation for a reviewer.
+
+### Test requirements
+
+- **FR-012**: A test MUST prove that the `--fast` flag sets the `FAST_MODE_ENABLED` module global in `MistHelper.py` to `True`.
+- **FR-013**: A test MUST prove that the absence of the flag leaves the module global at `False`.
+- **FR-014**: A test MUST fail when a contributor removes the `FAST_MODE_ENABLED` declaration from `MistHelper.py`.
+- **FR-015**: The test MUST read the module global on the `MistHelper` module itself. It MUST NOT read an attribute on a test double, because the two existing references in `tests/unit/serial_cc/test_switch_vc_stats.py` do that and neither one caught the defect.
+- **FR-016**: The test MUST restore the earlier value of the module global after each run, so that no later test reads a changed flag.
+
+### Tooling requirements
+
+- **FR-017**: The symbol table check MUST run without a manual step. A contributor MUST be able to run one command.
+- **FR-018**: The symbol table tool MUST read the file with the `ast` module. It MUST NOT run the file, because a sweep can leave a file that does not compile.
+- **FR-019**: The symbol table tool MUST accept a git revision for the earlier state, so that a contributor can compare against `main`.
+- **FR-020**: The symbol table tool MUST live under `tools/`, next to the other project tools.
+
+### Quality requirements
+
+- **FR-021**: Every quality gate MUST stay green. The unit test suite MUST keep its pass count and MUST gain the new tests.
+- **FR-022**: All prose, all code comments, and all commit text MUST follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md`.
+- **FR-023**: Every added Python line MUST carry an inline comment that explains why the line exists.
+- **FR-024**: Every meaningful action that the new tool takes MUST log before the action and after the action.
+
+### Key Entities
+
+- **Automated sweep**: A scripted change that edits many lines across one or more files without a per-line judgment.
+- **Symbol table**: The set of module-level names that a Python file defines. It holds each class, each function, each assignment target, and each import alias.
+- **Comment-only change**: A change in which every deleted line and every added line is a comment or a blank line.
+- **Silent defect**: A defect that no gate reports and that fails only on a path that no test covers.
+
+---
+
+## The four checks
+
+The table states each check, its command, and its expected result.
+
+| Check | Command | Expected result | Catches |
+| - | - | - | - |
+| Compile | `python -m py_compile <each changed .py file>` | Exit code 0 with no output | Defect 2, the stripped comment marker |
+| Lint | `python -m ruff check .` | Exit code 0 | A broken import and an undefined name |
+| Type | `python -m mypy src/ MistHelper.py wsgi.py --config-file pyproject.toml` | Exit code 0 | Defect 1, when another module reads the lost name |
+| Symbol table | `python -m tools.symbol_diff --base main <each changed .py file>` | Zero lost names and zero added names | Defect 1, in every case |
+
+**Warning**: The type check catches the lost name only where another module reads it. The symbol table check catches the loss in every case. A contributor must run both.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The project instructions hold a procedure that states all four checks and states the expected result for each one.
+- **SC-002**: A contributor who removes the `FAST_MODE_ENABLED` declaration sees the unit test suite fail with a message that names the flag.
+- **SC-003**: A test proves that the `--fast` flag sets the module global to `True`.
+- **SC-004**: A test proves that the absence of the flag leaves the module global at `False`.
+- **SC-005**: One command reports the lost names and the added names between the current tree and a named git revision.
+- **SC-006**: The symbol table tool reports the lost `FAST_MODE_ENABLED` name when a reviewer replays the sweep from pull request #1791.
+- **SC-007**: The symbol table tool reads a file that does not compile without raising an unhandled error.
+- **SC-008**: The procedure states that a sweep pull request body records the count of deleted lines that are not comments.
+- **SC-009**: Every quality gate stays green. The unit test suite gains the new tests and keeps every earlier pass.
+- **SC-010**: A contributor who never met this issue finds the procedure by a search of the project instructions for the word "sweep".
+
+---
+
+## Non-Goals
+
+- **NG-001**: This work does not add any lint suppression. It adds no `# noqa` directive, no `# type: ignore` comment, and no `# nosec` comment. The whole point is a repair, not a hidden result.
+- **NG-002**: This work does not revert pull request #1791. That pull request already repaired both defects.
+- **NG-003**: This work does not add a test for every command line flag. The `--fast` flag is the one that the defect touched.
+- **NG-004**: This work does not add a CI job for the symbol table check. The check runs before a commit, and a contributor runs it by hand. A CI job is a separate question.
+- **NG-005**: This work does not change the `MYPY_PATHS` value. Issue #888 already set it, and this work reads it.
+- **NG-006**: This work does not forbid an automated sweep. It states the checks that a sweep must pass.
+- **NG-007**: This work does not repair a defect that an earlier sweep left. No such defect is known today.
+- **NG-008**: This work does not add a rule to the ruff `select` list. The other four specifications in this set own those decisions.
+
+---
+
+## Assumptions
+
+- The `MYPY_PATHS` value stays at `src/ MistHelper.py wsgi.py`. A narrower value would remove one of the four checks.
+- A contributor runs the checks before the commit. The procedure states a manual step, not an automatic one.
+- The `ast` module parses every file that the repository holds. A file that does not parse produces a clear message from the tool, not a crash.
+- The two existing references to `FAST_MODE_ENABLED` in `tests/unit/serial_cc/test_switch_vc_stats.py` stay as they are. They test a different object and this work does not change them.
+- The four planned sweeps in the table above start after this work lands. A sweep that starts earlier carries the same risk that issue #1796 records.
+- A reviewer reads the pull request body. A count that the body states reaches the reviewer.
+
+---
+
+## Dependencies
+
+- Issue [#1707](https://github.com/jmorrison-juniper/MistHelper/issues/1707) requested the sweep that produced both defects.
+- Pull request #1791 carries the sweep and the repair. It is the reference case for success criterion SC-006.
+- Issue [#888](https://github.com/jmorrison-juniper/MistHelper/issues/888) widened the mypy scope to cover `MistHelper.py`. That change reported the first defect.
+- Issues [#1792](https://github.com/jmorrison-juniper/MistHelper/issues/1792), [#1793](https://github.com/jmorrison-juniper/MistHelper/issues/1793), [#1795](https://github.com/jmorrison-juniper/MistHelper/issues/1795), and [#886](https://github.com/jmorrison-juniper/MistHelper/issues/886) each plan a sweep. Each one needs this procedure.
+- The Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` govern all prose in this work.

--- a/specs/1796-comment-sweep-safety/tasks.md
+++ b/specs/1796-comment-sweep-safety/tasks.md
@@ -1,0 +1,164 @@
+# Tasks: Automated Sweep Safety Procedure
+
+**Feature**: `1796-comment-sweep-safety` | **Branch**: `chore/1796-sweep-safety` | **Date**: 2026-08-06
+
+**GitHub Issue**: [#1796](https://github.com/jmorrison-juniper/MistHelper/issues/1796)
+
+**Input**: Design documents from `specs/1796-comment-sweep-safety/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md)
+
+**Tests**: The specification requests new tests. Part C adds the `--fast` flag tests. Part A adds the tool tests. The existing suite must keep its pass count.
+
+**Branch rule**: Create `chore/1796-sweep-safety` from `main`. Do not branch from another feature branch.
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: The task can run in parallel with another task in the same phase. The tasks touch different files.
+- **[Story]**: The user story that owns the task. The value is `US1`, `US2`, or `US3`.
+- Each task names an exact file path or an exact command.
+
+## Rules that apply to every edit task
+
+1. Use `.venv\Scripts\python.exe` for every Python command. The global interpreter cannot import the project.
+2. Add no lint suppression. Non-goal NG-001 forbids a `# noqa` directive and a `# type: ignore` comment. The single `# nosec B404` comment on the `subprocess` import is the one recorded exception, and it needs a stated reason.
+3. Every added Python line carries an inline comment that states why the line exists. Principle VI requires it.
+4. Every meaningful action logs before the action and after the action. Principle VII requires it.
+5. Follow the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md` for every prose line.
+6. Use `pathlib` for every path. Never hardcode a path separator, because the tool runs on Windows and on Linux.
+7. Keep every function inside 5 parameters, 5 blocks, and 25 lines. The Five-Item Rule states the caps.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the environment and read the reference case.
+
+- [ ] T001 Create the branch with `git checkout -b chore/1796-sweep-safety main`. Confirm the result with `git branch --show-current`.
+- [ ] T002 Confirm that `.venv\Scripts\python.exe -m pytest --version` runs. Every later test command uses this interpreter.
+- [ ] T003 Read the reference case. Run `git show --stat 08a75d2` and confirm that the commit reports 53 insertions and 515 deletions in one file. That commit is pull request #1791, which carries both defects and the repair.
+- [ ] T004 Read the current state of the declaration. Confirm that `MistHelper.py` line 2382 holds `FAST_MODE_ENABLED: bool = False`. Confirm that line 5101 holds `global FAST_MODE_ENABLED` inside `_setup_runtime_flags`.
+- [ ] T005 Record the pre-change gate baseline. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ MistHelper.py wsgi.py --config-file pyproject.toml`, and `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q`. Save the unit test pass count, because SC-009 compares against it.
+
+---
+
+## Phase 2: User Story 1, Part A - The symbol table tool (Priority: P1)
+
+**Goal**: Build a tool that reports the module-level names that a change lost and the names that it added.
+
+**Independent Test**: The tool reports the lost name `FAST_MODE_ENABLED` when a reviewer replays the pull request #1791 sweep.
+
+**Warning**: The declaration uses an annotated assignment. Python parses that statement as `ast.AnnAssign`, not as `ast.Assign`. A tool that matches `ast.Assign` alone reports zero lost names on the exact defect it exists to catch. The generator `scripts/generate_menu_wiki.py` already lost months of output to this trap.
+
+- [ ] T006 Create the package directory `tools/symbol_diff/` with an empty `__init__.py`. Requirement FR-020 places the tool next to `tools/ste_linter` and `tools/compliance_analyzer`.
+- [ ] T007 [US1] Write the `collect_names` method in `tools/symbol_diff/comparator.py`. The method reads a source string with `ast.parse` and returns the module-level names. Handle `ast.Assign`, `ast.AnnAssign`, `ast.FunctionDef`, `ast.AsyncFunctionDef`, `ast.ClassDef`, `ast.Import`, and `ast.ImportFrom`. Requirement FR-005 and FR-018 state this behavior.
+- [ ] T008 [US1] Add the syntax error path to `collect_names`. Catch `SyntaxError` and print a message that names the file and the line. Do not raise. Requirement FR-018 and success criterion SC-007 demand a clear message, because defect 2 left a file that does not compile.
+- [ ] T009 [US1] Write the `read_revision` method in `tools/symbol_diff/comparator.py`. The method runs `git show <revision>:<path>` and returns the text. Pass a fixed argument list and request no shell. Add a `# nosec B404` comment on the `import subprocess` line in the style of `MistHelper.py` line 47, which names the seam and names the runner.
+- [ ] T010 [US1] Write the `compare` method in `tools/symbol_diff/comparator.py`. The method returns the lost names and the added names. Requirement FR-006 demands both directions, because an added name can shadow an import.
+- [ ] T011 [US1] Write the `report` method and the `run` method in `tools/symbol_diff/comparator.py`. The `run` method accepts a base revision and a list of paths, per FR-019. The `report` method returns exit code 1 when the delta holds any name and returns 0 when it holds none.
+- [ ] T012 [US1] Write the module entry point in `tools/symbol_diff/__init__.py`. Parse `--base` and the path list with `argparse`. Call one method on `SymbolTableComparator`. Add no wrapper function, per the project rule against wrappers.
+- [ ] T013 [US1] Prove SC-006. Run `.venv\Scripts\python.exe -m tools.symbol_diff --base 08a75d2~1 MistHelper.py` against a tree that replays the sweep before the repair. Confirm that the output names `FAST_MODE_ENABLED` as a lost name and that the exit code reads 1.
+- [ ] T014 [US1] Prove SC-007. Write a temporary file that holds invalid Python. Run the tool against it. Confirm that the tool prints a message that names the file and the line, and that the tool raises no unhandled error. Delete the temporary file.
+- [ ] T015 [US1] Write `tests/unit/tools/test_symbol_diff.py`. Cover the annotated assignment case, the plain assignment case, the class case, the import case, the lost name case, the added name case, and the syntax error case. The annotated assignment case is the most important one, because it is the defect from issue #1796.
+- [ ] T016 [US1] Verify part A. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r tools/symbol_diff`, and `.venv\Scripts\python.exe -m pytest tests/unit/tools/test_symbol_diff.py --no-cov -q`. Confirm that every check passes.
+
+**Checkpoint**: The tool reports the reference defect. SC-005, SC-006, and SC-007 now hold. Part B can start.
+
+---
+
+## Phase 3: User Story 3, Part B - The written procedure (Priority: P2)
+
+**Goal**: Record the four checks where a contributor finds them.
+
+**Independent Test**: A contributor searches the project instructions for the word "sweep" and finds the procedure.
+
+- [ ] T017 [US3] Add a section named "Automated Sweep Safety" to `.github/copilot-instructions.md`. Requirement FR-001 names that file as the location. Place the section near the "Full Deployment Pipeline" section, because both describe a pre-commit step.
+- [ ] T018 [US3] Write the four check rows into the new section. State the compile check per FR-002, the lint check per FR-003, the type check per FR-004, and the symbol table check per FR-005. State the exact command and the expected result for each one. Depends on T017, because both tasks edit the same file.
+- [ ] T019 [US3] State the type check scope by reference, not by value. The section must point at the `MYPY_PATHS` value in `.github/workflows/ci.yml` line 59. A repeated value drifts when issue #888 or a later change moves the scope.
+- [ ] T020 [US3] Write the three sweep rules into the same section. State that a comment sweep deletes comment lines only, per FR-008. State that the pull request body records the count of other deletions, per FR-009. State that a rebase repeats every check, per FR-010.
+- [ ] T021 [US3] Write the title rule into the same section. A sweep pull request title must name the sweep, per FR-011. State that a title such as "delete comments" sets the wrong expectation and that a reviewer then reads a 515-line difference as safe.
+- [ ] T022 [US3] Add a one-line pointer in `agents.md` under "Key Conventions". Do not repeat the procedure text. That file already names `.github/copilot-instructions.md` as the canonical source.
+- [ ] T023 [US3] Prove SC-010. Search both files for the word "sweep" and confirm that the search finds the procedure and finds the pointer.
+- [ ] T024 [US3] Check the new prose against the Simplified Technical English rules. Run `.venv\Scripts\python.exe -m tools.ste_linter .github/copilot-instructions.md` and `.venv\Scripts\python.exe -m tools.ste_linter agents.md`. Each file must score 80 or above.
+
+**Checkpoint**: The procedure exists where a contributor finds it. SC-001, SC-008, and SC-010 now hold. Part C can start.
+
+---
+
+## Phase 4: User Story 2, Part C - The fast flag test (Priority: P1)
+
+**Goal**: Prove that the `--fast` flag sets the module global and that a removal of the declaration fails the suite.
+
+**Independent Test**: A reviewer removes the declaration from `MistHelper.py`. The unit suite fails and the message names the flag.
+
+**Caution**: The test changes a module global. It must restore the earlier value after each run, or a later test reads a changed flag.
+
+- [ ] T025 [US2] Write `tests/unit/test_fast_mode_flag.py`. Add a fixture that saves the current value of `MistHelper.FAST_MODE_ENABLED` and restores it after each test, per FR-016.
+- [ ] T026 [US2] Write the positive test. Call `_setup_runtime_flags` with a namespace that holds `fast=True`. Read `MistHelper.FAST_MODE_ENABLED` on the module itself and confirm the value `True`. Requirement FR-012 and FR-015 state this behavior.
+- [ ] T027 [US2] Write the negative test. Call `_setup_runtime_flags` with a namespace that holds `fast=False`. Read the module global and confirm the value `False`. Requirement FR-013 states this behavior.
+- [ ] T028 [US2] Write the declaration test. Confirm that the `MistHelper` module holds the name `FAST_MODE_ENABLED` at module level and that its type is `bool`. This test fails when a sweep deletes the declaration, per FR-014.
+- [ ] T029 [US2] Prove SC-002. Remove the declaration from `MistHelper.py` in the working tree. Run `.venv\Scripts\python.exe -m pytest tests/unit/test_fast_mode_flag.py --no-cov -q` and confirm that a test fails and that the message names the flag. Restore the declaration with `git checkout -- MistHelper.py`. Run `git status` and confirm that the tree holds no leftover change.
+- [ ] T030 [US2] Confirm that the new test does not read a test double. Requirement FR-015 forbids it. The two existing references in `tests/unit/serial_cc/test_switch_vc_stats.py` set an attribute on a deps object, and neither one caught the defect. Leave those two references unchanged, per NG-003.
+- [ ] T031 [US2] Verify part C. Run `.venv\Scripts\python.exe -m pytest tests/unit --no-cov -q` and confirm that the pass count equals the T005 value plus the new tests. Confirm that no earlier test failed after the flag change.
+
+**Checkpoint**: The test covers the `--fast` flag. SC-002, SC-003, and SC-004 now hold.
+
+---
+
+## Phase 5: Polish and Final Validation
+
+**Purpose**: Prove every success criterion and open the pull request. These tasks change no source line.
+
+- [ ] T032 Run the full gate set exactly as CI runs it. Run `.venv\Scripts\python.exe -m ruff check .`, `.venv\Scripts\python.exe -m black --check --diff .`, `.venv\Scripts\python.exe -m mypy src/ MistHelper.py wsgi.py --config-file pyproject.toml`, `.venv\Scripts\python.exe -m pylint src/`, `.venv\Scripts\python.exe -m radon cc src/ -a -nb`, `.venv\Scripts\python.exe -m vulture src/ --min-confidence 80`, `.venv\Scripts\python.exe -m bandit -c pyproject.toml -r .`, and `.venv\Scripts\python.exe -m pytest --cov=src/ --cov-fail-under=80`. Do not scope a gate to the changed files only.
+- [ ] T033 [P] Apply the new procedure to this pull request. Run all four checks on every changed file. State the count of deleted lines that are not comments in the pull request body. The expected value is zero, because this work deletes no line.
+- [ ] T034 [P] Confirm that this work added no suppression beyond the recorded one. Run `git diff main...HEAD` and search for an added `# noqa` line and an added `# type: ignore` line. The expected count is zero. The single `# nosec B404` comment from T009 is the one recorded exception, per NG-001.
+- [ ] T035 [P] Confirm the Five-Item Rule. Read every method in `tools/symbol_diff/comparator.py` and confirm 5 parameters, 5 blocks, and 25 lines at most. Confirm that the class holds at most 5 public methods.
+- [ ] T036 Comment on the four planned sweeps. Run `gh issue comment <number> --body-file <file>` for issues #1792, #1793, #1795, and #886. Name this procedure and name the tool command. Delete the body file after each command returns.
+- [ ] T037 Open the pull request against `main` from `chore/1796-sweep-safety`. Write `Closes #1796` in the body. Link `specs/1796-comment-sweep-safety/spec.md`. State the T033 count. Complete the checklist in `.github/PULL_REQUEST_TEMPLATE.md`. Add the `auto-merge` label only after every check passes, including CodeQL.
+
+---
+
+## Dependencies and Execution Order
+
+### Phase order
+
+| Phase | Content | Starts after |
+| - | - | - |
+| 1 | Setup and the reference case | Nothing |
+| 2 | Part A, the symbol table tool | Phase 1 |
+| 3 | Part B, the written procedure | Phase 2, because the procedure names the tool command |
+| 4 | Part C, the fast flag test | Phase 1. It runs in parallel with Phase 2 and Phase 3. |
+| 5 | Polish and final validation | Phase 3 and Phase 4 |
+
+### Why the tool lands before the procedure
+
+The procedure states the exact command for each check. The symbol table command does not exist until Part A lands. A procedure that names a command that nobody can run has no effect.
+
+### Why Part C runs in parallel
+
+The `--fast` flag test reads `MistHelper.py`. It does not read the new tool and it does not read the procedure. A contributor can build it at the same time as Part A.
+
+---
+
+## Parallel Opportunities
+
+| Phase | Parallel tasks | Reason |
+| - | - | - |
+| 2 and 4 | The whole of Phase 4 runs beside Phase 2 | The two parts touch different files. |
+| 5 | T033, T034, T035 | The three checks read different data. |
+
+---
+
+## Implementation Strategy
+
+### Minimum viable delivery
+
+Part C alone delivers real value. The `--fast` flag test catches the exact defect from issue #1796 at every later change, including a hand edit. It takes one small file.
+
+Part A and Part B together deliver the general protection. They catch a lost name that no test covers, which is the wider class of defect.
+
+### Order of risk
+
+The largest risk is a tool that reports a clean result on the defect it exists to catch. The declaration uses an annotated assignment, and a tool that matches `ast.Assign` alone misses it. Task T007 and task T015 control that risk, and task T013 proves the result against the real reference case.


### PR DESCRIPTION
## Summary

This pull request adds a complete SpecKit set for five open lint debt issues. Each set holds `spec.md`, `plan.md`, and `tasks.md`.

The work stops short of implementation. It touches no source file, no `pyproject.toml`, and no workflow file. Every change sits under `specs/`.

## What each specification covers

| Directory | Issue | Subject | Measured count |
| - | - | - | - |
| `specs/1792-unused-noqa-directives/` | #1792 | Unused `# noqa` directives. Only `tasks.md` is new. The other two files gained a correction. | 286 |
| `specs/1793-root-logger-calls/` | #1793 | Root logger calls that carry no module name | 4478 |
| `specs/1794-blind-except-handlers/` | #1794 | Blind `except Exception` handlers | 500 |
| `specs/1795-small-correctness-rules/` | #1795 | Six small correctness rule families | 146 |
| `specs/1796-comment-sweep-safety/` | #1796 | A safety procedure for any automated sweep | not applicable |

## Measured baseline

A maintainer measured every count on 2026-08-06 at commit `08a75d2` with ruff 0.16.0 and pylint 4.0.6.

| Rule | Tool | Issue states | Measured | Verdict |
| - | - | - | - | - |
| RUF100 under `--extend-select` | ruff | not measured | 286 | new value |
| RUF100 under `--select` | ruff | 231 | 320 | the count moved |
| LOG015 | ruff | 4478 | 4478 | correct |
| BLE001 default | ruff | 412 | 412 | correct |
| BLE001 with `--ignore-noqa` | ruff | 500 | 500 | correct |
| RUF012 | ruff | 60 | 60 | correct |
| DTZ005 | ruff | 56 | 56 | correct |
| ISC004 | ruff | 13 | 13 | correct |
| SIM103 | ruff | not named | 9 | new family |
| C408 | ruff | 3 | 3 | correct |
| W1514 | pylint | 5 | 5 | correct |

## Two corrections to the existing 1792 documents

### The baseline moved from 231 to 286 in one day

A maintainer measured 231 on 2026-08-05. The value reads 286 on 2026-08-06. Two commits landed in between. The documents now state that the value is not stable and that an implementer must measure it again.

### The prescribed repair command was unsafe

The earlier requirement FR-002 read `ruff check . --select RUF100 --fix`.

**Warning**: That command form deletes 34 live suppressions and breaks the lint gate.

Ruff decides that a directive is unused when the named code produces no result **in the current run**. The `--select RUF100` form turns off `E`, `F`, `W`, `I`, `UP`, `B`, and `G`. Ruff then reports every `# noqa: E501` and every `# noqa: E731` as unused, even where the directive hides a real result.

| Command | RUF100 results |
| - | - |
| `ruff check . --select RUF100` | 320 |
| `ruff check . --extend-select RUF100` | 286 |

A comparison of the two result sets shows that all 34 extra results name a code that the project selects. Four samples follow.

| Site | Named code |
| - | - |
| src/export/org_inventory_exporter.py line 246 | E501 |
| src/export/site_anomaly_exporter.py line 182 | E731 |
| tests/maps/test_viewer_callbacks_wave_a.py line 46 | E402 |
| starlink_dashboard.py line 98 | F401 |

The requirement now reads `ruff check . --extend-select RUF100 --fix`.

## One correction to issue #1795

Issue #1795 names five families. They are `RUF012`, `DTZ005`, `ISC004`, `W1514`, and `C408`. Their total reads 137, and that value is correct.

A later verification command replaced `W1514` with `SIM103`. That command reports 141 for a different family set.

The specification covers all six families and states 146 as the total. It records the correction in a named section, so that a reader who compares the two numbers finds the reason.

## The shared non-goal

Every one of the five specifications states that the work does **not** authorize a new lint suppression.

Each set also records the current ruff `select` list at `pyproject.toml` line 164.

```toml
select = ["E", "F", "W", "I", "UP", "B", "G"]
```

None of the rule families in these five issues sits inside that list. No gate reports them today.

## The dependency order

```mermaid
flowchart TD
    A["#1796 sweep safety procedure"] --> B["#1792 remove 286 unused directives"]
    B --> C["#1794 audit 500 blind handlers"]
    B --> D["#1795 DTZ005 family, 1 hidden site"]
    A --> E["#1793 rewrite 4478 logging calls"]
```

Issue #1792 must land before issue #1794. Ruff reports 412 blind handlers by default and 500 with `--ignore-noqa`. The 88-line difference holds a `# noqa: BLE001` directive **and** a real blind handler. Those directives turn live on the day the team selects `BLE001`. A team that starts from the 412 count leaves 88 sites unaudited, and the gate reports a clean state that is not true.

Issue #1796 should land before every sweep, because it defines the checks that would have caught the defect in pull request #1791.

## Writing quality

Every file follows the Simplified Technical English rules in `documentation/ASD-STE100_writing-guide.md`. The gate is 80.

| File | Score |
| - | - |
| specs/1792-unused-noqa-directives/spec.md | 97 |
| specs/1792-unused-noqa-directives/plan.md | 99 |
| specs/1792-unused-noqa-directives/tasks.md | 96 |
| specs/1793-root-logger-calls/spec.md | 97 |
| specs/1793-root-logger-calls/plan.md | 99 |
| specs/1793-root-logger-calls/tasks.md | 96 |
| specs/1794-blind-except-handlers/spec.md | 97 |
| specs/1794-blind-except-handlers/plan.md | 98 |
| specs/1794-blind-except-handlers/tasks.md | 96 |
| specs/1795-small-correctness-rules/spec.md | 97 |
| specs/1795-small-correctness-rules/plan.md | 98 |
| specs/1795-small-correctness-rules/tasks.md | 96 |
| specs/1796-comment-sweep-safety/spec.md | 97 |
| specs/1796-comment-sweep-safety/plan.md | 98 |
| specs/1796-comment-sweep-safety/tasks.md | 96 |

## Conformance checklist

- [x] Every change sits under `specs/`. No source file, no configuration file, and no workflow file changed.
- [x] Each set matches the reference format in `specs/1032-bandit-severity-gate/`. It uses FR-###, SC-###, NG-###, and T### numbering with the `- [ ] T001` checkbox form.
- [x] Every count in every file comes from a measurement on 2026-08-06 at commit `08a75d2`.
- [x] Every specification states a non-goal that forbids a new lint suppression.
- [x] Every specification records the current ruff `select` list and states that the family is not selected.
- [x] Every file scores 80 or above on the Simplified Technical English linter.
- [x] The pull request references each issue and closes none, because a specification does not resolve an issue.

## Testing

No test applies. The change adds documentation only and touches no executable line.

Refs #1792
Refs #1793
Refs #1794
Refs #1795
Refs #1796
