### PR TITLE
docs(specs): reconcile six verified pre-work tasks in wave-2 spec (#994)

### DIFF
--- a/specs/193-main-decomposition-wave-2/tasks.md
+++ b/specs/193-main-decomposition-wave-2/tasks.md
@@ -12,12 +12,12 @@
 **Goal**: Lock the wave scope and hard-gate behavior before any extraction work starts.
 **Independent Test**: Scope guard checklist exists and is acknowledged before Phase 1.
 
-- [ ] T000 [US1] Record explicit out-of-scope guard in `specs/193-main-decomposition-wave-2/checklists/scope-guard.md` confirming `GlobalImportManager` is excluded from this wave and must not be modified except import rewiring strictly required by moved classes
-- [ ] T000A [US1] Record hard-gate remediation policy in `specs/193-main-decomposition-wave-2/checklists/scope-guard.md`: any failed validation/parity/import/runtime check must be remediated in-phase and re-run to pass before signoff
-- [ ] T000B [US1] Create shared import-cycle gate test `tests/contract/test_import_graph.py` with assertions covering extracted module boundaries and one-way layering (`MistHelper.py` orchestrator -> `src/*` modules)
-- [ ] T000C [US1] Create shared runtime coupling gate harness `tests/integration/test_runtime_coupling.py` with phase-selectable fixtures/profiles (`phase_1` through `phase_9`)
-- [ ] T000D [US2] Create deterministic parity contract at `specs/193-main-decomposition-wave-2/contracts/parity-contract.md` defining baseline sources, normalization rules, comparison dimensions, and fail criteria
-- [ ] T000E [US2] Capture pre-refactor parity baseline artifacts for all targeted menu/API/backend paths in `specs/193-main-decomposition-wave-2/checklists/parity-baseline/`
+- [X] T000 [US1] Record explicit out-of-scope guard in `specs/193-main-decomposition-wave-2/checklists/scope-guard.md` confirming `GlobalImportManager` is excluded from this wave and must not be modified except import rewiring strictly required by moved classes
+- [X] T000A [US1] Record hard-gate remediation policy in `specs/193-main-decomposition-wave-2/checklists/scope-guard.md`: any failed validation/parity/import/runtime check must be remediated in-phase and re-run to pass before signoff
+- [X] T000B [US1] Create shared import-cycle gate test `tests/contract/test_import_graph.py` with assertions covering extracted module boundaries and one-way layering (`MistHelper.py` orchestrator -> `src/*` modules)
+- [X] T000C [US1] Create shared runtime coupling gate harness `tests/integration/test_runtime_coupling.py` with phase-selectable fixtures/profiles (`phase_1` through `phase_9`)
+- [X] T000D [US2] Create deterministic parity contract at `specs/193-main-decomposition-wave-2/contracts/parity-contract.md` defining baseline sources, normalization rules, comparison dimensions, and fail criteria
+- [X] T000E [US2] Capture pre-refactor parity baseline artifacts for all targeted menu/API/backend paths in `specs/193-main-decomposition-wave-2/checklists/parity-baseline/`
 ---
 
 ## Format: `[ID] [P?] [Story] Description`


### PR DESCRIPTION
## Summary

Spec `193-main-decomposition-wave-2` reported 104 of 111 tasks complete. Six of the seven
outstanding tasks describe artifacts that already exist and already pass. The decomposition
work landed through the phase PRs, and the pre-work task rows were never reconciled.

This PR ticks those six rows. It changes no code.

Closes #994

## Verification

Each task was measured against the working tree before the checkbox moved.

| Task | Requires | Found | Result |
| - | - | - | - |
| T000 | `GlobalImportManager` exclusion recorded in `checklists/scope-guard.md` | present | PASS |
| T000A | hard-gate remediation policy in the same file | present | PASS |
| T000B | `tests/contract/test_import_graph.py` | exists, passes | PASS |
| T000C | `tests/integration/test_runtime_coupling.py` | exists, passes | PASS |
| T000D | `contracts/parity-contract.md` | exists, 63 lines | PASS |
| T000E | parity baseline evidence | 9 phases covered | PASS |

The two harnesses were run together:

```
python -m pytest tests/contract/test_import_graph.py tests/integration/test_runtime_coupling.py -q
15 passed in 0.85s
```

T000E evidence sits in `checklists/phase-N-menu-parity.md` and
`checklists/phase-N-output-parity.md` for phases 1 through 9, next to nine
`phase-N-gate.md` records. The scaffold README suggested a `parity-baseline/` naming
instead. The evidence is present for every phase, so the task intent is met. The naming
difference is recorded in the commit message rather than resolved by moving files, because
moving them would break the links already written into the phase gate records.

## What stays open

`T004B` remains unticked. It is the container deployment ceremony: commit, push, wait for CI,
pull the image, restart the container, verify at runtime. That needs a Podman host and cannot
be completed by editing a spec. The spec now reads 110 of 111.

## Risk

None to runtime behavior. The diff is six characters of Markdown checkbox state in one spec
file. No source file, test, workflow, or configuration file is touched.

## Conformance

- [x] Linked to the tracking issue
- [x] Every ticked task verified by measurement, not assumption
- [x] No secrets added
- [x] No code paths changed
