### PR TITLE
test(ste): stop the word-counter property tests flaking (#1803)

### DIFF
--- a/specs/1803-flaky-wordcount-property/spec.md
+++ b/specs/1803-flaky-wordcount-property/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: Stop the Word-Counter Property Tests Flaking
+
+**Issue**: #1803
+**Status**: In progress
+
+## Problem
+
+`tests/unit/ste_linter/test_properties.py::test_count_matches_plain_word_count` failed once in a
+full `pytest tests/unit` run, then passed on every attempt to reproduce it.
+
+| Attempt | Result |
+| - | - |
+| Full suite | failed |
+| Test alone | passed in 8.26s |
+| Test alone, `-p no:randomly` | passed in 32.78s |
+| Full suite, later run | passed, 9191 tests |
+
+A test that fails roughly half the time for reasons unrelated to the change under test blocks
+unrelated pull requests and trains reviewers to re-run until green. That habit hides real
+regressions.
+
+## Three candidate causes, all disproven
+
+The fix below is deliberately narrow, because the obvious explanations do not survive
+measurement. Recording them here so nobody spends the time again.
+
+**Hypothesis constants injection.** The theory was that Hypothesis 6.161 injects string
+constants harvested from the codebase into `from_regex`, producing a "word" holding a space.
+A probe generated 3000 example lists and checked every word against `^[a-z]{1,10}$`, then checked
+that `" ".join(words).split()` returns `len(words)`. Both counts were zero. The strategy does not
+escape its alphabet.
+
+**A counting defect in `WordCounter`.** Reading `tools/ste_linter/parsing/wordcount.py`, no path
+can alter the tally for this input. `_QUOTED_SPAN` needs a quote character, `_merge_number_units`
+fires only when `_NUMBER` matches and that pattern is `^[+-]?\d+(?:[.,]\d+)?%?$`, and `_is_word`
+returns true for any token holding an alphanumeric character. The property holds by construction.
+
+**State mutation by another test.** A search across `tests/` for anything touching `wordcount`,
+`WordCounter`, `_UNITS`, `_NUMBER`, or `_QUOTED_SPAN` found only `test_parsing.py` and this file.
+Neither patches module state.
+
+## The remaining mechanism
+
+Hypothesis reports a per-example deadline breach as a test failure, and the default deadline is
+200 milliseconds. A full suite runs under memory and CPU pressure that an isolated run does not
+have. That is the only mechanism found that is consistent with "fails in the full suite, never
+alone."
+
+This was not reproduced directly, because `WordCounter.count` completes well inside 1 millisecond
+on this input. The fix is applied on the strength of the symptom matching, not a captured repro,
+and this spec says so plainly.
+
+## Requirements
+
+- **FR-001**: Remove the per-example deadline from both property tests in the file.
+- **FR-002**: Leave both assertions unchanged, so a real counting defect still fails the build.
+- **FR-003**: Record the disproven theories where the next reader will find them.
+
+## Non-goals
+
+- **NG-001**: Do not weaken the strategies. The alphabet and sizes are correct.
+- **NG-002**: Do not change `WordCounter`. It is not at fault.
+- **NG-003**: Do not disable the tests or mark them `xfail`.
+
+## Success criteria
+
+- **SC-001**: Both properties still assert exactly what they asserted before.
+- **SC-002**: The STE linter test directory passes.
+- **SC-003**: The full unit suite passes.
+- **SC-004**: ruff and black pass on the changed file.

--- a/specs/1803-flaky-wordcount-property/tasks.md
+++ b/specs/1803-flaky-wordcount-property/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Stop the Word-Counter Property Tests Flaking
+
+**Spec**: `specs/1803-flaky-wordcount-property/spec.md`
+**Issue**: #1803
+
+## Phase 1: Root cause
+
+- [X] T001 Probe whether the `from_regex` strategy escapes `[a-z]{1,10}`. It does not.
+- [X] T002 Probe whether the space-join splits back to `len(words)`. It does.
+- [X] T003 Read `WordCounter.count` and confirm no path alters the tally. Confirmed.
+- [X] T004 Search the test tree for anything mutating the wordcount module. Nothing found.
+- [X] T005 Identify the remaining mechanism: the Hypothesis per-example deadline.
+
+## Phase 2: Fix
+
+- [X] T006 Add a shared `settings(deadline=None)` and apply it to both properties.
+- [X] T007 Comment the reason inline, naming the issue.
+
+## Phase 3: Verification
+
+- [X] T008 Confirm both assertions are unchanged.
+- [X] T009 Run the STE linter test directory.
+- [X] T010 Run ruff and black on the changed file.
+- [X] T011 Run the full unit suite.

--- a/tests/unit/ste_linter/test_properties.py
+++ b/tests/unit/ste_linter/test_properties.py
@@ -6,7 +6,7 @@ import pytest  # Skips the module when Hypothesis is not installed.
 
 pytest.importorskip("hypothesis")  # Skip these tests when Hypothesis is absent.
 
-from hypothesis import given  # noqa: E402  The decorator that drives the property tests.
+from hypothesis import given, settings  # noqa: E402  The decorator that drives the property tests.
 from hypothesis import strategies as st  # noqa: E402  Builds the input strategies.
 
 from tools.ste_linter.parsing.wordcount import WordCounter  # noqa: E402  The counter under test.
@@ -14,7 +14,16 @@ from tools.ste_linter.parsing.wordcount import WordCounter  # noqa: E402  The co
 # A strategy that builds a simple lower-case word with no special characters.
 _WORD = st.from_regex(r"[a-z]{1,10}", fullmatch=True)
 
+# Issue #1803: these properties failed once in a full-suite run and never in
+# isolation. Hypothesis reports a per-example deadline breach as a test
+# failure, and a full suite runs under memory and CPU pressure that an
+# isolated run does not have. Disabling the deadline removes the only
+# mechanism consistent with that symptom. The assertions themselves are
+# unchanged, so a real counting defect still fails the build.
+_NO_DEADLINE = settings(deadline=None)
 
+
+@_NO_DEADLINE
 @given(words=st.lists(_WORD, min_size=1, max_size=20))
 def test_count_matches_plain_word_count(words: list[str]) -> None:
     """A run of plain words counts to the number of words."""
@@ -22,6 +31,7 @@ def test_count_matches_plain_word_count(words: list[str]) -> None:
     assert WordCounter().count(text) == len(words)  # Each plain word counts once.
 
 
+@_NO_DEADLINE
 @given(text=st.text(alphabet="abcdefghij ", min_size=1, max_size=50))
 def test_count_is_never_negative(text: str) -> None:
     """The word count is never negative."""


### PR DESCRIPTION
## Summary

`test_count_matches_plain_word_count` failed once in a full `pytest tests/unit` run and passed
on every attempt to reproduce it. This removes the per-example deadline from both properties in
the file.

Closes #1803

## Three candidate causes, all disproven

The fix is deliberately narrow, because the obvious explanations do not survive measurement.
Recording them so nobody spends the time again.

**Hypothesis constants injection.** The theory was that Hypothesis 6.161 injects string constants
harvested from the codebase into `from_regex`, producing a "word" holding a space. A probe
generated 3000 example lists and checked every word against `^[a-z]{1,10}$`, then checked that
`" ".join(words).split()` returns `len(words)`:

```
generated words violating [a-z]{1,10}: 0
join/split mismatches: 0
```

**A counting defect in `WordCounter`.** No path in `count()` can alter the tally for this input.
`_QUOTED_SPAN` needs a quote character. `_merge_number_units` fires only when `_NUMBER` matches,
and that pattern is `^[+-]?\d+(?:[.,]\d+)?%?$`, which no lowercase word can satisfy. `_is_word`
returns true for any token holding an alphanumeric character. The property holds by construction.

**State mutation by another test.** A search across `tests/` for anything touching `wordcount`,
`WordCounter`, `_UNITS`, `_NUMBER`, or `_QUOTED_SPAN` found only `test_parsing.py` and this file.
Neither patches module state.

## What is left

Hypothesis reports a per-example deadline breach as a test failure, and the default is 200ms. A
full suite runs under memory and CPU pressure an isolated run does not have. That is the only
mechanism found consistent with "fails in the full suite, never alone."

I want to be straight about the limit of this evidence: **the deadline breach was not captured
directly.** `WordCounter.count` completes well inside 1ms on this input, so a tight-deadline
reproduction passed too. The fix rests on symptom matching, not a captured repro. The spec says
so plainly rather than implying a confirmed root cause.

If it flakes again after this, the next step is `--hypothesis-seed` capture in CI, not another
guess.

## What changed

A shared `settings(deadline=None)` applied to both properties. **Neither assertion changes**, so
a real counting defect still fails the build. The strategies are untouched, because the alphabet
and sizes are correct.

## Verification

| Gate | Result |
| - | - |
| ruff | All checks passed |
| black | 1 file left unchanged |
| pytest, STE linter directory | 91 passed |
| pytest, full unit suite | **9191 passed** |

## Conformance

- [x] Linked to the tracking issue
- [x] Root-cause candidates measured, not assumed
- [x] Assertions unchanged
- [x] No test disabled or marked xfail
- [x] Full unit suite green
