### PR TITLE
refactor(main): clear four length findings in MistHelper.py (#1009)

### DIFF
--- a/MistHelper.py
+++ b/MistHelper.py
@@ -4954,6 +4954,11 @@ def _add_output_format_arguments(parser: argparse.ArgumentParser) -> None:
             "Output format: 'csv' for CSV files (default) or 'sqlite' for hybrid database with natural primary keys"
         ),  # Output backend selector
     )
+    _add_systematic_test_flags(parser)  # The two --test variants share one concern.
+
+
+def _add_systematic_test_flags(parser: argparse.ArgumentParser) -> None:
+    """Register the systematic-test flags that drive the automated menu sweeps."""
     parser.add_argument(
         "--test",
         action="store_true",
@@ -4975,6 +4980,12 @@ def _add_output_format_arguments(parser: argparse.ArgumentParser) -> None:
 def _add_safety_arguments(parser: argparse.ArgumentParser) -> None:
     """Register the dry-run/address-check/SSL/no-env safety flags on the parser."""
     logging.debug("_add_safety_arguments: registering safety and validation flags")  # Log before adding
+    _add_destructive_safety_flags(parser)  # Flags that change what a destructive run does.
+    _add_external_call_flags(parser)  # Flags that change how outbound calls behave.
+
+
+def _add_destructive_safety_flags(parser: argparse.ArgumentParser) -> None:
+    """Register the flags that govern destructive and address-checking behavior."""
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -4989,6 +5000,10 @@ def _add_safety_arguments(parser: argparse.ArgumentParser) -> None:
             "Enable external address validation using Nominatim API for address comparison operations"
         ),  # Nominatim toggle
     )
+
+
+def _add_external_call_flags(parser: argparse.ArgumentParser) -> None:
+    """Register the flags that govern SSL verification and .env loading."""
     parser.add_argument(
         "--skip-ssl-verify",
         action="store_true",
@@ -5008,6 +5023,12 @@ def _add_safety_arguments(parser: argparse.ArgumentParser) -> None:
 def _add_interface_arguments(parser: argparse.ArgumentParser) -> None:
     """Register the TUI/login/web-portal/standalone interface flags on the parser."""
     logging.debug("_add_interface_arguments: registering interface and auth flags")  # Log before adding
+    _add_interface_mode_flags(parser)  # Flags that choose which front end runs.
+    _add_auth_and_backend_flags(parser)  # Flags that choose the auth path and the storage backend.
+
+
+def _add_interface_mode_flags(parser: argparse.ArgumentParser) -> None:
+    """Register the flags that select an alternative front end."""
     parser.add_argument(
         "--tui",
         action="store_true",
@@ -5016,18 +5037,22 @@ def _add_interface_arguments(parser: argparse.ArgumentParser) -> None:
         ),  # Rich TUI mode
     )
     parser.add_argument(
-        "--login",
-        action="store_true",
-        help=(
-            "Use interactive login (email/password) instead of API token - enables MSP-level API access"
-        ),  # Interactive auth
-    )
-    parser.add_argument(
         "--web-portal",
         action="store_true",
         help=(
             "Launch the web portal interface on port 8055 (or WEB_PORT env var) instead of the CLI menu"
         ),  # Gunicorn web portal
+    )
+
+
+def _add_auth_and_backend_flags(parser: argparse.ArgumentParser) -> None:
+    """Register the flags that select the authentication path and the storage backend."""
+    parser.add_argument(
+        "--login",
+        action="store_true",
+        help=(
+            "Use interactive login (email/password) instead of API token - enables MSP-level API access"
+        ),  # Interactive auth
     )
     parser.add_argument(
         "--standalone",
@@ -5071,15 +5096,24 @@ def _reject_unsupported_flag_variants(argv: list[str]) -> None:
     for token in argv:  # Scan every raw token in argv. Order-independent match.
         head = token.split("=", 1)[0]  # Strip any `=value` suffix so `--flag=1` is comparable.
         if head in _UNSUPPORTED_FLAG_VARIANTS:  # Only gate the explicitly-listed bad spellings.
-            supported = _UNSUPPORTED_FLAG_VARIANTS[head]  # Look up the canonical replacement.
-            message = (
-                f"error: unsupported flag '{head}'. "
-                f"Did you mean '{supported}'? "
-                "This CLI uses collapsed flag names without internal hyphens."
-            )
-            logging.error("Rejecting unsupported flag variant %r; suggest %r", head, supported)
-            print(message, file=sys.stderr)  # Surface guidance directly to the user.
-            sys.exit(2)  # argparse convention for CLI usage errors.
+            _exit_on_unsupported_flag(head, _UNSUPPORTED_FLAG_VARIANTS[head])  # Names the canonical flag.
+
+
+def _exit_on_unsupported_flag(head: str, supported: str) -> NoReturn:
+    """Report an unsupported flag spelling and exit with the argparse usage code.
+
+    Why:
+        Split from the scan loop so the caller stays inside the length budget.
+        The message must never reroute the user silently, per issue #1640.
+    """
+    message = (
+        f"error: unsupported flag '{head}'. "
+        f"Did you mean '{supported}'? "
+        "This CLI uses collapsed flag names without internal hyphens."
+    )
+    logging.error("Rejecting unsupported flag variant %r; suggest %r", head, supported)
+    print(message, file=sys.stderr)  # Surface guidance directly to the user.
+    sys.exit(2)  # argparse convention for CLI usage errors.
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:

--- a/specs/1009-misthelper-findings/spec.md
+++ b/specs/1009-misthelper-findings/spec.md
@@ -1,0 +1,51 @@
+# Feature Specification: Clear the Length Findings in MistHelper.py
+
+**Issue**: #1009
+**Status**: In progress
+
+## Problem
+
+`MistHelper.py` scored 77.0, grade C+, with 10 findings. Nine were `STRUCT-LENGTH`, each a
+function sitting one to six lines over the 25-line limit. The tenth is `CONV-COMMENTS`, a
+whole-file coverage measure.
+
+This issue previously asked to extract "the final 15 candidates" so the analyzer report reduces
+to just `menu_actions` and `GlobalImportManager`. That end state is not reachable by that work,
+because the file holds 148 module-level functions. The audit on the issue records the arithmetic.
+
+This spec takes the reachable goal instead: clear the findings.
+
+## Requirements
+
+- **FR-001**: Reduce each targeted function to 25 lines or fewer.
+- **FR-002**: Split by concern, so each new helper has a name that states what it registers.
+- **FR-003**: Preserve behavior exactly, including flag names, defaults, and help text.
+- **FR-004**: Keep `MistHelper.py --help` working, which proves the parser still builds.
+
+## Non-goals
+
+- **NG-001**: Do not attempt the `CONV-COMMENTS` finding. It is a whole-file measure needing its
+  own mechanical pass.
+- **NG-002**: Do not extract functions out of `MistHelper.py`. The file holding 148 functions is
+  not itself the defect. The findings are.
+- **NG-003**: Do not change any flag spelling or default. The parser surface is a contract.
+
+## Scope delivered in this pass
+
+| Function | Before | Action |
+| - | - | - |
+| `_add_safety_arguments` | 31 lines | split into destructive-safety and external-call flags |
+| `_add_interface_arguments` | 29 lines | split into interface-mode and auth/backend flags |
+| `_add_output_format_arguments` | 27 lines | split out the systematic-test flags |
+| `_reject_unsupported_flag_variants` | 31 lines | extracted the report-and-exit body |
+
+Five length findings remain, listed on the issue. They sit in the session and login paths rather
+than the argument parser, so they carry more behavioral risk and deserve their own pass.
+
+## Success criteria
+
+- **SC-001**: The compliance score rises above 77.0.
+- **SC-002**: The four targeted functions no longer appear in the report.
+- **SC-003**: Every quality gate passes: ruff, black, mypy.
+- **SC-004**: `MistHelper.py --help` still prints usage.
+- **SC-005**: The full unit and tools suites pass.

--- a/specs/1009-misthelper-findings/tasks.md
+++ b/specs/1009-misthelper-findings/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Clear the Length Findings in MistHelper.py
+
+**Spec**: `specs/1009-misthelper-findings/spec.md`
+**Issue**: #1009
+
+## Phase 1: Baseline
+
+- [X] T001 Record the score, grade, and the ten findings before the change.
+
+## Phase 2: Argument-parser helpers
+
+- [X] T002 Split `_add_safety_arguments` into destructive-safety and external-call flags.
+- [X] T003 Split `_add_interface_arguments` into interface-mode and auth/backend flags.
+- [X] T004 Split the systematic-test flags out of `_add_output_format_arguments`.
+
+## Phase 3: Flag validation
+
+- [X] T005 Extract the report-and-exit body of `_reject_unsupported_flag_variants`.
+
+## Phase 4: Verification
+
+- [X] T006 Confirm the four targeted functions left the report.
+- [X] T007 Confirm the score rose above 77.0.
+- [X] T008 Run ruff, black, and mypy.
+- [X] T009 Confirm `MistHelper.py --help` still prints usage.
+- [X] T010 Run the full unit and tools suites.


### PR DESCRIPTION
## Summary

`MistHelper.py` scored 77.0 at grade C+ with ten findings, nine of them `STRUCT-LENGTH`
functions sitting one to six lines over the 25-line limit. This clears the four in the
argument-parsing path.

Refs #1009

## Measured before and after

| Metric | Before | After |
| - | - | - |
| Score | 77.0 (C+) | **82.0 (B-)** |
| Findings | 10 | 6 |

## What changed

| Function | Before | Now |
| - | - | - |
| `_add_safety_arguments` | 31 lines, four flags, two jobs | delegates to `_add_destructive_safety_flags` and `_add_external_call_flags` |
| `_add_interface_arguments` | 29 lines | delegates to `_add_interface_mode_flags` and `_add_auth_and_backend_flags` |
| `_add_output_format_arguments` | 27 lines | systematic-test flags moved to `_add_systematic_test_flags` |
| `_reject_unsupported_flag_variants` | 31 lines | report-and-exit body moved to `_exit_on_unsupported_flag` |

The splits follow the concerns rather than the line count. `--dry-run` and `--address-check`
change what a destructive run does; `--skip-ssl-verify` and `--no-env` change how outbound calls
behave. `--tui` and `--web-portal` pick a front end; `--login` and `--standalone` pick an auth
path and a backend.

`_reject_unsupported_flag_variants` is worth a note: 19 of its 31 lines are a docstring that
earns its length by recording the #1640 requirement never to reroute a user silently. I did not
shorten it. Extracting the body was the right lever.

## Why I stopped at four

Five `STRUCT-LENGTH` findings remain, in the session and login paths:
`_get_latest_pypi_version`, `_attempt_interactive_login_with_rollback`, `_select_msp_and_org`,
`_check_token_rate_limit`, and `_install_default_request_timeout`.

Those carry real behavioral risk — token handling, MSP selection, and interactive login with
rollback — unlike the parser, which is declarative. They deserve their own pass with their own
review, not a tail-end addition to this diff.

The `CONV-COMMENTS` finding is a whole-file coverage measure at 79.3 percent and is recorded as
NG-001.

## Verification

| Gate | Result |
| - | - |
| ruff | All checks passed |
| black | 1 file left unchanged |
| mypy | no issues in 341 source files |
| `MistHelper.py --help` | prints usage, so the parser still builds |
| pytest, flag and argument subset | 524 passed |
| pytest, unit and tools | **9262 passed** |

Behavior is unchanged. Every flag name, default, and help string is preserved verbatim.

## Conformance

- [x] Linked to the tracking issue
- [x] Success criteria measured, not assumed
- [x] Parser surface unchanged, proven by `--help`
- [x] Inline comments state why, not what
- [x] Full suite green
