### PR TITLE
fix(db): route polyglot writes by host reachability, not by the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,28 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 - **Tests (Added)**: `TestRouterReprobe` and `TestRouterCloseRedisJson` in
   `tests/unit/test_router.py`. All seven new cases fail against the pre-fix
   router.
+### Route polyglot writes by host reachability, not by the container boundary (issue #1824)
+
+- **Fixed**: `DataExporter._is_standalone_mode` returned true whenever
+  MistHelper ran outside a container. Every ArangoDB and Redis write was
+  dropped on a workstation. `DatabaseRouter._csv_fallback` answered
+  `success=True`, so the loss left no trace in the log.
+- **Changed**: the decision now follows a TCP reachability probe against the
+  configured `ARANGO_HOST` and `REDIS_HOST`. MistHelper writes to the polyglot
+  backend whenever one of the two answers, inside or outside a container.
+- **Added**: `src.db.polyglot_hosts_unreachable` runs the probe and records
+  both verdicts through the `polyglot_host_probe` structured log event. The
+  probe uses a TCP connect, not a DNS lookup, because a hostname can resolve
+  while no service listens. The timeout is 0.5 seconds for each host.
+- **Added**: `DataExporter._standalone_probe` caches the verdict for the life
+  of the process, so an export pays the probe cost one time.
+- **Added**: one `WARNING` at the fallback point names the dropped polyglot
+  write and the two environment variables that fix it.
+- **Unchanged**: `MISTHELPER_STANDALONE` still forces the mode. The
+  `--standalone` flag still sets that variable.
+- **Tests (Added)**: `TestPolyglotHostProbe` in `tests/unit/test_standalone.py`
+  and the rewritten `TestIsStandaloneMode` in
+  `tests/unit/export/test_data_exporter.py`.
 
 ### Add five organization-scoped search operations, menus 230 to 234 (issues #1386, #1385, #1383, #1382, #1379)
 

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -14,6 +14,12 @@ from urllib.parse import urlparse
 
 import structlog
 
+ARANGO_DEFAULT_URL = "http://arangodb:8529"  # Compose service URL used when ARANGO_HOST is unset.
+ARANGO_DEFAULT_PORT = 8529  # Port applied when ARANGO_HOST carries no explicit port.
+REDIS_DEFAULT_HOST = "redis-stack"  # Compose service name used when REDIS_HOST is unset.
+REDIS_DEFAULT_PORT = 6379  # Port applied when REDIS_PORT is unset or unreadable.
+PROBE_TIMEOUT_SECONDS = 0.5  # Short TCP budget so a dead host never stalls an export.
+
 
 def configure_db_logging() -> None:
     """Configure structlog for the db package: JSON, ASCII-only, stdlib."""
@@ -58,9 +64,9 @@ class DatabaseConfig:
         preventing noisy retry loops when running outside a container.
         """
         explicit_standalone = os.environ.get("MISTHELPER_STANDALONE", "").lower() == "true"
-        arango_host = os.environ.get("ARANGO_HOST", "http://arangodb:8529")
-        redis_host = os.environ.get("REDIS_HOST", "redis-stack")
-        redis_port = int(os.environ.get("REDIS_PORT", "6379"))
+        arango_host = os.environ.get("ARANGO_HOST", ARANGO_DEFAULT_URL)
+        redis_host = os.environ.get("REDIS_HOST", REDIS_DEFAULT_HOST)
+        redis_port = _env_int("REDIS_PORT", REDIS_DEFAULT_PORT)
 
         standalone = explicit_standalone or _hosts_unreachable(arango_host, redis_host)
 
@@ -106,6 +112,47 @@ def _can_resolve(hostname: str) -> bool:
         return True
     except socket.gaierror:
         return False
+
+
+def _env_int(name: str, default: int) -> int:
+    """Return an integer environment variable, or the default when the value is absent or unreadable."""
+    raw = os.environ.get(name, "")  # Read the raw value so an empty string keeps the default.
+    try:
+        return int(raw)  # Convert the operator supplied value.
+    except ValueError:
+        return default  # An unreadable port must not stop an export.
+
+
+def _can_connect(hostname: str, port: int) -> bool:
+    """Return True when a TCP connect to the host and port succeeds inside the probe timeout."""
+    try:
+        with socket.create_connection((hostname, port), timeout=PROBE_TIMEOUT_SECONDS):  # Open and close one socket.
+            return True  # A service listens on that address.
+    except OSError:
+        return False  # A refused, filtered, or unresolvable address counts as silent.
+
+
+def polyglot_hosts_unreachable() -> bool:
+    """Return True when neither ArangoDB nor Redis answers a TCP connect.
+
+    The probe reads the same environment variables as ``DatabaseConfig.from_env``.
+    It opens a TCP connection because a hostname can resolve while no service listens.
+    A caller must cache the answer, because each call costs up to two timeouts.
+    """
+    log = structlog.get_logger(__name__)  # Bind the package logger for the probe record.
+    arango_url = os.environ.get("ARANGO_HOST", ARANGO_DEFAULT_URL)  # Read the configured ArangoDB URL.
+    redis_host = os.environ.get("REDIS_HOST", REDIS_DEFAULT_HOST)  # Read the configured Redis host.
+    parsed = urlparse(arango_url)  # Split the URL so the probe gets a host and a port.
+    arango_ok = _can_connect(parsed.hostname or "arangodb", parsed.port or ARANGO_DEFAULT_PORT)  # Probe ArangoDB.
+    redis_ok = _can_connect(redis_host, _env_int("REDIS_PORT", REDIS_DEFAULT_PORT))  # Probe Redis.
+    log.info(
+        "polyglot_host_probe",
+        arango_host=parsed.hostname,
+        arango_reachable=arango_ok,
+        redis_host=redis_host,
+        redis_reachable=redis_ok,
+    )  # Record both verdicts so a dropped write is traceable.
+    return not arango_ok and not redis_ok  # Only total silence makes the polyglot backend unusable.
 
 
 @dataclass

--- a/src/export/data_exporter.py
+++ b/src/export/data_exporter.py
@@ -17,18 +17,18 @@ from src.data.data_processing_utils import DataProcessingUtils
 from src.dataclasses.export_backend_options import ExportBackendOptions
 from src.refactors.endpoint_primary_key_strategies import ENDPOINT_PRIMARY_KEY_STRATEGIES
 from src.refactors.sqlite_database_writer import SQLiteDatabaseWriter
-from src.utils.environment_utils import EnvironmentUtils
 
 # Optional polyglot DB layer — mirror MistHelper's try/except so the exporter
 # still works when the optional dependency is missing.
 try:  # pragma: no cover - import guard mirrors MistHelper
-    from src.db import DatabaseConfig, configure_db_logging
+    from src.db import DatabaseConfig, configure_db_logging, polyglot_hosts_unreachable
     from src.db.router import DatabaseRouter
 
     DB_LAYER_AVAILABLE = True
 except Exception:  # pragma: no cover - graceful degradation when DB layer missing
     DatabaseConfig = None  # type: ignore[assignment, misc]
     configure_db_logging = None  # type: ignore[assignment]
+    polyglot_hosts_unreachable = None  # type: ignore[assignment]
     DatabaseRouter = None  # type: ignore[assignment, misc]
     DB_LAYER_AVAILABLE = False
 
@@ -129,21 +129,52 @@ class DataExporter:  # Multi-backend export facade.
         return csv_ok  # Return the primary result
 
     _standalone_logged = False  # One-shot standalone log guard.
+    _standalone_probe: bool | None = None  # Cached polyglot reachability verdict for the life of the process.
 
     @staticmethod
-    def _is_standalone_mode() -> bool:  # Detect non-container standalone.
-        """Auto-detect standalone mode: skip polyglot when not in a container."""
+    def _standalone_override() -> bool | None:
+        """Return the forced verdict from MISTHELPER_STANDALONE, or None when the operator set no override."""
         standalone_env = os.getenv("MISTHELPER_STANDALONE", "").lower()  # Read the override env.
         if standalone_env == "true":  # Explicit standalone request.
             return True  # Forced standalone.
         if standalone_env == "false":  # Forced non-standalone.
             return False  # Not standalone.
-        if not EnvironmentUtils.is_running_in_container():  # Auto-detect when not in container.
-            if not DataExporter._standalone_logged:  # Log once.
-                logging.info("Standalone mode auto-detected (not in container), skipping polyglot database")
-                DataExporter._standalone_logged = True  # Latch the one-shot log.
-            return True  # Standalone outside a container.
-        return False  # Containerized: not standalone.
+        return None  # No override, so the caller must probe the hosts.
+
+    @classmethod
+    def _polyglot_hosts_silent(cls) -> bool:
+        """Return True when no configured polyglot host answers. The probe runs one time for each process."""
+        if cls._standalone_probe is not None:  # A prior call already paid the probe cost.
+            return cls._standalone_probe
+        if not DataExporter._polyglot_db_layer_available():  # No DB layer means no host to probe.
+            cls._standalone_probe = True  # Cache the verdict so the check stays cheap.
+            return True
+        logging.debug("Probing the polyglot database hosts")  # Log before the network probe.
+        assert polyglot_hosts_unreachable is not None  # nosec B101 - _polyglot_db_layer_available proved the import.
+        cls._standalone_probe = polyglot_hosts_unreachable()  # Ask the db package for one TCP verdict.
+        logging.debug("Polyglot host probe: unreachable=%s", cls._standalone_probe)  # Log the verdict.
+        return cls._standalone_probe
+
+    @classmethod
+    def _is_standalone_mode(cls) -> bool:  # Decide whether the polyglot write must be skipped.
+        """Return True when MistHelper must write CSV and SQLite only.
+
+        The decision follows the reachability of the configured hosts, not the
+        container boundary. A workstation that reaches ArangoDB and Redis writes
+        to them.
+        """
+        override = cls._standalone_override()  # Honor an explicit operator decision first.
+        if override is not None:  # The operator named the mode.
+            return override
+        if not cls._polyglot_hosts_silent():  # At least one backend answers.
+            return False  # Run the polyglot write, inside or outside a container.
+        if not cls._standalone_logged:  # Emit the degraded-mode warning one time.
+            logging.warning(
+                "Polyglot database hosts do not answer. MistHelper writes CSV and SQLite only. "
+                "Set ARANGO_HOST and REDIS_HOST to reach the databases."
+            )  # Make the dropped polyglot write visible in the log.
+            cls._standalone_logged = True  # Latch the one-shot warning.
+        return True  # No backend answers, so stay in CSV and SQLite mode.
 
     @staticmethod
     def _should_skip_polyglot(api_function_name: str | None) -> bool:

--- a/tests/unit/export/test_data_exporter.py
+++ b/tests/unit/export/test_data_exporter.py
@@ -14,6 +14,7 @@ Why:
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 import types
 from unittest.mock import MagicMock, mock_open, patch
@@ -31,18 +32,20 @@ def _reset_class_state():
 
     Why:
         The DataExporter class caches ``_router``, ``_router_initialized``,
-        ``_last_snapshot_times``, and ``_standalone_logged`` at class scope.
-        Without a reset, ordering-sensitive tests would leak state.
+        ``_last_snapshot_times``, ``_standalone_logged``, and ``_standalone_probe``
+        at class scope. Without a reset, ordering-sensitive tests would leak state.
     """
     DataExporter._router = None
     DataExporter._router_initialized = False
     DataExporter._last_snapshot_times = {}
     DataExporter._standalone_logged = False
+    DataExporter._standalone_probe = None
     yield
     DataExporter._router = None
     DataExporter._router_initialized = False
     DataExporter._last_snapshot_times = {}
     DataExporter._standalone_logged = False
+    DataExporter._standalone_probe = None
 
 
 @pytest.fixture
@@ -238,24 +241,51 @@ class TestIsStandaloneMode:
         monkeypatch.setenv("MISTHELPER_STANDALONE", "false")
         assert DataExporter._is_standalone_mode() is False
 
-    def test_autodetect_not_in_container_logs_once(self, monkeypatch):
+    def test_silent_hosts_warn_once(self, monkeypatch, caplog):
+        """Issue #1824: an unreachable pair must warn one time, not drop the write in silence."""
         monkeypatch.delenv("MISTHELPER_STANDALONE", raising=False)
-        with patch(
-            "src.export.data_exporter.EnvironmentUtils.is_running_in_container",
-            return_value=False,
+        with (
+            patch.object(DataExporter, "_polyglot_db_layer_available", return_value=True),
+            patch("src.export.data_exporter.polyglot_hosts_unreachable", return_value=True) as probe,
+            caplog.at_level(logging.WARNING),
         ):
             assert DataExporter._is_standalone_mode() is True
             assert DataExporter._standalone_logged is True
-            # Second call reuses the latched log guard.
             assert DataExporter._is_standalone_mode() is True
+            probe.assert_called_once()  # The verdict is cached for the life of the process.
+        assert sum("do not answer" in record.message for record in caplog.records) == 1
 
-    def test_autodetect_in_container_returns_false(self, monkeypatch):
+    def test_reachable_hosts_outside_container_keep_polyglot(self, monkeypatch):
+        """Issue #1824: a workstation that reaches the databases must still write to them."""
         monkeypatch.delenv("MISTHELPER_STANDALONE", raising=False)
-        with patch(
-            "src.export.data_exporter.EnvironmentUtils.is_running_in_container",
-            return_value=True,
+        with (
+            patch.object(DataExporter, "_polyglot_db_layer_available", return_value=True),
+            patch("src.export.data_exporter.polyglot_hosts_unreachable", return_value=False),
+            patch(
+                "src.utils.environment_utils.EnvironmentUtils.is_running_in_container",
+                return_value=False,
+            ),
         ):
             assert DataExporter._is_standalone_mode() is False
+
+    def test_missing_db_layer_is_standalone(self, monkeypatch):
+        monkeypatch.delenv("MISTHELPER_STANDALONE", raising=False)
+        with patch.object(DataExporter, "_polyglot_db_layer_available", return_value=False):
+            assert DataExporter._is_standalone_mode() is True
+
+    def test_probe_result_is_cached(self, monkeypatch):
+        monkeypatch.delenv("MISTHELPER_STANDALONE", raising=False)
+        with (
+            patch.object(DataExporter, "_polyglot_db_layer_available", return_value=True),
+            patch("src.export.data_exporter.polyglot_hosts_unreachable", return_value=False) as probe,
+        ):
+            assert DataExporter._polyglot_hosts_silent() is False
+            assert DataExporter._polyglot_hosts_silent() is False
+            probe.assert_called_once()
+
+    def test_override_returns_none_when_unset(self, monkeypatch):
+        monkeypatch.delenv("MISTHELPER_STANDALONE", raising=False)
+        assert DataExporter._standalone_override() is None
 
 
 class TestShouldSkipPolyglot:

--- a/tests/unit/test_standalone.py
+++ b/tests/unit/test_standalone.py
@@ -85,3 +85,66 @@ class TestImportFallback:
         except ImportError:
             available = False
         assert isinstance(available, bool)
+
+
+class TestPolyglotHostProbe:
+    """Verify the TCP reachability probe that decides polyglot mode (issue #1824)."""
+
+    def test_both_silent_returns_true(self) -> None:
+        from src.db import polyglot_hosts_unreachable
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("src.db._can_connect", return_value=False),
+        ):
+            assert polyglot_hosts_unreachable() is True
+
+    def test_one_answer_returns_false(self) -> None:
+        from src.db import polyglot_hosts_unreachable
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("src.db._can_connect", side_effect=[True, False]),
+        ):
+            assert polyglot_hosts_unreachable() is False
+
+    def test_probe_reads_configured_hosts(self) -> None:
+        from src.db import polyglot_hosts_unreachable
+
+        env = {"ARANGO_HOST": "http://db.example:9999", "REDIS_HOST": "cache.example", "REDIS_PORT": "6380"}
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("src.db._can_connect", return_value=False) as connect,
+        ):
+            polyglot_hosts_unreachable()
+        assert connect.call_args_list[0].args == ("db.example", 9999)
+        assert connect.call_args_list[1].args == ("cache.example", 6380)
+
+    def test_url_without_port_uses_arango_default(self) -> None:
+        from src.db import ARANGO_DEFAULT_PORT, polyglot_hosts_unreachable
+
+        with (
+            patch.dict("os.environ", {"ARANGO_HOST": "http://db.example"}, clear=True),
+            patch("src.db._can_connect", return_value=False) as connect,
+        ):
+            polyglot_hosts_unreachable()
+        assert connect.call_args_list[0].args == ("db.example", ARANGO_DEFAULT_PORT)
+
+    def test_unreadable_port_falls_back_to_default(self) -> None:
+        from src.db import REDIS_DEFAULT_PORT, _env_int
+
+        with patch.dict("os.environ", {"REDIS_PORT": "not-a-port"}, clear=True):
+            assert _env_int("REDIS_PORT", REDIS_DEFAULT_PORT) == REDIS_DEFAULT_PORT
+
+    def test_can_connect_reports_a_refused_socket(self) -> None:
+        from src.db import _can_connect
+
+        with patch("src.db.socket.create_connection", side_effect=OSError("refused")):
+            assert _can_connect("db.example", 8529) is False
+
+    def test_can_connect_closes_a_live_socket(self) -> None:
+        from src.db import _can_connect
+
+        with patch("src.db.socket.create_connection") as create:
+            assert _can_connect("db.example", 8529) is True
+        create.assert_called_once()


### PR DESCRIPTION
Fixes #1824

## Problem

`DataExporter._is_standalone_mode` returned `True` whenever
`EnvironmentUtils.is_running_in_container()` returned `False`. Every ArangoDB
and Redis write was therefore dropped when a user ran MistHelper directly on a
workstation.

The loss was silent. `DatabaseRouter._csv_fallback` answers
`WriteResult(success=True, backend="csv_only")`, so the caller saw success and
no warning reached the log. Any feature that names ArangoDB as its primary
repository looked healthy and stored nothing.

## Change

| Area | Before | After |
| - | - | - |
| Decision input | The container boundary | A TCP probe of `ARANGO_HOST` and `REDIS_HOST` |
| Workstation with a live ArangoDB | CSV only, in silence | Writes to ArangoDB and Redis |
| No host answers | CSV only, in silence | CSV only, with one `WARNING` |
| `MISTHELPER_STANDALONE` | Forces the mode | Unchanged, still forces the mode |

- `src/db/__init__.py` gains `polyglot_hosts_unreachable()`. It probes both
  configured hosts and records each verdict through the `polyglot_host_probe`
  structured log event. The probe opens a TCP connection rather than a DNS
  lookup, because a hostname can resolve while no service listens. The timeout
  is 0.5 seconds for each host.
- `src/db/__init__.py` gains `_env_int`, so an unreadable `REDIS_PORT` falls
  back to 6379 instead of raising during config load.
- `DataExporter._standalone_probe` caches the verdict for the life of the
  process, so an export pays the probe cost one time.
- One `WARNING` at the fallback point names the dropped polyglot write and the
  two environment variables that fix it.
- `src/export/data_exporter.py` no longer imports `EnvironmentUtils`.

## Verification

```text
python -m pytest tests/unit/test_standalone.py tests/unit/export/test_data_exporter.py \
  tests/unit/ssh/test_ssh_runner_manager_extended.py -q
150 passed in 2.90s

python -m ruff check    <touched files>   All checks passed!
python -m black --check <touched files>   4 files would be left unchanged.
python -m mypy src/db/__init__.py src/export/data_exporter.py
Success: no issues found in 2 source files
```

New tests:

- `TestPolyglotHostProbe` in `tests/unit/test_standalone.py` covers both hosts
  silent, one host answering, the configured host and port reaching the probe,
  the ArangoDB default port, an unreadable `REDIS_PORT`, and both `_can_connect`
  branches.
- `TestIsStandaloneMode` in `tests/unit/export/test_data_exporter.py` now covers
  the one-shot warning, the reachable workstation case, the missing DB layer,
  and the probe cache.

## Impact

This unblocks #1823, which names ArangoDB as its primary repository.

## Conformance

- [x] Acceptance criteria of #1824 met
- [x] Tests added for the changed behavior
- [x] No secret added to the source
- [x] Ruff, Black, and mypy pass on the touched files
- [x] `CHANGELOG.md` updated under `[Unreleased]`
