### PR TITLE
fix(device): stop counting a refused reassignment PUT as a success

### DIFF
--- a/src/device/ap_profile_migration_manager.py
+++ b/src/device/ap_profile_migration_manager.py
@@ -256,14 +256,30 @@ class APProfileMigrationManager:
         # interrupted run leaves the file in a consistent partial state. The
         # in-memory ``payload`` dict is mutated in place; the returned value
         # is the same object -- kept explicit for readability.
-        final_payload = APProfileMigrationManager._run_reassignment_loop(
-            mist_session,
-            ap_records,
-            target_id,
-            backup_path,
-            payload,
-            progress_stride=_PROGRESS_STRIDE,
-        )
+        # WHY: issue #1700 -- Ctrl+C used to skip the audit emission below, so
+        # a stopped run left no JSONL row at all. Catch the interrupt, record
+        # the partial result, then re-raise after the audit row is written.
+        interrupted = False
+        try:
+            final_payload = APProfileMigrationManager._run_reassignment_loop(
+                mist_session,
+                ap_records,
+                target_id,
+                backup_path,
+                payload,
+                progress_stride=_PROGRESS_STRIDE,
+            )
+        except KeyboardInterrupt:
+            # WHY: the loop mutates ``payload`` in place, so it already holds
+            # every AP that was reassigned before the operator stopped the run.
+            final_payload = payload
+            final_payload["outcome"] = "interrupted"
+            interrupted = True
+            _LOGGER.warning(
+                "Migration interrupted by the operator after %d of %d APs. Writing the audit row.",
+                len(final_payload.get("aps_reassigned", [])),
+                len(ap_records),
+            )
 
         # WHY: use the in-memory final payload for the summary print so we
         # never re-read a file that may have been left in a partial state by
@@ -300,6 +316,11 @@ class APProfileMigrationManager:
                 },
             }
         )
+
+        # WHY: the audit row is on disk now, so the operator's Ctrl+C may travel
+        # on to the menu loop that reports the interruption.
+        if interrupted:
+            raise KeyboardInterrupt
 
     @staticmethod
     def revert_ap_profile_migration(session: Any | None = None) -> None:

--- a/src/device/ap_profile_migration_manager.py
+++ b/src/device/ap_profile_migration_manager.py
@@ -89,6 +89,40 @@ _MIGRATE_TELEMETRY_FILENAME = "ap_profile_migration_migrate.jsonl"
 # deleted from Mist since the migration (data-model 2.2 -- ``missing_count``).
 _REVERT_MISSING = "missing"
 
+# WHY: the mistapi SDK returns an APIResponse for an error status. It does not
+# raise. Any status at or above this floor means the PUT changed nothing.
+_HTTP_ERROR_FLOOR = 400
+
+
+class APProfileReassignmentError(RuntimeError):
+    """Raised when a reassignment PUT reports an error status.
+
+    Why:
+        Issue #1700 recorded 4030 PUT calls that changed no device profile.
+        The SDK answers an error status with an object, so the old code read
+        that object as a success. This exception makes the failure visible to
+        the retry loop, to the failure counters, and to the operator.
+
+    Attributes:
+        response: The SDK response object. ``_is_429`` reads ``status_code``
+            from this attribute, so a rate-limit answer still paces the run.
+        status_code: The HTTP status the SDK reported.
+    """
+
+    def __init__(self, response: Any, device_id: str) -> None:
+        """Build the error from the SDK response and the AP that failed.
+
+        Args:
+            response: The object ``updateSiteDevice`` returned.
+            device_id: The AP the PUT targeted, for the operator-facing text.
+        """
+        # WHY: _is_429 reads err.response.status_code. Keeping the original
+        # object here lets the existing pacing path see a 429 answer.
+        self.response = response
+        # WHY: cached so a caller reads the status without a second getattr.
+        self.status_code = getattr(response, "status_code", None)
+        super().__init__(f"updateSiteDevice reported HTTP {self.status_code} for device {device_id}")
+
 
 def _utc_iso_timestamp() -> str:
     """Return the current wall-clock time as an ISO 8601 extended UTC string.
@@ -1196,7 +1230,13 @@ class APProfileMigrationManager:
         # WHY: attempt indices 0, 1, 2. Sleep AFTER attempts 0 and 1 only.
         for attempt in range(len(_RETRY_BACKOFF_SECONDS) + 1):
             try:
-                _mist_site_devices.updateSiteDevice(session, ap_record["site_id"], ap_record["device_id"], body)
+                response = _mist_site_devices.updateSiteDevice(
+                    session, ap_record["site_id"], ap_record["device_id"], body
+                )
+                # WHY: issue #1700 -- the SDK answers an error status with an
+                # object instead of raising. Read that status before the call
+                # counts as a success.
+                APProfileMigrationManager._check_reassign_response(response, ap_record["device_id"])
                 return
             except Exception as exc:  # noqa: BLE001  # WHY: broad catch for retry policy.
                 last_exc = exc
@@ -1212,6 +1252,39 @@ class APProfileMigrationManager:
         # WHY: unreachable; guard against typing lint anyway.
         if last_exc is not None:
             raise last_exc
+
+    @staticmethod
+    def _check_reassign_response(response: Any, device_id: str) -> None:
+        """Raise when the SDK response reports an HTTP error status.
+
+        Why:
+            Issue #1700 -- ``updateSiteDevice`` answers an error status with an
+            ``APIResponse`` object. The old code discarded that object, so a
+            refused PUT counted as a reassigned AP. The operator saw a success
+            line for every one of 4030 calls that changed nothing.
+
+        Args:
+            response: The object ``updateSiteDevice`` returned.
+            device_id: The AP the PUT targeted, for the message text.
+
+        Raises:
+            APProfileReassignmentError: The response reports a status at or
+                above ``_HTTP_ERROR_FLOOR``.
+        """
+        # WHY: a stub or a mock carries no integer status. Treat an unreadable
+        # status as "cannot judge" so this check never invents a failure.
+        status_code = getattr(response, "status_code", None)
+        if not isinstance(status_code, int):
+            return
+        # WHY: 1xx, 2xx, and 3xx leave the reassignment claim intact.
+        if status_code < _HTTP_ERROR_FLOOR:
+            return
+        _LOGGER.warning(
+            "Reassignment PUT for device %s reported HTTP %s. The device profile did not change.",
+            device_id,
+            status_code,
+        )
+        raise APProfileReassignmentError(response, device_id)
 
     @staticmethod
     def _run_reassignment_loop(

--- a/tests/unit/device/test_ap_profile_migration_manager.py
+++ b/tests/unit/device/test_ap_profile_migration_manager.py
@@ -2065,3 +2065,73 @@ def test_migrate_integration_real_limiter_seeded_cache(
     # WHY: real PID math produced a non-zero delay for at least one call
     # since the seeded cache reports 4000/5000 used (limiter should throttle).
     assert any(s > 0 for s in sleep_args), f"expected real limiter to produce a non-zero delay; got {sleep_args[:10]!r}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1700 -- a PUT that answers an error status must not count as a success
+# ---------------------------------------------------------------------------
+
+
+class _StubResponse:
+    """Stand in for a mistapi APIResponse that carries only a status code."""
+
+    def __init__(self, status_code: int) -> None:
+        """Record the status code the SDK would report.
+
+        Args:
+            status_code: The HTTP status to expose to the code under test.
+        """
+        self.status_code = status_code
+
+
+def test_reassign_raises_on_error_status() -> None:
+    """An error status MUST raise instead of counting as a reassigned AP.
+
+    Why:
+        Issue #1700 -- the SDK answers 4xx with an object and never raises.
+        The old code discarded that object, so a refused PUT looked like a
+        success. This test pins the corrected behavior.
+    """
+    ap_record = _ap_record("dev-1", "site-1", "5c5b350e0001")
+
+    with (
+        patch("mistapi.api.v1.sites.devices.updateSiteDevice", return_value=_StubResponse(400)),
+        patch("src.device.ap_profile_migration_manager.time.sleep", return_value=None),
+        pytest.raises(apm_mod.APProfileReassignmentError) as excinfo,
+    ):
+        APProfileMigrationManager._reassign_one_ap(MagicMock(), ap_record, "tgt-profile-id")
+
+    assert excinfo.value.status_code == 400, "the exception MUST carry the status the SDK reported"
+    assert "dev-1" in str(excinfo.value), "the message MUST name the AP that failed"
+
+
+def test_reassign_accepts_success_status() -> None:
+    """A 2xx status MUST still count as a reassigned AP."""
+    ap_record = _ap_record("dev-2", "site-1", "5c5b350e0002")
+
+    with patch("mistapi.api.v1.sites.devices.updateSiteDevice", return_value=_StubResponse(200)):
+        APProfileMigrationManager._reassign_one_ap(MagicMock(), ap_record, "tgt-profile-id")
+
+
+def test_error_status_response_reaches_the_429_pacing_check() -> None:
+    """A 429 answered as an object MUST satisfy ``_is_429``.
+
+    Why:
+        The rate-limit pacing reads ``err.response.status_code``. A 429 that
+        arrives as a return value, not as a raised error, used to bypass that
+        pacing completely.
+    """
+    err = apm_mod.APProfileReassignmentError(_StubResponse(429), "dev-3")
+
+    assert APProfileMigrationManager._is_429(err) is True, "a 429 response MUST pace the run"
+
+
+def test_check_reassign_response_ignores_an_unreadable_status() -> None:
+    """A response without an integer status MUST NOT raise.
+
+    Why:
+        A caller may hand back ``None`` or a stub. The check reports a failure
+        only when it reads a real error status, so it never invents one.
+    """
+    APProfileMigrationManager._check_reassign_response(None, "dev-4")
+    APProfileMigrationManager._check_reassign_response(object(), "dev-5")

--- a/tests/unit/device/test_ap_profile_migration_manager.py
+++ b/tests/unit/device/test_ap_profile_migration_manager.py
@@ -2135,3 +2135,44 @@ def test_check_reassign_response_ignores_an_unreadable_status() -> None:
     """
     APProfileMigrationManager._check_reassign_response(None, "dev-4")
     APProfileMigrationManager._check_reassign_response(object(), "dev-5")
+
+
+def test_interrupted_migration_still_writes_the_audit_row(fake_mh: Any, tmp_path: Path) -> None:
+    """Ctrl+C during the loop MUST still append one migrate audit row.
+
+    Why:
+        Issue #1700 -- the operator stopped a run after 4030 APs and
+        ``ap_profile_migration_migrate.jsonl`` held no row for it. The audit
+        emission sat after the loop, so the interrupt skipped it.
+    """
+    src_id = "aaaa1111-2222-3333-4444-555566667777"
+    tgt_id = "bbbb1111-2222-3333-4444-555566667777"
+    src = (src_id, "src-name", _profile(src_id, "src-name"))
+    tgt = (tgt_id, "tgt-name", _profile(tgt_id, "tgt-name"))
+    aps = [_ap_record(f"d{i}", "site-1", f"5c5b350e{i:04x}") for i in range(4)]
+
+    fake_mh.InputUtils.safe_input.return_value = "MIGRATE"
+
+    audit_rows: list[dict[str, Any]] = []
+
+    def _stop_after_two(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        """Reassign two APs, then raise the operator interrupt."""
+        # WHY: the real loop mutates the payload in place before it stops.
+        payload = _args[4]
+        payload["aps_reassigned"].extend(["d0", "d1"])
+        raise KeyboardInterrupt
+
+    with (
+        patch.object(APProfileMigrationManager, "_pick_ap_device_profile", side_effect=[src, tgt]),
+        patch.object(APProfileMigrationManager, "_discover_aps_on_source_profile", return_value=aps),
+        patch.object(APProfileMigrationManager, "_write_backup_file", return_value=str(tmp_path / "backup.json")),
+        patch.object(APProfileMigrationManager, "_run_reassignment_loop", side_effect=_stop_after_two),
+        patch.object(APProfileMigrationManager, "_emit_migrate_audit", side_effect=audit_rows.append),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        APProfileMigrationManager.migrate_aps_between_device_profiles(session=MagicMock())
+
+    assert len(audit_rows) == 1, "an interrupted run MUST still write exactly one audit row"
+    assert audit_rows[0]["outcome"] == "interrupted", "the row MUST record the interrupted outcome"
+    assert audit_rows[0]["reassigned_count"] == 2, "the row MUST record the partial reassigned count"
+    assert audit_rows[0]["planned_count"] == 4, "the row MUST record the planned count"


### PR DESCRIPTION
## Summary

Two silent-failure defects from issue #1700, both in menu 207.

### 1. A refused PUT counted as a reassigned AP

`_reassign_one_ap` discarded the value that `updateSiteDevice` returned. The
mistapi SDK does not raise on an error status. `APIResponse` records the status
on the object and returns it. A 400, 403, or 404 answer therefore counted as a
success, and the run printed a success line for every call.

- `_check_reassign_response` reads the status code after every PUT. A status at
  or above 400 raises `APProfileReassignmentError`.
- `APProfileReassignmentError` keeps the response object, so the existing
  `_is_429` pacing check sees a rate-limit answer that arrives as a return
  value. That answer used to bypass pacing completely.
- An unreadable status stays a no-op. The check reports a failure only when it
  reads a real error status, so it never invents one.

The retry loop already wraps the PUT, so a refused call now retries and then
records a real failure instead of a false success.

### 2. An interrupted run wrote no audit row

The audit emission sat after the reassignment loop. `Ctrl+C` skipped it. The
reported run stopped after 4030 APs and left no row in
`ap_profile_migration_migrate.jsonl`.

- The loop now runs inside a `try`. A `KeyboardInterrupt` records the
  `interrupted` outcome and the partial reassigned count, writes the audit row,
  and then re-raises so the menu still reports the interruption.
- The loop already mutates the payload in place as each AP succeeds, so the
  partial count is accurate without any extra bookkeeping.

## Verification

- `pytest tests/unit/device/test_ap_profile_migration_manager.py` reports 42
  passed, up from 37. The 37 existing tests still pass unchanged.
- `ruff check`, `black --check`, and `py_compile` all pass.
- The first commit passed all 16 CI gates, including CodeQL, mypy strict,
  Bandit, and the pytest coverage gate.

## Review requirement

Menu 207 is a destructive operation. Repository policy requires explicit human
review for a destructive operation regardless of authorship, so this PR carries
no `auto-merge` label by design.

## Scope

This PR does not close #1700. The titled symptom, a PUT that answers `200` and
still changes nothing, needs a read-back of the device after the PUT. That
read-back doubles the API calls for a 6181 AP run, so it needs a design
decision first. The remaining work is recorded on the issue.
