### PR TITLE
fix(security): redact street addresses from address resolver logs

### DIFF
--- a/src/site/address_audit/address_resolver.py
+++ b/src/site/address_audit/address_resolver.py
@@ -16,6 +16,12 @@ A SQLite ``geocoding_cache`` table in ``data/mist_data.db`` is read before any
 Tier 2/3 call and upserted after, so reruns make zero external calls for
 unchanged addresses. Any failure degrades to ``ResolverResult(canonical_address
 =None)`` (the row classifies ``NO_RESULT``) -- the audit is never aborted.
+
+Log privacy policy (issue 1733): a street address is private data, and
+``data/script.log`` travels inside the menu-101 support bundle. Every log call in
+this module therefore passes an address through ``private_digest`` first. The
+digest is stable, so an operator can still follow one address across a run, but
+the log file never holds the address itself.
 """
 
 from __future__ import annotations  # PEP 604 union syntax on Python 3.13.
@@ -33,6 +39,7 @@ from src.site.address_audit.models import ResolveCandidates, ResolverResult  # R
 from src.site.address_audit.perf import PhaseTimer  # Per-phase timing to expose slow tiers.
 from src.site.address_audit.suite_patterns import SUITE_PATTERN as _SUITE_PATTERN  # Shared suite/unit detector.
 from src.utils.address_utils import AddressValidationConfig, NominatimValidator  # Reused Tier-2 validator.
+from src.utils.logger_utils import private_digest  # Keep street addresses out of data/script.log (issue 1733).
 
 _DB_RELATIVE_PATH = os.path.join("data", "mist_data.db")  # Constitution-fixed cache location.
 _NOMINATIM_MIN_INTERVAL = 1.1  # Seconds between Nominatim calls (>=1 req/sec ToS).
@@ -61,14 +68,14 @@ class AddressResolver:
         """Resolve one site's address: cache -> Tier 1 -> Tier 2 -> optional Tier 3."""
         query = self._build_query(candidates)  # Construct the human-readable query string.
         key = self._build_query_key(query)  # Normalize it into a cache key.
-        logging.info("Resolving address (key=%s)", key)  # Action-log the resolve start.
+        logging.info("Resolving address (key=%s)", private_digest(key))  # Log the digest, never the street.
         with self._perf.phase("cache_read"):  # Time the SQLite cache lookup.
             cached = self._from_cache(key)  # Cache read before any external call.
         if cached is not None:  # Cache hit -> zero external calls.
             return cached  # Return the cached result verbatim.
         result = self._resolve_uncached(candidates, query)  # Run the tier cascade.
         self._to_cache(key, result)  # Persist the outcome (including negatives).
-        logging.debug("Resolved key=%s via source=%s", key, result.source)  # Action-log the outcome.
+        logging.debug("Resolved key=%s via source=%s", private_digest(key), result.source)  # Digest hides the street.
         return result  # Hand the result back to the engine.
 
     def _resolve_uncached(self, candidates: ResolveCandidates, query: str) -> ResolverResult:
@@ -82,7 +89,7 @@ class AddressResolver:
                 ui = self._maybe_ui(candidates, query)  # Tier 3: Google-via-Mist authority (gated. Fail-soft).
             return self._combine(internal, osm, ui, query)  # Merge the tiers into one result. Candidates are unused.
         except Exception as exc:  # noqa: BLE001 -- one row must never abort the audit.
-            logging.warning("Resolve failed for key derived from '%s': %s", query, exc)  # Log and continue.
+            logging.warning("Resolve failed for key=%s: %s", private_digest(query), exc)  # Digest hides the street.
             return ResolverResult(query=query, canonical_address=None, source="internal", confidence=0.0)
 
     def _combine(
@@ -149,7 +156,8 @@ class AddressResolver:
         if not suite:  # Neither internal source supplies a suite Mist lacks.
             return None  # Nothing to add. Defer to Tier 2.
         clean = self._build_clean_suggestion(candidates.mist_address, suite)  # Mist base + suite, no pollution.
-        logging.debug("Tier 1 internal suggestion (suite=%s): %s", suite, clean)  # Trace the internal hit.
+        # WHY: log a digest and a suite-found flag. The suite and the street are both private (issue 1733).
+        logging.debug("Tier 1 internal suggestion (suite_found=%s, key=%s)", bool(suite), private_digest(clean))
         return ResolverResult(query="", canonical_address=clean, source="internal", confidence=0.7)
 
     def _pick_internal_suite(self, candidates: ResolveCandidates) -> str:  # WHY: keep suite fallback out of Tier 1.
@@ -190,7 +198,8 @@ class AddressResolver:
         self.external_calls += 1  # Count this external call for the run summary.
         mist_street = self._strip_suite_from_dict(candidates.mist_address)  # OSM has no suites -> validate street.
         csv_street = self._strip_suite_from_dict(candidates.csv_address)  # Strip suite so the street can match.
-        logging.info("Validating street via OpenStreetMap/Nominatim: %s", csv_street.get("address", query))
+        street_for_log = csv_street.get("address", query)  # WHY: name the street once so the digest call stays short.
+        logging.info("Validating street via Nominatim (key=%s)", private_digest(street_for_log))  # Digest, not street.
         validator = NominatimValidator(self._nominatim_config)  # Build the reused validator.
         outcome = validator.validate(mist_street, csv_street)  # Geocode both suite-stripped streets.
         comparison = outcome.get("comparison_validation", {})  # The CSV-side geocode result.
@@ -199,7 +208,8 @@ class AddressResolver:
             return None  # Defer to Tier 3 / NO_RESULT.
         confidence = float(comparison.get("confidence", 0.0))  # OSM importance-derived confidence.
         canonical = self._nominatim_canonical(candidates, comparison)  # Clean street line (not raw display_name).
-        logging.info("Nominatim validated street: %s (confidence=%.2f)", canonical, confidence)  # Visible hit.
+        # WHY: the digest proves which street matched without writing the street into the support bundle.
+        logging.info("Nominatim validated street (key=%s, confidence=%.2f)", private_digest(canonical), confidence)
         return ResolverResult(  # Build the Tier-2 result.
             query=query,  # Echo the query for caching.
             canonical_address=canonical,  # OSM-canonicalized address.
@@ -217,8 +227,8 @@ class AddressResolver:
     ) -> None:  # WHY: single-purpose helper keeps _validate_nominatim under the 25-line cap.
         """Emit the "no result" warning with the actual street that was geocoded."""
         street_for_log = csv_street.get("address") or mist_street.get("address") or query  # WHY: prefer the CSV try.
-        logging.warning(  # WHY: show the real street, not the business+suite query string.
-            "Nominatim returned no result for street '%s' (check network/SSL)", street_for_log
+        logging.warning(  # WHY: a digest identifies the failed street without exposing it.
+            "Nominatim returned no result for street key=%s (check network/SSL)", private_digest(street_for_log)
         )
 
     def _nominatim_canonical(self, candidates: ResolveCandidates, comparison: dict[str, Any]) -> str:
@@ -272,7 +282,7 @@ class AddressResolver:
         plain = self._consensus_address(candidates)  # The same address without the business prefix.
         if not plain:  # No usable plain query to retry with.
             return result  # Keep the (empty) primary result.
-        logging.info("Tier 3 retrying without business prefix: %s", plain)  # Action-log the fallback.
+        logging.info("Tier 3 retrying without business prefix (key=%s)", private_digest(plain))  # Digest the retry.
         self.external_calls += 1  # Count the fallback lookup.
         return self._ui_geocoder.geocode_via_ui(plain)  # Plain-address retry (fail-soft).
 
@@ -365,7 +375,8 @@ class AddressResolver:
             return False  # Nothing for the sources to disagree about.
         if not self._has_tied_leaders(numbers, distinct):  # WHY: single leader = majority-wins, no conflict.
             return False  # Clear leader breaks the tie -> not a conflict.
-        logging.info("Conflicting hint house numbers %s; no majority to trust", sorted(distinct))  # Explain the flag.
+        # WHY: a house number is part of a private address, so log the count only (issue 1733).
+        logging.info("Conflicting hint house numbers: %d distinct values, no majority to trust", len(distinct))
         return True  # True only when the sources actively disagree with no winner.
 
     @staticmethod
@@ -475,7 +486,7 @@ class AddressResolver:
         if row is None:  # No cached entry for this key (or read failed).
             return None  # Caller resolves live.
         self.cache_hits += 1  # Count the hit for the run summary.
-        logging.debug("cache hit for %s", key)  # Action-log the hit.
+        logging.debug("cache hit for key=%s", private_digest(key))  # Action-log the hit without the street.
         return self._row_to_result(row, key)  # WHY: hydration is a pure transform of tuple -> dataclass.
 
     def _fetch_cached_row(self, key: str) -> tuple[Any, Any, Any, Any] | None:  # WHY: split I/O from mapping.

--- a/src/utils/logger_utils.py
+++ b/src/utils/logger_utils.py
@@ -7,10 +7,13 @@ Target audience: Junior NOC engineers who should never see credentials
 in log files even when DEBUG level is enabled.
 """
 
+import hashlib  # One-way digests for private values that must stay correlatable in a log
 import logging  # Standard library logging for type annotations
 import re  # Regex for pattern-based redaction
 
 REDACTED_PLACEHOLDER = "***REDACTED***"  # Canonical placeholder for scrubbed values
+PRIVATE_DIGEST_EMPTY = "none"  # Token used when the caller supplies no private text
+_PRIVATE_DIGEST_LENGTH = 12  # Hex characters kept from the digest. Enough to stay unique within one run
 
 # Regex patterns that identify credential-like keys in log records.
 # Match is case-insensitive so "Password", "PASSWORD", "password" all trigger.
@@ -40,6 +43,38 @@ def redact_secret(value: str) -> str:
     """
     _ = value  # Accept the value so callers do not need to gate on None. Discard it
     return REDACTED_PLACEHOLDER  # Return placeholder instead of the real value
+
+
+def private_digest(value: str | None) -> str:
+    """Return a short one-way token for a private value so a log never shows the value.
+
+    Use this for personal data that is not a credential, such as a street
+    address. ``redact_secret`` returns the same placeholder for every input, so
+    two log lines about two different addresses look identical. This helper
+    returns a stable token instead. An operator can still follow one address
+    through a whole run, but the log file never holds the address itself.
+
+    The digest is one-way. A reader of the log cannot recover the address from
+    the token.
+
+    Args:
+        value: The private string to protect, such as a street address.
+
+    Returns:
+        ``"none"`` when the value is empty or holds only whitespace.
+        A 12-character lowercase hexadecimal token in every other case.
+
+    Example::
+
+        logging.info("Resolving address (key=%s)", private_digest(street))
+        # -> "Resolving address (key=3f8a1c2d9b04)"
+    """
+    if not value or not value.strip():  # No private text to protect. Keep the log line readable
+        return PRIVATE_DIGEST_EMPTY  # Constant token marks an absent value
+    normalized = " ".join(value.lower().split())  # Case and spacing must not change the token
+    encoded = normalized.encode("utf-8")  # SHA-256 needs bytes, and UTF-8 keeps non-ASCII input stable
+    digest = hashlib.sha256(encoded).hexdigest()  # One-way digest. The private value cannot be restored
+    return digest[:_PRIVATE_DIGEST_LENGTH]  # A short prefix keeps the log line readable
 
 
 def redact_if_sensitive(key: str, value: str) -> str:

--- a/tests/unit/site/address_audit/test_address_resolver_log_redaction.py
+++ b/tests/unit/site/address_audit/test_address_resolver_log_redaction.py
@@ -1,0 +1,193 @@
+"""Log-redaction tests for AddressResolver (issue 1733).
+
+CodeQL reported ten ``py/clear-text-logging-sensitive-data`` alerts in
+``src/site/address_audit/address_resolver.py``. Every alert wrote a street
+address into ``data/script.log``, and that log travels inside the menu-101
+support bundle. These tests prove that no street address reaches the log any
+more. Each test captures the log with ``caplog`` and asserts that the street
+text is absent while the stable digest is present.
+"""
+
+import logging  # Set the caplog capture level for DEBUG-level assertions.
+
+import pytest  # Fixtures for temporary paths and log capture.
+
+from src.site.address_audit import address_resolver as resolver_mod  # Patch the Nominatim validator.
+from src.site.address_audit.address_resolver import AddressResolver  # Class under test.
+from src.site.address_audit.models import ResolveCandidates, ResolverResult  # Resolver input and output.
+from src.utils.logger_utils import private_digest  # Expected digest value for each assertion.
+
+_STREET = "742 Evergreen Terrace Suite 12"  # A private street the log must never show.
+_CITY = "Springfield"  # City of the test address.
+_ADDRESS = {"address": _STREET, "city": _CITY, "state": "OR", "zip": "97475"}  # Full test address dict.
+
+
+class _MissValidator:
+    """Stand-in validator that always reports an invalid comparison."""
+
+    def __init__(self, config):
+        """Accept and drop the config so the constructor matches NominatimValidator."""
+        self._config = config  # Keep the config so the attribute exists for readers.
+
+    def validate(self, mist, comparison):
+        """Return an invalid comparison so the resolver takes the miss path."""
+        return {"comparison_validation": {"valid": False}}  # Force the "no result" warning.
+
+
+class _HitValidator:
+    """Stand-in validator that always reports a valid comparison."""
+
+    def __init__(self, config):
+        """Accept and drop the config so the constructor matches NominatimValidator."""
+        self._config = config  # Keep the config so the attribute exists for readers.
+
+    def validate(self, mist, comparison):
+        """Return a valid comparison so the resolver takes the hit path."""
+        return {"comparison_validation": {"valid": True, "confidence": 0.9, "display_name": _STREET}}
+
+
+def _candidates() -> ResolveCandidates:
+    """Return a candidate set whose every source carries the private street."""
+    return ResolveCandidates(mist_address=dict(_ADDRESS), csv_address=dict(_ADDRESS))  # One street, two sources.
+
+
+def _log_text(caplog: pytest.LogCaptureFixture) -> str:
+    """Return every captured log message joined into one string."""
+    return "\n".join(record.getMessage() for record in caplog.records)  # One buffer to search.
+
+
+class TestResolveLogsNoStreet:
+    """The resolve entry point logs a digest, never the street."""
+
+    def test_resolve_start_and_outcome_log_digest_only(
+        self, tmp_path, caplog: pytest.LogCaptureFixture, monkeypatch
+    ) -> None:
+        """Prove the start log and the outcome log both hide the street."""
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _MissValidator)  # Avoid a real network call.
+        monkeypatch.setattr(resolver_mod, "_NOMINATIM_MIN_INTERVAL", 0.0)  # Keep the test fast.
+        resolver = AddressResolver(db_path=str(tmp_path / "mist_data.db"))  # Isolated cache DB per test.
+        with caplog.at_level(logging.DEBUG):  # Capture INFO and DEBUG records together.
+            resolver.resolve(_candidates())  # Run one full resolution.
+        text = _log_text(caplog)  # Collapse the records into one searchable buffer.
+        assert _STREET not in text  # The street must never reach the log.
+        assert _CITY not in text  # The city must never reach the log either.
+        assert "Resolving address (key=" in text  # The start log still fires.
+        assert "Resolved key=" in text  # The outcome log still fires.
+
+    def test_cache_hit_logs_digest_only(self, tmp_path, caplog: pytest.LogCaptureFixture, monkeypatch) -> None:
+        """Prove the cache-hit log hides the street on the second resolve."""
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _MissValidator)  # Avoid a real network call.
+        monkeypatch.setattr(resolver_mod, "_NOMINATIM_MIN_INTERVAL", 0.0)  # Keep the test fast.
+        resolver = AddressResolver(db_path=str(tmp_path / "mist_data.db"))  # Isolated cache DB per test.
+        resolver.resolve(_candidates())  # First call fills the cache.
+        caplog.clear()  # Drop the first call's records so only the hit remains.
+        with caplog.at_level(logging.DEBUG):  # The cache-hit log is a DEBUG record.
+            resolver.resolve(_candidates())  # Second call hits the cache.
+        text = _log_text(caplog)  # Collapse the records into one searchable buffer.
+        assert _STREET not in text  # The street must never reach the log.
+        assert "cache hit for key=" in text  # The hit log still fires.
+        assert resolver.cache_hits == 1  # The counter proves the cache path ran.
+
+    def test_resolve_failure_logs_digest_only(self, tmp_path, caplog: pytest.LogCaptureFixture, monkeypatch) -> None:
+        """Prove the failure warning hides the street when a tier raises."""
+
+        def _boom(*args, **kwargs):
+            """Raise so the resolver takes its fail-soft warning path."""
+            raise RuntimeError("tier exploded")  # A generic failure. The message holds no address.
+
+        monkeypatch.setattr(AddressResolver, "_compare_internal", _boom)  # Force the except branch.
+        resolver = AddressResolver(db_path=str(tmp_path / "mist_data.db"))  # Isolated cache DB per test.
+        with caplog.at_level(logging.WARNING):  # The failure log is a WARNING record.
+            result = resolver.resolve(_candidates())  # Run the failing resolution.
+        text = _log_text(caplog)  # Collapse the records into one searchable buffer.
+        assert _STREET not in text  # The street must never reach the log.
+        assert "Resolve failed for key=" in text  # The warning still fires.
+        assert result.canonical_address is None  # The audit degrades instead of aborting.
+
+
+class TestTierLogsNoStreet:
+    """Every tier log carries a digest instead of the street."""
+
+    def test_tier1_suggestion_logs_digest_only(self, tmp_path, caplog: pytest.LogCaptureFixture) -> None:
+        """Prove the Tier-1 suggestion log hides both the street and the suite."""
+        resolver = AddressResolver(db_path=str(tmp_path / "mist_data.db"))  # Isolated cache DB per test.
+        mist_without_suite = {"address": "742 Evergreen Terrace", "city": _CITY, "state": "OR", "zip": "97475"}
+        candidates = ResolveCandidates(mist_address=mist_without_suite, csv_address=dict(_ADDRESS))  # Suite in CSV.
+        with caplog.at_level(logging.DEBUG):  # The Tier-1 log is a DEBUG record.
+            result = resolver._compare_internal(candidates)  # Run Tier 1 on its own.
+        text = _log_text(caplog)  # Collapse the records into one searchable buffer.
+        assert "Suite 12" not in text  # The suite is part of a private address.
+        assert "Evergreen" not in text  # The street name must not reach the log.
+        assert "suite_found=True" in text  # The operator still learns that a suite was found.
+        assert result is not None  # Tier 1 still returns its suggestion.
+
+    def test_nominatim_miss_logs_digest_only(self, tmp_path, caplog: pytest.LogCaptureFixture, monkeypatch) -> None:
+        """Prove the Nominatim "no result" warning hides the street."""
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _MissValidator)  # Force the miss path.
+        monkeypatch.setattr(resolver_mod, "_NOMINATIM_MIN_INTERVAL", 0.0)  # Keep the test fast.
+        resolver = AddressResolver(db_path=str(tmp_path / "mist_data.db"))  # Isolated cache DB per test.
+        with caplog.at_level(logging.INFO):  # Capture the start log and the miss warning.
+            outcome = resolver._validate_nominatim(_candidates(), _STREET)  # Run Tier 2 on its own.
+        text = _log_text(caplog)  # Collapse the records into one searchable buffer.
+        assert _STREET not in text  # The street must never reach the log.
+        assert private_digest("742 Evergreen Terrace") in text  # Tier 2 strips the suite before it geocodes.
+        assert "Nominatim returned no result for street key=" in text  # The warning still fires.
+        assert outcome is None  # A miss defers to the next tier.
+
+    def test_nominatim_hit_logs_digest_only(self, tmp_path, caplog: pytest.LogCaptureFixture, monkeypatch) -> None:
+        """Prove the Nominatim success log hides the canonical street."""
+        monkeypatch.setattr(resolver_mod, "NominatimValidator", _HitValidator)  # Force the hit path.
+        monkeypatch.setattr(resolver_mod, "_NOMINATIM_MIN_INTERVAL", 0.0)  # Keep the test fast.
+        resolver = AddressResolver(db_path=str(tmp_path / "mist_data.db"))  # Isolated cache DB per test.
+        with caplog.at_level(logging.INFO):  # The success log is an INFO record.
+            outcome = resolver._validate_nominatim(_candidates(), _STREET)  # Run Tier 2 on its own.
+        text = _log_text(caplog)  # Collapse the records into one searchable buffer.
+        assert _STREET not in text  # The street must never reach the log.
+        assert "Nominatim validated street (key=" in text  # The success log still fires.
+        assert outcome is not None  # Tier 2 still returns its result.
+
+    def test_tier3_retry_logs_digest_only(self, tmp_path, caplog: pytest.LogCaptureFixture) -> None:
+        """Prove the Tier-3 retry log hides the plain address."""
+        geocoder = _EmptyGeocoder()  # A geocoder that never finds an address forces the retry.
+        resolver = AddressResolver(db_path=str(tmp_path / "mist_data.db"), ui_geocoder=geocoder)  # Tier 3 enabled.
+        candidates = ResolveCandidates(  # A business name is required before the retry can run.
+            mist_address=dict(_ADDRESS), csv_address=dict(_ADDRESS), business_name="Kwik-E-Mart"
+        )
+        with caplog.at_level(logging.INFO):  # The retry log is an INFO record.
+            resolver._ui_lookup_with_fallback(candidates, f"Kwik-E-Mart {_STREET}")  # Run the fallback path.
+        text = _log_text(caplog)  # Collapse the records into one searchable buffer.
+        assert "Evergreen" not in text  # The street name must not reach the log.
+        assert "Tier 3 retrying without business prefix (key=" in text  # The retry log still fires.
+        assert geocoder.calls == 2  # The primary lookup and the retry both ran.
+
+
+class _EmptyGeocoder:
+    """Stand-in UI geocoder that always returns an empty result."""
+
+    def __init__(self) -> None:
+        """Start the call counter at zero."""
+        self.calls = 0  # Count every geocode call so the test can assert the retry ran.
+
+    def geocode_via_ui(self, query: str) -> ResolverResult:
+        """Return an empty result so the caller retries without the business prefix."""
+        self.calls += 1  # Record this lookup.
+        return ResolverResult(query=query, canonical_address=None)  # No address found.
+
+
+class TestConflictingHintsLogsNoHouseNumbers:
+    """The conflicting-hint log reports a count, never the house numbers."""
+
+    def test_conflict_log_reports_count_only(self, tmp_path, caplog: pytest.LogCaptureFixture) -> None:
+        """Prove the conflict log omits every house number."""
+        resolver = AddressResolver(db_path=str(tmp_path / "mist_data.db"))  # Isolated cache DB per test.
+        candidates = ResolveCandidates(  # Two sources disagree on the house number with no majority.
+            mist_address={"address": "742 Evergreen Terrace", "city": _CITY, "state": "OR", "zip": "97475"},
+            csv_address={"address": "913 Evergreen Terrace", "city": _CITY, "state": "OR", "zip": "97475"},
+        )
+        with caplog.at_level(logging.INFO):  # The conflict log is an INFO record.
+            conflicted = resolver.has_conflicting_hints(candidates)  # Run the conflict check.
+        text = _log_text(caplog)  # Collapse the records into one searchable buffer.
+        assert "742" not in text  # The first house number must not reach the log.
+        assert "913" not in text  # The second house number must not reach the log.
+        assert "2 distinct values" in text  # The operator still learns that two hints disagree.
+        assert conflicted is True  # The row is still flagged for manual review.

--- a/tests/unit/utils/test_logger_utils_private_digest.py
+++ b/tests/unit/utils/test_logger_utils_private_digest.py
@@ -1,0 +1,46 @@
+"""Unit tests for ``private_digest`` in ``src/utils/logger_utils.py`` (issue 1733).
+
+``private_digest`` protects personal data that is not a credential, such as a
+street address. These tests prove the token is stable, is not the input, and
+cannot be traced back to the input by a reader of the log.
+"""
+
+from src.utils.logger_utils import PRIVATE_DIGEST_EMPTY, private_digest  # Helper and its empty-value token.
+
+_STREET = "742 Evergreen Terrace Suite 12"  # A private street used across the tests.
+
+
+class TestPrivateDigest:
+    """The digest hides the value while it stays stable across calls."""
+
+    def test_digest_never_contains_the_input(self) -> None:
+        """Prove no part of the street survives inside the token."""
+        token = private_digest(_STREET)  # Build the token once.
+        assert _STREET not in token  # The whole street must be absent.
+        assert "Evergreen" not in token  # The street name must be absent.
+        assert "742" not in token  # The house number must be absent.
+
+    def test_digest_is_stable_for_the_same_value(self) -> None:
+        """Prove two calls with the same value return the same token."""
+        assert private_digest(_STREET) == private_digest(_STREET)  # An operator can follow one address.
+
+    def test_digest_ignores_case_and_spacing(self) -> None:
+        """Prove case and spacing changes do not change the token."""
+        noisy = "  742   EVERGREEN terrace   Suite 12 "  # The same street with noisy case and spacing.
+        assert private_digest(noisy) == private_digest(_STREET)  # Normalization keeps the token stable.
+
+    def test_digest_differs_for_different_values(self) -> None:
+        """Prove two different streets return two different tokens."""
+        assert private_digest(_STREET) != private_digest("913 Evergreen Terrace")  # Tokens stay distinguishable.
+
+    def test_digest_is_short_and_hexadecimal(self) -> None:
+        """Prove the token is a 12-character lowercase hexadecimal string."""
+        token = private_digest(_STREET)  # Build the token once.
+        assert len(token) == 12  # A short token keeps the log line readable.
+        assert all(character in "0123456789abcdef" for character in token)  # Lowercase hexadecimal only.
+
+    def test_empty_value_returns_the_empty_token(self) -> None:
+        """Prove an empty or whitespace value returns the constant empty token."""
+        assert private_digest("") == PRIVATE_DIGEST_EMPTY  # An empty string has nothing to protect.
+        assert private_digest("   ") == PRIVATE_DIGEST_EMPTY  # Whitespace alone has nothing to protect.
+        assert private_digest(None) == PRIVATE_DIGEST_EMPTY  # A missing value has nothing to protect.


### PR DESCRIPTION
Closes #1733

## Problem

CodeQL reported 10 `py/clear-text-logging-sensitive-data` alerts in
`src/site/address_audit/address_resolver.py`. Every alert wrote a street address
into `data/script.log`. That log travels inside the menu-101 support bundle, so a
reader of the bundle saw every audited street address.

## Fix

The project rule is fix over suppress. This pull request adds no suppression
comment. Every alert is fixed.

`src/utils/logger_utils.py` gains `private_digest()`. The helper returns a stable
12-character one-way token for private data that is not a credential. The
existing `redact_secret()` returns the same placeholder for every input, so two
log lines about two different addresses look identical. A digest keeps the lines
distinct. An operator can still follow one address across a run, and the log file
never holds the address.

## Triage verdicts

| Alert | Line | Verdict | Action |
| - | - | - | - |
| 174 | 64 | fixed | Log `private_digest(key)`. |
| 175 | 71 | fixed | Log `private_digest(key)`. |
| 176 | 85 | fixed | Log `private_digest(query)`. |
| 177 | 152 | fixed | Log `suite_found` flag plus `private_digest(clean)`. |
| 178 | 193 | fixed | Log `private_digest(street_for_log)`. |
| 179 | 202 | fixed | Log `private_digest(canonical)`. Keep the confidence. |
| 180 | 221 | fixed | Log `private_digest(street_for_log)`. |
| 181 | 275 | fixed | Log `private_digest(plain)`. |
| 182 | 368 | fixed | Log the count of distinct house numbers. |
| 183 | 478 | fixed | Log `private_digest(key)`. |

## Tests

- `tests/unit/site/address_audit/test_address_resolver_log_redaction.py` adds 8
  `caplog` tests. Each test asserts the street text is absent and the new message
  still fires.
- `tests/unit/utils/test_logger_utils_private_digest.py` adds 6 tests. They cover
  stability, normalization, distinctness, token shape, and the empty value.

## Verification

| Gate | Result |
| - | - |
| `python -m py_compile` (4 files) | pass |
| `python -m ruff check` (4 files) | pass |
| `python -m black --check` (4 files) | pass |
| `python -m pytest tests/unit/site/address_audit tests/unit/utils/test_logger_utils_private_digest.py -q` | 230 passed |

## Conformance

- [x] The change addresses every acceptance criterion in the issue.
- [x] The change adds tests that prove the sensitive value stays out of the log.
- [x] The change adds no secret to the source.
- [x] The change adds no blanket `# nosec` or `# noqa` suppression.
- [x] The change touches only `src/site/address_audit/address_resolver.py`,
      `src/utils/logger_utils.py`, and the two new test files.

Note: an operator must wait for CodeQL to finish before adding the `auto-merge`
label. The CodeQL alert count for this file is expected to reach 0.
