### PR TITLE
fix(starlink): configure logging before the bootstrap and round the GPS output

### DIFF
--- a/starlink_dashboard.py
+++ b/starlink_dashboard.py
@@ -1384,15 +1384,20 @@ class StarlinkDashboard(QMainWindow):
         """Pretty-print the location sub-message for DEBUG diagnostics."""
         logger.debug("Dumping the location sub-message for the diagnostics report")  # Log before the dump.
         print("\nLOCATION:")
-        # CodeQL py/clear-text-logging-sensitive-data alert 190 (latitude) and alert 191
-        # (longitude). Verdict: fixed. Review date: 2026-08-22. Reason: the two prints
-        # sent an exact coordinate pair to stdout, and a redirect or a recorded SSH
-        # session can capture that pair into a support bundle. The pair locates a
-        # customer site or a vehicle to within meters. The default output now rounds to
-        # GPS_PRECISION_DECIMALS, which locates the site to about 100 meters and still
-        # confirms the right terminal. An operator who needs the exact value sets
-        # GPS_EXACT_ENV_VAR. Next review trigger: a change to _format_gps_coordinate, a
-        # change to GPS_PRECISION_DECIMALS, or a new CodeQL alert on either print below.
+        # CodeQL py/clear-text-logging-sensitive-data reported these two lines as alert 190
+        # (latitude) and as alert 191 (longitude), because they printed the exact values.
+        # Verdict: fixed.
+        # Review date: 2026-08-22. Reason: the two prints sent an exact coordinate pair to
+        # stdout, and a redirect or a recorded SSH session can capture that pair into a
+        # support bundle. The pair locates a customer site or a vehicle to within meters.
+        # The default output now rounds to GPS_PRECISION_DECIMALS, which locates the site to
+        # about 100 meters and still confirms the right terminal. An operator who needs the
+        # exact value sets GPS_EXACT_ENV_VAR.
+        # The rounded value still reaches print, so CodeQL raised alert 193 and alert 194 on
+        # the same two lines. Verdict for that pair: accepted_with_rationale, dismissed in the
+        # security tab on 2026-08-22, because the value that reaches stdout is no longer an
+        # exact position. Next review trigger: a change to _format_gps_coordinate, a change to
+        # GPS_PRECISION_DECIMALS, or a new CodeQL alert on either print below.
         print(f"  - Latitude: {_format_gps_coordinate(loc.latitude)}")
         print(f"  - Longitude: {_format_gps_coordinate(loc.longitude)}")
         print(f"  - Altitude: {loc.altitude_meters}m")

--- a/starlink_dashboard.py
+++ b/starlink_dashboard.py
@@ -21,6 +21,50 @@ import sys
 from datetime import datetime
 from typing import Any
 
+# Configure logging first, because the bootstrap below writes DEBUG and INFO records.
+# The root logger holds no handler until basicConfig runs, so Python falls back to the
+# lastResort handler and drops every record below WARNING. The bootstrap resolves an
+# executable on PATH, downloads about 50 MB, and installs two large packages, so the
+# operator needs those records when the startup fails. See issue #1721.
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("starlink_dashboard")  # Named logger the whole module shares.
+
+# Default precision for a GPS coordinate the dashboard prints. Three decimal places
+# locate a site to about 100 meters, which confirms the right terminal without
+# publishing an exact position. See issue #1737.
+GPS_PRECISION_DECIMALS = 3
+# Environment variable an operator sets to opt in to the exact coordinate.
+GPS_EXACT_ENV_VAR = "STARLINK_DASHBOARD_EXACT_GPS"
+# Values that count as an opt-in. The set keeps the check to one term per concept.
+GPS_EXACT_OPT_IN_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _exact_gps_enabled() -> bool:
+    """Return True when the operator opted in to the exact GPS coordinate.
+
+    Returns:
+        bool: True when the opt-in environment variable holds an opt-in value.
+        False otherwise, which keeps the reduced precision default.
+    """
+    raw_value = os.environ.get(GPS_EXACT_ENV_VAR, "")  # An absent variable keeps the safe default.
+    enabled = raw_value.strip().lower() in GPS_EXACT_OPT_IN_VALUES  # Accept the common opt-in spellings.
+    logging.debug("Exact GPS output opt-in is %s", enabled)  # Record which mode the dump used.
+    return enabled
+
+
+def _format_gps_coordinate(value: Any) -> str:
+    """Return the coordinate as text, rounded unless the operator opted in.
+
+    Args:
+        value: The latitude or the longitude the Starlink terminal reported.
+
+    Returns:
+        str: The exact value when the operator opted in. The rounded value otherwise.
+    """
+    if _exact_gps_enabled():  # The operator asked for the exact position on purpose.
+        return str(value)  # Return the reported value with no change.
+    return f"{float(value):.{GPS_PRECISION_DECIMALS}f}"  # Round to about 100 meters.
+
 
 def _resolve_executable(name: str) -> str:
     """Return the absolute path of *name*, or *name* itself when PATH holds no match.
@@ -307,9 +351,8 @@ except ImportError as import_error:
     print("  pip install PyQt6")
     sys.exit(1)
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logger = logging.getLogger("starlink_dashboard")
+# Logging configuration moved to the top of this module under issue #1721, so the
+# bootstrap records above reach a handler.
 
 
 class MetricWidget(QFrame):
@@ -1339,12 +1382,23 @@ class StarlinkDashboard(QMainWindow):
     @staticmethod
     def _dump_diagnostics_location(loc) -> None:
         """Pretty-print the location sub-message for DEBUG diagnostics."""
+        logger.debug("Dumping the location sub-message for the diagnostics report")  # Log before the dump.
         print("\nLOCATION:")
-        print(f"  - Latitude: {loc.latitude}")
-        print(f"  - Longitude: {loc.longitude}")
+        # CodeQL py/clear-text-logging-sensitive-data alert 190 (latitude) and alert 191
+        # (longitude). Verdict: fixed. Review date: 2026-08-22. Reason: the two prints
+        # sent an exact coordinate pair to stdout, and a redirect or a recorded SSH
+        # session can capture that pair into a support bundle. The pair locates a
+        # customer site or a vehicle to within meters. The default output now rounds to
+        # GPS_PRECISION_DECIMALS, which locates the site to about 100 meters and still
+        # confirms the right terminal. An operator who needs the exact value sets
+        # GPS_EXACT_ENV_VAR. Next review trigger: a change to _format_gps_coordinate, a
+        # change to GPS_PRECISION_DECIMALS, or a new CodeQL alert on either print below.
+        print(f"  - Latitude: {_format_gps_coordinate(loc.latitude)}")
+        print(f"  - Longitude: {_format_gps_coordinate(loc.longitude)}")
         print(f"  - Altitude: {loc.altitude_meters}m")
-        if loc.uncertainty_meters_valid:
+        if loc.uncertainty_meters_valid:  # The terminal reports the uncertainty only when it is valid.
             print(f"  - Uncertainty: {loc.uncertainty_meters}m")
+        logger.debug("Dumped the location sub-message")  # Log after the dump.
 
     @staticmethod
     def _dump_diagnostics_alignment(align) -> None:

--- a/tests/unit/test_starlink_dashboard_startup_and_gps.py
+++ b/tests/unit/test_starlink_dashboard_startup_and_gps.py
@@ -1,0 +1,277 @@
+"""Tests for the starlink_dashboard startup order and for the GPS output precision.
+
+Issue #1721 moved the logging configuration above the dependency bootstrap.
+Issue #1737 reduced the default precision of a printed GPS coordinate.
+
+The module runs its dependency bootstrap at import time. That bootstrap can install
+packages and can call sys.exit, so these tests never import the module. They read the
+source, and they run only the symbols under test.
+"""
+
+import ast
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Absolute path to the module under test. The conftest fixture changes the working
+# directory for every test, so a relative path cannot find the file.
+MODULE_PATH = Path(__file__).resolve().parents[2] / "starlink_dashboard.py"
+
+# Symbols the GPS tests need. The loader below runs these and nothing else.
+GPS_SYMBOLS = frozenset(
+    {
+        "GPS_PRECISION_DECIMALS",
+        "GPS_EXACT_ENV_VAR",
+        "GPS_EXACT_OPT_IN_VALUES",
+        "_exact_gps_enabled",
+        "_format_gps_coordinate",
+        "_dump_diagnostics_location",
+    }
+)
+
+# A latitude and a longitude with more digits than the default output keeps.
+EXACT_LATITUDE = 37.7749295
+EXACT_LONGITUDE = -122.4194155
+
+
+class FakeLocation:
+    """Minimal stand-in for the location sub-message a Starlink terminal reports."""
+
+    def __init__(self, latitude: float, longitude: float) -> None:
+        """Store the two coordinates and the fields the dump reads.
+
+        Args:
+            latitude: The latitude the terminal reported.
+            longitude: The longitude the terminal reported.
+        """
+        self.latitude = latitude  # The dump prints this value through the format helper.
+        self.longitude = longitude  # The dump prints this value through the format helper.
+        self.altitude_meters = 12.5  # The dump prints the altitude with no change.
+        self.uncertainty_meters_valid = False  # Keep the optional branch out of the output.
+        self.uncertainty_meters = 0.0  # Present so the optional branch cannot raise.
+
+
+def _module_source() -> str:
+    """Return the source text of the module under test.
+
+    Returns:
+        str: The full file content.
+    """
+    return MODULE_PATH.read_text(encoding="utf-8")  # One read keeps every test on the same text.
+
+
+def _module_body() -> list[ast.stmt]:
+    """Return the top-level statements of the module under test.
+
+    Returns:
+        list[ast.stmt]: The module body in source order.
+    """
+    tree = ast.parse(_module_source(), filename=str(MODULE_PATH))  # Parse only, so no code runs.
+    return tree.body  # The caller reads the order of these statements.
+
+
+def _is_startup_statement(node: ast.stmt) -> bool:
+    """Return True when the statement runs at import time.
+
+    Args:
+        node: A top-level statement of the module.
+
+    Returns:
+        bool: False for a definition, because a definition only binds a name.
+    """
+    return not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+
+
+def _is_docstring(node: ast.stmt) -> bool:
+    """Return True when the statement is a bare string expression.
+
+    Args:
+        node: A top-level statement of the module.
+
+    Returns:
+        bool: True for the module docstring, which runs but does nothing.
+    """
+    return isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str)
+
+
+def _is_action_statement(node: ast.stmt) -> bool:
+    """Return True when the statement does startup work.
+
+    Args:
+        node: A top-level statement of the module.
+
+    Returns:
+        bool: False for a definition, an import, and the module docstring.
+    """
+    if not _is_startup_statement(node):  # A definition only binds a name.
+        return False
+    if isinstance(node, (ast.Import, ast.ImportFrom)):  # An import must stay at the top.
+        return False
+    return not _is_docstring(node)  # The docstring does no work.
+
+
+def _index_of_basic_config(body: list[ast.stmt]) -> int:
+    """Return the position of the logging.basicConfig call in the startup path.
+
+    Args:
+        body: The top-level statements of the module.
+
+    Returns:
+        int: The index of the call, or -1 when the startup path holds no call.
+    """
+    for index, node in enumerate(body):  # Walk the startup path in source order.
+        if not _is_startup_statement(node):  # A definition does not configure logging.
+            continue
+        for inner in ast.walk(node):  # Look inside the statement for the call.
+            if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute):
+                if inner.func.attr == "basicConfig":  # This is the configuration call.
+                    return index
+    return -1  # No call found, which the test reports as a failure.
+
+
+def _index_of_startup_call(body: list[ast.stmt], name: str) -> int:
+    """Return the position of the first startup call to *name*.
+
+    Args:
+        body: The top-level statements of the module.
+        name: The bare function name, such as "check_and_install_grpcio".
+
+    Returns:
+        int: The index of the call, or -1 when the startup path holds no call.
+    """
+    for index, node in enumerate(body):  # Walk the startup path in source order.
+        if not _is_startup_statement(node):  # Skip a definition, because it does not call anything.
+            continue
+        for inner in ast.walk(node):  # Look inside the statement for the call.
+            if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name):
+                if inner.func.id == name:  # This is the bootstrap call.
+                    return index
+    return -1  # No call found, which the test reports as a failure.
+
+
+def _collect_gps_nodes() -> list[ast.stmt]:
+    """Return the GPS symbols of the module, with every decorator removed.
+
+    Returns:
+        list[ast.stmt]: The picked nodes in source order.
+    """
+    picked: list[ast.stmt] = []  # Holds only the nodes the GPS tests need.
+    for node in ast.walk(ast.parse(_module_source(), filename=str(MODULE_PATH))):
+        if isinstance(node, ast.FunctionDef) and node.name in GPS_SYMBOLS:
+            node.decorator_list = []  # Drop staticmethod, so the function runs on its own.
+            picked.append(node)  # Keep the function for the exec below.
+        elif isinstance(node, ast.Assign) and _assigns_gps_symbol(node):
+            picked.append(node)  # Keep the constant the functions read.
+    picked.sort(key=lambda item: item.lineno)  # Restore source order, so names resolve.
+    return picked
+
+
+def _assigns_gps_symbol(node: ast.Assign) -> bool:
+    """Return True when the assignment binds a GPS symbol.
+
+    Args:
+        node: A top-level assignment statement.
+
+    Returns:
+        bool: True when any target name is a GPS symbol.
+    """
+    return any(isinstance(target, ast.Name) and target.id in GPS_SYMBOLS for target in node.targets)
+
+
+def _load_gps_namespace() -> dict[str, Any]:
+    """Run the GPS symbols in an isolated namespace and return it.
+
+    Returns:
+        dict[str, Any]: The namespace that holds the GPS constants and functions.
+    """
+    module = ast.Module(body=_collect_gps_nodes(), type_ignores=[])  # A module of picked nodes only.
+    namespace: dict[str, Any] = {
+        "os": os,  # The opt-in check reads the environment.
+        "logging": logging,  # The opt-in check writes a debug record.
+        "Any": Any,  # Python evaluates the annotation when it runs the def statement.
+        "logger": logging.getLogger("starlink_dashboard_test"),  # The dump writes debug records.
+    }
+    exec(compile(module, str(MODULE_PATH), "exec"), namespace)  # nosec B102 - the input is repository source.
+    return namespace  # The caller reads the loaded symbols from here.
+
+
+def test_logging_is_configured_before_the_dependency_bootstrap() -> None:
+    """The logging configuration must run before both bootstrap calls (issue #1721)."""
+    body = _module_body()  # Startup statements in source order.
+    config_index = _index_of_basic_config(body)  # Position of the logging configuration.
+    grpc_index = _index_of_startup_call(body, "check_and_install_grpcio")  # First bootstrap call.
+    pyqt_index = _index_of_startup_call(body, "check_and_install_pyqt6")  # Second bootstrap call.
+    assert config_index >= 0, "The startup path must call logging.basicConfig"
+    assert grpc_index >= 0, "The startup path must call check_and_install_grpcio"
+    assert pyqt_index >= 0, "The startup path must call check_and_install_pyqt6"
+    assert config_index < grpc_index, "logging.basicConfig must run before check_and_install_grpcio"
+    assert config_index < pyqt_index, "logging.basicConfig must run before check_and_install_pyqt6"
+
+
+def test_startup_configures_logging_before_any_other_startup_action() -> None:
+    """No startup action may run before the logging configuration (issue #1721)."""
+    body = _module_body()  # Startup statements in source order.
+    actions = [index for index, node in enumerate(body) if _is_action_statement(node)]  # Working statements.
+    config_index = _index_of_basic_config(body)  # Position of the logging configuration.
+    assert actions, "The module must hold at least one startup action"
+    assert config_index == actions[0], "logging.basicConfig must be the first startup action"
+
+
+def test_default_location_dump_rounds_both_coordinates() -> None:
+    """A default run must not print an exact coordinate pair (issue #1737)."""
+    namespace = _load_gps_namespace()  # Load the GPS symbols with no module import.
+    assert namespace["GPS_PRECISION_DECIMALS"] == 3, "The default precision must stay at three places"
+    latitude = namespace["_format_gps_coordinate"](EXACT_LATITUDE)  # Format the latitude.
+    longitude = namespace["_format_gps_coordinate"](EXACT_LONGITUDE)  # Format the longitude.
+    assert latitude == "37.775", "The default latitude must round to three decimal places"
+    assert longitude == "-122.419", "The default longitude must round to three decimal places"
+
+
+def test_default_location_dump_output_holds_no_exact_coordinate(capsys: pytest.CaptureFixture) -> None:
+    """The printed dump must hold the rounded pair and not the exact pair (issue #1737)."""
+    namespace = _load_gps_namespace()  # Load the GPS symbols with no module import.
+    namespace["_dump_diagnostics_location"](FakeLocation(EXACT_LATITUDE, EXACT_LONGITUDE))  # Run the dump.
+    output = capsys.readouterr().out  # Everything the dump sent to stdout.
+    assert "  - Latitude: 37.775\n" in output, "The dump must print the rounded latitude"
+    assert "  - Longitude: -122.419\n" in output, "The dump must print the rounded longitude"
+    assert str(EXACT_LATITUDE) not in output, "The dump must not print the exact latitude"
+    assert str(EXACT_LONGITUDE) not in output, "The dump must not print the exact longitude"
+
+
+def test_exact_coordinates_need_an_explicit_opt_in(
+    capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator who sets the opt-in variable gets the exact pair (issue #1737)."""
+    namespace = _load_gps_namespace()  # Load the GPS symbols with no module import.
+    monkeypatch.setenv(namespace["GPS_EXACT_ENV_VAR"], "1")  # Opt in for this test only.
+    namespace["_dump_diagnostics_location"](FakeLocation(EXACT_LATITUDE, EXACT_LONGITUDE))  # Run the dump.
+    output = capsys.readouterr().out  # Everything the dump sent to stdout.
+    assert str(EXACT_LATITUDE) in output, "The opt-in must print the exact latitude"
+    assert str(EXACT_LONGITUDE) in output, "The opt-in must print the exact longitude"
+
+
+def test_opt_in_variable_ignores_an_unrelated_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only an opt-in value turns on the exact output (issue #1737)."""
+    namespace = _load_gps_namespace()  # Load the GPS symbols with no module import.
+    monkeypatch.setenv(namespace["GPS_EXACT_ENV_VAR"], "0")  # A value that is not an opt-in.
+    assert namespace["_exact_gps_enabled"]() is False, "The value 0 must keep the safe default"
+    monkeypatch.setenv(namespace["GPS_EXACT_ENV_VAR"], " YES ")  # An opt-in with extra spaces.
+    assert namespace["_exact_gps_enabled"]() is True, "The value yes must turn on the exact output"
+
+
+def test_both_codeql_alerts_carry_a_recorded_verdict() -> None:
+    """Both GPS alerts must keep a verdict, a review date, and a review trigger (issue #1737)."""
+    source = _module_source()  # The full module text holds the verdict comment.
+    required = (
+        "py/clear-text-logging-sensitive-data",  # The rule the verdict answers.
+        "alert 190",  # The latitude alert.
+        "alert 191",  # The longitude alert.
+        "Verdict: fixed",  # The recorded verdict.
+        "Review date: 2026-08-22",  # The date of the review.
+        "Next review trigger:",  # The condition that reopens the review.
+    )
+    for marker in required:  # Each marker must survive any later edit.
+        assert marker in source, f"The verdict comment must hold {marker}"

--- a/tests/unit/test_starlink_dashboard_startup_and_gps.py
+++ b/tests/unit/test_starlink_dashboard_startup_and_gps.py
@@ -263,13 +263,16 @@ def test_opt_in_variable_ignores_an_unrelated_value(monkeypatch: pytest.MonkeyPa
 
 
 def test_both_codeql_alerts_carry_a_recorded_verdict() -> None:
-    """Both GPS alerts must keep a verdict, a review date, and a review trigger (issue #1737)."""
+    """Every GPS alert must keep a verdict, a review date, and a review trigger (issue #1737)."""
     source = _module_source()  # The full module text holds the verdict comment.
     required = (
         "py/clear-text-logging-sensitive-data",  # The rule the verdict answers.
-        "alert 190",  # The latitude alert.
-        "alert 191",  # The longitude alert.
-        "Verdict: fixed",  # The recorded verdict.
+        "alert 190",  # The original latitude alert.
+        "alert 191",  # The original longitude alert.
+        "alert 193",  # The residual latitude alert on the rounded value.
+        "alert 194",  # The residual longitude alert on the rounded value.
+        "Verdict: fixed",  # The verdict for the exact coordinate pair.
+        "accepted_with_rationale",  # The verdict for the residual rounded flow.
         "Review date: 2026-08-22",  # The date of the review.
         "Next review trigger:",  # The condition that reopens the review.
     )


### PR DESCRIPTION
Fixes #1721
Fixes #1737

Both issues touch `starlink_dashboard.py`, so one pull request closes both.

## Change 1 -- startup logging order (#1721)

The module called `logging.basicConfig` after the dependency bootstrap. Until that call ran, the root logger held no handler, so Python used the `lastResort` handler and dropped every record below WARNING. Every DEBUG record and every INFO record that the bootstrap wrote reached no output. The bootstrap resolves an executable on `PATH`, downloads about 50 MB, and installs two large packages, so the operator needs those records when the startup fails.

The `logging.basicConfig` call and the module logger now run at the top of the module, above `check_and_install_grpcio()` and above `check_and_install_pyqt6()`. No other startup behavior changes.

## Change 2 -- GPS coordinate precision (#1737)

`_dump_diagnostics_location()` printed an exact latitude and an exact longitude to stdout. That pair locates a customer site or a vehicle to within meters. A redirect or a recorded SSH session captures the pair to a file, and that file can travel inside a support bundle.

The default output now keeps three decimal places, which locates a site to about 100 meters. Three decimal places confirm the right terminal and publish no exact position. An operator who needs the exact value sets the environment variable `STARLINK_DASHBOARD_EXACT_GPS` to `1`, `true`, `yes`, or `on`.

New symbols: `GPS_PRECISION_DECIMALS`, `GPS_EXACT_ENV_VAR`, `GPS_EXACT_OPT_IN_VALUES`, `_exact_gps_enabled()`, and `_format_gps_coordinate()`.

## Verdict for both CodeQL alerts

| Alert | Statement | Verdict | Review date | Next review trigger |
| - | - | - | - | - |
| 190 | latitude print in `_dump_diagnostics_location` | fixed | 2026-08-22 | a change to `_format_gps_coordinate`, a change to `GPS_PRECISION_DECIMALS`, or a new CodeQL alert on either print |
| 191 | longitude print in `_dump_diagnostics_location` | fixed | 2026-08-22 | a change to `_format_gps_coordinate`, a change to `GPS_PRECISION_DECIMALS`, or a new CodeQL alert on either print |
| 193 | residual latitude flow on the rounded value | accepted_with_rationale | 2026-08-22 | the same trigger |
| 194 | residual longitude flow on the rounded value | accepted_with_rationale | 2026-08-22 | the same trigger |

Alert 190 and alert 191 covered the exact values. The rounding change fixes them, and they close when this branch lands on `main`.

CodeQL then raised alert 193 and alert 194 on the same two lines, because the taint path from the location message to `print` stays. The value that reaches stdout is no longer an exact position, so the residual pair carries the verdict `accepted_with_rationale`. I dismissed both in the security tab with the reason `won't fix` and a comment that names this pull request, the date, and the trigger. That mapping from verdict to API reason comes from `specs/1034-codeql-cleartext-logging/contracts/verdict-register.md`.

The verdict lives in an inline comment above the two prints. The comment states both verdicts, all four alert numbers, the review date, the reason, and the next review trigger. The test `test_both_codeql_alerts_carry_a_recorded_verdict` fails if anyone removes that comment.

## Tests

New file: `tests/unit/test_starlink_dashboard_startup_and_gps.py`, 7 tests.

The module runs its dependency bootstrap at import time, and that bootstrap can install packages and can call `sys.exit`. The tests therefore never import the module. They parse the source, and they run only the symbols under test.

| Test | What it proves |
| - | - |
| `test_logging_is_configured_before_the_dependency_bootstrap` | `logging.basicConfig` runs before both bootstrap calls |
| `test_startup_configures_logging_before_any_other_startup_action` | no startup action runs before the logging configuration |
| `test_default_location_dump_rounds_both_coordinates` | the format helper returns three decimal places |
| `test_default_location_dump_output_holds_no_exact_coordinate` | a default dump prints the rounded pair and not the exact pair |
| `test_exact_coordinates_need_an_explicit_opt_in` | the opt-in variable restores the exact pair |
| `test_opt_in_variable_ignores_an_unrelated_value` | only an opt-in value turns on the exact output |
| `test_both_codeql_alerts_carry_a_recorded_verdict` | the verdict comment holds both alerts, the date, and the trigger |

Revert check: I stashed the module, ran the suite against the previous version, and all 7 tests failed. I then restored the module and all 7 passed.

## Gate results

| Gate | Result |
| - | - |
| `python -m py_compile` | pass, both files |
| `python -m ruff check` | `All checks passed!`, both files |
| `python -m black --check` | `2 files would be left unchanged` |
| `python -m pytest tests/unit/test_starlink_dashboard_startup_and_gps.py` | 7 passed |
| `python -m pytest tests/test_issue_433_src_g_no_regress.py` | 1 passed |
| `vulture --min-confidence 70` | 0 findings |
| `radon cc -nC` | no block above complexity 10, average 2.70 |
| `interrogate -f 90` | 100 percent |
| `ste-linter starlink_dashboard.py` | 99/100, PASS |
| CodeQL on this pull request | pass, after the two residual alerts carried their verdict |

## Files

I edited `starlink_dashboard.py` and added `tests/unit/test_starlink_dashboard_startup_and_gps.py`. I edited no other file, because other agents own the rest of the tree in this fleet run.

I did not update `CHANGELOG.md`. That file is shared, and a parallel agent holds it. A follow-up commit can add the entry.

One item for a separate issue: `_status_part_location()` in the same module formats the same coordinate pair with four decimal places for the GUI status bar. CodeQL raised no alert there, and the value never reaches stdout, so I left the line alone. A future issue can align that line with `GPS_PRECISION_DECIMALS`.
