### PR TITLE
fix(security): log capture payload field names, not payload values

### DIFF
--- a/src/capture/packet_capture.py
+++ b/src/capture/packet_capture.py
@@ -545,6 +545,11 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
             logging.warning("No gateway selected or gateway selection failed - aborting capture")  # WHY: audit cancel
             return None  # WHY: propagate cancel to orchestrator
         gateway_mac = self.normalize_mac_address(gateway_mac)  # WHY: normalize before payload use
+        # CodeQL py/clear-text-logging-sensitive-data. Verdict: accepted_with_rationale.
+        # Reviewed 2026-08-22. A gateway MAC is a device identifier, and this tool exists to
+        # report device identity. The operator needs the MAC to match a log line to a capture.
+        # The line runs at DEBUG level and writes to the local log file on the operator host.
+        # Review again if the log ships to a remote collector, or if this line adds a secret.
         logging.debug("Selected and normalized gateway MAC: %s", gateway_mac)  # WHY: audit final MAC value
         logging.debug("Prompting for port selection from gateway")  # WHY: audit next interactive step
         port_selection_result = (
@@ -634,6 +639,11 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
             )  # WHY: audit user cancel
             return None  # WHY: signal caller to bail out
         switch_mac = self.normalize_mac_address(switch_mac)  # WHY: normalize before API call to match payload format
+        # CodeQL py/clear-text-logging-sensitive-data. Verdict: accepted_with_rationale.
+        # Reviewed 2026-08-22. A switch MAC is a device identifier, and this tool exists to
+        # report device identity. The operator needs the MAC to match a log line to a capture.
+        # The line runs at DEBUG level and writes to the local log file on the operator host.
+        # Review again if the log ships to a remote collector, or if this line adds a secret.
         logging.debug("Selected and normalized switch MAC: %s", switch_mac)  # WHY: audit final MAC value
         return switch_mac  # WHY: hand normalized MAC back to caller
 
@@ -843,6 +853,11 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         if ap_mac == "ALL_APS":  # WHY: sentinel routes to multi-AP flow
             return cast(str, ap_mac)  # WHY: caller dispatches to _start_site_scan_capture_all_aps
         ap_mac = self.normalize_mac_address(ap_mac)  # WHY: normalize before payload use
+        # CodeQL py/clear-text-logging-sensitive-data. Verdict: accepted_with_rationale.
+        # Reviewed 2026-08-22. An AP MAC is a device identifier, and this tool exists to
+        # report device identity. The operator needs the MAC to match a log line to a capture.
+        # The line runs at DEBUG level and writes to the local log file on the operator host.
+        # Review again if the log ships to a remote collector, or if this line adds a secret.
         logging.debug("Selected and normalized AP MAC: %s", ap_mac)  # WHY: audit final MAC value
         return ap_mac  # WHY: hand normalized MAC back
 
@@ -872,6 +887,28 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
         print(" SCAN RADIO CAPTURE CONFIGURATION")  # WHY: flow-identifying header
         print("-" * 80)  # WHY: banner end
 
+    @staticmethod
+    def _log_safe_payload_fields(payload: dict[str, Any]) -> str:
+        """Return the sorted field names of a capture payload as one string.
+
+        The summary holds the field names only. It holds no field value. A
+        capture payload can carry a device MAC, a client MAC, an SSID, a
+        tcpdump filter, or a future credential field. Each of these values
+        identifies a person or a device, so the log records the payload
+        shape and never the payload content.
+
+        Args:
+            payload: Capture payload that the caller sends to the Mist API.
+
+        Returns:
+            Comma-separated field names in sorted order.
+        """
+        logging.debug("Building a log-safe field summary for a capture payload")  # WHY: audit before the scrub
+        field_names = sorted(str(key) for key in payload)  # WHY: a key is a code literal, so it holds no user value
+        summary = ", ".join(field_names)  # WHY: one line suits the log record format
+        logging.debug("Field summary built with %d fields", len(field_names))  # WHY: audit after the scrub
+        return summary  # WHY: the caller logs this string in place of the raw payload
+
     def _scan_single_ap_run(self, site_id: str, ap_mac: str) -> None:
         """Gather remaining params and launch a single-AP scan capture."""
         band = self._prompt_scan_band()  # WHY: user picks 2.4/5/6 GHz
@@ -887,7 +924,11 @@ class PacketCaptureManager:  # WHY: primary orchestrator for Mist packet-capture
             "max_pkt_len": 1300,
             **scan_params,
         }
-        logging.debug("Payload constructed: %s", payload)  # WHY: audit constructed payload
+        # CodeQL py/clear-text-logging-sensitive-data. Verdict: fixed.
+        # Reviewed 2026-08-22. The old line logged the raw payload, so the AP MAC and every
+        # future payload field reached the log. The summary keeps the field names only.
+        fields = self._log_safe_payload_fields(payload)  # WHY: field names only, so no value reaches the log
+        logging.debug("Payload constructed with fields: %s", fields)  # WHY: audit the payload shape
         self._display_scan_capture_summary(payload, enable_loop)  # WHY: confirm before launch
         logging.info("User confirmed - executing site capture")  # WHY: audit launch
         self._run_site_capture(site_id, payload, enable_loop, check_ap_mac=ap_mac)  # WHY: launch via shared runner

--- a/tests/unit/capture/test_packet_capture_payload_logging.py
+++ b/tests/unit/capture/test_packet_capture_payload_logging.py
@@ -1,0 +1,96 @@
+"""Security tests for capture payload logging in ``PacketCaptureManager``.
+
+These tests protect the fix for issue #1734. CodeQL reported that the scan
+flow logged the whole capture payload as clear text. A capture payload can
+carry a device MAC, a client MAC, an SSID, a tcpdump filter, or a future
+credential field. The scan flow now logs the payload field names only.
+
+Each test fails if a later change restores the raw payload log line.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.capture.packet_capture import PacketCaptureManager
+
+AP_MAC = "001122334455"  # WHY: device identifier that the payload log must never hold
+SCAN_PARAMS: dict[str, Any] = {  # WHY: stand in for the radio prompts so the test needs no user input
+    "channel": 36,  # WHY: sample 5 GHz channel
+    "bandwidth": "40",  # WHY: sample channel width
+    "duration": 60,  # WHY: Mist enforces a 60 second minimum
+    "num_packets": 1024,  # WHY: default packet cap
+    "format": "pcap",  # WHY: default capture format
+}
+
+
+@pytest.fixture()
+def manager() -> PacketCaptureManager:
+    """Create a PacketCaptureManager with a deterministic org id."""
+    with patch("src.capture.packet_capture._get_config_utils") as config_utils:  # WHY: block the org id prompt
+        config_utils.return_value.get_cached_or_prompted_org_id.return_value = "org-1"  # WHY: fixed org id
+        return PacketCaptureManager(MagicMock(), org_id=None)  # WHY: a mock session makes no network call
+
+
+def _run_scan_flow(capture_manager: PacketCaptureManager) -> None:
+    """Run the single-AP scan flow with every collaborator replaced by a mock."""
+    with patch.multiple(  # WHY: class-level patch keeps mypy happy and needs no method assignment
+        PacketCaptureManager,
+        _prompt_scan_band=MagicMock(return_value="5"),  # WHY: skip the interactive band prompt
+        _gather_scan_radio_params=MagicMock(return_value=dict(SCAN_PARAMS)),  # WHY: skip the radio prompts
+        _prompt_loop_mode=MagicMock(return_value=False),  # WHY: a single capture keeps the flow short
+        _display_scan_capture_summary=MagicMock(),  # WHY: block the console summary
+        _run_site_capture=MagicMock(),  # WHY: block the live capture call
+    ):
+        capture_manager._scan_single_ap_run("site-1", AP_MAC)  # WHY: run the real payload log statement
+
+
+def _payload_log_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return every captured log message that reports the constructed payload."""
+    return [
+        record.getMessage() for record in caplog.records if "Payload constructed" in record.getMessage()
+    ]  # WHY: isolate the log line that issue #1734 flagged
+
+
+def test_payload_log_omits_the_ap_mac(manager: PacketCaptureManager, caplog: pytest.LogCaptureFixture) -> None:
+    """The scan flow must not write the AP MAC into the payload log line."""
+    with caplog.at_level(logging.DEBUG):  # WHY: the payload log line runs at DEBUG level
+        _run_scan_flow(manager)  # WHY: exercise the production code path
+    lines = _payload_log_lines(caplog)  # WHY: read back the payload log records
+    assert lines, "The scan flow must still log the payload shape"  # WHY: catch a silent removal of the audit line
+    assert all(AP_MAC not in line for line in lines)  # WHY: fails if a change restores the raw payload log
+
+
+def test_scan_flow_logs_no_mac_at_all(manager: PacketCaptureManager, caplog: pytest.LogCaptureFixture) -> None:
+    """No log record from the single-AP scan flow may hold the AP MAC."""
+    with caplog.at_level(logging.DEBUG):  # WHY: capture every record the flow emits
+        _run_scan_flow(manager)  # WHY: exercise the production code path
+    assert AP_MAC not in caplog.text  # WHY: broad guard against a new leak anywhere in this flow
+
+
+def test_payload_log_keeps_the_field_names(manager: PacketCaptureManager, caplog: pytest.LogCaptureFixture) -> None:
+    """The payload log line must keep the field names for the audit trail."""
+    with caplog.at_level(logging.DEBUG):  # WHY: the payload log line runs at DEBUG level
+        _run_scan_flow(manager)  # WHY: exercise the production code path
+    lines = _payload_log_lines(caplog)  # WHY: read back the payload log records
+    assert "ap_mac" in lines[0]  # WHY: the field name is a code literal and is safe to log
+    assert "channel" in lines[0]  # WHY: prove the summary covers the merged scan parameters
+
+
+def test_log_safe_payload_fields_drops_every_value() -> None:
+    """The helper returns sorted field names and no field value."""
+    payload = {"type": "scan", "ap_mac": AP_MAC, "ssid": "corp-wifi", "psk": "s3cret", "channel": 36}
+    summary = PacketCaptureManager._log_safe_payload_fields(payload)  # WHY: call the scrub helper directly
+    assert summary == "ap_mac, channel, psk, ssid, type"  # WHY: sorted names give a stable log line
+    assert AP_MAC not in summary  # WHY: a device identifier must not survive the scrub
+    assert "corp-wifi" not in summary  # WHY: an SSID must not survive the scrub
+    assert "s3cret" not in summary  # WHY: a credential must not survive the scrub
+
+
+def test_log_safe_payload_fields_handles_an_empty_payload() -> None:
+    """The helper returns an empty string when the payload holds no field."""
+    assert PacketCaptureManager._log_safe_payload_fields({}) == ""  # WHY: guard the boundary case


### PR DESCRIPTION
Fixes #1734

## What changed

CodeQL reported 4 `py/clear-text-logging-sensitive-data` alerts in
`src/capture/packet_capture.py`. This pull request triages all 4 and fixes the
one real leak.

### The payload log line (alert 187)

The old line was `logging.debug("Payload constructed: %s", payload)`.

The scan payload can hold these fields:

| Field | Source | Sensitivity |
| - | - | - |
| `type` | literal `"scan"` | none |
| `ap_mac` | user AP selection | device identifier |
| `band` | band prompt | none |
| `max_pkt_len` | literal `1300` | none |
| `channel` | channel prompt | none |
| `bandwidth` | bandwidth prompt | none |
| `duration` | duration prompt | none |
| `num_packets` | packet count prompt | none |
| `format` | format prompt | none |

The dict also merges `**scan_params`, so a future field enters the log line
with no review. Sibling payloads in the same module already carry `client_mac`,
`ssid`, and `tcpdump_expression`. Each of these values identifies a person or a
device.

The fix adds `PacketCaptureManager._log_safe_payload_fields`. The helper
returns the sorted field names and no field value. The scan flow now logs the
payload shape only. A field name is a code literal, so the summary cannot leak
a value that a later change adds.

### Verdict table

| Alert | Line (old) | Statement | Verdict |
| - | - | - | - |
| 184 | 548 | `Selected and normalized gateway MAC` | `accepted_with_rationale` |
| 185 | 637 | `Selected and normalized switch MAC` | `accepted_with_rationale` |
| 186 | 846 | `Selected and normalized AP MAC` | `accepted_with_rationale` |
| 187 | 890 | `Payload constructed` | `fixed` |

Each accepted line carries a comment that states the review date 2026-08-22,
the reason, and the next review trigger. The reason: a MAC address is a device
identifier, and this tool exists to report device identity. The operator needs
the MAC to match a log line to a capture. The line runs at DEBUG level and
writes to the local log file on the operator host. The trigger: review the line
again if the log ships to a remote collector, or if the line adds a secret.

Action for a maintainer: dismiss alerts 184, 185, and 186 in the code scanning
view as "won't fix", and cite the comment in the source.

## Tests

`tests/unit/capture/test_packet_capture_payload_logging.py` adds 5 tests:

- `test_payload_log_omits_the_ap_mac` drives the real scan flow and asserts the
  payload log record holds no AP MAC.
- `test_scan_flow_logs_no_mac_at_all` asserts no record in the flow holds the
  MAC.
- `test_payload_log_keeps_the_field_names` proves the audit value survives.
- `test_log_safe_payload_fields_drops_every_value` feeds a payload with a MAC,
  an SSID, and a pre-shared key, then asserts no value survives.
- `test_log_safe_payload_fields_handles_an_empty_payload` covers the boundary.

I proved the regression guard. I reverted the fix to log the raw payload and
re-ran the file. Two tests failed. I then restored the fix and all tests passed.

## Gate results

| Gate | Command | Result |
| - | - | - |
| Syntax | `python -m py_compile src/capture/packet_capture.py` | pass (exit 0) |
| Lint | `python -m ruff check` on both files | pass, "All checks passed!" |
| Format | `python -m black --check` on both files | pass, "2 files would be left unchanged" |
| Tests | `python -m pytest tests/unit/capture/ -q` | pass, 50 passed |

## File ownership

This pull request touches `src/capture/packet_capture.py` and one new file
under `tests/unit/capture/`. It touches no other file. It does not touch
`MistHelper.py`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
