### PR TITLE
feat(tools): report a module-level name that a sweep lost (#1796)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -137,6 +137,42 @@ podman ps  # Confirm container is running
 
 **Note**: Every changelog update triggers this pipeline - no standalone git operations.
 
+### Automated Sweep Safety
+
+An automated sweep is a code change. It carries more risk than a hand edit,
+because it changes many lines at once and because a reviewer reads it as a
+comment-only diff. Pull request #1791 deleted a live declaration and a comment
+marker inside a 515-line "delete comments" diff. Issue #1796 records the case.
+
+Run these four checks on every changed file before you commit a sweep.
+
+| Check | Command | Expected result |
+| - | - | - |
+| Compile | `python -m py_compile <file>` | No output |
+| Lint | `python -m ruff check .` | `All checks passed` |
+| Types | `python -m mypy $MYPY_PATHS --config-file pyproject.toml` | `Success` |
+| Symbols | `python -m tools.symbol_diff --base <base> <file>` | `no module-level name changed`, exit code 0 |
+
+Read the type check scope from the `MYPY_PATHS` value in
+`.github/workflows/ci.yml`. Do not repeat the value here, because a repeated
+value drifts when the scope moves.
+
+The symbol check exists because the other three checks miss a lost declaration.
+A deleted module global still compiles, and no test read that global. The tool
+compares the module-level names of the base revision against the work tree and
+reports every lost name and every added name. An added name can shadow an
+import, so the tool reports both directions.
+
+Obey these four rules for a sweep.
+
+1. A comment sweep deletes comment lines only.
+2. The pull request body states the count of deleted lines that are not
+   comments. The expected count is zero.
+3. A rebase repeats all four checks, because a rebase can reintroduce a loss.
+4. The pull request title names the sweep. A title such as "delete comments"
+   sets the wrong expectation, and a reviewer then reads a 515-line difference
+   as safe.
+
 ### Data Directory Permissions (CRITICAL)
 The container runs MistHelper as a non-root user (`misthelper`) for security. The mounted `data/` directory must be writable:
 ```bash

--- a/agents.md
+++ b/agents.md
@@ -60,6 +60,8 @@ git checkout main && git pull origin main
 - **File paths**: Use `os.path.join()` or `pathlib.Path()`, never hardcoded separators
 - **Container**: Podman primary, port 2200 (SSH), port 8055 (web UI)
 - **Zscaler**: Use GitHub Actions for container builds, never local `podman push`
+- **Automated sweep**: An automated sweep runs four checks before a commit. See
+  the "Automated Sweep Safety" section in `.github/copilot-instructions.md`.
 - **Inline comments on EVERY line** (NON-NEGOTIABLE): Every executable line of AI-generated
   code must have an inline comment explaining *why*, not just *what*. Code without comments
   is incomplete. When editing existing code, add comments to the entire block being touched.

--- a/tests/unit/test_fast_mode_flag.py
+++ b/tests/unit/test_fast_mode_flag.py
@@ -1,0 +1,88 @@
+"""Tests for the ``--fast`` command line flag.
+
+Issue #1796 reports that an automated sweep deleted the ``FAST_MODE_ENABLED``
+declaration from ``MistHelper.py``. No test read that module global, so no gate
+reported the loss. The flag then raised ``NameError`` at runtime.
+
+These tests read the module global on ``MistHelper`` itself. They never read a
+test double, per requirement FR-015. The two existing references in
+``tests/unit/serial_cc/test_switch_vc_stats.py`` set an attribute on a deps
+object, and neither one caught the defect.
+"""
+
+from __future__ import annotations  # Postponed annotations keep the type hints light.
+
+import argparse  # Builds the namespace that the function under test reads.
+from collections.abc import Iterator  # Types the fixture return value.
+
+import pytest  # Supplies the fixture decorator.
+
+import MistHelper  # The module that holds the flag under test.
+
+_MISSING = object()  # Sentinel for a module that holds no flag, so the guard test still runs.
+
+
+@pytest.fixture(name="restore_fast_mode", autouse=True)
+def fixture_restore_fast_mode() -> Iterator[None]:
+    """Save the module state before a test and restore it after the test.
+
+    Caution: the function under test writes a module global and registers the
+    parsed arguments in ``globals()``. Without this fixture a later test reads a
+    changed flag.
+
+    The fixture reads the flag through ``getattr`` with a sentinel. A missing
+    declaration must fail the guard test with a clear message. It must not raise
+    inside this fixture, because a setup error hides the reason.
+    """
+    saved_flag = getattr(MistHelper, "FAST_MODE_ENABLED", _MISSING)  # Save the flag, which may be absent.
+    saved_args = vars(MistHelper).get("args")  # Save the registered arguments, which may be absent.
+    yield  # Run the test.
+    if saved_flag is _MISSING:  # The module held no declaration before this test.
+        vars(MistHelper).pop("FAST_MODE_ENABLED", None)  # Leave the module as the test found it.
+    else:  # The module already declared the flag.
+        MistHelper.FAST_MODE_ENABLED = saved_flag  # Restore the earlier value for every later test.
+    if saved_args is None:  # The module held no registered arguments before this test.
+        vars(MistHelper).pop("args", None)  # Remove the name that the function under test added.
+    else:  # The module already held registered arguments.
+        MistHelper.args = saved_args  # Restore the earlier value.
+
+
+def _namespace(fast: bool) -> argparse.Namespace:
+    """Return the smallest namespace that the function under test reads."""
+    return argparse.Namespace(fast=fast, standalone=False)  # standalone stays False to write no env var.
+
+
+def test_fast_flag_sets_the_module_global(capsys: pytest.CaptureFixture[str]) -> None:
+    """The ``--fast`` flag sets ``MistHelper.FAST_MODE_ENABLED`` to True."""
+    MistHelper.FAST_MODE_ENABLED = False  # Start from the opposite value, so the test proves the write.
+    MistHelper._setup_runtime_flags(_namespace(fast=True))  # Apply the parsed command line flags.
+    capsys.readouterr()  # Drop the fast mode scope announcement, which this test does not read.
+    assert MistHelper.FAST_MODE_ENABLED is True  # The module global, not a test double, holds the value.
+
+
+def test_no_fast_flag_clears_the_module_global() -> None:
+    """A run without ``--fast`` sets ``MistHelper.FAST_MODE_ENABLED`` to False."""
+    MistHelper.FAST_MODE_ENABLED = True  # Start from the opposite value, so the test proves the write.
+    MistHelper._setup_runtime_flags(_namespace(fast=False))  # Apply the parsed command line flags.
+    assert MistHelper.FAST_MODE_ENABLED is False  # The default run leaves fast mode off.
+
+
+def test_fast_mode_declaration_exists() -> None:
+    """The module declares ``FAST_MODE_ENABLED`` at module level with a bool value.
+
+    This test fails when a sweep deletes the declaration, per requirement FR-014.
+    That deletion is the exact defect that issue #1796 reports.
+    """
+    assert hasattr(MistHelper, "FAST_MODE_ENABLED"), (
+        "MistHelper.py must declare the module global FAST_MODE_ENABLED. "
+        "A sweep that deletes the declaration breaks the --fast command line flag."
+    )  # Name the flag in the failure message, per success criterion SC-002.
+    assert isinstance(MistHelper.FAST_MODE_ENABLED, bool)  # The flag holds a bool, per the declaration.
+
+
+def test_fast_mode_reader_reads_the_module_global() -> None:
+    """The reader that the menu code calls returns the module global value."""
+    MistHelper.FAST_MODE_ENABLED = True  # Set the flag directly, without the command line path.
+    assert MistHelper._fast_mode_from_global() is True  # The reader observes the module global.
+    MistHelper.FAST_MODE_ENABLED = False  # Set the opposite value.
+    assert MistHelper._fast_mode_from_global() is False  # The reader observes the change.

--- a/tests/unit/tools/__init__.py
+++ b/tests/unit/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for the repository tools under ``tools/``."""

--- a/tests/unit/tools/test_symbol_diff.py
+++ b/tests/unit/tools/test_symbol_diff.py
@@ -1,0 +1,139 @@
+"""Tests for the module-level symbol table comparator.
+
+Issue #1796 reports that an automated comment sweep deleted a live declaration.
+The declaration used an annotated assignment, which Python parses as
+``ast.AnnAssign``. The annotated assignment case is therefore the most important
+test in this file. A comparator that matches ``ast.Assign`` alone reports a clean
+result on the exact defect that it exists to catch.
+"""
+
+from __future__ import annotations  # Postponed annotations keep the type hints light.
+
+from pathlib import Path  # Builds the temporary file path for the syntax error case.
+
+import pytest  # Supplies the tmp_path fixture and the parametrize marker.
+
+from tools.symbol_diff.comparator import SymbolDelta, SymbolTableComparator  # The code under test.
+
+
+@pytest.fixture(name="comparator")
+def fixture_comparator() -> SymbolTableComparator:
+    """Return a fresh comparator for one test."""
+    return SymbolTableComparator()  # The class holds no state, so a plain instance is enough.
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("FAST_MODE_ENABLED: bool = False", "FAST_MODE_ENABLED"),  # The issue #1796 defect shape.
+        ("PLAIN_NAME = 1", "PLAIN_NAME"),  # A plain assignment.
+        ("class SampleClass:\n    pass", "SampleClass"),  # A class definition.
+        ("def sample_function():\n    pass", "sample_function"),  # A function definition.
+        ("async def sample_coroutine():\n    pass", "sample_coroutine"),  # An async function definition.
+        ("import logging", "logging"),  # A plain import binds the root name.
+        ("import os.path", "os"),  # A dotted import binds the root name only.
+        ("import logging as log_module", "log_module"),  # An aliased import binds the alias.
+        ("from pathlib import Path", "Path"),  # A from-import binds the imported name.
+        ("FIRST, SECOND = 1, 2", "SECOND"),  # An unpacking target binds every nested name.
+    ],
+)
+def test_collect_names_finds_each_definition_shape(
+    comparator: SymbolTableComparator, source: str, expected: str
+) -> None:
+    """Every module-level definition shape contributes its bound name."""
+    names = comparator.collect_names(source, "sample.py")  # Parse the one-statement module.
+    assert names is not None  # A valid source always parses.
+    assert expected in names  # The parser reports the bound name.
+
+
+def test_collect_names_ignores_a_nested_definition(comparator: SymbolTableComparator) -> None:
+    """A name bound inside a function is not a module-level name."""
+    source = "def outer():\n    inner_name = 1\n    return inner_name"  # inner_name is a local name.
+    names = comparator.collect_names(source, "sample.py")  # Parse the module.
+    assert names == {"outer"}  # Only the function name reaches module level.
+
+
+def test_collect_names_reports_a_syntax_error_without_raising(
+    comparator: SymbolTableComparator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An uncompilable file yields None and a message that names the file and the line."""
+    names = comparator.collect_names("--- not python ---", "broken.py")  # Defect 2 of issue #1796.
+    assert names is None  # None means "unreadable", which differs from an empty set.
+    captured = capsys.readouterr().out  # Read the printed message.
+    assert "broken.py" in captured  # The message names the file.
+    assert "line" in captured  # The message names the line.
+
+
+def test_compare_reports_a_lost_annotated_global(comparator: SymbolTableComparator) -> None:
+    """A deleted annotated declaration appears in the lost names."""
+    base = comparator.collect_names("FAST_MODE_ENABLED: bool = False\n", "base")  # Before the sweep.
+    head = comparator.collect_names("\n", "head")  # After the sweep deleted the declaration.
+    assert base is not None and head is not None  # Both sides parse.
+    delta = comparator.compare(base, head, "MistHelper.py")  # Compare the two symbol tables.
+    assert delta.lost == ("FAST_MODE_ENABLED",)  # The comparator names the lost declaration.
+    assert delta.added == ()  # The sweep added no name.
+
+
+def test_compare_reports_an_added_name(comparator: SymbolTableComparator) -> None:
+    """A new module-level name appears in the added names, because it can shadow an import."""
+    base = comparator.collect_names("import logging\n", "base")  # Before the change.
+    head = comparator.collect_names("import logging\nlogging_helper = 1\n", "head")  # After the change.
+    assert base is not None and head is not None  # Both sides parse.
+    delta = comparator.compare(base, head, "sample.py")  # Compare the two symbol tables.
+    assert delta.added == ("logging_helper",)  # The comparator names the added declaration.
+    assert delta.lost == ()  # The change lost no name.
+
+
+def test_report_returns_zero_when_no_name_changed(
+    comparator: SymbolTableComparator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A clean comparison returns exit code 0, so a sweep continues."""
+    exit_code = comparator.report([SymbolDelta(path="sample.py")])  # No lost and no added name.
+    assert exit_code == 0  # Exit code 0 lets the sweep continue.
+    assert "no module-level name changed" in capsys.readouterr().out  # The clean result is stated.
+
+
+def test_report_returns_one_and_names_the_lost_symbol(
+    comparator: SymbolTableComparator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A lost name returns exit code 1 and prints the name, so a sweep stops."""
+    delta = SymbolDelta(path="MistHelper.py", lost=("FAST_MODE_ENABLED",))  # The issue #1796 case.
+    exit_code = comparator.report([delta])  # Print the report and read the exit code.
+    assert exit_code == 1  # Exit code 1 stops a sweep that changed the symbol table.
+    captured = capsys.readouterr().out  # Read the printed report.
+    assert "MistHelper.py" in captured  # The report names the file.
+    assert "FAST_MODE_ENABLED" in captured  # The report names the lost declaration.
+
+
+def test_read_revision_returns_none_for_an_unknown_path(comparator: SymbolTableComparator) -> None:
+    """git cannot read a path that no revision holds, so the method returns None."""
+    text = comparator.read_revision("HEAD", Path("no_such_file_for_symbol_diff.py"))  # Unknown path.
+    assert text is None  # The method reports the failure instead of raising.
+
+
+def test_read_revision_reads_a_tracked_file(comparator: SymbolTableComparator) -> None:
+    """git reads a tracked file at HEAD, which proves the base side of a comparison."""
+    text = comparator.read_revision("HEAD", Path("pyproject.toml"))  # A file every revision holds.
+    assert text is not None  # git resolved the revision and the path.
+    assert "[tool.ruff]" in text  # The text is the project configuration, not an error message.
+
+
+def test_run_reports_a_clean_tree_for_an_unchanged_file(
+    comparator: SymbolTableComparator, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A tracked file that the work tree did not change holds the same names, so the run exits 0."""
+    exit_code = comparator.run("HEAD", ["tools/ste_linter/scoring.py"])  # A tracked, unchanged file.
+    captured = capsys.readouterr().out  # Read the printed report.
+    assert exit_code == 0  # An unchanged file changes no module-level name.
+    assert "no module-level name changed" in captured  # The run compared the file rather than skipping it.
+    assert "cannot read" not in captured  # Prove that git resolved the path, so the pass is not vacuous.
+
+
+def test_run_skips_a_path_that_the_work_tree_lacks(
+    comparator: SymbolTableComparator, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """An unreadable path yields no delta, so the run reports a clean result."""
+    missing = tmp_path / "absent.py"  # A path that no file backs.
+    exit_code = comparator.run("HEAD", [str(missing)])  # Compare a path that nobody can read.
+    assert exit_code == 0  # A skipped path never invents a lost name.
+    assert "cannot read" in capsys.readouterr().out  # The run states why it skipped the path.

--- a/tools/symbol_diff/__init__.py
+++ b/tools/symbol_diff/__init__.py
@@ -1,0 +1,10 @@
+"""Module-level symbol table comparison for an automated sweep.
+
+Reports the module-level names that a change lost and the names that it added.
+An automated comment sweep must delete comment lines only. A sweep that deletes
+a declaration still compiles in many cases, so no gate reports it. This tool
+reports it. See ``specs/1796-comment-sweep-safety/`` for the full specification.
+"""
+
+# Package-level semantic version. Bump this when the report format changes.
+__version__ = "1.0.0"  # Read by the CLI --version flag and by the report header.

--- a/tools/symbol_diff/__main__.py
+++ b/tools/symbol_diff/__main__.py
@@ -1,0 +1,34 @@
+"""Module entry point for the symbol table comparator.
+
+Lets the tool run with ``python -m tools.symbol_diff``. It parses the command
+line, calls one method on ``SymbolTableComparator``, and uses its exit code.
+"""
+
+from __future__ import annotations  # Postponed annotations keep the type hints light.
+
+import argparse  # Parses the base revision and the path list.
+import logging  # Configures the log level before the first read.
+
+from . import __version__  # The reported version of the report format.
+from .comparator import SymbolTableComparator  # The one class that does the work.
+
+_DESCRIPTION = "Report the module-level names that a change lost and the names that it added."
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Return the command-line parser for the tool."""
+    parser = argparse.ArgumentParser(prog="tools.symbol_diff", description=_DESCRIPTION)  # Name the tool.
+    parser.add_argument("--base", required=True, help="The git revision to compare against.")  # Base side.
+    parser.add_argument("paths", nargs="+", help="One or more repository paths to compare.")  # Head side.
+    parser.add_argument("--verbose", action="store_true", help="Print the DEBUG log lines.")  # Log level.
+    parser.add_argument("--version", action="version", version=__version__)  # Report the format version.
+    return parser  # The caller parses the command line with this object.
+
+
+if __name__ == "__main__":  # Run only when called as a module.
+    arguments = _build_parser().parse_args()  # Read the base revision and the path list.
+    logging.basicConfig(  # Configure logging before the first read, so no startup line is dropped.
+        level=logging.DEBUG if arguments.verbose else logging.INFO,  # The flag selects the level.
+        format="%(asctime)s %(levelname)s %(message)s",  # An ASCII only format, per the logging rule.
+    )
+    raise SystemExit(SymbolTableComparator().run(arguments.base, arguments.paths))  # Use its exit code.

--- a/tools/symbol_diff/comparator.py
+++ b/tools/symbol_diff/comparator.py
@@ -1,0 +1,149 @@
+"""The symbol table comparator.
+
+Holds the ``SymbolTableComparator`` class and the ``SymbolDelta`` result record.
+The class reads a base revision from git, reads the work tree from disk, and
+reports the module-level names that the change lost and the names that it added.
+"""
+
+from __future__ import annotations  # Postponed annotations keep the type hints light.
+
+import ast  # Parses source text and never runs it, so a broken file stays readable.
+import logging  # Records each read and each comparison, per the action logging rule.
+import shutil  # Resolves the git executable to an absolute path before the call.
+import subprocess  # nosec B404 - The class queries git, and the call below uses shell=False.
+from dataclasses import dataclass  # Builds the immutable per-file result record.
+from pathlib import Path  # Holds every path, so no code hardcodes a separator.
+
+# The statement types that define a module-level name through a name attribute.
+# An annotated assignment parses as ast.AnnAssign, not as ast.Assign. A tool that
+# matches ast.Assign alone misses every annotated global, which is the exact
+# defect that issue #1796 reports.
+_DEFINITION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+# The repository root, derived from the location of this file. Every git call and
+# every relative path resolves against this directory. A pre-commit hook or a CI
+# step can then run the tool from any working directory and read the same files.
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class SymbolDelta:
+    """One comparison result for one file."""
+
+    path: str  # The repository path that the tool compared.
+    lost: tuple[str, ...] = ()  # Names present in the base revision and absent now.
+    added: tuple[str, ...] = ()  # Names absent in the base revision and present now.
+
+
+class SymbolTableComparator:
+    """Compares the module-level symbol table of a base revision against the work tree."""
+
+    def collect_names(self, source: str, label: str) -> set[str] | None:
+        """Return the module-level names in the source, or None when it does not parse."""
+        logging.debug("Parsing the module-level symbol table of %s", label)  # Log before the parse.
+        try:
+            tree = ast.parse(source)  # ast.parse reads text, so an uncompilable file stays readable.
+        except SyntaxError as error:  # Defect 2 of issue #1796 left a file that does not compile.
+            print(f"symbol_diff: {label} line {error.lineno or 0}: {error.msg}")  # Name the file and line.
+            logging.warning("Skipped %s because the source does not parse", label)  # Log after the failure.
+            return None  # A caller reads None as "unreadable", not as "no names".
+        names: set[str] = set()  # Accumulates the module-level names.
+        for node in tree.body:  # Only a top-level statement defines a module-level name.
+            names.update(self._names_of(node))  # Each statement contributes zero or more names.
+        logging.debug("Collected %d module-level names from %s", len(names), label)  # Log after the parse.
+        return names  # The caller compares this set against the other revision.
+
+    def read_revision(self, revision: str, path: Path) -> str | None:
+        """Return the text of the path at the revision, or None when git cannot read it."""
+        target = f"{revision}:{path.as_posix()}"  # git wants a forward-slash path on every platform.
+        git_path = shutil.which("git")  # Resolve an absolute path, so the call passes no bare name.
+        if git_path is None:  # A host without git cannot supply the base revision.
+            print("symbol_diff: PATH holds no git executable")  # Tell the operator what is missing.
+            return None  # The caller skips this file.
+        logging.info("Reading %s from git", target)  # Log before the read.
+        completed = subprocess.run(  # nosec B603 - shutil.which resolved the path and the rest are literals.
+            [git_path, "show", target],  # A fixed argument list, so no shell parses the target.
+            capture_output=True,  # Capture the file text from stdout.
+            text=True,  # Decode to str, because ast.parse reads text.
+            check=False,  # An unknown path returns 128, which this method reports itself.
+            cwd=_REPOSITORY_ROOT,  # Read the repository, not the caller working directory.
+        )
+        if completed.returncode != 0:  # git could not resolve the revision or the path.
+            print(f"symbol_diff: cannot read {target}")  # Name the unreadable target.
+            logging.warning("The git show command failed for %s", target)  # Log after the failure.
+            return None  # The caller skips this file.
+        logging.debug("Read %d characters from %s", len(completed.stdout), target)  # Log after the read.
+        return completed.stdout  # The caller parses this text.
+
+    def compare(self, base_names: set[str], head_names: set[str], path: str) -> SymbolDelta:
+        """Return the names that the change lost and the names that it added."""
+        logging.debug("Comparing the symbol table of %s", path)  # Log before the comparison.
+        lost = tuple(sorted(base_names - head_names))  # A lost name is the defect of issue #1796.
+        added = tuple(sorted(head_names - base_names))  # An added name can shadow an import.
+        logging.info("Found %d lost and %d added names in %s", len(lost), len(added), path)  # Log after.
+        return SymbolDelta(path=path, lost=lost, added=added)  # The report method prints this record.
+
+    def report(self, deltas: list[SymbolDelta]) -> int:
+        """Print every delta and return 1 when any file lost or added a name."""
+        changed = [delta for delta in deltas if delta.lost or delta.added]  # A quiet file needs no line.
+        for delta in changed:  # One group of lines for each changed file keeps the output readable.
+            print(f"symbol_diff: {delta.path}")  # Name the file before its names.
+            print(f"  lost:  {', '.join(delta.lost) or '(none)'}")  # A lost name blocks the sweep.
+            print(f"  added: {', '.join(delta.added) or '(none)'}")  # An added name can shadow an import.
+        if not changed:  # Every compared file holds the same module-level names.
+            print("symbol_diff: no module-level name changed")  # State the clean result plainly.
+            return 0  # Exit code 0 lets the sweep continue.
+        logging.info("Reported a symbol table change in %d file(s)", len(changed))  # Log the outcome.
+        return 1  # Exit code 1 stops a sweep that changed the symbol table.
+
+    def run(self, base: str, paths: list[str]) -> int:
+        """Compare every path against the base revision and return the process exit code."""
+        logging.info("Comparing %d path(s) against base revision %s", len(paths), base)  # Log before.
+        results = (self._inspect(base, Path(name)) for name in paths)  # One delta for each path.
+        deltas = [delta for delta in results if delta is not None]  # Drop the paths that nobody could read.
+        logging.debug("Collected %d comparable delta(s)", len(deltas))  # Log after the comparison.
+        return self.report(deltas)  # The report method owns the exit code.
+
+    def _inspect(self, base: str, path: Path) -> SymbolDelta | None:
+        """Return the delta for one path, or None when either revision does not parse."""
+        base_source = self.read_revision(base, path)  # The base text comes from git, not from disk.
+        head_source = self._read_worktree(path)  # The head text comes from the work tree.
+        if base_source is None or head_source is None:  # One side is missing, so no comparison is honest.
+            return None  # Report nothing rather than a false lost-name list.
+        base_names = self.collect_names(base_source, f"{base}:{path.as_posix()}")  # Names before the change.
+        head_names = self.collect_names(head_source, path.as_posix())  # Names after the change.
+        if base_names is None or head_names is None:  # A file that does not parse yields no trusted set.
+            return None  # The collect_names method already named the file and the line.
+        return self.compare(base_names, head_names, path.as_posix())  # Both sides parsed, so compare them.
+
+    def _read_worktree(self, path: Path) -> str | None:
+        """Return the work tree text of the path, or None when the read fails."""
+        logging.debug("Reading %s from the work tree", path.as_posix())  # Log before the read.
+        absolute = path if path.is_absolute() else _REPOSITORY_ROOT / path  # Match the git side.
+        try:
+            return absolute.read_text(encoding="utf-8")  # UTF-8 matches the project source encoding.
+        except OSError as error:  # A deleted path or a permission error reaches this branch.
+            print(f"symbol_diff: cannot read {path.as_posix()}: {error}")  # Name the unreadable path.
+            return None  # The caller skips this file.
+
+    def _names_of(self, node: ast.stmt) -> set[str]:
+        """Return the module-level names that one top-level statement defines."""
+        if isinstance(node, _DEFINITION_NODES):  # A function, an async function, or a class.
+            return {node.name}  # Each of the three node types carries one name attribute.
+        if isinstance(node, (ast.Import, ast.ImportFrom)):  # An import binds a name at module level.
+            return {alias.asname or alias.name.split(".")[0] for alias in node.names}  # Bind the root name.
+        if isinstance(node, ast.AnnAssign):  # An annotated assignment, such as NAME: bool = False.
+            return self._target_names([node.target])  # One target only, per the Python grammar.
+        if isinstance(node, ast.Assign):  # A plain assignment, such as NAME = False.
+            return self._target_names(node.targets)  # A chained assignment carries several targets.
+        return set()  # Any other statement defines no module-level name.
+
+    def _target_names(self, targets: list[ast.expr]) -> set[str]:
+        """Return the bound names inside an assignment target list."""
+        names: set[str] = set()  # Accumulates the bound names.
+        for target in targets:  # A target list holds one entry for each chained assignment.
+            if isinstance(target, ast.Name):  # The common case binds one plain name.
+                names.add(target.id)  # Record the bound name.
+            elif isinstance(target, (ast.Tuple, ast.List)):  # An unpacking target binds several names.
+                names.update(self._target_names(list(target.elts)))  # Recurse into the nested targets.
+        return names  # The caller adds these names to the module set.


### PR DESCRIPTION
Closes #1796

Spec: `specs/1796-comment-sweep-safety/spec.md`

## Problem

An automated comment sweep (PR #1791) deleted 515 lines from `MistHelper.py`. Two of the deleted lines were not comments. One was the live declaration `FAST_MODE_ENABLED: bool = False`. The other was a `#` marker, which left a file that `py_compile` rejected.

The compile error was loud. The lost declaration was quiet. It fails only when an operator passes `--fast`, because `_setup_runtime_flags` assigns to that name through a `global` statement.

Two gaps let it through. No test read the module global, and the type gate had reached `MistHelper.py` only days before.

## What this pull request adds

### 1. `tools/symbol_diff` - a symbol table comparator

`SymbolTableComparator` reads a base revision from git, reads the work tree, and reports every lost module-level name and every added module-level name.

```powershell
python -m tools.symbol_diff --base <base> MistHelper.py
```

Three design points carry the value.

- It handles `ast.AnnAssign` as well as `ast.Assign`. The lost declaration used an annotated assignment. A tool that matches `ast.Assign` alone reports a clean result on the exact defect it exists to catch. This repository already lost `scripts/generate_menu_wiki.py` to that same trap.
- It catches `SyntaxError` and names the file and the line. Defect 2 left a file that does not compile, so the tool parses text with `ast` and never imports the file.
- It resolves git and every relative path against the repository root. A pre-commit hook can then run it from any working directory.

It reports an added name too, because an added name can shadow an import.

### 2. `tests/unit/test_fast_mode_flag.py` - the missing coverage

Four tests read `MistHelper.FAST_MODE_ENABLED` on the module itself, never on a test double. An autouse fixture saves and restores the module global and the registered arguments.

### 3. The written procedure

`.github/copilot-instructions.md` gains an "Automated Sweep Safety" section that states the four checks, their exact commands, and the four sweep rules. `agents.md` gains a one-line pointer. The section reads the type check scope by reference from `MYPY_PATHS` in `.github/workflows/ci.yml`, so a repeated value cannot drift.

## Proof

Both success criteria were proven by removing the declaration from the work tree and restoring it afterwards.

**SC-006 - the tool reports the defect:**

```text
symbol_diff: MistHelper.py
  lost:  FAST_MODE_ENABLED
  added: (none)
TOOL_EXIT=1
```

**SC-002 - the suite fails and names the flag:**

```text
E   AttributeError: module 'MistHelper' has no attribute 'FAST_MODE_ENABLED'
```

`git status` confirmed a clean tree after the restore.

## Gate results

| Gate | Command | Result |
| - | - | - |
| Tests | `pytest tests/unit/tools/test_symbol_diff.py tests/unit/test_fast_mode_flag.py` | 24 passed |
| Lint | `ruff check` on the changed paths | All checks passed |
| Format | `black --check` on the changed paths | 6 files unchanged |
| Types | `mypy tools/symbol_diff/*.py --config-file pyproject.toml` | Success, no issues in 2 source files |
| Security | `bandit -c pyproject.toml -r tools/symbol_diff` | 0 issues at every severity |
| STE | `tools.ste_linter .github/copilot-instructions.md` | 95/100 PASS |
| STE | `tools.ste_linter agents.md` | 92/100 PASS |

## Conformance

- Deleted lines that are not comments: **0**. This work deletes no line.
- Added `# noqa` directives: **0**. Added `# type: ignore` comments: **0**.
- Recorded suppressions: `# nosec B404` on the `subprocess` import and `# nosec B603` on the `git show` call. Both name the seam. `shutil.which` resolves the path and the call passes a fixed argument list with `shell=False`, in the style of `tools/compliance_analyzer/engine.py`.
- `SymbolTableComparator` holds exactly 5 public methods. Every method stays inside 5 parameters and 25 lines.
- Every added executable line carries an inline comment. Every read and every comparison logs before and after.

## Files not touched

This branch edits no contested file. It does not touch `MistHelper.py`, so it cannot conflict with PR #1825. It also leaves `CHANGELOG.md` alone for the same reason, so a maintainer should add the changelog entry at merge time or in a follow-up.
