### PR TITLE
refactor(ssh): finish the spec 1031 echo sweep and record the CodeQL verdict

### DIFF
--- a/src/ssh/runtime/app_runner.py
+++ b/src/ssh/runtime/app_runner.py
@@ -32,6 +32,7 @@ from src.ssh.config.validators import (  # Shared input validators
     validate_username,
 )
 from src.ssh.runtime.interactive_mode import InteractiveMode  # Concrete REPL implementation
+from src.utils.console import echo  # WHY: spec 1031 console echo keeps stdout text and drops the WARNING level.
 from src.utils.input_utils import InputUtils  # EOF-safe input wrapper (issue #452)
 
 logger = logging.getLogger(__name__)  # WHY: module-scoped logger for #886 print-to-logger migration.
@@ -297,8 +298,8 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
             # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
             logger.error("X  No valid commands remaining")
             return []
-        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
-        logger.warning("!? Proceeding with %d valid commands", len(validated))  # Soft failure path
+        # WHY: spec 1031 console echo. The stdout text stays the same and the record drops to INFO.
+        echo("!? Proceeding with %d valid commands", len(validated))  # WHY: tell the operator the run continues.
         return validated
 
     @staticmethod
@@ -337,8 +338,8 @@ class AppRunner:  # WHY: decomposed orchestrator preserving legacy CLI entrypoin
         requested = request.args.max_threads or multiprocessing.cpu_count()  # CLI override or CPU count
         max_threads = _validate_thread_count(requested, len(request.hosts))  # Apply safety caps
         if max_threads != requested:  # Tell the user if we clamped their request
-            # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
-            logger.warning("!? Adjusted thread count from %d to %d", requested, max_threads)
+            # WHY: spec 1031 console echo. The stdout text stays the same and the record drops to INFO.
+            echo("!? Adjusted thread count from %d to %d", requested, max_threads)  # WHY: report the clamp.
         logging.info(
             "Dispatching to MultiHostRunner.run (%d hosts / %d cmds)", len(request.hosts), len(request.commands)
         )

--- a/src/ssh/shell_execution/shell_executor.py
+++ b/src/ssh/shell_execution/shell_executor.py
@@ -26,6 +26,8 @@ import time  # WHY: Timing for output loops, cleanup, total duration
 from dataclasses import dataclass  # WHY: Frozen slotted state bundle keeps _collect_output CC low
 from typing import Any  # WHY: paramiko Channel type is dynamic across paramiko versions
 
+from src.utils.console import echo  # WHY: spec 1031 console echo keeps stdout text and drops the WARNING level.
+
 logger = logging.getLogger(__name__)  # WHY: Module-scoped logger for the drain-progress staticmethod
 
 # Module-level constants - extracted so each method's CC stays low (no magic numbers in branches)
@@ -395,8 +397,8 @@ class ShellExecutor:
         state.output += (
             f"\n\n[OUTPUT TRUNCATED - Size limit of {cap_mb}MB reached]\n"  # WHY: Verbatim truncation marker
         )
-        # WHY: preserve operator notice verbatim. Route through logger for capture/redirection.
-        self.logger.warning("!? [%s] Output truncated at %dMB, draining remaining data...", hostname, cap_mb)
+        # WHY: spec 1031 console echo. The genuine truncation warning stays above at WARNING.
+        echo("!? [%s] Output truncated at %dMB, draining remaining data...", hostname, cap_mb)  # WHY: notify operator.
         state.truncated = True  # WHY: Loop will drain the tail and exit
 
     def _log_chunk_progress(

--- a/src/ssh/ssh_runner_manager.py
+++ b/src/ssh/ssh_runner_manager.py
@@ -18,6 +18,7 @@ from src.ssh.batch.multi_host_runner import (  # WHY: T013c/T039 extracted multi
 from src.ssh.config.csv_loader import CommandCsvLoader  # WHY: T013a extracted CSV command loader.
 from src.ssh.config.env_loader import EnvSshConfigLoader  # WHY: T013a extracted .env config loader.
 from src.ssh.runtime.app_runner import AppRunner  # WHY: T013d concrete CLI orchestrator, no facade.
+from src.utils.console import echo  # WHY: spec 1031 console echo keeps stdout text and drops the WARNING level.
 
 _PROGRESS_MENU_ID = "97"  # WHY: sentinel menu id shared by start/complete progress emissions.
 _PROGRESS_OPERATION = "ssh_runner"  # WHY: progress operation label used by telemetry sinks.
@@ -107,9 +108,18 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _echo_plan(hosts: Any, username: Any, commands: Any) -> None:  # WHY: extracted echo keeps caller ≤ 25 lines.
         """Echo the resolved execution plan back to the operator."""
-        logging.warning("!? Target hosts: %s", ", ".join(hosts))  # WHY: echo back what we are about to do.
-        logging.warning("!? Username: %s", username)  # WHY: user-visible username echo.
-        logging.warning("!? Commands: %s command(s)", len(commands) if commands else 0)  # WHY: echo count.
+        # CodeQL verdict for alerts 188 and 189, rule py/clear-text-logging-sensitive-data.
+        # Verdict: false_positive. Review date: 2026-08-22. Reason: the two records below
+        # hold a target host list and a login name. Neither value is a password. The rule
+        # raises the password class from a sibling credential in this module, not from
+        # these two values. The operator must read the plan before a bulk SSH run, so the
+        # project keeps both records. Next review trigger: a change that adds a password
+        # argument to _echo_plan, or a new alert on this function.
+        logging.info("Echoing the resolved SSH execution plan to the operator")  # WHY: pre-action log.
+        echo("!? Target hosts: %s", ", ".join(hosts))  # WHY: the operator confirms the target list before the run.
+        echo("!? Username: %s", username)  # WHY: the operator confirms the login account before the run.
+        echo("!? Commands: %s command(s)", len(commands) if commands else 0)  # WHY: the operator confirms the count.
+        logging.debug("Echoed plan for %d host(s)", len(hosts))  # WHY: post-action log with the host count.
 
     @staticmethod
     def _emit_completion(emitter: Any, op_start: float, cancelled: bool) -> None:  # WHY: telemetry helper.
@@ -304,7 +314,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
     @staticmethod
     def _execute_multi_host(hosts: Any, username: Any, password: Any, commands: Any) -> bool:  # WHY: fan-out path.
         """Execute the multi-host / multi-command SSH fan-out path via MultiHostRunner."""
-        logging.warning("\n!? Executing %s command(s) on %s host(s)", len(commands), len(hosts))
+        echo("\n!? Executing %s command(s) on %s host(s)", len(commands), len(hosts))  # WHY: stdout text unchanged.
         summary = MultiHostRunner.run(  # WHY: T013c/T039 direct call via immutable request bundle.
             MultiHostRunRequest(
                 hosts=tuple(hosts),  # WHY: convert list to tuple for frozen dataclass storage.
@@ -320,7 +330,7 @@ class SSHRunnerManager:  # WHY: staticmethod facade preserves the MistHelper pub
         successful = sum(  # WHY: count entries with truthy success flag.
             1 for result in summary.values() if isinstance(result, dict) and result.get("success", False)
         )
-        logging.warning("\n!? Execution Summary: %s/%s hosts successful", successful, len(summary))
+        echo("\n!? Execution Summary: %s/%s hosts successful", successful, len(summary))  # WHY: stdout text unchanged.
         return successful > 0
 
     @staticmethod

--- a/tests/unit/ssh/test_ssh_console_echo.py
+++ b/tests/unit/ssh/test_ssh_console_echo.py
@@ -1,0 +1,117 @@
+"""Unit tests for the spec 1031 console echo sweep across ``src/ssh`` (issue #1736).
+
+Why:
+    Spec 1031 moved every legacy console echo from the WARNING channel to the
+    ``echo()`` helper. The sweep missed eight lines under ``src/ssh``. These
+    tests lock the two properties that the sweep must hold. The stdout text
+    stays the same, and the record never lands on the WARNING channel.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from src.ssh.runtime.app_runner import AppRunner
+from src.ssh.shell_execution.shell_executor import ShellExecutor, _CollectState
+from src.ssh.ssh_runner_manager import SSHRunnerManager
+
+_ECHO_PREFIX = "!?"  # WHY: the marker that identifies a legacy console echo line.
+
+
+def _echo_records_above_info(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return every captured message at WARNING or above that carries the echo marker.
+
+    Why:
+        The converted lines must never reach the WARNING channel again. A
+        genuine warning on the same code path is allowed, so the filter looks
+        for the echo marker instead of counting every WARNING record.
+
+    Args:
+        caplog (pytest.LogCaptureFixture): The pytest log capture fixture.
+
+    Returns:
+        list[str]: The offending messages. An empty list means the sweep holds.
+    """
+    offenders = []  # WHY: collect the offending messages so a failure names them.
+    for record in caplog.records:  # WHY: inspect one captured record per iteration.
+        message = record.getMessage()  # WHY: render the template so the marker is visible.
+        if record.levelno >= logging.WARNING and _ECHO_PREFIX in message:  # WHY: flag echo text above INFO.
+            offenders.append(message)  # WHY: keep the message for the assertion report.
+    return offenders  # WHY: the caller asserts that this list is empty.
+
+
+def test_echo_plan_prints_expected_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    """The execution plan echo keeps the exact text that the operator saw before."""
+    SSHRunnerManager._echo_plan(["10.0.0.1", "10.0.0.2"], "netops", ["show version", "show chassis"])
+
+    captured = capsys.readouterr()  # WHY: read the stdout that the helper produced.
+    assert captured.out == ("!? Target hosts: 10.0.0.1, 10.0.0.2\n!? Username: netops\n!? Commands: 2 command(s)\n")
+    assert captured.err == ""  # WHY: the helper never writes to stderr.
+
+
+def test_echo_plan_never_records_on_the_warning_channel(caplog: pytest.LogCaptureFixture) -> None:
+    """The execution plan echo records at INFO, so a log grep for WARNING stays clean."""
+    caplog.set_level(logging.DEBUG)  # WHY: capture every level so an INFO record is visible.
+
+    SSHRunnerManager._echo_plan(["10.0.0.1"], "netops", [])
+
+    assert _echo_records_above_info(caplog) == []  # WHY: no echo text on the WARNING channel.
+    assert "!? Username: netops" in caplog.text  # WHY: the audit trail still holds the echoed line.
+
+
+def test_echo_plan_handles_an_empty_command_list(capsys: pytest.CaptureFixture[str]) -> None:
+    """An empty command list echoes a zero count, which matches the legacy text."""
+    SSHRunnerManager._echo_plan(["10.0.0.1"], "netops", [])
+
+    assert "!? Commands: 0 command(s)\n" in capsys.readouterr().out  # WHY: zero count text is preserved.
+
+
+def test_execute_multi_host_echoes_start_and_summary(
+    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+) -> None:
+    """The fan-out banner and the summary line print to stdout and record at INFO."""
+    caplog.set_level(logging.DEBUG)  # WHY: capture every level so the INFO record is visible.
+    fake_summary = {"10.0.0.1": {"success": True}, "10.0.0.2": {"success": False}}  # WHY: one pass, one fail.
+
+    with patch("src.ssh.ssh_runner_manager.MultiHostRunner.run", return_value=fake_summary):
+        result = SSHRunnerManager._execute_multi_host(["10.0.0.1", "10.0.0.2"], "netops", "secret", ["show version"])
+
+    assert result is True  # WHY: one successful host makes the run succeed.
+    assert capsys.readouterr().out == (
+        "\n!? Executing 1 command(s) on 2 host(s)\n\n!? Execution Summary: 1/2 hosts successful\n"
+    )
+    assert _echo_records_above_info(caplog) == []  # WHY: neither banner reaches the WARNING channel.
+
+
+def test_validate_commands_echoes_the_soft_failure_notice(
+    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+) -> None:
+    """The soft failure notice prints to stdout while the reject warning stays a warning."""
+    caplog.set_level(logging.DEBUG)  # WHY: capture every level so both records are visible.
+
+    validated = AppRunner._validate_commands(["show version", "bad\x00command"])
+
+    assert validated == ["show version"]  # WHY: the NUL command is rejected by the shared validator.
+    assert capsys.readouterr().out == "!? Proceeding with 1 valid commands\n"  # WHY: text is unchanged.
+    assert _echo_records_above_info(caplog) == []  # WHY: the echo left the WARNING channel.
+    assert "X  Invalid commands detected" in caplog.text  # WHY: the genuine warning is untouched.
+
+
+def test_apply_truncation_echoes_and_keeps_the_genuine_warning(
+    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+) -> None:
+    """The truncation echo moves to stdout while the size-limit warning stays at WARNING."""
+    caplog.set_level(logging.DEBUG)  # WHY: capture every level so both records are visible.
+    executor = ShellExecutor(client=None)  # WHY: the truncation helper never touches the client.
+    state = _CollectState()  # WHY: fresh collection state so the marker append is measurable.
+
+    executor._apply_truncation(state, "sw-01")
+
+    assert capsys.readouterr().out == "!? [sw-01] Output truncated at 100MB, draining remaining data...\n"
+    assert state.truncated is True  # WHY: the caller drains the tail once this flag is set.
+    assert _echo_records_above_info(caplog) == []  # WHY: the echo left the WARNING channel.
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]  # WHY: keep real warnings.
+    assert "Output size limit (100MB) reached, draining remaining data..." in warnings


### PR DESCRIPTION
Fixes #1736

## What changed

Spec 1031 moved about 170 legacy console echoes off the `WARNING` channel and onto
the `echo()` helper in `src/utils/console.py`. The sweep missed eight lines under
`src/ssh`. This pull request converts all eight and records the CodeQL verdict for
the two open alerts.

### Converted console echo lines: 8

| File | Symbol | Echo text |
| - | - | - |
| `src/ssh/ssh_runner_manager.py` | `_echo_plan` | `!? Target hosts: %s` |
| `src/ssh/ssh_runner_manager.py` | `_echo_plan` | `!? Username: %s` |
| `src/ssh/ssh_runner_manager.py` | `_echo_plan` | `!? Commands: %s command(s)` |
| `src/ssh/ssh_runner_manager.py` | `_execute_multi_host` | `\n!? Executing %s command(s) on %s host(s)` |
| `src/ssh/ssh_runner_manager.py` | `_execute_multi_host` | `\n!? Execution Summary: %s/%s hosts successful` |
| `src/ssh/runtime/app_runner.py` | `_validate_commands` | `!? Proceeding with %d valid commands` |
| `src/ssh/runtime/app_runner.py` | `_run_multi_host` | `!? Adjusted thread count from %d to %d` |
| `src/ssh/shell_execution/shell_executor.py` | `_apply_truncation` | `!? [%s] Output truncated at %dMB, draining remaining data...` |

A grep for a `!?` prefixed `logging.warning` or `logger.warning` under `src/ssh`
now returns zero matches.

### Text preservation

Every message string is byte-identical to the string before the change. The helper
writes it to stdout with `print()` and records it at `INFO`, which is the same
treatment the other converted sites received in pull request #1694. The `asctime`
and `levelname` prefix that the console log handler added is gone, because that
prefix removal is the point of spec 1031.

### Genuine warnings kept

- `shell_executor.py` still logs `Output size limit (%dMB) reached, draining
  remaining data...` at `WARNING`. Only the duplicate echo below it moved.
- `app_runner.py` still logs `X  Invalid commands detected: %s` at `WARNING` and
  `X  No valid commands remaining` at `ERROR`.

## CodeQL verdict

Rule: `py/clear-text-logging-sensitive-data`.

| Alert | Anchor | Verdict | Review date | Next review trigger |
| - | - | - | - | - |
| 188 | `_echo_plan` `"!? Target hosts: %s"` | `false_positive` | 2026-08-22 | A change that adds a password argument to `_echo_plan`, or a new alert on this function |
| 189 | `_echo_plan` `"!? Username: %s"` | `false_positive` | 2026-08-22 | A change that adds a password argument to `_echo_plan`, or a new alert on this function |

Reason: the two records hold a target host list and a login name. Neither value is
a password. The rule raises the password class from a sibling credential in the
module, not from these two values. The operator must read the plan before a bulk
SSH run, so the project keeps both records.

The verdict lives as an inline comment above the two statements in `_echo_plan()`,
so the suppression is defended in the code that a reviewer reads.

**Action still needed by a maintainer**: the API dismissal in clause C-7 of
`specs/1034-codeql-cleartext-logging/contracts/verdict-register.md` failed with
HTTP 403. The agent token holds no `security_events` scope. Run the command below
with a token that holds the scope.

```bash
for n in 188 189; do
  gh api -X PATCH "repos/jmorrison-juniper/MistHelper/code-scanning/alerts/$n" \
    -f state=dismissed \
    -f dismissed_reason="false positive" \
    -f dismissed_comment="The record holds a target host list or a login name. Neither value is a password. The rule raises the password class from a sibling credential in the module."
done
```

The verdict register at `specs/1034-codeql-cleartext-logging/verdict-register.md`
does not exist in the tree yet, and that path sits outside this pull request's file
ownership, so the two rows are not added here.

## Tests

New file `tests/unit/ssh/test_ssh_console_echo.py` holds six tests.

- `test_echo_plan_prints_expected_stdout` asserts the exact three-line stdout text.
- `test_echo_plan_never_records_on_the_warning_channel` asserts no echo text lands
  at `WARNING` or above, and asserts the audit trail still holds the line.
- `test_echo_plan_handles_an_empty_command_list` asserts the zero-count text.
- `test_execute_multi_host_echoes_start_and_summary` asserts the exact banner and
  summary stdout text and the absence of a `WARNING` record.
- `test_validate_commands_echoes_the_soft_failure_notice` asserts the stdout text
  and asserts the reject warning stays at `WARNING`.
- `test_apply_truncation_echoes_and_keeps_the_genuine_warning` asserts the stdout
  text and asserts the size-limit warning stays at `WARNING`.

## Gate results

| Gate | Command | Result |
| - | - | - |
| Syntax | `python -m py_compile` on the three changed modules | pass |
| Ruff | `python -m ruff check src/ssh/ tests/unit/ssh/` | pass, all checks passed |
| Black | `python -m black --check src/ssh/ tests/unit/ssh/` | pass, 33 files unchanged |
| pytest | `python -m pytest tests/unit/ssh/ -q` | pass, 197 passed |
| mypy | `python -m mypy` on the three changed modules, strict config | pass, no issues found |
| pydocstyle | `python -m pydocstyle` on the three changed modules | pass, zero violations |

## Acceptance criteria

- [x] The stdout message text that the operator reads does not change.
- [x] No `!?` prefixed console echo in `src/ssh/` calls `logging.warning`.
- [x] Both CodeQL alerts carry a recorded verdict with a defending comment.
- [x] The existing unit tests pass.

## File ownership

This pull request touches only `src/ssh/` and `tests/unit/ssh/`. No file outside
that scope is changed.
