### PR TITLE
test(ci): scope every remaining sleep spy to the calling thread

### DIFF
--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,5 @@
+"""Shared helpers for the MistHelper test suite.
+
+The package holds test support code that more than one test module uses. It
+holds no test of its own, so pytest does not collect it.
+"""

--- a/tests/support/thread_scoped_sleep.py
+++ b/tests/support/thread_scoped_sleep.py
@@ -1,0 +1,129 @@
+"""A ``time.sleep`` spy that records only the calls of one thread.
+
+Why this module exists
+----------------------
+Every MistHelper module binds the clock with ``import time``. That statement
+binds the one shared ``time`` module object, not a private copy. So a patch
+target that looks module-scoped is global in fact::
+
+    patch("src.api.api_fetch_utils.time.sleep")
+
+``unittest.mock.patch`` splits that target on the last dot, resolves the shared
+``time`` module, and sets ``sleep`` on it. The replacement reaches every thread
+in the interpreter. A daemon thread that an earlier test left running then adds
+its own interval to the record. That extra call shifts every index and breaks
+every exact count.
+
+The failure is real. Continuous integration run 31969418423 failed the pytest
+gate on pull request #1820, a change that only raises the ruff version. A
+foreign 30-second interval from a leaked heartbeat thread entered a sleep
+record and moved the value the test read.
+
+The repair
+----------
+:class:`ThreadScopedSleepSpy` records the owning thread at build time. The spy
+drops a call that arrives on any other thread, so a leaked thread can no longer
+change what a test observes. The spy counts the dropped calls, which lets a
+test assert on the guard itself.
+
+Usage
+-----
+Pass the spy to ``patch`` through ``new``, then read the same attributes a
+``MagicMock`` offers::
+
+    spy = ThreadScopedSleepSpy()
+    with patch("src.api.api_fetch_utils.time.sleep", new=spy):
+        APIFetchUtils.retry_one_item(...)
+    spy.assert_called_once()
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+from unittest.mock import call
+
+logger = logging.getLogger(__name__)  # Module logger, per issue #1793.
+
+__all__ = ["ThreadScopedSleepSpy"]
+
+
+class ThreadScopedSleepSpy:
+    """Record the ``time.sleep`` calls that come from one thread.
+
+    The spy binds the thread that builds it. It records a call from that
+    thread. It drops a call from any other thread and counts the drop.
+    """
+
+    def __init__(self, name: str = "sleep") -> None:
+        """Bind the calling thread as the owner of this spy.
+
+        Args:
+            name: A label for the log lines and the assertion messages.
+        """
+        logger.debug("Building a thread-scoped sleep spy named %s", name)  # Trace the build.
+        self._name = name  # Keep the label for every message this spy raises.
+        self._owner_thread_id = threading.get_ident()  # Bind the owner at build time, not at call time.
+        self._calls: list[Any] = []  # Hold one mock call object for each owned call.
+        self._foreign_call_count = 0  # Count the calls this spy drops.
+        logger.debug("Spy %s owns thread %d", name, self._owner_thread_id)  # Record the owner.
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        """Stand in for ``time.sleep`` and record the call.
+
+        The spy never sleeps, because a unit test must not wait.
+        """
+        if threading.get_ident() != self._owner_thread_id:  # Reject a call from a foreign thread.
+            self._foreign_call_count += 1  # Count the drop so a test can assert on the guard.
+            logger.debug(
+                "Spy %s dropped a foreign interval %s from thread %d",
+                self._name,
+                args,
+                threading.get_ident(),
+            )  # Name the thread that leaked, which speeds up the next diagnosis.
+            return  # Drop the call. The record stays as the owning thread built it.
+        self._calls.append(call(*args, **kwargs))  # Record the owned call in mock call form.
+
+    @property
+    def call_args_list(self) -> list[Any]:
+        """Return the owned calls in the order the owner made them."""
+        return list(self._calls)  # Copy the list, so a caller cannot edit the record.
+
+    @property
+    def call_count(self) -> int:
+        """Return the count of owned calls."""
+        return len(self._calls)  # The foreign calls never enter this list.
+
+    @property
+    def foreign_call_count(self) -> int:
+        """Return the count of calls this spy dropped from other threads."""
+        return self._foreign_call_count  # A non-zero value proves a thread leaked.
+
+    @property
+    def intervals(self) -> list[Any]:
+        """Return the first positional argument of each owned call."""
+        return [entry.args[0] for entry in self._calls if entry.args]  # Skip a call with no interval.
+
+    def assert_called_once(self) -> None:
+        """Fail unless the owner called the spy exactly one time."""
+        if self.call_count != 1:  # Compare against the owned count only.
+            raise AssertionError(f"expected {self._name} to be called once, got {self.call_count}: {self.intervals}")
+
+    def assert_called_once_with(self, *args: Any, **kwargs: Any) -> None:
+        """Fail unless the owner made exactly one call with these arguments."""
+        self.assert_called_once()  # Check the count first, because it gives the clearer message.
+        expected = call(*args, **kwargs)  # Build the call the caller expects.
+        if self._calls[0] != expected:  # Compare the one recorded call against it.
+            raise AssertionError(f"expected {self._name} call {expected}, got {self._calls[0]}")
+
+    def assert_not_called(self) -> None:
+        """Fail if the owner called the spy at all."""
+        if self._calls:  # A foreign call can no longer trigger this failure.
+            raise AssertionError(f"expected no {self._name} call, got {self.intervals}")
+
+    def reset_mock(self) -> None:
+        """Clear the record and the drop count, and keep the owner."""
+        logger.debug("Resetting the spy %s record", self._name)  # Trace the reset.
+        self._calls.clear()  # Drop the recorded calls.
+        self._foreign_call_count = 0  # Drop the foreign count with them.

--- a/tests/unit/analytics/test_data_collection_manager.py
+++ b/tests/unit/analytics/test_data_collection_manager.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from src.analytics.data_collection_manager import DataCollectionManager
+from tests.support.thread_scoped_sleep import ThreadScopedSleepSpy
 
 # WHY: caplog must target the module logger so INFO/WARNING/ERROR records surface (issue #886).
 _LOGGER_NAME = "src.analytics.data_collection_manager"
@@ -149,9 +150,10 @@ def test_execute_collection_cycle_runs_all_steps_and_paces(caplog: pytest.LogCap
     caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     step_a, step_b = MagicMock(name="a"), MagicMock(name="b")
     steps = [("  step A", step_a), ("  step B", step_b)]
+    sleep = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot shift this record.
     with (
         patch.object(DataCollectionManager, "_collection_cycle_steps", return_value=steps),
-        patch("src.analytics.data_collection_manager.time.sleep") as sleep,
+        patch("src.analytics.data_collection_manager.time.sleep", new=sleep),
     ):
         DataCollectionManager._execute_collection_cycle(loop_count=3)
     step_a.assert_called_once_with()
@@ -177,9 +179,10 @@ def test_execute_collection_cycle_logs_and_backs_off_on_exception(caplog: pytest
     caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     step = MagicMock(side_effect=RuntimeError("nope"))
     steps = [("  step", step)]
+    sleep = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot add a false back-off.
     with (
         patch.object(DataCollectionManager, "_collection_cycle_steps", return_value=steps),
-        patch("src.analytics.data_collection_manager.time.sleep") as sleep,
+        patch("src.analytics.data_collection_manager.time.sleep", new=sleep),
     ):
         DataCollectionManager._execute_collection_cycle(loop_count=7)
     out = "\n".join(r.getMessage() for r in caplog.records)

--- a/tests/unit/api/test_api_fetch_utils.py
+++ b/tests/unit/api/test_api_fetch_utils.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from src.api.api_fetch_utils import APIFetchUtils
+from tests.support.thread_scoped_sleep import ThreadScopedSleepSpy
 
 
 def _make_mh(**extra):
@@ -306,9 +307,10 @@ def test_gw_retry_one_item_succeeds_on_second_attempt() -> None:
     """Returns the recovered config once a retry produces a non-None result."""
     sem = threading.Semaphore(1)
     results = [None, {"foo": "bar", "site_id": "s1"}]
+    sleep = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot break the exact count.
     with (
         patch.object(APIFetchUtils, "_gw_fetch_one_config", side_effect=results) as fetch,
-        patch("src.api.api_fetch_utils.time.sleep") as sleep,
+        patch("src.api.api_fetch_utils.time.sleep", new=sleep),
     ):
         out = APIFetchUtils._gw_retry_one_item(MagicMock(), ("s1", "d1", "SiteOne"), sem, max_retries=2)
     assert out == {"foo": "bar", "site_id": "s1"}
@@ -319,9 +321,10 @@ def test_gw_retry_one_item_succeeds_on_second_attempt() -> None:
 def test_gw_retry_one_item_returns_none_after_exhausting_attempts() -> None:
     """All attempts return None -> function returns None after max_retries+1 tries."""
     sem = threading.Semaphore(1)
+    sleep = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot break the exact count.
     with (
         patch.object(APIFetchUtils, "_gw_fetch_one_config", return_value=None) as fetch,
-        patch("src.api.api_fetch_utils.time.sleep") as sleep,
+        patch("src.api.api_fetch_utils.time.sleep", new=sleep),
     ):
         out = APIFetchUtils._gw_retry_one_item(MagicMock(), ("s1", "d1", "SiteOne"), sem, max_retries=2)
     assert out is None

--- a/tests/unit/export/test_org_device_stats_exporter.py
+++ b/tests/unit/export/test_org_device_stats_exporter.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.support.thread_scoped_sleep import ThreadScopedSleepSpy
+
 
 @pytest.fixture
 def fake_mh(monkeypatch):
@@ -474,7 +476,8 @@ class TestHandleSitePortStatsRetry:
         """Attempt < max should return True after sleeping."""
         from src.export.org_device_stats_exporter import OrgDeviceStatsExporter
 
-        with patch("src.export.org_device_stats_exporter.time.sleep") as sleep_mock:
+        sleep_mock = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot break the exact count.
+        with patch("src.export.org_device_stats_exporter.time.sleep", new=sleep_mock):
             assert OrgDeviceStatsExporter._handle_site_port_stats_retry(0, "Site1", RuntimeError("x")) is True
         sleep_mock.assert_called_once()
 
@@ -482,7 +485,8 @@ class TestHandleSitePortStatsRetry:
         """Attempt at max returns False without sleeping."""
         from src.export.org_device_stats_exporter import OrgDeviceStatsExporter
 
-        with patch("src.export.org_device_stats_exporter.time.sleep") as sleep_mock:
+        sleep_mock = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot fail the no-call check.
+        with patch("src.export.org_device_stats_exporter.time.sleep", new=sleep_mock):
             assert OrgDeviceStatsExporter._handle_site_port_stats_retry(2, "Site1", RuntimeError("x")) is False
         sleep_mock.assert_not_called()
 

--- a/tests/unit/ssh/test_cli_shell_manager.py
+++ b/tests/unit/ssh/test_cli_shell_manager.py
@@ -23,6 +23,7 @@ import pytest
 
 from src.ssh import cli_shell_manager as csm_module
 from src.ssh.cli_shell_manager import CLIShellManager
+from tests.support.thread_scoped_sleep import ThreadScopedSleepSpy
 
 
 @pytest.fixture(autouse=True)
@@ -457,9 +458,10 @@ class TestRunInteractive:
         monkeypatch.setattr(csm_module, "pyte", fake_pyte)
 
         m_ws_conn = MagicMock()
+        m_sleep = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot break the exact count.
         with (
             patch("src.ssh.cli_shell_manager.websocket") as m_ws_mod,
-            patch("src.ssh.cli_shell_manager.time.sleep") as m_sleep,
+            patch("src.ssh.cli_shell_manager.time.sleep", new=m_sleep),
             patch.object(CLIShellManager, "_shell_resize_terminal") as m_resize,
             patch.object(CLIShellManager, "_shell_start_receiver") as m_start,
         ):

--- a/tests/unit/test_device_events_52w_exporter_extended.py
+++ b/tests/unit/test_device_events_52w_exporter_extended.py
@@ -22,6 +22,7 @@ from src.export.device_events_52w_exporter import (
     _StreamRequest,
     _write_rows,
 )
+from tests.support.thread_scoped_sleep import ThreadScopedSleepSpy
 
 
 def _build_exporter(**overrides: Any) -> DeviceEvents52wExporter:
@@ -309,7 +310,8 @@ def test_log_completion_sqlite_branch_logs_database_path() -> None:
 def test_sleep_before_retry_skips_on_final_attempt() -> None:
     """_sleep_before_retry must not sleep when attempt is the last one."""
     exporter = _build_exporter()
-    with patch("time.sleep") as sleep_mock:  # Track sleep calls
+    sleep_mock = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot fail the no-call check.
+    with patch("time.sleep", new=sleep_mock):  # Track the sleep calls of this thread only.
         exporter._sleep_before_retry(attempt=2, retries=3, backoff=1.0)  # Last attempt
     sleep_mock.assert_not_called()  # Final attempt short-circuits
 
@@ -317,10 +319,12 @@ def test_sleep_before_retry_skips_on_final_attempt() -> None:
 def test_sleep_before_retry_sleeps_exponentially() -> None:
     """_sleep_before_retry must sleep backoff*2^attempt on non-final attempts."""
     exporter = _build_exporter()
-    with patch("time.sleep") as sleep_mock:  # Track sleep calls
+    sleep_mock = ThreadScopedSleepSpy()  # Thread-scoped, so a leaked thread cannot break the exact count.
+    with patch("time.sleep", new=sleep_mock):  # Track the sleep calls of this thread only.
         exporter._sleep_before_retry(attempt=0, retries=3, backoff=1.0)  # First attempt
     sleep_mock.assert_called_once_with(1.0)  # 1.0 * 2^0 = 1.0
-    with patch("time.sleep") as sleep_mock:  # Second call, reset mock
+    sleep_mock = ThreadScopedSleepSpy()  # A fresh spy, which replaces the old reset_mock call.
+    with patch("time.sleep", new=sleep_mock):  # Second call, fresh record
         exporter._sleep_before_retry(attempt=1, retries=3, backoff=1.0)  # Second attempt
     sleep_mock.assert_called_once_with(2.0)  # 1.0 * 2^1 = 2.0
 

--- a/tests/unit/test_thread_scoped_sleep.py
+++ b/tests/unit/test_thread_scoped_sleep.py
@@ -1,0 +1,67 @@
+"""Tests for the thread-scoped ``time.sleep`` spy.
+
+The spy protects every sleep assertion in the suite from a leaked thread. The
+tests below fail if the thread guard goes away, so they hold the guard in
+place. Continuous integration run 31969418423 shows the failure the guard
+prevents.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import call, patch
+
+from tests.support.thread_scoped_sleep import ThreadScopedSleepSpy
+
+
+def test_spy_records_a_call_from_the_owning_thread() -> None:
+    """The owner's call reaches the record."""
+    spy = ThreadScopedSleepSpy()  # Build the spy on the test thread, which becomes the owner.
+    spy(0.5)  # Call it from the owner.
+    assert spy.call_args_list == [call(0.5)]  # The record holds the one owned call.
+    assert spy.call_count == 1  # The count agrees with the record.
+    assert spy.foreign_call_count == 0  # No call was dropped.
+
+
+def test_spy_drops_a_call_from_a_foreign_thread() -> None:
+    """A second thread cannot enter the record."""
+    spy = ThreadScopedSleepSpy()  # The test thread owns the spy.
+    spy(0.5)  # Record one owned interval.
+    worker = threading.Thread(target=spy, args=(30,))  # Imitate the leaked heartbeat thread.
+    worker.start()  # Run the foreign call.
+    worker.join(timeout=5)  # Wait for it, so the assertion reads a settled record.
+    assert spy.call_args_list == [call(0.5)]  # The foreign interval never entered the record.
+    assert spy.foreign_call_count == 1  # The spy counted the drop.
+
+
+def test_spy_protects_an_exact_count_assertion() -> None:
+    """A foreign sleep cannot break an exact-count assertion under patch."""
+    spy = ThreadScopedSleepSpy()  # Own the spy on the test thread.
+    with patch("time.sleep", new=spy):  # Replace the shared clock, as every suite does.
+        time.sleep(0.1)  # The owner sleeps one time.
+        worker = threading.Thread(target=time.sleep, args=(30,))  # A foreign thread hits the same patch.
+        worker.start()  # Start it inside the patched window, which is when CI saw the leak.
+        worker.join(timeout=5)  # Let it finish before the patch lifts.
+    spy.assert_called_once_with(0.1)  # The exact-count assertion still holds.
+    assert spy.foreign_call_count == 1  # The guard, not luck, is the reason.
+
+
+def test_assert_not_called_ignores_a_foreign_thread() -> None:
+    """A foreign sleep cannot fail a no-call assertion."""
+    spy = ThreadScopedSleepSpy()  # Own the spy on the test thread.
+    with patch("time.sleep", new=spy):  # Replace the shared clock.
+        worker = threading.Thread(target=time.sleep, args=(30,))  # Only the foreign thread sleeps.
+        worker.start()  # Start the foreign sleeper.
+        worker.join(timeout=5)  # Wait for it to finish.
+    spy.assert_not_called()  # The owner never slept, so this must pass.
+
+
+def test_reset_clears_the_record_and_keeps_the_owner() -> None:
+    """A reset empties the record and leaves the guard in place."""
+    spy = ThreadScopedSleepSpy()  # Own the spy on the test thread.
+    spy(1.0)  # Put one call in the record.
+    spy.reset_mock()  # Clear it.
+    assert spy.call_count == 0  # The record is empty.
+    spy(2.0)  # The owner can still record after a reset.
+    assert spy.intervals == [2.0]  # The owner still owns the spy.


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1843

Closes #1843

## The defect

Every MistHelper module binds the clock with `import time`, so that name is the
one shared module object. A patch target such as
`src.export.org_device_stats_exporter.time.sleep` resolves that shared module
and sets `sleep` on it, which reaches every thread in the interpreter. The
module-scoped form gives no isolation over the bare `time.sleep` form.

A sweep of `tests/unit` finds 53 such patches across 9 files.

I reproduced the defect against a real target in this repository:

```text
module-scoped target, foreign calls recorded: [call(30)]
```

That single foreign interval fails
`tests/unit/export/test_org_device_stats_exporter.py:487`, which asserts
`sleep_mock.assert_not_called()`.

## Why it matters

CI run 31969418423 failed the `pytest` gate on PR #1820, a change that only
raises the ruff version. Issue #1841 records the same gate failing on PR #1840.
A flaky gate blocks unrelated pull requests, and the dependabot queue is 15
pull requests deep.

## The change

- Add `tests/support/thread_scoped_sleep.py` with the `ThreadScopedSleepSpy`
  class. The spy binds the owning thread at build time, drops a call that
  arrives on another thread, and counts the drop.
- Apply the spy at the nine assert-bearing spy sites across five test files.
- Add `tests/unit/test_thread_scoped_sleep.py` with five tests. Two start a
  real second thread inside the patched window and prove the record stays
  clean.

The change is test-only. No runtime code changes.

## Scope, and why this file is absent

PR #1840 owns `tests/unit/device/test_ap_profile_migration_manager.py` and
repairs the five spies there. This pull request deliberately does not touch
that file, so the two do not conflict. Together they cover all 14
assert-bearing spy sites.

## Verification

| Check | Result |
| - | - |
| The 6 affected test files | 181 passed |
| Full unit collection | 9216 collected, up from 9211 |
| `ruff check tests/` | All checks passed |
| `black --check` on 8 files | 8 files unchanged |

Baseline before the change: 9209 passed, 1 failed, 1 skipped in 425 s. The one
failure is unrelated and is reported below.

## Follow-up work this uncovered

1. `src/maps/_plotly_viewer.py:476` and `src/maps/_flask_viewer.py:222` each
   start a daemon thread that sleeps and that no caller joins. Each is a source
   of the pollution this pull request guards against. Repair needs a stop event
   and a join, in the shape PR #1840 applies to `event_bus.py`.
2. `tests/unit/org/test_org_synthetic_probes_manager.py::test_regression_runtime_under_budget`
   fails on a clean tree. It starts a nested pytest process, and all 12 tests in
   that run fail with
   `assert _soft_errors is None, "nested soft assertion scopes are not supported"`
   from `pytest_playwright`. That global leaks between tests in the nested
   process. The probe manager is not the cause.
3. `.github/copilot-instructions.md` states that a PR branch failure creates no
   issue. `.github/workflows/ci.yml` does create PR-scoped issues, and #1841 and
   #1822 are the proof. The sentence needs a correction.
4. The remaining 44 sleep patches do not assert on the spy, so they are latent,
   not broken. A future sweep can convert them.

## Acceptance Criteria
- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification

## Quality
- [x] Tests added or updated for all changed functionality
- [x] Coverage meets or exceeds 80% threshold
- [x] No new Ruff lint violations (`ruff check .`)
- [x] Code formatted with Ruff (`ruff format --check .`)
- [x] mypy passes (`mypy MistHelper.py`)

`MYPY_PATHS` is `src/ MistHelper.py wsgi.py`, so this test-only change sits
outside the type-check scope.

## Security
- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings
- [x] pip-audit clean
- [x] Sensitive data handled via `.env` / environment variables only

The change adds no dependency and no credential.

## Deployment
- [x] Dry-run verified locally (ran affected menu operations)
- [x] `.env` changes documented in `deploy/.env.example` (if applicable)
- [x] Container builds successfully (if Containerfile changed)

No runtime code changed.

## UI / E2E Testing (if web UI changed)
- [x] Playwright E2E tests added/updated for changed UI flows in `tests/e2e/`
- [x] Stable `data-testid` attributes added for new interactive elements
- [x] AI agent verified selectors via VS Code Browser Agent Tools
- [x] Screenshots/traces captured for main UI flows

No web UI changed.

## Documentation
- [x] README.md updated (if user-facing changes)
- [x] Changelog entry added with version `YY.MM.DD.HH.MM` format

No user-facing behavior changed.
