### PR TITLE
fix(test): scope the AP migration pacing recorder to the test thread

### DIFF
--- a/tests/unit/device/test_ap_profile_migration_manager.py
+++ b/tests/unit/device/test_ap_profile_migration_manager.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 import json
 import logging
 import sys
+import threading
 import time
 import types
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -34,6 +36,43 @@ from src.device.ap_profile_migration_manager import APProfileMigrationManager
 # WHY: caplog / patch(...) targets must use the dotted module path so the
 # logger the code writes to matches the logger the test captures on.
 _LOGGER_NAME = "src.device.ap_profile_migration_manager"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sleep_recorder() -> tuple[list[float], Callable[[float], None]]:
+    """Build a pacing log and a recorder that accepts the calling thread only.
+
+    Why:
+        ``patch("src.device.ap_profile_migration_manager.time.sleep", ...)``
+        replaces the ``sleep`` attribute on the shared ``time`` module,
+        because the module under test does a plain ``import time``. The patch
+        is therefore process wide. A background thread that another test
+        started can call ``time.sleep`` while this test runs. That foreign
+        call lands in the pacing log, shifts every index by one, and breaks a
+        positional assertion. Issue #1822 recorded one such failure in CI.
+        This recorder compares the caller thread against the thread that
+        built the recorder and drops every foreign call.
+
+    Returns:
+        A pair. The first item is the ordered pacing log. The second item is
+        the recorder to pass as the ``side_effect`` of the sleep patch.
+    """
+    logging.info("Building a thread-scoped sleep recorder for the pacing assertions")
+    owner_thread_id = threading.get_ident()  # WHY: only this thread may add to the pacing log.
+    sleep_args: list[float] = []  # WHY: ordered pacing log that the assertions read by index.
+
+    def _record_sleep(secs: float) -> None:
+        """Record one pacing sleep when the call comes from the owning thread."""
+        if threading.get_ident() != owner_thread_id:  # WHY: a foreign thread must not shift the indexes.
+            return  # WHY: drop the foreign sleep so the pacing log stays exact.
+        sleep_args.append(secs)  # WHY: keep the ordered pacing log for the assertions.
+
+    logging.debug("Sleep recorder ready for thread %d", owner_thread_id)
+    return sleep_args, _record_sleep
 
 
 # ---------------------------------------------------------------------------
@@ -1516,11 +1555,8 @@ def test_migrate_hermetic_no_wall_clock_sleep(
     _seed_rate_limiter(fake_mh, delay=0.25)
     fake_mh.InputUtils.safe_input.return_value = "MIGRATE"
 
-    sleep_args: list[float] = []
-
-    def _record_sleep(secs: float) -> None:
-        """Record every pacing sleep argument so the test can sum them."""
-        sleep_args.append(secs)
+    # WHY: a thread-scoped recorder keeps a foreign thread out of the pacing log.
+    sleep_args, _record_sleep = _make_sleep_recorder()
 
     with (
         patch.object(APProfileMigrationManager, "_pick_ap_device_profile", side_effect=[src, tgt]),
@@ -1632,11 +1668,10 @@ def test_migrate_limiter_exception_falls_back_and_continues(
 
     get_delay_mock.side_effect = _delay_or_raise
 
-    sleep_args: list[float] = []
-
-    def _record_sleep(secs: float) -> None:
-        """Record every pacing sleep argument so the test can inspect them."""
-        sleep_args.append(secs)
+    # WHY: a thread-scoped recorder keeps a foreign thread out of the pacing log.
+    # Issue #1822: a process-wide sleep patch let one foreign sleep of 30 s shift
+    # every index, so the fallback landed at position 5 instead of position 4.
+    sleep_args, _record_sleep = _make_sleep_recorder()
 
     caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     with (
@@ -1656,6 +1691,43 @@ def test_migrate_limiter_exception_falls_back_and_continues(
     assert sleep_args[4] == pytest.approx(0.75), f"5th sleep arg expected 0.75, got {sleep_args[4]!r}"
     # WHY: the run completed all 10 APs (limiter fault MUST NOT halt).
     assert get_delay_mock.call_count == 10, f"expected 10 limiter consults, got {get_delay_mock.call_count}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1822 -- the pacing recorder ignores a sleep from a foreign thread
+# ---------------------------------------------------------------------------
+
+
+def test_sleep_recorder_ignores_a_foreign_thread() -> None:
+    """The pacing recorder MUST drop a sleep that another thread reports.
+
+    Why:
+        Issue #1822 -- ``patch("...ap_profile_migration_manager.time.sleep")``
+        replaces the attribute on the shared ``time`` module, so the patch is
+        process wide. A background thread that another test left running can
+        call ``time.sleep`` during this test. In CI one such call of 30 s
+        entered the pacing log and shifted the index that
+        ``test_migrate_limiter_exception_falls_back_and_continues`` reads.
+        This test locks the guard that removes that failure mode.
+    """
+    logging.info("Checking that the pacing recorder rejects a foreign thread")
+    sleep_args, record_sleep = _make_sleep_recorder()  # WHY: recorder is owned by this test thread.
+    record_sleep(0.1)  # WHY: the owning thread must reach the pacing log.
+
+    def _foreign_sleep() -> None:
+        """Report one long sleep from a thread that does not own the recorder."""
+        record_sleep(30)  # WHY: reproduce the exact foreign value seen in the CI failure.
+
+    foreign = threading.Thread(target=_foreign_sleep, name="issue-1822-foreign")
+    foreign.start()  # WHY: run the foreign call on a real second thread.
+    foreign.join(timeout=5.0)  # WHY: bounded join keeps the suite hermetic.
+    assert not foreign.is_alive(), "the foreign thread did not finish inside the join timeout"
+
+    record_sleep(0.2)  # WHY: a later owning-thread call must still append in order.
+    logging.debug("Pacing log after the foreign call is %r", sleep_args)
+
+    # WHY: the foreign 30 s value MUST NOT appear, and the order MUST hold.
+    assert sleep_args == [0.1, 0.2], f"foreign sleep leaked into the pacing log: {sleep_args!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -1772,11 +1844,8 @@ def test_revert_hermetic_no_wall_clock_sleep(
     _seed_rate_limiter(fake_mh, delay=0.25)
     fake_mh.InputUtils.safe_input.return_value = "REVERT"
 
-    sleep_args: list[float] = []
-
-    def _record_sleep(secs: float) -> None:
-        """Record every pacing sleep argument so the test can sum them."""
-        sleep_args.append(secs)
+    # WHY: a thread-scoped recorder keeps a foreign thread out of the pacing log.
+    sleep_args, _record_sleep = _make_sleep_recorder()
 
     start = time.perf_counter()
     with (
@@ -2046,11 +2115,9 @@ def test_migrate_integration_real_limiter_seeded_cache(
 
     fake_mh.InputUtils.safe_input.return_value = "MIGRATE"
 
-    sleep_args: list[float] = []
-
-    def _record_sleep(secs: float) -> None:
-        """Record every pacing sleep argument so the test can inspect them."""
-        sleep_args.append(secs)
+    # WHY: a thread-scoped recorder keeps a foreign thread out of the pacing log,
+    # so the exact count assertion below stays stable under a full-suite run.
+    sleep_args, _record_sleep = _make_sleep_recorder()
 
     with (
         patch.object(APProfileMigrationManager, "_pick_ap_device_profile", side_effect=[src, tgt]),


### PR DESCRIPTION
Fixes #1822

## Root cause

The pytest gate failed on PR #1820 with:

```
FAILED tests/unit/device/test_ap_profile_migration_manager.py::test_migrate_limiter_exception_falls_back_and_continues
AssertionError: 5th sleep arg expected 0.75, got 30
assert 30 == 0.75 +- 7.5e-07
```

The test patches `src.device.ap_profile_migration_manager.time.sleep`. The module under test does a plain `import time`, so that dotted target resolves to the shared `time` module object. `unittest.mock.patch` therefore replaces `time.sleep` for the whole process, not for one module. Any thread that is alive during the test and calls `time.sleep` lands in the test's `sleep_args` list.

The module has four `time.sleep` call sites. Three sit in the retry paths, and the test removes those by patching `_reassign_one_ap`. Only `_apply_pacing` can sleep, and it sleeps once for each of the 10 APs. The recorded list must therefore hold exactly 10 values. CI recorded an extra value of `30` before index 4. That value cannot come from the module. It came from another thread. The integer `30` also rules out `RECONNECT_WINDOW_SECONDS = 30.0`, which is a float.

The assertion reads `sleep_args[4]` by position, so one foreign sleep shifts every index and the fallback lands at position 5. The `0.75` warning assertion on the line above still passed, which confirms the production fallback path worked correctly.

**The production code is correct. The test recorder was unguarded.** No source file changes in this pull request.

## The ruff bump is safe

PR #1820 raises `ruff` from 0.16.1 to 0.16.3. That bump did not cause this failure. The pytest job installs `requirements.txt` and then runs pytest. Ruff is a lint binary that runs in a separate job, so the pinned version cannot change runtime behavior inside the pytest job. The last ten `ci.yml` runs on `main` are green.

## Changes

One file: `tests/unit/device/test_ap_profile_migration_manager.py`.

- Add `_make_sleep_recorder()`. It returns a pacing log plus a recorder that compares `threading.get_ident()` against the thread that built it, and drops every foreign call.
- Use that shared recorder in the four pacing tests. This also protects `test_real_limiter_pid_math_produces_delay`, which asserts an exact count of 50 sleeps.
- Add `test_sleep_recorder_ignores_a_foreign_thread`. The test calls the recorder from a real second thread with the same value of `30` that CI saw, then asserts the pacing log keeps only the owning-thread values. The test fails without the guard.

No test was deleted. No skip and no xfail was added.

## Test output

```
$ python -m pytest tests/unit/device/test_ap_profile_migration_manager.py -q
collected 38 items
tests\unit\device\test_ap_profile_migration_manager.py ................. [ 44%]
.....................                                                    [100%]
============================= 38 passed in 24.30s =============================
```

The module held 37 tests before this change and holds 38 after it.

Full unit suite after the change:

```
====== 1 failed, 9210 passed, 1 skipped, 4 warnings in 432.88s (0:07:12) ======
FAILED tests/unit/org/test_org_synthetic_probes_manager.py::test_regression_runtime_under_budget
```

Full unit suite before the change, same machine:

```
====== 1 failed, 9209 passed, 1 skipped, 4 warnings in 468.40s (0:07:48) ======
FAILED tests/unit/org/test_org_synthetic_probes_manager.py::test_regression_runtime_under_budget
```

That one failure is identical before and after, and it is unrelated to this change. The test spawns a nested pytest subprocess, and `pytest-playwright` in this local environment raises `nested soft assertion scopes are not supported`. CI does not hit it. The CI run for PR #1820 reported only the migration test as failing.

Other gates:

| Gate | Result |
| - | - |
| `python -m py_compile` | clean |
| `python -m ruff check .` | `All checks passed!` |
| `python -m black --check` | `1 file would be left unchanged.` |

## Conformance

- [x] The change addresses the root cause and does not hide it.
- [x] No dependency was pinned backwards.
- [x] No test was deleted, skipped, or marked xfail.
- [x] Every added executable line carries an inline comment that states the reason.
- [x] The added helper logs before the operation and after it, in ASCII only.
- [x] The prose follows Simplified Technical English.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
