### PR TITLE
ci: start the main workflows after a merge that GITHUB_TOKEN performs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,20 +1,55 @@
+# ================================================================
+# Auto-merge — merge a labeled pull request, then start the main gates
+# ================================================================
+# GitHub starts no workflow run from an event that GITHUB_TOKEN creates. The
+# rule stops a recursive loop. This workflow merges with GITHUB_TOKEN, so a
+# merge commit lands on main and starts no push run. Issue #1851 records the
+# effect. The security tab, the container image, and the post-merge gate
+# result all went stale.
+#
+# A workflow_dispatch call is the one exception that GitHub honors. The second
+# job below therefore starts each main workflow with an explicit dispatch call.
+# ================================================================
 name: Auto-merge
 
 on:
   pull_request:
-    types: [labeled, synchronize, opened, reopened]
+    # The closed type carries the merge result. The dispatch job below reads
+    # that result and repairs main in seconds.
+    types: [labeled, synchronize, opened, reopened, closed]
+  schedule:
+    # The backstop. GitHub can suppress the closed event above, because
+    # GITHUB_TOKEN performs the merge. The hourly run repairs main even when
+    # no merge event arrives.
+    - cron: '37 * * * *'
+  # A maintainer can start the dispatch job by hand after an outage.
+  workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+# Each job below states the permissions that the job needs. The empty map here
+# removes every other permission from every job.
+permissions: {}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  # The workflows that a push to main starts. The dispatch job reads this one
+  # list, so a new main workflow needs one edit only.
+  MAIN_WORKFLOWS: 'ci.yml codeql.yml container-build.yml'
 
 jobs:
   auto-merge:
-    if: contains(github.event.pull_request.labels.*.name, 'auto-merge')
+    name: "Enable auto-merge"
+    # A closed pull request cannot accept auto-merge, so the closed type stops
+    # here.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.action != 'closed'
+      && contains(github.event.pull_request.labels.*.name, 'auto-merge')
     runs-on: ubuntu-latest
+    permissions:
+      # The merge writes to the base branch.
+      contents: write
+      # The action sets the auto-merge state on the pull request.
+      pull-requests: write
     steps:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
@@ -22,3 +57,80 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
+
+  dispatch-main-workflows:
+    name: "Start the main workflows that missed the tip"
+    # Two paths reach this job. Path one is a merge into main, and that path
+    # repairs main in seconds. Path two is the hourly schedule or a manual
+    # start, and that path repairs main when no merge event arrives.
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.action == 'closed'
+      && github.event.pull_request.merged == true
+      && github.event.pull_request.base.ref == 'main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # A dispatch call creates a workflow run, so the job needs write access
+      # to the Actions API. This scope is the only added permission.
+      actions: write
+      # The tip lookup reads one commit from the main branch.
+      contents: read
+    steps:
+      - name: Start each main workflow that missed the tip of main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # Read the tip first. A comparison against the tip stops a duplicate
+          # run when a human merge already started the push workflows.
+          if ! tip="$(gh api "repos/${GH_REPO}/commits/main" --jq '.sha')"; then
+            echo "::error::The lookup of the tip of main failed. No workflow started."
+            exit 1
+          fi
+          echo "The tip of main is ${tip}."
+
+          started=''
+          current=''
+          failed=''
+          # MAIN_WORKFLOWS stays unquoted, because the loop needs the split on
+          # each space.
+          for workflow in ${MAIN_WORKFLOWS}; do
+            # The list holds a queued run too, so a dispatch from a moment ago
+            # already counts as coverage of the tip.
+            newest="$(gh run list --workflow "${workflow}" --branch main --limit 1 --json headSha --jq '.[0].headSha // "none"')" || newest='unknown'
+            if [ "${newest}" = "${tip}" ]; then
+              echo "${workflow} already covers the tip."
+              current="${current}${workflow} "
+              continue
+            fi
+            echo "${workflow} reports ${newest}, so the workflow missed the tip."
+            # One failed call must not stop the remaining calls, so the loop
+            # records the name and continues.
+            if gh workflow run "${workflow}" --ref main; then
+              echo "Started ${workflow} on main."
+              started="${started}${workflow} "
+            else
+              echo "::error::The dispatch call for ${workflow} on main failed."
+              failed="${failed}${workflow} "
+            fi
+          done
+
+          # The summary gives the maintainer one place to read the result.
+          {
+            echo "## Post-merge dispatch"
+            echo ""
+            echo "**Tip of main:** \`${tip}\`"
+            echo ""
+            echo "- **Started:** ${started:-none}"
+            echo "- **Already current:** ${current:-none}"
+            echo "- **Failed:** ${failed:-none}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          # The merge is complete and correct. Report a dispatch failure as a
+          # separate fault, so no reader treats a red job as a bad merge.
+          if [ -n "${failed}" ]; then
+            echo "::error::The merge is complete. These workflows did not start: ${failed}"
+            exit 1
+          fi
+          echo "Every main workflow now covers the tip of main."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,16 +598,19 @@ jobs:
           RESULTS[interrogate]="${{ needs.interrogate.result }}"
           RESULTS[ops_portal]="${{ needs.ops_portal.result }}"
 
-          # Scope: PR failures get scoped title (per-PR), push failures use gate-only title (dedup across pushes).
+          # Scope: a PR failure gets a scoped title (per-PR). A branch failure uses a
+          # gate-only title, so repeated runs on the same branch reuse one issue.
           if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_NUMBER" ]; then
             SCOPE="PR #${PR_NUMBER}"
             SEARCH_PREFIX="CI: quality-gate"
             TITLE_SUFFIX=" (PR #${PR_NUMBER})"
             PR_LINK="**PR**: #${PR_NUMBER} — ${PR_TITLE}"
           else
-            SCOPE="push to ${HEAD_REF}"
+            # A run on main now arrives by dispatch as well as by push, so the
+            # wording names the branch instead of the trigger. See issue #1851.
+            SCOPE="run on ${HEAD_REF}"
             TITLE_SUFFIX=""
-            PR_LINK="**Push**: \`${HEAD_REF}\`"
+            PR_LINK="**Run scope**: \`${HEAD_REF}\`"
           fi
 
           for gate in "${!RESULTS[@]}"; do
@@ -677,7 +680,10 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref || github.ref_name }}
-          IS_MAIN_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          # A run on main is authoritative for the issue state. A merge that
+          # GITHUB_TOKEN performs starts no push run, so the Auto-merge
+          # workflow dispatches this workflow instead. See issue #1851.
+          IS_MAIN_RUN: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
         run: |
           declare -A RESULTS
           RESULTS[ruff]="${{ needs.ruff.result }}"
@@ -697,11 +703,11 @@ jobs:
             result="${RESULTS[$gate]}"
             if [ "$result" = "success" ]; then
               # On PR events: close only the PR-scoped issue for this gate.
-              # On main push: close all open issues for this gate (main is authoritative).
+              # On a run on main: close all open issues for this gate (main is authoritative).
               if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_NUMBER" ]; then
                 EXACT_TITLE="CI: quality-gate \`${gate}\` failed (PR #${PR_NUMBER})"
                 SEARCH_QUERY="in:title \"${EXACT_TITLE}\""
-              elif [ "$IS_MAIN_PUSH" = "true" ]; then
+              elif [ "$IS_MAIN_RUN" = "true" ]; then
                 SEARCH_QUERY="in:title \"CI: quality-gate \`${gate}\` failed\""
               else
                 continue

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   schedule:
     - cron: '0 6 * * 1'
+  # GitHub starts no push run for a merge that GITHUB_TOKEN performs, so the
+  # scan on main went stale. Issue #1851 records the effect. An explicit
+  # dispatch is the exception that GitHub honors, and the Auto-merge workflow
+  # calls this trigger after every merge into main.
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -12,6 +12,9 @@ on:
       - 'src/**'
       - 'web_portal/**'
       - 'tests/**'
+  # GitHub starts no push run for a merge that GITHUB_TOKEN performs, so the
+  # image on the registry went stale. Issue #1851 records the effect. The
+  # Auto-merge workflow calls this trigger after every merge into main.
   workflow_dispatch:
     inputs:
       version_override:


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1851

Fixes #1851

## Problem

The last `push` workflow run on `main` is dated 2026-08-07. GitHub starts no workflow
run from an event that `GITHUB_TOKEN` creates, and `.github/workflows/auto-merge.yml`
merges with `GITHUB_TOKEN`. Every merge since that date reached `main` with no
CodeQL scan, no quality gate, and no container image.

A live check on the tip of `main` confirms the report:

```text
tip of main                  = a3631aeb5c003f59b2865807c359c675f461258c
ci.yml newest run on main    = a8756ea0525c689cddf3821698af6ff551fb67cd
codeql.yml newest run        = a8756ea0525c689cddf3821698af6ff551fb67cd
container-build.yml newest   = a8756ea0525c689cddf3821698af6ff551fb67cd
```

## Chosen option and reason

This pull request implements **option 3** from the issue. A `workflow_dispatch`
call is the one event that GitHub honors from `GITHUB_TOKEN`, so the auto-merge
workflow starts each `main` workflow with an explicit call.

- Option 1 needs a new repository secret, and a secret needs an owner and a
  rotation plan.
- Option 2 keys on the completion of the auto-merge run. That run completes when
  auto-merge turns on, not when the merge lands, so the trigger fires too early.
- Option 4 narrows the stale window for CodeQL only. It repairs neither the
  container image nor the post-merge gate.

## Changed files

| File | Change |
| - | - |
| `.github/workflows/codeql.yml` | Add the `workflow_dispatch` trigger. The `push`, `pull_request`, and `schedule` triggers stay. |
| `.github/workflows/container-build.yml` | Comment only. The `workflow_dispatch` trigger already exists. |
| `.github/workflows/ci.yml` | The `workflow_dispatch` trigger already exists. Rename `IS_MAIN_PUSH` to `IS_MAIN_RUN`, so a dispatched run on `main` still closes a resolved quality-gate issue. Name the branch instead of the trigger in an auto-created issue. |
| `.github/workflows/auto-merge.yml` | Add the `dispatch-main-workflows` job. Move each permission onto the job that needs it. |

## How the new job behaves

1. The job reads the tip of `main`.
2. For each workflow in `MAIN_WORKFLOWS`, the job reads the newest run on `main`.
3. If the newest run reports the tip, the job skips that workflow. A human merge
   already starts the push workflows, so this test stops a duplicate run.
4. If the newest run misses the tip, the job calls `gh workflow run <file> --ref main`.
5. If one call fails, the loop continues. The job marks each failure with an
   error annotation and exits with a non-zero code at the end. The message states
   that the merge is complete, so no reader treats a red job as a bad merge.
6. The job writes a summary that names the started, the current, and the failed
   workflows.

Two paths reach the job. The fast path is the `closed` type of the
`pull_request` event, and that path repairs `main` in seconds. The backstop is an
hourly schedule, because GitHub can also suppress the `closed` event that the
fast path reads. The backstop repairs `main` inside one hour even when no event
arrives.

## Permissions

The workflow default is now `permissions: {}`, so a job receives no scope that
the job does not name.

| Job | Scopes | Reason |
| - | - | - |
| `auto-merge` | `contents: write`, `pull-requests: write` | The merge writes to the base branch and sets the auto-merge state. These scopes moved from the workflow level and are not new. |
| `dispatch-main-workflows` | `actions: write`, `contents: read` | A dispatch call creates a workflow run. The tip lookup reads one commit. |

`actions: write` is the only added scope.

## Validation

1. Every changed file parses:

   ```powershell
   python -c "import yaml,sys; [yaml.safe_load(open(p,encoding='utf-8')) for p in sys.argv[1:]]; print('yaml ok')" `
     .github/workflows/ci.yml .github/workflows/auto-merge.yml `
     .github/workflows/codeql.yml .github/workflows/container-build.yml
   # yaml ok
   ```

2. The parsed triggers report `workflow_dispatch` on all three target workflows:

   ```text
   ci.yml:              ['pull_request', 'push', 'workflow_call', 'workflow_dispatch']
   codeql.yml:          ['pull_request', 'push', 'schedule', 'workflow_dispatch']
   container-build.yml: ['push', 'workflow_dispatch']
   auto-merge.yml:      ['pull_request', 'schedule', 'workflow_dispatch']
   ```

3. `bash -n` reports no syntax error in the shell of the new step.

4. The step ran offline against a stubbed `gh` command in four cases:

   | Case | Result |
   | - | - |
   | `main` stale, every call succeeds | All three workflows start. Exit code 0. |
   | `main` stale, the CodeQL call fails | The other two workflows still start. The error annotation names CodeQL. Exit code 1. |
   | Every workflow covers the tip | No workflow starts. Exit code 0. |
   | The tip lookup fails | No workflow starts. The message says so. Exit code 1. |

5. This host holds neither `actionlint` nor `shellcheck`, so neither tool ran.

## Remaining work for the maintainer

- Confirm the first post-merge dispatch after this merge. Read
  `gh run list --branch main --limit 6` and expect the three workflows on the tip
  of `main`.
- The hourly backstop starts on the next hour after this merge. It repairs the
  15-day gap even when the `closed` event never arrives.
- The dispatch ignores the `paths` filter of `container-build.yml`, because a
  filter applies to a push only. A merge that changes documentation alone now
  rebuilds the image. This keeps `latest` on the tip of `main`, which is an
  acceptance criterion of the issue.

## Acceptance Criteria
- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification

## Quality
- [x] Tests added or updated for all changed functionality — the shell of the new step ran offline in four cases against a stubbed `gh`
- [x] Coverage meets or exceeds 80% threshold — no Python code changed
- [x] No new Ruff lint violations (`ruff check .`) — no Python code changed
- [x] Code formatted with Ruff (`ruff format --check .`) — no Python code changed
- [x] mypy passes (`mypy MistHelper.py`) — no Python code changed

## Security
- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings (`bandit -r MistHelper.py -c pyproject.toml`) — no Python code changed
- [x] pip-audit clean (`pip-audit -r requirements.txt`) — no dependency changed
- [x] Sensitive data handled via `.env` / environment variables only — the new job reads `GITHUB_TOKEN` only

## Deployment
- [x] Dry-run verified locally (ran affected menu operations) — no menu operation changed
- [x] `.env` changes documented in `deploy/.env.example` (if applicable) — no new variable
- [x] Container builds successfully (if Containerfile changed) — the `Containerfile` did not change

## UI / E2E Testing (if web UI changed)
- [x] Playwright E2E tests added/updated for changed UI flows in `tests/e2e/` — no web UI changed
- [x] Stable `data-testid` attributes added for new interactive elements — no web UI changed
- [x] AI agent verified selectors via VS Code Browser Agent Tools — no web UI changed
- [x] Screenshots/traces captured for main UI flows (attached or in CI artifacts) — no web UI changed

## Documentation
- [x] README.md updated (if user-facing changes) — no user-facing behavior changed
- [x] Changelog entry added with version `YY.MM.DD.HH.MM` format — the change covers CI only and ships no product version

## Review note

Do not add the `auto-merge` label. This pull request changes workflow
permissions, so a human must read it first.
