### PR TITLE
fix(maps): stop the browser-open thread leak and repair the Dash auto-open

### DIFF
--- a/src/maps/_browser_opener.py
+++ b/src/maps/_browser_opener.py
@@ -1,0 +1,109 @@
+"""Delayed browser opener for the map viewers.
+
+Both map viewers open the system browser a short time after the local server
+starts. The delay lets the server bind its port before the browser sends the
+first request.
+
+This module holds that behavior in one class. The class replaces two bare
+``time.sleep`` calls that ran on a daemon thread that no caller joined. A
+sleeping thread has two costs. The thread pollutes a global ``time.sleep`` spy
+in the test suite, and a caller cannot shut the viewer down and know the thread
+finished.
+
+:class:`DelayedBrowserOpener` waits on a :class:`threading.Event` instead. A
+stop request returns at once, and :meth:`DelayedBrowserOpener.stop` joins the
+thread before it returns.
+"""
+
+from __future__ import annotations  # WHY: Lets the annotations name the class before Python finishes the class body.
+
+import logging  # WHY: The module reports each lifecycle step, so an operator can trace a browser that never opened.
+import threading  # WHY: The wait and the join both need the threading primitives.
+import webbrowser  # WHY: The class opens the viewer URL in the default browser of the operator.
+
+logger = logging.getLogger(__name__)  # WHY: A module logger groups these lines and avoids the root logger.
+
+DEFAULT_OPEN_DELAY_S = 1.5  # WHY: The local server needs about this long to bind its port before it answers.
+DEFAULT_JOIN_TIMEOUT_S = 5.0  # WHY: A bounded join stops a shutdown from blocking forever on a stuck thread.
+_THREAD_NAME = "maps-browser-opener"  # WHY: A named thread makes a leaked thread easy to find in a stack dump.
+
+
+class DelayedBrowserOpener:
+    """Open one URL in the system browser after a delay, on a thread a caller can stop.
+
+    The caller supplies the finished URL. The class never builds an address from
+    a port, because a wrong value in an address is hard to see in a log.
+    """
+
+    def __init__(self, url: str, delay_s: float = DEFAULT_OPEN_DELAY_S) -> None:
+        """Store the target URL and the delay, and prepare the stop control."""
+        self._url = url  # WHY: The finished URL removes the chance to bind a wrong value into the address.
+        self._delay_s = delay_s  # WHY: The caller can shorten the delay in a test to keep the run fast.
+        self._stop_event = threading.Event()  # WHY: An event wait ends at once on a stop, unlike a sleep.
+        self._thread: threading.Thread | None = None  # WHY: The handle lets stop join the thread it started.
+        self._lock = threading.Lock()  # WHY: The lock keeps a concurrent start and stop from racing on the handle.
+
+    @property
+    def url(self) -> str:
+        """Return the URL that this opener sends to the browser."""
+        return self._url  # WHY: A read-only view lets a caller log the target without reaching into the class.
+
+    def is_running(self) -> bool:
+        """Report whether the opener thread is alive."""
+        with self._lock:  # WHY: The read must not race with a start that replaces the handle.
+            thread = self._thread  # WHY: A local copy keeps the liveness test outside the lock.
+        return thread is not None and thread.is_alive()  # WHY: A finished thread counts as not running.
+
+    def start(self) -> None:
+        """Start the wait. A second call while the thread runs does nothing."""
+        with self._lock:  # WHY: The guard and the assignment must happen as one step.
+            if self._thread is not None and self._thread.is_alive():  # WHY: A second thread would open two browsers.
+                logger.debug("The browser opener already runs for %s, so this start does nothing", self._url)
+                return  # WHY: The guard makes a repeated start safe for the caller.
+            self._stop_event.clear()  # WHY: A reused opener must not inherit the stop flag of the previous run.
+            self._thread = threading.Thread(  # WHY: The open must not block the caller that starts the server.
+                target=self._wait_then_open, name=_THREAD_NAME, daemon=True
+            )
+            logger.info("The browser opener starts for %s after %.1f seconds", self._url, self._delay_s)
+            self._thread.start()  # WHY: The start happens under the lock, so is_running reports the truth at once.
+
+    def stop(self, timeout_s: float = DEFAULT_JOIN_TIMEOUT_S) -> None:
+        """Cancel the wait and join the thread. Log a warning if the thread outlives the join."""
+        self._stop_event.set()  # WHY: The set ends the wait at once, so the join returns without the full delay.
+        with self._lock:  # WHY: The read must not race with a start that replaces the handle.
+            thread = self._thread  # WHY: The join must run outside the lock, or a start would block on it.
+        if thread is None:  # WHY: A stop before any start is a valid call from a cleanup path.
+            logger.debug("The browser opener for %s holds no thread, so this stop does nothing", self._url)
+            return  # WHY: Nothing to join.
+        logger.info("The browser opener stops for %s", self._url)  # WHY: Records the shutdown request.
+        thread.join(timeout_s)  # WHY: The bounded join keeps a stuck thread from blocking the shutdown.
+        if thread.is_alive():  # WHY: A live thread after the join means the wait did not end.
+            logger.warning("The browser opener thread for %s outlived the %.1f second join", self._url, timeout_s)
+            return  # WHY: The handle stays, so a later stop can try the join again.
+        self._clear_finished_thread(thread)  # WHY: A cleared handle lets a later start create a fresh thread.
+
+    def _clear_finished_thread(self, thread: threading.Thread) -> None:
+        """Drop the stored handle if it still refers to the thread that just finished."""
+        with self._lock:  # WHY: The compare and the clear must happen as one step.
+            if self._thread is thread:  # WHY: A start between the join and this line owns a newer thread.
+                self._thread = None  # WHY: The cleared handle reports the opener as not running.
+        logger.debug("The browser opener thread for %s finished", self._url)  # WHY: Confirms the clean exit.
+
+    def _wait_then_open(self) -> None:
+        """Wait for the delay, then open the browser. A stop request cancels the open."""
+        if self._stop_event.wait(self._delay_s):  # WHY: A true answer means a stop arrived before the delay ended.
+            logger.info("A stop request cancelled the browser open for %s", self._url)
+            return  # WHY: The caller shut the viewer down, so the browser must not open.
+        logger.info("The browser opener opens %s", self._url)  # WHY: Records the attempt before the call.
+        if not self._open_url():  # WHY: A failed open must not stop the thread from ending cleanly.
+            return  # WHY: The helper already logged the failure.
+        logger.debug("The browser opened %s", self._url)  # WHY: Confirms the result after the call.
+
+    def _open_url(self) -> bool:
+        """Send the URL to the default browser. Return False if the browser refused the URL."""
+        try:
+            webbrowser.open(self._url)  # WHY: The default browser is the one the operator expects to see.
+        except (webbrowser.Error, OSError) as error:  # WHY: A headless host raises instead of opening a window.
+            logger.warning("The browser refused to open %s: %s", self._url, error)
+            return False  # WHY: The caller logs nothing more, because this line already named the cause.
+        return True  # WHY: A true answer lets the caller log the success.

--- a/src/maps/_flask_viewer.py
+++ b/src/maps/_flask_viewer.py
@@ -18,6 +18,9 @@ from typing import Any  # WHY: precise typing for injected callables + site/map 
 
 import mistapi  # type: ignore[import-untyped]  # WHY: Mist SDK is the source of truth for site maps + image URLs.
 
+from src.maps._browser_opener import (
+    DelayedBrowserOpener,
+)  # WHY: one stoppable opener replaces the daemon thread that no caller joined.
 from src.maps._container_detection import is_running_in_container  # WHY: gate 0.0.0.0 bind to container envs only.
 
 logger = logging.getLogger(__name__)  # WHY: module-scoped logger keeps route-handler emissions grouped in logs.
@@ -207,22 +210,21 @@ def _print_flask_viewer_banner(host: str, port: int) -> None:
     logger.info("%s", _BANNER_SEPARATOR)  # WHY: trailing divider signals end of banner block.
 
 
-def _maybe_open_browser(port: int) -> None:
-    """Spawn a daemon thread to open the browser after a short delay, unless in a container."""
-    import threading  # WHY: local import keeps stdlib threading out of the module import graph unless invoked.
-    import webbrowser  # WHY: local import mirrors threading -- optional path when running headless.
+def _maybe_open_browser(port: int) -> DelayedBrowserOpener | None:
+    """Start a delayed browser open, unless the viewer runs in a container.
 
+    Returns the opener so the caller can stop the thread. Returns ``None`` in a
+    container, because the host opens the browser there.
+    """
     if is_running_in_container():
-        return  # WHY: containers expose ports externally. Caller handles browser launch on the host side.
-
-    def open_browser() -> None:
-        """Wait briefly then point the default browser at the local Flask server."""
-        import time  # WHY: local import scopes time to the delayed launch only.
-
-        time.sleep(_BROWSER_OPEN_DELAY_S)  # WHY: lets Flask bind before we hit it with the first HTTP request.
-        webbrowser.open(f"http://{_LOCALHOST_BIND}:{port}")  # WHY: hardcode loopback -- container path exits early.
-
-    threading.Thread(target=open_browser, daemon=True).start()  # WHY: daemon flag prevents blocking process exit.
+        # WHY: containers expose ports externally. Caller handles browser launch on the host side.
+        logger.debug("The viewer runs in a container, so it schedules no browser open")
+        return None  # WHY: The caller has no thread to stop on this path.
+    url = f"http://{_LOCALHOST_BIND}:{port}"  # WHY: hardcode loopback -- container path exits early.
+    logger.info("The viewer schedules a browser open to %s", url)  # WHY: Records the request before the start.
+    opener = DelayedBrowserOpener(url, delay_s=_BROWSER_OPEN_DELAY_S)  # WHY: The delay lets Flask bind the port.
+    opener.start()  # WHY: The wait runs off the main thread, so the Flask server can start.
+    return opener  # WHY: The caller stops this opener after the server returns.
 
 
 def _run_flask_server(flask_app, host: str, port: int) -> None:
@@ -1336,5 +1338,9 @@ def launch_flask_viewer(ctx: FlaskViewerContext):
     flask_app = _build_flask_app(ctx)  # WHY: helper handles imports + Flask config + route registration.
     flask_host, flask_port = _resolve_flask_bind_address()  # WHY: pick loopback versus all-interfaces based on env.
     _print_flask_viewer_banner(flask_host, flask_port)  # WHY: operator-facing status before the blocking run call.
-    _maybe_open_browser(flask_port)  # WHY: fires only on desktop -- container path exits early inside the helper.
-    _run_flask_server(flask_app, flask_host, flask_port)  # WHY: blocking call -- returns on Ctrl+C or fatal error.
+    browser_opener = _maybe_open_browser(flask_port)  # WHY: fires only on desktop -- container path returns None.
+    try:
+        _run_flask_server(flask_app, flask_host, flask_port)  # WHY: blocking call -- returns on Ctrl+C or fatal error.
+    finally:
+        if browser_opener is not None:  # WHY: a container run scheduled no opener, so it has no thread to join.
+            browser_opener.stop()  # WHY: the join runs on every exit path, so no thread outlives the server.

--- a/src/maps/_plotly_viewer.py
+++ b/src/maps/_plotly_viewer.py
@@ -20,9 +20,7 @@ from __future__ import annotations  # WHY: Enable PEP 563 lazy annotation resolu
 import importlib.util  # WHY: Runtime check for optional deps (plotly/dash/PIL) without hard import cost.
 import logging  # WHY: Emit viewer lifecycle + validation diagnostics to project logger.
 import os  # WHY: Read DASH_PORT env var and check container flags for host binding.
-import threading  # WHY: Run browser-open timer off the main event loop.
-import time  # WHY: Sleep briefly before opening browser so Dash server is ready.
-import webbrowser  # WHY: Auto-open the viewer URL in the operator's default browser.
+import webbrowser  # WHY: The static fallback path opens a local HTML file in the browser of the operator.
 from math import cos, pi, radians, sin  # WHY: Compute crosshair angles + coverage-circle points.
 from typing import Any  # WHY: Type MapsManager wrapper attr without importing the concrete class.
 
@@ -37,11 +35,16 @@ from src.dataclasses.map_viewer_deps import (  # WHY: Grouped scope/data/optiona
     MapViewerOptional,  # WHY: Optional overlays (coverage_data, all_maps, all_sites).
     MapViewerScope,  # WHY: Site/map identity bundle for the viewer session.
 )
+from src.maps._browser_opener import (
+    DelayedBrowserOpener,
+)  # WHY: One stoppable opener replaces the daemon thread that no caller joined.
 from src.maps._container_detection import (
     is_running_in_container,
 )  # WHY: Bind Dash to 0.0.0.0 when containerized so host can reach it.
 
 logger = logging.getLogger(__name__)  # WHY: Module-scoped logger for lifecycle + validation traces.
+
+_DASH_LOOPBACK_HOST = "127.0.0.1"  # WHY: The browser and the Dash server share a host, so loopback always reaches it.
 
 # Optional visualization imports -- these mirror the checks in
 # maps_manager.py so the extracted code sees the same runtime symbols
@@ -92,6 +95,8 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
 
     def __init__(self, maps_manager: Any) -> None:  # WHY: Bind wrapped MapsManager instance.
         self._mm = maps_manager  # WHY: Store reference for __getattr__ delegation lookups.
+        # WHY: The explicit None stops __getattr__ from forwarding this name to the wrapped manager.
+        self._browser_opener: DelayedBrowserOpener | None = None
 
     def __getattr__(self, name: str) -> Any:  # WHY: Called only when normal lookup fails.
         # Called only when normal lookup fails. Do not use self._mm
@@ -469,13 +474,6 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
 
         launcher = _ViewerLauncher(self)  # WHY: Bind wrapped viewer so helper methods stay reachable.
         launcher.run(scope, data, optional)  # WHY: Execute the full Dash viewer workflow.
-
-    def _open_browser_after_delay(dash_port: int) -> None:  # WHY: Delayed browser auto-open.
-        """Wait for the Dash server to start, then open the system browser to the viewer URL."""
-        logger.info("Browser auto-open: scheduling open to http://127.0.0.1:%s", dash_port)  # Trace start
-        time.sleep(1.5)  # Wait for Dash server to initialize (matches original delay)
-        webbrowser.open(f"http://127.0.0.1:{dash_port}")  # Launch system browser
-        logger.debug("Browser opened to http://127.0.0.1:%s", dash_port)  # Mirror original log
 
     # ------------------------------------------------------------------
     # Wave E2 helpers extracted from _launch_plotly_viewer to drive CC <= 10
@@ -877,13 +875,23 @@ class _PlotlyViewer:  # WHY: Class boundary for extracted Plotly/Dash viewer met
         logger.info("Starting Dash server on http://%s:%s", dash_host, dash_port)  # Mirror original log
 
     def _schedule_browser_open(self, dash_port: int) -> None:
-        """Start a daemon thread that opens the browser shortly after server boots (skip in container)."""
-        if is_running_in_container():  # No display in container. Skip browser
-            return
+        """Start a delayed browser open for the Dash viewer. A container run skips the open."""
+        if is_running_in_container():  # WHY: A container has no display, and the host opens the browser instead.
+            logger.debug("The viewer runs in a container, so it schedules no browser open")
+            return  # WHY: Nothing to schedule.
+        url = f"http://{_DASH_LOOPBACK_HOST}:{dash_port}"  # WHY: The finished URL removes a port-binding mistake.
+        logger.info("The viewer schedules a browser open to %s", url)  # WHY: Records the request before the start.
+        self._browser_opener = DelayedBrowserOpener(url)  # WHY: The stored opener lets stop join the thread later.
+        self._browser_opener.start()  # WHY: The wait runs off the main thread, so the Dash server can start.
 
-        threading.Thread(  # Background thread -> _open_browser_after_delay
-            target=self._open_browser_after_delay, args=(dash_port,), daemon=True
-        ).start()
+    def stop(self) -> None:
+        """Stop the browser opener and join its thread before this method returns."""
+        if self._browser_opener is None:  # WHY: A viewer that never scheduled an open has nothing to join.
+            logger.debug("The viewer holds no browser opener, so this stop does nothing")
+            return  # WHY: Nothing to stop.
+        logger.info("The viewer stops the browser opener")  # WHY: Records the shutdown request.
+        self._browser_opener.stop()  # WHY: The call ends the wait and joins the thread under a timeout.
+        logger.debug("The viewer finished the browser opener shutdown")  # WHY: Confirms the result after the call.
 
     @staticmethod
     def _run_dash_server(app: object, dash_host: str, dash_port: int) -> None:

--- a/src/maps/_viewer_launch.py
+++ b/src/maps/_viewer_launch.py
@@ -419,7 +419,10 @@ class _ViewerLauncher:  # WHY: Class boundary that owns the extracted launch wor
         dash_host, dash_port = self._viewer._resolve_dash_binding(os)  # WHY: Container-aware host/port.
         self._viewer._print_dash_startup_banner(dash_host, dash_port)  # WHY: User-facing banner.
         self._viewer._schedule_browser_open(dash_port)  # WHY: Background browser open (no-op in containers).
-        self._viewer._run_dash_server(app, dash_host, dash_port)  # WHY: Blocking run + KeyboardInterrupt handler.
+        try:
+            self._viewer._run_dash_server(app, dash_host, dash_port)  # WHY: Blocking run + KeyboardInterrupt handler.
+        finally:
+            self._viewer.stop()  # WHY: The join runs on every exit path, so no browser thread outlives the server.
 
 
 def _pack_session_ctx(

--- a/tests/maps/test_browser_opener.py
+++ b/tests/maps/test_browser_opener.py
@@ -1,0 +1,215 @@
+"""Unit tests for the delayed browser opener and its two map-viewer callers.
+
+The tests cover issue #1845 and issue #1854.
+
+Issue #1845 asks for a thread that a caller can stop and join. Issue #1854
+records a signature mistake that raised ``TypeError`` inside the viewer thread
+on every Dash launch.
+"""
+
+from __future__ import annotations
+
+import threading
+import webbrowser
+
+import pytest
+
+from src.maps._browser_opener import DelayedBrowserOpener
+
+_NO_DELAY_S = 0.0  # WHY: A zero delay keeps every test fast without a sleep.
+_LONG_DELAY_S = 30.0  # WHY: A long delay proves that stop ends the wait early, not that the wait expired.
+_JOIN_TIMEOUT_S = 5.0  # WHY: A bounded wait fails the test instead of hanging the suite.
+
+
+class _ThreadExceptionRecorder:
+    """Record every exception that a thread raises, because a thread never reraises into the test."""
+
+    def __init__(self) -> None:
+        self.failures: list[BaseException] = []  # WHY: The list holds each captured thread failure.
+
+    def __call__(self, args) -> None:
+        """Store the raised exception so a test can assert the thread stayed clean."""
+        self.failures.append(args.exc_value)  # WHY: The value carries the type and the message.
+
+
+@pytest.fixture
+def thread_failures(monkeypatch: pytest.MonkeyPatch) -> _ThreadExceptionRecorder:
+    """Capture thread exceptions for the duration of one test."""
+    recorder = _ThreadExceptionRecorder()  # WHY: One recorder per test keeps the assertions independent.
+    monkeypatch.setattr(threading, "excepthook", recorder)  # WHY: The hook is the only route to a thread failure.
+    return recorder
+
+
+@pytest.fixture
+def opened_urls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace the real browser call so no test opens a window."""
+    urls: list[str] = []  # WHY: The list records each URL the code sends to the browser.
+    monkeypatch.setattr(webbrowser, "open", urls.append)  # WHY: A recording stub keeps the test headless.
+    return urls
+
+
+def _wait_for(predicate, timeout_s: float = _JOIN_TIMEOUT_S) -> bool:
+    """Poll a predicate until it answers True or the timeout expires."""
+    deadline = threading.Event()  # WHY: The event supplies a bounded wait without a sleep call.
+    for _ in range(int(timeout_s * 100)):  # WHY: A capped loop cannot hang the suite.
+        if predicate():  # WHY: The predicate reports the state the test waits for.
+            return True  # WHY: The condition arrived inside the timeout.
+        deadline.wait(0.01)  # WHY: A short wait yields the processor to the worker thread.
+    return False  # WHY: The timeout expired, so the caller fails the test.
+
+
+def test_start_opens_the_url(opened_urls: list[str], thread_failures: _ThreadExceptionRecorder) -> None:
+    """A started opener sends the exact URL to the browser."""
+    opener = DelayedBrowserOpener("http://127.0.0.1:8050", delay_s=_NO_DELAY_S)
+    opener.start()
+    assert _wait_for(lambda: bool(opened_urls))  # WHY: The wait removes the race between the open and the stop.
+    opener.stop()
+
+    assert opened_urls == ["http://127.0.0.1:8050"]
+    assert thread_failures.failures == []
+
+
+def test_stop_joins_the_thread_before_it_returns(opened_urls: list[str]) -> None:
+    """The thread has finished by the time stop returns. This is the issue #1845 contract."""
+    opener = DelayedBrowserOpener("http://127.0.0.1:8050", delay_s=_LONG_DELAY_S)
+    opener.start()
+    assert opener.is_running()
+
+    opener.stop()
+
+    assert not opener.is_running()
+    assert opened_urls == []
+
+
+def test_stop_cancels_the_pending_open(opened_urls: list[str]) -> None:
+    """A stop during the wait cancels the browser open."""
+    opener = DelayedBrowserOpener("http://127.0.0.1:8050", delay_s=_LONG_DELAY_S)
+    opener.start()
+    opener.stop()
+
+    assert opened_urls == []
+
+
+def test_second_start_does_not_add_a_thread(opened_urls: list[str]) -> None:
+    """A second start while the thread runs does nothing, so the browser opens one time."""
+    opener = DelayedBrowserOpener("http://127.0.0.1:8050", delay_s=_LONG_DELAY_S)
+    opener.start()
+    first_thread = opener._thread
+    opener.start()
+
+    assert opener._thread is first_thread
+    opener.stop()
+
+
+def test_stop_without_start_does_nothing() -> None:
+    """A stop on an unused opener returns without an error."""
+    opener = DelayedBrowserOpener("http://127.0.0.1:8050", delay_s=_NO_DELAY_S)
+    opener.stop()
+
+    assert not opener.is_running()
+
+
+def test_stop_warns_when_the_thread_outlives_the_join(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A thread that outlives the join produces a WARNING, and the shutdown still returns."""
+    release = threading.Event()  # WHY: The event holds the worker inside the browser call.
+    monkeypatch.setattr(webbrowser, "open", lambda _url: release.wait(_JOIN_TIMEOUT_S))
+    opener = DelayedBrowserOpener("http://127.0.0.1:8050", delay_s=_NO_DELAY_S)
+    opener.start()
+    assert _wait_for(opener.is_running)
+
+    with caplog.at_level("WARNING"):
+        opener.stop(timeout_s=0.05)
+
+    assert "outlived" in caplog.text
+    release.set()  # WHY: The release lets the worker finish, so the suite leaks no thread.
+    assert _wait_for(lambda: not opener.is_running())
+
+
+def test_a_refused_browser_open_logs_a_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, thread_failures: _ThreadExceptionRecorder
+) -> None:
+    """A headless host raises from the browser call. The thread logs the cause and ends cleanly."""
+
+    def _refuse(_url: str) -> None:
+        """Raise the error that a host without a browser raises."""
+        raise webbrowser.Error("no browser")
+
+    monkeypatch.setattr(webbrowser, "open", _refuse)
+    opener = DelayedBrowserOpener("http://127.0.0.1:8050", delay_s=_NO_DELAY_S)
+
+    with caplog.at_level("WARNING"):
+        opener.start()
+        assert _wait_for(lambda: "refused to open" in caplog.text)  # WHY: The wait removes the start-stop race.
+        opener.stop()
+
+    assert "refused to open" in caplog.text
+    assert thread_failures.failures == []
+
+
+def test_plotly_viewer_schedules_and_stops_the_open(
+    monkeypatch: pytest.MonkeyPatch, opened_urls: list[str], thread_failures: _ThreadExceptionRecorder
+) -> None:
+    """The Dash viewer opens the loopback URL and joins the thread.
+
+    This test is the regression guard for issue #1854. The previous code started
+    a bound method whose signature took no argument and passed one argument to
+    it. The thread then raised ``TypeError`` and opened no browser.
+    """
+    from src.maps import _plotly_viewer
+
+    monkeypatch.setattr(_plotly_viewer, "is_running_in_container", lambda: False)
+    monkeypatch.setattr(
+        _plotly_viewer,
+        "DelayedBrowserOpener",
+        lambda url, delay_s=_NO_DELAY_S: DelayedBrowserOpener(url, delay_s=_NO_DELAY_S),
+    )
+    viewer = _plotly_viewer._PlotlyViewer(None)
+
+    viewer._schedule_browser_open(8050)
+    assert _wait_for(lambda: bool(opened_urls))  # WHY: The wait removes the race between the open and the stop.
+    viewer.stop()
+
+    assert opened_urls == ["http://127.0.0.1:8050"]
+    assert thread_failures.failures == []
+
+
+def test_plotly_viewer_skips_the_open_in_a_container(monkeypatch: pytest.MonkeyPatch, opened_urls: list[str]) -> None:
+    """A container run schedules no browser open, because the host owns the browser."""
+    from src.maps import _plotly_viewer
+
+    monkeypatch.setattr(_plotly_viewer, "is_running_in_container", lambda: True)
+    viewer = _plotly_viewer._PlotlyViewer(None)
+
+    viewer._schedule_browser_open(8050)
+    viewer.stop()
+
+    assert viewer._browser_opener is None
+    assert opened_urls == []
+
+
+def test_flask_viewer_returns_a_stoppable_opener(monkeypatch: pytest.MonkeyPatch, opened_urls: list[str]) -> None:
+    """The Flask viewer hands the opener back, so the caller can join the thread."""
+    pytest.importorskip("mistapi")  # WHY: The Flask viewer imports the Mist SDK at module scope.
+    from src.maps import _flask_viewer
+
+    monkeypatch.setattr(_flask_viewer, "is_running_in_container", lambda: False)
+    monkeypatch.setattr(_flask_viewer, "_BROWSER_OPEN_DELAY_S", _NO_DELAY_S)
+
+    opener = _flask_viewer._maybe_open_browser(8051)
+
+    assert opener is not None
+    assert opener.url == "http://127.0.0.1:8051"
+    opener.stop()
+    assert not opener.is_running()
+
+
+def test_flask_viewer_skips_the_open_in_a_container(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A container run returns no opener, so the caller has no thread to join."""
+    pytest.importorskip("mistapi")  # WHY: The Flask viewer imports the Mist SDK at module scope.
+    from src.maps import _flask_viewer
+
+    monkeypatch.setattr(_flask_viewer, "is_running_in_container", lambda: True)
+
+    assert _flask_viewer._maybe_open_browser(8051) is None


### PR DESCRIPTION
## Summary

This pull request repairs two defects in the map viewers. Both sit in the same
code, so one change fixes both.

`Fixes #1845`
`Fixes #1854`

### Issue #1845 — a leaked sleeping thread

Two viewers started a daemon thread that called a bare `time.sleep`, and no
caller ever joined the thread.

| File | Old line | Old call |
| - | - | - |
| `src/maps/_plotly_viewer.py` | 476 | `time.sleep(1.5)` |
| `src/maps/_flask_viewer.py` | 222 | `time.sleep(_BROWSER_OPEN_DELAY_S)` |

A sleeping thread has two costs. The thread pollutes a global `time.sleep` spy,
which issue #1843 records and CI run 31969418423 shows as a gate failure. A
caller also cannot shut a viewer down and know the thread finished.

### Issue #1854 — the Dash browser open raised `TypeError`

`_PlotlyViewer._open_browser_after_delay` declared one parameter, `dash_port`,
and carried no `@staticmethod` decorator. Python therefore bound `self` to
`dash_port`. The caller passed the port as a second positional argument, so the
thread raised `TypeError` on every Dash launch.

The Dash viewer never opened a browser. The operator read the banner
`! Map viewer will open in your default browser` and saw no window. The failure
wrote a traceback from a background thread.

## What changed

1. Added `src/maps/_browser_opener.py` with a `DelayedBrowserOpener` class. The
   class waits on a `threading.Event`, so a stop request ends the wait at once.
2. `stop()` joins the thread under a timeout. The method logs a WARNING if the
   thread outlives the join.
3. `start()` carries a guard, so a second call while the thread runs does
   nothing.
4. The class takes the finished URL, not a port. A finished URL removes the
   chance to bind a wrong value into the address, which is the mistake that
   issue #1854 records.
5. `_flask_viewer._maybe_open_browser` returns the opener, and
   `launch_flask_viewer` stops it in a `finally` block.
6. `_PlotlyViewer` gained `stop()`, and `_viewer_launch._serve_dash_app` calls
   it in a `finally` block. The join therefore runs on every exit path, which
   includes the `KeyboardInterrupt` path.
7. Deleted `_open_browser_after_delay`, and removed the `threading` and `time`
   imports that no other line used.

The two viewers now share one opener, so the delayed-open behavior lives in one
place instead of two.

## Tests

`tests/maps/test_browser_opener.py` holds 11 tests.

| Test | Proves |
| - | - |
| `test_start_opens_the_url` | The opener sends the exact URL. |
| `test_stop_joins_the_thread_before_it_returns` | The issue #1845 contract. |
| `test_stop_cancels_the_pending_open` | A stop during the wait opens no browser. |
| `test_second_start_does_not_add_a_thread` | The start guard holds. |
| `test_stop_without_start_does_nothing` | A cleanup path stays safe. |
| `test_stop_warns_when_the_thread_outlives_the_join` | The WARNING reaches the log. |
| `test_a_refused_browser_open_logs_a_warning` | A headless host logs the cause. |
| `test_plotly_viewer_schedules_and_stops_the_open` | The issue #1854 regression guard. |
| `test_plotly_viewer_skips_the_open_in_a_container` | A container schedules no open. |
| `test_flask_viewer_returns_a_stoppable_opener` | The caller can join the thread. |
| `test_flask_viewer_skips_the_open_in_a_container` | A container returns no opener. |

Two tests capture `threading.excepthook`. A thread never reraises into the test,
so without that capture a signature mistake passes in silence. That is the exact
reason issue #1854 stayed hidden.

## Validation

| Gate | Result |
| - | - |
| `ruff check .` | `All checks passed!` |
| `black --check` | No file needs a change. |
| `python -m py_compile` | No output. |
| `pydocstyle` | No finding on the new module. |
| `interrogate` | 100 percent docstring coverage on the new module. |
| `radon cc -nc` | No block above the complexity limit. |
| `bandit` | No finding on the new module. |
| `pytest tests/maps/ tests/unit/refactors/test_maps_manager_launcher.py` | 171 passed, 2 skipped. |

The 2 skips need `mistapi`, which the local host does not hold. CI installs the
package from `requirements.txt`, so both tests run there.

Five tests in `test_phase1_integration.py` and `test_viewer_callbacks_wave_e2.py`
fail on the local host because `plotly` is absent. A run against the stashed tree
reports the same five failures, so this change adds no regression. CI installs
`plotly`.

## Reviewer notes

This change removes two module-level names from `src/maps/_plotly_viewer.py`,
the `threading` import and the `time` import. The removal is deliberate, because
no other line in that module used either name. This pull request is a refactor,
not a comment sweep, so the loss is expected.

`mypy` did not run on this host, because the local environment does not hold the
package. The CI type gate covers `src/`, and the new module carries a full set of
annotations.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
