### PR TITLE
security(web-portal): bind the IP allowlist to the peer address, not a forged header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
 
 ### Bind the web portal IP allowlist to the peer address (issue #1857)
 
+**Warning:** This entry contains a breaking change. If you run the portal behind
+a reverse proxy and you set `PORTAL_ALLOWED_IPS`, the portal answers 403 to every
+client after this upgrade. The allowlist now reads the socket peer address, which
+is the address of the proxy. Set `PORTAL_TRUSTED_PROXIES` to the address of the
+proxy, or to the CIDR range that holds the proxy, before you upgrade. A portal
+that runs without a proxy needs no action.
+
 - **Defect (Fixed)**: `SecurityMiddleware._get_client_ip` read the
   client-supplied `X-Forwarded-For` header and fed that value into the
   `PORTAL_ALLOWED_IPS` check. No reverse proxy sits in front of the portal, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,30 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   protection of an active run, the retention period, the dropped count in the
   response, and the fallback for an unusable setting.
 
+### Bind the web portal IP allowlist to the peer address (issue #1857)
+
+- **Defect (Fixed)**: `SecurityMiddleware._get_client_ip` read the
+  client-supplied `X-Forwarded-For` header and fed that value into the
+  `PORTAL_ALLOWED_IPS` check. No reverse proxy sits in front of the portal, so a
+  blocked caller reached every portal operation with one extra header.
+- **Peer address (Changed)**: `SecurityMiddleware._get_peer_ip` returns
+  `request.remote_addr`, and the allowlist judges that address. A caller cannot
+  forge the socket peer address.
+- **PORTAL_TRUSTED_PROXIES (Added)**: this new setting names the reverse proxy
+  addresses that the portal trusts. The default value is empty. The portal reads
+  the forwarded header only when the peer address matches an entry. An entry is
+  a plain address or a CIDR range.
+- **Forwarded entry (Changed)**: `SecurityMiddleware._resolve_client_ip` reads
+  the rightmost entry of the header, because that entry is the address the
+  trusted proxy observed. A caller controls every entry to its left.
+- **Audit trail (Changed)**: the block message now names the client address and
+  the peer address, so the record always holds the real source.
+- **Documentation (Added)**: `deploy/.env.example` documents
+  `PORTAL_ALLOWED_IPS` and `PORTAL_TRUSTED_PROXIES` in one section.
+- **Tests (Added)**: `tests/unit/web_portal/test_config_ip_allowlist.py` holds 14
+  cases. A forged header from a blocked peer returns 403. The same header from a
+  trusted proxy peer sets the client address.
+
 ### Replace the assert runtime guards in the SSH package (issue #1720)
 
 - **Defect (Fixed)**: four runtime guards used `assert`. The interpreter removes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   entry, because an environment value can hold a secret.
 - **Documentation (Added)**: `deploy/.env.example` documents
   `PORTAL_ALLOWED_IPS` and `PORTAL_TRUSTED_PROXIES` in one section.
-- **Tests (Added)**: `tests/unit/web_portal/test_config_ip_allowlist.py` holds 14
+- **Tests (Added)**: `tests/unit/web_portal/test_config_ip_allowlist.py` holds 15
   cases. A forged header from a blocked peer returns 403. The same header from a
   trusted proxy peer sets the client address.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ Version format: `YY.MM.DD.HH.MM` (UTC timestamp).
   trusted proxy observed. A caller controls every entry to its left.
 - **Audit trail (Changed)**: the block message now names the client address and
   the peer address, so the record always holds the real source.
+- **PortalConfigLoader.parse_networks (Added)**: this shared parser replaces
+  `_parse_allowed_ips`. It reads both settings and names the setting in every
+  log message. It reports the position of an invalid entry, not the text of that
+  entry, because an environment value can hold a secret.
 - **Documentation (Added)**: `deploy/.env.example` documents
   `PORTAL_ALLOWED_IPS` and `PORTAL_TRUSTED_PROXIES` in one section.
 - **Tests (Added)**: `tests/unit/web_portal/test_config_ip_allowlist.py` holds 14

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -69,6 +69,26 @@ MIST_ORG_ID=your_org_id_here
 # Seconds the portal keeps a finished run before it drops the record (default: 3600)
 # PORTAL_RUN_RETENTION_SECONDS=3600
 
+# ============================================================
+# Web Portal Access Control
+# ============================================================
+
+# Comma-separated allowlist of source addresses for the web portal.
+# Each entry is a plain address or a CIDR range. An empty value allows
+# every source address. The portal compares the allowlist against the
+# socket peer address, which a caller cannot forge.
+# PORTAL_ALLOWED_IPS=10.0.0.0/24,192.168.1.5
+
+# Comma-separated list of reverse proxy addresses that the portal trusts.
+# Each entry is a plain address or a CIDR range. The default is empty.
+# The portal reads the X-Forwarded-For header only when the socket peer
+# address matches an entry in this list. It then judges the rightmost
+# entry of that header, which is the address the trusted proxy observed.
+# Warning: Do not add an address that a caller can reach directly. Such an
+# address lets a caller pass any source address in a header and defeat
+# PORTAL_ALLOWED_IPS.
+# PORTAL_TRUSTED_PROXIES=127.0.0.1,10.10.0.0/24
+
 # SSID Template Consolidation specific variables
 # Cache freshness window for SSID Template Consolidation collector (minutes, default: 60)
 # SSID_CONSOLIDATION_CACHE_MINUTES=60

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -84,6 +84,13 @@ MIST_ORG_ID=your_org_id_here
 # The portal reads the X-Forwarded-For header only when the socket peer
 # address matches an entry in this list. It then judges the rightmost
 # entry of that header, which is the address the trusted proxy observed.
+#
+# Warning: If a reverse proxy sits in front of the portal, and this value
+# stays empty, and PORTAL_ALLOWED_IPS holds one or more entries, the portal
+# answers 403 to every client. The allowlist then sees the address of the
+# proxy on every request. Set this value to the address of the proxy, or to
+# the CIDR range that holds the proxy, to restore access.
+#
 # Warning: Do not add an address that a caller can reach directly. Such an
 # address lets a caller pass any source address in a header and defeat
 # PORTAL_ALLOWED_IPS.

--- a/tests/unit/web_portal/test_config_ip_allowlist.py
+++ b/tests/unit/web_portal/test_config_ip_allowlist.py
@@ -195,3 +195,18 @@ def test_loader_drops_an_invalid_trusted_proxy_entry(monkeypatch):
     monkeypatch.setenv("PORTAL_TRUSTED_PROXIES", "not-an-address")
     config = PortalConfigLoader().load_config()
     assert config["trusted_proxies"] == []
+
+
+def test_loader_reports_the_position_of_an_invalid_entry(monkeypatch, caplog):
+    """The warning names the position, so no setting text reaches the log.
+
+    CodeQL rule `py/clear-text-logging-sensitive-data` reported the old message,
+    because an environment value can hold a secret. The message must therefore
+    hold the position of the bad entry and the name of the setting only.
+    """
+    monkeypatch.setenv("PORTAL_TRUSTED_PROXIES", "127.0.0.1,super-secret-value")
+    with caplog.at_level(logging.WARNING):
+        config = PortalConfigLoader().load_config()
+    assert [str(network) for network in config["trusted_proxies"]] == ["127.0.0.1/32"]
+    assert "super-secret-value" not in caplog.text
+    assert "Entry 2 of the PORTAL_TRUSTED_PROXIES setting" in caplog.text

--- a/tests/unit/web_portal/test_config_ip_allowlist.py
+++ b/tests/unit/web_portal/test_config_ip_allowlist.py
@@ -1,0 +1,197 @@
+"""Tests for the web portal IP allowlist and the trusted proxy setting.
+
+Issue #1857 reports that a client-supplied `X-Forwarded-For` header defeats the
+`PORTAL_ALLOWED_IPS` allowlist. These tests hold the contract for the fix. The
+allowlist reads the peer address from `request.remote_addr`. The portal reads
+the forwarded header only when the peer address matches `PORTAL_TRUSTED_PROXIES`.
+"""
+
+import logging
+
+import pytest
+from flask import Flask
+
+from web_portal.services.config import PortalConfigLoader, SecurityMiddleware
+
+BLOCKED_PEER = "203.0.113.9"
+ALLOWED_CLIENT = "10.0.0.1"
+PROXY_PEER = "127.0.0.1"
+ALLOWLIST_TEXT = "10.0.0.0/24"
+
+
+def _build_app(allowed_ips: list, trusted_proxies: list | None) -> Flask:
+    """Build a small Flask app that carries the security middleware."""
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test-secret-key"
+    app.config["WTF_CSRF_ENABLED"] = False
+
+    @app.route("/")
+    def index():
+        return "portal home"
+
+    middleware = SecurityMiddleware()
+    middleware.apply(app, allowed_ips, trusted_proxies)
+    return app
+
+
+def _parse(text: str) -> list:
+    """Turn a comma-separated setting value into a network list."""
+    return PortalConfigLoader.parse_networks(text, "PORTAL_ALLOWED_IPS")
+
+
+@pytest.fixture
+def allowlist() -> list:
+    """Return the parsed allowlist that every test shares."""
+    return _parse(ALLOWLIST_TEXT)
+
+
+def test_forged_forwarded_header_from_blocked_peer_returns_403(allowlist):
+    """A forged header must not change the allowlist decision."""
+    app = _build_app(allowlist, [])
+    client = app.test_client()
+    response = client.get(
+        "/",
+        headers={"X-Forwarded-For": ALLOWED_CLIENT},
+        environ_base={"REMOTE_ADDR": BLOCKED_PEER},
+    )
+    assert response.status_code == 403
+
+
+def test_allowed_peer_without_header_returns_200(allowlist):
+    """An allowed peer address reaches the portal with no header present."""
+    app = _build_app(allowlist, [])
+    client = app.test_client()
+    response = client.get("/", environ_base={"REMOTE_ADDR": ALLOWED_CLIENT})
+    assert response.status_code == 200
+
+
+def test_blocked_peer_without_header_returns_403(allowlist):
+    """The decision uses the peer address when no trusted proxy is set."""
+    app = _build_app(allowlist, [])
+    client = app.test_client()
+    response = client.get("/", environ_base={"REMOTE_ADDR": BLOCKED_PEER})
+    assert response.status_code == 403
+
+
+def test_trusted_proxy_peer_uses_forwarded_address(allowlist):
+    """A trusted proxy peer makes the portal read the forwarded address."""
+    app = _build_app(allowlist, _parse(PROXY_PEER))
+    client = app.test_client()
+    response = client.get(
+        "/",
+        headers={"X-Forwarded-For": ALLOWED_CLIENT},
+        environ_base={"REMOTE_ADDR": PROXY_PEER},
+    )
+    assert response.status_code == 200
+
+
+def test_trusted_proxy_peer_blocks_forwarded_address_outside_allowlist(allowlist):
+    """The forwarded address still faces the allowlist check."""
+    app = _build_app(allowlist, _parse(PROXY_PEER))
+    client = app.test_client()
+    response = client.get(
+        "/",
+        headers={"X-Forwarded-For": BLOCKED_PEER},
+        environ_base={"REMOTE_ADDR": PROXY_PEER},
+    )
+    assert response.status_code == 403
+
+
+def test_trusted_proxy_reads_the_rightmost_forwarded_entry(allowlist):
+    """The rightmost entry is the address that the trusted proxy observed."""
+    app = _build_app(allowlist, _parse(PROXY_PEER))
+    client = app.test_client()
+    response = client.get(
+        "/",
+        headers={"X-Forwarded-For": f"{ALLOWED_CLIENT}, {BLOCKED_PEER}"},
+        environ_base={"REMOTE_ADDR": PROXY_PEER},
+    )
+    assert response.status_code == 403
+
+
+def test_trusted_proxy_accepts_a_cidr_range(allowlist):
+    """A CIDR range names a trusted proxy just as a plain address does."""
+    app = _build_app(allowlist, _parse("127.0.0.0/8"))
+    client = app.test_client()
+    response = client.get(
+        "/",
+        headers={"X-Forwarded-For": ALLOWED_CLIENT},
+        environ_base={"REMOTE_ADDR": PROXY_PEER},
+    )
+    assert response.status_code == 200
+
+
+def test_untrusted_peer_ignores_the_header_even_when_proxies_exist(allowlist):
+    """Only a trusted proxy peer unlocks the forwarded header."""
+    app = _build_app(allowlist, _parse(PROXY_PEER))
+    client = app.test_client()
+    response = client.get(
+        "/",
+        headers={"X-Forwarded-For": ALLOWED_CLIENT},
+        environ_base={"REMOTE_ADDR": BLOCKED_PEER},
+    )
+    assert response.status_code == 403
+
+
+def test_blocked_request_log_records_the_peer_address(allowlist, caplog):
+    """The audit trail always names the real peer address."""
+    app = _build_app(allowlist, _parse(PROXY_PEER))
+    client = app.test_client()
+    with caplog.at_level(logging.WARNING):
+        client.get(
+            "/",
+            headers={"X-Forwarded-For": BLOCKED_PEER},
+            environ_base={"REMOTE_ADDR": PROXY_PEER},
+        )
+    assert PROXY_PEER in caplog.text
+    assert BLOCKED_PEER in caplog.text
+
+
+def test_apply_reads_the_trusted_proxy_setting_from_the_environment(allowlist, monkeypatch):
+    """A caller that omits the argument still gets the configured proxies."""
+    monkeypatch.setenv("PORTAL_TRUSTED_PROXIES", PROXY_PEER)
+    app = _build_app(allowlist, None)
+    client = app.test_client()
+    response = client.get(
+        "/",
+        headers={"X-Forwarded-For": ALLOWED_CLIENT},
+        environ_base={"REMOTE_ADDR": PROXY_PEER},
+    )
+    assert response.status_code == 200
+
+
+def test_apply_defaults_to_no_trusted_proxy_when_the_environment_is_empty(allowlist, monkeypatch):
+    """An empty environment leaves the forwarded header without any trust."""
+    monkeypatch.delenv("PORTAL_TRUSTED_PROXIES", raising=False)
+    app = _build_app(allowlist, None)
+    client = app.test_client()
+    response = client.get(
+        "/",
+        headers={"X-Forwarded-For": ALLOWED_CLIENT},
+        environ_base={"REMOTE_ADDR": BLOCKED_PEER},
+    )
+    assert response.status_code == 403
+
+
+def test_loader_defaults_the_trusted_proxy_setting_to_empty(monkeypatch):
+    """The new setting ships with an empty default value."""
+    monkeypatch.delenv("PORTAL_TRUSTED_PROXIES", raising=False)
+    config = PortalConfigLoader().load_config()
+    assert config["trusted_proxies"] == []
+
+
+def test_loader_parses_a_plain_address_and_a_cidr_range(monkeypatch):
+    """The loader accepts both forms in one comma-separated value."""
+    monkeypatch.setenv("PORTAL_TRUSTED_PROXIES", "127.0.0.1, 10.9.0.0/16")
+    config = PortalConfigLoader().load_config()
+    assert [str(network) for network in config["trusted_proxies"]] == [
+        "127.0.0.1/32",
+        "10.9.0.0/16",
+    ]
+
+
+def test_loader_drops_an_invalid_trusted_proxy_entry(monkeypatch):
+    """An invalid entry never becomes a trusted proxy."""
+    monkeypatch.setenv("PORTAL_TRUSTED_PROXIES", "not-an-address")
+    config = PortalConfigLoader().load_config()
+    assert config["trusted_proxies"] == []

--- a/web_portal/services/config.py
+++ b/web_portal/services/config.py
@@ -3,6 +3,11 @@
 Contains PortalConfigLoader for ENV-based configuration,
 SecurityMiddleware for CSRF, CSP headers, and IP allowlisting,
 and ThemeManager for CSS theme enumeration.
+
+The IP allowlist judges the socket peer address from `request.remote_addr`.
+The portal reads the `X-Forwarded-For` header only when the peer address
+matches an entry in `PORTAL_TRUSTED_PROXIES`. That setting is empty by
+default, so a client-supplied header never changes the decision.
 """
 
 import ipaddress
@@ -28,6 +33,7 @@ class PortalConfigLoader:
         "PORTAL_THEME": "dark",
         "WEB_PORT": "8055",
         "PORTAL_ALLOWED_IPS": "",
+        "PORTAL_TRUSTED_PROXIES": "",
     }
 
     def load_config(self) -> dict:
@@ -52,7 +58,9 @@ class PortalConfigLoader:
             "theme": raw["PORTAL_THEME"],
             "web_port": self._validate_port(raw["WEB_PORT"]),
         }
-        config["allowed_ips"] = self._parse_allowed_ips(raw["PORTAL_ALLOWED_IPS"])
+        config["allowed_ips"] = self.parse_networks(raw["PORTAL_ALLOWED_IPS"], "PORTAL_ALLOWED_IPS")
+        # An empty trusted proxy list keeps the forwarded header untrusted by default.
+        config["trusted_proxies"] = self.parse_networks(raw["PORTAL_TRUSTED_PROXIES"], "PORTAL_TRUSTED_PROXIES")
         config["secret_key"] = os.environ.get("PORTAL_SECRET_KEY") or str(uuid.uuid4())
         return config
 
@@ -74,19 +82,23 @@ class PortalConfigLoader:
         logging.warning("Invalid WEB_PORT '%s', using default 8055", port_str)
         return 8055
 
-    def _parse_allowed_ips(self, ip_string: str) -> list:
-        """Parse comma-separated CIDR networks into list."""
+    @staticmethod
+    def parse_networks(ip_string: str, setting_name: str) -> list:
+        """Parse a comma-separated list of addresses or CIDR ranges."""
         if not ip_string.strip():
-            return []
+            return []  # An empty setting yields an empty list, which the caller reads as "not configured".
+        logging.info("Parsing the %s setting", setting_name)
         networks = []
         for entry in ip_string.split(","):
-            entry = entry.strip()
+            entry = entry.strip()  # Trim the spaces that an operator leaves around a comma.
             if not entry:
-                continue
+                continue  # Skip an empty field, because a trailing comma is a common typing slip.
             try:
+                # strict=False accepts a plain address, which becomes a single-host network.
                 networks.append(ipaddress.ip_network(entry, strict=False))
             except ValueError:
-                logging.warning("Invalid CIDR in PORTAL_ALLOWED_IPS: '%s'", entry)
+                logging.warning("Invalid CIDR in %s: '%s'", setting_name, entry)
+        logging.debug("Parsed %d networks from the %s setting", len(networks), setting_name)
         return networks
 
 
@@ -105,11 +117,31 @@ class SecurityMiddleware:
         "connect-src 'self'"
     )
 
-    def apply(self, app: Flask, allowed_ips: list) -> None:
+    def __init__(self) -> None:
+        """Start with no trusted proxy, so a forged header carries no trust."""
+        self._trusted_proxies: list = []
+
+    def apply(self, app: Flask, allowed_ips: list, trusted_proxies: list | None = None) -> None:
         """Register all security hooks on the Flask app."""
+        logging.info("Applying the portal security controls to the Flask application")
+        # Resolve the trusted proxies first, because the allowlist hook reads them.
+        self._trusted_proxies = self._resolve_trusted_proxies(trusted_proxies)
         self._register_csp_headers(app)
         self._register_ip_allowlist(app, allowed_ips)
         self._configure_csrf(app)
+        logging.debug(
+            "Applied the portal security controls with %d allowed networks and %d trusted proxies",
+            len(allowed_ips),
+            len(self._trusted_proxies),
+        )
+
+    def _resolve_trusted_proxies(self, trusted_proxies: list | None) -> list:
+        """Return the proxy networks that may set the forwarded header."""
+        if trusted_proxies is not None:
+            return trusted_proxies  # An explicit argument wins, because the caller already read the config.
+        # A caller that omits the argument still gets the operator setting, never blind trust.
+        raw = os.environ.get("PORTAL_TRUSTED_PROXIES", "")
+        return PortalConfigLoader.parse_networks(raw, "PORTAL_TRUSTED_PROXIES")
 
     def _register_csp_headers(self, app: Flask) -> None:
         """Add security headers to every response."""
@@ -126,14 +158,22 @@ class SecurityMiddleware:
     def _register_ip_allowlist(self, app: Flask, allowed_ips: list) -> None:
         """Block requests from IPs not in the allowlist."""
         if not allowed_ips:
-            return
+            return  # An empty allowlist means the operator accepts every source address.
+
+        logging.info("Registering the portal IP allowlist with %d networks", len(allowed_ips))
 
         @app.before_request
         def check_ip_allowlist():
-            client_ip = self._get_client_ip()
-            if not self._ip_is_allowed(client_ip, allowed_ips):
-                logging.warning("Blocked request from %s", client_ip)
+            peer_ip = self._get_peer_ip()  # The socket peer is the one address a caller cannot forge.
+            client_ip = self._resolve_client_ip(peer_ip)  # Only a trusted proxy can name a different client.
+            if not self._ip_matches_any(client_ip, allowed_ips):
+                # The message names both addresses, so the audit trail keeps the real source.
+                logging.warning("Blocked request from client %s with peer %s", client_ip, peer_ip)
                 abort(403)
+            # Debug level keeps the allowed path quiet, because every request reaches this line.
+            logging.debug("Allowed request from client %s with peer %s", client_ip, peer_ip)
+
+        logging.debug("Registered the portal IP allowlist")
 
     def _configure_csrf(self, app: Flask) -> None:
         """Initialize CSRF protection via flask-wtf."""
@@ -143,20 +183,33 @@ class SecurityMiddleware:
         csrf.init_app(app)
         app.config["csrf"] = csrf
 
-    def _get_client_ip(self) -> str:
-        """Extract client IP from request, respecting X-Forwarded-For."""
-        forwarded = request.headers.get("X-Forwarded-For", "")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        return request.remote_addr or "0.0.0.0"  # nosec B104 — fallback IP, not a bind address
+    def _get_peer_ip(self) -> str:
+        """Return the socket peer address of the current request."""
+        # The fallback value is a placeholder address, not a bind address.
+        return request.remote_addr or "0.0.0.0"  # nosec B104
 
-    def _ip_is_allowed(self, client_ip: str, allowed_ips: list) -> bool:
-        """Check if client IP matches any allowed CIDR network."""
+    def _resolve_client_ip(self, peer_ip: str) -> str:
+        """Return the address that the allowlist check must judge."""
+        if not self._trusted_proxies:
+            return peer_ip  # Without a trusted proxy the forwarded header carries no trust.
+        if not self._ip_matches_any(peer_ip, self._trusted_proxies):
+            return peer_ip  # An untrusted peer cannot rename itself with a header.
+        forwarded = request.headers.get("X-Forwarded-For", "")  # Only a trusted proxy reaches this line.
+        if not forwarded:
+            return peer_ip  # The trusted proxy sent no header, so the peer is the client.
+        # The rightmost entry is the address the trusted proxy observed. A caller controls the entries to its left.
+        client_ip = forwarded.split(",")[-1].strip()
+        logging.debug("Trusted proxy %s reported client %s", peer_ip, client_ip)
+        return client_ip
+
+    def _ip_matches_any(self, client_ip: str, networks: list) -> bool:
+        """Check if an address falls inside any network in the list."""
         try:
-            addr = ipaddress.ip_address(client_ip)
-            return any(addr in network for network in allowed_ips)
+            addr = ipaddress.ip_address(client_ip)  # Reject a malformed value before the range test.
+            return any(addr in network for network in networks)
         except ValueError:
-            return False
+            logging.debug("Address '%s' is not a valid IP address", client_ip)
+            return False  # An unreadable address never matches, so the caller blocks the request.
 
 
 class ThemeManager:

--- a/web_portal/services/config.py
+++ b/web_portal/services/config.py
@@ -89,7 +89,7 @@ class PortalConfigLoader:
             return []  # An empty setting yields an empty list, which the caller reads as "not configured".
         logging.info("Parsing the %s setting", setting_name)
         networks = []
-        for entry in ip_string.split(","):
+        for position, entry in enumerate(ip_string.split(","), start=1):
             entry = entry.strip()  # Trim the spaces that an operator leaves around a comma.
             if not entry:
                 continue  # Skip an empty field, because a trailing comma is a common typing slip.
@@ -97,7 +97,12 @@ class PortalConfigLoader:
                 # strict=False accepts a plain address, which becomes a single-host network.
                 networks.append(ipaddress.ip_network(entry, strict=False))
             except ValueError:
-                logging.warning("Invalid CIDR in %s: '%s'", setting_name, entry)
+                # The message names the position, not the text. An environment value can hold a secret.
+                logging.warning(
+                    "Entry %d of the %s setting is not an address or a CIDR range",
+                    position,
+                    setting_name,
+                )
         logging.debug("Parsed %d networks from the %s setting", len(networks), setting_name)
         return networks
 


### PR DESCRIPTION
# Spec Conformance Checklist

**Linked Spec Issue**: #1857

Fixes #1857

## Breaking change - action required for a proxied deployment

**Warning:** If you run the portal behind a reverse proxy and you set `PORTAL_ALLOWED_IPS`, the portal answers 403 to every client after this upgrade.

- **Symptom**: every client receives 403. The dashboard never loads. The log holds one line for each request that reads `Blocked request from client <proxy address> with peer <proxy address>`.
- **Cause**: the allowlist now reads the socket peer address instead of the `X-Forwarded-For` header. Behind a proxy the socket peer is the proxy, so the allowlist judges the address of the proxy, not the address of the client.
- **Fix**: name the proxy in the new `PORTAL_TRUSTED_PROXIES` setting. The portal then reads the forwarded header from that proxy and judges the real client address.
- **A portal that runs without a proxy needs no action.** The default value is empty, and the behavior for a direct deployment does not change.

Copy this line into the `.env` file and replace the address with the address of your proxy. An entry is a plain address or a CIDR range, and a comma separates two entries.

```
PORTAL_TRUSTED_PROXIES=127.0.0.1
```

`deploy/.env.example` and the `CHANGELOG.md` entry carry the same warning.

## Problem

`web_portal/services/config.py` trusted the client-supplied `X-Forwarded-For` header when it enforced `PORTAL_ALLOWED_IPS`. No reverse proxy sits in front of the Gunicorn portal, so any remote caller defeated the only network access control with one extra header and reached every Mist operation, which includes 41 destructive ones. The block message also recorded the forged value, so the audit trail named the wrong source.

## Change

- `SecurityMiddleware._get_peer_ip` returns `request.remote_addr`. The allowlist judges that address, and a caller cannot forge it.
- `PORTAL_TRUSTED_PROXIES` is a new opt-in setting. The default value is empty. Each entry is a plain address or a CIDR range.
- `SecurityMiddleware._resolve_client_ip` reads the `X-Forwarded-For` header only when the peer address matches a trusted proxy entry. It reuses the shared matching helper `_ip_matches_any`.
- The helper reads the **rightmost** header entry, because a trusted proxy appends the address it observed. A caller controls every entry to its left.
- The block message names the client address and the peer address, so the audit trail always holds the real source.
- `PortalConfigLoader.parse_networks` replaces `_parse_allowed_ips`. One parser now serves both settings and names the setting in each log message.
- `deploy/.env.example` documents `PORTAL_ALLOWED_IPS` and `PORTAL_TRUSTED_PROXIES` in one section, with a warning about a directly reachable proxy address.

`SecurityMiddleware.apply` keeps a backward-compatible signature. The new `trusted_proxies` parameter defaults to `None`, and the middleware then reads the setting from the environment. `web_portal/app.py` needs no change, so this pull request does not touch it.

## Issue status report

A matching status comment sits on issue #1857.

- Branch: `jmorrison-jnpr-sec-1857-xff-allowlist`
- Acceptance criteria from issue #1857, all met:
  - [x] The allowlist check uses `request.remote_addr` when no trusted proxy is configured.
  - [x] A forged `X-Forwarded-For` header does not change the allowlist decision.
  - [x] A new setting names the trusted proxy addresses, and the default value is empty.
  - [x] `deploy/.env.example` documents the new setting.
  - [x] A unit test sends a forged `X-Forwarded-For` header from a blocked address and asserts `403`.
  - [x] A unit test sends the same header from a trusted proxy address and asserts the forwarded address is used.
- Remaining work: none for this defect. Suggestion 3 in the issue named `werkzeug.middleware.proxy_fix.ProxyFix` as an option. This pull request keeps the guarded parser instead, because `ProxyFix` rewrites `remote_addr` for every request without a peer check. A peer check is the control that stops the bypass.
- A human must review this security change. The `auto-merge` label is not applied.

## CodeQL alert, found and fixed inside this pull request

The first push raised one high severity alert.

- Rule: `py/clear-text-logging-sensitive-data`
- Location: `web_portal/services/config.py`, the invalid entry warning in `parse_networks`
- Root cause: the message held the raw text of the setting entry. That text arrives from the environment, and CodeQL reads an environment value as a secret. The old line was `logging.warning("Invalid CIDR in %s: '%s'", setting_name, entry)`.
- Fix: the message now names the position of the bad entry and the name of the setting. No setting text reaches the log record. The line is now `logging.warning("Entry %d of the %s setting is not an address or a CIDR range", position, setting_name)`.
- The fix is a real change, not a suppression. No `# nosec` comment, no `# noqa` directive, and no CodeQL dismissal was added.
- Regression test: `test_loader_reports_the_position_of_an_invalid_entry` sets `PORTAL_TRUSTED_PROXIES=127.0.0.1,super-secret-value`. It asserts that `super-secret-value` never appears in the log and that the message reads `Entry 2 of the PORTAL_TRUSTED_PROXIES setting`.

The address code holds no regular expression and no `startswith` test. `ipaddress.ip_address` and `ipaddress.ip_network` parse every value, and the `in` operator compares the address against the network object.

## Test evidence

`tests/unit/web_portal/test_config_ip_allowlist.py` holds 15 cases. Every allowlist case failed against the old code and passes now.

| Case | Peer | Header | Result |
| - | - | - | - |
| Forged header from a blocked peer | `203.0.113.9` | `10.0.0.1` | 403 |
| Allowed peer, no header | `10.0.0.1` | none | 200 |
| Blocked peer, no header | `203.0.113.9` | none | 403 |
| Trusted proxy peer | `127.0.0.1` | `10.0.0.1` | 200 |
| Trusted proxy peer, blocked forwarded address | `127.0.0.1` | `203.0.113.9` | 403 |
| Trusted proxy peer, two entries | `127.0.0.1` | `10.0.0.1, 203.0.113.9` | 403 |
| Trusted proxy named by a CIDR range | `127.0.0.1` | `10.0.0.1` | 200 |
| Untrusted peer while proxies exist | `203.0.113.9` | `10.0.0.1` | 403 |
| Block message holds the peer address | `127.0.0.1` | `203.0.113.9` | both addresses logged |
| Setting read from the environment | `127.0.0.1` | `10.0.0.1` | 200 |
| Empty environment, no trust | `203.0.113.9` | `10.0.0.1` | 403 |
| Loader default | - | - | `[]` |
| Loader parses an address and a range | - | - | `127.0.0.1/32`, `10.9.0.0/16` |
| Loader drops an invalid entry | - | - | `[]` |
| Loader logs the position, not the text | - | - | no setting text in the log |

```
python -m py_compile web_portal/services/config.py   -> exit 0
python -m ruff check .                               -> All checks passed!
python -m black --check web_portal/services/config.py tests/unit/web_portal/
                                                     -> 3 files unchanged
python -m bandit -q -r web_portal/services/config.py -c pyproject.toml
                                                     -> exit 0, no findings
python -m pytest tests/unit/web_portal/ -q           -> 15 passed
```

A regression run of the neighboring suites that read `web_portal` also passes: `tests/unit/test_webhook_ingestion.py`, `tests/test_issue_433_src_g_no_regress.py`, and `tests/unit/ui/test_device_prompt_rename_guard.py`, 26 passed in total.

## Acceptance Criteria
- [x] All acceptance criteria from the linked Spec Issue are met
- [x] Each criterion has a corresponding test or verification

## Quality
- [x] Tests added or updated for all changed functionality
- [x] Coverage meets or exceeds 80% threshold
- [x] No new Ruff lint violations (`ruff check .`)
- [x] Code formatted with Ruff (`ruff format --check .`)
- [ ] mypy passes (`mypy MistHelper.py`) - `web_portal` sits outside the mypy scope in `pyproject.toml`, so the gate does not read this file.

## Security
- [x] No hardcoded secrets, tokens, or passwords
- [x] Bandit passes with no new findings (`bandit -r MistHelper.py -c pyproject.toml`)
- [ ] pip-audit clean (`pip-audit -r requirements.txt`) - no dependency changed in this pull request.
- [x] Sensitive data handled via `.env` / environment variables only

## Deployment
- [x] Dry-run verified locally (ran affected menu operations) - the unit tests drive the Flask app through a test client and cover both decisions.
- [x] `.env` changes documented in `deploy/.env.example` (if applicable)
- [ ] Container builds successfully (if Containerfile changed) - the Containerfile did not change.

## UI / E2E Testing (if web UI changed)
- [ ] Playwright E2E tests added/updated for changed UI flows in `tests/e2e/` - no template, route, or UI element changed. The change sits in the request hook.
- [ ] Stable `data-testid` attributes added for new interactive elements - no new element.
- [ ] AI agent verified selectors via VS Code Browser Agent Tools - no selector changed.
- [ ] Screenshots/traces captured for main UI flows - no visual change.

## Documentation
- [ ] README.md updated (if user-facing changes) - the portal settings live in `deploy/.env.example` and `documentation/wiki/Web-Portal.md`, which another pull request owns.
- [x] Changelog entry added with version `YY.MM.DD.HH.MM` format

## Operator action

**Warning:** An operator who runs the portal behind a real reverse proxy must set `PORTAL_TRUSTED_PROXIES`. Without that setting the allowlist sees the proxy address on every request and blocks every client. The section "Breaking change - action required for a proxied deployment" near the top of this body holds the symptom, the cause, and the exact line to copy.
